### PR TITLE
fix(web): place onboarding showcase sidebar on the right

### DIFF
--- a/packages/web/src/components/ShortcutShowcase/PracticeCalendar.tsx
+++ b/packages/web/src/components/ShortcutShowcase/PracticeCalendar.tsx
@@ -111,11 +111,11 @@ const PracticeSidebar: FC<{ showPageJumpHints: boolean }> = ({
   return (
     <div
       aria-hidden
-      className="relative flex w-28 shrink-0 flex-col gap-3 border-border border-r pr-3"
+      className="relative flex w-28 shrink-0 flex-col gap-3 border-border border-l pl-3"
       data-practice-jump="sidebar"
     >
       {showPageJumpHints && (
-        <ShortcutHint className="absolute top-1 right-1 z-10">2</ShortcutHint>
+        <ShortcutHint className="absolute top-1 left-1 z-10">2</ShortcutHint>
       )}
       <div className="font-medium text-text-muted text-xs">{monthLabel}</div>
       <div className="h-20 rounded-md bg-surface-overlay" />
@@ -127,10 +127,11 @@ const PracticeSidebar: FC<{ showPageJumpHints: boolean }> = ({
 };
 
 /**
- * The showcase's fake grid: a sidebar, day columns, hour lines, and
- * time-positioned blocks. Deliberately not the real TimedGrid, which drags
- * in stores and scroll plumbing the lesson does not need; geometry is plain
- * percentage math off the practice state.
+ * The showcase's fake grid: day columns, hour lines, time-positioned
+ * blocks, and a right-hand sidebar matching the real calendar. Deliberately
+ * not the real TimedGrid, which drags in stores and scroll plumbing the
+ * lesson does not need; geometry is plain percentage math off the practice
+ * state.
  */
 export const PracticeCalendar: FC<{
   state: PracticeState;
@@ -147,63 +148,65 @@ export const PracticeCalendar: FC<{
       className="relative flex h-full min-h-0 w-full select-none"
       data-practice-jump="calendar"
     >
-      <PracticeSidebar showPageJumpHints={showPageJumpHints} />
-
-      {/* Time column */}
-      <div className="flex w-14 shrink-0 flex-col border-border border-r pr-2 text-right">
-        <div className="h-7" />
-        <div className="relative flex-1">
-          {hours.map((hour) => (
-            <span
-              key={hour}
-              className="absolute right-2 -translate-y-1/2 text-[10px] text-text-muted"
-              style={{
-                top: `${(((hour - SHOWCASE_GRID_START_HOUR) * 60) / TOTAL_MIN) * 100}%`,
-              }}
-            >
-              {formatHour(hour)}
-            </span>
-          ))}
-        </div>
-      </div>
-
-      {/* Day columns */}
-      {Array.from({ length: SHOWCASE_DAY_COUNT }, (_, dayIndex) => (
-        <div
-          key={DAY_LABELS[dayIndex]}
-          className="flex min-w-0 flex-1 flex-col border-border border-r last:border-r-0"
-        >
-          <div className="flex h-7 items-center justify-center font-medium text-text-muted text-xs">
-            {DAY_LABELS[dayIndex]}
-          </div>
+      <div className="flex min-w-0 flex-1">
+        {/* Time column */}
+        <div className="flex w-14 shrink-0 flex-col border-border border-r pr-2 text-right">
+          <div className="h-7" />
           <div className="relative flex-1">
-            {showPageJumpHints && dayIndex === 0 && (
-              <ShortcutHint className="absolute top-2 left-1 z-10">
-                1
-              </ShortcutHint>
-            )}
             {hours.map((hour) => (
-              <div
+              <span
                 key={hour}
-                className="absolute inset-x-0 border-border/60 border-t"
+                className="absolute right-2 -translate-y-1/2 text-[10px] text-text-muted"
                 style={{
                   top: `${(((hour - SHOWCASE_GRID_START_HOUR) * 60) / TOTAL_MIN) * 100}%`,
                 }}
-              />
+              >
+                {formatHour(hour)}
+              </span>
             ))}
-            {state.events
-              .filter((block) => block.dayIndex === dayIndex)
-              .map((block) => (
-                <PracticeBlock
-                  key={block.id}
-                  block={block}
-                  state={state}
-                  onTitleCommit={onTitleCommit}
-                />
-              ))}
           </div>
         </div>
-      ))}
+
+        {/* Day columns */}
+        {Array.from({ length: SHOWCASE_DAY_COUNT }, (_, dayIndex) => (
+          <div
+            key={DAY_LABELS[dayIndex]}
+            className="flex min-w-0 flex-1 flex-col border-border border-r last:border-r-0"
+          >
+            <div className="flex h-7 items-center justify-center font-medium text-text-muted text-xs">
+              {DAY_LABELS[dayIndex]}
+            </div>
+            <div className="relative flex-1">
+              {showPageJumpHints && dayIndex === 0 && (
+                <ShortcutHint className="absolute top-2 left-1 z-10">
+                  1
+                </ShortcutHint>
+              )}
+              {hours.map((hour) => (
+                <div
+                  key={hour}
+                  className="absolute inset-x-0 border-border/60 border-t"
+                  style={{
+                    top: `${(((hour - SHOWCASE_GRID_START_HOUR) * 60) / TOTAL_MIN) * 100}%`,
+                  }}
+                />
+              ))}
+              {state.events
+                .filter((block) => block.dayIndex === dayIndex)
+                .map((block) => (
+                  <PracticeBlock
+                    key={block.id}
+                    block={block}
+                    state={state}
+                    onTitleCommit={onTitleCommit}
+                  />
+                ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <PracticeSidebar showPageJumpHints={showPageJumpHints} />
     </div>
   );
 };

--- a/packages/web/src/components/ShortcutShowcase/PracticeCalendar.tsx
+++ b/packages/web/src/components/ShortcutShowcase/PracticeCalendar.tsx
@@ -111,7 +111,7 @@ const PracticeSidebar: FC<{ showPageJumpHints: boolean }> = ({
   return (
     <div
       aria-hidden
-      className="relative flex w-28 shrink-0 flex-col gap-3 border-border border-l pl-3"
+      className="relative flex w-28 shrink-0 flex-col gap-3 pl-3"
       data-practice-jump="sidebar"
     >
       {showPageJumpHints && (
@@ -148,63 +148,61 @@ export const PracticeCalendar: FC<{
       className="relative flex h-full min-h-0 w-full select-none"
       data-practice-jump="calendar"
     >
-      <div className="flex min-w-0 flex-1">
-        {/* Time column */}
-        <div className="flex w-14 shrink-0 flex-col border-border border-r pr-2 text-right">
-          <div className="h-7" />
+      {/* Time column */}
+      <div className="flex w-14 shrink-0 flex-col border-border border-r pr-2 text-right">
+        <div className="h-7" />
+        <div className="relative flex-1">
+          {hours.map((hour) => (
+            <span
+              key={hour}
+              className="absolute right-2 -translate-y-1/2 text-[10px] text-text-muted"
+              style={{
+                top: `${(((hour - SHOWCASE_GRID_START_HOUR) * 60) / TOTAL_MIN) * 100}%`,
+              }}
+            >
+              {formatHour(hour)}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Day columns */}
+      {Array.from({ length: SHOWCASE_DAY_COUNT }, (_, dayIndex) => (
+        <div
+          key={DAY_LABELS[dayIndex]}
+          className="flex min-w-0 flex-1 flex-col border-border border-r"
+        >
+          <div className="flex h-7 items-center justify-center font-medium text-text-muted text-xs">
+            {DAY_LABELS[dayIndex]}
+          </div>
           <div className="relative flex-1">
+            {showPageJumpHints && dayIndex === 0 && (
+              <ShortcutHint className="absolute top-2 left-1 z-10">
+                1
+              </ShortcutHint>
+            )}
             {hours.map((hour) => (
-              <span
+              <div
                 key={hour}
-                className="absolute right-2 -translate-y-1/2 text-[10px] text-text-muted"
+                className="absolute inset-x-0 border-border/60 border-t"
                 style={{
                   top: `${(((hour - SHOWCASE_GRID_START_HOUR) * 60) / TOTAL_MIN) * 100}%`,
                 }}
-              >
-                {formatHour(hour)}
-              </span>
+              />
             ))}
-          </div>
-        </div>
-
-        {/* Day columns */}
-        {Array.from({ length: SHOWCASE_DAY_COUNT }, (_, dayIndex) => (
-          <div
-            key={DAY_LABELS[dayIndex]}
-            className="flex min-w-0 flex-1 flex-col border-border border-r last:border-r-0"
-          >
-            <div className="flex h-7 items-center justify-center font-medium text-text-muted text-xs">
-              {DAY_LABELS[dayIndex]}
-            </div>
-            <div className="relative flex-1">
-              {showPageJumpHints && dayIndex === 0 && (
-                <ShortcutHint className="absolute top-2 left-1 z-10">
-                  1
-                </ShortcutHint>
-              )}
-              {hours.map((hour) => (
-                <div
-                  key={hour}
-                  className="absolute inset-x-0 border-border/60 border-t"
-                  style={{
-                    top: `${(((hour - SHOWCASE_GRID_START_HOUR) * 60) / TOTAL_MIN) * 100}%`,
-                  }}
+            {state.events
+              .filter((block) => block.dayIndex === dayIndex)
+              .map((block) => (
+                <PracticeBlock
+                  key={block.id}
+                  block={block}
+                  state={state}
+                  onTitleCommit={onTitleCommit}
                 />
               ))}
-              {state.events
-                .filter((block) => block.dayIndex === dayIndex)
-                .map((block) => (
-                  <PracticeBlock
-                    key={block.id}
-                    block={block}
-                    state={state}
-                    onTitleCommit={onTitleCommit}
-                  />
-                ))}
-            </div>
           </div>
-        ))}
-      </div>
+        </div>
+      ))}
 
       <PracticeSidebar showPageJumpHints={showPageJumpHints} />
     </div>

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
@@ -237,6 +237,17 @@ describe("ShortcutShowcase", () => {
     expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
   });
 
+  it("places the practice sidebar after the grid, matching the real calendar", () => {
+    render(<ShortcutShowcase />);
+    act(() => shortcutShowcaseActions.replay());
+
+    const monday = screen.getByText("Mon");
+    const upNext = screen.getByText("Up next", { hidden: true });
+    expect(
+      monday.compareDocumentPosition(upNext) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).not.toBe(0);
+  });
+
   it("advances the hold-Mod level after revealing jump keys", () => {
     const modKey = resolveModifier("Mod") === "Meta" ? "Meta" : "Control";
     render(<ShortcutShowcase />);

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
@@ -242,7 +242,7 @@ describe("ShortcutShowcase", () => {
     act(() => shortcutShowcaseActions.replay());
 
     const monday = screen.getByText("Mon");
-    const upNext = screen.getByText("Up next", { hidden: true });
+    const upNext = screen.getByText("Up next");
     expect(
       monday.compareDocumentPosition(upNext) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).not.toBe(0);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The shortcut-practice sandbox rendered its month-picker / Up next chrome on the **left** of the fake grid. The real calendar pins that sidebar on the **right**. This moves the practice sidebar to the right so the first calendar a new user sees matches the one they graduate into.

The lesson copy (Level N/6, Skip) stays on the left. Only the sandbox calendar's sidebar moves.

![Practice calendar with August / Up next on the right](https://cursor.com/artifacts/c/art-866c5dcc-5c87-483c-b2df-8694bace0648)

<a href="https://cursor.com/agents/bc-817c56e5-8e78-40c6-be71-44b46462bbb6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshowcase_sidebar_on_right.mp4"><img src="https://cursor.com/artifacts/c/art-f97cd861-1ba7-4883-b51c-1a57bd9f7ed9" alt="showcase_sidebar_on_right.mp4" /></a>

## Simplicity

Reorder the practice-calendar flex children. Wednesday's right border divides the sidebar, so no extra wrapper or `last:border-r-0` is needed. Jump chip sits on the grid-facing side.

## Automated validation

- `bun test:web -- packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx` — 33 pass after the simplify, including the document-order assertion that "Up next" follows "Mon".
- Prior head: `bun run type-check` and `bun run lint` pass; GitHub CI 21/21 green on `9005110`.
- Browser: welcome → practice overlay. August / Up next sits on the right of the fake grid. Skip (Esc) lands on Week view with the real sidebar also on the right.

## Independent review

```
VERDICT: no confirmed findings
FINDINGS:
```

Read of the complete `origin/main...HEAD` diff: DOM reorder of `aria-hidden` chrome, padding/border mirror, one text-query layout test. No state, race, focus, auth, or data-loss defects.

## Test plan

- `bun test:web -- packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx`
- `bun run type-check`
- `bun run lint`
- Browser walkthrough of the showcase and skip-to-calendar path

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-817c56e5-8e78-40c6-be71-44b46462bbb6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-817c56e5-8e78-40c6-be71-44b46462bbb6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

