### PR TITLE
feat(scripts): document error-autofix as a governed routine

### DIFF
--- a/.agents/handoffs/WP-06.md
+++ b/.agents/handoffs/WP-06.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+task_id: "WP-06"
+from: Implementer
+to: Verifier
+owner: Verifier
+status: verifying
+artifact:
+  - path: docs/CI-CD/error-autofix-routine.md
+  - path: docs/CI-CD/workflows.md
+  - path: .github/prompts/error-autofix.md
+  - path: packages/scripts/src/testing/error-autofix-routine.test.ts
+evidence:
+  - command: bun test packages/scripts/src/testing/error-autofix-routine.test.ts
+    result: 3 pass, 0 fail
+    log: bun test v1.3.14
+assumptions:
+  - "ERROR_AUTOFIX_ENABLED and AUTOFIX_MODE are repo variables and were not changed"
+  - "drills are documented, not executed in production"
+open_risks:
+  - "markdown-only PRs skip Test workflow; the scripts test is required so unit CI runs"
+next_deadline: 2026-08-26T18:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-06 governs the existing error-autofix loop. Receiver: Verifier. Next
+check: `bun test packages/scripts/src/testing/error-autofix-routine.test.ts`.

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,4 +13,5 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| WP-03 | high | cursor-agent | verifying | `.agents/skills/review/SKILL.md` | ship invokes verify/simplify/review; verdict format present | 2026-08-26T18:00:00Z | 0 | none |
+| WP-05 | medium | cursor-agent | waiting | `.agents/skills/README.md` | PR #2872 | 2026-08-26T18:00:00Z | 0 | none |
+| WP-06 | medium | Verifier | verifying | `docs/CI-CD/error-autofix-routine.md` | `bun test packages/scripts/src/testing/error-autofix-routine.test.ts` | 2026-08-26T18:00:00Z | 0 | none |

--- a/.github/prompts/error-autofix.md
+++ b/.github/prompts/error-autofix.md
@@ -113,6 +113,9 @@ leave it off — the PR still exists for human review, which is a fine outcome.
 ## Hard rules (all modes)
 
 - At handoff boundaries, write a typed record per `.agents/handoffs/SCHEMA.md`.
+  When you open a PR, also write `.agents/handoffs/<issue-number>.md` and a
+  `.agents/ledger.md` row **on the PR branch** (`task_id` is the issue
+  number). You cannot write those files to `main` from this job.
 
 - Never edit any denied path — see the confidence rubric above.
 - Never force-push.

