### PR TITLE
fix(sync): bound occurrence projection by document count, not event count

### DIFF
--- a/packages/sync/src/domain/reproject.test.ts
+++ b/packages/sync/src/domain/reproject.test.ts
@@ -1,0 +1,126 @@
+import { reprojectOccurrencesBatch } from "@sync/domain/reproject";
+import { type EventRecord } from "@sync/storage/contracts/event.contracts";
+import { type EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { describe, expect, it } from "bun:test";
+
+const now = () => new Date("2026-07-10T00:00:00.000Z");
+
+// Records the shape of every transaction reprojectOccurrencesBatch would open,
+// which is the thing under test — the batching, not the writes.
+function recordingOccurrences() {
+  const transactions: number[][] = [];
+  const repo = {
+    replaceForEvents: async (
+      entries: readonly { occurrences: unknown[] }[],
+    ) => {
+      transactions.push(entries.map((entry) => entry.occurrences.length));
+    },
+  } as unknown as EventOccurrenceRepository;
+  return { repo, transactions };
+}
+
+const event = (id: string, recurring: boolean): EventRecord =>
+  ({
+    _id: id,
+    generation: 0,
+    tenantId: "t",
+    principalId: "p",
+    calendarId: "c",
+    connectionId: "conn",
+    providerEventId: id,
+    content: {
+      title: id,
+      description: "",
+      location: null,
+      organizer: null,
+      attendees: [],
+      conference: null,
+    },
+    busy: true,
+    cancelled: false,
+    // A daily rule expands to one occurrence per day across the sync horizon,
+    // so a handful of these events is worth thousands of documents.
+    recurrence: recurring
+      ? { kind: "seriesMaster", rules: ["RRULE:FREQ=DAILY"] }
+      : { kind: "single" },
+    schedule: {
+      kind: "timed",
+      start: "2026-07-10T15:00:00.000Z",
+      end: "2026-07-10T16:00:00.000Z",
+      timeZone: "UTC",
+    },
+  }) as unknown as EventRecord;
+
+const total = (transaction: number[]) =>
+  transaction.reduce((sum, n) => sum + n, 0);
+
+describe("reprojectOccurrencesBatch", () => {
+  it("writes an ordinary batch as a single transaction", async () => {
+    const { repo, transactions } = recordingOccurrences();
+
+    await reprojectOccurrencesBatch(
+      repo,
+      Array.from({ length: 50 }, (_, i) => ({ event: event(`e${i}`, false) })),
+      now,
+    );
+
+    expect(transactions).toHaveLength(1);
+    expect(transactions[0]).toHaveLength(50);
+  });
+
+  // The caller batches by EVENT count, which does not bound the write: on Atlas
+  // a batch of recurring events overran the WiredTiger cache ("transaction is
+  // too large", code 388) and wedged a production import for five days.
+  it("splits a batch so no transaction exceeds the occurrence cap", async () => {
+    const { repo, transactions } = recordingOccurrences();
+
+    await reprojectOccurrencesBatch(
+      repo,
+      Array.from({ length: 20 }, (_, i) => ({ event: event(`r${i}`, true) })),
+      now,
+    );
+
+    expect(transactions.length).toBeGreaterThan(1);
+    for (const transaction of transactions) {
+      expect(total(transaction)).toBeLessThanOrEqual(2_000);
+    }
+  });
+
+  it("projects every entry exactly once across the split", async () => {
+    const { repo, transactions } = recordingOccurrences();
+    const entries = Array.from({ length: 20 }, (_, i) => ({
+      event: event(`r${i}`, true),
+    }));
+
+    await reprojectOccurrencesBatch(repo, entries, now);
+
+    expect(transactions.flat()).toHaveLength(entries.length);
+  });
+
+  // An entry is never split across transactions: replaceForEvents deletes and
+  // re-inserts per (eventId, generation), so that pair has to stay atomic even
+  // when one event's own expansion is larger than the cap.
+  it("keeps an oversized single entry in one transaction, alone", async () => {
+    const { repo, transactions } = recordingOccurrences();
+
+    await reprojectOccurrencesBatch(
+      repo,
+      [
+        { event: event("small", false) },
+        { event: event("huge", true) },
+        { event: event("after", false) },
+      ],
+      now,
+    );
+
+    const huge = transactions.find((t) => t.some((n) => n > 2_000));
+    if (huge) expect(huge).toHaveLength(1);
+    expect(transactions.flat()).toHaveLength(3);
+  });
+
+  it("does nothing for an empty batch", async () => {
+    const { repo, transactions } = recordingOccurrences();
+    await reprojectOccurrencesBatch(repo, [], now);
+    expect(transactions).toHaveLength(0);
+  });
+});

--- a/packages/sync/src/domain/reproject.ts
+++ b/packages/sync/src/domain/reproject.ts
@@ -23,6 +23,23 @@ export interface ReprojectBatchEntry {
   excludedInstants?: readonly DateTime[];
 }
 
+// How many occurrence documents one transaction may carry.
+//
+// The caller batches by EVENT count (PROJECTION_BATCH_SIZE in
+// provider-page-applier.ts), which does not bound the write at all: a single
+// recurring event expands to hundreds of occurrences, so a batch of 200 events
+// can be tens of thousands of documents. On Atlas that overran the WiredTiger
+// cache -- "transaction is too large and will not fit in the storage engine
+// cache" (code 388) -- and the failure is deterministic, so the initial import
+// for one production calendar failed on all 20 attempts, exhausted its requeue
+// budget, and sat wedged for five days with that user's calendar never
+// importing (2026-08-23).
+//
+// Event count was never the right unit. Chunk by what the storage engine
+// actually measures. Small enough to stay far from the cache ceiling, large
+// enough that ordinary pages (a few occurrences per event) still commit once.
+const MAX_OCCURRENCES_PER_TRANSACTION = 2_000;
+
 // Batched form of reprojectOccurrences: every entry's rows are computed the
 // same way, but written in one transaction instead of one per event. For a
 // provider page touching hundreds/thousands of events (an initial import),
@@ -40,5 +57,25 @@ export async function reprojectOccurrencesBatch(
     generation: event.generation,
     occurrences: projectOccurrences(event, horizon, excludedInstants),
   }));
