### PR TITLE
docs(agents): record GitHub MCP contents-write needed to merge

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -118,10 +118,22 @@ nearest focused local command, fix the root cause in a separate commit, push,
 and watch again. Address actionable review feedback.
 
 Squash-merge only when required checks and review gates pass, the base is
-correct, and validation supports confidence. Capture the merge SHA, then watch
-workflows triggered on `main` for release tagging, image publication, staging
-deployment, and health checks. Treat release/deploy failures as incidents;
-report evidence rather than making unrequested infrastructure changes.
+correct, and validation supports confidence. Use GitHub MCP
+`merge_pull_request` with `merge_method: squash`. Do not use `gh pr merge`
+unless a user-provided `GH_TOKEN` is present in the environment — the
+sandbox `gh` token is a read-only GitHub App installation and cannot merge.
+
+If merge returns `403 Resource not accessible by personal access token`,
+Contents write is missing on the GitHub MCP identity. Stop and tell the
+user to grant **Contents: Read and write** (plus **Pull requests: Read and
+write**) on `KeepSoftwareSimple/compass-calendar` for that token, and to
+add the same PAT as `GH_TOKEN` on the `ccal` cloud environment. Do not
+treat a 403 as a successful ship.
+
+Capture the merge SHA, then watch workflows triggered on `main` for release
+tagging, image publication, staging deployment, and health checks. Treat
+release/deploy failures as incidents; report evidence rather than making
+unrequested infrastructure changes.
 
 ## Report
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,3 +162,16 @@ everything runs through Bun, so that mismatch is not a blocker.
   `compass.yaml`. Without them the backend still runs and serves
   anonymous/health traffic, but do not attempt login flows (see the AGENTS.md
   rule) until those are configured.
+- GitHub merge (`/ship` squash-merge) is a permission on the **GitHub MCP**
+  identity, not the sandbox `gh` CLI. `gh` uses a read-only Cursor GitHub App
+  token (`ghs_…`, account `cursor`) and returns `403 Resource not accessible
+  by integration` for writes. Squash-merge uses GitHub MCP
+  `merge_pull_request`, which authenticates as the connected user. That token
+  must have **Contents: Read and write** and **Pull requests: Read and write**
+  on `KeepSoftwareSimple/compass-calendar`. `403 Resource not accessible by
+  personal access token` on merge means Contents write is missing — do not
+  treat that as a successful ship. Grant Contents write on the GitHub MCP /
+  Cursor GitHub connection, and add a fine-grained PAT with those same
+  permissions as `GH_TOKEN` on the `ccal` cloud environment
+  (https://cursor.com/dashboard/cloud-agents/environments/e/a8d6d701-95d6-11f1-ba66-0e7d0216e441).
+  New agent runs pick up the secret; the current session will not.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cloud agents cannot squash-merge Compass PRs with the sandbox `gh` token. This records the actual requirement: GitHub MCP `merge_pull_request` needs **Contents: Read and write** (plus Pull requests write) on this repo, and a `GH_TOKEN` on the `ccal` cloud environment as the workaround for `gh`.

A `403 Resource not accessible by personal access token` means Contents write is missing. Do not treat that as a successful `/ship`.

## Simplicity

Docs only. No runtime change.

## Automated validation

Docs-only; no tests.

## Independent review

Not required for this documentation.

## Test plan

- After a PAT with Contents write is added as `GH_TOKEN` on the `ccal` environment, a **new** cloud agent run should be able to squash-merge via GitHub MCP (and `gh` if that token is used).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e8d005e-c11e-4a51-96b2-984635f59af9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e8d005e-c11e-4a51-96b2-984635f59af9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

