### PR TITLE
fix(web): clamp near-midnight timed drafts to end at midnight

### DIFF
--- a/packages/web/src/common/utils/draft/draft.util.test.ts
+++ b/packages/web/src/common/utils/draft/draft.util.test.ts
@@ -102,6 +102,27 @@ describe("shortcut draft creation", () => {
     expectSameTime(gridDraft?.values.schedule.end, "2026-06-01T11:15:00.000Z");
   });
 
+  it("clamps a near-midnight timed draft to end at midnight instead of spanning days", async () => {
+    // 23:22 -> start rounds to 23:30; a full hour would cross midnight and
+    // send the draft to the all-day row (multi-day timed display).
+    setSystemTime(new Date("2026-05-20T23:22:00.000Z"));
+
+    await createTimedDraft(
+      true,
+      dayjs("2026-05-18T00:00:00.000Z"),
+      "createShortcut",
+    );
+
+    const { gridDraft, status } = useDraftStore.getState();
+
+    expect(status?.eventType).toBe(Categories_Event.TIMED);
+    expectSameTime(
+      gridDraft?.values.schedule.start,
+      "2026-05-20T23:30:00.000Z",
+    );
+    expectSameTime(gridDraft?.values.schedule.end, "2026-05-21T00:00:00.000Z");
+  });
+
   it("stores a provided calendarId on timed shortcut drafts", async () => {
     setSystemTime(new Date("2026-05-20T10:07:00.000Z"));
     const calendarId = CalendarIdSchema.parse(createObjectIdString());

--- a/packages/web/src/common/utils/draft/draft.util.ts
+++ b/packages/web/src/common/utils/draft/draft.util.ts
@@ -79,7 +79,15 @@ export const getDraftTimes = (isCurrentWeek: boolean, startOfWeek: Dayjs) => {
   const fullStart = isCurrentWeek ? now : startOfWeek.hour(now.hour());
   const _start = fullStart.minute(nextMinuteInterval).second(0);
 
-  const _end = _start.add(1, "hour");
+  // Clamp to midnight: a default that crossed into the next day would render
+  // in the all-day row (multi-day timed display), which is a surprising place
+  // for "create an event now" to land. Ending exactly at midnight still
+  // counts as inside the day, so the draft stays in the timed grid.
+  const midnightAfterStart = _start.add(1, "day").startOf("day");
+  const oneHourEnd = _start.add(1, "hour");
+  const _end = oneHourEnd.isAfter(midnightAfterStart)
+    ? midnightAfterStart
+    : oneHourEnd;
   const startDate = _start.format();
   const endDate = _end.format();
 


### PR DESCRIPTION
## Summary

Pressing `c` between 23:00 and midnight created a default draft whose one-hour span crossed into the next day, and day-spanning timed events render in the all-day row (#2404) — so "create an event now" landed in the all-day row instead of the timed grid. This is also the root cause of the e2e failures blocking the release pipeline: every helper that creates a timed event waits for the card in `#mainGrid`, so any CI run between 23:00 and 00:00 UTC fails (shift-hold + spatial-focus on main run 32787060090, onboarding first-run on #2857 — all on Dockerfile-only diffs, green before 23:00 UTC).

Fix: clamp the default end to midnight. An event ending exactly at the next day's 00:00 still counts as inside one day (`isTimedEventInsideOneDay`), so the draft stays timed and visible where the user (and the tests) expect it.

## Simplicity

Three-line clamp in `getDraftTimes` with a comment naming the all-day-row consequence; no new helpers.

## Automated validation

- Reproduced deterministically: `TZ=Etc/UTC bunx playwright test e2e/timed/shift-hold-event-hints.spec.ts` at 23:2x UTC fails 3/3 without the fix (same failures/error contexts as CI: the created event renders as `All-day event: …` in the page snapshot) and passes 4/4 with it (spatial-focus included). Under local MDT both pass, which is why this never reproduced during the workday.
- `bun test` on draft.util + week/day shortcut suites: 102 pass, including a new regression test pinning 23:22 → draft 23:30–00:00.

## Independent review

Not run — three-line clamp verified by deterministic before/after reproduction of the exact CI failure.

## Test plan

- New unit test: near-midnight `c` draft ends at midnight, stays `TIMED`.
- `TZ=Etc/UTC` e2e reproduction above (before: 3 failed; after: 4 passed).
- type-check and biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)