### PR TITLE
fix(billing): verify Stripe webhook signatures under Bun

### DIFF
--- a/docs/features/billing.md
+++ b/docs/features/billing.md
@@ -29,8 +29,10 @@ network never flashes a gate at a user before the real value loads.
 **Enable-day caveat:** existing signed-in accounts are not grandfathered (see
 below) — flipping `enforcement: true` while Stripe is configured immediately
 puts any hosted user without a Stripe subscription id into `awaiting_checkout`
-and shows them `BillingGateModal`. Run `bun run cli backfill-billing` (or set
-`BACKFILL_CUTOFF`) first if that's not the intended effect for existing users.
+and shows them `BillingGateModal`. Neither `backfill-billing` nor
+`BACKFILL_CUTOFF` changes that — see below. Sparing existing users would take
+a real code change, so treat the flip as the moment every hosted account
+without a Stripe subscription goes read-only.
 
 ## What users see
 
@@ -51,7 +53,14 @@ subscription id (including missing billing, `none`, and local/backfill
 `bun run cli backfill-billing` stamps `awaiting_checkout` on rows that still
 lack `billing.subscriptionStatus`. The default `BACKFILL_CUTOFF` is far in
 the future so every such row is included; set it to a past instant to skip
-newer signups. A trial only begins through Stripe Checkout.
+newer signups.
+
+`BACKFILL_CUTOFF` is **not** a grandfathering switch. It only decides which
+rows get *stamped*, and `deriveBillingStatus` already gates a missing
+`billing` object through the same `awaiting_checkout` branch — so stamped and
+unstamped rows are equally read-only. Running the backfill makes the state
+explicit for reporting; it grants nobody access. A trial only begins through
+Stripe Checkout.
 
 ## Staging
 
@@ -72,8 +81,13 @@ must subscribe to Checkout and Subscriptions snapshot events, not Accounts v2:
 `staging-selfhosted` must not get those secrets — it is the live regression
 that self-host stays writable.
 
-Sales tax (`automatic_tax`) is a Stripe Dashboard decision, not a code one,
-and should be settled before production keys.
+Sales tax is enabled in code: the Checkout Session passes
+`automatic_tax`, `customer_update.address`, and `billing_address_collection`
+together (all three are required when an existing `customer` is passed). The
+Dashboard half is the part that must be settled before production keys —
+register each jurisdiction under Tax > Registrations and set a product tax
+code, in test and live mode separately. Without a registration Stripe
+calculates zero tax rather than erroring, so a missing one is silent.
 
 ## Key files
 

--- a/packages/backend/src/billing/controllers/billing.webhook.controller.ts
+++ b/packages/backend/src/billing/controllers/billing.webhook.controller.ts
@@ -32,7 +32,10 @@ class BillingWebhookController {
     }
 
     try {
-      const event = getStripeClient().webhooks.constructEvent(
+      // Must be the async variant: under Bun the SDK selects
+      // SubtleCryptoProvider, whose synchronous HMAC path throws
+      // unconditionally, so constructEvent() rejects every signature.
+      const event = await getStripeClient().webhooks.constructEventAsync(
         req.body,
         signature,
         CONFIG.STRIPE_WEBHOOK_SECRET,

--- a/packages/backend/src/billing/services/billing.webhook.service.db.test.ts
+++ b/packages/backend/src/billing/services/billing.webhook.service.db.test.ts
@@ -1,5 +1,5 @@
 import { type Request, type Response } from "express";
-import type Stripe from "stripe";
+import Stripe from "stripe";
 import { Status } from "@core/errors/status.codes";
 import {
   cleanupCollections,
@@ -9,7 +9,10 @@ import {
 import { mockEnv } from "@backend/__tests__/helpers/mock.setup";
 import billingWebhookController from "@backend/billing/controllers/billing.webhook.controller";
 import { processStripeEvent } from "@backend/billing/services/billing.webhook.service";
-import { setStripeClientForTests } from "@backend/billing/services/stripe.client";
+import {
+  STRIPE_API_VERSION,
+  setStripeClientForTests,
+} from "@backend/billing/services/stripe.client";
 import mongoService from "@backend/common/services/mongo.service";
 import {
   afterAll,
@@ -85,7 +88,7 @@ describe("Stripe webhook", () => {
     using _env = mockEnv(stripeConfigured);
     setStripeClientForTests({
       webhooks: {
-        constructEvent: () => {
+        constructEventAsync: () => {
           throw new Error(
             "No signatures found matching the expected signature",
           );
@@ -108,6 +111,121 @@ describe("Stripe webhook", () => {
     expect(json.mock.calls[0]?.[0]).toEqual({
       error: "No signatures found matching the expected signature",
     });
+  });
+
+  /**
+   * The other webhook tests stub the Stripe client wholesale, so the SDK's
+   * own signature verification never runs. These two use the real
+   * `webhooks` object and stub only the API call, which is the difference
+   * between testing our dispatch and testing that Stripe events can get in
+   * at all. Under Bun the SDK picks an async-only crypto provider, so a
+   * synchronous constructEvent() fails here no matter how valid the
+   * signature is.
+   */
+  const realStripe = () =>
+    new Stripe(stripeConfigured.STRIPE_SECRET_KEY, {
+      apiVersion: STRIPE_API_VERSION,
+    });
+
+  const checkoutPayload = (userId: string) =>
+    JSON.stringify({
+      id: "evt_signed_1",
+      type: "checkout.session.completed",
+      created: 1_775_000_100,
+      data: {
+        object: {
+          id: "cs_signed_1",
+          client_reference_id: userId,
+          customer: "cus_1",
+          subscription: "sub_1",
+        },
+      },
+    });
+
+  const seedAwaitingUser = async (email: string) => {
+    const userId = mongoService.objectId();
+    await mongoService.user.insertOne({
+      _id: userId,
+      email,
+      name: "Signed",
+      firstName: "Signed",
+      lastName: "User",
+      locale: "en",
+      billing: { subscriptionStatus: "awaiting_checkout" },
+    });
+    return userId;
+  };
+
+  it("accepts an event carrying a genuine Stripe signature", async () => {
+    using _env = mockEnv(stripeConfigured);
+    const userId = await seedAwaitingUser("signed@example.com");
+    const stripe = realStripe();
+    setStripeClientForTests({
+      webhooks: stripe.webhooks,
+      subscriptions: {
+        retrieve: mock(() =>
+          Promise.resolve(
+            subscription({ metadata: { compassUserId: userId.toString() } }),
+          ),
+        ),
+      },
+    } as unknown as Stripe);
+
+    const payload = checkoutPayload(userId.toString());
+    const signature = await stripe.webhooks.generateTestHeaderStringAsync({
+      payload,
+      secret: stripeConfigured.STRIPE_WEBHOOK_SECRET,
+    });
+
+    const { res, json } = jsonRes();
+    await billingWebhookController.handleStripe(
+      {
+        body: Buffer.from(payload),
+        headers: { "stripe-signature": signature },
+      } as unknown as Request,
+      res,
+    );
+
+    expect((res.status as ReturnType<typeof mock>).mock.calls[0]?.[0]).toBe(
+      Status.OK,
+    );
+    expect(json).toHaveBeenCalledWith({ received: true });
+    const stored = await mongoService.user.findOne({ _id: userId });
+    expect(stored?.billing?.subscriptionStatus).toBe("trialing");
+    expect(stored?.billing?.stripeSubscriptionId).toBe("sub_1");
+    expect(await mongoService.billingEvent.countDocuments()).toBe(1);
+  });
+
+  it("rejects a payload edited after it was signed", async () => {
+    using _env = mockEnv(stripeConfigured);
+    const userId = await seedAwaitingUser("tampered@example.com");
+    const stripe = realStripe();
+    setStripeClientForTests({
+      webhooks: stripe.webhooks,
+      subscriptions: { retrieve: mock() },
+    } as unknown as Stripe);
+
+    const payload = checkoutPayload(userId.toString());
+    const signature = await stripe.webhooks.generateTestHeaderStringAsync({
+      payload,
+      secret: stripeConfigured.STRIPE_WEBHOOK_SECRET,
+    });
+
+    const { res } = jsonRes();
+    await billingWebhookController.handleStripe(
+      {
+        body: Buffer.from(payload.replace("cus_1", "cus_evil")),
+        headers: { "stripe-signature": signature },
+      } as unknown as Request,
+      res,
+    );
+
+    expect((res.status as ReturnType<typeof mock>).mock.calls[0]?.[0]).toBe(
+      Status.BAD_REQUEST,
+    );
+    const stored = await mongoService.user.findOne({ _id: userId });
+    expect(stored?.billing?.stripeSubscriptionId).toBeUndefined();
+    expect(await mongoService.billingEvent.countDocuments()).toBe(0);
   });
 
   it("links customer and subscription ids from checkout.session.completed", async () => {

--- a/packages/backend/src/billing/services/stripe.service.db.test.ts
+++ b/packages/backend/src/billing/services/stripe.service.db.test.ts
@@ -79,6 +79,19 @@ describe("StripeService", () => {
     expect(
       (sessionArgs as { payment_method_types?: unknown }).payment_method_types,
     ).toBeUndefined();
+    // Stripe Tax needs all three together with an existing customer: drop
+    // one and tax silently calculates as zero instead of erroring.
+    expect(
+      sessionArgs as {
+        automatic_tax?: unknown;
+        customer_update?: unknown;
+        billing_address_collection?: unknown;
+      },
+    ).toMatchObject({
+      automatic_tax: { enabled: true },
+      customer_update: { address: "auto" },
+      billing_address_collection: "required",
+    });
     expect(sessionsCreate.mock.calls[0]?.[1]).toEqual({
       idempotencyKey: `compass-checkout-v2-${userId.toString()}`,
     });

--- a/packages/backend/src/billing/services/stripe.service.ts
+++ b/packages/backend/src/billing/services/stripe.service.ts
@@ -83,6 +83,13 @@ class StripeService {
           // Card is required to start the trial. Default is `always`, but pin
           // it so a Dashboard setting cannot silently skip collection.
           payment_method_collection: "always",
+          // Stripe Tax is a create-param, not a Dashboard toggle. Because we
+          // always pass an existing `customer`, these three go together: the
+          // billing address has to be collected and written back to the
+          // Customer or there is no address to calculate tax from.
+          automatic_tax: { enabled: true },
+          customer_update: { address: "auto" },
+          billing_address_collection: "required",
           subscription_data: {
             ...(grantTrial
               ? {

--- a/packages/core/src/constants/billing.constants.ts
+++ b/packages/core/src/constants/billing.constants.ts
@@ -3,10 +3,12 @@
  * share one source. The Stripe price id is a deployment secret and lives
  * in config, not here.
  *
- * BACKFILL_CUTOFF is the single dated switch for grandfathering: only
+ * BACKFILL_CUTOFF bounds which rows `backfill-billing` stamps: only
  * accounts with `signedUpAt <= cutoff` (or missing `signedUpAt`) are
- * placed on a trial. A far-future default means nobody is grandfathered.
- * Reverting to grandfathering is a one-line change to this value.
+ * stamped `awaiting_checkout`. It is NOT a grandfathering switch --
+ * `deriveBillingStatus` gates a missing `billing` object through the same
+ * read-only branch, so skipping a row here changes nothing about its
+ * access. Grandfathering would need a real code change.
  */
 export const BILLING_PLAN = {
   TRIAL_LENGTH_DAYS: 7,

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -54,7 +54,7 @@ export default class CompassCLI {
       .helpOption(false)
       .allowUnknownOption(true)
       .description(
-        "place existing accounts without billing status onto a 7-day trial (--apply to write)",
+        "stamp awaiting_checkout on accounts with no billing status (--apply to write)",
       );
 
     program


### PR DESCRIPTION
## The bug

`billing.webhook.controller.ts` called the **synchronous** `webhooks.constructEvent()`. Under Bun the Stripe SDK selects `SubtleCryptoProvider`, whose sync HMAC path throws unconditionally, so signature verification could never succeed **at any signature**.

Staging confirmed it, live:

```
$ curl -X POST https://staging.compasscalendar.com/api/billing/webhook/stripe \
    -H 'stripe-signature: t=1,v1=deadbeef' -d '{}'
HTTP 400
{"error":"SubtleCryptoProvider cannot be used in a synchronous context.
Use `await constructEventAsync(...)` instead of `constructEvent(...)`"}
```

And so did the staging database: **2** users with a `stripeCustomerId`, **0** with a `stripeSubscriptionId`, `billingEvent` collection **empty**. No webhook has ever been processed. Someone had already started a checkout there and it silently went nowhere. With enforcement on, a customer could have paid and stayed gated read-only forever.

## Why no test caught it

Every webhook test stubs the Stripe client wholesale, so the SDK's own crypto path never runs. The single test touching `constructEvent` replaced it with a fake that threw a hand-written "bad signature" error — proving the dispatch logic while never exercising the verification it depends on.

The two new tests use the **real** `webhooks` object and stub only the API call: one asserts a genuine signature reaches the DB (200, `stripeSubscriptionId` written, `billingEvent` row), one asserts a payload edited after signing is rejected (400, no write). Both were confirmed to fail against `constructEvent` before the fix, with the same `SubtleCryptoProvider → verifyHeader → constructEvent` stack seen on staging.

## Also here

**Stripe Tax**, ahead of production keys. `automatic_tax` is a Checkout Session create-param, not a Dashboard toggle, and because we always pass an existing `customer` it needs `customer_update.address` and `billing_address_collection` alongside it. All three are asserted together in the checkout test, since dropping one makes tax calculate as zero rather than error.

**Three stale grandfathering claims corrected.** `BACKFILL_CUTOFF`'s comment said reverting to grandfathering was "a one-line change to this value". It isn't: the cutoff only bounds which rows get *stamped*, and `deriveBillingStatus` gates a missing `billing` object through the same `awaiting_checkout` branch, so stamped and unstamped rows are equally read-only. Same correction in `docs/features/billing.md` and the `backfill-billing` CLI description.

## Verification

- `test:backend` 428 pass / 0 fail, `test:core` 619 pass / 0 fail, `test:scripts` 70 pass / 0 fail
- `type-check` and `biome check` clean
- Raw-body ordering in `express.server.ts` re-confirmed: `express.raw()` scoped to `STRIPE_WEBHOOK_PATH` still precedes `express.json()`

Production is untouched by this PR: no Stripe secrets, no `BILLING_ENFORCEMENT`, no backfill. Next step is the staging edge-case pass before any prod decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
