### PR TITLE
feat(web): polish welcome and expand shortcut practice

### DIFF
--- a/.agents/handoffs/2879.md
+++ b/.agents/handoffs/2879.md
@@ -1,9 +1,9 @@
 ---
 schema_version: 1
 task_id: "2879"
-from: Manager
-to: Verifier
-owner: Verifier
+from: Reviewer
+to: Manager
+owner: Manager
 status: verifying
 artifact:
   - path: packages/web/src/components/WelcomeModal/WelcomeGuideBody.tsx
@@ -13,12 +13,14 @@ artifact:
   - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/2879
 evidence:
   - command: bun run verify
-    result: pending — CI on prior head failed knip (unused PRACTICE_JUMP_TARGETS) and e2e (Do it for me click blocked by pointer suppression). Fixes are on 8e3cc96f7; verifier must quote bun run verify output.
+    result: "Selected packages: web; Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e; Checks skipped: (none); All checks passed. web 2346 pass / 0 fail; e2e 35 passed including shortcut-showcase."
+  - command: bun run knip
+    result: pass (PRACTICE_JUMP_TARGETS export removed)
 assumptions:
   - "task is welcome/onboarding polish on packages/web plus e2e/docs; no core contract change"
   - "production deploy is user-authorized after staging health is green"
 open_risks:
-  - "prior CI e2e/knip failures on 1fd6cb6b9; local verify plus Playwright required before merge"
+  - "signed-in staging QA needs compasscaltest3@gmail.com; anonymous welcome/practice can be checked without auth"
 next_deadline: 2026-08-26T06:00:00Z
 retry: 0
 approval: none
@@ -26,9 +28,8 @@ waiting_on: null
 escalation: null
 ---
 
-Ship #2879: welcome heading/copy/login chips, skippable six-mission practice,
-U skip-to-signup. Implementer fixed hold-mod nowrap, unused export, and e2e
-D-key assist. Next: `/verify-change`, then `/simplify`, `/review`, ready PR,
-squash-merge, watch staging, then production dispatch.
+Verifier: PASS. Simplify: no behavior-preserving commit (practice per-mission
+branches and auth letter listener are already the smallest surfaces).
+Independent review: no confirmed findings.
 
-Suggested skills: `/verify-change`, `/simplify`, `/review`, `/qa-test-staging`
+Suggested skills: `/qa-test-staging` after squash-merge and staging health.

--- a/.agents/handoffs/2879.md
+++ b/.agents/handoffs/2879.md
@@ -1,0 +1,34 @@
+---
+schema_version: 1
+task_id: "2879"
+from: Manager
+to: Verifier
+owner: Verifier
+status: verifying
+artifact:
+  - path: packages/web/src/components/WelcomeModal/WelcomeGuideBody.tsx
+  - path: packages/web/src/components/AuthModal/AuthModal.tsx
+  - path: packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
+  - path: e2e/onboarding/shortcut-showcase.spec.ts
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/2879
+evidence:
+  - command: bun run verify
+    result: pending — CI on prior head failed knip (unused PRACTICE_JUMP_TARGETS) and e2e (Do it for me click blocked by pointer suppression). Fixes are on 8e3cc96f7; verifier must quote bun run verify output.
+assumptions:
+  - "task is welcome/onboarding polish on packages/web plus e2e/docs; no core contract change"
+  - "production deploy is user-authorized after staging health is green"
+open_risks:
+  - "prior CI e2e/knip failures on 1fd6cb6b9; local verify plus Playwright required before merge"
+next_deadline: 2026-08-26T06:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+Ship #2879: welcome heading/copy/login chips, skippable six-mission practice,
+U skip-to-signup. Implementer fixed hold-mod nowrap, unused export, and e2e
+D-key assist. Next: `/verify-change`, then `/simplify`, `/review`, ready PR,
+squash-merge, watch staging, then production dispatch.
+
+Suggested skills: `/verify-change`, `/simplify`, `/review`, `/qa-test-staging`

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,4 +13,4 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 2879 | high | Verifier | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/2879 | bun run verify (pending) | 2026-08-26T06:00:00Z | 0 | none |
+| 2879 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/2879 | bun run verify PASS; review: no confirmed findings | 2026-08-26T06:00:00Z | 0 | none |

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,3 +13,4 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 2879 | high | Verifier | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/2879 | bun run verify (pending) | 2026-08-26T06:00:00Z | 0 | none |

--- a/docs/frontend/frontend-runtime-flow.md
+++ b/docs/frontend/frontend-runtime-flow.md
@@ -82,12 +82,13 @@ Welcome → signup → first-event contract:
 - the Shortcut Showcase therefore has three entries: welcome dismiss,
   post-signup, and the command palette's "Practice shortcuts".
   `showcase.steps.ts` holds the order; taught keycaps come from
-  `packages/web/src/shortcuts/keymap.ts`. One lesson gates the exit — create,
-  then title-and-save, taught as a single continuous motion rather than two
-  steps — and is the only shortcut the arena implements
-- every showcase step offers **Skip to calendar**, and **Skip to sign up** for
-  anyone not already signed in; Escape does the former. There is no confirm in
-  the way
+  `packages/web/src/shortcuts/keymap.ts`. Six skippable missions teach create
+  (C then title then Enter), hold-Mod page jumps, `S` event jump, Shift+arrow
+  nudge, `E` then `T` to target a title, and Cmd+K on a practice-only
+  palette, then graduation hands off to the real calendar
+- every showcase step offers **Skip to calendar** (`X`), and **Skip to sign
+  up** (`U`) for anyone not already signed in; Escape does the former. There
+  is no confirm in the way
 - graduating the showcase hands off directly to `FirstEventPrompt`, a
   non-blocking card on the real calendar (not an app-lock modal) that asks the
   user to press `C` on a real event. It is shown once the showcase has been

--- a/e2e/onboarding/shortcut-showcase.spec.ts
+++ b/e2e/onboarding/shortcut-showcase.spec.ts
@@ -25,30 +25,33 @@ test("exploring without an account starts the practice", async ({ page }) => {
   ).toBeVisible();
 });
 
