### PR TITLE
feat(web): focus nearest event on unfocused arrow keys

### DIFF
--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -20,7 +20,7 @@ Use this guide to validate:
 - opening and using the command palette (Cmd+K), including undo/redo rows
 - creating events with keyboard shortcuts (C, A in both Day and Week view)
 - editing events with the same keys in Day and Week (Delete, Shift+arrows, draft arrows)
-- focusing events with arrow keys (chronological in Day, spatial in Week)
+- focusing events with arrow keys (chronological in Day, spatial in Week), including the first arrow when nothing is focused (nearest to now)
 - toggling event-jump chips (`S`); the mouse is permanently inert (Compass is keyboard-only)
 - toggling the sidebar (])
 - undoing / redoing with the keyboard (Cmd+Z / Cmd+Shift+Z)
@@ -221,7 +221,7 @@ Pressing Delete while an event is focused in the Day or Week grid deletes it —
 ### Steps
 
 1. Navigate to `/week`.
-2. Focus an event in the grid (click it or press `U` then ArrowUp/ArrowDown).
+2. Focus an event in the grid (click it, press `U`, or press any Arrow key when nothing is focused).
 3. Press Delete.
 4. Navigate to `/day` and repeat with a focused event.
 
@@ -406,7 +406,7 @@ If time is limited, run these checks before shipping shortcut-related changes:
 9. No shortcuts fire inside a focused text input except Cmd+K.
 10. Shift+ArrowLeft/Right move a focused event by one day in both Day and Week view.
 11. Arrow keys reposition an open draft in both Day and Week view.
-12. With a focused event and no draft open: in Week view ArrowUp/ArrowDown stay on the same day and ArrowLeft/Right jump to the time-nearest event on the previous/next non-empty day; in Day view all four arrows move chronological focus.
+12. With no event focused and no particular control focused (document body), any Arrow key focuses the timed event nearest now in the current Day/Week view (in-progress, else next upcoming, else most recently ended; today preferred in Week; all-day only if no timed events). Further arrows then follow the existing rules. `U` still focuses the first DOM-order event. With a focused event and no draft open: in Week view ArrowUp/ArrowDown stay on the same day and ArrowLeft/Right jump to the time-nearest event on the previous/next non-empty day; in Day view all four arrows move chronological focus.
 13. Cmd+D / Ctrl+D duplicates a focused event in Day and Week view.
 14. With a focused event, `E` then `T` opens the form with the title focused; `E` then `A` / `C` jump to account / color; bare `E` alone does nothing.
 15. Pressing `S` shows event jump chips; a day letter + digit focuses that event; Shift+Tab does not show chips.

--- a/packages/web/src/grid/shortcuts/focus-adjacent-grid-event.test.ts
+++ b/packages/web/src/grid/shortcuts/focus-adjacent-grid-event.test.ts
@@ -4,13 +4,19 @@ import { type GridEvent } from "@web/common/types/web.event.types";
 import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
 import {
   getChronologicallyAdjacentTarget,
+  getNearestTargetToNow,
   getSpatiallyAdjacentTarget,
 } from "@web/grid/shortcuts/focus-adjacent-grid-event";
 import { describe, expect, it } from "bun:test";
 
