### PR TITLE
fix(web): restore month picker capsule and match week start

### DIFF
--- a/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.test.tsx
+++ b/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.test.tsx
@@ -95,4 +95,55 @@ describe("MonthPicker", () => {
       "react-datepicker__day--selected",
     );
   });
+
+  it("starts weekday columns on Monday when the week view starts Monday", () => {
+    render(
+      <MonthPicker
+        onSelectDate={mock()}
+        selectedDate={dayjs("2026-05-13")}
+        viewEnd={dayjs("2026-05-17")}
+        viewStart={dayjs("2026-05-11")}
+      />,
+    );
+
+    const weekdayHeaders = screen
+      .getByRole("group", { name: "Date navigation" })
+      .querySelectorAll(".react-datepicker__day-name");
+    expect([...weekdayHeaders].map((header) => header.textContent)).toEqual([
+      "M",
+      "T",
+      "W",
+      "T",
+      "F",
+      "S",
+      "S",
+    ]);
+
+    const monday = dayNamed("Choose Monday, May 11th, 2026");
+    const sunday = dayNamed("Choose Sunday, May 17th, 2026");
+    const previousSunday = dayNamed("Choose Sunday, May 10th, 2026");
+
+    expect(monday.closest(".react-datepicker__week")).toBe(
+      sunday.closest(".react-datepicker__week"),
+    );
+    expect(previousSunday.closest(".react-datepicker__week")).not.toBe(
+      monday.closest(".react-datepicker__week"),
+    );
+  });
+
+  it("keeps Sunday-first columns for a single-day Day view window", () => {
+    render(
+      <MonthPicker
+        onSelectDate={mock()}
+        selectedDate={dayjs("2026-05-13")}
+        viewEnd={dayjs("2026-05-13")}
+        viewStart={dayjs("2026-05-13")}
+      />,
+    );
+
+    const firstHeader = screen
+      .getByRole("group", { name: "Date navigation" })
+      .querySelector(".react-datepicker__day-name");
+    expect(firstHeader?.textContent).toBe("S");
+  });
 });

