### PR TITLE
fix(sync): retire hidden google calendars and clear inactive channels

### DIFF
--- a/.agents/handoffs/2876.md
+++ b/.agents/handoffs/2876.md
@@ -1,0 +1,33 @@
+---
+schema_version: 1
+task_id: "2876"
+from: Manager
+to: Human
+owner: Manager
+status: verifying
+artifact:
+  - path: packages/sync/src/providers/google/google-calendar.adapter.ts
+  - path: packages/sync/src/domain/calendar-list-sync.service.ts
+  - path: packages/sync/src/domain/sync-job-dispatch.service.ts
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/2876
+evidence:
+  - command: bun run verify
+    result: "Selected packages: sync; checks run test:sync, type-check, lint, knip; all passed"
+  - command: bun run test:sync
+    result: "983 pass, 0 fail"
+assumptions:
+  - "Google leaves calendarList `selected` frozen when a calendar is hidden from the list; confirmed against prod provider_calendars data (hidden && selected cohort matches the resurrected sidebar entries)"
+open_risks:
+  - "hidden-but-selected calendars a user genuinely wants imported stop syncing; judged not a real use case since Google's own UI does not show them"
+next_deadline: 2026-08-26T18:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+Ship record for PR #2876: hidden Google calendars map inactive regardless of
+the fossil `selected` flag; inactive calendars get their local push-channel
+fields cleared via one self-gating updateMany in the calendar-list pass plus
+a level-triggered clear in dispatch's inactive-drop branch. Independent
+review: no confirmed findings. Status moves to done at squash-merge.

--- a/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
@@ -353,6 +353,68 @@ describe("syncCalendarList", () => {
     expect(goneEventsResource?.subscriptionExpiresAt).toBeNull();
   });
 
