### PR TITLE
fix(self-host): serve web assets with proper cache headers

### DIFF
--- a/self-host/serve-web.ts
+++ b/self-host/serve-web.ts
@@ -62,18 +62,14 @@ async function fileResponse(
     return null;
   }
 
-  const headers = new Headers();
   const type = contentType(filePath);
-
-  if (type) {
-    headers.set("Content-Type", type);
-  }
-
   const etag = `"${fileStat.size.toString(16)}-${fileStat.mtimeMs.toString(16)}"`;
-
-  headers.set("Cache-Control", cacheControl(resolvedFilePath));
-  headers.set("ETag", etag);
-  headers.set("Last-Modified", fileStat.mtime.toUTCString());
+  const headers = {
+    ...(type ? { "Content-Type": type } : {}),
+    "Cache-Control": cacheControl(resolvedFilePath),
+    ETag: etag,
+    "Last-Modified": fileStat.mtime.toUTCString(),
+  };
 
   if (isNotModified(request, etag, fileStat.mtimeMs)) {
     return new Response(null, { status: 304, headers });
@@ -99,9 +95,7 @@ function isNotModified(
   const ifNoneMatch = request.headers.get("if-none-match");
 
   if (ifNoneMatch !== null) {
-    return ifNoneMatch
-      .split(",")
-      .some((tag) => tag.trim().replace(/^W\//, "") === etag);
+    return ifNoneMatch.trim().replace(/^W\//, "") === etag;
   }
 
   const ifModifiedSince = Date.parse(

--- a/self-host/serve-web.ts
+++ b/self-host/serve-web.ts
@@ -1,3 +1,4 @@
+import { type Stats } from "node:fs";
 import { realpath, stat } from "node:fs/promises";
 import path from "node:path";
 
@@ -22,15 +23,28 @@ function badRequest(): Response {
   return new Response("Bad Request", { status: 400 });
 }
 
+function cacheControl(filePath: string): string {
+  // Only Bun's split chunks (chunk-<hash>.js and their .js.map) are
+  // content-hashed, so their URLs change with their content. Everything else
+  // keeps a stable name across deploys while its content changes — including
+  // index.js, index.css, and index.js.map — and must revalidate via the
+  // ETag/Last-Modified sent below.
+  return path.basename(filePath).startsWith("chunk-")
+    ? "public, max-age=31536000, immutable"
+    : "no-cache";
+}
+
 function contentType(filePath: string): string | undefined {
   return textTypes[path.extname(filePath)];
 }
 
 async function fileResponse(
+  request: Request,
   filePath: string,
   resolvedRoot: string,
 ): Promise<Response | null> {
   let resolvedFilePath: string;
+  let fileStat: Stats;
 
   try {
     resolvedFilePath = await realpath(filePath);
@@ -39,19 +53,33 @@ async function fileResponse(
       return null;
     }
 
-    if (!(await stat(resolvedFilePath)).isFile()) {
+    fileStat = await stat(resolvedFilePath);
+
+    if (!fileStat.isFile()) {
       return null;
     }
   } catch {
     return null;
   }
 
-  const file = Bun.file(resolvedFilePath);
+  const headers = new Headers();
   const type = contentType(filePath);
 
-  return new Response(file, {
-    headers: type ? { "Content-Type": type } : {},
-  });
+  if (type) {
+    headers.set("Content-Type", type);
+  }
+
+  const etag = `"${fileStat.size.toString(16)}-${fileStat.mtimeMs.toString(16)}"`;
+
+  headers.set("Cache-Control", cacheControl(resolvedFilePath));
+  headers.set("ETag", etag);
+  headers.set("Last-Modified", fileStat.mtime.toUTCString());
+
+  if (isNotModified(request, etag, fileStat.mtimeMs)) {
+    return new Response(null, { status: 304, headers });
+  }
+
+  return new Response(Bun.file(resolvedFilePath), { headers });
 }
 
 function isInsideRoot(resolvedRoot: string, resolvedPath: string): boolean {
@@ -60,6 +88,30 @@ function isInsideRoot(resolvedRoot: string, resolvedPath: string): boolean {
   return (
     relativePath === "" ||
     (!relativePath.startsWith("..") && !path.isAbsolute(relativePath))
+  );
+}
+
+function isNotModified(
+  request: Request,
+  etag: string,
+  mtimeMs: number,
+): boolean {
+  const ifNoneMatch = request.headers.get("if-none-match");
+
+  if (ifNoneMatch !== null) {
+    return ifNoneMatch
+      .split(",")
+      .some((tag) => tag.trim().replace(/^W\//, "") === etag);
+  }
+
+  const ifModifiedSince = Date.parse(
+    request.headers.get("if-modified-since") ?? "",
+  );
+
+  // HTTP dates carry whole seconds, so compare mtime at second precision.
+  return (
+    !Number.isNaN(ifModifiedSince) &&
+    Math.floor(mtimeMs / 1000) * 1000 <= ifModifiedSince
   );
 }
 
@@ -122,6 +174,7 @@ Bun.serve({
     }
 
     const indexResponse = await fileResponse(
+      request,
       path.join(root, "index.html"),
       resolvedRoot,
     );
@@ -131,7 +184,11 @@ Bun.serve({
     }
 
     const requestedPath = path.join(root, safePath || "index.html");
-    const staticResponse = await fileResponse(requestedPath, resolvedRoot);
+    const staticResponse = await fileResponse(
+      request,
+      requestedPath,
+      resolvedRoot,
+    );
 
     if (staticResponse) {
       return staticResponse;


### PR DESCRIPTION
## Summary
- Bun's content-hashed split chunks (`chunk-*.js`, `chunk-*.js.map`) now get `Cache-Control: public, max-age=31536000, immutable` — verified against actual `Bun.build()` output that the `chunk-` filename prefix corresponds exactly to Bun's own `kind: "chunk"` / chunk sourcemaps (zero mismatches either direction).
- Stable-named mutable files (`index.html`, `index.js`, `index.css`, `index.js.map`, `version.json`, favicon, other copied static assets, and the SPA fallback) get `Cache-Control: no-cache` plus an `ETag` and `Last-Modified`, so revisits revalidate with a cheap 304 instead of re-downloading the ~1.1MB bundle.
- Fixes the #1 root cause identified in the LCP investigation: assets were served with zero caching headers, forcing full re-downloads on every visit once the browser's heuristic cache expired.

## Test plan
- [x] `bun run type-check` and `biome check self-host/serve-web.ts` pass
- [x] Manual curl verification against a real build root: chunk files → immutable; stable files → `no-cache` + ETag/Last-Modified; matching `If-None-Match` → 304 empty body; stale etag → 200; `If-Modified-Since` fresh/stale → 304/200; 404 and SPA fallback unchanged
- [x] Confirmed via `Bun.build()` inspection that `kind: "chunk"`/`"sourcemap"` outputs are exactly the `chunk-*` prefixed files, with `index.js.map` correctly excluded (stable name, changes every deploy)
- [x] `.github/workflows/perf-budget.yml` path filters don't include `self-host/**` and it serves via `npx serve`, not `serve-web.ts`, so it's unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)