### PR TITLE
fix(docker): create runtime user with groupadd on trixie bun images

### DIFF
--- a/.github/docker/Dockerfile.web
+++ b/.github/docker/Dockerfile.web
@@ -47,8 +47,10 @@ FROM oven/bun:1.3.14-slim AS runtime
 
 WORKDIR /app
 
-RUN addgroup --system --gid 1001 compass \
- && adduser --system --uid 1001 --ingroup compass --no-create-home compass
+# groupadd/useradd, not addgroup/adduser: Debian 13 (trixie) based
+# oven/bun slim images no longer ship the adduser package.
+RUN groupadd --system --gid 1001 compass \
+ && useradd --system --uid 1001 --gid compass --no-create-home --shell /usr/sbin/nologin compass
 
 ENV WEB_PORT=9080
 ENV WEB_ROOT=/app/build/web

--- a/self-host/Dockerfile.backend
+++ b/self-host/Dockerfile.backend
@@ -10,8 +10,10 @@ FROM oven/bun:1.2.18-slim AS runtime
 
 WORKDIR /app
 
-RUN addgroup --system --gid 1001 compass \
- && adduser --system --uid 1001 --ingroup compass --no-create-home compass
+# groupadd/useradd, not addgroup/adduser: Debian 13 (trixie) based
+# oven/bun slim images no longer ship the adduser package.
+RUN groupadd --system --gid 1001 compass \
+ && useradd --system --uid 1001 --gid compass --no-create-home --shell /usr/sbin/nologin compass
 
 COPY --from=build --chown=compass:compass /app/build/backend ./
 RUN mkdir -p /app/logs && chown compass:compass /app/logs

--- a/self-host/Dockerfile.sync
+++ b/self-host/Dockerfile.sync
@@ -10,8 +10,10 @@ FROM oven/bun:1.2.18-slim AS runtime
 
 WORKDIR /app
 
-RUN addgroup --system --gid 1001 compass \
- && adduser --system --uid 1001 --ingroup compass --no-create-home compass
+# groupadd/useradd, not addgroup/adduser: Debian 13 (trixie) based
+# oven/bun slim images no longer ship the adduser package.
+RUN groupadd --system --gid 1001 compass \
+ && useradd --system --uid 1001 --gid compass --no-create-home --shell /usr/sbin/nologin compass
 
 COPY --from=build --chown=compass:compass /app/build/sync ./
 RUN mkdir -p /app/logs && chown compass:compass /app/logs

--- a/self-host/Dockerfile.web
+++ b/self-host/Dockerfile.web
@@ -36,8 +36,10 @@ FROM oven/bun:1.3.14-slim AS runtime
 
 WORKDIR /app
 
-RUN addgroup --system --gid 1001 compass \
- && adduser --system --uid 1001 --ingroup compass --no-create-home compass
+# groupadd/useradd, not addgroup/adduser: Debian 13 (trixie) based
+# oven/bun slim images no longer ship the adduser package.
+RUN groupadd --system --gid 1001 compass \
+ && useradd --system --uid 1001 --gid compass --no-create-home --shell /usr/sbin/nologin compass
 
 ENV WEB_PORT=9080
 ENV WEB_ROOT=/app/build/web


### PR DESCRIPTION
## Summary

Release on main is still failing after #2856: the bun 1.3.14 bump fixed the metafile error but moved the web runtime stage to a Debian 13 (trixie) base, which no longer preinstalls the `adduser` package — `addgroup` exits 127 and every Docker publish fails, so staging deploys remain skipped (runs 32786856512, 32787060619).

Switch all four Dockerfiles to `groupadd`/`useradd` (from the `passwd` package, present on both the old Debian 12 base still used by backend/sync and on trixie), with `--shell /usr/sbin/nologin` pinned explicitly since `adduser --system` used to set it implicitly. Backend/sync base images are deliberately untouched — this only future-proofs their user creation for when they bump.

## Simplicity

Mechanical 2-line swap per Dockerfile plus a comment naming the trixie constraint; no version changes beyond what #2856 already did.

## Automated validation

- `docker build -f .github/docker/Dockerfile.web .` completes locally on the fixed file (it fails at the `addgroup` step on current main).
- The built image runs and serves `/` with HTTP 200 as the `compass` user.
- The `groupadd`/`useradd` pair verified directly against both `oven/bun:1.2.18-slim` (Debian 12) and `oven/bun:1.3.14-slim` (trixie); the `SYS_UID_MAX` warning is pre-existing semantics (uid 1001 was already out of system range under `adduser`).

## Independent review

Not run — Dockerfile-only mechanical change; validation above builds and runs the actual artifact, which no PR check does.

## Test plan

- Local: the docker build + container smoke test above (CI has no image-build check; breakage only surfaces on main's publish job).
- After merge: watch "Release on main" → Publish Docker images → Deploy staging for the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)