### PR TITLE
fix(web): align timed grid hour labels with events

### DIFF
--- a/packages/web/src/grid/components/HourLabelColumn.test.tsx
+++ b/packages/web/src/grid/components/HourLabelColumn.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { TIMED_HOUR_SLOT_HEIGHT_CLASS } from "@web/grid/grid.constants";
+import { describe, expect, it } from "bun:test";
+import "@testing-library/jest-dom";
+import { HourLabelColumn } from "./HourLabelColumn";
+
+describe("HourLabelColumn", () => {
+  it("sizes each slot as one visible hour without flex-shrinking the stack", () => {
+    render(<HourLabelColumn labels={["1 AM", "2 AM", "11 PM"]} width={50} />);
+
+    const firstSlot = screen.getByText("1 AM").parentElement;
+    const column = firstSlot?.parentElement;
+
+    expect(firstSlot).toHaveClass(TIMED_HOUR_SLOT_HEIGHT_CLASS);
+    expect(screen.getByText("11 PM").parentElement).toHaveClass(
+      TIMED_HOUR_SLOT_HEIGHT_CLASS,
+    );
+    expect(column).not.toHaveClass("flex");
+    expect(column).not.toHaveClass("flex-col");
+  });
+});

--- a/packages/web/src/grid/components/HourLabelColumn.tsx
+++ b/packages/web/src/grid/components/HourLabelColumn.tsx
@@ -1,3 +1,5 @@
+import { TIMED_HOUR_SLOT_HEIGHT_CLASS } from "@web/grid/grid.constants";
+
 export function HourLabelColumn({
   colors,
   labels,
@@ -8,10 +10,13 @@ export function HourLabelColumn({
   width: number;
 }) {
   return (
-    <div className="flex h-full flex-col" style={{ width }}>
+    // Block flow, not flex-col: 23 labels (1 AM–11 PM) must overflow this
+    // viewport-tall column at one grid-hour each. Flex-shrink would compress
+    // them into the visible 13 hours and misalign labels with events.
+    <div className="h-full" style={{ width }}>
       {labels.map((label, hour) => (
         <div
-          className="h-[calc(100%/var(--calendar-visible-hours))] text-text-muted"
+          className={`${TIMED_HOUR_SLOT_HEIGHT_CLASS} text-text-muted`}
           // biome-ignore lint/suspicious/noArrayIndexKey: hour slot identity; DST can repeat a wall-clock label.
           key={`hour-${hour + 1}`}
           style={colors ? { color: colors[hour] } : undefined}

--- a/packages/web/src/grid/components/TimedGrid.test.tsx
+++ b/packages/web/src/grid/components/TimedGrid.test.tsx
@@ -1,9 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import dayjs from "@core/util/date/dayjs";
+import { DATA_TIMED_GRID_ROW } from "@web/common/constants/web.constants";
+import { TIMED_HOUR_SLOT_HEIGHT_CLASS } from "@web/grid/grid.constants";
 import { ALL_DAY_COLUMN_TINT_PERCENT } from "@web/grid/utils/allDayColumnTint.util";
-import { TimedGrid } from "./TimedGrid";
 import { describe, expect, it } from "bun:test";
+import "@testing-library/jest-dom";
+import { TimedGrid } from "./TimedGrid";
 
 const today = dayjs("2026-04-24T12:00:00.000Z");
 
@@ -60,5 +63,23 @@ describe("TimedGrid", () => {
     expect(column.style.backgroundColor).toContain(
       `${ALL_DAY_COLUMN_TINT_PERCENT}%`,
     );
+  });
+
+  it("uses the same hour-slot height for labels and timed grid rows", () => {
+    render(
+      <TimedGrid
+        eventsLayer={null}
+        timedColumnsRef={() => {}}
+        timedGridRef={() => {}}
+        today={today}
+        visibleDates={[{ date: today, key: "today" }]}
+      />,
+    );
+
+    const labelSlot = screen.getByText("1 AM").parentElement;
+    const hourRow = document.querySelector(`[${DATA_TIMED_GRID_ROW}]`);
+
+    expect(labelSlot).toHaveClass(TIMED_HOUR_SLOT_HEIGHT_CLASS);
+    expect(hourRow).toHaveClass(TIMED_HOUR_SLOT_HEIGHT_CLASS);
   });
 });

--- a/packages/web/src/grid/components/TimedGrid.tsx
+++ b/packages/web/src/grid/components/TimedGrid.tsx
@@ -16,6 +16,7 @@ import { ScrollableRegion } from "@web/components/ScrollableRegion/ScrollableReg
 import { CalendarTimeColumn } from "@web/grid/components/CalendarTimeColumn";
 import {
   EVENT_WIDTH_MINIMUM,
+  TIMED_HOUR_SLOT_HEIGHT_CLASS,
   TIMED_VISIBLE_HOURS,
 } from "@web/grid/grid.constants";
 import { useGridMarginLeft } from "@web/grid/grid-margin";
@@ -129,7 +130,7 @@ export const TimedGrid: FC<TimedGridProps> = ({
       >
         {getHourLabels(true).map((dayTime) => (
           <div
-            className="relative flex h-[calc(100%/var(--calendar-visible-hours))] w-full items-start border-border border-b"
+            className={`relative flex ${TIMED_HOUR_SLOT_HEIGHT_CLASS} w-full items-start border-border border-b`}
             key={dayTime}
             {...{ [DATA_TIMED_GRID_ROW]: "true" }}
           />

--- a/packages/web/src/grid/grid.constants.ts
+++ b/packages/web/src/grid/grid.constants.ts
@@ -48,3 +48,8 @@ export function gridMarginLeftFor(hasSecondaryTimeZone: boolean): number {
 }
 export const GRID_TIME_STEP = 15;
 export const TIMED_VISIBLE_HOURS = 13;
+// One timed-grid hour. 100% is the viewport-tall parent (h-full), so each
+// slot is viewport / TIMED_VISIBLE_HOURS — the same basis events and hour
+// lines use. Do not put this on a 23-hour-tall parent.
+export const TIMED_HOUR_SLOT_HEIGHT_CLASS =
+  "h-[calc(100%/var(--calendar-visible-hours))]";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hour labels on the timed grid were compressed into the visible viewport after the time-travel second column extraction. `HourLabelColumn` stacked 23 labels (`1 AM`–`11 PM`) in a `flex-col` container with `h-full`, so flex-shrink packed them into 13 visible hours instead of one grid-hour each. Events and hour lines still used `viewport / 13`, which is why a 10 AM event sat next to the 5 PM label and labels ran out in the afternoon.

This restores block flow so each label slot overflows the viewport-tall column at `viewport / TIMED_VISIBLE_HOURS`, matching hour lines. A shared `TIMED_HOUR_SLOT_HEIGHT_CLASS` keeps the two from drifting.

## Simplicity

The layout contract was already correct on hour lines (block children of an `h-full` parent). Labels now use that same geometry instead of a taller column or a different percentage basis.

## Automated validation

In progress — focused web tests and a week-view check that a 10 AM event sits on the 10 AM line.

## Independent review

Pending after validation.

## Test plan

Pending: `bun test:web` for `HourLabelColumn` / `TimedGrid`, then `bun run lint`, then week/day grid visual check including `Z` time-travel.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2308ec1c-565a-4c48-81f2-4daa76ead294?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2308ec1c-565a-4c48-81f2-4daa76ead294&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