--- a/docs/CI-CD/error-autofix-routine.md
+++ b/docs/CI-CD/error-autofix-routine.md
@@ -1,0 +1,102 @@
+# Routine: error-autofix
+
+Govern the existing Error autofix loop. Do not invent a second unattended
+workflow. Kill switch and mode stay as repo variables — this document does
+not flip them.
+
+```text
+ROUTINE: error-autofix
+TRIGGER: issues opened by posthog[bot] | workflow_dispatch
+INPUT: GitHub issue + PostHog fingerprint
+SKILL/PROMPT: .github/prompts/error-autofix.md
+OUTPUT: issue comment and/or PR with Fixes #<n>
+IDEMPOTENCY: one PR per issue; preflight skips labeled/already-handled
+RETRY: dispatch a fresh run (do not “Re-run jobs” on a failed snapshot)
+APPROVAL: AUTOFIX_MODE=triage|pr|merge; automerge-candidate + merge-guard
+STOP: repo var ERROR_AUTOFIX_ENABLED
+HEARTBEAT: Discord via existing notify scripts on skip/fail/needs-human
+VERIFIER: .github/scripts/autofix-merge-guard.sh (not the LLM)
+```
+
+Sources of truth:
+
+| Concern | File |
+| --- | --- |
+| Trigger, concurrency, kill switch, mode | `.github/workflows/error-autofix.yml` |
+| Post-deploy Discord/GitHub follow-up | `.github/workflows/error-autofix-postdeploy.yml` |
+| Agent instructions | `.github/prompts/error-autofix.md` |
+| Preflight (cheap stop before the LLM) | `.github/scripts/autofix-preflight.sh` |
+| Merge-guard Verifier (denied paths, size) | `.github/scripts/autofix-merge-guard.sh` |
+| Shared notify helpers | `.github/scripts/autofix-lib.sh` |
+
+## Stop switch and mode
+
+- `ERROR_AUTOFIX_ENABLED` must be the string `true` or the workflow does
+  not run. Flip it in GitHub → Settings → Variables. Turning it off does
+  not delete existing comments, PRs, or labels.
+- `AUTOFIX_MODE`:
+  - `triage` — comment only, no PR
+  - `pr` — may open a PR; a human merges
+  - `merge` — may open a PR and label `automerge-candidate`; merge-guard
+    is the Verifier and may strip that label / add `autofix:needs-human`
+- Production deploy is never automatic. Staging-only PostHog errors must
+  never receive `automerge-candidate`.
+
+## Idempotency
+
+Key: **GitHub issue number** (plus the PostHog fingerprint in the issue
+body for humans). Preflight skips if the issue already has the `autofix`
+label. The prompt forbids a second PR that also says `Fixes #<n>`.
+`concurrency.group: error-autofix` with `cancel-in-progress: false` means
+a second issue **waits**, it does not cancel the first run.
+
+## Retry
+
+Do not use “Re-run jobs” on a failed Autofix run — that reuses the
+workflow file snapshot from the failed attempt. Dispatch a **fresh** run
+(`workflow_dispatch` with the issue number) after removing the `autofix`
+label if preflight would skip it as already handled.
+
+## Handoff
+
+When the agent opens a PR, it writes `.agents/handoffs/<issue-number>.md`
+(WP-02 schema) and a `.agents/ledger.md` row **on the PR branch**. It
+cannot write those files to `main` from the autofix job. `task_id` is the
+issue number.
+
+## Drills (documented, not run)
+
+Operator checklist. Mark `documented` unless a human authorizes a live
+staging drill.
+
+| Drill | Expected evidence |
+| --- | --- |
+| Kill switch off | Workflow `if:` skips; no agent job |
+| Missing PostHog fingerprint / MCP empty | Bucket **unknown / insufficient signal**; issue comment; `autofix:needs-human`; **no PR** |
+| Duplicate open for the same issue | Preflight skip and/or prompt “one PR per issue”; **no second PR** |
+| Second issue while a run is in flight | Queued behind `concurrency.group: error-autofix`; first run not cancelled |
+| Staging-only error | No `automerge-candidate` |
+| Denied-path diff | Merge-guard downgrades `automerge-candidate`, adds `autofix:needs-human`. Authoritative list: `DENIED_PATH_PATTERNS` in `.github/scripts/autofix-merge-guard.sh` (do not widen from this doc) |
+| Merge-guard size fail | Same downgrade if files &gt; `MAX_FILES=8` or lines &gt; `MAX_LINES=250` in that script |
+| `workflow_dispatch` triage on a safe issue | Comment only; mode unchanged |
+
+## Recovery packet
+
+Fill this when a run goes wrong. Do **not** blindly re-run the whole
+workflow.
+
+```text
+task_id: <GitHub issue number>
+last_successful_action: <preflight skip | comment | PR opened | merge-guard downgrade>
+writes_after_that_point: <files, labels, comments, Discord>
+external_state: <issue labels, open PRs with Fixes #<n>, Discord message>
+rollback: <close stray PR, remove automerge-candidate, leave evidence>
+human_decision: <re-dispatch | leave | revert>
+```
+
+## Activation (operator, after this WP)
+
+1. Confirm `ERROR_AUTOFIX_ENABLED` and `AUTOFIX_MODE` in repo variables
+   (do not change them in this WP).
+2. Optional: `workflow_dispatch` on a **safe** issue with mode `triage`.
+3. Table-top the drills above before considering `pr` / `merge`.

--- a/docs/CI-CD/workflows.md
+++ b/docs/CI-CD/workflows.md
@@ -4,14 +4,23 @@ Compass uses GitHub Actions for continuous integration, Docker Hub for image dis
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| Test | Push / PR to `main` | Runs lint, type-check, and unit tests |
+| Test | Push / PR to `main` | Runs lint, knip, type-check, and unit tests |
+| PR body | Pull request | Fails empty template sections (including docs-only PRs) |
+| Test (e2e) | Push / PR to `main` | Playwright e2e (docs-only diffs skipped) |
 | CodeQL | Push / PR to `main` | Static security analysis |
+| Performance budget | Push / PR touching web/core | Lighthouse budget (not a required merge check) |
+| Error autofix (`error-autofix.yml`) | `posthog[bot]` issue / `workflow_dispatch` | Governed Routine: triage or fix PostHog error issues |
+| Error autofix post-deploy (`error-autofix-postdeploy.yml`) | `Release on main` completed | Notifies Discord/GitHub of autofix release outcome |
 | Release on main | Push to `main` | Auto-increments patch version, publishes Docker images, then deploys staging |
 | Publish Docker images | Reusable workflow / manual dispatch / manual `v*.*.*` tag push | Builds and pushes Docker images only |
 | Deploy staging | Reusable workflow / manual dispatch | Pulls published images on staging, restarts the stack, then runs deploy health checks |
 | Deploy production | Manual dispatch | Deploys a release tag to production, then runs cloud deploy health checks |
 | Deploy health check | Reusable workflow | Validates the deployed staging stack and alerts Discord on failure |
 | Sync docs to compass-docs | Push to `main` touching `docs/**` | Mirrors this `docs/` directory to docs.compasscalendar.com |
