### PR TITLE
feat(agents): write typed handoffs in-repo instead of OS temp

### DIFF
--- a/.agents/handoffs/README.md
+++ b/.agents/handoffs/README.md
@@ -1,0 +1,13 @@
+# Agent handoffs
+
+Typed records for the next session. Schema:
+[SCHEMA.md](SCHEMA.md). Skill: `/handoff`.
+
+Write `.agents/handoffs/<task_id>.md` in this directory. Update
+[`.agents/ledger.md`](../ledger.md) in the same turn. Do not write to OS
+temp.
+
+`issue-0.md` is the documented example. Delete live handoffs in the same
+commit that closes the task (`status: done` or escalated-and-closed). Do
+not commit secrets, `compass.yaml` contents, tokens, or personal calendar
+data.

--- a/.agents/handoffs/SCHEMA.md
+++ b/.agents/handoffs/SCHEMA.md
@@ -12,6 +12,14 @@ optional context and is **not** required to act.
 
 `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
+## Write-gate vs full record
+
+`/handoff` **refuses to write** unless these are present: `task_id`, `owner`,
+`status`, `artifact`, `evidence`.
+
+A valid v1 file must still include every field in the table. Use empty lists,
+`0`, `none`, or `null` when there is nothing to report. Do not omit keys.
+
 ## Required fields
 
 | Field | Meaning |
@@ -32,29 +40,23 @@ optional context and is **not** required to act.
 | `waiting_on` | Dependency name when `status` is `waiting`; otherwise `null`. |
 | `escalation` | Packet when `status` is `escalated`; otherwise `null`. |
 
-Separate fact, decision, evidence, and artifact. Do not collapse them into
-one summary paragraph. Additive fields in later schema versions are OK;
+Separate fact, evidence, and artifact. Do not collapse them into one
+summary paragraph. Additive fields in later schema versions are OK;
 renaming the meaning of an existing field is not.
 
 ## Rejection rules
 
-Refuse to write (or refuse to accept) a handoff when:
+Refuse to write when `task_id`, `owner`, `status`, `artifact`, or `evidence`
+is missing. Refuse to accept a file when:
 
-1. Any required field is missing.
-2. `schema_version` is missing or not `1`.
-3. `status` is not in the enum.
-4. `owner` is empty or lists more than one owner.
-5. `artifact` has no existing `path` and no `url`.
-6. `evidence` is missing, empty, or is only a prose claim.
-7. Completion is asserted with invalid phrases instead of pointers (see
-   below).
-8. The workspace is not writable — escalate; do **not** fall back to OS
-   temp.
-
-`/handoff` prefers refuse-to-advance: if `task_id`, `owner`, `status`,
-`artifact`, or `evidence` is missing, stop and request the field. Do not
-write the file. Do not write `status: waiting` as a substitute for missing
-evidence.
+1. `schema_version` is missing or not `1`.
+2. `status` is not in the enum.
+3. `owner` is empty or names more than one owner.
+4. `artifact` has no existing `path` and no `url`.
+5. `evidence` is empty or uses an invalid completion (below).
+6. The workspace is not writable — escalate; do **not** fall back to OS temp.
+7. `waiting_on` is `null` while `status` is `waiting`, or `escalation` is
+   `null` while `status` is `escalated`.
 
 ## Invalid completions
 
@@ -67,34 +69,13 @@ These are **not** evidence and must not advance `status` to `done` or
 - "tests probably pass"
 - any claim with no command/log/path/url pointer that exists
 
-Status only advances when `artifact` and `evidence` are pointers that exist.
+Status only advances when `artifact` points at an existing path or URL and
+`evidence` has a runnable `command` plus a non-phrase `result`.
 
 ## Valid example
 
-```yaml
-schema_version: 1
-task_id: "issue-0"
-from: Implementer
-to: Verifier
-owner: Verifier
-status: verifying
-artifact:
-  - path: packages/scripts/src/testing/verify.ts
-  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/0
-evidence:
-  - command: bun run test:scripts
-    result: pass
-    log: "45 pass, 0 fail"
-assumptions:
-  - "anonymous IndexedDB mode is enough"
-open_risks:
-  - "SSE pair not exercised"
-next_deadline: 2026-08-26T18:00:00Z
-retry: 0
-approval: none
-waiting_on: null
-escalation: null
-```
+The documented file is [issue-0.md](issue-0.md). Receivers should use that
+record, not a second copy here.
 
 ## Malformed example (must reject)
 
@@ -109,6 +90,13 @@ artifact: []
 evidence:
   - command: ""
     result: "looks good"
+assumptions: []
+open_risks: []
+next_deadline: 2026-08-26T18:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
 ```
 
 Rejected because `artifact` is empty, `evidence` has no command, and

