### PR TITLE
fix(backend): log event mutation failures, not just reads

### DIFF
--- a/packages/backend/src/event/controllers/event.controller.test.ts
+++ b/packages/backend/src/event/controllers/event.controller.test.ts
@@ -5,7 +5,11 @@ import { Status } from "@core/errors/status.codes";
 import calendarService from "@backend/calendar/services/calendar.service";
 import { CONFIG } from "@backend/common/constants/config.constants";
 import * as syncServiceFactory from "@backend/common/services/sync-service/sync-service.factory";
-import eventController from "./event.controller";
+import {
+  eventMutationError,
+  toEventMutationError,
+} from "@backend/event/event.error";
+import eventController, { logLevelForEventFailure } from "./event.controller";
 import {
   afterEach,
   beforeEach,
@@ -428,6 +432,80 @@ describe("EventController", () => {
       code: "INVALID_INPUT",
       message: "Cannot delete events for another user",
       retryable: false,
+    });
+  });
+});
+
+// This controller answers every error through `send`, which never reaches the
+// global error handler — so `send` is the only place an event failure gets
+// logged, for reads and writes alike, and PostHogExceptionTransport only
+// listens at `error`.
+describe("logLevelForEventFailure", () => {
+  // Normal outcomes of a user action. Logging these would file exceptions for
+  // everyday misses and bury the real defects.
+  it.each([
+    ["EVENT_NOT_FOUND", Status.NOT_FOUND],
+    ["INVALID_INPUT", Status.BAD_REQUEST],
+    ["CALENDAR_READ_ONLY", Status.FORBIDDEN],
+    ["GOOGLE_REVOKED", Status.GONE],
+    ["RECURRENCE_CONFLICT", Status.CONFLICT],
+  ] as const)("does not log %s (%d)", (_code, status) => {
+    expect(logLevelForEventFailure(status)).toBeUndefined();
+  });
+
+  // Mutations already split 503/502 by kind, so their status carries the
+  // operational-vs-defect distinction on its own.
+  it("keeps a mutation SYNC_UNAVAILABLE (503) at warn", () => {
+    expect(logLevelForEventFailure(Status.SERVICE_UNAVAILABLE)).toBe("warn");
+  });
+
+  it.each([
+    ["PROVIDER_FAILURE", 502 as Status],
+    ["unmapped failure", Status.INTERNAL_SERVER],
+  ] as const)("reports a mutation %s at error", (_label, status) => {
+    expect(logLevelForEventFailure(status)).toBe("error");
+  });
+
+  // The read path answers EVERY Sync kind with PROVIDER_FAILURE (502), so its
+  // status alone would report a Sync restart as a defect. The kind decides.
+  it("keeps a read failure at warn when Sync was merely unavailable", () => {
+    expect(
+      logLevelForEventFailure(502 as Status, {
+        kind: "unavailable",
+        correlationId: "corr-1",
+      }),
+    ).toBe("warn");
+  });
+
+  it("reports a read failure at error when Sync rejected the query", () => {
+    // The 2026-08-25 >20-calendar outage: badRequest behind a 502.
+    expect(
+      logLevelForEventFailure(502 as Status, {
+        kind: "badRequest",
+        status: 400,
+        correlationId: "corr-2",
+      }),
+    ).toBe("error");
+  });
+});
+
+describe("EventMutationException syncError", () => {
+  it("carries the Sync failure without leaking it to the client", () => {
+    const e = eventMutationError("PROVIDER_FAILURE", "Failed to list events", {
+      kind: "badRequest",
+      status: 400,
+      correlationId: "corr-secret",
+    });
+
+    expect(e.syncError?.kind).toBe("badRequest");
+
+    // The correlation id must stay out of the response: it is per-request, and
+    // the browser has no use for it.
+    const { body } = toEventMutationError(e);
+    expect(body).toEqual({
+      code: "PROVIDER_FAILURE",
+      message: "Failed to list events",
+      retryable: true,
     });
   });
 });

