### PR TITLE
fix(sync): put the sanitized cause in the job-failure error message

### DIFF
--- a/packages/sync/src/domain/sync-job-worker.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.db.test.ts
@@ -342,8 +342,12 @@ describe("SyncJobWorker", () => {
     await worker.runOnce();
 
     expect(errors).toHaveLength(1);
-    expect(errors[0]?.error.message).toContain(job.kind);
-    expect(errors[0]?.error.message).toContain(String(job._id));
+    // The sanitized cause must be IN the message: the PostHog exception title
+    // is built from the message alone, so a bare "attempt N failed" hides the
+    // real error in event properties.
+    expect(errors[0]?.error.message).toBe(
+      `Sync job incrementalPull (${job._id}) attempt 1 failed: flaky`,
+    );
     expect(errors[0]?.error.cause).toBe(cause);
     expect(errors[0]?.job.resourceId).toBe(job.resourceId);
     expect(errors[0]?.job.connectionId).toEqual(job.connectionId);

--- a/packages/sync/src/domain/sync-job-worker.service.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.ts
@@ -198,12 +198,16 @@ export class SyncJobWorker {
     } catch (error) {
       // An engine threw (a transient provider/storage error dispatch does not
       // model as a status). Treat it as retryable; the cap still bounds it.
-      // Log the cause — without this, staging imports fail silently and the
-      // UI stays stuck on "Syncing calendar" with only a retryableTransient
-      // job row to show for it.
+      // The sanitized cause goes in the MESSAGE, not just `cause`: the PostHog
+      // exception title is built from the message alone, so without it every
+      // failure kind collapses into one opaque "attempt N failed" issue and
+      // the real error hides in event properties.
+      const lastError = sanitizeJobLastError(error);
       this.#onError(
         new Error(
-          `Sync job ${job.kind} (${job._id}) attempt ${job.attempt} failed`,
+          `Sync job ${job.kind} (${job._id}) attempt ${job.attempt} failed${
+            lastError ? `: ${lastError}` : ""
+          }`,
           { cause: error instanceof Error ? error : undefined },
         ),
         job,


### PR DESCRIPTION
## Why

PostHog issue [019fd9ff ("Sync job engine failed")](https://us.posthog.com/project/165441/error_tracking/019fd9ff-1a0f-75b3-a383-2dbd46ba7109) is a catch-all: every sync job failure of every kind fingerprints to the one wrapper `Error` built in `#runJob`, whose message is a bare "Sync job <kind> (<id>) attempt N failed". The real cause rides only in `.cause`, which the PostHog transport stores as hidden event properties (`root_cause`/`cause_chain`) — never in the visible title. Diagnosing the latest wave (production `MongoBulkWriteError: -31800: transaction is too large…`, root-cause-fixed by #2843) required SQL against the event properties; the earlier Google-401 wave had the same problem.

## What

- Append `sanitizeJobLastError(error)` to the wrapper message, so future titles read `…attempt 5 failed: -31800: transaction is too large…`. The sanitizer is already the operator-facing redaction path (status/reason only, never request-derived secrets, 500-char cap) and is already imported in this file.
- Strengthen the existing engine-throw test to assert the full message, cause included.

Grouping does not fragment: the PostHog fingerprint is stack-based (messages already varied by attempt number under a single fingerprint).

## Verification

- `test-mongo-env.ts sync -- sync-job-worker.service.db.test.ts`: 26 pass
- `bun run type-check`: clean
- biome: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)