-const event = (id: string, startDate: string, isAllDay = false): GridEvent => ({
+const event = (
+  id: string,
+  startDate: string,
+  isAllDay = false,
+  endDate?: string,
+): GridEvent => ({
   _id: id,
-  endDate: isAllDay ? "2026-05-21" : "2026-05-20T10:00:00.000",
+  endDate: endDate ?? (isAllDay ? "2026-05-21" : "2026-05-20T10:00:00.000"),
   isAllDay,
   origin: Origin.COMPASS,
   position: gridEventDefaultPosition,
@@ -183,5 +189,196 @@ describe("getSpatiallyAdjacentTarget", () => {
     });
 
     expect(next?.eventId).toBe("wed-noon");
+  });
+});
+
+describe("getNearestTargetToNow", () => {
+  const now = dayjs("2026-05-20T12:00:00.000");
+
+  it("returns null when nothing is visible", () => {
+    expect(
+      getNearestTargetToNow({
+        allDayEvents: [],
+        now,
+        timedEvents: [event("a", "2026-05-20T09:00:00.000")],
+        visible: [],
+      }),
+    ).toBeNull();
+  });
+
+  it("picks the overlapping timed event over earlier and later ones", () => {
+    const earlier = target("earlier", "timed");
+    const overlapping = target("now", "timed");
+    const later = target("later", "timed");
+    const picked = getNearestTargetToNow({
+      allDayEvents: [],
+      now,
+      timedEvents: [
+        event(
+          "earlier",
+          "2026-05-20T09:00:00.000",
+          false,
+          "2026-05-20T10:00:00.000",
+        ),
+        event(
+          "now",
+          "2026-05-20T11:00:00.000",
+          false,
+          "2026-05-20T13:00:00.000",
+        ),
+        event(
+          "later",
+          "2026-05-20T15:00:00.000",
+          false,
+          "2026-05-20T16:00:00.000",
+        ),
+      ],
+      visible: [later, earlier, overlapping],
+    });
+
+    expect(picked?.eventId).toBe("now");
+  });
+
+  it("picks the overlapping event that ends soonest", () => {
+    const longer = target("longer", "timed");
+    const shorter = target("shorter", "timed");
+    const picked = getNearestTargetToNow({
+      allDayEvents: [],
+      now,
+      timedEvents: [
+        event(
+          "longer",
+          "2026-05-20T11:00:00.000",
+          false,
+          "2026-05-20T14:00:00.000",
+        ),
+        event(
+          "shorter",
+          "2026-05-20T11:30:00.000",
+          false,
+          "2026-05-20T12:30:00.000",
+        ),
+      ],
+      visible: [longer, shorter],
+    });
+
+    expect(picked?.eventId).toBe("shorter");
+  });
+
+  it("picks the next upcoming event when nothing overlaps now", () => {
+    const morning = target("morning", "timed");
+    const afternoon = target("afternoon", "timed");
+    const evening = target("evening", "timed");
+    const picked = getNearestTargetToNow({
+      allDayEvents: [],
+      now,
+      timedEvents: [
+        event(
+          "morning",
+          "2026-05-20T09:00:00.000",
+          false,
+          "2026-05-20T10:00:00.000",
+        ),
+        event(
+          "afternoon",
+          "2026-05-20T15:00:00.000",
+          false,
+          "2026-05-20T16:00:00.000",
+        ),
+        event(
+          "evening",
+          "2026-05-20T17:00:00.000",
+          false,
+          "2026-05-20T18:00:00.000",
+        ),
+      ],
+      visible: [evening, morning, afternoon],
+    });
+
+    expect(picked?.eventId).toBe("afternoon");
+  });
+
+  it("picks the most recently ended event when every candidate is past", () => {
+    const morning = target("morning", "timed");
+    const afternoon = target("afternoon", "timed");
+    const picked = getNearestTargetToNow({
+      allDayEvents: [],
+      now: dayjs("2026-05-20T18:00:00.000"),
+      timedEvents: [
+        event(
+          "morning",
+          "2026-05-20T09:00:00.000",
+          false,
+          "2026-05-20T10:00:00.000",
+        ),
+        event(
+          "afternoon",
+          "2026-05-20T15:00:00.000",
+          false,
+          "2026-05-20T16:00:00.000",
+        ),
+      ],
+      visible: [morning, afternoon],
+    });
+
+    expect(picked?.eventId).toBe("afternoon");
+  });
+
+  it("restricts to today when any candidate is today", () => {
+    const wednesdayMorning = target("wed-am", "timed");
+    const thursdayAfternoon = target("thu-pm", "timed");
+    const picked = getNearestTargetToNow({
+      allDayEvents: [],
+      now,
+      timedEvents: [
+        event(
+          "wed-am",
+          "2026-05-20T09:00:00.000",
+          false,
+          "2026-05-20T10:00:00.000",
+        ),
+        event(
+          "thu-pm",
+          "2026-05-21T15:00:00.000",
+          false,
+          "2026-05-21T16:00:00.000",
+        ),
+      ],
+      visible: [thursdayAfternoon, wednesdayMorning],
+    });
+
+    expect(picked?.eventId).toBe("wed-am");
+  });
+
+  it("prefers timed events over all-day even when all-day covers today", () => {
+    const allDay = target("all", "all-day");
+    const timed = target("timed", "timed");
+    const picked = getNearestTargetToNow({
+      allDayEvents: [event("all", "2026-05-20", true)],
+      now,
+      timedEvents: [
+        event(
+          "timed",
+          "2026-05-20T15:00:00.000",
+          false,
+          "2026-05-20T16:00:00.000",
+        ),
+      ],
+      visible: [allDay, timed],
+    });
+
+    expect(picked?.eventId).toBe("timed");
+  });
+
+  it("falls back to all-day when no timed candidate is visible", () => {
+    const allDay = target("all", "all-day");
+    const picked = getNearestTargetToNow({
+      allDayEvents: [event("all", "2026-05-20", true)],
+      now,
+      timedEvents: [],
+      visible: [allDay],
+    });
+
+    expect(picked?.eventId).toBe("all");
   });
 });

