### PR TITLE
fix(sync): give calendar-list rediscovery its own staleness clock

### DIFF
--- a/.agents/handoffs/2876.md
+++ b/.agents/handoffs/2876.md
@@ -4,7 +4,7 @@ task_id: "2876"
 from: Manager
 to: Human
 owner: Manager
-status: verifying
+status: done
 artifact:
   - path: packages/sync/src/providers/google/google-calendar.adapter.ts
   - path: packages/sync/src/domain/calendar-list-sync.service.ts
@@ -15,11 +15,16 @@ evidence:
     result: "Selected packages: sync; checks run test:sync, type-check, lint, knip; all passed"
   - command: bun run test:sync
     result: "983 pass, 0 fail"
+  - command: gh pr merge 2876 --squash --delete-branch
+    result: "MERGED a91fbe5d7ef2b5283e7e373cacad474a5443f89f"
+  - command: gh workflow run deploy-production.yml -f tag=v1.1.293
+    result: "Deploy to production=success; Health check production=success (run 32906034590)"
 assumptions:
   - "Google leaves calendarList `selected` frozen when a calendar is hidden from the list; confirmed against prod provider_calendars data (hidden && selected cohort matches the resurrected sidebar entries)"
 open_risks:
   - "hidden-but-selected calendars a user genuinely wants imported stop syncing; judged not a real use case since Google's own UI does not show them"
-next_deadline: 2026-08-26T18:00:00Z
+  - "WRONG, corrected 2026-08-27: assumed existing fossil rows would retire on the next daily rediscovery sweep. They did not. The sweep selected on lastSuccessAt, which every incremental pass stamps, so an active user's focus refreshes held it perpetually fresh and the sweep never fired for them - only the 64 IDLE connections self-healed. Fixed by the lastFullListAt clock on branch claude/calendar-list-full-list-clock."
+next_deadline: null
 retry: 0
 approval: none
 waiting_on: null
@@ -30,4 +35,5 @@ Ship record for PR #2876: hidden Google calendars map inactive regardless of
 the fossil `selected` flag; inactive calendars get their local push-channel
 fields cleared via one self-gating updateMany in the calendar-list pass plus
 a level-triggered clear in dispatch's inactive-drop branch. Independent
-review: no confirmed findings. Status moves to done at squash-merge.
+review: no confirmed findings. Squash-merged as a91fbe5d7, released v1.1.293,
+deployed to staging and production with green health checks 2026-08-25.

--- a/packages/sync/src/domain/calendar-list-rediscovery.db.test.ts
+++ b/packages/sync/src/domain/calendar-list-rediscovery.db.test.ts
@@ -27,12 +27,25 @@ describe("calendar-list rediscovery sweep (rediscoverStaleCalendarLists)", () =>
   const deps = () => ({ resources, jobs });
 
   // A connection's calendarList resource, holding a cursor (as a live
-  // connection's does after its initial connect) and a given lastSuccessAt.
+  // connection's does after its initial connect).
+  //
+  // `fullListedAt` is the clock this sweep selects on; `lastSuccessAt` defaults
+  // to match it, because a real full pass stamps both. Pass them SEPARATELY to
+  // model the bug this sweep exists to survive: an active user's incremental
+  // passes keep lastSuccessAt fresh while lastFullListAt stays old.
   // Pass withCredential: false to simulate a dead/disconnected connection.
   const seedCalendarListResource = async (
-    lastSuccessAt: Date | null,
-    options: { withCredential?: boolean } = {},
+    options: {
+      fullListedAt?: Date | null;
+      lastSuccessAt?: Date | null;
+      withCredential?: boolean;
+    } = {},
   ): Promise<SyncResourceRecord> => {
+    const fullListedAt = options.fullListedAt ?? null;
+    const lastSuccessAt =
+      options.lastSuccessAt === undefined
+        ? fullListedAt
+        : options.lastSuccessAt;
     const tenantId = objectId() as SyncResourceRecord["tenantId"];
     const principalId = objectId() as SyncResourceRecord["principalId"];
     const connectionId = objectId() as SyncResourceRecord["connectionId"];
@@ -60,6 +73,14 @@ describe("calendar-list rediscovery sweep (rediscoverStaleCalendarLists)", () =>
         lastSuccessAt,
       );
     }
+    if (fullListedAt) {
+      await resources.markFullListCompleted(
+        tenantId,
+        principalId,
+        resource._id,
+        fullListedAt,
+      );
+    }
     return resource;
   };
 
