### PR TITLE
feat(billing): add audit-stripe-config to catch Stripe drift

### DIFF
--- a/docs/features/billing.md
+++ b/docs/features/billing.md
@@ -89,6 +89,28 @@ register each jurisdiction under Tax > Registrations and set a product tax
 code, in test and live mode separately. Without a registration Stripe
 calculates zero tax rather than erroring, so a missing one is silent.
 
+## Checking Stripe config against the build
+
+```
+COMPASS_CONFIG_FILE=~/.compass/staging.compass.yaml bun run cli audit-stripe-config
+```
+
+Read-only; exits 1 on drift so it can gate a deploy. It compares the live
+Stripe account against `STRIPE_API_VERSION`, `HANDLED_TYPES`, and
+`STRIPE_WEBHOOK_PATH` -- the same constants the runtime reads, so there is no
+second list to keep in step.
+
+**A webhook endpoint's `api_version` is fixed at creation and cannot be
+updated.** An endpoint created in the Dashboard silently inherits whatever the
+account default is that day, which is how it drifts away from the version the
+SDK is pinned to. Realigning means creating a replacement endpoint, rotating
+`STRIPE_WEBHOOK_SECRET`, redeploying, and deleting the old one -- so let the
+audit tell you rather than finding out during a checkout.
+
+Note that Stripe Tax being inactive is a **checkout outage**, not a warning:
+`automatic_tax` is enabled on every session, and Stripe rejects session
+creation outright when Tax is not active.
+
 ## Key files
 
 - Plan/price copy: `packages/core/src/constants/billing.constants.ts`

--- a/packages/backend/src/billing/services/billing.webhook.service.ts
+++ b/packages/backend/src/billing/services/billing.webhook.service.ts
@@ -9,7 +9,12 @@ import mongoService from "@backend/common/services/mongo.service";
 
 const logger = Logger("app:billing.webhook");
 
