### PR TITLE
Jump event-form fields with Mod+digit, hint chips on hold

### DIFF
--- a/packages/web/src/common/utils/form/form.util.ts
+++ b/packages/web/src/common/utils/form/form.util.ts
@@ -19,59 +19,63 @@ const queryEventFormElement = <T extends Element>(selector: string): T | null =>
 export const getEventFormElement = (): HTMLElement | null =>
   queryEventFormElement<HTMLElement>(EVENT_FORM_SELECTOR);
 
-const focusFirstMatch = (selectors: string[]) => {
+const findFirstMatch = (selectors: string[]): HTMLElement | null => {
   for (const selector of selectors) {
     const element = queryEventFormElement<HTMLElement>(selector);
     if (element) {
-      element.focus();
-      return true;
+      return element;
     }
   }
-  return false;
+  return null;
 };
+
+/** Per-field fallback selectors, in priority order. */
+const FIELD_SELECTORS: Record<EventFormFocusField, string[]> = {
+  title: [`${EVENT_FORM_SELECTOR} input[name="Event Title"]`],
+  location: [
+    `${EVENT_FORM_SELECTOR} #event-form-location`,
+    `${EVENT_FORM_SELECTOR} input[name="Event Location"]`,
+  ],
+  description: [`#event-form-description`],
+  // Timed events expose a start-time combobox; all-day uses the date input.
+  start: [
+    `${EVENT_FORM_SELECTOR} #startTimePicker`,
+    `${EVENT_FORM_SELECTOR} input[title="Pick Start Date"]`,
+  ],
+  end: [
+    `${EVENT_FORM_SELECTOR} #endTimePicker`,
+    `${EVENT_FORM_SELECTOR} input[title="Pick End Date"]`,
+  ],
+  recurrence: [
+    `${EVENT_FORM_SELECTOR} #event-form-recurrence button[aria-label="Edit recurrence"]`,
+    `${EVENT_FORM_SELECTOR} #event-form-recurrence button[aria-label="Repeat"]`,
+  ],
+  calendar: [`#event-form-calendar`],
+  // Prefer the selected swatch so arrow keys move from the current color.
+  color: [
+    `#event-form-color input[type="radio"]:checked`,
+    `#event-form-color input[type="radio"]`,
+  ],
+};
+
+/**
+ * The element a field jump would focus, or null if the field isn't currently
+ * rendered (e.g. the calendar picker on an edit draft). Used both to focus
+ * and to anchor hint chips to the same target.
+ */
+export const getEventFormFieldElement = (
+  field: EventFormFocusField,
+): HTMLElement | null => findFirstMatch(FIELD_SELECTORS[field]);
 
 /**
  * Focus a field inside the docked event form. The grid card and sidebar form
  * live in separate trees, so sequence shortcuts hop via the DOM.
  */
 export const focusEventFormField = (field: EventFormFocusField): boolean => {
-  switch (field) {
-    case "title":
-      return focusFirstMatch([
-        `${EVENT_FORM_SELECTOR} input[name="Event Title"]`,
-      ]);
-    case "location":
-      return focusFirstMatch([
-        `${EVENT_FORM_SELECTOR} #event-form-location`,
-        `${EVENT_FORM_SELECTOR} input[name="Event Location"]`,
-      ]);
-    case "description":
-      return focusFirstMatch([`#event-form-description`]);
-    case "start":
-      // Timed events expose a start-time combobox; all-day uses the date input.
-      return focusFirstMatch([
-        `${EVENT_FORM_SELECTOR} #startTimePicker`,
-        `${EVENT_FORM_SELECTOR} input[title="Pick Start Date"]`,
-      ]);
-    case "end":
-      return focusFirstMatch([
-        `${EVENT_FORM_SELECTOR} #endTimePicker`,
-        `${EVENT_FORM_SELECTOR} input[title="Pick End Date"]`,
-      ]);
-    case "recurrence":
-      return focusFirstMatch([
-        `${EVENT_FORM_SELECTOR} #event-form-recurrence button[aria-label="Edit recurrence"]`,
-        `${EVENT_FORM_SELECTOR} #event-form-recurrence button[aria-label="Repeat"]`,
-      ]);
-    case "calendar":
-      return focusFirstMatch([`#event-form-calendar`]);
-    case "color":
-      // Prefer the selected swatch so arrow keys move from the current color.
-      return focusFirstMatch([
-        `#event-form-color input[type="radio"]:checked`,
-        `#event-form-color input[type="radio"]`,
-      ]);
-  }
+  const element = getEventFormFieldElement(field);
+  if (!element) return false;
+  element.focus();
+  return true;
 };
 
 // The grid draft card and the sidebar-docked form live in separate component

--- a/packages/web/src/shortcuts/digit-pick.util.test.ts
+++ b/packages/web/src/shortcuts/digit-pick.util.test.ts
@@ -1,4 +1,7 @@
-import { digitPickIndex } from "@web/shortcuts/digit-pick.util";
+import {
+  digitPickIndex,
+  physicalDigitIndex,
+} from "@web/shortcuts/digit-pick.util";
 import { describe, expect, it } from "bun:test";
 
 const event = (
@@ -42,5 +45,22 @@ describe("digitPickIndex", () => {
     expect(
       digitPickIndex(event({ code: "ArrowRight", key: "ArrowRight" })),
     ).toBeNull();
+  });
+});
+
+describe("physicalDigitIndex", () => {
+  it("matches the physical top row and numpad fallback like digitPickIndex", () => {
+    expect(physicalDigitIndex(event({ code: "Digit1", key: "1" }))).toBe(0);
+    expect(physicalDigitIndex(event({ code: "Numpad3", key: "3" }))).toBe(2);
+    expect(physicalDigitIndex(event({ code: "KeyA", key: "a" }))).toBeNull();
+  });
+
+  it("ignores modifiers, unlike digitPickIndex", () => {
+    expect(physicalDigitIndex(event({ code: "Digit1", metaKey: true }))).toBe(
+      0,
+    );
+    expect(physicalDigitIndex(event({ code: "Digit1", ctrlKey: true }))).toBe(
+      0,
+    );
   });
 });

