### PR TITLE
fix(docker): create runtime user with useradd in web images

### DIFF
--- a/.github/docker/Dockerfile.web
+++ b/.github/docker/Dockerfile.web
@@ -47,8 +47,8 @@ FROM oven/bun:1.3.14-slim AS runtime
 
 WORKDIR /app
 
-RUN addgroup --system --gid 1001 compass \
- && adduser --system --uid 1001 --ingroup compass --no-create-home compass
+RUN groupadd --system --gid 1001 compass \
+ && useradd --system --uid 1001 --gid compass --no-create-home compass
 
 ENV WEB_PORT=9080
 ENV WEB_ROOT=/app/build/web

--- a/self-host/Dockerfile.web
+++ b/self-host/Dockerfile.web
@@ -36,8 +36,8 @@ FROM oven/bun:1.3.14-slim AS runtime
 
 WORKDIR /app
 
-RUN addgroup --system --gid 1001 compass \
- && adduser --system --uid 1001 --ingroup compass --no-create-home compass
+RUN groupadd --system --gid 1001 compass \
+ && useradd --system --uid 1001 --gid compass --no-create-home compass
 
 ENV WEB_PORT=9080
 ENV WEB_ROOT=/app/build/web


### PR DESCRIPTION
## What

Replace `addgroup`/`adduser` with `groupadd`/`useradd` in the runtime stage of `.github/docker/Dockerfile.web` and `self-host/Dockerfile.web`. The `compass` user keeps uid/gid 1001.

## Why

Second failure mode in the [Release rerun](https://github.com/KeepSoftwareSimple/compass-calendar/actions/runs/32787060619) after #2856's Bun 1.3.14 bump: `oven/bun:1.3.14-slim` no longer ships Debian's `adduser`/`addgroup` wrapper scripts, so the user-creation step exits 127. The image demonstrably contains `groupadd`/`useradd` - its own layer history creates the built-in `bun` user with them (verified by pulling the image config blob from the registry).

Backend/sync Dockerfiles still run `oven/bun:1.2.18`, where the wrappers exist, and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)