### PR TITLE
fix(web): keep pointer event hints executable

### DIFF
--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -303,7 +303,7 @@ Pressing `S` shows event-jump chips. Week view chips use day prefixes (`SU`/`M`/
 
 ### UX
 
-Compass is the keyboard calendar: pointer clicks, right-clicks, and double-clicks do not perform the clicked action (scroll and hover still work). A blocked click on a known action shows a transient, contextual hint with the keyboard path for that action. Clicking an event also activates its jump assignments, so the displayed event token works immediately without first pressing `S`. Keyboard activation is unaffected: Enter/Space on a native button still works, Shift+F10 still opens the focused event's context menu, and `M` opens it directly.
+Compass is the keyboard calendar: pointer clicks, right-clicks, and double-clicks do not perform the clicked action (scroll and hover still work). A blocked click on a known action shows a transient, contextual hint with the keyboard path for that action. Clicking an event also activates its jump assignments and selects that event, so the displayed token plus Enter works immediately without first pressing `S`. Keyboard activation is unaffected: Enter/Space on a native button still works, Shift+F10 still opens the focused event's context menu, and `M` opens it directly.
 
 ### Steps
 
@@ -315,7 +315,7 @@ Compass is the keyboard calendar: pointer clicks, right-clicks, and double-click
 
 ### Expected Results
 
-- Clicking an event does not open or focus it, but jump chips appear and the hint identifies that event's exact token plus `Enter`; the shown sequence opens the event without an initial `S`.
+- Clicking an event does not open it, but jump chips appear, the event is selected, and the hint identifies that event's exact token plus `Enter`; the shown sequence opens the event without an initial `S`.
 - Clicking either sidebar control does not toggle the sidebar; the hint says to press `]` and uses open/close language matching the current state.
 - Unannotated controls retain the generic keyboard-only fallback while contextual coverage is expanded.
 - Right-click does not open the context menu; `M` (or Shift+F10) on a focused event does.

--- a/e2e/timed/mouse-inert.spec.ts
+++ b/e2e/timed/mouse-inert.spec.ts
@@ -27,7 +27,7 @@ test("mouse clicks are inert and show the keyboard-only hint", async ({
 
   await eventButton.click({ force: true });
   await expect(page.getByLabel("Title")).toHaveCount(0);
-  await expect(eventButton).not.toBeFocused();
+  await expect(eventButton).toBeFocused();
   await expect(page.locator("[data-pointer-hint]")).toBeVisible();
 
   // Clicking empty grid does not open a draft either.
@@ -35,8 +35,10 @@ test("mouse clicks are inert and show the keyboard-only hint", async ({
   await page.mouse.click(x, y);
   await expect(page.getByLabel("Title")).toHaveCount(0);
 
-  // The keyboard path still opens it.
-  await eventButton.focus();
+  // A blocked click still selects the event so Enter opens it without
+  // an extra keyboard focus step.
+  await eventButton.click({ force: true });
+  await expect(page.getByLabel("Title")).toHaveCount(0);
   await page.keyboard.press("Enter");
   await expect(page.getByLabel("Title")).toBeVisible();
 });

--- a/packages/web/src/components/PointerHint/PointerHint.test.tsx
+++ b/packages/web/src/components/PointerHint/PointerHint.test.tsx
@@ -102,4 +102,19 @@ describe("PointerHint", () => {
     expect(screen.getByRole("status")).toHaveTextContent("Keyboard only.");
     expect(screen.getByRole("status")).not.toHaveTextContent("Press");
   });
+
+  it("keeps the contextual sentence after the session reminder threshold", () => {
+    sessionStorage.setItem(HINT_COUNT_KEY, "3");
+    render(<PointerHint />);
+
+    act(() => {
+      pointerBlockActions.pulseBlockedClick({
+        actionId: POINTER_ACTIONS.sidebarClose,
+      });
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Press ] to close the sidebar.",
+    );
+  });
 });

--- a/packages/web/src/components/PointerHint/PointerHint.test.tsx
+++ b/packages/web/src/components/PointerHint/PointerHint.test.tsx
@@ -79,7 +79,7 @@ describe("PointerHint", () => {
     render(<PointerHint />);
 
     act(() => {
-      eventJumpActions.setPointerHintKey("W2");
+      eventJumpActions.setPointerHint({ eventId: "event-1", key: "W2" });
       pointerBlockActions.pulseBlockedClick({
         actionId: POINTER_ACTIONS.eventOpen,
         eventId: "event-1",

--- a/packages/web/src/components/PointerHint/PointerHint.tsx
+++ b/packages/web/src/components/PointerHint/PointerHint.tsx
@@ -43,6 +43,11 @@ const Key = ({ children }: { children: string }) => (
   <kbd className="c-keycap">{children}</kbd>
 );
 
+const isContextualAttempt = (attempt: BlockedPointerAttempt | null) =>
+  attempt?.actionId === POINTER_ACTIONS.sidebarClose ||
+  attempt?.actionId === POINTER_ACTIONS.sidebarOpen ||
+  attempt?.actionId === POINTER_ACTIONS.eventOpen;
+
 const pointerHintMessage = ({
   attempt,
   eventJumpKey,
@@ -116,9 +121,12 @@ export const PointerHint: FC = () => {
     const brief = next > HINT_FULL_LIMIT;
     setIsBrief(brief);
     setIsVisible(true);
+    const contextual = isContextualAttempt(
+      usePointerBlockStore.getState().latestAttempt,
+    );
     const timer = window.setTimeout(
       () => setIsVisible(false),
-      brief ? HINT_BRIEF_MS : HINT_VISIBLE_MS,
+      brief && !contextual ? HINT_BRIEF_MS : HINT_VISIBLE_MS,
     );
     return () => window.clearTimeout(timer);
   }, [pulse]);

--- a/packages/web/src/shortcuts/keyboard-only/usePointerSuppression.ts
+++ b/packages/web/src/shortcuts/keyboard-only/usePointerSuppression.ts
@@ -29,8 +29,11 @@ export function usePointerSuppression() {
         pointerBlockActions.pulseBlockedClick(attempt);
         if (jumpEventId) {
           // Never let a prior event's assignment flash for a new/locked target.
-          eventJumpActions.setPointerHintKey(null);
+          eventJumpActions.setPointerHint(null);
           requestPointerEventJump(jumpEventId);
+        } else {
+          // Jump mode swallows unmatched printable keys, including `]`.
+          eventJumpActions.setActive(false);
         }
       },
     });

--- a/packages/web/src/shortcuts/shift-hint/event-jump.store.ts
+++ b/packages/web/src/shortcuts/shift-hint/event-jump.store.ts
@@ -10,6 +10,8 @@ export type EventJumpState = {
   announcement: string;
   /** Assignment surfaced after a blocked click selects a specific event. */
   pointerHintKey: string | null;
+  /** Event that owns `pointerHintKey`, so rebuilds can refresh the token. */
+  pointerHintEventId: string | null;
 };
 
 export const initialEventJumpState: EventJumpState = {
@@ -17,6 +19,7 @@ export const initialEventJumpState: EventJumpState = {
   activeDayKeys: [],
   announcement: "",
   pointerHintKey: null,
+  pointerHintEventId: null,
 };
 
 export const useEventJumpStore = create<EventJumpState>()(
@@ -35,7 +38,9 @@ export const eventJumpActions = {
           ? useEventJumpStore.getState().activeDayKeys
           : [],
         announcement: isActive ? "Event jump on" : "Event jump off",
-        ...(!isActive ? { pointerHintKey: null } : {}),
+        ...(!isActive
+          ? { pointerHintKey: null, pointerHintEventId: null }
+          : {}),
       },
       false,
       { type: "setActive" },
@@ -54,10 +59,15 @@ export const eventJumpActions = {
       false,
       { type: "setActiveDayKeys" },
     ),
-  setPointerHintKey: (pointerHintKey: string | null) =>
-    useEventJumpStore.setState({ pointerHintKey }, false, {
-      type: "setPointerHintKey",
-    }),
+  setPointerHint: (pointerHint: { eventId: string; key: string } | null) =>
+    useEventJumpStore.setState(
+      {
+        pointerHintKey: pointerHint?.key ?? null,
+        pointerHintEventId: pointerHint?.eventId ?? null,
+      },
+      false,
+      { type: "setPointerHint" },
+    ),
   reset: () =>
     useEventJumpStore.setState(initialEventJumpState, false, { type: "reset" }),
 };

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx
@@ -175,6 +175,74 @@ describe("useShiftHoldEventHints", () => {
     );
   });
 
+  it("does not steal focus to the first-of-day while typing a clicked event token", () => {
+    const { focus } = mountHints();
+
+    act(() => {
+      requestPointerEventJump(EVENT_B);
+    });
+    focus.mockClear();
+
+    act(() => {
+      dispatch("keydown", "w");
+    });
+
+    expect(focus).not.toHaveBeenCalled();
+    expect(useEventJumpStore.getState().pointerHintEventId).toBe(EVENT_B);
+  });
+
+  it("commits a clicked prefix token without waiting for a longer sibling", () => {
+    const focus = mock((_target: { eventId: string }) => {});
+    const ids = Array.from({ length: 20 }, (_, index) =>
+      EventIdSchema.parse(index.toString(16).padStart(24, "c")),
+    );
+    const clicked = ids[1]!;
+    const elements = ids.map((id) => {
+      const el = document.createElement("button");
+      el.textContent = id;
+      document.body.appendChild(el);
+      return el;
+    });
+    const timedEvents = ids.map((id, index) =>
+      timedFixture(
+        id,
+        `2026-08-05T${String(8 + Math.floor(index / 6)).padStart(2, "0")}:${String((index % 6) * 10).padStart(2, "0")}:00.000Z`,
+      ),
+    );
+
+    renderHook(() =>
+      useShiftHoldEventHints({
+        focus: (target) => focus(target),
+        listVisible: () =>
+          ids.map((id, index) => ({
+            eventId: id,
+            eventType: "timed" as const,
+            element: elements[index]!,
+          })),
+        mode: "week",
+        timedEvents,
+      }),
+    );
+
+    act(() => {
+      requestPointerEventJump(clicked);
+    });
+    expect(useEventJumpStore.getState().pointerHintKey).toBe("W2");
+    focus.mockClear();
+
+    act(() => {
+      dispatch("keydown", "w");
+      dispatch("keydown", "2");
+    });
+
+    expect(focus).toHaveBeenLastCalledWith(
+      expect.objectContaining({ eventId: clicked }),
+    );
+    expect(focus).not.toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: ids[0] }),
+    );
+  });
+
   it("swallows unmatched letters while jump is active", () => {
     mountHints();
 

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx
@@ -18,6 +18,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 const EVENT_A = EventIdSchema.parse("aaaaaaaaaaaaaaaaaaaaaaaa");
 const EVENT_B = EventIdSchema.parse("bbbbbbbbbbbbbbbbbbbbbbbb");
 const EVENT_C = EventIdSchema.parse("cccccccccccccccccccccccc");
+const EVENT_D = EventIdSchema.parse("dddddddddddddddddddddddd");
 
 const dispatch = (
   type: "keydown" | "keyup",
@@ -153,7 +154,11 @@ describe("useShiftHoldEventHints", () => {
     expect(useEventJumpStore.getState()).toMatchObject({
       isActive: true,
       pointerHintKey: "W2",
+      pointerHintEventId: EVENT_B,
     });
+    expect(focus).toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: EVENT_B }),
+    );
     expect(result.current.hints.map((hint) => hint.hint)).toEqual([
       "w1",
       "w2",
@@ -190,6 +195,92 @@ describe("useShiftHoldEventHints", () => {
 
     expect(event.defaultPrevented).toBe(true);
     expect(useEventJumpStore.getState().isActive).toBe(true);
+  });
+
+  it("stops swallowing printable keys when jump mode is cleared", () => {
+    mountHints();
+
+    act(() => {
+      requestPointerEventJump(EVENT_B);
+    });
+    expect(useEventJumpStore.getState().isActive).toBe(true);
+
+    const whileActive = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      key: "]",
+    });
+    document.dispatchEvent(whileActive);
+    expect(whileActive.defaultPrevented).toBe(true);
+
+    act(() => {
+      eventJumpActions.setActive(false);
+    });
+
+    const afterClear = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      key: "]",
+    });
+    document.dispatchEvent(afterClear);
+    expect(afterClear.defaultPrevented).toBe(false);
+  });
+
+  it("refreshes the pointer hint token when an earlier event appears", () => {
+    const focus = mock((_target: { eventId: string }) => {});
+    const events = [
+      timedFixture(EVENT_A, "2026-08-05T09:00:00.000Z"),
+      timedFixture(EVENT_B, "2026-08-05T11:00:00.000Z"),
+      timedFixture(EVENT_C, "2026-08-06T13:00:00.000Z"),
+    ];
+    const elements = [EVENT_A, EVENT_B, EVENT_C, EVENT_D].map((id) => {
+      const el = document.createElement("button");
+      el.textContent = id;
+      document.body.appendChild(el);
+      return el;
+    });
+
+    const { rerender } = renderHook(
+      ({ timedEvents }) =>
+        useShiftHoldEventHints({
+          focus: (target) => focus(target),
+          listVisible: () =>
+            timedEvents.flatMap((event) => {
+              const index = [EVENT_A, EVENT_B, EVENT_C, EVENT_D].indexOf(
+                event._id as typeof EVENT_A,
+              );
+              if (index < 0) return [];
+              return [
+                {
+                  eventId: event._id as string,
+                  eventType: "timed" as const,
+                  element: elements[index]!,
+                },
+              ];
+            }),
+          mode: "week",
+          timedEvents,
+        }),
+      { initialProps: { timedEvents: events } },
+    );
+
+    act(() => {
+      requestPointerEventJump(EVENT_B);
+    });
+    expect(useEventJumpStore.getState().pointerHintKey).toBe("W2");
+
+    act(() => {
+      rerender({
+        timedEvents: [
+          timedFixture(EVENT_D, "2026-08-05T08:00:00.000Z"),
+          ...events,
+        ],
+      });
+    });
+
+    expect(useEventJumpStore.getState().pointerHintKey).toBe("W3");
   });
 
   it("does not activate on bare Shift or Shift+Tab", () => {

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
@@ -387,8 +387,15 @@ export function useShiftHoldEventHints({
       bufferRef.current = "";
       eventJumpActions.setActive(true);
       eventJumpActions.setActiveDayKeys([assignment.dayKey]);
-      eventJumpActions.setPointerHintKey(assignment.hint.toUpperCase());
+      eventJumpActions.setPointerHint({
+        eventId: assignment.eventId,
+        key: assignment.hint.toUpperCase(),
+      });
       setHints(toActiveHints(assignments, visibleByIdRef.current));
+      // Focus now so the advertised Enter path works, including when this
+      // token is a prefix of a longer sibling (W2 vs W20) that would otherwise
+      // wait 400ms before focusing.
+      focusEvent(eventId);
     };
 
     document.addEventListener("keydown", onKeyDown, true);
@@ -440,6 +447,21 @@ export function useShiftHoldEventHints({
     );
     assignmentsRef.current = assignments;
     visibleByIdRef.current = visibleById;
+    const pointerHintEventId = useEventJumpStore.getState().pointerHintEventId;
+    if (pointerHintEventId) {
+      const assignment = assignments.find(
+        (item) => item.eventId === pointerHintEventId,
+      );
+      const nextKey = assignment?.hint.toUpperCase() ?? null;
+      if (!assignment) {
+        eventJumpActions.setPointerHint(null);
+      } else if (nextKey !== useEventJumpStore.getState().pointerHintKey) {
+        eventJumpActions.setPointerHint({
+          eventId: assignment.eventId,
+          key: nextKey,
+        });
+      }
+    }
     const source = bufferRef.current
       ? filterHintsByPrefix(assignments, bufferRef.current)
       : assignments;

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
@@ -338,7 +338,19 @@ export function useShiftHoldEventHints({
             (assignment) => assignment.eventId === match.pendingExactEventId,
           );
           if (exact) {
-            scheduleAmbiguousCommit(exact.eventId, exact.dayKey, match.buffer);
+            // The advertised token plus Enter should not wait 400ms just
+            // because a longer sibling exists (W2 vs W20).
+            if (
+              exact.eventId === useEventJumpStore.getState().pointerHintEventId
+            ) {
+              commitFocus(exact.eventId, exact.dayKey, match.buffer);
+            } else {
+              scheduleAmbiguousCommit(
+                exact.eventId,
+                exact.dayKey,
+                match.buffer,
+              );
+            }
           }
         } else {
           clearAmbiguousCommitTimer();
@@ -356,7 +368,18 @@ export function useShiftHoldEventHints({
         );
         // Keep chips for the selected day so a following digit can refine.
         publishFiltered(match.dayPrefix);
-        focusEvent(match.firstEventId);
+        const pointerHintEventId =
+          useEventJumpStore.getState().pointerHintEventId;
+        const keepClickedEvent =
+          !!pointerHintEventId &&
+          assignmentsRef.current.some(
+            (item) =>
+              item.eventId === pointerHintEventId &&
+              item.dayKey === match.dayKey,
+          );
+        if (!keepClickedEvent) {
+          focusEvent(match.firstEventId);
+        }
         return;
       }
 

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
@@ -452,14 +452,16 @@ export function useShiftHoldEventHints({
       const assignment = assignments.find(
         (item) => item.eventId === pointerHintEventId,
       );
-      const nextKey = assignment?.hint.toUpperCase() ?? null;
       if (!assignment) {
         eventJumpActions.setPointerHint(null);
-      } else if (nextKey !== useEventJumpStore.getState().pointerHintKey) {
-        eventJumpActions.setPointerHint({
-          eventId: assignment.eventId,
-          key: nextKey,
-        });
+      } else {
+        const nextKey = assignment.hint.toUpperCase();
+        if (nextKey !== useEventJumpStore.getState().pointerHintKey) {
+          eventJumpActions.setPointerHint({
+            eventId: assignment.eventId,
+            key: nextKey,
+          });
+        }
       }
     }
     const source = bufferRef.current


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #2836 so the taught pointer shortcuts actually run.

- Clicking an event focuses it, so Enter opens it even when its token is a prefix of a longer sibling (`W2` vs `W20`).
- Typing that taught day prefix no longer steals focus to the first event of the day, and a clicked prefix token commits immediately instead of waiting 400ms.
- Non-event blocked clicks exit jump mode, so `]` is not swallowed after an event click.
- The taught token refreshes when assignments change, so an inserted earlier event does not leave a stale `W2` on screen.
- Contextual event/sidebar hints stay visible for 2.5s even after the session's generic-reminder threshold.
- The mouse-inert e2e now expects a blocked event click to select the event, then Enter to open it, matching scenario 13.

## Simplicity

Behavior-only follow-up. Reuse `setPointerHint`, `setActive(false)`, and the existing assignment rebuild. Prefix-token typing reuses the existing selectDay/prefix match results instead of a parallel jump parser.

## Automated validation

- Focused web tests for jump hints, pointer hint copy, and pointer-action classification. New prefix-token cases pass in `useShiftHoldEventHints.test.tsx`.
- Full `bun test:web`: 2218 pass, 0 fail (before the prefix-token commit).
- `bun run type-check` after narrowing the rebuilt hint key type.
- `bunx playwright test e2e/timed/mouse-inert.spec.ts`: 3 pass.
- Browser walkthrough: click event then Enter opens the form; click sidebar then `]` closes it.

## Independent review

Confirmed on the #2836/#2834 diffs and landed here after #2836 squash-merged:

1. Ambiguous prefix tokens plus immediate Enter failed unless the event was focused — click now focuses.
2. Jump mode swallowed `]` after an event click — non-event blocked clicks now exit jump mode.
3. Stale `pointerHintKey` after assignment rebuild — store now tracks `pointerHintEventId` and refreshes the token.
4. Typing `W2` after clicking `W2` (with `W20` present) stole focus to the first-of-day and waited 400ms — both are skipped for the taught event.

## Test plan

- `bun test:web -- packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx packages/web/src/components/PointerHint/PointerHint.test.tsx packages/web/src/shortcuts/keyboard-only/pointer-action.test.ts`
- `bun run type-check`
- `bun test:web`
- `bunx playwright test e2e/timed/mouse-inert.spec.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9e080a2-5550-4b20-b435-7a0f62aeaefc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9e080a2-5550-4b20-b435-7a0f62aeaefc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

