### PR TITLE
feat(web): reveal page-level jump targets while holding mod

### DIFF
--- a/packages/web/src/components/CalendarHeader/CalendarHeader.tsx
+++ b/packages/web/src/components/CalendarHeader/CalendarHeader.tsx
@@ -6,6 +6,7 @@ import { SelectView } from "@web/components/SelectView/SelectView";
 import { useVersionCheck } from "@web/components/Sidebar/SidebarActions/useVersionCheck";
 import { SidebarToggleButton } from "@web/components/Sidebar/SidebarToggleButton";
 import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
+import { pageJumpAttrs } from "@web/shortcuts/page-jump/page-jump.targets";
 
 interface Props {
   /** Left-aligned heading text (e.g. "June 2026" or "Wednesday, July 1"). */
@@ -46,7 +47,10 @@ export const CalendarHeader: FC<Props> = ({
           positioned inside this cluster and must paint below the header. */}
       <div className="flex min-w-0 flex-1 items-center gap-3">
         {showNavigation && onPrev && onNext && (
-          <>
+          <div
+            className="flex items-center gap-3"
+            {...pageJumpAttrs("navigation")}
+          >
             <TooltipWrapper shortcut="J">
               <ArrowButton
                 direction="left"
@@ -61,7 +65,7 @@ export const CalendarHeader: FC<Props> = ({
                 onClick={onNext}
               />
             </TooltipWrapper>
-          </>
+          </div>
         )}
         <SelectView label={label} onToday={onToday} />
         {isUpdateAvailable ? (

--- a/packages/web/src/components/ShortcutShowcase/showcase.steps.ts
+++ b/packages/web/src/components/ShortcutShowcase/showcase.steps.ts
@@ -42,7 +42,14 @@ const STEP_CONTENT: Record<ShowcaseStepId, Omit<ShowcaseStep, "id">> = {
   },
   graduation: {
     title: "You've shown great control, young cap'n.",
-    body: "That was practice. Your real calendar is next — the same two keys put a real event on it.",
+    // Seeds the one habit that reveals the rest: holding Mod shows jump keys
+    // wherever you are (form fields, page areas), so graduation teaches the
+    // gesture instead of a checklist of shortcuts.
+    body: [
+      "That was practice. Your real calendar is next — the same two keys put a real event on it. And whenever you wonder where to go, hold ",
+      { key: KEYMAP.jumpPageTarget.holdModifier },
+      " to see where you can jump.",
+    ],
   },
 };
 

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
@@ -19,6 +19,7 @@ import {
 } from "@web/calendars/collapsed-accounts.store";
 import { useCalendarVisibility } from "@web/calendars/useCalendarVisibility";
 import { useConnectedAccountEmails } from "@web/calendars/useDefaultTargetCalendar";
+import { pageJumpAttrs } from "@web/shortcuts/page-jump/page-jump.targets";
 import { AccountSectionHeader } from "./AccountSectionHeader";
 import { AnonymousCalendarRow } from "./AnonymousCalendarRow";
 import { CalendarListHeader } from "./CalendarListHeader";
@@ -75,7 +76,7 @@ export const CalendarList: FC = () => {
       : renderRows(rows, accountCalendarListId(key));
 
   return (
-    <section aria-label="Calendars">
+    <section aria-label="Calendars" {...pageJumpAttrs("calendars")}>
       {/* Every connected account carries its own heading below, so the generic
           banner is only for users who have none yet and are signed in. Anonymous
           users get a single calendar row instead. Showing it alongside account

--- a/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.tsx
+++ b/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.tsx
@@ -2,6 +2,7 @@ import { type FC, useEffect, useRef, useState } from "react";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { ID_DATEPICKER_SIDEBAR } from "@web/common/constants/web.constants";
 import { DatePicker } from "@web/components/DatePicker/DatePicker";
+import { pageJumpAttrs } from "@web/shortcuts/page-jump/page-jump.targets";
 
 interface Props {
   monthsShown?: number;
@@ -50,6 +51,7 @@ export const MonthPicker: FC<Props> = ({
       className={`c-month-picker ${monthPickerClassName}`}
       data-testid="Month picker"
       aria-label="Date navigation"
+      {...pageJumpAttrs("month-picker")}
     >
       <DatePicker
         animationOnToggle={false}

--- a/packages/web/src/components/Sidebar/UpNextCard/UpNextCard.tsx
+++ b/packages/web/src/components/Sidebar/UpNextCard/UpNextCard.tsx
@@ -2,6 +2,7 @@ import { VideoCameraIcon } from "@phosphor-icons/react";
 import { type FC } from "react";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
+import { pageJumpAttrs } from "@web/shortcuts/page-jump/page-jump.targets";
 import { useUpNextEvent } from "./useUpNextEvent";
 
 /**
@@ -58,7 +59,7 @@ export const UpNextCard: FC = () => {
     : undefined;
 
   return (
-    <section aria-label="Up next">
+    <section aria-label="Up next" {...pageJumpAttrs("up-next")}>
       {upNext ? (
         <div className="group relative flex min-h-14 w-full min-w-0 flex-col gap-0.5 rounded bg-surface px-2 py-1.5 hover:brightness-110">
           {/* Covers the whole card so clicking anywhere opens the event -

--- a/packages/web/src/components/WelcomeModal/WelcomeGuideBody.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeGuideBody.tsx
@@ -95,7 +95,8 @@ export function WelcomeGuideBody() {
       >
         Hold
         <ShortcutKeys keys={["Mod"]} />
-        to see keys, then press 1–5.
+        to see keys, then press 1–5. The same hold reveals jump keys all over
+        Compass.
       </p>
     </>
   );

--- a/packages/web/src/shortcuts/form-digit-jump/useFormDigitJumpShortcut.ts
+++ b/packages/web/src/shortcuts/form-digit-jump/useFormDigitJumpShortcut.ts
@@ -1,155 +1,36 @@
-import { resolveModifier } from "@tanstack/react-hotkeys";
-import { useEffect, useState } from "react";
 import { focusEventFormField } from "@web/common/utils/form/form.util";
-import { isAppLocked } from "@web/shortcuts/app-lock";
 import { physicalDigitIndex } from "@web/shortcuts/digit-pick.util";
 import {
   EDIT_SEQUENCE_FIELD_BY_DIGIT,
   FORM_FIELD_DIGITS,
 } from "@web/shortcuts/edit-sequence/edit-sequence.fields";
-import { normalizedKeyboardKey } from "@web/shortcuts/is-bare-letter-key";
+import { useModHoldHintShortcut } from "@web/shortcuts/mod-hold/useModHoldHintShortcut";
 
-/**
- * How long Mod must be held, with nothing else pressed, before hint chips
- * appear. Matches the `e`-leader's ARM_WINDOW_MS cadence so both hold
- * gestures feel the same.
- */
-export const MOD_HOLD_HINT_MS = 600;
+export { MOD_HOLD_HINT_MS } from "@web/shortcuts/mod-hold/useModHoldHintShortcut";
 
 /** 0-based physical-digit index -> field digit, i.e. the form's DOM order. */
 const DIGIT_ORDER = FORM_FIELD_DIGITS.map((entry) => entry.digit);
 
 /**
  * Mod+digit jumps focus straight to a form field (1=title ... 8=description;
- * see edit-sequence.fields.ts for the assignment). Holding Mod alone for
- * MOD_HOLD_HINT_MS reveals the mapping as hint chips (FormDigitHintOverlay),
- * the same discoverability contract as the `e`-leader's which-key menu — but
- * driven by a hold instead of a second keypress.
+ * see edit-sequence.fields.ts for the assignment). Holding Mod alone reveals
+ * the mapping as hint chips (FormDigitHintOverlay) via the shared hold-Mod
+ * engine — the same discoverability contract as the `e`-leader's which-key
+ * menu, but driven by a hold instead of a second keypress.
  *
  * Mounted from EventForm, so this hook is live exactly while the form is
  * open; no separate "is the form open" gate is needed.
- *
- * Safari may still switch tabs for some Cmd+digit combos despite
- * preventDefault; Chromium and Firefox honor it.
  */
 export function useFormDigitJumpShortcut(): { areHintsVisible: boolean } {
-  const [areHintsVisible, setAreHintsVisible] = useState(false);
+  return useModHoldHintShortcut({
+    onModChord: (event) => {
+      const index = physicalDigitIndex(event);
+      const digit = index !== null ? DIGIT_ORDER[index] : undefined;
+      const field = digit ? EDIT_SEQUENCE_FIELD_BY_DIGIT[digit] : undefined;
+      if (!field) return false;
 
-  useEffect(() => {
-    const isMac = resolveModifier("Mod") === "Meta";
-    const modKey = isMac ? "Meta" : "Control";
-    let holdTimeoutId: ReturnType<typeof setTimeout> | null = null;
-    let hintsVisible = false;
-    const suppressKeyUp = new Set<string>();
-
-    const clearHoldTimer = () => {
-      if (holdTimeoutId !== null) {
-        clearTimeout(holdTimeoutId);
-        holdTimeoutId = null;
-      }
-    };
-
-    const hideHints = () => {
-      clearHoldTimer();
-      if (hintsVisible) {
-        hintsVisible = false;
-        setAreHintsVisible(false);
-      }
-    };
-
-    const armHoldTimer = () => {
-      holdTimeoutId = setTimeout(() => {
-        holdTimeoutId = null;
-        hintsVisible = true;
-        setAreHintsVisible(true);
-      }, MOD_HOLD_HINT_MS);
-    };
-
-    const isModOnly = (event: KeyboardEvent) =>
-      isMac
-        ? event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey
-        : event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey;
-
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.defaultPrevented) return;
-      if (isAppLocked()) {
-        hideHints();
-        return;
-      }
-
-      if (event.key === modKey) {
-        // Held modifiers auto-repeat; only the initial press should start the
-        // clock, or the timer would keep resetting for as long as Mod stays down.
-        if (event.repeat) return;
-        if (!hintsVisible && holdTimeoutId === null) {
-          armHoldTimer();
-        }
-        return;
-      }
-
-      if (isModOnly(event)) {
-        const index = physicalDigitIndex(event);
-        const digit = index !== null ? DIGIT_ORDER[index] : undefined;
-        const field = digit ? EDIT_SEQUENCE_FIELD_BY_DIGIT[digit] : undefined;
-
-        if (field) {
-          event.preventDefault();
-          event.stopPropagation();
-          // macOS swallows this key's keyup while Cmd is held and replays it
-          // with metaKey:false on release; suppress so nothing downstream
-          // reacts to that replay as a bare keystroke.
-          suppressKeyUp.add(normalizedKeyboardKey(event));
-          hideHints();
-          focusEventFormField(field);
-          return;
-        }
-      }
-
-      // Any other keydown (including an unmatched Mod chord like Mod+K) means
-      // the user wasn't pausing to look; only a fresh Mod press re-arms it.
-      clearHoldTimer();
-    };
-
-    const onKeyUp = (event: KeyboardEvent) => {
-      const key = normalizedKeyboardKey(event);
-      if (suppressKeyUp.has(key)) {
-        suppressKeyUp.delete(key);
-        event.preventDefault();
-        event.stopPropagation();
-        return;
-      }
-
-      if (event.key === modKey) {
-        hideHints();
-      }
-    };
-
-    // Clicking away or losing the window abandons the gesture rather than
-    // leaving chips pinned to a form the user isn't looking at. Window
-    // switches (Cmd+Tab) can swallow the Meta keyup entirely, so blur and
-    // visibilitychange are covered independently of onKeyUp.
-    const onPointerDown = () => hideHints();
-    const onWindowBlur = () => hideHints();
-    const onVisibilityChange = () => {
-      if (document.visibilityState === "hidden") hideHints();
-    };
-
-    document.addEventListener("keydown", onKeyDown, true);
-    document.addEventListener("keyup", onKeyUp, true);
-    document.addEventListener("pointerdown", onPointerDown, true);
-    window.addEventListener("blur", onWindowBlur);
-    document.addEventListener("visibilitychange", onVisibilityChange);
-
-    return () => {
-      hideHints();
-      suppressKeyUp.clear();
-      document.removeEventListener("keydown", onKeyDown, true);
-      document.removeEventListener("keyup", onKeyUp, true);
-      document.removeEventListener("pointerdown", onPointerDown, true);
-      window.removeEventListener("blur", onWindowBlur);
-      document.removeEventListener("visibilitychange", onVisibilityChange);
-    };
-  }, []);
-
-  return { areHintsVisible };
+      focusEventFormField(field);
+      return true;
+    },
+  });
 }

--- a/packages/web/src/shortcuts/keymap.ts
+++ b/packages/web/src/shortcuts/keymap.ts
@@ -21,6 +21,13 @@ export const KEYMAP = {
     digits: ["1", "8"],
     keycaps: ["Mod", "1-8"],
   },
+  // Same hold-Mod gesture outside the form: digits follow PAGE_JUMP_TARGETS
+  // order (page-jump.targets.ts).
+  jumpPageTarget: {
+    holdModifier: "Mod",
+    digits: ["1", "4"],
+    keycaps: ["Mod", "1-4"],
+  },
   moveFocus: {
     hotkeys: {
       up: "ArrowUp",

--- a/packages/web/src/shortcuts/mod-hold/useModHoldHintShortcut.ts
+++ b/packages/web/src/shortcuts/mod-hold/useModHoldHintShortcut.ts
@@ -1,0 +1,155 @@
+import { resolveModifier } from "@tanstack/react-hotkeys";
+import { useEffect, useRef, useState } from "react";
+import { isAppLocked } from "@web/shortcuts/app-lock";
+import { normalizedKeyboardKey } from "@web/shortcuts/is-bare-letter-key";
+
+/**
+ * How long Mod must be held, with nothing else pressed, before hint chips
+ * appear. Matches the `e`-leader's ARM_WINDOW_MS cadence so both hold
+ * gestures feel the same.
+ */
+export const MOD_HOLD_HINT_MS = 600;
+
+/**
+ * The hold-Mod discoverability engine: holding the platform Mod key alone for
+ * MOD_HOLD_HINT_MS flips `areHintsVisible` on (an overlay renders keycap
+ * chips over the jump targets), and a Mod chord dispatches through
+ * `onModChord`. Each surface supplies only its own digit-to-target mapping —
+ * the event form's fields (useFormDigitJumpShortcut) and the page's areas
+ * (usePageJumpShortcut) share this one gesture so the muscle memory of
+ * "hold Mod to see where to go next" works the same everywhere.
+ *
+ * `onModChord` receives every keydown while Mod (and no other modifier) is
+ * held and returns whether it consumed the key; a consumed key is
+ * preventDefaulted and its macOS keyup replay suppressed.
+ *
+ * Safari may still switch tabs for some Cmd+digit combos despite
+ * preventDefault; Chromium and Firefox honor it.
+ */
+export function useModHoldHintShortcut({
+  enabled = true,
+  onModChord,
+}: {
+  enabled?: boolean;
+  onModChord: (event: KeyboardEvent) => boolean;
+}): { areHintsVisible: boolean } {
+  const [areHintsVisible, setAreHintsVisible] = useState(false);
+  const onModChordRef = useRef(onModChord);
+  onModChordRef.current = onModChord;
+
+  useEffect(() => {
+    if (!enabled) {
+      setAreHintsVisible(false);
+      return;
+    }
+
+    const isMac = resolveModifier("Mod") === "Meta";
+    const modKey = isMac ? "Meta" : "Control";
+    let holdTimeoutId: ReturnType<typeof setTimeout> | null = null;
+    let hintsVisible = false;
+    const suppressKeyUp = new Set<string>();
+
+    const clearHoldTimer = () => {
+      if (holdTimeoutId !== null) {
+        clearTimeout(holdTimeoutId);
+        holdTimeoutId = null;
+      }
+    };
+
+    const hideHints = () => {
+      clearHoldTimer();
+      if (hintsVisible) {
+        hintsVisible = false;
+        setAreHintsVisible(false);
+      }
+    };
+
+    const armHoldTimer = () => {
+      holdTimeoutId = setTimeout(() => {
+        holdTimeoutId = null;
+        hintsVisible = true;
+        setAreHintsVisible(true);
+      }, MOD_HOLD_HINT_MS);
+    };
+
+    const isModOnly = (event: KeyboardEvent) =>
+      isMac
+        ? event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey
+        : event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      if (isAppLocked()) {
+        hideHints();
+        return;
+      }
+
+      if (event.key === modKey) {
+        // Held modifiers auto-repeat; only the initial press should start the
+        // clock, or the timer would keep resetting for as long as Mod stays down.
+        if (event.repeat) return;
+        if (!hintsVisible && holdTimeoutId === null) {
+          armHoldTimer();
+        }
+        return;
+      }
+
+      if (isModOnly(event) && onModChordRef.current(event)) {
+        event.preventDefault();
+        event.stopPropagation();
+        // macOS swallows this key's keyup while Cmd is held and replays it
+        // with metaKey:false on release; suppress so nothing downstream
+        // reacts to that replay as a bare keystroke.
+        suppressKeyUp.add(normalizedKeyboardKey(event));
+        hideHints();
+        return;
+      }
+
+      // Any other keydown (including an unmatched Mod chord like Mod+K) means
+      // the user wasn't pausing to look; only a fresh Mod press re-arms it.
+      clearHoldTimer();
+    };
+
+    const onKeyUp = (event: KeyboardEvent) => {
+      const key = normalizedKeyboardKey(event);
+      if (suppressKeyUp.has(key)) {
+        suppressKeyUp.delete(key);
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+
+      if (event.key === modKey) {
+        hideHints();
+      }
+    };
+
+    // Clicking away or losing the window abandons the gesture rather than
+    // leaving chips pinned to a spot the user isn't looking at. Window
+    // switches (Cmd+Tab) can swallow the Meta keyup entirely, so blur and
+    // visibilitychange are covered independently of onKeyUp.
+    const onPointerDown = () => hideHints();
+    const onWindowBlur = () => hideHints();
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "hidden") hideHints();
+    };
+
+    document.addEventListener("keydown", onKeyDown, true);
+    document.addEventListener("keyup", onKeyUp, true);
+    document.addEventListener("pointerdown", onPointerDown, true);
+    window.addEventListener("blur", onWindowBlur);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      hideHints();
+      suppressKeyUp.clear();
+      document.removeEventListener("keydown", onKeyDown, true);
+      document.removeEventListener("keyup", onKeyUp, true);
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      window.removeEventListener("blur", onWindowBlur);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [enabled]);
+
+  return { areHintsVisible };
+}

--- a/packages/web/src/shortcuts/page-jump/PageJumpHintOverlay.test.tsx
+++ b/packages/web/src/shortcuts/page-jump/PageJumpHintOverlay.test.tsx
@@ -1,0 +1,124 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { PageJumpHintOverlay } from "@web/shortcuts/page-jump/PageJumpHintOverlay";
+import {
+  PAGE_JUMP_ATTRIBUTE,
+  type PageJumpTargetId,
+} from "@web/shortcuts/page-jump/page-jump.targets";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+const box = (
+  top: number,
+  left: number,
+  bottom: number,
+  right: number,
+): DOMRect =>
+  ({
+    top,
+    left,
+    bottom,
+    right,
+    width: right - left,
+    height: bottom - top,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  }) as DOMRect;
+
+const stubRect = (element: HTMLElement, rect: DOMRect) => {
+  element.getBoundingClientRect = () => rect;
+};
+
+const overlayRoot = () => document.querySelector("[data-page-jump-hints]");
+const chipsWrapper = () => overlayRoot()?.querySelector("[aria-hidden]");
+const chipDigits = () =>
+  Array.from(chipsWrapper()?.children ?? []).map((el) => el.textContent);
+
+const addAnchor = (
+  id: PageJumpTargetId,
+  { focusable = true }: { focusable?: boolean } = {},
+): HTMLElement => {
+  const anchor = document.createElement("section");
+  anchor.setAttribute(PAGE_JUMP_ATTRIBUTE, id);
+  if (focusable) {
+    anchor.append(document.createElement("button"));
+  }
+  stubRect(anchor, box(100, 80, 140, 240));
+  document.body.append(anchor);
+  return anchor;
+};
+
+describe("PageJumpHintOverlay", () => {
+  let originalInnerHeight: number;
+  let originalInnerWidth: number;
+
+  beforeEach(() => {
+    originalInnerHeight = window.innerHeight;
+    originalInnerWidth = window.innerWidth;
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 800,
+    });
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1200,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    document.body.replaceChildren();
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: originalInnerHeight,
+    });
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: originalInnerWidth,
+    });
+  });
+
+  it("renders nothing when not visible", () => {
+    addAnchor("navigation");
+    render(<PageJumpHintOverlay visible={false} />);
+
+    expect(overlayRoot()).toBeNull();
+  });
+
+  it("renders nothing when no target is present", () => {
+    render(<PageJumpHintOverlay visible={true} />);
+
+    expect(overlayRoot()).toBeNull();
+  });
+
+  it("renders a chip for each mounted target, skipping absent ones", () => {
+    addAnchor("navigation");
+    addAnchor("month-picker");
+    // No up-next / calendars anchors: e.g. the sidebar is collapsed.
+    render(<PageJumpHintOverlay visible={true} />);
+
+    expect(chipDigits()).toEqual(["1", "2"]);
+  });
+
+  it("skips a mounted target with nothing focusable", () => {
+    addAnchor("navigation");
+    // The empty Up Next card renders its section but no interactive element,
+    // so its digit would do nothing and must not be advertised.
+    addAnchor("up-next", { focusable: false });
+    render(<PageJumpHintOverlay visible={true} />);
+
+    expect(chipDigits()).toEqual(["1"]);
+    expect(screen.getByRole("status").textContent).not.toContain("up next");
+  });
+
+  it("exposes a screen-reader summary while the visible chips stay aria-hidden", () => {
+    addAnchor("navigation");
+    addAnchor("month-picker");
+    render(<PageJumpHintOverlay visible={true} />);
+
+    const status = screen.getByRole("status");
+    expect(status.textContent).toContain("Jump to?");
+    expect(status.textContent).toContain("1 for view navigation");
+    expect(status.textContent).toContain("2 for month picker");
+    expect(chipsWrapper()?.getAttribute("aria-hidden")).not.toBeNull();
+  });
+});

--- a/packages/web/src/shortcuts/page-jump/PageJumpHintOverlay.tsx
+++ b/packages/web/src/shortcuts/page-jump/PageJumpHintOverlay.tsx
@@ -1,0 +1,78 @@
+import { createPortal } from "react-dom";
+import { Z_INDEX_TOOLTIP } from "@web/common/constants/web.constants";
+import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
+import {
+  getPageJumpAnchor,
+  getPageJumpFocusElement,
+  PAGE_JUMP_TARGETS,
+} from "@web/shortcuts/page-jump/page-jump.targets";
+import { getVisibleHintRect } from "@web/shortcuts/shift-hint/shift-hint-visible-rect";
+import { useHintLayoutRefresh } from "@web/shortcuts/useHintLayoutRefresh";
+
+/**
+ * Numbered keycap chips anchored to each page jump target while Mod is held
+ * (see usePageJumpShortcut). Portaled like FormDigitHintOverlay so scroll
+ * containers cannot clip a chip on a target near their edge.
+ */
+export function PageJumpHintOverlay({ visible }: { visible: boolean }) {
+  useHintLayoutRefresh(visible);
+
+  if (!visible || typeof document === "undefined") {
+    return null;
+  }
+
+  // Only targets that would actually take focus get announced or chipped —
+  // e.g. a collapsed sidebar unmounts the month picker, and an empty Up Next
+  // card has nothing focusable, so their digits would do nothing there.
+  const presentTargets = PAGE_JUMP_TARGETS.flatMap((target) => {
+    const anchor = getPageJumpAnchor(target.id);
+    if (!anchor || !getPageJumpFocusElement(target.id)) return [];
+    return [{ ...target, anchor }];
+  });
+
+  if (presentTargets.length === 0) {
+    return null;
+  }
+
+  const srText = `Jump to? ${presentTargets
+    .map((target) => `${target.digit} for ${target.label.toLowerCase()}`)
+    .join(", ")}. Release the modifier to dismiss.`;
+
+  return createPortal(
+    <div
+      className="pointer-events-none fixed inset-0"
+      data-page-jump-hints=""
+      style={{ zIndex: Z_INDEX_TOOLTIP }}
+    >
+      <span aria-live="polite" className="sr-only" role="status">
+        {srText}
+      </span>
+      <div aria-hidden>
+        {presentTargets.map((target) => {
+          const visibleRect = getVisibleHintRect(target.anchor);
+          if (!visibleRect) {
+            // Scrolled out of view; the shortcut still works, but a
+            // portaled chip with nothing to anchor to would float in place.
+            return null;
+          }
+
+          const chipWidth = 22;
+
+          return (
+            <span
+              key={target.id}
+              className="absolute"
+              style={{
+                top: visibleRect.top + 2,
+                left: Math.max(4, visibleRect.right - chipWidth),
+              }}
+            >
+              <ShortcutHint>{target.digit}</ShortcutHint>
+            </span>
+          );
+        })}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/packages/web/src/shortcuts/page-jump/PageJumpHints.tsx
+++ b/packages/web/src/shortcuts/page-jump/PageJumpHints.tsx
@@ -1,0 +1,11 @@
+import { PageJumpHintOverlay } from "@web/shortcuts/page-jump/PageJumpHintOverlay";
+import { usePageJumpShortcut } from "@web/shortcuts/page-jump/usePageJumpShortcut";
+
+/**
+ * Self-contained mount for the page-level hold-Mod jump gesture: hook plus
+ * hint overlay. Rendered once per calendar view (Day, Week).
+ */
+export function PageJumpHints() {
+  const { areHintsVisible } = usePageJumpShortcut();
+  return <PageJumpHintOverlay visible={areHintsVisible} />;
+}

--- a/packages/web/src/shortcuts/page-jump/page-jump.targets.test.ts
+++ b/packages/web/src/shortcuts/page-jump/page-jump.targets.test.ts
@@ -1,0 +1,82 @@
+import {
+  focusPageJumpTarget,
+  getPageJumpFocusElement,
+  PAGE_JUMP_ATTRIBUTE,
+  PAGE_JUMP_TARGETS,
+  type PageJumpTargetId,
+} from "@web/shortcuts/page-jump/page-jump.targets";
+import { afterEach, describe, expect, it } from "bun:test";
+
+const addAnchor = (id: PageJumpTargetId): HTMLElement => {
+  const anchor = document.createElement("section");
+  anchor.setAttribute(PAGE_JUMP_ATTRIBUTE, id);
+  document.body.append(anchor);
+  return anchor;
+};
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("PAGE_JUMP_TARGETS", () => {
+  it("assigns sequential digits matching each target's list position", () => {
+    // usePageJumpShortcut resolves a pressed digit by index, so the digit
+    // shown on a chip must always equal index + 1.
+    PAGE_JUMP_TARGETS.forEach((target, index) => {
+      expect(target.digit).toBe(String(index + 1));
+    });
+  });
+});
+
+describe("getPageJumpFocusElement", () => {
+  it("returns null when the anchor is not mounted", () => {
+    expect(getPageJumpFocusElement("month-picker")).toBeNull();
+  });
+
+  it("returns null when the anchor has nothing focusable", () => {
+    // Matches the empty Up Next card: a section with only static text.
+    const anchor = addAnchor("up-next");
+    anchor.append(document.createTextNode("All clear"));
+
+    expect(getPageJumpFocusElement("up-next")).toBeNull();
+  });
+
+  it("prefers an explicit tabindex=0 roving stop over earlier buttons", () => {
+    // Mirrors the month picker: react-datepicker's prev/next buttons come
+    // first in DOM order, but exactly one day keeps tabindex=0.
+    const anchor = addAnchor("month-picker");
+    const prevMonth = document.createElement("button");
+    anchor.append(prevMonth);
+    const day = document.createElement("div");
+    day.setAttribute("tabindex", "0");
+    anchor.append(day);
+
+    expect(getPageJumpFocusElement("month-picker")).toBe(day);
+  });
+
+  it("falls back to the first interactive element", () => {
+    const anchor = addAnchor("navigation");
+    const disabled = document.createElement("button");
+    disabled.disabled = true;
+    anchor.append(disabled);
+    const arrow = document.createElement("button");
+    anchor.append(arrow);
+
+    expect(getPageJumpFocusElement("navigation")).toBe(arrow);
+  });
+});
+
+describe("focusPageJumpTarget", () => {
+  it("focuses the resolved element and reports success", () => {
+    const anchor = addAnchor("calendars");
+    const toggle = document.createElement("button");
+    anchor.append(toggle);
+
+    expect(focusPageJumpTarget("calendars")).toBe(true);
+    expect(document.activeElement).toBe(toggle);
+  });
+
+  it("reports failure when the target cannot take focus", () => {
+    expect(focusPageJumpTarget("calendars")).toBe(false);
+  });
+});

--- a/packages/web/src/shortcuts/page-jump/page-jump.targets.ts
+++ b/packages/web/src/shortcuts/page-jump/page-jump.targets.ts
@@ -1,0 +1,72 @@
+/**
+ * Page-level jump targets for the hold-Mod hint gesture while no event form
+ * is open: Mod+digit focuses a page area, and holding Mod alone reveals the
+ * digits as chips (PageJumpHintOverlay) — the same contract as the form's
+ * Mod+digit field jumps, so one habit covers both surfaces.
+ *
+ * Components opt in by spreading `pageJumpAttrs(id)` on their container;
+ * digits come from this list's order, so it is the single place to add,
+ * remove, or renumber a target. An unmounted anchor (collapsed sidebar,
+ * empty Up Next) simply gets no chip and its digit does nothing.
+ */
+
+export const PAGE_JUMP_ATTRIBUTE = "data-page-jump";
+
+export type PageJumpTargetId =
+  | "navigation"
+  | "month-picker"
+  | "up-next"
+  | "calendars";
+
+export type PageJumpTarget = {
+  digit: string;
+  id: PageJumpTargetId;
+  label: string;
+};
+
+export const PAGE_JUMP_TARGETS: readonly PageJumpTarget[] = [
+  { digit: "1", id: "navigation", label: "View navigation" },
+  { digit: "2", id: "month-picker", label: "Month picker" },
+  { digit: "3", id: "up-next", label: "Up next" },
+  { digit: "4", id: "calendars", label: "Calendar list" },
+];
+
+/** Spread onto a component's container element to mark it as a jump target. */
+export const pageJumpAttrs = (
+  id: PageJumpTargetId,
+): { [PAGE_JUMP_ATTRIBUTE]: PageJumpTargetId } => ({
+  [PAGE_JUMP_ATTRIBUTE]: id,
+});
+
+export const getPageJumpAnchor = (id: PageJumpTargetId): HTMLElement | null =>
+  document.querySelector<HTMLElement>(`[${PAGE_JUMP_ATTRIBUTE}="${id}"]`);
+
+const INTERACTIVE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/**
+ * The element a jump would focus, or null if the target isn't currently
+ * usable. An explicit `[tabindex="0"]` wins over document order so a roving
+ * tab stop (the month picker keeps exactly one day at tabindex=0) is landed
+ * on directly, and arrow keys / Tab work from there right away.
+ */
+export const getPageJumpFocusElement = (
+  id: PageJumpTargetId,
+): HTMLElement | null => {
+  const anchor = getPageJumpAnchor(id);
+  if (!anchor) return null;
+  return (
+    anchor.querySelector<HTMLElement>('[tabindex="0"]') ??
+    (anchor.matches(INTERACTIVE_SELECTOR)
+      ? anchor
+      : anchor.querySelector<HTMLElement>(INTERACTIVE_SELECTOR))
+  );
+};
+
+/** Focus a page jump target; returns whether a focusable element was found. */
+export const focusPageJumpTarget = (id: PageJumpTargetId): boolean => {
+  const element = getPageJumpFocusElement(id);
+  if (!element) return false;
+  element.focus();
+  return true;
+};

--- a/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.test.tsx
+++ b/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.test.tsx
@@ -1,0 +1,234 @@
+import { resolveModifier } from "@tanstack/react-hotkeys";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import {
+  createGridEventDraft,
+  timedGridSchedule,
+} from "@web/events/grid-event-draft.adapter";
+import {
+  draftActions,
+  initialDraftState,
+  useDraftStore,
+} from "@web/events/stores/draft.store";
+import { clearAppLockReasons, setAppLockReason } from "@web/shortcuts/app-lock";
+import { MOD_HOLD_HINT_MS } from "@web/shortcuts/mod-hold/useModHoldHintShortcut";
+import {
+  PAGE_JUMP_ATTRIBUTE,
+  type PageJumpTargetId,
+} from "@web/shortcuts/page-jump/page-jump.targets";
+import { usePageJumpShortcut } from "@web/shortcuts/page-jump/usePageJumpShortcut";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+/** Matches what the hook resolves Mod to on this platform. */
+const isMac = resolveModifier("Mod") === "Meta";
+const MOD_KEY = isMac ? "Meta" : "Control";
+const MOD_INIT: KeyboardEventInit = isMac
+  ? { metaKey: true }
+  : { ctrlKey: true };
+
+const PAST_HOLD_MS = MOD_HOLD_HINT_MS + 150;
+const waitPastHold = () =>
+  new Promise((resolve) => setTimeout(resolve, PAST_HOLD_MS));
+
+const dispatch = (type: "keydown" | "keyup", init: KeyboardEventInit) => {
+  const event = new KeyboardEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    ...init,
+  });
+  document.dispatchEvent(event);
+  return event;
+};
+
+const pressModDown = () => dispatch("keydown", { key: MOD_KEY, ...MOD_INIT });
+
+const pressModDigit = (digit: string) =>
+  dispatch("keydown", { key: digit, code: `Digit${digit}`, ...MOD_INIT });
+
+/**
+ * Minimal page DOM with real anchors, so focusPageJumpTarget (the hook's real
+ * dispatch target) actually moves focus instead of needing to be mocked.
+ */
+const buildPage = () => {
+  const addAnchor = (id: PageJumpTargetId) => {
+    const anchor = document.createElement("section");
+    anchor.setAttribute(PAGE_JUMP_ATTRIBUTE, id);
+    document.body.append(anchor);
+    return anchor;
+  };
+
+  const prevArrow = document.createElement("button");
+  addAnchor("navigation").append(prevArrow);
+
+  // Roving tab stop, like react-datepicker's focused day.
+  const monthDay = document.createElement("div");
+  monthDay.setAttribute("tabindex", "0");
+  addAnchor("month-picker").append(monthDay);
+
+  return { prevArrow, monthDay };
+};
+
+const openEventForm = () => {
+  draftActions.startGridDraft({
+    activity: "gridClick",
+    draft: createGridEventDraft(
+      timedGridSchedule(
+        new Date("2026-05-20T10:00:00"),
+        new Date("2026-05-20T11:00:00"),
+      ),
+    ),
+  });
+};
+
+describe("usePageJumpShortcut", () => {
+  beforeEach(() => {
+    clearAppLockReasons();
+  });
+
+  afterEach(() => {
+    clearAppLockReasons();
+    useDraftStore.setState(initialDraftState, true);
+    document.body.innerHTML = "";
+  });
+
+  describe("Mod+digit dispatch", () => {
+    it("jumps to the mapped page target and prevents default", () => {
+      const { monthDay } = buildPage();
+      renderHook(() => usePageJumpShortcut());
+
+      const event = pressModDigit("2");
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(monthDay).toHaveFocus();
+    });
+
+    it("leaves an unmapped digit alone", () => {
+      buildPage();
+      renderHook(() => usePageJumpShortcut());
+
+      const event = pressModDigit("9");
+
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("leaves the digit alone when its target is not mounted", () => {
+      // Collapsed sidebar: no month-picker anchor, so Mod+2 stays a browser
+      // shortcut instead of being swallowed with nothing to focus.
+      renderHook(() => usePageJumpShortcut());
+
+      const event = pressModDigit("2");
+
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("ignores a bare digit with no modifier held", () => {
+      const { prevArrow } = buildPage();
+      prevArrow.focus();
+      renderHook(() => usePageJumpShortcut());
+
+      const event = dispatch("keydown", { key: "2", code: "Digit2" });
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(prevArrow).toHaveFocus();
+    });
+  });
+
+  describe("hold-Mod hint chips", () => {
+    it("shows hints once Mod is held past the threshold", async () => {
+      buildPage();
+      const { result } = renderHook(() => usePageJumpShortcut());
+
+      pressModDown();
+      await act(async () => {
+        await waitPastHold();
+      });
+
+      await waitFor(() => {
+        expect(result.current.areHintsVisible).toBe(true);
+      });
+    });
+
+    it("hides hints on Mod keyup", async () => {
+      buildPage();
+      const { result } = renderHook(() => usePageJumpShortcut());
+
+      pressModDown();
+      await act(async () => {
+        await waitPastHold();
+      });
+      await waitFor(() => expect(result.current.areHintsVisible).toBe(true));
+
+      act(() => {
+        dispatch("keyup", { key: MOD_KEY, ...MOD_INIT });
+      });
+
+      expect(result.current.areHintsVisible).toBe(false);
+    });
+  });
+
+  describe("while the event form is open", () => {
+    it("does not dispatch: the form's digit jumps own the gesture", () => {
+      const { monthDay, prevArrow } = buildPage();
+      prevArrow.focus();
+      act(() => {
+        openEventForm();
+      });
+      renderHook(() => usePageJumpShortcut());
+
+      const event = pressModDigit("2");
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(monthDay).not.toHaveFocus();
+    });
+
+    it("does not arm hints", async () => {
+      buildPage();
+      act(() => {
+        openEventForm();
+      });
+      const { result } = renderHook(() => usePageJumpShortcut());
+
+      pressModDown();
+      await act(async () => {
+        await waitPastHold();
+      });
+
+      expect(result.current.areHintsVisible).toBe(false);
+    });
+
+    it("hides hints the moment the form opens mid-hold", async () => {
+      buildPage();
+      const { result } = renderHook(() => usePageJumpShortcut());
+
+      pressModDown();
+      await act(async () => {
+        await waitPastHold();
+      });
+      await waitFor(() => expect(result.current.areHintsVisible).toBe(true));
+
+      act(() => {
+        openEventForm();
+      });
+
+      await waitFor(() => {
+        expect(result.current.areHintsVisible).toBe(false);
+      });
+    });
+  });
+
+  it("does not dispatch or arm hints while the app is locked", async () => {
+    const { monthDay, prevArrow } = buildPage();
+    prevArrow.focus();
+    setAppLockReason("test-lock", true);
+    const { result } = renderHook(() => usePageJumpShortcut());
+
+    pressModDigit("2");
+    expect(monthDay).not.toHaveFocus();
+
+    pressModDown();
+    await act(async () => {
+      await waitPastHold();
+    });
+    expect(result.current.areHintsVisible).toBe(false);
+  });
+});

--- a/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.ts
+++ b/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.ts
@@ -1,0 +1,32 @@
+import {
+  selectIsEventFormOpen,
+  useDraftStore,
+} from "@web/events/stores/draft.store";
+import { physicalDigitIndex } from "@web/shortcuts/digit-pick.util";
+import { useModHoldHintShortcut } from "@web/shortcuts/mod-hold/useModHoldHintShortcut";
+import {
+  focusPageJumpTarget,
+  PAGE_JUMP_TARGETS,
+} from "@web/shortcuts/page-jump/page-jump.targets";
+
+/**
+ * Mod+digit jumps focus to a page area (see PAGE_JUMP_TARGETS); holding Mod
+ * alone reveals the digits via the shared hold-Mod engine.
+ *
+ * Disabled while the event form is open: the form's own Mod+digit field
+ * jumps (useFormDigitJumpShortcut) own the gesture then, so the two digit
+ * maps never overlap.
+ */
+export function usePageJumpShortcut(): { areHintsVisible: boolean } {
+  const isEventFormOpen = useDraftStore(selectIsEventFormOpen);
+
+  return useModHoldHintShortcut({
+    enabled: !isEventFormOpen,
+    onModChord: (event) => {
+      const index = physicalDigitIndex(event);
+      const target = index !== null ? PAGE_JUMP_TARGETS[index] : undefined;
+      if (!target) return false;
+      return focusPageJumpTarget(target.id);
+    },
+  });
+}

--- a/packages/web/src/shortcuts/shortcuts.menu.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.menu.test.ts
@@ -207,12 +207,20 @@ describe("shortcut menu sections", () => {
         { keys: ["u"], label: "Focus calendar event" },
         { keys: ["s"], label: "Toggle event jump keys" },
         { keys: ["f"], label: "Focus latest notice" },
+        {
+          keys: ["Mod", "1-4"],
+          label: "Jump to a page area (hold Mod for hints)",
+        },
       ]);
       expect(stripMetadata(findFocus("week")?.shortcuts ?? [])).toEqual([
         { keys: ["i"], label: "Focus sidebar" },
         { keys: ["u"], label: "Focus calendar event" },
         { keys: ["s"], label: "Toggle event jump keys" },
         { keys: ["f"], label: "Focus latest notice" },
+        {
+          keys: ["Mod", "1-4"],
+          label: "Jump to a page area (hold Mod for hints)",
+        },
       ]);
     });
 

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -182,6 +182,15 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
     label: "Focus latest notice",
     section: "focus",
   },
+  // One row instead of one per target: the digit assignment lives in
+  // page-jump.targets.ts, and in-the-moment discovery is the hold-Mod hint
+  // overlay's job (mirrors edit-jump-field-digit below).
+  {
+    id: "focus-page-jump",
+    keys: [...KEYMAP.jumpPageTarget.keycaps],
+    label: "Jump to a page area (hold Mod for hints)",
+    section: "focus",
+  },
 
   // Edit
   {

--- a/packages/web/src/shortcuts/tips/shortcut-tips.data.test.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-tips.data.test.ts
@@ -24,6 +24,10 @@ describe("getTipPlainText", () => {
     expect(plainTextById["edge-cycle"]).toBe(
       "Press Tab to move between start and end",
     );
+    const mod = expandModInShortcutDisplay("Mod") === "Meta" ? "Cmd" : "Ctrl";
+    expect(plainTextById["page-jump"]).toBe(
+      `Hold ${mod} to see where you can jump next`,
+    );
   });
 
   it("joins a chord's keys with + and speaks Mod as Cmd or Ctrl", () => {

--- a/packages/web/src/shortcuts/tips/shortcut-tips.data.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-tips.data.ts
@@ -4,7 +4,8 @@ export type ShortcutTipId =
   | "edit-sequence"
   | "nudge"
   | "target-event"
-  | "edge-cycle";
+  | "edge-cycle"
+  | "page-jump";
 
 export type ShortcutTipPart =
   | string
@@ -63,6 +64,10 @@ export function getShortcutTips(): ShortcutTip[] {
     {
       id: "edge-cycle",
       parts: ["Press ", { key: "Tab" }, " to move between start and end"],
+    },
+    {
+      id: "page-jump",
+      parts: ["Hold ", { key: "Mod" }, " to see where you can jump next"],
     },
   ];
 }

--- a/packages/web/src/shortcuts/tips/useShortcutTipTrigger.ts
+++ b/packages/web/src/shortcuts/tips/useShortcutTipTrigger.ts
@@ -60,6 +60,11 @@ export function useShortcutTipTrigger() {
         shortcutTipsActions.actedOn("target-event");
       } else if (activeTipId === "edge-cycle" && event.key === "Tab") {
         shortcutTipsActions.actedOn("edge-cycle");
+      } else if (
+        activeTipId === "page-jump" &&
+        (event.key === "Meta" || event.key === "Control")
+      ) {
+        shortcutTipsActions.actedOn("page-jump");
       }
     };
 

--- a/packages/web/src/views/Day/view/DayViewContent.tsx
+++ b/packages/web/src/views/Day/view/DayViewContent.tsx
@@ -23,6 +23,7 @@ import {
   viewActions,
 } from "@web/events/stores/view.store";
 import { useCalendarViewShortcuts } from "@web/grid/shortcuts/useCalendarViewShortcuts";
+import { PageJumpHints } from "@web/shortcuts/page-jump/PageJumpHints";
 import { getShortcutMenuSections } from "@web/shortcuts/shortcuts.registry";
 import { TimezoneMismatchBannerGate } from "@web/timezone/TimezoneMismatchBannerGate";
 import { DayCalendarGrid } from "@web/views/Day/components/Calendar/DayCalendarGrid";
@@ -118,6 +119,7 @@ export const DayViewContent = memo(() => {
         placeholder={getCommandPalettePlaceholder("day")}
       />
       <Dedication />
+      <PageJumpHints />
 
       <div
         id={ID_MAIN}

--- a/packages/web/src/views/Week/WeekView.tsx
+++ b/packages/web/src/views/Week/WeekView.tsx
@@ -21,6 +21,7 @@ import {
   useViewStore,
   viewActions,
 } from "@web/events/stores/view.store";
+import { PageJumpHints } from "@web/shortcuts/page-jump/PageJumpHints";
 import { getShortcutMenuSections } from "@web/shortcuts/shortcuts.registry";
 import { TimezoneMismatchBannerGate } from "@web/timezone/TimezoneMismatchBannerGate";
 import { Dedication } from "@web/views/Week/components/Dedication/Dedication";
@@ -139,6 +140,7 @@ export const WeekView = () => {
         placeholder={getCommandPalettePlaceholder("week")}
       />
       <Dedication />
+      <PageJumpHints />
 
       <Shortcuts shortcutsProps={shortcutProps}>
         <div


### PR DESCRIPTION
## Summary

Extends the event form's hold-Mod hint pattern to the whole page, so "hold Mod to see where you can jump next" becomes one habit that works everywhere:

- Holding Mod with no event form open reveals numbered keycap chips over page areas: header navigation arrows (1), month picker (2), up-next card (3), and calendar list (4). Pressing the digit jumps focus there — e.g. Mod+2 lands on the month picker's focused day, so arrows navigate dates and Tab reaches the month arrows immediately.
- The gesture engine behind the form's existing Mod+digit field jumps is extracted into a shared hook (`useModHoldHintShortcut`); both surfaces now share one hold/arm/dismiss state machine, macOS keyup-replay suppression, and app-lock handling.
- Targets are declared once in `page-jump.targets.ts`; components opt in by spreading a data attribute on their container. Absent targets (collapsed sidebar, empty Up Next card) get no chip and their digit is left to the browser.
- Page jumps are disabled while the event form is open, so the form's digit map (1–8) and the page's digit map (1–4) never overlap.
- The pattern is surfaced where users learn shortcuts: a new `?`-legend row in the Focus section, a new rotating sidebar tip ("Hold ⌘ to see where you can jump next"), a mention in the welcome guide's FAQ hint line, and a sentence in the shortcut showcase's graduation step.

## Simplicity

- One gesture engine instead of two near-identical 150-line hooks: `useFormDigitJumpShortcut` shrank to a ~15-line mapping over the shared engine, and the new `usePageJumpShortcut` is the same shape.
- Targets are a single declarative list plus a data attribute — adding a target is one list entry and one attribute spread, with digit assignment derived from list order.
- The overlay reuses the existing `ShortcutHint`, `getVisibleHintRect`, and `useHintLayoutRefresh` building blocks rather than introducing new positioning code.
- Onboarding stays one lesson: per the recorded drop-off history in `showcase.steps.ts`, the pattern is a sentence in graduation rather than a new lesson.

## Automated validation

- `bun test:web` over `src/shortcuts`, `src/components/{ShortcutShowcase,WelcomeModal,Sidebar,CalendarHeader}`: 405 pass after updating the focus-section legend expectation.
- `bun test:web` over `src/views/Forms/EventForm` + `shortcuts.menu.test.ts`: 147 pass (form digit jumps unchanged after the engine extraction).
- `bun test:web` over `src/views/Day` + `WeekView.render.test.tsx`: 76 pass with the new `PageJumpHints` mounted.

## Independent review

- Re-read the extracted engine against the original form hook line-by-line: behavior is preserved (arm/repeat/cancel semantics, keyup-replay suppression, blur/visibility/pointer dismissal, app-lock gating), with the digit→field mapping the only extracted variable.
- Checked digit-collision and overlay-collision paths: the page hook is disabled via `selectIsEventFormOpen`, the form hook only mounts with the form, and both no-op under the app lock (command palette, welcome modal).
- Verified chips are never advertised for dead targets: chip rendering and the screen-reader summary both go through the same focus-element resolution used by the jump itself.

## Test plan

```
bun test:web packages/web/src/shortcuts packages/web/src/components/ShortcutShowcase packages/web/src/components/WelcomeModal packages/web/src/components/Sidebar packages/web/src/components/CalendarHeader
bun test:web packages/web/src/views/Forms/EventForm packages/web/src/shortcuts/shortcuts.menu.test.ts
bun test:web packages/web/src/views/Day packages/web/src/views/Week/WeekView.render.test.tsx
bun type-check
bun lint
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVhv8KGdRKr59dZi5UQVet

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVhv8KGdRKr59dZi5UQVet)_