### PR TITLE
feat(web): pan timed grid one hour with alt+arrows

### DIFF
--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -16,7 +16,7 @@ Use this guide to validate:
 - navigating between views with the keyboard (D, W)
 - navigating between days in Day view (J, K, T)
 - navigating between weeks in Week view (J, K, T)
-- scrolling the timed grid with PageUp / PageDown, including while an event is focused
+- scrolling the timed grid with PageUp / PageDown and Alt+ArrowUp / Alt+ArrowDown, including while an event is focused
 - opening and using the command palette (Cmd+K), including undo/redo rows
 - creating events with keyboard shortcuts (C, A in both Day and Week view)
 - editing events with the same keys in Day and Week (Delete, Shift+arrows, draft arrows)
@@ -343,24 +343,26 @@ All view-navigation and action shortcuts are suppressed when the user is focused
 
 ---
 
-## Scenario 15: Scroll The Timed Grid With PageUp / PageDown
+## Scenario 15: Scroll The Timed Grid With PageUp / PageDown And Alt+Arrows
 
 ### UX
 
-PageUp and PageDown always scroll the timed grid by one viewport, even when focus is on an event card, the sidebar, or another control. Arrow keys still move event focus; J/K still change the visible day or week. The shortcuts do not fire while typing in an input.
+PageUp and PageDown always scroll the timed grid by one viewport. Alt+ArrowUp and Alt+ArrowDown pan it by one hour. Both work even when focus is on an event card, the sidebar, or another control. Bare arrows still move event focus; J/K still change the visible day or week. The shortcuts do not fire while typing in an input.
 
 ### Steps
 
 1. Navigate to `/week` (or `/day`).
 2. Click an event so it is focused.
 3. Press PageDown, then PageUp.
-4. Open an event form, focus the title, and press PageDown.
+4. Press Alt+ArrowDown, then Alt+ArrowUp (Option+Arrow on Mac).
+5. Open an event form, focus the title, and press PageDown, then Alt+ArrowDown.
 
 ### Expected Results
 
-- PageDown moves the timed grid later in the day; PageUp moves it earlier.
-- The focused event does not change solely because of PageUp / PageDown.
-- PageDown does nothing while the title input is focused.
+- PageDown moves the timed grid later in the day by one viewport; PageUp moves it earlier by one viewport.
+- Alt+ArrowDown moves the timed grid later by one hour; Alt+ArrowUp moves it earlier by one hour.
+- The focused event does not change solely because of these scroll shortcuts.
+- PageDown and Alt+ArrowDown do nothing while the title input is focused.
 
 ---
 
@@ -384,4 +386,5 @@ If time is limited, run these checks before shipping shortcut-related changes:
 14. With a focused event, `E` then `T` opens the form with the title focused; `E` then `A` / `C` jump to account / color; bare `E` alone does nothing.
 15. Pressing `S` shows event jump chips; a day letter + digit focuses that event; Shift+Tab does not show chips.
 16. Mouse clicks, right-clicks, and double-clicks are inert everywhere; a blocked click shows the keyboard-only hint. `M` opens the focused event's menu; `F` focuses the newest notice.
-17. PageUp / PageDown scroll the timed grid in Day and Week view even when an event is focused; they do not fire in a text input.
+17. PageUp / PageDown scroll the timed grid by one viewport in Day and Week view even when an event is focused; they do not fire in a text input.
+18. Alt+ArrowUp / Alt+ArrowDown pan the timed grid by one hour in Day and Week view even when an event is focused; they do not fire in a text input.

--- a/packages/web/src/grid/shortcuts/scroll-timed-grid.test.ts
+++ b/packages/web/src/grid/shortcuts/scroll-timed-grid.test.ts
@@ -1,28 +1,44 @@
 import { ID_GRID_MAIN } from "@web/common/constants/web.constants";
-import { scrollTimedGridByPage } from "@web/grid/shortcuts/scroll-timed-grid";
+import { scrollTimedGrid } from "@web/grid/shortcuts/scroll-timed-grid";
 import { afterEach, describe, expect, it, mock } from "bun:test";
 
