### PR TITLE
fix(web): match CefSharp scanner noise by shape, not fixed id

### DIFF
--- a/packages/web/src/auth/posthog/posthog-exception-filter.util.test.ts
+++ b/packages/web/src/auth/posthog/posthog-exception-filter.util.test.ts
@@ -48,7 +48,7 @@ describe("filterPosthogBeforeSend", () => {
     ).toBeNull();
   });
 
-  it("drops the exact CefSharp scanner signature", () => {
+  it("drops the CefSharp scanner signature", () => {
     expect(
       filterPosthogBeforeSend(
         exceptionEvent([
@@ -56,6 +56,20 @@ describe("filterPosthogBeforeSend", () => {
             type: "Error",
             value:
               "Object Not Found Matching Id:1, MethodName:update, ParamCount:4",
+          },
+        ]),
+      ),
+    ).toBeNull();
+  });
+
+  it("drops the CefSharp scanner signature regardless of the scan id", () => {
+    expect(
+      filterPosthogBeforeSend(
+        exceptionEvent([
+          {
+            type: "Error",
+            value:
+              "Object Not Found Matching Id:2, MethodName:update, ParamCount:4",
           },
         ]),
       ),

--- a/packages/web/src/auth/posthog/posthog-exception-filter.util.ts
+++ b/packages/web/src/auth/posthog/posthog-exception-filter.util.ts
@@ -2,11 +2,12 @@ import { type CaptureResult } from "posthog-js";
 import { isTransientBrowserNetworkMessage } from "@web/api/util/backend-unavailable-error.util";
 
 /**
- * Exact unhandledrejection signature emitted by CefSharp / embedded WebView
- * automation scanners. No app frames, not actionable.
+ * Unhandledrejection signature emitted by CefSharp / embedded WebView
+ * automation scanners. No app frames, not actionable. The numeric id varies
+ * per scan (seen Id:1, Id:2, ...), so match the shape rather than one value.
  */
-const CEFSHARP_SCANNER_MESSAGE =
-  "Object Not Found Matching Id:1, MethodName:update, ParamCount:4";
+const CEFSHARP_SCANNER_MESSAGE_PATTERN =
+  /^Object Not Found Matching Id:\d+, MethodName:update, ParamCount:4$/;
 
 /**
  * Browser-sanitized cross-origin `window.onerror` message. Same-origin app
@@ -70,7 +71,7 @@ const hasStackFrames = (entry: ExceptionEntry): boolean => {
 const isDroppableException = (entry: ExceptionEntry): boolean => {
   if (typeof entry.value !== "string") return false;
 
-  if (entry.value === CEFSHARP_SCANNER_MESSAGE) return true;
+  if (CEFSHARP_SCANNER_MESSAGE_PATTERN.test(entry.value)) return true;
 
   if (RESIZE_OBSERVER_LOOP_MESSAGES.has(entry.value)) return true;
 


### PR DESCRIPTION
## Summary
- The PostHog `before_send` exception filter drops the CefSharp/embedded-WebView automation scanner's unhandledrejection noise (`Object Not Found Matching Id:N, MethodName:update, ParamCount:4`), but it matched only the exact string seen with `Id:1`.
- The scanner increments the id per pass, so `Id:2` (and presumably any other id) slipped through as a fresh, non-actionable error-tracking issue — that's what filed #2829.
- Swapped the exact string match for a regex that matches the shape of the message instead of one observed instance.

Fixes #2829

## Test plan
- [x] `bun test packages/web/src/auth/posthog/posthog-exception-filter.util.test.ts` — 13/13 pass, including new case for `Id:2`
- [x] `bun run type-check` — clean