### PR TITLE
feat(web): explain time travel and exit with escape

### DIFF
--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -373,19 +373,23 @@ PageUp and PageDown always scroll the timed grid by one viewport. Alt+ArrowUp an
 
 ### UX
 
-Bare `Z` opens the time-travel timezone picker in Day and Week view. Cmd+Z / Ctrl+Z remains undo. Escape closes the picker without dropping an existing secondary hour column.
+Bare `Z` opens the time-travel timezone picker in Day and Week view. Cmd+Z / Ctrl+Z remains undo. Escape on the picker closes it without dropping an existing secondary hour column. Escape on the grid while traveling clears the extra column. The second timezone has no click-to-dismiss control; the sidebar hint advertises Esc to exit.
 
 ### Steps
 
 1. Navigate to `/week`.
 2. Press `Z`.
-3. Choose a timezone, then press Escape from the grid.
-4. Press Cmd+Z / Ctrl+Z after an undoable action.
+3. Confirm the picker describes comparing hours in a second timezone, then choose a timezone.
+4. Press Escape from the grid.
+5. Press `Z` again, choose a timezone, then press Escape while the picker is still open.
+6. Press Cmd+Z / Ctrl+Z after an undoable action.
 
 ### Expected Results
 
-- `Z` opens the Time travel picker.
-- A second hour column appears after a zone is chosen and survives reload until removed.
+- `Z` opens the Time travel picker with a one-line description of the feature.
+- A second hour column appears after a zone is chosen and survives reload until removed. Both timezone abbreviations show in the gutter; there is no X control.
+- The sidebar hint reads that two timezones are showing and Esc exits.
+- Escape from the grid while traveling clears the extra column.
 - Escape closes the picker and leaves the extra column in place.
 - Cmd+Z undoes; it does not open time travel.
 

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
@@ -32,6 +32,11 @@ import {
   getPartsPlainText,
   getShortcutHint,
 } from "@web/shortcuts/tips/shortcut-tips.data";
