### PR TITLE
fix(scripts): align bun run verify with required CI checks

### DIFF
--- a/.agents/skills/verify-change/SKILL.md
+++ b/.agents/skills/verify-change/SKILL.md
@@ -44,8 +44,11 @@ then run the package acceptance command before declaring the package green.
 
 ## 3. Use the diff helper deliberately
 
-`bun run verify` selects checks from the git diff. Run it when useful, but read
-its reported selection and add missing checks for:
+`bun run verify` runs the required-check subset for the merge-base vs
+`origin/main` plus the working tree: detected `test:<pkg>` scripts, then
+`type-check`, `lint`, and `knip`, plus `test:a11y`/`test:e2e` when web or
+`e2e/` changed. Read the printed skip list. A green run is not CI-complete if
+Playwright was skipped. Add extra checks when the subset cannot cover:
 
 - shared schemas consumed across packages
 - migrations and persistence

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,8 +46,9 @@ Validation defaults:
 - Keep regression tests that protect real behavior. Remove temporary tests,
   scripts, debug hooks, or code added only to confirm a one-time hypothesis once
   that verification is complete.
-- Use `bun run verify` when you want the repo helper to choose checks from the
-  git diff, but confirm its output before treating the task as done.
+- Use `bun run verify` when you want the repo helper to choose the
+  required-check subset from the git diff. Read the skip list before treating
+  the task as done.
 - Use `bun run lint` before pushing when the work is not docs-only.
 
 ## Lookups

--- a/docs/development/testing-playbook.md
+++ b/docs/development/testing-playbook.md
@@ -13,9 +13,18 @@ bun run test:web
 bun run test:backend
 bun run test:scripts
 bun run type-check
