### PR TITLE
fix(web): sync month picker highlights with days in view

### DIFF
--- a/packages/web/src/__tests__/setup/test-lifecycle.ts
+++ b/packages/web/src/__tests__/setup/test-lifecycle.ts
@@ -40,18 +40,6 @@ function resetDocument() {
   clearAppLockReasons();
   clearFloatingLayerReasons();
   document.documentElement.removeAttribute("style");
-  for (const style of document.head.querySelectorAll("style")) {
-    if (
-      !style.textContent?.includes(":has(.react-datepicker__day--selected)")
-    ) {
-      continue;
-    }
-
-    style.textContent = style.textContent.replaceAll(
-      /[^{}]+:has\(\.react-datepicker__day--selected\)[^{]*\{[^{}]*\}/g,
-      "",
-    );
-  }
 }
 
 function resetBrowserState() {

--- a/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.test.tsx
+++ b/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.test.tsx
@@ -2,10 +2,13 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import dayjs from "@core/util/date/dayjs";
 import { MonthPicker } from "@web/components/Sidebar/MonthPicker/MonthPicker";
+import { MONTH_PICKER_IN_VIEW_CLASS } from "./monthPickerDayClassName";
 import { describe, expect, it, mock } from "bun:test";
 
 const getSelectedDay = () =>
   document.querySelector(".react-datepicker__day--selected");
+
+const dayNamed = (label: string) => screen.getByLabelText(label);
 
 describe("MonthPicker", () => {
   it("keeps the clicked date selected while navigation catches up", async () => {
@@ -16,6 +19,8 @@ describe("MonthPicker", () => {
       <MonthPicker
         onSelectDate={onSelectDate}
         selectedDate={dayjs("2026-05-18")}
+        viewEnd={dayjs("2026-05-23")}
+        viewStart={dayjs("2026-05-17")}
       />,
     );
 
@@ -24,6 +29,70 @@ describe("MonthPicker", () => {
     expect(onSelectDate).toHaveBeenCalledTimes(1);
     expect(getSelectedDay()?.getAttribute("aria-label")).toBe(
       "Choose Monday, May 25th, 2026",
+    );
+  });
+
+  it("highlights the visible Sun-Sat window, not adjacent days", () => {
+    render(
+      <MonthPicker
+        onSelectDate={mock()}
+        selectedDate={dayjs("2026-05-13")}
+        viewEnd={dayjs("2026-05-16")}
+        viewStart={dayjs("2026-05-10")}
+      />,
+    );
+
+    expect(dayNamed("Choose Sunday, May 10th, 2026")).toHaveClass(
+      MONTH_PICKER_IN_VIEW_CLASS,
+    );
+    expect(dayNamed("Choose Saturday, May 16th, 2026")).toHaveClass(
+      MONTH_PICKER_IN_VIEW_CLASS,
+    );
+    expect(dayNamed("Choose Saturday, May 9th, 2026")).not.toHaveClass(
+      MONTH_PICKER_IN_VIEW_CLASS,
+    );
+    expect(dayNamed("Choose Sunday, May 17th, 2026")).not.toHaveClass(
+      MONTH_PICKER_IN_VIEW_CLASS,
+    );
+  });
+
+  it("moves the in-view band when the visible window shifts while selection stays", () => {
+    const { rerender } = render(
+      <MonthPicker
+        onSelectDate={mock()}
+        selectedDate={dayjs("2026-05-13")}
+        viewEnd={dayjs("2026-05-16")}
+        viewStart={dayjs("2026-05-10")}
+      />,
+    );
+
+    expect(dayNamed("Choose Wednesday, May 13th, 2026")).toHaveClass(
+      "react-datepicker__day--selected",
+    );
+
+    rerender(
+      <MonthPicker
+        onSelectDate={mock()}
+        selectedDate={dayjs("2026-05-13")}
+        viewEnd={dayjs("2026-05-17")}
+        viewStart={dayjs("2026-05-11")}
+      />,
+    );
+
+    expect(dayNamed("Choose Saturday, May 9th, 2026")).not.toHaveClass(
+      MONTH_PICKER_IN_VIEW_CLASS,
+    );
+    expect(dayNamed("Choose Sunday, May 10th, 2026")).not.toHaveClass(
+      MONTH_PICKER_IN_VIEW_CLASS,
+    );
+    expect(dayNamed("Choose Monday, May 11th, 2026")).toHaveClass(
+      MONTH_PICKER_IN_VIEW_CLASS,
+    );
+    expect(dayNamed("Choose Sunday, May 17th, 2026")).toHaveClass(
+      MONTH_PICKER_IN_VIEW_CLASS,
+    );
+    expect(dayNamed("Choose Wednesday, May 13th, 2026")).toHaveClass(
+      "react-datepicker__day--selected",
     );
   });
 });

--- a/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.tsx
+++ b/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.tsx
@@ -3,11 +3,14 @@ import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { ID_DATEPICKER_SIDEBAR } from "@web/common/constants/web.constants";
 import { DatePicker } from "@web/components/DatePicker/DatePicker";
 import { pageJumpAttrs } from "@web/shortcuts/page-jump/page-jump.targets";
+import { getMonthPickerDayClassName } from "./monthPickerDayClassName";
 
 interface Props {
   monthsShown?: number;
   onSelectDate: (date: Dayjs) => void;
   selectedDate: Dayjs;
+  viewEnd: Dayjs;
+  viewStart: Dayjs;
 }
 
 const monthPickerClassName =
@@ -19,6 +22,8 @@ export const MonthPicker: FC<Props> = ({
   monthsShown,
   onSelectDate,
   selectedDate,
+  viewEnd,
+  viewStart,
 }) => {
   const selectedDateKey = selectedDate.format(
     dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT,
@@ -37,14 +42,13 @@ export const MonthPicker: FC<Props> = ({
     );
   }, [selectedDateKey]);
 
-  const getDayClassName = (date: Date) => {
-    const dateKey = dayjs(date).format(dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT);
-
-    return dateKey ===
-      focusedDate.format(dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT)
-      ? "!font-semibold"
-      : "!font-light";
-  };
+  const getDayClassName = (date: Date) =>
+    getMonthPickerDayClassName({
+      date: dayjs(date),
+      selectedDate: focusedDate,
+      viewEnd,
+      viewStart,
+    });
 
   return (
     <fieldset

--- a/packages/web/src/components/Sidebar/MonthPicker/monthPickerDayClassName.test.ts
+++ b/packages/web/src/components/Sidebar/MonthPicker/monthPickerDayClassName.test.ts
@@ -1,0 +1,63 @@
+import dayjs from "@core/util/date/dayjs";
+import {
+  getMonthPickerDayClassName,
+  MONTH_PICKER_IN_VIEW_CLASS,
+  MONTH_PICKER_IN_VIEW_END_CLASS,
+  MONTH_PICKER_IN_VIEW_START_CLASS,
+} from "./monthPickerDayClassName";
+import { describe, expect, it } from "bun:test";
+
+const selectedDate = dayjs("2026-05-13");
+
+const classNameFor = (date: string, viewStart: string, viewEnd: string) =>
+  getMonthPickerDayClassName({
+    date: dayjs(date),
+    selectedDate,
+    viewEnd: dayjs(viewEnd),
+    viewStart: dayjs(viewStart),
+  });
+
+describe("getMonthPickerDayClassName", () => {
+  it("marks a Sun-Sat window as in view with row start and end on the edges", () => {
+    expect(classNameFor("2026-05-10", "2026-05-10", "2026-05-16")).toContain(
+      MONTH_PICKER_IN_VIEW_CLASS,
+    );
+    expect(classNameFor("2026-05-10", "2026-05-10", "2026-05-16")).toContain(
+      MONTH_PICKER_IN_VIEW_START_CLASS,
+    );
+    expect(classNameFor("2026-05-16", "2026-05-10", "2026-05-16")).toContain(
+      MONTH_PICKER_IN_VIEW_END_CLASS,
+    );
+    expect(classNameFor("2026-05-13", "2026-05-10", "2026-05-16")).toContain(
+      "!font-semibold",
+    );
+    expect(
+      classNameFor("2026-05-09", "2026-05-10", "2026-05-16"),
+    ).not.toContain(MONTH_PICKER_IN_VIEW_CLASS);
+    expect(
+      classNameFor("2026-05-17", "2026-05-10", "2026-05-16"),
+    ).not.toContain(MONTH_PICKER_IN_VIEW_CLASS);
+  });
+
+  it("moves the in-view band with a Shift+K window while keeping selection", () => {
+    const shifted = classNameFor("2026-05-13", "2026-05-11", "2026-05-17");
+
+    expect(
+      classNameFor("2026-05-10", "2026-05-11", "2026-05-17"),
+    ).not.toContain(MONTH_PICKER_IN_VIEW_CLASS);
+    expect(classNameFor("2026-05-11", "2026-05-11", "2026-05-17")).toContain(
+      MONTH_PICKER_IN_VIEW_START_CLASS,
+    );
+    expect(classNameFor("2026-05-16", "2026-05-11", "2026-05-17")).toContain(
+      MONTH_PICKER_IN_VIEW_END_CLASS,
+    );
+    expect(classNameFor("2026-05-17", "2026-05-11", "2026-05-17")).toContain(
+      MONTH_PICKER_IN_VIEW_START_CLASS,
+    );
+    expect(classNameFor("2026-05-17", "2026-05-11", "2026-05-17")).toContain(
+      MONTH_PICKER_IN_VIEW_END_CLASS,
+    );
+    expect(shifted).toContain(MONTH_PICKER_IN_VIEW_CLASS);
+    expect(shifted).toContain("!font-semibold");
+  });
+});

--- a/packages/web/src/components/Sidebar/MonthPicker/monthPickerDayClassName.ts
+++ b/packages/web/src/components/Sidebar/MonthPicker/monthPickerDayClassName.ts
@@ -1,0 +1,41 @@
+import { type Dayjs } from "@core/util/date/dayjs";
+
+export const MONTH_PICKER_IN_VIEW_CLASS = "react-datepicker__day--in-view";
+export const MONTH_PICKER_IN_VIEW_START_CLASS =
+  "react-datepicker__day--in-view-start";
+export const MONTH_PICKER_IN_VIEW_END_CLASS =
+  "react-datepicker__day--in-view-end";
+
+export function getMonthPickerDayClassName({
+  date,
+  selectedDate,
+  viewEnd,
+  viewStart,
+}: {
+  date: Dayjs;
+  selectedDate: Dayjs;
+  viewEnd: Dayjs;
+  viewStart: Dayjs;
+}): string {
+  const isSelected = date.isSame(selectedDate, "day");
+  const classes = [isSelected ? "!font-semibold" : "!font-light"];
+
+  if (!date.isBetween(viewStart, viewEnd, "day", "[]")) {
+    return classes.join(" ");
+  }
+
+  classes.push(MONTH_PICKER_IN_VIEW_CLASS);
+
+  if (
+    date.isSame(viewStart, "day") ||
+    date.isSame(date.startOf("week"), "day")
+  ) {
+    classes.push(MONTH_PICKER_IN_VIEW_START_CLASS);
+  }
+
+  if (date.isSame(viewEnd, "day") || date.isSame(date.endOf("week"), "day")) {
+    classes.push(MONTH_PICKER_IN_VIEW_END_CLASS);
+  }
+
+  return classes.join(" ");
+}

--- a/packages/web/src/components/Sidebar/Sidebar.test.tsx
+++ b/packages/web/src/components/Sidebar/Sidebar.test.tsx
@@ -67,6 +67,8 @@ const sidebarProps = {
   calendarDate: dayjs("2026-05-12"),
   onSelectDate: mock(),
   shortcutSections: [],
+  viewEnd: dayjs("2026-05-16"),
+  viewStart: dayjs("2026-05-10"),
 };
 
 describe("Sidebar", () => {

--- a/packages/web/src/components/Sidebar/Sidebar.tsx
+++ b/packages/web/src/components/Sidebar/Sidebar.tsx
@@ -32,6 +32,8 @@ export interface SidebarProps extends HTMLAttributes<HTMLDivElement> {
   onSelectDate: (date: Dayjs) => void;
   shortcutSections: ShortcutOverlaySection[];
   shortcutsViewLabel?: string;
+  viewEnd: Dayjs;
+  viewStart: Dayjs;
 }
 
 export function Sidebar({
@@ -41,6 +43,8 @@ export function Sidebar({
   onSelectDate,
   shortcutSections,
   shortcutsViewLabel,
+  viewEnd,
+  viewStart,
   ...props
 }: SidebarProps) {
   const isEventFormOpen = useDraftStore(selectIsEventFormOpen);
@@ -68,6 +72,8 @@ export function Sidebar({
               monthsShown={monthsShown}
               onSelectDate={onSelectDate}
               selectedDate={calendarDate}
+              viewEnd={viewEnd}
+              viewStart={viewStart}
             />
           </Suspense>
           <UpNextCard />

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -926,17 +926,33 @@
     background: var(--date-picker-selected-bg);
     content: "";
   }
-  /* Band follows the visible window, not the calendar week of --selected. */
+  /*
+   * Tile in-view days flush so the band is one pill per row, including
+   * windows that are not Sun-Sat. Day-name labels use the same flex so
+   * they stay aligned with the dates.
+   */
+  & .react-datepicker__week,
+  & .react-datepicker__day-names {
+    justify-content: stretch;
+  }
+  & .react-datepicker__day,
+  & .react-datepicker__day-name {
+    display: flex;
+    flex: 1;
+    align-items: center;
+    justify-content: center;
+  }
   & .react-datepicker__day--in-view {
     position: relative;
     isolation: isolate;
   }
   & .react-datepicker__day--in-view::after {
     position: absolute;
-    inset: 0 -3px;
-    z-index: -2;
+    inset: 0;
+    z-index: -1;
     background: var(--date-picker-hover-bg);
     content: "";
+    pointer-events: none;
   }
   & .react-datepicker__day--in-view-start::after {
     border-top-left-radius: var(--radius-default);

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -926,20 +926,24 @@
     background: var(--date-picker-selected-bg);
     content: "";
   }
-  & .react-datepicker__week:has(.react-datepicker__day--selected) {
+  /* Band follows the visible window, not the calendar week of --selected. */
+  & .react-datepicker__day--in-view {
     position: relative;
+    isolation: isolate;
   }
-  & .react-datepicker__week:has(.react-datepicker__day--selected)::before {
+  & .react-datepicker__day--in-view::after {
     position: absolute;
     inset: 0 -3px;
-    border-radius: var(--radius-default);
+    z-index: -2;
     background: var(--date-picker-hover-bg);
     content: "";
   }
-  &
-    .react-datepicker__week:has(.react-datepicker__day--selected)
-    .react-datepicker__day {
-    position: relative;
-    z-index: 10;
+  & .react-datepicker__day--in-view-start::after {
+    border-top-left-radius: var(--radius-default);
+    border-bottom-left-radius: var(--radius-default);
+  }
+  & .react-datepicker__day--in-view-end::after {
+    border-top-right-radius: var(--radius-default);
+    border-bottom-right-radius: var(--radius-default);
   }
 }

--- a/packages/web/src/views/Day/view/DayViewContent.tsx
+++ b/packages/web/src/views/Day/view/DayViewContent.tsx
@@ -143,6 +143,8 @@ export const DayViewContent = memo(() => {
           onSelectDate={navigateToDate}
           shortcutSections={shortcutSections}
           shortcutsViewLabel="Day"
+          viewEnd={dateInView}
+          viewStart={dateInView}
         />
       </ResizableSidebarPanel>
     </div>

--- a/packages/web/src/views/Week/WeekView.tsx
+++ b/packages/web/src/views/Week/WeekView.tsx
@@ -187,6 +187,8 @@ export const WeekView = () => {
               onSelectDate={goToDateFromSidebar}
               shortcutSections={shortcutSections}
               shortcutsViewLabel="Week"
+              viewEnd={weekProps.component.endOfView}
+              viewStart={weekProps.component.startOfView}
             />
           </ResizableSidebarPanel>
         </ContextMenuWrapper>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Shift+J / Shift+K move the week grid by one day, but the sidebar month picker still painted the **calendar week of the selected day**. After a day-shift, that band no longer matched the days on screen.

The picker now receives `viewStart` / `viewEnd` from Week and Day, marks those days as in view, and paints the hover-bg band on that range. Selected-day circle is unchanged. A window that crosses Sunday becomes two rounded pills instead of one wrong Sun–Sat row.

## Simplicity

Selected-date clamp (`useSidebarCalendarDate`) is left alone. The band is a class + CSS change on the existing picker, not a second datepicker API or range-selection mode.

## Automated validation

- `bun test:web -- packages/web/src/components/Sidebar/MonthPicker packages/web/src/components/Sidebar/Sidebar.test.tsx` — 7 pass
- `bun run verify` — test:web, type-check, lint, knip passed
- Browser: Shift+K from Aug 23–29 moves the picker band to Mon 24–Sun 30 while the selected circle stays on the 26th; Shift+J returns the band to 23–29

![Month picker aligned week band on Aug 23-29](https://cursor.com/artifacts/c/art-ad73bccd-de88-4a28-aaf0-a0320233bcf9)
![Month picker after Shift+K: band on Aug 24-29 plus Aug 30](https://cursor.com/artifacts/c/art-51156a2a-1a5f-48b5-8c9b-49335573a340)
<a href="https://cursor.com/agents/bc-096938f5-d721-426c-8e31-4273e01f33aa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmonth_picker_shift_jk_clean.webm"><img src="https://cursor.com/artifacts/c/art-01f25bc3-fa62-4f0e-ab70-0422bb1a7479" alt="month_picker_shift_jk_clean.webm" /></a>

## Independent review

Self-review of the branch diff: no confirmed findings. In-view is visual-only (same as the previous week-row band). `viewStart`/`viewEnd` are destructured on `Sidebar` so they do not leak to the DOM.

## Test plan

- `bun test:web -- packages/web/src/components/Sidebar/MonthPicker packages/web/src/components/Sidebar/Sidebar.test.tsx`
- `bun run verify`
- `bun run lint`
- Playwright against `http://localhost:9080`: Shift+K / Shift+J class + screenshot check

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-096938f5-d721-426c-8e31-4273e01f33aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-096938f5-d721-426c-8e31-4273e01f33aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