--- a/.agents/handoffs/SCHEMA.md
+++ b/.agents/handoffs/SCHEMA.md
@@ -1,0 +1,123 @@
+# Handoff schema (v1)
+
+Versioned contract for passing work between agent sessions. Pass artifacts
+and evidence pointers, not transcripts. Unknown `schema_version` values are
+rejected; the Manager keeps the producer artifact.
+
+Files live at `.agents/handoffs/<task_id>.md`. YAML frontmatter is required
+and must match this schema. A short markdown body after the frontmatter is
+optional context and is **not** required to act.
+
+## Status enum
+
+`queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
+
+## Required fields
+
+| Field | Meaning |
+| --- | --- |
+| `schema_version` | Integer. Receivers accept `1` only. |
+| `task_id` | GitHub issue, PR number, or `WP-*` / branch name until WP-07. |
+| `from` | Role that produced this record. |
+| `to` | Role that should act next. |
+| `owner` | Exactly one current owner. |
+| `status` | One value from the enum. |
+| `artifact` | Pointers (repo `path` and/or `url`) that exist. |
+| `evidence` | How to check: `command` + `result` + optional `log` pointer. |
+| `assumptions` | List. Empty list is allowed. |
+| `open_risks` | List. Empty list is allowed. |
+| `next_deadline` | ISO-8601 timestamp, or `null` only when status is `done`. |
+| `retry` | Non-negative integer. |
+| `approval` | `none` \| `ask` \| `human`. |
+| `waiting_on` | Dependency name when `status` is `waiting`; otherwise `null`. |
+| `escalation` | Packet when `status` is `escalated`; otherwise `null`. |
+
+Separate fact, decision, evidence, and artifact. Do not collapse them into
+one summary paragraph. Additive fields in later schema versions are OK;
+renaming the meaning of an existing field is not.
+
+## Rejection rules
+
+Refuse to write (or refuse to accept) a handoff when:
+
+1. Any required field is missing.
+2. `schema_version` is missing or not `1`.
+3. `status` is not in the enum.
+4. `owner` is empty or lists more than one owner.
+5. `artifact` has no existing `path` and no `url`.
+6. `evidence` is missing, empty, or is only a prose claim.
+7. Completion is asserted with invalid phrases instead of pointers (see
+   below).
+8. The workspace is not writable — escalate; do **not** fall back to OS
+   temp.
+
+`/handoff` prefers refuse-to-advance: if `task_id`, `owner`, `status`,
+`artifact`, or `evidence` is missing, stop and request the field. Do not
+write the file. Do not write `status: waiting` as a substitute for missing
+evidence.
+
+## Invalid completions
+
+These are **not** evidence and must not advance `status` to `done` or
+`verifying`:
+
+- "done"
+- "looks good"
+- "should be fine"
+- "tests probably pass"
+- any claim with no command/log/path/url pointer that exists
+
+Status only advances when `artifact` and `evidence` are pointers that exist.
+
+## Valid example
+
+```yaml
+schema_version: 1
+task_id: "issue-0"
+from: Implementer
+to: Verifier
+owner: Verifier
+status: verifying
+artifact:
+  - path: packages/scripts/src/testing/verify.ts
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/0
+evidence:
+  - command: bun run test:scripts
+    result: pass
+    log: "45 pass, 0 fail"
+assumptions:
+  - "anonymous IndexedDB mode is enough"
+open_risks:
+  - "SSE pair not exercised"
+next_deadline: 2026-08-26T18:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+```
+
+## Malformed example (must reject)
+
+```yaml
+schema_version: 1
+task_id: "issue-0"
+from: Implementer
+to: Verifier
+owner: Verifier
+status: done
+artifact: []
+evidence:
+  - command: ""
+    result: "looks good"
+```
+
+Rejected because `artifact` is empty, `evidence` has no command, and
+`result` is an invalid completion phrase.
+
+## Receiver checklist
+
+Given only this file, a receiver must be able to name:
+
+1. `owner`
+2. `artifact` (path or URL)
+3. the next check (`evidence[].command`)

--- a/.agents/handoffs/WP-02.md
+++ b/.agents/handoffs/WP-02.md
@@ -1,0 +1,32 @@
+---
+schema_version: 1
+task_id: "WP-02"
+from: Implementer
+to: Verifier
+owner: Verifier
+status: verifying
+artifact:
+  - path: .agents/handoffs/SCHEMA.md
+  - path: .agents/skills/handoff/SKILL.md
+  - path: .agents/ledger.md
+evidence:
+  - command: python3 -c "import pathlib,re,yaml; p=pathlib.Path('.agents/handoffs/issue-0.md'); t=p.read_text(); fm=re.match(r'^---\\n(.*?)\\n---\\n', t, re.S); d=yaml.safe_load(fm.group(1)); assert d['schema_version']==1 and d['owner'] and d['artifact'] and d['evidence']"
+    result: pass
+    log: "issue-0 example: schema-valid; owner=Verifier"
+  - command: bun run lint
+    result: pass
+    log: "exit 0; 10 pre-existing warnings unrelated"
+assumptions:
+  - "WP-01 PR #2865 is CI-green but unmerged (PAT cannot squash-merge)"
+open_risks:
+  - "squash-merge 403 blocks marking WP-01 done on main"
+next_deadline: 2026-08-26T18:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+## Suggested skills
+
+`/verify-change` (docs-only: lint), `/ship`.

--- a/.agents/handoffs/issue-0.md
+++ b/.agents/handoffs/issue-0.md
@@ -1,0 +1,26 @@
+---
+schema_version: 1
+task_id: "issue-0"
+from: Implementer
+to: Verifier
+owner: Verifier
+status: verifying
+artifact:
+  - path: .agents/handoffs/SCHEMA.md
+evidence:
+  - command: test -f .agents/handoffs/SCHEMA.md
+    result: pass
+    log: schema file exists
+assumptions:
+  - "this file is a documented example, not a live task"
+open_risks: []
+next_deadline: 2026-08-26T18:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+Documented example only. A receiver can name owner (`Verifier`), artifact
+(`.agents/handoffs/SCHEMA.md`), and next check (`test -f .agents/handoffs/SCHEMA.md`)
+without the producer transcript.

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -1,0 +1,14 @@
+# Agent ledger
+
+Manager-owned. Update at every typed handoff. Delete rows when status is
+`done` or escalated-and-closed. GitHub is the human inbox; this table is
+what the Manager reads first.
+
+Do not append transcripts. Change the row. One current `owner` per
+`task_id`.
+
+Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
+
+| task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| issue-0 | low | Verifier | verifying | `.agents/handoffs/SCHEMA.md` | `test -f .agents/handoffs/SCHEMA.md` → pass (documented example) | 2026-08-26T18:00:00Z | 0 | none |

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -5,10 +5,12 @@ Manager-owned. Update at every typed handoff. Delete rows when status is
 what the Manager reads first.
 
 Do not append transcripts. Change the row. One current `owner` per
-`task_id`.
+`task_id`. `priority` is ledger-only (not a handoff field); default `medium`
+when unknown. The documented example is `.agents/handoffs/issue-0.md`, not a
+ledger row.
 
 Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| issue-0 | low | Verifier | verifying | `.agents/handoffs/SCHEMA.md` | `test -f .agents/handoffs/SCHEMA.md` → pass (documented example) | 2026-08-26T18:00:00Z | 0 | none |
+| WP-02 | high | cursor-agent | verifying | `.agents/handoffs/SCHEMA.md` | schema-valid `issue-0.md`; dry-run write/delete yes | 2026-08-26T18:00:00Z | 0 | none |

--- a/.agents/skills/chaos/SKILL.md
+++ b/.agents/skills/chaos/SKILL.md
@@ -111,6 +111,8 @@ report from a speculative concern.
 
 ## 5. Simplify, review, and release
 
+At handoff boundaries, write a typed record per `.agents/handoffs/SCHEMA.md`.
+
 1. Invoke `/simplify` on the complete base-to-head diff after the fix. Apply
    behavior-preserving simplifications, commit them separately when they change
    code, and re-run behavior-adjacent checks.

--- a/.agents/skills/handoff/SKILL.md
+++ b/.agents/skills/handoff/SKILL.md
@@ -1,15 +1,43 @@
 ---
 name: handoff
-description: Compact the current conversation into a handoff document for another agent to pick up.
+description: Compact the current conversation into a typed in-repo handoff so a fresh agent can continue the work.
 argument-hint: "What will the next session be used for?"
 ---
 
-Write a handoff document summarising the current conversation so a fresh agent can continue the work. Save to the temporary directory of the user's OS - not the current workspace.
+Write a typed handoff so a fresh agent can continue without the producer
+transcript. Follow [`.agents/handoffs/SCHEMA.md`](../../handoffs/SCHEMA.md).
 
-Include a "suggested skills" section in the document, which suggests skills that the agent should invoke.
+If the user passed arguments, treat them as the next session’s focus and
+tailor `to`, `artifact`, and `evidence` accordingly.
 
-Do not duplicate content already captured in other artifacts (PRDs, plans, ADRs, issues, commits, diffs). Reference them by path or URL instead.
+## Write path
 
-Redact any sensitive information, such as API keys, passwords, or personally identifiable information.
+1. Collect required fields: `task_id`, `from`, `to`, `owner`, `status`,
+   `artifact`, `evidence`. Also fill `assumptions`, `open_risks`,
+   `next_deadline`, `retry`, `approval`, `waiting_on`, `escalation`.
+2. If `task_id`, `owner`, `status`, `artifact`, or `evidence` is missing,
+   **stop**. Request the missing field. Do not write a file. Do not fall
+   back to OS temp. Do not write `status: waiting` as a substitute for
+   missing evidence.
+3. Validate against the schema: `schema_version: 1`, status enum, exactly
+   one `owner`, artifact pointers that exist, evidence commands/results
+   that are not invalid completions ("done", "looks good", and the rest
+   listed in the schema).
+4. If the workspace is not writable, escalate. Never write to OS temp.
+5. Write `.agents/handoffs/<task_id>.md` with YAML frontmatter matching the
+   schema, then an optional short body. The body is not required to act.
+6. Update [`.agents/ledger.md`](../../ledger.md) in the same turn (create
+   it if absent): one row per in-flight `task_id`. Change the row; do not
+   append a transcript.
+7. Include a "suggested skills" section in the body.
+8. Do not duplicate PRDs, plans, ADRs, issues, commits, or diffs — link
+   them by path or URL.
+9. Redact secrets: API keys, passwords, tokens, `compass.yaml` contents,
+   personal calendar data, and personally identifiable information.
+10. Delete the handoff file in the same commit that closes the task, except
+    the documented `issue-0` example.
 
-If the user passed arguments, treat them as a description of what the next session will focus on and tailor the doc accordingly.
+## Suggested skills
+
+After the record is written, list skills the receiver should invoke
+(for example `/verify-change`, `/ship`, `/local-dev-bootstrap`).

--- a/.agents/skills/handoff/SKILL.md
+++ b/.agents/skills/handoff/SKILL.md
@@ -27,9 +27,10 @@ tailor `to`, `artifact`, and `evidence` accordingly.
 5. Write `.agents/handoffs/<task_id>.md` with YAML frontmatter matching the
    schema, then an optional short body. The body is not required to act.
 6. Update [`.agents/ledger.md`](../../ledger.md) in the same turn (create
-   it if absent): one row per in-flight `task_id`. Change the row; do not
-   append a transcript.
-7. Include a "suggested skills" section in the body.
+   it if absent): one row per in-flight `task_id`. Default `priority` to
+   `medium` if unknown. Change the row; do not append a transcript.
+7. Optionally include a "suggested skills" section in the body (not required
+   to act).
 8. Do not duplicate PRDs, plans, ADRs, issues, commits, or diffs — link
    them by path or URL.
 9. Redact secrets: API keys, passwords, tokens, `compass.yaml` contents,

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -17,6 +17,8 @@ merge or release work remains.
 - Inspect live configuration rather than assuming ports, checks, or workflows.
 - Pause for ambiguous product decisions, unconfirmed correctness, unrelated
   infrastructure failures, or incomplete confidence.
+- At handoff boundaries, write a typed record per
+  `.agents/handoffs/SCHEMA.md`.
 
 ## 1. Preflight
 

--- a/.github/prompts/error-autofix.md
+++ b/.github/prompts/error-autofix.md
@@ -112,6 +112,8 @@ leave it off — the PR still exists for human review, which is a fine outcome.
 
 ## Hard rules (all modes)
 
+- At handoff boundaries, write a typed record per `.agents/handoffs/SCHEMA.md`.
+
 - Never edit any denied path — see the confidence rubric above.
 - Never force-push.
 - One PR per issue — if a PR already exists for this issue (check open PRs

--- a/packages/scripts/src/testing/handoff-schema.test.ts
+++ b/packages/scripts/src/testing/handoff-schema.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+
+describe("typed handoff ledger", () => {
+  it("ships a v1 schema and in-repo /handoff write path", () => {
+    expect(existsSync(".agents/handoffs/SCHEMA.md")).toBe(true);
+    expect(existsSync(".agents/ledger.md")).toBe(true);
+    expect(existsSync(".agents/handoffs/issue-0.md")).toBe(true);
+
+    const schema = readFileSync(".agents/handoffs/SCHEMA.md", "utf8");
+    expect(schema).toContain("schema_version");
+    expect(schema).toContain(
+      "`queued` | `running` | `waiting` | `verifying` | `done` | `escalated`",
+    );
+
+    const skill = readFileSync(".agents/skills/handoff/SKILL.md", "utf8");
+    expect(skill).toContain(".agents/handoffs/");
+    expect(skill).not.toContain("temporary directory of the user's OS");
+    expect(skill).toContain("Do not fall");
+  });
+});

--- a/wip/restructure/TRACKING.md
+++ b/wip/restructure/TRACKING.md
@@ -11,7 +11,7 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | PACK-WRITE | high | docs-session | done | `wip/restructure/` | this directory exists; WPs have finish lines and session prompts | — | 0 | none (docs-only pack) |
 | WP-01 | high | — | queued | [WP-01-verify-ci-parity.md](WP-01-verify-ci-parity.md) | — | when picked up: +1 session | 0 | none |
-| WP-02 | high | — | queued | [WP-02-typed-handoff-ledger.md](WP-02-typed-handoff-ledger.md) | — | when picked up: +1 session | 0 | none |
+| WP-02 | high | cursor-agent | verifying | [WP-02-typed-handoff-ledger.md](WP-02-typed-handoff-ledger.md) | schema + in-repo `/handoff` + ledger; issue-0 example valid; dry-run write/delete yes | this session | 0 | none |
 | WP-03 | high | — | queued | [WP-03-split-ship-review-verifier.md](WP-03-split-ship-review-verifier.md) | — | after WP-02 `done` | 0 | none |
 | WP-04 | high | — | queued | [WP-04-hard-constraints.md](WP-04-hard-constraints.md) | — | after WP-01 `done` | 0 | none |
 | WP-05 | medium | — | queued | [WP-05-skill-registry.md](WP-05-skill-registry.md) | — | after WP-03 `done` | 0 | none |
@@ -50,4 +50,4 @@ Record elapsed minutes, exceptions, quality 1–5, rework.
 
 | date | task_id | decision required | recommended option | alternatives tried | cost of waiting | safest default |
 | --- | --- | --- | --- | --- | --- | --- |
-| | | | | | | |
+| 2026-08-25 | WP-01 | squash-merge of PR #2865 (CI 20/20) | merge with a token that has `pull_request: write` | `gh pr merge --squash` and REST merge both 403 on this PAT | pack stays blocked before WP-04 | leave #2865 open; continue WP-02 |

--- a/wip/restructure/WP-02-typed-handoff-ledger.md
+++ b/wip/restructure/WP-02-typed-handoff-ledger.md
@@ -1,8 +1,8 @@
 # WP-02 — Typed handoff and Manager ledger
 
 **task_id:** WP-02
-**status:** queued
-**owner:** Implementer (agents) then Verifier
+**status:** verifying
+**owner:** cursor-agent
 **depends on:** none (may overlap WP-01; different files)
 **next owner after done:** WP-03, WP-06, WP-07
 
@@ -121,11 +121,17 @@ example).
 ## Evidence
 
 ```text
