### PR TITLE
Make shortcut practice more human

### DIFF
--- a/docs/frontend/frontend-runtime-flow.md
+++ b/docs/frontend/frontend-runtime-flow.md
@@ -82,13 +82,13 @@ Welcome → signup → first-event contract:
 - the Shortcut Showcase therefore has three entries: welcome dismiss,
   post-signup, and the command palette's "Practice shortcuts".
   `showcase.steps.ts` holds the order; taught keycaps come from
-  `packages/web/src/shortcuts/keymap.ts`. Six skippable missions teach create
+  `packages/web/src/shortcuts/keymap.ts`. Six skippable levels teach create
   (C then title then Enter), hold-Mod page jumps, `S` event jump, Shift+arrow
   nudge, `E` then `T` to target a title, and Cmd+K on a practice-only
   palette, then graduation hands off to the real calendar
-- every showcase step offers **Skip to calendar** (`X`), and **Skip to sign
-  up** (`U`) for anyone not already signed in; Escape does the former. There
-  is no confirm in the way
+- every showcase step offers **Skip** (`Esc`), and **Skip to sign
+  up** (`U`) for anyone not already signed in. Escape closes the practice
+  palette or title editor first, then leaves. There is no confirm in the way
 - graduating the showcase hands off directly to `FirstEventPrompt`, a
   non-blocking card on the real calendar (not an app-lock modal) that asks the
   user to press `C` on a real event. It is shown once the showcase has been

--- a/e2e/onboarding/shortcut-showcase.spec.ts
+++ b/e2e/onboarding/shortcut-showcase.spec.ts
@@ -16,6 +16,46 @@ const leaveWelcome = async (page: Page) => {
   await expect(welcomeDialog).toBeHidden();
 };
 
