### PR TITLE
Jump to events without first pressing S

### DIFF
--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -275,11 +275,11 @@ After deleting or moving an event, pressing Cmd+Z (Mac) or Ctrl+Z (Windows/Linux
 
 ---
 
-## Scenario 12: Tap S To Jump Focus To An Event By Day Prefix
+## Scenario 12: Jump Focus To An Event By Day Prefix
 
 ### UX
 
-Pressing `S` shows event-jump chips. Week view chips use day prefixes (`SU`/`M`/`T`/`W`/`R`/`F`/`SA`) plus a per-day index (`W4`, `SU1`). Day view uses numeric chips (`1`, `2`, …). Pressing a day letter highlights that column and focuses its first event; a following digit focuses that index. `Esc` exits (in day view a second `S` also toggles off). Bare Shift and Shift+Tab do not show jump chips.
+Pressing `S` shows event-jump chips. Week view chips use day prefixes (`SU`/`M`/`T`/`W`/`R`/`F`/`SA`) plus a per-day index (`W4`, `SU1`). Day view uses numeric chips (`1`, `2`, …). Pressing a day letter highlights that column and focuses its first event; a following digit focuses that index. Memorized tokens (`W`, `W2`, day-view `1`) also work without first pressing `S`, except where a competing command still applies: bare `T` stays “go to today”, focused `M` stays “open event menu”, and `F` stays “focus latest notice” while a notice is visible. `Esc` exits (in day view a second `S` also toggles off). Bare Shift and Shift+Tab do not show jump chips.
 
 ### Steps
 
@@ -287,15 +287,18 @@ Pressing `S` shows event-jump chips. Week view chips use day prefixes (`SU`/`M`/
 2. Press `S` once; chips should appear.
 3. Press the day letter on a chip (for example `W` for Wednesday), then optionally a digit (`2`) or use arrow keys.
 4. Press `Esc` to exit.
-5. Press Shift alone or Shift+Tab and confirm jump mode does not activate.
+5. Without pressing `S`, type a claimable day token (for example `W` or `W2`) and confirm the matching event is focused.
+6. Press Shift alone or Shift+Tab and confirm jump mode does not activate.
 
 ### Expected Results
 
 - Chips appear on events currently visible in the grid when `S` is pressed and stay until Esc. Scrolled-off events keep their jump keys but hide their chips.
 - A day letter highlights that column and focuses the first event; digits refine to `Wn`.
+- The same day letter / digit tokens work without a prior `S` when no competing command applies; `S` remains available to reveal every chip.
+- Bare `T` still goes to today while jump is off. With an event focused, `M` still opens the event menu. With a visible notice, `F` still focuses that notice.
 - Arrow keys keep jump mode on so letter-then-arrows works.
 - Shift alone / Shift+Tab / Shift+J do not toggle jump mode.
-- While a modal holds the app lock, or focus is in an editable field, `S` does not toggle jump mode.
+- While a modal holds the app lock, or focus is in an editable field, `S` and leaderless jump tokens do not activate jump mode.
 
 ---
 
@@ -413,7 +416,7 @@ If time is limited, run these checks before shipping shortcut-related changes:
 12. With no event focused and no particular control focused (document body), any Arrow key focuses the timed event nearest now in the current Day/Week view (in-progress, else next upcoming, else most recently ended; today preferred in Week; all-day only if no timed events). Further arrows then follow the existing rules. `U` still focuses the first DOM-order event. With a focused event and no draft open: in Week view ArrowUp/ArrowDown stay on the same day and ArrowLeft/Right jump to the time-nearest event on the previous/next non-empty day; in Day view all four arrows move chronological focus.
 13. Cmd+D / Ctrl+D duplicates a focused event in Day and Week view.
 14. With a focused event, `E` then `T` opens the form with the title focused; `E` then `A` / `C` jump to account / color; bare `E` alone does nothing.
-15. Pressing `S` shows event jump chips; a day letter + digit focuses that event; Shift+Tab does not show chips.
+15. Pressing `S` shows event jump chips; a day letter + digit focuses that event; the same tokens work without a prior `S` when no competing command applies; Shift+Tab does not show chips.
 16. Mouse clicks, right-clicks, and double-clicks are inert everywhere; a blocked click shows the keyboard-only hint. `M` opens the focused event's menu; `F` focuses the newest notice.
 17. PageUp / PageDown scroll the timed grid by one viewport in Day and Week view even when an event is focused; they do not fire in a text input.
 18. Alt+ArrowUp / Alt+ArrowDown pan the timed grid by one hour in Day and Week view even when an event is focused; they do not fire in a text input.

--- a/e2e/timed/shift-hold-event-hints.spec.ts
+++ b/e2e/timed/shift-hold-event-hints.spec.ts
@@ -125,6 +125,34 @@ test("tap s shows day-prefix jump keys and focuses the assigned event", async ({
   await expect(shiftHintOverlay(page)).toHaveCount(0);
 });
 
+test("day prefix focuses an event without first pressing s", async ({
+  page,
+}) => {
+  await prepareCalendarPage(page);
+
+  const title = createEventTitle("Leaderless Jump");
+  await createTimedEventOffsetBy(page, title, 0);
+  await blurActive(page);
+
+  const [saved] = await getSavedEventsByTitle(page, title);
+  const weekday = new Date(saved.startDate).getDay();
+  const key = weekday === 3 ? "w" : weekday === 4 ? "r" : null;
+  if (!key) {
+    test.skip(
+      true,
+      "leaderless e2e uses Wednesday/Thursday prefixes; other days are covered by unit tests",
+    );
+    return;
+  }
+
+  await page.keyboard.press(key);
+
+  await expect(
+    page.locator("#mainGrid").getByRole("button", { name: title }),
+  ).toBeFocused();
+  await expect(shiftHintOverlay(page)).toHaveCount(1);
+});
+
 test("Shift+Tab does not toggle event jump keys", async ({ page }) => {
   await prepareCalendarPage(page);
 

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx
@@ -13,6 +13,7 @@ import {
   resetEditSequenceArm,
   useEditSequenceShortcut,
 } from "@web/shortcuts/useEditSequenceShortcut";
+import { WEEK_INTERACTION_EVENT_ID_ATTRIBUTE } from "@web/views/Week/interaction/registry/week-event.registry";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const EVENT_A = EventIdSchema.parse("aaaaaaaaaaaaaaaaaaaaaaaa");
@@ -65,9 +66,18 @@ describe("useShiftHoldEventHints", () => {
     document.body.innerHTML = "";
   });
 
-  const mountHints = (mode: "week" | "day" = "week") => {
+  const mountHints = (
+    mode: "week" | "day" = "week",
+    timedEvents?: GridEvent[],
+  ) => {
     const focus = mock((_target: { eventId: string }) => {});
-    const elements = [EVENT_A, EVENT_B, EVENT_C].map((id) => {
+    const events = timedEvents ?? [
+      timedFixture(EVENT_A, "2026-08-05T09:00:00.000Z"),
+      timedFixture(EVENT_B, "2026-08-05T11:00:00.000Z"),
+      timedFixture(EVENT_C, "2026-08-06T13:00:00.000Z"),
+    ];
+    const ids = events.map((event) => event._id as string);
+    const elements = ids.map((id) => {
       const el = document.createElement("button");
       el.textContent = id;
       el.getBoundingClientRect = () =>
@@ -86,27 +96,21 @@ describe("useShiftHoldEventHints", () => {
       return el;
     });
 
-    // Wednesday / Thursday / Friday so prefixes are W / R / F.
-    const timedEvents = [
-      timedFixture(EVENT_A, "2026-08-05T09:00:00.000Z"),
-      timedFixture(EVENT_B, "2026-08-05T11:00:00.000Z"),
-      timedFixture(EVENT_C, "2026-08-06T13:00:00.000Z"),
-    ];
-
     const { result } = renderHook(() =>
       useShiftHoldEventHints({
         focus: (target) => focus(target),
-        listVisible: () => [
-          { eventId: EVENT_A, eventType: "timed", element: elements[0]! },
-          { eventId: EVENT_B, eventType: "timed", element: elements[1]! },
-          { eventId: EVENT_C, eventType: "timed", element: elements[2]! },
-        ],
+        listVisible: () =>
+          ids.map((id, index) => ({
+            eventId: id,
+            eventType: "timed" as const,
+            element: elements[index]!,
+          })),
         mode,
-        timedEvents,
+        timedEvents: events,
       }),
     );
 
-    return { focus, result, elements };
+    return { focus, result, elements, ids };
   };
 
   it("toggles hints on s and focuses via day prefix", () => {
@@ -142,6 +146,243 @@ describe("useShiftHoldEventHints", () => {
       expect.objectContaining({ eventId: EVENT_B, element: elements[1] }),
     );
     expect(useEventJumpStore.getState().isActive).toBe(true);
+  });
+
+  it("focuses a day prefix without first pressing s", () => {
+    const { focus, result, elements } = mountHints();
+
+    const event = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      key: "w",
+    });
+    act(() => {
+      document.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(useEventJumpStore.getState().isActive).toBe(true);
+    expect(focus).toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: EVENT_A, element: elements[0] }),
+    );
+    expect(useEventJumpStore.getState().activeDayKeys).toEqual(["2026-08-05"]);
+    expect(result.current.hints.map((hint) => hint.hint)).toEqual(["w1", "w2"]);
+  });
+
+  it("refines a leaderless day prefix with a following digit", () => {
+    const { focus, elements } = mountHints();
+
+    act(() => {
+      dispatch("keydown", "w");
+      dispatch("keydown", "2");
+    });
+
+    expect(focus).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ eventId: EVENT_A, element: elements[0] }),
+    );
+    expect(focus).toHaveBeenLastCalledWith(
+      expect.objectContaining({ eventId: EVENT_B, element: elements[1] }),
+    );
+    expect(useEventJumpStore.getState().isActive).toBe(true);
+  });
+
+  it("does not claim a day letter with no events that day", () => {
+    const { focus, result } = mountHints("week", [
+      timedFixture(EVENT_C, "2026-08-06T13:00:00.000Z"),
+    ]);
+
+    const event = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      key: "w",
+    });
+    act(() => {
+      document.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(useEventJumpStore.getState().isActive).toBe(false);
+    expect(focus).not.toHaveBeenCalled();
+    expect(result.current.hints).toEqual([]);
+  });
+
+  it("focuses a day-view index without first pressing s", () => {
+    const { focus, elements } = mountHints("day");
+
+    act(() => {
+      dispatch("keydown", "1");
+    });
+
+    expect(useEventJumpStore.getState().isActive).toBe(true);
+    expect(focus).toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: EVENT_A, element: elements[0] }),
+    );
+  });
+
+  it("does not claim t while jump is off so today still works", () => {
+    const { focus } = mountHints("week", [
+      timedFixture(EVENT_A, "2026-08-04T09:00:00.000Z"),
+    ]);
+
+    const event = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      key: "t",
+    });
+    act(() => {
+      document.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(useEventJumpStore.getState().isActive).toBe(false);
+    expect(focus).not.toHaveBeenCalled();
+  });
+
+  it("does not claim m while a calendar event is focused", () => {
+    const { focus, elements } = mountHints("week", [
+      timedFixture(EVENT_A, "2026-08-03T09:00:00.000Z"),
+    ]);
+    elements[0]!.setAttribute(WEEK_INTERACTION_EVENT_ID_ATTRIBUTE, EVENT_A);
+    elements[0]!.focus();
+
+    const event = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      key: "m",
+    });
+    act(() => {
+      document.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(useEventJumpStore.getState().isActive).toBe(false);
+    expect(focus).not.toHaveBeenCalled();
+  });
+
+  it("claims m when no calendar event is focused", () => {
+    const { focus, elements } = mountHints("week", [
+      timedFixture(EVENT_A, "2026-08-03T09:00:00.000Z"),
+    ]);
+
+    act(() => {
+      dispatch("keydown", "m");
+    });
+
+    expect(useEventJumpStore.getState().isActive).toBe(true);
+    expect(focus).toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: EVENT_A, element: elements[0] }),
+    );
+  });
+
+  it("does not claim f while a notice is visible", () => {
+    const { focus } = mountHints("week", [
+      timedFixture(EVENT_A, "2026-08-07T09:00:00.000Z"),
+    ]);
+    const notice = document.createElement("div");
+    notice.setAttribute("data-notice", "");
+    const button = document.createElement("button");
+    button.textContent = "Sign up";
+    notice.appendChild(button);
+    document.body.appendChild(notice);
+
+    const event = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      key: "f",
+    });
+    act(() => {
+      document.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(useEventJumpStore.getState().isActive).toBe(false);
+    expect(focus).not.toHaveBeenCalled();
+  });
+
+  it("claims f when no notice is visible", () => {
+    const { focus, elements } = mountHints("week", [
+      timedFixture(EVENT_A, "2026-08-07T09:00:00.000Z"),
+    ]);
+
+    act(() => {
+      dispatch("keydown", "f");
+    });
+
+    expect(useEventJumpStore.getState().isActive).toBe(true);
+    expect(focus).toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: EVENT_A, element: elements[0] }),
+    );
+  });
+
+  it("does not claim a leaderless jump while typing", () => {
+    const { focus } = mountHints();
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    act(() => {
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          key: "w",
+        }),
+      );
+    });
+
+    expect(useEventJumpStore.getState().isActive).toBe(false);
+    expect(focus).not.toHaveBeenCalled();
+  });
+
+  it("does not claim a leaderless jump while app-locked", () => {
+    setAppLockReason("test-modal", true);
+    const { focus } = mountHints();
+
+    act(() => {
+      dispatch("keydown", "w");
+    });
+
+    expect(useEventJumpStore.getState().isActive).toBe(false);
+    expect(focus).not.toHaveBeenCalled();
+  });
+
+  it("does not claim a mapped e-sequence key while the sequence is armed", () => {
+    const onSequence = mock(() => {});
+    renderHook(() => useEditSequenceShortcut({ onSequence }));
+    const { focus } = mountHints();
+
+    act(() => {
+      dispatch("keydown", "e");
+      dispatch("keydown", "r");
+    });
+
+    expect(onSequence).toHaveBeenCalledWith("recurrence");
+    expect(useEventJumpStore.getState().isActive).toBe(false);
+    expect(focus).not.toHaveBeenCalled();
+  });
+
+  it("does not claim unmatched letters while jump is off", () => {
+    mountHints();
+
+    const event = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      key: "c",
+    });
+    act(() => {
+      document.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(useEventJumpStore.getState().isActive).toBe(false);
   });
 
   it("turns a blocked event click into a directly usable event sequence", () => {

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
@@ -2,8 +2,10 @@ import { useEffect, useRef, useState } from "react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
+import { getCalendarEventIdFromElement } from "@web/common/utils/event/event.util";
 import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
 import { isAppLocked } from "@web/shortcuts/app-lock";
+import { EVENT_MENU_LETTER } from "@web/shortcuts/context-menu/useEventContextMenuShortcut";
 import { isHigherEscapeOwner } from "@web/shortcuts/escape-ownership";
 import {
   isBareLetterKey,
@@ -16,9 +18,15 @@ import {
 } from "@web/shortcuts/keyboard-only/pointer-action";
 import { KEYMAP } from "@web/shortcuts/keymap";
 import {
+  findNextNoticeTarget,
+  getVisibleNotices,
+} from "@web/shortcuts/notice-focus/notice-focus";
+import { FOCUS_NOTICE_LETTER } from "@web/shortcuts/notice-focus/useFocusNoticeShortcut";
+import {
   assignDayJumpKeys,
   type DayJumpAssignment,
   type DayJumpLabelMode,
+  type DayJumpMatchResult,
   DIGIT_AMBIGUOUS_COMMIT_MS,
   filterHintsByPrefix,
   matchDayJumpKeystroke,
@@ -51,6 +59,41 @@ const DAY_NAME_BY_PREFIX: Record<string, string> = {
   r: "Thursday",
   f: "Friday",
   sa: "Saturday",
+};
+
+/** Bare `t` stays "go to today" while jump is off. */
+const TODAY_LETTER = "t";
+
+/**
+ * Competing single-letter commands that still apply while jump is off.
+ * `t` always wins (today). `f` / `m` win only when their action has a target.
+ */
+const competingShortcutApplies = (key: string): boolean => {
+  if (key === TODAY_LETTER) return true;
+  if (key === FOCUS_NOTICE_LETTER) {
+    return (
+      findNextNoticeTarget(getVisibleNotices(), document.activeElement) !== null
+    );
+  }
+  if (key === EVENT_MENU_LETTER) {
+    const active = document.activeElement;
+    return (
+      active instanceof HTMLElement &&
+      getCalendarEventIdFromElement(active) !== null
+    );
+  }
+  return false;
+};
+
+const isUnmodifiedSingleChar = (event: KeyboardEvent) => {
+  const key = keyboardKey(event);
+  return (
+    key.length === 1 &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.altKey &&
+    !event.shiftKey
+  );
 };
 
 const FALLBACK_SCHEDULE = {
@@ -118,9 +161,11 @@ const buildDayJumpAssignments = (
 };
 
 /**
- * Press `s` to show day-prefix jump labels. Esc exits. Day letters (and digits
- * after a day) win over global shortcuts while active. In day view, a second
- * `s` toggles off; in week view `s` keeps Sunday/Saturday prefix meaning.
+ * Press `s` to show day-prefix jump labels, or type a jump token (`w`, `w1`,
+ * day-view `1`…) without `s` when no competing command still applies. Esc
+ * exits. Day letters (and digits after a day) win over global shortcuts while
+ * active. In day view, a second `s` toggles off; in week view `s` keeps
+ * Sunday/Saturday prefix meaning.
  */
 export function useShiftHoldEventHints({
   allDayEvents = [],
@@ -257,75 +302,7 @@ export function useShiftHoldEventHints({
       }, DIGIT_AMBIGUOUS_COMMIT_MS);
     };
 
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.defaultPrevented) return;
-
-      if (!isActiveRef.current) {
-        if (!isBareLetterKey(event, KEYMAP.eventJump.bareLetter)) return;
-        if (isAppLocked() || isEditableKeyboardTarget(event)) return;
-        if (isEditSequenceArmed()) return;
-
-        event.preventDefault();
-        event.stopPropagation();
-        activate();
-        if (isActiveRef.current) {
-          suppressKeyUpRef.current.add("s");
-        }
-        return;
-      }
-
-      if (isAppLocked() || isEditableKeyboardTarget(event)) {
-        deactivate();
-        return;
-      }
-
-      if (event.key === "Escape") {
-        if (isHigherEscapeOwner()) return;
-        event.preventDefault();
-        event.stopPropagation();
-        deactivate();
-        return;
-      }
-
-      // Arrows keep mode on so letter-then-arrows can move focus.
-      if (keyboardKey(event).startsWith("Arrow")) {
-        clearAmbiguousCommitTimer();
-        stripDigitBuffer();
-        return;
-      }
-
-      if (event.metaKey || event.ctrlKey || event.altKey) {
-        return;
-      }
-
-      const key = normalizedKeyboardKey(event);
-      if (key.length !== 1) return;
-
-      // Swallow j/k and other unmatched printable shortcuts while jump is on.
-      const match = matchDayJumpKeystroke({
-        assignments: assignmentsRef.current,
-        key,
-        buffer: bufferRef.current,
-        mode: modeRef.current,
-      });
-
-      if (!match) {
-        clearAmbiguousCommitTimer();
-        stripDigitBuffer();
-        event.preventDefault();
-        event.stopPropagation();
-        suppressKeyUpRef.current.add(key);
-        // Day view has no letter prefixes; a second `s` toggles off.
-        if (modeRef.current === "day" && key === "s") {
-          deactivate();
-        }
-        return;
-      }
-
-      event.preventDefault();
-      event.stopPropagation();
-      suppressKeyUpRef.current.add(key);
-
+    const applyMatch = (match: NonNullable<DayJumpMatchResult>) => {
       if (match.kind === "prefix") {
         bufferRef.current = match.buffer;
         eventJumpActions.setActiveDayKeys(
@@ -384,6 +361,99 @@ export function useShiftHoldEventHints({
       }
 
       commitFocus(match.eventId, match.dayKey, match.buffer);
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+
+      if (!isActiveRef.current) {
+        if (isAppLocked() || isEditableKeyboardTarget(event)) return;
+        if (isEditSequenceArmed()) return;
+        if (!isUnmodifiedSingleChar(event)) return;
+
+        if (isBareLetterKey(event, KEYMAP.eventJump.bareLetter)) {
+          event.preventDefault();
+          event.stopPropagation();
+          activate();
+          if (isActiveRef.current) {
+            suppressKeyUpRef.current.add("s");
+          }
+          return;
+        }
+
+        const key = normalizedKeyboardKey(event);
+        const assignments = rebuildAssignments();
+        if (assignments.length === 0) return;
+
+        const match = matchDayJumpKeystroke({
+          assignments,
+          key,
+          buffer: "",
+          mode: modeRef.current,
+        });
+        if (!match || competingShortcutApplies(key)) return;
+
+        event.preventDefault();
+        event.stopPropagation();
+        activate();
+        if (!isActiveRef.current) return;
+        suppressKeyUpRef.current.add(key);
+        applyMatch(match);
+        return;
+      }
+
+      if (isAppLocked() || isEditableKeyboardTarget(event)) {
+        deactivate();
+        return;
+      }
+
+      if (event.key === "Escape") {
+        if (isHigherEscapeOwner()) return;
+        event.preventDefault();
+        event.stopPropagation();
+        deactivate();
+        return;
+      }
+
+      // Arrows keep mode on so letter-then-arrows can move focus.
+      if (keyboardKey(event).startsWith("Arrow")) {
+        clearAmbiguousCommitTimer();
+        stripDigitBuffer();
+        return;
+      }
+
+      if (event.metaKey || event.ctrlKey || event.altKey) {
+        return;
+      }
+
+      const key = normalizedKeyboardKey(event);
+      if (key.length !== 1) return;
+
+      // Swallow j/k and other unmatched printable shortcuts while jump is on.
+      const match = matchDayJumpKeystroke({
+        assignments: assignmentsRef.current,
+        key,
+        buffer: bufferRef.current,
+        mode: modeRef.current,
+      });
+
+      if (!match) {
+        clearAmbiguousCommitTimer();
+        stripDigitBuffer();
+        event.preventDefault();
+        event.stopPropagation();
+        suppressKeyUpRef.current.add(key);
+        // Day view has no letter prefixes; a second `s` toggles off.
+        if (modeRef.current === "day" && key === "s") {
+          deactivate();
+        }
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      suppressKeyUpRef.current.add(key);
+      applyMatch(match);
     };
 
     const onKeyUp = (event: KeyboardEvent) => {

--- a/packages/web/src/shortcuts/tips/shortcut-tips.data.test.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-tips.data.test.ts
@@ -30,7 +30,9 @@ describe("getHintPlainText", () => {
     expect(plainTextById["page-jump"]).toBe(
       `Hold ${mod} to see where you can jump`,
     );
-    expect(plainTextById["event-jump"]).toBe("Press S to show event keys");
+    expect(plainTextById["event-jump"]).toBe(
+      "Press S to show event keys, or a day key to jump",
+    );
     expect(plainTextById.nudge).toBe("Hold Shift and press an arrow to move");
     expect(plainTextById["command-palette"]).toBe(
       `Press ${mod}+K to open the command palette`,

--- a/packages/web/src/shortcuts/tips/shortcut-tips.data.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-tips.data.ts
@@ -89,7 +89,11 @@ export const SHORTCUT_HINTS: Record<ShortcutHintId, ShortcutHint> = {
   },
   "event-jump": {
     id: "event-jump",
-    parts: ["Press ", { key: eventJumpKey }, " to show event keys"],
+    parts: [
+      "Press ",
+      { key: eventJumpKey },
+      " to show event keys, or a day key to jump",
+    ],
   },
   nudge: {
     id: "nudge",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Memorized event-jump tokens (`W`, `W2`, day-view `1`, …) now focus the matching event without a prior `S`. `S` remains the optional reveal-all toggle.

While jump is off, a token is claimed only when it is a valid first keystroke **and** no competing command still applies:

- `T` stays go-to-today
- focused `M` stays open-event-menu
- `F` stays focus-notice when a notice is visible
- weekends still start with `S` (`SU` / `SA`)

After a leaderless hit, jump stays on until Esc (same as after `S`), so a following digit can refine the index.

## Simplicity

The matcher already treated a unique day letter as select-day. This change runs that matcher on the first keystroke and shares `applyMatch` with the existing `S`-then-letter path. Competing-command guards are small DOM checks (`t` always, `m`/`f` only when they have a target).

## Automated validation

- `bun run verify`: selected `test:web`, `type-check`, `lint`, `knip` — passed. Playwright was skipped until Chromium was installed.
- `bun test:web` on `useShiftHoldEventHints.test.tsx` plus tip/notice/menu/sidebar tests: pass
- `bunx playwright test e2e/timed/shift-hold-event-hints.spec.ts`: 4 passed, including leaderless `r` on Thursday
- Browser: created a Thursday event, pressed `R` with no prior `S`, event focused with `R1` chip; `S` still reveals; `T` does not enter jump mode

![Thursday event with R1 chip after pressing R without S](https://cursor.com/artifacts/c/art-7afb407c-4928-4d62-b8ba-a1324c00a17d)
<a href="https://cursor.com/agents/bc-5334b686-f7eb-4a4b-856f-7b2f32834c13/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fleaderless_r_jump_without_s.mp4"><img src="https://cursor.com/artifacts/c/art-fb06ff1d-3ce2-4df2-b15b-552b9a37f675" alt="leaderless_r_jump_without_s.mp4" /></a>

## Independent review

Not requested.

## Test plan

- `bun test:web packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx packages/web/src/shortcuts/tips/shortcut-tips.data.test.ts packages/web/src/shortcuts/notice-focus/useFocusNoticeShortcut.test.tsx packages/web/src/shortcuts/context-menu/useEventContextMenuShortcut.test.tsx packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx`
- `bun run verify`
- `bun run lint`
- `bunx playwright test e2e/timed/shift-hold-event-hints.spec.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5334b686-f7eb-4a4b-856f-7b2f32834c13?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5334b686-f7eb-4a4b-856f-7b2f32834c13&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

