### PR TITLE
ci: add Lighthouse performance budget gate

### DIFF
--- a/.github/perf/assert-budget.ts
+++ b/.github/perf/assert-budget.ts
@@ -1,0 +1,155 @@
+/**
+ * Performance budget gate, invoked by .github/workflows/perf-budget.yml.
+ *
+ * Runs Lighthouse (desktop preset) against the compressed local server a few
+ * times and asserts the median against the budgets below. Medians are used
+ * because single Lighthouse runs vary run-to-run, especially on CI runners.
+ *
+ * Lighthouse is pinned because @lhci/cli's bundled Lighthouse 12 reports
+ * NO_LCP against current Chrome; 13.x traces LCP correctly.
+ *
+ * Baseline when this was set up (2026-08-24, desktop preset over gzip):
+ * LCP ~1.9s, FCP ~0.8s, script transfer ~1,085 KB.
+ */
+import { mkdirSync } from "node:fs";
+
+const LIGHTHOUSE_VERSION = "13.4.1";
+const URL_UNDER_TEST = process.env.PERF_URL || "http://localhost:9161/";
+const RUNS = 3;
+const REPORT_DIR = "perf-reports";
+
+/** [label, budget, unit, level] — level "error" fails the job, "warn" logs. */
+const BUDGETS = [
+  {
+    metric: "lcp",
+    label: "Largest Contentful Paint",
+    max: 3000,
+    unit: "ms",
+    level: "error",
+  },
+  {
+    metric: "fcp",
+    label: "First Contentful Paint",
+    max: 1500,
+    unit: "ms",
+    level: "warn",
+  },
+  {
+    metric: "scriptBytes",
+    label: "Script transfer size",
+    max: 1_350_000,
+    unit: "bytes",
+    level: "error",
+  },
+] as const;
+
+interface RunMetrics {
+  lcp: number;
+  fcp: number;
+  scriptBytes: number;
+}
+
+interface LighthouseReport {
+  audits: Record<
+    string,
+    {
+      numericValue?: number;
+      errorMessage?: string;
+      details?: {
+        items?: Array<{ resourceType?: string; transferSize?: number }>;
+      };
+    }
+  >;
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length / 2)];
+}
+
+async function runLighthouse(runIndex: number): Promise<RunMetrics> {
+  const reportPath = `${REPORT_DIR}/run-${runIndex}.json`;
+  const proc = Bun.spawn(
+    [
+      "npx",
+      "--yes",
+      `lighthouse@${LIGHTHOUSE_VERSION}`,
+      URL_UNDER_TEST,
+      "--preset=desktop",
+      "--only-categories=performance",
+      "--output=json",
+      `--output-path=${reportPath}`,
+      "--chrome-flags=--headless=new --no-sandbox",
+      "--quiet",
+    ],
+    { stdout: "inherit", stderr: "inherit" },
+  );
+
+  if ((await proc.exited) !== 0) {
+    throw new Error(`Lighthouse run ${runIndex} exited non-zero`);
+  }
+
+  const report = (await Bun.file(reportPath).json()) as LighthouseReport;
+  const lcpAudit = report.audits["largest-contentful-paint"];
+  const fcpAudit = report.audits["first-contentful-paint"];
+
+  if (typeof lcpAudit?.numericValue !== "number") {
+    throw new Error(
+      `Run ${runIndex} produced no LCP value (${lcpAudit?.errorMessage ?? "unknown error"})`,
+    );
+  }
+  if (typeof fcpAudit?.numericValue !== "number") {
+    throw new Error(`Run ${runIndex} produced no FCP value`);
+  }
+
+  const scriptRow = report.audits["resource-summary"]?.details?.items?.find(
+    (item) => item.resourceType === "script",
+  );
+
+  return {
+    lcp: lcpAudit.numericValue,
+    fcp: fcpAudit.numericValue,
+    scriptBytes: scriptRow?.transferSize ?? 0,
+  };
+}
+
+mkdirSync(REPORT_DIR, { recursive: true });
+
+const runs: RunMetrics[] = [];
+for (let i = 1; i <= RUNS; i++) {
+  console.log(`\nLighthouse run ${i}/${RUNS} against ${URL_UNDER_TEST}...`);
+  runs.push(await runLighthouse(i));
+}
+
+const medians: RunMetrics = {
+  lcp: median(runs.map((r) => r.lcp)),
+  fcp: median(runs.map((r) => r.fcp)),
+  scriptBytes: median(runs.map((r) => r.scriptBytes)),
+};
+
+console.log(`\nPerformance budget (median of ${RUNS} runs):`);
+let failed = false;
+for (const budget of BUDGETS) {
+  const value = medians[budget.metric];
+  const overBudget = value > budget.max;
+  const status = overBudget
+    ? budget.level === "error"
+      ? "FAIL"
+      : "WARN"
+    : "ok";
+  const all = runs.map((r) => Math.round(r[budget.metric])).join(", ");
+
+  console.log(
+    `  [${status}] ${budget.label}: ${Math.round(value)} ${budget.unit}` +
+      ` (budget ${budget.max} ${budget.unit}; runs: ${all})`,
+  );
+  if (overBudget && budget.level === "error") {
+    failed = true;
+  }
+}
+
+if (failed) {
+  console.error("\nPerformance budget exceeded.");
+  process.exit(1);
+}
+console.log("\nPerformance budget met.");