--- a/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.tsx
+++ b/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.tsx
@@ -60,6 +60,9 @@ export const MonthPicker: FC<Props> = ({
       <DatePicker
         animationOnToggle={false}
         calendarClassName={ID_DATEPICKER_SIDEBAR}
+        calendarStartDay={
+          viewStart.isSame(viewEnd, "day") ? 0 : viewStart.day()
+        }
         dayClassName={getDayClassName}
         headerActionsClassName={headerActionsClassName}
         headerClassName="!relative !justify-start !px-0 !pb-3"

--- a/packages/web/src/components/Sidebar/MonthPicker/monthPickerDayClassName.test.ts
+++ b/packages/web/src/components/Sidebar/MonthPicker/monthPickerDayClassName.test.ts
@@ -2,8 +2,6 @@ import dayjs from "@core/util/date/dayjs";
 import {
   getMonthPickerDayClassName,
   MONTH_PICKER_IN_VIEW_CLASS,
-  MONTH_PICKER_IN_VIEW_END_CLASS,
-  MONTH_PICKER_IN_VIEW_START_CLASS,
 } from "./monthPickerDayClassName";
 import { describe, expect, it } from "bun:test";
 
@@ -18,15 +16,12 @@ const classNameFor = (date: string, viewStart: string, viewEnd: string) =>
   });
 
 describe("getMonthPickerDayClassName", () => {
-  it("marks a Sun-Sat window as in view with row start and end on the edges", () => {
+  it("marks a Sun-Sat window as in view", () => {
     expect(classNameFor("2026-05-10", "2026-05-10", "2026-05-16")).toContain(
       MONTH_PICKER_IN_VIEW_CLASS,
     );
-    expect(classNameFor("2026-05-10", "2026-05-10", "2026-05-16")).toContain(
-      MONTH_PICKER_IN_VIEW_START_CLASS,
-    );
     expect(classNameFor("2026-05-16", "2026-05-10", "2026-05-16")).toContain(
-      MONTH_PICKER_IN_VIEW_END_CLASS,
+      MONTH_PICKER_IN_VIEW_CLASS,
     );
     expect(classNameFor("2026-05-13", "2026-05-10", "2026-05-16")).toContain(
       "!font-semibold",
@@ -46,16 +41,10 @@ describe("getMonthPickerDayClassName", () => {
       classNameFor("2026-05-10", "2026-05-11", "2026-05-17"),
     ).not.toContain(MONTH_PICKER_IN_VIEW_CLASS);
     expect(classNameFor("2026-05-11", "2026-05-11", "2026-05-17")).toContain(
-      MONTH_PICKER_IN_VIEW_START_CLASS,
-    );
-    expect(classNameFor("2026-05-16", "2026-05-11", "2026-05-17")).toContain(
-      MONTH_PICKER_IN_VIEW_END_CLASS,
+      MONTH_PICKER_IN_VIEW_CLASS,
     );
     expect(classNameFor("2026-05-17", "2026-05-11", "2026-05-17")).toContain(
-      MONTH_PICKER_IN_VIEW_START_CLASS,
-    );
-    expect(classNameFor("2026-05-17", "2026-05-11", "2026-05-17")).toContain(
-      MONTH_PICKER_IN_VIEW_END_CLASS,
+      MONTH_PICKER_IN_VIEW_CLASS,
     );
     expect(shifted).toContain(MONTH_PICKER_IN_VIEW_CLASS);
     expect(shifted).toContain("!font-semibold");

--- a/packages/web/src/components/Sidebar/MonthPicker/monthPickerDayClassName.ts
+++ b/packages/web/src/components/Sidebar/MonthPicker/monthPickerDayClassName.ts
@@ -1,10 +1,6 @@
 import { type Dayjs } from "@core/util/date/dayjs";
 
 export const MONTH_PICKER_IN_VIEW_CLASS = "react-datepicker__day--in-view";
-export const MONTH_PICKER_IN_VIEW_START_CLASS =
-  "react-datepicker__day--in-view-start";
-export const MONTH_PICKER_IN_VIEW_END_CLASS =
-  "react-datepicker__day--in-view-end";
 
 export function getMonthPickerDayClassName({
   date,
@@ -20,21 +16,8 @@ export function getMonthPickerDayClassName({
   const isSelected = date.isSame(selectedDate, "day");
   const classes = [isSelected ? "!font-semibold" : "!font-light"];
 
-  if (!date.isBetween(viewStart, viewEnd, "day", "[]")) {
-    return classes.join(" ");
-  }
-
-  classes.push(MONTH_PICKER_IN_VIEW_CLASS);
-
-  if (
-    date.isSame(viewStart, "day") ||
-    date.isSame(date.startOf("week"), "day")
-  ) {
-    classes.push(MONTH_PICKER_IN_VIEW_START_CLASS);
-  }
-
-  if (date.isSame(viewEnd, "day") || date.isSame(date.endOf("week"), "day")) {
-    classes.push(MONTH_PICKER_IN_VIEW_END_CLASS);
+  if (date.isBetween(viewStart, viewEnd, "day", "[]")) {
+    classes.push(MONTH_PICKER_IN_VIEW_CLASS);
   }
 
   return classes.join(" ");

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -926,40 +926,21 @@
     background: var(--date-picker-selected-bg);
     content: "";
   }
-  /*
-   * Tile in-view days flush so the band is one pill per row, including
-   * windows that are not Sun-Sat. Day-name labels use the same flex so
-   * they stay aligned with the dates.
-   */
-  & .react-datepicker__week,
-  & .react-datepicker__day-names {
-    justify-content: stretch;
-  }
-  & .react-datepicker__day,
-  & .react-datepicker__day-name {
-    display: flex;
-    flex: 1;
-    align-items: center;
-    justify-content: center;
-  }
-  & .react-datepicker__day--in-view {
+  /* One capsule on the week row that contains the visible window. */
+  & .react-datepicker__week:has(.react-datepicker__day--in-view) {
     position: relative;
-    isolation: isolate;
   }
-  & .react-datepicker__day--in-view::after {
+  & .react-datepicker__week:has(.react-datepicker__day--in-view)::before {
     position: absolute;
-    inset: 0;
-    z-index: -1;
+    inset: 0 -3px;
+    border-radius: var(--radius-default);
     background: var(--date-picker-hover-bg);
     content: "";
-    pointer-events: none;
   }
-  & .react-datepicker__day--in-view-start::after {
-    border-top-left-radius: var(--radius-default);
-    border-bottom-left-radius: var(--radius-default);
-  }
-  & .react-datepicker__day--in-view-end::after {
-    border-top-right-radius: var(--radius-default);
-    border-bottom-right-radius: var(--radius-default);
+  &
+    .react-datepicker__week:has(.react-datepicker__day--in-view)
+    .react-datepicker__day {
+    position: relative;
+    z-index: 10;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #2881. Shift+J/K correctly moved the in-view days, but the band split across two Sunday-first rows (Fri–Sat + Sun–Thu) instead of the single inset capsule in the good-light / good-dark references.

The sidebar picker now starts its weekday columns on the same day as the week view (`calendarStartDay={viewStart.day()}`), so a Mon–Sun window is one row. The highlight is the original week-row capsule keyed off `--in-view`. Day view stays Sunday-first so changing days does not rotate the month.

## Simplicity

Dropped the per-day tile / start / end classes. Column rotation is one react-datepicker prop; the capsule is the pre-#2881 week `::before` rule pointed at in-view days.

## Automated validation

- `bun test:web -- packages/web/src/components/Sidebar/MonthPicker` — 7 pass
- `bun run verify` — test:web, type-check, lint, knip, test:a11y, test:e2e all passed
- Browser: Sunday-start capsule matches the good references; Shift+K to Monday start rotates headers to `M T W T F S S` and keeps one capsule on Aug 24–30

![Dark theme Sunday-start capsule on Aug 23-29](https://cursor.com/artifacts/c/art-5c24e590-f32f-4d95-8903-3e56016ca6c9)
![Dark theme Monday-start capsule on Aug 24-30](https://cursor.com/artifacts/c/art-bf556b0c-768f-4dac-8f8f-49ab5660a286)
![Light theme Sunday-start capsule on Aug 23-29](https://cursor.com/artifacts/c/art-352207af-f7f9-4d1b-af49-87be505130df)
![Light theme Monday-start capsule on Aug 24-30](https://cursor.com/artifacts/c/art-076e830f-590d-49e0-8f5c-f7bd5756f374)
<a href="https://cursor.com/agents/bc-096938f5-d721-426c-8e31-4273e01f33aa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmonth_picker_capsule_monday_start.webm"><img src="https://cursor.com/artifacts/c/art-b5d974c9-7660-456d-af17-d39c23502b82" alt="month_picker_capsule_monday_start.webm" /></a>

## Independent review

Self-review of the branch diff: no confirmed findings. Day view keeps `calendarStartDay={0}` when start and end are the same day. Grid/event-form pickers are unchanged.

## Test plan

- `bun test:web -- packages/web/src/components/Sidebar/MonthPicker`
- `bun run verify`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-096938f5-d721-426c-8e31-4273e01f33aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-096938f5-d721-426c-8e31-4273e01f33aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