-const HANDLED_TYPES = new Set<Stripe.Event.Type>([
+/**
+ * The only event types this handler acts on. Exported so
+ * `cli audit-stripe-config` can compare a live Stripe endpoint against the
+ * same source of truth the handler uses, rather than a second hand-kept list.
+ */
+export const HANDLED_TYPES = new Set<Stripe.Event.Type>([
   "checkout.session.completed",
   "customer.subscription.created",
   "customer.subscription.updated",

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -1,5 +1,6 @@
 import { CliValidator } from "@scripts/cli.validator";
 import { runAuditConnectionIdentity } from "@scripts/commands/audit-connection-identity";
+import { runAuditStripeConfig } from "@scripts/commands/audit-stripe-config";
 import { runBackfillBilling } from "@scripts/commands/backfill-billing";
 import { runManageFailedJobs } from "@scripts/commands/manage-failed-jobs";
 import { runPurgeUser } from "@scripts/commands/purge-user";
@@ -30,6 +31,9 @@ export default class CompassCLI {
         break;
       case cmd === "audit-connection-identity":
         await runAuditConnectionIdentity();
+        break;
+      case cmd === "audit-stripe-config":
+        await runAuditStripeConfig();
         break;
       default:
         this.validator.exitHelpfully(`${cmd as string} is not a supported cmd`);
@@ -63,6 +67,14 @@ export default class CompassCLI {
       .allowUnknownOption(true)
       .description(
         "Report connected Google accounts that are another Compass user's login identity (read-only)",
+      );
+
+    program
+      .command("audit-stripe-config")
+      .helpOption(false)
+      .allowUnknownOption(true)
+      .description(
+        "Check the live Stripe account against this build: webhook url/events/api_version, price, and Tax status (read-only, exits 1 on drift)",
       );
 
     program

--- a/packages/scripts/src/commands/audit-stripe-config.ts
+++ b/packages/scripts/src/commands/audit-stripe-config.ts
@@ -1,0 +1,138 @@
+import { Logger } from "@core/logger/winston.logger";
+import { STRIPE_WEBHOOK_PATH } from "@backend/billing/billing.constants";
+import { HANDLED_TYPES } from "@backend/billing/services/billing.webhook.service";
+import {
+  getStripeClient,
+  STRIPE_API_VERSION,
+} from "@backend/billing/services/stripe.client";
+import { CONFIG } from "@backend/common/constants/config.constants";
+import { isStripeConfigured } from "@backend/common/constants/config.util";
+
+const logger = Logger("scripts.commands.audit-stripe-config");
+
+/**
+ * Compares the live Stripe account against what this build expects, so
+ * drift is something you run one command to find instead of something you
+ * discover during a checkout.
+ *
+ * Every expectation reads the same constant the runtime reads --
+ * STRIPE_API_VERSION, HANDLED_TYPES, STRIPE_WEBHOOK_PATH -- so there is no
+ * second list to keep in step. Read-only. Exits 1 when anything is off so
+ * it can gate a deploy.
+ *
+ *   COMPASS_CONFIG_FILE=~/.compass/staging.compass.yaml bun run cli audit-stripe-config
+ */
+export async function runAuditStripeConfig(): Promise<void> {
+  const problems: string[] = [];
+  const report: Record<string, unknown> = {};
+
+  try {
+    if (!isStripeConfigured(CONFIG)) {
+      process.stdout.write(
+        `${JSON.stringify({ stripeConfigured: false, problems: ["Stripe is not configured for this environment"] }, null, 2)}\n`,
+      );
+      process.exit(1);
+    }
+
+    const stripe = getStripeClient();
+    // BASEURL is the api url (".../api") and STRIPE_WEBHOOK_PATH already
+    // carries its own "/api" prefix, so build from the origin.
+    const expectedUrl = `${new URL(CONFIG.BASEURL).origin}${STRIPE_WEBHOOK_PATH}`;
+    const expectedEvents = [...HANDLED_TYPES].sort();
+
+    const endpoints = await stripe.webhookEndpoints.list({ limit: 100 });
+    const mine = endpoints.data.filter((e) => e.url === expectedUrl);
+    report["expectedWebhookUrl"] = expectedUrl;
+    report["endpoints"] = mine.map((e) => ({
+      id: e.id,
+      status: e.status,
+      api_version: e.api_version,
+      enabled_events: e.enabled_events,
+    }));
+
+    if (mine.length === 0) {
+      problems.push(`No Stripe webhook endpoint points at ${expectedUrl}`);
+    }
+    if (mine.length > 1) {
+      problems.push(
+        `${mine.length} webhook endpoints point at ${expectedUrl}; only one should. Duplicates double-deliver and only one signing secret can be configured.`,
+      );
+    }
+
+    for (const endpoint of mine) {
+      if (endpoint.status !== "enabled") {
+        problems.push(`Endpoint ${endpoint.id} is ${endpoint.status}`);
+      }
+      if (endpoint.api_version !== STRIPE_API_VERSION) {
+        problems.push(
+          `Endpoint ${endpoint.id} delivers ${endpoint.api_version} but this build pins ${STRIPE_API_VERSION}. api_version cannot be updated in place -- recreate the endpoint and rotate STRIPE_WEBHOOK_SECRET.`,
+        );
+      }
+      const actual = [...(endpoint.enabled_events ?? [])].sort();
+      const missing = expectedEvents.filter((t) => !actual.includes(t));
+      const extra = actual.filter(
+        (t) => !expectedEvents.includes(t as (typeof expectedEvents)[number]),
+      );
+      if (missing.length) {
+        problems.push(
+          `Endpoint ${endpoint.id} is missing handled events: ${missing.join(", ")}`,
+        );
+      }
+      if (extra.length) {
+        problems.push(
+          `Endpoint ${endpoint.id} subscribes to events nothing handles: ${extra.join(", ")}`,
+        );
+      }
+    }
+
+    const price = await stripe.prices.retrieve(CONFIG.STRIPE_PRICE_ID!, {
+      expand: ["product"],
+    });
+    const product = price.product as { id: string; tax_code?: unknown };
+    report["price"] = {
+      id: price.id,
+      active: price.active,
+      unit_amount: price.unit_amount,
+      tax_behavior: price.tax_behavior,
+      product: product.id,
+      product_tax_code: product.tax_code ?? null,
+    };
+    if (!price.active) problems.push(`Price ${price.id} is inactive`);
+
+    const tax = await stripe.tax.settings.retrieve();
+    report["tax"] = {
+      status: tax.status,
+      missing_fields: tax.status_details?.pending?.missing_fields ?? null,
+    };
+    // automatic_tax is enabled on every Checkout Session, and Stripe rejects
+    // session creation outright when Tax is not active -- so this is a
+    // checkout outage, not a reporting nicety.
+    if (tax.status !== "active") {
+      problems.push(
+        `Stripe Tax is ${tax.status}; Checkout Session creation fails while automatic_tax is enabled. Missing: ${(tax.status_details?.pending?.missing_fields ?? []).join(", ") || "unknown"}`,
+      );
+    }
+    if (price.tax_behavior === "unspecified") {
+      problems.push(
+        `Price ${price.id} has tax_behavior "unspecified"; set it (immutable once set) so tax is not guessed from the account default`,
+      );
+    }
+    if (!product.tax_code) {
+      problems.push(
+        `Product ${product.id} has no tax_code; Stripe falls back to the account default category`,
+      );
+    }
+
+    report["problems"] = problems;
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    if (problems.length) {
+      logger.error(`audit-stripe-config found ${problems.length} problem(s)`);
+      process.exit(1);
+    }
+    logger.info("audit-stripe-config clean");
+    process.exit(0);
+  } catch (error) {
+    logger.error(error);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Why

A Stripe webhook endpoint's `api_version` is **fixed at creation and cannot be updated** — `-d api_version=...` is rejected as an unknown parameter. An endpoint created in the Dashboard silently inherits whatever the account default is that day, while the code pins its own version independently. Nothing connects the two, so they drift apart the moment Stripe ships a new version, and the symptom only appears if a payload shape you depend on changes.

Staging's endpoint was delivering `2026-07-29.dahlia` while the SDK pins `2025-08-27.basil` (stripe@18.5.0's `LatestApiVersion`, which has no knowledge of dahlia at all). Nothing surfaced that until it was looked for by hand.

## What

`bun run cli audit-stripe-config` — read-only, exits 1 on drift so it can gate a deploy:

- webhook endpoint exists at the expected URL, is enabled, and there is exactly one (duplicates double-deliver and only one signing secret can be configured)
- its `api_version` matches `STRIPE_API_VERSION`
- its `enabled_events` matches `HANDLED_TYPES` exactly, reporting both missing and unhandled-but-subscribed
- price active, `tax_behavior` set, product `tax_code` set
- Stripe Tax `status: active`

Every expectation imports the constant the runtime reads rather than restating it — `STRIPE_API_VERSION`, `HANDLED_TYPES`, `STRIPE_WEBHOOK_PATH`. `HANDLED_TYPES` is exported for this. A check with its own copy of the list is just a second thing to drift.

Stripe Tax being inactive is reported as a **checkout outage**, not a warning. Since `automatic_tax` shipped, Stripe rejects session creation outright when Tax is not active:

```
You must have a valid head office address to enable automatic tax
calculation in test mode.
```

## Verification

Both paths exercised against real Stripe:

```
staging (configured, aligned)  → "problems": []            exit 0
production (no Stripe keys)    → "Stripe is not configured" exit 1
```

`test:backend` 428 pass / 0 fail, `test:scripts` 70 pass / 0 fail, type-check and biome clean.

Staging's endpoint has since been recreated at `2025-08-27.basil` with `STRIPE_WEBHOOK_SECRET` rotated, and a genuine Stripe-signed event now returns `200 {"received":true}` end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