-describe("scrollTimedGridByPage", () => {
+const mountGrid = (clientHeight: number) => {
+  const grid = document.createElement("section");
+  grid.id = ID_GRID_MAIN;
+  Object.defineProperty(grid, "clientHeight", { value: clientHeight });
+  const scrollBy = mock();
+  grid.scrollBy = scrollBy as typeof grid.scrollBy;
+  document.body.append(grid);
+  return { grid, scrollBy };
+};
+
+describe("scrollTimedGrid", () => {
   afterEach(() => {
     document.getElementById(ID_GRID_MAIN)?.remove();
   });
 
   it("scrolls the timed grid by one viewport in the requested direction", () => {
-    const grid = document.createElement("section");
-    grid.id = ID_GRID_MAIN;
-    Object.defineProperty(grid, "clientHeight", { value: 400 });
-    const scrollBy = mock();
-    grid.scrollBy = scrollBy as typeof grid.scrollBy;
-    document.body.append(grid);
+    const { scrollBy } = mountGrid(390);
 
-    expect(scrollTimedGridByPage("down")).toBe(true);
-    expect(scrollBy).toHaveBeenCalledWith({ top: 400 });
+    expect(scrollTimedGrid("down", "page")).toBe(true);
+    expect(scrollBy).toHaveBeenCalledWith({ top: 390 });
 
-    expect(scrollTimedGridByPage("up")).toBe(true);
-    expect(scrollBy).toHaveBeenCalledWith({ top: -400 });
+    expect(scrollTimedGrid("up", "page")).toBe(true);
+    expect(scrollBy).toHaveBeenCalledWith({ top: -390 });
+  });
+
+  it("scrolls the timed grid by one hour in the requested direction", () => {
+    const { scrollBy } = mountGrid(390);
+
+    expect(scrollTimedGrid("down", "hour")).toBe(true);
+    expect(scrollBy).toHaveBeenCalledWith({ top: 30 });
+
+    expect(scrollTimedGrid("up", "hour")).toBe(true);
+    expect(scrollBy).toHaveBeenCalledWith({ top: -30 });
   });
 
   it("no-ops when the timed grid is not in the document", () => {
-    expect(scrollTimedGridByPage("down")).toBe(false);
+    expect(scrollTimedGrid("down", "page")).toBe(false);
+    expect(scrollTimedGrid("down", "hour")).toBe(false);
   });
 });

--- a/packages/web/src/grid/shortcuts/scroll-timed-grid.ts
+++ b/packages/web/src/grid/shortcuts/scroll-timed-grid.ts
@@ -1,20 +1,29 @@
 import { ID_GRID_MAIN } from "@web/common/constants/web.constants";
 import { getElemById } from "@web/common/utils/grid/grid.util";
+import { TIMED_VISIBLE_HOURS } from "@web/grid/grid.constants";
 
 export type TimedGridScrollDirection = "up" | "down";
+export type TimedGridScrollUnit = "page" | "hour";
+
+const deltaForUnit = (
+  clientHeight: number,
+  unit: TimedGridScrollUnit,
+): number =>
+  unit === "page" ? clientHeight : clientHeight / TIMED_VISIBLE_HOURS;
 
 /**
- * Pages the timed grid scroller by one viewport. Returns whether a grid
- * was found so callers can preventDefault only when the shortcut actually
- * applied.
+ * Scrolls the timed grid by one viewport or one hour. Returns whether a
+ * grid was found so callers can preventDefault only when the shortcut
+ * actually applied.
  */
-export const scrollTimedGridByPage = (
+export const scrollTimedGrid = (
   direction: TimedGridScrollDirection,
+  unit: TimedGridScrollUnit,
 ): boolean => {
   const grid = getElemById(ID_GRID_MAIN);
   if (!grid) return false;
 
-  const delta = grid.clientHeight;
+  const delta = deltaForUnit(grid.clientHeight, unit);
   if (delta <= 0) return false;
 
   grid.scrollBy({ top: direction === "down" ? delta : -delta });

--- a/packages/web/src/grid/shortcuts/scroll-timed-grid.ts
+++ b/packages/web/src/grid/shortcuts/scroll-timed-grid.ts
@@ -5,12 +5,6 @@ import { TIMED_VISIBLE_HOURS } from "@web/grid/grid.constants";
 export type TimedGridScrollDirection = "up" | "down";
 export type TimedGridScrollUnit = "page" | "hour";
 
-const deltaForUnit = (
-  clientHeight: number,
-  unit: TimedGridScrollUnit,
-): number =>
-  unit === "page" ? clientHeight : clientHeight / TIMED_VISIBLE_HOURS;
-
 /**
  * Scrolls the timed grid by one viewport or one hour. Returns whether a
  * grid was found so callers can preventDefault only when the shortcut
@@ -23,7 +17,10 @@ export const scrollTimedGrid = (
   const grid = getElemById(ID_GRID_MAIN);
   if (!grid) return false;
 
-  const delta = deltaForUnit(grid.clientHeight, unit);
+  const delta =
+    unit === "page"
+      ? grid.clientHeight
+      : grid.clientHeight / TIMED_VISIBLE_HOURS;
   if (delta <= 0) return false;
 
   grid.scrollBy({ top: direction === "down" ? delta : -delta });

--- a/packages/web/src/grid/shortcuts/useCalendarViewShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useCalendarViewShortcuts.ts
@@ -18,7 +18,8 @@ export interface CalendarViewShortcutsConfig {
 /**
  * Shared Day/Week view shortcuts: j/k navigate the period, t goes to today,
  * "c" creates a timed event, "a" an all-day event, "u" focuses the calendar;
- * PageUp/PageDown scroll the timed grid via `useGridScrollShortcuts`.
+ * PageUp/PageDown and Alt+ArrowUp/Down scroll the timed grid via
+ * `useGridScrollShortcuts`.
  * Shift+J/K register only when the view provides a handler (Week's window
  * shift). "i" (focus sidebar) is registered separately via
  * useFocusSidebarShortcut. Behavior lives in each view's owner; this is only

--- a/packages/web/src/grid/shortcuts/useGridScrollShortcuts.test.tsx
+++ b/packages/web/src/grid/shortcuts/useGridScrollShortcuts.test.tsx
@@ -64,8 +64,51 @@ describe("useGridScrollShortcuts", () => {
 
     renderHook(() => useGridScrollShortcuts(), { wrapper });
     pressKey("PageDown", {}, input);
+    pressKey(
+      "ArrowDown",
+      { keyDownInit: { altKey: true }, keyUpInit: { altKey: true } },
+      input,
+    );
 
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(scrollBy).not.toHaveBeenCalled();
+  });
+
+  it("pans the grid by one hour with Alt+ArrowDown and Alt+ArrowUp", async () => {
+    renderHook(() => useGridScrollShortcuts(), { wrapper });
+
+    const hourDelta = 500 / 13;
+    const altArrow = {
+      keyDownInit: { altKey: true },
+      keyUpInit: { altKey: true },
+    };
+
+    pressKey("ArrowDown", altArrow);
+    await waitFor(() => {
+      expect(scrollBy).toHaveBeenCalledWith({ top: hourDelta });
+    });
+
+    pressKey("ArrowUp", altArrow);
+    await waitFor(() => {
+      expect(scrollBy).toHaveBeenCalledWith({ top: -hourDelta });
+    });
+  });
+
+  it("pans by one hour when an event-like control is focused", async () => {
+    const button = document.createElement("button");
+    button.textContent = "Standup";
+    document.body.append(button);
+    button.focus();
+
+    renderHook(() => useGridScrollShortcuts(), { wrapper });
+    pressKey(
+      "ArrowDown",
+      { keyDownInit: { altKey: true }, keyUpInit: { altKey: true } },
+      button,
+    );
+
+    await waitFor(() => {
+      expect(scrollBy).toHaveBeenCalledWith({ top: 500 / 13 });
+    });
   });
 });

--- a/packages/web/src/grid/shortcuts/useGridScrollShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useGridScrollShortcuts.ts
@@ -1,26 +1,37 @@
-import { scrollTimedGridByPage } from "@web/grid/shortcuts/scroll-timed-grid";
+import {
+  scrollTimedGrid,
+  type TimedGridScrollUnit,
+} from "@web/grid/shortcuts/scroll-timed-grid";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 
 const scrollGridFromShortcut = (
   direction: "up" | "down",
+  unit: TimedGridScrollUnit,
   event: KeyboardEvent,
 ) => {
-  if (!scrollTimedGridByPage(direction)) return;
+  if (!scrollTimedGrid(direction, unit)) return;
 
   event.preventDefault();
   event.stopPropagation();
 };
 
 /**
- * PageUp / PageDown always scroll the timed grid, even when focus is on an
- * event card or another non-grid control. Arrow keys stay reserved for
+ * PageUp / PageDown page the timed grid by one viewport; Alt+ArrowUp /
+ * Alt+ArrowDown pan it by one hour. Both fire even when focus is on an
+ * event card or another non-grid control. Bare arrows stay reserved for
  * event focus; J/K stay reserved for day/week navigation.
  */
 export function useGridScrollShortcuts() {
   useAppShortcut("PageUp", (event) => {
-    scrollGridFromShortcut("up", event);
+    scrollGridFromShortcut("up", "page", event);
   });
   useAppShortcut("PageDown", (event) => {
-    scrollGridFromShortcut("down", event);
+    scrollGridFromShortcut("down", "page", event);
+  });
+  useAppShortcut("Alt+ArrowUp", (event) => {
+    scrollGridFromShortcut("up", "hour", event);
+  });
+  useAppShortcut("Alt+ArrowDown", (event) => {
+    scrollGridFromShortcut("down", "hour", event);
   });
 }

--- a/packages/web/src/shortcuts/shortcuts.menu.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.menu.test.ts
@@ -75,7 +75,7 @@ describe("shortcut menu sections", () => {
       ]);
     });
 
-    it("lists PageUp/PageDown grid scroll in day and week, not life", () => {
+    it("lists PageUp/PageDown and Alt+Arrow grid scroll in day and week, not life", () => {
       for (const view of ["day", "week"] as const) {
         const [navigate] = getShortcutMenuSections({
           view,
@@ -90,6 +90,14 @@ describe("shortcut menu sections", () => {
           keys: ["PageDown"],
           label: "Scroll grid down",
         });
+        expect(stripMetadata(navigate.shortcuts)).toContainEqual({
+          keys: ["Alt", "ArrowUp"],
+          label: "Scroll grid up one hour",
+        });
+        expect(stripMetadata(navigate.shortcuts)).toContainEqual({
+          keys: ["Alt", "ArrowDown"],
+          label: "Scroll grid down one hour",
+        });
       }
 
       const [lifeNavigate] = getShortcutMenuSections({
@@ -103,6 +111,14 @@ describe("shortcut menu sections", () => {
       expect(stripMetadata(lifeNavigate.shortcuts)).not.toContainEqual({
         keys: ["PageDown"],
         label: "Scroll grid down",
+      });
+      expect(stripMetadata(lifeNavigate.shortcuts)).not.toContainEqual({
+        keys: ["Alt", "ArrowUp"],
+        label: "Scroll grid up one hour",
+      });
+      expect(stripMetadata(lifeNavigate.shortcuts)).not.toContainEqual({
+        keys: ["Alt", "ArrowDown"],
+        label: "Scroll grid down one hour",
       });
     });
 

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -98,6 +98,18 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
     label: "Scroll grid down",
     section: "navigate",
   },
+  {
+    id: "nav-scroll-hour-up",
+    keys: caps("Alt+ArrowUp"),
+    label: "Scroll grid up one hour",
+    section: "navigate",
+  },
+  {
+    id: "nav-scroll-hour-down",
+    keys: caps("Alt+ArrowDown"),
+    label: "Scroll grid down one hour",
+    section: "navigate",
+  },
 
   // Navigate - View switchers (all views)
   {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a gradual keyboard pan for the timed grid so users can shift the visible hours without the mouse wheel or a full-page jump.

- `Alt+ArrowUp` / `Alt+ArrowDown` (Option+Arrow on Mac) scroll `#mainGrid` by one hour (`clientHeight / 13`)
- `PageUp` / `PageDown` still jump by one viewport
- Bare arrows still move event focus; `J`/`K` still change the day or week
- Same contract as page scroll: works with an event focused, ignored while typing in an input, Day and Week only

![Week grid at midnight before hour pans](https://cursor.com/artifacts/c/art-12256222-16eb-4222-a18c-25c726ad9ae9)
![Week grid after five Alt+ArrowDown hour pans](https://cursor.com/artifacts/c/art-d6fa2da4-422f-4438-8f40-d2884c672064)
![Shortcuts overlay listing Alt+Arrow hour scroll](https://cursor.com/artifacts/c/art-3cacf7b5-095e-4c90-a447-151865619b59)
<a href="https://cursor.com/agents/bc-72549f17-efb2-48ba-b92a-5b0cf60a50bb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Falt_arrow_hour_scroll_and_page_jump.mp4"><img src="https://cursor.com/artifacts/c/art-35f44930-b7e8-4121-9586-09ed10a2efe3" alt="alt_arrow_hour_scroll_and_page_jump.mp4" /></a>

## Simplicity

The page and hour paths share one `scrollTimedGrid(direction, unit)` helper. A follow-up commit inlined the one-call delta helper. No new React state, effects, or custom hold-to-scroll loop — keydown plus native repeat, matching PageUp/PageDown.

## Automated validation

Playwright against `http://localhost:9080/week` (anonymous IndexedDB, welcome skipped):

- PageUp: `scrollTop` 619 → 0
- Alt+ArrowDown: +56px per press (`731 / 13 = 56.23`); five presses → 280px; top hour 1 AM → 5 AM
- Alt+ArrowUp: −56px
- PageDown: large jump, clamped at end of day (`scrollTop` 619)
- `?` overlay search "scroll" lists PageUp/PageDown and Alt+Arrow hour bindings

## Independent review

Read-only review of `main...HEAD`: no confirmed findings. Alt+Arrow does not fire the bare-arrow focus handler because TanStack requires exact modifiers.

## Test plan

- `bun test:web -- packages/web/src/grid/shortcuts/scroll-timed-grid.test.ts packages/web/src/grid/shortcuts/useGridScrollShortcuts.test.tsx packages/web/src/shortcuts/shortcuts.menu.test.ts` — 24 pass
- `bun run lint` — exit 0 (pre-existing warnings only)
- GitHub CI on this branch: lint, type-check, knip, unit (web/core/backend/sync/scripts), e2e, CodeQL — all pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72549f17-efb2-48ba-b92a-5b0cf60a50bb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72549f17-efb2-48ba-b92a-5b0cf60a50bb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