@@ -75,9 +96,9 @@ describe("calendar-list rediscovery sweep (rediscoverStaleCalendarLists)", () =>
     });
 
   it("clears the cursor and enqueues a connection-scoped calendarListSync for a stale resource", async () => {
-    const stale = await seedCalendarListResource(
-      new Date("2026-08-01T00:00:00.000Z"),
-    );
+    const stale = await seedCalendarListResource({
+      fullListedAt: new Date("2026-08-01T00:00:00.000Z"),
+    });
 
     const enqueued = await rediscoverStaleCalendarLists(
       deps(),
@@ -88,9 +109,12 @@ describe("calendar-list rediscovery sweep (rediscoverStaleCalendarLists)", () =>
     expect(enqueued).toBe(1);
     const record = await resourceById(stale._id);
     expect(record?.syncCursor).toBeNull();
-    // lastSuccessAt is the staleness key the sweep sorts on; clearing the
-    // cursor must not also touch it, or the resource would re-win the front
-    // of every subsequent sweep before the pass it triggered ever runs.
+    // lastFullListAt is the staleness key the sweep selects on; clearing the
+    // cursor must not also stamp it, or the resource would look satisfied for a
+    // day on the strength of a pass that has not run yet.
+    expect(record?.lastFullListAt).toEqual(
+      new Date("2026-08-01T00:00:00.000Z"),
+    );
     expect(record?.lastSuccessAt).toEqual(new Date("2026-08-01T00:00:00.000Z"));
 
     const job = await jobByKey(`calendarListSync:${stale.connectionId}`);
@@ -101,8 +125,10 @@ describe("calendar-list rediscovery sweep (rediscoverStaleCalendarLists)", () =>
     expect(job?.tenantId).toBe(stale.tenantId);
   });
 
-  it("skips a resource re-listed more recently than the threshold", async () => {
-    await seedCalendarListResource(new Date("2026-08-06T12:00:00.000Z")); // after staleBefore
+  it("skips a resource fully re-listed more recently than the threshold", async () => {
+    await seedCalendarListResource({
+      fullListedAt: new Date("2026-08-06T12:00:00.000Z"), // after staleBefore
+    });
 
     const enqueued = await rediscoverStaleCalendarLists(
       deps(),
@@ -114,8 +140,51 @@ describe("calendar-list rediscovery sweep (rediscoverStaleCalendarLists)", () =>
     expect(await jobCount()).toBe(0);
   });
 
-  it("re-discovers a resource that has never succeeded", async () => {
-    const fresh = await seedCalendarListResource(null);
+  it("re-discovers an active user whose incremental passes keep lastSuccessAt fresh", async () => {
+    // THE BUG (2026-08-27). The web client refreshes on every page load and
+    // every alt-tab-back after 30s, and each one runs an incremental
+    // calendarList pass that stamps lastSuccessAt. While the sweep selected on
+    // that field, a daily user could never age into it, so the full pass that
+    // retires hidden/removed calendars never ran for them — the connections
+    // that self-healed after #2876 were the IDLE ones. Selecting on
+    // lastFullListAt is what makes usage stop suppressing the repair.
+    const active = await seedCalendarListResource({
+      fullListedAt: new Date("2026-08-04T00:00:00.000Z"),
+      lastSuccessAt: new Date("2026-08-06T23:00:00.000Z"),
+    });
+
+    const enqueued = await rediscoverStaleCalendarLists(
+      deps(),
+      staleBefore,
+      now,
+    );
+
+    expect(enqueued).toBe(1);
+    expect(
+      await jobByKey(`calendarListSync:${active.connectionId}`),
+    ).not.toBeNull();
+  });
+
+  it("skips a resource whose full list is fresh even when lastSuccessAt is stale", async () => {
+    // The inverse of the case above: pins that we SWAPPED the selection key
+    // rather than adding a second one that ORs the old behavior back in.
+    await seedCalendarListResource({
+      fullListedAt: new Date("2026-08-06T12:00:00.000Z"),
+      lastSuccessAt: new Date("2026-08-01T00:00:00.000Z"),
+    });
+
+    const enqueued = await rediscoverStaleCalendarLists(
+      deps(),
+      staleBefore,
+      now,
+    );
+
+    expect(enqueued).toBe(0);
+    expect(await jobCount()).toBe(0);
+  });
+
+  it("re-discovers a resource that has never been fully listed", async () => {
+    const fresh = await seedCalendarListResource();
 
     const enqueued = await rediscoverStaleCalendarLists(
       deps(),
@@ -129,15 +198,54 @@ describe("calendar-list rediscovery sweep (rediscoverStaleCalendarLists)", () =>
     ).not.toBeNull();
   });
 
+  it("re-discovers a row written before lastFullListAt existed", async () => {
+    // The self-backfill, and the reason no migration script ships with this
+    // field: every row predating it has the key ABSENT, not null. Inserted raw
+    // rather than through ensure() so the schema default cannot write a null
+    // and make this pass for the wrong reason — Mongo's null predicate has to
+    // match the missing key on its own.
+    const tenantId = objectId() as SyncResourceRecord["tenantId"];
+    const principalId = objectId() as SyncResourceRecord["principalId"];
+    const connectionId = objectId() as SyncResourceRecord["connectionId"];
+    const legacy = await resources.ensure({
+      tenantId,
+      principalId,
+      connectionId,
+      resourceKind: "calendarList",
+      calendarId: null,
+    });
+    await credentials.store({
+      connectionId,
+      provider: "google",
+      refreshToken: "refresh-token",
+      scopes: [],
+    });
+    await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.syncResources)
+      .updateOne({ _id: legacy._id }, { $unset: { lastFullListAt: "" } });
+
+    const enqueued = await rediscoverStaleCalendarLists(
+      deps(),
+      staleBefore,
+      now,
+    );
+
+    expect(enqueued).toBe(1);
+    expect(
+      await jobByKey(`calendarListSync:${legacy.connectionId}`),
+    ).not.toBeNull();
+  });
+
   it("coalesces onto an already-pending calendarListSync job while still clearing the cursor", async () => {
     // registerConnection may have already enqueued calendarListSync (e.g. a
     // reconnect raced the sweep). The sweep's enqueue must collapse onto that
     // job rather than mint a second one, since JobRepository.enqueue only
     // $setOnInsert's — but the cursor clear still has to land, because
     // whichever job runs reads the cursor fresh at execution time.
-    const stale = await seedCalendarListResource(
-      new Date("2026-08-01T00:00:00.000Z"),
-    );
+    const stale = await seedCalendarListResource({
+      fullListedAt: new Date("2026-08-01T00:00:00.000Z"),
+    });
     await jobs.enqueue({
       tenantId: stale.tenantId,
       principalId: stale.principalId,
@@ -170,12 +278,12 @@ describe("calendar-list rediscovery sweep (rediscoverStaleCalendarLists)", () =>
   });
 
   it("excludes a resource whose connection has no stored credential, however stale", async () => {
-    const deadCredential = await seedCalendarListResource(null, {
+    const deadCredential = await seedCalendarListResource({
       withCredential: false,
     });
-    const healthy = await seedCalendarListResource(
-      new Date("2026-08-01T00:00:00.000Z"),
-    );
+    const healthy = await seedCalendarListResource({
+      fullListedAt: new Date("2026-08-01T00:00:00.000Z"),
+    });
 
     const enqueued = await rediscoverStaleCalendarLists(
       deps(),
@@ -193,15 +301,17 @@ describe("calendar-list rediscovery sweep (rediscoverStaleCalendarLists)", () =>
   });
 
   it("rotates a permanently-failing connection behind others via lastAttemptAt", async () => {
-    // Without stamping lastAttemptAt, a connection whose discovery always
-    // errors before succeeding ties at lastAttemptAt: null forever and
-    // re-wins the front of every sweep, starving the resources behind it —
-    // the same dead-credential-cohort pathology reconcile hit on 2026-07-29,
-    // here for calendarList resources instead of events.
-    const doomed = await seedCalendarListResource(null);
-    const healthy = await seedCalendarListResource(
-      new Date("2026-08-01T00:00:00.000Z"),
-    );
+    // Why lastAttemptAt stays the PRIMARY sort key even though the filter moved
+    // to lastFullListAt: a connection whose full pass always throws never
+    // stamps lastFullListAt, so sorting on that field first would leave it at
+    // null, re-winning the front of every sweep and starving everyone behind it
+    // — the dead-credential-cohort pathology reconcile hit on 2026-07-29.
+    // syncCalendarList stamps lastAttemptAt before the token fetch can fail, so
+    // the doomed connection rotates to the back after a single attempt.
+    const doomed = await seedCalendarListResource();
+    const healthy = await seedCalendarListResource({
+      fullListedAt: new Date("2026-08-01T00:00:00.000Z"),
+    });
     await resources.markAttempt(
       doomed.tenantId,
       doomed.principalId,
@@ -226,12 +336,12 @@ describe("calendar-list rediscovery sweep (rediscoverStaleCalendarLists)", () =>
   });
 
   it("skips a connection whose cursor clear or enqueue fails and sweeps the rest", async () => {
-    const poisoned = await seedCalendarListResource(
-      new Date("2026-08-01T00:00:00.000Z"),
-    );
-    const healthy = await seedCalendarListResource(
-      new Date("2026-08-02T00:00:00.000Z"),
-    );
+    const poisoned = await seedCalendarListResource({
+      fullListedAt: new Date("2026-08-01T00:00:00.000Z"),
+    });
+    const healthy = await seedCalendarListResource({
+      fullListedAt: new Date("2026-08-02T00:00:00.000Z"),
+    });
     // A job doc that cannot be parsed back out, sitting on the coalescing key
     // the sweep is about to reuse — mirrors the 2026-07-31 fleet-freeze shape
     // (resource-sweep-enqueue.reconcile.db.test.ts) for this sweep's own key.

--- a/packages/sync/src/domain/calendar-list-rediscovery.service.ts
+++ b/packages/sync/src/domain/calendar-list-rediscovery.service.ts
@@ -12,11 +12,16 @@ export interface CalendarListRediscoveryDeps {
   onError?: (error: unknown, resourceId: string) => void;
 }
 
-// Force a FULL calendar-list re-discovery for every connection whose last
-// discovery is older than `before`, so a calendar deleted or unshared at the
+// Force a FULL calendar-list re-discovery for every connection whose last full
+// enumeration (lastFullListAt, NOT lastSuccessAt — see listStaleCalendarLists)
+// is older than `before`, so a calendar deleted, hidden, or unshared at the
 // provider eventually gets retired even though calendarListSync otherwise only
-// ever runs once, at connect (connection.routes.ts's registerConnection is the
-// only other enqueue site).
+// ever runs incrementally.
+//
+// This is the guaranteed floor. The calendarList push route also clears the
+// cursor, which converges within seconds — but only for connections that hold a
+// live channel AND whose user actually changed something, so it cannot be the
+// only mechanism.
 //
 // syncCalendarList decides full-vs-incremental purely from whether the stored
 // cursor is null (`fullList = resource.syncCursor === null`), so clearing the

--- a/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
@@ -201,9 +201,13 @@ describe("syncCalendarList", () => {
     expect(job?.coalescingKey).toBe(`initialImport:${eventsResources[0]?._id}`);
   });
 
-  it("clears persisted unwatchable verdicts on a full pass so each gets one retry", async () => {
-    const conn = connection();
-    // First full pass discovers the calendar and bootstraps its events resource.
+  // Run a full pass, mark the connection's events resource unwatchable at
+  // `markedAt`, then run a second full pass. Returns the verdict as that second
+  // pass left it.
+  const watchVerdictAfterSecondFullPass = async (
+    conn: ProviderConnectionRecord,
+    markedAt: Date,
+  ) => {
     await syncCalendarList(
       deps(
         new FakeDiscovery([
@@ -221,11 +225,10 @@ describe("syncCalendarList", () => {
       conn.tenantId,
       conn.principalId,
       String(eventsResource?.["_id"]),
-      now(),
+      markedAt,
     );
 
-    // Next pass is full again (no cursor stored) - the verdict is cleared for
-    // one fresh watch attempt.
+    // Full again (no cursor stored).
     await syncCalendarList(
       deps(
         new FakeDiscovery([
@@ -240,7 +243,32 @@ describe("syncCalendarList", () => {
       .db()
       .collection(SYNC_COLLECTIONS.syncResources)
       .findOne({ connectionId: conn._id, resourceKind: "events" });
-    expect(after?.["watchUnsupportedAt"]).toBeNull();
+    return after?.["watchUnsupportedAt"];
+  };
+
+  it("clears an unwatchable verdict older than a day on a full pass so it gets one retry", async () => {
+    const verdict = await watchVerdictAfterSecondFullPass(
+      connection(),
+      new Date("2026-07-08T00:00:00.000Z"), // two days before now()
+    );
+
+    expect(verdict).toBeNull();
+  });
+
+  it("leaves a fresh unwatchable verdict alone so repeated full passes cost no watch calls", async () => {
+    // A calendarList push forces a full pass, so full passes are no longer
+    // reliably daily. Without the age gate, a user editing their calendar list
+    // N times a day would hand every unwatchable calendar N futile watch calls,
+    // each immediately re-marked — the "one futile attempt per pull, forever"
+    // wart the marker was introduced to kill.
+    const markedAt = new Date("2026-07-09T23:00:00.000Z"); // an hour before now()
+
+    const verdict = await watchVerdictAfterSecondFullPass(
+      connection(),
+      markedAt,
+    );
+
+    expect(verdict).toEqual(markedAt);
   });
 
   it("retires a calendar no longer present on a full list", async () => {
@@ -408,6 +436,79 @@ describe("syncCalendarList", () => {
       .findOne({ _id: hidesEventsResourceId });
     expect(hidesEventsResource?.subscriptionId).toBeNull();
     expect(hidesEventsResource?.subscriptionExpiresAt).toBeNull();
+    // The reason the channel is cleared at all: the calendar itself went
+    // inactive, which is what drops it out of the sidebar.
+    const hides = (await calendarDocs(conn)).find(
+      (d) => d.providerCalendarId === "hides",
+    );
+    expect(hides?.active).toBe(false);
+  });
+
+  it("stamps lastFullListAt on a full pass", async () => {
+    const conn = connection();
+
+    await syncCalendarList(
+      deps(
+        new FakeDiscovery([
+          { calendars: [discovered("primary")], cursor: "c1" },
+        ]),
+      ),
+      conn,
+      now,
+    );
+
+    expect((await calendarListResource(conn))?.lastFullListAt).toEqual(now());
+  });
+
+  it("does not stamp lastFullListAt on an incremental pass", async () => {
+    // The bug this whole field exists for. An incremental pass reconciles only
+    // what changed, so it cannot answer "is this calendar still listed?" — if it
+    // advanced the rediscovery clock, an active user's focus refreshes would
+    // hold the sweep off forever and hidden calendars would never retire.
+    const conn = connection();
+    await syncCalendarList(
+      deps(
+        new FakeDiscovery([
+          { calendars: [discovered("primary")], cursor: "c1" },
+        ]),
+      ),
+      conn,
+      now,
+    );
+    const later = () => new Date("2026-07-11T00:00:00.000Z");
+
+    await syncCalendarList(
+      deps(
+        new FakeDiscovery([
+          { calendars: [discovered("primary")], cursor: "c2" },
+        ]),
+      ),
+      conn,
+      later,
+    );
+
+    const resource = await calendarListResource(conn);
+    expect(resource?.lastFullListAt).toEqual(now()); // still the FULL pass's stamp
+    expect(resource?.lastSuccessAt).toEqual(later()); // which advanced regardless
+  });
+
+  it("does not stamp lastFullListAt when a full list comes back empty", async () => {
+    // An empty full list is a provider non-answer, not an enumeration. Stamping
+    // here would mark the resource satisfied for a day on the one pass that
+    // reconciled nothing; leaving it unstamped means the sweep retries next tick.
+    const conn = connection();
+
+    await syncCalendarList(
+      deps(new FakeDiscovery([{ calendars: [], cursor: null }])),
+      conn,
+      now,
+    );
+
+    // Read raw, so the key is ABSENT rather than defaulted to null — `?? null`
+    // accepts either, since both mean "never fully listed" to the sweep's filter.
+    expect(
+      (await calendarListResource(conn))?.lastFullListAt ?? null,
+    ).toBeNull();
   });
 
   it("logs a warning naming the calendars a full pass retired", async () => {
@@ -635,6 +736,9 @@ describe("syncCalendarList", () => {
       (d) => d.providerCalendarId === "stale",
     );
     expect(stale?.active).toBe(false);
+    // And it counts as a full enumeration for the rediscovery clock — the
+    // fallback re-listed everything, so the sweep has nothing left to force.
+    expect((await calendarListResource(conn))?.lastFullListAt).toEqual(now());
   });
 
   it("throws on a non-cursor discovery failure so the worker retries", async () => {

--- a/packages/sync/src/domain/calendar-list-sync.service.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.ts
@@ -15,6 +15,12 @@ import { type JobRepository } from "@sync/storage/repositories/job.repository";
 import { type ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 
+// How long an unwatchable verdict must stand before a full pass gives that
+// calendar another watch attempt. Scopes the retry to the verdict rather than to
+// however often full passes run, which stopped being daily once a calendarList
+// push started forcing one.
+const WATCH_UNSUPPORTED_RETRY_AFTER_MS = 24 * 60 * 60_000;
+
 export interface CalendarListSyncDeps {
   calendars: ProviderCalendarRepository;
   resources: SyncResourceRepository;
@@ -55,6 +61,12 @@ export interface CalendarListSyncResult {
 // NOT mean removal — only a FULL pass retires calendars no longer listed. An
 // expired cursor drops to a full re-list rather than retrying a dead token; any
 // other discovery failure throws so the worker retries with backoff.
+//
+// A full pass stamps lastFullListAt, which is the ONLY clock the rediscovery
+// sweep selects on. It is not lastSuccessAt because incremental passes stamp
+// that too: the web client's focus refreshes kept it perpetually fresh for
+// active users, so they never aged into the sweep and the retirement pass never
+// ran for exactly the people with the most calendar churn (2026-08-27).
 export async function syncCalendarList(
   deps: CalendarListSyncDeps,
   connection: ProviderConnectionRecord,
@@ -147,24 +159,31 @@ export async function syncCalendarList(
   }
 
   // Only a full pass sees the complete set, so only then can a calendar's absence
-  // mean it was removed. An incremental pass reports removals as active:false
-  // entries (handled by the upsert above), so it must not retire the absent.
+  // mean it was removed. An incremental pass is BELIEVED to report a removal or a
+  // hide as an active:false entry (handled by the upsert above), so it must not
+  // retire the absent — but nothing in this repo can prove what Google actually
+  // returns for a hidden-flag flip, and the fake behind the adapter seam cannot
+  // observe it. The push path clears the cursor precisely so we re-enumerate
+  // instead of resting on that belief.
   //
   // Guard on a non-empty result: an account always has at least a primary
   // calendar, so a full list of zero is treated as a non-answer (a provider
   // hiccup that returned empty instead of throwing) rather than "all removed" —
   // retiring every calendar on an empty blip would be user-visible damage.
+  const appliedFullList = fullList && discovery.calendars.length > 0;
   let retiredIds: ProviderCalendarId[] = [];
-  if (fullList && discovery.calendars.length > 0) {
+  if (appliedFullList) {
     // A full pass is the retry cadence for unwatchable calendars: clear the
     // persisted watchUnsupportedAt verdicts so each gets one fresh watch
-    // attempt (the pull path re-marks any the provider still refuses). Runs
-    // daily via the rediscovery sweep — the pre-marker behavior was one
-    // futile watch attempt per pull, forever.
+    // attempt (the pull path re-marks any the provider still refuses). The
+    // age gate is what keeps that roughly daily now that a push also forces a
+    // full pass — without it, a user editing their calendar list repeatedly
+    // would burn a futile watch call per unwatchable calendar per edit.
     await deps.resources.clearWatchUnsupportedByConnection(
       tenantId,
       principalId,
       connectionId,
+      new Date(now().getTime() - WATCH_UNSUPPORTED_RETRY_AFTER_MS),
     );
     retiredIds = await deps.calendars.deactivateAbsent(
       tenantId,
@@ -239,6 +258,23 @@ export async function syncCalendarList(
     discovery.cursor,
     now(),
   );
+
+  // Advance the rediscovery sweep's staleness clock, but only for a pass that
+  // actually applied a complete enumeration. Stamped HERE rather than inside the
+  // appliedFullList block above so it means "a full pass persisted end to end" —
+  // stamping before the reconciliation would let a throw partway through suppress
+  // the sweep for a full day on a pass that never finished. An empty full list is
+  // deliberately left unstamped (it is a provider non-answer, see above), so the
+  // sweep retries it next tick; the lastAttemptAt-first sort is what keeps that
+  // retry from squatting.
+  if (appliedFullList) {
+    await deps.resources.markFullListCompleted(
+      tenantId,
+      principalId,
+      resource._id,
+      now(),
+    );
+  }
 
   // Retire the change this pass served — but only if nothing moved the marker
   // while the provider was being read. A failed match means a notification

--- a/packages/sync/src/server/notification.routes.db.test.ts
+++ b/packages/sync/src/server/notification.routes.db.test.ts
@@ -217,6 +217,115 @@ describe("POST /sync/notifications/google", () => {
     expect(await jobCount(`incrementalPull:${resource._id}`)).toBe(0);
   });
 
+  it("clears the calendar-list cursor so the resulting pass re-enumerates", async () => {
+    // A calendarList notification means the LIST itself changed. Listing
+    // incrementally from the stored cursor would rest on the (untested, and
+    // untestable from in here) assumption that Google reports a hidden-flag flip
+    // as a changed entry. Clearing the cursor re-enumerates instead, which is
+    // what makes a calendar hidden in Google leave the sidebar in seconds rather
+    // than waiting on the daily sweep.
+    const resource = await seedSubscription(
+      new Date(Date.now() + 60 * 60 * 1000),
+      TOKEN,
+      "calendarList",
+    );
+    await resources.advanceCursor(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+      "stored-token",
+      new Date(),
+    );
+    await startService();
+
+    await post(googHeaders());
+
+    const stored = await mongo.db
+      .collection(SYNC_COLLECTIONS.syncResources)
+      .findOne({ _id: resource._id });
+    expect(stored?.["syncCursor"]).toBeNull();
+    // Only the cursor: the sweep's staleness clock must not advance on the
+    // strength of a pass that has merely been scheduled. Read raw, so the key is
+    // absent rather than defaulted to null; both mean "never fully listed".
+    expect(stored?.["lastFullListAt"] ?? null).toBeNull();
+  });
+
+  it("does not clear the cursor for an events channel", async () => {
+    // Scoping guard. An events cursor clear would force a full re-import of
+    // every event on the calendar, which is enormously more expensive than the
+    // re-enumeration this buys on the calendarList side.
+    const resource = await seedSubscription();
+    await resources.advanceCursor(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+      "stored-token",
+      new Date(),
+    );
+    await startService();
+
+    await post(googHeaders());
+
+    const stored = await mongo.db
+      .collection(SYNC_COLLECTIONS.syncResources)
+      .findOne({ _id: resource._id });
+    expect(stored?.["syncCursor"]).toBe("stored-token");
+  });
+
+  it("does not clear the calendar-list cursor on a spoofed notification", async () => {
+    // Otherwise anyone who could guess a channel id could force unbounded full
+    // re-enumerations (~1 provider call per calendar each).
+    const resource = await seedSubscription(
+      new Date(Date.now() + 60 * 60 * 1000),
+      TOKEN,
+      "calendarList",
+    );
+    await resources.advanceCursor(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+      "stored-token",
+      new Date(),
+    );
+    await startService();
+
+    await post(googHeaders({ "x-goog-channel-token": "wrong" }));
+
+    const stored = await mongo.db
+      .collection(SYNC_COLLECTIONS.syncResources)
+      .findOne({ _id: resource._id });
+    expect(stored?.["syncCursor"]).toBe("stored-token");
+  });
+
+  it("clears the calendar-list cursor even when a sync job already exists", async () => {
+    // The enqueue no-ops against an already-pending (or claimed) job on this
+    // connection's coalescing key. The cursor clear is what still lands, and
+    // whichever job ultimately runs reads it fresh — the same reasoning the
+    // rediscovery sweep relies on.
+    const resource = await seedSubscription(
+      new Date(Date.now() + 60 * 60 * 1000),
+      TOKEN,
+      "calendarList",
+    );
+    await resources.advanceCursor(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+      "stored-token",
+      new Date(),
+    );
+    await startService();
+
+    await post(googHeaders());
+    await post(googHeaders()); // duplicate delivery, coalesces
+
+    expect(await jobCount(`calendarListSync:${resource.connectionId}`)).toBe(1);
+    const stored = await mongo.db
+      .collection(SYNC_COLLECTIONS.syncResources)
+      .findOne({ _id: resource._id });
+    expect(stored?.["syncCursor"]).toBeNull();
+  });
+
   it("accepts and drops notifications in passive mode", async () => {
     const { _id: resourceId } = await seedSubscription();
     await startService(testConfig({ EXECUTION: "passive" }));

--- a/packages/sync/src/server/notification.routes.ts
+++ b/packages/sync/src/server/notification.routes.ts
@@ -82,6 +82,24 @@ export function registerNotificationRoutes(
       // Only an authentic change schedules work. Coalescing on the resource
       // collapses duplicate deliveries of the same change into one job.
       if (verdict.status === "process" && resource) {
+        // A calendarList notification means the LIST itself changed, so make the
+        // resulting pass re-enumerate instead of listing incrementally from the
+        // stored cursor. Clearing the cursor is the one existing mechanism for
+        // that (syncCalendarList reads it fresh at execution time), so this works
+        // whether the pass comes from the enqueue below or from a job that
+        // already coalesced on this connection's key.
+        //
+        // Scoped to calendarList: clearing an events cursor would force a full
+        // re-import. Done first because its failure mode is the harmless one — a
+        // cleared cursor with no job just means the next pass runs full, whereas
+        // a stamped marker with no clear would strand the change on the sweep.
+        if (resource.resourceKind === "calendarList") {
+          await resources.clearSyncCursor(
+            resource.tenantId,
+            resource.principalId,
+            resource._id,
+          );
+        }
         // Stamp BEFORE enqueuing. The enqueue below no-ops whenever a job
         // already holds this coalescing key — including the CLAIMED row of a
         // job already in flight, which may have read the provider before this

--- a/packages/sync/src/storage/contracts/sync-resource.contracts.ts
+++ b/packages/sync/src/storage/contracts/sync-resource.contracts.ts
@@ -58,6 +58,25 @@ export const SyncResourceRecordSchema = z.strictObject({
   activeGeneration: z.number().int().min(0).default(0),
   lastAttemptAt: z.date().nullable(),
   lastSuccessAt: z.date().nullable(),
+  // calendarList only: when a pass last applied a COMPLETE enumeration — a full
+  // list that returned at least one calendar, persisted end to end. This is the
+  // staleness clock the rediscovery sweep selects on.
+  //
+  // Deliberately NOT lastSuccessAt, which advanceCursor stamps on every pass,
+  // incremental ones included. The web client refreshes on each page load and
+  // each alt-tab-back after 30s, and every one of those enqueues an incremental
+  // calendarList pass — so an active user's lastSuccessAt never aged past the
+  // sweep's 24h threshold, they never became eligible, and the full pass that
+  // retires hidden/removed calendars never ran for them. Using the app disabled
+  // its own repair: the 64 connections that self-healed after #2876 were the
+  // IDLE ones (2026-08-27).
+  //
+  // Null (or absent — Mongo's null predicate matches missing) means "never
+  // fully listed", which sorts as maximally stale. That is what makes this
+  // field self-backfilling: every pre-existing row is eligible on deploy.
+  // Defaults tolerate rows written before the field — REQUIRED, see
+  // watchUnsupportedAt below.
+  lastFullListAt: z.date().nullable().default(null),
   // Set when the provider durably rejects reads for this resource (a
   // non-transient 4xx retries cannot fix — see the readFailed settlement for
   // events resources and the discoveryFailed settlement for calendarList in

--- a/packages/sync/src/storage/repositories/sync-resource.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.db.test.ts
@@ -347,6 +347,119 @@ describe("SyncResourceRepository", () => {
     expect(read?.syncCursor).toBeNull();
   });
 
+  it("stamps lastFullListAt without disturbing the other timing fields", async () => {
+    const resource = await repo.ensure(
+      upsert({ resourceKind: "calendarList" }),
+    );
+    const at = new Date("2026-08-27T12:00:00.000Z");
+
+    await repo.markFullListCompleted(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+      at,
+    );
+
+    const read = await repo.findById(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+    );
+    expect(read?.lastFullListAt).toEqual(at);
+    expect(read?.lastSuccessAt).toBeNull();
+    expect(read?.syncCursor).toBeNull();
+  });
+
+  it("does not stamp lastFullListAt when advancing the cursor", async () => {
+    // The regression guard for the whole starvation bug. advanceCursor runs on
+    // EVERY successful pass, incremental ones included; if it also moved the
+    // full-list clock, an active user's focus refreshes would keep that clock
+    // fresh and the rediscovery sweep could never select them (2026-08-27).
+    const resource = await repo.ensure(
+      upsert({ resourceKind: "calendarList" }),
+    );
+    const at = new Date("2026-08-27T12:00:00.000Z");
+
+    await repo.advanceCursor(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+      "incremental-token",
+      at,
+    );
+
+    const read = await repo.findById(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+    );
+    expect(read?.lastSuccessAt).toEqual(at);
+    expect(read?.lastFullListAt).toBeNull();
+  });
+
+  it("does not let another principal stamp lastFullListAt (tenant isolation)", async () => {
+    const resource = await repo.ensure(
+      upsert({ resourceKind: "calendarList" }),
+    );
+
+    await repo.markFullListCompleted(
+      resource.tenantId,
+      objectId() as SyncResourceUpsert["principalId"],
+      resource._id,
+      new Date("2026-08-27T12:00:00.000Z"),
+    );
+
+    const read = await repo.findById(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+    );
+    expect(read?.lastFullListAt).toBeNull();
+  });
+
+  it("clears an unwatchable verdict older than the retry window but leaves a fresh one", async () => {
+    // The age gate exists because a calendarList push now also forces a full
+    // pass: without it, every push would hand each unwatchable calendar another
+    // futile watch call, which is the pre-marker wart in a new costume.
+    const tenantId = objectId() as SyncResourceUpsert["tenantId"];
+    const principalId = objectId() as SyncResourceUpsert["principalId"];
+    const connectionId = objectId() as SyncResourceUpsert["connectionId"];
+    const stale = await repo.ensure(
+      upsert({ tenantId, principalId, connectionId }),
+    );
+    const fresh = await repo.ensure(
+      upsert({ tenantId, principalId, connectionId }),
+    );
+    await repo.markWatchUnsupported(
+      tenantId,
+      principalId,
+      stale._id,
+      new Date("2026-08-25T00:00:00.000Z"),
+    );
+    await repo.markWatchUnsupported(
+      tenantId,
+      principalId,
+      fresh._id,
+      new Date("2026-08-27T11:00:00.000Z"),
+    );
+
+    await repo.clearWatchUnsupportedByConnection(
+      tenantId,
+      principalId,
+      connectionId,
+      new Date("2026-08-26T12:00:00.000Z"),
+    );
+
+    expect(
+      (await repo.findById(tenantId, principalId, stale._id))
+        ?.watchUnsupportedAt,
+    ).toBeNull();
+    expect(
+      (await repo.findById(tenantId, principalId, fresh._id))
+        ?.watchUnsupportedAt,
+    ).toEqual(new Date("2026-08-27T11:00:00.000Z"));
+  });
+
   it("scopes findById to the owning principal", async () => {
     const resource = await repo.ensure(upsert());
     expect(

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -147,6 +147,21 @@ export class SyncResourceRepository {
     await this.#patch(tenantId, principalId, id, { lastAttemptAt: at });
   }
 
+  // Stamp the calendarList full-enumeration clock the rediscovery sweep selects
+  // on. Deliberately NOT folded into advanceCursor, which every resource kind
+  // calls on any successful pass: the whole point of this field is that it
+  // advances ONLY when a pass actually enumerated everything, so a flag
+  // threaded through advanceCursor would be hardcoded false at every other call
+  // site and one miswiring would silently restore the starvation bug.
+  async markFullListCompleted(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    id: string,
+    at: Date,
+  ): Promise<void> {
+    await this.#patch(tenantId, principalId, id, { lastFullListAt: at });
+  }
+
   // Save mid-batch page progress without moving the incremental cursor.
   async setPageCheckpoint(
     tenantId: TenantId,
@@ -317,21 +332,28 @@ export class SyncResourceRepository {
   }
 
   // Give every unwatchable-marked resource on a connection one fresh watch
-  // attempt. Called from the calendar-list FULL discovery pass, which the
-  // rediscovery sweep forces daily — so a calendar the provider starts
-  // supporting is retried at that cadence rather than never (or on every
-  // pull, which was the pre-marker wart).
+  // attempt — but only where the verdict is older than `olderThan`, so a
+  // calendar gets at most one retry per that interval.
+  //
+  // The age gate makes the retry cadence a property of the VERDICT rather than
+  // of however often full passes happen to run. It used to ride on the full
+  // pass being daily, which stopped being true once a calendarList push also
+  // forces one: without this, a user editing their calendar list N times a day
+  // would burn N futile watch calls per unwatchable calendar, re-marked each
+  // time — the pre-marker "one futile attempt per pull, forever" wart, back in
+  // a new form.
   async clearWatchUnsupportedByConnection(
     tenantId: TenantId,
     principalId: PrincipalId,
     connectionId: ConnectionId,
+    olderThan: Date,
   ): Promise<void> {
     await this.collection.updateMany(
       {
         tenantId,
         principalId,
         connectionId,
-        watchUnsupportedAt: { $ne: null },
+        watchUnsupportedAt: { $ne: null, $lt: olderThan },
       },
       { $set: { watchUnsupportedAt: null, updatedAt: new Date() } },
     );
@@ -624,15 +646,28 @@ export class SyncResourceRepository {
     return records.map((r) => SyncResourceRecordSchema.parse(r));
   }
 
-  // calendarList resources whose last successful discovery is older than
-  // `before` (or which never succeeded), rotated oldest-attempt-first, bounded.
-  // This is the calendar-list rediscovery sweep's input — the periodic re-run
-  // that catches a calendar deleted or unshared at the provider, since
-  // calendarListSync otherwise only ever runs once, at connect. Same GLOBAL
-  // scan + credential-exclusion shape as listStaleEvents, for the same reason
-  // (2026-07-29 dead-credential tie-break bias) - uses the resource_last_success
-  // / resource_last_attempt indexes, which already lead with resourceKind so no
-  // new index is needed for this kind.
+  // calendarList resources whose last FULL enumeration is older than `before`
+  // (or which never had one), rotated oldest-attempt-first, bounded. This is the
+  // calendar-list rediscovery sweep's input — the periodic re-run that catches a
+  // calendar deleted, hidden, or unshared at the provider, since calendarListSync
+  // otherwise only ever runs once, at connect.
+  //
+  // Selects on lastFullListAt, NOT lastSuccessAt: incremental passes stamp
+  // lastSuccessAt too, and an active user's focus refreshes kept it perpetually
+  // under the threshold, so they never became eligible and never got the full
+  // pass (2026-08-27 — see the field's comment).
+  //
+  // lastAttemptAt stays the PRIMARY sort key even though the filter moved.
+  // syncCalendarList stamps it before the token fetch can fail, so a connection
+  // whose full pass always throws rotates to the back after one attempt.
+  // Sorting on lastFullListAt first would leave such a row at null, re-winning
+  // the front of every cycle forever — the 2026-07-29 dead-credential tie-break
+  // bias in a new field.
+  //
+  // Same GLOBAL scan + credential-exclusion shape as listStaleEvents. Uses the
+  // resource_last_attempt index for the sort's lead key; lastFullListAt itself
+  // is filtered in memory, which is free at this collection's size and could not
+  // be index-served anyway (the sort runs after $lookup).
   async listStaleCalendarLists(
     before: Date,
     limit: number,
@@ -640,9 +675,9 @@ export class SyncResourceRepository {
     return this.#listForSweep(
       {
         resourceKind: "calendarList",
-        $or: [{ lastSuccessAt: { $lt: before } }, { lastSuccessAt: null }],
+        $or: [{ lastFullListAt: { $lt: before } }, { lastFullListAt: null }],
       },
-      { lastAttemptAt: 1, lastSuccessAt: 1 },
+      { lastAttemptAt: 1, lastFullListAt: 1 },
       limit,
     );
   }
@@ -650,10 +685,14 @@ export class SyncResourceRepository {
   // Clear the calendarList resource's incremental cursor so the next
   // calendarListSync pass — whichever job runs it, sweep-enqueued or otherwise
   // — goes full rather than incremental (syncCalendarList treats a null cursor
-  // as `fullList`). Deliberately leaves lastSuccessAt untouched: that field is
-  // the staleness key the rediscovery sweep sorts on, and touching it here
-  // would let a resource that hasn't actually re-synced yet win the front of
-  // every subsequent sweep cycle.
+  // as `fullList`). Two callers: the rediscovery sweep, and the calendarList
+  // push route (a notification means the list genuinely changed, so that pass
+  // should re-enumerate rather than trust incremental).
+  //
+  // Deliberately leaves the timing fields untouched: lastFullListAt is the
+  // staleness key the rediscovery sweep selects on, and stamping it here — before
+  // the pass it merely SCHEDULED has actually run — would mark the resource
+  // satisfied for a day on the strength of an intention.
   async clearSyncCursor(
     tenantId: TenantId,
     principalId: PrincipalId,


### PR DESCRIPTION
## Summary

Compass kept showing Google sub-calendars that no longer appear in Google's own left rail. [#2876](https://github.com/KeepSoftwareSimple/compass-calendar/pull/2876) fixed the mapping rule (hidden → inactive), but that rule only ever *applies* on a FULL calendar-list pass, and active users structurally never got one.

Only the `calendarListRediscovery` sweep forces a full pass, and it selected resources whose `lastSuccessAt` was older than 24h. But `advanceCursor` stamps `lastSuccessAt` on **every** pass, incremental included — and the web client fires a refresh on every page load and every alt-tab-back after 30s (`useSyncFocusRefresh`), each one an incremental calendarList pass.

**So opening the app reset the very clock that gated the repair.** Anyone using Compass daily could never age past the threshold. Confirmed against production: after #2876 deployed, 64 *idle* connections got full lists and 100 calendars correctly went inactive, while the reporting user's two *active* connections had had no full pass in 47h and still showed stale rows.

Three changes:

- **`lastFullListAt`** — a clock stamped only when a pass actually applied a complete enumeration, persisted end to end. `listStaleCalendarLists` selects on it instead of `lastSuccessAt`. `lastAttemptAt` stays the *primary* sort key so a connection whose full pass always fails rotates to the back instead of squatting at the head of every cycle (the 2026-07-29 dead-credential pathology).
- **Full-list on push** — a calendarList notification means the list genuinely changed, so the route clears the cursor and that pass re-enumerates. Scoped to `calendarList`; clearing an events cursor would force a full re-import.
- **Age-gated watch retry** — `clearWatchUnsupportedByConnection` gains an `olderThan` window. It previously relied on full passes being daily; the change above makes them per-push, which would otherwise hand every unwatchable calendar a futile watch call per edit. The retry cadence is now a property of the verdict rather than of however often full passes happen to run.

**No migration.** The field defaults to `null`, and Mongo's null predicate matches missing keys, so every existing row is sweep-eligible on deploy. Production has 69 credentialed calendarList resources and a sweep limit of 100, so the backfill drains in a single ~10-minute tick.

## Simplicity

No new sweep, no new index, no repair script, no change to the 24h window or the 10-minute tick. The fix is one field, one filter, one stamp site, plus reusing the single existing mechanism for forcing a full pass (clear the cursor) from a second caller.

`markFullListCompleted` is deliberately kept out of `advanceCursor`: that method is the shared success stamp for every resource kind, so a `fullList` flag would be hardcoded `false` at every other call site and one miswiring would silently restore this bug. Same reasoning the codebase already records for `clearCursorExpiry`.

No index was added. Both `resource_last_success` and `resource_last_attempt` already lead with `resourceKind`, and the sort runs after `$lookup` so it could not be index-served regardless.

## Automated validation

Read-only production queries (MongoDB MCP) established the bug and sized the backfill:

- Reporting user's `provider_calendars` all stamped `2026-08-25T15:43` — before the #2876 deploy at 22:25 — while their calendarList resources succeeded at `2026-08-27T03:20`. `upsertByProviderCalendar` bumps `updatedAt` unconditionally, so those passes were provably incremental.
- Both resources succeeded within 250ms of each other, matching the per-principal fan-out in `refreshPrincipalCalendars`, not two independent push events.
- Fleet: 40 live connections had gone 7+ days without a full list, one at 32 days.
- Backfill scope: 69 credentialed calendarList resources, 743 credential-less (excluded by the sweep's own `$lookup`), **0** already carrying `lastFullListAt`.

## Independent review

Independent `code-reviewer` pass over `git diff origin/main...HEAD`, given the change's intent and asked to challenge six specific failure modes: squatting in the bounded sweep, unbounded `repeatWhileChanged` loops, strict-schema parse safety on pre-existing rows, cursor-clear scoping, stamp placement, and the age gate starving a retry.

Verdict: **no confirmed defects.** Squatting closed by the `lastAttemptAt`-first sort; loops bounded by `MAX_PULL_PASSES = 3`; schema safe via `.default(null)` and exercised by a test that `$unset`s the key rather than relying on a written null; cursor clear correctly gated to `calendarList`; no path found that stamps the clock on an incomplete pass or fails to stamp a genuine one; the gate throttles the watch retry to once per 24h per verdict without ever blocking it. No test found that would pass under broken production code.

## Test plan

```
bun run verify   # sync: test:sync, type-check, lint, knip — all passed (999 pass, 0 fail)
```

Ran on this branch's own base and again after rebasing onto current `origin/main`.

The two tests that encode the bug were confirmed to **fail** when `listStaleCalendarLists` is reverted to `lastSuccessAt`, and only those two:

```
(fail) re-discovers an active user whose incremental passes keep lastSuccessAt fresh
(fail) skips a resource whose full list is fresh even when lastSuccessAt is stale
 997 pass, 2 fail
```

New coverage: full-list clock stamped on a full pass / not on an incremental / not on an empty non-answer / stamped on the `cursorExpired` re-list; `advanceCursor` does not touch the clock; sweep selects a legacy row with the key absent; anti-squat rotation; cursor cleared on a calendarList push, not on events, not on a spoofed notification, and still cleared when a job already holds the coalescing key; watch verdict cleared when older than the window and left alone when fresh.

## Known limits

- **This will not clear already-stale calendars via the push path.** Production shows 61 of 68 calendarList channels have never received a push — almost certainly because people rarely change their calendar list, not because push is broken (7 have fired). The `lastFullListAt` backfill is what repairs existing rows.
- **The hidden-flip assumption stays unproven.** The code assumes an incremental pass reports a hide as an `active: false` entry; no test asserts it, and the adapter's test fake structurally cannot observe `showHidden`/`showDeleted`. The push-path cursor clear is the hedge — it re-enumerates rather than trusting it. Worth one manual confirmation against real Google post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