+
+Error autofix is a governed Routine. Contract, drills, and recovery packet:
+[error-autofix-routine.md](./error-autofix-routine.md). Kill switch
+(`ERROR_AUTOFIX_ENABLED`) and mode (`AUTOFIX_MODE`) stay as repo variables.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ Internal documentation for engineers and agents working in the Compass repo.
 - [Performance Baselines](./development/performance-baselines.md)
 - [Types And Validation](./development/types-and-validation.md)
 - [CI/CD Workflows](./CI-CD/workflows.md)
+- [Error Autofix Routine](./CI-CD/error-autofix-routine.md)
 - [CLI And Maintenance Commands](./development/cli.md)
 - [Versioning](./CI-CD/versioning.md)
 

--- a/packages/scripts/src/testing/error-autofix-routine.test.ts
+++ b/packages/scripts/src/testing/error-autofix-routine.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+
+describe("error-autofix Routine contract", () => {
+  it("lists autofix workflows and points at the Routine doc", () => {
+    const workflows = readFileSync("docs/CI-CD/workflows.md", "utf8");
+    expect(workflows).toContain("error-autofix.yml");
+    expect(workflows).toContain("error-autofix-postdeploy.yml");
+    expect(workflows).toContain("error-autofix-routine.md");
+    expect(existsSync("docs/CI-CD/error-autofix-routine.md")).toBe(true);
+  });
+
+  it("documents trigger, stop, retry, verifier, and typed handoff", () => {
+    const routine = readFileSync("docs/CI-CD/error-autofix-routine.md", "utf8");
+    expect(routine).toContain("ROUTINE: error-autofix");
+    expect(routine).toContain(
+      "TRIGGER: issues opened by posthog[bot] | workflow_dispatch",
+    );
+    expect(routine).toContain("STOP: repo var ERROR_AUTOFIX_ENABLED");
+    expect(routine).toContain(
+      "RETRY: dispatch a fresh run (do not “Re-run jobs” on a failed snapshot)",
+    );
+    expect(routine).toContain(
+      "VERIFIER: .github/scripts/autofix-merge-guard.sh",
+    );
+    expect(routine).toContain(".agents/handoffs/<issue-number>.md");
+    expect(routine).toContain("on the PR branch");
+    expect(routine).toContain("unknown / insufficient signal");
+    expect(routine).toContain("last_successful_action:");
+    expect(routine).toContain("documented, not run");
+
+    const prompt = readFileSync(".github/prompts/error-autofix.md", "utf8");
+    expect(prompt).toContain(".agents/handoffs/<issue-number>.md");
+    expect(prompt).toContain("on the PR branch");
+  });
+
+  it("keeps merge-guard as the Verifier with unchanged size rails", () => {
+    const guard = readFileSync(
+      ".github/scripts/autofix-merge-guard.sh",
+      "utf8",
+    );
+    expect(guard).toContain("DENIED_PATH_PATTERNS=(");
+    expect(guard).toMatch(/^MAX_FILES=8$/m);
+    expect(guard).toMatch(/^MAX_LINES=250$/m);
+
+    const routine = readFileSync("docs/CI-CD/error-autofix-routine.md", "utf8");
+    expect(routine).toContain("MAX_FILES=8");
+    expect(routine).toContain("MAX_LINES=250");
+    expect(routine).toContain("DENIED_PATH_PATTERNS");
+    expect(routine).toContain("do not widen from this doc");
+  });
+});

--- a/wip/restructure/TRACKING.md
+++ b/wip/restructure/TRACKING.md
@@ -14,9 +14,9 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 | WP-02 | high | cursor-agent | done | [WP-02-typed-handoff-ledger.md](WP-02-typed-handoff-ledger.md) | merged #2866 (`8cc2a03ca`); schema + in-repo `/handoff` + ledger | — | 0 | none |
 | WP-03 | high | cursor-agent | done | [WP-03-split-ship-review-verifier.md](WP-03-split-ship-review-verifier.md) | merged #2867 (`024925eb2`); `/ship` Manager; `/review`; verify-change verdict | — | 0 | none |
 | WP-04 | high | Implementer | done | [WP-04-hard-constraints.md](WP-04-hard-constraints.md) | merged #2868 (`d2e3946d9`); checker in lint; pr-body workflow | — | 0 | none |