-schema path:
-handoff skill diff summary:
-ledger path:
-dry-run file created and removed: yes/no
-ship/chaos/autofix one-line pointers: yes/no
+schema path: .agents/handoffs/SCHEMA.md
+handoff skill diff summary: writes .agents/handoffs/<task_id>.md with YAML
+  frontmatter; refuses missing task_id/owner/status/artifact/evidence; never
+  OS temp; updates .agents/ledger.md; redacts secrets
+ledger path: .agents/ledger.md
+dry-run file created and removed: yes
+ship/chaos/autofix one-line pointers: yes
+git check-ignore: .agents/handoffs/ and ledger are not ignored
+receiver from issue-0.md only: owner=Verifier,
+  artifact=.agents/handoffs/SCHEMA.md,
+  next check=test -f .agents/handoffs/SCHEMA.md
 ```
 
 ## Out of scope


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`/handoff` wrote markdown to OS temp with no `task_id`, owner, status, evidence, or deadline. This WP adds the typed in-repo contract:

- `.agents/handoffs/SCHEMA.md` — v1 fields, status enum, refuse-to-write gate, invalid completions
- `/handoff` writes `.agents/handoffs/<task_id>.md` and updates `.agents/ledger.md`; refuses missing `task_id` / `owner` / `status` / `artifact` / `evidence`; never falls back to OS temp
- Seeded ledger (Manager table). GitHub stays the human inbox
- Documented `issue-0.md` example; live `WP-02.md` handoff
- One-line pointers in `/ship`, `/chaos`, and `.github/prompts/error-autofix.md`
- `packages/scripts/src/testing/handoff-schema.test.ts` so required unit CI runs (markdown-only PRs skip the Test workflow and stay BLOCKED)

`.gitignore` does not ignore `.agents/handoffs/` or the ledger.

## Simplicity

Follow-up commit after three read-only reviews: one write-gate (five fields), one valid example (`issue-0.md`), malformed example keeps all keys and only breaks artifact/evidence, ledger does not treat the example as live work, `priority` is ledger-only with default `medium`.

## Automated validation

- Parsed `issue-0.md` YAML: `schema_version: 1`, owner=`Verifier`, artifact=`.agents/handoffs/SCHEMA.md`, next check=`test -f .agents/handoffs/SCHEMA.md`
- Dry-run wrote `.agents/handoffs/WP-02-dry-run.md` then deleted it
- Missing-evidence path: no file written
- `git check-ignore` does not ignore schema or ledger
- `bun run lint` — exit 0 (10 pre-existing warnings, unrelated)
- `bun test packages/scripts/src/testing/handoff-schema.test.ts` — 1 pass

## Independent review

Self read-only review plus simplify reviewers. Confirmed: dual `issue-0` examples and refuse-list split — fixed in the simplify commit. No remaining confirmed defects.

## Test plan

Executed:

- YAML parse of `issue-0.md`
- dry-run write + delete
- `git check-ignore`
- `bun run lint`
- `bun test packages/scripts/src/testing/handoff-schema.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1e729d3-21f7-460a-a6a2-cf411b9d72ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1e729d3-21f7-460a-a6a2-cf411b9d72ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

