### PR TITLE
fix(backend): report event-read Sync defects at error so they reach PostHog

### DIFF
--- a/packages/backend/src/common/services/sync-service/sync-proxy-error.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-proxy-error.test.ts
@@ -1,9 +1,11 @@
 import { BaseError } from "@core/errors/errors.base";
 import { Status } from "@core/errors/status.codes";
 import {
+  logLevelForSyncClientError,
   throwSyncCommandSubmitFailure,
   throwSyncProxyFailure,
 } from "@backend/common/services/sync-service/sync-proxy-error";
+import { type SyncClientErrorKind } from "@backend/common/services/sync-service/sync-service.client";
 import {
   EventMutationException,
   toEventMutationError,
@@ -86,6 +88,56 @@ describe("sync-proxy-error", () => {
       const mapped = toEventMutationError(e);
       expect(mapped.status).toBe(502);
       expect(mapped.body.retryable).toBe(true);
+    }
+  });
+});
+
+describe("logLevelForSyncClientError", () => {
+  // Only our own backpressure / a Sync restart stays quiet.
+  it.each([
+    "timeout",
+    "unavailable",
+  ] as const)("keeps %s at warn so a Sync restart files no exception", (kind) => {
+    expect(logLevelForSyncClientError(kind)).toBe("warn");
+  });
+
+  // These are defects, and PostHogExceptionTransport only listens at `error`:
+  // logging them at `warn` is what let the >20-calendar badRequest outage run
+  // for a day with no error-tracking issue (2026-08-25).
+  it.each([
+    "badRequest",
+    "unauthorized",
+    "notFound",
+    "conflict",
+    "invalidResponse",
+    "unexpectedStatus",
+  ] as const)("reports %s at error so it is captured as an exception", (kind) => {
+    expect(logLevelForSyncClientError(kind)).toBe("error");
+  });
+
+  // Pins the two to one rule: a new kind must not be quiet on the log side
+  // while the status side treats it as a 502 defect.
+  it("stays consistent with the status mapping for every kind", () => {
+    const kinds: SyncClientErrorKind[] = [
+      "timeout",
+      "unavailable",
+      "badRequest",
+      "unauthorized",
+      "notFound",
+      "conflict",
+      "invalidResponse",
+      "unexpectedStatus",
+    ];
+
+    for (const kind of kinds) {
+      let status: number | undefined;
+      try {
+        throwSyncProxyFailure(kind, "msg");
+      } catch (e) {
+        status = (e as BaseError).statusCode;
+      }
+      const expected = status === Status.SERVICE_UNAVAILABLE ? "warn" : "error";
+      expect(logLevelForSyncClientError(kind)).toBe(expected);
     }
   });
 });

--- a/packages/backend/src/common/services/sync-service/sync-proxy-error.ts
+++ b/packages/backend/src/common/services/sync-service/sync-proxy-error.ts
@@ -4,13 +4,33 @@ import { error } from "@backend/common/errors/handlers/error.handler";
 import { type SyncClientErrorKind } from "@backend/common/services/sync-service/sync-service.client";
 import { eventMutationError } from "@backend/event/event.error";
 