-| WP-05 | medium | — | queued | [WP-05-skill-registry.md](WP-05-skill-registry.md) | — | after WP-03 `done` | 0 | none |
-| WP-06 | medium | — | queued | [WP-06-autofix-routine.md](WP-06-autofix-routine.md) | — | after WP-02 and WP-03 `done` | 0 | none |
-| WP-07 | medium | cursor-agent | verifying | [WP-07-agent-ready-intake.md](WP-07-agent-ready-intake.md) | `.github/ISSUE_TEMPLATE/3-agent-task.yml`; label `agent-ready` created | this session | 0 | none |
+| WP-05 | medium | cursor-agent | waiting | [WP-05-skill-registry.md](WP-05-skill-registry.md) | PR #2872 (CI after WP-07 rebase) | after WP-03 `done` | 0 | none |
+| WP-06 | medium | cursor-agent | verifying | [WP-06-autofix-routine.md](WP-06-autofix-routine.md) | `docs/CI-CD/error-autofix-routine.md`; drills documented, not run | this session | 0 | none |
+| WP-07 | medium | cursor-agent | done | [WP-07-agent-ready-intake.md](WP-07-agent-ready-intake.md) | merged #2869 (`125c3f0fd`); `3-agent-task.yml`; label `agent-ready` | — | 0 | none |
 | WP-08 | low | — | queued | [WP-08-architecture-as-training.md](WP-08-architecture-as-training.md) | gated: only if discovery remains the bottleneck after WP-01–05 | after WP-05 `done` + scale-gate review | 0 | human: run or cancel |
 
 ## Delivery-loop baseline (fill after WP-03)

--- a/wip/restructure/WP-06-autofix-routine.md
+++ b/wip/restructure/WP-06-autofix-routine.md
@@ -1,7 +1,7 @@
 # WP-06 — Error autofix as a governed Routine
 
 **task_id:** WP-06
-**status:** queued
+**status:** verifying
 **owner:** On-call / Implementer (docs + drills), human for enabling modes
 **depends on:** WP-02 `done`, WP-03 `done`
 **next owner after done:** WP-07 may overlap; do not add new Routines yet
@@ -110,11 +110,11 @@ escalate; do not silently widen denied paths.
 ## Evidence
 
 ```text
-workflows.md table includes autofix: yes/no
-routine doc path:
-prompt handoff sentence: yes/no
-drills: documented | run
-modes unchanged (must be yes):
+workflows.md table includes autofix: yes
+routine doc path: docs/CI-CD/error-autofix-routine.md
+prompt handoff sentence: yes (.agents/handoffs/<issue-number>.md on the PR branch)
+drills: documented
+modes unchanged (must be yes): yes
 ```
 
 ## Out of scope
@@ -135,14 +135,14 @@ run in `TRACKING.md` if it happens.
 
 ```yaml
 task_id: WP-06
-from:
-to: Implementer
-status:
-artifact:
-evidence:
-assumptions:
-open_risks:
-next_deadline:
+from: Implementer
+to: Verifier
+status: verifying
+artifact: docs/CI-CD/error-autofix-routine.md
+evidence: packages/scripts/src/testing/error-autofix-routine.test.ts
+assumptions: ERROR_AUTOFIX_ENABLED and AUTOFIX_MODE unchanged
+open_risks: live drills not run (documented only)
+next_deadline: this PR
 ```
 
 ## Session prompt


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

WP-06 from `wip/restructure/`. Documents the existing Error autofix loop as a governed Routine: trigger, idempotency, retry, approval, stop switch, heartbeat, drills, and recovery packet. The autofix prompt writes a typed handoff on the PR branch. Merge-guard stays the Verifier. `ERROR_AUTOFIX_ENABLED` and `AUTOFIX_MODE` are unchanged.

Rebased onto `main` after WP-05 (#2872) merged (`84902a18d`). TRACKING marks WP-05 done.

## Simplicity

No new workflow. Docs and a scripts contract test that the workflow table, prompt, and merge-guard rails stay aligned.

## Automated validation

`bun test packages/scripts/src/testing/error-autofix-routine.test.ts` — 3 pass, 0 fail. After merging `origin/main`, also `bun test packages/scripts/src/testing/skill-registry.test.ts` — 2 pass. `bun run lint` — exit 0 (pre-existing warnings only). Kill switch and mode not flipped in YAML.

## Independent review

`/review` of WP-06 files vs `origin/main` before the TRACKING merge.

```text
VERDICT: no confirmed findings
FINDINGS: none
```

Pointer: `.agents/handoffs/WP-06.md`.

## Test plan

`bun test packages/scripts/src/testing/error-autofix-routine.test.ts` (3 pass). `bun run lint` (exit 0). Live autofix drills documented, not run.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1e729d3-21f7-460a-a6a2-cf411b9d72ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1e729d3-21f7-460a-a6a2-cf411b9d72ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

