### PR TITLE
fix(sync): measure push delivery with a durable timestamp

### DIFF
--- a/packages/sync/src/storage/contracts/sync-resource.contracts.ts
+++ b/packages/sync/src/storage/contracts/sync-resource.contracts.ts
@@ -108,6 +108,16 @@ export const SyncResourceRecordSchema = z.strictObject({
   // Defaults tolerate rows written before the field — REQUIRED, see
   // watchUnsupportedAt above.
   changeNotifiedAt: z.date().nullable().default(null),
+  // When a push notification was last ACCEPTED for this resource. Set beside
+  // changeNotifiedAt and never cleared, which is the whole point: the marker
+  // above is a PENDING flag that the serving pull clears within seconds, so on
+  // a healthy fleet it reads null almost always and cannot answer "is push
+  // delivery working?". Confusing the two produced a fleet gauge that was
+  // ~100% "never notified" whether push was healthy or completely dead
+  // (2026-08-23). This field is the durable evidence.
+  // Defaults tolerate rows written before the field — REQUIRED, see
+  // watchUnsupportedAt above.
+  pushLastReceivedAt: z.date().nullable().default(null),
   // How many incremental pulls in a row the provider has rejected with an
   // expired cursor, and until when this resource is held off because of it.
   //

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -246,7 +246,13 @@ export class SyncResourceRepository {
     id: string,
     at: Date,
   ): Promise<void> {
-    await this.#patch(tenantId, principalId, id, { changeNotifiedAt: at });
+    // pushLastReceivedAt is deliberately NOT cleared by the serving pull:
+    // changeNotifiedAt answers "is a change still owed?", this answers "has
+    // push delivery ever worked here?".
+    await this.#patch(tenantId, principalId, id, {
+      changeNotifiedAt: at,
+      pushLastReceivedAt: at,
+    });
   }
 
   // Clear the change marker a pull has now served, but only if it still holds

--- a/packages/sync/src/telemetry/health-snapshot.service.db.test.ts
+++ b/packages/sync/src/telemetry/health-snapshot.service.db.test.ts
@@ -132,7 +132,7 @@ describe("computeHealthSnapshot", () => {
     expect(snapshot.jobs.oldestDueAgeMs).toBe(15_000);
     expect(snapshot.subscriptions.healthy).toBe(1);
     expect(snapshot.subscriptions.missing).toBe(1);
-    // The subscribed resource in this fixture has no changeNotifiedAt, so it
+    // The subscribed resource in this fixture has never received a push, so it
     // counts as never notified — the signal that push delivery is broken.
     expect(snapshot.subscriptions.neverNotified).toBe(1);
     expect(snapshot.freshness.sampleSize).toBe(2);
@@ -142,6 +142,57 @@ describe("computeHealthSnapshot", () => {
 
     // R-SEC-04 / S44: aggregates must never carry content or credential shapes.
     assertNoSafetyCanary(snapshot);
+  });
+
+  // The gauge used to read changeNotifiedAt, which the serving pull CLEARS
+  // within seconds. That made a fleet with perfectly healthy push delivery
+  // report ~100% "never notified", so the number said the same thing whether
+  // push worked or was completely dead (2026-08-23).
+  it("does not count a resource whose push was received and then served", async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const connectionId = objectId() as ConnectionId;
+    const resource = await resources.ensure({
+      tenantId,
+      principalId,
+      connectionId,
+      resourceKind: "events",
+      calendarId: objectId() as never,
+    });
+    await resources.updateSubscription(tenantId, principalId, resource._id, {
+      subscriptionId: "ch-served",
+      subscriptionResourceId: "res-served",
+      subscriptionToken: "tok-served",
+      subscriptionExpiresAt: new Date(
+        NOW.getTime() + HEALTH_SUBSCRIPTION_RENEW_BEFORE_MS + 60_000,
+      ),
+    });
+
+    const notifiedAt = new Date(NOW.getTime() - 30_000);
+    await resources.markChangeNotified(
+      tenantId,
+      principalId,
+      resource._id,
+      notifiedAt,
+    );
+    // The pull that serves the notification clears the pending marker.
+    await resources.clearChangeNotifiedIfUnchanged(
+      tenantId,
+      principalId,
+      resource._id,
+      notifiedAt,
+    );
+
+    const stored = await resources.findById(
+      tenantId,
+      principalId,
+      resource._id,
+    );
+    expect(stored?.changeNotifiedAt).toBeNull();
+    expect(stored?.pushLastReceivedAt).toEqual(notifiedAt);
+
+    const snapshot = await computeHealthSnapshot(deps());
+    expect(snapshot.subscriptions.neverNotified).toBe(0);
   });
 
   it("emits through PostHog when a client is configured", async () => {

--- a/packages/sync/src/telemetry/health-snapshot.service.ts
+++ b/packages/sync/src/telemetry/health-snapshot.service.ts
@@ -161,13 +161,16 @@ async function summarizeSubscriptions(
         ...eventsFilter,
         subscriptionId: null,
       }),
-      // `$eq: null` matches a missing field too, which is what a resource that
-      // predates changeNotifiedAt looks like — deliberately counted, since such a
-      // resource has equally never been notified.
+      // pushLastReceivedAt, NOT changeNotifiedAt: the latter is a pending
+      // marker the serving pull clears within seconds, so counting it reported
+      // a fully unnotified fleet even while push was working perfectly.
+      // `$eq: null` matches a missing field too, which is what a resource
+      // predating the field looks like — deliberately counted, since such a
+      // resource has equally never been observed receiving a push.
       collection.countDocuments({
         ...eventsFilter,
         subscriptionId: { $ne: null },
-        changeNotifiedAt: null,
+        pushLastReceivedAt: null,
       }),
     ]);
 


### PR DESCRIPTION
## Why

The `neverNotified` gauge added in #2841 counted resources whose `changeNotifiedAt` was null, on the belief that the field records "a push has been received here".

It does not. `changeNotifiedAt` is a **pending** marker: set when a notification arrives, and *cleared by the pull that serves it*, usually within seconds. Its own contract comment says exactly that. I read the fleet-wide nulls during the outage as evidence of the outage, when in fact a completely healthy fleet reads the same way almost all the time.

So the gauge reported ~100% "never notified" whether push delivery was perfect or entirely dead — the one thing a health signal must never do.

Production proved it within the hour of deploying #2841. A real Google notification arrived and was served end to end:

```
17:24:33 Sync resource 6a6f3ed9… (calendar 6a6f3ed8…): push latency 2823ms over 1 pass(es), 0 changed, 1 deleted
```

…and `countDocuments({changeNotifiedAt: {$ne: null}})` was still **0**, because the pull had already cleared the marker.

## What

Add `pushLastReceivedAt`, set beside `changeNotifiedAt` in `markChangeNotified` and never cleared, and count that instead.

The two fields now answer different questions, which is what was conflated:

- `changeNotifiedAt` — "is a change still owed?" (drives the compare-and-clear that catches a notification landing mid-pull)
- `pushLastReceivedAt` — "has push delivery ever worked here?" (drives the gauge and the alarm)

## Verification

- `test:sync` 981 pass / 0 fail.
- New test asserts a resource whose push was received *and then served* is not counted as never-notified.
- **Confirmed the test catches the bug**: pointing the gauge back at `changeNotifiedAt` fails exactly one test, the new one.

## Note on rollout

Existing rows read as null and so count as never-notified until their first push. That is the safe direction — it can briefly overstate the problem on a fresh deploy, never hide one — and the hour-long confirmation streak from #2844 keeps it from alarming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)