+bun run verify
 ```
 
 Avoid defaulting to `bun run test` unless you really need the full suite.
+
+`bun run verify` selects the **required-check subset** from the merge-base vs
+`origin/main` plus the working tree: `test:<pkg>` for each detected package,
+then `type-check`, `lint`, and `knip`. Web or `e2e/` changes also select
+`test:a11y` and `test:e2e`. Read the printed skip list before treating a green
+run as CI-complete — missing Playwright Chromium skips those jobs and reports
+incomplete parity instead of claiming they passed. GitHub still runs the full
+unit matrix and e2e on every non-docs PR; this helper does not.
 
 ## CI Unit Test Workflow
 

--- a/packages/scripts/src/testing/verify.test.ts
+++ b/packages/scripts/src/testing/verify.test.ts
@@ -1,0 +1,308 @@
+import {
+  chromiumInstallLocationFromDryRun,
+  collectChangedFiles,
+  type GitCommands,
+  mapFilesToPackages,
+  PLAYWRIGHT_INSTALL_COMMAND,
+  planVerify,
+  resolveMergeBase,
+  runVerify,
+  type SpawnFn,
+  type SpawnResult,
+} from "@scripts/testing/verify";
+import { describe, expect, it } from "bun:test";
+
+function gitStub(options: {
+  refs?: string[];
+  mergeBases?: Record<string, string>;
+  diffs?: Record<string, string[]>;
+  untracked?: string[];
+  fetch?: () => void;
+}): GitCommands {
+  const refs = new Set(options.refs ?? ["origin/main", "main"]);
+  const mergeBases = options.mergeBases ?? { "HEAD:origin/main": "abc123" };
+  const diffs = options.diffs ?? {};
+  return {
+    hasRef: (ref) => refs.has(ref),
+    fetch: options.fetch ?? (() => undefined),
+    mergeBase: (a, b) => mergeBases[`${a}:${b}`] ?? null,
+    diffNameOnly: (args) => {
+      const key = args.join(" ");
+      return diffs[key] ?? [];
+    },
+    untrackedNames: () => options.untracked ?? [],
+  };
+}
+
+function recordingSpawn(options?: { results?: Record<string, SpawnResult> }): {
+  spawn: SpawnFn;
+  commands: string[][];
+} {
+  const commands: string[][] = [];
+  const spawn: SpawnFn = (cmd) => {
+    commands.push(cmd);
+    const key = cmd.join(" ");
+    return (
+      options?.results?.[key] ?? {
+        exitCode: 0,
+        stdout: "",
+        stderr: "",
+      }
+    );
+  };
+  return { spawn, commands };
+}
+
+function captureLogs() {
+  const lines: string[] = [];
+  const errors: string[] = [];
+  return {
+    lines,
+    errors,
+    log: {
+      log: (message: string) => {
+        lines.push(message);
+      },
+      error: (message: string) => {
+        errors.push(message);
+      },
+    },
+  };
+}
+
+describe("mapFilesToPackages", () => {
+  it("maps package prefixes and e2e/ to web", () => {
+    expect(
+      mapFilesToPackages([
+        "packages/scripts/src/testing/verify.ts",
+        "packages/core/src/types/event.ts",
+        "e2e/calendar.spec.ts",
+        "README.md",
+        ".github/workflows/test-unit.yml",
+      ]),
+    ).toEqual(["core", "web", "scripts"]);
+  });
+
+  it("does not invent core/web for docs-only or empty diffs", () => {
+    expect(
+      mapFilesToPackages(["docs/development/testing-playbook.md"]),
+    ).toEqual([]);
+    expect(mapFilesToPackages(["README.md", "AGENTS.md"])).toEqual([]);
+    expect(mapFilesToPackages([])).toEqual([]);
+  });
+});
+
+describe("planVerify", () => {
+  it("runs type-check, lint, and knip with no invented packages", () => {
+    const plan = planVerify({
+      packages: [],
+      files: ["docs/README.md"],
+      playwrightChromiumAvailable: false,
+    });
+    expect(plan.packages).toEqual([]);
+    expect(plan.checks.map((check) => check.id)).toEqual([
+      "type-check",
+      "lint",
+      "knip",
+    ]);
+    expect(plan.checks.find((check) => check.id === "type-check")?.cmd).toEqual(
+      ["bun", "run", "type-check"],
+    );
+    expect(plan.checks.find((check) => check.id === "knip")?.cmd).toEqual([
+      "bun",
+      "run",
+      "knip",
+    ]);
+    expect(plan.playwrightSelected).toBe(false);
+    expect(plan.ciParityComplete).toBe(true);
+  });
+
+  it("selects a11y and e2e for an e2e/-only diff when Chromium is present", () => {
+    const files = ["e2e/calendar.spec.ts"];
+    const plan = planVerify({
+      packages: mapFilesToPackages(files),
+      files,
+      playwrightChromiumAvailable: true,
+    });
+    expect(plan.packages).toEqual(["web"]);
+    expect(plan.checks.map((check) => check.id)).toEqual([
+      "test:web",
+      "type-check",
+      "lint",
+      "knip",
+      "test:a11y",
+      "test:e2e",
+    ]);
+  });
+
+  it("skips Playwright checks when Chromium is missing", () => {
+    const files = ["packages/web/src/App.tsx"];
+    const plan = planVerify({
+      packages: mapFilesToPackages(files),
+      files,
+      playwrightChromiumAvailable: false,
+    });
+    expect(plan.checks.map((check) => check.id)).not.toContain("test:e2e");
+    expect(plan.skips.map((skip) => skip.id)).toEqual([
+      "test:a11y",
+      "test:e2e",
+    ]);
+    expect(plan.skips[0]?.reason).toContain(PLAYWRIGHT_INSTALL_COMMAND);
+    expect(plan.ciParityComplete).toBe(false);
+  });
+});
+
+describe("resolveMergeBase and collectChangedFiles", () => {
+  it("fetches origin/main when missing, then unions committed, staged, unstaged, and untracked files", () => {
+    let fetched = false;
+    const git = gitStub({
+      refs: ["main"],
+      mergeBases: { "HEAD:origin/main": "deadbeef" },
+      fetch: () => {
+        fetched = true;
+      },
+      diffs: {
+        "deadbeef...HEAD": ["packages/scripts/src/testing/verify.ts"],
+        "--cached": ["packages/scripts/src/testing/verify.test.ts"],
+        "": ["docs/development/testing-playbook.md"],
+      },
+      untracked: ["packages/web/src/App.tsx"],
+    });
+    git.hasRef = (ref) => {
+      if (ref === "origin/main") return fetched;
+      return ref === "main";
+    };
+
+    const mergeBase = resolveMergeBase(git);
+    expect(fetched).toBe(true);
+    expect(mergeBase).toEqual({ sha: "deadbeef", ref: "origin/main" });
+    expect(collectChangedFiles(git, mergeBase.sha)).toEqual([
+      "packages/scripts/src/testing/verify.ts",
+      "packages/scripts/src/testing/verify.test.ts",
+      "docs/development/testing-playbook.md",
+      "packages/web/src/App.tsx",
+    ]);
+  });
+
+  it("falls back to main when origin/main cannot be resolved", () => {
+    const git = gitStub({
+      refs: ["main"],
+      mergeBases: { "HEAD:main": "fff111" },
+    });
+    expect(resolveMergeBase(git)).toEqual({ sha: "fff111", ref: "main" });
+  });
+});
+
+describe("chromiumInstallLocationFromDryRun", () => {
+  it("parses the Chromium install location from playwright dry-run output", () => {
+    const output = [
+      "Chrome for Testing 131.0.6778.33 (playwright chromium v1148)",
+      "  Install location:    /home/user/.cache/ms-playwright/chromium-1148",
+      "  Download url:        https://example.invalid/chromium.zip",
+    ].join("\n");
+    expect(chromiumInstallLocationFromDryRun(output)).toBe(
+      "/home/user/.cache/ms-playwright/chromium-1148",
+    );
+  });
+});
+
+describe("runVerify", () => {
+  it("runs scripts tests plus type-check, lint, and knip for a scripts-only tree", () => {
+    const { spawn, commands } = recordingSpawn();
+    const logs = captureLogs();
+    const exitCode = runVerify([], {
+      git: gitStub({
+        diffs: {
+          "abc123...HEAD": ["packages/scripts/src/testing/verify.ts"],
+        },
+      }),
+      spawn,
+      log: logs.log,
+      chromiumAvailable: () => false,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(commands).toEqual([
+      ["bun", "run", "test:scripts"],
+      ["bun", "run", "type-check"],
+      ["bun", "run", "lint"],
+      ["bun", "run", "knip"],
+    ]);
+    expect(
+      logs.lines.some((line) => line.includes("no packages detected")),
+    ).toBe(false);
+    expect(logs.lines.join("\n")).toContain("Detected changes in: scripts");
+    expect(logs.lines.join("\n")).toContain("All checks passed");
+  });
+
+  it("prints no packages detected and still runs type-check, lint, and knip", () => {
+    const { spawn, commands } = recordingSpawn();
+    const logs = captureLogs();
+    const exitCode = runVerify([], {
+      git: gitStub({
+        diffs: { "abc123...HEAD": ["README.md"] },
+      }),
+      spawn,
+      log: logs.log,
+      chromiumAvailable: () => false,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(commands).toEqual([
+      ["bun", "run", "type-check"],
+      ["bun", "run", "lint"],
+      ["bun", "run", "knip"],
+    ]);
+    expect(logs.lines).toContain("no packages detected");
+    expect(logs.lines.join("\n")).not.toContain("falling back to: core");
+  });
+
+  it("exits 1 and lists type-check when that spawn fails", () => {
+    const { spawn } = recordingSpawn({
+      results: {
+        "bun run type-check": {
+          exitCode: 1,
+          stdout: "",
+          stderr: "type error",
+        },
+      },
+    });
+    const logs = captureLogs();
+    const exitCode = runVerify([], {
+      git: gitStub({
+        diffs: { "abc123...HEAD": ["packages/scripts/src/testing/verify.ts"] },
+      }),
+      spawn,
+      log: logs.log,
+      chromiumAvailable: () => false,
+    });
+
+    expect(exitCode).toBe(1);
+    expect(logs.errors.join("\n")).toContain("Failed: type-check");
+  });
+
+  it("selects e2e for an e2e/-only diff and reports incomplete parity when Chromium is missing", () => {
+    const { spawn, commands } = recordingSpawn();
+    const logs = captureLogs();
+    const exitCode = runVerify([], {
+      git: gitStub({
+        diffs: { "abc123...HEAD": ["e2e/calendar.spec.ts"] },
+      }),
+      spawn,
+      log: logs.log,
+      chromiumAvailable: () => false,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(commands).toEqual([
+      ["bun", "run", "test:web"],
+      ["bun", "run", "type-check"],
+      ["bun", "run", "lint"],
+      ["bun", "run", "knip"],
+    ]);
+    expect(logs.lines.join("\n")).toContain("Skipping test:e2e");
+    expect(logs.lines.join("\n")).toContain(PLAYWRIGHT_INSTALL_COMMAND);
+    expect(logs.lines.join("\n")).toContain("CI parity incomplete");
+    expect(logs.lines.join("\n")).not.toContain("All checks passed");
+  });
+});

--- a/packages/scripts/src/testing/verify.test.ts
+++ b/packages/scripts/src/testing/verify.test.ts
@@ -24,7 +24,10 @@ function gitStub(options: {
   const diffs = options.diffs ?? {};
   return {
     hasRef: (ref) => refs.has(ref),
-    fetch: options.fetch ?? (() => undefined),
+    fetch: () => {
+      refs.add("origin/main");
+      options.fetch?.();
+    },
     mergeBase: (a, b) => mergeBases[`${a}:${b}`] ?? null,
     diffNameOnly: (args) => {
       const key = args.join(" ");
@@ -96,7 +99,6 @@ describe("planVerify", () => {
   it("runs type-check, lint, and knip with no invented packages", () => {
     const plan = planVerify({
       packages: [],
-      files: ["docs/README.md"],
       playwrightChromiumAvailable: false,
     });
     expect(plan.packages).toEqual([]);
@@ -114,14 +116,13 @@ describe("planVerify", () => {
       "knip",
     ]);
     expect(plan.playwrightSelected).toBe(false);
-    expect(plan.ciParityComplete).toBe(true);
+    expect(plan.skips).toEqual([]);
   });
 
   it("selects a11y and e2e for an e2e/-only diff when Chromium is present", () => {
     const files = ["e2e/calendar.spec.ts"];
     const plan = planVerify({
       packages: mapFilesToPackages(files),
-      files,
       playwrightChromiumAvailable: true,
     });
     expect(plan.packages).toEqual(["web"]);
@@ -139,7 +140,6 @@ describe("planVerify", () => {
     const files = ["packages/web/src/App.tsx"];
     const plan = planVerify({
       packages: mapFilesToPackages(files),
-      files,
       playwrightChromiumAvailable: false,
     });
     expect(plan.checks.map((check) => check.id)).not.toContain("test:e2e");
@@ -148,7 +148,7 @@ describe("planVerify", () => {
       "test:e2e",
     ]);
     expect(plan.skips[0]?.reason).toContain(PLAYWRIGHT_INSTALL_COMMAND);
-    expect(plan.ciParityComplete).toBe(false);
+    expect(plan.playwrightSelected).toBe(true);
   });
 });
 
@@ -168,11 +168,6 @@ describe("resolveMergeBase and collectChangedFiles", () => {
       },
       untracked: ["packages/web/src/App.tsx"],
     });
-    git.hasRef = (ref) => {
-      if (ref === "origin/main") return fetched;
-      return ref === "main";
-    };
-
     const mergeBase = resolveMergeBase(git);
     expect(fetched).toBe(true);
     expect(mergeBase).toEqual({ sha: "deadbeef", ref: "origin/main" });

--- a/packages/scripts/src/testing/verify.ts
+++ b/packages/scripts/src/testing/verify.ts
@@ -16,42 +16,17 @@ import { existsSync } from "node:fs";
  *   bun run verify core web     — run specific suites + required static checks
  */
 
-type BunRuntime = {
-  spawnSync(input: {
-    cmd: string[];
-    cwd?: string;
-    env?: Record<string, string | undefined>;
-    stderr?: "inherit" | "pipe";
-    stdin?: "inherit" | "pipe";
-    stdout?: "inherit" | "pipe";
-  }): {
-    exitCode: number;
-    stdout?: Uint8Array | string;
-    stderr?: Uint8Array | string;
-  };
-};
-
-const bunRuntime = (globalThis as unknown as { Bun: BunRuntime }).Bun;
-
-export const VALID_PACKAGES = [
-  "core",
-  "sync",
-  "web",
-  "backend",
-  "scripts",
-] as const;
+const VALID_PACKAGES = ["core", "sync", "web", "backend", "scripts"] as const;
 export type Package = (typeof VALID_PACKAGES)[number];
 
-const PACKAGE_PREFIXES: Record<string, Package> = {
-  "packages/core/": "core",
-  "packages/sync/": "sync",
-  "packages/web/": "web",
-  "packages/backend/": "backend",
-  "packages/scripts/": "scripts",
-};
+const PACKAGE_PREFIXES: Record<string, Package> = Object.fromEntries(
+  VALID_PACKAGES.map((pkg) => [`packages/${pkg}/`, pkg]),
+);
 
 const MERGE_BASE_REFS = ["origin/main", "main", "master"] as const;
 export const PLAYWRIGHT_INSTALL_COMMAND = "bunx playwright install chromium";
+const CHROMIUM_MISSING_REASON = `Playwright Chromium missing; install with: ${PLAYWRIGHT_INSTALL_COMMAND}`;
+const PLAYWRIGHT_CHECKS = ["test:a11y", "test:e2e"] as const;
 
 export type GitCommands = {
   hasRef(ref: string): boolean;
@@ -95,7 +70,6 @@ export type VerifyPlan = {
   checks: PlannedCheck[];
   skips: PlannedSkip[];
   playwrightSelected: boolean;
-  ciParityComplete: boolean;
 };
 
 export type VerifyDeps = {
@@ -104,6 +78,18 @@ export type VerifyDeps = {
   log: Logger;
   chromiumAvailable?: (spawn: SpawnFn) => boolean;
 };
+
+function isPackage(value: string): value is Package {
+  return (VALID_PACKAGES as readonly string[]).includes(value);
+}
+
+function isPlaywrightCheck(checkId: string): boolean {
+  return (PLAYWRIGHT_CHECKS as readonly string[]).includes(checkId);
+}
+
+function combinedSpawnOutput(result: SpawnResult): string {
+  return `${result.stdout}\n${result.stderr}`;
+}
 
 export function mapFilesToPackages(files: string[]): Package[] {
   const packages = new Set<Package>();
@@ -121,16 +107,6 @@ export function mapFilesToPackages(files: string[]): Package[] {
   return VALID_PACKAGES.filter((pkg) => packages.has(pkg));
 }
 
-export function playwrightTouched(
-  files: string[],
-  packages: Package[],
-): boolean {
-  if (packages.includes("web")) return true;
-  return files.some(
-    (file) => file.startsWith("packages/web/") || file.startsWith("e2e/"),
-  );
-}
-
 export function chromiumInstallLocationFromDryRun(
   output: string,
 ): string | null {
@@ -140,19 +116,19 @@ export function chromiumInstallLocationFromDryRun(
   return match?.[1] ?? null;
 }
 
-export function detectChromiumAvailable(spawn: SpawnFn): boolean {
+function detectChromiumAvailable(spawn: SpawnFn): boolean {
   const result = spawn(
     ["bunx", "playwright", "install", "--dry-run", "chromium"],
     { stdio: "pipe" },
   );
-  const output = `${result.stdout}\n${result.stderr}`;
-  const location = chromiumInstallLocationFromDryRun(output);
+  const location = chromiumInstallLocationFromDryRun(
+    combinedSpawnOutput(result),
+  );
   return location != null && existsSync(location);
 }
 
 export function planVerify(input: {
   packages: Package[];
-  files: string[];
   playwrightChromiumAvailable: boolean;
 }): VerifyPlan {
   const packages = VALID_PACKAGES.filter((pkg) => input.packages.includes(pkg));
@@ -166,16 +142,17 @@ export function planVerify(input: {
   checks.push({ id: "knip", cmd: ["bun", "run", "knip"] });
 
   const skips: PlannedSkip[] = [];
-  const playwrightSelected = playwrightTouched(input.files, packages);
+  const playwrightSelected = packages.includes("web");
 
   if (playwrightSelected) {
     if (input.playwrightChromiumAvailable) {
-      checks.push({ id: "test:a11y", cmd: ["bun", "run", "test:a11y"] });
-      checks.push({ id: "test:e2e", cmd: ["bun", "run", "test:e2e"] });
+      for (const id of PLAYWRIGHT_CHECKS) {
+        checks.push({ id, cmd: ["bun", "run", id] });
+      }
     } else {
-      const reason = `Playwright Chromium missing; install with: ${PLAYWRIGHT_INSTALL_COMMAND}`;
-      skips.push({ id: "test:a11y", reason });
-      skips.push({ id: "test:e2e", reason });
+      for (const id of PLAYWRIGHT_CHECKS) {
+        skips.push({ id, reason: CHROMIUM_MISSING_REASON });
+      }
     }
   }
 
@@ -184,7 +161,6 @@ export function planVerify(input: {
     checks,
     skips,
     playwrightSelected,
-    ciParityComplete: skips.length === 0,
   };
 }
 
@@ -214,14 +190,15 @@ export function collectChangedFiles(
   git: GitCommands,
   mergeBase: string,
 ): string[] {
-  const committed = git.diffNameOnly([`${mergeBase}...HEAD`]);
-  const staged = git.diffNameOnly(["--cached"]);
-  const unstaged = git.diffNameOnly([]);
-  const untracked = git.untrackedNames();
-  return uniquePaths([...committed, ...staged, ...unstaged, ...untracked]);
+  return unique([
+    ...git.diffNameOnly([`${mergeBase}...HEAD`]),
+    ...git.diffNameOnly(["--cached"]),
+    ...git.diffNameOnly([]),
+    ...git.untrackedNames(),
+  ]);
 }
 
-export function defaultGit(): GitCommands {
+function defaultGit(): GitCommands {
   return {
     hasRef(ref: string): boolean {
       try {
@@ -253,10 +230,10 @@ export function defaultGit(): GitCommands {
   };
 }
 
-export function defaultSpawn(): SpawnFn {
+function defaultSpawn(): SpawnFn {
   return (cmd, options) => {
     const inherit = options?.stdio !== "pipe";
-    const result = bunRuntime.spawnSync({
+    const result = Bun.spawnSync({
       cmd,
       cwd: process.cwd(),
       env: options?.env ?? { ...process.env },
@@ -284,49 +261,42 @@ export function runVerify(
   const chromiumAvailable = deps.chromiumAvailable ?? detectChromiumAvailable;
 
   let packages: Package[];
-  let files: string[] = [];
-  let mergeBase: { sha: string; ref: string } | null = null;
 
   if (args.length > 0) {
-    const invalid = args.filter(
-      (arg) => !VALID_PACKAGES.includes(arg as Package),
-    );
+    const invalid = args.filter((arg) => !isPackage(arg));
     if (invalid.length > 0) {
       log.error(
         `Unknown package(s): ${invalid.join(", ")}. Valid: ${VALID_PACKAGES.join(", ")}`,
       );
       return 1;
     }
-    packages = args as Package[];
+    packages = args.filter(isPackage);
   } else {
     try {
-      mergeBase = resolveMergeBase(git);
+      const mergeBase = resolveMergeBase(git);
+      const files = collectChangedFiles(git, mergeBase.sha);
+      packages = mapFilesToPackages(files);
+      log.log(`merge-base: ${mergeBase.sha} (${mergeBase.ref})`);
+      log.log(
+        `files used for detection (${files.length}): ${
+          files.length > 0 ? files.join(", ") : "(none)"
+        }`,
+      );
+      if (packages.length === 0) {
+        log.log("no packages detected");
+      } else {
+        log.log(`Detected changes in: ${packages.join(", ")}`);
+      }
     } catch (error) {
       log.error(error instanceof Error ? error.message : String(error));
       return 1;
     }
-    files = collectChangedFiles(git, mergeBase.sha);
-    packages = mapFilesToPackages(files);
-    log.log(`merge-base: ${mergeBase.sha} (${mergeBase.ref})`);
-    log.log(
-      `files used for detection (${files.length}): ${
-        files.length > 0 ? files.join(", ") : "(none)"
-      }`,
-    );
-    if (packages.length === 0) {
-      log.log("no packages detected");
-    } else {
-      log.log(`Detected changes in: ${packages.join(", ")}`);
-    }
   }
 
-  const detectionFiles =
-    args.length > 0 ? packagesToSyntheticFiles(packages) : files;
-  const needsPlaywright = playwrightTouched(detectionFiles, packages);
+  const playwrightSelected = packages.includes("web");
   const plan = planVerify({
     packages,
-    files: detectionFiles,
-    playwrightChromiumAvailable: needsPlaywright
+    playwrightChromiumAvailable: playwrightSelected
       ? chromiumAvailable(spawn)
       : true,
   });
@@ -339,9 +309,11 @@ export function runVerify(
   }
 
   const failed: string[] = [];
+  const skips = [...plan.skips];
+  const executed: string[] = [];
   for (const check of plan.checks) {
     log.log(`\n→ ${check.id}`);
-    const inheritIo = check.id !== "test:a11y" && check.id !== "test:e2e";
+    const inheritIo = !isPlaywrightCheck(check.id);
     const result = spawn(check.cmd, {
       env: spawnEnvFor(check.id),
       stdio: inheritIo ? "inherit" : "pipe",
@@ -352,30 +324,26 @@ export function runVerify(
     }
     if (result.exitCode !== 0) {
       if (isMissingPlaywrightBrowser(result, check.id)) {
-        plan.skips.push({
-          id: check.id,
-          reason: `Playwright Chromium missing; install with: ${PLAYWRIGHT_INSTALL_COMMAND}`,
-        });
-        plan.ciParityComplete = false;
-        log.log(
-          `Skipping ${check.id}: Playwright Chromium missing; install with: ${PLAYWRIGHT_INSTALL_COMMAND}`,
-        );
+        skips.push({ id: check.id, reason: CHROMIUM_MISSING_REASON });
+        log.log(`Skipping ${check.id}: ${CHROMIUM_MISSING_REASON}`);
         continue;
       }
       failed.push(check.id);
+      continue;
     }
+    executed.push(check.id);
   }
+
+  const ciParityComplete = skips.length === 0;
 
   log.log("\nSummary");
   log.log(
     `Selected packages: ${plan.packages.length > 0 ? plan.packages.join(", ") : "(none)"}`,
   );
-  log.log(
-    `Checks run: ${plan.checks.map((check) => check.id).join(", ") || "(none)"}`,
-  );
-  if (plan.skips.length > 0) {
+  log.log(`Checks run: ${executed.join(", ") || "(none)"}`);
+  if (skips.length > 0) {
     log.log(
-      `Checks skipped: ${plan.skips.map((skip) => `${skip.id} (${skip.reason})`).join("; ")}`,
+      `Checks skipped: ${skips.map((skip) => `${skip.id} (${skip.reason})`).join("; ")}`,
     );
   } else {
     log.log("Checks skipped: (none)");
@@ -386,20 +354,17 @@ export function runVerify(
     return 1;
   }
 
-  if (!plan.ciParityComplete) {
-    const reasons = uniquePaths(plan.skips.map((skip) => skip.reason));
+  if (!ciParityComplete) {
     log.log(
-      `\n✓ selected checks passed; CI parity incomplete: ${reasons.join("; ")}`,
+      `\n✓ selected checks passed; CI parity incomplete: ${unique(
+        skips.map((skip) => skip.reason),
+      ).join("; ")}`,
     );
     return 0;
   }
 
   log.log("\n✓ All checks passed");
   return 0;
-}
-
-function packagesToSyntheticFiles(packages: Package[]): string[] {
-  return packages.map((pkg) => `packages/${pkg}/src/changed.ts`);
 }
 
 function splitLines(output: string): string[] {
@@ -411,15 +376,9 @@ function splitLines(output: string): string[] {
 
 function spawnEnvFor(checkId: string): Record<string, string | undefined> {
   const timezone = process.env["TZ"] ?? "Etc/UTC";
-  if (
-    checkId.startsWith("test:") &&
-    !checkId.startsWith("test:a11y") &&
-    checkId !== "test:e2e"
-  ) {
+  if (isPlaywrightCheck(checkId)) return playwrightEnv(timezone);
+  if (checkId.startsWith("test:")) {
     return { ...process.env, NODE_ENV: "test", TZ: timezone };
-  }
-  if (checkId === "test:a11y" || checkId === "test:e2e") {
-    return playwrightEnv(timezone);
   }
   return { ...process.env, TZ: timezone };
 }
@@ -448,8 +407,8 @@ function isMissingPlaywrightBrowser(
   result: SpawnResult,
   checkId: string,
 ): boolean {
-  if (checkId !== "test:a11y" && checkId !== "test:e2e") return false;
-  const output = `${result.stdout}\n${result.stderr}`.toLowerCase();
+  if (!isPlaywrightCheck(checkId)) return false;
+  const output = combinedSpawnOutput(result).toLowerCase();
   return (
     output.includes("executable doesn't exist") ||
     output.includes("browserType.launch") ||
@@ -458,8 +417,8 @@ function isMissingPlaywrightBrowser(
   );
 }
 
-function uniquePaths(paths: string[]): string[] {
-  return [...new Set(paths.filter(Boolean))];
+function unique(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
 }
 
 function execGit(args: string[]): string {

--- a/packages/scripts/src/testing/verify.ts
+++ b/packages/scripts/src/testing/verify.ts
@@ -1,16 +1,19 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
 
 /**
- * Smart verify script for AI coding loops.
- * Detects which packages changed via git diff and runs the minimum
- * necessary test suites plus type-check and lint.
+ * Local required-check subset for AI coding loops.
  *
- * Test execution is delegated to the root `test:<project>` package.json scripts.
+ * Detects packages from the merge-base vs origin/main plus the working tree,
+ * then runs the matching `test:<pkg>` scripts plus type-check, lint, and knip.
+ * Web or e2e/ changes also select Playwright a11y and e2e, unless Chromium is
+ * missing — in that case the helper skips those checks and reports incomplete
+ * CI parity instead of a silent pass.
  *
  * Usage:
- *   bun run verify              — auto-detect from git diff
- *   bun run verify web          — run web suite + type-check + lint
- *   bun run verify core web     — run specific suites + type-check + lint
+ *   bun run verify              — auto-detect from git
+ *   bun run verify web          — run web suite + required static checks
+ *   bun run verify core web     — run specific suites + required static checks
  */
 
 type BunRuntime = {
@@ -18,16 +21,26 @@ type BunRuntime = {
     cmd: string[];
     cwd?: string;
     env?: Record<string, string | undefined>;
-    stderr?: "inherit";
-    stdin?: "inherit";
-    stdout?: "inherit";
-  }): { exitCode: number };
+    stderr?: "inherit" | "pipe";
+    stdin?: "inherit" | "pipe";
+    stdout?: "inherit" | "pipe";
+  }): {
+    exitCode: number;
+    stdout?: Uint8Array | string;
+    stderr?: Uint8Array | string;
+  };
 };
 
 const bunRuntime = (globalThis as unknown as { Bun: BunRuntime }).Bun;
 
-const VALID_PACKAGES = ["core", "sync", "web", "backend", "scripts"] as const;
-type Package = (typeof VALID_PACKAGES)[number];
+export const VALID_PACKAGES = [
+  "core",
+  "sync",
+  "web",
+  "backend",
+  "scripts",
+] as const;
+export type Package = (typeof VALID_PACKAGES)[number];
 
 const PACKAGE_PREFIXES: Record<string, Package> = {
   "packages/core/": "core",
@@ -37,97 +50,381 @@ const PACKAGE_PREFIXES: Record<string, Package> = {
   "packages/scripts/": "scripts",
 };
 
-function getChangedPackages(): Package[] {
-  try {
-    const output = execSync("git diff --name-only HEAD", {
-      encoding: "utf-8",
-      stdio: ["pipe", "pipe", "pipe"],
-    }).trim();
+const MERGE_BASE_REFS = ["origin/main", "main", "master"] as const;
+export const PLAYWRIGHT_INSTALL_COMMAND = "bunx playwright install chromium";
 
-    if (!output) {
-      // Fall back to staged + unstaged changes
-      const staged = execSync("git diff --name-only --cached", {
-        encoding: "utf-8",
-        stdio: ["pipe", "pipe", "pipe"],
-      }).trim();
-      const unstaged = execSync("git diff --name-only", {
-        encoding: "utf-8",
-        stdio: ["pipe", "pipe", "pipe"],
-      }).trim();
-      const combined = [staged, unstaged].filter(Boolean).join("\n");
-      if (!combined) return [];
-      return mapFilesToPackages(combined.split("\n"));
-    }
+export type GitCommands = {
+  hasRef(ref: string): boolean;
+  fetch(remote: string, branch: string): void;
+  mergeBase(a: string, b: string): string | null;
+  diffNameOnly(args: string[]): string[];
+  untrackedNames(): string[];
+};
 
-    return mapFilesToPackages(output.split("\n"));
-  } catch {
-    return [];
-  }
-}
+export type SpawnResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
 
-function mapFilesToPackages(files: string[]): Package[] {
+export type SpawnFn = (
+  cmd: string[],
+  options?: {
+    env?: Record<string, string | undefined>;
+    stdio?: "inherit" | "pipe";
+  },
+) => SpawnResult;
+
+export type Logger = {
+  log(message: string): void;
+  error(message: string): void;
+};
+
+export type PlannedCheck = {
+  id: string;
+  cmd: string[];
+};
+
+export type PlannedSkip = {
+  id: string;
+  reason: string;
+};
+
+export type VerifyPlan = {
+  packages: Package[];
+  checks: PlannedCheck[];
+  skips: PlannedSkip[];
+  playwrightSelected: boolean;
+  ciParityComplete: boolean;
+};
+
+export type VerifyDeps = {
+  git: GitCommands;
+  spawn: SpawnFn;
+  log: Logger;
+  chromiumAvailable?: (spawn: SpawnFn) => boolean;
+};
+
+export function mapFilesToPackages(files: string[]): Package[] {
   const packages = new Set<Package>();
   for (const file of files) {
+    if (file.startsWith("e2e/")) {
+      packages.add("web");
+      continue;
+    }
     for (const [prefix, pkg] of Object.entries(PACKAGE_PREFIXES)) {
       if (file.startsWith(prefix)) {
         packages.add(pkg);
       }
     }
   }
-  return Array.from(packages);
+  return VALID_PACKAGES.filter((pkg) => packages.has(pkg));
 }
 
-function runPackage(pkg: Package): boolean {
-  console.log(`\n→ test:${pkg}`);
-  const result = bunRuntime.spawnSync({
+export function playwrightTouched(
+  files: string[],
+  packages: Package[],
+): boolean {
+  if (packages.includes("web")) return true;
+  return files.some(
+    (file) => file.startsWith("packages/web/") || file.startsWith("e2e/"),
+  );
+}
+
+export function chromiumInstallLocationFromDryRun(
+  output: string,
+): string | null {
+  const match = output.match(
+    /playwright chromium[^\n]*\n[ \t]+Install location:[ \t]+(\S+)/i,
+  );
+  return match?.[1] ?? null;
+}
+
+export function detectChromiumAvailable(spawn: SpawnFn): boolean {
+  const result = spawn(
+    ["bunx", "playwright", "install", "--dry-run", "chromium"],
+    { stdio: "pipe" },
+  );
+  const output = `${result.stdout}\n${result.stderr}`;
+  const location = chromiumInstallLocationFromDryRun(output);
+  return location != null && existsSync(location);
+}
+
+export function planVerify(input: {
+  packages: Package[];
+  files: string[];
+  playwrightChromiumAvailable: boolean;
+}): VerifyPlan {
+  const packages = VALID_PACKAGES.filter((pkg) => input.packages.includes(pkg));
+  const checks: PlannedCheck[] = packages.map((pkg) => ({
+    id: `test:${pkg}`,
     cmd: ["bun", "run", `test:${pkg}`],
-    cwd: process.cwd(),
-    env: {
-      ...process.env,
-      NODE_ENV: "test",
-      TZ: process.env["TZ"] ?? "Etc/UTC",
-    },
-    stderr: "inherit",
-    stdin: "inherit",
-    stdout: "inherit",
-  });
-  return result.exitCode === 0;
+  }));
+
+  checks.push({ id: "type-check", cmd: ["bun", "run", "type-check"] });
+  checks.push({ id: "lint", cmd: ["bun", "run", "lint"] });
+  checks.push({ id: "knip", cmd: ["bun", "run", "knip"] });
+
+  const skips: PlannedSkip[] = [];
+  const playwrightSelected = playwrightTouched(input.files, packages);
+
+  if (playwrightSelected) {
+    if (input.playwrightChromiumAvailable) {
+      checks.push({ id: "test:a11y", cmd: ["bun", "run", "test:a11y"] });
+      checks.push({ id: "test:e2e", cmd: ["bun", "run", "test:e2e"] });
+    } else {
+      const reason = `Playwright Chromium missing; install with: ${PLAYWRIGHT_INSTALL_COMMAND}`;
+      skips.push({ id: "test:a11y", reason });
+      skips.push({ id: "test:e2e", reason });
+    }
+  }
+
+  return {
+    packages,
+    checks,
+    skips,
+    playwrightSelected,
+    ciParityComplete: skips.length === 0,
+  };
 }
 
-function runTypeCheck(): boolean {
-  console.log("\n→ type-check");
-  const result = bunRuntime.spawnSync({
-    cmd: ["bunx", "tsc", "--noEmit"],
-    cwd: process.cwd(),
-    env: {
-      ...process.env,
-      TZ: process.env["TZ"] ?? "Etc/UTC",
-    },
-    stderr: "inherit",
-    stdin: "inherit",
-    stdout: "inherit",
-  });
-  return result.exitCode === 0;
+export function resolveMergeBase(git: GitCommands): {
+  sha: string;
+  ref: string;
+} {
+  for (const ref of MERGE_BASE_REFS) {
+    if (ref === "origin/main" && !git.hasRef(ref)) {
+      try {
+        git.fetch("origin", "main");
+      } catch {
+        // Fall through to main/master when origin/main cannot be fetched.
+      }
+    }
+    if (!git.hasRef(ref)) continue;
+    const sha = git.mergeBase("HEAD", ref);
+    if (sha) return { sha, ref };
+  }
+
+  throw new Error(
+    "Could not resolve merge-base against origin/main, main, or master. Fetch origin/main instead of comparing against HEAD.",
+  );
 }
 
-function runLint(): boolean {
-  console.log("\n→ lint");
-  const result = bunRuntime.spawnSync({
-    cmd: ["bun", "run", "lint"],
-    cwd: process.cwd(),
-    env: {
-      ...process.env,
-      TZ: process.env["TZ"] ?? "Etc/UTC",
-    },
-    stderr: "inherit",
-    stdin: "inherit",
-    stdout: "inherit",
-  });
-  return result.exitCode === 0;
+export function collectChangedFiles(
+  git: GitCommands,
+  mergeBase: string,
+): string[] {
+  const committed = git.diffNameOnly([`${mergeBase}...HEAD`]);
+  const staged = git.diffNameOnly(["--cached"]);
+  const unstaged = git.diffNameOnly([]);
+  const untracked = git.untrackedNames();
+  return uniquePaths([...committed, ...staged, ...unstaged, ...untracked]);
 }
 
-function runA11y(): boolean {
-  console.log("\n→ test:a11y");
+export function defaultGit(): GitCommands {
+  return {
+    hasRef(ref: string): boolean {
+      try {
+        execGit(["rev-parse", "--verify", "--quiet", ref]);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    fetch(remote: string, branch: string): void {
+      execGit(["fetch", remote, branch]);
+    },
+    mergeBase(a: string, b: string): string | null {
+      try {
+        const sha = execGit(["merge-base", a, b]).trim();
+        return sha.length > 0 ? sha : null;
+      } catch {
+        return null;
+      }
+    },
+    diffNameOnly(args: string[]): string[] {
+      return splitLines(execGit(["diff", "--name-only", ...args]));
+    },
+    untrackedNames(): string[] {
+      return splitLines(
+        execGit(["ls-files", "--others", "--exclude-standard"]),
+      );
+    },
+  };
+}
+
+export function defaultSpawn(): SpawnFn {
+  return (cmd, options) => {
+    const inherit = options?.stdio !== "pipe";
+    const result = bunRuntime.spawnSync({
+      cmd,
+      cwd: process.cwd(),
+      env: options?.env ?? { ...process.env },
+      stderr: inherit ? "inherit" : "pipe",
+      stdin: inherit ? "inherit" : "pipe",
+      stdout: inherit ? "inherit" : "pipe",
+    });
+    return {
+      exitCode: result.exitCode,
+      stdout: decodeSpawnOutput(result.stdout),
+      stderr: decodeSpawnOutput(result.stderr),
+    };
+  };
+}
+
+export function runVerify(
+  args: string[],
+  deps: VerifyDeps = {
+    git: defaultGit(),
+    spawn: defaultSpawn(),
+    log: { log: console.log, error: console.error },
+  },
+): number {
+  const { git, spawn, log } = deps;
+  const chromiumAvailable = deps.chromiumAvailable ?? detectChromiumAvailable;
+
+  let packages: Package[];
+  let files: string[] = [];
+  let mergeBase: { sha: string; ref: string } | null = null;
+
+  if (args.length > 0) {
+    const invalid = args.filter(
+      (arg) => !VALID_PACKAGES.includes(arg as Package),
+    );
+    if (invalid.length > 0) {
+      log.error(
+        `Unknown package(s): ${invalid.join(", ")}. Valid: ${VALID_PACKAGES.join(", ")}`,
+      );
+      return 1;
+    }
+    packages = args as Package[];
+  } else {
+    try {
+      mergeBase = resolveMergeBase(git);
+    } catch (error) {
+      log.error(error instanceof Error ? error.message : String(error));
+      return 1;
+    }
+    files = collectChangedFiles(git, mergeBase.sha);
+    packages = mapFilesToPackages(files);
+    log.log(`merge-base: ${mergeBase.sha} (${mergeBase.ref})`);
+    log.log(
+      `files used for detection (${files.length}): ${
+        files.length > 0 ? files.join(", ") : "(none)"
+      }`,
+    );
+    if (packages.length === 0) {
+      log.log("no packages detected");
+    } else {
+      log.log(`Detected changes in: ${packages.join(", ")}`);
+    }
+  }
+
+  const detectionFiles =
+    args.length > 0 ? packagesToSyntheticFiles(packages) : files;
+  const needsPlaywright = playwrightTouched(detectionFiles, packages);
+  const plan = planVerify({
+    packages,
+    files: detectionFiles,
+    playwrightChromiumAvailable: needsPlaywright
+      ? chromiumAvailable(spawn)
+      : true,
+  });
+
+  log.log(`Running: ${plan.checks.map((check) => check.id).join(" → ")}`);
+  if (plan.skips.length > 0) {
+    for (const skip of plan.skips) {
+      log.log(`Skipping ${skip.id}: ${skip.reason}`);
+    }
+  }
+
+  const failed: string[] = [];
+  for (const check of plan.checks) {
+    log.log(`\n→ ${check.id}`);
+    const inheritIo = check.id !== "test:a11y" && check.id !== "test:e2e";
+    const result = spawn(check.cmd, {
+      env: spawnEnvFor(check.id),
+      stdio: inheritIo ? "inherit" : "pipe",
+    });
+    if (!inheritIo) {
+      if (result.stdout) process.stdout.write(result.stdout);
+      if (result.stderr) process.stderr.write(result.stderr);
+    }
+    if (result.exitCode !== 0) {
+      if (isMissingPlaywrightBrowser(result, check.id)) {
+        plan.skips.push({
+          id: check.id,
+          reason: `Playwright Chromium missing; install with: ${PLAYWRIGHT_INSTALL_COMMAND}`,
+        });
+        plan.ciParityComplete = false;
+        log.log(
+          `Skipping ${check.id}: Playwright Chromium missing; install with: ${PLAYWRIGHT_INSTALL_COMMAND}`,
+        );
+        continue;
+      }
+      failed.push(check.id);
+    }
+  }
+
+  log.log("\nSummary");
+  log.log(
+    `Selected packages: ${plan.packages.length > 0 ? plan.packages.join(", ") : "(none)"}`,
+  );
+  log.log(
+    `Checks run: ${plan.checks.map((check) => check.id).join(", ") || "(none)"}`,
+  );
+  if (plan.skips.length > 0) {
+    log.log(
+      `Checks skipped: ${plan.skips.map((skip) => `${skip.id} (${skip.reason})`).join("; ")}`,
+    );
+  } else {
+    log.log("Checks skipped: (none)");
+  }
+
+  if (failed.length > 0) {
+    log.error(`\nFailed: ${failed.join(", ")}`);
+    return 1;
+  }
+
+  if (!plan.ciParityComplete) {
+    const reasons = uniquePaths(plan.skips.map((skip) => skip.reason));
+    log.log(
+      `\n✓ selected checks passed; CI parity incomplete: ${reasons.join("; ")}`,
+    );
+    return 0;
+  }
+
+  log.log("\n✓ All checks passed");
+  return 0;
+}
+
+function packagesToSyntheticFiles(packages: Package[]): string[] {
+  return packages.map((pkg) => `packages/${pkg}/src/changed.ts`);
+}
+
+function splitLines(output: string): string[] {
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function spawnEnvFor(checkId: string): Record<string, string | undefined> {
+  const timezone = process.env["TZ"] ?? "Etc/UTC";
+  if (
+    checkId.startsWith("test:") &&
+    !checkId.startsWith("test:a11y") &&
+    checkId !== "test:e2e"
+  ) {
+    return { ...process.env, NODE_ENV: "test", TZ: timezone };
+  }
+  if (checkId === "test:a11y" || checkId === "test:e2e") {
+    return playwrightEnv(timezone);
+  }
+  return { ...process.env, TZ: timezone };
+}
+
+function playwrightEnv(timezone: string): Record<string, string | undefined> {
   // Playwright's Bun web server reports a color-env conflict when the parent
   // process forces ANSI colors, and Node 26 reports its known module-loader
   // deprecation. These are upstream runtime diagnostics, not test failures;
@@ -140,87 +437,44 @@ function runA11y(): boolean {
     NO_COLOR: _noColor,
     ...processEnvWithoutColorOverrides
   } = process.env;
-  const result = bunRuntime.spawnSync({
-    cmd: ["bun", "run", "test:a11y"],
-    cwd: process.cwd(),
-    env: {
-      ...processEnvWithoutColorOverrides,
-      TZ: process.env["TZ"] ?? "Etc/UTC",
-      NODE_OPTIONS: nodeOptions,
-    },
-    stderr: "inherit",
-    stdin: "inherit",
-    stdout: "inherit",
+  return {
+    ...processEnvWithoutColorOverrides,
+    TZ: timezone,
+    NODE_OPTIONS: nodeOptions,
+  };
+}
+
+function isMissingPlaywrightBrowser(
+  result: SpawnResult,
+  checkId: string,
+): boolean {
+  if (checkId !== "test:a11y" && checkId !== "test:e2e") return false;
+  const output = `${result.stdout}\n${result.stderr}`.toLowerCase();
+  return (
+    output.includes("executable doesn't exist") ||
+    output.includes("browserType.launch") ||
+    output.includes("playwright chromium") ||
+    (output.includes("chromium") && output.includes("install"))
+  );
+}
+
+function uniquePaths(paths: string[]): string[] {
+  return [...new Set(paths.filter(Boolean))];
+}
+
+function execGit(args: string[]): string {
+  return execFileSync("git", args, {
+    encoding: "utf-8",
+    stdio: ["pipe", "pipe", "pipe"],
   });
-  return result.exitCode === 0;
 }
 
-function describeChecks(packagesToRun: Package[]): string {
-  const checks = [...packagesToRun, "type-check", "lint"];
-
-  if (packagesToRun.includes("web")) {
-    checks.push("test:a11y");
-  }
-
-  return checks.join(" → ");
+function decodeSpawnOutput(value: Uint8Array | string | undefined): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  return new TextDecoder().decode(value);
 }
 
-function main() {
-  const args = process.argv.slice(2);
-
-  let packagesToRun: Package[];
-
-  if (args.length > 0) {
-    const invalid = args.filter((a) => !VALID_PACKAGES.includes(a as Package));
-    if (invalid.length > 0) {
-      console.error(
-        `Unknown package(s): ${invalid.join(", ")}. Valid: ${VALID_PACKAGES.join(", ")}`,
-      );
-      process.exit(1);
-    }
-    packagesToRun = args as Package[];
-    console.log(`Running: ${describeChecks(packagesToRun)}`);
-  } else {
-    packagesToRun = getChangedPackages();
-
-    if (packagesToRun.length === 0) {
-      console.log(
-        "No changed packages detected — falling back to: core → web → type-check → lint → test:a11y",
-      );
-      packagesToRun = ["core", "web"];
-    } else {
-      console.log(
-        `Detected changes in: ${packagesToRun.join(", ")}\nRunning: ${describeChecks(packagesToRun)}`,
-      );
-    }
-  }
-
-  const failed: string[] = [];
-
-  for (const pkg of packagesToRun) {
-    if (!runPackage(pkg)) {
-      failed.push(`test:${pkg}`);
-    }
-  }
-
-  if (!runTypeCheck()) {
-    failed.push("type-check");
-  }
-
-  if (!runLint()) {
-    failed.push("lint");
-  }
-
-  if (packagesToRun.includes("web") && !runA11y()) {
-    failed.push("test:a11y");
-  }
-
-  if (failed.length > 0) {
-    console.error(`\nFailed: ${failed.join(", ")}`);
-    process.exit(1);
-  }
-
-  console.log("\n✓ All checks passed");
+if (import.meta.main) {
+  process.exit(runVerify(process.argv.slice(2)));
 }
-
-main();

--- a/wip/restructure/TRACKING.md
+++ b/wip/restructure/TRACKING.md
@@ -10,7 +10,7 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | PACK-WRITE | high | docs-session | done | `wip/restructure/` | this directory exists; WPs have finish lines and session prompts | — | 0 | none (docs-only pack) |
-| WP-01 | high | — | queued | [WP-01-verify-ci-parity.md](WP-01-verify-ci-parity.md) | — | when picked up: +1 session | 0 | none |
+| WP-01 | high | cursor-agent | verifying | [WP-01-verify-ci-parity.md](WP-01-verify-ci-parity.md) | `bun run verify` selected scripts → type-check → lint → knip; test:scripts 45 pass; CI parity complete for this diff | this session | 0 | none |
 | WP-02 | high | — | queued | [WP-02-typed-handoff-ledger.md](WP-02-typed-handoff-ledger.md) | — | when picked up: +1 session | 0 | none |
 | WP-03 | high | — | queued | [WP-03-split-ship-review-verifier.md](WP-03-split-ship-review-verifier.md) | — | after WP-02 `done` | 0 | none |
 | WP-04 | high | — | queued | [WP-04-hard-constraints.md](WP-04-hard-constraints.md) | — | after WP-01 `done` | 0 | none |

--- a/wip/restructure/WP-01-verify-ci-parity.md
+++ b/wip/restructure/WP-01-verify-ci-parity.md
@@ -1,8 +1,8 @@
 # WP-01 — Verify / CI parity
 
 **task_id:** WP-01
-**status:** queued
-**owner:** Implementer (scripts) then Verifier
+**status:** verifying
+**owner:** cursor-agent
 **depends on:** none
 **next owner after done:** WP-04 can start; WP-02 may run in parallel
 
@@ -87,14 +87,26 @@ On a branch that differs from `origin/main` in more than one package,
 
 ## Evidence
 
-Record in this section when implementing:
-
 ```text
