### PR TITLE
fix(sync): accept 21+ repeated calendarIds params on the internal event read

### DIFF
--- a/packages/backend/src/event/controllers/event.controller.ts
+++ b/packages/backend/src/event/controllers/event.controller.ts
@@ -1,6 +1,7 @@
 import { type Request, type Response } from "express";
 import { type SessionRequest } from "supertokens-node/framework/express";
 import { Status } from "@core/errors/status.codes";
+import { Logger } from "@core/logger/winston.logger";
 import {
   type CreateEventInput,
   CreateEventInputSchema,
@@ -38,6 +39,8 @@ import {
   toEventMutationError,
 } from "@backend/event/event.error";
 import eventService from "@backend/event/services/event.service";
+
+const logger = Logger("app:event.controller");
 
 const send = (res: Response, e: unknown) => {
   const { status, body } = toEventMutationError(e);
@@ -81,6 +84,13 @@ const resolveSyncCalendarIds = async (
   ]);
 
   if (!calendarsResult.ok) {
+    // The thrown error's message never reaches a log (only the generic
+    // PROVIDER_FAILURE blurb does), so record the actionable detail here.
+    logger.warn(
+      `Failed to list calendars from sync (${calendarsResult.error.kind}) ` +
+        `[status=${calendarsResult.error.status}] ` +
+        `[correlationId=${calendarsResult.error.correlationId}]`,
+    );
     throw eventMutationError(
       "PROVIDER_FAILURE",
       `Failed to list calendars from sync (${calendarsResult.error.kind})`,
@@ -127,6 +137,11 @@ const listAllFullEvents = async (
     };
     const result = await client.listFullEvents(principal, pageQuery);
     if (!result.ok) {
+      logger.warn(
+        `Failed to list events from sync (${result.error.kind}) ` +
+          `[status=${result.error.status}] ` +
+          `[correlationId=${result.error.correlationId}]`,
+      );
       throw eventMutationError(
         "PROVIDER_FAILURE",
         `Failed to list events from sync (${result.error.kind})`,

--- a/packages/sync/src/server/connection.routes.db.test.ts
+++ b/packages/sync/src/server/connection.routes.db.test.ts
@@ -1332,6 +1332,30 @@ describe("GET /internal/events/full", () => {
     });
   });
 
+  // Express's default "extended" query parser (qs) turns 21+ repeated keys
+  // into an object (arrayLimit: 20), which made this route 400 for any user
+  // with more than 20 calendars. Guards the "simple" parser in buildSyncApp.
+  it("accepts more than 20 repeated calendarIds params", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const calendarId = objectId() as EventRecord["calendarId"];
+    const event = await seedEvent(tenantId, principalId, { calendarId });
+    await seedOccurrence(tenantId, principalId, {
+      eventId: event._id,
+      calendarId: calendarId as EventOccurrenceRecord["calendarId"],
+    });
+    await startService();
+
+    const ids = [calendarId, ...Array.from({ length: 24 }, () => objectId())];
+    const query = ids.map((id) => `calendarIds=${id}`).join("&");
+    const res = await get(tenantId, principalId, `${query}&${wideRange()}`);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { instances: unknown[] };
+    expect(body.instances).toHaveLength(1);
+    expect(body.instances[0]).toMatchObject({ eventId: event._id });
+  });
+
   it("returns instance rows plus one back-filled series master row", async () => {
     const tenantId = objectId();
     const principalId = objectId();

--- a/packages/sync/src/server/sync.server.ts
+++ b/packages/sync/src/server/sync.server.ts
@@ -25,6 +25,11 @@ export function buildSyncApp(deps: {
   // Caddy terminates TLS and proxies `/sync/*` with X-Forwarded-For. One hop
   // of trust keeps express-rate-limit from rejecting those public routes.
   app.set("trust proxy", 1);
+  // Every query param here is flat, but the default "extended" parser (qs)
+  // turns 21+ repeated keys into an object (arrayLimit: 20) — which broke
+  // /internal/events/full for any user with more than 20 calendars. The
+  // "simple" parser collects repeated keys into a plain array, unbounded.
+  app.set("query parser", "simple");
   app.use(express.json());
 
   registerHealthRoutes(app, deps);


### PR DESCRIPTION
## Problem

Prod users with **more than 20 active calendars** cannot load events: every `GET /api/event?kind=range` returns 502 and the web app shows "Couldn't load events."

## Root cause

- The API serializes calendar ids to Sync as repeated query params (`calendarIds=a&calendarIds=b&…`).
- Express 4's default "extended" query parser (qs) has `arrayLimit: 20`: **21+ repeated keys parse as an object** (`{"0": id, "1": id, …}`), not an array.
- Sync's `/internal/events/full` route then fails its query schema parse and answers 400 `invalid_query`, which the API maps to the browser-facing 502.

Confirmed against prod with signed internal replays: 20 ids → 200 with events; 21 ids → 400 `invalid_query`. Exactly the qs boundary.

## Fix

- `buildSyncApp` now sets Express's `"simple"` query parser. Every Sync query param is flat, and the internal client's `calendarIds` is the only repeated param it ever sends, so nothing depends on extended parsing. Repeated keys now collect into a plain, unbounded array. No contract change; ≤20-id requests parse identically under both parsers, so there is no deploy-order skew.
- The API's event read path now logs the Sync failure kind/status/correlationId before throwing `PROVIDER_FAILURE` — the thrown error's detail never reaches any log, which is why this incident had to be diagnosed by replaying signed requests server-side.
- Regression test: `/internal/events/full` with 25 repeated `calendarIds` through the real `buildSyncApp` server (red before the fix, green after).

## Testing

- `bun test:sync packages/sync/src/server/connection.routes.db.test.ts` — 49 pass (new test fails with the parser line removed)
- `bun test:backend packages/backend/src/event/controllers/event.controller.test.ts` — 12 pass
- `bun run type-check` clean, biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)