### PR TITLE
feat(web): share availability from day and week views

### DIFF
--- a/.agents/handoffs/2885.md
+++ b/.agents/handoffs/2885.md
@@ -1,0 +1,37 @@
+---
+schema_version: 1
+task_id: "2885"
+from: Verifier
+to: Manager
+owner: Manager
+status: escalated
+artifact:
+  - path: docs/features/share-availability.md
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/2885
+  - path: packages/web/src/availability/AvailabilityGridOverlay.tsx
+evidence:
+  - command: git diff HEAD^ --stat
+    result: Existing PR contains the 333-line documentation-only feature specification; implementation is pending.
+  - command: bun type-check
+    result: Passed after implementation commit 5d11691.
+  - command: mise exec bun@1.3.14 -- bun test --preload ./packages/web/src/__tests__/web.preload.ts ./packages/web/src/availability/AvailabilityPanel.test.tsx ./packages/web/src/availability/availability-slot.util.test.ts ./packages/web/src/availability/availability-message.util.test.ts ./packages/web/src/grid/shortcuts/useCalendarViewShortcuts.test.tsx
+    result: Passed 18 tests with 0 failures after commit b8b3b94.
+  - command: mise exec bun@1.3.14 -- bun run test:web
+    result: Failed in unchanged AuthModal reset-password tests and cascaded; isolated AuthModal run reproduced the two timeouts.
+assumptions:
+  - The checked-in specification is the frozen MVP product contract.
+  - Scope is frontend-only Day and Week desktop behavior.
+open_risks:
+  - Required test:web remains red in unchanged AuthModal tests, so verifier cannot issue PASS.
+  - Playwright accessibility and E2E checks were not reached.
+next_deadline: 2026-08-27T12:00:00Z
+retry: 2
+approval: human
+waiting_on: null
+escalation:
+  reason: Verifier remained RETRY after two implementation retries because required package acceptance is red in unchanged AuthModal tests.
+  requested_action: Maintainer should resolve or explicitly waive the unrelated AuthModal suite failure, then rerun verification before merge.
+---
+
+Implement the full Share Availability specification, then route through verify,
+simplify, independent review, PR checks, and squash merge.

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -15,3 +15,4 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | 2878 | medium | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/2878 | bun run verify: web, type-check, lint, knip passed; bun test:a11y 7 passed | 2026-08-26T03:00:00Z | 0 | none |
 | 2879 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/2879 | bun run verify PASS; review: no confirmed findings | 2026-08-26T06:00:00Z | 0 | none |
+| 2885 | high | Manager | escalated | b8b3b94 | availability 18/18 and type-check pass; required test:web red in unchanged AuthModal tests after 2 retries | 2026-08-27T12:00:00Z | 2 | human |

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ Internal documentation for engineers and agents working in the Compass repo.
 - Local-first or storage behavior: [Offline Storage And Migrations](./features/offline-storage-and-migrations.md)
 - Backend routes and API behavior: [Backend Route Map](./backend/README.md), [Backend Request Flow](./backend/backend-request-flow.md), [Backend Error Handling](./backend/backend-error-handling.md)
 - Trial, pricing, or Stripe: [Billing And Trial](./features/billing.md)
+- Sharing free time as copyable text: [Share Availability](./features/share-availability.md)
 - A new calendar integration or Google-sync behavior: [Google Sync And SSE Flow](./features/google-sync-and-sse-flow.md), the `packages/sync` domain code directly
 
 ## Architecture And Domain

