### PR TITLE
feat(web): pick event color and calendar by digit

### DIFF
--- a/packages/web/src/components/ContextMenu/ContextMenuItems.test.tsx
+++ b/packages/web/src/components/ContextMenu/ContextMenuItems.test.tsx
@@ -1,4 +1,5 @@
 import { QueryClient } from "@tanstack/react-query";
+import { fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { type ReactElement } from "react";
 import {
@@ -148,6 +149,38 @@ describe("ContextMenuItems", () => {
 
     await user.click(screen.getByRole("menuitemradio", { name: "Coral" }));
     expect(setColor).toHaveBeenCalledWith("coral");
+    expect(mockClose).toHaveBeenCalled();
+  });
+
+  it("picks a color by digit from the swatch strip and closes", () => {
+    const event = createMockGridEvent({ title: "Test Event" });
+    const setColor = mock();
+
+    const { ContextMenuItemsView } =
+      require("./ContextMenuItems") as typeof import("./ContextMenuItems");
+
+    renderWithTheme(
+      <ContextMenuItemsView
+        event={event}
+        close={mockClose}
+        actions={{
+          delete: mock(),
+          duplicate: mock(),
+          edit: mock(),
+          setColor,
+        }}
+      />,
+      { event },
+    );
+
+    // The pick is index-based off the fieldset, not target-relative - firing
+    // on "Coral" still picks index 0 ("Calendar default").
+    const anyFocusedSwatch = screen.getByRole("menuitemradio", {
+      name: "Coral",
+    });
+    fireEvent.keyDown(anyFocusedSwatch, { code: "Digit1", key: "1" });
+
+    expect(setColor).toHaveBeenCalledWith(null);
     expect(mockClose).toHaveBeenCalled();
   });
 

--- a/packages/web/src/components/ContextMenu/ContextMenuItems.tsx
+++ b/packages/web/src/components/ContextMenu/ContextMenuItems.tsx
@@ -16,6 +16,10 @@ import {
 } from "@web/common/styles/theme.util";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { draftActions } from "@web/events/stores/draft.store";
+import {
+  digitPickIndex,
+  PICK_KEY_LABELS,
+} from "@web/shortcuts/digit-pick.util";
 import { useDeleteEvent } from "@web/views/Forms/hooks/useDeleteEvent";
 import { useDuplicateEvent } from "@web/views/Forms/hooks/useDuplicateEvent";
 import { useSetEventColor } from "@web/views/Forms/hooks/useSetEventColor";
@@ -109,6 +113,10 @@ export function ContextMenuItemsView({
 
   const nav = useContext(ContextMenuNavContext);
   const selectedColor = event.color ?? null;
+  const pickColor = (color: EventColorSlot | null) => {
+    actions.setColor(color);
+    close();
+  };
 
   return (
     // role="none" keeps the menu -> menuitem ownership valid across this
@@ -141,17 +149,26 @@ export function ContextMenuItemsView({
         );
       })}
       {!isReadOnly && (
-        <fieldset className="m-0 min-w-0 border-border border-t px-3 py-2">
+        <fieldset
+          className="group/menu-colors m-0 min-w-0 border-border border-t px-3 py-2"
+          onKeyDown={(keyEvent) => {
+            const pickIndex = digitPickIndex(keyEvent);
+            const pickedColor =
+              pickIndex === null ? undefined : COLOR_OPTIONS[pickIndex];
+            if (pickedColor !== undefined) {
+              keyEvent.preventDefault();
+              keyEvent.stopPropagation();
+              pickColor(pickedColor);
+            }
+          }}
+        >
           <legend className="sr-only">Event color</legend>
           <div className="grid grid-cols-6 gap-1.5">
             {COLOR_OPTIONS.map((slot, colorIndex) => {
               const index = menuActions.length + colorIndex;
               const label = eventColorLabel(slot);
               const checked = selectedColor === slot;
-              const select = () => {
-                actions.setColor(slot);
-                close();
-              };
+              const select = () => pickColor(slot);
               const itemProps = nav
                 ? nav.getItemProps({ onClick: select })
                 : { onClick: select };
@@ -183,6 +200,14 @@ export function ContextMenuItemsView({
                   <span className="c-context-tooltip" role="tooltip">
                     {label}
                   </span>
+                  {PICK_KEY_LABELS[colorIndex] && (
+                    <span
+                      aria-hidden
+                      className="pointer-events-none invisible absolute inset-0 flex items-center justify-center rounded-sm bg-bg-primary/70 font-semibold text-[10px] text-text group-focus-within/menu-colors:visible"
+                    >
+                      {PICK_KEY_LABELS[colorIndex]}
+                    </span>
+                  )}
                 </span>
               );
             })}

--- a/packages/web/src/shortcuts/digit-pick.util.test.ts
+++ b/packages/web/src/shortcuts/digit-pick.util.test.ts
@@ -1,0 +1,46 @@
+import { digitPickIndex } from "@web/shortcuts/digit-pick.util";
+import { describe, expect, it } from "bun:test";
+
+const event = (
+  overrides: Partial<
+    Pick<KeyboardEvent, "code" | "key" | "ctrlKey" | "metaKey" | "altKey">
+  >,
+) => ({
+  code: "",
+  key: "",
+  ctrlKey: false,
+  metaKey: false,
+  altKey: false,
+  ...overrides,
+});
+
+describe("digitPickIndex", () => {
+  it("maps the physical top row to 0-based indices", () => {
+    expect(digitPickIndex(event({ code: "Digit1", key: "1" }))).toBe(0);
+    expect(digitPickIndex(event({ code: "Digit9", key: "9" }))).toBe(8);
+    expect(digitPickIndex(event({ code: "Digit0", key: "0" }))).toBe(9);
+    expect(digitPickIndex(event({ code: "Minus", key: "-" }))).toBe(10);
+    expect(digitPickIndex(event({ code: "Equal", key: "=" }))).toBe(11);
+  });
+
+  it("falls back to a plain digit key for numpad input", () => {
+    expect(digitPickIndex(event({ code: "Numpad3", key: "3" }))).toBe(2);
+  });
+
+  it("matches AZERTY's unshifted top row by physical code", () => {
+    expect(digitPickIndex(event({ code: "Digit1", key: "&" }))).toBe(0);
+  });
+
+  it("ignores Ctrl, Meta, and Alt combinations", () => {
+    expect(digitPickIndex(event({ code: "Digit1", ctrlKey: true }))).toBeNull();
+    expect(digitPickIndex(event({ code: "Digit1", metaKey: true }))).toBeNull();
+    expect(digitPickIndex(event({ code: "Digit1", altKey: true }))).toBeNull();
+  });
+
+  it("returns null for non-digit keys", () => {
+    expect(digitPickIndex(event({ code: "KeyA", key: "a" }))).toBeNull();
+    expect(
+      digitPickIndex(event({ code: "ArrowRight", key: "ArrowRight" })),
+    ).toBeNull();
+  });
+});

--- a/packages/web/src/shortcuts/digit-pick.util.ts
+++ b/packages/web/src/shortcuts/digit-pick.util.ts
@@ -1,0 +1,62 @@
+/**
+ * Physical top-row keys, left to right, mapped to 0-based option indices.
+ * `event.code` is layout-independent (AZERTY's unshifted top row still
+ * reports "Digit1"...), so this is the match target; the labels mirror the
+ * row order so a rendered chip is self-describing.
+ */
+const PICK_CODES = [
+  "Digit1",
+  "Digit2",
+  "Digit3",
+  "Digit4",
+  "Digit5",
+  "Digit6",
+  "Digit7",
+  "Digit8",
+  "Digit9",
+  "Digit0",
+  "Minus",
+  "Equal",
+];
+
+export const PICK_KEY_LABELS = [
+  "1",
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
+  "0",
+  "-",
+  "=",
+];
+
+/**
+ * Numpad and other codes report a plain digit `key` with no `code` match.
+ * Derived from PICK_KEY_LABELS (only the "1".."9","0" entries have a digit
+ * `key` at all) so the fallback can't drift from the labels shown on-screen.
+ */
+const KEY_FALLBACK_INDEX: Record<string, number> = Object.fromEntries(
+  PICK_KEY_LABELS.slice(0, 10).map((label, index) => [label, index]),
+);
+
+/**
+ * Resolves a keydown to a 0-based pick index for direct-select widgets (the
+ * event color picker, calendar select). Returns null for anything else,
+ * including Ctrl/Meta/Alt combos (browser tab switching, macOS symbols).
+ * Shift is allowed since some layouts require it to type digits.
+ */
+export function digitPickIndex(
+  event: Pick<KeyboardEvent, "code" | "key" | "ctrlKey" | "metaKey" | "altKey">,
+): number | null {
+  if (event.ctrlKey || event.metaKey || event.altKey) return null;
+
+  const codeIndex = PICK_CODES.indexOf(event.code);
+  if (codeIndex !== -1) return codeIndex;
+
+  const keyIndex = KEY_FALLBACK_INDEX[event.key];
+  return keyIndex === undefined ? null : keyIndex;
+}

--- a/packages/web/src/shortcuts/shortcuts.registry.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.test.ts
@@ -146,6 +146,22 @@ describe("shortcuts.registry", () => {
       }).map((shortcut) => shortcut.id);
       expect(open).toContain("edit-field-leader-in-form");
     });
+
+    it("lists the digit-pick row regardless of form state, since it also applies in the context menu", () => {
+      const closed = filterShortcutsByContext({
+        view: "day",
+        isViewingCurrentPeriod: true,
+        isFormOpen: false,
+      }).map((shortcut) => shortcut.id);
+      expect(closed).toContain("edit-pick-by-number");
+
+      const open = filterShortcutsByContext({
+        view: "day",
+        isViewingCurrentPeriod: true,
+        isFormOpen: true,
+      }).map((shortcut) => shortcut.id);
+      expect(open).toContain("edit-pick-by-number");
+    });
   });
 
   describe("getShortcutsBySection", () => {

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -241,6 +241,14 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
     section: "edit",
     when: { isFormOpen: true },
   },
+  // Not form-gated: the same digit pick also runs in the event context
+  // menu's color swatch strip, independent of whether the form is open.
+  {
+    id: "edit-pick-by-number",
+    keys: ["1-9", "0", "-", "="],
+    label: "Pick focused color or calendar",
+    section: "edit",
+  },
   {
     id: "edit-focus-prev",
     keys: [KEYMAP.moveFocus.hotkeys.up],

--- a/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.test.tsx
@@ -1,4 +1,10 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   type Calendar,
@@ -98,7 +104,8 @@ describe("CalendarSelect", () => {
       .getAllByRole("option")
       .map((option) => option.textContent);
 
-    expect(optionNames).toEqual(["Personal (primary)", "Team"]);
+    // Trailing digit is the appended pick-key chip (1st, 2nd option).
+    expect(optionNames).toEqual(["Personal (primary)1", "Team2"]);
     expect(within(listbox).queryByText("Holidays")).not.toBeInTheDocument();
     expect(within(listbox).queryByText("Archived")).not.toBeInTheDocument();
   });
@@ -278,10 +285,63 @@ describe("CalendarSelect", () => {
     await openDropdown();
 
     // Alphabetically "Aardvark" sorts first, but it belongs to the newer
-    // account, so it comes second.
+    // account, so it comes second. Trailing digit is the pick-key chip.
     expect(
       screen.getAllByRole("option").map((option) => option.textContent),
-    ).toEqual(["Zebraold@example.com", "Aardvarknew@example.com"]);
+    ).toEqual(["Zebraold@example.com1", "Aardvarknew@example.com2"]);
+  });
+
+  it("picks a calendar by digit from the closed trigger without opening it", async () => {
+    const primary = makeCalendar({ name: "Personal", isPrimary: true });
+    const team = makeCalendar({ name: "Team" });
+    const onChange = mock();
+
+    renderCalendarSelect([primary, team], { onChange });
+
+    const button = screen.getByRole("combobox", { name: /calendar/i });
+    button.focus();
+    fireEvent.keyDown(button, { code: "Digit2", key: "2" });
+
+    expect(onChange).toHaveBeenCalledWith(team.id);
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("picks a calendar by digit from the open list and shows per-option chips", async () => {
+    const primary = makeCalendar({ name: "Personal", isPrimary: true });
+    const team = makeCalendar({ name: "Team" });
+    const onChange = mock();
+
+    renderCalendarSelect([primary, team], { onChange });
+    await openDropdown();
+
+    expect(
+      within(
+        screen.getByRole("option", { name: "Personal (primary)" }),
+      ).getByText("1"),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByRole("option", { name: "Team" })).getByText("2"),
+    ).toBeInTheDocument();
+
+    fireEvent.keyDown(screen.getByRole("listbox"), {
+      code: "Digit2",
+      key: "2",
+    });
+
+    expect(onChange).toHaveBeenCalledWith(team.id);
+  });
+
+  it("ignores an out-of-range digit", async () => {
+    const primary = makeCalendar({ name: "Personal", isPrimary: true });
+    const onChange = mock();
+
+    renderCalendarSelect([primary], { onChange });
+
+    const button = screen.getByRole("combobox", { name: /calendar/i });
+    button.focus();
+    fireEvent.keyDown(button, { code: "Digit9", key: "9" });
+
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   it("displays the user's starred calendar as the default target", async () => {

--- a/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.tsx
+++ b/packages/web/src/views/Forms/EventForm/CalendarSelect/CalendarSelect.tsx
@@ -7,7 +7,7 @@ import {
   useRole,
 } from "@floating-ui/react";
 import classNames from "classnames";
-import { useId, useRef, useState } from "react";
+import { type KeyboardEvent, useId, useRef, useState } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
@@ -21,6 +21,11 @@ import {
   useDefaultTargetCalendar,
 } from "@web/calendars/useDefaultTargetCalendar";
 import { Z_INDEX_FLOATING_MENU } from "@web/common/constants/web.constants";
+import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
+import {
+  digitPickIndex,
+  PICK_KEY_LABELS,
+} from "@web/shortcuts/digit-pick.util";
 import { useFloatingLayer } from "@web/shortcuts/floating-layer";
 
 interface CalendarSelectProps {
@@ -125,6 +130,21 @@ export const CalendarSelect = ({
     setIsOpen(false);
   };
 
+  // Picks the Nth calendar directly, whether the list is open or still
+  // closed - lets Mod+E, A, <digit> commit without opening it. Shared by the
+  // trigger and the floating list's onKeyDown so the two never diverge.
+  const pickCalendarByDigit = (e: KeyboardEvent<Element>): boolean => {
+    const pickIndex = digitPickIndex(e);
+    const pickedCalendar =
+      pickIndex === null ? undefined : writableCalendars[pickIndex];
+    if (!pickedCalendar) return false;
+
+    e.preventDefault();
+    e.stopPropagation();
+    selectCalendar(pickedCalendar);
+    return true;
+  };
+
   if (writableCalendars.length === 0) {
     return (
       <p className="my-1.5 text-error text-xs">
@@ -147,6 +167,8 @@ export const CalendarSelect = ({
         ref={refs.setReference}
         {...getReferenceProps({
           onKeyDown: (e) => {
+            if (pickCalendarByDigit(e)) return;
+
             // While the list is open, focus can sit on this trigger for a
             // frame - useListNavigation moves it to the active option
             // asynchronously - so a fast ArrowDown+Enter lands Enter here.
@@ -198,6 +220,8 @@ export const CalendarSelect = ({
           ref={refs.setFloating}
           {...getFloatingProps({
             onKeyDown: (e) => {
+              if (pickCalendarByDigit(e)) return;
+
               if (
                 activeIndex !== null &&
                 (e.key === "Enter" || e.key === " ")
@@ -256,6 +280,11 @@ export const CalendarSelect = ({
                     {calendar.accountEmail}
                   </span>
                 ) : null}
+                {index < PICK_KEY_LABELS.length && (
+                  <ShortcutHint className="shrink-0">
+                    {PICK_KEY_LABELS[index]}
+                  </ShortcutHint>
+                )}
               </div>
             );
           })}

--- a/packages/web/src/views/Forms/EventForm/EventColorPicker/EventColorPicker.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventColorPicker/EventColorPicker.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, mock } from "bun:test";
 import "@testing-library/jest-dom";
@@ -29,5 +29,78 @@ describe("EventColorPicker", () => {
       screen.getByRole("tooltip", { name: "Calendar default" }),
     ).toBeInTheDocument();
     expect(screen.getByRole("tooltip", { name: "Coral" })).toBeInTheDocument();
+  });
+
+  it("picks a swatch directly by its top-row digit and moves focus to it", () => {
+    const onChange = mock();
+    const { rerender } = render(
+      <EventColorPicker value={null} onChange={onChange} />,
+    );
+
+    const defaultRadio = screen.getByRole("radio", {
+      name: "Calendar default",
+    });
+    const mintRadio = screen.getByRole("radio", { name: "Mint" });
+    defaultRadio.focus();
+
+    fireEvent.keyDown(defaultRadio, { code: "Digit3", key: "3" });
+
+    expect(onChange).toHaveBeenCalledWith("mint");
+    rerender(<EventColorPicker value="mint" onChange={onChange} />);
+    expect(mintRadio).toHaveFocus();
+  });
+
+  it("picks calendar default with the first digit and red with the last pick key", () => {
+    const onChange = mock();
+    render(<EventColorPicker value="mint" onChange={onChange} />);
+
+    const mintRadio = screen.getByRole("radio", { name: "Mint" });
+    mintRadio.focus();
+
+    fireEvent.keyDown(mintRadio, { code: "Digit1", key: "1" });
+    expect(onChange).toHaveBeenLastCalledWith(null);
+
+    fireEvent.keyDown(mintRadio, { code: "Equal", key: "=" });
+    expect(onChange).toHaveBeenLastCalledWith("red");
+  });
+
+  it("ignores a digit held with a modifier", () => {
+    const onChange = mock();
+    render(<EventColorPicker value={null} onChange={onChange} />);
+
+    const defaultRadio = screen.getByRole("radio", {
+      name: "Calendar default",
+    });
+    defaultRadio.focus();
+
+    fireEvent.keyDown(defaultRadio, {
+      code: "Digit3",
+      key: "3",
+      ctrlKey: true,
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("leaves arrow-key navigation untouched", () => {
+    const onChange = mock();
+    render(<EventColorPicker value={null} onChange={onChange} />);
+
+    const defaultRadio = screen.getByRole("radio", {
+      name: "Calendar default",
+    });
+    defaultRadio.focus();
+
+    fireEvent.keyDown(defaultRadio, { code: "ArrowRight", key: "ArrowRight" });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("shows a pick-key chip on every swatch, hidden until the group is focused", () => {
+    render(<EventColorPicker value={null} onChange={mock()} />);
+
+    const chip = screen.getByText("3", { selector: "span[aria-hidden]" });
+    expect(chip).toHaveClass("invisible");
+    expect(chip).toHaveClass("group-focus-within/picker:visible");
   });
 });

--- a/packages/web/src/views/Forms/EventForm/EventColorPicker/EventColorPicker.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventColorPicker/EventColorPicker.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from "react";
+import { type KeyboardEvent, type ReactNode } from "react";
 import {
   type EventColorSlot,
   EventColorSlotSchema,
@@ -7,8 +7,16 @@ import {
   EVENT_COLOR_SLOT_HEX,
   eventColorLabel,
 } from "@web/common/styles/theme.util";
+import {
+  digitPickIndex,
+  PICK_KEY_LABELS,
+} from "@web/shortcuts/digit-pick.util";
 
 const COLOR_SLOTS = EventColorSlotSchema.options;
+
+// Mirrors the render order below: "Calendar default" swatch, then each
+// color slot. Digit-pick indexes into this list.
+const PICK_OPTIONS: Array<EventColorSlot | null> = [null, ...COLOR_SLOTS];
 
 export interface EventColorPickerProps {
   value: EventColorSlot | null;
@@ -24,9 +32,11 @@ const swatchClassName =
 
 const ColorSwatch = ({
   label,
+  pickKey,
   children,
 }: {
   label: string;
+  pickKey: string | undefined;
   children: ReactNode;
 }) => (
   <span className="group relative inline-flex">
@@ -34,6 +44,14 @@ const ColorSwatch = ({
     <span className="c-context-tooltip" role="tooltip">
       {label}
     </span>
+    {pickKey && (
+      <span
+        aria-hidden
+        className="pointer-events-none invisible absolute inset-0 flex items-center justify-center rounded-sm bg-bg-primary/70 font-semibold text-[10px] text-text group-focus-within/picker:visible"
+      >
+        {pickKey}
+      </span>
+    )}
   </span>
 );
 
@@ -42,36 +60,67 @@ export const EventColorPicker = ({
   onChange,
   name = "event-color",
   id,
-}: EventColorPickerProps) => (
-  <fieldset id={id} className="m-0 min-w-0 border-0 p-0">
-    <legend className="sr-only">Event color</legend>
-    <div className="flex flex-wrap items-center gap-1.5">
-      <ColorSwatch label={eventColorLabel(null)}>
-        <input
-          type="radio"
-          name={name}
-          checked={value === null}
-          aria-label={eventColorLabel(null)}
-          className={`${swatchClassName} border-border bg-bg-primary`}
-          onChange={() => onChange(null)}
-        />
-      </ColorSwatch>
-      {COLOR_SLOTS.map((slot) => {
-        const label = eventColorLabel(slot);
-        return (
-          <ColorSwatch key={slot} label={label}>
-            <input
-              type="radio"
-              name={name}
-              checked={value === slot}
-              aria-label={label}
-              className={swatchClassName}
-              style={{ backgroundColor: EVENT_COLOR_SLOT_HEX[slot] }}
-              onChange={() => onChange(slot)}
-            />
-          </ColorSwatch>
-        );
-      })}
-    </div>
-  </fieldset>
-);
+}: EventColorPickerProps) => {
+  // Lets a single keypress pick a swatch directly instead of arrowing
+  // through all 12. Only fires while focus is already inside the group
+  // (radios bubble here), which is also exactly when the pick-key chips
+  // are visible. Arrows/Tab/Space/Enter pass through untouched.
+  const handleKeyDown = (event: KeyboardEvent<HTMLFieldSetElement>) => {
+    const index = digitPickIndex(event);
+    if (index === null || index >= PICK_OPTIONS.length) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    onChange(PICK_OPTIONS[index] ?? null);
+    // Query by the same index just picked, rather than trusting radio order
+    // in the DOM to match PICK_OPTIONS order.
+    event.currentTarget
+      .querySelector<HTMLInputElement>(`input[data-pick-index="${index}"]`)
+      ?.focus();
+  };
+
+  return (
+    <fieldset
+      id={id}
+      className="group/picker m-0 min-w-0 border-0 p-0"
+      onKeyDown={handleKeyDown}
+    >
+      <legend className="sr-only">Event color</legend>
+      <div className="flex flex-wrap items-center gap-1.5">
+        <ColorSwatch label={eventColorLabel(null)} pickKey={PICK_KEY_LABELS[0]}>
+          <input
+            type="radio"
+            name={name}
+            checked={value === null}
+            aria-label={eventColorLabel(null)}
+            className={`${swatchClassName} border-border bg-bg-primary`}
+            onChange={() => onChange(null)}
+            data-pick-index={0}
+          />
+        </ColorSwatch>
+        {COLOR_SLOTS.map((slot, slotIndex) => {
+          const label = eventColorLabel(slot);
+          const index = slotIndex + 1;
+          return (
+            <ColorSwatch
+              key={slot}
+              label={label}
+              pickKey={PICK_KEY_LABELS[index]}
+            >
+              <input
+                type="radio"
+                name={name}
+                checked={value === slot}
+                aria-label={label}
+                className={swatchClassName}
+                style={{ backgroundColor: EVENT_COLOR_SLOT_HEX[slot] }}
+                onChange={() => onChange(slot)}
+                data-pick-index={index}
+              />
+            </ColorSwatch>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+};

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -138,6 +138,21 @@ function dispatchKey(target: HTMLElement, key: string) {
   return event;
 }
 
+// digitPickIndex matches on the physical `code` first; a bare `key` (as
+// dispatchKey sends) only exercises its numpad fallback path. Set `code` too
+// so this hits the primary match real keyboards actually send.
+function dispatchDigitKey(target: HTMLElement, code: string, key: string) {
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    code,
+    key,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
 function dispatchArrowDown(target: HTMLElement) {
   const event = new KeyboardEvent("keydown", {
     bubbles: true,
@@ -486,6 +501,52 @@ describe("EventForm", () => {
     expect(
       screen.getByRole("radio", { name: "Calendar default" }),
     ).toHaveFocus();
+  });
+
+  it("picks a color directly with a digit after jumping to the color field", () => {
+    function Harness() {
+      const [draft, setDraft] = useState<GridEventDraft | null>(
+        createEditDraft(),
+      );
+
+      if (!draft) return null;
+
+      return (
+        <WithEditLeader>
+          <EventForm
+            draft={draft}
+            isDraft={false}
+            isExistingEvent={true}
+            onClose={mock()}
+            onDelete={mock()}
+            onDuplicate={mock()}
+            onSubmit={mock()}
+            setDraft={setDraft}
+          />
+        </WithEditLeader>
+      );
+    }
+
+    renderWithStore(<Harness />);
+
+    const titleField = screen.getByPlaceholderText("Title");
+    act(() => titleField.focus());
+
+    dispatchModKey(titleField, "e");
+    dispatchKey(titleField, "c");
+
+    const defaultRadio = screen.getByRole("radio", {
+      name: "Calendar default",
+    });
+    expect(defaultRadio).toHaveFocus();
+
+    let event: KeyboardEvent;
+    act(() => {
+      event = dispatchDigitKey(defaultRadio, "Digit4", "4");
+    });
+
+    expect(event!.defaultPrevented).toBe(true);
+    expect(screen.getByRole("radio", { name: "Plum" })).toHaveFocus();
   });
 
   it("does not jump focus when a bare letter is typed without the Mod+E leader", () => {


### PR DESCRIPTION
## Summary
- Add single-keypress direct pick (top-row digits 1-9, 0, -, =) to the event color radio group, the calendar select, and the context menu's color swatch grid, so any of the 12 color slots or calendar options can be reached in one keystroke instead of arrowing through them one at a time
- Composes with the existing Mod+E-then-C which-key jump for a 3-key path to any color (Mod+E, C, digit)
- Pick-key chips render on the swatches only while the group has keyboard focus, via CSS `:focus-within` (zero JS, invisible to mouse users)
- Shared `digitPickIndex` helper in `digit-pick.util.ts` centralizes the layout-independent key matching (`event.code` primary match, digit `key` fallback for numpad)

## Test plan
- [x] `bun run type-check` clean
- [x] 89 targeted unit/integration tests pass across the 6 touched files
- [x] Manual browser verification: `Mod+E` → `C` → `6` picks Gold; `=` picks Red; chips visible only while focused; calendar-select digit-pick works from the closed trigger without opening the dropdown
- [x] Multi-agent code review (8 angles) + fix round: corrected the shortcuts-legend row (was "1-9" and wrongly form-gated; now lists all 12 keys and applies unconditionally since the context-menu path doesn't require the form to be open), removed a hand-duplicated key-fallback table, routed the context-menu digit-pick through the same commit closure as click/Enter, consolidated CalendarSelect's two copies of the pick logic into one function, and closed a DOM-order-trust gap in the color picker's post-pick focus call

🤖 Generated with [Claude Code](https://claude.com/claude-code)