### PR TITLE
feat(web): add book personal onboarding command

### DIFF
--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -126,7 +126,7 @@ Pressing Cmd+K opens the command palette from any view, including while a text i
 ### Expected Results
 
 - The command palette opens immediately.
-- Items include: Create event, Create all-day event, Go to Today, Practice shortcuts, Show welcome guide, Undo last change, Redo last change, Log Out.
+- Items include: Create event, Create all-day event, Go to Today, Practice shortcuts, Show welcome guide, Undo last change, Redo last change, Log Out, Book personal onboarding.
 - Undo / Redo rows show their keycaps and stay disabled when there is no history.
 - Google Calendar connection status and actions appear in the sidebar, not the command palette.
 - Typing filters the list.

--- a/packages/web/src/components/CommandPalette/more.cmd.constants.test.ts
+++ b/packages/web/src/components/CommandPalette/more.cmd.constants.test.ts
@@ -1,6 +1,7 @@
 import {
   getCommandPalettePlaceholder,
   getMoreCommandPaletteSections,
+  PERSONAL_ONBOARDING_URL,
 } from "@web/components/CommandPalette/more.cmd.constants";
 import {
   feedbackActions,
@@ -11,19 +12,29 @@ import {
   selectIsAboutOpen,
   useSettingsStore,
 } from "@web/settings/settings.store";
-import { beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
 describe("getMoreCommandPaletteSections", () => {
+  const originalWindowOpen = window.open;
+  const mockWindowOpen = mock();
+
   beforeEach(() => {
     feedbackActions.close();
     useSettingsStore.setState({ isAboutOpen: false });
+    mockWindowOpen.mockClear();
+    window.open = mockWindowOpen;
+  });
+
+  afterEach(() => {
+    window.open = originalWindowOpen;
   });
 
   it("omits feedback commands when PostHog is not enabled", () => {
     const [section] = getMoreCommandPaletteSections("week", false);
 
-    expect(section.items).toHaveLength(1);
-    expect(section.items[0].label).toBe("About Compass");
+    expect(section.items).toHaveLength(2);
+    expect(section.items[0].label).toBe("Book personal onboarding");
+    expect(section.items[1].label).toBe("About Compass");
     expect(getCommandPalettePlaceholder("day", false)).not.toContain("bug");
     expect(getCommandPalettePlaceholder("week", false)).not.toContain(
       "feedback",
@@ -32,7 +43,7 @@ describe("getMoreCommandPaletteSections", () => {
 
   it("opens the feedback request from the cloud command", () => {
     const [section] = getMoreCommandPaletteSections("day", true);
-    expect(section.items).toHaveLength(2);
+    expect(section.items).toHaveLength(3);
     expect(
       section.items.find((item) => item.id === "report-bug"),
     ).toBeUndefined();
@@ -67,5 +78,21 @@ describe("getMoreCommandPaletteSections", () => {
     about?.onClick?.();
 
     expect(selectIsAboutOpen(useSettingsStore.getState())).toBe(true);
+  });
+
+  it("opens the personal onboarding Calendly link in a new tab", () => {
+    const [section] = getMoreCommandPaletteSections("week", false);
+    const bookOnboarding = section.items.find(
+      (item) => item.id === "book-personal-onboarding",
+    );
+
+    bookOnboarding?.onClick?.();
+
+    expect(mockWindowOpen).toHaveBeenCalledTimes(1);
+    expect(mockWindowOpen).toHaveBeenCalledWith(
+      PERSONAL_ONBOARDING_URL,
+      "_blank",
+      "noopener,noreferrer",
+    );
   });
 });

--- a/packages/web/src/components/CommandPalette/more.cmd.constants.ts
+++ b/packages/web/src/components/CommandPalette/more.cmd.constants.ts
@@ -1,10 +1,13 @@
-import { ChatsIcon, InfoIcon } from "@phosphor-icons/react";
+import { CalendarCheckIcon, ChatsIcon, InfoIcon } from "@phosphor-icons/react";
 import { isPosthogEnabled } from "@web/auth/posthog/posthog.util";
 import { type CommandSection } from "@web/components/CommandPalette/command-palette.types";
 import { feedbackActions } from "@web/components/Feedback/feedback.store";
 import { settingsActions } from "@web/settings/settings.store";
 import { type ViewName } from "@web/shortcuts/shortcuts.constants";
 import { type CommandPaletteViewName } from "./navigation.cmd.constants";
+
+export const PERSONAL_ONBOARDING_URL =
+  "https://calendly.com/switchback-tech/compass-onboarding";
 
 export function getCommandPalettePlaceholder(
   currentView: CommandPaletteViewName,
@@ -47,6 +50,26 @@ export function getMoreCommandPaletteSections(
       id: "advanced",
       items: [
         ...feedbackItems,
+        {
+          id: "book-personal-onboarding",
+          label: "Book personal onboarding",
+          icon: CalendarCheckIcon,
+          keywords: [
+            "calendly",
+            "onboarding",
+            "book",
+            "meeting",
+            "call",
+            "demo",
+            "setup",
+          ],
+          onClick: () =>
+            window.open(
+              PERSONAL_ONBOARDING_URL,
+              "_blank",
+              "noopener,noreferrer",
+            ),
+        },
         {
           id: "about",
           label: "About Compass",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a command palette **More** row labeled "Book personal onboarding" that opens `https://calendly.com/switchback-tech/compass-onboarding` in a new tab (`noopener,noreferrer`). The item is available on Day, Week, and Life palettes with no auth gate.

## Simplicity

One new row in the existing More-section helper, plus a named URL constant. Palette close-on-select is already handled by `CommandPaletteContent`.

## Automated validation

Focused CommandPalette tests passed (27 pass / 0 fail), including a `window.open` assertion for the Calendly URL. Browser walkthrough: open palette, type "onboarding", select the row, Calendly tab loads, palette closes.

![Command palette filtered to Book personal onboarding](https://cursor.com/artifacts/c/art-00f56fad-99ae-4264-a11c-a9ea3c2e9e2f)
![Calendly Compass Onboarding page opened from the palette](https://cursor.com/artifacts/c/art-22afdd9a-1915-4ffc-84fe-85953ae09f3d)
<a href="https://cursor.com/agents/bc-e1f51638-2179-4b3b-b45a-32700adf2d48/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbook_personal_onboarding_command_palette.mp4"><img src="https://cursor.com/artifacts/c/art-80b96438-41c7-42b4-8fe3-ff4afff8cf33" alt="book_personal_onboarding_command_palette.mp4" /></a>

## Independent review

Pending a reviewer. This change is a single palette row plus tests.

## Test plan

- `bun test:web packages/web/src/components/CommandPalette/more.cmd.constants.test.ts packages/web/src/components/CommandPalette/CommandPalette.test.tsx` — 27 pass, 0 fail
- `bun lint` — exit 0 (pre-existing warnings only)
- Manual: `bun run dev:web` at http://localhost:9080, Ctrl+K, type `onboarding`, select **Book personal onboarding** — opens Calendly in a new tab and closes the palette

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1f51638-2179-4b3b-b45a-32700adf2d48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1f51638-2179-4b3b-b45a-32700adf2d48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