+const holdModAndPress = async (page: Page, key: string) => {
+  // Linux CI resolves Mod to Control; macOS to Meta. Hold both so the
+  // platform-specific hold tracker and the chord check both fire.
+  await page.keyboard.down("Control");
+  await page.keyboard.down("Meta");
+  await page.keyboard.press(key);
+  await page.keyboard.up("Meta");
+  await page.keyboard.up("Control");
+};
+
+const playThroughLevels = async (page: Page) => {
+  const showcase = page.getByRole("region", { name: "Shortcut practice" });
+
+  await page.keyboard.press("c");
+  await expect(showcase).toContainText("Type a title, then press Enter");
+  await page.keyboard.type("Practice Event");
+  await page.keyboard.press("Enter");
+  await expect(showcase).toContainText("Practice Event");
+  await expect(showcase).toContainText("Level 2/6");
+  await expect(showcase).toContainText("See where to go: reveal the jump keys");
+
+  await holdModAndPress(page, "1");
+  await expect(showcase).toContainText("Pick a target");
+
+  await page.keyboard.press("s");
+  await page.keyboard.press("f");
+  await expect(showcase).toContainText("Nudge it into place");
+
+  await page.keyboard.press("Shift+ArrowRight");
+  await expect(showcase).toContainText("Grab the title");
+
+  await page.keyboard.press("e");
+  await page.keyboard.press("t");
+  await page.keyboard.press("Enter");
+  await expect(showcase).toContainText("When you forget, ask the palette");
+
+  await holdModAndPress(page, "k");
+  await page.keyboard.press("Enter");
+};
+
 test("exploring without an account starts the practice", async ({ page }) => {
   await page.goto("/week", { waitUntil: "domcontentloaded" });
   await leaveWelcome(page);
@@ -25,7 +65,7 @@ test("exploring without an account starts the practice", async ({ page }) => {
   ).toBeVisible();
 });
 
-test("the welcome-started practice runs create then D through graduation", async ({
+test("the welcome-started practice runs the taught keys through graduation", async ({
   page,
 }) => {
   await page.goto("/week", { waitUntil: "domcontentloaded" });
@@ -34,35 +74,17 @@ test("the welcome-started practice runs create then D through graduation", async
   const showcase = page.getByRole("region", { name: "Shortcut practice" });
   await expect(showcase).toContainText("Drop an event on the board");
   await expect(showcase).toContainText("Press C to start a new event.");
-  await expect(showcase).toContainText("Mission 1 of 6");
+  await expect(showcase).toContainText("Level 1/6");
+  await expect(showcase.getByRole("button", { name: /^Skip$/ })).toBeVisible();
 
-  await page.keyboard.press("c");
-  await expect(showcase).toContainText("Type a title, then press Enter");
+  await playThroughLevels(page);
 
-  await page.keyboard.type("Practice Event");
-  await page.keyboard.press("Enter");
-  await expect(showcase).toContainText("Practice Event");
-  await expect(showcase).toContainText("Mission 2 of 6");
-
-  // Compass blocks trusted pointer clicks; D is the assist binding.
-  const remainingMissions = [
-    "Hold fast — reveal the jump keys",
-    "Pick a target",
-    "Nudge it into place",
-    "Grab the title",
-    "When you forget, ask the palette",
-  ];
-  for (const title of remainingMissions) {
-    await expect(showcase).toContainText(title);
-    await page.keyboard.press("d");
-  }
-
-  // Not a mission, so it carries no chip; N passes without prompting.
+  // Not a level, so it carries no chip; N passes without prompting.
   await expect(showcase).toContainText("Never miss a meeting");
-  await expect(showcase).not.toContainText("Mission 7 of");
+  await expect(showcase).not.toContainText("Level 7/");
   await page.keyboard.press("n");
 
-  await expect(showcase).toContainText("young cap'n");
+  await expect(showcase).toContainText("you've got this");
   await page.keyboard.press("Enter");
   await expect(showcase).toHaveCount(0);
 
@@ -82,19 +104,12 @@ test("taking the notifications offer opts in and moves on", async ({
   await leaveWelcome(page);
 
   const showcase = page.getByRole("region", { name: "Shortcut practice" });
-  await page.keyboard.press("c");
-  await page.keyboard.type("Practice Event");
-  await page.keyboard.press("Enter");
-
-  // D assists through the remaining missions to reach the offer.
-  for (let i = 0; i < 5; i += 1) {
-    await page.keyboard.press("d");
-  }
+  await playThroughLevels(page);
 
   await expect(showcase).toContainText("Never miss a meeting");
   await page.keyboard.press("Enter");
 
-  await expect(showcase).toContainText("young cap'n");
+  await expect(showcase).toContainText("you've got this");
   await expect
     .poll(() =>
       page.evaluate(() =>

--- a/packages/web/src/auth/posthog/track.ts
+++ b/packages/web/src/auth/posthog/track.ts
@@ -12,7 +12,6 @@ export type ProductEvent =
   | "shortcut_showcase_step_completed"
   | "shortcut_showcase_skipped"
   | "shortcut_showcase_finished"
-  | "shortcut_showcase_assist_used"
   | "first_event_prompt_shown"
   | "first_event_prompt_completed"
   | "first_event_prompt_dismissed"

--- a/packages/web/src/components/ShortcutShowcase/PracticeCalendar.tsx
+++ b/packages/web/src/components/ShortcutShowcase/PracticeCalendar.tsx
@@ -98,16 +98,61 @@ const PracticeBlock: FC<{
   );
 };
 
+const WEEKDAY_INITIALS = ["S", "M", "T", "W", "T", "F", "S"];
+
 /**
- * The showcase's fake grid: day columns, hour lines, and time-positioned
- * blocks, and nothing else. Deliberately not the real TimedGrid, which drags
+ * Static month-picker chrome so the sandbox reads like the real sidebar.
+ * Not interactive: the lesson only needs a place to park a jump chip.
+ */
+const PracticeSidebar: FC<{ showPageJumpHints: boolean }> = ({
+  showPageJumpHints,
+}) => {
+  const monthLabel = dayjs().format("MMMM");
+
+  return (
+    <div
+      aria-hidden
+      className="relative flex w-28 shrink-0 flex-col gap-3 border-border border-r pr-3"
+      data-practice-jump="sidebar"
+    >
+      {showPageJumpHints && (
+        <ShortcutHint className="absolute top-1 right-1 z-10">2</ShortcutHint>
+      )}
+      <div className="font-medium text-text-muted text-xs">{monthLabel}</div>
+      <div className="grid grid-cols-7 gap-px">
+        {WEEKDAY_INITIALS.map((label, index) => (
+          <span
+            key={`${label}-${index}`}
+            className="text-center text-[8px] text-text-muted"
+          >
+            {label}
+          </span>
+        ))}
+        {Array.from({ length: 35 }, (_, index) => (
+          <span
+            key={index}
+            className="mx-auto size-2 rounded-sm bg-surface-overlay"
+          />
+        ))}
+      </div>
+      <div className="rounded-md bg-surface-overlay px-2 py-1.5 text-[10px] text-text-muted">
+        Up next
+      </div>
+    </div>
+  );
+};
+
+/**
+ * The showcase's fake grid: a sidebar, day columns, hour lines, and
+ * time-positioned blocks. Deliberately not the real TimedGrid, which drags
  * in stores and scroll plumbing the lesson does not need; geometry is plain
  * percentage math off the practice state.
  */
 export const PracticeCalendar: FC<{
   state: PracticeState;
   onTitleCommit: (title: string) => void;
-}> = ({ state, onTitleCommit }) => {
+  showPageJumpHints?: boolean;
+}> = ({ state, onTitleCommit, showPageJumpHints = false }) => {
   const hours: number[] = [];
   for (let h = SHOWCASE_GRID_START_HOUR; h < SHOWCASE_GRID_END_HOUR; h += 1) {
     hours.push(h);
@@ -118,6 +163,8 @@ export const PracticeCalendar: FC<{
       className="relative flex h-full min-h-0 w-full select-none"
       data-practice-jump="calendar"
     >
+      <PracticeSidebar showPageJumpHints={showPageJumpHints} />
+
       {/* Time column */}
       <div className="flex w-14 shrink-0 flex-col border-border border-r pr-2 text-right">
         <div className="h-7" />
@@ -146,6 +193,11 @@ export const PracticeCalendar: FC<{
             {DAY_LABELS[dayIndex]}
           </div>
           <div className="relative flex-1">
+            {showPageJumpHints && dayIndex === 0 && (
+              <ShortcutHint className="absolute top-2 left-1 z-10">
+                1
+              </ShortcutHint>
+            )}
             {hours.map((hour) => (
               <div
                 key={hour}

--- a/packages/web/src/components/ShortcutShowcase/PracticeCalendar.tsx
+++ b/packages/web/src/components/ShortcutShowcase/PracticeCalendar.tsx
@@ -98,11 +98,10 @@ const PracticeBlock: FC<{
   );
 };
 
-const WEEKDAY_INITIALS = ["S", "M", "T", "W", "T", "F", "S"];
-
 /**
  * Static month-picker chrome so the sandbox reads like the real sidebar.
  * Not interactive: the lesson only needs a place to park a jump chip.
+ * Cells are unlabeled so they cannot collide with event jump letters.
  */
 const PracticeSidebar: FC<{ showPageJumpHints: boolean }> = ({
   showPageJumpHints,
@@ -119,22 +118,7 @@ const PracticeSidebar: FC<{ showPageJumpHints: boolean }> = ({
         <ShortcutHint className="absolute top-1 right-1 z-10">2</ShortcutHint>
       )}
       <div className="font-medium text-text-muted text-xs">{monthLabel}</div>
-      <div className="grid grid-cols-7 gap-px">
-        {WEEKDAY_INITIALS.map((label, index) => (
-          <span
-            key={`${label}-${index}`}
-            className="text-center text-[8px] text-text-muted"
-          >
-            {label}
-          </span>
-        ))}
-        {Array.from({ length: 35 }, (_, index) => (
-          <span
-            key={index}
-            className="mx-auto size-2 rounded-sm bg-surface-overlay"
-          />
-        ))}
-      </div>
+      <div className="h-20 rounded-md bg-surface-overlay" />
       <div className="rounded-md bg-surface-overlay px-2 py-1.5 text-[10px] text-text-muted">
         Up next
       </div>

--- a/packages/web/src/components/ShortcutShowcase/PracticePalette.tsx
+++ b/packages/web/src/components/ShortcutShowcase/PracticePalette.tsx
@@ -2,7 +2,7 @@ import { type FC } from "react";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 
 /**
- * Sandbox-only command palette for the showcase palette mission. The real
+ * Sandbox-only command palette for the showcase palette level. The real
  * palette stays locked behind the takeover's app-lock; this overlay teaches
  * Mod+K without navigating the live app.
  */

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
@@ -7,7 +7,7 @@ import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 import { ShortcutShowcase } from "@web/components/ShortcutShowcase/ShortcutShowcase";
 import {
-  SHOWCASE_MISSION_IDS,
+  SHOWCASE_LEVEL_IDS,
   SHOWCASE_STEP_IDS,
   type ShowcaseStepId,
 } from "@web/components/ShortcutShowcase/showcase.steps";
@@ -69,7 +69,7 @@ describe("ShortcutShowcase", () => {
 
     act(() => shortcutShowcaseActions.replay());
 
-    const first = screen.getByRole("button", { name: /Do it for me/ });
+    const first = screen.getByRole("button", { name: /Skip to sign up/ });
     expect(first).toHaveFocus();
 
     await user.tab({ shift: true });
@@ -107,13 +107,13 @@ describe("ShortcutShowcase", () => {
     expect(screen.getByLabelText("Shortcut practice")).toBeTruthy();
   });
 
-  it("teaches create as one motion, then continues to the next mission", async () => {
+  it("teaches create as one motion, then continues to the next level", async () => {
     const user = userEvent.setup();
     render(<ShortcutShowcase />);
     act(() => shortcutShowcaseActions.replay());
     expect(currentStepId()).toBe("create");
     expect(screen.getByText("Press C to start a new event.")).toBeTruthy();
-    expect(screen.getByText("Mission 1 of 6")).toBeTruthy();
+    expect(screen.getByText("Level 1/6")).toBeTruthy();
 
     pressKey("c");
     expect(currentStepId()).toBe("create");
@@ -125,16 +125,21 @@ describe("ShortcutShowcase", () => {
     );
     expect(currentStepId()).toBe("pageJump");
     expect(screen.getByText("Coffee with Alex")).toBeTruthy();
-    expect(screen.getByText("Mission 2 of 6")).toBeTruthy();
+    expect(screen.getByText("Level 2/6")).toBeTruthy();
+    expect(
+      screen.getByText("See where to go: reveal the jump keys"),
+    ).toBeTruthy();
   });
 
   it("graduates on Enter from the graduation step", async () => {
     render(<ShortcutShowcase />);
     showStep("graduation");
-    expect(screen.getByText(/young cap'n/)).toBeTruthy();
+    expect(screen.getByText(/you've got this/)).toBeTruthy();
 
-    const enterCompass = screen.getByRole("button", { name: "Enter Compass" });
-    expect(within(enterCompass).queryByText("Enter")).toBeNull();
+    const seeCalendar = screen.getByRole("button", {
+      name: "See your calendar",
+    });
+    expect(within(seeCalendar).queryByText("Enter")).toBeNull();
 
     pressKey("Enter");
     expect(screen.getByLabelText("Shortcut practice")).toHaveAttribute(
@@ -154,17 +159,17 @@ describe("ShortcutShowcase", () => {
     expect(screen.queryByLabelText("Shortcut practice")).toBeNull();
   });
 
-  it("fades the takeover on Enter Compass, then unmounts", async () => {
+  it("fades the takeover on See your calendar, then unmounts", async () => {
     const user = userEvent.setup();
     render(<ShortcutShowcase />);
     showStep("graduation");
 
-    await user.click(screen.getByRole("button", { name: "Enter Compass" }));
+    await user.click(screen.getByRole("button", { name: "See your calendar" }));
     expect(screen.getByLabelText("Shortcut practice")).toHaveAttribute(
       "data-closing",
     );
     expect(
-      screen.getByRole("button", { name: "Enter Compass" }),
+      screen.getByRole("button", { name: "See your calendar" }),
     ).toBeDisabled();
     expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
 
@@ -207,8 +212,10 @@ describe("ShortcutShowcase", () => {
     }
   });
 
-  it("'Do it for me' advances one mission at a time through graduation", async () => {
+  it("walks every level with the taught keys, then graduates", async () => {
     const user = userEvent.setup();
+    const isMac = resolveModifier("Mod") === "Meta";
+    const modKey = isMac ? "Meta" : "Control";
     render(
       <>
         <button type="button">Outside calendar</button>
@@ -218,27 +225,50 @@ describe("ShortcutShowcase", () => {
     const outside = screen.getByRole("button", { name: "Outside calendar" });
     act(() => shortcutShowcaseActions.replay());
 
-    for (let i = 0; i < SHOWCASE_MISSION_IDS.length; i += 1) {
-      expect(currentStepId()).toBe(SHOWCASE_MISSION_IDS[i]);
-      await user.click(screen.getByRole("button", { name: "Do it for me" }));
-    }
+    expect(currentStepId()).toBe(SHOWCASE_LEVEL_IDS[0]);
+    pressKey("c");
+    await user.type(
+      screen.getByLabelText("Event title"),
+      "Coffee with Alex{Enter}",
+    );
 
-    // The loop above is untouched by the notifications step: it is not a
-    // mission, so it sits after the last one rather than inside the count.
+    expect(currentStepId()).toBe("pageJump");
+    pressKey(modKey);
+    pressKey("1", { code: "Digit1" });
+
+    expect(currentStepId()).toBe("eventJump");
+    pressKey("s");
+    pressKey("f");
+
+    expect(currentStepId()).toBe("nudge");
+    pressKey("ArrowRight", { shiftKey: true });
+
+    expect(currentStepId()).toBe("editTitle");
+    pressKey("e");
+    pressKey("t");
+    await user.type(screen.getByLabelText("Event title"), "{Enter}");
+
+    expect(currentStepId()).toBe("palette");
+    pressKey("k", isMac ? { metaKey: true } : { ctrlKey: true });
+    pressKey("Enter");
+
     expect(currentStepId()).toBe("notifications");
     await user.click(screen.getByRole("button", { name: "Not now" }));
 
     expect(currentStepId()).toBe("graduation");
     expect(screen.queryByRole("button", { name: "Do it for me" })).toBeNull();
-    const enterCompass = screen.getByRole("button", { name: "Enter Compass" });
+    expect(screen.queryByRole("button", { name: /^Skip$/ })).toBeNull();
+    const seeCalendar = screen.getByRole("button", {
+      name: "See your calendar",
+    });
     await waitFor(() => {
-      expect(enterCompass).toHaveFocus();
+      expect(seeCalendar).toHaveFocus();
     });
 
     await user.tab({ shift: true });
     expect(outside).not.toHaveFocus();
     await user.tab();
-    expect(enterCompass).toHaveFocus();
+    expect(seeCalendar).toHaveFocus();
   });
 
   it("does not treat S as skip-to-signup; U leaves for signup", () => {
@@ -246,6 +276,8 @@ describe("ShortcutShowcase", () => {
     act(() => shortcutShowcaseActions.replay());
 
     pressKey("s");
+    pressKey("d");
+    pressKey("x");
     expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
     expect(currentStepId()).toBe("create");
 
@@ -253,7 +285,7 @@ describe("ShortcutShowcase", () => {
     expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
   });
 
-  it("advances the hold-Mod mission after revealing jump keys", () => {
+  it("advances the hold-Mod level after revealing jump keys", () => {
     const modKey = resolveModifier("Mod") === "Meta" ? "Meta" : "Control";
     render(<ShortcutShowcase />);
     showStep("pageJump");
@@ -308,8 +340,33 @@ describe("ShortcutShowcase", () => {
     expect(screen.getByLabelText("Practice command palette")).toBeTruthy();
 
     pressKey("Enter");
-    // The last mission hands off to the notifications offer, then graduation.
+    // The last level hands off to the notifications offer, then graduation.
     expect(currentStepId()).toBe("notifications");
+  });
+
+  it("does not open the practice palette on Mod+K before the palette level", () => {
+    const isMac = resolveModifier("Mod") === "Meta";
+    render(<ShortcutShowcase />);
+    showStep("create");
+
+    pressKey("k", isMac ? { metaKey: true } : { ctrlKey: true });
+    expect(screen.queryByLabelText("Practice command palette")).toBeNull();
+    expect(currentStepId()).toBe("create");
+  });
+
+  it("Escape closes the practice palette and stays on the palette level", () => {
+    const isMac = resolveModifier("Mod") === "Meta";
+    render(<ShortcutShowcase />);
+    showStep("palette");
+
+    pressKey("k", isMac ? { metaKey: true } : { ctrlKey: true });
+    expect(screen.getByLabelText("Practice command palette")).toBeTruthy();
+
+    pressKey("Escape");
+    expect(screen.queryByLabelText("Practice command palette")).toBeNull();
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
+    expect(currentStepId()).toBe("palette");
+    expect(screen.getByText("When you forget, ask the palette")).toBeTruthy();
   });
 
   it("offers 'Skip to sign up' from the first step and leaves on the first click", async () => {
@@ -327,12 +384,12 @@ describe("ShortcutShowcase", () => {
     ).toBe("true");
   });
 
-  it("Skip to calendar leaves straight away, without a confirm", async () => {
+  it("Skip leaves straight away, without a confirm", async () => {
     const user = userEvent.setup();
     render(<ShortcutShowcase />);
     act(() => shortcutShowcaseActions.replay());
 
-    await user.click(screen.getByRole("button", { name: "Skip to calendar" }));
+    await user.click(screen.getByRole("button", { name: /^Skip$/ }));
     expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
     expect(screen.queryByLabelText("Shortcut practice")).toBeNull();
   });
@@ -470,7 +527,7 @@ describe("ShortcutShowcase", () => {
 
       // Enter is the step's shortcut, but a focused button owns it first:
       // asking to leave must not raise a permission prompt instead.
-      screen.getByRole("button", { name: /Skip to calendar/ }).focus();
+      screen.getByRole("button", { name: /^Skip$/ }).focus();
       await user.keyboard("{Enter}");
 
       expect(seam.mocks.requestPermission).not.toHaveBeenCalled();
@@ -508,7 +565,7 @@ describe("ShortcutShowcase", () => {
       render(<ShortcutShowcase />);
       showStep("notifications");
 
-      // D and U belong to buttons this step does not render; C drives a
+      // U belongs to a button this step does not render; C drives a
       // practice board this step is not teaching.
       await user.keyboard("d");
       await user.keyboard("u");
@@ -531,12 +588,12 @@ describe("ShortcutShowcase", () => {
       expect(currentStepId()).toBe("graduation");
     });
 
-    it("carries no mission chip, because it teaches no key", () => {
+    it("carries no level chip, because it teaches no key", () => {
       installPort();
       render(<ShortcutShowcase />);
       showStep("notifications");
 
-      expect(screen.queryByText(/^Mission \d+ of \d+$/)).toBeNull();
+      expect(screen.queryByText(/^Level \d+\/\d+$/)).toBeNull();
     });
 
     it("still offers the door out to the calendar", () => {
@@ -544,7 +601,7 @@ describe("ShortcutShowcase", () => {
       render(<ShortcutShowcase />);
       showStep("notifications");
 
-      pressKey("x");
+      pressKey("Escape");
       expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
     });
   });

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
@@ -34,7 +34,7 @@ import {
 } from "@web/components/ShortcutShowcase/practice.state";
 import {
   getCreateLessonPhase,
-  getMissionLabel,
+  getLevelLabel,
   getShowcaseStep,
 } from "@web/components/ShortcutShowcase/showcase.steps";
 import {
@@ -48,6 +48,7 @@ import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import { getNotificationPort } from "@web/notifications/notification.port";
 import { notificationActions } from "@web/notifications/notification.store";
+import { settingsActions } from "@web/settings/settings.store";
 import { useAppLockReason } from "@web/shortcuts/app-lock";
 import {
   isBareLetterKey,
@@ -82,7 +83,7 @@ const arrowDirection = (key: string): PracticeNudgeDirection | null => {
  * behavior is a deliberately simplified reimplementation against ephemeral
  * practice state, so nothing here touches storage or the real grid stores.
  *
- * Missions teach create, hold-Mod jumps, event jump, nudge, the E-then-T
+ * Levels teach create, hold-Mod jumps, event jump, nudge, the E-then-T
  * edit sequence, and Cmd+K; graduation hands off to a prompt on the real
  * calendar. Skip is always offered.
  */
@@ -173,11 +174,18 @@ const ShowcaseTakeover: FC = () => {
   }, [seatFocus, stepId, practice.editor, paletteOpen]);
 
   useEffect(() => {
+    const claim = (event: KeyboardEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+    };
+
     const onKeyDown = (event: KeyboardEvent) => {
       const store = useShortcutShowcaseStore.getState();
       if (!store.isActive) return;
       if (closingRef.current) {
         event.stopPropagation();
+        event.stopImmediatePropagation();
         return;
       }
       const currentStepId = stepIdAt(store.stepIndex);
@@ -199,8 +207,8 @@ const ShowcaseTakeover: FC = () => {
       }
 
       if (event.key === "Escape") {
-        event.preventDefault();
-        event.stopPropagation();
+        claim(event);
+        settingsActions.closeCmdPalette();
         if (paletteOpenRef.current) {
           setPaletteOpen(false);
           return;
@@ -216,28 +224,26 @@ const ShowcaseTakeover: FC = () => {
         return;
       }
 
+      const isModChord = event.metaKey || event.ctrlKey;
+      if (isModChord && keyboardKey(event).toLowerCase() === "k") {
+        claim(event);
+        if (currentStepId === "palette" && !paletteOpenRef.current) {
+          setPaletteOpen(true);
+        }
+        return;
+      }
+
       if (paletteOpenRef.current) {
         if (event.key === "Enter") {
-          event.preventDefault();
+          claim(event);
           setPaletteOpen(false);
           if (currentStepId === "palette") advance();
         }
         return;
       }
 
-      const isModChord = event.metaKey || event.ctrlKey;
-      if (
-        currentStepId === "palette" &&
-        isModChord &&
-        keyboardKey(event).toLowerCase() === "k"
-      ) {
-        event.preventDefault();
-        setPaletteOpen(true);
-        return;
-      }
-
       if (currentStepId === "graduation" && event.key === "Enter") {
-        event.preventDefault();
+        claim(event);
         graduateRef.current();
         return;
       }
@@ -246,7 +252,7 @@ const ShowcaseTakeover: FC = () => {
       if (currentStepId === "notifications") {
         // Unlike graduation, this step renders several buttons, so Enter is
         // the step's shortcut only when no button owns it - otherwise
-        // "Not now" and "Skip to calendar" would raise a permission prompt
+        // "Not now" and "Skip" would raise a permission prompt
         // instead of doing what they say. Auto-repeat is ignored too: the
         // Enter that committed a practice title must not carry into the
         // offer once the input unmounts.
@@ -258,12 +264,12 @@ const ShowcaseTakeover: FC = () => {
           !focusedButton &&
           sideActionsRef.current.notificationsSupported
         ) {
-          event.preventDefault();
+          claim(event);
           sideActionsRef.current.enableNotifications();
           return;
         }
         if (isBareLetterKey(event, "n")) {
-          event.preventDefault();
+          claim(event);
           shortcutShowcaseActions.advance();
           return;
         }
@@ -272,7 +278,7 @@ const ShowcaseTakeover: FC = () => {
       if (currentStepId === "pageJump") {
         const digit = /^Digit([12])$/.exec(event.code);
         if (digit && hasRevealedJumpsRef.current) {
-          event.preventDefault();
+          claim(event);
           advance();
           return;
         }
@@ -281,7 +287,7 @@ const ShowcaseTakeover: FC = () => {
       if (currentStepId === "nudge") {
         const direction = arrowDirection(event.key);
         if (event.shiftKey && direction) {
-          event.preventDefault();
+          claim(event);
           const before = practiceRef.current;
           const next = apply((state) => nudgeFocused(state, direction));
           if (next !== before) advance();
@@ -295,14 +301,14 @@ const ShowcaseTakeover: FC = () => {
         currentStepId !== "notifications" &&
         isBareLetterKey(event, KEYMAP.createEvent.hotkey.toLowerCase())
       ) {
-        event.preventDefault();
+        claim(event);
         apply(createDraft);
         return;
       }
 
       if (currentStepId === "eventJump") {
         if (isBareLetterKey(event, KEYMAP.eventJump.bareLetter)) {
-          event.preventDefault();
+          claim(event);
           apply(toggleJumpHints);
           return;
         }
@@ -311,7 +317,7 @@ const ShowcaseTakeover: FC = () => {
           const before = practiceRef.current;
           const next = apply((state) => jumpToEvent(state, jumpKey));
           if (next !== before) {
-            event.preventDefault();
+            claim(event);
             advance();
             return;
           }
@@ -320,7 +326,7 @@ const ShowcaseTakeover: FC = () => {
 
       if (currentStepId === "editTitle") {
         if (isBareLetterKey(event, KEYMAP.editTitle.sequence.leader)) {
-          event.preventDefault();
+          claim(event);
           apply(armEdit);
           return;
         }
@@ -328,7 +334,7 @@ const ShowcaseTakeover: FC = () => {
           practiceRef.current.editArmed &&
           isBareLetterKey(event, KEYMAP.editTitle.sequence.second)
         ) {
-          event.preventDefault();
+          claim(event);
           apply(openTitleFromEdit);
           return;
         }
@@ -338,26 +344,15 @@ const ShowcaseTakeover: FC = () => {
       }
 
       if (currentStepId !== "graduation") {
-        // D and U are practice affordances: the notifications offer has no
-        // board action to perform, and no lesson to skip past. X still leaves.
-        if (currentStepId !== "notifications") {
-          if (isBareLetterKey(event, "d")) {
-            event.preventDefault();
-            sideActionsRef.current.doItForMe();
-            return;
-          }
-          if (
-            isBareLetterKey(event, "u") &&
-            !sideActionsRef.current.authenticated
-          ) {
-            event.preventDefault();
-            sideActionsRef.current.skipToSignup();
-            return;
-          }
-        }
-        if (isBareLetterKey(event, "x")) {
-          event.preventDefault();
-          shortcutShowcaseActions.skip();
+        // U is a practice affordance: the notifications offer has no
+        // board action to perform, and no lesson to skip past. Esc leaves.
+        if (
+          currentStepId !== "notifications" &&
+          isBareLetterKey(event, "u") &&
+          !sideActionsRef.current.authenticated
+        ) {
+          claim(event);
+          sideActionsRef.current.skipToSignup();
         }
       }
     };
@@ -376,32 +371,6 @@ const ShowcaseTakeover: FC = () => {
       window.removeEventListener("blur", clearMod);
     };
   }, [apply]);
-
-  const doItForMe = () => {
-    track("shortcut_showcase_assist_used", { step: stepId });
-    if (stepId === "create") {
-      apply(createDraft);
-      apply((state) => commitTitle(state, "Coffee with Alex"));
-    } else if (stepId === "eventJump") {
-      apply((state) => jumpToEvent({ ...state, jumpHintsVisible: true }, "f"));
-    } else if (stepId === "nudge") {
-      apply((state) => nudgeFocused(state, "right"));
-    } else if (stepId === "editTitle") {
-      apply((state) => {
-        const opened = openTitleFromEdit({
-          ...ensureFocused(state),
-          editArmed: true,
-        });
-        const focused = opened.events.find(
-          (event) => event.id === opened.focusedId,
-        );
-        return commitTitle(opened, focused?.title ?? "");
-      });
-    } else if (stepId === "palette") {
-      setPaletteOpen(false);
-    }
-    advance();
-  };
 
   const runPracticeCommand = () => {
     apply((state) => ({
@@ -436,14 +405,12 @@ const ShowcaseTakeover: FC = () => {
   };
 
   const sideActionsRef = useRef({
-    doItForMe,
     skipToSignup,
     authenticated,
     enableNotifications,
     notificationsSupported,
   });
   sideActionsRef.current = {
-    doItForMe,
     skipToSignup,
     authenticated,
     enableNotifications,
@@ -458,7 +425,7 @@ const ShowcaseTakeover: FC = () => {
         }
       : getShowcaseStep(stepId);
 
-  const missionLabel = getMissionLabel(stepId);
+  const levelLabel = getLevelLabel(stepId);
   const showPageJumpHints = isModHeld && stepId === "pageJump";
 
   return (
@@ -474,16 +441,10 @@ const ShowcaseTakeover: FC = () => {
       <div
         className={`flex h-[80vh] max-h-160 w-full max-w-5xl gap-8 px-8 ${closing ? "c-showcase-enter-stage" : ""}`}
       >
-        <aside
-          className="relative flex w-80 shrink-0 flex-col justify-center gap-4"
-          data-practice-jump="lesson"
-        >
-          {showPageJumpHints && (
-            <ShortcutHint className="absolute top-0 right-0">1</ShortcutHint>
-          )}
-          {missionLabel && (
+        <aside className="flex w-80 shrink-0 flex-col justify-center gap-4">
+          {levelLabel && (
             <p className="font-medium text-accent text-xs uppercase tracking-wide">
-              {missionLabel}
+              {levelLabel}
             </p>
           )}
           <h2 className="font-semibold text-lg text-text">{step.title}</h2>
@@ -504,7 +465,7 @@ const ShowcaseTakeover: FC = () => {
                   disabled={closing}
                   onClick={graduate}
                 >
-                  Enter Compass
+                  See your calendar
                 </button>
                 <ShortcutHint className="shrink-0">Enter</ShortcutHint>
               </div>
@@ -536,14 +497,6 @@ const ShowcaseTakeover: FC = () => {
               </>
             ) : (
               <>
-                <button
-                  type="button"
-                  className={PRIMARY_BUTTON_CLASS}
-                  onClick={doItForMe}
-                >
-                  Do it for me
-                  <ShortcutHint className="shrink-0">D</ShortcutHint>
-                </button>
                 {!authenticated && (
                   <button
                     type="button"
@@ -562,22 +515,18 @@ const ShowcaseTakeover: FC = () => {
                 className={TEXT_BUTTON_CLASS}
                 onClick={() => shortcutShowcaseActions.skip()}
               >
-                Skip to calendar
-                <ShortcutHint className="shrink-0">X</ShortcutHint>
+                Skip
+                <ShortcutHint className="shrink-0">Esc</ShortcutHint>
               </button>
             )}
           </div>
         </aside>
         <div className="relative min-w-0 flex-1 rounded-xl border border-border bg-surface p-4 shadow-xl">
-          {showPageJumpHints && (
-            <ShortcutHint className="absolute top-3 right-3 z-10">
-              2
-            </ShortcutHint>
-          )}
           {paletteOpen && <PracticePalette onRun={runPracticeCommand} />}
           <PracticeCalendar
             state={practice}
             onTitleCommit={handleTitleCommit}
+            showPageJumpHints={showPageJumpHints}
           />
         </div>
       </div>

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
@@ -496,18 +496,16 @@ const ShowcaseTakeover: FC = () => {
                 </button>
               </>
             ) : (
-              <>
-                {!authenticated && (
-                  <button
-                    type="button"
-                    className={SECONDARY_BUTTON_CLASS}
-                    onClick={skipToSignup}
-                  >
-                    Skip to sign up
-                    <ShortcutHint className="shrink-0">U</ShortcutHint>
-                  </button>
-                )}
-              </>
+              !authenticated && (
+                <button
+                  type="button"
+                  className={SECONDARY_BUTTON_CLASS}
+                  onClick={skipToSignup}
+                >
+                  Skip to sign up
+                  <ShortcutHint className="shrink-0">U</ShortcutHint>
+                </button>
+              )
             )}
             {stepId !== "graduation" && (
               <button

--- a/packages/web/src/components/ShortcutShowcase/showcase.steps.ts
+++ b/packages/web/src/components/ShortcutShowcase/showcase.steps.ts
@@ -4,13 +4,13 @@ import { type ShortcutTipPart } from "@web/shortcuts/tips/shortcut-tips.data";
 /**
  * Single source of truth for showcase step order.
  *
- * Missions teach the core keyboard patterns on a sandbox calendar, then
+ * Levels teach the core keyboard patterns on a sandbox calendar, then
  * graduation hands off to a prompt on the real calendar. Skip is always
  * offered: the practice is a game, not a gate.
  *
  * "notifications" rides in this list to get the step plumbing, but it is not
- * a mission: it asks for a browser permission rather than teaching a key, so
- * it stays out of SHOWCASE_MISSION_IDS and renders no "Mission N of M" chip.
+ * a level: it asks for a browser permission rather than teaching a key, so
+ * it stays out of SHOWCASE_LEVEL_IDS and renders no "Level N/M" chip.
  */
 const STEP_IDS = [
   "create",
@@ -27,7 +27,7 @@ export type ShowcaseStepId = (typeof STEP_IDS)[number];
 
 export const SHOWCASE_STEP_IDS: readonly ShowcaseStepId[] = STEP_IDS;
 
-export const SHOWCASE_MISSION_IDS = STEP_IDS.filter(
+export const SHOWCASE_LEVEL_IDS = STEP_IDS.filter(
   (id): id is Exclude<ShowcaseStepId, "graduation" | "notifications"> =>
     id !== "graduation" && id !== "notifications",
 );
@@ -51,7 +51,7 @@ const STEP_CONTENT: Record<ShowcaseStepId, Omit<ShowcaseStep, "id">> = {
     keycaps: KEYMAP.createEvent.keycaps,
   },
   pageJump: {
-    title: "Hold fast — reveal the jump keys",
+    title: "See where to go: reveal the jump keys",
     body: [
       "Hold ",
       { key: KEYMAP.jumpPageTarget.holdModifier },
@@ -102,9 +102,9 @@ const STEP_CONTENT: Record<ShowcaseStepId, Omit<ShowcaseStep, "id">> = {
     body: "Compass can nudge you five minutes before a timed event starts, even when this tab is in the background. You can turn it off any time from the command palette.",
   },
   graduation: {
-    title: "You've shown great control, young cap'n.",
+    title: "That's the practice — you've got this.",
     body: [
-      "That was practice. Your real calendar is next — the same two keys put a real event on it. And whenever you wonder where to go, hold ",
+      "You're done practicing. Those keys work the same on your real calendar. Whenever you wonder where to go, hold ",
       { key: KEYMAP.jumpPageTarget.holdModifier },
       " to see where you can jump.",
     ],
@@ -115,10 +115,10 @@ export function getShowcaseStep(id: ShowcaseStepId): ShowcaseStep {
   return { id, ...STEP_CONTENT[id] };
 }
 
-export function getMissionLabel(id: ShowcaseStepId): string | null {
+export function getLevelLabel(id: ShowcaseStepId): string | null {
   if (id === "graduation" || id === "notifications") return null;
-  const number = SHOWCASE_MISSION_IDS.indexOf(id) + 1;
-  return `Mission ${number} of ${SHOWCASE_MISSION_IDS.length}`;
+  const number = SHOWCASE_LEVEL_IDS.indexOf(id) + 1;
+  return `Level ${number}/${SHOWCASE_LEVEL_IDS.length}`;
 }
 
 /**

--- a/packages/web/src/components/ShortcutShowcase/showcase.store.ts
+++ b/packages/web/src/components/ShortcutShowcase/showcase.store.ts
@@ -83,7 +83,7 @@ export const shortcutShowcaseActions = {
   /**
    * Leaving before graduation. There is no "are you sure?" in the way: the
    * showcase is an offer, and the flow it guards (sign up, connect a calendar)
-   * matters more than the missions.
+   * matters more than the levels.
    */
   skip: (exit: ShowcaseExit = "calendar") => {
     const { isActive, stepIndex } = useShortcutShowcaseStore.getState();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Polish the Shortcut Showcase so practice reads as levels, skip is obvious, jump keys land on a sidebar and grid, and Esc no longer dumps the user out of the takeover while a command palette stays open.

- Label steps `Level N/M` (e.g. `Level 2/6`) and retitle Level 2 to “See where to go: reveal the jump keys”
- Remove **Do it for me** / `D` / `X`; rename the leave action to **Skip** with an Esc hint
- Add a static sidebar to the practice calendar and park jump chips on the timed grid (`1`) and sidebar (`2`)
- Swallow `Mod+K` and Esc in the takeover so the real palette cannot leak; Esc closes the practice palette and stays on Level 6
- Graduation copy is a short congratulations with **See your calendar** + Enter and the existing curtain reveal

![Level 1 with Skip and Esc](https://cursor.com/artifacts/c/art-834b0838-6592-4b70-83ca-bd1f166fa8d8)
![Level 2 jump-key lesson with sidebar](https://cursor.com/artifacts/c/art-41b1840f-56bf-4f9b-b040-ae85cc86a7af)
![Graduation congratulations](https://cursor.com/artifacts/c/art-3cae71e7-5118-4652-84d6-4a5a1e66c05c)
<a href="https://cursor.com/agents/bc-344104ef-1418-4b38-bf17-c5bdb2158d99/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshortcut_practice_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-85bb6e34-c53c-4e2d-86d6-bb31571edbd6" alt="shortcut_practice_walkthrough.mp4" /></a>

## Simplicity

Deleted the assist path (`doItForMe`, `D`, `shortcut_showcase_assist_used`) rather than renaming it. Jump chips moved into `PracticeCalendar` instead of adding a second overlay. Palette leak is stopped in the existing capture listener.

## Automated validation

- Browser walkthrough: Level labels, Skip/Esc, Level 2 sidebar+grid, palette Esc stays on Level 6, graduation + calendar reveal
- Unit: `bun test:web packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx` — 32 pass
- E2E: `bunx playwright test e2e/onboarding/shortcut-showcase.spec.ts` — 5 pass
- GitHub CI on the latest push: lint, type-check, unit (all packages), e2e, knip, lighthouse, CodeQL — all green

## Independent review

Not yet requested.

## Test plan

- `bun test:web packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx`
- `bunx playwright test e2e/onboarding/shortcut-showcase.spec.ts`
- `bunx biome check` on the edited showcase files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-344104ef-1418-4b38-bf17-c5bdb2158d99?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-344104ef-1418-4b38-bf17-c5bdb2158d99&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

