### PR TITLE
feat(scripts): enforce agent constraints in lint and PR body

### DIFF
--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -1,0 +1,35 @@
+name: PR body
+
+# Runs on every pull_request, including markdown-only PRs that skip Test/e2e
+# via paths-ignore. Docs PRs are not blocked on unit/e2e; they still must fill
+# Automated validation, Independent review, and Test plan (a short docs-only
+# note is enough). Do not fold this job into test-unit.yml: that workflow's
+# paths-ignore would hide the check on docs PRs, and making it a required
+# check there would BLOCK markdown PRs on missing unit/e2e jobs.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  pr-body:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v6
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Check required PR template sections
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: bun packages/scripts/src/testing/check-pr-body.ts

--- a/docs/development/testing-playbook.md
+++ b/docs/development/testing-playbook.md
@@ -31,6 +31,19 @@ Unit workflow (`test-unit.yml`):
 - uses `fail-fast: false`, so one failing lane does not cancel the others
 - runs `bun run test:<project>` in each lane after dependency install
 - runs every lane with `TZ: Etc/UTC` set
+- `bun run lint` also runs `check-semantic-colors.ts` and
+  `check-agent-constraints.ts` (barrels, web-test locators, backend/sync
+  `mongoService` imports, duplicate `EventSchema`)
+
+PR template workflow (`.github/workflows/pr-body.yml`):
+
+- triggers on every pull request, including markdown-only PRs that skip
+  Test/e2e via `paths-ignore`
+- fails if `## Automated validation`, `## Independent review`, or
+  `## Test plan` is missing, empty (HTML comments only), or uses task boxes
+- fail closed when the PR body cannot be read
+- docs-only PRs still fill those three sections (a short docs-only note is
+  enough); they are not blocked on missing unit/e2e jobs
 
 Local parity commands:
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dev:sync": "cd packages/sync && bun --watch src/app.ts",
     "dev:update": "git checkout main && git pull &&bun install",
     "dev:web": "bun run dev:ports web && cd packages/web &&bun run dev.ts",
-    "lint": "bun packages/scripts/src/testing/check-semantic-colors.ts && biome check .",
+    "lint": "bun packages/scripts/src/testing/check-semantic-colors.ts && bun packages/scripts/src/testing/check-agent-constraints.ts && biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
     "format:check": "biome format .",