+import { TIME_TRAVEL_HINT_PARTS } from "@web/timezone/TimeTravelIndicator";
+import {
+  resetTimeTravelStoreForTests,
+  setTimeTravelZone,
+} from "@web/timezone/time-travel.store";
 import {
   afterAll,
   afterEach,
@@ -108,6 +113,7 @@ const seedKeyboardPlaceDraft = () => {
 };
 
 const KEYBOARD_PLACE_HINT = getPartsPlainText(KEYBOARD_PLACE_HINT_PARTS);
+const TIME_TRAVEL_HINT = getPartsPlainText(TIME_TRAVEL_HINT_PARTS);
 const CREATE_EVENT_HINT = getHintPlainText(getShortcutHint("create-event"));
 const FIRST_EVENT_SAVE_HINT = getHintPlainText(
   getShortcutHint("first-event-save"),
@@ -134,6 +140,7 @@ describe("SidebarStatusBar", () => {
     useEventJumpStore.setState(initialEventJumpState, true);
     useEdgeFocusStore.setState(initialEdgeFocusState, true);
     useFirstEventPromptStore.setState(initialFirstEventPromptState, true);
+    resetTimeTravelStoreForTests();
     document.body.innerHTML = "";
   });
 
@@ -142,6 +149,7 @@ describe("SidebarStatusBar", () => {
     useEventJumpStore.setState(initialEventJumpState, true);
     useEdgeFocusStore.setState(initialEdgeFocusState, true);
     useFirstEventPromptStore.setState(initialFirstEventPromptState, true);
+    resetTimeTravelStoreForTests();
     document.body.innerHTML = "";
   });
 
@@ -403,5 +411,37 @@ describe("SidebarStatusBar", () => {
 
     expect(screen.getByRole("status")).toHaveTextContent("Editing start time");
     expect(screen.queryByText(KEYBOARD_PLACE_HINT)).not.toBeInTheDocument();
+  });
+
+  it("replaces the idle shortcut tip with the time travel hint", () => {
+    setTimeTravelZone("America/Denver");
+    const { wrapper } = createStoreWrapper();
+
+    render(<SidebarStatusBar />, { wrapper });
+
+    expect(screen.getByRole("status")).toHaveTextContent(TIME_TRAVEL_HINT);
+    expect(screen.queryByText(CREATE_EVENT_HINT)).not.toBeInTheDocument();
+  });
+
+  it("yields the time travel hint to keyboardPlace", () => {
+    setTimeTravelZone("America/Denver");
+    seedKeyboardPlaceDraft();
+    const { wrapper } = createStoreWrapper();
+
+    render(<SidebarStatusBar />, { wrapper });
+
+    expect(screen.getByRole("status")).toHaveTextContent(KEYBOARD_PLACE_HINT);
+    expect(screen.queryByText(TIME_TRAVEL_HINT)).not.toBeInTheDocument();
+  });
+
+  it("yields the time travel hint to event jump", () => {
+    setTimeTravelZone("America/Denver");
+    eventJumpActions.setActive(true);
+    const { wrapper } = createStoreWrapper();
+
+    render(<SidebarStatusBar />, { wrapper });
+
+    expect(screen.getByRole("status")).toHaveTextContent("Event jump · Esc");
+    expect(screen.queryByText(TIME_TRAVEL_HINT)).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
@@ -29,6 +29,8 @@ import {
 import { ShortcutTipIndicator } from "@web/shortcuts/tips/ShortcutTipIndicator";
 import { useShortcutHintContext } from "@web/shortcuts/tips/useShortcutHintContext";
 import { useSseDegraded } from "@web/sse/hooks/useSseDegraded";
+import { TimeTravelIndicator } from "@web/timezone/TimeTravelIndicator";
+import { useTimeTravelZone } from "@web/timezone/time-travel.store";
 
 /**
  * Pinned status bar at the bottom of the sidebar, just above the actions bar.
@@ -52,6 +54,7 @@ export const SidebarStatusBar: FC = () => {
   const draftActivity = useDraftStore(selectDraftActivity);
   const isDraftFormOpen = useDraftStore(selectIsEventFormOpen);
   const isKeyboardPlace = draftActivity === "keyboardPlace" && !isDraftFormOpen;
+  const isTimeTraveling = useTimeTravelZone() !== null;
   const isSaving = useHasPendingEventMutations();
   // The unscoped hook's `connection` is the primary connection (the one
   // whose own state matches the aggregate) - without it, an account's
@@ -87,7 +90,11 @@ export const SidebarStatusBar: FC = () => {
   ) : isKeyboardPlace ? (
     <KeyboardPlaceIndicator />
   ) : !status ? (
-    <ShortcutTipIndicator hint={hint} />
+    isTimeTraveling ? (
+      <TimeTravelIndicator />
+    ) : (
+      <ShortcutTipIndicator hint={hint} />
+    )
   ) : null;
 
   return (

--- a/packages/web/src/grid/shortcuts/useCalendarViewShortcuts.test.tsx
+++ b/packages/web/src/grid/shortcuts/useCalendarViewShortcuts.test.tsx
@@ -3,6 +3,22 @@ import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import { act, type PropsWithChildren } from "react";
 import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
 import {
+  createGridEventDraft,
+  timedGridSchedule,
+} from "@web/events/grid-event-draft.adapter";
+import { draftActions } from "@web/events/stores/draft.store";
+import {
+  edgeFocusActions,
+  initialEdgeFocusState,
+  useEdgeFocusStore,
+} from "@web/grid/shortcuts/edge-focus.store";
+import { eventJumpActions } from "@web/shortcuts/shift-hint/event-jump.store";
+import {
+  getTimeTravelZone,
+  resetTimeTravelStoreForTests,
+  setTimeTravelZone,
+} from "@web/timezone/time-travel.store";
+import {
   selectTimezoneDialogOpen,
   selectTimezoneDialogPurpose,
   timezoneDialogActions,
@@ -22,6 +38,10 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   document.body.innerHTML = "";
+  resetTimeTravelStoreForTests();
+  draftActions.discard();
+  useEdgeFocusStore.setState(initialEdgeFocusState, true);
+  eventJumpActions.reset();
 });
 
 describe("useCalendarViewShortcuts", () => {
@@ -146,5 +166,64 @@ describe("useCalendarViewShortcuts", () => {
     act(() => {
       timezoneDialogActions.close();
     });
+  });
+
+  it("clears time travel on Escape", () => {
+    setTimeTravelZone("America/Denver");
+    renderHook(() => useCalendarViewShortcuts({}), { wrapper });
+
+    pressKey("Escape");
+
+    expect(getTimeTravelZone()).toBeNull();
+  });
+
+  it("does not clear time travel on Escape when no secondary zone is set", () => {
+    renderHook(() => useCalendarViewShortcuts({}), { wrapper });
+
+    pressKey("Escape");
+
+    expect(getTimeTravelZone()).toBeNull();
+  });
+
+  it("does not clear time travel on Escape while edge focus is active", () => {
+    setTimeTravelZone("America/Denver");
+    edgeFocusActions.setEdge(
+      "aaaaaaaaaaaaaaaaaaaaaaaa",
+      "startDate",
+      "Editing start time",
+    );
+    renderHook(() => useCalendarViewShortcuts({}), { wrapper });
+
+    pressKey("Escape");
+
+    expect(getTimeTravelZone()).toBe("America/Denver");
+  });
+
+  it("does not clear time travel on Escape during keyboard place", () => {
+    setTimeTravelZone("America/Denver");
+    draftActions.startGridDraft({
+      activity: "keyboardPlace",
+      draft: createGridEventDraft(
+        timedGridSchedule(
+          new Date("2026-05-20T09:00:00.000"),
+          new Date("2026-05-20T10:00:00.000"),
+        ),
+      ),
+    });
+    renderHook(() => useCalendarViewShortcuts({}), { wrapper });
+
+    pressKey("Escape");
+
+    expect(getTimeTravelZone()).toBe("America/Denver");
+  });
+
+  it("does not clear time travel on Escape while event jump is active", () => {
+    setTimeTravelZone("America/Denver");
+    eventJumpActions.setActive(true);
+    renderHook(() => useCalendarViewShortcuts({}), { wrapper });
+
+    pressKey("Escape");
+
+    expect(getTimeTravelZone()).toBe("America/Denver");
   });
 });

--- a/packages/web/src/grid/shortcuts/useCalendarViewShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useCalendarViewShortcuts.ts
@@ -1,9 +1,17 @@
+import { useDraftStore } from "@web/events/stores/draft.store";
+import { useEdgeFocusStore } from "@web/grid/shortcuts/edge-focus.store";
 import { useGridScrollShortcuts } from "@web/grid/shortcuts/useGridScrollShortcuts";
+import { isHigherEscapeOwner } from "@web/shortcuts/escape-ownership";
 import { KEYMAP } from "@web/shortcuts/keymap";
+import { isEventJumpActive } from "@web/shortcuts/shift-hint/event-jump.store";
 import {
   useAppShortcut,
   useAppShortcutUp,
 } from "@web/shortcuts/useAppShortcut";
+import {
+  setTimeTravelZone,
+  useTimeTravelZone,
+} from "@web/timezone/time-travel.store";
 import { timezoneDialogActions } from "@web/timezone/timezone-dialog.store";
 
 export interface CalendarViewShortcutsConfig {
@@ -31,6 +39,7 @@ export interface CalendarViewShortcutsConfig {
  * the thin key-registration boundary.
  */
 export function useCalendarViewShortcuts(config: CalendarViewShortcutsConfig) {
+  const timeTravelZone = useTimeTravelZone();
   useGridScrollShortcuts();
 
   useAppShortcutUp("J", () => config.onPrevPeriod?.());
@@ -51,5 +60,23 @@ export function useCalendarViewShortcuts(config: CalendarViewShortcutsConfig) {
   // match this binding the way Mod+D vs D does on keyup.
   useAppShortcut("Z", () =>
     timezoneDialogActions.open(undefined, "time-travel"),
+  );
+  useAppShortcut(
+    "Escape",
+    () => {
+      if (isHigherEscapeOwner()) return;
+      if (useEdgeFocusStore.getState().eventId) return;
+      if (isEventJumpActive()) return;
+      const { gridDraft, status } = useDraftStore.getState();
+      if (
+        status?.activity === "keyboardPlace" &&
+        !status.isFormOpen &&
+        gridDraft
+      ) {
+        return;
+      }
+      setTimeTravelZone(null);
+    },
+    { enabled: timeTravelZone !== null },
   );
 }

--- a/packages/web/src/timezone/GridTimezoneLabel.test.tsx
+++ b/packages/web/src/timezone/GridTimezoneLabel.test.tsx
@@ -172,8 +172,7 @@ describe("GridTimezoneLabel", () => {
     }
   });
 
-  it("shows both abbreviations and a remove control while time traveling", async () => {
-    const user = userEvent.setup();
+  it("shows both abbreviations without a remove control while time traveling", () => {
     act(() => {
       setEffectiveTimeZoneForTests("America/New_York");
       setTimeTravelZone("America/Denver");
@@ -194,19 +193,9 @@ describe("GridTimezoneLabel", () => {
         name: `Calendar timezone: ${formatTimeZoneAbbreviation("America/New_York")}`,
       }),
     ).toBeInTheDocument();
-
-    await user.click(
-      screen.getByRole("button", { name: "Remove time travel timezone" }),
-    );
-
     expect(
-      screen.queryByRole("group", { name: "Time travel timezones" }),
+      screen.queryByRole("button", { name: "Remove time travel timezone" }),
     ).not.toBeInTheDocument();
-    expect(
-      screen.getByRole("button", {
-        name: `Calendar timezone: ${formatTimeZoneAbbreviation("America/New_York")}`,
-      }),
-    ).toHaveFocus();
     act(() => {
       resetTimeTravelStoreForTests();
     });

--- a/packages/web/src/timezone/GridTimezoneLabel.tsx
+++ b/packages/web/src/timezone/GridTimezoneLabel.tsx
@@ -1,5 +1,4 @@
-import { XIcon } from "@phosphor-icons/react";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { useMinuteTick } from "@web/common/hooks/useMinuteTick";
 import { GRID_TIME_COLUMN_WIDTH } from "@web/grid/grid.constants";
 import {
@@ -7,13 +6,13 @@ import {
   useEffectiveTimeZone,
 } from "@web/timezone/effective-timezone.store";
 import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
-import {
-  setTimeTravelZone,
-  useTimeTravelZone,
-} from "@web/timezone/time-travel.store";
+import { useTimeTravelZone } from "@web/timezone/time-travel.store";
 import { timezoneDialogActions } from "@web/timezone/timezone-dialog.store";
 
 const BROWSER_ZONE_POLL_MS = 60_000;
+
+const travelingLabelClassName =
+  "c-focus-ring min-h-6 truncate rounded-sm px-0.5 text-center text-[10px] text-text-muted leading-none hover:text-text";
 
 /**
  * Week/Day grid-corner control showing the effective timezone abbreviation.
@@ -23,7 +22,6 @@ export const GridTimezoneLabel = () => {
   const timeZone = useEffectiveTimeZone();
   const timeTravelZone = useTimeTravelZone();
   const now = useMinuteTick();
-  const calendarButtonRef = useRef<HTMLButtonElement>(null);
 
   // There is no timezonechange event. Poll so Auto mode follows an OS change
   // without a tab blur. Do not refresh on mount — that would wipe a test pin
@@ -54,37 +52,21 @@ export const GridTimezoneLabel = () => {
       role={isTraveling ? "group" : undefined}
     >
       {isTraveling ? (
-        <div
-          className="flex items-center justify-center gap-0.5"
+        <button
+          aria-label={`Time travel timezone: ${travelAbbreviation}`}
+          className={travelingLabelClassName}
+          onClick={openTimeTravel}
           style={{ width: GRID_TIME_COLUMN_WIDTH }}
+          type="button"
         >
-          <button
-            aria-label={`Time travel timezone: ${travelAbbreviation}`}
-            className="c-focus-ring min-h-6 min-w-0 truncate rounded-sm px-0.5 text-center text-[10px] text-text-muted leading-none hover:text-text"
-            onClick={openTimeTravel}
-            type="button"
-          >
-            {travelAbbreviation}
-          </button>
-          <button
-            aria-label="Remove time travel timezone"
-            className="c-focus-ring flex size-4 shrink-0 items-center justify-center rounded-sm text-text-muted hover:text-text"
-            onClick={() => {
-              setTimeTravelZone(null);
-              calendarButtonRef.current?.focus();
-            }}
-            type="button"
-          >
-            <XIcon aria-hidden="true" className="size-3" />
-          </button>
-        </div>
+          {travelAbbreviation}
+        </button>
       ) : null}
       <button
-        ref={calendarButtonRef}
         aria-label={`Calendar timezone: ${abbreviation}`}
         className={
           isTraveling
-            ? "c-focus-ring min-h-6 truncate rounded-sm px-0.5 text-center text-[10px] text-text-muted leading-none hover:text-text"
+            ? travelingLabelClassName
             : "c-focus-ring min-h-6 w-full max-w-full truncate rounded-sm px-0.5 text-center text-[10px] text-text-muted leading-none hover:text-text"
         }
         onClick={openTimeTravel}

--- a/packages/web/src/timezone/TimeTravelIndicator.tsx
+++ b/packages/web/src/timezone/TimeTravelIndicator.tsx
@@ -1,0 +1,25 @@
+import { type FC } from "react";
+import { ShortcutTipParts } from "@web/shortcuts/tips/ShortcutTipParts";
+import { type ShortcutTipPart } from "@web/shortcuts/tips/shortcut-tips.data";
+
+export const TIME_TRAVEL_HINT_PARTS: readonly ShortcutTipPart[] = [
+  "Two timezones · ",
+  { key: "Esc" },
+  " to exit",
+];
+
+/**
+ * Contextual sidebar hint while a secondary hour column is showing:
+ * Esc clears time travel from the grid.
+ */
+export const TimeTravelIndicator: FC = () => {
+  return (
+    <span
+      aria-live="polite"
+      className="truncate text-text-muted text-xs opacity-80"
+      role="status"
+    >
+      <ShortcutTipParts parts={TIME_TRAVEL_HINT_PARTS} />
+    </span>
+  );
+};

--- a/packages/web/src/timezone/TimezonePickerDialog.test.tsx
+++ b/packages/web/src/timezone/TimezonePickerDialog.test.tsx
@@ -104,7 +104,9 @@ describe("TimezonePickerDialog", () => {
     ).not.toBeInTheDocument();
     expect(
       screen.getByRole("dialog", { name: "Time travel" }),
-    ).toBeInTheDocument();
+    ).toHaveAccessibleDescription(
+      "Compare your calendar hours in a second timezone.",
+    );
 
     await user.type(
       screen.getByRole("combobox", { name: "Search timezones" }),

--- a/packages/web/src/timezone/TimezonePickerDialog.tsx
+++ b/packages/web/src/timezone/TimezonePickerDialog.tsx
@@ -129,6 +129,11 @@ export function TimezonePickerDialog({
   return (
     <OverlayPanel
       title={isTimeTravel ? "Time travel" : "Change default timezone"}
+      message={
+        isTimeTravel
+          ? "Compare your calendar hours in a second timezone."
+          : undefined
+      }
       onDismiss={onDismiss}
       restoreFocus={restoreFocus}
       initialFocusRef={searchRef}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Time travel was hard to understand and hard to leave from the keyboard.

- The `Z` picker now has a one-line description: “Compare your calendar hours in a second timezone.”
- While a secondary timezone is showing, the sidebar hint reads “Two timezones · Esc to exit”.
- Escape on the grid clears the extra hour column. Escape on the picker still only dismisses the picker.
- The mouse-only X next to the second timezone abbreviation is gone.

## Simplicity

Removed the click-only dismiss control instead of teaching users to focus it. Escape already owns “leave this mode” elsewhere (keyboard place, event jump), so time travel uses the same pattern.

## Automated validation

Focused web tests (46 pass): picker description, dual abbreviations without a remove control, sidebar hint priority, and Esc clearing the secondary zone while standing down for edge focus, keyboard place, and event jump.

`bun run verify` selected web: `test:web` → `type-check` → `lint` → `knip`. Selected checks passed. Playwright a11y/e2e skipped (Chromium not installed in this environment).

Browser (anonymous `dev:web`): `Z` shows the description; choosing Denver adds a second hour column with no X; the sidebar shows Esc to exit; grid Esc clears the extra column; picker Esc keeps it.

## Independent review

Pending.

## Test plan

- `bun run test:web --` on `TimezonePickerDialog.test.tsx`, `GridTimezoneLabel.test.tsx`, `SidebarStatusBar.test.tsx`, `useCalendarViewShortcuts.test.tsx` (46 pass)
- `bun run verify` (web suite + type-check + lint + knip)

![Time travel picker with one-line description](https://cursor.com/artifacts/c/art-23c60c86-fb6c-461e-b441-89a64e501d24)
![Two timezone columns and sidebar Esc-to-exit hint](https://cursor.com/artifacts/c/art-53759c25-c209-4bf4-9e25-570bba13d03c)
<a href="https://cursor.com/agents/bc-e24e18b2-e4cb-4502-9a49-eb784db14bc3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftime_travel_picker_hint_and_esc_exit.mp4"><img src="https://cursor.com/artifacts/c/art-0ecdfd81-9dd4-43e6-a491-63e9af74150b" alt="time_travel_picker_hint_and_esc_exit.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e24e18b2-e4cb-4502-9a49-eb784db14bc3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e24e18b2-e4cb-4502-9a49-eb784db14bc3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

