### PR TITLE
feat(web): cycle sidebar shortcut tips after demonstrated primitives

### DIFF
--- a/.agents/handoffs/2898.md
+++ b/.agents/handoffs/2898.md
@@ -1,0 +1,29 @@
+---
+schema_version: 1
+task_id: "2898"
+from: Reviewer
+to: Manager
+owner: Manager
+status: verifying
+artifact:
+  - path: packages/web/src/shortcuts/tips/selectShortcutHint.ts
+  - url: https://github.com/keepsoftwaresimple/compass-calendar/pull/2898
+evidence:
+  - command: bun test:web -- packages/web/src/shortcuts/tips/selectShortcutHint.test.ts packages/web/src/shortcuts/tips/shortcut-tips.data.test.ts packages/web/src/shortcuts/tips/useShortcutHintContext.test.tsx packages/web/src/shortcuts/tips/shortcut-tips.progress.store.test.ts packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx packages/web/src/shortcuts/page-jump/usePageJumpShortcut.test.tsx
+    result: "62 pass, 0 fail"
+  - command: bun run lint
+    result: "Checked 1505 files. Found 12 pre-existing warnings. No new errors."
+assumptions:
+  - "Demonstrate call sites only fire on successful primitive use, not raw keydown"
+  - "Device-local demonstrated-id list is acceptable, matching other compass.* prefs"
+open_risks: []
+next_deadline: 2026-08-27T06:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+Reviewer verdict: no confirmed findings.
+
+Suggested skills: none. Manager should squash-merge after required checks are green.

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -17,3 +17,4 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 | 2879 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/2879 | bun run verify PASS; review: no confirmed findings | 2026-08-26T06:00:00Z | 0 | none |
 | WP-shortcut-showcase-simplify | medium | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/2890 | verifier PASS; simplify no change; independent re-review no findings | 2026-08-26T23:00:00Z | 2 | none |
 | 2891 | medium | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/2893 | bun run verify PASS; review: no confirmed findings | 2026-08-27T00:00:00Z | 0 | none |
+| 2898 | medium | Manager | verifying | https://github.com/keepsoftwaresimple/compass-calendar/pull/2898 | focused web 62 pass; lint clean of new errors; review: no confirmed findings | 2026-08-27T06:00:00Z | 0 | none |

--- a/docs/development/feature-file-map.md
+++ b/docs/development/feature-file-map.md
@@ -78,6 +78,7 @@ labels outside the registry.
 - Registry (source of truth for `?` legend): `packages/web/src/shortcuts/shortcuts.registry.ts`
 - Taught bindings (handlers + Shortcut Showcase keycaps): `packages/web/src/shortcuts/keymap.ts`
 - Sidebar next-shortcut selector: `packages/web/src/shortcuts/tips/selectShortcutHint.ts`
+- Sidebar tip progress (demonstrated primitives): `packages/web/src/shortcuts/tips/shortcut-tips.progress.store.ts`
 - Global shell shortcuts (sidebar `]`, palette, settings, navigation): `packages/web/src/shortcuts/useGlobalShortcuts.ts`
 - Event-jump chips (`S`): `packages/web/src/shortcuts/shift-hint/`
 - Pointer suppression (mouse permanently inert; keyboard clicks pass): `packages/web/src/shortcuts/keyboard-only/`

--- a/packages/web/src/__tests__/utils/state/reset-stores.ts
+++ b/packages/web/src/__tests__/utils/state/reset-stores.ts
@@ -48,6 +48,7 @@ import {
   initialEventJumpState,
   useEventJumpStore,
 } from "@web/shortcuts/shift-hint/event-jump.store";
+import { resetShortcutHintProgressStoreForTests } from "@web/shortcuts/tips/shortcut-tips.progress.store";
 import { resetEffectiveTimeZoneStoreForTests } from "@web/timezone/effective-timezone.store";
 import { resetTimeTravelStoreForTests } from "@web/timezone/time-travel.store";
 import { useTimezoneDialogStore } from "@web/timezone/timezone-dialog.store";
