### PR TITLE
fix(sync): stop the cursor-expiry repair storm, and make a dead push path loud

### DIFF
--- a/.github/scripts/deploy-health-check.sh
+++ b/.github/scripts/deploy-health-check.sh
@@ -349,6 +349,67 @@ validate_backend_health() {
   check_passed "backend-health"
 }
 
+# The Sync service owns /sync/* -- Google's OAuth redirect (/sync/google) and
+# the push webhook (/sync/notifications/google). Those paths are reverse-proxied
+# by a Caddyfile that lives on the host and NOT in this repo, so an edit for an
+# unrelated reason can silently route them to the web app instead. That happened
+# on 2026-08-14 and went unnoticed for nine days: Google got 200 OK with the
+# SPA's HTML for every push, treated each as delivered, and never retried, so
+# real-time sync was dead fleet-wide and no user could connect a calendar.
+#
+# Both failure modes are invisible to every other check here -- the containers
+# are healthy and the API answers -- which is exactly why this one exists.
+#
+# The web app answers any path with 200 and text/html. Sync rejects a
+# notification carrying none of Google's headers with 400. So an html
+# content-type, or any status other than 400, means the route is misdirected.
+validate_sync_webhook_route() {
+  require_env FRONTEND_URL || return 1
+
+  local base probe method url out status ctype
+  base="${FRONTEND_URL%/}"
+
+  # Each probe is "METHOD URL": the webhook is a POST route and the OAuth
+  # callback a GET one, and hitting either with the wrong verb makes Express
+  # answer its own html 404, which looks exactly like the misroute we are
+  # testing for.
+  for probe in \
+    "POST $base/sync/notifications/google" \
+    "GET $base/sync/google"; do
+    method=${probe%% *}
+    url=${probe#* }
+
+    if is_local_url "$url" && [ -n "${SSH_TARGET:-}" ]; then
+      out=$(ssh_remote "curl -sS -X $method --max-time 20 -o /dev/null -w '%{http_code} %{content_type}' $(printf '%q' "$url")" 2>&1)
+    else
+      out=$(curl -sS -X "$method" --max-time 20 -o /dev/null -w '%{http_code} %{content_type}' "$url" 2>&1)
+    fi
+    if [ $? -ne 0 ]; then
+      printf 'curl failed for %s: %s\n' "$url" "$out" >&2
+      return 1
+    fi
+
+    status=${out%% *}
+    ctype=${out#* }
+
+    case "$ctype" in
+      text/html*)
+        printf 'the web app is answering %s (content-type %s): /sync/* is not proxied to the Sync service. Check the host Caddyfile for a `handle /sync/*` block.\n' "$url" "$ctype" >&2
+        return 1
+        ;;
+    esac
+
+    case "$url" in
+      */sync/notifications/google)
+        if [ "$status" != "400" ]; then
+          printf 'expected 400 from Sync at %s for a notification with no Google headers, got %s (content-type %s)\n' "$url" "$status" "$ctype" >&2
+          return 1
+        fi
+        ;;
+    esac
+  done
+}
+
 setup_ssh() {
   require_env SSH_HOST || return 1
   require_env SSH_USER || return 1
@@ -546,6 +607,7 @@ run_all_checks() {
     SUPPRESS_FRONTEND_FINISH=1 validate_frontend_version >/tmp/compass-frontend-version-check.log 2>&1 || true
   fi
   run_check "backend-health" validate_backend_health
+  run_check "sync-webhook-route" validate_sync_webhook_route
   run_check "compass-status" ssh_remote "cd ~/compass && ./compass status"
   run_check "compose-services" remote_check_stack
   run_check "compose-logs-readable" remote_check_logs

--- a/docs/self-hosting/server-guide.md
+++ b/docs/self-hosting/server-guide.md
@@ -170,7 +170,9 @@ compass.example.com {  # <- this is the only line you need to change
 
  # Sync public surface (OAuth callback + Google push). The `sync` container
  # runs by default, so this block is required — omitting it breaks Google
- # Calendar connect.
+ # Calendar connect AND silently kills real-time sync. Keep it above the
+ # catch-all `handle` below, and proxy only `/sync/*`: the Sync service's
+ # private `/internal/*` routes share port 3010 and must never be exposed.
  handle /sync/* {
   reverse_proxy 127.0.0.1:3010
  }
@@ -185,6 +187,16 @@ This tells Caddy to serve your public domain over HTTPS, send `/api/*` requests
 to the Compass backend on `127.0.0.1:3000`, send `/sync/*` to the Sync service
 on `127.0.0.1:3010` (Google OAuth redirect `/sync/google` and push notifications),
 and send everything else to the web app on `127.0.0.1:9080`.
+
+> **Editing this file later?** Edit the live `/etc/caddy/Caddyfile`, never a
+> backup copy. Compass's own production host lost the `/sync/*` block for nine
+> days in August 2026 because an unrelated edit was made against a stale backup.
+> Nothing looked wrong: containers stayed healthy, the API answered, and the web
+> app served `/sync/notifications/google` with a `200`, so Google treated every
+> push notification as delivered and never retried. Calendar changes still
+> arrived, just via the slow reconcile sweep instead of within seconds, and no
+> new calendar could be connected at all. The `sync-webhook-route` deploy health
+> check exists to catch exactly this.
 
 Save the file and validate your changes:
 

--- a/packages/backend/src/common/services/sync-service/sync-proxy-error.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-proxy-error.test.ts
@@ -53,12 +53,36 @@ describe("sync-proxy-error", () => {
     }
   });
 
-  it("maps command submit timeout to retryable PROVIDER_FAILURE", () => {
+  // Backpressure from Sync is not a provider verdict. It used to surface as a
+  // 502 on mutations while the read path already used 503, which made a Sync
+  // throttle indistinguishable from a bad gateway in the logs (2026-08-23).
+  it.each([
+    "timeout",
+    "unavailable",
+  ] as const)("maps command submit %s to retryable SYNC_UNAVAILABLE 503", (kind) => {
     try {
-      throwSyncCommandSubmitFailure("timeout");
+      throwSyncCommandSubmitFailure(kind);
       throw new Error("expected throw");
     } catch (e) {
       expect(e).toBeInstanceOf(EventMutationException);
+      expect((e as EventMutationException).mutationCode).toBe(
+        "SYNC_UNAVAILABLE",
+      );
+      const mapped = toEventMutationError(e);
+      expect(mapped.status).toBe(Status.SERVICE_UNAVAILABLE);
+      expect(mapped.body.retryable).toBe(true);
+    }
+  });
+
+  it("still maps an unexpected command submit failure to PROVIDER_FAILURE 502", () => {
+    try {
+      throwSyncCommandSubmitFailure("unexpectedStatus");
+      throw new Error("expected throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(EventMutationException);
+      expect((e as EventMutationException).mutationCode).toBe(
+        "PROVIDER_FAILURE",
+      );
       const mapped = toEventMutationError(e);
       expect(mapped.status).toBe(502);
       expect(mapped.body.retryable).toBe(true);

--- a/packages/backend/src/common/services/sync-service/sync-proxy-error.ts
+++ b/packages/backend/src/common/services/sync-service/sync-proxy-error.ts
@@ -24,15 +24,23 @@ export function throwSyncProxyFailure(
   );
 }
 
-// Map a failed Sync command submit. Always PROVIDER_FAILURE so clients never
-// see GenericError.NotSure / HTTP 600. Timeout/unavailable stay retryable
-// because Sync may already have applied the write.
+// Map a failed Sync command submit. Never GenericError.NotSure / HTTP 600.
+// Timeout/unavailable are our own backpressure rather than a provider verdict,
+// so they mirror the read path's 503 instead of surfacing as a 502 (the two
+// paths disagreed until 2026-08-23, which made a Sync throttle look like a bad
+// gateway in the logs). Both stay retryable: Sync may already have applied the
+// write, so a caller MUST retry with the SAME idempotency key.
 export function throwSyncCommandSubmitFailure(
   kind: SyncClientErrorKind,
 ): never {
-  const message =
-    kind === "timeout" || kind === "unavailable"
-      ? `Sync command ${kind}; the mutation may already be applied`
-      : `Failed to submit command to sync (${kind})`;
-  throw eventMutationError("PROVIDER_FAILURE", message);
+  if (kind === "timeout" || kind === "unavailable") {
+    throw eventMutationError(
+      "SYNC_UNAVAILABLE",
+      `Sync command ${kind}; the mutation may already be applied`,
+    );
+  }
+  throw eventMutationError(
+    "PROVIDER_FAILURE",
+    `Failed to submit command to sync (${kind})`,
+  );
 }

--- a/packages/backend/src/event/event.error.ts
+++ b/packages/backend/src/event/event.error.ts
@@ -19,6 +19,7 @@ const STATUS_BY_CODE: Record<EventMutationErrorCode, Status> = {
   INVALID_SCHEDULE: Status.BAD_REQUEST,
   INVALID_OCCURRENCE_ID: Status.BAD_REQUEST,
   PROVIDER_FAILURE: 502 as Status,
+  SYNC_UNAVAILABLE: Status.SERVICE_UNAVAILABLE,
   // 410 Gone, not 401: SuperTokens treats every 401 as a Compass session
   // expiry and retries the request after refresh. Google revocation must not
   // share that status or event creates loop until maxRetryAttemptsForSessionRefresh.
@@ -42,6 +43,7 @@ const RETRYABLE_BY_CODE: Record<EventMutationErrorCode, boolean> = {
   INVALID_SCHEDULE: false,
   INVALID_OCCURRENCE_ID: false,
   PROVIDER_FAILURE: true,
+  SYNC_UNAVAILABLE: true,
   GOOGLE_REVOKED: false,
   MAINTENANCE: true,
   MOVE_UNSUPPORTED: false,

--- a/packages/core/src/errors/status.codes.ts
+++ b/packages/core/src/errors/status.codes.ts
@@ -13,6 +13,7 @@ export enum Status {
   NOT_FOUND = 404,
   CONFLICT = 409,
   GONE = 410,
+  TOO_MANY_REQUESTS = 429,
 
   /* 5xx - Server Error */
   INTERNAL_SERVER = 500,

--- a/packages/core/src/types/event-command.contracts.ts
+++ b/packages/core/src/types/event-command.contracts.ts
@@ -146,6 +146,11 @@ export const EventMutationErrorCodeSchema = z.enum([
   // reference but malformed.
   "INVALID_OCCURRENCE_ID",
   "PROVIDER_FAILURE",
+  // Sync itself was unreachable, timed out, or shed load (429/503) before the
+  // command reached a provider. Distinct from PROVIDER_FAILURE, which means the
+  // provider answered badly: this is our own backpressure, so it is a 503 and
+  // always safe to retry with the same idempotency key.
+  "SYNC_UNAVAILABLE",
   "GOOGLE_REVOKED",
   // Scoped cutover maintenance: cloud/provider mutations paused (S50).
   "MAINTENANCE",

--- a/packages/core/src/types/sync/health.contracts.test.ts
+++ b/packages/core/src/types/sync/health.contracts.test.ts
@@ -30,6 +30,7 @@ const sample = (): SyncHealthSnapshot => ({
     renewSoon: 1,
     expired: 0,
     missing: 2,
+    neverNotified: 3,
   },
   freshness: {
     sampleSize: 9,

--- a/packages/core/src/types/sync/health.contracts.ts
+++ b/packages/core/src/types/sync/health.contracts.ts
@@ -31,6 +31,14 @@ export const SyncHealthSubscriptionCountsSchema = z.strictObject({
   renewSoon: z.number().int().nonnegative(),
   expired: z.number().int().nonnegative(),
   missing: z.number().int().nonnegative(),
+  // Resources holding a live subscription that have NEVER had a push
+  // notification delivered. The whole fleet sat at this number for at least
+  // nine days in August 2026 because the reverse proxy stopped routing
+  // /sync/* to the Sync service: Google got 200 OK with the web app's HTML,
+  // counted every push as delivered, and never retried. Nothing else went
+  // red — the reconcile sweep quietly absorbed the load and calendars just
+  // got slow. This is the number that makes that visible.
+  neverNotified: z.number().int().nonnegative(),
 });
 export type SyncHealthSubscriptionCounts = z.infer<
   typeof SyncHealthSubscriptionCountsSchema

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -349,12 +349,26 @@ function buildHealthSnapshotSweep(
       // SweepScheduler always passes `before`; health ignore it and use now.
       sweep: async () => {
         // A single Atlas/DNS blip must not skip the whole 5-minute gauge.
-        await withTransientMongoRetry(() =>
+        const snapshot = await withTransientMongoRetry(() =>
           emitHealthSnapshot({
             deps: { mongo, identity },
             client,
           }),
         );
+        // Every live channel unnotified means push delivery is broken fleet
+        // wide, not that calendars are quiet. It looks like nothing is wrong:
+        // the reconcile sweep keeps calendars up to date on its ~10 minute
+        // cadence, so the only symptom is slowness. Prod ran this way for nine
+        // days in August 2026 with the number sitting at 425 of 425, because
+        // the reverse proxy had stopped routing /sync/* here. A PostHog gauge
+        // alone did not surface it, so say it in the log too.
+        const { neverNotified, healthy, renewSoon } = snapshot.subscriptions;
+        const live = healthy + renewSoon;
+        if (live > 0 && neverNotified >= live) {
+          logger.error(
+            `Sync push delivery looks broken: all ${live} live subscription(s) have never received a notification. Check that the reverse proxy routes /sync/* to this service.`,
+          );
+        }
         return 1;
       },
     },

--- a/packages/sync/src/domain/calendar-pull.service.ts
+++ b/packages/sync/src/domain/calendar-pull.service.ts
@@ -53,14 +53,6 @@ export type CalendarPullResult =
       // incrementally — initial import owns it until it produces one.
       status: "notImported";
       resource: SyncResourceRecord;
-    }
-  | {
-      // This calendar's cursor keeps expiring, so it is being held off. No
-      // provider call was made. The last repair already rebuilt the calendar
-      // from scratch, so the stored data is current — skipping costs freshness
-      // only for the hold-off window, not correctness.
-      status: "cursorBackoff";
-      resource: SyncResourceRecord;
     };
 
 // Apply the provider's incremental changes for one already-imported calendar.
@@ -104,16 +96,6 @@ export async function pullCalendarChanges(
   );
   if (resource.syncCursor === null) {
     return { status: "notImported", resource };
-  }
-
-  // Held off after repeated cursor expiries. Checked after markAttempt (so the
-  // resource still rotates to the back of the sweep ordering) and before the
-  // token fetch, so a held-off calendar costs no provider call at all.
-  if (
-    resource.cursorExpiredBackoffUntil !== null &&
-    resource.cursorExpiredBackoffUntil > now()
-  ) {
-    return { status: "cursorBackoff", resource };
   }
 
   // Read the change marker BEFORE the first provider read. Everything this pull

--- a/packages/sync/src/domain/calendar-pull.service.ts
+++ b/packages/sync/src/domain/calendar-pull.service.ts
@@ -53,6 +53,14 @@ export type CalendarPullResult =
       // incrementally — initial import owns it until it produces one.
       status: "notImported";
       resource: SyncResourceRecord;
+    }
+  | {
+      // This calendar's cursor keeps expiring, so it is being held off. No
+      // provider call was made. The last repair already rebuilt the calendar
+      // from scratch, so the stored data is current — skipping costs freshness
+      // only for the hold-off window, not correctness.
+      status: "cursorBackoff";
+      resource: SyncResourceRecord;
     };
 
 // Apply the provider's incremental changes for one already-imported calendar.
@@ -96,6 +104,16 @@ export async function pullCalendarChanges(
   );
   if (resource.syncCursor === null) {
     return { status: "notImported", resource };
+  }
+
+  // Held off after repeated cursor expiries. Checked after markAttempt (so the
+  // resource still rotates to the back of the sweep ordering) and before the
+  // token fetch, so a held-off calendar costs no provider call at all.
+  if (
+    resource.cursorExpiredBackoffUntil !== null &&
+    resource.cursorExpiredBackoffUntil > now()
+  ) {
+    return { status: "cursorBackoff", resource };
   }
 
   // Read the change marker BEFORE the first provider read. Everything this pull

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -461,15 +461,31 @@ describe("dispatchSyncJob", () => {
     expect(held?.cursorExpiredBackoffUntil).toEqual(
       new Date(now().getTime() + 5 * 60_000),
     );
+  });
 
-    // Now within the hold-off: the pull settles without touching the provider.
-    const reader = alwaysExpired();
-    const dropped = await dispatchSyncJob(
+  // The behaviour the feature exists for, seeded directly rather than reached
+  // through three laps, so it still runs when the ladder above changes.
+  it("settles a pull inside the hold-off without touching the provider", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "stale-cursor");
+    await resources.recordCursorExpiry(
+      calendar.tenantId,
+      calendar.principalId,
+      resource._id,
+      new Date(now().getTime() + 5 * 60_000),
+    );
+
+    const reader = new FakeReader(
+      [],
+      new ProviderEventReadError("cursorExpired", "gone"),
+    );
+    const outcome = await dispatchSyncJob(
       deps(reader),
       jobFor(resource, "incrementalPull"),
       now,
     );
-    expect(dropped.result).toBe("drop");
+
+    expect(outcome.result).toBe("drop");
     expect(reader.calls).toHaveLength(0);
   });
 

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -416,6 +416,127 @@ describe("dispatchSyncJob", () => {
     expect(outcome.followup.resourceId).toBe(resource._id);
   });
 
+  // A calendar whose provider never sustains an incremental cursor (Google's
+  // derived holiday calendars 410 a token minutes old) used to re-run
+  // pull -> repair -> pull every ~45s forever: one prod resource reached
+  // activeGeneration 1919 in four weeks (2026-08-23).
+  it("counts consecutive cursor expiries and eventually holds off the pull", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "stale-cursor");
+    const alwaysExpired = () =>
+      new FakeReader([], new ProviderEventReadError("cursorExpired", "gone"));
+
+    // The first two laps are deliberately free, so an ordinary calendar whose
+    // token genuinely aged out heals with no added latency.
+    for (const expectedStreak of [1, 2]) {
+      const outcome = await dispatchSyncJob(
+        deps(alwaysExpired()),
+        jobFor(resource, "incrementalPull"),
+        now,
+      );
+      expect(outcome.result).toBe("done");
+      const stored = await resources.findById(
+        calendar.tenantId,
+        calendar.principalId,
+        resource._id,
+      );
+      expect(stored?.cursorExpiredStreak).toBe(expectedStreak);
+      expect(stored?.cursorExpiredBackoffUntil).toEqual(now());
+    }
+
+    // The third lap is where the cursor is judged unrecoverable and the
+    // hold-off starts widening.
+    const third = await dispatchSyncJob(
+      deps(alwaysExpired()),
+      jobFor(resource, "incrementalPull"),
+      now,
+    );
+    expect(third.result).toBe("done");
+    const held = await resources.findById(
+      calendar.tenantId,
+      calendar.principalId,
+      resource._id,
+    );
+    expect(held?.cursorExpiredStreak).toBe(3);
+    expect(held?.cursorExpiredBackoffUntil).toEqual(
+      new Date(now().getTime() + 5 * 60_000),
+    );
+
+    // Now within the hold-off: the pull settles without touching the provider.
+    const reader = alwaysExpired();
+    const dropped = await dispatchSyncJob(
+      deps(reader),
+      jobFor(resource, "incrementalPull"),
+      now,
+    );
+    expect(dropped.result).toBe("drop");
+    expect(reader.calls).toHaveLength(0);
+  });
+
+  it("clears the expiry streak once a pull applies through the cursor again", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "stale-cursor");
+
+    await dispatchSyncJob(
+      deps(
+        new FakeReader([], new ProviderEventReadError("cursorExpired", "gone")),
+      ),
+      jobFor(resource, "incrementalPull"),
+      now,
+    );
+    const expired = await resources.findById(
+      calendar.tenantId,
+      calendar.principalId,
+      resource._id,
+    );
+    expect(expired?.cursorExpiredStreak).toBe(1);
+
+    await dispatchSyncJob(
+      deps(
+        new FakeReader([
+          page([single("new-1")], { nextSyncToken: "cursor-2" }),
+        ]),
+      ),
+      jobFor(resource, "incrementalPull"),
+      now,
+    );
+    const healed = await resources.findById(
+      calendar.tenantId,
+      calendar.principalId,
+      resource._id,
+    );
+    expect(healed?.cursorExpiredStreak).toBe(0);
+    expect(healed?.cursorExpiredBackoffUntil).toBeNull();
+  });
+
+  // Both stale-resource finders order by lastAttemptAt, so a drop that did not
+  // stamp it kept the resource pinned to the front of every sweep and it was
+  // re-enqueued forever (22 such drops in 19 minutes on prod, 2026-08-23).
+  it("stamps the attempt when dropping a job for an inactive calendar", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-1");
+    await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.providerCalendars)
+      .updateOne({ _id: calendar._id }, { $set: { active: false } });
+
+    const reader = new FakeReader([]);
+    const outcome = await dispatchSyncJob(
+      deps(reader),
+      jobFor(resource, "incrementalPull"),
+      now,
+    );
+
+    expect(outcome.result).toBe("drop");
+    expect(reader.calls).toHaveLength(0);
+    const stored = await resources.findById(
+      calendar.tenantId,
+      calendar.principalId,
+      resource._id,
+    );
+    expect(stored?.lastAttemptAt).toEqual(now());
+  });
+
   it("hands off a pull on a never-imported resource to an initial import", async () => {
     const calendar = await seedCalendar();
     const resource = await seedResource(calendar, null); // no cursor

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -334,6 +334,30 @@ async function runSyncJob(
     };
   }
 
+  // Scheduling, not provider logic, so it sits here rather than inside the
+  // pull: a calendar whose cursor the provider keeps rejecting is held off from
+  // incremental pulls, because every expiry costs a full repair lap and some
+  // calendars never sustain a cursor at all. Only incrementalPull is gated --
+  // repair is what makes the data current again and must still run, and a
+  // bootstrapCatchup is finishing a one-time chain that should not stall.
+  // Stamp the attempt for the same reason the inactive drop above does.
+  if (
+    job.kind === "incrementalPull" &&
+    resource.cursorExpiredBackoffUntil !== null &&
+    resource.cursorExpiredBackoffUntil > now()
+  ) {
+    await deps.resources.markAttempt(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+      now(),
+    );
+    return {
+      result: "drop",
+      reason: `calendar ${calendar._id} cursor keeps expiring; holding off pulls until ${resource.cursorExpiredBackoffUntil.toISOString()}`,
+    };
+  }
+
   switch (job.kind) {
     case "initialImport": {
       // Idempotent: a resource that already holds a cursor no-ops inside.
@@ -406,14 +430,6 @@ async function runSyncJob(
           followup: resourceJob(resource, "initialImport", now()),
         };
       }
-      if (pull.status === "cursorBackoff") {
-        // Held off after repeated expiries; the last repair already rebuilt
-        // this calendar. No provider call was made, so just settle.
-        return {
-          result: "drop",
-          reason: `calendar ${calendar._id} cursor keeps expiring; holding off pulls until ${pull.resource.cursorExpiredBackoffUntil?.toISOString()}`,
-        };
-      }
       // cursorExpired: the provider cursor is unusable; a repair rebuilds.
       // The repair runs NOW (it is what makes the data current again); the
       // widening hold-off applies to the next PULL, so a calendar whose cursor
@@ -458,9 +474,6 @@ async function runSyncJob(
           followup: resourceJob(resource, "initialImport", now()),
         };
       }
-      // A bootstrapping resource is never held off (it has no streak yet), but
-      // the status is part of the union — treat it like the expiry it stands in
-      // for and let the repair finish the bootstrap.
       deps.log?.warn(
         `Sync resource ${resource._id} (calendar ${calendar._id}): cursor expired on bootstrap catch-up pull, enqueuing repair`,
       );
@@ -568,11 +581,11 @@ const CURSOR_EXPIRY_HOLD_OFF_MS = [
   6 * 60 * 60_000,
 ];
 
+// `streak` is always >= 1: the caller derives it from a nonnegative stored
+// count plus this lap. The `?? 0` is for noUncheckedIndexedAccess, not a real
+// out-of-range case.
 function cursorExpiryHoldOffMs(streak: number): number {
-  const index = Math.min(
-    Math.max(streak - 1, 0),
-    CURSOR_EXPIRY_HOLD_OFF_MS.length - 1,
-  );
+  const index = Math.min(streak - 1, CURSOR_EXPIRY_HOLD_OFF_MS.length - 1);
   return CURSOR_EXPIRY_HOLD_OFF_MS[index] ?? 0;
 }
 

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -315,6 +315,19 @@ async function runSyncJob(
   // initialImport for a deactivated calendar kept its coalescing key and burned
   // Google quota on every sweep until an operator noticed (2026-07-30).
   if (!calendar.active) {
+    // Stamp the attempt even though nothing ran. Both stale-resource finders
+    // select from sync_resources alone (it carries no active flag) and order by
+    // lastAttemptAt, so a resource that drops WITHOUT stamping keeps its old
+    // timestamp, sorts to the front of every batch, and is re-enqueued forever:
+    // 22 such drops in 19 minutes on prod, crowding out calendars that had real
+    // work (2026-08-23). Stamping rotates it to the back of the line, and
+    // removes it from the foreground finder's window entirely.
+    await deps.resources.markAttempt(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+      now(),
+    );
     return {
       result: "drop",
       reason: `calendar ${calendar._id} is inactive; sync resumes if it is reactivated`,
@@ -357,6 +370,15 @@ async function runSyncJob(
     case "incrementalPull": {
       const pull = await pullUntilQuiet(deps, calendar, now);
       if (pull.status === "applied") {
+        // The stored cursor worked, so whatever streak it had is over. Guarded
+        // so the overwhelmingly common healthy pull writes nothing.
+        if (pull.resource.cursorExpiredStreak > 0) {
+          await deps.resources.clearCursorExpiry(
+            resource.tenantId,
+            resource.principalId,
+            resource._id,
+          );
+        }
         await appendCalendarInvalidation(deps, calendar, now());
         // Bootstrap a channel for an imported calendar that has none. The
         // initialImport followup is otherwise the ONLY thing that ever opens
@@ -384,9 +406,29 @@ async function runSyncJob(
           followup: resourceJob(resource, "initialImport", now()),
         };
       }
+      if (pull.status === "cursorBackoff") {
+        // Held off after repeated expiries; the last repair already rebuilt
+        // this calendar. No provider call was made, so just settle.
+        return {
+          result: "drop",
+          reason: `calendar ${calendar._id} cursor keeps expiring; holding off pulls until ${pull.resource.cursorExpiredBackoffUntil?.toISOString()}`,
+        };
+      }
       // cursorExpired: the provider cursor is unusable; a repair rebuilds.
+      // The repair runs NOW (it is what makes the data current again); the
+      // widening hold-off applies to the next PULL, so a calendar whose cursor
+      // never survives settles into a slow full-rebuild cadence instead of
+      // re-running the whole lap every ~45s.
+      const streak = pull.resource.cursorExpiredStreak + 1;
+      const holdOffMs = cursorExpiryHoldOffMs(streak);
+      await deps.resources.recordCursorExpiry(
+        resource.tenantId,
+        resource.principalId,
+        resource._id,
+        new Date(now().getTime() + holdOffMs),
+      );
       deps.log?.warn(
-        `Sync resource ${resource._id} (calendar ${calendar._id}): cursor expired on incremental pull, enqueuing repair`,
+        `Sync resource ${resource._id} (calendar ${calendar._id}): cursor expired on incremental pull (streak ${streak}), enqueuing repair and holding off pulls for ${Math.round(holdOffMs / 1000)}s`,
       );
       return {
         result: "done",
@@ -416,6 +458,9 @@ async function runSyncJob(
           followup: resourceJob(resource, "initialImport", now()),
         };
       }
+      // A bootstrapping resource is never held off (it has no streak yet), but
+      // the status is part of the union — treat it like the expiry it stands in
+      // for and let the repair finish the bootstrap.
       deps.log?.warn(
         `Sync resource ${resource._id} (calendar ${calendar._id}): cursor expired on bootstrap catch-up pull, enqueuing repair`,
       );
@@ -505,6 +550,31 @@ async function runSyncJob(
 // On giving up, the change marker is left set and the reconcile sweep covers
 // the remainder — slow, but bounded and visible in the log.
 const MAX_PULL_PASSES = 3;
+
+// How long to stop pulling a calendar after N consecutive cursor expiries.
+// The first two laps are free, so an ordinary calendar whose token genuinely
+// aged out (a long outage, a provider-side reissue) heals on the spot with no
+// added latency. Past that the cursor is not coming back — Google's derived
+// holiday calendars 410 a token minutes old, every time — and the only useful
+// response is to stop asking so often. Each lap still runs a full repair, so
+// the calendar stays correct at this cadence; it just stops burning a drain
+// lane and Google quota every ~45s (2026-08-23).
+const CURSOR_EXPIRY_HOLD_OFF_MS = [
+  0,
+  0,
+  5 * 60_000,
+  15 * 60_000,
+  60 * 60_000,
+  6 * 60 * 60_000,
+];
+
+function cursorExpiryHoldOffMs(streak: number): number {
+  const index = Math.min(
+    Math.max(streak - 1, 0),
+    CURSOR_EXPIRY_HOLD_OFF_MS.length - 1,
+  );
+  return CURSOR_EXPIRY_HOLD_OFF_MS[index] ?? 0;
+}
 
 // Pull until no notification arrives mid-pull, then report the last result.
 //

--- a/packages/sync/src/server/internal-http.ts
+++ b/packages/sync/src/server/internal-http.ts
@@ -1,18 +1,41 @@
 import { type Request, type RequestHandler, type Response } from "express";
 import { rateLimit } from "express-rate-limit";
 import { Status } from "@core/errors/status.codes";
+import { Logger } from "@core/logger/winston.logger";
 import { type InternalAuthedRequest } from "@sync/auth/internal-auth";
 import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
+
+const logger = Logger("sync:internal-http");
 
 // A generous backstop, not a throttle: the only caller is the trusted Compass
 // API over a private network, so this bounds a runaway loop or a compromised
 // caller rather than shaping normal traffic. Keyed per client ip, fixed window.
 // Shared by every internal authed route so they share one budget.
+//
+// The budget has to clear the API's *aggregate* steady state, because every
+// backend->Sync call arrives from one container ip and therefore shares a
+// single bucket: per-principal foreground refresh, the global change-feed
+// poll, connection-status checks, and the page-at-a-time event range drain.
+// 300/min did not - it sat about 1.3x idle load, so a couple of concurrent
+// users emptied the bucket and Sync 429ed the API, which surfaced to users as
+// 502/503 on reads and mutations (2026-08-23). Sized well above any legitimate
+// peak: a real runaway loop still trips it, normal traffic never does.
+const INTERNAL_RATE_LIMIT_PER_MINUTE = 6_000;
+
 export const internalRateLimit: RequestHandler = rateLimit({
   windowMs: 60_000,
-  limit: 300,
+  limit: INTERNAL_RATE_LIMIT_PER_MINUTE,
   standardHeaders: true,
   legacyHeaders: false,
+  // Tripping this is never normal. Say so loudly: the previous limit throttled
+  // the API silently for days because express-rate-limit just returns 429 and
+  // the API only sees an opaque `unavailable`.
+  handler: (req, res) => {
+    logger.error(
+      `Internal rate limit exceeded (${INTERNAL_RATE_LIMIT_PER_MINUTE}/min) for ${req.ip} on ${req.method} ${req.path}; the API is being throttled`,
+    );
+    res.status(Status.TOO_MANY_REQUESTS).json({ error: "rate_limited" });
+  },
 });
 
 // Read the verified auth context. The middleware always sets it on success;

--- a/packages/sync/src/server/internal-http.ts
+++ b/packages/sync/src/server/internal-http.ts
@@ -16,10 +16,12 @@ const logger = Logger("sync:internal-http");
 // backend->Sync call arrives from one container ip and therefore shares a
 // single bucket: per-principal foreground refresh, the global change-feed
 // poll, connection-status checks, and the page-at-a-time event range drain.
-// 300/min did not - it sat about 1.3x idle load, so a couple of concurrent
-// users emptied the bucket and Sync 429ed the API, which surfaced to users as
-// 502/503 on reads and mutations (2026-08-23). Sized well above any legitimate
-// peak: a real runaway loop still trips it, normal traffic never does.
+// Measured idle load on prod is ~105/min, so the previous 300/min left under
+// 3x headroom on a value this comment calls a backstop — thin enough that a
+// handful of concurrent users would have started shedding load. To be clear
+// about what this did NOT cause: the 2026-08-23 502/503 bursts came from a
+// cursor-expiry repair storm stalling Sync, not from this limiter, which was
+// never observed to trip. Raised so it cannot become the next surprise.
 const INTERNAL_RATE_LIMIT_PER_MINUTE = 6_000;
 
 export const internalRateLimit: RequestHandler = rateLimit({
@@ -27,9 +29,9 @@ export const internalRateLimit: RequestHandler = rateLimit({
   limit: INTERNAL_RATE_LIMIT_PER_MINUTE,
   standardHeaders: true,
   legacyHeaders: false,
-  // Tripping this is never normal. Say so loudly: the previous limit throttled
-  // the API silently for days because express-rate-limit just returns 429 and
-  // the API only sees an opaque `unavailable`.
+  // Tripping this is never normal. Say so loudly: express-rate-limit otherwise
+  // just returns 429 and the API only ever sees an opaque `unavailable`, so a
+  // throttle is indistinguishable from Sync being down.
   handler: (req, res) => {
     logger.error(
       `Internal rate limit exceeded (${INTERNAL_RATE_LIMIT_PER_MINUTE}/min) for ${req.ip} on ${req.method} ${req.path}; the API is being throttled`,

--- a/packages/sync/src/storage/contracts/sync-resource.contracts.ts
+++ b/packages/sync/src/storage/contracts/sync-resource.contracts.ts
@@ -108,6 +108,22 @@ export const SyncResourceRecordSchema = z.strictObject({
   // Defaults tolerate rows written before the field — REQUIRED, see
   // watchUnsupportedAt above.
   changeNotifiedAt: z.date().nullable().default(null),
+  // How many incremental pulls in a row the provider has rejected with an
+  // expired cursor, and until when this resource is held off because of it.
+  //
+  // Some provider calendars never sustain an incremental cursor: Google's
+  // derived holiday calendars (en.usa#holiday@...) 410 a freshly issued
+  // nextSyncToken within a minute, so pull -> repair -> pull re-ran forever.
+  // Each lap did a full authoritative rebuild, so the DATA stayed correct — the
+  // cost was the loop itself: one prod resource reached activeGeneration 1919
+  // in four weeks and the churn crowded the drain lanes real calendars share
+  // (2026-08-23). The streak drives a widening hold-off so a chronically
+  // uncursorable calendar settles at a slow poll instead of a hot loop; a pull
+  // that finally applies clears both.
+  // Defaults tolerate rows written before the field — REQUIRED, see
+  // watchUnsupportedAt above.
+  cursorExpiredStreak: z.number().int().nonnegative().default(0),
+  cursorExpiredBackoffUntil: z.date().nullable().default(null),
   createdAt: z.date(),
   updatedAt: z.date(),
 });

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -177,6 +177,40 @@ export class SyncResourceRepository {
     });
   }
 
+  // Count one cursor-expiry lap and hold the resource off until `until`.
+  // $inc rather than a computed set so concurrent drains cannot lose a lap; a
+  // row written before the field reads as 0 and increments from there.
+  async recordCursorExpiry(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    id: string,
+    until: Date,
+  ): Promise<void> {
+    await this.collection.updateOne(
+      { _id: id, tenantId, principalId },
+      {
+        $inc: { cursorExpiredStreak: 1 },
+        $set: { cursorExpiredBackoffUntil: until, updatedAt: new Date() },
+      },
+    );
+  }
+
+  // A pull actually applied changes through the stored cursor, so the cursor
+  // works again: forget the streak. Deliberately NOT folded into advanceCursor,
+  // which a repair also calls — a repair writing a fresh token is exactly the
+  // lap we are counting, so clearing there would reset the streak every lap and
+  // the hold-off could never widen.
+  async clearCursorExpiry(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    id: string,
+  ): Promise<void> {
+    await this.#patch(tenantId, principalId, id, {
+      cursorExpiredStreak: 0,
+      cursorExpiredBackoffUntil: null,
+    });
+  }
+
   // Record that the provider DURABLY rejected reads for this resource (a 4xx
   // retrying cannot fix). The job that hit it is settled and removed rather than
   // left to burn its retry ladder, so this marker is the only evidence left —

--- a/packages/sync/src/telemetry/health-snapshot.service.db.test.ts
+++ b/packages/sync/src/telemetry/health-snapshot.service.db.test.ts
@@ -132,6 +132,9 @@ describe("computeHealthSnapshot", () => {
     expect(snapshot.jobs.oldestDueAgeMs).toBe(15_000);
     expect(snapshot.subscriptions.healthy).toBe(1);
     expect(snapshot.subscriptions.missing).toBe(1);
+    // The subscribed resource in this fixture has no changeNotifiedAt, so it
+    // counts as never notified — the signal that push delivery is broken.
+    expect(snapshot.subscriptions.neverNotified).toBe(1);
     expect(snapshot.freshness.sampleSize).toBe(2);
     expect(snapshot.freshness.p50Ms).toBeGreaterThan(0);
     expect(snapshot.freshness.percentOver30s).toBeGreaterThan(0);

--- a/packages/sync/src/telemetry/health-snapshot.service.ts
+++ b/packages/sync/src/telemetry/health-snapshot.service.ts
@@ -140,29 +140,38 @@ async function summarizeSubscriptions(
   const collection = db.collection(SYNC_COLLECTIONS.syncResources);
   const eventsFilter = { resourceKind: "events" as const };
 
-  const [healthy, renewSoon, expired, missing] = await Promise.all([
-    collection.countDocuments({
-      ...eventsFilter,
-      subscriptionId: { $ne: null },
-      subscriptionExpiresAt: { $gte: renewBefore },
-    }),
-    collection.countDocuments({
-      ...eventsFilter,
-      subscriptionId: { $ne: null },
-      subscriptionExpiresAt: { $gte: now, $lt: renewBefore },
-    }),
-    collection.countDocuments({
-      ...eventsFilter,
-      subscriptionId: { $ne: null },
-      subscriptionExpiresAt: { $lt: now },
-    }),
-    collection.countDocuments({
-      ...eventsFilter,
-      subscriptionId: null,
-    }),
-  ]);
+  const [healthy, renewSoon, expired, missing, neverNotified] =
+    await Promise.all([
+      collection.countDocuments({
+        ...eventsFilter,
+        subscriptionId: { $ne: null },
+        subscriptionExpiresAt: { $gte: renewBefore },
+      }),
+      collection.countDocuments({
+        ...eventsFilter,
+        subscriptionId: { $ne: null },
+        subscriptionExpiresAt: { $gte: now, $lt: renewBefore },
+      }),
+      collection.countDocuments({
+        ...eventsFilter,
+        subscriptionId: { $ne: null },
+        subscriptionExpiresAt: { $lt: now },
+      }),
+      collection.countDocuments({
+        ...eventsFilter,
+        subscriptionId: null,
+      }),
+      // `$eq: null` matches a missing field too, which is what a resource that
+      // predates changeNotifiedAt looks like — deliberately counted, since such a
+      // resource has equally never been notified.
+      collection.countDocuments({
+        ...eventsFilter,
+        subscriptionId: { $ne: null },
+        changeNotifiedAt: null,
+      }),
+    ]);
 
-  return { healthy, renewSoon, expired, missing };
+  return { healthy, renewSoon, expired, missing, neverNotified };
 }
 
 async function summarizeFreshness(


### PR DESCRIPTION
## Why

Production served bursts of 502/503 on event reads and deletes, and calendar changes took up to 15 minutes to appear. Investigation of the live host and the `compass_sync` database turned up two separate problems.

**A repair storm stalling Sync (this PR's main fix).** The reconcile sweep enqueues ~100 pulls at a time. Around 36 resources hold a cursor the provider will never honour again — Google's derived holiday calendars (`en.usa#holiday@...`) return 410 for a `nextSyncToken` minutes old — so each sweep turned a batch of those pulls into simultaneous full repairs. Nine at once was observed:

```
15:06:35 Sync reconcile sweep enqueued 100 pull(s)
15:06:35 ...cursor expired on incremental pull, enqueuing repair   x9
```

Each repair re-lists the whole calendar, reprojects its occurrences, then deletes below-generation rows. The herd saturates the 4 drain lanes for several seconds and Sync stops answering the API, which surfaces as 502 on the event range read (any one calendar's failure fails the whole query) and 503 on the calendar list. The 5xx arrive in matching bursts — 73 in a single minute, then quiet for minutes. One prod resource reached `activeGeneration` 1919 in four weeks; the fleet max was 6407.

**A totally dead push path (fixed on the host; guards added here).** The prod Caddyfile had no `handle /sync/*` block, so `POST /sync/notifications/google` returned the SPA's HTML with a `200`. Google saw success and never retried: **all 425 subscribed resources had `changeNotifiedAt: null`** — not one push notification had ever been ingested — and `/sync/google` meant no user could connect a Google Calendar since 2026-08-14. The regression is dated precisely: `Caddyfile.before-sync-route-20260801` shows the block was added Aug 1, and the current file differs from that *pre-Aug-1 backup* only by a `/pricing` entry, so an Aug 14 edit made against the stale backup silently reverted it. Route restored and verified with a synthetic Google push.

## What

The repair data was never wrong — every lap is a full authoritative rebuild — so that fix is cadence, not correctness.

- **Cursor-expiry hold-off.** Count consecutive expiries per resource and widen a hold-off on the *pull*, while still repairing immediately so the calendar stays current. A calendar whose cursor never survives settles into a slow full-rebuild (5m → 15m → 1h → 6h) instead of re-running the lap every ~45s. The first two laps are free, so an ordinary calendar whose token genuinely aged out heals with no added latency. The gate lives in dispatch, not in the pull: it is scheduling, and nothing about it needs what the pull knows.
- **Inactive calendars stop starving the sweep.** Stamp `lastAttemptAt` when dropping a job for an inactive calendar. Both stale-resource finders order by `lastAttemptAt` and select from `sync_resources` (which carries no active flag), so a drop that did not stamp pinned the resource to the front of every sweep forever — 22 such drops in 19 minutes.
- **`sync-webhook-route` deploy health check.** The web app answers any path with 200 text/html; Sync rejects a header-less notification with 400. So an html content-type, or any other status, means `/sync/*` is misrouted. Verified against production (passes) and against a host with no `/sync` route (fails, with the Caddyfile hint).
- **`subscriptions.neverNotified` gauge**, counting live subscriptions that have never had a push delivered — prod sat at 425 of 425 for the whole outage. When every live channel is unnotified, the sweep also logs an error naming the likely cause.
- **Server-guide warning** that the Caddyfile must be edited live rather than from a backup, and that only `/sync/*` may be proxied (Sync's private `/internal/*` routes share port 3010).
- **Internal rate limit 300/min → 6000/min, and it now logs when it trips.** Measured idle load is ~105/min against one shared per-ip bucket. To be explicit: this was **not** the cause of the bursts and was never observed to trip — it is hardening, and the code comment says so.
- **`SYNC_UNAVAILABLE` (503) for command backpressure.** A timed-out or unavailable command submit mapped to `PROVIDER_FAILURE` (502) while the read path already used 503. Backpressure from our own service is not a provider verdict. Both remain retryable with the same idempotency key.

## Verification

- `test:sync` 975 pass / 0 fail (4 new), `test:core` 551 pass, `test:backend` 362 pass, type-check and lint clean. All 20 CI checks green.
- New tests cover the widening hold-off, the hold-off drop seeded directly (so it still runs if the ladder constants change), the streak clearing once a pull applies again, the inactive-calendar attempt stamp, and the `neverNotified` gauge.
- After deploy: `activeGeneration` on `6a662800acf42800601132d6` and `6a7df340127b1f4a000b5549` should stop climbing, and the "cursor expired... enqueuing repair" lines should stop repeating every ~45s.

## Follow-ups deliberately not in this PR

- The `markAttempt`-on-drop fix is applied at one of ~10 drop sites; `"resource has no calendar"` and `"calendar no longer exists"` have the same front-of-line pinning. The general fix is to stamp once in the worker's drop path for any job carrying a `resourceId`.
- A held-off resource still costs a cheap enqueue→claim→drop lap per reconcile cycle, because `listStaleEvents` matches on `lastSuccessAt`, which the drop never advances. A generic `nextEligibleAt` exclusion in the sweep finders would close that and serve any future backoff reason.
- The Caddyfile itself is still not version-controlled. The health check now catches the regression, which is the load-bearing part, but rendering the file from the repo is the real fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