+// The one place that decides which Sync failures are operational: our own
+// backpressure or a Sync restart the caller retries through, versus a defect
+// (a drifted internalAuthToken, a broken response contract, a query Sync
+// rejects outright). Everything below branches on this rather than repeating
+// the kind list.
+const isOperationalKind = (kind: SyncClientErrorKind) =>
+  kind === "timeout" || kind === "unavailable";
+
+// The log level a caller should use for a failed Sync call, mirroring
+// logLevelForError's operational-503 downgrade. Callers that answer their own
+// errors (the event controller writes responses directly, so the global error
+// handler never logs the exception) must choose the level themselves, and
+// PostHogExceptionTransport only listens at `error` — so a defect logged at
+// `warn` is never captured as an exception.
+export function logLevelForSyncClientError(
+  kind: SyncClientErrorKind,
+): "warn" | "error" {
+  return isOperationalKind(kind) ? "warn" : "error";
+}
+
 // Map a failed Sync HTTP call on a read/proxy route into a real HTTP status.
 // Never Status.UNSURE (600). Timeout/unavailable → 503; other failures → 502.
 export function throwSyncProxyFailure(
   kind: SyncClientErrorKind,
   userMessage: string,
 ): never {
-  if (kind === "timeout" || kind === "unavailable") {
+  if (isOperationalKind(kind)) {
     throw error(AuthError.SyncConnectionUnavailable, userMessage);
   }
   throw error(
@@ -33,7 +53,7 @@ export function throwSyncProxyFailure(
 export function throwSyncCommandSubmitFailure(
   kind: SyncClientErrorKind,
 ): never {
-  if (kind === "timeout" || kind === "unavailable") {
+  if (isOperationalKind(kind)) {
     throw eventMutationError(
       "SYNC_UNAVAILABLE",
       `Sync command ${kind}; the mutation may already be applied`,

--- a/packages/backend/src/event/controllers/event.controller.ts
+++ b/packages/backend/src/event/controllers/event.controller.ts
@@ -31,8 +31,14 @@ import {
 } from "@backend/common/services/sync-service/event-command.translation";
 import { syncEventInstanceToBrowser } from "@backend/common/services/sync-service/event-list.translation";
 import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
-import { throwSyncCommandSubmitFailure } from "@backend/common/services/sync-service/sync-proxy-error";
-import { type SyncServiceClient } from "@backend/common/services/sync-service/sync-service.client";
+import {
+  logLevelForSyncClientError,
+  throwSyncCommandSubmitFailure,
+} from "@backend/common/services/sync-service/sync-proxy-error";
+import {
+  type SyncClientError,
+  type SyncServiceClient,
+} from "@backend/common/services/sync-service/sync-service.client";
 import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
 import {
   eventMutationError,
@@ -45,6 +51,20 @@ const logger = Logger("app:event.controller");
 const send = (res: Response, e: unknown) => {
   const { status, body } = toEventMutationError(e);
   res.status(status).json(body);
+};
+
+// Log a failed Sync read. This controller answers every error through `send`,
+// which writes the response directly and never reaches the global error
+// handler — so unlike the proxy routes (unwrap-sync-result), nothing
+// downstream logs the exception, and PostHogExceptionTransport only listens
+// at `error`. The level is therefore chosen here rather than inherited:
+// a defect logged at `warn` is silently never reported, which is how the
+// 2026-08-25 >20-calendar outage ran for a day with no error-tracking issue.
+const logSyncReadFailure = (message: string, error: SyncClientError) => {
+  logger[logLevelForSyncClientError(error.kind)](
+    `${message} (${error.kind}) [status=${error.status}] ` +
+      `[correlationId=${error.correlationId}]`,
+  );
 };
 
 const parseListQuery = (query: Request["query"]): EventListQuery => {
@@ -86,10 +106,9 @@ const resolveSyncCalendarIds = async (
   if (!calendarsResult.ok) {
     // The thrown error's message never reaches a log (only the generic
     // PROVIDER_FAILURE blurb does), so record the actionable detail here.
-    logger.warn(
-      `Failed to list calendars from sync (${calendarsResult.error.kind}) ` +
-        `[status=${calendarsResult.error.status}] ` +
-        `[correlationId=${calendarsResult.error.correlationId}]`,
+    logSyncReadFailure(
+      "Failed to list calendars from sync",
+      calendarsResult.error,
     );
     throw eventMutationError(
       "PROVIDER_FAILURE",
@@ -137,11 +156,7 @@ const listAllFullEvents = async (
     };
     const result = await client.listFullEvents(principal, pageQuery);
     if (!result.ok) {
-      logger.warn(
-        `Failed to list events from sync (${result.error.kind}) ` +
-          `[status=${result.error.status}] ` +
-          `[correlationId=${result.error.correlationId}]`,
-      );
+      logSyncReadFailure("Failed to list events from sync", result.error);
       throw eventMutationError(
         "PROVIDER_FAILURE",
         `Failed to list events from sync (${result.error.kind})`,


### PR DESCRIPTION
Follow-up to #2860. That PR added warn-level breadcrumbs on the event read path, but `warn` is below the threshold that actually matters, so the observability gap it was meant to close stayed open.

## Why the warn logs weren't enough

`EventController` answers every error through `send`, which does `res.status().json()` and never reaches the global error handler. So unlike the proxy routes (`unwrap-sync-result` → handler → `logLevelForError`), nothing downstream logs the exception — and `PostHogExceptionTransport` is a winston transport at `level: "error"`. A defect logged at `warn` is never captured.

That is why the >20-calendar 502 ran for a day with a **healthy** autofix pipeline and zero error-tracking issues: nothing was ever captured, so nothing could be filed. For contrast, `calendar.controller.ts` uses `res.promise(Promise.reject(e))` and its identical "Failed to list calendars from sync" message *does* have a PostHog issue with 84 occurrences.

## Change

The level now follows the failure kind:

- `timeout` / `unavailable` stay at `warn` — our own backpressure or a Sync restart the caller retries through, mirroring `logLevelForError`'s operational-503 downgrade so a Sync deploy doesn't file issues.
- Everything else (`badRequest`, `unauthorized`, `notFound`, `conflict`, `invalidResponse`, `unexpectedStatus`) logs at `error` — a drifted internal auth token, a broken response contract, or a query Sync rejects outright. `badRequest` is exactly the shape of the outage.

The timeout/unavailable-vs-rest split already existed in `sync-proxy-error.ts`, so rather than re-encoding it I hoisted it into one `isOperationalKind` predicate that both `throwSyncProxyFailure`/`throwSyncCommandSubmitFailure` and the new `logLevelForSyncClientError` branch on. A test pins the two together, so a future error kind can't end up quiet on the log side while the status side treats it as a 502 defect.

## Testing

- `sync-proxy-error.test.ts` — new `logLevelForSyncClientError` describe (verified red: flattening the rule to always-`warn` fails 7 tests)
- backend sync-service + event + calendar suites: 164 pass
- `bun run type-check` clean, biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)