### PR TITLE
Allow-list all tool calls so cloud sessions stop prompting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,14 @@
   "permissions": {
     "defaultMode": "bypassPermissions",
     "allow": [
+      "Bash",
+      "WebFetch",
+      "WebSearch",
+      "mcp__Claude_Code_Remote",
+      "mcp__claude-code-remote",
+      "mcp__github",
+      "mcp__PostHog",
+      "mcp__Claude_Preview",
       "Bash(bun run test:*)",
       "Bash(bun run lint)",
       "Bash(bun run lint:fix)",


### PR DESCRIPTION
## Summary

Cloud sessions (claude.ai/code / desktop cloud tab) ignore `"defaultMode": "bypassPermissions"` from settings files — bypass mode isn't available in cloud sessions at all — so MCP tools like `Claude_Code_Remote create_trigger` still raised a permission prompt on every use. `permissions.allow` rules **are** honored in cloud sessions in every mode, so this adds blanket allow rules for `Bash`, `WebFetch`, `WebSearch`, and every tool from the `Claude_Code_Remote` (both name spellings), `github`, `PostHog`, and `Claude_Preview` MCP servers.

Existing `deny` rules (force push, `rm -rf`, `.env` reads/edits) are evaluated before allow rules in every mode, so those guardrails still hold.

## Simplicity

Eight lines added to the existing `permissions.allow` array; no new files or mechanisms. The existing narrow `Bash(...)` entries are kept as-is (subsumed by the bare `Bash` rule, harmless).

## Automated validation

`jq -e '.permissions.allow | length'` parses the edited file and returns 47 entries — valid JSON, array intact. Behavioral effect (no prompt on the next `create_trigger` call) is only observable in a fresh cloud session, since settings are read from the clone at session start.

## Independent review

Not run — 8-line JSON config addition; verified against the Claude Code permissions docs (allow-rule syntax `mcp__<server>` matches all tools from a server; cloud sessions honor allow rules but ignore `bypassPermissions`/`dontAsk` from settings files).

## Test plan

- `jq -e '.permissions.allow | length' .claude/settings.json` → 47 (valid JSON)
- After merge: start a new cloud session on this repo and confirm `Claude_Code_Remote` tool calls (e.g. `create_trigger`) run without a permission dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yPMxtEd8XtHTcAMgcwww9

---
_Generated by [Claude Code](https://claude.ai/code/session_013yPMxtEd8XtHTcAMgcwww9)_