--- a/docs/features/share-availability.md
+++ b/docs/features/share-availability.md
@@ -1,0 +1,332 @@
+# Share Availability — Implementation Specification
+
+Status: **Ready for implementation**
+Scope: **Frontend-only MVP; Day and Week views; desktop keyboard and pointer**
+
+## 1. Summary
+
+Share Availability turns free time into a concise plain-text message. Pressing
+`A` enters availability mode, Compass proposes future 30-minute slots in the
+visible calendar window, and the user toggles or draws slots before copying the
+message. An optional recipient time zone renders every interval in both zones.
+
+This is selection and formatting only. It does not create events, reserve time,
+create booking links, contact recipients, or persist availability to a server.
+
+## 2. Goals and non-goals
+
+### Goals
+
+- Produce an accurate, human-friendly message with few keystrokes.
+- Make the four most useful free slots selected by default.
+- Keep keyboard and pointer workflows at parity.
+- Never propose or allow a slot wholly or partly in the past.
+- Make source and recipient zones unambiguous, including across DST.
+- Work in anonymous/local mode and with connected calendars.
+
+### Non-goals for MVP
+
+- Booking pages, group polls, attendees, meeting metadata, or configurable
+  conflict policies.
+- Saving/reusing slot sets or syncing them across devices.
+- Natural-language editing of the generated message.
+- Mobile support. The existing mobile gate remains unchanged.
+
+## 3. Entry, exit, and shortcut changes
+
+### Entry
+
+- From Day or Week view, while no input, modal, event draft, or app lock owns
+  the keyboard, `A` enters availability mode.
+- Add **Share availability — A** to the Create shortcut section and a **Share
+  availability** command-palette row.
+- Entry opens a collapsed sidebar without changing the visible range or scroll.
+- If an event form is open, `A` remains suppressed and must not discard it.
+
+### All-day creation remap
+
+- Remap **Create all-day event** from `A` to the simultaneous chord `Shift+C`
+  in Day, Week, command-palette keycaps, shortcut registry, onboarding/showcase
+  copy if present, tests, and acceptance docs.
+- This is a chord, not sequential `Shift`, then `C`.
+- Plain `C` continues to create a timed event.
+
+### Exit
+
+- `Escape` exits availability mode and restores the normal sidebar. If the
+  zone picker is open, the first `Escape` closes only the picker.
+- The sidebar close button exits the mode and closes the sidebar.
+- Top-level view navigation exits and discards availability state.
+- Copying does not exit, so the user can adjust and copy again.
+- Restore focus to the grid, or to the command launcher if still mounted.
+
+## 4. Availability-mode layout
+
+### Sidebar
+
+Replace the normal month picker / Up Next / calendar list body with an
+`AvailabilityPanel`, while retaining `SidebarShell` and its close control.
+
+Panel order:
+
+1. Heading **Share availability** and close button.
+2. Read-only live preview of the exact clipboard text.
+3. Source-zone chip; **Add recipient timezone** (`Z`); removable recipient chip.
+4. Help: **Arrow keys move · Enter or Space toggles · drag to add**.
+5. Sticky **Copy to clipboard** footer with `⌘ C` on macOS or `Ctrl C` elsewhere.
+
+When empty, disable and rename the button **Select a time to copy**. The preview
+is generated document text rather than a textbox, but remains pointer-selectable.
+
+### Grid
+
+- Render slots in a dedicated overlay above backgrounds and below event cards.
+  Never model slots as events or put them in event caches.
+- Unselected candidates use low-emphasis semantic accent; selected slots use a
+  high-emphasis fill and selected marker; the active slot has a separate focus
+  ring distinguishable from selection.
+- Busy and past cells have no candidate and cannot be selected.
+- Do not obscure event text, the now line, or day labels.
+- Grid and preview update immediately after selection changes.
+
+## 5. Slot model and conflict rules
+
+Use instants for correctness and IANA zone IDs for presentation:
+
+```ts
+type AvailabilitySlot = {
+  id: string; // `${start}/${end}`
+  start: string; // ISO instant
+  end: string; // ISO instant
+  selected: boolean;
+  origin: "suggested" | "user";
+};
+```
+
+State is ephemeral and feature-local (Zustand store or provider), not event
+draft state. Store instants and zone IDs; derive labels. Adjacent cells may be
+stored separately but normalize into intervals for preview/copy.
+
+### Candidate generation
+
+1. Use the visible Day/Week interval, clipped to `now`.
+2. Use 30-minute duration with starts aligned to local `:00`/`:30` in the
+   effective/source zone.
+3. Generate only 09:00–17:00 Monday–Friday; the last slot ends at 17:00.
+4. Exclude any candidate overlapping a timed event by even one instant;
+   end-equals-start is not overlap.
+5. An all-day event makes its local date unavailable.
+6. Include events from every calendar available to the repository, even hidden
+   calendars. Cancelled/deleted and transparent/free events do not block when
+   known; otherwise treat returned events as busy (fail safe).
+7. Never generate `start < now`. Recheck on toggle and copy so long-open panels
+   cannot copy a newly past slot.
+
+Candidate generation and normalization are pure, unit-tested utilities. Fetch
+the visible range independently of the visible-calendar-filtered grid model.
+
+### Four default selections
+
+Select up to four candidates deterministically:
+
+1. Rank weekdays chronologically from the first visible future day.
+2. Within a day rank by distance from 10:00, then 14:00, then earlier start.
+3. First pass: at most one per day.
+4. Second pass fills remaining positions, keeping at least 60 minutes between
+   selected starts on one day where possible.
+5. Stop at four; if fewer exist, select all; if none, show the empty state.
+
+This spreads choices across days, favors ordinary work hours, and is testable.
+Defaults compute once on entry. Query refreshes remove new conflicts but do not
+select replacements, avoiding surprising changes under the user.
+
+### User-created slots
+
+- Drag on empty timed-grid space to create a selected interval, snapping to
+  30-minute boundaries with a 30-minute minimum.
+- Support upward/downward drag; clamp to the day, `now`, and 09:00–17:00.
+- A drag may span adjacent free cells and normalizes to one interval. It stops
+  at rather than crosses a busy interval.
+- Clicking a candidate toggles its 30-minute slot.
+- In this mode, drag/click must not create drafts or move/resize events. Event
+  cards remain visible but non-editable until exit.
+
+## 6. Keyboard interaction
+
+On entry, activate the earliest selected candidate, otherwise the earliest
+available candidate.
+
+- `ArrowUp`/`ArrowDown`: previous/next candidate on the same day.
+- `ArrowLeft`/`ArrowRight`: nearest start time on the adjacent visible day,
+  continuing across days with no candidates.
+- `Enter` or `Space`: toggle active candidate.
+- `Z`: use the existing zone search UI with a new `availability-recipient`
+  purpose; commit only to this mode, not pinning or time travel.
+- `Mod+C`: copy while the mode owns the shortcut and prevent browser copy.
+- Suspend normal creation, navigation, editing, event-jump, and time-travel
+  shortcuts. Global Escape/sidebar rules remain as above.
+
+Use roving focus or `aria-activedescendant`, not a tab stop per cell. Expose the
+overlay as a multiselectable grid/listbox. Accessible names include full source
+date, time range, and **selected**/**not selected**; announce changes politely.
+
+## 7. Time-zone behavior
+
+- Freeze `useEffectiveTimeZone()` as the source zone on entry. Show its
+  abbreviation while retaining its IANA ID.
+- Extend the existing picker with an explicit recipient purpose/callback; never
+  temporarily mutate the time-travel store.
+- Selecting the same IANA zone as source removes the recipient zone.
+- Calculate abbreviations per interval. If DST changes within the slot set, use
+  the applicable abbreviation on each row.
+- The heading uses slash-separated abbreviations only when each zone has one
+  unambiguous abbreviation across selected slots (for example `MDT/GMT`).
+  Otherwise use compact IANA-derived labels (for example `Denver/London`) and
+  retain per-row abbreviations.
+
+## 8. Message formatting
+
+Preview and clipboard call the same pure formatter. Output uses `\n`, no
+Markdown, no trailing whitespace, and no final newline. Use Compass's 12/24-hour
+preference if one exists, otherwise locale-default formatting.
+
+Single zone:
+
+```text
+Do any of these times (MDT) work for you?
+
+August 27 (Thursday):
+- 10:00am–10:30am (MDT)
+- 2:00pm–2:30pm (MDT)
+```
+
+Two zones:
+
+```text
+Do any of these times (EST/GMT) work for you?
+
+March 6 (Friday):
+- 8:00am–8:30am (EST) / 1:00pm–1:30pm (GMT)
+- 9:30am–10:00am (EST) / 2:30pm–3:00pm (GMT)
+```
+
+Rules:
+
+- Sort by source start and group by source calendar date.
+- Heading is `MMMM D (dddd):`; include year when different from the current
+  source-zone year or the selection spans years.
+- Merge exactly adjacent selected cells with no conflict gap.
+- Use an en dash without spaces and ` / ` between zones.
+- Always show a zone abbreviation per bullet.
+- If the recipient date differs, prefix its short date, e.g.
+  `11:30pm–12:00am (MDT) / Mar 7, 6:30am–7:00am (GMT)`.
+- Empty preview: **Select times on the calendar to build your message.** Never
+  copy this placeholder.
+
+## 9. Copy feedback and failures
+
+- Button and `Mod+C` call `navigator.clipboard.writeText` with formatter output.
+- Success toast: **Copied slots to clipboard.** in the normal `aria-live`
+  status region and existing toast position/timing.
+- On rejection/unavailability show **Couldn’t copy availability. Select the
+  message and copy it manually.**, focus the preview, and select it
+  programmatically. Never show success.
+- Before copy, remove newly past or conflicting slots. If none remain, disable
+  copy and announce why.
+
+## 10. Loading, empty, error, and live-update states
+
+- While conflicts load, show panel/grid skeletons and disable copy; never flash
+  unverified suggestions.
+- No candidates: **No free 30-minute times in this view.** Offer **Next week**
+  in Week or **Next day** in Day; navigation recomputes defaults.
+- Query failure: **Availability couldn’t be checked. Try again.** with retry.
+  Fail closed and offer no unchecked slots.
+- If a live update creates a conflict, remove the slot, update preview, and
+  announce **A selected time was removed because it is no longer free.**
+
+## 11. Architecture and file ownership
+
+Create `packages/web/src/availability/` without a barrel file:
+
+- `availability.store.ts`: mode, active/selected slots, and zones.
+- `availability-slot.util.ts`: candidates, overlap, ranking, normalization.
+- `availability-message.util.ts`: deterministic formatter.
+- `useAvailabilityEvents.ts`: all-calendar range query.
+- `useAvailabilityShortcuts.ts`: mode-owned bindings.
+- `AvailabilityPanel.tsx`: sidebar UI.
+- `AvailabilityGridOverlay.tsx`: semantic grid layer.
+- A small toast utility using existing toast primitives.
+
+Integration points:
+
+- `Sidebar.tsx` renders availability content ahead of normal content; event
+  details retain priority because the mode cannot enter over a draft.
+- Day/Week owners provide visible dates/range and mount the overlay.
+- `useCalendarViewShortcuts.ts` remaps all-day creation and enters the mode.
+- Update `shortcuts.registry.ts`, command-palette event constants, and any
+  keymap/showcase source together.
+- Extend `timezone-dialog.store.ts` and `TimezonePickerDialog.tsx` with the
+  recipient selection purpose without coupling it to time travel.
+
+No backend/core contract is needed because no data crosses a network boundary.
+
+## 12. Privacy-safe analytics
+
+When analytics consent is active, emit no titles, calendar IDs, dates, times, or
+zone IDs. Suggested events:
+
+- `availability_opened` (`view`, `entrypoint`)
+- `availability_slot_toggled` (`selected`, `origin`)
+- `availability_recipient_zone_added`
+- `availability_copied` (`slot_count`, `interval_count`, `has_recipient_zone`)
+- `availability_copy_failed` (`reason_category`)
+- `availability_closed` (`copied`, `selected_slot_count`)
+
+## 13. Test plan
+
+### Unit
+
+- Alignment, window/future clipping, timed/all-day overlap, boundary equality,
+  hidden-calendar conflicts, and DST days.
+- Default ranking with zero, fewer than four, and many candidates.
+- Adjacent merge, sorting/grouping, year/date rollover, 12/24-hour output,
+  one/two zones, and DST abbreviation changes.
+
+### React Testing Library
+
+- Entry/exit, draft suppression, and sidebar replacement/restoration.
+- Arrow navigation, roving focus, toggles, and live announcements.
+- `Z` selection without changing pinned/time-travel state.
+- Button/`Mod+C` success/failure, disabled/empty, query, and live-conflict states.
+- Registry, command palette, and `Shift+C` all-day regression.
+- Use role/name/text queries and `user-event`, never CSS/data locators.
+
+### Integration / E2E
+
+1. Enter Week mode with events and verify exactly four valid defaults.
+2. Toggle by keyboard and drag a multi-cell interval; no event draft opens.
+3. Add a recipient zone whose date differs, copy, and compare exact clipboard
+   text with the preview.
+4. Confirm past, busy, and all-day periods cannot be selected.
+5. After exit, confirm `Shift+C` creates all-day and `C` creates timed.
+6. Run accessibility checks in light/dark themes and reduced motion.
+
+## 14. Acceptance criteria
+
+- `A` enters from idle Day/Week views in one keystroke.
+- Up to four free, future working-hour slots are selected deterministically,
+  including conflicts from hidden calendars.
+- Pointer and keyboard users can change slots without mutating events.
+- Preview exactly matches successful clipboard content.
+- Recipient-zone output is instant-correct and leaves global zones unchanged.
+- Empty selections cannot copy; success and failures are announced.
+- `Shift+C` replaces `A` everywhere for all-day creation.
+- Tests cover selection, formatting edges, keyboard, clipboard, and shortcuts.
+
+## 15. Deferred product decisions
+
+Do not block MVP on configurable duration/working hours, calendar-specific
+conflicts, persisted presets, booking links, editable prose, multiple recipient
+zones, or history-based ranking. Each needs a separate product and privacy
+decision.

--- a/e2e/utils/event-test-utils.ts
+++ b/e2e/utils/event-test-utils.ts
@@ -297,11 +297,11 @@ export const openTimedEventFormWithKeyboard = async (page: Page) => {
   await titleInput.waitFor({ state: "visible", timeout: FORM_TIMEOUT });
 };
 
-/** Opens an all-day draft via the `a` shortcut. */
+/** Opens an all-day draft via the `Shift+C` shortcut. */
 export const openAllDayEventFormWithKeyboard = async (page: Page) => {
   await blurActiveElement(page);
   await page.locator("#mainGrid").focus();
-  await page.keyboard.press("a");
+  await page.keyboard.press("Shift+C");
   await getFormTitleInput(page).waitFor({
     state: "visible",
     timeout: FORM_TIMEOUT,

--- a/packages/web/src/__tests__/utils/state/reset-stores.ts
+++ b/packages/web/src/__tests__/utils/state/reset-stores.ts
@@ -4,10 +4,15 @@
  * test isolation comes from resetting them between tests instead of building
  * a fresh store per render.
  */
+
 import {
   initialUserMetadataState,
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
+import {
+  initialAvailabilityState,
+  useAvailabilityStore,
+} from "@web/availability/availability.store";
 import { resetCalendarVisibilityStoreForTests } from "@web/calendars/calendar-visibility.store";
 import { resetCollapsedAccountsStoreForTests } from "@web/calendars/collapsed-accounts.store";
 import { resetDefaultCalendarStoreForTests } from "@web/calendars/default-calendar.store";
@@ -54,6 +59,7 @@ import { useTimezoneDialogStore } from "@web/timezone/timezone-dialog.store";
 type StoreReset = () => void;
 
 const storeResets: StoreReset[] = [
+  () => useAvailabilityStore.setState(initialAvailabilityState, true),
   () => useSettingsStore.setState(initialSettingsState, true),
   () => useViewStore.setState(initialViewState, true),
   () => useUserMetadataStore.setState(initialUserMetadataState, true),

--- a/packages/web/src/__tests__/utils/state/seed-stores.ts
+++ b/packages/web/src/__tests__/utils/state/seed-stores.ts
@@ -3,6 +3,10 @@ import {
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
 import {
+  type AvailabilityState,
+  useAvailabilityStore,
+} from "@web/availability/availability.store";
+import {
   type State_DraftEvent,
   useDraftStore,
 } from "@web/events/stores/draft.store";
@@ -16,6 +20,7 @@ type ViewState = ReturnType<typeof useViewStore.getState>;
  * State shape accepted by the render helpers' `state` option.
  */
 export type TestAppState = {
+  availability?: Partial<AvailabilityState>;
   events?: { draft?: Partial<State_DraftEvent> };
   settings?: Partial<SettingsState>;
   userMetadata?: Partial<UserMetadataState>;
@@ -26,7 +31,8 @@ export type TestAppState = {
 export function seedStoresFromState(state?: TestAppState): void {
   if (!state) return;
 
-  const { events, settings, userMetadata, view } = state;
+  const { availability, events, settings, userMetadata, view } = state;
+  if (availability) useAvailabilityStore.setState(availability);
   if (events?.draft) useDraftStore.setState(events.draft);
   if (settings) useSettingsStore.setState(settings);
   if (userMetadata) useUserMetadataStore.setState(userMetadata);

--- a/packages/web/src/auth/posthog/track.ts
+++ b/packages/web/src/auth/posthog/track.ts
@@ -25,7 +25,13 @@ export type ProductEvent =
   | "billing_gate_cta_clicked"
   | "notifications_enabled"
   | "notifications_disabled"
-  | "notifications_enable_denied";
+  | "notifications_enable_denied"
+  | "availability_opened"
+  | "availability_slot_toggled"
+  | "availability_recipient_zone_added"
+  | "availability_copied"
+  | "availability_copy_failed"
+  | "availability_closed";
 
 /**
  * Fire-and-forget capture for the small set of product-activation events.

--- a/packages/web/src/availability/AvailabilityGridOverlay.tsx
+++ b/packages/web/src/availability/AvailabilityGridOverlay.tsx
@@ -1,0 +1,36 @@
+import {
+  availabilityActions,
+  useAvailabilityStore,
+} from "./availability.store";
+
+export function AvailabilityGridOverlay() {
+  const { activeId, isOpen, slots, sourceZone } = useAvailabilityStore();
+  if (!isOpen) return null;
+  return (
+    <div
+      aria-label="Availability times"
+      aria-multiselectable="true"
+      className="pointer-events-none absolute inset-0 z-10"
+      role="listbox"
+    >
+      <div className="pointer-events-auto absolute right-2 bottom-2 flex max-h-[45%] w-56 flex-col gap-1 overflow-auto rounded border border-border bg-surface-panel/95 p-2 shadow-lg">
+        {slots.map((slot) => {
+          const label = `${new Intl.DateTimeFormat(undefined, { timeZone: sourceZone, weekday: "short", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }).format(new Date(slot.start))}, ${slot.selected ? "selected" : "not selected"}`;
+          return (
+            <button
+              aria-label={label}
+              aria-selected={slot.selected}
+              className={`c-focus-ring rounded px-2 py-1 text-left text-xs ${slot.selected ? "bg-accent-primary text-background" : "bg-accent-secondary text-text"} ${activeId === slot.id ? "ring-2 ring-text" : ""}`}
+              key={slot.id}
+              onClick={() => availabilityActions.toggle(slot.id)}
+              role="option"
+              type="button"
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/availability/AvailabilityGridOverlay.tsx
+++ b/packages/web/src/availability/AvailabilityGridOverlay.tsx
@@ -64,7 +64,7 @@ export function AvailabilityGridOverlay({
             key={slot.id}
             onClick={() => availabilityActions.toggle(slot.id)}
             onPointerDown={(event) => {
-              event.currentTarget.setPointerCapture(event.pointerId);
+              event.currentTarget.setPointerCapture?.(event.pointerId);
               dragStart.current = slot.id;
             }}
             onPointerEnter={() => {

--- a/packages/web/src/availability/AvailabilityGridOverlay.tsx
+++ b/packages/web/src/availability/AvailabilityGridOverlay.tsx
@@ -1,0 +1,94 @@
+import { useRef } from "react";
+import {
+  availabilityActions,
+  useAvailabilityStore,
+} from "./availability.store";
+
+interface Props {
+  visibleDates: string[];
+  hourHeight?: number;
+}
+
+const dateKey = (iso: string, zone: string) =>
+  new Intl.DateTimeFormat("en-CA", {
+    timeZone: zone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(new Date(iso));
+
+export function AvailabilityGridOverlay({
+  visibleDates,
+  hourHeight = 48,
+}: Props) {
+  const { activeId, isOpen, slots, sourceZone, status } =
+    useAvailabilityStore();
+  const dragStart = useRef<string | null>(null);
+  if (!isOpen) return null;
+  if (status === "loading")
+    return (
+      <div
+        aria-label="Checking availability"
+        className="absolute inset-0 z-10 animate-pulse bg-surface-panel/20"
+        role="status"
+      />
+    );
+  if (status === "error") return null;
+  return (
+    <div
+      aria-label="Availability times"
+      aria-multiselectable="true"
+      className="pointer-events-none absolute inset-0 z-10"
+      role="listbox"
+    >
+      {slots.map((slot) => {
+        const dayIndex = visibleDates.indexOf(dateKey(slot.start, sourceZone));
+        if (dayIndex < 0) return null;
+        const parts = Object.fromEntries(
+          new Intl.DateTimeFormat("en-US", {
+            timeZone: sourceZone,
+            hour: "2-digit",
+            minute: "2-digit",
+            hourCycle: "h23",
+          })
+            .formatToParts(new Date(slot.start))
+            .map(({ type, value }) => [type, value]),
+        );
+        const minutes = Number(parts.hour) * 60 + Number(parts.minute);
+        const label = `${new Intl.DateTimeFormat(undefined, { timeZone: sourceZone, weekday: "long", month: "long", day: "numeric", hour: "numeric", minute: "2-digit" }).format(new Date(slot.start))}, ${slot.selected ? "selected" : "not selected"}`;
+        return (
+          <button
+            aria-label={label}
+            aria-selected={slot.selected}
+            className={`c-focus-ring pointer-events-auto absolute rounded-sm border border-accent-primary/40 text-left text-xs ${slot.selected ? "bg-accent-primary/80 text-background" : "bg-accent-secondary/50 text-text"} ${activeId === slot.id ? "ring-2 ring-text" : ""}`}
+            key={slot.id}
+            onClick={() => availabilityActions.toggle(slot.id)}
+            onPointerDown={(event) => {
+              event.currentTarget.setPointerCapture?.(event.pointerId);
+              dragStart.current = slot.id;
+            }}
+            onPointerEnter={() => {
+              if (dragStart.current)
+                availabilityActions.selectRange(dragStart.current, slot.id);
+            }}
+            onPointerUp={() => {
+              if (dragStart.current)
+                availabilityActions.selectRange(dragStart.current, slot.id);
+              dragStart.current = null;
+            }}
+            role="option"
+            style={{
+              left: `${(dayIndex / visibleDates.length) * 100}%`,
+              top: `${(minutes / 60) * hourHeight}px`,
+              width: `${100 / visibleDates.length}%`,
+              height: `${hourHeight / 2}px`,
+            }}
+            type="button"
+          >
+            <span className="sr-only">{label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/web/src/availability/AvailabilityGridOverlay.tsx
+++ b/packages/web/src/availability/AvailabilityGridOverlay.tsx
@@ -1,11 +1,39 @@
+import { useRef } from "react";
 import {
   availabilityActions,
   useAvailabilityStore,
 } from "./availability.store";
 
-export function AvailabilityGridOverlay() {
-  const { activeId, isOpen, slots, sourceZone } = useAvailabilityStore();
+interface Props {
+  visibleDates: string[];
+  hourHeight?: number;
+}
+
+const dateKey = (iso: string, zone: string) =>
+  new Intl.DateTimeFormat("en-CA", {
+    timeZone: zone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(new Date(iso));
+
+export function AvailabilityGridOverlay({
+  visibleDates,
+  hourHeight = 48,
+}: Props) {
+  const { activeId, isOpen, slots, sourceZone, status } =
+    useAvailabilityStore();
+  const dragStart = useRef<string | null>(null);
   if (!isOpen) return null;
+  if (status === "loading")
+    return (
+      <div
+        aria-label="Checking availability"
+        className="absolute inset-0 z-10 animate-pulse bg-surface-panel/20"
+        role="status"
+      />
+    );
+  if (status === "error") return null;
   return (
     <div
       aria-label="Availability times"
@@ -13,24 +41,54 @@ export function AvailabilityGridOverlay() {
       className="pointer-events-none absolute inset-0 z-10"
       role="listbox"
     >
-      <div className="pointer-events-auto absolute right-2 bottom-2 flex max-h-[45%] w-56 flex-col gap-1 overflow-auto rounded border border-border bg-surface-panel/95 p-2 shadow-lg">
-        {slots.map((slot) => {
-          const label = `${new Intl.DateTimeFormat(undefined, { timeZone: sourceZone, weekday: "short", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }).format(new Date(slot.start))}, ${slot.selected ? "selected" : "not selected"}`;
-          return (
-            <button
-              aria-label={label}
-              aria-selected={slot.selected}
-              className={`c-focus-ring rounded px-2 py-1 text-left text-xs ${slot.selected ? "bg-accent-primary text-background" : "bg-accent-secondary text-text"} ${activeId === slot.id ? "ring-2 ring-text" : ""}`}
-              key={slot.id}
-              onClick={() => availabilityActions.toggle(slot.id)}
-              role="option"
-              type="button"
-            >
-              {label}
-            </button>
-          );
-        })}
-      </div>
+      {slots.map((slot) => {
+        const dayIndex = visibleDates.indexOf(dateKey(slot.start, sourceZone));
+        if (dayIndex < 0) return null;
+        const parts = Object.fromEntries(
+          new Intl.DateTimeFormat("en-US", {
+            timeZone: sourceZone,
+            hour: "2-digit",
+            minute: "2-digit",
+            hourCycle: "h23",
+          })
+            .formatToParts(new Date(slot.start))
+            .map(({ type, value }) => [type, value]),
+        );
+        const minutes = Number(parts.hour) * 60 + Number(parts.minute);
+        const label = `${new Intl.DateTimeFormat(undefined, { timeZone: sourceZone, weekday: "long", month: "long", day: "numeric", hour: "numeric", minute: "2-digit" }).format(new Date(slot.start))}, ${slot.selected ? "selected" : "not selected"}`;
+        return (
+          <button
+            aria-label={label}
+            aria-selected={slot.selected}
+            className={`c-focus-ring pointer-events-auto absolute rounded-sm border border-accent-primary/40 text-left text-xs ${slot.selected ? "bg-accent-primary/80 text-background" : "bg-accent-secondary/50 text-text"} ${activeId === slot.id ? "ring-2 ring-text" : ""}`}
+            key={slot.id}
+            onClick={() => availabilityActions.toggle(slot.id)}
+            onPointerDown={(event) => {
+              event.currentTarget.setPointerCapture(event.pointerId);
+              dragStart.current = slot.id;
+            }}
+            onPointerEnter={() => {
+              if (dragStart.current)
+                availabilityActions.selectRange(dragStart.current, slot.id);
+            }}
+            onPointerUp={() => {
+              if (dragStart.current)
+                availabilityActions.selectRange(dragStart.current, slot.id);
+              dragStart.current = null;
+            }}
+            role="option"
+            style={{
+              left: `${(dayIndex / visibleDates.length) * 100}%`,
+              top: `${(minutes / 60) * hourHeight}px`,
+              width: `${100 / visibleDates.length}%`,
+              height: `${hourHeight / 2}px`,
+            }}
+            type="button"
+          >
+            <span className="sr-only">{label}</span>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/packages/web/src/availability/AvailabilityPanel.test.tsx
+++ b/packages/web/src/availability/AvailabilityPanel.test.tsx
@@ -1,0 +1,133 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { getTimeTravelZone } from "@web/timezone/time-travel.store";
+import { useTimezoneDialogStore } from "@web/timezone/timezone-dialog.store";
+import { AvailabilityGridOverlay } from "./AvailabilityGridOverlay";
+import { AvailabilityPanel } from "./AvailabilityPanel";
+import {
+  availabilityActions,
+  useAvailabilityStore,
+} from "./availability.store";
+import { describe, expect, it, mock } from "bun:test";
+
+const slot = (hour: number, selected = false) => {
+  const start = `2099-08-27T${String(hour).padStart(2, "0")}:00:00.000Z`;
+  const end = `2099-08-27T${String(hour).padStart(2, "0")}:30:00.000Z`;
+  return {
+    id: `${start}/${end}`,
+    start,
+    end,
+    selected,
+    origin: "suggested" as const,
+  };
+};
+
+describe("AvailabilityPanel", () => {
+  it("disables empty copy and shows loading, error, and live announcements", () => {
+    availabilityActions.open();
+    availabilityActions.setStatus("loading");
+    const view = render(<AvailabilityPanel />);
+    expect(
+      screen.getByRole("button", { name: "Copy availability to clipboard" }),
+    ).toBeDisabled();
+    expect(screen.getByText("Checking your calendars…")).toBeInTheDocument();
+
+    act(() => {
+      availabilityActions.setStatus("error");
+      availabilityActions.announce(
+        "A selected time was removed because it is no longer free.",
+      );
+    });
+    view.rerender(<AvailabilityPanel />);
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Availability couldn’t be checked",
+    );
+    expect(
+      screen.getByText(
+        "A selected time was removed because it is no longer free.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("copies the exact preview", async () => {
+    const user = userEvent.setup();
+    const writeText = mock().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    availabilityActions.open([slot(10, true)]);
+    availabilityActions.setStatus("ready");
+    render(<AvailabilityPanel />);
+    const preview = screen.getByRole("region", {
+      name: "Availability message preview",
+    });
+    await user.click(
+      screen.getByRole("button", { name: "Copy availability to clipboard" }),
+    );
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(preview.textContent),
+    );
+  });
+
+  it("focuses the preview when clipboard access is rejected", async () => {
+    const user = userEvent.setup();
+    const writeText = mock(() => Promise.reject(new Error("denied")));
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    availabilityActions.open([slot(10, true)]);
+    availabilityActions.setStatus("ready");
+    render(<AvailabilityPanel />);
+    await user.click(
+      screen.getByRole("button", { name: "Copy availability to clipboard" }),
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole("region", { name: "Availability message preview" }),
+      ).toHaveFocus(),
+    );
+  });
+
+  it("commits recipient selection without mutating time travel", async () => {
+    const user = userEvent.setup();
+    availabilityActions.open([slot(10, true)]);
+    availabilityActions.setStatus("ready");
+    render(<AvailabilityPanel />);
+    await user.click(
+      screen.getByRole("button", { name: /Add recipient timezone/ }),
+    );
+    expect(useTimezoneDialogStore.getState().purpose).toBe(
+      "availability-recipient",
+    );
+    act(() => useTimezoneDialogStore.getState().onSelect?.("Europe/London"));
+    expect(useAvailabilityStore.getState().recipientZone).toBe("Europe/London");
+    expect(getTimeTravelZone()).toBeNull();
+  });
+});
+
+describe("AvailabilityGridOverlay", () => {
+  it("toggles a cell and pointer-drags across adjacent free cells", () => {
+    availabilityActions.open([slot(9), slot(10), slot(11)]);
+    availabilityActions.setStatus("ready");
+    render(
+      <AvailabilityGridOverlay hourHeight={40} visibleDates={["2099-08-27"]} />,
+    );
+    const options = screen.getAllByRole("option");
+    fireEvent.click(options[0]!);
+    expect(useAvailabilityStore.getState().slots[0]?.selected).toBe(true);
+    fireEvent.pointerDown(options[1]!, { pointerId: 1 });
+    fireEvent.pointerEnter(options[2]!, { pointerId: 1 });
+    fireEvent.pointerUp(options[2]!, { pointerId: 1 });
+    expect(
+      useAvailabilityStore.getState().slots.map(({ selected }) => selected),
+    ).toEqual([true, true, true]);
+  });
+});

--- a/packages/web/src/availability/AvailabilityPanel.tsx
+++ b/packages/web/src/availability/AvailabilityPanel.tsx
@@ -1,0 +1,144 @@
+import { XIcon } from "@phosphor-icons/react";
+import { useMemo, useRef } from "react";
+import { track } from "@web/auth/posthog/track";
+import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
+import { Btn } from "@web/components/Button/Button";
+import { timezoneDialogActions } from "@web/timezone/timezone-dialog.store";
+import {
+  availabilityActions,
+  useAvailabilityStore,
+} from "./availability.store";
+import { formatAvailabilityMessage } from "./availability-message.util";
+
+const EMPTY_MESSAGE = "Select times on the calendar to build your message.";
+
+export function AvailabilityPanel() {
+  const state = useAvailabilityStore();
+  const previewRef = useRef<HTMLDivElement>(null);
+  const selected = state.slots.filter(
+    (slot) => slot.selected && new Date(slot.start).getTime() >= Date.now(),
+  );
+  const message = useMemo(
+    () =>
+      selected.length
+        ? formatAvailabilityMessage({
+            slots: selected,
+            sourceTimeZone: state.sourceZone,
+            recipientTimeZone: state.recipientZone ?? undefined,
+          })
+        : "",
+    [selected, state.recipientZone, state.sourceZone],
+  );
+
+  const copy = async () => {
+    if (!message) return;
+    try {
+      await navigator.clipboard.writeText(message);
+      availabilityActions.markCopied();
+      track("availability_copied", {
+        slot_count: String(selected.length),
+        has_recipient_zone: String(Boolean(state.recipientZone)),
+      });
+      showStatusToast("availability-copied", "Copied slots to clipboard.");
+    } catch {
+      track("availability_copy_failed", { reason_category: "clipboard" });
+      showStatusToast(
+        "availability-copy-failed",
+        "Couldn’t copy availability. Select the message and copy it manually.",
+      );
+      previewRef.current?.focus();
+      const selection = window.getSelection();
+      if (selection && previewRef.current) {
+        const range = document.createRange();
+        range.selectNodeContents(previewRef.current);
+        selection.removeAllRanges();
+        selection.addRange(range);
+      }
+    }
+  };
+
+  return (
+    <section
+      aria-label="Share availability"
+      className="flex min-h-0 flex-1 flex-col"
+    >
+      <div className="flex items-center justify-between px-4 pb-3">
+        <h2 className="font-semibold text-base">Share availability</h2>
+        <Btn
+          aria-label="Close share availability"
+          className="h-8 w-8 text-text-muted"
+          onClick={availabilityActions.close}
+        >
+          <XIcon aria-hidden size={16} />
+        </Btn>
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-4">
+        <div aria-live="polite" className="sr-only">
+          {state.announcement}
+        </div>
+        {state.status === "loading" ? <p>Checking your calendars…</p> : null}
+        {state.status === "error" ? (
+          <div role="alert">
+            <p>Availability couldn’t be checked. Try again.</p>
+            <button
+              className="c-focus-ring underline"
+              onClick={() => window.dispatchEvent(new Event("focus"))}
+              type="button"
+            >
+              Retry
+            </button>
+          </div>
+        ) : null}
+        <section
+          aria-label="Availability message preview"
+          className="select-text whitespace-pre-wrap rounded border border-border bg-surface-overlay p-3 text-sm text-text"
+          ref={previewRef}
+          tabIndex={-1}
+        >
+          {message || EMPTY_MESSAGE}
+        </section>
+        <div className="flex flex-wrap items-center gap-2 text-xs">
+          <span className="rounded-full bg-accent-secondary px-2 py-1">
+            {state.sourceZone}
+          </span>
+          {state.recipientZone ? (
+            <button
+              className="c-focus-ring rounded-full bg-accent-secondary px-2 py-1"
+              onClick={() => availabilityActions.setRecipientZone(null)}
+              type="button"
+            >
+              {state.recipientZone} ×
+            </button>
+          ) : (
+            <button
+              className="c-focus-ring text-text-muted underline"
+              onClick={() =>
+                timezoneDialogActions.open(
+                  undefined,
+                  "availability-recipient",
+                  availabilityActions.setRecipientZone,
+                )
+              }
+              type="button"
+            >
+              Add recipient timezone (Z)
+            </button>
+          )}
+        </div>
+        <p className="text-text-muted text-xs">
+          Arrow keys move · Enter or Space toggles · drag to add
+        </p>
+      </div>
+      <div className="sticky bottom-0 border-border border-t bg-surface-panel p-4">
+        <Btn
+          aria-label="Copy availability to clipboard"
+          className="w-full bg-accent-primary px-3 py-2 font-medium text-background text-sm disabled:cursor-not-allowed disabled:opacity-50"
+          disabled={!message || state.status !== "ready"}
+          onClick={() => void copy()}
+        >
+          {message ? "Copy to clipboard  ·  Mod C" : "Select a time to copy"}
+        </Btn>
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/availability/AvailabilityPanel.tsx
+++ b/packages/web/src/availability/AvailabilityPanel.tsx
@@ -1,0 +1,122 @@
+import { XIcon } from "@phosphor-icons/react";
+import { useMemo, useRef } from "react";
+import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
+import { Btn } from "@web/components/Button/Button";
+import { timezoneDialogActions } from "@web/timezone/timezone-dialog.store";
+import {
+  availabilityActions,
+  useAvailabilityStore,
+} from "./availability.store";
+import { formatAvailabilityMessage } from "./availability-message.util";
+
+const EMPTY_MESSAGE = "Select times on the calendar to build your message.";
+
+export function AvailabilityPanel() {
+  const state = useAvailabilityStore();
+  const previewRef = useRef<HTMLDivElement>(null);
+  const selected = state.slots.filter(
+    (slot) => slot.selected && new Date(slot.start).getTime() >= Date.now(),
+  );
+  const message = useMemo(
+    () =>
+      selected.length
+        ? formatAvailabilityMessage({
+            slots: selected,
+            sourceTimeZone: state.sourceZone,
+            recipientTimeZone: state.recipientZone ?? undefined,
+          })
+        : "",
+    [selected, state.recipientZone, state.sourceZone],
+  );
+
+  const copy = async () => {
+    if (!message) return;
+    try {
+      await navigator.clipboard.writeText(message);
+      availabilityActions.markCopied();
+      showStatusToast("availability-copied", "Copied slots to clipboard.");
+    } catch {
+      showStatusToast(
+        "availability-copy-failed",
+        "Couldn’t copy availability. Select the message and copy it manually.",
+      );
+      previewRef.current?.focus();
+      const selection = window.getSelection();
+      if (selection && previewRef.current) {
+        const range = document.createRange();
+        range.selectNodeContents(previewRef.current);
+        selection.removeAllRanges();
+        selection.addRange(range);
+      }
+    }
+  };
+
+  return (
+    <section
+      aria-label="Share availability"
+      className="flex min-h-0 flex-1 flex-col"
+    >
+      <div className="flex items-center justify-between px-4 pb-3">
+        <h2 className="font-semibold text-base">Share availability</h2>
+        <Btn
+          aria-label="Close share availability"
+          className="h-8 w-8 text-text-muted"
+          onClick={availabilityActions.close}
+        >
+          <XIcon aria-hidden size={16} />
+        </Btn>
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-4">
+        <section
+          aria-label="Availability message preview"
+          className="select-text whitespace-pre-wrap rounded border border-border bg-surface-overlay p-3 text-sm text-text"
+          ref={previewRef}
+          tabIndex={-1}
+        >
+          {message || EMPTY_MESSAGE}
+        </section>
+        <div className="flex flex-wrap items-center gap-2 text-xs">
+          <span className="rounded-full bg-accent-secondary px-2 py-1">
+            {state.sourceZone}
+          </span>
+          {state.recipientZone ? (
+            <button
+              className="c-focus-ring rounded-full bg-accent-secondary px-2 py-1"
+              onClick={() => availabilityActions.setRecipientZone(null)}
+              type="button"
+            >
+              {state.recipientZone} ×
+            </button>
+          ) : (
+            <button
+              className="c-focus-ring text-text-muted underline"
+              onClick={() =>
+                timezoneDialogActions.open(
+                  undefined,
+                  "availability-recipient",
+                  availabilityActions.setRecipientZone,
+                )
+              }
+              type="button"
+            >
+              Add recipient timezone (Z)
+            </button>
+          )}
+        </div>
+        <p className="text-text-muted text-xs">
+          Arrow keys move · Enter or Space toggles · drag to add
+        </p>
+      </div>
+      <div className="sticky bottom-0 border-border border-t bg-surface-panel p-4">
+        <Btn
+          aria-label="Copy availability to clipboard"
+          className="w-full bg-accent-primary px-3 py-2 font-medium text-background text-sm disabled:cursor-not-allowed disabled:opacity-50"
+          disabled={!message}
+          onClick={() => void copy()}
+        >
+          {message ? "Copy to clipboard  ·  Mod C" : "Select a time to copy"}
+        </Btn>
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/availability/AvailabilityPanel.tsx
+++ b/packages/web/src/availability/AvailabilityPanel.tsx
@@ -1,5 +1,6 @@
 import { XIcon } from "@phosphor-icons/react";
 import { useMemo, useRef } from "react";
+import { track } from "@web/auth/posthog/track";
 import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
 import { Btn } from "@web/components/Button/Button";
 import { timezoneDialogActions } from "@web/timezone/timezone-dialog.store";
@@ -34,8 +35,13 @@ export function AvailabilityPanel() {
     try {
       await navigator.clipboard.writeText(message);
       availabilityActions.markCopied();
+      track("availability_copied", {
+        slot_count: String(selected.length),
+        has_recipient_zone: String(Boolean(state.recipientZone)),
+      });
       showStatusToast("availability-copied", "Copied slots to clipboard.");
     } catch {
+      track("availability_copy_failed", { reason_category: "clipboard" });
       showStatusToast(
         "availability-copy-failed",
         "Couldn’t copy availability. Select the message and copy it manually.",
@@ -67,6 +73,22 @@ export function AvailabilityPanel() {
         </Btn>
       </div>
       <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-4">
+        <div aria-live="polite" className="sr-only">
+          {state.announcement}
+        </div>
+        {state.status === "loading" ? <p>Checking your calendars…</p> : null}
+        {state.status === "error" ? (
+          <div role="alert">
+            <p>Availability couldn’t be checked. Try again.</p>
+            <button
+              className="c-focus-ring underline"
+              onClick={() => window.dispatchEvent(new Event("focus"))}
+              type="button"
+            >
+              Retry
+            </button>
+          </div>
+        ) : null}
         <section
           aria-label="Availability message preview"
           className="select-text whitespace-pre-wrap rounded border border-border bg-surface-overlay p-3 text-sm text-text"
@@ -111,7 +133,7 @@ export function AvailabilityPanel() {
         <Btn
           aria-label="Copy availability to clipboard"
           className="w-full bg-accent-primary px-3 py-2 font-medium text-background text-sm disabled:cursor-not-allowed disabled:opacity-50"
-          disabled={!message}
+          disabled={!message || state.status !== "ready"}
           onClick={() => void copy()}
         >
           {message ? "Copy to clipboard  ·  Mod C" : "Select a time to copy"}

--- a/packages/web/src/availability/availability-message.util.test.ts
+++ b/packages/web/src/availability/availability-message.util.test.ts
@@ -1,0 +1,71 @@
+import {
+  EMPTY_AVAILABILITY_MESSAGE,
+  formatAvailabilityMessage,
+} from "./availability-message.util";
+import { type AvailabilitySlot } from "./availability-slot.util";
+import { describe, expect, it } from "bun:test";
+
+const slot = (start: string, end: string): AvailabilitySlot => ({
+  id: `${start}/${end}`,
+  start,
+  end,
+  selected: true,
+  origin: "suggested",
+});
+
+describe("formatAvailabilityMessage", () => {
+  it("returns the placeholder for an empty selection", () => {
+    expect(
+      formatAvailabilityMessage({
+        slots: [],
+        sourceTimeZone: "America/Denver",
+      }),
+    ).toBe(EMPTY_AVAILABILITY_MESSAGE);
+  });
+
+  it("merges adjacent slots and formats the exact single-zone document", () => {
+    expect(
+      formatAvailabilityMessage({
+        slots: [
+          slot("2026-08-27T16:00:00.000Z", "2026-08-27T16:30:00.000Z"),
+          slot("2026-08-27T16:30:00.000Z", "2026-08-27T17:00:00.000Z"),
+          slot("2026-08-27T20:00:00.000Z", "2026-08-27T20:30:00.000Z"),
+        ],
+        sourceTimeZone: "America/Denver",
+        now: new Date("2026-06-01T00:00:00Z"),
+        hourCycle: "h12",
+      }),
+    ).toBe(
+      "Do any of these times (MDT) work for you?\n\nAugust 27 (Thursday):\n- 10:00am–11:00am (MDT)\n- 2:00pm–2:30pm (MDT)",
+    );
+  });
+
+  it("formats a recipient zone and prefixes its differing date", () => {
+    expect(
+      formatAvailabilityMessage({
+        slots: [slot("2026-03-07T06:30:00.000Z", "2026-03-07T07:00:00.000Z")],
+        sourceTimeZone: "America/Denver",
+        recipientTimeZone: "Europe/London",
+        now: new Date("2026-03-01T00:00:00Z"),
+        hourCycle: "h12",
+      }),
+    ).toContain("- 11:30pm–12:00am (MST) / Mar 7, 6:30am–7:00am (GMT)");
+  });
+
+  it("uses compact zone labels when selected intervals span DST abbreviations", () => {
+    const output = formatAvailabilityMessage({
+      slots: [
+        slot("2026-03-06T17:00:00Z", "2026-03-06T17:30:00Z"),
+        slot("2026-03-09T16:00:00Z", "2026-03-09T16:30:00Z"),
+      ],
+      sourceTimeZone: "America/Denver",
+      now: new Date("2026-03-01T00:00:00Z"),
+      hourCycle: "h23",
+    });
+    expect(
+      output.startsWith("Do any of these times (Denver) work for you?"),
+    ).toBe(true);
+    expect(output).toContain("(MST)");
+    expect(output).toContain("(MDT)");
+  });
+});

--- a/packages/web/src/availability/availability-message.util.ts
+++ b/packages/web/src/availability/availability-message.util.ts
@@ -1,0 +1,130 @@
+import {
+  type AvailabilitySlot,
+  normalizeAvailabilitySlots,
+} from "@web/availability/availability-slot.util";
+import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
+
+export const EMPTY_AVAILABILITY_MESSAGE =
+  "Select times on the calendar to build your message.";
+
+type FormatAvailabilityMessageOptions = {
+  slots: readonly AvailabilitySlot[];
+  sourceTimeZone: string;
+  recipientTimeZone?: string;
+  now?: Date;
+  locale?: string;
+  hourCycle?: "h12" | "h23";
+};
+
+const parts = (
+  date: Date,
+  timeZone: string,
+  locale: string,
+  options: Intl.DateTimeFormatOptions,
+) => new Intl.DateTimeFormat(locale, { timeZone, ...options }).format(date);
+const dateKey = (date: Date, timeZone: string) => {
+  const values = Object.fromEntries(
+    new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    })
+      .formatToParts(date)
+      .map(({ type, value }) => [type, value]),
+  );
+  return `${values.year}-${values.month}-${values.day}`;
+};
+const zoneLabel = (zone: string) =>
+  zone.split("/").at(-1)?.replaceAll("_", " ") ?? zone;
+
+function rangeLabel(
+  start: Date,
+  end: Date,
+  timeZone: string,
+  locale: string,
+  hourCycle?: "h12" | "h23",
+) {
+  const format: Intl.DateTimeFormatOptions = {
+    hour: "numeric",
+    minute: "2-digit",
+    hourCycle,
+  };
+  return `${parts(start, timeZone, locale, format)}–${parts(end, timeZone, locale, format)}`
+    .replaceAll(" ", "")
+    .replaceAll("AM", "am")
+    .replaceAll("PM", "pm");
+}
+
+export function formatAvailabilityMessage({
+  slots,
+  sourceTimeZone,
+  recipientTimeZone,
+  now = new Date(),
+  locale = "en-US",
+  hourCycle,
+}: FormatAvailabilityMessageOptions): string {
+  const intervals = normalizeAvailabilitySlots(slots);
+  if (!intervals.length) return EMPTY_AVAILABILITY_MESSAGE;
+  const abbreviations = (zone: string) =>
+    new Set(
+      intervals.map((slot) =>
+        formatTimeZoneAbbreviation(zone, new Date(slot.start)),
+      ),
+    );
+  const sourceAbbreviations = abbreviations(sourceTimeZone);
+  const recipientAbbreviations = recipientTimeZone
+    ? abbreviations(recipientTimeZone)
+    : undefined;
+  const headingZone =
+    sourceAbbreviations.size === 1 &&
+    (!recipientAbbreviations || recipientAbbreviations.size === 1)
+      ? [sourceAbbreviations, recipientAbbreviations]
+          .filter(Boolean)
+          .map((values) => [...values!][0])
+          .join("/")
+      : [
+          zoneLabel(sourceTimeZone),
+          recipientTimeZone && zoneLabel(recipientTimeZone),
+        ]
+          .filter(Boolean)
+          .join("/");
+  const sourceYears = new Set(
+    intervals.map((slot) =>
+      parts(new Date(slot.start), sourceTimeZone, "en-US", { year: "numeric" }),
+    ),
+  );
+  const currentYear = parts(now, sourceTimeZone, "en-US", { year: "numeric" });
+  const includeYear = sourceYears.size > 1 || !sourceYears.has(currentYear);
+  const groups = new Map<string, AvailabilitySlot[]>();
+  for (const interval of intervals) {
+    const key = dateKey(new Date(interval.start), sourceTimeZone);
+    groups.set(key, [...(groups.get(key) ?? []), interval]);
+  }
+  const lines = [`Do any of these times (${headingZone}) work for you?`, ""];
+  for (const group of groups.values()) {
+    const first = new Date(group[0].start);
+    const date = parts(first, sourceTimeZone, locale, {
+      month: "long",
+      day: "numeric",
+      ...(includeYear && { year: "numeric" }),
+    });
+    const weekday = parts(first, sourceTimeZone, locale, { weekday: "long" });
+    lines.push(`${date} (${weekday}):`);
+    for (const interval of group) {
+      const start = new Date(interval.start);
+      const end = new Date(interval.end);
+      const source = `${rangeLabel(start, end, sourceTimeZone, locale, hourCycle)} (${formatTimeZoneAbbreviation(sourceTimeZone, start)})`;
+      let bullet = `- ${source}`;
+      if (recipientTimeZone) {
+        const recipientDatePrefix =
+          dateKey(start, recipientTimeZone) === dateKey(start, sourceTimeZone)
+            ? ""
+            : `${parts(start, recipientTimeZone, locale, { month: "short", day: "numeric" })}, `;
+        bullet += ` / ${recipientDatePrefix}${rangeLabel(start, end, recipientTimeZone, locale, hourCycle)} (${formatTimeZoneAbbreviation(recipientTimeZone, start)})`;
+      }
+      lines.push(bullet);
+    }
+  }
+  return lines.join("\n");
+}

--- a/packages/web/src/availability/availability-slot.util.test.ts
+++ b/packages/web/src/availability/availability-slot.util.test.ts
@@ -1,0 +1,98 @@
+import {
+  type AvailabilitySlot,
+  generateAvailabilitySlots,
+  normalizeAvailabilitySlots,
+  selectDefaultAvailabilitySlots,
+} from "./availability-slot.util";
+import { describe, expect, it } from "bun:test";
+
+const zone = "America/Denver";
+
+describe("generateAvailabilitySlots", () => {
+  it("generates aligned weekday working-hour slots and clips past starts", () => {
+    const slots = generateAvailabilitySlots({
+      rangeStart: "2026-08-24T06:00:00Z",
+      rangeEnd: "2026-08-25T06:00:00Z",
+      now: "2026-08-24T16:15:00Z",
+      timeZone: zone,
+    });
+    expect(slots[0].start).toBe("2026-08-24T16:30:00.000Z");
+    expect(slots.at(-1)?.end).toBe("2026-08-24T23:00:00.000Z");
+  });
+
+  it("excludes overlaps and all-day dates but permits touching boundaries", () => {
+    const slots = generateAvailabilitySlots({
+      rangeStart: "2026-08-24T06:00:00Z",
+      rangeEnd: "2026-08-26T06:00:00Z",
+      now: "2026-08-24T06:00:00Z",
+      timeZone: zone,
+      conflicts: [
+        { start: "2026-08-24T16:30:00Z", end: "2026-08-24T17:00:00Z" },
+        { date: "2026-08-25", allDay: true },
+        {
+          start: "2026-08-24T18:00:00Z",
+          end: "2026-08-24T19:00:00Z",
+          busy: false,
+        },
+      ],
+    });
+    expect(
+      slots.some((slot) => slot.start === "2026-08-24T16:00:00.000Z"),
+    ).toBe(true);
+    expect(
+      slots.some((slot) => slot.start === "2026-08-24T16:30:00.000Z"),
+    ).toBe(false);
+    expect(slots.some((slot) => slot.start.startsWith("2026-08-25"))).toBe(
+      false,
+    );
+  });
+});
+
+describe("selection and normalization", () => {
+  const slot = (start: string): AvailabilitySlot => {
+    const end = new Date(Date.parse(start) + 30 * 60_000).toISOString();
+    return {
+      id: `${start}/${end}`,
+      start,
+      end,
+      selected: false,
+      origin: "suggested",
+    };
+  };
+
+  it("spreads defaults across days, then maintains one-hour spacing", () => {
+    const candidates = [
+      slot("2026-08-24T16:00:00.000Z"),
+      slot("2026-08-24T16:30:00.000Z"),
+      slot("2026-08-24T17:00:00.000Z"),
+      slot("2026-08-25T20:00:00.000Z"),
+      slot("2026-08-26T15:00:00.000Z"),
+    ];
+    const selected = selectDefaultAvailabilitySlots(candidates, zone).filter(
+      (value) => value.selected,
+    );
+    expect(selected.map((value) => value.start)).toEqual([
+      "2026-08-24T16:00:00.000Z",
+      "2026-08-24T17:00:00.000Z",
+      "2026-08-25T20:00:00.000Z",
+      "2026-08-26T15:00:00.000Z",
+    ]);
+  });
+
+  it("merges only exactly adjacent selected slots", () => {
+    const values = [
+      slot("2026-08-24T16:00:00.000Z"),
+      slot("2026-08-24T16:30:00.000Z"),
+      slot("2026-08-24T17:30:00.000Z"),
+    ].map((value) => ({ ...value, selected: true }));
+    expect(
+      normalizeAvailabilitySlots(values).map(({ start, end }) => ({
+        start,
+        end,
+      })),
+    ).toEqual([
+      { start: "2026-08-24T16:00:00.000Z", end: "2026-08-24T17:00:00.000Z" },
+      { start: "2026-08-24T17:30:00.000Z", end: "2026-08-24T18:00:00.000Z" },
+    ]);
+  });
+});

--- a/packages/web/src/availability/availability-slot.util.ts
+++ b/packages/web/src/availability/availability-slot.util.ts
@@ -1,0 +1,184 @@
+import dayjs from "@core/util/date/dayjs";
+
+export type AvailabilitySlot = {
+  id: string;
+  start: string;
+  end: string;
+  selected: boolean;
+  origin: "suggested" | "user";
+};
+
+export type AvailabilityConflict =
+  | { start: string; end: string; allDay?: false; busy?: boolean }
+  | { date: string; allDay: true; busy?: boolean };
+
+export type GenerateAvailabilitySlotsOptions = {
+  rangeStart: string | Date;
+  rangeEnd: string | Date;
+  now: string | Date;
+  timeZone: string;
+  conflicts?: readonly AvailabilityConflict[];
+};
+
+const SLOT_MINUTES = 30;
+
+export function intervalsOverlap(
+  first: Pick<AvailabilitySlot, "start" | "end">,
+  second: { start: string; end: string },
+): boolean {
+  return (
+    Date.parse(first.start) < Date.parse(second.end) &&
+    Date.parse(second.start) < Date.parse(first.end)
+  );
+}
+
+export function generateAvailabilitySlots({
+  rangeStart,
+  rangeEnd,
+  now,
+  timeZone,
+  conflicts = [],
+}: GenerateAvailabilitySlotsOptions): AvailabilitySlot[] {
+  const lowerBound = Math.max(
+    new Date(rangeStart).getTime(),
+    new Date(now).getTime(),
+  );
+  const upperBound = new Date(rangeEnd).getTime();
+  if (lowerBound >= upperBound) return [];
+
+  const blockedDates = new Set(
+    conflicts
+      .filter(
+        (
+          conflict,
+        ): conflict is Extract<AvailabilityConflict, { allDay: true }> =>
+          conflict.busy !== false && conflict.allDay === true,
+      )
+      .map((conflict) => conflict.date),
+  );
+  const timedConflicts = conflicts.filter(
+    (conflict): conflict is Extract<AvailabilityConflict, { allDay?: false }> =>
+      conflict.busy !== false && !conflict.allDay,
+  );
+  const firstDate = dayjs(rangeStart).tz(timeZone).startOf("day");
+  const lastDate = dayjs(rangeEnd).tz(timeZone).startOf("day");
+  const slots: AvailabilitySlot[] = [];
+
+  for (
+    let date = firstDate;
+    !date.isAfter(lastDate, "day");
+    date = date.add(1, "day")
+  ) {
+    const weekday = date.day();
+    const localDate = date.format("YYYY-MM-DD");
+    if (weekday === 0 || weekday === 6 || blockedDates.has(localDate)) continue;
+
+    for (let hour = 9; hour < 17; hour += 1) {
+      for (const minute of [0, 30]) {
+        const start = dayjs.tz(
+          `${localDate} ${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`,
+          "YYYY-MM-DD HH:mm",
+          timeZone,
+        );
+        const end = start.add(SLOT_MINUTES, "minute");
+        const startMs = start.valueOf();
+        const endMs = end.valueOf();
+        if (startMs < lowerBound || endMs > upperBound) continue;
+        const slot = { start: start.toISOString(), end: end.toISOString() };
+        if (timedConflicts.some((conflict) => intervalsOverlap(slot, conflict)))
+          continue;
+        slots.push({
+          id: `${slot.start}/${slot.end}`,
+          ...slot,
+          selected: false,
+          origin: "suggested",
+        });
+      }
+    }
+  }
+  return slots;
+}
+
+function localParts(slot: AvailabilitySlot, timeZone: string) {
+  const local = dayjs(slot.start).tz(timeZone);
+  return {
+    date: local.format("YYYY-MM-DD"),
+    minutes: local.hour() * 60 + local.minute(),
+  };
+}
+
+export function selectDefaultAvailabilitySlots(
+  slots: readonly AvailabilitySlot[],
+  timeZone: string,
+  limit = 4,
+): AvailabilitySlot[] {
+  const sorted = [...slots].sort((a, b) => {
+    const left = localParts(a, timeZone);
+    const right = localParts(b, timeZone);
+    return (
+      left.date.localeCompare(right.date) ||
+      Math.abs(left.minutes - 600) - Math.abs(right.minutes - 600) ||
+      Math.abs(left.minutes - 840) - Math.abs(right.minutes - 840) ||
+      left.minutes - right.minutes ||
+      a.start.localeCompare(b.start)
+    );
+  });
+  const selected = new Set<string>();
+  const days = new Set<string>();
+  for (const slot of sorted) {
+    const day = localParts(slot, timeZone).date;
+    if (!days.has(day)) {
+      selected.add(slot.id);
+      days.add(day);
+      if (selected.size === limit) break;
+    }
+  }
+
+  if (selected.size < limit) {
+    const fill = (requireSpacing: boolean) => {
+      for (const slot of sorted) {
+        if (selected.has(slot.id)) continue;
+        const candidate = localParts(slot, timeZone);
+        const sameDayStarts = sorted
+          .filter(
+            (other) =>
+              selected.has(other.id) &&
+              localParts(other, timeZone).date === candidate.date,
+          )
+          .map((other) => localParts(other, timeZone).minutes);
+        if (
+          requireSpacing &&
+          sameDayStarts.some(
+            (minutes) => Math.abs(minutes - candidate.minutes) < 60,
+          )
+        )
+          continue;
+        selected.add(slot.id);
+        if (selected.size === limit) return;
+      }
+    };
+    fill(true);
+    if (selected.size < limit) fill(false);
+  }
+  return slots.map((slot) => ({ ...slot, selected: selected.has(slot.id) }));
+}
+
+export function normalizeAvailabilitySlots(
+  slots: readonly AvailabilitySlot[],
+): AvailabilitySlot[] {
+  const selected = slots
+    .filter((slot) => slot.selected)
+    .sort((a, b) => Date.parse(a.start) - Date.parse(b.start));
+  const normalized: AvailabilitySlot[] = [];
+  for (const slot of selected) {
+    const previous = normalized.at(-1);
+    if (previous && previous.end === slot.start) {
+      previous.end = slot.end;
+      previous.id = `${previous.start}/${previous.end}`;
+      if (slot.origin === "user") previous.origin = "user";
+    } else {
+      normalized.push({ ...slot });
+    }
+  }
+  return normalized;
+}

--- a/packages/web/src/availability/availability.store.ts
+++ b/packages/web/src/availability/availability.store.ts
@@ -1,0 +1,76 @@
+import { create } from "zustand";
+import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
+import { type AvailabilitySlot } from "./availability-slot.util";
+
+interface AvailabilityState {
+  isOpen: boolean;
+  sourceZone: string;
+  recipientZone: string | null;
+  slots: AvailabilitySlot[];
+  activeId: string | null;
+  copied: boolean;
+}
+
+const initialState: AvailabilityState = {
+  isOpen: false,
+  sourceZone: "UTC",
+  recipientZone: null,
+  slots: [],
+  activeId: null,
+  copied: false,
+};
+
+export const useAvailabilityStore = create<AvailabilityState>()(
+  () => initialState,
+);
+
+export const availabilityActions = {
+  open(slots: AvailabilitySlot[] = []) {
+    const selected = slots.find((slot) => slot.selected) ?? slots[0];
+    useAvailabilityStore.setState({
+      ...initialState,
+      isOpen: true,
+      sourceZone: getEffectiveTimeZone(),
+      slots,
+      activeId: selected?.id ?? null,
+    });
+  },
+  close() {
+    useAvailabilityStore.setState(initialState);
+  },
+  setSlots(slots: AvailabilitySlot[]) {
+    const current = useAvailabilityStore.getState();
+    useAvailabilityStore.setState({
+      slots,
+      activeId: slots.some(({ id }) => id === current.activeId)
+        ? current.activeId
+        : ((slots.find((slot) => slot.selected) ?? slots[0])?.id ?? null),
+    });
+  },
+  toggle(id: string) {
+    const now = Date.now();
+    useAvailabilityStore.setState((state) => ({
+      slots: state.slots.map((slot) =>
+        slot.id === id && new Date(slot.start).getTime() >= now
+          ? { ...slot, selected: !slot.selected, origin: "user" }
+          : slot,
+      ),
+      activeId: id,
+    }));
+  },
+  setActive(activeId: string) {
+    useAvailabilityStore.setState({ activeId });
+  },
+  setRecipientZone(recipientZone: string | null) {
+    const { sourceZone } = useAvailabilityStore.getState();
+    useAvailabilityStore.setState({
+      recipientZone: recipientZone === sourceZone ? null : recipientZone,
+    });
+  },
+  markCopied() {
+    useAvailabilityStore.setState({ copied: true });
+  },
+};
+
+export const selectAvailabilityOpen = (state: AvailabilityState) =>
+  state.isOpen;

--- a/packages/web/src/availability/availability.store.ts
+++ b/packages/web/src/availability/availability.store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { track } from "@web/auth/posthog/track";
 import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 import { type AvailabilitySlot } from "./availability-slot.util";
 
@@ -9,6 +10,8 @@ interface AvailabilityState {
   slots: AvailabilitySlot[];
   activeId: string | null;
   copied: boolean;
+  status: "idle" | "loading" | "ready" | "error";
+  announcement: string;
 }
 
 const initialState: AvailabilityState = {
@@ -18,6 +21,8 @@ const initialState: AvailabilityState = {
   slots: [],
   activeId: null,
   copied: false,
+  status: "idle",
+  announcement: "",
 };
 
 export const useAvailabilityStore = create<AvailabilityState>()(
@@ -26,6 +31,7 @@ export const useAvailabilityStore = create<AvailabilityState>()(
 
 export const availabilityActions = {
   open(slots: AvailabilitySlot[] = []) {
+    track("availability_opened");
     const selected = slots.find((slot) => slot.selected) ?? slots[0];
     useAvailabilityStore.setState({
       ...initialState,
@@ -36,6 +42,14 @@ export const availabilityActions = {
     });
   },
   close() {
+    const state = useAvailabilityStore.getState();
+    if (state.isOpen)
+      track("availability_closed", {
+        copied: String(state.copied),
+        selected_slot_count: String(
+          state.slots.filter(({ selected }) => selected).length,
+        ),
+      });
     useAvailabilityStore.setState(initialState);
   },
   setSlots(slots: AvailabilitySlot[]) {
@@ -45,6 +59,40 @@ export const availabilityActions = {
       activeId: slots.some(({ id }) => id === current.activeId)
         ? current.activeId
         : ((slots.find((slot) => slot.selected) ?? slots[0])?.id ?? null),
+      status: "ready",
+    });
+  },
+  setStatus(status: AvailabilityState["status"]) {
+    useAvailabilityStore.setState({ status });
+  },
+  announce(announcement: string) {
+    useAvailabilityStore.setState({ announcement });
+  },
+  selectRange(startId: string, endId: string) {
+    useAvailabilityStore.setState((state) => {
+      const start = state.slots.findIndex(({ id }) => id === startId);
+      const end = state.slots.findIndex(({ id }) => id === endId);
+      if (start < 0 || end < 0) return state;
+      const low = Math.min(start, end);
+      const high = Math.max(start, end);
+      const day = new Date(state.slots[start]?.start ?? 0).toLocaleDateString(
+        "en-CA",
+        { timeZone: state.sourceZone },
+      );
+      return {
+        slots: state.slots.map((slot, index) => ({
+          ...slot,
+          selected:
+            slot.selected ||
+            (index >= low &&
+              index <= high &&
+              new Date(slot.start).toLocaleDateString("en-CA", {
+                timeZone: state.sourceZone,
+              }) === day),
+          origin: index >= low && index <= high ? "user" : slot.origin,
+        })),
+        activeId: endId,
+      };
     });
   },
   toggle(id: string) {
@@ -57,6 +105,14 @@ export const availabilityActions = {
       ),
       activeId: id,
     }));
+    const slot = useAvailabilityStore
+      .getState()
+      .slots.find((item) => item.id === id);
+    if (slot)
+      track("availability_slot_toggled", {
+        selected: String(slot.selected),
+        origin: slot.origin,
+      });
   },
   setActive(activeId: string) {
     useAvailabilityStore.setState({ activeId });
@@ -66,6 +122,8 @@ export const availabilityActions = {
     useAvailabilityStore.setState({
       recipientZone: recipientZone === sourceZone ? null : recipientZone,
     });
+    if (recipientZone && recipientZone !== sourceZone)
+      track("availability_recipient_zone_added");
   },
   markCopied() {
     useAvailabilityStore.setState({ copied: true });

--- a/packages/web/src/availability/availability.store.ts
+++ b/packages/web/src/availability/availability.store.ts
@@ -3,7 +3,7 @@ import { track } from "@web/auth/posthog/track";
 import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 import { type AvailabilitySlot } from "./availability-slot.util";
 
-interface AvailabilityState {
+export interface AvailabilityState {
   isOpen: boolean;
   sourceZone: string;
   recipientZone: string | null;
@@ -14,7 +14,7 @@ interface AvailabilityState {
   announcement: string;
 }
 
-const initialState: AvailabilityState = {
+export const initialAvailabilityState: AvailabilityState = {
   isOpen: false,
   sourceZone: "UTC",
   recipientZone: null,
@@ -26,7 +26,7 @@ const initialState: AvailabilityState = {
 };
 
 export const useAvailabilityStore = create<AvailabilityState>()(
-  () => initialState,
+  () => initialAvailabilityState,
 );
 
 export const availabilityActions = {
@@ -34,7 +34,7 @@ export const availabilityActions = {
     track("availability_opened");
     const selected = slots.find((slot) => slot.selected) ?? slots[0];
     useAvailabilityStore.setState({
-      ...initialState,
+      ...initialAvailabilityState,
       isOpen: true,
       sourceZone: getEffectiveTimeZone(),
       slots,
@@ -50,7 +50,7 @@ export const availabilityActions = {
           state.slots.filter(({ selected }) => selected).length,
         ),
       });
-    useAvailabilityStore.setState(initialState);
+    useAvailabilityStore.setState(initialAvailabilityState);
   },
   setSlots(slots: AvailabilitySlot[]) {
     const current = useAvailabilityStore.getState();

--- a/packages/web/src/availability/availability.store.ts
+++ b/packages/web/src/availability/availability.store.ts
@@ -1,0 +1,134 @@
+import { create } from "zustand";
+import { track } from "@web/auth/posthog/track";
+import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
+import { type AvailabilitySlot } from "./availability-slot.util";
+
+export interface AvailabilityState {
+  isOpen: boolean;
+  sourceZone: string;
+  recipientZone: string | null;
+  slots: AvailabilitySlot[];
+  activeId: string | null;
+  copied: boolean;
+  status: "idle" | "loading" | "ready" | "error";
+  announcement: string;
+}
+
+export const initialAvailabilityState: AvailabilityState = {
+  isOpen: false,
+  sourceZone: "UTC",
+  recipientZone: null,
+  slots: [],
+  activeId: null,
+  copied: false,
+  status: "idle",
+  announcement: "",
+};
+
+export const useAvailabilityStore = create<AvailabilityState>()(
+  () => initialAvailabilityState,
+);
+
+export const availabilityActions = {
+  open(slots: AvailabilitySlot[] = []) {
+    track("availability_opened");
+    const selected = slots.find((slot) => slot.selected) ?? slots[0];
+    useAvailabilityStore.setState({
+      ...initialAvailabilityState,
+      isOpen: true,
+      sourceZone: getEffectiveTimeZone(),
+      slots,
+      activeId: selected?.id ?? null,
+    });
+  },
+  close() {
+    const state = useAvailabilityStore.getState();
+    if (state.isOpen)
+      track("availability_closed", {
+        copied: String(state.copied),
+        selected_slot_count: String(
+          state.slots.filter(({ selected }) => selected).length,
+        ),
+      });
+    useAvailabilityStore.setState(initialAvailabilityState);
+  },
+  setSlots(slots: AvailabilitySlot[]) {
+    const current = useAvailabilityStore.getState();
+    useAvailabilityStore.setState({
+      slots,
+      activeId: slots.some(({ id }) => id === current.activeId)
+        ? current.activeId
+        : ((slots.find((slot) => slot.selected) ?? slots[0])?.id ?? null),
+      status: "ready",
+    });
+  },
+  setStatus(status: AvailabilityState["status"]) {
+    useAvailabilityStore.setState({ status });
+  },
+  announce(announcement: string) {
+    useAvailabilityStore.setState({ announcement });
+  },
+  selectRange(startId: string, endId: string) {
+    useAvailabilityStore.setState((state) => {
+      const start = state.slots.findIndex(({ id }) => id === startId);
+      const end = state.slots.findIndex(({ id }) => id === endId);
+      if (start < 0 || end < 0) return state;
+      const low = Math.min(start, end);
+      const high = Math.max(start, end);
+      const day = new Date(state.slots[start]?.start ?? 0).toLocaleDateString(
+        "en-CA",
+        { timeZone: state.sourceZone },
+      );
+      return {
+        slots: state.slots.map((slot, index) => ({
+          ...slot,
+          selected:
+            slot.selected ||
+            (index >= low &&
+              index <= high &&
+              new Date(slot.start).toLocaleDateString("en-CA", {
+                timeZone: state.sourceZone,
+              }) === day),
+          origin: index >= low && index <= high ? "user" : slot.origin,
+        })),
+        activeId: endId,
+      };
+    });
+  },
+  toggle(id: string) {
+    const now = Date.now();
+    useAvailabilityStore.setState((state) => ({
+      slots: state.slots.map((slot) =>
+        slot.id === id && new Date(slot.start).getTime() >= now
+          ? { ...slot, selected: !slot.selected, origin: "user" }
+          : slot,
+      ),
+      activeId: id,
+    }));
+    const slot = useAvailabilityStore
+      .getState()
+      .slots.find((item) => item.id === id);
+    if (slot)
+      track("availability_slot_toggled", {
+        selected: String(slot.selected),
+        origin: slot.origin,
+      });
+  },
+  setActive(activeId: string) {
+    useAvailabilityStore.setState({ activeId });
+  },
+  setRecipientZone(recipientZone: string | null) {
+    const { sourceZone } = useAvailabilityStore.getState();
+    useAvailabilityStore.setState({
+      recipientZone: recipientZone === sourceZone ? null : recipientZone,
+    });
+    if (recipientZone && recipientZone !== sourceZone)
+      track("availability_recipient_zone_added");
+  },
+  markCopied() {
+    useAvailabilityStore.setState({ copied: true });
+  },
+};
+
+export const selectAvailabilityOpen = (state: AvailabilityState) =>
+  state.isOpen;

--- a/packages/web/src/availability/useAvailabilityEvents.ts
+++ b/packages/web/src/availability/useAvailabilityEvents.ts
@@ -1,0 +1,64 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo } from "react";
+import { type Dayjs } from "@core/util/date/dayjs";
+import { useCalendarsQuery } from "@web/calendars/calendar.query";
+import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
+import { weekEventsQueryOptions } from "@web/events/queries/event.query.options";
+import { useEventRepositorySource } from "@web/events/repositories/event.repository.source.store";
+import {
+  availabilityActions,
+  useAvailabilityStore,
+} from "./availability.store";
+import {
+  type AvailabilityConflict,
+  generateAvailabilitySlots,
+  selectDefaultAvailabilitySlots,
+} from "./availability-slot.util";
+
+export function useAvailabilityEvents(start: Dayjs, end: Dayjs) {
+  const isOpen = useAvailabilityStore((state) => state.isOpen);
+  const sourceZone = useAvailabilityStore((state) => state.sourceZone);
+  const source = useEventRepositorySource();
+  const calendars = useCalendarsQuery();
+  const calendarIds = useMemo(
+    () =>
+      calendars.data?.filter(({ isActive }) => isActive).map(({ id }) => id),
+    [calendars.data],
+  );
+  const query = useQuery({
+    ...weekEventsQueryOptions({
+      source,
+      startDate: toUTCOffset(start.startOf("day")),
+      endDate: toUTCOffset(end.add(1, "day").startOf("day")),
+      calendarIds,
+    }),
+    enabled: isOpen && calendars.isSuccess,
+  });
+  useEffect(() => {
+    if (!isOpen || !query.data) return;
+    const conflicts = query.data.ids.reduce<AvailabilityConflict[]>(
+      (result, id) => {
+        const event = query.data?.entities[id];
+        if (!event) return result;
+        if (event.schedule.kind === "allDay") {
+          result.push({ date: event.schedule.start, allDay: true });
+        } else {
+          result.push({ start: event.schedule.start, end: event.schedule.end });
+        }
+        return result;
+      },
+      [],
+    );
+    const generated = generateAvailabilitySlots({
+      rangeStart: start.toDate(),
+      rangeEnd: end.add(1, "day").startOf("day").toDate(),
+      now: new Date(),
+      timeZone: sourceZone,
+      conflicts,
+    });
+    availabilityActions.setSlots(
+      selectDefaultAvailabilitySlots(generated, sourceZone),
+    );
+  }, [end, isOpen, query.data, sourceZone, start]);
+  return query;
+}

--- a/packages/web/src/availability/useAvailabilityEvents.ts
+++ b/packages/web/src/availability/useAvailabilityEvents.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { type Dayjs } from "@core/util/date/dayjs";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
@@ -25,6 +25,16 @@ export function useAvailabilityEvents(start: Dayjs, end: Dayjs) {
       calendars.data?.filter(({ isActive }) => isActive).map(({ id }) => id),
     [calendars.data],
   );
+  const rangeKey = `${start.format("YYYY-MM-DD")}/${end.format("YYYY-MM-DD")}`;
+  const previousRange = useRef(rangeKey);
+  useEffect(() => {
+    if (
+      previousRange.current !== rangeKey &&
+      useAvailabilityStore.getState().isOpen
+    )
+      availabilityActions.close();
+    previousRange.current = rangeKey;
+  }, [rangeKey]);
   const query = useQuery({
     ...weekEventsQueryOptions({
       source,
@@ -35,7 +45,10 @@ export function useAvailabilityEvents(start: Dayjs, end: Dayjs) {
     enabled: isOpen && calendars.isSuccess,
   });
   useEffect(() => {
-    if (!isOpen || !query.data) return;
+    if (!isOpen) return;
+    if (query.isPending) availabilityActions.setStatus("loading");
+    if (query.isError) availabilityActions.setStatus("error");
+    if (!query.data) return;
     const conflicts = query.data.ids.reduce<AvailabilityConflict[]>(
       (result, id) => {
         const event = query.data?.entities[id];
@@ -56,9 +69,39 @@ export function useAvailabilityEvents(start: Dayjs, end: Dayjs) {
       timeZone: sourceZone,
       conflicts,
     });
-    availabilityActions.setSlots(
-      selectDefaultAvailabilitySlots(generated, sourceZone),
+    const existing = useAvailabilityStore.getState().slots;
+    if (!existing.length) {
+      availabilityActions.setSlots(
+        selectDefaultAvailabilitySlots(generated, sourceZone),
+      );
+      return;
+    }
+    const generatedIds = new Set(generated.map(({ id }) => id));
+    const removedSelected = existing.some(
+      (slot) => slot.selected && !generatedIds.has(slot.id),
     );
-  }, [end, isOpen, query.data, sourceZone, start]);
+    const selectedIds = new Set(
+      existing.filter(({ selected }) => selected).map(({ id }) => id),
+    );
+    availabilityActions.setSlots(
+      generated.map((slot) => ({
+        ...slot,
+        selected: selectedIds.has(slot.id),
+        origin: selectedIds.has(slot.id) ? "user" : slot.origin,
+      })),
+    );
+    if (removedSelected)
+      availabilityActions.announce(
+        "A selected time was removed because it is no longer free.",
+      );
+  }, [
+    end,
+    isOpen,
+    query.data,
+    query.isError,
+    query.isPending,
+    sourceZone,
+    start,
+  ]);
   return query;
 }

--- a/packages/web/src/availability/useAvailabilityEvents.ts
+++ b/packages/web/src/availability/useAvailabilityEvents.ts
@@ -1,0 +1,107 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useRef } from "react";
+import { type Dayjs } from "@core/util/date/dayjs";
+import { useCalendarsQuery } from "@web/calendars/calendar.query";
+import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
+import { weekEventsQueryOptions } from "@web/events/queries/event.query.options";
+import { useEventRepositorySource } from "@web/events/repositories/event.repository.source.store";
+import {
+  availabilityActions,
+  useAvailabilityStore,
+} from "./availability.store";
+import {
+  type AvailabilityConflict,
+  generateAvailabilitySlots,
+  selectDefaultAvailabilitySlots,
+} from "./availability-slot.util";
+
+export function useAvailabilityEvents(start: Dayjs, end: Dayjs) {
+  const isOpen = useAvailabilityStore((state) => state.isOpen);
+  const sourceZone = useAvailabilityStore((state) => state.sourceZone);
+  const source = useEventRepositorySource();
+  const calendars = useCalendarsQuery();
+  const calendarIds = useMemo(
+    () =>
+      calendars.data?.filter(({ isActive }) => isActive).map(({ id }) => id),
+    [calendars.data],
+  );
+  const rangeKey = `${start.format("YYYY-MM-DD")}/${end.format("YYYY-MM-DD")}`;
+  const previousRange = useRef(rangeKey);
+  useEffect(() => {
+    if (
+      previousRange.current !== rangeKey &&
+      useAvailabilityStore.getState().isOpen
+    )
+      availabilityActions.close();
+    previousRange.current = rangeKey;
+  }, [rangeKey]);
+  const query = useQuery({
+    ...weekEventsQueryOptions({
+      source,
+      startDate: toUTCOffset(start.startOf("day")),
+      endDate: toUTCOffset(end.add(1, "day").startOf("day")),
+      calendarIds,
+    }),
+    enabled: isOpen && calendars.isSuccess,
+  });
+  useEffect(() => {
+    if (!isOpen) return;
+    if (query.isPending) availabilityActions.setStatus("loading");
+    if (query.isError) availabilityActions.setStatus("error");
+    if (!query.data) return;
+    const conflicts = query.data.ids.reduce<AvailabilityConflict[]>(
+      (result, id) => {
+        const event = query.data?.entities[id];
+        if (!event) return result;
+        if (event.schedule.kind === "allDay") {
+          result.push({ date: event.schedule.start, allDay: true });
+        } else {
+          result.push({ start: event.schedule.start, end: event.schedule.end });
+        }
+        return result;
+      },
+      [],
+    );
+    const generated = generateAvailabilitySlots({
+      rangeStart: start.toDate(),
+      rangeEnd: end.add(1, "day").startOf("day").toDate(),
+      now: new Date(),
+      timeZone: sourceZone,
+      conflicts,
+    });
+    const existing = useAvailabilityStore.getState().slots;
+    if (!existing.length) {
+      availabilityActions.setSlots(
+        selectDefaultAvailabilitySlots(generated, sourceZone),
+      );
+      return;
+    }
+    const generatedIds = new Set(generated.map(({ id }) => id));
+    const removedSelected = existing.some(
+      (slot) => slot.selected && !generatedIds.has(slot.id),
+    );
+    const selectedIds = new Set(
+      existing.filter(({ selected }) => selected).map(({ id }) => id),
+    );
+    availabilityActions.setSlots(
+      generated.map((slot) => ({
+        ...slot,
+        selected: selectedIds.has(slot.id),
+        origin: selectedIds.has(slot.id) ? "user" : slot.origin,
+      })),
+    );
+    if (removedSelected)
+      availabilityActions.announce(
+        "A selected time was removed because it is no longer free.",
+      );
+  }, [
+    end,
+    isOpen,
+    query.data,
+    query.isError,
+    query.isPending,
+    sourceZone,
+    start,
+  ]);
+  return query;
+}

--- a/packages/web/src/availability/useAvailabilityShortcuts.ts
+++ b/packages/web/src/availability/useAvailabilityShortcuts.ts
@@ -1,0 +1,58 @@
+import { useEffect } from "react";
+import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
+import { timezoneDialogActions } from "@web/timezone/timezone-dialog.store";
+import {
+  availabilityActions,
+  useAvailabilityStore,
+} from "./availability.store";
+
+export function useAvailabilityShortcuts() {
+  const state = useAvailabilityStore();
+  const enabled = state.isOpen;
+  const activeIndex = state.slots.findIndex(({ id }) => id === state.activeId);
+  const move = (delta: number) => {
+    if (!state.slots.length) return;
+    const next =
+      state.slots[
+        (activeIndex + delta + state.slots.length) % state.slots.length
+      ];
+    if (next) availabilityActions.setActive(next.id);
+  };
+  useAppShortcut("ArrowUp", () => move(-1), { enabled });
+  useAppShortcut("ArrowDown", () => move(1), { enabled });
+  useAppShortcut("ArrowLeft", () => move(-1), { enabled });
+  useAppShortcut("ArrowRight", () => move(1), { enabled });
+  useAppShortcut(
+    "Enter",
+    () => state.activeId && availabilityActions.toggle(state.activeId),
+    { enabled },
+  );
+  useAppShortcut(
+    "Space",
+    () => state.activeId && availabilityActions.toggle(state.activeId),
+    { enabled },
+  );
+  useAppShortcut(
+    "Z",
+    () =>
+      timezoneDialogActions.open(
+        undefined,
+        "availability-recipient",
+        availabilityActions.setRecipientZone,
+      ),
+    { enabled },
+  );
+  useAppShortcut("Escape", availabilityActions.close, { enabled });
+  useAppShortcut(
+    "Mod+C",
+    () =>
+      document
+        .querySelector<HTMLButtonElement>(
+          "[aria-label='Copy availability to clipboard']",
+        )
+        ?.click(),
+    { enabled },
+  );
+
+  useEffect(() => () => availabilityActions.close(), []);
+}

--- a/packages/web/src/availability/useAvailabilityShortcuts.ts
+++ b/packages/web/src/availability/useAvailabilityShortcuts.ts
@@ -1,0 +1,113 @@
+import { useEffect } from "react";
+import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
+import { timezoneDialogActions } from "@web/timezone/timezone-dialog.store";
+import {
+  availabilityActions,
+  useAvailabilityStore,
+} from "./availability.store";
+
+export function useAvailabilityShortcuts() {
+  const state = useAvailabilityStore();
+  const enabled = state.isOpen;
+  const activeIndex = state.slots.findIndex(({ id }) => id === state.activeId);
+  const move = (delta: number) => {
+    if (!state.slots.length) return;
+    const next =
+      state.slots[
+        (activeIndex + delta + state.slots.length) % state.slots.length
+      ];
+    if (next) availabilityActions.setActive(next.id);
+  };
+  const moveHorizontal = (delta: -1 | 1) => {
+    const active = state.slots[activeIndex];
+    if (!active) return;
+    const activeDate = new Date(active.start);
+    const activeDay = activeDate.toLocaleDateString("en-CA", {
+      timeZone: state.sourceZone,
+    });
+    const activeMinutes = Number(
+      new Intl.DateTimeFormat("en-US", {
+        timeZone: state.sourceZone,
+        hour: "2-digit",
+        minute: "2-digit",
+        hourCycle: "h23",
+      })
+        .format(activeDate)
+        .replace(":", ""),
+    );
+    const days = [
+      ...new Set(
+        state.slots.map((slot) =>
+          new Date(slot.start).toLocaleDateString("en-CA", {
+            timeZone: state.sourceZone,
+          }),
+        ),
+      ),
+    ];
+    const dayIndex = days.indexOf(activeDay);
+    const targetDay = days[dayIndex + delta];
+    if (!targetDay) return;
+    const nearest = state.slots
+      .filter(
+        (slot) =>
+          new Date(slot.start).toLocaleDateString("en-CA", {
+            timeZone: state.sourceZone,
+          }) === targetDay,
+      )
+      .sort((a, b) => {
+        const value = (slot: typeof a) =>
+          Number(
+            new Intl.DateTimeFormat("en-US", {
+              timeZone: state.sourceZone,
+              hour: "2-digit",
+              minute: "2-digit",
+              hourCycle: "h23",
+            })
+              .format(new Date(slot.start))
+              .replace(":", ""),
+          );
+        return (
+          Math.abs(value(a) - activeMinutes) -
+          Math.abs(value(b) - activeMinutes)
+        );
+      })[0];
+    if (nearest) availabilityActions.setActive(nearest.id);
+  };
+  useAppShortcut("ArrowUp", () => move(-1), { enabled });
+  useAppShortcut("ArrowDown", () => move(1), { enabled });
+  useAppShortcut("ArrowLeft", () => moveHorizontal(-1), { enabled });
+  useAppShortcut("ArrowRight", () => moveHorizontal(1), { enabled });
+  useAppShortcut(
+    "Enter",
+    () => state.activeId && availabilityActions.toggle(state.activeId),
+    { enabled },
+  );
+  useAppShortcut(
+    "Space",
+    () => state.activeId && availabilityActions.toggle(state.activeId),
+    { enabled },
+  );
+  useAppShortcut(
+    "Z",
+    () =>
+      timezoneDialogActions.open(
+        undefined,
+        "availability-recipient",
+        availabilityActions.setRecipientZone,
+      ),
+    { enabled },
+  );
+  useAppShortcut("Escape", availabilityActions.close, { enabled });
+  useAppShortcut(
+    "Mod+C",
+    () =>
+      document
+        .querySelector<HTMLButtonElement>(
+          "[aria-label='Copy availability to clipboard']",
+        )
+        ?.click(),
+    { enabled },
+  );
+
+  useEffect(() => () => availabilityActions.close(), []);
+}

--- a/packages/web/src/availability/useAvailabilityShortcuts.ts
+++ b/packages/web/src/availability/useAvailabilityShortcuts.ts
@@ -18,10 +18,65 @@ export function useAvailabilityShortcuts() {
       ];
     if (next) availabilityActions.setActive(next.id);
   };
+  const moveHorizontal = (delta: -1 | 1) => {
+    const active = state.slots[activeIndex];
+    if (!active) return;
+    const activeDate = new Date(active.start);
+    const activeDay = activeDate.toLocaleDateString("en-CA", {
+      timeZone: state.sourceZone,
+    });
+    const activeMinutes = Number(
+      new Intl.DateTimeFormat("en-US", {
+        timeZone: state.sourceZone,
+        hour: "2-digit",
+        minute: "2-digit",
+        hourCycle: "h23",
+      })
+        .format(activeDate)
+        .replace(":", ""),
+    );
+    const days = [
+      ...new Set(
+        state.slots.map((slot) =>
+          new Date(slot.start).toLocaleDateString("en-CA", {
+            timeZone: state.sourceZone,
+          }),
+        ),
+      ),
+    ];
+    const dayIndex = days.indexOf(activeDay);
+    const targetDay = days[dayIndex + delta];
+    if (!targetDay) return;
+    const nearest = state.slots
+      .filter(
+        (slot) =>
+          new Date(slot.start).toLocaleDateString("en-CA", {
+            timeZone: state.sourceZone,
+          }) === targetDay,
+      )
+      .sort((a, b) => {
+        const value = (slot: typeof a) =>
+          Number(
+            new Intl.DateTimeFormat("en-US", {
+              timeZone: state.sourceZone,
+              hour: "2-digit",
+              minute: "2-digit",
+              hourCycle: "h23",
+            })
+              .format(new Date(slot.start))
+              .replace(":", ""),
+          );
+        return (
+          Math.abs(value(a) - activeMinutes) -
+          Math.abs(value(b) - activeMinutes)
+        );
+      })[0];
+    if (nearest) availabilityActions.setActive(nearest.id);
+  };
   useAppShortcut("ArrowUp", () => move(-1), { enabled });
   useAppShortcut("ArrowDown", () => move(1), { enabled });
-  useAppShortcut("ArrowLeft", () => move(-1), { enabled });
-  useAppShortcut("ArrowRight", () => move(1), { enabled });
+  useAppShortcut("ArrowLeft", () => moveHorizontal(-1), { enabled });
+  useAppShortcut("ArrowRight", () => moveHorizontal(1), { enabled });
   useAppShortcut(
     "Enter",
     () => state.activeId && availabilityActions.toggle(state.activeId),

--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -194,8 +194,8 @@ describe("CommandPalette", () => {
     fireEvent.keyDown(input, { key: "ArrowDown" });
     expect(activeRowText(container)).toBe("Go to Today");
 
-    // Walk down to "Create all-day event", then the next ArrowDown skips the
-    // disabled Undo row and lands on the Appearance section's theme toggle.
+    // Walk down through the Create section. The ArrowDown after Share
+    // availability skips the disabled Undo row and lands on Appearance.
     fireEvent.keyDown(input, { key: "ArrowDown" }); // Go to Day
     fireEvent.keyDown(input, { key: "ArrowDown" }); // Go to Life
     fireEvent.keyDown(input, { key: "ArrowDown" }); // Show shortcuts
@@ -203,6 +203,8 @@ describe("CommandPalette", () => {
     fireEvent.keyDown(input, { key: "ArrowDown" }); // Create event
     fireEvent.keyDown(input, { key: "ArrowDown" }); // Create all-day event
     expect(activeRowText(container)).toBe("Create all-day event");
+    fireEvent.keyDown(input, { key: "ArrowDown" }); // Share availability
+    expect(activeRowText(container)).toBe("Share availability");
     fireEvent.keyDown(input, { key: "ArrowDown" }); // skips Undo last change
     expect(activeRowText(container)).toBe("Switch to light theme");
   });

--- a/packages/web/src/components/CommandPalette/event.cmd.constants.ts
+++ b/packages/web/src/components/CommandPalette/event.cmd.constants.ts
@@ -1,6 +1,8 @@
 import { PlusIcon } from "@phosphor-icons/react";
+import { availabilityActions } from "@web/availability/availability.store";
 import { emitViewCommand } from "@web/common/utils/dom/view-command-bus";
 import { type CommandItem } from "@web/components/CommandPalette/command-palette.types";
+import { viewActions } from "@web/events/stores/view.store";
 
 /**
  * View-agnostic "Common Actions" for the command palette. Emitting a view
@@ -23,8 +25,20 @@ export const eventCommandPaletteItems: CommandItem[] = [
     id: "create-allday-event",
     label: "Create all-day event",
     icon: PlusIcon,
-    shortcut: "a",
+    shortcut: "shift+c",
     keywords: ["new event", "add event", "all day"],
     onClick: () => queueMicrotask(() => emitViewCommand("CREATE_ALLDAY_DRAFT")),
+  },
+  {
+    id: "share-availability",
+    label: "Share availability",
+    icon: PlusIcon,
+    shortcut: "a",
+    keywords: ["free time", "availability", "share times"],
+    onClick: () =>
+      queueMicrotask(() => {
+        availabilityActions.open();
+        viewActions.setSidebarOpen(true);
+      }),
   },
 ];

--- a/packages/web/src/components/Sidebar/Sidebar.tsx
+++ b/packages/web/src/components/Sidebar/Sidebar.tsx
@@ -1,6 +1,11 @@
 import { lazyRouteComponent } from "@tanstack/react-router";
 import { type HTMLAttributes, type ReactNode, Suspense } from "react";
 import { type Dayjs } from "@core/util/date/dayjs";
+import { AvailabilityPanel } from "@web/availability/AvailabilityPanel";
+import {
+  selectAvailabilityOpen,
+  useAvailabilityStore,
+} from "@web/availability/availability.store";
 import {
   selectIsEventFormOpen,
   useDraftStore,
@@ -49,6 +54,7 @@ export function Sidebar({
 }: SidebarProps) {
   const isEventFormOpen = useDraftStore(selectIsEventFormOpen);
   const showEventDetails = Boolean(eventDetails) && isEventFormOpen;
+  const isAvailabilityOpen = useAvailabilityStore(selectAvailabilityOpen);
 
   return (
     <SidebarShell
@@ -65,6 +71,8 @@ export function Sidebar({
         >
           {eventDetails}
         </section>
+      ) : isAvailabilityOpen ? (
+        <AvailabilityPanel />
       ) : (
         <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto px-4 pb-5 [scrollbar-gutter:stable]">
           <Suspense fallback={<div aria-hidden className="h-63" />}>

--- a/packages/web/src/grid/shortcuts/useCalendarViewShortcuts.test.tsx
+++ b/packages/web/src/grid/shortcuts/useCalendarViewShortcuts.test.tsx
@@ -30,6 +30,7 @@ describe("useCalendarViewShortcuts", () => {
     const onNextPeriod = mock();
     const onCreateTimedEvent = mock();
     const onCreateAllDayEvent = mock();
+    const onShareAvailability = mock();
 
     renderHook(
       () =>
@@ -38,6 +39,7 @@ describe("useCalendarViewShortcuts", () => {
           onNextPeriod,
           onCreateTimedEvent,
           onCreateAllDayEvent,
+          onShareAvailability,
         }),
       { wrapper },
     );
@@ -45,12 +47,17 @@ describe("useCalendarViewShortcuts", () => {
     pressKey("j");
     pressKey("k");
     pressKey("c");
+    pressKey("C", {
+      keyDownInit: { shiftKey: true },
+      keyUpInit: { shiftKey: true },
+    });
     pressKey("a");
 
     expect(onPrevPeriod).toHaveBeenCalledTimes(1);
     expect(onNextPeriod).toHaveBeenCalledTimes(1);
     expect(onCreateTimedEvent).toHaveBeenCalledTimes(1);
     expect(onCreateAllDayEvent).toHaveBeenCalledTimes(1);
+    expect(onShareAvailability).toHaveBeenCalledTimes(1);
   });
 
   it("creates a timed event with C", async () => {
@@ -75,7 +82,11 @@ describe("useCalendarViewShortcuts", () => {
     renderHook(() => useCalendarViewShortcuts({ onCreateAllDayEvent }), {
       wrapper,
     });
-    pressKey("A", {}, input);
+    pressKey(
+      "C",
+      { keyDownInit: { shiftKey: true }, keyUpInit: { shiftKey: true } },
+      input,
+    );
 
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(onCreateAllDayEvent).not.toHaveBeenCalled();

--- a/packages/web/src/grid/shortcuts/useCalendarViewShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useCalendarViewShortcuts.ts
@@ -23,7 +23,8 @@ export interface CalendarViewShortcutsConfig {
 
 /**
  * Shared Day/Week view shortcuts: j/k navigate the period, t goes to today,
- * "c" creates a timed event, "a" an all-day event, "u" focuses the calendar;
+ * "c" creates a timed event, Shift+C creates an all-day event, "a" opens
+ * Share Availability, and "u" focuses the calendar;
  * PageUp/PageDown and Alt+ArrowUp/Down scroll the timed grid via
  * `useGridScrollShortcuts`.
  * Shift+J/K register only when the view provides a handler (Week's window

--- a/packages/web/src/grid/shortcuts/useCalendarViewShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useCalendarViewShortcuts.ts
@@ -1,3 +1,4 @@
+import { useAvailabilityStore } from "@web/availability/availability.store";
 import { useGridScrollShortcuts } from "@web/grid/shortcuts/useGridScrollShortcuts";
 import { KEYMAP } from "@web/shortcuts/keymap";
 import {
@@ -17,6 +18,7 @@ export interface CalendarViewShortcutsConfig {
   onCreateAllDayEvent?: () => void;
   onCreateTimedEvent?: () => void;
   onFocusCalendar?: () => void;
+  onShareAvailability?: () => void;
 }
 
 /**
@@ -30,6 +32,7 @@ export interface CalendarViewShortcutsConfig {
  * the thin key-registration boundary.
  */
 export function useCalendarViewShortcuts(config: CalendarViewShortcutsConfig) {
+  const availabilityOpen = useAvailabilityStore((state) => state.isOpen);
   useGridScrollShortcuts();
 
   useAppShortcutUp("J", () => config.onPrevPeriod?.());
@@ -41,14 +44,21 @@ export function useCalendarViewShortcuts(config: CalendarViewShortcutsConfig) {
     enabled: config.onShiftViewForward !== undefined,
   });
   useAppShortcutUp("T", () => config.onGoToToday?.());
-  useAppShortcutUp("A", () => config.onCreateAllDayEvent?.());
+  useAppShortcutUp("A", () => config.onShareAvailability?.(), {
+    enabled: !availabilityOpen,
+  });
+  useAppShortcutUp("Shift+C", () => config.onCreateAllDayEvent?.(), {
+    enabled: !availabilityOpen,
+  });
   useAppShortcutUp(KEYMAP.createEvent.hotkey, () =>
     config.onCreateTimedEvent?.(),
   );
   useAppShortcutUp("U", () => config.onFocusCalendar?.());
   // Keydown so a macOS Cmd+Z keyup-replay (meta already released) cannot
   // match this binding the way Mod+D vs D does on keyup.
-  useAppShortcut("Z", () =>
-    timezoneDialogActions.open(undefined, "time-travel"),
+  useAppShortcut(
+    "Z",
+    () => timezoneDialogActions.open(undefined, "time-travel"),
+    { enabled: !availabilityOpen },
   );
 }

--- a/packages/web/src/shortcuts/shortcuts.menu.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.menu.test.ts
@@ -164,13 +164,23 @@ describe("shortcut menu sections", () => {
         );
 
       expect(stripMetadata(findCreate("day")?.shortcuts ?? [])).toContainEqual({
-        keys: ["a"],
+        keys: ["Shift", "C"],
         label: "Create all-day event",
       });
       expect(stripMetadata(findCreate("week")?.shortcuts ?? [])).toContainEqual(
         {
-          keys: ["a"],
+          keys: ["Shift", "C"],
           label: "Create all-day event",
+        },
+      );
+      expect(stripMetadata(findCreate("day")?.shortcuts ?? [])).toContainEqual({
+        keys: ["A"],
+        label: "Share availability",
+      });
+      expect(stripMetadata(findCreate("week")?.shortcuts ?? [])).toContainEqual(
+        {
+          keys: ["A"],
+          label: "Share availability",
         },
       );
       expect(stripMetadata(findCreate("day")?.shortcuts ?? [])).toContainEqual({

--- a/packages/web/src/shortcuts/shortcuts.menu.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.menu.test.ts
@@ -183,6 +183,12 @@ describe("shortcut menu sections", () => {
           label: "Share availability",
         },
       );
+      expect(stripMetadata(findCreate("day")?.shortcuts ?? [])).not.toContainEqual(
+        {
+          keys: ["A"],
+          label: "Create all-day event",
+        },
+      );
       expect(stripMetadata(findCreate("day")?.shortcuts ?? [])).toContainEqual({
         keys: ["Shift", "Arrow keys"],
         label: "Place timed draft on grid",

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -140,8 +140,14 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
   },
   {
     id: "create-allday",
-    keys: ["a"],
+    keys: ["Shift", "C"],
     label: "Create all-day event",
+    section: "create",
+  },
+  {
+    id: "share-availability",
+    keys: ["A"],
+    label: "Share availability",
     section: "create",
   },
   {

--- a/packages/web/src/timezone/TimezoneDialogHost.tsx
+++ b/packages/web/src/timezone/TimezoneDialogHost.tsx
@@ -1,5 +1,6 @@
 import { TimezonePickerDialog } from "@web/timezone/TimezonePickerDialog";
 import {
+  selectTimezoneDialogOnSelect,
   selectTimezoneDialogOpen,
   selectTimezoneDialogPurpose,
   selectTimezoneDialogRestoreFocus,
@@ -11,6 +12,7 @@ export function TimezoneDialogHost() {
   const isOpen = useTimezoneDialogStore(selectTimezoneDialogOpen);
   const purpose = useTimezoneDialogStore(selectTimezoneDialogPurpose);
   const restoreFocus = useTimezoneDialogStore(selectTimezoneDialogRestoreFocus);
+  const onSelect = useTimezoneDialogStore(selectTimezoneDialogOnSelect);
   if (!isOpen) return null;
 
   return (
@@ -18,6 +20,7 @@ export function TimezoneDialogHost() {
       onDismiss={timezoneDialogActions.close}
       purpose={purpose}
       restoreFocus={restoreFocus}
+      onSelect={onSelect}
     />
   );
 }

--- a/packages/web/src/timezone/TimezonePickerDialog.tsx
+++ b/packages/web/src/timezone/TimezonePickerDialog.tsx
@@ -35,14 +35,17 @@ interface TimezonePickerDialogProps {
   onDismiss: () => void;
   purpose?: TimezoneDialogPurpose;
   restoreFocus?: () => void;
+  onSelect?: (timeZone: string | null) => void;
 }
 
 export function TimezonePickerDialog({
   onDismiss,
   purpose = "pin",
   restoreFocus,
+  onSelect,
 }: TimezonePickerDialogProps) {
   const isTimeTravel = purpose === "time-travel";
+  const isAvailability = purpose === "availability-recipient";
   const effectiveTimeZone = useEffectiveTimeZone();
   const pinnedTimeZone = usePinnedTimeZone();
   const timeTravelZone = useTimeTravelZone();
@@ -85,7 +88,9 @@ export function TimezonePickerDialog({
   }, [currentActiveId, listId]);
 
   const commit = (timeZone: string | null) => {
-    if (isTimeTravel) {
+    if (isAvailability) {
+      onSelect?.(timeZone);
+    } else if (isTimeTravel) {
       setTimeTravelZone(timeZone);
     } else {
       setPinnedTimeZone(timeZone);
@@ -128,7 +133,13 @@ export function TimezonePickerDialog({
 
   return (
     <OverlayPanel
-      title={isTimeTravel ? "Time travel" : "Change default timezone"}
+      title={
+        isTimeTravel
+          ? "Time travel"
+          : isAvailability
+            ? "Add recipient timezone"
+            : "Change default timezone"
+      }
       onDismiss={onDismiss}
       restoreFocus={restoreFocus}
       initialFocusRef={searchRef}
@@ -185,7 +196,7 @@ export function TimezonePickerDialog({
               selected={false}
             />
           ) : null}
-          {isTimeTravel ? null : (
+          {isTimeTravel || isAvailability ? null : (
             <TimezoneOptionButton
               active={currentActiveId === AUTO_ID}
               description={`Currently ${browserAbbreviation}`}

--- a/packages/web/src/timezone/timezone-dialog.store.ts
+++ b/packages/web/src/timezone/timezone-dialog.store.ts
@@ -1,11 +1,15 @@
 import { create } from "zustand";
 
-export type TimezoneDialogPurpose = "pin" | "time-travel";
+export type TimezoneDialogPurpose =
+  | "pin"
+  | "time-travel"
+  | "availability-recipient";
 
 interface TimezoneDialogState {
   isOpen: boolean;
   purpose: TimezoneDialogPurpose;
   restoreFocus?: () => void;
+  onSelect?: (timeZone: string | null) => void;
 }
 
 export const useTimezoneDialogStore = create<TimezoneDialogState>()(() => ({
@@ -14,13 +18,23 @@ export const useTimezoneDialogStore = create<TimezoneDialogState>()(() => ({
 }));
 
 export const timezoneDialogActions = {
-  open: (restoreFocus?: () => void, purpose: TimezoneDialogPurpose = "pin") =>
-    useTimezoneDialogStore.setState({ isOpen: true, purpose, restoreFocus }),
+  open: (
+    restoreFocus?: () => void,
+    purpose: TimezoneDialogPurpose = "pin",
+    onSelect?: (timeZone: string | null) => void,
+  ) =>
+    useTimezoneDialogStore.setState({
+      isOpen: true,
+      purpose,
+      restoreFocus,
+      onSelect,
+    }),
   close: () =>
     useTimezoneDialogStore.setState({
       isOpen: false,
       purpose: "pin",
       restoreFocus: undefined,
+      onSelect: undefined,
     }),
 };
 
@@ -32,3 +46,5 @@ export const selectTimezoneDialogPurpose = (state: TimezoneDialogState) =>
 
 export const selectTimezoneDialogRestoreFocus = (state: TimezoneDialogState) =>
   state.restoreFocus;
+export const selectTimezoneDialogOnSelect = (state: TimezoneDialogState) =>
+  state.onSelect;

--- a/packages/web/src/views/Day/view/DayViewContent.tsx
+++ b/packages/web/src/views/Day/view/DayViewContent.tsx
@@ -143,7 +143,9 @@ export const DayViewContent = memo(() => {
 
         <div className="flex w-full flex-1 overflow-hidden">
           <DayCalendarGrid />
-          <AvailabilityGridOverlay />
+          <AvailabilityGridOverlay
+            visibleDates={[dateInView.format("YYYY-MM-DD")]}
+          />
         </div>
       </div>
 

--- a/packages/web/src/views/Day/view/DayViewContent.tsx
+++ b/packages/web/src/views/Day/view/DayViewContent.tsx
@@ -1,4 +1,8 @@
 import { memo, useCallback, useMemo, useRef } from "react";
+import { AvailabilityGridOverlay } from "@web/availability/AvailabilityGridOverlay";
+import { availabilityActions } from "@web/availability/availability.store";
+import { useAvailabilityEvents } from "@web/availability/useAvailabilityEvents";
+import { useAvailabilityShortcuts } from "@web/availability/useAvailabilityShortcuts";
 import { ID_MAIN } from "@web/common/constants/web.constants";
 import { useHorizontalNavigation } from "@web/common/hooks/useHorizontalNavigation";
 import { emitViewCommand } from "@web/common/utils/dom/view-command-bus";
@@ -44,6 +48,8 @@ export const DayViewContent = memo(() => {
   const mainRef = useRef<HTMLDivElement | null>(null);
 
   const dateInView = useDateInView();
+  useAvailabilityEvents(dateInView, dateInView);
+  useAvailabilityShortcuts();
   const { today } = useToday();
   const isViewingToday = dateInView.isSame(today, "day");
 
@@ -94,6 +100,10 @@ export const DayViewContent = memo(() => {
   useCalendarViewShortcuts({
     onCreateTimedEvent: handleCreateTimedEvent,
     onCreateAllDayEvent: handleCreateAllDayEvent,
+    onShareAvailability: () => {
+      availabilityActions.open();
+      viewActions.setSidebarOpen(true);
+    },
     onFocusCalendar: focusFirstDayCalendarEvent,
     onNextPeriod: navigateToNextDay,
     onPrevPeriod: navigateToPreviousDay,
@@ -133,6 +143,7 @@ export const DayViewContent = memo(() => {
 
         <div className="flex w-full flex-1 overflow-hidden">
           <DayCalendarGrid />
+          <AvailabilityGridOverlay />
         </div>
       </div>
 

--- a/packages/web/src/views/Day/view/DayViewContent.tsx
+++ b/packages/web/src/views/Day/view/DayViewContent.tsx
@@ -1,4 +1,8 @@
 import { memo, useCallback, useMemo, useRef } from "react";
+import { AvailabilityGridOverlay } from "@web/availability/AvailabilityGridOverlay";
+import { availabilityActions } from "@web/availability/availability.store";
+import { useAvailabilityEvents } from "@web/availability/useAvailabilityEvents";
+import { useAvailabilityShortcuts } from "@web/availability/useAvailabilityShortcuts";
 import { ID_MAIN } from "@web/common/constants/web.constants";
 import { useHorizontalNavigation } from "@web/common/hooks/useHorizontalNavigation";
 import { emitViewCommand } from "@web/common/utils/dom/view-command-bus";
@@ -44,6 +48,8 @@ export const DayViewContent = memo(() => {
   const mainRef = useRef<HTMLDivElement | null>(null);
 
   const dateInView = useDateInView();
+  useAvailabilityEvents(dateInView, dateInView);
+  useAvailabilityShortcuts();
   const { today } = useToday();
   const isViewingToday = dateInView.isSame(today, "day");
 
@@ -94,6 +100,10 @@ export const DayViewContent = memo(() => {
   useCalendarViewShortcuts({
     onCreateTimedEvent: handleCreateTimedEvent,
     onCreateAllDayEvent: handleCreateAllDayEvent,
+    onShareAvailability: () => {
+      availabilityActions.open();
+      viewActions.setSidebarOpen(true);
+    },
     onFocusCalendar: focusFirstDayCalendarEvent,
     onNextPeriod: navigateToNextDay,
     onPrevPeriod: navigateToPreviousDay,
@@ -133,6 +143,9 @@ export const DayViewContent = memo(() => {
 
         <div className="flex w-full flex-1 overflow-hidden">
           <DayCalendarGrid />
+          <AvailabilityGridOverlay
+            visibleDates={[dateInView.format("YYYY-MM-DD")]}
+          />
         </div>
       </div>
 

--- a/packages/web/src/views/Week/WeekView.tsx
+++ b/packages/web/src/views/Week/WeekView.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useMemo, useRef } from "react";
+import { useAvailabilityEvents } from "@web/availability/useAvailabilityEvents";
+import { useAvailabilityShortcuts } from "@web/availability/useAvailabilityShortcuts";
 import { ID_MAIN } from "@web/common/constants/web.constants";
 import { useHorizontalNavigation } from "@web/common/hooks/useHorizontalNavigation";
 import { CalendarConnectionBannerGate } from "@web/components/CalendarConnectionBanner/CalendarConnectionBannerGate";
@@ -54,6 +56,11 @@ export const WeekView = () => {
   const { trackRef, visibleDayCount } = useVisibleDayCount();
 
   const weekProps = useWeek(today, visibleDayCount);
+  useAvailabilityEvents(
+    weekProps.component.startOfView,
+    weekProps.component.endOfView,
+  );
+  useAvailabilityShortcuts();
   const mainRef = useRef<HTMLDivElement | null>(null);
   const weekTrackElementRef = useRef<HTMLDivElement | null>(null);
   const setTrackRef = useCallback(

--- a/packages/web/src/views/Week/WeekView.tsx
+++ b/packages/web/src/views/Week/WeekView.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useMemo, useRef } from "react";
-import { AvailabilityGridOverlay } from "@web/availability/AvailabilityGridOverlay";
 import { useAvailabilityEvents } from "@web/availability/useAvailabilityEvents";
 import { useAvailabilityShortcuts } from "@web/availability/useAvailabilityShortcuts";
 import { ID_MAIN } from "@web/common/constants/web.constants";
@@ -181,7 +180,6 @@ export const WeekView = () => {
                   weekProps={weekProps}
                 />
               </ContextMenuWrapper>
-              <AvailabilityGridOverlay />
             </div>
           </WeekGridScrollArea>
         </div>

--- a/packages/web/src/views/Week/WeekView.tsx
+++ b/packages/web/src/views/Week/WeekView.tsx
@@ -1,4 +1,7 @@
 import { useCallback, useMemo, useRef } from "react";
+import { AvailabilityGridOverlay } from "@web/availability/AvailabilityGridOverlay";
+import { useAvailabilityEvents } from "@web/availability/useAvailabilityEvents";
+import { useAvailabilityShortcuts } from "@web/availability/useAvailabilityShortcuts";
 import { ID_MAIN } from "@web/common/constants/web.constants";
 import { useHorizontalNavigation } from "@web/common/hooks/useHorizontalNavigation";
 import { CalendarConnectionBannerGate } from "@web/components/CalendarConnectionBanner/CalendarConnectionBannerGate";
@@ -54,6 +57,11 @@ export const WeekView = () => {
   const { trackRef, visibleDayCount } = useVisibleDayCount();
 
   const weekProps = useWeek(today, visibleDayCount);
+  useAvailabilityEvents(
+    weekProps.component.startOfView,
+    weekProps.component.endOfView,
+  );
+  useAvailabilityShortcuts();
   const mainRef = useRef<HTMLDivElement | null>(null);
   const weekTrackElementRef = useRef<HTMLDivElement | null>(null);
   const setTrackRef = useCallback(
@@ -173,6 +181,7 @@ export const WeekView = () => {
                   weekProps={weekProps}
                 />
               </ContextMenuWrapper>
+              <AvailabilityGridOverlay />
             </div>
           </WeekGridScrollArea>
         </div>

--- a/packages/web/src/views/Week/components/Grid/Grid.tsx
+++ b/packages/web/src/views/Week/components/Grid/Grid.tsx
@@ -7,6 +7,7 @@ import {
   isFirstImportFailed,
   isFirstImportInProgress,
 } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
+import { AvailabilityGridOverlay } from "@web/availability/AvailabilityGridOverlay";
 import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
 import { selectGridDraft, useDraftStore } from "@web/events/stores/draft.store";
 import { EventGrid, isEventGridLoading } from "@web/grid/components/EventGrid";
@@ -140,6 +141,12 @@ export const Grid: FC<Props> = ({
                 timedEventsLayer={timedEventsLayer}
                 today={today}
                 visibleDates={visibleDates}
+              />
+              <AvailabilityGridOverlay
+                hourHeight={measurements.hourHeight}
+                visibleDates={weekDays.map((date) =>
+                  date.format(YEAR_MONTH_DAY_FORMAT),
+                )}
               />
             </div>
           )}

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
@@ -15,6 +15,7 @@ import {
 } from "@web/__tests__/utils/event-query-test-data";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
+import { useAvailabilityStore } from "@web/availability/availability.store";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { ID_EVENT_FORM, ID_SIDEBAR } from "@web/common/constants/web.constants";
 import { getBrowserTimeZone } from "@web/common/utils/datetime/web.date.util";
@@ -1153,7 +1154,7 @@ describe("useWeekShortcutOwner sidebar focus", () => {
   });
 });
 
-// D6: "C"/"A" used to call the create functions directly *and* subscribe to
+// D6: create shortcuts used to call the create functions directly *and* subscribe to
 // the view command bus (two paths to the same result). They now only emit
 // on the bus, matching Day's convention - these presses exercise that path.
 describe("useWeekShortcutOwner create shortcuts", () => {
@@ -1168,14 +1169,27 @@ describe("useWeekShortcutOwner create shortcuts", () => {
     });
   });
 
-  it("starts an all-day createShortcut draft when A is pressed", async () => {
+  it("starts an all-day createShortcut draft when Shift+C is pressed", async () => {
     renderShortcuts();
-    pressKey("A");
+    pressKey("C", {
+      keyDownInit: { shiftKey: true },
+      keyUpInit: { shiftKey: true },
+    });
 
     await waitFor(() => {
       const { gridDraft, status } = useDraftStore.getState();
       expect(status?.activity).toBe("createShortcut");
       expect(gridDraft?.values.calendarId).toBe(writableCalendar.id);
+    });
+  });
+
+  it("opens Share Availability instead of an all-day draft when A is pressed", async () => {
+    renderShortcuts();
+    act(() => pressKey("A"));
+
+    await waitFor(() => {
+      expect(useAvailabilityStore.getState().isOpen).toBe(true);
+      expect(useDraftStore.getState().gridDraft).toBeNull();
     });
   });
 });

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
@@ -140,7 +140,7 @@ export const useWeekShortcutOwner = ({
   }, [canSeedDraft, defaultTargetCalendarId, isCurrentWeek, startOfView]);
 
   // The command palette's create-event rows (event.cmd.constants.ts) can only
-  // reach this view through the bus; the "C"/"A" keys below call the create
+  // reach this view through the bus; the C/Shift+C keys below call the create
   // functions directly. Resubscribes when the create handlers change (week in
   // view or default target calendar).
   useEffect(() => {

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef } from "react";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+import { availabilityActions } from "@web/availability/availability.store";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { useDefaultTargetCalendar } from "@web/calendars/useDefaultTargetCalendar";
 import { onViewCommand } from "@web/common/utils/dom/view-command-bus";
@@ -16,6 +17,7 @@ import {
   isEventFormOpen,
   useDraftStore,
 } from "@web/events/stores/draft.store";
+import { viewActions } from "@web/events/stores/view.store";
 import { useCalendarViewShortcuts } from "@web/grid/shortcuts/useCalendarViewShortcuts";
 import { useGridEventEditShortcuts } from "@web/grid/shortcuts/useGridEventEditShortcuts";
 import { useGridEventFormFieldSequences } from "@web/grid/shortcuts/useGridEventFormFieldSequences";
@@ -243,6 +245,10 @@ export const useWeekShortcutOwner = ({
     onShiftViewForward: shiftViewForward,
     onGoToToday: toToday,
     onCreateAllDayEvent: createAllDayDraftEvent,
+    onShareAvailability: () => {
+      availabilityActions.open();
+      viewActions.setSidebarOpen(true);
+    },
     onCreateTimedEvent: createTimedDraftEvent,
     onFocusCalendar: focusFirstCalendarEvent,
   });


### PR DESCRIPTION
## Summary

- Implement Share Availability in Day and Week views with deterministic future free-slot suggestions, geometry-aligned selection cells, click/drag and keyboard interaction.
- Generate exact single- or dual-timezone clipboard text, recipient timezone selection, feedback, live-conflict handling, and privacy-safe analytics.
- Remap all-day creation to `Shift+C` while assigning `A` to availability mode.
- Add pure utility, shortcut, and RTL interaction coverage, plus the implementation specification.

## Simplicity

The feature keeps ephemeral selection in a feature-local Zustand store, derives labels/messages through pure utilities, and queries all active calendars without putting availability into event caches. The `/simplify` gate is pending because verifier did not pass.

## Automated validation

- Availability-focused RTL/unit/shortcut run: 18 passed, 0 failed.
- Type-check passed under pinned Bun 1.3.14.
- Required `test:web` is blocked by two unchanged AuthModal reset-password timeouts that reproduce in isolation; cascading failures follow.
- Browser screenshot attempt was environment-blocked by a dev-server CSS chunk MIME error.

## Independent review

Verifier handoff: `.agents/handoffs/2885.md`. Verdict remains **RETRY** after two implementation retries. Independent `/review` is intentionally not advanced until validation passes.

## Test plan

- `mise exec bun@1.3.14 -- bun test --preload ./packages/web/src/__tests__/web.preload.ts ./packages/web/src/availability/AvailabilityPanel.test.tsx ./packages/web/src/availability/availability-slot.util.test.ts ./packages/web/src/availability/availability-message.util.test.ts ./packages/web/src/grid/shortcuts/useCalendarViewShortcuts.test.tsx` — passed, 18 tests.
- `mise exec bun@1.3.14 -- bun run type-check` — passed.
- `git diff --check origin/main...HEAD` — passed.
- `mise exec bun@1.3.14 -- bun run test:web` — failed in unchanged AuthModal tests.
- `mise exec bun@1.3.14 -- bun test --preload ./packages/web/src/__tests__/web.preload.ts ./packages/web/src/components/AuthModal/AuthModal.test.tsx` — reproduced the same two unchanged timeouts in isolation.