--- a/.github/perf/compass.perf.yaml
+++ b/.github/perf/compass.perf.yaml
@@ -1,0 +1,21 @@
+# Build-time config for the CI performance budget (perf-budget.yml).
+# Only the values baked into the web bundle matter (nodeEnv, apiUrl,
+# empty PostHog key so analytics stays out of the measurement); the rest
+# exist to satisfy config schema validation and are never used.
+runtime:
+  nodeEnv: production
+  timezone: Etc/UTC
+web:
+  url: http://localhost:9161
+backend:
+  # Nothing listens on 3000 in the perf job; boot-time API calls fail fast,
+  # same as the e2e suite's setup.
+  apiUrl: http://localhost:3000/api
+  compassToken: unused-perf-build
+mongo:
+  uri: mongodb://localhost:27017/unused
+supertokens:
+  uri: http://localhost:3567
+  key: unused-perf-build
+google:
+  clientId: unused-perf-build

--- a/.github/workflows/perf-budget.yml
+++ b/.github/workflows/perf-budget.yml
@@ -1,0 +1,91 @@
+name: Performance budget
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "packages/web/**"
+      - "packages/core/**"
+      - "bun.lock"
+      - ".github/perf/**"
+      - ".github/workflows/perf-budget.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/web/**"
+      - "packages/core/**"
+      - "bun.lock"
+      - ".github/perf/**"
+      - ".github/workflows/perf-budget.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: perf-budget-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v6
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install Dependencies
+        run: |
+          bun install --frozen-lockfile
+
+      - name: Build web bundle
+        env:
+          COMPASS_CONFIG_FILE: ${{ github.workspace }}/.github/perf/compass.perf.yaml
+        run: |
+          cd packages/web && bun run build.ts
+
+      - name: Serve build with compression
+        # `serve` gzips responses the way production Caddy does in front of
+        # serve-web.ts; measuring uncompressed delivery would inflate LCP by
+        # ~2s and flag the file server instead of the app.
+        run: |
+          npx --yes serve@14 -s build/web -l 9161 --no-clipboard &
+          for i in $(seq 1 30); do
+            if curl -sf -o /dev/null http://localhost:9161/; then exit 0; fi
+            sleep 1
+          done
+          echo "Static server never came up" >&2
+          exit 1
+
+      - name: Run Lighthouse budget assertions
+        run: |
+          bun .github/perf/assert-budget.ts
+
+      - name: Upload Lighthouse reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-reports
+          path: perf-reports
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ packages/web/node_modules/
 packages/web/build/
 playwright-report/
 test-results/
+perf-reports/
 tmp/


### PR DESCRIPTION
## Why

PostHog web vitals show production LCP averaging 3.5–6.9s over the past 7 days (Google's "good" threshold is <2.5s), with the worst day correlating with dead/rage click spikes. This PR adds the CI guardrail from that investigation so regressions get flagged before they ship; the investigation writeup with the underlying causes is in the session report.

## What

- **`.github/workflows/perf-budget.yml`** — on PRs touching `packages/web`, `packages/core`, or `bun.lock`: builds the web bundle, serves it with gzip compression (matching what production Caddy does in front of `serve-web.ts`), and runs Lighthouse (desktop preset) 3 times.
- **`.github/perf/assert-budget.ts`** — asserts medians: **fails** when LCP > 3,000ms or compressed script transfer > 1,350KB; **warns** when FCP > 1,500ms. Reports upload as a workflow artifact.
- **`.github/perf/compass.perf.yaml`** — build config for the perf job (prod nodeEnv, PostHog disabled so analytics stays out of the measurement).

## Notes

- Lighthouse is pinned to 13.4.1: `@lhci/cli` (even latest) bundles Lighthouse 12, which reports `NO_LCP` against current Chrome — verified locally before abandoning LHCI.
- The job serves with gzip on purpose: measuring `serve-web.ts` uncompressed inflates LCP ~2s for a deficiency production doesn't have (Caddy compresses).
- Baseline at setup (median of 3 desktop runs): LCP ~1.9s, FCP ~0.8s, script ~1,085KB — so the budgets have ~35%/20% headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)