-merge-base used:
+merge-base used: 1dbee3ed730c0c7f8e0eaae731fc0da70bf44358 (origin/main)
 commands:
+  bun test packages/scripts/src/testing/verify.test.ts  → 12 pass
+  bun run test:scripts                                  → 45 pass, 0 fail
+  bun run type-check                                    → exit 0
+  bun run lint                                          → exit 0 (10 pre-existing warnings, unrelated)
+  bun run verify                                        → exit 0
 stdout excerpt (selection + summary):
-test:scripts result:
-CI parity claim (complete | incomplete + reason):
+  merge-base: 1dbee3ed730c0c7f8e0eaae731fc0da70bf44358 (origin/main)
+  files used for detection (6): .agents/skills/verify-change/SKILL.md, AGENTS.md, docs/development/testing-playbook.md, packages/scripts/src/testing/verify.ts, wip/restructure/TRACKING.md, wip/restructure/WP-01-verify-ci-parity.md
+  Detected changes in: scripts
+  Running: test:scripts → type-check → lint → knip
+  Selected packages: scripts
+  Checks run: test:scripts, type-check, lint, knip
+  Checks skipped: (none)
+  ✓ All checks passed
+test:scripts result: 45 pass, 0 fail
+CI parity claim (complete | incomplete + reason): complete for this scripts-only diff
+independent review: self diff review; no confirmed defects. Notes: GitHub still runs e2e on every non-docs PR; local verify selects e2e only for web/e2e paths (documented as required-check subset). Untracked files are included via git ls-files --others --exclude-standard.
 ```
 
 ## Out of scope


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`bun run verify` was a false-green helper: it diffed only `HEAD`, type-checked with `bunx tsc --noEmit` instead of `bun run type-check`, skipped knip and e2e, and fell back to `core`+`web` when detection was empty.

This change makes the helper the required-check subset agents actually need:

- Detect packages from `git merge-base HEAD origin/main` plus staged, unstaged, and untracked paths
- Run `test:<pkg>` for each detected package, then `bun run type-check`, `bun run lint`, and `bun run knip`
- Select `test:a11y` and `test:e2e` when `packages/web/**` or `e2e/**` changed; skip with an install command instead of claiming CI parity if Playwright Chromium is missing
- Print merge-base, files, checks run, and skips; never invent `core`/`web` on empty detection
- Focused scripts tests cover mapping, empty detection, type-check failure, knip invocation, and e2e selection
- `/verify-change` and the testing playbook now describe the helper as a required-check subset whose skip list must be read

## Simplicity

Separate commit after three read-only reviews:

- Playwright selection uses `packages.includes("web")` (`e2e/` already maps to web); removed synthetic file paths
- Skip state is local, not a mutated plan field
- One Playwright-check helper and one missing-Chromium reason string
- `Bun.spawnSync` directly; package prefixes derived from `VALID_PACKAGES`

Skipped: tightening missing-browser heuristics; running e2e on scripts-only diffs to match GitHub (WP finish line selects e2e only for web/`e2e/` paths).

## Automated validation

Scripts-only working tree vs `origin/main`:

- merge-base: `1dbee3ed730c0c7f8e0eaae731fc0da70bf44358` (`origin/main`)
- detected packages: `scripts`
- running: `test:scripts → type-check → lint → knip`
- `bun test packages/scripts/src/testing/verify.test.ts` — 12 pass
- `bun run test:scripts` — 45 pass, 0 fail
- `bun run type-check` — exit 0
- `bun run lint` — exit 0 (10 pre-existing warnings on unrelated web files)
- `bun run verify` — exit 0, CI parity complete for this diff
- no `core`/`web` fallback; no e2e claim on a scripts-only change

## Independent review

Self read-only diff review before WP-03 `/review` exists. No confirmed defects. Parallel simplify reviewers (quality, performance, reuse) produced the cleanup above. Remaining note: GitHub still runs e2e on every non-docs PR; local verify selects e2e only for web/e2e paths (documented as the required-check subset).

## Test plan

Executed:

- `bun test packages/scripts/src/testing/verify.test.ts`
- `bun run test:scripts`
- `bun run type-check`
- `bun run lint`
- `bun run verify`

Not run: `test:e2e` / `test:a11y` (this diff does not touch web or e2e). GitHub CI still runs e2e on non-docs PRs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1e729d3-21f7-460a-a6a2-cf411b9d72ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1e729d3-21f7-460a-a6a2-cf411b9d72ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