--- a/packages/web/src/shortcuts/digit-pick.util.ts
+++ b/packages/web/src/shortcuts/digit-pick.util.ts
@@ -44,6 +44,21 @@ const KEY_FALLBACK_INDEX: Record<string, number> = Object.fromEntries(
 );
 
 /**
+ * Resolves a keydown to a 0-based physical-key index, modifier-agnostic.
+ * `event.code` is layout-independent, so this also backs Mod+digit form-field
+ * jumps (`useFormDigitJumpShortcut`), not just the bare-digit pickers below.
+ */
+export function physicalDigitIndex(
+  event: Pick<KeyboardEvent, "code" | "key">,
+): number | null {
+  const codeIndex = PICK_CODES.indexOf(event.code);
+  if (codeIndex !== -1) return codeIndex;
+
+  const keyIndex = KEY_FALLBACK_INDEX[event.key];
+  return keyIndex === undefined ? null : keyIndex;
+}
+
+/**
  * Resolves a keydown to a 0-based pick index for direct-select widgets (the
  * event color picker, calendar select). Returns null for anything else,
  * including Ctrl/Meta/Alt combos (browser tab switching, macOS symbols).
@@ -54,9 +69,5 @@ export function digitPickIndex(
 ): number | null {
   if (event.ctrlKey || event.metaKey || event.altKey) return null;
 
-  const codeIndex = PICK_CODES.indexOf(event.code);
-  if (codeIndex !== -1) return codeIndex;
-
-  const keyIndex = KEY_FALLBACK_INDEX[event.key];
-  return keyIndex === undefined ? null : keyIndex;
+  return physicalDigitIndex(event);
 }

--- a/packages/web/src/shortcuts/edit-sequence/edit-sequence.fields.test.ts
+++ b/packages/web/src/shortcuts/edit-sequence/edit-sequence.fields.test.ts
@@ -1,0 +1,42 @@
+import {
+  EDIT_SEQUENCE_FIELD_BY_DIGIT,
+  EDIT_SEQUENCE_FIELDS,
+  FORM_FIELD_DIGITS,
+} from "@web/shortcuts/edit-sequence/edit-sequence.fields";
+import { describe, expect, it } from "bun:test";
+
+describe("edit-sequence.fields", () => {
+  it("assigns a unique digit 1-8 to every field", () => {
+    const digits = EDIT_SEQUENCE_FIELDS.map((entry) => entry.digit);
+    expect([...digits].sort()).toEqual([
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "8",
+    ]);
+    expect(new Set(digits).size).toBe(digits.length);
+  });
+
+  it("orders FORM_FIELD_DIGITS to match the form's DOM order", () => {
+    expect(FORM_FIELD_DIGITS.map((entry) => entry.field)).toEqual([
+      "title",
+      "start",
+      "end",
+      "recurrence",
+      "calendar",
+      "color",
+      "location",
+      "description",
+    ]);
+  });
+
+  it("maps every digit back to its field for dispatch", () => {
+    for (const entry of EDIT_SEQUENCE_FIELDS) {
+      expect(EDIT_SEQUENCE_FIELD_BY_DIGIT[entry.digit]).toBe(entry.field);
+    }
+  });
+});

--- a/packages/web/src/shortcuts/edit-sequence/edit-sequence.fields.ts
+++ b/packages/web/src/shortcuts/edit-sequence/edit-sequence.fields.ts
@@ -8,27 +8,45 @@ import { type EventFormFocusField } from "@web/common/utils/form/form.util";
  * Data-only on purpose. The legend registry imports it, and pulling React or
  * the hotkeys runtime into that module would be a regression.
  */
+// `digit` is the field's Mod+digit jump shortcut, assigned in the form's DOM
+// order (title → schedule → recurrence → calendar → color → location →
+// description) so the mapping is guessable without the hold-Mod hint chips.
+// The array itself keeps its original key-taught order (unrelated to digit
+// order) since EditSequenceMenu renders straight off this order.
 export const EDIT_SEQUENCE_FIELDS = [
-  { key: "t", field: "title", label: "Title" },
-  { key: "l", field: "location", label: "Location" },
-  { key: "d", field: "description", label: "Description" },
-  { key: "s", field: "start", label: "Start time" },
-  { key: "e", field: "end", label: "End time" },
-  { key: "r", field: "recurrence", label: "Recurrence" },
+  { key: "t", field: "title", label: "Title", digit: "1" },
+  { key: "l", field: "location", label: "Location", digit: "7" },
+  { key: "d", field: "description", label: "Description", digit: "8" },
+  { key: "s", field: "start", label: "Start time", digit: "2" },
+  { key: "e", field: "end", label: "End time", digit: "3" },
+  { key: "r", field: "recurrence", label: "Recurrence", digit: "4" },
   // `a` = account: the calendar picker chooses which calendar/account hosts
   // the event. `c` = color, so the letter matches the field name users reach for.
-  { key: "a", field: "calendar", label: "Account" },
-  { key: "c", field: "color", label: "Color" },
+  { key: "a", field: "calendar", label: "Account", digit: "5" },
+  { key: "c", field: "color", label: "Color", digit: "6" },
 ] as const satisfies readonly {
   key: string;
   field: EventFormFocusField;
   label: string;
+  digit: string;
 }[];
 
 export type EditSequenceSecondKey =
   (typeof EDIT_SEQUENCE_FIELDS)[number]["key"];
 
+export type EditSequenceDigit = (typeof EDIT_SEQUENCE_FIELDS)[number]["digit"];
+
 /** Second key → form field, for dispatch. */
 export const EDIT_SEQUENCE_FIELD_BY_KEY = Object.fromEntries(
   EDIT_SEQUENCE_FIELDS.map(({ key, field }) => [key, field]),
 ) as Record<EditSequenceSecondKey, EventFormFocusField>;
+
+/** Digit → form field, for Mod+digit dispatch. */
+export const EDIT_SEQUENCE_FIELD_BY_DIGIT = Object.fromEntries(
+  EDIT_SEQUENCE_FIELDS.map(({ digit, field }) => [digit, field]),
+) as Record<EditSequenceDigit, EventFormFocusField>;
+
+/** Digit-ascending view of the same table, i.e. the form's DOM order. */
+export const FORM_FIELD_DIGITS = [...EDIT_SEQUENCE_FIELDS].sort(
+  (a, b) => Number(a.digit) - Number(b.digit),
+);

--- a/packages/web/src/shortcuts/form-digit-jump/FormDigitHintOverlay.test.tsx
+++ b/packages/web/src/shortcuts/form-digit-jump/FormDigitHintOverlay.test.tsx
@@ -157,4 +157,13 @@ describe("FormDigitHintOverlay", () => {
     expect(status.textContent).toContain("8 for description");
     expect(chipsWrapper()?.getAttribute("aria-hidden")).not.toBeNull();
   });
+
+  it("does not announce a field with no chip, so the screen-reader summary never advertises a dead shortcut", () => {
+    buildForm();
+    render(<FormDigitHintOverlay visible={true} />);
+
+    // No #event-form-calendar element was added (edit-draft state), so digit
+    // 5 has neither a chip nor an announcement.
+    expect(screen.getByRole("status").textContent).not.toContain("calendar");
+  });
 });

