### PR TITLE
fix(web): let keyboard navigation reach read-only events

### DIFF
--- a/packages/web/src/grid/interaction/event.targeting.ts
+++ b/packages/web/src/grid/interaction/event.targeting.ts
@@ -7,12 +7,20 @@ export type GridEventTarget<TType extends string> =
   RegisteredEventTarget<TType>;
 
 export const createGridEventTargeting = <TType extends string>({
+  eventIdAttribute,
+  eventTypeAttribute,
+  isEventType,
+  readOnlyAttribute,
   registry,
-  targetSelector,
 }: {
+  eventIdAttribute: string;
+  eventTypeAttribute: string;
+  isEventType: (value: string | null) => value is TType;
+  readOnlyAttribute: string;
   registry: EventRegistry<TType>;
-  targetSelector: string;
 }) => {
+  const targetSelector = `[${eventIdAttribute}][${eventTypeAttribute}]`;
+
   const toTarget = (element: Element | null): GridEventTarget<TType> | null => {
     if (!(element instanceof HTMLElement)) return null;
 
@@ -26,28 +34,79 @@ export const createGridEventTargeting = <TType extends string>({
     };
   };
 
-  function listVisible(root: ParentNode = document): GridEventTarget<TType>[] {
+  /** Read attributes only - no registration required. */
+  const toUnregisteredTarget = (
+    element: HTMLElement,
+  ): GridEventTarget<TType> | null => {
+    const eventId = element.getAttribute(eventIdAttribute);
+    const eventType = element.getAttribute(eventTypeAttribute);
+    if (!eventId || !isEventType(eventType)) return null;
+
+    return { element, eventId, eventType };
+  };
+
+  /**
+   * Every visible card the keyboard can land on: registered ones plus
+   * read-only ones. Read-only cards deliberately stay out of the registry
+   * (that absence is the drag/resize gate), but they are still focusable and
+   * can open their details, so navigation has to reach them. Drafts and
+   * recurring previews carry the id attributes too and are excluded - only
+   * the read-only marker opts an unregistered card in.
+   *
+   * This is a navigation list, never an authorization one: what may be
+   * mutated is decided by `getFocusedGridEventTarget` plus the read-only
+   * predicate at the call site.
+   */
+  function listNavigable(
+    root: ParentNode = document,
+  ): GridEventTarget<TType>[] {
     const candidates = root.querySelectorAll(targetSelector);
-    const visible: GridEventTarget<TType>[] = [];
+    const navigable: GridEventTarget<TType>[] = [];
 
     for (const candidate of candidates) {
-      const target = toTarget(candidate);
+      if (!(candidate instanceof HTMLElement)) continue;
+      const target =
+        toTarget(candidate) ??
+        (candidate.hasAttribute(readOnlyAttribute)
+          ? toUnregisteredTarget(candidate)
+          : null);
       if (target && isVisibleEventElement(target.element)) {
-        visible.push(target);
+        navigable.push(target);
       }
     }
 
-    return visible;
+    return navigable;
   }
+
+  /**
+   * The focused card, including a read-only one. Kept separate from
+   * `getFocusedGridEventTarget` on purpose: consumers that mutate an event
+   * (delete, duplicate, nudge, open-for-edit) must keep asking the registry,
+   * or a read-only card would become an edit target. Only navigation - which
+   * merely moves focus - should reach for this.
+   */
+  const getFocusedNavigable = (): GridEventTarget<TType> | null => {
+    const element = document.activeElement;
+    if (!(element instanceof HTMLElement)) return null;
+
+    const registered = toTarget(element);
+    if (registered) return registered;
+
+    // Match resolveFromTarget: focus may sit on a descendant of the card.
+    const readOnlyCard = element.closest<HTMLElement>(`[${readOnlyAttribute}]`);
+    return readOnlyCard ? toUnregisteredTarget(readOnlyCard) : null;
+  };
 
   return {
     focusGridEventTarget: (target: GridEventTarget<TType>): void => {
       target.element.focus();
     },
-    getFirstVisibleGridEventTarget: (
+    getFocusedNavigableGridEventTarget: getFocusedNavigable,
+    getFirstNavigableGridEventTarget: (
       root: ParentNode = document,
-    ): GridEventTarget<TType> | null => listVisible(root)[0] ?? null,
-    listVisibleGridEventTargets: listVisible,
+    ): GridEventTarget<TType> | null => listNavigable(root)[0] ?? null,
+    listNavigableGridEventTargets: listNavigable,
+    /** Registry-backed: the gate for anything that mutates the event. */
     getFocusedGridEventTarget: (): GridEventTarget<TType> | null =>
       toTarget(document.activeElement),
   };

--- a/packages/web/src/grid/interaction/view-event-registry.test.ts
+++ b/packages/web/src/grid/interaction/view-event-registry.test.ts
@@ -2,6 +2,7 @@ import {
   calendarEventIdElementSelector,
   calendarEventIdValueSelector,
   createViewInteractionRegistry,
+  GRID_EVENT_READ_ONLY_ATTRIBUTE,
   readCalendarEventIdFromElement,
 } from "./view-event-registry";
 import { afterEach, describe, expect, it } from "bun:test";
@@ -88,6 +89,22 @@ describe("createViewInteractionRegistry", () => {
     });
   });
 
+  it("getInteractionTargetAttributes marks a read-only card", () => {
+    const day = createViewInteractionRegistry("day");
+
+    expect(
+      day.getInteractionTargetAttributes({
+        eventId: "event-1",
+        eventType: "timed",
+        isReadOnly: true,
+      }),
+    ).toEqual({
+      "data-day-interaction-event-id": "event-1",
+      "data-day-interaction-event-type": "timed",
+      [GRID_EVENT_READ_ONLY_ATTRIBUTE]: "true",
+    });
+  });
+
   it("createRegistry produces a fresh, independent registry each call", () => {
     const day = createViewInteractionRegistry("day");
     const isolated = day.createRegistry();
@@ -114,9 +131,56 @@ describe("createViewInteractionRegistry", () => {
       eventType: "timed",
     });
 
-    expect(day.targeting.getFirstVisibleGridEventTarget()).toMatchObject({
+    expect(day.targeting.getFirstNavigableGridEventTarget()).toMatchObject({
       eventId: "event-1",
       eventType: "timed",
     });
   });
+
+  it("navigates to a read-only card that is never a drag/resize target", () => {
+    const week = createViewInteractionRegistry("week");
+    const readOnly = appendVisibleCard(week, "read-only-event");
+    readOnly.setAttribute(GRID_EVENT_READ_ONLY_ATTRIBUTE, "true");
+
+    const registered = appendVisibleCard(week, "writable-event");
+    week.registry.register({
+      element: registered,
+      eventId: "writable-event",
+      eventType: "timed",
+    });
+
+    expect(
+      week.targeting.listNavigableGridEventTargets().map((t) => t.eventId),
+    ).toEqual(["read-only-event", "writable-event"]);
+    // The registry - the drag/resize gate - still refuses it.
+    expect(week.registry.resolve("read-only-event", "timed")).toBeNull();
+
+    readOnly.focus();
+    expect(week.targeting.getFocusedGridEventTarget()).toBeNull();
+    expect(week.targeting.getFocusedNavigableGridEventTarget()?.eventId).toBe(
+      "read-only-event",
+    );
+  });
+
+  it("leaves unregistered drafts and previews out of the navigable list", () => {
+    const week = createViewInteractionRegistry("week");
+    appendVisibleCard(week, "draft-event");
+
+    expect(week.targeting.listNavigableGridEventTargets()).toEqual([]);
+  });
 });
+
+/** A card stamped with the view's id/type attributes and visible to jsdom. */
+const appendVisibleCard = (
+  view: ReturnType<typeof createViewInteractionRegistry>,
+  eventId: string,
+) => {
+  const element = document.body.appendChild(document.createElement("button"));
+  Object.defineProperty(element, "offsetParent", {
+    configurable: true,
+    get: () => document.body,
+  });
+  element.setAttribute(view.idAttribute, eventId);
+  element.setAttribute(view.typeAttribute, "timed");
+  return element;
+};

--- a/packages/web/src/grid/interaction/view-event-registry.ts
+++ b/packages/web/src/grid/interaction/view-event-registry.ts
@@ -19,6 +19,14 @@ export type ViewRegisteredEventTarget =
 export type ViewEventRegistry = EventRegistry<ViewInteractionEventType>;
 
 /**
+ * Marks a card that renders read-only (unwritable calendar or busy content).
+ * Those cards never enter the interaction registry - that absence is what
+ * stops the drag/resize engine from targeting them - so this attribute is the
+ * only way targeting can still find them for jump labels and focus.
+ */
+export const GRID_EVENT_READ_ONLY_ATTRIBUTE = "data-grid-event-readonly";
+
+/**
  * The `data-${viewName}-interaction-event-*` attribute names alone, with no
  * registry attached - for call sites (like stripping these attributes off a
  * cloned draft-event node) that need the naming scheme but have no reason to
@@ -86,10 +94,12 @@ export const createViewInteractionRegistry = (viewName: string) => {
   const getInteractionTargetAttributes = ({
     eventId,
     eventType,
+    isReadOnly = false,
   }: {
     eventId: string | undefined;
     eventType: ViewInteractionEventType;
-  }) => {
+    isReadOnly?: boolean;
+  }): Record<string, string> => {
     if (!eventId) {
       return {};
     }
@@ -97,13 +107,17 @@ export const createViewInteractionRegistry = (viewName: string) => {
     return {
       [idAttribute]: eventId,
       [typeAttribute]: eventType,
+      ...(isReadOnly ? { [GRID_EVENT_READ_ONLY_ATTRIBUTE]: "true" } : {}),
     };
   };
 
   const registry = createRegistry();
   const targeting = createGridEventTargeting({
+    eventIdAttribute: idAttribute,
+    eventTypeAttribute: typeAttribute,
+    isEventType: isViewInteractionEventType,
+    readOnlyAttribute: GRID_EVENT_READ_ONLY_ATTRIBUTE,
     registry,
-    targetSelector: `[${idAttribute}][${typeAttribute}]`,
   });
 
   const useRegistrationRef = ({

--- a/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
@@ -178,8 +178,12 @@ export function useGridEventEditShortcuts({
   repositionDraftByKey: (key: string) => boolean;
   targeting: {
     focus: (target: FocusableGridEventTarget) => void;
+    /** Registry-backed: the gate for any action that mutates the event. */
     getFocused: () => GridEventShortcutTarget | null;
-    listVisible: () => FocusableGridEventTarget[];
+    /** Also sees read-only cards - navigation only, never edits. */
+    getFocusedNavigable: () => FocusableGridEventTarget | null;
+    /** Also lists read-only cards - navigation only, never edits. */
+    listNavigable: () => FocusableGridEventTarget[];
   };
   timedEvents: GridEvent[];
 }) {
@@ -458,7 +462,9 @@ export function useGridEventEditShortcuts({
       return;
     }
 
-    if (targeting.getFocused() || useDraftStore.getState().gridDraft) {
+    // getFocusedNavigable, not getFocused: a focused read-only card is still a
+    // focused card, and the guard's job is to not drop a new draft under one.
+    if (targeting.getFocusedNavigable() || useDraftStore.getState().gridDraft) {
       return;
     }
 
@@ -592,16 +598,16 @@ export function useGridEventEditShortcuts({
               keyboardEvent.key === "ArrowLeft"
                 ? "previous"
                 : "next",
-            focused: targeting.getFocused(),
+            focused: targeting.getFocusedNavigable(),
             timedEvents,
-            visible: targeting.listVisible(),
+            visible: targeting.listNavigable(),
           })
         : getSpatiallyAdjacentTarget({
             allDayEvents,
             direction: SPATIAL_DIRECTION[keyboardEvent.key],
-            focused: targeting.getFocused(),
+            focused: targeting.getFocusedNavigable(),
             timedEvents,
-            visible: targeting.listVisible(),
+            visible: targeting.listNavigable(),
             weekDays: dayBoundary.weekDays,
           });
     if (!adjacent) return;

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarEventCards.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarEventCards.tsx
@@ -68,9 +68,10 @@ export const DayAllDayCalendarEvent = ({
         ? getDayInteractionTargetAttributes({
             eventId: event._id,
             eventType: "all-day",
+            isReadOnly,
           })
         : undefined,
-    [event._id, hasEventIdentity],
+    [event._id, hasEventIdentity, isReadOnly],
   );
   const position = getAllDayEventPosition(event, {
     columnIndex,
@@ -131,9 +132,10 @@ export const DayTimedCalendarEvent = ({
         ? getDayInteractionTargetAttributes({
             eventId: event._id,
             eventType: "timed",
+            isReadOnly,
           })
         : undefined,
-    [event._id, hasEventIdentity],
+    [event._id, hasEventIdentity, isReadOnly],
   );
   const deckBoxShadow = (() => {
     if (!isDeck) return undefined;

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
@@ -31,7 +31,10 @@ import {
   initialEdgeFocusState,
   useEdgeFocusStore,
 } from "@web/grid/shortcuts/edge-focus.store";
-import { dayEventRegistry } from "@web/views/Day/interaction/registry/day-event.registry";
+import {
+  dayEventRegistry,
+  getDayInteractionTargetAttributes,
+} from "@web/views/Day/interaction/registry/day-event.registry";
 import { useDayEventNudgeShortcuts } from "./useDayEventNudgeShortcuts";
 import {
   afterEach,
@@ -122,6 +125,28 @@ const focusCalendarTarget = (
   return button;
 };
 
+/** A read-only card: attributes stamped, deliberately never registered. */
+const addReadOnlyCalendarTarget = (
+  eventId: string,
+  eventType: "all-day" | "timed" = "timed",
+) => {
+  const button = document.createElement("button");
+  Object.defineProperty(button, "offsetParent", {
+    configurable: true,
+    get: () => document.body,
+  });
+  const attributes = getDayInteractionTargetAttributes({
+    eventId,
+    eventType,
+    isReadOnly: true,
+  });
+  for (const [key, value] of Object.entries(attributes)) {
+    button.setAttribute(key, value);
+  }
+  document.body.appendChild(button);
+  return button;
+};
+
 const renderEditShortcuts = ({
   allDayEvents = [],
   navigateToDate,
@@ -166,7 +191,7 @@ const renderEditShortcuts = ({
     markWrite: async () => {},
     reportError: () => {},
   };
-  renderHook(
+  const rendered = renderHook(
     () =>
       useDayEventNudgeShortcuts({
         allDayEvents,
@@ -180,7 +205,7 @@ const renderEditShortcuts = ({
       queryClient,
     },
   );
-  return { queryClient };
+  return { queryClient, rendered };
 };
 
 const offsetString = (date: Dayjs) =>
@@ -213,6 +238,21 @@ afterEach(() => {
 });
 
 describe("useDayEventNudgeShortcuts", () => {
+  it("labels a read-only event for event jump even though it never registers", () => {
+    const readOnlyButton = addReadOnlyCalendarTarget(TIMED_EVENT_ID);
+    const { rendered } = renderEditShortcuts();
+
+    act(() => {
+      pressKey("s");
+    });
+
+    // Compare ids, never the nodes: a failed toEqual on a jsdom element
+    // serializes the whole tree and eats the test process.
+    const hints = rendered.result.current.shiftHints;
+    expect(hints.map((hint) => hint.eventId)).toEqual([TIMED_EVENT_ID]);
+    expect(hints[0]?.element).toBe(readOnlyButton);
+  });
+
   it("moves the focused timed event 15 minutes earlier with Shift+ArrowUp", async () => {
     focusCalendarTarget(TIMED_EVENT_ID, "timed");
     const { queryClient } = renderEditShortcuts();
@@ -422,6 +462,28 @@ describe("useDayEventNudgeShortcuts", () => {
     pressKey("ArrowDown");
 
     expect(document.activeElement).toBe(later);
+  });
+
+  it("focuses a read-only event with ArrowDown", () => {
+    const earlier = focusCalendarTarget(TIMED_EVENT_ID, "timed");
+    const readOnly = addReadOnlyCalendarTarget(LATER_TIMED_EVENT_ID);
+    earlier.focus();
+    renderEditShortcuts({ timedEvents: [timedEvent, laterTimedEvent] });
+
+    pressKey("ArrowDown");
+
+    expect(document.activeElement).toBe(readOnly);
+  });
+
+  it("navigates back off a focused read-only event with ArrowUp", () => {
+    const earlier = focusCalendarTarget(TIMED_EVENT_ID, "timed");
+    const readOnly = addReadOnlyCalendarTarget(LATER_TIMED_EVENT_ID);
+    readOnly.focus();
+    renderEditShortcuts({ timedEvents: [timedEvent, laterTimedEvent] });
+
+    pressKey("ArrowUp");
+
+    expect(document.activeElement).toBe(earlier);
   });
 
   it("focuses the chronologically next event with ArrowRight", () => {

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.ts
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.ts
@@ -36,10 +36,14 @@ export function useDayEventNudgeShortcuts({
   getEditSequenceAnchor: () => HTMLElement | null;
   shiftHints: ActiveShiftHint[];
 } {
+  // getFocused is registry-backed and gates everything that mutates an event.
+  // The navigable pair also covers read-only cards, which can be focused and
+  // navigated but never edited.
   const targeting = {
     focus: dayEventTargeting.focusGridEventTarget,
     getFocused: dayEventTargeting.getFocusedGridEventTarget,
-    listVisible: dayEventTargeting.listVisibleGridEventTargets,
+    getFocusedNavigable: dayEventTargeting.getFocusedNavigableGridEventTarget,
+    listNavigable: dayEventTargeting.listNavigableGridEventTargets,
   };
 
   useGridEventEditShortcuts({
@@ -85,7 +89,7 @@ export function useDayEventNudgeShortcuts({
   const { hints: shiftHints } = useShiftHoldEventHints({
     allDayEvents,
     focus: targeting.focus,
-    listVisible: targeting.listVisible,
+    listVisible: targeting.listNavigable,
     mode: "day",
     timedEvents,
   });

--- a/packages/web/src/views/Day/interaction/day-event.focus.ts
+++ b/packages/web/src/views/Day/interaction/day-event.focus.ts
@@ -1,7 +1,7 @@
 import { dayEventTargeting } from "@web/views/Day/interaction/registry/day-event.registry";
 
 export function focusFirstDayCalendarEvent() {
-  const target = dayEventTargeting.getFirstVisibleGridEventTarget();
+  const target = dayEventTargeting.getFirstNavigableGridEventTarget();
 
   if (!target) {
     return;

--- a/packages/web/src/views/Day/interaction/targeting/day-event.targeting.test.ts
+++ b/packages/web/src/views/Day/interaction/targeting/day-event.targeting.test.ts
@@ -59,7 +59,7 @@ describe("dayGridEventTargeting", () => {
     addEventButton({ eventId: "hidden", isVisible: false });
     const firstVisible = addEventButton({ eventId: "visible" });
 
-    expect(dayEventTargeting.getFirstVisibleGridEventTarget()).toMatchObject({
+    expect(dayEventTargeting.getFirstNavigableGridEventTarget()).toMatchObject({
       element: firstVisible,
       eventId: "visible",
       eventType: "timed",
@@ -68,7 +68,7 @@ describe("dayGridEventTargeting", () => {
 
   it("focuses a returned calendar target", () => {
     const button = addEventButton({ eventId: "target" });
-    const target = dayEventTargeting.getFirstVisibleGridEventTarget();
+    const target = dayEventTargeting.getFirstNavigableGridEventTarget();
 
     if (!target) throw new Error("expected target");
     dayEventTargeting.focusGridEventTarget(target);
@@ -81,7 +81,7 @@ describe("dayGridEventTargeting", () => {
     const first = addEventButton({ eventId: "first" });
     const second = addEventButton({ eventId: "second" });
 
-    expect(dayEventTargeting.listVisibleGridEventTargets()).toEqual([
+    expect(dayEventTargeting.listNavigableGridEventTargets()).toEqual([
       expect.objectContaining({ element: first, eventId: "first" }),
       expect.objectContaining({ element: second, eventId: "second" }),
     ]);

--- a/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
@@ -173,9 +173,10 @@ const AllDayEventItem = ({
         ? getWeekInteractionTargetAttributes({
             eventId: event._id,
             eventType: "all-day",
+            isReadOnly,
           })
         : undefined,
-    [event._id, hasEventIdentity],
+    [event._id, hasEventIdentity, isReadOnly],
   );
   return (
     <AllDayEventMemo

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
@@ -193,9 +193,10 @@ const MainGridEventItem = ({
         ? getWeekInteractionTargetAttributes({
             eventId: event._id,
             eventType: "timed",
+            isReadOnly,
           })
         : undefined,
-    [event._id, hasEventIdentity],
+    [event._id, hasEventIdentity, isReadOnly],
   );
   return (
     <GridEventMemo

--- a/packages/web/src/views/Week/components/Grid/MainGrid/eventReadOnlyInteraction.test.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/eventReadOnlyInteraction.test.tsx
@@ -22,10 +22,12 @@ import { createCompassQueryClient } from "@web/api/query-client";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import { draftActions, useDraftStore } from "@web/events/stores/draft.store";
+import { GRID_EVENT_READ_ONLY_ATTRIBUTE } from "@web/grid/interaction/view-event-registry";
 import { type Measurements_Grid } from "@web/views/Week/hooks/grid/useGridLayout";
 import {
   WEEK_INTERACTION_EVENT_ID_ATTRIBUTE,
   weekEventRegistry,
+  weekEventTargeting,
 } from "@web/views/Week/interaction/registry/week-event.registry";
 import { AllDayEvents } from "../AllDayRow/AllDayEvents";
 import { MainGridEvents } from "./MainGridEvents";
@@ -190,6 +192,27 @@ describe("Week grid read-only interaction gate", () => {
     const card = screen.getByRole("button", { name: /shared meeting/i });
     expect(card).toHaveAttribute(WEEK_INTERACTION_EVENT_ID_ATTRIBUTE, event.id);
     expect(weekEventRegistry.resolve(event.id, "timed")).toBeNull();
+  });
+
+  it("marks a read-only timed event so keyboard navigation still reaches it", () => {
+    const readOnlyCalendar = makeCalendar();
+    seededCalendars = [readOnlyCalendar];
+    const event = createTimedEvent(readOnlyCalendar.id);
+    seededEvents = [event];
+
+    renderMainGridEvents();
+
+    const card = screen.getByRole("button", { name: /shared meeting/i });
+    expect(card).toHaveAttribute(GRID_EVENT_READ_ONLY_ATTRIBUTE, "true");
+    // jsdom lays nothing out, so stand in for the visibility check.
+    Object.defineProperty(card, "offsetParent", {
+      configurable: true,
+      get: () => document.body,
+    });
+
+    expect(
+      weekEventTargeting.listNavigableGridEventTargets().map((t) => t.eventId),
+    ).toEqual([event.id]);
   });
 
   it("keeps registering a writable-calendar timed event as an interaction target", () => {

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
@@ -213,6 +213,28 @@ const addDraftTarget = (
   return button;
 };
 
+/** A read-only card: attributes stamped, deliberately never registered. */
+const addReadOnlyCalendarTarget = (
+  eventId: string,
+  eventType: "all-day" | "timed" = "timed",
+) => {
+  const button = document.createElement("button");
+  Object.defineProperty(button, "offsetParent", {
+    configurable: true,
+    get: () => document.body,
+  });
+  const attributes = getWeekInteractionTargetAttributes({
+    eventId,
+    eventType,
+    isReadOnly: true,
+  });
+  for (const [key, value] of Object.entries(attributes)) {
+    if (value !== undefined) button.setAttribute(key, value);
+  }
+  document.body.appendChild(button);
+  return button;
+};
+
 const seedFocusedKeyboardPlaceDraft = () => {
   const draft = createGridEventDraft(
     timedGridSchedule(
@@ -272,7 +294,7 @@ const renderShortcuts = (options?: {
 
   const shiftViewByDay = mock();
 
-  renderHook(
+  const rendered = renderHook(
     () =>
       useWeekShortcutOwner({
         endOfView: dayjs("2026-05-24T00:00:00.000"),
@@ -295,7 +317,7 @@ const renderShortcuts = (options?: {
     { wrapper },
   );
 
-  return { queryClient, shiftViewByDay };
+  return { queryClient, rendered, shiftViewByDay };
 };
 
 describe("useWeekShortcutOwner day shifting", () => {
@@ -326,6 +348,26 @@ describe("useWeekShortcutOwner calendar event targeting", () => {
     await waitFor(() => {
       expect(document.activeElement).toBe(button);
     });
+  });
+
+  it("labels a read-only event for event jump even though it never registers", () => {
+    const readOnlyButton = addReadOnlyCalendarTarget(readOnlyEvent.id);
+
+    const { rendered } = renderShortcuts({
+      includeEditableEvent: false,
+      extraEvents: [readOnlyEvent],
+      calendars: [writableCalendar, readOnlyCalendar],
+    });
+
+    act(() => {
+      pressKey("s");
+    });
+
+    // Compare ids, never the nodes: a failed toEqual on a jsdom element
+    // serializes the whole tree and eats the test process.
+    const hints = rendered.result.current.shiftHints;
+    expect(hints.map((hint) => hint.eventId)).toEqual([readOnlyEvent.id]);
+    expect(hints[0]?.element).toBe(readOnlyButton);
   });
 
   it("moves the active shortcut-created draft with arrow keys", () => {
@@ -482,6 +524,53 @@ describe("useWeekShortcutOwner calendar event targeting", () => {
     pressKey("ArrowDown");
 
     expect(document.activeElement).toBe(later);
+  });
+
+  it("focuses a read-only event with ArrowDown", () => {
+    const earlier = addCalendarTarget(editableEvent.id);
+    const readOnly = addReadOnlyCalendarTarget(readOnlyEvent.id);
+    earlier.focus();
+    renderShortcuts({
+      extraEvents: [readOnlyEvent],
+      calendars: [writableCalendar, readOnlyCalendar],
+    });
+
+    pressKey("ArrowDown");
+
+    expect(document.activeElement).toBe(readOnly);
+  });
+
+  it("navigates back off a focused read-only event with ArrowUp", () => {
+    const earlier = addCalendarTarget(editableEvent.id);
+    const readOnly = addReadOnlyCalendarTarget(readOnlyEvent.id);
+    readOnly.focus();
+    renderShortcuts({
+      extraEvents: [readOnlyEvent],
+      calendars: [writableCalendar, readOnlyCalendar],
+    });
+
+    pressKey("ArrowUp");
+
+    expect(document.activeElement).toBe(earlier);
+  });
+
+  it("does not place a draft under an unregistered read-only card with Shift+Arrow", async () => {
+    // The read-only card is unregistered, exactly as the grid renders it -
+    // registering it (as the older gating tests do) hides this fall-through.
+    addReadOnlyCalendarTarget(readOnlyEvent.id).focus();
+    const { queryClient } = renderShortcuts({
+      includeEditableEvent: false,
+      extraEvents: [readOnlyEvent],
+      calendars: [writableCalendar, readOnlyCalendar],
+    });
+
+    pressKey("ArrowRight", shiftKey);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(getEditMutation(queryClient)).toBeUndefined();
+    expect(useDraftStore.getState().gridDraft).toBeNull();
   });
 
   it("does not leave the day with ArrowDown when no later same-day event exists", () => {

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
@@ -160,16 +160,20 @@ export const useWeekShortcutOwner = ({
   useFocusSidebarShortcut();
 
   const focusFirstCalendarEvent = useCallback(() => {
-    const target = weekEventTargeting.getFirstVisibleGridEventTarget();
+    const target = weekEventTargeting.getFirstNavigableGridEventTarget();
     if (!target) return;
 
     weekEventTargeting.focusGridEventTarget(target);
   }, []);
 
+  // getFocused is registry-backed and gates everything that mutates an event.
+  // The navigable pair also covers read-only cards, which can be focused and
+  // navigated but never edited.
   const targeting = {
     focus: weekEventTargeting.focusGridEventTarget,
     getFocused: weekEventTargeting.getFocusedGridEventTarget,
-    listVisible: weekEventTargeting.listVisibleGridEventTargets,
+    getFocusedNavigable: weekEventTargeting.getFocusedNavigableGridEventTarget,
+    listNavigable: weekEventTargeting.listNavigableGridEventTargets,
   };
 
   // Set when a Shift+Arrow nudge carried an event across the window edge;
@@ -246,7 +250,7 @@ export const useWeekShortcutOwner = ({
   const { hints: shiftHints } = useShiftHoldEventHints({
     allDayEvents,
     focus: targeting.focus,
-    listVisible: targeting.listVisible,
+    listVisible: targeting.listNavigable,
     mode: "week",
     timedEvents,
   });

--- a/packages/web/src/views/Week/interaction/targeting/week-event.targeting.test.ts
+++ b/packages/web/src/views/Week/interaction/targeting/week-event.targeting.test.ts
@@ -59,16 +59,18 @@ describe("weekGridEventTargeting", () => {
     addEventButton({ eventId: "hidden", isVisible: false });
     const firstVisible = addEventButton({ eventId: "visible" });
 
-    expect(weekEventTargeting.getFirstVisibleGridEventTarget()).toMatchObject({
-      element: firstVisible,
-      eventId: "visible",
-      eventType: "timed",
-    });
+    expect(weekEventTargeting.getFirstNavigableGridEventTarget()).toMatchObject(
+      {
+        element: firstVisible,
+        eventId: "visible",
+        eventType: "timed",
+      },
+    );
   });
 
   it("focuses a returned calendar target", () => {
     const button = addEventButton({ eventId: "target" });
-    const target = weekEventTargeting.getFirstVisibleGridEventTarget();
+    const target = weekEventTargeting.getFirstNavigableGridEventTarget();
 
     if (!target) throw new Error("expected target");
     weekEventTargeting.focusGridEventTarget(target);
@@ -81,7 +83,7 @@ describe("weekGridEventTargeting", () => {
     const first = addEventButton({ eventId: "first" });
     const second = addEventButton({ eventId: "second" });
 
-    expect(weekEventTargeting.listVisibleGridEventTargets()).toEqual([
+    expect(weekEventTargeting.listNavigableGridEventTargets()).toEqual([
       expect.objectContaining({ element: first, eventId: "first" }),
       expect.objectContaining({ element: second, eventId: "second" }),
     ]);


### PR DESCRIPTION
## What

Read-only events (unwritable calendar, busy content, multi-day display bars) were invisible to the keyboard: no `s` jump label, unreachable by arrow keys, and arrows did nothing while one was focused.


## Why it happened

Read-only cards deliberately never enter the interaction registry — that absence is what stops the drag/resize engine from targeting them. But targeting resolved every candidate *through* that registry, so navigation inherited a gate meant only for mutation.

## The split

The registry stays the sole gate for anything that mutates an event. Navigation gets its own read-only-aware pair:

| | mutation gate | navigation |
|---|---|---|
| focused | `getFocusedGridEventTarget` | `getFocusedNavigableGridEventTarget` |
| list | (registry `resolve`) | `listNavigableGridEventTargets` |

A `data-grid-event-readonly` marker opts read-only cards into the navigable list. Drafts and recurring previews carry the id attributes too and stay excluded — only the marker opts an unregistered card in.

`getFocusedGridEventTarget` was deliberately **not** widened: it also feeds `useGridEventFormFieldSequences`, which has no read-only gate of its own and would have opened an editable draft on an uneditable event.

## Bug this surfaced

The Shift+Arrow place-create guard read the registry-backed resolver, so a focused read-only card fell through and **seeded a new draft** — the opposite of what its own comment promised. The existing test missed it because it *registers* the read-only fixture, which the real grid never does.

## Testing

`bun test:web` — 2234 pass, 0 fail. Type-check and Biome clean.

Seven new tests, each verified to fail when the wiring is reverted:
- Week + Day: `s` labels a read-only event
- Week + Day: arrow keys focus a read-only event, and navigate back off one
- Week: Shift+Arrow under a focused unregistered read-only card places no draft
- Registry: read-only is navigable but never registered; drafts stay excluded

Not verified in a live browser — read-only events need a shared/reader calendar, which a local anon dev session has no way to produce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