-  await occurrences.replaceForEvents(replacements);
+
+  let chunk: typeof replacements = [];
+  let pending = 0;
+  for (const replacement of replacements) {
+    // Flush what is already queued before adding an entry that would push the
+    // chunk over. An entry is never split: replaceForEvents deletes and
+    // re-inserts per (eventId, generation), and that pair must stay atomic, so
+    // one event whose own expansion exceeds the cap still goes in a single
+    // transaction -- it just goes alone.
+    if (
+      chunk.length > 0 &&
+      pending + replacement.occurrences.length > MAX_OCCURRENCES_PER_TRANSACTION
+    ) {
+      await occurrences.replaceForEvents(chunk);
+      chunk = [];
+      pending = 0;
+    }
+    chunk.push(replacement);
+    pending += replacement.occurrences.length;
+  }
+  if (chunk.length > 0) await occurrences.replaceForEvents(chunk);
 }


### PR DESCRIPTION
## Why

An initial import on production failed on all 20 attempts, exhausted its requeue budget, and left one user's calendar unimported for five days. Requeuing the wedged job reproduced the failure immediately:

```
-31800: transaction is too large and will not fit in the storage engine cache
(oldest pinned transaction ID rolled back for eviction)   [code 388]
```

`reprojectOccurrencesBatch` wrote every entry it was handed in a single transaction, and the caller (`provider-page-applier`) chunks by **event** count — `PROJECTION_BATCH_SIZE = 200`. Event count never bounded the write. One recurring event expands to an occurrence per day across the sync horizon, so 200 of them is tens of thousands of documents, well past the WiredTiger cache on Atlas.

The existing comments in both `reproject.ts` and `event-occurrence.repository.ts` only ever reasoned about Atlas's 60s transaction *lifetime* limit. Transaction *size* was unguarded.

This is latent for any user with many recurring events, not just the one who hit it.

## What

Chunk by what the storage engine actually measures: accumulate entries until the next one would push the transaction past 2000 occurrence documents, then flush.

An entry is never split across transactions — `replaceForEvents` deletes and re-inserts per `(eventId, generation)` and that pair has to stay atomic — so an event whose own expansion exceeds the cap still commits in one transaction, just alone.

Ordinary pages (a few occurrences per event) still commit exactly once, so this keeps the batching win that replaced the old per-event transaction.

## Verification

- New `reproject.test.ts` (5 tests) uses a recording fake to assert the transaction shapes directly: ordinary batches stay one transaction, recurring batches split, no transaction exceeds the cap, every entry is projected exactly once across the split, and an oversized entry goes alone.
- **Confirmed the test catches the bug**: reverting the chunking makes the cap assertion fail, and only that one.
- `test:sync` 980 pass / 0 fail, type-check and lint clean.

## Note

The failure was deterministic, not transient, but the job was classified `retryableTransient` and burned 20 attempts plus 3 self-heal requeues against it. Worth a separate look at whether a code-388 write error should be classified as retryable at all — retrying it can never succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)