@@ -81,6 +82,7 @@ const storeResets: StoreReset[] = [
   () => useThemeStore.setState(useThemeStore.getInitialState(), true),
   () => usePointerBlockStore.setState(initialPointerBlockState, true),
   () => useEventJumpStore.setState(initialEventJumpState, true),
+  resetShortcutHintProgressStoreForTests,
 ];
 
 export function resetAllStores() {

--- a/packages/web/src/common/constants/storage.constants.ts
+++ b/packages/web/src/common/constants/storage.constants.ts
@@ -15,6 +15,9 @@ type StorageKey =
   | "compass.onboarding.first-event-done"
   | "compass.trial.started-at"
   | "compass.shortcuts.tips-muted"
+  // Demonstrated sidebar shortcut-tip ids (JSON). Device-local; an unknown
+  // id is skipped on read, not an error.
+  | "compass.shortcuts.tips-demonstrated"
   | "compass.sidebar.width"
   | "compass.theme"
   | "compass.life.preferences"
@@ -54,6 +57,7 @@ export const STORAGE_KEYS: Record<
   | "FIRST_EVENT_DONE"
   | "TRIAL_STARTED_AT"
   | "SHORTCUT_TIPS_MUTED"
+  | "SHORTCUT_TIPS_DEMONSTRATED"
   | "LIFE_PREFERENCES"
   | "SIDEBAR_WIDTH"
   | "SIDEBAR_OPEN"
@@ -81,6 +85,7 @@ export const STORAGE_KEYS: Record<
   FIRST_EVENT_DONE: "compass.onboarding.first-event-done",
   TRIAL_STARTED_AT: "compass.trial.started-at",
   SHORTCUT_TIPS_MUTED: "compass.shortcuts.tips-muted",
+  SHORTCUT_TIPS_DEMONSTRATED: "compass.shortcuts.tips-demonstrated",
   LIFE_PREFERENCES: "compass.life.preferences",
   SIDEBAR_WIDTH: "compass.sidebar.width",
   SIDEBAR_OPEN: "compass.view.sidebar-open",

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
@@ -32,6 +32,7 @@ import {
   getPartsPlainText,
   getShortcutHint,
 } from "@web/shortcuts/tips/shortcut-tips.data";
+import { shortcutHintProgressActions } from "@web/shortcuts/tips/shortcut-tips.progress.store";
 import { TIME_TRAVEL_HINT_PARTS } from "@web/timezone/TimeTravelIndicator";
 import {
   resetTimeTravelStoreForTests,
@@ -119,6 +120,7 @@ const FIRST_EVENT_SAVE_HINT = getHintPlainText(
   getShortcutHint("first-event-save"),
 );
 const PAGE_JUMP_HINT = getHintPlainText(getShortcutHint("page-jump"));
+const EVENT_JUMP_HINT = getHintPlainText(getShortcutHint("event-jump"));
 const EDIT_SEQUENCE_HINT = getHintPlainText(getShortcutHint("edit-sequence"));
 
 const focusCalendarEvent = () => {
@@ -366,6 +368,16 @@ describe("SidebarStatusBar", () => {
     render(<SidebarStatusBar />, { wrapper });
 
     expect(screen.getByRole("status")).toHaveTextContent(PAGE_JUMP_HINT);
+  });
+
+  it("advances to the event-jump tip once hold-Mod has been demonstrated", () => {
+    useFirstEventPromptStore.setState({ isDone: true }, false);
+    shortcutHintProgressActions.demonstrate("page-jump");
+    const { wrapper } = createStoreWrapper();
+
+    render(<SidebarStatusBar />, { wrapper });
+
+    expect(screen.getByRole("status")).toHaveTextContent(EVENT_JUMP_HINT);
   });
 
   it("shows edit-sequence when a calendar event is focused", () => {

--- a/packages/web/src/grid/shortcuts/useCalendarViewShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useCalendarViewShortcuts.ts
@@ -4,6 +4,7 @@ import { useGridScrollShortcuts } from "@web/grid/shortcuts/useGridScrollShortcu
 import { isHigherEscapeOwner } from "@web/shortcuts/escape-ownership";
 import { KEYMAP } from "@web/shortcuts/keymap";
 import { isEventJumpActive } from "@web/shortcuts/shift-hint/event-jump.store";
+import { shortcutHintProgressActions } from "@web/shortcuts/tips/shortcut-tips.progress.store";
 import {
   useAppShortcut,
   useAppShortcutUp,
@@ -52,9 +53,11 @@ export function useCalendarViewShortcuts(config: CalendarViewShortcutsConfig) {
   });
   useAppShortcutUp("T", () => config.onGoToToday?.());
   useAppShortcutUp("Shift+C", () => config.onCreateAllDayEvent?.());
-  useAppShortcutUp(KEYMAP.createEvent.hotkey, () =>
-    config.onCreateTimedEvent?.(),
-  );
+  useAppShortcutUp(KEYMAP.createEvent.hotkey, () => {
+    if (!config.onCreateTimedEvent) return;
+    config.onCreateTimedEvent();
+    shortcutHintProgressActions.demonstrate("create-event");
+  });
   useAppShortcutUp("U", () => config.onFocusCalendar?.());
   // Keydown so a macOS Cmd+Z keyup-replay (meta already released) cannot
   // match this binding the way Mod+D vs D does on keyup.

--- a/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
@@ -65,6 +65,7 @@ import {
 } from "@web/grid/shortcuts/focus-adjacent-grid-event";
 import { isHigherEscapeOwner } from "@web/shortcuts/escape-ownership";
 import { KEYMAP } from "@web/shortcuts/keymap";
+import { shortcutHintProgressActions } from "@web/shortcuts/tips/shortcut-tips.progress.store";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 import { deleteEventAndDiscardDraft } from "@web/views/Forms/hooks/useDeleteEvent";
 
@@ -450,6 +451,7 @@ export function useGridEventEditShortcuts({
         event,
         keyboardEvent,
         onNudge: (nudgedEvent) => {
+          shortcutHintProgressActions.demonstrate("nudge");
           updateEvent({ event: nudgedEvent }, true, {
             onOptimisticApplied: () => draftActions.discard(),
           });

--- a/packages/web/src/shortcuts/form-digit-jump/useFormDigitJumpShortcut.ts
+++ b/packages/web/src/shortcuts/form-digit-jump/useFormDigitJumpShortcut.ts
@@ -5,6 +5,7 @@ import {
   FORM_FIELD_DIGITS,
 } from "@web/shortcuts/edit-sequence/edit-sequence.fields";
 import { useModHoldHintShortcut } from "@web/shortcuts/mod-hold/useModHoldHintShortcut";
+import { shortcutHintProgressActions } from "@web/shortcuts/tips/shortcut-tips.progress.store";
 
 export { MOD_HOLD_HINT_MS } from "@web/shortcuts/mod-hold/useModHoldHintShortcut";
 
@@ -23,6 +24,8 @@ const DIGIT_ORDER = FORM_FIELD_DIGITS.map((entry) => entry.digit);
  */
 export function useFormDigitJumpShortcut(): { areHintsVisible: boolean } {
   return useModHoldHintShortcut({
+    onHintsRevealed: () =>
+      shortcutHintProgressActions.demonstrate("save-draft"),
     onModChord: (event) => {
       const index = physicalDigitIndex(event);
       const digit = index !== null ? DIGIT_ORDER[index] : undefined;

--- a/packages/web/src/shortcuts/mod-hold/useModHoldHintShortcut.ts
+++ b/packages/web/src/shortcuts/mod-hold/useModHoldHintShortcut.ts
@@ -29,13 +29,18 @@ export const MOD_HOLD_HINT_MS = 600;
 export function useModHoldHintShortcut({
   enabled = true,
   onModChord,
+  onHintsRevealed,
 }: {
   enabled?: boolean;
   onModChord: (event: KeyboardEvent) => boolean;
+  /** Fires once when hold-Mod chips actually appear, not on a bare Mod tap. */
+  onHintsRevealed?: () => void;
 }): { areHintsVisible: boolean } {
   const [areHintsVisible, setAreHintsVisible] = useState(false);
   const onModChordRef = useRef(onModChord);
   onModChordRef.current = onModChord;
+  const onHintsRevealedRef = useRef(onHintsRevealed);
+  onHintsRevealedRef.current = onHintsRevealed;
 
   useEffect(() => {
     if (!enabled) {
@@ -69,6 +74,7 @@ export function useModHoldHintShortcut({
         holdTimeoutId = null;
         hintsVisible = true;
         setAreHintsVisible(true);
+        onHintsRevealedRef.current?.();
       }, MOD_HOLD_HINT_MS);
     };
 

--- a/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.test.tsx
+++ b/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.test.tsx
@@ -163,7 +163,7 @@ describe("usePageJumpShortcut", () => {
       await waitFor(() => {
         expect(result.current.areHintsVisible).toBe(true);
       });
-      expect(getShortcutHintProgress().demonstratedIds).toContain("page-jump");
+      expect(getShortcutHintProgress()).toContain("page-jump");
     });
 
     it("hides hints on Mod keyup", async () => {

--- a/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.test.tsx
+++ b/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.test.tsx
@@ -17,6 +17,7 @@ import {
   type PageJumpTargetId,
 } from "@web/shortcuts/page-jump/page-jump.targets";
 import { usePageJumpShortcut } from "@web/shortcuts/page-jump/usePageJumpShortcut";
+import { getShortcutHintProgress } from "@web/shortcuts/tips/shortcut-tips.progress.store";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
 /** Matches what the hook resolves Mod to on this platform. */
@@ -162,6 +163,7 @@ describe("usePageJumpShortcut", () => {
       await waitFor(() => {
         expect(result.current.areHintsVisible).toBe(true);
       });
+      expect(getShortcutHintProgress().demonstratedIds).toContain("page-jump");
     });
 
     it("hides hints on Mod keyup", async () => {

--- a/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.ts
+++ b/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.ts
@@ -9,6 +9,7 @@ import {
   focusPageJumpTarget,
   type PageJumpTargets,
 } from "@web/shortcuts/page-jump/page-jump.targets";
+import { shortcutHintProgressActions } from "@web/shortcuts/tips/shortcut-tips.progress.store";
 
 /**
  * Mod+digit jumps focus to a page area (see the `targets` list); holding Mod
@@ -25,6 +26,7 @@ export function usePageJumpShortcut(
 
   return useModHoldHintShortcut({
     enabled: !isEventFormOpen,
+    onHintsRevealed: () => shortcutHintProgressActions.demonstrate("page-jump"),
     onModChord: (event) => {
       const index = physicalDigitIndex(event);
       const target = index !== null ? targets[index] : undefined;

--- a/packages/web/src/shortcuts/shift-hint/event-jump.store.ts
+++ b/packages/web/src/shortcuts/shift-hint/event-jump.store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 import { IS_DEV } from "@web/common/constants/env.constants";
+import { shortcutHintProgressActions } from "@web/shortcuts/tips/shortcut-tips.progress.store";
 
 export type EventJumpState = {
   isActive: boolean;
@@ -30,7 +31,8 @@ export const useEventJumpStore = create<EventJumpState>()(
 );
 
 export const eventJumpActions = {
-  setActive: (isActive: boolean) =>
+  setActive: (isActive: boolean) => {
+    if (isActive) shortcutHintProgressActions.demonstrate("event-jump");
     useEventJumpStore.setState(
       {
         isActive,
@@ -44,7 +46,8 @@ export const eventJumpActions = {
       },
       false,
       { type: "setActive" },
-    ),
+    );
+  },
   /** Clear a lingering exit announcement after the live region has spoken. */
   clearAnnouncement: () =>
     useEventJumpStore.setState({ announcement: "" }, false, {

--- a/packages/web/src/shortcuts/tips/selectShortcutHint.test.ts
+++ b/packages/web/src/shortcuts/tips/selectShortcutHint.test.ts
@@ -8,6 +8,11 @@ const calendarIdle = {
   firstEventDone: false,
 };
 
+const afterFirstEvent = {
+  ...calendarIdle,
+  firstEventDone: true,
+};
+
 describe("selectShortcutHint", () => {
   it("teaches title then Enter while the first-event form is open", () => {
     expect(
@@ -51,12 +56,7 @@ describe("selectShortcutHint", () => {
   });
 
   it("teaches hold-Mod on an idle calendar after the first event", () => {
-    expect(
-      selectShortcutHint({
-        ...calendarIdle,
-        firstEventDone: true,
-      }).id,
-    ).toBe("page-jump");
+    expect(selectShortcutHint(afterFirstEvent).id).toBe("page-jump");
   });
 
   it("keeps form hints ahead of Life, focus, and first-event create", () => {
@@ -68,5 +68,88 @@ describe("selectShortcutHint", () => {
         firstEventDone: true,
       }).id,
     ).toBe("save-draft");
+  });
+
+  it("skips hold-Mod on an idle calendar once the user has demonstrated it", () => {
+    expect(
+      selectShortcutHint(afterFirstEvent, {
+        demonstratedIds: ["page-jump"],
+        lastUsedId: "page-jump",
+      }).id,
+    ).toBe("event-jump");
+  });
+
+  it("walks the idle pool in showcase order as primitives are demonstrated", () => {
+    expect(
+      selectShortcutHint(afterFirstEvent, {
+        demonstratedIds: ["page-jump", "event-jump"],
+      }).id,
+    ).toBe("command-palette");
+    expect(
+      selectShortcutHint(afterFirstEvent, {
+        demonstratedIds: ["page-jump", "event-jump", "command-palette"],
+      }).id,
+    ).toBe("create-event");
+  });
+
+  it("rotates the idle pool after every primitive has been demonstrated", () => {
+    const allIdle = [
+      "page-jump",
+      "event-jump",
+      "command-palette",
+      "create-event",
+    ] as const;
+
+    expect(
+      selectShortcutHint(afterFirstEvent, {
+        demonstratedIds: allIdle,
+        lastUsedId: "page-jump",
+      }).id,
+    ).toBe("event-jump");
+    expect(
+      selectShortcutHint(afterFirstEvent, {
+        demonstratedIds: allIdle,
+        lastUsedId: "create-event",
+      }).id,
+    ).toBe("page-jump");
+  });
+
+  it("teaches nudge after the edit sequence once an event is focused", () => {
+    expect(
+      selectShortcutHint(
+        { ...afterFirstEvent, eventFocused: true },
+        { demonstratedIds: ["edit-sequence"], lastUsedId: "edit-sequence" },
+      ).id,
+    ).toBe("nudge");
+  });
+
+  it("falls through to the command palette after save-draft is demonstrated", () => {
+    expect(
+      selectShortcutHint(
+        { ...afterFirstEvent, isFormOpen: true },
+        { demonstratedIds: ["save-draft"], lastUsedId: "save-draft" },
+      ).id,
+    ).toBe("command-palette");
+  });
+
+  it("falls through to the command palette after Life T is demonstrated", () => {
+    expect(
+      selectShortcutHint(
+        { ...calendarIdle, isLifeView: true },
+        { demonstratedIds: ["life-this-week"], lastUsedId: "life-this-week" },
+      ).id,
+    ).toBe("command-palette");
+  });
+
+  it("keeps the first-event save funnel sticky even after Enter is demonstrated", () => {
+    expect(
+      selectShortcutHint(
+        { ...calendarIdle, isFormOpen: true },
+        {
+          demonstratedIds: ["first-event-save"],
+          lastUsedId: "first-event-save",
+        },
+      ).id,
+    ).toBe("first-event-save");
   });
 });

--- a/packages/web/src/shortcuts/tips/selectShortcutHint.test.ts
+++ b/packages/web/src/shortcuts/tips/selectShortcutHint.test.ts
@@ -71,85 +71,72 @@ describe("selectShortcutHint", () => {
   });
 
   it("skips hold-Mod on an idle calendar once the user has demonstrated it", () => {
-    expect(
-      selectShortcutHint(afterFirstEvent, {
-        demonstratedIds: ["page-jump"],
-        lastUsedId: "page-jump",
-      }).id,
-    ).toBe("event-jump");
+    expect(selectShortcutHint(afterFirstEvent, ["page-jump"]).id).toBe(
+      "event-jump",
+    );
   });
 
   it("walks the idle pool in showcase order as primitives are demonstrated", () => {
     expect(
-      selectShortcutHint(afterFirstEvent, {
-        demonstratedIds: ["page-jump", "event-jump"],
-      }).id,
+      selectShortcutHint(afterFirstEvent, ["page-jump", "event-jump"]).id,
     ).toBe("command-palette");
     expect(
-      selectShortcutHint(afterFirstEvent, {
-        demonstratedIds: ["page-jump", "event-jump", "command-palette"],
-      }).id,
+      selectShortcutHint(afterFirstEvent, [
+        "page-jump",
+        "event-jump",
+        "command-palette",
+      ]).id,
     ).toBe("create-event");
   });
 
   it("rotates the idle pool after every primitive has been demonstrated", () => {
-    const allIdle = [
-      "page-jump",
-      "event-jump",
-      "command-palette",
-      "create-event",
-    ] as const;
-
     expect(
-      selectShortcutHint(afterFirstEvent, {
-        demonstratedIds: allIdle,
-        lastUsedId: "page-jump",
-      }).id,
+      selectShortcutHint(afterFirstEvent, [
+        "event-jump",
+        "command-palette",
+        "create-event",
+        "page-jump",
+      ]).id,
     ).toBe("event-jump");
     expect(
-      selectShortcutHint(afterFirstEvent, {
-        demonstratedIds: allIdle,
-        lastUsedId: "create-event",
-      }).id,
+      selectShortcutHint(afterFirstEvent, [
+        "page-jump",
+        "event-jump",
+        "command-palette",
+        "create-event",
+      ]).id,
     ).toBe("page-jump");
   });
 
   it("teaches nudge after the edit sequence once an event is focused", () => {
     expect(
-      selectShortcutHint(
-        { ...afterFirstEvent, eventFocused: true },
-        { demonstratedIds: ["edit-sequence"], lastUsedId: "edit-sequence" },
-      ).id,
+      selectShortcutHint({ ...afterFirstEvent, eventFocused: true }, [
+        "edit-sequence",
+      ]).id,
     ).toBe("nudge");
   });
 
   it("falls through to the command palette after save-draft is demonstrated", () => {
     expect(
-      selectShortcutHint(
-        { ...afterFirstEvent, isFormOpen: true },
-        { demonstratedIds: ["save-draft"], lastUsedId: "save-draft" },
-      ).id,
+      selectShortcutHint({ ...afterFirstEvent, isFormOpen: true }, [
+        "save-draft",
+      ]).id,
     ).toBe("command-palette");
   });
 
   it("falls through to the command palette after Life T is demonstrated", () => {
     expect(
-      selectShortcutHint(
-        { ...calendarIdle, isLifeView: true },
-        { demonstratedIds: ["life-this-week"], lastUsedId: "life-this-week" },
-      ).id,
+      selectShortcutHint({ ...calendarIdle, isLifeView: true }, [
+        "life-this-week",
+      ]).id,
     ).toBe("command-palette");
   });
 
   it("keeps the first-event save funnel sticky even after Enter is demonstrated", () => {
     expect(
-      selectShortcutHint(
-        { ...calendarIdle, isFormOpen: true },
-        {
-          demonstratedIds: ["first-event-save"],
-          lastUsedId: "first-event-save",
-        },
-      ).id,
+      selectShortcutHint({ ...calendarIdle, isFormOpen: true }, [
+        "first-event-save",
+      ]).id,
     ).toBe("first-event-save");
   });
 });

--- a/packages/web/src/shortcuts/tips/selectShortcutHint.ts
+++ b/packages/web/src/shortcuts/tips/selectShortcutHint.ts
@@ -11,11 +11,6 @@ export type ShortcutHintContext = {
   firstEventDone: boolean;
 };
 
-export type ShortcutHintSelectionProgress = {
-  demonstratedIds?: readonly ShortcutHintId[];
-  lastUsedId?: ShortcutHintId | null;
-};
-
 const IDLE_POOL = [
   "page-jump",
   "event-jump",
@@ -41,12 +36,12 @@ const LIFE_POOL = [
 
 function pickFromPool(
   pool: readonly ShortcutHintId[],
-  demonstratedIds: ReadonlySet<ShortcutHintId>,
-  lastUsedId: ShortcutHintId | null,
+  demonstratedIds: readonly ShortcutHintId[],
 ): ShortcutHintId {
-  const unused = pool.find((id) => !demonstratedIds.has(id));
+  const unused = pool.find((id) => !demonstratedIds.includes(id));
   if (unused) return unused;
 
+  const lastUsedId = demonstratedIds[demonstratedIds.length - 1];
   const lastIndex = lastUsedId ? pool.indexOf(lastUsedId) : -1;
   return pool[(lastIndex + 1) % pool.length];
 }
@@ -60,12 +55,10 @@ function pickFromPool(
  */
 export function selectShortcutHint(
   ctx: ShortcutHintContext,
-  progress: ShortcutHintSelectionProgress = {},
+  demonstratedIds: readonly ShortcutHintId[] = [],
 ): ShortcutHint {
-  const demonstratedIds = new Set(progress.demonstratedIds ?? []);
-  const lastUsedId = progress.lastUsedId ?? null;
   const pick = (pool: readonly ShortcutHintId[]) =>
-    getShortcutHint(pickFromPool(pool, demonstratedIds, lastUsedId));
+    getShortcutHint(pickFromPool(pool, demonstratedIds));
 
   if (ctx.isFormOpen && !ctx.firstEventDone) {
     return getShortcutHint("first-event-save");

--- a/packages/web/src/shortcuts/tips/selectShortcutHint.ts
+++ b/packages/web/src/shortcuts/tips/selectShortcutHint.ts
@@ -1,6 +1,7 @@
 import {
   getShortcutHint,
   type ShortcutHint,
+  type ShortcutHintId,
 } from "@web/shortcuts/tips/shortcut-tips.data";
 
 export type ShortcutHintContext = {
@@ -10,25 +11,76 @@ export type ShortcutHintContext = {
   firstEventDone: boolean;
 };
 
+export type ShortcutHintSelectionProgress = {
+  demonstratedIds?: readonly ShortcutHintId[];
+  lastUsedId?: ShortcutHintId | null;
+};
+
+const IDLE_POOL = [
+  "page-jump",
+  "event-jump",
+  "command-palette",
+  "create-event",
+] as const satisfies readonly ShortcutHintId[];
+
+const FOCUSED_POOL = [
+  "edit-sequence",
+  "nudge",
+  ...IDLE_POOL,
+] as const satisfies readonly ShortcutHintId[];
+
+const FORM_POOL = [
+  "save-draft",
+  "command-palette",
+] as const satisfies readonly ShortcutHintId[];
+
+const LIFE_POOL = [
+  "life-this-week",
+  "command-palette",
+] as const satisfies readonly ShortcutHintId[];
+
+function pickFromPool(
+  pool: readonly ShortcutHintId[],
+  demonstratedIds: ReadonlySet<ShortcutHintId>,
+  lastUsedId: ShortcutHintId | null,
+): ShortcutHintId {
+  const unused = pool.find((id) => !demonstratedIds.has(id));
+  if (unused) return unused;
+
+  const lastIndex = lastUsedId ? pool.indexOf(lastUsedId) : -1;
+  return pool[(lastIndex + 1) % pool.length];
+}
+
 /**
- * First-match next-shortcut for the sidebar status bar. Mode indicators and
- * operational status (saving, delayed sync) are chosen by the bar itself.
+ * Next-shortcut for the sidebar status bar. First-event create/save stay
+ * sticky; afterwards the pick is the first undemonstrated id in a context
+ * pool ordered by Shortcut Showcase levels, then a rotation once the pool
+ * is exhausted. Mode indicators and operational status are chosen by the
+ * bar itself.
  */
-export function selectShortcutHint(ctx: ShortcutHintContext): ShortcutHint {
+export function selectShortcutHint(
+  ctx: ShortcutHintContext,
+  progress: ShortcutHintSelectionProgress = {},
+): ShortcutHint {
+  const demonstratedIds = new Set(progress.demonstratedIds ?? []);
+  const lastUsedId = progress.lastUsedId ?? null;
+  const pick = (pool: readonly ShortcutHintId[]) =>
+    getShortcutHint(pickFromPool(pool, demonstratedIds, lastUsedId));
+
   if (ctx.isFormOpen && !ctx.firstEventDone) {
     return getShortcutHint("first-event-save");
   }
   if (ctx.isFormOpen) {
-    return getShortcutHint("save-draft");
+    return pick(FORM_POOL);
   }
   if (ctx.isLifeView) {
-    return getShortcutHint("life-this-week");
+    return pick(LIFE_POOL);
   }
   if (ctx.eventFocused) {
-    return getShortcutHint("edit-sequence");
+    return pick(FOCUSED_POOL);
   }
   if (!ctx.firstEventDone) {
     return getShortcutHint("create-event");
   }
-  return getShortcutHint("page-jump");
+  return pick(IDLE_POOL);
 }

--- a/packages/web/src/shortcuts/tips/shortcut-tips.data.test.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-tips.data.test.ts
@@ -30,6 +30,11 @@ describe("getHintPlainText", () => {
     expect(plainTextById["page-jump"]).toBe(
       `Hold ${mod} to see where you can jump`,
     );
+    expect(plainTextById["event-jump"]).toBe("Press S to show event keys");
+    expect(plainTextById.nudge).toBe("Hold Shift and press an arrow to move");
+    expect(plainTextById["command-palette"]).toBe(
+      `Press ${mod}+K to open the command palette`,
+    );
   });
 
   it("joins a chord's keys with + and speaks Mod as Cmd or Ctrl", () => {

--- a/packages/web/src/shortcuts/tips/shortcut-tips.data.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-tips.data.ts
@@ -12,22 +12,6 @@ export type ShortcutHintId =
   | "event-jump"
   | "command-palette";
 
-export const SHORTCUT_HINT_IDS = [
-  "first-event-save",
-  "save-draft",
-  "life-this-week",
-  "edit-sequence",
-  "nudge",
-  "create-event",
-  "page-jump",
-  "event-jump",
-  "command-palette",
-] as const satisfies readonly ShortcutHintId[];
-
-export function isShortcutHintId(value: string): value is ShortcutHintId {
-  return (SHORTCUT_HINT_IDS as readonly string[]).includes(value);
-}
-
 export type ShortcutTipPart =
   | string
   | { key: string }
@@ -123,4 +107,8 @@ export const SHORTCUT_HINTS: Record<ShortcutHintId, ShortcutHint> = {
 
 export function getShortcutHint(id: ShortcutHintId): ShortcutHint {
   return SHORTCUT_HINTS[id];
+}
+
+export function isShortcutHintId(value: string): value is ShortcutHintId {
+  return Object.hasOwn(SHORTCUT_HINTS, value);
 }

--- a/packages/web/src/shortcuts/tips/shortcut-tips.data.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-tips.data.ts
@@ -6,8 +6,27 @@ export type ShortcutHintId =
   | "save-draft"
   | "life-this-week"
   | "edit-sequence"
+  | "nudge"
   | "create-event"
-  | "page-jump";
+  | "page-jump"
+  | "event-jump"
+  | "command-palette";
+
+export const SHORTCUT_HINT_IDS = [
+  "first-event-save",
+  "save-draft",
+  "life-this-week",
+  "edit-sequence",
+  "nudge",
+  "create-event",
+  "page-jump",
+  "event-jump",
+  "command-palette",
+] as const satisfies readonly ShortcutHintId[];
+
+export function isShortcutHintId(value: string): value is ShortcutHintId {
+  return (SHORTCUT_HINT_IDS as readonly string[]).includes(value);
+}
 
 export type ShortcutTipPart =
   | string
@@ -41,6 +60,8 @@ export const getHintPlainText = (hint: ShortcutHint): string =>
 const [createKey] = KEYMAP.createEvent.keycaps;
 const [saveKey] = KEYMAP.saveDraft.keycaps;
 const [editLeader, editSecond] = KEYMAP.editTitle.keycaps;
+const [eventJumpKey] = KEYMAP.eventJump.keycaps;
+const [nudgeModifier] = KEYMAP.moveEvent.keycaps;
 
 export const SHORTCUT_HINTS: Record<ShortcutHintId, ShortcutHint> = {
   "first-event-save": {
@@ -80,6 +101,22 @@ export const SHORTCUT_HINTS: Record<ShortcutHintId, ShortcutHint> = {
       "Hold ",
       { key: KEYMAP.jumpPageTarget.holdModifier },
       " to see where you can jump",
+    ],
+  },
+  "event-jump": {
+    id: "event-jump",
+    parts: ["Press ", { key: eventJumpKey }, " to show event keys"],
+  },
+  nudge: {
+    id: "nudge",
+    parts: ["Hold ", { key: nudgeModifier }, " and press an arrow to move"],
+  },
+  "command-palette": {
+    id: "command-palette",
+    parts: [
+      "Press ",
+      { keys: KEYMAP.commandPalette.keycaps },
+      " to open the command palette",
     ],
   },
 };

--- a/packages/web/src/shortcuts/tips/shortcut-tips.progress.storage.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-tips.progress.storage.ts
@@ -6,50 +6,35 @@ import {
   type ShortcutHintId,
 } from "@web/shortcuts/tips/shortcut-tips.data";
 
-export type ShortcutHintProgress = {
-  demonstratedIds: readonly ShortcutHintId[];
-  lastUsedId: ShortcutHintId | null;
-};
+// Most-recent-last list of demonstrated tip ids. Rotation uses the last
+// entry; unused picks ignore order.
+const DemonstratedIdsSchema = z.array(z.string()).readonly();
 
-export const EMPTY_SHORTCUT_HINT_PROGRESS: ShortcutHintProgress = {
-  demonstratedIds: [],
-  lastUsedId: null,
-};
-
-const ProgressSchema = z.object({
-  demonstratedIds: z.array(z.string()),
-  lastUsedId: z.string().nullable(),
-});
-
-export function readShortcutHintProgress(): ShortcutHintProgress {
+export function readShortcutHintProgress(): readonly ShortcutHintId[] {
   const raw = persistentBrowserStore.get(
     STORAGE_KEYS.SHORTCUT_TIPS_DEMONSTRATED,
   );
-  if (!raw) return EMPTY_SHORTCUT_HINT_PROGRESS;
+  if (!raw) return [];
 
   try {
-    const parsed = ProgressSchema.parse(JSON.parse(raw));
-    const demonstratedIds = parsed.demonstratedIds.filter(isShortcutHintId);
-    const lastUsedId =
-      parsed.lastUsedId && isShortcutHintId(parsed.lastUsedId)
-        ? parsed.lastUsedId
-        : null;
-    return { demonstratedIds, lastUsedId };
+    return DemonstratedIdsSchema.parse(JSON.parse(raw)).filter(
+      isShortcutHintId,
+    );
   } catch {
-    return EMPTY_SHORTCUT_HINT_PROGRESS;
+    return [];
   }
 }
 
 export function writeShortcutHintProgress(
-  progress: ShortcutHintProgress,
+  ids: readonly ShortcutHintId[],
 ): boolean {
-  if (progress.demonstratedIds.length === 0 && progress.lastUsedId === null) {
+  if (ids.length === 0) {
     return persistentBrowserStore.remove(
       STORAGE_KEYS.SHORTCUT_TIPS_DEMONSTRATED,
     );
   }
   return persistentBrowserStore.set(
     STORAGE_KEYS.SHORTCUT_TIPS_DEMONSTRATED,
-    JSON.stringify(progress),
+    JSON.stringify(ids),
   );
 }

--- a/packages/web/src/shortcuts/tips/shortcut-tips.progress.storage.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-tips.progress.storage.ts
@@ -1,0 +1,55 @@
+import { z } from "zod/v4";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import {
+  isShortcutHintId,
+  type ShortcutHintId,
+} from "@web/shortcuts/tips/shortcut-tips.data";
+
+export type ShortcutHintProgress = {
+  demonstratedIds: readonly ShortcutHintId[];
+  lastUsedId: ShortcutHintId | null;
+};
+
+export const EMPTY_SHORTCUT_HINT_PROGRESS: ShortcutHintProgress = {
+  demonstratedIds: [],
+  lastUsedId: null,
+};
+
+const ProgressSchema = z.object({
+  demonstratedIds: z.array(z.string()),
+  lastUsedId: z.string().nullable(),
+});
+
+export function readShortcutHintProgress(): ShortcutHintProgress {
+  const raw = persistentBrowserStore.get(
+    STORAGE_KEYS.SHORTCUT_TIPS_DEMONSTRATED,
+  );
+  if (!raw) return EMPTY_SHORTCUT_HINT_PROGRESS;
+
+  try {
+    const parsed = ProgressSchema.parse(JSON.parse(raw));
+    const demonstratedIds = parsed.demonstratedIds.filter(isShortcutHintId);
+    const lastUsedId =
+      parsed.lastUsedId && isShortcutHintId(parsed.lastUsedId)
+        ? parsed.lastUsedId
+        : null;
+    return { demonstratedIds, lastUsedId };
+  } catch {
+    return EMPTY_SHORTCUT_HINT_PROGRESS;
+  }
+}
+
+export function writeShortcutHintProgress(
+  progress: ShortcutHintProgress,
+): boolean {
+  if (progress.demonstratedIds.length === 0 && progress.lastUsedId === null) {
+    return persistentBrowserStore.remove(
+      STORAGE_KEYS.SHORTCUT_TIPS_DEMONSTRATED,
+    );
+  }
+  return persistentBrowserStore.set(
+    STORAGE_KEYS.SHORTCUT_TIPS_DEMONSTRATED,
+    JSON.stringify(progress),
+  );
+}

--- a/packages/web/src/shortcuts/tips/shortcut-tips.progress.store.test.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-tips.progress.store.test.ts
@@ -15,34 +15,22 @@ import { describe, expect, it } from "bun:test";
 describe("shortcutHintProgress", () => {
   it("records a demonstrated primitive and notifies subscribers", () => {
     const { result } = renderHook(() => useShortcutHintProgress());
-    expect(result.current).toEqual({
-      demonstratedIds: [],
-      lastUsedId: null,
-    });
+    expect(result.current).toEqual([]);
 
     act(() => shortcutHintProgressActions.demonstrate("page-jump"));
 
-    expect(result.current).toEqual({
-      demonstratedIds: ["page-jump"],
-      lastUsedId: "page-jump",
-    });
-    expect(readShortcutHintProgress()).toEqual({
-      demonstratedIds: ["page-jump"],
-      lastUsedId: "page-jump",
-    });
+    expect(result.current).toEqual(["page-jump"]);
+    expect(readShortcutHintProgress()).toEqual(["page-jump"]);
   });
 
-  it("does not duplicate an already demonstrated id, but updates lastUsedId", () => {
+  it("moves a repeated primitive to the end instead of duplicating it", () => {
     const { result } = renderHook(() => useShortcutHintProgress());
 
     act(() => shortcutHintProgressActions.demonstrate("page-jump"));
     act(() => shortcutHintProgressActions.demonstrate("event-jump"));
     act(() => shortcutHintProgressActions.demonstrate("page-jump"));
 
-    expect(result.current).toEqual({
-      demonstratedIds: ["page-jump", "event-jump"],
-      lastUsedId: "page-jump",
-    });
+    expect(result.current).toEqual(["event-jump", "page-jump"]);
   });
 
   it("does not persist while the Shortcut Showcase is open", () => {
@@ -51,42 +39,27 @@ describe("shortcutHintProgress", () => {
 
     act(() => shortcutHintProgressActions.demonstrate("page-jump"));
 
-    expect(result.current).toEqual({
-      demonstratedIds: [],
-      lastUsedId: null,
-    });
-    expect(readShortcutHintProgress()).toEqual({
-      demonstratedIds: [],
-      lastUsedId: null,
-    });
+    expect(result.current).toEqual([]);
+    expect(readShortcutHintProgress()).toEqual([]);
 
     useShortcutShowcaseStore.setState(initialShortcutShowcaseState, true);
   });
 
-  it("falls back to empty progress for corrupt storage", () => {
+  it("falls back to an empty list for corrupt storage", () => {
     persistentBrowserStore.set(
       STORAGE_KEYS.SHORTCUT_TIPS_DEMONSTRATED,
       "{not json",
     );
 
-    expect(readShortcutHintProgress()).toEqual({
-      demonstratedIds: [],
-      lastUsedId: null,
-    });
+    expect(readShortcutHintProgress()).toEqual([]);
   });
 
   it("skips unknown ids from storage", () => {
     persistentBrowserStore.set(
       STORAGE_KEYS.SHORTCUT_TIPS_DEMONSTRATED,
-      JSON.stringify({
-        demonstratedIds: ["page-jump", "not-a-hint"],
-        lastUsedId: "also-bad",
-      }),
+      JSON.stringify(["page-jump", "not-a-hint"]),
     );
 
-    expect(readShortcutHintProgress()).toEqual({
-      demonstratedIds: ["page-jump"],
-      lastUsedId: null,
-    });
+    expect(readShortcutHintProgress()).toEqual(["page-jump"]);
   });
 });

--- a/packages/web/src/shortcuts/tips/shortcut-tips.progress.store.test.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-tips.progress.store.test.ts
@@ -1,0 +1,92 @@
+import { act, renderHook } from "@testing-library/react";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import {
+  initialShortcutShowcaseState,
+  useShortcutShowcaseStore,
+} from "@web/components/ShortcutShowcase/showcase.store";
+import { readShortcutHintProgress } from "@web/shortcuts/tips/shortcut-tips.progress.storage";
+import {
+  shortcutHintProgressActions,
+  useShortcutHintProgress,
+} from "@web/shortcuts/tips/shortcut-tips.progress.store";
+import { describe, expect, it } from "bun:test";
+
+describe("shortcutHintProgress", () => {
+  it("records a demonstrated primitive and notifies subscribers", () => {
+    const { result } = renderHook(() => useShortcutHintProgress());
+    expect(result.current).toEqual({
+      demonstratedIds: [],
+      lastUsedId: null,
+    });
+
+    act(() => shortcutHintProgressActions.demonstrate("page-jump"));
+
+    expect(result.current).toEqual({
+      demonstratedIds: ["page-jump"],
+      lastUsedId: "page-jump",
+    });
+    expect(readShortcutHintProgress()).toEqual({
+      demonstratedIds: ["page-jump"],
+      lastUsedId: "page-jump",
+    });
+  });
+
+  it("does not duplicate an already demonstrated id, but updates lastUsedId", () => {
+    const { result } = renderHook(() => useShortcutHintProgress());
+
+    act(() => shortcutHintProgressActions.demonstrate("page-jump"));
+    act(() => shortcutHintProgressActions.demonstrate("event-jump"));
+    act(() => shortcutHintProgressActions.demonstrate("page-jump"));
+
+    expect(result.current).toEqual({
+      demonstratedIds: ["page-jump", "event-jump"],
+      lastUsedId: "page-jump",
+    });
+  });
+
+  it("does not persist while the Shortcut Showcase is open", () => {
+    useShortcutShowcaseStore.setState({ isActive: true }, false);
+    const { result } = renderHook(() => useShortcutHintProgress());
+
+    act(() => shortcutHintProgressActions.demonstrate("page-jump"));
+
+    expect(result.current).toEqual({
+      demonstratedIds: [],
+      lastUsedId: null,
+    });
+    expect(readShortcutHintProgress()).toEqual({
+      demonstratedIds: [],
+      lastUsedId: null,
+    });
+
+    useShortcutShowcaseStore.setState(initialShortcutShowcaseState, true);
+  });
+
+  it("falls back to empty progress for corrupt storage", () => {
+    persistentBrowserStore.set(
+      STORAGE_KEYS.SHORTCUT_TIPS_DEMONSTRATED,
+      "{not json",
+    );
+
+    expect(readShortcutHintProgress()).toEqual({
+      demonstratedIds: [],
+      lastUsedId: null,
+    });
+  });
+
+  it("skips unknown ids from storage", () => {
+    persistentBrowserStore.set(
+      STORAGE_KEYS.SHORTCUT_TIPS_DEMONSTRATED,
+      JSON.stringify({
+        demonstratedIds: ["page-jump", "not-a-hint"],
+        lastUsedId: "also-bad",
+      }),
+    );
+
+    expect(readShortcutHintProgress()).toEqual({
+      demonstratedIds: ["page-jump"],
+      lastUsedId: null,
+    });
+  });
+});

--- a/packages/web/src/shortcuts/tips/shortcut-tips.progress.store.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-tips.progress.store.ts
@@ -7,13 +7,11 @@ import {
 import { useShortcutShowcaseStore } from "@web/components/ShortcutShowcase/showcase.store";
 import { type ShortcutHintId } from "@web/shortcuts/tips/shortcut-tips.data";
 import {
-  EMPTY_SHORTCUT_HINT_PROGRESS,
   readShortcutHintProgress,
-  type ShortcutHintProgress,
   writeShortcutHintProgress,
 } from "@web/shortcuts/tips/shortcut-tips.progress.storage";
 
-const progressStore = createExternalStore<ShortcutHintProgress>(
+const progressStore = createExternalStore<readonly ShortcutHintId[]>(
   readShortcutHintProgress(),
 );
 
@@ -34,11 +32,11 @@ function subscribe(onChange: () => void): () => void {
   };
 }
 
-export function getShortcutHintProgress(): ShortcutHintProgress {
+export function getShortcutHintProgress(): readonly ShortcutHintId[] {
   return progressStore.get();
 }
 
-export function useShortcutHintProgress(): ShortcutHintProgress {
+export function useShortcutHintProgress(): readonly ShortcutHintId[] {
   return useSyncExternalStore(subscribe, progressStore.get);
 }
 
@@ -51,16 +49,9 @@ export const shortcutHintProgressActions = {
     if (useShortcutShowcaseStore.getState().isActive) return;
 
     const current = progressStore.get();
-    const demonstratedIds = current.demonstratedIds.includes(id)
-      ? current.demonstratedIds
-      : [...current.demonstratedIds, id];
-    const next: ShortcutHintProgress = { demonstratedIds, lastUsedId: id };
-    if (
-      next.lastUsedId === current.lastUsedId &&
-      next.demonstratedIds === current.demonstratedIds
-    ) {
-      return;
-    }
+    if (current[current.length - 1] === id) return;
+
+    const next = [...current.filter((existing) => existing !== id), id];
     if (writeShortcutHintProgress(next)) progressStore.set(next);
   },
 };
@@ -68,6 +59,5 @@ export const shortcutHintProgressActions = {
 /** Test-only: resyncs the in-memory store from storage. Registered in
  * reset-stores.ts for between-test cleanup. */
 export function resetShortcutHintProgressStoreForTests(): void {
-  progressStore.set(EMPTY_SHORTCUT_HINT_PROGRESS);
   refreshFromStorage();
 }

--- a/packages/web/src/shortcuts/tips/shortcut-tips.progress.store.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-tips.progress.store.ts
@@ -1,0 +1,73 @@
+import { useSyncExternalStore } from "react";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import {
+  createExternalStore,
+  subscribeToStorageKey,
+} from "@web/common/utils/external-store.util";
+import { useShortcutShowcaseStore } from "@web/components/ShortcutShowcase/showcase.store";
+import { type ShortcutHintId } from "@web/shortcuts/tips/shortcut-tips.data";
+import {
+  EMPTY_SHORTCUT_HINT_PROGRESS,
+  readShortcutHintProgress,
+  type ShortcutHintProgress,
+  writeShortcutHintProgress,
+} from "@web/shortcuts/tips/shortcut-tips.progress.storage";
+
+const progressStore = createExternalStore<ShortcutHintProgress>(
+  readShortcutHintProgress(),
+);
+
+function refreshFromStorage(): void {
+  progressStore.set(readShortcutHintProgress());
+}
+
+function subscribe(onChange: () => void): () => void {
+  const unsubscribeStore = progressStore.subscribe(onChange);
+  const unsubscribeStorage = subscribeToStorageKey(
+    STORAGE_KEYS.SHORTCUT_TIPS_DEMONSTRATED,
+    refreshFromStorage,
+  );
+
+  return () => {
+    unsubscribeStore();
+    unsubscribeStorage();
+  };
+}
+
+export function getShortcutHintProgress(): ShortcutHintProgress {
+  return progressStore.get();
+}
+
+export function useShortcutHintProgress(): ShortcutHintProgress {
+  return useSyncExternalStore(subscribe, progressStore.get);
+}
+
+export const shortcutHintProgressActions = {
+  /**
+   * Records that the user performed a taught primitive. No-ops while the
+   * Shortcut Showcase is open so practice does not skip real-calendar tips.
+   */
+  demonstrate: (id: ShortcutHintId): void => {
+    if (useShortcutShowcaseStore.getState().isActive) return;
+
+    const current = progressStore.get();
+    const demonstratedIds = current.demonstratedIds.includes(id)
+      ? current.demonstratedIds
+      : [...current.demonstratedIds, id];
+    const next: ShortcutHintProgress = { demonstratedIds, lastUsedId: id };
+    if (
+      next.lastUsedId === current.lastUsedId &&
+      next.demonstratedIds === current.demonstratedIds
+    ) {
+      return;
+    }
+    if (writeShortcutHintProgress(next)) progressStore.set(next);
+  },
+};
+
+/** Test-only: resyncs the in-memory store from storage. Registered in
+ * reset-stores.ts for between-test cleanup. */
+export function resetShortcutHintProgressStoreForTests(): void {
+  progressStore.set(EMPTY_SHORTCUT_HINT_PROGRESS);
+  refreshFromStorage();
+}

--- a/packages/web/src/shortcuts/tips/useShortcutHintContext.test.tsx
+++ b/packages/web/src/shortcuts/tips/useShortcutHintContext.test.tsx
@@ -9,6 +9,7 @@ import {
 } from "@web/events/grid-event-draft.adapter";
 import { draftActions } from "@web/events/stores/draft.store";
 import { CALENDAR_VIEW_INTERACTION_ID_ATTRIBUTES } from "@web/grid/interaction/view-event-registry";
+import { shortcutHintProgressActions } from "@web/shortcuts/tips/shortcut-tips.progress.store";
 import { useShortcutHintContext } from "@web/shortcuts/tips/useShortcutHintContext";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
@@ -74,5 +75,15 @@ describe("useShortcutHintContext", () => {
     window.history.replaceState({}, "", "/life");
     const { result } = renderHook(() => useShortcutHintContext());
     expect(result.current.id).toBe("life-this-week");
+  });
+
+  it("advances to event-jump after hold-Mod is demonstrated", () => {
+    useFirstEventPromptStore.setState({ isDone: true }, false);
+    const { result } = renderHook(() => useShortcutHintContext());
+    expect(result.current.id).toBe("page-jump");
+
+    act(() => shortcutHintProgressActions.demonstrate("page-jump"));
+
+    expect(result.current.id).toBe("event-jump");
   });
 });

--- a/packages/web/src/shortcuts/tips/useShortcutHintContext.ts
+++ b/packages/web/src/shortcuts/tips/useShortcutHintContext.ts
@@ -9,6 +9,7 @@ import {
   useDraftStore,
 } from "@web/events/stores/draft.store";
 import { selectShortcutHint } from "@web/shortcuts/tips/selectShortcutHint";
+import { useShortcutHintProgress } from "@web/shortcuts/tips/shortcut-tips.progress.store";
 import { useIsAnyCalendarEventFocused } from "@web/shortcuts/tips/useIsAnyCalendarEventFocused";
 
 /**
@@ -22,11 +23,15 @@ export function useShortcutHintContext() {
   const isFormOpen = useDraftStore(selectIsEventFormOpen);
   const eventFocused = useIsAnyCalendarEventFocused();
   const isLifeView = isLifePathname(window.location.pathname);
+  const progress = useShortcutHintProgress();
 
-  return selectShortcutHint({
-    isFormOpen,
-    isLifeView,
-    eventFocused,
-    firstEventDone: firstEventDone || isCelebrating,
-  });
+  return selectShortcutHint(
+    {
+      isFormOpen,
+      isLifeView,
+      eventFocused,
+      firstEventDone: firstEventDone || isCelebrating,
+    },
+    progress,
+  );
 }

--- a/packages/web/src/shortcuts/useEditSequenceShortcut.ts
+++ b/packages/web/src/shortcuts/useEditSequenceShortcut.ts
@@ -20,6 +20,7 @@ import {
 } from "@web/shortcuts/is-bare-letter-key";
 import { KEYMAP } from "@web/shortcuts/keymap";
 import { isEventJumpActive } from "@web/shortcuts/shift-hint/event-jump.store";
+import { shortcutHintProgressActions } from "@web/shortcuts/tips/shortcut-tips.progress.store";
 
 /**
  * How long the leader stays silent. A second key inside this window fires with
@@ -141,6 +142,7 @@ export function useEditSequenceShortcut({
           suppressKeyUp.add(key);
           disarm();
           onSequenceRef.current(field);
+          shortcutHintProgressActions.demonstrate("edit-sequence");
           return;
         }
 

--- a/packages/web/src/shortcuts/useGlobalShortcuts.ts
+++ b/packages/web/src/shortcuts/useGlobalShortcuts.ts
@@ -2,11 +2,15 @@ import { type RegisterableHotkey } from "@tanstack/react-hotkeys";
 import { useLocation, useNavigate } from "@tanstack/react-router";
 import { useRef } from "react";
 import { viewActions } from "@web/events/stores/view.store";
-import { settingsActions } from "@web/settings/settings.store";
+import {
+  settingsActions,
+  useSettingsStore,
+} from "@web/settings/settings.store";
 import {
   LIFE_SHORTCUT,
   VIEW_SHORTCUTS,
 } from "@web/shortcuts/shortcuts.constants";
+import { shortcutHintProgressActions } from "@web/shortcuts/tips/shortcut-tips.progress.store";
 import {
   useAppShortcut,
   useAppShortcutUp,
@@ -74,7 +78,11 @@ export function useNavigationShortcuts() {
   useAppShortcut(
     "Mod+K",
     () => {
+      const wasOpen = useSettingsStore.getState().isCmdPaletteOpen;
       settingsActions.toggleCmdPalette();
+      if (!wasOpen) {
+        shortcutHintProgressActions.demonstrate("command-palette");
+      }
     },
     {
       ignoreInputs: false,

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -55,6 +55,7 @@ import { FormDigitHintOverlay } from "@web/shortcuts/form-digit-jump/FormDigitHi
 import { useFormDigitJumpShortcut } from "@web/shortcuts/form-digit-jump/useFormDigitJumpShortcut";
 import { keyboardKey } from "@web/shortcuts/is-bare-letter-key";
 import { KEYMAP } from "@web/shortcuts/keymap";
+import { shortcutHintProgressActions } from "@web/shortcuts/tips/shortcut-tips.progress.store";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 import { AttendeeField } from "@web/views/Forms/EventForm/AttendeeField/AttendeeField";
 import { EnableContactSuggestionsNudge } from "@web/views/Forms/EventForm/AttendeeField/EnableContactSuggestionsNudge";
@@ -589,6 +590,8 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
           : { kind: "timed", start, end, timeZone: schedule.timeZone },
       );
 
+      shortcutHintProgressActions.demonstrate("save-draft");
+      shortcutHintProgressActions.demonstrate("first-event-save");
       onSubmit(withSchedule);
     };
 

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -591,7 +591,6 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
       );
 
       shortcutHintProgressActions.demonstrate("save-draft");
-      shortcutHintProgressActions.demonstrate("first-event-save");
       onSubmit(withSchedule);
     };
 

--- a/packages/web/src/views/Life/LifeView.tsx
+++ b/packages/web/src/views/Life/LifeView.tsx
@@ -19,6 +19,7 @@ import {
   pageJumpAttrs,
 } from "@web/shortcuts/page-jump/page-jump.targets";
 import { getShortcutMenuSections } from "@web/shortcuts/shortcuts.registry";
+import { shortcutHintProgressActions } from "@web/shortcuts/tips/shortcut-tips.progress.store";
 import { useAppShortcutUp } from "@web/shortcuts/useAppShortcut";
 import { LifeGrid } from "./LifeGrid";
 import { LifeSidebarContent } from "./LifeSidebarContent";
@@ -123,6 +124,7 @@ export function LifeView({ today }: LifeViewProps) {
 
     currentWeek.scrollIntoView({ behavior: "smooth", block: "center" });
     currentWeek.focus();
+    shortcutHintProgressActions.demonstrate("life-this-week");
   }, []);
   const cycleVariation = useCallback(
     (direction: -1 | 1) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sidebar shortcut tips no longer stick on “Hold Mod to see where you can jump” after the first event. When the user performs a taught primitive, that tip is retired and the bar advances through the Shortcut Showcase patterns (hold-Mod → event jump → command palette → create; focused events teach edit-sequence then nudge first).

First-event create/save stay sticky. Demonstrations persist as a most-recent-last id list in localStorage and are ignored while the Shortcut Showcase is open.

## Simplicity

Progress is a single id array (same shape as recent commands), not a `{ demonstratedIds, lastUsedId }` object. The selector takes that list directly. `first-event-save` is not recorded because it is never in a rotation pool.

## Automated validation

Focused web tests: 62 pass, 0 fail.

`bun run verify` (pre-simplify): selected packages web; checks run `test:web`, `type-check`, `lint`, `knip`; all passed. Playwright skipped (Chromium not installed).

Post-simplify: same focused 62 pass; `bun run lint` — no new errors (12 pre-existing warnings).

Browser (anonymous `dev:web` on `/week` after first-event-done): idle sidebar showed “Hold ⌘ to see where you can jump”; after a 2s Control hold it changed to “Press S to show event keys”.

![Idle hold-Mod sidebar tip](https://cursor.com/artifacts/c/art-0568c58f-6464-454c-840e-ebf02fc24fd9)
![Sidebar tip after Control hold](https://cursor.com/artifacts/c/art-8c1ed620-6d59-4af8-a1d3-41c5df7ad17f)

## Independent review

`.agents/handoffs/2898.md` — Reviewer verdict: no confirmed findings.

## Test plan

- `bun test:web -- packages/web/src/shortcuts/tips/selectShortcutHint.test.ts packages/web/src/shortcuts/tips/shortcut-tips.data.test.ts packages/web/src/shortcuts/tips/useShortcutHintContext.test.tsx packages/web/src/shortcuts/tips/shortcut-tips.progress.store.test.ts packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx packages/web/src/shortcuts/page-jump/usePageJumpShortcut.test.tsx` — 62 pass
- `bun run lint` — no new errors
- Browser: hold Control on idle week after first event; tip advances from hold-Mod to event-jump (`S`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11532b53-6064-4356-b30f-90a46ebb2df8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11532b53-6064-4356-b30f-90a46ebb2df8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

