### PR TITLE
perf(web): modulepreload boot-critical chunks in index.html

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -22,7 +22,14 @@
     {
       "name": "Web build (static)",
       "runtimeExecutable": "bunx",
-      "runtimeArgs": ["serve@14", "-s", "build/web", "-l", "9162", "--no-clipboard"],
+      "runtimeArgs": [
+        "serve@14",
+        "-s",
+        "build/web",
+        "-l",
+        "9162",
+        "--no-clipboard"
+      ],
       "port": 9162
     }
   ]

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -18,6 +18,12 @@
       "runtimeExecutable": "bun",
       "runtimeArgs": ["run", "debug:web"],
       "port": 8080
+    },
+    {
+      "name": "Web build (static)",
+      "runtimeExecutable": "bunx",
+      "runtimeArgs": ["serve@14", "-s", "build/web", "-l", "9162", "--no-clipboard"],
+      "port": 9162
     }
   ]
 }

--- a/packages/web/build.ts
+++ b/packages/web/build.ts
@@ -1,5 +1,6 @@
 import { loadCompassConfig } from "@core/config/compass.config";
 import { copyStaticAssets } from "./copy-static-assets";
+import { injectModulePreloads } from "./inject-module-preloads";
 import { postcssPlugin } from "./plugins/postcss.plugin";
 import { execSync } from "node:child_process";
 import path from "node:path";
@@ -81,8 +82,11 @@ await Bun.write(
 );
 
 await copyStaticAssets(OUTDIR);
+const preloaded = await injectModulePreloads(OUTDIR);
 
 // biome-ignore lint/suspicious/noConsole: Preserve build progress output.
 console.log(`Build complete → ${OUTDIR}`);
 // biome-ignore lint/suspicious/noConsole: Preserve build progress output.
 console.log(`  ${result.outputs.length} files written`);
+// biome-ignore lint/suspicious/noConsole: Preserve build progress output.
+console.log(`  ${preloaded.length} boot chunks modulepreloaded in index.html`);