--- a/packages/web/src/grid/shortcuts/focus-adjacent-grid-event.ts
+++ b/packages/web/src/grid/shortcuts/focus-adjacent-grid-event.ts
@@ -25,6 +25,8 @@ type TargetSchedule = {
   dayKey: string;
   /** Absolute start for chronological ordering within a day. */
   startMs: number;
+  /** Absolute end; exclusive for overlap (`start <= now < end`). */
+  endMs: number;
   /**
    * Minutes from local midnight. Cross-day Left/Right pick the event whose
    * clock time is nearest the focused event (not absolute datetime distance).
@@ -47,9 +49,11 @@ const buildScheduleById = (
   const scheduleById = new Map<string, TargetSchedule>();
   for (const event of [...allDayEvents, ...timedEvents]) {
     if (!event._id || !event.startDate) continue;
+    const start = dayjs(event.startDate);
     scheduleById.set(event._id, {
       dayKey: dayKeyFromStart(event.startDate),
-      startMs: dayjs(event.startDate).valueOf(),
+      startMs: start.valueOf(),
+      endMs: event.endDate ? dayjs(event.endDate).valueOf() : start.valueOf(),
       minutesFromMidnight: minutesFromMidnight(event.startDate),
     });
   }
@@ -190,4 +194,72 @@ export function getSpatiallyAdjacentTarget({
     }
   }
   return nearest;
+}
+
+/**
+ * Seed target when nothing is focused: the most relevant event in the current
+ * Day/Week surface relative to `now`. Prefers today when any candidate is
+ * today; prefers timed over all-day; then in-progress (soonest end), else
+ * next upcoming, else most recently ended.
+ */
+export function getNearestTargetToNow({
+  allDayEvents,
+  now = dayjs(),
+  timedEvents,
+  visible,
+}: {
+  allDayEvents: GridEvent[];
+  now?: Dayjs;
+  timedEvents: GridEvent[];
+  visible: FocusableGridEventTarget[];
+}): FocusableGridEventTarget | null {
+  if (visible.length === 0) return null;
+
+  const scheduleById = buildScheduleById(allDayEvents, timedEvents);
+  const todayKey = now.format("YYYY-MM-DD");
+  const todayVisible = visible.filter(
+    (target) => scheduleById.get(target.eventId)?.dayKey === todayKey,
+  );
+  const inView = todayVisible.length > 0 ? todayVisible : visible;
+  const timed = inView.filter((target) => target.eventType === "timed");
+  const pool = timed.length > 0 ? timed : inView;
+
+  const nowMs = now.valueOf();
+  let best: FocusableGridEventTarget | null = null;
+  let bestKind = 3;
+  let bestKey = Number.POSITIVE_INFINITY;
+
+  for (const target of pool) {
+    const schedule = scheduleById.get(target.eventId);
+    if (!schedule) continue;
+
+    const { startMs, endMs } = schedule;
+    // 0 overlapping, 1 upcoming, 2 past. Lower kind always wins.
+    let kind: 0 | 1 | 2;
+    let key: number;
+    if (startMs <= nowMs && nowMs < endMs) {
+      kind = 0;
+      key = endMs;
+    } else if (startMs > nowMs) {
+      kind = 1;
+      key = startMs;
+    } else {
+      kind = 2;
+      key = -endMs;
+    }
+
+    if (kind > bestKind) continue;
+    if (kind < bestKind || key < bestKey) {
+      best = target;
+      bestKind = kind;
+      bestKey = key;
+      continue;
+    }
+    if (key > bestKey || !best) continue;
+    if (compareTargetsChronologically(target, best, scheduleById) < 0) {
+      best = target;
+    }
+  }
+
+  return best;
 }

--- a/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
@@ -56,6 +56,7 @@ import {
   findCalendarEventForTarget,
   type GridEventShortcutTarget,
   getChronologicallyAdjacentTarget,
+  getNearestTargetToNow,
   getSpatiallyAdjacentTarget,
 } from "@web/grid/shortcuts/focus-adjacent-grid-event";
 import { isHigherEscapeOwner } from "@web/shortcuts/escape-ownership";
@@ -81,6 +82,16 @@ const SPATIAL_DIRECTION = {
 
 const isArrowKey = (key: string): key is keyof typeof SPATIAL_DIRECTION =>
   key in SPATIAL_DIRECTION;
+
+/** First visit / returning from another tab: nothing particular is focused. */
+const isUnspecifiedDocumentFocus = () => {
+  const active = document.activeElement;
+  return (
+    active == null ||
+    active === document.body ||
+    active === document.documentElement
+  );
+};
 
 // Week view: refuse moves that would leave the visible week window.
 const isOutsideVisibleWeek = (
@@ -586,30 +597,44 @@ export function useGridEventEditShortcuts({
     if (isEventFormOpen()) return;
     if (!isArrowKey(keyboardEvent.key)) return;
 
+    const focused = targeting.getFocusedNavigable();
+    const visible = targeting.listNavigable();
+
     // Day view: all four arrows move chronological focus. Period changes stay
     // on j/k (same split as week view: arrows focus, j/k navigate). Week uses
-    // spatial adjacency across the visible days.
-    const adjacent =
-      dayBoundary.kind === "follow"
-        ? getChronologicallyAdjacentTarget({
-            allDayEvents,
-            direction:
-              keyboardEvent.key === "ArrowUp" ||
-              keyboardEvent.key === "ArrowLeft"
-                ? "previous"
-                : "next",
-            focused: targeting.getFocusedNavigable(),
-            timedEvents,
-            visible: targeting.listNavigable(),
-          })
-        : getSpatiallyAdjacentTarget({
-            allDayEvents,
-            direction: SPATIAL_DIRECTION[keyboardEvent.key],
-            focused: targeting.getFocusedNavigable(),
-            timedEvents,
-            visible: targeting.listNavigable(),
-            weekDays: dayBoundary.weekDays,
-          });
+    // spatial adjacency across the visible days. With no event focused and
+    // no particular control focused, the first arrow seeds the nearest-to-now
+    // event instead of no-op'ing.
+    let adjacent: FocusableGridEventTarget | null = null;
+    if (focused) {
+      adjacent =
+        dayBoundary.kind === "follow"
+          ? getChronologicallyAdjacentTarget({
+              allDayEvents,
+              direction:
+                keyboardEvent.key === "ArrowUp" ||
+                keyboardEvent.key === "ArrowLeft"
+                  ? "previous"
+                  : "next",
+              focused,
+              timedEvents,
+              visible,
+            })
+          : getSpatiallyAdjacentTarget({
+              allDayEvents,
+              direction: SPATIAL_DIRECTION[keyboardEvent.key],
+              focused,
+              timedEvents,
+              visible,
+              weekDays: dayBoundary.weekDays,
+            });
+    } else if (isUnspecifiedDocumentFocus()) {
+      adjacent = getNearestTargetToNow({
+        allDayEvents,
+        timedEvents,
+        visible,
+      });
+    }
     if (!adjacent) return;
 
     keyboardEvent.preventDefault();

--- a/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
@@ -7,7 +7,11 @@ import {
   useCalendarLookup,
 } from "@web/calendars/useCalendarLookup";
 import { useDefaultTargetCalendar } from "@web/calendars/useDefaultTargetCalendar";
-import { ID_SIDEBAR } from "@web/common/constants/web.constants";
+import {
+  ID_GRID_MAIN,
+  ID_SIDEBAR,
+  ID_WEEK_GRID_SCROLLER,
+} from "@web/common/constants/web.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { getVisibleGridStartMinute } from "@web/common/utils/draft/draft.util";
 import {
@@ -83,14 +87,24 @@ const SPATIAL_DIRECTION = {
 const isArrowKey = (key: string): key is keyof typeof SPATIAL_DIRECTION =>
   key in SPATIAL_DIRECTION;
 
-/** First visit / returning from another tab: nothing particular is focused. */
+/**
+ * First visit / returning from another tab / calendar canvas: nothing
+ * particular is focused. The timed grid and week scroller are WCAG
+ * scrollable regions (`tabIndex=0`), not interactive controls — treating
+ * them as unspecified is what lets Arrow keys enter the event list after
+ * a click on the calendar.
+ */
 const isUnspecifiedDocumentFocus = () => {
   const active = document.activeElement;
-  return (
+  if (
     active == null ||
     active === document.body ||
     active === document.documentElement
-  );
+  ) {
+    return true;
+  }
+  if (!(active instanceof HTMLElement)) return false;
+  return active.id === ID_GRID_MAIN || active.id === ID_WEEK_GRID_SCROLLER;
 };
 
 // Week view: refuse moves that would leave the visible week window.

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
@@ -518,9 +518,12 @@ describe("useDayEventNudgeShortcuts", () => {
     expect(navigateToDate).not.toHaveBeenCalled();
   });
 
-  it("does not change focus with ArrowRight when nothing is focused", () => {
-    focusCalendarTarget(TIMED_EVENT_ID, "timed").blur();
-    focusCalendarTarget(LATER_TIMED_EVENT_ID, "timed").blur();
+  it("focuses the nearest-to-now event with ArrowRight when nothing is focused", () => {
+    setSystemTime(new Date("2026-05-20T09:30:00.000"));
+    const earlier = focusCalendarTarget(TIMED_EVENT_ID, "timed");
+    const later = focusCalendarTarget(LATER_TIMED_EVENT_ID, "timed");
+    earlier.blur();
+    later.blur();
     const navigateToDate = mock(() => {});
     renderEditShortcuts({
       navigateToDate,
@@ -529,8 +532,26 @@ describe("useDayEventNudgeShortcuts", () => {
 
     pressKey("ArrowRight");
 
+    expect(document.activeElement).toBe(earlier);
     expect(navigateToDate).not.toHaveBeenCalled();
-    expect(document.activeElement).not.toBeInstanceOf(HTMLButtonElement);
+
+    pressKey("ArrowRight");
+
+    expect(document.activeElement).toBe(later);
+    expect(navigateToDate).not.toHaveBeenCalled();
+  });
+
+  it("does not steal ArrowRight from a focused non-event button", () => {
+    focusCalendarTarget(TIMED_EVENT_ID, "timed").blur();
+    const chrome = document.createElement("button");
+    chrome.textContent = "Sidebar";
+    document.body.appendChild(chrome);
+    chrome.focus();
+    renderEditShortcuts({ timedEvents: [timedEvent, laterTimedEvent] });
+
+    pressKey("ArrowRight", {}, chrome);
+
+    expect(document.activeElement).toBe(chrome);
   });
 
   it("moves the active shortcut-created draft with arrow keys", () => {

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
@@ -541,6 +541,24 @@ describe("useDayEventNudgeShortcuts", () => {
     expect(navigateToDate).not.toHaveBeenCalled();
   });
 
+  it("focuses the nearest-to-now event when the timed grid canvas is focused", () => {
+    setSystemTime(new Date("2026-05-20T09:30:00.000"));
+    const earlier = focusCalendarTarget(TIMED_EVENT_ID, "timed");
+    earlier.blur();
+    const grid = document.createElement("section");
+    grid.id = "mainGrid";
+    grid.tabIndex = 0;
+    document.body.appendChild(grid);
+    grid.focus();
+    renderEditShortcuts({
+      timedEvents: [timedEvent, laterTimedEvent],
+    });
+
+    pressKey("ArrowRight");
+
+    expect(document.activeElement).toBe(earlier);
+  });
+
   it("does not steal ArrowRight from a focused non-event button", () => {
     focusCalendarTarget(TIMED_EVENT_ID, "timed").blur();
     const chrome = document.createElement("button");

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
@@ -37,7 +37,15 @@ import {
   getWeekInteractionTargetAttributes,
   weekEventRegistry,
 } from "@web/views/Week/interaction/registry/week-event.registry";
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  setSystemTime,
+} from "bun:test";
 
 // Fixed 24-hex-char ids so fixtures satisfy EventIdSchema (real ObjectId
 // shape) while staying stable/readable across assertions.
@@ -175,6 +183,7 @@ afterEach(() => {
   useViewStore.setState(initialViewState);
   useEdgeFocusStore.setState(initialEdgeFocusState, true);
   draftActions.discard();
+  setSystemTime();
 });
 
 const addCalendarTarget = (
@@ -524,6 +533,74 @@ describe("useWeekShortcutOwner calendar event targeting", () => {
     pressKey("ArrowDown");
 
     expect(document.activeElement).toBe(later);
+  });
+
+  it("focuses the nearest-to-now event when nothing is focused, then continues with arrows", () => {
+    setSystemTime(new Date("2026-05-20T09:30:00.000Z"));
+    const sameDayLaterId = EventIdSchema.parse("ffffffffffffffffffffffff");
+    const sameDayLater = createMockEvent({
+      id: sameDayLaterId,
+      content: { kind: "details", title: "Same day later", description: "" },
+      schedule: EventScheduleSchema.parse({
+        kind: "timed",
+        start: "2026-05-20T14:00:00.000Z",
+        end: "2026-05-20T15:00:00.000Z",
+        timeZone: "UTC",
+      }),
+    });
+    const earlier = addCalendarTarget(editableEvent.id);
+    const later = addCalendarTarget(sameDayLaterId);
+    addCalendarTarget(leftmostEvent.id);
+    earlier.blur();
+    later.blur();
+    renderShortcuts({
+      includeLeftmostEvent: true,
+      extraEvents: [sameDayLater],
+    });
+
+    pressKey("ArrowRight");
+
+    expect(document.activeElement).toBe(earlier);
+
+    pressKey("ArrowDown");
+
+    expect(document.activeElement).toBe(later);
+  });
+
+  it("does not steal ArrowRight from a focused non-event button", () => {
+    setSystemTime(new Date("2026-05-20T09:30:00.000Z"));
+    addCalendarTarget(editableEvent.id).blur();
+    const chrome = document.createElement("button");
+    chrome.textContent = "Sidebar";
+    document.body.appendChild(chrome);
+    chrome.focus();
+    renderShortcuts();
+
+    pressKey("ArrowRight", {}, chrome);
+
+    expect(document.activeElement).toBe(chrome);
+  });
+
+  it("repositions an active draft with arrows instead of seeding unfocused events", () => {
+    setSystemTime(new Date("2026-05-20T09:30:00.000Z"));
+    const saved = addCalendarTarget(editableEvent.id);
+    saved.blur();
+    const draft = createGridEventDraft(
+      timedGridSchedule(
+        new Date("2026-05-20T09:00:00.000"),
+        new Date("2026-05-20T10:00:00.000"),
+      ),
+    );
+    draftActions.startGridDraft({ activity: "createShortcut", draft });
+    renderShortcuts();
+
+    pressKey("ArrowRight");
+
+    const schedule = useDraftStore.getState().gridDraft?.values.schedule;
+    expect(dayjs(schedule?.start).format()).toBe(
+      dayjs("2026-05-21T09:00:00.000").format(),
+    );
+    expect(document.activeElement).not.toBe(saved);
   });
 
   it("focuses a read-only event with ArrowDown", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When nothing particular is focused (first visit, returning from another tab, or focus on the calendar canvas), the first Arrow key focuses the most relevant event in the current Day/Week view. Further arrows keep the existing chronological (Day) and spatial (Week) adjacency behavior.

The seed target is the timed event nearest now: in-progress (soonest end), else next upcoming, else most recently ended. Today is preferred when it is on screen; all-day events are used only if no timed candidates exist. Arrows are not stolen from a focused button, input, or other control. `U` still focuses the first DOM-order event; `T` still only scrolls to now.

The timed grid and week scroller are WCAG `tabIndex=0` sections, so a click on the calendar canvas is treated the same as document body.

## Simplicity

The picker is a pure helper next to the existing adjacency functions. Day and Week both pick it up through the shared `moveDraftOrFocusAdjacent` owner. Delete, Shift+Arrow, and `E` sequences stay focused-only.

## Automated validation

Playwright against the running anonymous week view (`http://localhost:9080/week`):

- Body focused, ArrowDown → `Now Meeting` (nearest to the now line)
- Second ArrowDown → `Later Meeting`
- `#mainGrid` canvas focused, ArrowDown → `Now Meeting`
- Sidebar "Previous month" focused, ArrowDown → stays on that button

![First ArrowDown focuses Now Meeting](https://cursor.com/artifacts/c/art-75f29699-f18f-443b-9bc9-23494b7f1ea2)
![Second ArrowDown moves focus to Later Meeting](https://cursor.com/artifacts/c/art-5cbe444b-3090-40df-905f-57a89e76263b)

## Independent review

Pending reviewer. Unit coverage lives in `focus-adjacent-grid-event.test.ts`, `useDayEventNudgeShortcuts.test.tsx`, and `useWeekShortcutOwner.test.tsx`.

## Test plan

- `bun run test:web packages/web/src/grid/shortcuts/focus-adjacent-grid-event.test.ts packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx` — 101 pass, 0 fail
- `bunx biome check` on the touched files — clean
- `bun run lint` — exit 0 (pre-existing warnings only)
- Playwright browser check of the idle-arrow path on `bun run dev:web` (results above)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-031c4b84-3cec-4471-b534-35949a629a9a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-031c4b84-3cec-4471-b534-35949a629a9a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