-test("the welcome-started practice runs the one-lesson happy path", async ({
+test("the welcome-started practice runs create then D through graduation", async ({
   page,
 }) => {
   await page.goto("/week", { waitUntil: "domcontentloaded" });
   await leaveWelcome(page);
 
   const showcase = page.getByRole("region", { name: "Shortcut practice" });
-  await expect(showcase).toContainText("Create an event");
+  await expect(showcase).toContainText("Drop an event on the board");
   await expect(showcase).toContainText("Press C to start a new event.");
+  await expect(showcase).toContainText("Mission 1 of 6");
 
   await page.keyboard.press("c");
   await expect(showcase).toContainText("Type a title, then press Enter");
 
-  // The practice title editor autofocuses; Enter commits it.
   await page.keyboard.type("Practice Event");
   await page.keyboard.press("Enter");
-  await expect(showcase).toContainText("young cap'n");
   await expect(showcase).toContainText("Practice Event");
+  await expect(showcase).toContainText("Mission 2 of 6");
 
+  for (let i = 0; i < 5; i += 1) {
+    await showcase.getByRole("button", { name: "Do it for me" }).click();
+  }
+
+  await expect(showcase).toContainText("young cap'n");
   await page.keyboard.press("Enter");
   await expect(showcase).toHaveCount(0);
 
-  // Graduation lands on the real calendar: seeded events + the handoff to
-  // create a real one.
   await expect(
     page.getByRole("complementary", { name: "Create your first event" }),
   ).toBeVisible();
@@ -61,14 +64,12 @@ test("Skip to sign up leaves the practice for the signup form on step 1", async 
   await leaveWelcome(page);
 
   const showcase = page.getByRole("region", { name: "Shortcut practice" });
-  await expect(showcase).toContainText("Create an event");
+  await expect(showcase).toContainText("Drop an event on the board");
 
-  // One click, from the first step, with no lesson finished and no confirm.
-  // The advertised S letter, not a click: the side actions are key-bound.
   await expect(
     showcase.getByRole("button", { name: /Skip to sign up/ }),
   ).toBeVisible();
-  await page.keyboard.press("s");
+  await page.keyboard.press("u");
   await expect(showcase).toHaveCount(0);
   await expect(page).toHaveURL(/auth=signup/);
 });
@@ -80,7 +81,7 @@ test("Escape leaves the practice and it never auto-replays", async ({
   await leaveWelcome(page);
 
   const showcase = page.getByRole("region", { name: "Shortcut practice" });
-  await expect(showcase).toContainText("Create an event");
+  await expect(showcase).toContainText("Drop an event on the board");
 
   await page.keyboard.press("Escape");
   await expect(showcase).toHaveCount(0);

--- a/e2e/onboarding/shortcut-showcase.spec.ts
+++ b/e2e/onboarding/shortcut-showcase.spec.ts
@@ -44,8 +44,17 @@ test("the welcome-started practice runs create then D through graduation", async
   await expect(showcase).toContainText("Practice Event");
   await expect(showcase).toContainText("Mission 2 of 6");
 
-  for (let i = 0; i < 5; i += 1) {
-    await showcase.getByRole("button", { name: "Do it for me" }).click();
+  // Compass blocks trusted pointer clicks; D is the assist binding.
+  const remainingMissions = [
+    "Hold fast — reveal the jump keys",
+    "Pick a target",
+    "Nudge it into place",
+    "Grab the title",
+    "When you forget, ask the palette",
+  ];
+  for (const title of remainingMissions) {
+    await expect(showcase).toContainText(title);
+    await page.keyboard.press("d");
   }
 
   await expect(showcase).toContainText("young cap'n");

--- a/packages/web/src/components/AuthModal/AuthModal.test.tsx
+++ b/packages/web/src/components/AuthModal/AuthModal.test.tsx
@@ -9,7 +9,7 @@ import {
 } from "@tanstack/react-router";
 import { act, type ReactElement } from "react";
 import "@testing-library/jest-dom";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createTestEmailPasswordPort } from "@web/__tests__/helpers/web-test-seams";
 import { createTestRouter } from "@web/__tests__/utils/providers/createTestRouter";
@@ -1080,6 +1080,87 @@ describe("URL Parameter Support", () => {
         screen.getByRole("heading", { name: /nice to meet you/i }),
       ).toBeInTheDocument();
     });
+  });
+});
+
+describe("Shortcut hints", () => {
+  beforeEach(() => {
+    installAuthModalTestSeams();
+  });
+
+  it("shows U, G, and Enter chips on login and switches to signup with U", async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(<ModalTrigger />);
+
+    await user.click(screen.getByRole("button", { name: /open modal/i }));
+    await waitForAuthModal();
+
+    expect(
+      within(screen.getByRole("button", { name: /^sign up$/i })).getByText("U"),
+    ).toBeTruthy();
+    expect(
+      within(
+        screen.getByRole("button", { name: "Continue with Google" }),
+      ).getByText("G"),
+    ).toBeTruthy();
+    expect(
+      within(screen.getByRole("button", { name: /^log in$/i })).getByText(
+        "Enter",
+      ),
+    ).toBeTruthy();
+
+    await user.keyboard("u");
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /nice to meet you/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("types letters into email instead of switching views", async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(<ModalTrigger />);
+    await user.click(screen.getByRole("button", { name: /open modal/i }));
+    await waitForAuthModal();
+
+    const email = screen.getByLabelText(/email/i);
+    await user.click(email);
+    await user.keyboard("user@example.com");
+
+    expect(email).toHaveValue("user@example.com");
+    expect(
+      screen.getByRole("heading", { name: /hey, welcome back/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows i on signup and switches back to login with i", async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(<div />, "/?auth=signup");
+    await waitForAuthModal(/nice to meet you/i);
+
+    expect(
+      within(screen.getByRole("button", { name: /^log in$/i })).getByText("i"),
+    ).toBeTruthy();
+
+    await user.keyboard("i");
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /hey, welcome back/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("starts Google auth with G when focus is not in a field", async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(<ModalTrigger />);
+    await user.click(screen.getByRole("button", { name: /open modal/i }));
+    await waitForAuthModal();
+
+    await user.keyboard("g");
+
+    expect(mockGoogleLogin).toHaveBeenCalled();
   });
 });
 

--- a/packages/web/src/components/AuthModal/AuthModal.tsx
+++ b/packages/web/src/components/AuthModal/AuthModal.tsx
@@ -4,13 +4,16 @@ import { type FC, useCallback, useEffect, useRef, useState } from "react";
 import { consumeGoogleAuthNeedsConsentRetry } from "@web/auth/google/authorization/google-authorization.storage";
 import { useStartGoogleAuthorization } from "@web/auth/google/authorization/useStartGoogleAuthorization";
 import { useIsGoogleAvailable } from "@web/auth/google/hooks/useIsGoogleAvailable/useIsGoogleAvailable";
+import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
 import {
   dismissErrorToast,
   SESSION_EXPIRED_TOAST_ID,
 } from "@web/common/utils/toast/error-toast.util";
 import { GoogleButton } from "@web/components/AuthModal/components/GoogleButton";
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
+import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 import { useAppLockReason } from "@web/shortcuts/app-lock";
+import { keyboardKey } from "@web/shortcuts/is-bare-letter-key";
 import { ForgotPasswordForm } from "./forms/ForgotPasswordForm";
 import { LogInForm } from "./forms/LogInForm";
 import { ResetPasswordForm } from "./forms/ResetPasswordForm";
@@ -109,11 +112,47 @@ export const AuthModal: FC = () => {
     setView("forgotPassword");
   }, [setView]);
 
+  const showAuthSwitch = isLoginView || currentView === "signUp";
+
+  useEffect(() => {
+    if (!isOpen || !showAuthSwitch) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      if (isEditableKeyboardTarget(event)) return;
+      const key = keyboardKey(event).toLowerCase();
+      if (key === "g" && isGoogleAvailable) {
+        event.preventDefault();
+        handleGoogleSignIn();
+        return;
+      }
+      if (key === "u" && isLoginView) {
+        event.preventDefault();
+        setView("signUp");
+        return;
+      }
+      if (key === "i" && currentView === "signUp") {
+        event.preventDefault();
+        setView("login");
+      }
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [
+    currentView,
+    handleGoogleSignIn,
+    isGoogleAvailable,
+    isLoginView,
+    isOpen,
+    setView,
+    showAuthSwitch,
+  ]);
+
   if (!isOpen) {
     return null;
   }
 
-  const showAuthSwitch = isLoginView || currentView === "signUp";
   const showGoogleAuth = currentView !== "resetPassword" && isGoogleAvailable;
   const showSubmitError =
     submitError !== null && (isLoginView || currentView === "signUp");
@@ -137,9 +176,12 @@ export const AuthModal: FC = () => {
           <button
             type="button"
             onClick={handleSwitchAuth}
-            className="shrink-0 rounded-3xl bg-[#c2c6cc] px-4 py-1.5 text-[#1f1f1f] text-xs transition-all hover:bg-[#d1d5da]"
+            className="inline-flex shrink-0 items-center gap-2 rounded-3xl bg-[#c2c6cc] px-4 py-1.5 text-[#1f1f1f] text-xs transition-all hover:bg-[#d1d5da]"
           >
             {isLoginView ? "Sign up" : "Log in"}
+            <ShortcutHint className="shrink-0">
+              {isLoginView ? "U" : "i"}
+            </ShortcutHint>
           </button>
         ) : null
       }
@@ -200,6 +242,7 @@ export const AuthModal: FC = () => {
               onClick={handleGoogleSignIn}
               disabled={isGoogleAuthLoading}
               label="Continue with Google"
+              shortcutKey="G"
               style={{ width: "100%" }}
             />
           </>

--- a/packages/web/src/components/AuthModal/components/GoogleButton.tsx
+++ b/packages/web/src/components/AuthModal/components/GoogleButton.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import type React from "react";
+import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 
 /**
  * Monochrome Google "G" logo SVG
@@ -37,11 +38,13 @@ export const GoogleButton = ({
   onClick,
   disabled,
   label = "Sign in with Google",
+  shortcutKey,
   style,
 }: {
   onClick: () => void;
   disabled?: boolean;
   label?: string;
+  shortcutKey?: string;
   style?: React.CSSProperties;
 }) => {
   return (
@@ -63,6 +66,9 @@ export const GoogleButton = ({
     >
       <GoogleGLogo size={18} />
       <span>{label}</span>
+      {shortcutKey ? (
+        <ShortcutHint className="shrink-0">{shortcutKey}</ShortcutHint>
+      ) : null}
     </button>
   );
 };

--- a/packages/web/src/components/AuthModal/forms/LogInForm.tsx
+++ b/packages/web/src/components/AuthModal/forms/LogInForm.tsx
@@ -3,6 +3,7 @@ import {
   type LogInFormData,
   LogInSchema,
 } from "@web/auth/compass/schemas/auth.schemas";
+import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 import { AuthButton } from "../components/AuthButton";
 import { AuthInput } from "../components/AuthInput";
 import { useZodForm } from "../hooks/useZodForm";
@@ -75,10 +76,12 @@ export const LogInForm: FC<SignInFormProps> = ({
 
       <AuthButton
         type="submit"
+        className="inline-flex items-center justify-center gap-2"
         disabled={!form.isValid}
         isLoading={isSubmitting}
       >
         Log in
+        <ShortcutHint className="shrink-0">Enter</ShortcutHint>
       </AuthButton>
     </form>
   );

--- a/packages/web/src/components/AuthModal/forms/SignUpForm.tsx
+++ b/packages/web/src/components/AuthModal/forms/SignUpForm.tsx
@@ -3,6 +3,7 @@ import {
   type SignUpFormData,
   SignUpSchema,
 } from "@web/auth/compass/schemas/auth.schemas";
+import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 import { AuthButton } from "../components/AuthButton";
 import { AuthInput } from "../components/AuthInput";
 import { useZodForm } from "../hooks/useZodForm";
@@ -80,10 +81,12 @@ export const SignUpForm: FC<SignUpFormProps> = ({
 
       <AuthButton
         type="submit"
+        className="inline-flex items-center justify-center gap-2"
         disabled={!form.isValid}
         isLoading={isSubmitting}
       >
         Sign up
+        <ShortcutHint className="shrink-0">Enter</ShortcutHint>
       </AuthButton>
     </form>
   );

--- a/packages/web/src/components/ShortcutShowcase/PracticeCalendar.tsx
+++ b/packages/web/src/components/ShortcutShowcase/PracticeCalendar.tsx
@@ -13,6 +13,7 @@ import {
   SHOWCASE_GRID_END_HOUR,
   SHOWCASE_GRID_START_HOUR,
 } from "@web/components/ShortcutShowcase/practice.state";
+import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 
 const DAY_LABELS = ["Mon", "Tue", "Wed"];
 const GRID_START_MIN = SHOWCASE_GRID_START_HOUR * 60;
@@ -74,7 +75,19 @@ const PracticeBlock: FC<{
           }}
         />
       ) : (
-        <div className="truncate font-medium">{block.title || "New event"}</div>
+        <div className="flex items-start justify-between gap-1">
+          <div className="min-w-0 truncate font-medium">
+            {block.title || "New event"}
+          </div>
+          {state.jumpHintsVisible && (
+            <ShortcutHint className="shrink-0">
+              {block.jumpKey.toUpperCase()}
+            </ShortcutHint>
+          )}
+          {state.editArmed && isFocused && (
+            <ShortcutHint className="shrink-0">T</ShortcutHint>
+          )}
+        </div>
       )}
       {height > 8 && (
         <div className="truncate opacity-80">
@@ -101,7 +114,10 @@ export const PracticeCalendar: FC<{
   }
 
   return (
-    <div className="relative flex h-full min-h-0 w-full select-none">
+    <div
+      className="relative flex h-full min-h-0 w-full select-none"
+      data-practice-jump="calendar"
+    >
       {/* Time column */}
       <div className="flex w-14 shrink-0 flex-col border-border border-r pr-2 text-right">
         <div className="h-7" />

--- a/packages/web/src/components/ShortcutShowcase/PracticePalette.tsx
+++ b/packages/web/src/components/ShortcutShowcase/PracticePalette.tsx
@@ -1,0 +1,29 @@
+import { type FC } from "react";
+import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
+
+/**
+ * Sandbox-only command palette for the showcase palette mission. The real
+ * palette stays locked behind the takeover's app-lock; this overlay teaches
+ * Mod+K without navigating the live app.
+ */
+export const PracticePalette: FC<{
+  onRun: () => void;
+}> = ({ onRun }) => {
+  return (
+    <div
+      role="dialog"
+      aria-label="Practice command palette"
+      className="absolute inset-x-4 top-8 z-10 rounded-xl border border-border bg-surface-raised p-3 shadow-xl"
+    >
+      <p className="mb-2 text-text-muted text-xs">Command palette</p>
+      <button
+        type="button"
+        className="c-focus-ring flex w-full items-center justify-between gap-2 rounded-md bg-surface-overlay px-3 py-2 text-left text-sm text-text"
+        onClick={onRun}
+      >
+        Focus Team sync
+        <ShortcutHint className="shrink-0">Enter</ShortcutHint>
+      </button>
+    </div>
+  );
+};

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
@@ -1,10 +1,12 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { resolveModifier } from "@tanstack/react-hotkeys";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { dispatchMissingKey } from "@web/__tests__/utils/keyboard.test.util";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 import { ShortcutShowcase } from "@web/components/ShortcutShowcase/ShortcutShowcase";
 import {
+  SHOWCASE_MISSION_IDS,
   SHOWCASE_STEP_IDS,
   type ShowcaseStepId,
 } from "@web/components/ShortcutShowcase/showcase.steps";
@@ -102,32 +104,34 @@ describe("ShortcutShowcase", () => {
     expect(screen.getByLabelText("Shortcut practice")).toBeTruthy();
   });
 
-  it("teaches create as one motion, and graduates on Enter", async () => {
+  it("teaches create as one motion, then continues to the next mission", async () => {
     const user = userEvent.setup();
     render(<ShortcutShowcase />);
     act(() => shortcutShowcaseActions.replay());
     expect(currentStepId()).toBe("create");
     expect(screen.getByText("Press C to start a new event.")).toBeTruthy();
+    expect(screen.getByText("Mission 1 of 6")).toBeTruthy();
 
-    // C opens a draft with its title editor; the lesson stays on "create"
-    // and the hint swaps rather than advancing to a second step.
     pressKey("c");
     expect(currentStepId()).toBe("create");
     expect(screen.getByText(/Type a title, then press Enter/)).toBeTruthy();
 
-    // Typing a title and pressing Enter commits it and advances.
     await user.type(
       screen.getByLabelText("Event title"),
       "Coffee with Alex{Enter}",
     );
-    expect(currentStepId()).toBe("graduation");
+    expect(currentStepId()).toBe("pageJump");
     expect(screen.getByText("Coffee with Alex")).toBeTruthy();
+    expect(screen.getByText("Mission 2 of 6")).toBeTruthy();
+  });
+
+  it("graduates on Enter from the graduation step", async () => {
+    render(<ShortcutShowcase />);
+    showStep("graduation");
     expect(screen.getByText(/young cap'n/)).toBeTruthy();
-    await waitFor(() => {
-      expect(
-        screen.getByRole("button", { name: /Enter Compass/ }),
-      ).toHaveFocus();
-    });
+
+    const enterCompass = screen.getByRole("button", { name: "Enter Compass" });
+    expect(within(enterCompass).queryByText("Enter")).toBeNull();
 
     pressKey("Enter");
     expect(screen.getByLabelText("Shortcut practice")).toHaveAttribute(
@@ -145,9 +149,6 @@ describe("ShortcutShowcase", () => {
       { timeout: 2000 },
     );
     expect(screen.queryByLabelText("Shortcut practice")).toBeNull();
-    expect(
-      persistentBrowserStore.get(STORAGE_KEYS.HAS_SEEN_SHORTCUT_SHOWCASE),
-    ).toBe("true");
   });
 
   it("fades the takeover on Enter Compass, then unmounts", async () => {
@@ -203,7 +204,7 @@ describe("ShortcutShowcase", () => {
     }
   });
 
-  it("'Do it for me' performs the whole lesson and lands on graduation", async () => {
+  it("'Do it for me' advances one mission at a time through graduation", async () => {
     const user = userEvent.setup();
     render(
       <>
@@ -214,8 +215,11 @@ describe("ShortcutShowcase", () => {
     const outside = screen.getByRole("button", { name: "Outside calendar" });
     act(() => shortcutShowcaseActions.replay());
 
-    // No idle wait or failed attempt required: the way out is always offered.
-    await user.click(screen.getByRole("button", { name: "Do it for me" }));
+    for (let i = 0; i < SHOWCASE_MISSION_IDS.length; i += 1) {
+      expect(currentStepId()).toBe(SHOWCASE_MISSION_IDS[i]);
+      await user.click(screen.getByRole("button", { name: "Do it for me" }));
+    }
+
     expect(currentStepId()).toBe("graduation");
     expect(screen.queryByRole("button", { name: "Do it for me" })).toBeNull();
     const enterCompass = screen.getByRole("button", { name: "Enter Compass" });
@@ -227,6 +231,76 @@ describe("ShortcutShowcase", () => {
     expect(outside).not.toHaveFocus();
     await user.tab();
     expect(enterCompass).toHaveFocus();
+  });
+
+  it("does not treat S as skip-to-signup; U leaves for signup", () => {
+    render(<ShortcutShowcase />);
+    act(() => shortcutShowcaseActions.replay());
+
+    pressKey("s");
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
+    expect(currentStepId()).toBe("create");
+
+    pressKey("u");
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
+  });
+
+  it("advances the hold-Mod mission after revealing jump keys", () => {
+    const modKey = resolveModifier("Mod") === "Meta" ? "Meta" : "Control";
+    render(<ShortcutShowcase />);
+    showStep("pageJump");
+
+    pressKey(modKey);
+    expect(screen.getByText("1")).toBeTruthy();
+    expect(screen.getByText("2")).toBeTruthy();
+
+    pressKey("1", { code: "Digit1" });
+    expect(currentStepId()).toBe("eventJump");
+  });
+
+  it("teaches S then a letter to land on an event", () => {
+    render(<ShortcutShowcase />);
+    showStep("eventJump");
+
+    pressKey("s");
+    expect(screen.getByText("F")).toBeTruthy();
+
+    pressKey("f");
+    expect(currentStepId()).toBe("nudge");
+  });
+
+  it("teaches Shift+arrow to nudge the focused event", () => {
+    render(<ShortcutShowcase />);
+    showStep("nudge");
+
+    pressKey("ArrowRight", { shiftKey: true });
+    expect(currentStepId()).toBe("editTitle");
+  });
+
+  it("teaches E then T to target the title", async () => {
+    const user = userEvent.setup();
+    render(<ShortcutShowcase />);
+    showStep("editTitle");
+
+    pressKey("e");
+    pressKey("t");
+    expect(currentStepId()).toBe("editTitle");
+    expect(screen.getByLabelText("Event title")).toBeTruthy();
+
+    await user.type(screen.getByLabelText("Event title"), "{Enter}");
+    expect(currentStepId()).toBe("palette");
+  });
+
+  it("opens a practice palette with Mod+K and completes on Enter", () => {
+    const isMac = resolveModifier("Mod") === "Meta";
+    render(<ShortcutShowcase />);
+    showStep("palette");
+
+    pressKey("k", isMac ? { metaKey: true } : { ctrlKey: true });
+    expect(screen.getByLabelText("Practice command palette")).toBeTruthy();
+
+    pressKey("Enter");
+    expect(currentStepId()).toBe("graduation");
   });
 
   it("offers 'Skip to sign up' from the first step and leaves on the first click", async () => {

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
@@ -1,3 +1,4 @@
+import { resolveModifier } from "@tanstack/react-hotkeys";
 import {
   type FC,
   type KeyboardEvent as ReactKeyboardEvent,
@@ -15,14 +16,25 @@ import { useDismissTransition } from "@web/common/hooks/useDismissTransition";
 import { getFocusableElements } from "@web/common/utils/focusable-elements";
 import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
 import { PracticeCalendar } from "@web/components/ShortcutShowcase/PracticeCalendar";
+import { PracticePalette } from "@web/components/ShortcutShowcase/PracticePalette";
 import {
+  armEdit,
   commitTitle,
   createDraft,
+  disarmEdit,
+  ensureFocused,
   initialPracticeState,
+  jumpToEvent,
+  nudgeFocused,
+  openTitleFromEdit,
+  PRACTICE_TEAM_SYNC_ID,
+  type PracticeNudgeDirection,
   type PracticeState,
+  toggleJumpHints,
 } from "@web/components/ShortcutShowcase/practice.state";
 import {
   getCreateLessonPhase,
+  getMissionLabel,
   getShowcaseStep,
 } from "@web/components/ShortcutShowcase/showcase.steps";
 import {
@@ -35,16 +47,32 @@ import {
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import { useAppLockReason } from "@web/shortcuts/app-lock";
-import { isBareLetterKey } from "@web/shortcuts/is-bare-letter-key";
+import {
+  isBareLetterKey,
+  keyboardKey,
+} from "@web/shortcuts/is-bare-letter-key";
 import { KEYMAP } from "@web/shortcuts/keymap";
 import { ShortcutTipParts } from "@web/shortcuts/tips/ShortcutTipParts";
 
 const TEXT_BUTTON_CLASS =
-  "c-focus-ring rounded-md px-2 py-1 text-text-muted text-xs hover:bg-surface-overlay hover:text-text";
+  "c-focus-ring inline-flex items-center gap-2 rounded-md px-2 py-1 text-text-muted text-xs hover:bg-surface-overlay hover:text-text";
 const PRIMARY_BUTTON_CLASS =
-  "c-button c-button-primary rounded-full px-4 py-1.5 text-xs";
+  "c-button c-button-primary inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-xs";
 const SECONDARY_BUTTON_CLASS =
-  "c-button c-button-secondary rounded-full px-4 py-1.5 text-xs";
+  "c-button c-button-secondary inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-xs";
+
+const isPlatformModKey = (event: KeyboardEvent) =>
+  resolveModifier("Mod") === "Meta"
+    ? event.key === "Meta"
+    : event.key === "Control";
+
+const arrowDirection = (key: string): PracticeNudgeDirection | null => {
+  if (key === "ArrowUp") return "up";
+  if (key === "ArrowDown") return "down";
+  if (key === "ArrowLeft") return "left";
+  if (key === "ArrowRight") return "right";
+  return null;
+};
 
 /**
  * Full-screen practice arena shown before a new user ever sees the real
@@ -52,8 +80,9 @@ const SECONDARY_BUTTON_CLASS =
  * behavior is a deliberately simplified reimplementation against ephemeral
  * practice state, so nothing here touches storage or the real grid stores.
  *
- * One lesson, taught as one continuous motion (create.steps.ts explains why);
- * graduation hands off to a prompt on the real calendar, not a checklist.
+ * Missions teach create, hold-Mod jumps, event jump, nudge, the E-then-T
+ * edit sequence, and Cmd+K; graduation hands off to a prompt on the real
+ * calendar. Skip is always offered.
  */
 const ShowcaseTakeover: FC = () => {
   const stepIndex = useShortcutShowcaseStore(selectShowcaseStepIndex);
@@ -62,25 +91,22 @@ const ShowcaseTakeover: FC = () => {
   const closingRef = useRef(false);
   closingRef.current = closing;
   const { openModal } = useAuthModal();
-  // Post-signup is now the showcase's main entry, and "sign up" is not an exit
-  // for someone who just did.
   const { authenticated } = useContext(SessionContext);
+  const [isModHeld, setIsModHeld] = useState(false);
+  const hasRevealedJumpsRef = useRef(false);
+  const [paletteOpen, setPaletteOpen] = useState(false);
+  const paletteOpenRef = useRef(false);
+  paletteOpenRef.current = paletteOpen;
 
-  // The takeover owns the keyboard: silence every real app handler
-  // (useAppShortcut, the e-sequence, bare letters s/f/m) while it is up.
   useAppLockReason("shortcutShowcase", true);
 
   const graduate = () => {
-    // Persist before the curtain so a reload during the reveal does not
-    // relaunch the takeover. finish() marks seen again when it unmounts.
     shortcutShowcaseActions.markSeen();
     beginDismiss(() => shortcutShowcaseActions.finish());
   };
   const graduateRef = useRef(graduate);
   graduateRef.current = graduate;
 
-  // The showcase is the last thing between a curious visitor and the flow that
-  // actually matters, so it always offers the door rather than guarding it.
   const skipToSignup = () => {
     shortcutShowcaseActions.skip("signup");
     track("signup_started", { source: "shortcut_showcase" });
@@ -123,9 +149,8 @@ const ShowcaseTakeover: FC = () => {
   const handleTitleCommit = useCallback(
     (title: string) => {
       apply((state) => commitTitle(state, title));
-      if (
-        stepIdAt(useShortcutShowcaseStore.getState().stepIndex) === "create"
-      ) {
+      const id = stepIdAt(useShortcutShowcaseStore.getState().stepIndex);
+      if (id === "create" || id === "editTitle") {
         advance();
       }
     },
@@ -143,7 +168,7 @@ const ShowcaseTakeover: FC = () => {
   // biome-ignore lint/correctness/useExhaustiveDependencies: stepId and practice.editor trigger a reseat after lesson chrome unmounts; seatFocus does not read them.
   useEffect(() => {
     seatFocus();
-  }, [seatFocus, stepId, practice.editor]);
+  }, [seatFocus, stepId, practice.editor, paletteOpen]);
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -155,7 +180,13 @@ const ShowcaseTakeover: FC = () => {
       }
       const currentStepId = stepIdAt(store.stepIndex);
 
-      // Let the title editor own typing; only Escape passes through it.
+      if (isPlatformModKey(event)) {
+        setIsModHeld(true);
+        if (currentStepId === "pageJump") {
+          hasRevealedJumpsRef.current = true;
+        }
+      }
+
       const target = event.target;
       if (
         target instanceof HTMLElement &&
@@ -168,9 +199,10 @@ const ShowcaseTakeover: FC = () => {
       if (event.key === "Escape") {
         event.preventDefault();
         event.stopPropagation();
-        // Escape inside the title editor closes the editor, never the
-        // showcase. The editor input is uncontrolled, so the typed text lives
-        // in the DOM, not in state.
+        if (paletteOpenRef.current) {
+          setPaletteOpen(false);
+          return;
+        }
         if (practiceRef.current.editor) {
           const input = document.querySelector<HTMLInputElement>(
             "[data-practice-title-input]",
@@ -182,22 +214,95 @@ const ShowcaseTakeover: FC = () => {
         return;
       }
 
+      if (paletteOpenRef.current) {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          setPaletteOpen(false);
+          if (currentStepId === "palette") advance();
+        }
+        return;
+      }
+
+      const isModChord = event.metaKey || event.ctrlKey;
+      if (
+        currentStepId === "palette" &&
+        isModChord &&
+        keyboardKey(event).toLowerCase() === "k"
+      ) {
+        event.preventDefault();
+        setPaletteOpen(true);
+        return;
+      }
+
       if (currentStepId === "graduation" && event.key === "Enter") {
         event.preventDefault();
         graduateRef.current();
         return;
       }
 
+      if (currentStepId === "pageJump") {
+        const digit = /^Digit([12])$/.exec(event.code);
+        if (digit && hasRevealedJumpsRef.current) {
+          event.preventDefault();
+          advance();
+          return;
+        }
+      }
+
+      if (currentStepId === "nudge") {
+        const direction = arrowDirection(event.key);
+        if (event.shiftKey && direction) {
+          event.preventDefault();
+          const before = practiceRef.current;
+          const next = apply((state) => nudgeFocused(state, direction));
+          if (next !== before) advance();
+          return;
+        }
+      }
+
       if (isBareLetterKey(event, KEYMAP.createEvent.hotkey.toLowerCase())) {
         event.preventDefault();
-        // Create never advances by itself: the lesson advances on title
-        // commit, so C -> type -> Enter reads as one motion, not two steps.
         apply(createDraft);
         return;
       }
 
-      // Side actions, letter-bound so the practice screen never needs a
-      // mouse. Only outside graduation - there Enter is the single action.
+      if (currentStepId === "eventJump") {
+        if (isBareLetterKey(event, KEYMAP.eventJump.bareLetter)) {
+          event.preventDefault();
+          apply(toggleJumpHints);
+          return;
+        }
+        const jumpKey = keyboardKey(event).toLowerCase();
+        if (jumpKey.length === 1 && practiceRef.current.jumpHintsVisible) {
+          const before = practiceRef.current;
+          const next = apply((state) => jumpToEvent(state, jumpKey));
+          if (next !== before) {
+            event.preventDefault();
+            advance();
+            return;
+          }
+        }
+      }
+
+      if (currentStepId === "editTitle") {
+        if (isBareLetterKey(event, KEYMAP.editTitle.sequence.leader)) {
+          event.preventDefault();
+          apply(armEdit);
+          return;
+        }
+        if (
+          practiceRef.current.editArmed &&
+          isBareLetterKey(event, KEYMAP.editTitle.sequence.second)
+        ) {
+          event.preventDefault();
+          apply(openTitleFromEdit);
+          return;
+        }
+        if (practiceRef.current.editArmed && event.key.length === 1) {
+          apply(disarmEdit);
+        }
+      }
+
       if (currentStepId !== "graduation") {
         if (isBareLetterKey(event, "d")) {
           event.preventDefault();
@@ -205,7 +310,7 @@ const ShowcaseTakeover: FC = () => {
           return;
         }
         if (
-          isBareLetterKey(event, "s") &&
+          isBareLetterKey(event, "u") &&
           !sideActionsRef.current.authenticated
         ) {
           event.preventDefault();
@@ -215,27 +320,60 @@ const ShowcaseTakeover: FC = () => {
         if (isBareLetterKey(event, "x")) {
           event.preventDefault();
           shortcutShowcaseActions.skip();
-          return;
         }
       }
     };
 
+    const onKeyUp = (event: KeyboardEvent) => {
+      if (isPlatformModKey(event)) setIsModHeld(false);
+    };
+    const clearMod = () => setIsModHeld(false);
+
     document.addEventListener("keydown", onKeyDown, true);
-    return () => document.removeEventListener("keydown", onKeyDown, true);
+    document.addEventListener("keyup", onKeyUp, true);
+    window.addEventListener("blur", clearMod);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown, true);
+      document.removeEventListener("keyup", onKeyUp, true);
+      window.removeEventListener("blur", clearMod);
+    };
   }, [apply]);
 
-  // Performs the lesson's action on the practice board, then moves on.
   const doItForMe = () => {
     track("shortcut_showcase_assist_used", { step: stepId });
     if (stepId === "create") {
       apply(createDraft);
       apply((state) => commitTitle(state, "Coffee with Alex"));
+    } else if (stepId === "eventJump") {
+      apply((state) => jumpToEvent({ ...state, jumpHintsVisible: true }, "f"));
+    } else if (stepId === "nudge") {
+      apply((state) => nudgeFocused(state, "right"));
+    } else if (stepId === "editTitle") {
+      apply((state) => {
+        const opened = openTitleFromEdit({
+          ...ensureFocused(state),
+          editArmed: true,
+        });
+        const focused = opened.events.find(
+          (event) => event.id === opened.focusedId,
+        );
+        return commitTitle(opened, focused?.title ?? "");
+      });
+    } else if (stepId === "palette") {
+      setPaletteOpen(false);
     }
     advance();
   };
 
-  // Side-action letters for the capture listener; refs because the listener
-  // mounts once (same pattern as graduateRef).
+  const runPracticeCommand = () => {
+    apply((state) => ({
+      ...ensureFocused(state),
+      focusedId: PRACTICE_TEAM_SYNC_ID,
+    }));
+    setPaletteOpen(false);
+    if (stepId === "palette") advance();
+  };
+
   const sideActionsRef = useRef({ doItForMe, skipToSignup, authenticated });
   sideActionsRef.current = { doItForMe, skipToSignup, authenticated };
 
@@ -245,7 +383,10 @@ const ShowcaseTakeover: FC = () => {
           ...getShowcaseStep("create"),
           ...getCreateLessonPhase(Boolean(practice.editor)),
         }
-      : getShowcaseStep("graduation");
+      : getShowcaseStep(stepId);
+
+  const missionLabel = getMissionLabel(stepId);
+  const showPageJumpHints = isModHeld && stepId === "pageJump";
 
   return (
     <section
@@ -260,7 +401,18 @@ const ShowcaseTakeover: FC = () => {
       <div
         className={`flex h-[80vh] max-h-160 w-full max-w-5xl gap-8 px-8 ${closing ? "c-showcase-enter-stage" : ""}`}
       >
-        <aside className="flex w-80 shrink-0 flex-col justify-center gap-4">
+        <aside
+          className="relative flex w-80 shrink-0 flex-col justify-center gap-4"
+          data-practice-jump="lesson"
+        >
+          {showPageJumpHints && (
+            <ShortcutHint className="absolute top-0 right-0">1</ShortcutHint>
+          )}
+          {missionLabel && (
+            <p className="font-medium text-accent text-xs uppercase tracking-wide">
+              {missionLabel}
+            </p>
+          )}
           <h2 className="font-semibold text-lg text-text">{step.title}</h2>
           <p className="text-sm text-text-muted">
             {typeof step.body === "string" ? (
@@ -272,14 +424,17 @@ const ShowcaseTakeover: FC = () => {
           {step.keycaps && <ShortcutKeys keys={[...step.keycaps]} />}
           <div className="flex flex-wrap items-center gap-2 pt-2">
             {stepId === "graduation" ? (
-              <button
-                type="button"
-                className={PRIMARY_BUTTON_CLASS}
-                disabled={closing}
-                onClick={graduate}
-              >
-                Enter Compass <ShortcutHint>Enter</ShortcutHint>
-              </button>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  className={PRIMARY_BUTTON_CLASS}
+                  disabled={closing}
+                  onClick={graduate}
+                >
+                  Enter Compass
+                </button>
+                <ShortcutHint className="shrink-0">Enter</ShortcutHint>
+              </div>
             ) : (
               <>
                 <button
@@ -287,7 +442,8 @@ const ShowcaseTakeover: FC = () => {
                   className={PRIMARY_BUTTON_CLASS}
                   onClick={doItForMe}
                 >
-                  Do it for me <ShortcutHint>D</ShortcutHint>
+                  Do it for me
+                  <ShortcutHint className="shrink-0">D</ShortcutHint>
                 </button>
                 {!authenticated && (
                   <button
@@ -295,7 +451,8 @@ const ShowcaseTakeover: FC = () => {
                     className={SECONDARY_BUTTON_CLASS}
                     onClick={skipToSignup}
                   >
-                    Skip to sign up <ShortcutHint>S</ShortcutHint>
+                    Skip to sign up
+                    <ShortcutHint className="shrink-0">U</ShortcutHint>
                   </button>
                 )}
               </>
@@ -306,12 +463,19 @@ const ShowcaseTakeover: FC = () => {
                 className={TEXT_BUTTON_CLASS}
                 onClick={() => shortcutShowcaseActions.skip()}
               >
-                Skip to calendar <ShortcutHint>X</ShortcutHint>
+                Skip to calendar
+                <ShortcutHint className="shrink-0">X</ShortcutHint>
               </button>
             )}
           </div>
         </aside>
-        <div className="min-w-0 flex-1 rounded-xl border border-border bg-surface p-4 shadow-xl">
+        <div className="relative min-w-0 flex-1 rounded-xl border border-border bg-surface p-4 shadow-xl">
+          {showPageJumpHints && (
+            <ShortcutHint className="absolute top-3 right-3 z-10">
+              2
+            </ShortcutHint>
+          )}
+          {paletteOpen && <PracticePalette onRun={runPracticeCommand} />}
           <PracticeCalendar
             state={practice}
             onTitleCommit={handleTitleCommit}

--- a/packages/web/src/components/ShortcutShowcase/practice.state.test.ts
+++ b/packages/web/src/components/ShortcutShowcase/practice.state.test.ts
@@ -70,7 +70,7 @@ describe("practice state transitions", () => {
     expect(armed.editArmed).toBe(true);
 
     const opened = openTitleFromEdit(armed);
-    expect(opened.editor?.eventId).toBe(focused.focusedId);
+    expect(opened.editor?.eventId).toBe(focused.focusedId ?? undefined);
     expect(opened.editor?.isNew).toBe(false);
     expect(opened.editArmed).toBe(false);
   });

--- a/packages/web/src/components/ShortcutShowcase/practice.state.test.ts
+++ b/packages/web/src/components/ShortcutShowcase/practice.state.test.ts
@@ -1,7 +1,14 @@
 import {
+  armEdit,
   commitTitle,
   createDraft,
+  ensureFocused,
   initialPracticeState,
+  jumpToEvent,
+  nudgeFocused,
+  openTitleFromEdit,
+  PRACTICE_TEAM_SYNC_ID,
+  toggleJumpHints,
 } from "@web/components/ShortcutShowcase/practice.state";
 import { describe, expect, it } from "bun:test";
 
@@ -34,5 +41,37 @@ describe("practice state transitions", () => {
     expect(commitTitle(initialPracticeState, "nope")).toBe(
       initialPracticeState,
     );
+  });
+
+  it("jumps to an event only while letter hints are visible", () => {
+    expect(jumpToEvent(initialPracticeState, "f")).toBe(initialPracticeState);
+
+    const hinted = toggleJumpHints(initialPracticeState);
+    expect(hinted.jumpHintsVisible).toBe(true);
+
+    const jumped = jumpToEvent(hinted, "f");
+    expect(jumped.focusedId).toBe(PRACTICE_TEAM_SYNC_ID);
+    expect(jumped.jumpHintsVisible).toBe(false);
+  });
+
+  it("nudges the focused event to a neighboring day", () => {
+    const focused = ensureFocused(initialPracticeState);
+    const team = focused.events.find((event) => event.id === focused.focusedId);
+    expect(team).toBeTruthy();
+
+    const moved = nudgeFocused(focused, "right");
+    const next = moved.events.find((event) => event.id === focused.focusedId);
+    expect(next?.dayIndex).toBe((team?.dayIndex ?? 0) + 1);
+  });
+
+  it("opens the title field from an armed edit sequence", () => {
+    const focused = ensureFocused(initialPracticeState);
+    const armed = armEdit(focused);
+    expect(armed.editArmed).toBe(true);
+
+    const opened = openTitleFromEdit(armed);
+    expect(opened.editor?.eventId).toBe(focused.focusedId);
+    expect(opened.editor?.isNew).toBe(false);
+    expect(opened.editArmed).toBe(false);
   });
 });

--- a/packages/web/src/components/ShortcutShowcase/practice.state.ts
+++ b/packages/web/src/components/ShortcutShowcase/practice.state.ts
@@ -22,12 +22,6 @@ export type PracticeEventBlock = {
 
 export type PracticeNudgeDirection = "up" | "down" | "left" | "right";
 
-export type PracticeJumpTarget = {
-  digit: string;
-  id: "lesson" | "calendar";
-  label: string;
-};
-
 export type PracticeState = {
   events: PracticeEventBlock[];
   focusedId: string | null;
@@ -43,11 +37,6 @@ export const SHOWCASE_GRID_END_HOUR = 18;
 export const SHOWCASE_DAY_COUNT = 3;
 export const PRACTICE_NUDGE_MIN = 15;
 export const PRACTICE_TEAM_SYNC_ID = "practice-team-sync";
-
-export const PRACTICE_JUMP_TARGETS: readonly PracticeJumpTarget[] = [
-  { digit: "1", id: "lesson", label: "Lesson" },
-  { digit: "2", id: "calendar", label: "Calendar" },
-];
 
 const PRACTICE_DRAFT_ID = "practice-draft";
 const GRID_START_MIN = SHOWCASE_GRID_START_HOUR * 60;

--- a/packages/web/src/components/ShortcutShowcase/practice.state.ts
+++ b/packages/web/src/components/ShortcutShowcase/practice.state.ts
@@ -5,11 +5,6 @@ import { type EventColorSlot } from "@core/types/event-color.contracts";
  * touches storage, queries, or the real grid stores: the blocks exist only
  * while the takeover is mounted, so every transition can be a plain pure
  * function with no side effects.
- *
- * Only the one gating lesson lives here (create a draft, then title-and-save
- * as one continuous motion). Graduation hands off to a prompt on the real
- * calendar, not a checklist that reimplements jump, move, stretch, place and
- * undo.
  */
 
 export type PracticeEventBlock = {
@@ -21,6 +16,16 @@ export type PracticeEventBlock = {
   startMin: number;
   endMin: number;
   color?: EventColorSlot;
+  /** Letter shown while event-jump hints are visible. */
+  jumpKey: string;
+};
+
+export type PracticeNudgeDirection = "up" | "down" | "left" | "right";
+
+export type PracticeJumpTarget = {
+  digit: string;
+  id: "lesson" | "calendar";
+  label: string;
 };
 
 export type PracticeState = {
@@ -28,13 +33,25 @@ export type PracticeState = {
   focusedId: string | null;
   /** Open title editor; `isNew` marks the create-step draft. */
   editor: { eventId: string; isNew: boolean } | null;
+  jumpHintsVisible: boolean;
+  /** `e` leader is armed; `t` opens the title field. */
+  editArmed: boolean;
 };
 
 export const SHOWCASE_GRID_START_HOUR = 8;
 export const SHOWCASE_GRID_END_HOUR = 18;
 export const SHOWCASE_DAY_COUNT = 3;
+export const PRACTICE_NUDGE_MIN = 15;
+export const PRACTICE_TEAM_SYNC_ID = "practice-team-sync";
+
+export const PRACTICE_JUMP_TARGETS: readonly PracticeJumpTarget[] = [
+  { digit: "1", id: "lesson", label: "Lesson" },
+  { digit: "2", id: "calendar", label: "Calendar" },
+];
 
 const PRACTICE_DRAFT_ID = "practice-draft";
+const GRID_START_MIN = SHOWCASE_GRID_START_HOUR * 60;
+const GRID_END_MIN = SHOWCASE_GRID_END_HOUR * 60;
 
 export const initialPracticeState: PracticeState = {
   events: [
@@ -44,14 +61,16 @@ export const initialPracticeState: PracticeState = {
       dayIndex: 0,
       startMin: 9 * 60,
       endMin: 10 * 60,
+      jumpKey: "a",
     },
     {
-      id: "practice-team-sync",
+      id: PRACTICE_TEAM_SYNC_ID,
       title: "Team sync",
       dayIndex: 1,
       startMin: 10 * 60,
       endMin: 11 * 60,
       color: "blue",
+      jumpKey: "f",
     },
     {
       id: "practice-gym",
@@ -60,10 +79,13 @@ export const initialPracticeState: PracticeState = {
       startMin: 12 * 60,
       endMin: 12 * 60 + 45,
       color: "green",
+      jumpKey: "g",
     },
   ],
   focusedId: null,
   editor: null,
+  jumpHintsVisible: false,
+  editArmed: false,
 };
 
 export const createDraft = (state: PracticeState): PracticeState => {
@@ -74,12 +96,14 @@ export const createDraft = (state: PracticeState): PracticeState => {
     dayIndex: 1,
     startMin: 13 * 60,
     endMin: 14 * 60,
+    jumpKey: "n",
   };
   return {
     ...state,
-    events: [...state.events.filter((e) => e.id !== draft.id), draft],
+    events: [...state.events.filter((event) => event.id !== draft.id), draft],
     focusedId: draft.id,
     editor: { eventId: draft.id, isNew: true },
+    editArmed: false,
   };
 };
 
@@ -94,5 +118,92 @@ export const commitTitle = (
       ? { ...event, title: title.trim() || "New event" }
       : event,
   );
-  return { ...state, events, editor: null };
+  return { ...state, events, editor: null, editArmed: false };
 };
+
+export const toggleJumpHints = (state: PracticeState): PracticeState => ({
+  ...state,
+  jumpHintsVisible: !state.jumpHintsVisible,
+});
+
+export const jumpToEvent = (
+  state: PracticeState,
+  jumpKey: string,
+): PracticeState => {
+  if (!state.jumpHintsVisible) return state;
+  const match = state.events.find(
+    (event) => event.jumpKey === jumpKey.toLowerCase(),
+  );
+  if (!match) return state;
+  return { ...state, focusedId: match.id, jumpHintsVisible: false };
+};
+
+export const ensureFocused = (state: PracticeState): PracticeState => {
+  if (
+    state.focusedId &&
+    state.events.some((event) => event.id === state.focusedId)
+  ) {
+    return state;
+  }
+  const fallback =
+    state.events.find((event) => event.id === PRACTICE_TEAM_SYNC_ID) ??
+    state.events[0];
+  if (!fallback) return state;
+  return { ...state, focusedId: fallback.id };
+};
+
+export const nudgeFocused = (
+  state: PracticeState,
+  direction: PracticeNudgeDirection,
+): PracticeState => {
+  const focused = ensureFocused(state);
+  if (!focused.focusedId) return state;
+
+  let moved = false;
+  const events = focused.events.map((event) => {
+    if (event.id !== focused.focusedId) return event;
+    if (direction === "left" || direction === "right") {
+      const dayIndex = Math.max(
+        0,
+        Math.min(
+          SHOWCASE_DAY_COUNT - 1,
+          event.dayIndex + (direction === "right" ? 1 : -1),
+        ),
+      );
+      if (dayIndex === event.dayIndex) return event;
+      moved = true;
+      return { ...event, dayIndex };
+    }
+    const duration = event.endMin - event.startMin;
+    const delta =
+      direction === "down" ? PRACTICE_NUDGE_MIN : -PRACTICE_NUDGE_MIN;
+    const startMin = Math.max(
+      GRID_START_MIN,
+      Math.min(GRID_END_MIN - duration, event.startMin + delta),
+    );
+    if (startMin === event.startMin) return event;
+    moved = true;
+    return { ...event, startMin, endMin: startMin + duration };
+  });
+
+  if (!moved) return focused === state ? state : focused;
+  return { ...focused, events };
+};
+
+export const armEdit = (state: PracticeState): PracticeState => {
+  const focused = ensureFocused(state);
+  if (!focused.focusedId || focused.editor) return state;
+  return { ...focused, editArmed: true };
+};
+
+export const openTitleFromEdit = (state: PracticeState): PracticeState => {
+  if (!state.editArmed || !state.focusedId) return state;
+  return {
+    ...state,
+    editArmed: false,
+    editor: { eventId: state.focusedId, isNew: false },
+  };
+};
+
+export const disarmEdit = (state: PracticeState): PracticeState =>
+  state.editArmed ? { ...state, editArmed: false } : state;

--- a/packages/web/src/components/ShortcutShowcase/showcase.steps.ts
+++ b/packages/web/src/components/ShortcutShowcase/showcase.steps.ts
@@ -4,22 +4,27 @@ import { type ShortcutTipPart } from "@web/shortcuts/tips/shortcut-tips.data";
 /**
  * Single source of truth for showcase step order.
  *
- * One lesson, deliberately. The ten-lesson version lost 40% of the people who
- * cleared step one before graduation (113 -> 68 over 30 days); cutting it to
- * two lessons (create, then save) still left the highest drop-off of any step
- * on the artificial boundary between "press C" and "type a title" - one
- * continuous motion taught as two. What is left is that one loop, taught as
- * one lesson with a hint that advances as the user acts (see
- * getCreateLessonPhase): put an event on the calendar without touching the
- * mouse. Graduation now hands off to a prompt on the real calendar, not a
- * checklist that re-teaches jump, move, stretch, place and undo on sample
- * events - "graduation" is the exit, not a lesson.
+ * Missions teach the core keyboard patterns on a sandbox calendar, then
+ * graduation hands off to a prompt on the real calendar. Skip is always
+ * offered: the practice is a game, not a gate.
  */
-const STEP_IDS = ["create", "graduation"] as const;
+const STEP_IDS = [
+  "create",
+  "pageJump",
+  "eventJump",
+  "nudge",
+  "editTitle",
+  "palette",
+  "graduation",
+] as const;
 
 export type ShowcaseStepId = (typeof STEP_IDS)[number];
 
 export const SHOWCASE_STEP_IDS: readonly ShowcaseStepId[] = STEP_IDS;
+
+export const SHOWCASE_MISSION_IDS = STEP_IDS.filter(
+  (id): id is Exclude<ShowcaseStepId, "graduation"> => id !== "graduation",
+);
 
 export type ShowcaseStep = {
   id: ShowcaseStepId;
@@ -33,18 +38,61 @@ export type ShowcaseStep = {
   keycaps?: readonly string[];
 };
 
-// Keycaps reference KEYMAP so a remap updates the hints automatically.
 const STEP_CONTENT: Record<ShowcaseStepId, Omit<ShowcaseStep, "id">> = {
   create: {
-    title: "Create an event",
+    title: "Drop an event on the board",
     body: "Press C to start a new event.",
     keycaps: KEYMAP.createEvent.keycaps,
   },
+  pageJump: {
+    title: "Hold fast — reveal the jump keys",
+    body: [
+      "Hold ",
+      { key: KEYMAP.jumpPageTarget.holdModifier },
+      " to see jump keys, then press 1 or 2.",
+    ],
+    keycaps: ["Mod", "1-2"],
+  },
+  eventJump: {
+    title: "Pick a target",
+    body: [
+      "Tap ",
+      { key: "S" },
+      " to show event keys, then press a letter to land on one.",
+    ],
+    keycaps: KEYMAP.eventJump.keycaps,
+  },
+  nudge: {
+    title: "Nudge it into place",
+    body: [
+      "Hold ",
+      { key: "Shift" },
+      " and press an arrow to move the focused event.",
+    ],
+    keycaps: KEYMAP.moveEvent.keycaps,
+  },
+  editTitle: {
+    title: "Grab the title",
+    body: [
+      "With an event focused, press ",
+      { key: "E" },
+      " then ",
+      { key: "T" },
+      " to target the title.",
+    ],
+    keycaps: KEYMAP.editTitle.keycaps,
+  },
+  palette: {
+    title: "When you forget, ask the palette",
+    body: [
+      "Press ",
+      { keys: KEYMAP.commandPalette.keycaps },
+      " to open the command palette. Enter runs the highlighted command.",
+    ],
+    keycaps: KEYMAP.commandPalette.keycaps,
+  },
   graduation: {
     title: "You've shown great control, young cap'n.",
-    // Seeds the one habit that reveals the rest: holding Mod shows jump keys
-    // wherever you are (form fields, page areas), so graduation teaches the
-    // gesture instead of a checklist of shortcuts.
     body: [
       "That was practice. Your real calendar is next — the same two keys put a real event on it. And whenever you wonder where to go, hold ",
       { key: KEYMAP.jumpPageTarget.holdModifier },
@@ -55,6 +103,12 @@ const STEP_CONTENT: Record<ShowcaseStepId, Omit<ShowcaseStep, "id">> = {
 
 export function getShowcaseStep(id: ShowcaseStepId): ShowcaseStep {
   return { id, ...STEP_CONTENT[id] };
+}
+
+export function getMissionLabel(id: ShowcaseStepId): string | null {
+  if (id === "graduation") return null;
+  const number = SHOWCASE_MISSION_IDS.indexOf(id) + 1;
+  return `Mission ${number} of ${SHOWCASE_MISSION_IDS.length}`;
 }
 
 /**

--- a/packages/web/src/components/ShortcutShowcase/showcase.store.ts
+++ b/packages/web/src/components/ShortcutShowcase/showcase.store.ts
@@ -83,7 +83,7 @@ export const shortcutShowcaseActions = {
   /**
    * Leaving before graduation. There is no "are you sure?" in the way: the
    * showcase is an offer, and the flow it guards (sign up, connect a calendar)
-   * matters more than the two lessons.
+   * matters more than the missions.
    */
   skip: (exit: ShowcaseExit = "calendar") => {
     const { isActive, stepIndex } = useShortcutShowcaseStore.getState();

--- a/packages/web/src/components/WelcomeModal/WelcomeGuideBody.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeGuideBody.test.tsx
@@ -30,8 +30,8 @@ describe("WelcomeGuideBody", () => {
   it("explains that numbered shortcuts open the FAQ", () => {
     render(<WelcomeGuideBody />);
 
-    expect(screen.getByText(/to see keys/)).toBeTruthy();
-    expect(screen.getByText(/then press 1–5/)).toBeTruthy();
+    expect(screen.getByText(/to see keys, then press 1–5/)).toBeTruthy();
+    expect(screen.getByText(/The same hold reveals jump keys/)).toBeTruthy();
   });
 
   it("toggles a FAQ with a bare digit", async () => {

--- a/packages/web/src/components/WelcomeModal/WelcomeGuideBody.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeGuideBody.test.tsx
@@ -30,7 +30,8 @@ describe("WelcomeGuideBody", () => {
   it("explains that numbered shortcuts open the FAQ", () => {
     render(<WelcomeGuideBody />);
 
-    expect(screen.getByText(/to see keys, then press 1–5/)).toBeTruthy();
+    expect(screen.getByText(/to see keys/)).toBeTruthy();
+    expect(screen.getByText(/then press 1–5/)).toBeTruthy();
   });
 
   it("toggles a FAQ with a bare digit", async () => {
@@ -77,5 +78,20 @@ describe("WelcomeGuideBody", () => {
     await user.click(question);
 
     expect(question).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("explains why the mouse does not work", async () => {
+    const user = userEvent.setup();
+    render(<WelcomeGuideBody />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Why doesn't my mouse work?" }),
+    );
+
+    expect(
+      screen.getByText(
+        /Compass is keyboard-driven to help users stay in the flow/,
+      ),
+    ).toBeTruthy();
   });
 });

--- a/packages/web/src/components/WelcomeModal/WelcomeGuideBody.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeGuideBody.tsx
@@ -89,11 +89,11 @@ export function WelcomeGuideBody() {
         })}
       </div>
 
-      <p id={faqHintId} className="text-text-muted text-xs">
-        <span className="whitespace-nowrap">
-          Hold <ShortcutKeys keys={["Mod"]} /> to see keys
-        </span>
-        , then press 1–5. The same hold reveals jump keys all over Compass.
+      <p id={faqHintId} className="text-text-muted text-xs leading-relaxed">
+        <span className="inline-flex items-center gap-1 whitespace-nowrap">
+          Hold <ShortcutKeys keys={["Mod"]} /> to see keys, then press 1–5.
+        </span>{" "}
+        The same hold reveals jump keys all over Compass.
       </p>
     </>
   );

--- a/packages/web/src/components/WelcomeModal/WelcomeGuideBody.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeGuideBody.tsx
@@ -39,7 +39,7 @@ export function WelcomeGuideBody() {
     <>
       <div className="flex w-full flex-col gap-2">
         <h2 className="font-bold text-2xl text-text leading-snug">
-          Keyboard calendar
+          The Keyboard Calendar
         </h2>
         <p className="text-text-muted">
           Rediscover the joy of shortcuts as you build your perfect schedule. No
@@ -89,14 +89,11 @@ export function WelcomeGuideBody() {
         })}
       </div>
 
-      <p
-        id={faqHintId}
-        className="flex flex-wrap items-center gap-1 text-text-muted text-xs"
-      >
-        Hold
-        <ShortcutKeys keys={["Mod"]} />
-        to see keys, then press 1–5. The same hold reveals jump keys all over
-        Compass.
+      <p id={faqHintId} className="text-text-muted text-xs">
+        <span className="whitespace-nowrap">
+          Hold <ShortcutKeys keys={["Mod"]} /> to see keys
+        </span>
+        , then press 1–5. The same hold reveals jump keys all over Compass.
       </p>
     </>
   );

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -98,7 +98,7 @@ describe("WelcomeModal", () => {
 
     expect(
       screen.getByRole("heading", {
-        name: "Keyboard calendar",
+        name: "The Keyboard Calendar",
       }),
     ).toBeTruthy();
     expect(screen.getByText(/No clicks allowed/)).toBeTruthy();
@@ -214,7 +214,7 @@ describe("WelcomeModal", () => {
 
     for (const [name, key] of [
       ["Sign up", "U"],
-      ["Log in", "I"],
+      ["Log in", "i"],
       ["Explore without an account", "S"],
     ] as const) {
       const hint = within(screen.getByRole("button", { name })).getByText(key);
@@ -420,6 +420,11 @@ describe("WelcomeModal", () => {
       ).toBeTruthy();
       expect(
         screen.getByText(/Signs you up and connects your Google Calendar/),
+      ).toBeTruthy();
+      expect(
+        within(
+          screen.getByRole("button", { name: "Continue with Google" }),
+        ).getByText("G"),
       ).toBeTruthy();
       // Email signup steps aside to a clearly secondary label.
       expect(

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -203,7 +203,7 @@ export function WelcomeModal() {
               className="c-button-compact c-button-secondary rounded-3xl px-4 py-1.5 text-xs"
             >
               Log in
-              <ShortcutHint className="ml-2">I</ShortcutHint>
+              <ShortcutHint className="ml-2">i</ShortcutHint>
             </button>
           </div>
         </div>
@@ -221,11 +221,11 @@ export function WelcomeModal() {
                 onClick={handOffToGoogle}
                 disabled={isGoogleAuthLoading}
                 label="Continue with Google"
+                shortcutKey="G"
                 style={{ width: "100%" }}
               />
               <p className="text-center text-text-muted text-xs">
                 Signs you up and connects your Google Calendar.
-                <ShortcutHint className="ml-2">G</ShortcutHint>
               </p>
             </>
           )}

--- a/packages/web/src/components/WelcomeModal/faq.ts
+++ b/packages/web/src/components/WelcomeModal/faq.ts
@@ -15,11 +15,11 @@ export const FAQ_ITEMS = [
   {
     question: "Why doesn't my mouse work?",
     answer:
-      "Compass is keyboard only, on purpose. Clicks do nothing; every action has a key. That constraint is what makes the shortcuts stick, and within a day or two you'll be moving faster than any mouse allows. Scrolling still works.",
+      "Compass is keyboard-driven to help users stay in the flow. Disabling clicks forces us to deliver a first-class keyboard experience.",
   },
   {
     question: "I don't know any shortcuts yet. Will I be lost?",
     answer:
-      "No. The practice arena teaches the core motion in under a minute, hints appear right when they're useful, and ? opens the full legend. Cmd+K opens a command palette for anything you can't remember.",
+      "No. The practice arena walks you through the core shortcut patterns, hints appear right when they're useful, and ? opens the full legend. Cmd+K opens a command palette for anything you can't remember.",
   },
 ];

--- a/packages/web/src/shortcuts/keymap.ts
+++ b/packages/web/src/shortcuts/keymap.ts
@@ -51,4 +51,5 @@ export const KEYMAP = {
   edgeFocus: { hotkey: "Tab", keycaps: ["Tab"] },
   undo: { hotkey: "Mod+Z", keycaps: ["Mod", "Z"] },
   redo: { hotkey: "Mod+Shift+Z", keycaps: ["Mod", "Shift", "Z"] },
+  commandPalette: { hotkey: "Mod+K", keycaps: ["Mod", "K"] },
 } as const;

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -350,7 +350,7 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
   },
   {
     id: "other-palette",
-    keys: ["Mod", "k"],
+    keys: [...KEYMAP.commandPalette.keycaps],
     label: "Command Palette",
     section: "other",
   },

--- a/packages/web/src/shortcuts/tips/ShortcutTipParts.tsx
+++ b/packages/web/src/shortcuts/tips/ShortcutTipParts.tsx
@@ -21,14 +21,19 @@ export const ShortcutTipParts: FC<{
   return (
     <span>
       <span className="sr-only">{plainText}</span>
-      <span aria-hidden className="inline-flex flex-wrap items-center gap-1">
+      <span aria-hidden>
         {parts.map((part, i) =>
           typeof part === "string" ? (
             // biome-ignore lint/suspicious/noArrayIndexKey: parts are a fixed, order-stable literal
             <span key={i}>{part}</span>
           ) : (
             // biome-ignore lint/suspicious/noArrayIndexKey: parts are a fixed, order-stable literal
-            <ShortcutKeys key={i} keys={[...partKeycaps(part)]} />
+            <span
+              key={i}
+              className="inline-flex whitespace-nowrap align-text-bottom"
+            >
+              <ShortcutKeys keys={[...partKeycaps(part)]} />
+            </span>
           ),
         )}
       </span>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves the welcome screen and first-run shortcut practice:

- Welcome heading is **The Keyboard Calendar**; login chip is lowercase `i`; Hold+Mod stays on one line with “to see keys”; mouse FAQ matches the new copy.
- Login and signup show the same always-visible shortcut chips as welcome (`U` / `i` / `G` / `Enter`) and those letters work when focus is not in a field.
- Shortcut practice is a skippable six-mission game (create, hold-Mod jumps, `S` event jump, Shift+arrow nudge, `E` then `T`, Cmd+K) before graduation. Skip-to-signup is `U` so `S` can teach event jump. Hint chips no longer overlap button labels.

CI follow-ups on this branch: e2e drives “Do it for me” with `D` (trusted pointer clicks are blocked), and the unused `PRACTICE_JUMP_TARGETS` export is removed.

## Simplicity

Practice still uses ephemeral sandbox state (no real grid stores). Auth reuses `GoogleButton` / `ShortcutHint` rather than a second hint system. Skip remains available on every mission. `/simplify` inspected the branch diff and made no further code change: per-mission branches and the auth letter listener are already the smallest surfaces.

## Automated validation

`bun run verify` (merge-base `origin/main`):

```
Selected packages: web
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)
✓ All checks passed
```

web: 2346 pass / 0 fail. Playwright e2e: 35 passed, including create-then-D through graduation and `U` skip-to-signup. GitHub Test/e2e/knip on `c488755bc` were green; this markdown-only ship-record commit should skip those jobs.

## Independent review

Handoff: `.agents/handoffs/2879.md`

```
VERDICT: no confirmed findings
FINDINGS:
(none)
```

## Test plan

- `bun run verify` — web, type-check, lint, knip, test:a11y, test:e2e
- GitHub checks on `c488755bc`: lint, knip, type-check, unit matrix, e2e, CodeQL, pr-body

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79707fde-610a-451b-89e1-1da82fae78e3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79707fde-610a-451b-89e1-1da82fae78e3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