+  it("clears the push channel when a calendar is upserted inactive on an incremental pass", async () => {
+    // A hidden or deleted calendar arrives as an active:false ENTRY (not an
+    // absence), so it never goes through deactivateAbsent — the channel
+    // cleanup must cover the upsert path too, or the resource squats at the
+    // head of every renewal sweep (dispatch drops subscriptionMaintain for
+    // inactive calendars, so subscriptionExpiresAt never advances).
+    const conn = connection();
+    // Full pass discovers "hides" active and returns a cursor, so the next
+    // pass is incremental.
+    await syncCalendarList(
+      deps(
+        new FakeDiscovery([
+          {
+            calendars: [discovered("primary"), discovered("hides")],
+            cursor: "c1",
+          },
+        ]),
+      ),
+      conn,
+      now,
+    );
+    const hidesCalendar = (await calendarDocs(conn)).find(
+      (d) => d.providerCalendarId === "hides",
+    );
+    const hidesEventsResourceId = (
+      await storage.db().collection(SYNC_COLLECTIONS.syncResources).findOne({
+        connectionId: conn._id,
+        resourceKind: "events",
+        calendarId: hidesCalendar?._id,
+      })
+    )?._id as string;
+    await resources.updateSubscription(
+      conn.tenantId,
+      conn.principalId,
+      hidesEventsResourceId,
+      {
+        subscriptionId: "channel-1",
+        subscriptionResourceId: "resource-1",
+        subscriptionToken: "token-1",
+        subscriptionExpiresAt: new Date("2026-08-01T00:00:00.000Z"),
+      },
+    );
+
+    // Incremental pass (the stored cursor is "c1") reports "hides" inactive.
+    await syncCalendarList(
+      deps(
+        new FakeDiscovery([
+          { calendars: [discovered("hides", false)], cursor: "c2" },
+        ]),
+      ),
+      conn,
+      now,
+    );
+
+    const hidesEventsResource = await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.syncResources)
+      .findOne({ _id: hidesEventsResourceId });
+    expect(hidesEventsResource?.subscriptionId).toBeNull();
+    expect(hidesEventsResource?.subscriptionExpiresAt).toBeNull();
+  });
+
   it("logs a warning naming the calendars a full pass retired", async () => {
     const conn = connection();
     await syncCalendarList(

--- a/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
@@ -117,6 +117,37 @@ describe("syncCalendarList", () => {
       .collection(SYNC_COLLECTIONS.syncResources)
       .findOne({ connectionId: conn._id, resourceKind: "calendarList" });
 
+  // Give a discovered calendar's events resource an established push channel,
+  // as a calendar with prior sync history would hold. Returns the resource id
+  // so the test can assert on the cleared fields afterwards.
+  const seedSubscribedEventsResource = async (
+    conn: ProviderConnectionRecord,
+    providerCalendarId: string,
+  ) => {
+    const calendar = (await calendarDocs(conn)).find(
+      (d) => d.providerCalendarId === providerCalendarId,
+    );
+    const resourceId = (
+      await storage.db().collection(SYNC_COLLECTIONS.syncResources).findOne({
+        connectionId: conn._id,
+        resourceKind: "events",
+        calendarId: calendar?._id,
+      })
+    )?._id as string;
+    await resources.updateSubscription(
+      conn.tenantId,
+      conn.principalId,
+      resourceId,
+      {
+        subscriptionId: "channel-1",
+        subscriptionResourceId: "resource-1",
+        subscriptionToken: "token-1",
+        subscriptionExpiresAt: new Date("2026-08-01T00:00:00.000Z"),
+      },
+    );
+    return resourceId;
+  };
+
   it("discovers calendars, persists them, and enqueues an import per active calendar", async () => {
     const conn = connection();
     const discovery = new FakeDiscovery([
@@ -310,28 +341,9 @@ describe("syncCalendarList", () => {
       conn,
       now,
     );
-    const goneCalendar = (await calendarDocs(conn)).find(
-      (d) => d.providerCalendarId === "gone",
-    );
-    const goneEventsResourceId = (
-      await storage.db().collection(SYNC_COLLECTIONS.syncResources).findOne({
-        connectionId: conn._id,
-        resourceKind: "events",
-        calendarId: goneCalendar?._id,
-      })
-    )?._id as string;
-    // Simulate an established push channel, as a calendar with prior sync
-    // history would hold.
-    await resources.updateSubscription(
-      conn.tenantId,
-      conn.principalId,
-      goneEventsResourceId,
-      {
-        subscriptionId: "channel-1",
-        subscriptionResourceId: "resource-1",
-        subscriptionToken: "token-1",
-        subscriptionExpiresAt: new Date("2026-08-01T00:00:00.000Z"),
-      },
+    const goneEventsResourceId = await seedSubscribedEventsResource(
+      conn,
+      "gone",
     );
 
     // Second full pass omits "gone", retiring it.
@@ -374,26 +386,9 @@ describe("syncCalendarList", () => {
       conn,
       now,
     );
-    const hidesCalendar = (await calendarDocs(conn)).find(
-      (d) => d.providerCalendarId === "hides",
-    );
-    const hidesEventsResourceId = (
-      await storage.db().collection(SYNC_COLLECTIONS.syncResources).findOne({
-        connectionId: conn._id,
-        resourceKind: "events",
-        calendarId: hidesCalendar?._id,
-      })
-    )?._id as string;
-    await resources.updateSubscription(
-      conn.tenantId,
-      conn.principalId,
-      hidesEventsResourceId,
-      {
-        subscriptionId: "channel-1",
-        subscriptionResourceId: "resource-1",
-        subscriptionToken: "token-1",
-        subscriptionExpiresAt: new Date("2026-08-01T00:00:00.000Z"),
-      },
+    const hidesEventsResourceId = await seedSubscribedEventsResource(
+      conn,
+      "hides",
     );
 
     // Incremental pass (the stored cursor is "c1") reports "hides" inactive.

--- a/packages/sync/src/domain/calendar-list-sync.service.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.ts
@@ -1,4 +1,7 @@
-import { type ProviderCalendarSourceId } from "@core/types/sync/identity.contracts";
+import {
+  type ProviderCalendarId,
+  type ProviderCalendarSourceId,
+} from "@core/types/sync/identity.contracts";
 import { discoverCalendarsWithAuthRetry } from "@sync/domain/discover-calendars-with-auth-retry";
 import { type AccessTokenSource } from "@sync/domain/provider-write-ladder";
 import {
@@ -151,7 +154,7 @@ export async function syncCalendarList(
   // calendar, so a full list of zero is treated as a non-answer (a provider
   // hiccup that returned empty instead of throwing) rather than "all removed" —
   // retiring every calendar on an empty blip would be user-visible damage.
-  let retiredIds: string[] = [];
+  let retiredIds: ProviderCalendarId[] = [];
   if (fullList && discovery.calendars.length > 0) {
     // A full pass is the retry cadence for unwatchable calendars: clear the
     // persisted watchUnsupportedAt verdicts so each gets one fresh watch
@@ -184,33 +187,25 @@ export async function syncCalendarList(
   // for inactive calendars, so subscriptionExpiresAt never advances and the
   // row would squat at the head of every renewal sweep forever
   // (listExpiringSubscriptions sorts soonest-expiry first with no other
-  // exclusion). Clearing the local fields here, rather than calling the
-  // provider to stop the channel, is deliberate: Google's channels lapse on
-  // their own within 30 days, so the remote channel is a harmless,
-  // self-healing wart, not something worth a provider call and a new adapter
-  // dependency.
-  const inactiveIds = new Set<string>([
-    ...retiredIds,
-    ...upserted.filter((r) => !r.active).map((r) => r._id),
-  ]);
-  if (inactiveIds.size > 0) {
-    const connectionResources = await deps.resources.listByConnection(
+  // exclusion). The clear is one self-gating updateMany because hidden and
+  // deleted calendars are re-reported inactive on EVERY daily full pass, not
+  // just the transition one — steady state must cost one no-op write, not a
+  // read of the connection's resources. Clearing the local fields, rather
+  // than calling the provider to stop the channel, is deliberate: Google's
+  // channels lapse on their own within 30 days, so the remote channel is a
+  // harmless, self-healing wart, not something worth a provider call and a
+  // new adapter dependency.
+  const inactiveIds = [
+    ...new Set([
+      ...retiredIds,
+      ...upserted.filter((r) => !r.active).map((r) => r._id),
+    ]),
+  ];
+  if (inactiveIds.length > 0) {
+    await deps.resources.clearSubscriptionsByCalendarIds(
       tenantId,
       principalId,
-      connectionId,
-    );
-    const subscribedInactive = connectionResources.filter(
-      (r) =>
-        r.calendarId &&
-        inactiveIds.has(r.calendarId) &&
-        r.subscriptionId !== null,
-    );
-    // Independent writes to distinct resources: clear them concurrently
-    // rather than one round trip per retired calendar.
-    await Promise.all(
-      subscribedInactive.map((r) =>
-        deps.resources.clearSubscription(tenantId, principalId, r._id),
-      ),
+      inactiveIds,
     );
   }
 

--- a/packages/sync/src/domain/calendar-list-sync.service.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.ts
@@ -151,6 +151,7 @@ export async function syncCalendarList(
   // calendar, so a full list of zero is treated as a non-answer (a provider
   // hiccup that returned empty instead of throwing) rather than "all removed" —
   // retiring every calendar on an empty blip would be user-visible damage.
+  let retiredIds: string[] = [];
   if (fullList && discovery.calendars.length > 0) {
     // A full pass is the retry cadence for unwatchable calendars: clear the
     // persisted watchUnsupportedAt verdicts so each gets one fresh watch
@@ -162,7 +163,7 @@ export async function syncCalendarList(
       principalId,
       connectionId,
     );
-    const retiredIds = await deps.calendars.deactivateAbsent(
+    retiredIds = await deps.calendars.deactivateAbsent(
       tenantId,
       principalId,
       connectionId,
@@ -174,36 +175,43 @@ export async function syncCalendarList(
       deps.log?.warn(
         `Sync retired ${retiredIds.length} calendar(s) absent from a full list on connection ${connectionId}: ${retiredIds.join(", ")}`,
       );
-      // The calendar is gone at the provider, so its push channel (if any) can
-      // never be renewed there. Dispatch already drops subscriptionMaintain for
-      // an inactive calendar, which means its subscriptionExpiresAt never
-      // advances — left alone, the row would squat at the head of every
-      // renewal sweep forever (listExpiringSubscriptions sorts soonest-expiry
-      // first with no other exclusion). Clearing the local fields here, rather
-      // than calling the provider to stop the channel, is deliberate: the
-      // calendar already 404s, and Google's channels lapse on their own within
-      // 30 days regardless, so the remote channel is a harmless, self-healing
-      // wart, not something worth a provider call and a new adapter dependency.
-      const retiredIdSet = new Set<string>(retiredIds);
-      const resources = await deps.resources.listByConnection(
-        tenantId,
-        principalId,
-        connectionId,
-      );
-      const subscribedRetired = resources.filter(
-        (r) =>
-          r.calendarId &&
-          retiredIdSet.has(r.calendarId) &&
-          r.subscriptionId !== null,
-      );
-      // Independent writes to distinct resources: clear them concurrently
-      // rather than one round trip per retired calendar.
-      await Promise.all(
-        subscribedRetired.map((r) =>
-          deps.resources.clearSubscription(tenantId, principalId, r._id),
-        ),
-      );
     }
+  }
+
+  // An inactive calendar — retired above for being absent from a full list, or
+  // upserted inactive because the provider reports it deleted or hidden — can
+  // never have its push channel renewed: dispatch drops subscriptionMaintain
+  // for inactive calendars, so subscriptionExpiresAt never advances and the
+  // row would squat at the head of every renewal sweep forever
+  // (listExpiringSubscriptions sorts soonest-expiry first with no other
+  // exclusion). Clearing the local fields here, rather than calling the
+  // provider to stop the channel, is deliberate: Google's channels lapse on
+  // their own within 30 days, so the remote channel is a harmless,
+  // self-healing wart, not something worth a provider call and a new adapter
+  // dependency.
+  const inactiveIds = new Set<string>([
+    ...retiredIds,
+    ...upserted.filter((r) => !r.active).map((r) => r._id),
+  ]);
+  if (inactiveIds.size > 0) {
+    const connectionResources = await deps.resources.listByConnection(
+      tenantId,
+      principalId,
+      connectionId,
+    );
+    const subscribedInactive = connectionResources.filter(
+      (r) =>
+        r.calendarId &&
+        inactiveIds.has(r.calendarId) &&
+        r.subscriptionId !== null,
+    );
+    // Independent writes to distinct resources: clear them concurrently
+    // rather than one round trip per retired calendar.
+    await Promise.all(
+      subscribedInactive.map((r) =>
+        deps.resources.clearSubscription(tenantId, principalId, r._id),
+      ),
+    );
   }
 
   // Bootstrap events sync for each active calendar: ensure its events resource

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -553,6 +553,45 @@ describe("dispatchSyncJob", () => {
     expect(stored?.lastAttemptAt).toEqual(now());
   });
 
+  it("clears a lingering push channel when dropping a job for an inactive calendar", async () => {
+    // The renewal sweep sorts on subscriptionExpiresAt alone, so a channel
+    // left on an inactive calendar would win the head of every sweep forever
+    // — the drop is where the invariant is enforced regardless of how the
+    // calendar became inactive.
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, "cursor-1");
+    await resources.updateSubscription(
+      calendar.tenantId,
+      calendar.principalId,
+      resource._id,
+      {
+        subscriptionId: "channel-1",
+        subscriptionResourceId: "resource-1",
+        subscriptionToken: "token-1",
+        subscriptionExpiresAt: new Date("2026-08-01T00:00:00.000Z"),
+      },
+    );
+    await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.providerCalendars)
+      .updateOne({ _id: calendar._id }, { $set: { active: false } });
+
+    const outcome = await dispatchSyncJob(
+      deps(new FakeReader([])),
+      jobFor(resource, "subscriptionMaintain"),
+      now,
+    );
+
+    expect(outcome.result).toBe("drop");
+    const stored = await resources.findById(
+      calendar.tenantId,
+      calendar.principalId,
+      resource._id,
+    );
+    expect(stored?.subscriptionId).toBeNull();
+    expect(stored?.subscriptionExpiresAt).toBeNull();
+  });
+
   it("hands off a pull on a never-imported resource to an initial import", async () => {
     const calendar = await seedCalendar();
     const resource = await seedResource(calendar, null); // no cursor

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -328,6 +328,21 @@ async function runSyncJob(
       resource._id,
       now(),
     );
+    // Same shape for the renewal sweep, which sorts on subscriptionExpiresAt
+    // alone: a channel on an inactive calendar can never be renewed (this
+    // drop is all subscriptionMaintain would do), so a lingering subscription
+    // squats at the head of every sweep. The calendar-list pass clears
+    // channels when it observes a calendar inactive, but only for calendars
+    // the provider still lists — this level-triggered clear also converges
+    // rows that went inactive before that cleanup existed and have since
+    // vanished from the provider's list entirely.
+    if (resource.subscriptionId !== null) {
+      await deps.resources.clearSubscription(
+        resource.tenantId,
+        resource.principalId,
+        resource._id,
+      );
+    }
     return {
       result: "drop",
       reason: `calendar ${calendar._id} is inactive; sync resumes if it is reactivated`,

--- a/packages/sync/src/providers/google/google-calendar.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-calendar.adapter.test.ts
@@ -277,11 +277,13 @@ describe("GoogleCalendarAdapter", () => {
     expect(active).toEqual({ live: true, gone: false, hidden: false });
   });
 
-  it("keeps a hidden calendar active when Google is still showing it", async () => {
+  it("marks a hidden calendar inactive even when selected is still true", async () => {
+    // Hiding a calendar in Google leaves the API's `selected` flag frozen at
+    // its pre-hide value, so hidden+selected must not resurrect the calendar.
     const api = new FakeCalendarListApi([
       page({
         items: [
-          entry({ id: "shown-hidden", hidden: true, selected: true }),
+          entry({ id: "hidden-but-selected", hidden: true, selected: true }),
           entry({ id: "unselected-hidden", hidden: true, selected: false }),
           entry({ id: "hidden-omitted-selected", hidden: true }),
           entry({
@@ -303,7 +305,7 @@ describe("GoogleCalendarAdapter", () => {
     );
 
     expect(active).toEqual({
-      "shown-hidden": true,
+      "hidden-but-selected": false,
       "unselected-hidden": false,
       "hidden-omitted-selected": false,
       "deleted-but-selected": false,

--- a/packages/sync/src/providers/google/google-calendar.adapter.ts
+++ b/packages/sync/src/providers/google/google-calendar.adapter.ts
@@ -223,12 +223,11 @@ async function mapCalendar(
     color: item.backgroundColor || null,
     eventLabels: await api.getEventLabels(item.id),
     primary: item.primary === true,
-    // Deleted calendars are gone. Hidden-from-list is not the same as
-    // "Google is not showing this": the Calendar UI still displays events
-    // when selected is true. Import those so connection health cannot stay
-    // green while a selected calendar is silently skipped.
-    active:
-      item.deleted !== true && (item.hidden !== true || item.selected === true),
+    // Deleted calendars are gone, and hidden ones are too: hiding a calendar
+    // removes it (and its events) from the Calendar UI without clearing the
+    // API's `selected` flag, so `selected` on a hidden calendar is a fossil
+    // from before the hide, not a signal Google is still showing it.
+    active: item.deleted !== true && item.hidden !== true,
     accessRole,
     capabilities: CAPABILITIES_BY_ROLE[accessRole],
   };

--- a/packages/sync/src/providers/provider-calendar.port.ts
+++ b/packages/sync/src/providers/provider-calendar.port.ts
@@ -22,9 +22,8 @@ export interface DiscoveredCalendar {
   }[];
   // The provider designates this as the account's default calendar.
   readonly primary: boolean;
-  // The calendar is present for the account. Deleted calendars are inactive.
-  // Hidden-from-list calendars stay active when the provider is still showing
-  // their events (Google's selected flag).
+  // The calendar is present in the provider's UI for the account. Deleted and
+  // hidden-from-list calendars are both inactive.
   readonly active: boolean;
   readonly accessRole: CalendarAccessRole;
   readonly capabilities: SyncCalendarCapabilities;

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -3,6 +3,7 @@ import { type SyncEventCalendarId } from "@core/types/sync/event.contracts";
 import {
   type ConnectionId,
   type PrincipalId,
+  type ProviderCalendarId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
@@ -347,6 +348,35 @@ export class SyncResourceRepository {
       subscriptionToken: null,
       subscriptionExpiresAt: null,
     });
+  }
+
+  // Clear the local push-channel fields on every resource of the given
+  // calendars that still holds one. Self-gating single round trip: the filter
+  // matches nothing once cleared, which matters because the calendar-list
+  // full pass re-reports hidden/deleted calendars as inactive every day, not
+  // just on the pass where they transition.
+  async clearSubscriptionsByCalendarIds(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    calendarIds: readonly ProviderCalendarId[],
+  ): Promise<void> {
+    await this.collection.updateMany(
+      {
+        tenantId,
+        principalId,
+        calendarId: { $in: [...calendarIds] },
+        subscriptionId: { $ne: null },
+      },
+      {
+        $set: {
+          subscriptionId: null,
+          subscriptionResourceId: null,
+          subscriptionToken: null,
+          subscriptionExpiresAt: null,
+          updatedAt: new Date(),
+        },
+      },
+    );
   }
 
   // Find the resource a provider push channel belongs to. Keyed on the channel


### PR DESCRIPTION
## Summary

Google Calendar leaves the calendarList `selected` flag frozen at its pre-hide value when a user hides a calendar from their list, and the Calendar UI stops showing a hidden calendar entirely. Discovery's active rule (`hidden !== true || selected === true`) treated that fossil flag as "Google is still showing this," so every calendar a user ever hid with the checkbox on was resurrected in the Compass sidebar, imported, and watched. Confirmed against prod data: the mismatched calendars are exactly the `hidden && selected` cohort, while `hidden && !selected` ones were correctly retired.

- Map hidden calendars inactive regardless of `selected` (`google-calendar.adapter.ts`).
- Clear local push-channel fields for any calendar that lands inactive — via full-list absence or an `active: false` upsert — with one self-gating `updateMany` (`clearSubscriptionsByCalendarIds`). Previously only absence-retired calendars were cleaned, so a newly-inactive calendar's channel would squat at the head of every renewal sweep (`listExpiringSubscriptions` sorts on `subscriptionExpiresAt` with no active filter).
- Level-triggered backstop: dispatch's inactive-calendar drop branch also clears a lingering subscription, so rows that went inactive before this cleanup existed (and may have since vanished from the provider's list) converge on their first sweep selection — same shape as the `lastAttemptAt` stamp already in that branch.

No migration needed: the daily calendar-list rediscovery sweep re-lists every connection with `showHidden`/`showDeleted`, so existing hidden calendars flip inactive (and their channels clear) within a day of deploy.

## Simplicity

Simplify pass replaced the initial read-then-filter-then-N-writes cleanup with the single self-gating `updateMany` (hidden calendars are re-reported inactive on **every** daily full pass, so steady state must be a no-op write, not a per-connection resource fetch), and hoisted duplicated push-channel test seeding into a shared local helper.

## Automated validation

- Adapter maps all four hidden/deleted/selected combinations to inactive; only clean calendars stay active (google-calendar.adapter.test.ts).
- Incremental pass reporting a calendar `active: false` clears its events resource's subscription fields (calendar-list-sync.service.db.test.ts).
- Dispatch drop for an inactive calendar clears a lingering channel (sync-job-dispatch.service.db.test.ts).

## Independent review

Independent read-only review of the complete base-to-head diff (state, race, cleanup, boundary, security, data-loss): **no confirmed findings**. Verified ID-space correctness of the `$in` filter (`ProviderCalendarId` vs `SyncEventCalendarId`), `(tenantId, principalId)` scoping on the new write, no-op steady state of `subscriptionId: { $ne: null }`, race convergence via the dispatch-side clear, and that webhooks on a cleared channel fall into the existing quiet-reject path.

## Test plan

- `bun run verify` → Selected packages: sync · Checks run: test:sync, type-check, lint, knip · Checks skipped: (none) · ✓ All checks passed
- `bun run test:sync` → 983 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