--- a/packages/web/src/shortcuts/form-digit-jump/FormDigitHintOverlay.test.tsx
+++ b/packages/web/src/shortcuts/form-digit-jump/FormDigitHintOverlay.test.tsx
@@ -1,0 +1,160 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { FormDigitHintOverlay } from "@web/shortcuts/form-digit-jump/FormDigitHintOverlay";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+const box = (
+  top: number,
+  left: number,
+  bottom: number,
+  right: number,
+): DOMRect =>
+  ({
+    top,
+    left,
+    bottom,
+    right,
+    width: right - left,
+    height: bottom - top,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  }) as DOMRect;
+
+const stubRect = (element: HTMLElement, rect: DOMRect) => {
+  element.getBoundingClientRect = () => rect;
+};
+
+const overlayRoot = () => document.querySelector("[data-form-digit-hints]");
+const chipsWrapper = () => overlayRoot()?.querySelector("[aria-hidden]");
+const chipDigits = () =>
+  Array.from(chipsWrapper()?.children ?? []).map((el) => el.textContent);
+
+/**
+ * Builds a minimal event-form DOM matching the real selectors
+ * (`common/utils/form/form.util.ts`'s FIELD_SELECTORS) for every field except
+ * calendar, which callers add separately to test its conditional absence.
+ */
+const buildForm = () => {
+  const form = document.createElement("form");
+  form.setAttribute("name", "Event Form");
+  document.body.append(form);
+
+  const title = document.createElement("input");
+  title.setAttribute("name", "Event Title");
+  form.append(title);
+
+  const start = document.createElement("input");
+  start.id = "startTimePicker";
+  form.append(start);
+
+  const end = document.createElement("input");
+  end.id = "endTimePicker";
+  form.append(end);
+
+  const recurrence = document.createElement("div");
+  recurrence.id = "event-form-recurrence";
+  const recurrenceButton = document.createElement("button");
+  recurrenceButton.setAttribute("aria-label", "Edit recurrence");
+  recurrence.append(recurrenceButton);
+  form.append(recurrence);
+
+  const color = document.createElement("div");
+  color.id = "event-form-color";
+  const radio = document.createElement("input");
+  radio.type = "radio";
+  color.append(radio);
+  document.body.append(color);
+
+  const location = document.createElement("div");
+  location.id = "event-form-location";
+  form.append(location);
+
+  const description = document.createElement("div");
+  description.id = "event-form-description";
+  document.body.append(description);
+
+  const elements = [
+    title,
+    start,
+    end,
+    recurrenceButton,
+    radio,
+    location,
+    description,
+  ];
+  for (const element of elements) {
+    stubRect(element, box(100, 80, 140, 240));
+  }
+
+  return { form };
+};
+
+describe("FormDigitHintOverlay", () => {
+  let originalInnerHeight: number;
+  let originalInnerWidth: number;
+
+  beforeEach(() => {
+    originalInnerHeight = window.innerHeight;
+    originalInnerWidth = window.innerWidth;
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 800,
+    });
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1200,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    document.body.replaceChildren();
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: originalInnerHeight,
+    });
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: originalInnerWidth,
+    });
+  });
+
+  it("renders nothing when not visible", () => {
+    buildForm();
+    render(<FormDigitHintOverlay visible={false} />);
+
+    expect(overlayRoot()).toBeNull();
+  });
+
+  it("renders a chip for every present field except the missing calendar picker", () => {
+    buildForm();
+    render(<FormDigitHintOverlay visible={true} />);
+
+    // Digit 5 (calendar) has no chip: no #event-form-calendar element was added,
+    // matching an edit draft where the calendar picker isn't rendered.
+    expect(chipDigits()).toEqual(["1", "2", "3", "4", "6", "7", "8"]);
+  });
+
+  it("renders the calendar chip once the picker is present", () => {
+    buildForm();
+    const calendar = document.createElement("div");
+    calendar.id = "event-form-calendar";
+    stubRect(calendar, box(100, 80, 140, 240));
+    document.body.append(calendar);
+
+    render(<FormDigitHintOverlay visible={true} />);
+
+    expect(chipDigits()).toEqual(["1", "2", "3", "4", "5", "6", "7", "8"]);
+  });
+
+  it("exposes a screen-reader summary while the visible chips stay aria-hidden", () => {
+    buildForm();
+    render(<FormDigitHintOverlay visible={true} />);
+
+    const status = screen.getByRole("status");
+    expect(status.textContent).toContain("Jump to field?");
+    expect(status.textContent).toContain("1 for title");
+    expect(status.textContent).toContain("8 for description");
+    expect(chipsWrapper()?.getAttribute("aria-hidden")).not.toBeNull();
+  });
+});

--- a/packages/web/src/shortcuts/form-digit-jump/FormDigitHintOverlay.tsx
+++ b/packages/web/src/shortcuts/form-digit-jump/FormDigitHintOverlay.tsx
@@ -1,15 +1,10 @@
-import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { Z_INDEX_TOOLTIP } from "@web/common/constants/web.constants";
 import { getEventFormFieldElement } from "@web/common/utils/form/form.util";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 import { FORM_FIELD_DIGITS } from "@web/shortcuts/edit-sequence/edit-sequence.fields";
 import { getVisibleHintRect } from "@web/shortcuts/shift-hint/shift-hint-visible-rect";