--- a/packages/backend/src/event/controllers/event.controller.ts
+++ b/packages/backend/src/event/controllers/event.controller.ts
@@ -41,6 +41,7 @@ import {
 } from "@backend/common/services/sync-service/sync-service.client";
 import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
 import {
+  EventMutationException,
   eventMutationError,
   toEventMutationError,
 } from "@backend/event/event.error";
@@ -48,23 +49,51 @@ import eventService from "@backend/event/services/event.service";
 
 const logger = Logger("app:event.controller");
 
-const send = (res: Response, e: unknown) => {
-  const { status, body } = toEventMutationError(e);
-  res.status(status).json(body);
+// Every handler in this controller answers through `send`, which writes the
+// response directly and never reaches the global error handler — so unlike
+// the proxy routes (unwrap-sync-result), nothing downstream logs the
+// exception. This is the only place an event read OR write failure can be
+// recorded, and PostHogExceptionTransport only listens at `error`, so a
+// defect logged any quieter is never captured: that is how the 2026-08-25
+// >20-calendar outage ran for a day with no error-tracking issue.
+//
+// Below 500 stays unlogged. A missing event, invalid input, a read-only
+// calendar or revoked Google grant is a normal outcome of a user action, not
+// a defect, and filing those as exceptions would bury the real ones.
+// Exported for tests: the level decision is the part worth pinning, and the
+// module-level `logger` cannot be spied on from a test (Logger() builds a new
+// winston instance per call).
+export const logLevelForEventFailure = (
+  status: Status,
+  syncError?: SyncClientError,
+): "warn" | "error" | undefined => {
+  if (status < Status.INTERNAL_SERVER) return undefined;
+  // Prefer the Sync failure kind when there is one: the read path answers
+  // every kind with PROVIDER_FAILURE (502), so its status cannot distinguish
+  // a Sync restart from a defect. Mutations already split 503/502 by kind
+  // (throwSyncCommandSubmitFailure), so status alone is right for them.
+  if (syncError) return logLevelForSyncClientError(syncError.kind);
+  return status === Status.SERVICE_UNAVAILABLE ? "warn" : "error";
 };
 
-// Log a failed Sync read. This controller answers every error through `send`,
-// which writes the response directly and never reaches the global error
-// handler — so unlike the proxy routes (unwrap-sync-result), nothing
-// downstream logs the exception, and PostHogExceptionTransport only listens
-// at `error`. The level is therefore chosen here rather than inherited:
-// a defect logged at `warn` is silently never reported, which is how the
-// 2026-08-25 >20-calendar outage ran for a day with no error-tracking issue.
-const logSyncReadFailure = (message: string, error: SyncClientError) => {
-  logger[logLevelForSyncClientError(error.kind)](
-    `${message} (${error.kind}) [status=${error.status}] ` +
-      `[correlationId=${error.correlationId}]`,
-  );
+const send = (res: Response, e: unknown) => {
+  const { status, body } = toEventMutationError(e);
+  const syncError =
+    e instanceof EventMutationException ? e.syncError : undefined;
+  const level = logLevelForEventFailure(status, syncError);
+
+  if (level) {
+    // The correlation id goes here rather than into `body.message`: PostHog
+    // groups issues by the message, so a per-request id in it would split one
+    // defect into an issue per occurrence.
+    const detail = syncError
+      ? ` (${syncError.kind}) [status=${syncError.status}] ` +
+        `[correlationId=${syncError.correlationId}]`
+      : "";
+    logger[level](`${body.code}: ${body.message}${detail}`);
+  }
+
+  res.status(status).json(body);
 };
 
 const parseListQuery = (query: Request["query"]): EventListQuery => {
@@ -104,15 +133,10 @@ const resolveSyncCalendarIds = async (
   ]);
 
   if (!calendarsResult.ok) {
-    // The thrown error's message never reaches a log (only the generic
-    // PROVIDER_FAILURE blurb does), so record the actionable detail here.
-    logSyncReadFailure(
-      "Failed to list calendars from sync",
-      calendarsResult.error,
-    );
     throw eventMutationError(
       "PROVIDER_FAILURE",
       `Failed to list calendars from sync (${calendarsResult.error.kind})`,
+      calendarsResult.error,
     );
   }
 
@@ -156,10 +180,10 @@ const listAllFullEvents = async (
     };
     const result = await client.listFullEvents(principal, pageQuery);
     if (!result.ok) {
-      logSyncReadFailure("Failed to list events from sync", result.error);
       throw eventMutationError(
         "PROVIDER_FAILURE",
         `Failed to list events from sync (${result.error.kind})`,
+        result.error,
       );
     }
     instances.push(...result.value.instances);

--- a/packages/backend/src/event/event.error.ts
+++ b/packages/backend/src/event/event.error.ts
@@ -5,6 +5,7 @@ import {
   type EventMutationError,
   type EventMutationErrorCodeSchema,
 } from "@core/types/event-command.contracts";
+import { type SyncClientError } from "@backend/common/services/sync-service/sync-service.client";
 
 export type EventMutationErrorCode = z.infer<
   typeof EventMutationErrorCodeSchema
@@ -56,6 +57,13 @@ export class EventMutationException extends BaseError {
   constructor(
     public readonly mutationCode: EventMutationErrorCode,
     message: string,
+    // The Sync failure behind this error, when it came from a Sync call. Kept
+    // off the client payload (`toEventMutationError` never reads it) and used
+    // only for logging: the event read path answers every Sync failure with
+    // PROVIDER_FAILURE, so its status alone cannot tell a Sync restart from a
+    // defect, and the correlation id belongs in the log rather than in the
+    // message, which PostHog groups issues by.
+    public readonly syncError?: SyncClientError,
   ) {
     super(
       mutationCode,
@@ -70,7 +78,9 @@ export class EventMutationException extends BaseError {
 export const eventMutationError = (
   code: EventMutationErrorCode,
   message: string,
-): EventMutationException => new EventMutationException(code, message);
+  syncError?: SyncClientError,
+): EventMutationException =>
+  new EventMutationException(code, message, syncError);
 
 /**
  * Maps any thrown error into the strict EventMutationError envelope (B5).


### PR DESCRIPTION
Completes the observability thread from #2860 / #2861. Those covered the two event **read** paths; the **mutation** paths still logged nothing at all.

## Problem

A failed Sync command submit, a provider rejection (`mapSyncFailure`), a cancelled command, or a non-terminal command all answered the browser and vanished — no log line, so nothing for `PostHogExceptionTransport` to capture and nothing for error-autofix to act on. The event controller answers every error through `send`, which never reaches the global error handler, so there is no other place these could be recorded.

Their failure sites are scattered across `submitCommandOrThrow` and `mapSyncFailure`, so logging at each one would be repetitive and easy to forget on the next site added.

## Change

Log once in `send` — the choke point every handler already funnels through. That covers reads and writes together, and by construction can't be missed by a future failure site.

The level rule:

- **Below 500: not logged.** A missing event, invalid input, a read-only calendar, or a revoked Google grant is a normal outcome of a user action. Filing those as exceptions would bury the real defects.
- **500+: level follows the status** — 503 (`SYNC_UNAVAILABLE`, `MAINTENANCE`) is operational and logs at `warn`; everything else at `error`.
- **Exception:** the read path answers *every* Sync kind with `PROVIDER_FAILURE` (502), so its status can't tell a Sync restart from a defect. `EventMutationException` now optionally carries the `SyncClientError` behind it, and when present the kind decides (reusing `logLevelForSyncClientError` from #2861).

Carrying the sync error also keeps the correlation id out of `message` — PostHog groups issues by the message, so a per-request id there would split one defect into an issue per occurrence. It's appended as log detail only, and a test asserts it never reaches the client payload.

This replaces #2861's read-only helper, so reads are now logged once rather than twice (which would otherwise have produced two PostHog issues per read failure).

## Testing

- `logLevelForEventFailure` describe covering the sub-500 silence, mutation 503/502, and read-path kind-awareness. Verified load-bearing: removing the sub-500 guard fails 5 tests; ignoring `syncError` fails 1.
- New test asserting `syncError` is carried but never serialized to the client.
- backend event + sync-service suites: 155 pass. `bun run type-check` and biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)