--- a/packages/scripts/src/testing/check-agent-constraints.test.ts
+++ b/packages/scripts/src/testing/check-agent-constraints.test.ts
@@ -1,0 +1,130 @@
+import {
+  duplicateEventSchemaHits,
+  isBarrelSource,
+  locatorHits,
+  mongoServiceImportHits,
+  scanConstraints,
+} from "./check-agent-constraints";
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+describe("isBarrelSource", () => {
+  it("treats export-from index modules as barrels", () => {
+    expect(isBarrelSource('export { Foo } from "./Foo";\n')).toBe(true);
+    expect(isBarrelSource('export * from "./widgets";\n')).toBe(true);
+  });
+
+  it("treats import-then-named-export as a barrel", () => {
+    expect(
+      isBarrelSource('import { Foo } from "./Foo";\nexport { Foo };\n'),
+    ).toBe(true);
+  });
+
+  it("does not treat the web app entry as a barrel", () => {
+    expect(
+      isBarrelSource(`
+import { initPosthog } from "@web/auth/posthog/posthog.bootstrap";
+initPosthog();
+void import("./app.bootstrap");
+`),
+    ).toBe(false);
+  });
+
+  it("does not treat router config that defines its own exports as a barrel", () => {
+    expect(
+      isBarrelSource(`
+import { createRouter } from "@tanstack/react-router";
+import { routeTree } from "@web/routers/router.routes";
+export const router = createRouter({ routeTree });
+`),
+    ).toBe(false);
+  });
+});
+
+describe("locatorHits", () => {
+  it("flags RTL getByTestId and querySelector", () => {
+    expect(locatorHits('screen.getByTestId("x");\n')).toEqual([1]);
+    expect(locatorHits('container.querySelector(".foo");\n')).toEqual([1]);
+  });
+
+  it("does not flag production data-* attributes", () => {
+    expect(locatorHits('<div data-state="open" />\n')).toEqual([]);
+  });
+});
+
+describe("mongoServiceImportHits", () => {
+  it("flags backend mongoService imports", () => {
+    expect(
+      mongoServiceImportHits(
+        'import mongoService from "@backend/common/services/mongo.service";\n',
+      ),
+    ).toEqual([1]);
+  });
+
+  it("does not flag sync-mongo.service", () => {
+    expect(
+      mongoServiceImportHits(
+        'import { type SyncMongoService } from "@sync/storage/sync-mongo.service";\n',
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("duplicateEventSchemaHits", () => {
+  it("flags a local EventSchema zod object", () => {
+    expect(
+      duplicateEventSchemaHits(
+        "const EventSchema = z.object({\n  title: z.string(),\n});\n",
+      ),
+    ).toEqual([1]);
+  });
+
+  it("does not flag CompassEventSchema from core", () => {
+    expect(
+      duplicateEventSchemaHits(
+        'import { CompassEventSchema } from "@compass/core/types/compass-event.contracts";\n',
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("scanConstraints", () => {
+  it("fails a new barrel, locator, mongoService import, and duplicate schema", () => {
+    const root = mkdtempSync(join(tmpdir(), "agent-constraints-"));
+    writeTree(root, {
+      "packages/web/src/foo/index.ts": 'export { Foo } from "./Foo";\n',
+      "packages/web/src/index.tsx":
+        'import { init } from "@web/auth/posthog/posthog.bootstrap";\nvoid import("./app.bootstrap");\n',
+      "packages/web/src/Widget.test.tsx": 'screen.getByTestId("x");\n',
+      "packages/web/src/Widget.tsx": '<div data-state="open" />\n',
+      "packages/backend/src/new.service.test.ts":
+        'import mongoService from "@backend/common/services/mongo.service";\n',
+      "packages/web/src/dup.ts":
+        "const EventSchema = z.object({ title: z.string() });\n",
+    });
+
+    const hits = scanConstraints(root).map((hit) => `${hit.rule}:${hit.path}`);
+    expect(hits).toContain("barrel:packages/web/src/foo/index.ts");
+    expect(hits).toContain("web-locator:packages/web/src/Widget.test.tsx");
+    expect(hits).toContain(
+      "mongoService-import:packages/backend/src/new.service.test.ts",
+    );
+    expect(hits).toContain("duplicate-event-schema:packages/web/src/dup.ts");
+    expect(hits.some((hit) => hit.includes("packages/web/src/index.tsx"))).toBe(
+      false,
+    );
+    expect(
+      hits.some((hit) => hit.includes("packages/web/src/Widget.tsx")),
+    ).toBe(false);
+  });
+});
+
+function writeTree(root: string, files: Record<string, string>): void {
+  for (const [rel, source] of Object.entries(files)) {
+    const path = join(root, rel);
+    mkdirSync(join(path, ".."), { recursive: true });
+    writeFileSync(path, source);
+  }
+}

--- a/packages/scripts/src/testing/check-agent-constraints.ts
+++ b/packages/scripts/src/testing/check-agent-constraints.ts
@@ -1,0 +1,188 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const repoRoot = join(import.meta.dir, "../../../..");
+
+const APP_ENTRY = "packages/web/src/index.tsx";
+
+const SOURCE_EXT = /\.(ts|tsx)$/;
+
+/** Existing component barrels. Do not add paths; delete these in a follow-up. */
+export const BARREL_ALLOWLIST = new Set([
+  "packages/web/src/components/AbsoluteOverflowLoader/index.ts",
+  "packages/web/src/components/Tooltip/index.ts",
+  "packages/web/src/views/Forms/EventForm/SaveSection/index.ts",
+  "packages/web/src/views/GoogleAuthCallback/index.ts",
+  "packages/web/src/views/NotFound/index.ts",
+]);
+
+/** Existing web tests that still use CSS/`data-*` locators. Do not add paths. */
+export const WEB_LOCATOR_ALLOWLIST = new Set([
+  "packages/web/src/components/AuthenticatedLayout/AuthenticatedLayout.test.tsx",
+  "packages/web/src/components/CommandPalette/CommandPalette.test.tsx",
+  "packages/web/src/components/ContextMenu/contextMenuLayering.test.tsx",
+  "packages/web/src/components/Focusable/Focusable.test.tsx",
+  "packages/web/src/components/SelectView/SelectView.test.tsx",
+  "packages/web/src/components/Shortcuts/ShortcutKeys.test.tsx",
+  "packages/web/src/components/Shortcuts/ShortcutList.test.tsx",
+  "packages/web/src/components/Sidebar/CalendarList/AnonymousCalendarRow.test.tsx",
+  "packages/web/src/components/Sidebar/MonthPicker/MonthPicker.test.tsx",
+  "packages/web/src/components/Tooltip/TooltipWrapper.test.tsx",
+  "packages/web/src/grid/components/EventCard.test.tsx",
+  "packages/web/src/grid/components/EventGrid.test.tsx",
+  "packages/web/src/grid/components/TimedGrid.test.tsx",
+  "packages/web/src/shortcuts/edit-sequence/EditSequenceMenu.test.tsx",
+  "packages/web/src/shortcuts/form-digit-jump/FormDigitHintOverlay.test.tsx",
+  "packages/web/src/shortcuts/page-jump/PageJumpHintOverlay.test.tsx",
+  "packages/web/src/shortcuts/shift-hint/ShiftHintOverlay.test.tsx",
+  "packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.test.tsx",
+  "packages/web/src/views/Forms/EventForm/EventForm.readOnly.test.tsx",
+  "packages/web/src/views/Life/LifeView.test.tsx",
+]);
+
+/**
+ * Backend tests that still import the mongoService singleton.
+ * Follow-up: migrate to setupTestDb. Do not add paths.
+ * scripts `*.db.test.ts` and sync's `sync-mongo.service` are out of scope.
+ */
+export const MONGO_SERVICE_TEST_ALLOWLIST = new Set([
+  "packages/backend/src/auth/services/google/google.auth.service.db.test.ts",
+  "packages/backend/src/billing/billing.guard.db.test.ts",
+  "packages/backend/src/billing/services/billing.service.db.test.ts",
+  "packages/backend/src/billing/services/billing.webhook.service.db.test.ts",
+  "packages/backend/src/billing/services/stripe.service.db.test.ts",
+  "packages/backend/src/calendar/services/calendar.service.db.test.ts",
+  "packages/backend/src/common/services/mongo.service.test.ts",
+  "packages/backend/src/health/controllers/health.controller.db.test.ts",
+  "packages/backend/src/user/controllers/user.controller.db.test.ts",
+  "packages/backend/src/user/services/user.service.db.test.ts",
+]);
+
+const REEXPORT_FROM =
+  /export\s+(?:\*|type\s+\{[^}]*\}|\{[^}]*\})\s+from\s+["']/;
+const LOCAL_IMPORT =
+  /import\s+(?:type\s+)?[\s\S]*?\s+from\s+["']\.\.?\/[^"']+["']/;
+const BARE_NAMED_EXPORT = /export\s+\{[^}]+\}\s*;/;
+const WEB_LOCATOR =
+  /\bgetByTestId\s*\(|\bquerySelector(All)?\s*\(|\bgetByClassName\s*\(/;
+const MONGO_SERVICE_IMPORT = /from\s+["'][^"']*(?<!sync-)mongo\.service["']/;
+const DUPLICATE_EVENT_SCHEMA =
+  /(?:const|let|var)\s+EventSchema\s*=\s*z\.object/;
+
+export type ConstraintHit = { path: string; rule: string; line: number };
+
+export function isBarrelSource(source: string): boolean {
+  if (REEXPORT_FROM.test(source)) return true;
+  return LOCAL_IMPORT.test(source) && BARE_NAMED_EXPORT.test(source);
+}
+
+export function locatorHits(source: string): number[] {
+  return lineNumbers(source, WEB_LOCATOR);
+}
+
+export function mongoServiceImportHits(source: string): number[] {
+  return lineNumbers(source, MONGO_SERVICE_IMPORT);
+}
+
+export function duplicateEventSchemaHits(source: string): number[] {
+  return lineNumbers(source, DUPLICATE_EVENT_SCHEMA);
+}
+
+export function scanConstraints(root = repoRoot): ConstraintHit[] {
+  const hits: ConstraintHit[] = [];
+  for (const file of walk(join(root, "packages"))) {
+    const rel = posixRel(root, file);
+    const source = readFileSync(file, "utf8");
+
+    if (isIndexModule(rel) && rel !== APP_ENTRY && isBarrelSource(source)) {
+      if (!BARREL_ALLOWLIST.has(rel)) {
+        hits.push({ path: rel, rule: "barrel", line: 1 });
+      }
+    }
+
+    if (isWebTest(rel) && !WEB_LOCATOR_ALLOWLIST.has(rel)) {
+      for (const line of locatorHits(source)) {
+        hits.push({ path: rel, rule: "web-locator", line });
+      }
+    }
+
+    if (isBackendOrSyncTest(rel) && !MONGO_SERVICE_TEST_ALLOWLIST.has(rel)) {
+      for (const line of mongoServiceImportHits(source)) {
+        hits.push({ path: rel, rule: "mongoService-import", line });
+      }
+    }
+
+    if (
+      (rel.startsWith("packages/web/") ||
+        rel.startsWith("packages/backend/")) &&
+      !rel.includes(".test.") &&
+      !rel.includes(".spec.")
+    ) {
+      for (const line of duplicateEventSchemaHits(source)) {
+        hits.push({ path: rel, rule: "duplicate-event-schema", line });
+      }
+    }
+  }
+  return hits;
+}
+
+function isIndexModule(rel: string): boolean {
+  return rel.endsWith("/index.ts") || rel.endsWith("/index.tsx");
+}
+
+function isWebTest(rel: string): boolean {
+  return (
+    rel.startsWith("packages/web/") &&
+    (rel.endsWith(".test.ts") ||
+      rel.endsWith(".test.tsx") ||
+      rel.endsWith(".spec.ts") ||
+      rel.endsWith(".spec.tsx"))
+  );
+}
+
+function isBackendOrSyncTest(rel: string): boolean {
+  return (
+    (rel.startsWith("packages/backend/") || rel.startsWith("packages/sync/")) &&
+    (rel.includes(".test.") || rel.includes(".spec."))
+  );
+}
+
+function lineNumbers(source: string, pattern: RegExp): number[] {
+  const flags = pattern.flags.includes("g")
+    ? pattern.flags
+    : `${pattern.flags}g`;
+  const global = new RegExp(pattern.source, flags);
+  const lines: number[] = [];
+  for (const match of source.matchAll(global)) {
+    if (match.index == null) continue;
+    lines.push(source.slice(0, match.index).split("\n").length);
+  }
+  return lines;
+}
+
+function walk(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "build") return [];
+      return walk(path);
+    }
+    if (!SOURCE_EXT.test(entry.name)) return [];
+    return [path];
+  });
+}
+
+function posixRel(root: string, file: string): string {
+  return relative(root, file).split("\\").join("/");
+}
+
+if (import.meta.main) {
+  const hits = scanConstraints();
+  if (hits.length > 0) {
+    console.error("Agent constraint violations:");
+    for (const hit of hits) {
+      console.error(`${hit.path}:${hit.line} ${hit.rule}`);
+    }
+    process.exit(1);
+  }
+}

--- a/packages/scripts/src/testing/check-pr-body.test.ts
+++ b/packages/scripts/src/testing/check-pr-body.test.ts
@@ -1,0 +1,63 @@
+import { checkPrBody } from "./check-pr-body";
+import { describe, expect, it } from "bun:test";
+
+const FILLED = `## Summary
+
+Adds a constraints checker.
+
+## Automated validation
+
+bun packages/scripts/src/testing/check-agent-constraints.ts exited 0.
+
+## Independent review
+
+Self review of the scripts diff; no production edits.
+
+## Test plan
+
+bun test:scripts and bun run lint.
+`;
+
+describe("checkPrBody", () => {
+  it("accepts a template with executed evidence in required sections", () => {
+    expect(checkPrBody(FILLED)).toEqual([]);
+  });
+
+  it("fails closed on a missing or empty body", () => {
+    expect(checkPrBody(null)).toEqual([
+      "PR body is empty or unreadable (fail closed)",
+    ]);
+    expect(checkPrBody("   ")).toEqual([
+      "PR body is empty or unreadable (fail closed)",
+    ]);
+  });
+
+  it("fails when Test plan is only an HTML comment", () => {
+    const body = FILLED.replace(
+      "bun test:scripts and bun run lint.",
+      "<!-- Commands actually run. -->",
+    );
+    expect(checkPrBody(body).some((issue) => issue.includes("Test plan"))).toBe(
+      true,
+    );
+  });
+
+  it("fails missing required headings", () => {
+    const issues = checkPrBody(
+      "## Summary\n\nhello world this is long enough\n",
+    );
+    expect(issues).toContain("missing ## Automated validation");
+    expect(issues).toContain("missing ## Independent review");
+    expect(issues).toContain("missing ## Test plan");
+  });
+
+  it("rejects unchecked task boxes as evidence", () => {
+    const body = FILLED.replace(
+      "bun test:scripts and bun run lint.",
+      "- [ ] run tests\nThis is otherwise long enough.",
+    );
+    expect(
+      checkPrBody(body).some((issue) => issue.includes("task boxes")),
+    ).toBe(true);
+  });
+});

--- a/packages/scripts/src/testing/check-pr-body.test.ts
+++ b/packages/scripts/src/testing/check-pr-body.test.ts
@@ -42,6 +42,16 @@ describe("checkPrBody", () => {
     );
   });
 
+  it("fails when Test plan is only nested HTML comments", () => {
+    const body = FILLED.replace(
+      "bun test:scripts and bun run lint.",
+      "<!--<!-- -->-->",
+    );
+    expect(checkPrBody(body).some((issue) => issue.includes("Test plan"))).toBe(
+      true,
+    );
+  });
+
   it("fails missing required headings", () => {
     const issues = checkPrBody(
       "## Summary\n\nhello world this is long enough\n",

--- a/packages/scripts/src/testing/check-pr-body.ts
+++ b/packages/scripts/src/testing/check-pr-body.ts
@@ -51,7 +51,7 @@ export function splitMarkdownSections(body: string): Map<string, string> {
   const matches = [...body.matchAll(heading)];
   for (let i = 0; i < matches.length; i++) {
     const match = matches[i];
-    if (match.index == null) continue;
+    if (match == null || match.index == null) continue;
     const title = match[1]?.trim() ?? "";
     const start = match.index + match[0].length;
     const end = matches[i + 1]?.index ?? body.length;

--- a/packages/scripts/src/testing/check-pr-body.ts
+++ b/packages/scripts/src/testing/check-pr-body.ts
@@ -39,10 +39,26 @@ export function checkPrBody(body: string | null | undefined): string[] {
 }
 
 export function visibleSectionText(raw: string): string {
-  return raw
-    .replace(/<!--[\s\S]*?-->/g, "")
-    .replace(/\s+/g, " ")
-    .trim();
+  return stripHtmlComments(raw).replace(/\s+/g, " ").trim();
+}
+
+function stripHtmlComments(text: string): string {
+  let result = "";
+  let remaining = text;
+  while (remaining.length > 0) {
+    const start = remaining.indexOf("<!--");
+    if (start === -1) {
+      result += remaining;
+      break;
+    }
+    result += remaining.slice(0, start);
+    const end = remaining.indexOf("-->", start + 4);
+    if (end === -1) {
+      break;
+    }
+    remaining = remaining.slice(end + 3);
+  }
+  return result;
 }
 
 export function splitMarkdownSections(body: string): Map<string, string> {

--- a/packages/scripts/src/testing/check-pr-body.ts
+++ b/packages/scripts/src/testing/check-pr-body.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from "node:fs";
+
+export const REQUIRED_PR_SECTIONS = [
+  "Automated validation",
+  "Independent review",
+  "Test plan",
+] as const;
+
+export const MIN_SECTION_CHARS = 12;
+
+const TASK_BOX = /^\s*[-*]\s+\[[ xX]\]/m;
+
+export function checkPrBody(body: string | null | undefined): string[] {
+  if (body == null || body.trim().length === 0) {
+    return ["PR body is empty or unreadable (fail closed)"];
+  }
+
+  const sections = splitMarkdownSections(body);
+  const issues: string[] = [];
+
+  for (const heading of REQUIRED_PR_SECTIONS) {
+    const raw = sections.get(heading);
+    if (raw == null) {
+      issues.push(`missing ## ${heading}`);
+      continue;
+    }
+    if (TASK_BOX.test(raw)) {
+      issues.push(`## ${heading}: task boxes are not evidence`);
+    }
+    const visible = visibleSectionText(raw);
+    if (visible.length < MIN_SECTION_CHARS) {
+      issues.push(
+        `## ${heading}: needs executed evidence (found ${visible.length} visible characters; minimum ${MIN_SECTION_CHARS})`,
+      );
+    }
+  }
+
+  return issues;
+}
+
+export function visibleSectionText(raw: string): string {
+  return raw
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function splitMarkdownSections(body: string): Map<string, string> {
+  const sections = new Map<string, string>();
+  const heading = /^##\s+(.+)$/gm;
+  const matches = [...body.matchAll(heading)];
+  for (let i = 0; i < matches.length; i++) {
+    const match = matches[i];
+    if (match.index == null) continue;
+    const title = match[1]?.trim() ?? "";
+    const start = match.index + match[0].length;
+    const end = matches[i + 1]?.index ?? body.length;
+    sections.set(title, body.slice(start, end));
+  }
+  return sections;
+}
+
+function readBodyFromCli(): string | null {
+  if (process.env["PR_BODY"] != null) return process.env["PR_BODY"];
+  const path = process.argv[2];
+  if (path) return readFileSync(path, "utf8");
+  return null;
+}
+
+if (import.meta.main) {
+  const issues = checkPrBody(readBodyFromCli());
+  if (issues.length > 0) {
+    console.error("PR body is incomplete:");
+    for (const issue of issues) {
+      console.error(`- ${issue}`);
+    }
+    process.exit(1);
+  }
+}

--- a/packages/scripts/src/testing/test-parallel.test.ts
+++ b/packages/scripts/src/testing/test-parallel.test.ts
@@ -1,0 +1,35 @@
+import { parallelArgsFor, testArgvFor } from "./test-parallel";
+import { describe, expect, it } from "bun:test";
+
+const argvOpts = {
+  preloadPath: "packages/web/src/__tests__/web.preload.ts",
+  bunFlags: [] as string[],
+  targets: ["./packages/web/src"],
+};
+
+describe("parallelArgsFor", () => {
+  it("omits --parallel for the web profile", () => {
+    expect(parallelArgsFor("web")).toEqual([]);
+  });
+
+  it("keeps --parallel for mongo-free non-web profiles", () => {
+    expect(parallelArgsFor("core")).toEqual(["--parallel"]);
+    expect(parallelArgsFor("backend-fast")).toEqual(["--parallel"]);
+  });
+});
+
+describe("testArgvFor", () => {
+  it("does not pass --parallel when the web profile builds argv", () => {
+    expect(testArgvFor("web", argvOpts)).not.toContain("--parallel");
+  });
+
+  it("passes --parallel for core", () => {
+    expect(
+      testArgvFor("core", {
+        ...argvOpts,
+        preloadPath: "packages/scripts/src/testing/core.preload.ts",
+        targets: ["./packages/core/src"],
+      }),
+    ).toContain("--parallel");
+  });
+});

--- a/packages/scripts/src/testing/test-parallel.ts
+++ b/packages/scripts/src/testing/test-parallel.ts
@@ -14,9 +14,7 @@ import {
 } from "./runner-utils";
 import { resolve } from "node:path";
 
-warnIfBunVersionMismatch("1.3.14");
-
-type ProfileName =
+export type ProfileName =
   | "core"
   | "web"
   | "backend-fast"
@@ -57,64 +55,88 @@ const PROFILES: Record<
   },
 };
 
-const profile = process.argv[2] as ProfileName;
-const separatorIndex = process.argv.indexOf("--");
-const extraArgs =
-  separatorIndex === -1
-    ? process.argv.slice(3)
-    : process.argv.slice(separatorIndex + 1);
-
-if (!profile || !PROFILES[profile]) {
-  console.error(
-    "Usage: test-parallel.ts <core|web|backend-fast|sync-fast|scripts-fast> -- [bun test flags/paths...]",
-  );
-  process.exit(2);
-}
-
-const { preload, scan, label } = PROFILES[profile];
-const preloadPath = resolve(preload);
-const { targets, bunFlags } = resolveTestTargets(scan, extraArgs, {
-  expandDirectory: true,
-});
-
-const started = Date.now();
-
-const needsHookTimeout =
-  profile === "backend-fast" ||
-  profile === "sync-fast" ||
-  profile === "scripts-fast";
-
 // Web uses jsdom + MSW XHR patching + module singletons that Bun's parallel
 // `--isolate` clears between files (MSW's oldXMLHttpRequest becomes undefined).
 // One process, sequential files is still far faster than the old per-file launcher.
-const parallelFlag = profile === "web" ? [] : ["--parallel"];
+export function parallelArgsFor(profile: ProfileName): string[] {
+  return profile === "web" ? [] : ["--parallel"];
+}
 
-const testTargets = [
-  "bun",
-  "test",
-  ...parallelFlag,
-  ...(needsHookTimeout ? ["--timeout", "60000"] : []),
-  "--preload",
-  preloadPath,
-  ...bunFlags,
-  ...targets,
-];
+export function testArgvFor(
+  profile: ProfileName,
+  opts: {
+    preloadPath: string;
+    bunFlags: string[];
+    targets: string[];
+  },
+): string[] {
+  const needsHookTimeout =
+    profile === "backend-fast" ||
+    profile === "sync-fast" ||
+    profile === "scripts-fast";
 
-console.log(`Running ${label}...`);
+  return [
+    "bun",
+    "test",
+    ...parallelArgsFor(profile),
+    ...(needsHookTimeout ? ["--timeout", "60000"] : []),
+    "--preload",
+    opts.preloadPath,
+    ...opts.bunFlags,
+    ...opts.targets,
+  ];
+}
 
-const spawnEnv =
-  profile === "backend-fast" || profile === "scripts-fast"
-    ? backendTestSpawnEnv(FAST_MONGO_URI)
-    : { ...process.env, TZ: "Etc/UTC", NODE_ENV: "test" };
+async function runCli(): Promise<void> {
+  warnIfBunVersionMismatch("1.3.14");
 
-const proc = Bun.spawn(testTargets, {
-  env: spawnEnv,
-  stdout: "inherit",
-  stderr: "inherit",
-});
-const code = await proc.exited;
-console.log(`\n${label}: finished in ${formatDuration(started)}s`);
+  const profile = process.argv[2] as ProfileName;
+  const separatorIndex = process.argv.indexOf("--");
+  const extraArgs =
+    separatorIndex === -1
+      ? process.argv.slice(3)
+      : process.argv.slice(separatorIndex + 1);
 
-if (code !== 0) {
-  process.exit(code ?? 1);
+  if (!profile || !PROFILES[profile]) {
+    console.error(
+      "Usage: test-parallel.ts <core|web|backend-fast|sync-fast|scripts-fast> -- [bun test flags/paths...]",
+    );
+    process.exit(2);
+  }
+
+  const { preload, scan, label } = PROFILES[profile];
+  const preloadPath = resolve(preload);
+  const { targets, bunFlags } = resolveTestTargets(scan, extraArgs, {
+    expandDirectory: true,
+  });
+
+  const started = Date.now();
+  const testTargets = testArgvFor(profile, {
+    preloadPath,
+    bunFlags,
+    targets,
+  });
+
+  console.log(`Running ${label}...`);
+
+  const spawnEnv =
+    profile === "backend-fast" || profile === "scripts-fast"
+      ? backendTestSpawnEnv(FAST_MONGO_URI)
+      : { ...process.env, TZ: "Etc/UTC", NODE_ENV: "test" };
+
+  const proc = Bun.spawn(testTargets, {
+    env: spawnEnv,
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const code = await proc.exited;
+  console.log(`\n${label}: finished in ${formatDuration(started)}s`);
+
+  if (code !== 0) {
+    process.exit(code ?? 1);
+  }
+}
+
+if (import.meta.main) {
+  await runCli();
 }

--- a/wip/restructure/TRACKING.md
+++ b/wip/restructure/TRACKING.md
@@ -13,7 +13,7 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 | WP-01 | high | — | queued | [WP-01-verify-ci-parity.md](WP-01-verify-ci-parity.md) | — | when picked up: +1 session | 0 | none |
 | WP-02 | high | — | queued | [WP-02-typed-handoff-ledger.md](WP-02-typed-handoff-ledger.md) | — | when picked up: +1 session | 0 | none |
 | WP-03 | high | — | queued | [WP-03-split-ship-review-verifier.md](WP-03-split-ship-review-verifier.md) | — | after WP-02 `done` | 0 | none |
-| WP-04 | high | — | queued | [WP-04-hard-constraints.md](WP-04-hard-constraints.md) | — | after WP-01 `done` | 0 | none |
+| WP-04 | high | Implementer | verifying | [WP-04-hard-constraints.md](WP-04-hard-constraints.md) | checker + PR-body job on `cursor/hard-constraints-72ec`; WP-01 still unmerged | after WP-01 merge | 0 | none |
 | WP-05 | medium | — | queued | [WP-05-skill-registry.md](WP-05-skill-registry.md) | — | after WP-03 `done` | 0 | none |
 | WP-06 | medium | — | queued | [WP-06-autofix-routine.md](WP-06-autofix-routine.md) | — | after WP-02 and WP-03 `done` | 0 | none |
 | WP-07 | medium | — | queued | [WP-07-agent-ready-intake.md](WP-07-agent-ready-intake.md) | — | after WP-02 `done` | 0 | none |
@@ -50,4 +50,4 @@ Record elapsed minutes, exceptions, quality 1–5, rework.
 
 | date | task_id | decision required | recommended option | alternatives tried | cost of waiting | safest default |
 | --- | --- | --- | --- | --- | --- | --- |
-| | | | | | | |
+| 2026-08-25 | PACK | squash-merge 403 for this PAT (`pull_request: write`) | human merges #2865, then #2866, then stacked PRs | `gh pr merge` and REST merge both 403 | WP-01–07 stay off main | leave PRs open and keep implementing |

--- a/wip/restructure/WP-04-hard-constraints.md
+++ b/wip/restructure/WP-04-hard-constraints.md
@@ -1,7 +1,7 @@
 # WP-04 — Hard constraints (environment as training data)
 
 **task_id:** WP-04
-**status:** queued
+**status:** verifying
 **owner:** Implementer (scripts/CI) then Verifier
 **depends on:** WP-01 `done` (verify is the local gate these checks should
 join where cheap)
@@ -110,12 +110,34 @@ Recurring Compass comments that are already machine-checkable:
 ## Evidence
 
 ```text
-checker path:
-CI wiring:
+checker path: packages/scripts/src/testing/check-agent-constraints.ts
+CI wiring: package.json lint runs the checker before biome (114ms, <15s);
+  bun run verify (WP-01) already runs lint, so local parity follows once WP-01
+  is on main. PR body is a separate workflow (not test-unit.yml) so markdown
+  PRs are not BLOCKED on missing unit/e2e.
 allowlist paths:
-biome a11y promotions:
-PR-body job:
-bun run <checker> on main: pass/fail excerpt:
+  barrels (existing component barrels only; routers/index.tsx is router
+  config, not a barrel; app entry excluded):
+    packages/web/src/components/AbsoluteOverflowLoader/index.ts
+    packages/web/src/components/Tooltip/index.ts
+    packages/web/src/views/Forms/EventForm/SaveSection/index.ts
+    packages/web/src/views/GoogleAuthCallback/index.ts
+    packages/web/src/views/NotFound/index.ts
+  web locators: 20 existing web test files (see WEB_LOCATOR_ALLOWLIST)
+  mongoService: 10 existing backend test files (see
+    MONGO_SERVICE_TEST_ALLOWLIST). scripts *.db.test.ts not scanned.
+    sync-mongo.service is not the banned import.
+biome a11y promotions: none. Remaining warn rules all have documented
+  biome-ignore exceptions (and one live useAriaPropsSupportedByRole hit in
+  GridTimezoneLabel.tsx). Leftovers: noNoninteractiveTabindex,
+  noRedundantRoles, noStaticElementInteractions,
+  useAriaPropsSupportedByRole, useSemanticElements.
+PR-body job: .github/workflows/pr-body.yml (job pr-body). Docs-only PRs
+  still must fill the three sections; a short docs-only note is enough.
+  Fail closed on empty/unreadable body. Task boxes rejected.
+bun run checker on this tree: exit 0 (114ms). Fixture tests: 20 pass.
+web --parallel: parallelArgsFor("web") === []; testArgvFor("web") omits
+  --parallel. CLI wrapped in import.meta.main.
 ```
 
 ## Out of scope
@@ -139,14 +161,14 @@ bun run <checker> on main: pass/fail excerpt:
 
 ```yaml
 task_id: WP-04
-from:
-to: Implementer
-status:
-artifact:
-evidence:
-assumptions:
-open_risks:
-next_deadline:
+from: Implementer
+to: Verifier
+status: verifying
+artifact: packages/scripts/src/testing/check-agent-constraints.ts; .github/workflows/pr-body.yml
+evidence: checker exit 0 in 114ms; 20 focused scripts tests pass; bun run lint exit 0
+assumptions: WP-01 still unmerged on main; lint is the shared gate
+open_risks: this PAT cannot squash-merge; pr-body is not a GitHub required check yet
+next_deadline: after CI green; human merges WP-01 then this PR
 ```
 
 ## Session prompt


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

WP-04: convert recurring review comments into lint/CI. A new `check-agent-constraints.ts` fails new package barrels (allowlisted existing component barrels; app entry and `routers/index.tsx` are not barrels), web-test `getByTestId`/`querySelector` locators, backend/sync `mongoService` imports (scripts db tests and `sync-mongo.service` out of scope), and duplicate `EventSchema = z.object` copies in web/backend. `bun run lint` runs the checker (~114ms). The web test runner exports `parallelArgsFor` / `testArgvFor` so profile `web` cannot regain `--parallel` without a failing unit test. A dedicated `pr-body` workflow (no `paths-ignore`) fails empty `## Automated validation`, `## Independent review`, and `## Test plan` on every PR, including docs-only diffs, so those PRs are not blocked on missing unit/e2e jobs.

Biome a11y warn rules were inventoried and none promoted: each leftover still has documented `biome-ignore` exceptions, plus one live `useAriaPropsSupportedByRole` hit in `GridTimezoneLabel.tsx`.

Depends on WP-01 (`bun run verify` already runs lint) for local CI parity once #2865 is on main. This PR is based on current `main` and does not require that merge to land.

## Simplicity

One checker script next to `check-semantic-colors.ts`, wired into existing `lint`. PR body lives in its own workflow so Test's `paths-ignore` does not hide it. Allowlists are the current tree, not new exceptions. `test-parallel.ts` CLI is wrapped in `import.meta.main` so the guard can import argv builders without spawning tests.

## Automated validation

- `bun packages/scripts/src/testing/check-agent-constraints.ts` — exit 0 in 114ms on this tree
- `bun test packages/scripts/src/testing/check-agent-constraints.test.ts packages/scripts/src/testing/check-pr-body.test.ts packages/scripts/src/testing/test-parallel.test.ts` — 20 pass
- `bun run test:scripts` — 53 pass, 0 fail
- `bun run lint` — exit 0 (pre-existing biome warnings only)
- `bun run knip` — exit 0
- `bun run type-check` — exit 0 after narrowing a possibly-undefined heading match

## Independent review

Self read-only review of this scripts/CI diff (`/review` lives on WP-03 / #2867 and is not on this base). Confirmed: `routers/index.tsx` classified as router config not a barrel; mongo regex does not flag `sync-mongo.service`; production `data-*` is not scanned; web `--parallel` is asserted via imported argv, not a source grep; docs-only PRs still fill the three template sections. No production application code changed.

## Test plan

```
bun packages/scripts/src/testing/check-agent-constraints.ts
bun test packages/scripts/src/testing/check-agent-constraints.test.ts packages/scripts/src/testing/check-pr-body.test.ts packages/scripts/src/testing/test-parallel.test.ts
bun run test:scripts
bun run lint
bun run knip
bun run type-check
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1e729d3-21f7-460a-a6a2-cf411b9d72ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1e729d3-21f7-460a-a6a2-cf411b9d72ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