-
-/** Screen-reader copy, so the visible chips can stay aria-hidden. */
-const SR_TEXT = `Jump to field? ${FORM_FIELD_DIGITS.map(
-  (entry) => `${entry.digit} for ${entry.label.toLowerCase()}`,
-).join(", ")}. Release the modifier to dismiss.`;
+import { useHintLayoutRefresh } from "@web/shortcuts/useHintLayoutRefresh";
 
 /**
  * Numbered keycap chips anchored next to each form field while Mod is held
@@ -17,24 +12,23 @@ const SR_TEXT = `Jump to field? ${FORM_FIELD_DIGITS.map(
  * scrollable form body cannot clip a chip on a field near its edge.
  */
 export function FormDigitHintOverlay({ visible }: { visible: boolean }) {
-  const [, setLayoutTick] = useState(0);
-
-  useEffect(() => {
-    if (!visible) return;
-
-    const refresh = () => setLayoutTick((tick) => tick + 1);
-    window.addEventListener("resize", refresh);
-    // Capture scroll from the form's own scrollable body.
-    window.addEventListener("scroll", refresh, true);
-    return () => {
-      window.removeEventListener("resize", refresh);
-      window.removeEventListener("scroll", refresh, true);
-    };
-  }, [visible]);
+  useHintLayoutRefresh(visible);
 
   if (!visible || typeof document === "undefined") {
     return null;
   }
+
+  // Only fields whose element is currently rendered get announced or
+  // chipped, e.g. the calendar picker (digit 5) isn't rendered on an edit
+  // draft, so the shortcut wouldn't do anything there.
+  const presentFields = FORM_FIELD_DIGITS.flatMap((entry) => {
+    const anchor = getEventFormFieldElement(entry.field);
+    return anchor ? [{ ...entry, anchor }] : [];
+  });
+
+  const srText = `Jump to field? ${presentFields
+    .map((entry) => `${entry.digit} for ${entry.label.toLowerCase()}`)
+    .join(", ")}. Release the modifier to dismiss.`;
 
   return createPortal(
     <div
@@ -43,18 +37,14 @@ export function FormDigitHintOverlay({ visible }: { visible: boolean }) {
       style={{ zIndex: Z_INDEX_TOOLTIP }}
     >
       <span aria-live="polite" className="sr-only" role="status">
-        {SR_TEXT}
+        {srText}
       </span>
       <div aria-hidden>
-        {FORM_FIELD_DIGITS.map((entry) => {
-          const anchor = getEventFormFieldElement(entry.field);
-          if (!anchor) {
-            // e.g. the calendar picker (digit 5) on an edit draft.
-            return null;
-          }
-
-          const visibleRect = getVisibleHintRect(anchor);
+        {presentFields.map((entry) => {
+          const visibleRect = getVisibleHintRect(entry.anchor);
           if (!visibleRect) {
+            // Scrolled out of view; the shortcut still works, but a
+            // portaled chip with nothing to anchor to would float in place.
             return null;
           }
 

--- a/packages/web/src/shortcuts/form-digit-jump/FormDigitHintOverlay.tsx
+++ b/packages/web/src/shortcuts/form-digit-jump/FormDigitHintOverlay.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { Z_INDEX_TOOLTIP } from "@web/common/constants/web.constants";
+import { getEventFormFieldElement } from "@web/common/utils/form/form.util";
+import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
+import { FORM_FIELD_DIGITS } from "@web/shortcuts/edit-sequence/edit-sequence.fields";
+import { getVisibleHintRect } from "@web/shortcuts/shift-hint/shift-hint-visible-rect";
+
+/** Screen-reader copy, so the visible chips can stay aria-hidden. */
+const SR_TEXT = `Jump to field? ${FORM_FIELD_DIGITS.map(
+  (entry) => `${entry.digit} for ${entry.label.toLowerCase()}`,
+).join(", ")}. Release the modifier to dismiss.`;
+
+/**
+ * Numbered keycap chips anchored next to each form field while Mod is held
+ * (see useFormDigitJumpShortcut). Portaled like ShiftHintOverlay so the
+ * scrollable form body cannot clip a chip on a field near its edge.
+ */
+export function FormDigitHintOverlay({ visible }: { visible: boolean }) {
+  const [, setLayoutTick] = useState(0);
+
+  useEffect(() => {
+    if (!visible) return;
+
+    const refresh = () => setLayoutTick((tick) => tick + 1);
+    window.addEventListener("resize", refresh);
+    // Capture scroll from the form's own scrollable body.
+    window.addEventListener("scroll", refresh, true);
+    return () => {
+      window.removeEventListener("resize", refresh);
+      window.removeEventListener("scroll", refresh, true);
+    };
+  }, [visible]);
+
+  if (!visible || typeof document === "undefined") {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      className="pointer-events-none fixed inset-0"
+      data-form-digit-hints=""
+      style={{ zIndex: Z_INDEX_TOOLTIP }}
+    >
+      <span aria-live="polite" className="sr-only" role="status">
+        {SR_TEXT}
+      </span>
+      <div aria-hidden>
+        {FORM_FIELD_DIGITS.map((entry) => {
+          const anchor = getEventFormFieldElement(entry.field);
+          if (!anchor) {
+            // e.g. the calendar picker (digit 5) on an edit draft.
+            return null;
+          }
+
+          const visibleRect = getVisibleHintRect(anchor);
+          if (!visibleRect) {
+            return null;
+          }
+
+          const chipWidth = 22;
+
+          return (
+            <span
+              key={entry.field}
+              className="absolute"
+              style={{
+                top: visibleRect.top + 2,
+                left: Math.max(4, visibleRect.right - chipWidth),
+              }}
+            >
+              <ShortcutHint>{entry.digit}</ShortcutHint>
+            </span>
+          );
+        })}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/packages/web/src/shortcuts/form-digit-jump/useFormDigitJumpShortcut.test.tsx
+++ b/packages/web/src/shortcuts/form-digit-jump/useFormDigitJumpShortcut.test.tsx
@@ -1,0 +1,245 @@
+import { resolveModifier } from "@tanstack/react-hotkeys";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { clearAppLockReasons, setAppLockReason } from "@web/shortcuts/app-lock";
+import {
+  MOD_HOLD_HINT_MS,
+  useFormDigitJumpShortcut,
+} from "@web/shortcuts/form-digit-jump/useFormDigitJumpShortcut";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+const focusEventFormField = mock((_field: string) => true);
+
+mock.module("@web/common/utils/form/form.util", () => ({
+  focusEventFormField,
+}));
+
+/** Matches what the hook resolves Mod to on this platform. */
+const isMac = resolveModifier("Mod") === "Meta";
+const MOD_KEY = isMac ? "Meta" : "Control";
+const MOD_INIT: KeyboardEventInit = isMac
+  ? { metaKey: true }
+  : { ctrlKey: true };
+
+const PAST_HOLD_MS = MOD_HOLD_HINT_MS + 150;
+const waitPastHold = () =>
+  new Promise((resolve) => setTimeout(resolve, PAST_HOLD_MS));
+
+const dispatch = (type: "keydown" | "keyup", init: KeyboardEventInit) => {
+  const event = new KeyboardEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    ...init,
+  });
+  document.dispatchEvent(event);
+  return event;
+};
+
+const pressModDown = ({ repeat = false }: { repeat?: boolean } = {}) =>
+  dispatch("keydown", { key: MOD_KEY, repeat, ...MOD_INIT });
+const releaseMod = () => dispatch("keyup", { key: MOD_KEY, ...MOD_INIT });
+
+const pressModDigit = (digit: string, code: string) =>
+  dispatch("keydown", { key: digit, code, ...MOD_INIT });
+
+describe("useFormDigitJumpShortcut", () => {
+  beforeEach(() => {
+    clearAppLockReasons();
+    focusEventFormField.mockClear();
+  });
+
+  afterEach(() => {
+    clearAppLockReasons();
+    document.body.innerHTML = "";
+  });
+
+  describe("Mod+digit dispatch", () => {
+    it("jumps to the mapped field and prevents default", () => {
+      renderHook(() => useFormDigitJumpShortcut());
+
+      const event = pressModDigit("3", "Digit3");
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(focusEventFormField).toHaveBeenCalledWith("end");
+    });
+
+    it("maps every digit 1-8 to its field, in DOM order", () => {
+      renderHook(() => useFormDigitJumpShortcut());
+
+      const cases = [
+        ["1", "title"],
+        ["2", "start"],
+        ["3", "end"],
+        ["4", "recurrence"],
+        ["5", "calendar"],
+        ["6", "color"],
+        ["7", "location"],
+        ["8", "description"],
+      ] as const;
+
+      for (const [digit, field] of cases) {
+        focusEventFormField.mockClear();
+        pressModDigit(digit, `Digit${digit}`);
+        expect(focusEventFormField).toHaveBeenCalledWith(field);
+      }
+    });
+
+    it("ignores a bare digit with no modifier held", () => {
+      renderHook(() => useFormDigitJumpShortcut());
+
+      const event = dispatch("keydown", { key: "3", code: "Digit3" });
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(focusEventFormField).not.toHaveBeenCalled();
+    });
+
+    it("ignores Mod+Shift+digit", () => {
+      renderHook(() => useFormDigitJumpShortcut());
+
+      const event = dispatch("keydown", {
+        key: "3",
+        code: "Digit3",
+        shiftKey: true,
+        ...MOD_INIT,
+      });
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(focusEventFormField).not.toHaveBeenCalled();
+    });
+
+    it("ignores Mod+Alt+digit", () => {
+      renderHook(() => useFormDigitJumpShortcut());
+
+      const event = dispatch("keydown", {
+        key: "3",
+        code: "Digit3",
+        altKey: true,
+        ...MOD_INIT,
+      });
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(focusEventFormField).not.toHaveBeenCalled();
+    });
+
+    it("suppresses the digit's replayed keyup (macOS metaKey-false replay)", () => {
+      renderHook(() => useFormDigitJumpShortcut());
+
+      pressModDigit("3", "Digit3");
+      // macOS replays the keyup after Cmd is released, with metaKey already false.
+      const keyUp = dispatch("keyup", { key: "3", code: "Digit3" });
+
+      expect(keyUp.defaultPrevented).toBe(true);
+    });
+  });
+
+  describe("hold-Mod hint chips", () => {
+    it("stays hidden before the hold threshold", () => {
+      const { result } = renderHook(() => useFormDigitJumpShortcut());
+
+      pressModDown();
+
+      expect(result.current.areHintsVisible).toBe(false);
+    });
+
+    it("shows hints once Mod is held past the threshold", async () => {
+      const { result } = renderHook(() => useFormDigitJumpShortcut());
+
+      pressModDown();
+      await act(async () => {
+        await waitPastHold();
+      });
+
+      await waitFor(() => {
+        expect(result.current.areHintsVisible).toBe(true);
+      });
+    });
+
+    it("hides hints on Mod keyup", async () => {
+      const { result } = renderHook(() => useFormDigitJumpShortcut());
+
+      pressModDown();
+      await act(async () => {
+        await waitPastHold();
+      });
+      await waitFor(() => expect(result.current.areHintsVisible).toBe(true));
+
+      act(() => {
+        releaseMod();
+      });
+
+      expect(result.current.areHintsVisible).toBe(false);
+    });
+
+    it("does not re-arm on a repeated Mod keydown", async () => {
+      const { result } = renderHook(() => useFormDigitJumpShortcut());
+
+      pressModDown({ repeat: true });
+      await act(async () => {
+        await waitPastHold();
+      });
+
+      expect(result.current.areHintsVisible).toBe(false);
+    });
+
+    it("cancels the pending hold when another chord is pressed", async () => {
+      const { result } = renderHook(() => useFormDigitJumpShortcut());
+
+      pressModDown();
+      // Mod+K: not a mapped digit, so it just cancels the pending arm.
+      act(() => {
+        dispatch("keydown", { key: "k", ...MOD_INIT });
+      });
+      await act(async () => {
+        await waitPastHold();
+      });
+
+      expect(result.current.areHintsVisible).toBe(false);
+    });
+
+    it("hides on window blur", async () => {
+      const { result } = renderHook(() => useFormDigitJumpShortcut());
+
+      pressModDown();
+      await act(async () => {
+        await waitPastHold();
+      });
+      await waitFor(() => expect(result.current.areHintsVisible).toBe(true));
+
+      act(() => {
+        window.dispatchEvent(new Event("blur"));
+      });
+
+      expect(result.current.areHintsVisible).toBe(false);
+    });
+
+    it("hides on pointerdown", async () => {
+      const { result } = renderHook(() => useFormDigitJumpShortcut());
+
+      pressModDown();
+      await act(async () => {
+        await waitPastHold();
+      });
+      await waitFor(() => expect(result.current.areHintsVisible).toBe(true));
+
+      act(() => {
+        document.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+      });
+
+      expect(result.current.areHintsVisible).toBe(false);
+    });
+  });
+
+  it("does not dispatch or arm hints while the app is locked", async () => {
+    setAppLockReason("test-lock", true);
+    const { result } = renderHook(() => useFormDigitJumpShortcut());
+
+    pressModDigit("3", "Digit3");
+    expect(focusEventFormField).not.toHaveBeenCalled();
+
+    pressModDown();
+    await act(async () => {
+      await waitPastHold();
+    });
+    expect(result.current.areHintsVisible).toBe(false);
+  });
+});

--- a/packages/web/src/shortcuts/form-digit-jump/useFormDigitJumpShortcut.test.tsx
+++ b/packages/web/src/shortcuts/form-digit-jump/useFormDigitJumpShortcut.test.tsx
@@ -5,13 +5,7 @@ import {
   MOD_HOLD_HINT_MS,
   useFormDigitJumpShortcut,
 } from "@web/shortcuts/form-digit-jump/useFormDigitJumpShortcut";
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
-
-const focusEventFormField = mock((_field: string) => true);
-
-mock.module("@web/common/utils/form/form.util", () => ({
-  focusEventFormField,
-}));
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
 /** Matches what the hook resolves Mod to on this platform. */
 const isMac = resolveModifier("Mod") === "Meta";
@@ -42,10 +36,79 @@ const releaseMod = () => dispatch("keyup", { key: MOD_KEY, ...MOD_INIT });
 const pressModDigit = (digit: string, code: string) =>
   dispatch("keydown", { key: digit, code, ...MOD_INIT });
 
+/**
+ * A minimal real event-form DOM matching form.util.ts's FIELD_SELECTORS, so
+ * focusEventFormField (the hook's real dispatch target) actually moves focus
+ * instead of needing to be mocked. Mocking `form.util` here would replace it
+ * process-wide for every other test file that imports it (bun's mock.module
+ * has no per-file scope), so this builds real elements instead.
+ */
+const buildForm = () => {
+  const form = document.createElement("form");
+  form.setAttribute("name", "Event Form");
+  document.body.append(form);
+
+  const title = document.createElement("input");
+  title.setAttribute("name", "Event Title");
+  form.append(title);
+
+  const start = document.createElement("input");
+  start.id = "startTimePicker";
+  form.append(start);
+
+  const end = document.createElement("input");
+  end.id = "endTimePicker";
+  form.append(end);
+
+  const recurrence = document.createElement("div");
+  recurrence.id = "event-form-recurrence";
+  const recurrenceButton = document.createElement("button");
+  recurrenceButton.setAttribute("aria-label", "Edit recurrence");
+  recurrence.append(recurrenceButton);
+  form.append(recurrence);
+
+  // A real button, like CalendarSelect.tsx (see the id on its own combobox
+  // button) — a plain div would silently fail to focus in jsdom too.
+  const calendar = document.createElement("button");
+  calendar.id = "event-form-calendar";
+  document.body.append(calendar);
+
+  const color = document.createElement("div");
+  color.id = "event-form-color";
+  const radio = document.createElement("input");
+  radio.type = "radio";
+  color.append(radio);
+  document.body.append(color);
+
+  // A real input, like the Location Focusable in EventForm.tsx.
+  const location = document.createElement("input");
+  location.id = "event-form-location";
+  form.append(location);
+
+  // Real usage sets this id on TipTap's contenteditable root, which is what
+  // makes it focusable; jsdom doesn't treat contenteditable as focusable on
+  // its own, so tabIndex is also set to reproduce that here.
+  const description = document.createElement("div");
+  description.id = "event-form-description";
+  description.contentEditable = "true";
+  description.tabIndex = 0;
+  document.body.append(description);
+
+  return {
+    title,
+    start,
+    end,
+    recurrence: recurrenceButton,
+    calendar,
+    color: radio,
+    location,
+    description,
+  };
+};
+
 describe("useFormDigitJumpShortcut", () => {
   beforeEach(() => {
     clearAppLockReasons();
-    focusEventFormField.mockClear();
   });
 
   afterEach(() => {
@@ -55,45 +118,51 @@ describe("useFormDigitJumpShortcut", () => {
 
   describe("Mod+digit dispatch", () => {
     it("jumps to the mapped field and prevents default", () => {
+      const fields = buildForm();
+      fields.title.focus();
       renderHook(() => useFormDigitJumpShortcut());
 
       const event = pressModDigit("3", "Digit3");
 
       expect(event.defaultPrevented).toBe(true);
-      expect(focusEventFormField).toHaveBeenCalledWith("end");
+      expect(fields.end).toHaveFocus();
     });
 
     it("maps every digit 1-8 to its field, in DOM order", () => {
+      const fields = buildForm();
       renderHook(() => useFormDigitJumpShortcut());
 
       const cases = [
-        ["1", "title"],
-        ["2", "start"],
-        ["3", "end"],
-        ["4", "recurrence"],
-        ["5", "calendar"],
-        ["6", "color"],
-        ["7", "location"],
-        ["8", "description"],
+        ["1", fields.title],
+        ["2", fields.start],
+        ["3", fields.end],
+        ["4", fields.recurrence],
+        ["5", fields.calendar],
+        ["6", fields.color],
+        ["7", fields.location],
+        ["8", fields.description],
       ] as const;
 
-      for (const [digit, field] of cases) {
-        focusEventFormField.mockClear();
+      for (const [digit, element] of cases) {
         pressModDigit(digit, `Digit${digit}`);
-        expect(focusEventFormField).toHaveBeenCalledWith(field);
+        expect(element).toHaveFocus();
       }
     });
 
     it("ignores a bare digit with no modifier held", () => {
+      const fields = buildForm();
+      fields.title.focus();
       renderHook(() => useFormDigitJumpShortcut());
 
       const event = dispatch("keydown", { key: "3", code: "Digit3" });
 
       expect(event.defaultPrevented).toBe(false);
-      expect(focusEventFormField).not.toHaveBeenCalled();
+      expect(fields.title).toHaveFocus();
     });
 
     it("ignores Mod+Shift+digit", () => {
+      const fields = buildForm();
+      fields.title.focus();
       renderHook(() => useFormDigitJumpShortcut());
 
       const event = dispatch("keydown", {
@@ -104,10 +173,12 @@ describe("useFormDigitJumpShortcut", () => {
       });
 
       expect(event.defaultPrevented).toBe(false);
-      expect(focusEventFormField).not.toHaveBeenCalled();
+      expect(fields.title).toHaveFocus();
     });
 
     it("ignores Mod+Alt+digit", () => {
+      const fields = buildForm();
+      fields.title.focus();
       renderHook(() => useFormDigitJumpShortcut());
 
       const event = dispatch("keydown", {
@@ -118,10 +189,11 @@ describe("useFormDigitJumpShortcut", () => {
       });
 
       expect(event.defaultPrevented).toBe(false);
-      expect(focusEventFormField).not.toHaveBeenCalled();
+      expect(fields.title).toHaveFocus();
     });
 
     it("suppresses the digit's replayed keyup (macOS metaKey-false replay)", () => {
+      buildForm();
       renderHook(() => useFormDigitJumpShortcut());
 
       pressModDigit("3", "Digit3");
@@ -230,11 +302,13 @@ describe("useFormDigitJumpShortcut", () => {
   });
 
   it("does not dispatch or arm hints while the app is locked", async () => {
+    const fields = buildForm();
+    fields.title.focus();
     setAppLockReason("test-lock", true);
     const { result } = renderHook(() => useFormDigitJumpShortcut());
 
     pressModDigit("3", "Digit3");
-    expect(focusEventFormField).not.toHaveBeenCalled();
+    expect(fields.title).toHaveFocus();
 
     pressModDown();
     await act(async () => {

--- a/packages/web/src/shortcuts/form-digit-jump/useFormDigitJumpShortcut.ts
+++ b/packages/web/src/shortcuts/form-digit-jump/useFormDigitJumpShortcut.ts
@@ -1,0 +1,155 @@
+import { resolveModifier } from "@tanstack/react-hotkeys";
+import { useEffect, useState } from "react";
+import { focusEventFormField } from "@web/common/utils/form/form.util";
+import { isAppLocked } from "@web/shortcuts/app-lock";
+import { physicalDigitIndex } from "@web/shortcuts/digit-pick.util";
+import {
+  EDIT_SEQUENCE_FIELD_BY_DIGIT,
+  FORM_FIELD_DIGITS,
+} from "@web/shortcuts/edit-sequence/edit-sequence.fields";
+import { normalizedKeyboardKey } from "@web/shortcuts/is-bare-letter-key";
+
+/**
+ * How long Mod must be held, with nothing else pressed, before hint chips
+ * appear. Matches the `e`-leader's ARM_WINDOW_MS cadence so both hold
+ * gestures feel the same.
+ */
+export const MOD_HOLD_HINT_MS = 600;
+
+/** 0-based physical-digit index -> field digit, i.e. the form's DOM order. */
+const DIGIT_ORDER = FORM_FIELD_DIGITS.map((entry) => entry.digit);
+
+/**
+ * Mod+digit jumps focus straight to a form field (1=title ... 8=description;
+ * see edit-sequence.fields.ts for the assignment). Holding Mod alone for
+ * MOD_HOLD_HINT_MS reveals the mapping as hint chips (FormDigitHintOverlay),
+ * the same discoverability contract as the `e`-leader's which-key menu — but
+ * driven by a hold instead of a second keypress.
+ *
+ * Mounted from EventForm, so this hook is live exactly while the form is
+ * open; no separate "is the form open" gate is needed.
+ *
+ * Safari may still switch tabs for some Cmd+digit combos despite
+ * preventDefault; Chromium and Firefox honor it.
+ */
+export function useFormDigitJumpShortcut(): { areHintsVisible: boolean } {
+  const [areHintsVisible, setAreHintsVisible] = useState(false);
+
+  useEffect(() => {
+    const isMac = resolveModifier("Mod") === "Meta";
+    const modKey = isMac ? "Meta" : "Control";
+    let holdTimeoutId: ReturnType<typeof setTimeout> | null = null;
+    let hintsVisible = false;
+    const suppressKeyUp = new Set<string>();
+
+    const clearHoldTimer = () => {
+      if (holdTimeoutId !== null) {
+        clearTimeout(holdTimeoutId);
+        holdTimeoutId = null;
+      }
+    };
+
+    const hideHints = () => {
+      clearHoldTimer();
+      if (hintsVisible) {
+        hintsVisible = false;
+        setAreHintsVisible(false);
+      }
+    };
+
+    const armHoldTimer = () => {
+      holdTimeoutId = setTimeout(() => {
+        holdTimeoutId = null;
+        hintsVisible = true;
+        setAreHintsVisible(true);
+      }, MOD_HOLD_HINT_MS);
+    };
+
+    const isModOnly = (event: KeyboardEvent) =>
+      isMac
+        ? event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey
+        : event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      if (isAppLocked()) {
+        hideHints();
+        return;
+      }
+
+      if (event.key === modKey) {
+        // Held modifiers auto-repeat; only the initial press should start the
+        // clock, or the timer would keep resetting for as long as Mod stays down.
+        if (event.repeat) return;
+        if (!hintsVisible && holdTimeoutId === null) {
+          armHoldTimer();
+        }
+        return;
+      }
+
+      if (isModOnly(event)) {
+        const index = physicalDigitIndex(event);
+        const digit = index !== null ? DIGIT_ORDER[index] : undefined;
+        const field = digit ? EDIT_SEQUENCE_FIELD_BY_DIGIT[digit] : undefined;
+
+        if (field) {
+          event.preventDefault();
+          event.stopPropagation();
+          // macOS swallows this key's keyup while Cmd is held and replays it
+          // with metaKey:false on release; suppress so nothing downstream
+          // reacts to that replay as a bare keystroke.
+          suppressKeyUp.add(normalizedKeyboardKey(event));
+          hideHints();
+          focusEventFormField(field);
+          return;
+        }
+      }
+
+      // Any other keydown (including an unmatched Mod chord like Mod+K) means
+      // the user wasn't pausing to look; only a fresh Mod press re-arms it.
+      clearHoldTimer();
+    };
+
+    const onKeyUp = (event: KeyboardEvent) => {
+      const key = normalizedKeyboardKey(event);
+      if (suppressKeyUp.has(key)) {
+        suppressKeyUp.delete(key);
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+
+      if (event.key === modKey) {
+        hideHints();
+      }
+    };
+
+    // Clicking away or losing the window abandons the gesture rather than
+    // leaving chips pinned to a form the user isn't looking at. Window
+    // switches (Cmd+Tab) can swallow the Meta keyup entirely, so blur and
+    // visibilitychange are covered independently of onKeyUp.
+    const onPointerDown = () => hideHints();
+    const onWindowBlur = () => hideHints();
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "hidden") hideHints();
+    };
+
+    document.addEventListener("keydown", onKeyDown, true);
+    document.addEventListener("keyup", onKeyUp, true);
+    document.addEventListener("pointerdown", onPointerDown, true);
+    window.addEventListener("blur", onWindowBlur);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      hideHints();
+      suppressKeyUp.clear();
+      document.removeEventListener("keydown", onKeyDown, true);
+      document.removeEventListener("keyup", onKeyUp, true);
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      window.removeEventListener("blur", onWindowBlur);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, []);
+
+  return { areHintsVisible };
+}

--- a/packages/web/src/shortcuts/keymap.ts
+++ b/packages/web/src/shortcuts/keymap.ts
@@ -3,9 +3,10 @@
  *
  * Each entry pairs the runtime binding with the keycaps shown in hints so a
  * remap here propagates to the real handlers, the showcase, and its hint
- * chips in one edit. Bindings come in three shapes because the app has three
+ * chips in one edit. Bindings come in four shapes because the app has four
  * dispatch styles: tanstack hotkey strings, the bespoke `e`… sequence engine,
- * and bare-letter capture listeners (`s`, `f`, `m`).
+ * bare-letter capture listeners (`s`, `f`, `m`), and the hold-Mod + digit-chord
+ * engine (`jumpFormField`).
  *
  * Only taught bindings live here — this is not a registry of every shortcut.
  * `shortcuts.registry.ts` remains the display list for the help overlay; its
@@ -15,6 +16,11 @@
 export const KEYMAP = {
   createEvent: { hotkey: "C", keycaps: ["C"] },
   saveDraft: { hotkey: "Enter", keycaps: ["Enter"] },
+  jumpFormField: {
+    holdModifier: "Mod",
+    digits: ["1", "8"],
+    keycaps: ["Mod", "1-8"],
+  },
   moveFocus: {
     hotkeys: {
       up: "ArrowUp",

--- a/packages/web/src/shortcuts/shift-hint/ShiftHintOverlay.tsx
+++ b/packages/web/src/shortcuts/shift-hint/ShiftHintOverlay.tsx
@@ -1,29 +1,16 @@
-import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { Z_INDEX_TOOLTIP } from "@web/common/constants/web.constants";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 import { getVisibleHintRect } from "@web/shortcuts/shift-hint/shift-hint-visible-rect";
 import { type ActiveShiftHint } from "@web/shortcuts/shift-hint/useShiftHoldEventHints";
+import { useHintLayoutRefresh } from "@web/shortcuts/useHintLayoutRefresh";
 
 /**
  * Fixed-position keycap chips anchored to event cards while event-jump mode
  * is on. Portaled so overflow-hidden cards do not clip the hints.
  */
 export function ShiftHintOverlay({ hints }: { hints: ActiveShiftHint[] }) {
-  const [, setLayoutTick] = useState(0);
-
-  useEffect(() => {
-    if (hints.length === 0) return;
-
-    const refresh = () => setLayoutTick((tick) => tick + 1);
-    window.addEventListener("resize", refresh);
-    // Capture scroll from nested grid scrollers.
-    window.addEventListener("scroll", refresh, true);
-    return () => {
-      window.removeEventListener("resize", refresh);
-      window.removeEventListener("scroll", refresh, true);
-    };
-  }, [hints.length]);
+  useHintLayoutRefresh(hints.length > 0);
 
   if (hints.length === 0 || typeof document === "undefined") {
     return null;

--- a/packages/web/src/shortcuts/shortcuts.registry.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.test.ts
@@ -147,6 +147,22 @@ describe("shortcuts.registry", () => {
       expect(open).toContain("edit-field-leader-in-form");
     });
 
+    it("excludes the digit-jump row when the form is closed and includes it when open", () => {
+      const closed = filterShortcutsByContext({
+        view: "day",
+        isViewingCurrentPeriod: true,
+        isFormOpen: false,
+      }).map((shortcut) => shortcut.id);
+      expect(closed).not.toContain("edit-jump-field-digit");
+
+      const open = filterShortcutsByContext({
+        view: "day",
+        isViewingCurrentPeriod: true,
+        isFormOpen: true,
+      }).map((shortcut) => shortcut.id);
+      expect(open).toContain("edit-jump-field-digit");
+    });
+
     it("lists the digit-pick row regardless of form state, since it also applies in the context menu", () => {
       const closed = filterShortcutsByContext({
         view: "day",

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -241,6 +241,16 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
     section: "edit",
     when: { isFormOpen: true },
   },
+  // One row instead of eight duplicates: the digit assignment is the same
+  // table as edit-focus-* above (just numbered instead of lettered), and
+  // in-the-moment discovery is the hold-Mod hint overlay's job.
+  {
+    id: "edit-jump-field-digit",
+    keys: [...KEYMAP.jumpFormField.keycaps],
+    label: "Jump to form field (hold Mod for hints)",
+    section: "edit",
+    when: { isFormOpen: true },
+  },
   // Not form-gated: the same digit pick also runs in the event context
   // menu's color swatch strip, independent of whether the form is open.
   {

--- a/packages/web/src/shortcuts/useHintLayoutRefresh.test.ts
+++ b/packages/web/src/shortcuts/useHintLayoutRefresh.test.ts
@@ -1,0 +1,50 @@
+import { act, renderHook } from "@testing-library/react";
+import { useHintLayoutRefresh } from "@web/shortcuts/useHintLayoutRefresh";
+import { describe, expect, it } from "bun:test";
+
+describe("useHintLayoutRefresh", () => {
+  it("re-renders on window resize while active", () => {
+    let renders = 0;
+    renderHook(() => {
+      renders += 1;
+      useHintLayoutRefresh(true);
+    });
+    const afterMount = renders;
+
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    expect(renders).toBe(afterMount + 1);
+  });
+
+  it("re-renders on a capture-phase scroll while active", () => {
+    let renders = 0;
+    renderHook(() => {
+      renders += 1;
+      useHintLayoutRefresh(true);
+    });
+    const afterMount = renders;
+
+    act(() => {
+      document.dispatchEvent(new Event("scroll", { bubbles: false }));
+    });
+
+    expect(renders).toBe(afterMount + 1);
+  });
+
+  it("does not listen while inactive", () => {
+    let renders = 0;
+    renderHook(() => {
+      renders += 1;
+      useHintLayoutRefresh(false);
+    });
+    const afterMount = renders;
+
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    expect(renders).toBe(afterMount);
+  });
+});

--- a/packages/web/src/shortcuts/useHintLayoutRefresh.ts
+++ b/packages/web/src/shortcuts/useHintLayoutRefresh.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Forces a re-render on window resize or any (possibly nested) scroll while
+ * `active`, so portaled hint chips re-measure their anchors' positions.
+ * Shared by ShiftHintOverlay and FormDigitHintOverlay.
+ */
+export function useHintLayoutRefresh(active: boolean): void {
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    if (!active) return;
+
+    const refresh = () => setTick((tick) => tick + 1);
+    window.addEventListener("resize", refresh);
+    // Capture scroll from nested scrollers (grid, form body).
+    window.addEventListener("scroll", refresh, true);
+    return () => {
+      window.removeEventListener("resize", refresh);
+      window.removeEventListener("scroll", refresh, true);
+    };
+  }, [active]);
+}

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -153,6 +153,25 @@ function dispatchDigitKey(target: HTMLElement, code: string, key: string) {
   return event;
 }
 
+// digitPickIndex/physicalDigitIndex match on the physical `code` first; set
+// it alongside `key` so this hits the primary match real keyboards send.
+function dispatchModDigitKey(target: HTMLElement, code: string, key: string) {
+  const modifierKey = resolveModifier("Mod");
+  const isControl = modifierKey === "Control";
+
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    code,
+    ctrlKey: isControl,
+    key,
+    metaKey: !isControl,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
 function dispatchArrowDown(target: HTMLElement) {
   const event = new KeyboardEvent("keydown", {
     bubbles: true,
@@ -571,6 +590,139 @@ describe("EventForm", () => {
     const event = dispatchKey(titleField, "l");
 
     expect(event.defaultPrevented).toBe(false);
+    expect(titleField).toHaveFocus();
+  });
+
+  it("jumps focus to the location field with Mod+7 from the title field", () => {
+    renderWithStore(
+      <EventForm
+        draft={createEditDraft()}
+        isDraft={false}
+        isExistingEvent={true}
+        onClose={mock()}
+        onDelete={mock()}
+        onDuplicate={mock()}
+        onSubmit={mock()}
+        setDraft={mock()}
+      />,
+    );
+
+    const titleField = screen.getByPlaceholderText("Title");
+    act(() => titleField.focus());
+
+    const event = dispatchModDigitKey(titleField, "Digit7", "7");
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(screen.getByRole("textbox", { name: "Location" })).toHaveFocus();
+  });
+
+  it("jumps focus to the checked color swatch with Mod+6 from the title field", () => {
+    renderWithStore(
+      <EventForm
+        draft={createEditDraft()}
+        isDraft={false}
+        isExistingEvent={true}
+        onClose={mock()}
+        onDelete={mock()}
+        onDuplicate={mock()}
+        onSubmit={mock()}
+        setDraft={mock()}
+      />,
+    );
+
+    const titleField = screen.getByPlaceholderText("Title");
+    act(() => titleField.focus());
+
+    dispatchModDigitKey(titleField, "Digit6", "6");
+
+    expect(
+      screen.getByRole("radio", { name: "Calendar default" }),
+    ).toHaveFocus();
+  });
+
+  it("jumps focus to the description field with Mod+8 from the title field", () => {
+    renderWithStore(
+      <EventForm
+        draft={createEditDraft({ description: "Plan the launch" })}
+        isDraft={false}
+        isExistingEvent={true}
+        onClose={mock()}
+        onDelete={mock()}
+        onDuplicate={mock()}
+        onSubmit={mock()}
+        setDraft={mock()}
+      />,
+    );
+
+    const titleField = screen.getByPlaceholderText("Title");
+    act(() => titleField.focus());
+
+    dispatchModDigitKey(titleField, "Digit8", "8");
+
+    expect(screen.getByRole("textbox", { name: "Description" })).toHaveFocus();
+  });
+
+  it("picks a color directly with a bare digit after jumping to color with Mod+6", () => {
+    function Harness() {
+      const [draft, setDraft] = useState<GridEventDraft | null>(
+        createEditDraft(),
+      );
+
+      if (!draft) return null;
+
+      return (
+        <EventForm
+          draft={draft}
+          isDraft={false}
+          isExistingEvent={true}
+          onClose={mock()}
+          onDelete={mock()}
+          onDuplicate={mock()}
+          onSubmit={mock()}
+          setDraft={setDraft}
+        />
+      );
+    }
+
+    renderWithStore(<Harness />);
+
+    const titleField = screen.getByPlaceholderText("Title");
+    act(() => titleField.focus());
+
+    dispatchModDigitKey(titleField, "Digit6", "6");
+
+    const defaultRadio = screen.getByRole("radio", {
+      name: "Calendar default",
+    });
+    expect(defaultRadio).toHaveFocus();
+
+    let event: KeyboardEvent;
+    act(() => {
+      event = dispatchDigitKey(defaultRadio, "Digit4", "4");
+    });
+
+    expect(event!.defaultPrevented).toBe(true);
+    expect(screen.getByRole("radio", { name: "Plum" })).toHaveFocus();
+  });
+
+  it("does not throw jumping to the calendar field (Mod+5) on an edit draft, which has no calendar picker", () => {
+    renderWithStore(
+      <EventForm
+        draft={createEditDraft()}
+        isDraft={false}
+        isExistingEvent={true}
+        onClose={mock()}
+        onDelete={mock()}
+        onDuplicate={mock()}
+        onSubmit={mock()}
+        setDraft={mock()}
+      />,
+    );
+
+    const titleField = screen.getByPlaceholderText("Title");
+    act(() => titleField.focus());
+
+    expect(() => dispatchModDigitKey(titleField, "Digit5", "5")).not.toThrow();
     expect(titleField).toHaveFocus();
   });
 

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -48,6 +48,8 @@ import {
 } from "@web/events/grid-event-draft.adapter";
 import { BUSY_EVENT_TITLE } from "@web/events/queries/event.view-model";
 import { useEventById } from "@web/events/queries/useEventById";
+import { FormDigitHintOverlay } from "@web/shortcuts/form-digit-jump/FormDigitHintOverlay";
+import { useFormDigitJumpShortcut } from "@web/shortcuts/form-digit-jump/useFormDigitJumpShortcut";
 import { keyboardKey } from "@web/shortcuts/is-bare-letter-key";
 import { KEYMAP } from "@web/shortcuts/keymap";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
@@ -674,6 +676,8 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
     const { isConfirmOpen, onCancelConfirm, onDiscardConfirm } =
       useEscapeToCloseForm(onClose);
 
+    const { areHintsVisible } = useFormDigitJumpShortcut();
+
     const titleErrorField = fieldErrors?.["content.title"]
       ? "content.title"
       : fieldErrors?.title
@@ -918,6 +922,7 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
           onCancel={onCancelConfirm}
           onDiscard={onDiscardConfirm}
         />
+        <FormDigitHintOverlay visible={areHintsVisible} />
       </>
     );
   },


### PR DESCRIPTION
## Summary

- Reaching a distant form field (e.g. the color picker) required many TABs after opening the event form. `Mod+1`..`Mod+8` now jumps focus straight to a field, assigned in the form's DOM order: 1=title, 2=start, 3=end, 4=recurrence, 5=calendar, 6=color, 7=location, 8=description.
- Holding `Mod` alone for 600ms (no other key) reveals the mapping as numbered hint chips anchored next to each section — the same discoverability contract as the existing `e`-leader which-key menu, but triggered by a hold instead of a second keypress.
- Reuses the existing `EDIT_SEQUENCE_FIELDS` table (adding a `digit` column) and `focusEventFormField`/`getEventFormFieldElement` as the single source of truth for both the letter leader and the new digit jumps, plus `digit-pick.util`'s physical-key matching for keyboard-layout-independent digit resolution.
- Registered in `SHORTCUTS_REGISTRY` (gated on `isFormOpen`) so the `?` legend documents it.

## Simplicity

- No new state-management system: the hold/dispatch logic is one hook (`useFormDigitJumpShortcut`) mounted directly in `EventForm`, mirroring how `Mod+D`/`Mod+Enter` are already registered there — no extra "is the form open" gate needed.
- `form.util.ts`'s `focusEventFormField` was refactored (behavior-preserving) to expose `getEventFormFieldElement`, so the hint overlay anchors to the exact element a jump would focus, instead of duplicating selector logic.
- The hint overlay's resize/scroll layout-refresh effect was identical to `ShiftHintOverlay`'s, so it's now a shared `useHintLayoutRefresh` hook instead of two near-copies.
- The digit table lives on the *existing* `EDIT_SEQUENCE_FIELDS` array (data-only, already the single source of truth for the letter leader) rather than a second field list.

## Automated validation

- Manual trace through the code paths (macOS Cmd-keyup replay, Cmd+Tab/window-blur clearing hints, browser tab-switch `preventDefault`, app-lock gating, edit-draft's missing calendar picker) — see inline comments where each is handled.
- Full local test run via the repo's supported runner (`bun run test:web`): 2283 pass, 0 fail.
- `bunx typescript@7.0.2 --noEmit` (root, `packages/web/tsconfig.app.json`, `packages/web/tsconfig.test.json`): clean.
- `biome check` on all touched/added files: clean.

## Independent review

Ran `/code-review high` against the diff before opening this PR. It surfaced one real bug and two quality issues, all fixed here:

- **Confirmed, fixed**: `useFormDigitJumpShortcut.test.tsx` used `mock.module("...form.util", ...)` to stub `focusEventFormField`, which replaces that module process-wide for the rest of the bun test run (no per-file scope) — breaking `form.util.test.ts` and `EventForm.test.tsx` whenever the full suite ran together. Rewrote the test to build a real, minimally-faithful form DOM and assert on actual focus movement instead.
- **Confirmed, fixed**: the hint overlay's screen-reader announcement listed every field unconditionally, while the visible chips correctly skipped fields with no rendered element (e.g. the calendar picker on an edit draft) — a screen-reader user would hear a shortcut advertised that silently did nothing. Both now derive from the same "present fields" list.
- **Confirmed, fixed**: `FormDigitHintOverlay` duplicated `ShiftHintOverlay`'s resize/scroll refresh effect verbatim. Extracted `useHintLayoutRefresh` and switched both overlays to it.

## Test plan

- `bun run test:web` — 2283 pass, 0 fail (project's supported sharded runner)
- `bun test` (unsharded, from `packages/web`) — same set of pre-existing, unrelated failures as on `main` (Sync/SSE/Google-connect tests with cross-file timing issues); none from files touched in this PR
- `bun run type-check` — clean
- `bunx biome check` on all touched/added files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016dtV7ifdEqX1bV5duXpxCv)_