--- a/packages/web/build.ts
+++ b/packages/web/build.ts
@@ -63,6 +63,7 @@ const result = await Bun.build({
   sourcemap: "external",
   minify: true,
   splitting: true,
+  metafile: true,
   define,
   plugins: [postcssPlugin],
   publicPath: "/",
@@ -82,7 +83,7 @@ await Bun.write(
 );
 
 await copyStaticAssets(OUTDIR);
-const preloaded = await injectModulePreloads(OUTDIR);
+const preloaded = await injectModulePreloads(OUTDIR, result.metafile);
 
 // biome-ignore lint/suspicious/noConsole: Preserve build progress output.
 console.log(`Build complete → ${OUTDIR}`);

--- a/packages/web/inject-module-preloads.ts
+++ b/packages/web/inject-module-preloads.ts
@@ -1,0 +1,89 @@
+import path from "node:path";
+
+// Bun.build exposes no per-output import metadata (BuildArtifact is just
+// path/kind/hash/...), so the import graph is recovered from the emitted files
+// themselves. Bun's minifier writes every specifier double-quoted, but the
+// patterns tolerate single quotes and whitespace so a non-minified build
+// parses the same way.
+const STATIC_IMPORT_RE =
+  /\bimport\s*["']([^"']+)["']|\bfrom\s*["']([^"']+)["']/g;
+const DYNAMIC_IMPORT_RE = /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g;
+
+function parseImports(source: string) {
+  const staticSpecs: string[] = [];
+  const dynamicSpecs: string[] = [];
+  for (const match of source.matchAll(STATIC_IMPORT_RE)) {
+    staticSpecs.push((match[1] ?? match[2]) as string);
+  }
+  for (const match of source.matchAll(DYNAMIC_IMPORT_RE)) {
+    dynamicSpecs.push(match[1] as string);
+  }
+  return { staticSpecs, dynamicSpecs };
+}
+
+/**
+ * Injects `<link rel="modulepreload">` tags for every boot-critical chunk into
+ * the built index.html, so the browser fetches the whole boot graph in
+ * parallel instead of discovering it one import level (= one round-trip) at a
+ * time: index.js -> its static chunks -> app.bootstrap -> ~25 more chunks.
+ *
+ * Boot-critical means the static-import closure of index.js plus the
+ * static-import closure of index.js's own dynamic imports. index.js's lone
+ * dynamic import (app.bootstrap) always executes on boot, so it counts; a
+ * second dynamic import added to index.tsx would get preloaded on the same
+ * assumption. Dynamic imports in deeper chunks are the lazy route views and
+ * are deliberately NOT followed.
+ */
+export async function injectModulePreloads(outdir: string): Promise<string[]> {
+  const entry = "index.js";
+  const critical: string[] = [];
+  const seen = new Set([entry]);
+  const queue = [entry];
+
+  while (queue.length > 0) {
+    const chunk = queue.shift() as string;
+    const source = await Bun.file(path.join(outdir, chunk)).text();
+    const { staticSpecs, dynamicSpecs } = parseImports(source);
+    const followed =
+      chunk === entry ? [...staticSpecs, ...dynamicSpecs] : staticSpecs;
+
+    for (const spec of followed) {
+      // Specifiers are root-relative URLs (publicPath "/"). Skip anything that
+      // isn't an emitted .js sibling: the regexes can in principle match
+      // import-shaped text inside a string literal.
+      const name = spec.replace(/^\.?\//, "");
+      if (!name.endsWith(".js") || seen.has(name)) continue;
+      if (!(await Bun.file(path.join(outdir, name)).exists())) continue;
+      seen.add(name);
+      critical.push(name);
+      queue.push(name);
+    }
+  }
+
+  if (critical.length === 0) {
+    // With splitting enabled index.js always imports chunks; an empty walk
+    // means the specifier parsing regressed (e.g. Bun changed emit syntax).
+    throw new Error(`No boot-critical chunks found walking ${entry}`);
+  }
+
+  const htmlPath = path.join(outdir, "index.html");
+  const html = await Bun.file(htmlPath).text();
+  // Anchor on the LAST closing head tag: an HTML comment earlier in <head>
+  // can contain the literal tag text, and injecting there would leave the
+  // links commented out and inert.
+  const anchor = html.lastIndexOf("</head>");
+  if (anchor === -1) {
+    throw new Error(`${htmlPath} has no </head> to inject preloads into`);
+  }
+  const links = critical
+    .map((name) => `    <link rel="modulepreload" href="/${name}" />`)
+    .join("\n");
+  const indentStart =
+    anchor - (/[ \t]*$/.exec(html.slice(0, anchor))?.[0].length ?? 0);
+  await Bun.write(
+    htmlPath,
+    `${html.slice(0, indentStart)}${links}\n  ${html.slice(anchor)}`,
+  );
+
+  return critical;
+}

--- a/packages/web/inject-module-preloads.ts
+++ b/packages/web/inject-module-preloads.ts
@@ -8,10 +8,21 @@ interface Metafile {
     string,
     {
       imports: Array<{ path: string; kind: string }>;
+      inputs?: Record<string, unknown>;
       entryPoint?: string;
     }
   >;
 }
+
+// Dynamic imports made from deeper chunks are normally the lazy route views
+// and excluded from preloading, but some of them always execute on boot. Each
+// source file listed here gets its containing chunk (plus that chunk's static
+// closure) preloaded as well. RootShell is the root route's component - kept
+// a lazy import only so route-shape tests can mock its auth stack (see
+// router.routes.tsx) - and renders on every page load, 404s included.
+// Metafile input keys are relative to the build's cwd, so entries here are
+// matched by path suffix.
+export const ALWAYS_BOOT_SOURCES = ["src/components/RootShell/RootShell.tsx"];
 
 /**
  * Injects `<link rel="modulepreload">` tags for every boot-critical chunk into
@@ -24,11 +35,13 @@ interface Metafile {
  * dynamic import (app.bootstrap) always executes on boot, so it counts; a
  * second dynamic import added to index.tsx would get preloaded on the same
  * assumption. Dynamic imports in deeper chunks are the lazy route views and
- * are deliberately NOT followed.
+ * are deliberately NOT followed - except the chunks holding
+ * ALWAYS_BOOT_SOURCES, which are lazy imports that still run on every boot.
  */
 export async function injectModulePreloads(
   outdir: string,
   metafile: string | object | undefined,
+  alwaysBootSources: string[] = ALWAYS_BOOT_SOURCES,
 ): Promise<string[]> {
   if (!metafile) {
     throw new Error(
@@ -46,9 +59,24 @@ export async function injectModulePreloads(
     throw new Error("No entrypoint output found in the build metafile");
   }
 
-  const critical: string[] = [];
-  const seen = new Set([entry]);
-  const queue = [entry];
+  const roots = [entry];
+  for (const source of alwaysBootSources) {
+    const chunk = Object.keys(meta.outputs).find((key) =>
+      Object.keys(meta.outputs[key].inputs ?? {}).some(
+        (input) => input === source || input.endsWith(`/${source}`),
+      ),
+    );
+    if (!chunk) {
+      throw new Error(
+        `Always-boot source ${source} is in no build output; update ALWAYS_BOOT_SOURCES in inject-module-preloads.ts`,
+      );
+    }
+    if (!roots.includes(chunk)) roots.push(chunk);
+  }
+
+  const critical = roots.filter((key) => key !== entry);
+  const seen = new Set(roots);
+  const queue = [...roots];
   while (queue.length > 0) {
     const key = queue.shift() as string;
     for (const imp of meta.outputs[key].imports) {

--- a/packages/web/inject-module-preloads.ts
+++ b/packages/web/inject-module-preloads.ts
@@ -1,24 +1,16 @@
 import path from "node:path";
 
-// Bun.build exposes no per-output import metadata (BuildArtifact is just
-// path/kind/hash/...), so the import graph is recovered from the emitted files
-// themselves. Bun's minifier writes every specifier double-quoted, but the
-// patterns tolerate single quotes and whitespace so a non-minified build
-// parses the same way.
-const STATIC_IMPORT_RE =
-  /\bimport\s*["']([^"']+)["']|\bfrom\s*["']([^"']+)["']/g;
-const DYNAMIC_IMPORT_RE = /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g;
-
-function parseImports(source: string) {
-  const staticSpecs: string[] = [];
-  const dynamicSpecs: string[] = [];
-  for (const match of source.matchAll(STATIC_IMPORT_RE)) {
-    staticSpecs.push((match[1] ?? match[2]) as string);
-  }
-  for (const match of source.matchAll(DYNAMIC_IMPORT_RE)) {
-    dynamicSpecs.push(match[1] as string);
-  }
-  return { staticSpecs, dynamicSpecs };
+// Only the metafile fields used here. build.ts passes Bun.build's metafile
+// (metafile: true), which lists every output's imports with their kind, so no
+// parsing of the emitted sources is needed.
+interface Metafile {
+  outputs: Record<
+    string,
+    {
+      imports: Array<{ path: string; kind: string }>;
+      entryPoint?: string;
+    }
+  >;
 }
 
 /**
@@ -27,63 +19,79 @@ function parseImports(source: string) {
  * parallel instead of discovering it one import level (= one round-trip) at a
  * time: index.js -> its static chunks -> app.bootstrap -> ~25 more chunks.
  *
- * Boot-critical means the static-import closure of index.js plus the
- * static-import closure of index.js's own dynamic imports. index.js's lone
+ * Boot-critical means the static-import closure of the entry plus the
+ * static-import closure of the entry's own dynamic imports. index.js's lone
  * dynamic import (app.bootstrap) always executes on boot, so it counts; a
  * second dynamic import added to index.tsx would get preloaded on the same
  * assumption. Dynamic imports in deeper chunks are the lazy route views and
  * are deliberately NOT followed.
  */
-export async function injectModulePreloads(outdir: string): Promise<string[]> {
-  const entry = "index.js";
+export async function injectModulePreloads(
+  outdir: string,
+  metafile: string | object | undefined,
+): Promise<string[]> {
+  if (!metafile) {
+    throw new Error(
+      "Bun.build returned no metafile; build.ts must pass metafile: true",
+    );
+  }
+  const meta = (
+    typeof metafile === "string" ? JSON.parse(metafile) : metafile
+  ) as Metafile;
+
+  const entry = Object.keys(meta.outputs).find(
+    (key) => meta.outputs[key].entryPoint,
+  );
+  if (!entry) {
+    throw new Error("No entrypoint output found in the build metafile");
+  }
+
   const critical: string[] = [];
   const seen = new Set([entry]);
   const queue = [entry];
-
   while (queue.length > 0) {
-    const chunk = queue.shift() as string;
-    const source = await Bun.file(path.join(outdir, chunk)).text();
-    const { staticSpecs, dynamicSpecs } = parseImports(source);
-    const followed =
-      chunk === entry ? [...staticSpecs, ...dynamicSpecs] : staticSpecs;
-
-    for (const spec of followed) {
-      // Specifiers are root-relative URLs (publicPath "/"). Skip anything that
-      // isn't an emitted .js sibling: the regexes can in principle match
-      // import-shaped text inside a string literal.
-      const name = spec.replace(/^\.?\//, "");
-      if (!name.endsWith(".js") || seen.has(name)) continue;
-      if (!(await Bun.file(path.join(outdir, name)).exists())) continue;
-      seen.add(name);
-      critical.push(name);
-      queue.push(name);
+    const key = queue.shift() as string;
+    for (const imp of meta.outputs[key].imports) {
+      const bootCritical =
+        imp.kind === "import-statement" ||
+        (key === entry && imp.kind === "dynamic-import");
+      if (!bootCritical) continue;
+      if (!imp.path.endsWith(".js") || seen.has(imp.path)) continue;
+      if (!(imp.path in meta.outputs)) continue;
+      seen.add(imp.path);
+      critical.push(imp.path);
+      queue.push(imp.path);
     }
   }
 
   if (critical.length === 0) {
-    // With splitting enabled index.js always imports chunks; an empty walk
-    // means the specifier parsing regressed (e.g. Bun changed emit syntax).
+    // With splitting enabled the entry always imports chunks; an empty walk
+    // means the metafile shape changed or the wrong output was picked.
     throw new Error(`No boot-critical chunks found walking ${entry}`);
   }
 
+  // Metafile paths are outdir-relative ("./chunk-x.js"); the page serves them
+  // from the root (publicPath "/").
+  const names = critical.map((key) => key.replace(/^\.\//, ""));
+
   const htmlPath = path.join(outdir, "index.html");
   const html = await Bun.file(htmlPath).text();
-  // Anchor on the LAST closing head tag: an HTML comment earlier in <head>
-  // can contain the literal tag text, and injecting there would leave the
-  // links commented out and inert.
-  const anchor = html.lastIndexOf("</head>");
-  if (anchor === -1) {
-    throw new Error(`${htmlPath} has no </head> to inject preloads into`);
+  const links = `${names
+    .map((name) => `  <link rel="modulepreload" href="/${name}" />`)
+    .join("\n")}\n`;
+  let sawHead = false;
+  const rewritten = new HTMLRewriter()
+    .on("head", {
+      element(el) {
+        sawHead = true;
+        el.append(links, { html: true });
+      },
+    })
+    .transform(html);
+  if (!sawHead) {
+    throw new Error(`${htmlPath} has no <head> to inject preloads into`);
   }
-  const links = critical
-    .map((name) => `    <link rel="modulepreload" href="/${name}" />`)
-    .join("\n");
-  const indentStart =
-    anchor - (/[ \t]*$/.exec(html.slice(0, anchor))?.[0].length ?? 0);
-  await Bun.write(
-    htmlPath,
-    `${html.slice(0, indentStart)}${links}\n  ${html.slice(anchor)}`,
-  );
+  await Bun.write(htmlPath, rewritten);
 
-  return critical;
+  return names;
 }

--- a/packages/web/src/__tests__/inject-module-preloads.test.ts
+++ b/packages/web/src/__tests__/inject-module-preloads.test.ts
@@ -13,6 +13,9 @@ const HTML = `<!doctype html>
 </html>
 `;
 
+const staticImport = (p: string) => ({ path: p, kind: "import-statement" });
+const dynamicImport = (p: string) => ({ path: p, kind: "dynamic-import" });
+
 describe("injectModulePreloads", () => {
   let outdir: string;
 
@@ -24,25 +27,36 @@ describe("injectModulePreloads", () => {
     rmSync(outdir, { recursive: true, force: true });
   });
 
-  const write = (name: string, content: string) =>
-    Bun.write(path.join(outdir, name), content);
+  const writeHtml = (content: string) =>
+    Bun.write(path.join(outdir, "index.html"), content);
+
+  const readHtml = () => Bun.file(path.join(outdir, "index.html")).text();
 
   it("preloads the static closure plus the entry's boot dynamic import, excluding lazy chunks", async () => {
-    await write(
-      "index.js",
-      'import{a}from"/chunk-static.js";import("/chunk-boot.js").then(({bootstrapApp:b})=>b());',
-    );
-    await write("chunk-static.js", 'import"/chunk-deep.js";export var a=1;');
-    await write("chunk-deep.js", "export var d=1;");
-    await write(
-      "chunk-boot.js",
-      'import{s}from"/chunk-shared.js";var v=()=>import("/chunk-lazy.js");export var bootstrapApp=()=>s(v);',
-    );
-    await write("chunk-shared.js", "export var s=1;");
-    await write("chunk-lazy.js", "export var l=1;");
-    await write("index.html", HTML);
+    await writeHtml(HTML);
+    const metafile = {
+      outputs: {
+        "./index.js": {
+          entryPoint: "src/index.tsx",
+          imports: [
+            staticImport("./chunk-static.js"),
+            dynamicImport("./chunk-boot.js"),
+          ],
+        },
+        "./chunk-static.js": { imports: [staticImport("./chunk-deep.js")] },
+        "./chunk-deep.js": { imports: [] },
+        "./chunk-boot.js": {
+          imports: [
+            staticImport("./chunk-shared.js"),
+            dynamicImport("./chunk-lazy.js"),
+          ],
+        },
+        "./chunk-shared.js": { imports: [] },
+        "./chunk-lazy.js": { imports: [] },
+      },
+    };
 
-    const critical = await injectModulePreloads(outdir);
+    const critical = await injectModulePreloads(outdir, metafile);
 
     expect(critical).toEqual([
       "chunk-static.js",
@@ -50,98 +64,102 @@ describe("injectModulePreloads", () => {
       "chunk-deep.js",
       "chunk-shared.js",
     ]);
-    const html = await Bun.file(path.join(outdir, "index.html")).text();
-    expect(html).toBe(`<!doctype html>
+    expect(await readHtml()).toBe(`<!doctype html>
 <html>
   <head>
     <link rel="stylesheet" href="/index.css" />
     <link rel="modulepreload" href="/chunk-static.js" />
-    <link rel="modulepreload" href="/chunk-boot.js" />
-    <link rel="modulepreload" href="/chunk-deep.js" />
-    <link rel="modulepreload" href="/chunk-shared.js" />
-  </head>
+  <link rel="modulepreload" href="/chunk-boot.js" />
+  <link rel="modulepreload" href="/chunk-deep.js" />
+  <link rel="modulepreload" href="/chunk-shared.js" />
+</head>
   <body></body>
 </html>
 `);
   });
 
-  it("ignores import-shaped text that names no emitted file", async () => {
-    await write(
-      "index.js",
-      'import"/chunk-real.js";var msg="failed: import(\\"/chunk-ghost.js\\")";',
-    );
-    await write("chunk-real.js", "export var r=1;");
-    await write("index.html", HTML);
+  it("visits shared chunks once and accepts a JSON-string metafile", async () => {
+    await writeHtml(HTML);
+    const metafile = JSON.stringify({
+      outputs: {
+        "./index.js": {
+          entryPoint: "src/index.tsx",
+          imports: [staticImport("./chunk-a.js"), staticImport("./chunk-b.js")],
+        },
+        "./chunk-a.js": { imports: [staticImport("./chunk-shared.js")] },
+        "./chunk-b.js": { imports: [staticImport("./chunk-shared.js")] },
+        "./chunk-shared.js": { imports: [] },
+      },
+    });
 
-    const critical = await injectModulePreloads(outdir);
+    const critical = await injectModulePreloads(outdir, metafile);
 
-    expect(critical).toEqual(["chunk-real.js"]);
+    expect(critical).toEqual(["chunk-a.js", "chunk-b.js", "chunk-shared.js"]);
   });
 
-  it("visits shared chunks once", async () => {
-    await write(
-      "index.js",
-      'import"/chunk-a.js";import"/chunk-b.js";import("/chunk-boot.js");',
-    );
-    await write("chunk-a.js", 'import{x}from"/chunk-shared.js";');
-    await write("chunk-b.js", 'import{x}from"/chunk-shared.js";');
-    await write("chunk-boot.js", 'import{x}from"/chunk-shared.js";');
-    await write("chunk-shared.js", "export var x=1;");
-    await write("index.html", HTML);
-
-    const critical = await injectModulePreloads(outdir);
-
-    expect(critical).toEqual([
-      "chunk-a.js",
-      "chunk-b.js",
-      "chunk-boot.js",
-      "chunk-shared.js",
-    ]);
-  });
-
-  it("injects at the real end of head, not inside a comment mentioning the tag", async () => {
-    await write("index.js", 'import"/chunk-a.js";');
-    await write("chunk-a.js", "export var a=1;");
-    await write(
-      "index.html",
-      `<!doctype html>
+  it("injects inside head even when a comment contains the closing tag text", async () => {
+    await writeHtml(`<!doctype html>
 <html>
   <head>
     <!-- links are injected before </head> -->
   </head>
   <body></body>
 </html>
-`,
-    );
+`);
+    const metafile = {
+      outputs: {
+        "./index.js": {
+          entryPoint: "src/index.tsx",
+          imports: [staticImport("./chunk-a.js")],
+        },
+        "./chunk-a.js": { imports: [] },
+      },
+    };
 
-    await injectModulePreloads(outdir);
+    await injectModulePreloads(outdir, metafile);
 
-    const html = await Bun.file(path.join(outdir, "index.html")).text();
-    expect(html).toBe(`<!doctype html>
+    expect(await readHtml()).toBe(`<!doctype html>
 <html>
   <head>
     <!-- links are injected before </head> -->
     <link rel="modulepreload" href="/chunk-a.js" />
-  </head>
+</head>
   <body></body>
 </html>
 `);
   });
 
-  it("fails loudly when the walk finds no chunks", async () => {
-    await write("index.js", "console.log(1);");
-    await write("index.html", HTML);
+  it("fails loudly when the build passes no metafile", async () => {
+    await writeHtml(HTML);
 
-    expect(injectModulePreloads(outdir)).rejects.toThrow(
+    expect(injectModulePreloads(outdir, undefined)).rejects.toThrow("metafile");
+  });
+
+  it("fails loudly when the walk finds no chunks", async () => {
+    await writeHtml(HTML);
+    const metafile = {
+      outputs: {
+        "./index.js": { entryPoint: "src/index.tsx", imports: [] },
+      },
+    };
+
+    expect(injectModulePreloads(outdir, metafile)).rejects.toThrow(
       "No boot-critical chunks found",
     );
   });
 
-  it("fails loudly when index.html has no </head>", async () => {
-    await write("index.js", 'import"/chunk-a.js";');
-    await write("chunk-a.js", "export var a=1;");
-    await write("index.html", "<html><body></body></html>");
+  it("fails loudly when index.html has no head", async () => {
+    await writeHtml("<html><body></body></html>");
+    const metafile = {
+      outputs: {
+        "./index.js": {
+          entryPoint: "src/index.tsx",
+          imports: [staticImport("./chunk-a.js")],
+        },
+        "./chunk-a.js": { imports: [] },
+      },
+    };
 
-    expect(injectModulePreloads(outdir)).rejects.toThrow("</head>");
+    expect(injectModulePreloads(outdir, metafile)).rejects.toThrow("no <head>");
   });
 });

--- a/packages/web/src/__tests__/inject-module-preloads.test.ts
+++ b/packages/web/src/__tests__/inject-module-preloads.test.ts
@@ -1,0 +1,147 @@
+import { injectModulePreloads } from "../../inject-module-preloads";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const HTML = `<!doctype html>
+<html>
+  <head>
+    <link rel="stylesheet" href="/index.css" />
+  </head>
+  <body></body>
+</html>
+`;
+
+describe("injectModulePreloads", () => {
+  let outdir: string;
+
+  beforeEach(() => {
+    outdir = mkdtempSync(path.join(tmpdir(), "inject-preloads-"));
+  });
+
+  afterEach(() => {
+    rmSync(outdir, { recursive: true, force: true });
+  });
+
+  const write = (name: string, content: string) =>
+    Bun.write(path.join(outdir, name), content);
+
+  it("preloads the static closure plus the entry's boot dynamic import, excluding lazy chunks", async () => {
+    await write(
+      "index.js",
+      'import{a}from"/chunk-static.js";import("/chunk-boot.js").then(({bootstrapApp:b})=>b());',
+    );
+    await write("chunk-static.js", 'import"/chunk-deep.js";export var a=1;');
+    await write("chunk-deep.js", "export var d=1;");
+    await write(
+      "chunk-boot.js",
+      'import{s}from"/chunk-shared.js";var v=()=>import("/chunk-lazy.js");export var bootstrapApp=()=>s(v);',
+    );
+    await write("chunk-shared.js", "export var s=1;");
+    await write("chunk-lazy.js", "export var l=1;");
+    await write("index.html", HTML);
+
+    const critical = await injectModulePreloads(outdir);
+
+    expect(critical).toEqual([
+      "chunk-static.js",
+      "chunk-boot.js",
+      "chunk-deep.js",
+      "chunk-shared.js",
+    ]);
+    const html = await Bun.file(path.join(outdir, "index.html")).text();
+    expect(html).toBe(`<!doctype html>
+<html>
+  <head>
+    <link rel="stylesheet" href="/index.css" />
+    <link rel="modulepreload" href="/chunk-static.js" />
+    <link rel="modulepreload" href="/chunk-boot.js" />
+    <link rel="modulepreload" href="/chunk-deep.js" />
+    <link rel="modulepreload" href="/chunk-shared.js" />
+  </head>
+  <body></body>
+</html>
+`);
+  });
+
+  it("ignores import-shaped text that names no emitted file", async () => {
+    await write(
+      "index.js",
+      'import"/chunk-real.js";var msg="failed: import(\\"/chunk-ghost.js\\")";',
+    );
+    await write("chunk-real.js", "export var r=1;");
+    await write("index.html", HTML);
+
+    const critical = await injectModulePreloads(outdir);
+
+    expect(critical).toEqual(["chunk-real.js"]);
+  });
+
+  it("visits shared chunks once", async () => {
+    await write(
+      "index.js",
+      'import"/chunk-a.js";import"/chunk-b.js";import("/chunk-boot.js");',
+    );
+    await write("chunk-a.js", 'import{x}from"/chunk-shared.js";');
+    await write("chunk-b.js", 'import{x}from"/chunk-shared.js";');
+    await write("chunk-boot.js", 'import{x}from"/chunk-shared.js";');
+    await write("chunk-shared.js", "export var x=1;");
+    await write("index.html", HTML);
+
+    const critical = await injectModulePreloads(outdir);
+
+    expect(critical).toEqual([
+      "chunk-a.js",
+      "chunk-b.js",
+      "chunk-boot.js",
+      "chunk-shared.js",
+    ]);
+  });
+
+  it("injects at the real end of head, not inside a comment mentioning the tag", async () => {
+    await write("index.js", 'import"/chunk-a.js";');
+    await write("chunk-a.js", "export var a=1;");
+    await write(
+      "index.html",
+      `<!doctype html>
+<html>
+  <head>
+    <!-- links are injected before </head> -->
+  </head>
+  <body></body>
+</html>
+`,
+    );
+
+    await injectModulePreloads(outdir);
+
+    const html = await Bun.file(path.join(outdir, "index.html")).text();
+    expect(html).toBe(`<!doctype html>
+<html>
+  <head>
+    <!-- links are injected before </head> -->
+    <link rel="modulepreload" href="/chunk-a.js" />
+  </head>
+  <body></body>
+</html>
+`);
+  });
+
+  it("fails loudly when the walk finds no chunks", async () => {
+    await write("index.js", "console.log(1);");
+    await write("index.html", HTML);
+
+    expect(injectModulePreloads(outdir)).rejects.toThrow(
+      "No boot-critical chunks found",
+    );
+  });
+
+  it("fails loudly when index.html has no </head>", async () => {
+    await write("index.js", 'import"/chunk-a.js";');
+    await write("chunk-a.js", "export var a=1;");
+    await write("index.html", "<html><body></body></html>");
+
+    expect(injectModulePreloads(outdir)).rejects.toThrow("</head>");
+  });
+});

--- a/packages/web/src/__tests__/inject-module-preloads.test.ts
+++ b/packages/web/src/__tests__/inject-module-preloads.test.ts
@@ -56,7 +56,7 @@ describe("injectModulePreloads", () => {
       },
     };
 
-    const critical = await injectModulePreloads(outdir, metafile);
+    const critical = await injectModulePreloads(outdir, metafile, []);
 
     expect(critical).toEqual([
       "chunk-static.js",
@@ -92,9 +92,61 @@ describe("injectModulePreloads", () => {
       },
     });
 
-    const critical = await injectModulePreloads(outdir, metafile);
+    const critical = await injectModulePreloads(outdir, metafile, []);
 
     expect(critical).toEqual(["chunk-a.js", "chunk-b.js", "chunk-shared.js"]);
+  });
+
+  it("preloads the chunk holding an always-boot source plus its static closure", async () => {
+    await writeHtml(HTML);
+    const metafile = {
+      outputs: {
+        "./index.js": {
+          entryPoint: "src/index.tsx",
+          imports: [staticImport("./chunk-boot.js")],
+        },
+        "./chunk-boot.js": {
+          imports: [dynamicImport("./chunk-rootshell.js")],
+        },
+        "./chunk-rootshell.js": {
+          // Input keys are cwd-relative in real builds; matched by suffix.
+          inputs: { "packages/web/src/components/RootShell/RootShell.tsx": {} },
+          imports: [
+            staticImport("./chunk-auth.js"),
+            dynamicImport("./chunk-lazy.js"),
+          ],
+        },
+        "./chunk-auth.js": { imports: [] },
+        "./chunk-lazy.js": { imports: [] },
+      },
+    };
+
+    const critical = await injectModulePreloads(outdir, metafile, [
+      "packages/web/src/components/RootShell/RootShell.tsx",
+    ]);
+
+    expect(critical).toEqual([
+      "chunk-rootshell.js",
+      "chunk-boot.js",
+      "chunk-auth.js",
+    ]);
+  });
+
+  it("fails loudly when an always-boot source is in no output", async () => {
+    await writeHtml(HTML);
+    const metafile = {
+      outputs: {
+        "./index.js": {
+          entryPoint: "src/index.tsx",
+          imports: [staticImport("./chunk-a.js")],
+        },
+        "./chunk-a.js": { imports: [] },
+      },
+    };
+
+    expect(
+      injectModulePreloads(outdir, metafile, ["packages/web/src/Gone.tsx"]),
+    ).rejects.toThrow("Always-boot source");
   });
 
   it("injects inside head even when a comment contains the closing tag text", async () => {
@@ -116,7 +168,7 @@ describe("injectModulePreloads", () => {
       },
     };
 
-    await injectModulePreloads(outdir, metafile);
+    await injectModulePreloads(outdir, metafile, []);
 
     expect(await readHtml()).toBe(`<!doctype html>
 <html>
@@ -143,7 +195,7 @@ describe("injectModulePreloads", () => {
       },
     };
 
-    expect(injectModulePreloads(outdir, metafile)).rejects.toThrow(
+    expect(injectModulePreloads(outdir, metafile, [])).rejects.toThrow(
       "No boot-critical chunks found",
     );
   });
@@ -160,6 +212,8 @@ describe("injectModulePreloads", () => {
       },
     };
 
-    expect(injectModulePreloads(outdir, metafile)).rejects.toThrow("no <head>");
+    expect(injectModulePreloads(outdir, metafile, [])).rejects.toThrow(
+      "no <head>",
+    );
   });
 });

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -106,9 +106,7 @@
       copy-static-assets.ts asserts both exist at build time.
 
       The built copy of this file additionally gets modulepreload links for
-      every boot-critical chunk, injected at the end of head by
-      inject-module-preloads.ts. (Don't write a literal closing head tag in
-      this comment: the injector anchors on the first one it finds.)
+      every boot-critical chunk, appended to head by inject-module-preloads.ts.
     -->
     <link rel="stylesheet" href="/index.css" />
   </head>

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -104,6 +104,11 @@
       Bun names the src/index.tsx entrypoint's outputs after the entry file
       (/index.js + /index.css), so this file can reference them statically.
       copy-static-assets.ts asserts both exist at build time.
+
+      The built copy of this file additionally gets modulepreload links for
+      every boot-critical chunk, injected at the end of head by
+      inject-module-preloads.ts. (Don't write a literal closing head tag in
+      this comment: the injector anchors on the first one it finds.)
     -->
     <link rel="stylesheet" href="/index.css" />
   </head>


### PR DESCRIPTION
## What

At build time, after `Bun.build` completes, compute the boot-critical chunk set from the build's metafile and inject `<link rel="modulepreload">` tags for it into the built `index.html` (new `packages/web/inject-module-preloads.ts`, called from `build.ts` right after `copyStaticAssets`).

## Why

The app loads through a 3+ level discovery waterfall: `index.html` references only `/index.js` (~836 bytes), which statically imports 5 chunks, then dynamically imports the app.bootstrap chunk, which statically imports ~25 more (react-dom, rrule, supertokens...). The browser discovers each level only after downloading the previous one, costing a round-trip per level - a contributor to slow production LCP.

## How

- `Bun.build({ metafile: true })` exposes each output's imports with static/dynamic kinds; BFS from the entry follows static imports everywhere plus the entry's own dynamic imports (its lone dynamic import is app.bootstrap, which always executes on boot). Dynamic imports in deeper chunks are the lazy route views and are not followed.
- Exception: `ALWAYS_BOOT_SOURCES` lists source files that are dynamically imported yet still run on every boot - currently RootShell, the root route's component (lazy only so route-shape tests can mock its auth stack), which renders on every page load including 404s. Each listed source resolves to its containing chunk via the metafile's per-output `inputs` and is seeded as an extra BFS root; resolution failure fails the build loudly so a rename can't silently drop the preload.
- Links are injected with Bun's built-in `HTMLRewriter` targeting the parsed `head` element - structurally immune to closing-tag text inside HTML comments.
- On the current build: **40 of 59 chunks preloaded**; no lazy route chunk is preloaded.

## Review process

- 4-angle simplify pass (reuse/simplification/efficiency/altitude) found the original regex-based import parsing re-derived data `metafile: true` already provides - rewritten (commit 9d035e9b7).
- Independent correctness review confirmed one finding: the RootShell/AuthModal subgraph loads on every boot but was excluded by the entry-only dynamic rule - fixed with the allowlist (commit c5017e780), verified by the AuthModal-string-bearing chunk appearing in the preload list.

## Verification

- 8 unit tests (`packages/web/src/__tests__/inject-module-preloads.test.ts`), type-check and biome clean.
- Served the real build and measured with the Resource Timing API: without preloads, boot chunks start in 4 discovery levels spanning ~300ms even at localhost RTT; with preloads, all 40 boot chunks start simultaneously (~8ms after HTML), initiated by the preload scanner; lazy chunks still load on demand.
- Perf-budget Lighthouse gate green locally and in CI (LCP ~1.9s vs 3s budget, script transfer unchanged - same bytes, better scheduling). A stripped-baseline A/B showed the lab LCP delta is within run variance: Lantern's fixed 40ms RTT barely exercises the waterfall, so the win scales with real network latency, which is where production LCP suffers.

Also adds a "Web build (static)" launch.json entry for serving the production build locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
