### PR TITLE
fix(web): commit focused time on enter and raise option contrast

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -852,11 +852,6 @@
   & .timepicker__indicators {
     display: none;
   }
-  & .timepicker__option--is-selected,
-  & .timepicker__option--is-focused {
-    background: hsl(0 0 100 / 10%);
-    color: var(--text);
-  }
   & .timepicker__control {
     min-height: 38px;
     border: 0;

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.test.tsx
@@ -229,6 +229,28 @@ describe("TimePicker Enter commit", () => {
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   });
 
+  it("commits a clicked filtered option instead of the announced first match", async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness
+        initialValue={nineFortyFive}
+        options={dayOptions}
+        freshOptions
+      />,
+    );
+
+    const combobox = screen.getByRole("combobox", { name: "Start time" });
+    await user.click(combobox);
+    await user.type(combobox, "12:45");
+    expect(focusedOptionName(combobox)).toHaveTextContent("12:45 AM");
+
+    await user.click(screen.getByRole("option", { name: "12:45 PM" }));
+
+    expect(screen.getByText("12:45 PM")).toBeInTheDocument();
+    expect(screen.queryByText("9:45 AM")).not.toBeInTheDocument();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
   it("commits the first filtered match on Enter without arrowing", async () => {
     const user = userEvent.setup();
     render(

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.test.tsx
@@ -14,6 +14,7 @@ const intervalOptions: SelectOption<string>[] = [
 const dayOptions = getTimeOptions();
 const onePm = { label: "1 PM", value: "1:00 PM" };
 const fiveThirty = { label: "5:30 PM", value: "5:30 PM" };
+const nineFortyFive = { label: "9:45 AM", value: "9:45 AM" };
 
 function Harness({
   initialValue = intervalOptions[0],
@@ -199,5 +200,68 @@ describe("TimePicker arrow-key focus", () => {
 
     await user.keyboard("{ArrowDown}{ArrowDown}");
     expect(focusedOptionName(combobox)).toHaveTextContent("5:45 PM");
+  });
+});
+
+describe("TimePicker Enter commit", () => {
+  it("commits the arrow-focused meridiem, not the draft time", async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness
+        initialValue={nineFortyFive}
+        options={dayOptions}
+        freshOptions
+      />,
+    );
+
+    const combobox = screen.getByRole("combobox", { name: "Start time" });
+    await user.click(combobox);
+    await user.type(combobox, "12:45");
+    expect(focusedOptionName(combobox)).toHaveTextContent("12:45 AM");
+
+    await user.keyboard("{ArrowDown}");
+    expect(focusedOptionName(combobox)).toHaveTextContent("12:45 PM");
+
+    await user.keyboard("{Enter}");
+
+    expect(screen.getByText("12:45 PM")).toBeInTheDocument();
+    expect(screen.queryByText("9:45 AM")).not.toBeInTheDocument();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("commits the first filtered match on Enter without arrowing", async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness
+        initialValue={nineFortyFive}
+        options={dayOptions}
+        freshOptions
+      />,
+    );
+
+    const combobox = screen.getByRole("combobox", { name: "Start time" });
+    await user.click(combobox);
+    await user.type(combobox, "12:45");
+    await user.keyboard("{Enter}");
+
+    expect(screen.getByText("12:45 AM")).toBeInTheDocument();
+    expect(screen.queryByText("9:45 AM")).not.toBeInTheDocument();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("keeps the original time when Enter is pressed without changing the draft", async () => {
+    const user = userEvent.setup();
+    render(<Harness initialValue={onePm} options={dayOptions} freshOptions />);
+
+    await user.tab();
+    await user.tab();
+    expect(screen.getByRole("combobox", { name: "Start time" })).toHaveFocus();
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+    await user.keyboard("{Enter}");
+
+    expect(screen.getByText("1 PM")).toBeInTheDocument();
+    expect(screen.queryByText("12 AM")).not.toBeInTheDocument();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.tsx
@@ -88,6 +88,7 @@ export const TimePicker = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const scrollRafRef = useRef<number | null>(null);
   const userAdjustedRef = useRef(false);
+  const remapEnterRef = useRef(false);
   const layerId = useId();
   useFloatingLayer(`timePicker:${layerId}`, isMenuOpen);
 
@@ -147,9 +148,14 @@ export const TimePicker = ({
         //@ts-expect-error uses custom onChange to manage focus in parent
         onChange={(option: SelectOption<string> | null) => {
           if (!option) return;
-          // react-select's internal focusedOption can stay on the draft
-          // time after the list is filtered. Prefer the announced row.
-          _onChange(focusedMenuOption() ?? option);
+          // Enter-only: react-select can report the draft time after a
+          // filter. Pointer clicks must keep the clicked option.
+          if (remapEnterRef.current) {
+            remapEnterRef.current = false;
+            _onChange(focusedMenuOption() ?? option);
+            return;
+          }
+          _onChange(option);
         }}
         onKeyDown={(e) => {
           const key = e.key;
@@ -169,6 +175,8 @@ export const TimePicker = ({
             if (!userAdjustedRef.current) {
               e.preventDefault();
               setIsMenuOpen(false);
+            } else {
+              remapEnterRef.current = true;
             }
           }
 
@@ -204,6 +212,7 @@ export const TimePicker = ({
           scheduleScrollToSelected();
         }}
         onMenuClose={() => {
+          remapEnterRef.current = false;
           cancelScrollToSelected();
           setIsMenuOpen(false);
         }}

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.tsx
@@ -61,9 +61,12 @@ function optionFromFocusedMenu(
   options: TimeOption[] | undefined,
   currentValue: string | undefined,
 ): TimeOption | undefined {
-  const focusedLabel = container
-    ?.getElementsByClassName(`${TIMEPICKER}__option--is-focused`)[0]
-    ?.textContent?.trim();
+  const combobox = container?.querySelector<HTMLElement>('[role="combobox"]');
+  const activeId = combobox?.getAttribute("aria-activedescendant");
+  const focusedEl = activeId
+    ? document.getElementById(activeId)
+    : container?.getElementsByClassName(`${TIMEPICKER}__option--is-focused`)[0];
+  const focusedLabel = focusedEl?.textContent?.trim();
   if (!focusedLabel) return undefined;
 
   const listed = options?.find((option) => option.label === focusedLabel);
@@ -121,13 +124,12 @@ export const TimePicker = ({
     };
   }, []);
 
+  const focusedMenuOption = () =>
+    optionFromFocusedMenu(containerRef.current, selectOptions, value?.value);
+
   const commitFocusedOption = () => {
     if (!userAdjustedRef.current) return;
-    const option = optionFromFocusedMenu(
-      containerRef.current,
-      selectOptions,
-      value?.value,
-    );
+    const option = focusedMenuOption();
     if (option) _onChange(option);
   };
 
@@ -143,7 +145,12 @@ export const TimePicker = ({
         blurInputOnSelect
         menuIsOpen={isMenuOpen}
         //@ts-expect-error uses custom onChange to manage focus in parent
-        onChange={_onChange}
+        onChange={(option: SelectOption<string> | null) => {
+          if (!option) return;
+          // react-select's internal focusedOption can stay on the draft
+          // time after the list is filtered. Prefer the announced row.
+          _onChange(focusedMenuOption() ?? option);
+        }}
         onKeyDown={(e) => {
           const key = e.key;
 
@@ -151,8 +158,18 @@ export const TimePicker = ({
             userAdjustedRef.current = true;
           }
 
-          if (key === "Backspace") {
+          if (key === "Enter" || key === "Backspace") {
             e.stopPropagation();
+          }
+
+          if (key === "Enter" && !e.nativeEvent.isComposing) {
+            // Bare Enter must not adopt the first list row (often 12 AM).
+            // After typing or arrowing, let react-select select so it
+            // clears the filter; onChange remaps to the announced row.
+            if (!userAdjustedRef.current) {
+              e.preventDefault();
+              setIsMenuOpen(false);
+            }
           }
 
           if (key === "Shift") {
@@ -162,19 +179,6 @@ export const TimePicker = ({
           if (key === "Escape") {
             setIsMenuOpen(false);
             e.stopPropagation();
-          }
-
-          if (key === "Enter") {
-            // react-select's internal focusedOption can stay on the
-            // draft time after the list is filtered. Commit the DOM
-            // focused row instead, and preventDefault so the stale
-            // option is not also selected.
-            e.stopPropagation();
-            if (e.nativeEvent.isComposing) return;
-            e.preventDefault();
-            commitFocusedOption();
-            setIsMenuOpen(false);
-            return;
           }
 
           if (key === "Tab") {

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.tsx
@@ -30,8 +30,19 @@ const themeColor =
 const timePickerTextStyles = {
   singleValue: themeColor("var(--text)"),
   input: themeColor("var(--text)"),
-  option: themeColor("var(--text)"),
   placeholder: themeColor("var(--text-muted)"),
+  option: (
+    base: CSSObjectWithLabel,
+    { isFocused, isSelected }: { isFocused: boolean; isSelected: boolean },
+  ): CSSObjectWithLabel => ({
+    ...base,
+    color: isFocused ? "var(--on-accent)" : "var(--text)",
+    backgroundColor: isFocused
+      ? "var(--accent)"
+      : isSelected
+        ? "var(--surface-raised)"
+        : "transparent",
+  }),
 };
 
 const TIMEPICKER = "timepicker";
@@ -110,6 +121,16 @@ export const TimePicker = ({
     };
   }, []);
 
+  const commitFocusedOption = () => {
+    if (!userAdjustedRef.current) return;
+    const option = optionFromFocusedMenu(
+      containerRef.current,
+      selectOptions,
+      value?.value,
+    );
+    if (option) _onChange(option);
+  };
+
   return (
     <div ref={containerRef} className="c-time-picker">
       <CreatableSelect
@@ -130,7 +151,7 @@ export const TimePicker = ({
             userAdjustedRef.current = true;
           }
 
-          if (key === "Enter" || key === "Backspace") {
+          if (key === "Backspace") {
             e.stopPropagation();
           }
 
@@ -143,6 +164,19 @@ export const TimePicker = ({
             e.stopPropagation();
           }
 
+          if (key === "Enter") {
+            // react-select's internal focusedOption can stay on the
+            // draft time after the list is filtered. Commit the DOM
+            // focused row instead, and preventDefault so the stale
+            // option is not also selected.
+            e.stopPropagation();
+            if (e.nativeEvent.isComposing) return;
+            e.preventDefault();
+            commitFocusedOption();
+            setIsMenuOpen(false);
+            return;
+          }
+
           if (key === "Tab") {
             // Commit only after the user changed the draft (arrows or
             // typing). Bare Tab through must leave the current time
@@ -151,14 +185,7 @@ export const TimePicker = ({
             // with blurInputOnSelect, leaves focus on the document
             // instead of the next field.
             if (e.nativeEvent.isComposing) return;
-            if (!e.shiftKey && userAdjustedRef.current) {
-              const option = optionFromFocusedMenu(
-                containerRef.current,
-                selectOptions,
-                value?.value,
-              );
-              if (option) _onChange(option);
-            }
+            if (!e.shiftKey) commitFocusedOption();
             setIsMenuOpen(false);
           }
         }}

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/FreqSelect.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/FreqSelect.tsx
@@ -89,17 +89,18 @@ export const FreqSelect = ({
           maxHeight: "none",
           overflowY: "visible",
         }),
-        // Same recipe as .timepicker__option--is-selected/--is-focused
-        // (index.css) - a translucent white overlay reads as a highlight on
-        // both themes' surfaces rather than needing per-theme tuning.
+        // Same recipe as TimePicker option styles — accent fill on
+        // focus so the highlight is readable on both themes.
         option: (styles, { isDisabled, isFocused, isSelected }) => ({
           ...styles,
           backgroundColor: isDisabled
             ? undefined
-            : isSelected || isFocused
-              ? "hsl(0 0 100 / 10%)"
-              : "transparent",
-          color: "var(--text)",
+            : isFocused
+              ? "var(--accent)"
+              : isSelected
+                ? "var(--surface-raised)"
+                : "transparent",
+          color: isFocused ? "var(--on-accent)" : "var(--text)",
           opacity: isDisabled ? 0.5 : 1,
           cursor: isDisabled ? "not-allowed" : "default",
         }),


### PR DESCRIPTION
## Summary

Time pickers now commit the announced focused option on Enter so filtering `12:45` and arrowing to `12:45 PM` no longer snaps back to the grid draft time. Bare Enter/Tab without edits still leave the draft alone. Pointer clicks keep the clicked option (Enter-only remap). Focused menu rows use `--accent` / `--on-accent` instead of a 10% white overlay that disappeared on Light Beach. The same highlight tokens apply to the recurrence frequency select.

## Simplicity

Tab still uses `commitFocusedOption()`. Enter lets react-select finish the select so the filter text clears, then remaps only that commit to the `aria-activedescendant` row. Click/touch do not go through that remap.

## Automated validation

- Focused TimePicker/TimePickers tests: 23 pass, including type `12:45` + ArrowDown + Enter → `12:45 PM`, Enter on first match, bare Enter keeps the draft, and click `12:45 PM` after typing.
- `bun run test:web`: 2253 pass, 0 fail
- `bun run lint`: exit 0 (pre-existing warnings only)

Browser at http://localhost:9080 (anonymous IndexedDB): Light Beach, `c` to create, type `12:45`, ArrowDown to `12:45 PM` (dark fill, light text), Enter → start became `12:45 PM`. Bare Enter kept `12:45 PM`. Tab through left the end time unchanged. Dark theme focused row remained readable.

## Independent review

First review found a high: remapping every `onChange` could steal a click after typing (`blockOptionHover`). Fixed by remapping only when Enter set `remapEnterRef`, plus a click regression test. Re-review: no new confirmed findings.

## Test plan

- `bun test:web packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.test.tsx packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.test.tsx`
- `bun run test:web`
- `bun run lint`
- Browser: Light Beach Enter path, bare Enter, Tab-through, dark-theme focus contrast