### PR TITLE
feat(web): show guest RSVP status and jump with e a

### DIFF
--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -237,7 +237,7 @@ Pressing Delete while an event is focused in the Day or Week grid deletes it —
 
 ### UX
 
-With a grid event focused and no form field being typed in, pressing `E` then `T` within a short window opens that event's form (if needed) and places the caret in the title. The same `E`-prefix pattern targets description (`D`), start (`S`), end (`E`), recurrence (`R`), account (`A`), and color (`C`).
+With a grid event focused and no form field being typed in, pressing `E` then `T` within a short window opens that event's form (if needed) and places the caret in the title. The same `E`-prefix pattern targets description (`D`), start (`S`), end (`E`), recurrence (`R`), guests (`A`), and color (`C`). Account (calendar picker) is Mod+5 only.
 
 ### Steps
 
@@ -415,7 +415,7 @@ If time is limited, run these checks before shipping shortcut-related changes:
 11. Arrow keys reposition an open draft in both Day and Week view.
 12. With no event focused and no particular control focused (document body), any Arrow key focuses the timed event nearest now in the current Day/Week view (in-progress, else next upcoming, else most recently ended; today preferred in Week; all-day only if no timed events). Further arrows then follow the existing rules. `U` still focuses the first DOM-order event. With a focused event and no draft open: in Week view ArrowUp/ArrowDown stay on the same day and ArrowLeft/Right jump to the time-nearest event on the previous/next non-empty day; in Day view all four arrows move chronological focus.
 13. Cmd+D / Ctrl+D duplicates a focused event in Day and Week view.
-14. With a focused event, `E` then `T` opens the form with the title focused; `E` then `A` / `C` jump to account / color; bare `E` alone does nothing.
+14. With a focused event, `E` then `T` opens the form with the title focused; `E` then `A` / `C` jump to guests / color; bare `E` alone does nothing.
 15. Pressing `S` shows event jump chips; a day letter + digit focuses that event; the same tokens work without a prior `S` when no competing command applies; Shift+Tab does not show chips.
 16. Mouse clicks, right-clicks, and double-clicks are inert everywhere; a blocked click shows the keyboard-only hint. `M` opens the focused event's menu; `F` focuses the newest notice.
 17. PageUp / PageDown scroll the timed grid by one viewport in Day and Week view even when an event is focused; they do not fire in a text input.

--- a/docs/development/feature-file-map.md
+++ b/docs/development/feature-file-map.md
@@ -42,6 +42,7 @@ RSVP](../features/attendees.md).
 
 - Attendee/RSVP write contracts: `packages/core/src/types/event-command.contracts.ts`, `packages/core/src/types/event-attendance.contracts.ts`
 - Guest-list editor: `packages/web/src/views/Forms/EventForm/AttendeeField/AttendeeField.tsx`
+- RSVP status badge and tally: `packages/web/src/views/Forms/EventForm/AttendeeRsvpStatus.tsx`, `packages/web/src/views/Forms/EventForm/attendee-rsvp.ts`, `packages/web/src/views/Forms/EventForm/EventDetailsSection.tsx`
 - Save-time invitation prompt: `packages/web/src/views/Forms/EventForm/SendInvitationsDialog.tsx`, `packages/web/src/views/Forms/hooks/useSaveEventForm.ts`
 - RSVP control and scope dialog: `packages/web/src/views/Forms/EventForm/RsvpControl.tsx`, `packages/web/src/views/Forms/EventForm/RsvpScopeDialog.tsx`
 - Contact suggestions hook: `packages/web/src/views/Forms/EventForm/AttendeeField/useContactSuggestions.ts`

--- a/docs/features/attendees.md
+++ b/docs/features/attendees.md
@@ -75,6 +75,16 @@ Source: `packages/core/src/types/event-command.contracts.ts`
   A recurring series-base edit that changed the guest set narrows
   `RecurrenceScopeDialog` to "All Events" only
   (`RecurrenceScopeDialog.test.tsx`).
+- Incoming RSVP from other attendees is visible to the host without
+  photos: chips and the read-only guest list show a compact status badge
+  (yes / no / maybe / awaiting) looked up from the live `Attendee[]` by
+  email. The write path stays `{email, displayName}` — `responseStatus`
+  never rides `AttendeeInput`. The guest summary uses the same observer
+  labels (`1 guest (0 yes, 1 awaiting)`), distinct from the user's own
+  Going / Maybe / Decline control. Jump to the guest field with `e` then
+  `a`, or Mod+8 while the form is open (Mod+9 is notes; Account keeps
+  Mod+5 with no letter). When the combobox is hidden (invitee / read-only
+  / occurrence), the same shortcuts focus the read-only guest list.
 - Typing an invalid string never creates a chip — `AttendeeField`'s
   `isValidAttendeeEmail` gate rejects it inline ("Enter a valid email
   address") and nothing reaches `onChange`

--- a/e2e/attendees/attendee-editor.spec.ts
+++ b/e2e/attendees/attendee-editor.spec.ts
@@ -36,6 +36,9 @@ test("adding a guest prompts to send invitations and puts the replaced guest set
 
   await openEventForm(page, "Design Review");
 
+  await expect(page.getByText("2 guests (2 yes, 0 awaiting)")).toBeVisible();
+  await expect(page.getByLabelText("Bob B, yes")).toBeVisible();
+
   const combobox = getGuestCombobox(page);
   await combobox.fill("dana@example.com");
   await page.keyboard.press("Enter");

--- a/e2e/attendees/attendee-editor.spec.ts
+++ b/e2e/attendees/attendee-editor.spec.ts
@@ -37,7 +37,7 @@ test("adding a guest prompts to send invitations and puts the replaced guest set
   await openEventForm(page, "Design Review");
 
   await expect(page.getByText("2 guests (2 yes, 0 awaiting)")).toBeVisible();
-  await expect(page.getByLabelText("Bob B, yes")).toBeVisible();
+  await expect(page.getByLabel("Bob B, yes")).toBeVisible();
 
   const combobox = getGuestCombobox(page);
   await combobox.fill("dana@example.com");

--- a/e2e/attendees/rsvp.spec.ts
+++ b/e2e/attendees/rsvp.spec.ts
@@ -64,6 +64,8 @@ test("answering a single event posts immediately with scope single and no dialog
 
   await openEventForm(page, "Team Offsite");
 
+  await expect(page.getByText("2 guests (1 yes, 1 awaiting)")).toBeVisible();
+
   const group = getRsvpGroup(page);
   await expect(group).toBeVisible();
   // Unanswered (needsAction): no radio is checked yet.

--- a/packages/web/src/common/utils/form/form.util.test.ts
+++ b/packages/web/src/common/utils/form/form.util.test.ts
@@ -175,6 +175,8 @@ describe("form.util", () => {
       colorOther.type = "radio";
       colorOther.name = "event-color";
       color.append(colorSelected, colorOther);
+      const attendees = document.createElement("input");
+      attendees.id = "event-form-attendees";
       form.append(
         title,
         location,
@@ -184,6 +186,7 @@ describe("form.util", () => {
         recurrence,
         calendar,
         color,
+        attendees,
       );
       document.body.appendChild(form);
       return {
@@ -195,6 +198,7 @@ describe("form.util", () => {
         repeat,
         calendar,
         colorSelected,
+        attendees,
       };
     };
 
@@ -224,6 +228,9 @@ describe("form.util", () => {
 
       expect(focusEventFormField("color")).toBe(true);
       expect(document.activeElement).toBe(fields.colorSelected);
+
+      expect(focusEventFormField("attendees")).toBe(true);
+      expect(document.activeElement).toBe(fields.attendees);
     });
 
     it("falls back to start/end date inputs when time pickers are absent", () => {
@@ -260,6 +267,19 @@ describe("form.util", () => {
       document.body.appendChild(form);
 
       expect(focusEventFormField("location")).toBe(false);
+    });
+
+    it("falls back to the read-only guest list when the combobox is absent", () => {
+      const form = document.createElement("form");
+      form.setAttribute("name", ID_EVENT_FORM);
+      const guestList = document.createElement("div");
+      guestList.id = "event-form-guest-list";
+      guestList.tabIndex = -1;
+      form.append(guestList);
+      document.body.appendChild(form);
+
+      expect(focusEventFormField("attendees")).toBe(true);
+      expect(document.activeElement).toBe(guestList);
     });
 
     it("keeps focusEventFormTitle as a title helper", () => {

--- a/packages/web/src/common/utils/form/form.util.ts
+++ b/packages/web/src/common/utils/form/form.util.ts
@@ -57,12 +57,7 @@ const FIELD_SELECTORS: Record<EventFormFocusField, string[]> = {
     `#event-form-color input[type="radio"]:checked`,
     `#event-form-color input[type="radio"]`,
   ],
-  attendees: [
-    `${EVENT_FORM_SELECTOR} #event-form-attendees`,
-    `#event-form-attendees`,
-    `${EVENT_FORM_SELECTOR} #event-form-guest-list`,
-    `#event-form-guest-list`,
-  ],
+  attendees: [`#event-form-attendees`, `#event-form-guest-list`],
 };
 
 /**

--- a/packages/web/src/common/utils/form/form.util.ts
+++ b/packages/web/src/common/utils/form/form.util.ts
@@ -10,7 +10,8 @@ export type EventFormFocusField =
   | "end"
   | "recurrence"
   | "calendar"
-  | "color";
+  | "color"
+  | "attendees";
 
 const queryEventFormElement = <T extends Element>(selector: string): T | null =>
   document.querySelector<T>(selector);
@@ -55,6 +56,12 @@ const FIELD_SELECTORS: Record<EventFormFocusField, string[]> = {
   color: [
     `#event-form-color input[type="radio"]:checked`,
     `#event-form-color input[type="radio"]`,
+  ],
+  attendees: [
+    `${EVENT_FORM_SELECTOR} #event-form-attendees`,
+    `#event-form-attendees`,
+    `${EVENT_FORM_SELECTOR} #event-form-guest-list`,
+    `#event-form-guest-list`,
   ],
 };
 

--- a/packages/web/src/shortcuts/edit-sequence/EditSequenceMenu.test.tsx
+++ b/packages/web/src/shortcuts/edit-sequence/EditSequenceMenu.test.tsx
@@ -42,11 +42,11 @@ describe("EditSequenceMenu", () => {
       screen.getByRole("status", { hidden: true }).textContent,
     ).toStrictEqual(
       "Edit which field? T for title, L for location, D for description, " +
-        "S for start time, E for end time, R for recurrence, A for account, " +
-        "C for color. " +
+        "S for start time, E for end time, R for recurrence, C for color, " +
+        "A for guests. " +
         "Escape to cancel." +
         "Edit which field?TTitleLLocationDDescriptionSStart timeEEnd time" +
-        "RRecurrenceAAccountCColorEsc to cancel",
+        "RRecurrenceCColorAGuestsEsc to cancel",
     );
   });
 
@@ -62,11 +62,12 @@ describe("EditSequenceMenu", () => {
       "Start time",
       "End time",
       "Recurrence",
-      "Account",
       "Color",
+      "Guests",
     ]) {
       expect(menu?.textContent).toContain(label);
     }
+    expect(menu?.textContent).not.toContain("Account");
   });
 
   it("still renders when the anchor is gone, using the viewport fallback", () => {

--- a/packages/web/src/shortcuts/edit-sequence/EditSequenceMenu.tsx
+++ b/packages/web/src/shortcuts/edit-sequence/EditSequenceMenu.tsx
@@ -9,7 +9,7 @@ import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { Z_INDEX_TOOLTIP } from "@web/common/constants/web.constants";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
-import { EDIT_SEQUENCE_FIELDS } from "@web/shortcuts/edit-sequence/edit-sequence.fields";
+import { EDIT_SEQUENCE_LETTER_FIELDS } from "@web/shortcuts/edit-sequence/edit-sequence.fields";
 import {
   selectEditSequenceMenuVisible,
   useEditSequenceStore,
@@ -19,7 +19,7 @@ const MENU_WIDTH = 260;
 const GAP = 8;
 
 /** Screen-reader copy, so the visible chips can stay aria-hidden. */
-const SR_TEXT = `Edit which field? ${EDIT_SEQUENCE_FIELDS.map(
+const SR_TEXT = `Edit which field? ${EDIT_SEQUENCE_LETTER_FIELDS.map(
   (option) => `${option.key.toUpperCase()} for ${option.label.toLowerCase()}`,
 ).join(", ")}. Escape to cancel.`;
 
@@ -111,7 +111,7 @@ export function EditSequenceMenu({
             Edit which field?
           </span>
           <div className="grid grid-cols-2 gap-x-2 gap-y-1">
-            {EDIT_SEQUENCE_FIELDS.map((option) => (
+            {EDIT_SEQUENCE_LETTER_FIELDS.map((option) => (
               <span
                 key={option.key}
                 className="flex items-center gap-1.5 text-text text-xs"

--- a/packages/web/src/shortcuts/edit-sequence/edit-sequence.fields.test.ts
+++ b/packages/web/src/shortcuts/edit-sequence/edit-sequence.fields.test.ts
@@ -6,7 +6,7 @@ import {
 import { describe, expect, it } from "bun:test";
 
 describe("edit-sequence.fields", () => {
-  it("assigns a unique digit 1-8 to every field", () => {
+  it("assigns a unique digit 1-9 to every field", () => {
     const digits = EDIT_SEQUENCE_FIELDS.map((entry) => entry.digit);
     expect([...digits].sort()).toEqual([
       "1",
@@ -17,6 +17,7 @@ describe("edit-sequence.fields", () => {
       "6",
       "7",
       "8",
+      "9",
     ]);
     expect(new Set(digits).size).toBe(digits.length);
   });
@@ -30,6 +31,7 @@ describe("edit-sequence.fields", () => {
       "calendar",
       "color",
       "location",
+      "attendees",
       "description",
     ]);
   });

--- a/packages/web/src/shortcuts/edit-sequence/edit-sequence.fields.ts
+++ b/packages/web/src/shortcuts/edit-sequence/edit-sequence.fields.ts
@@ -10,35 +10,44 @@ import { type EventFormFocusField } from "@web/common/utils/form/form.util";
  */
 // `digit` is the field's Mod+digit jump shortcut, assigned in the form's DOM
 // order (title → schedule → recurrence → calendar → color → location →
-// description) so the mapping is guessable without the hold-Mod hint chips.
-// The array itself keeps its original key-taught order (unrelated to digit
-// order) since EditSequenceMenu renders straight off this order.
+// attendees → description) so the mapping is guessable without the hold-Mod
+// hint chips. The array itself keeps its original key-taught order (unrelated
+// to digit order) since EditSequenceMenu renders straight off this order.
+// Account keeps digit 5 but has no letter key: `a` is guests.
 export const EDIT_SEQUENCE_FIELDS = [
   { key: "t", field: "title", label: "Title", digit: "1" },
   { key: "l", field: "location", label: "Location", digit: "7" },
-  { key: "d", field: "description", label: "Description", digit: "8" },
+  { key: "d", field: "description", label: "Description", digit: "9" },
   { key: "s", field: "start", label: "Start time", digit: "2" },
   { key: "e", field: "end", label: "End time", digit: "3" },
   { key: "r", field: "recurrence", label: "Recurrence", digit: "4" },
-  // `a` = account: the calendar picker chooses which calendar/account hosts
-  // the event. `c` = color, so the letter matches the field name users reach for.
-  { key: "a", field: "calendar", label: "Account", digit: "5" },
+  { field: "calendar", label: "Account", digit: "5" },
   { key: "c", field: "color", label: "Color", digit: "6" },
+  { key: "a", field: "attendees", label: "Guests", digit: "8" },
 ] as const satisfies readonly {
-  key: string;
+  key?: string;
   field: EventFormFocusField;
   label: string;
   digit: string;
 }[];
 
+export const hasEditSequenceKey = (
+  entry: (typeof EDIT_SEQUENCE_FIELDS)[number],
+): entry is (typeof EDIT_SEQUENCE_FIELDS)[number] & { key: string } =>
+  "key" in entry && typeof entry.key === "string";
+
+/** Letter-sequence rows only — Account is digit-only. */
+export const EDIT_SEQUENCE_LETTER_FIELDS =
+  EDIT_SEQUENCE_FIELDS.filter(hasEditSequenceKey);
+
 export type EditSequenceSecondKey =
-  (typeof EDIT_SEQUENCE_FIELDS)[number]["key"];
+  (typeof EDIT_SEQUENCE_LETTER_FIELDS)[number]["key"];
 
 export type EditSequenceDigit = (typeof EDIT_SEQUENCE_FIELDS)[number]["digit"];
 
 /** Second key → form field, for dispatch. */
 export const EDIT_SEQUENCE_FIELD_BY_KEY = Object.fromEntries(
-  EDIT_SEQUENCE_FIELDS.map(({ key, field }) => [key, field]),
+  EDIT_SEQUENCE_LETTER_FIELDS.map(({ key, field }) => [key, field]),
 ) as Record<EditSequenceSecondKey, EventFormFocusField>;
 
 /** Digit → form field, for Mod+digit dispatch. */

--- a/packages/web/src/shortcuts/edit-sequence/edit-sequence.fields.ts
+++ b/packages/web/src/shortcuts/edit-sequence/edit-sequence.fields.ts
@@ -31,10 +31,10 @@ export const EDIT_SEQUENCE_FIELDS = [
   digit: string;
 }[];
 
-export const hasEditSequenceKey = (
+const hasEditSequenceKey = (
   entry: (typeof EDIT_SEQUENCE_FIELDS)[number],
 ): entry is (typeof EDIT_SEQUENCE_FIELDS)[number] & { key: string } =>
-  "key" in entry && typeof entry.key === "string";
+  "key" in entry;
 
 /** Letter-sequence rows only — Account is digit-only. */
 export const EDIT_SEQUENCE_LETTER_FIELDS =

--- a/packages/web/src/shortcuts/form-digit-jump/FormDigitHintOverlay.test.tsx
+++ b/packages/web/src/shortcuts/form-digit-jump/FormDigitHintOverlay.test.tsx
@@ -69,6 +69,10 @@ const buildForm = () => {
   location.id = "event-form-location";
   form.append(location);
 
+  const attendees = document.createElement("input");
+  attendees.id = "event-form-attendees";
+  form.append(attendees);
+
   const description = document.createElement("div");
   description.id = "event-form-description";
   document.body.append(description);
@@ -80,6 +84,7 @@ const buildForm = () => {
     recurrenceButton,
     radio,
     location,
+    attendees,
     description,
   ];
   for (const element of elements) {
@@ -132,7 +137,7 @@ describe("FormDigitHintOverlay", () => {
 
     // Digit 5 (calendar) has no chip: no #event-form-calendar element was added,
     // matching an edit draft where the calendar picker isn't rendered.
-    expect(chipDigits()).toEqual(["1", "2", "3", "4", "6", "7", "8"]);
+    expect(chipDigits()).toEqual(["1", "2", "3", "4", "6", "7", "8", "9"]);
   });
 
   it("renders the calendar chip once the picker is present", () => {
@@ -144,7 +149,7 @@ describe("FormDigitHintOverlay", () => {
 
     render(<FormDigitHintOverlay visible={true} />);
 
-    expect(chipDigits()).toEqual(["1", "2", "3", "4", "5", "6", "7", "8"]);
+    expect(chipDigits()).toEqual(["1", "2", "3", "4", "5", "6", "7", "8", "9"]);
   });
 
   it("exposes a screen-reader summary while the visible chips stay aria-hidden", () => {
@@ -154,7 +159,8 @@ describe("FormDigitHintOverlay", () => {
     const status = screen.getByRole("status");
     expect(status.textContent).toContain("Jump to field?");
     expect(status.textContent).toContain("1 for title");
-    expect(status.textContent).toContain("8 for description");
+    expect(status.textContent).toContain("8 for guests");
+    expect(status.textContent).toContain("9 for description");
     expect(chipsWrapper()?.getAttribute("aria-hidden")).not.toBeNull();
   });
 

--- a/packages/web/src/shortcuts/form-digit-jump/useFormDigitJumpShortcut.test.tsx
+++ b/packages/web/src/shortcuts/form-digit-jump/useFormDigitJumpShortcut.test.tsx
@@ -80,10 +80,13 @@ const buildForm = () => {
   color.append(radio);
   document.body.append(color);
 
-  // A real input, like the Location Focusable in EventForm.tsx.
   const location = document.createElement("input");
   location.id = "event-form-location";
   form.append(location);
+
+  const attendees = document.createElement("input");
+  attendees.id = "event-form-attendees";
+  form.append(attendees);
 
   // Real usage sets this id on TipTap's contenteditable root, which is what
   // makes it focusable; jsdom doesn't treat contenteditable as focusable on
@@ -102,6 +105,7 @@ const buildForm = () => {
     calendar,
     color: radio,
     location,
+    attendees,
     description,
   };
 };
@@ -128,7 +132,7 @@ describe("useFormDigitJumpShortcut", () => {
       expect(fields.end).toHaveFocus();
     });
 
-    it("maps every digit 1-8 to its field, in DOM order", () => {
+    it("maps every digit 1-9 to its field, in DOM order", () => {
       const fields = buildForm();
       renderHook(() => useFormDigitJumpShortcut());
 
@@ -140,7 +144,8 @@ describe("useFormDigitJumpShortcut", () => {
         ["5", fields.calendar],
         ["6", fields.color],
         ["7", fields.location],
-        ["8", fields.description],
+        ["8", fields.attendees],
+        ["9", fields.description],
       ] as const;
 
       for (const [digit, element] of cases) {

--- a/packages/web/src/shortcuts/form-digit-jump/useFormDigitJumpShortcut.ts
+++ b/packages/web/src/shortcuts/form-digit-jump/useFormDigitJumpShortcut.ts
@@ -13,7 +13,7 @@ export { MOD_HOLD_HINT_MS } from "@web/shortcuts/mod-hold/useModHoldHintShortcut
 const DIGIT_ORDER = FORM_FIELD_DIGITS.map((entry) => entry.digit);
 
 /**
- * Mod+digit jumps focus straight to a form field (1=title ... 8=description;
+ * Mod+digit jumps focus straight to a form field (1=title ... 9=description;
  * see edit-sequence.fields.ts for the assignment). Holding Mod alone reveals
  * the mapping as hint chips (FormDigitHintOverlay) via the shared hold-Mod
  * engine — the same discoverability contract as the `e`-leader's which-key

--- a/packages/web/src/shortcuts/keymap.ts
+++ b/packages/web/src/shortcuts/keymap.ts
@@ -18,8 +18,8 @@ export const KEYMAP = {
   saveDraft: { hotkey: "Enter", keycaps: ["Enter"] },
   jumpFormField: {
     holdModifier: "Mod",
-    digits: ["1", "8"],
-    keycaps: ["Mod", "1-8"],
+    digits: ["1", "9"],
+    keycaps: ["Mod", "1-9"],
   },
   // Same hold-Mod gesture outside the form: digits follow the active view's
   // target list order (page-jump.targets.ts).

--- a/packages/web/src/shortcuts/shortcuts.menu.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.menu.test.ts
@@ -309,8 +309,11 @@ describe("shortcut menu sections", () => {
         });
         expect(shortcuts).toContainEqual({
           keys: ["e", "a"],
-          label: "Edit account",
+          label: "Edit guests",
         });
+        expect(
+          shortcuts.some((shortcut) => shortcut.label === "Edit account"),
+        ).toBe(false);
         expect(shortcuts).toContainEqual({
           keys: ["e", "c"],
           label: "Edit color",

--- a/packages/web/src/shortcuts/shortcuts.registry.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.test.ts
@@ -137,7 +137,8 @@ describe("shortcuts.registry", () => {
       expect(ids).toContain("edit-focus-start");
       expect(ids).toContain("edit-focus-end");
       expect(ids).toContain("edit-focus-recurrence");
-      expect(ids).toContain("edit-focus-calendar");
+      expect(ids).toContain("edit-focus-attendees");
+      expect(ids).not.toContain("edit-focus-calendar");
       expect(ids).toContain("edit-focus-color");
     });
 

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -1,4 +1,4 @@
-import { EDIT_SEQUENCE_FIELDS } from "@web/shortcuts/edit-sequence/edit-sequence.fields";
+import { EDIT_SEQUENCE_LETTER_FIELDS } from "@web/shortcuts/edit-sequence/edit-sequence.fields";
 import { type Shortcut } from "@web/shortcuts/global.shortcut.types";
 import { KEYMAP } from "@web/shortcuts/keymap";
 import { type ShortcutOverlaySection } from "@web/shortcuts/shortcuts-overlay.types";
@@ -204,7 +204,7 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
   // reference, and gating these on live DOM focus made them vanish the moment
   // the legend took focus to open. In-the-moment discovery is the which-key
   // menu's job instead.
-  ...EDIT_SEQUENCE_FIELDS.map(({ field, key, label }) => ({
+  ...EDIT_SEQUENCE_LETTER_FIELDS.map(({ field, key, label }) => ({
     id: `edit-focus-${field}`,
     keys: ["e", key],
     label: `Edit ${label.toLowerCase()}`,

--- a/packages/web/src/shortcuts/useEditSequenceShortcut.test.tsx
+++ b/packages/web/src/shortcuts/useEditSequenceShortcut.test.tsx
@@ -76,7 +76,7 @@ describe("useEditSequenceShortcut", () => {
         ["s", "start"],
         ["e", "end"],
         ["r", "recurrence"],
-        ["a", "calendar"],
+        ["a", "attendees"],
         ["c", "color"],
       ] as const;
 

--- a/packages/web/src/views/Forms/EventForm/AttendeeField/AttendeeField.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/AttendeeField/AttendeeField.test.tsx
@@ -66,6 +66,9 @@ describe("AttendeeField", () => {
 
     expect(onValueChange).toHaveBeenCalledWith([alice]);
     expect(screen.getByText("alice@example.com")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("alice@example.com, awaiting"),
+    ).toBeInTheDocument();
     expect(onFormSubmit).not.toHaveBeenCalled();
   });
 
@@ -114,9 +117,27 @@ describe("AttendeeField", () => {
     );
 
     expect(screen.getByText("Bob B")).toBeInTheDocument();
+    expect(screen.getByLabelText("Bob B, awaiting")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Remove Bob B" }));
 
     expect(onValueChange).toHaveBeenCalledWith([alice]);
+  });
+
+  it("paints provider RSVP on chips from the display-only status map", () => {
+    const statusByEmail = new Map([
+      ["alice@example.com", "accepted" as const],
+      ["bob@example.com", "declined" as const],
+    ]);
+    render(
+      <AttendeeField
+        value={[alice, bob]}
+        onChange={() => {}}
+        statusByEmail={statusByEmail}
+      />,
+    );
+
+    expect(screen.getByLabelText("alice@example.com, yes")).toBeInTheDocument();
+    expect(screen.getByLabelText("Bob B, no")).toBeInTheDocument();
   });
 
   it("removes the last chip with Backspace on an empty input", async () => {

--- a/packages/web/src/views/Forms/EventForm/AttendeeField/AttendeeField.tsx
+++ b/packages/web/src/views/Forms/EventForm/AttendeeField/AttendeeField.tsx
@@ -313,15 +313,9 @@ export const AttendeeField = ({
             isValidAttendeeEmail(candidate) &&
             !selectedEmails.has(candidate.trim().toLowerCase())
           }
-          getNewOptionData={(candidate) => {
-            const email = candidate.trim();
-            return {
-              value: email.toLowerCase(),
-              label: email,
-              attendee: { email, displayName: null },
-              responseStatus: "needsAction",
-            };
-          }}
+          getNewOptionData={(candidate) =>
+            toOption({ email: candidate.trim(), displayName: null })
+          }
           formatCreateLabel={(candidate) => `Add "${candidate.trim()}"`}
           noOptionsMessage={({ inputValue: query }) => {
             const email = query.trim();

--- a/packages/web/src/views/Forms/EventForm/AttendeeField/AttendeeField.tsx
+++ b/packages/web/src/views/Forms/EventForm/AttendeeField/AttendeeField.tsx
@@ -12,11 +12,21 @@ import {
   type GroupBase,
   type MenuProps,
   type MultiValue,
+  type MultiValueGenericProps,
+  type MultiValueProps,
   components as selectComponents,
 } from "react-select";
 import CreatableSelect from "react-select/creatable";
-import { type AttendeeInput } from "@core/types/event-attendance.contracts";
+import {
+  type AttendeeInput,
+  type AttendeeResponseStatus,
+} from "@core/types/event-attendance.contracts";
 import { useFloatingLayer } from "@web/shortcuts/floating-layer";
+import { AttendeeRsvpStatus } from "@web/views/Forms/EventForm/AttendeeRsvpStatus";
+import {
+  ATTENDEE_RSVP_LABEL,
+  statusForEmail,
+} from "@web/views/Forms/EventForm/attendee-rsvp";
 
 /**
  * Pluggable suggestion source for the guest combobox. WP-06 plugs the
@@ -35,12 +45,18 @@ interface AttendeeOption {
   value: string;
   label: string;
   attendee: AttendeeInput;
+  /** Display-only. Never round-trips into the write-input attendee. */
+  responseStatus: AttendeeResponseStatus;
 }
 
-const toOption = (attendee: AttendeeInput): AttendeeOption => ({
+const toOption = (
+  attendee: AttendeeInput,
+  responseStatus: AttendeeResponseStatus = "needsAction",
+): AttendeeOption => ({
   value: attendee.email.toLowerCase(),
   label: attendee.displayName ?? attendee.email,
   attendee,
+  responseStatus,
 });
 
 // Pragmatic shape check, not RFC 5322: something@something.tld with no
@@ -76,7 +92,32 @@ const AttendeeMenu = (
   );
 };
 
-const attendeeFieldComponents = { Menu: AttendeeMenu };
+const AttendeeMultiValueLabel = (
+  props: MultiValueGenericProps<AttendeeOption, true>,
+) => (
+  <selectComponents.MultiValueLabel {...props}>
+    <span className="inline-flex items-center gap-1">
+      <AttendeeRsvpStatus status={props.data.responseStatus} />
+      {props.children}
+    </span>
+  </selectComponents.MultiValueLabel>
+);
+
+const AttendeeMultiValue = (props: MultiValueProps<AttendeeOption, true>) => (
+  <selectComponents.MultiValue
+    {...props}
+    innerProps={{
+      ...props.innerProps,
+      "aria-label": `${props.data.label}, ${ATTENDEE_RSVP_LABEL[props.data.responseStatus]}`,
+    }}
+  />
+);
+
+const attendeeFieldComponents = {
+  Menu: AttendeeMenu,
+  MultiValue: AttendeeMultiValue,
+  MultiValueLabel: AttendeeMultiValueLabel,
+};
 
 // react-select's emotion style objects beat class-based CSS for these text
 // roles — same recipe as TimePicker/FreqSelect.
@@ -104,7 +145,12 @@ const attendeeFieldStyles = {
     backgroundColor: "var(--surface-raised)",
     borderRadius: "var(--radius-default)",
   }),
-  multiValueLabel: themeColor("var(--text)"),
+  multiValueLabel: (base: CSSObjectWithLabel): CSSObjectWithLabel => ({
+    ...base,
+    color: "var(--text)",
+    display: "flex",
+    alignItems: "center",
+  }),
   multiValueRemove: (base: CSSObjectWithLabel): CSSObjectWithLabel => ({
     ...base,
     color: "var(--text-muted)",
@@ -121,6 +167,11 @@ export interface AttendeeFieldProps {
   value: readonly AttendeeInput[];
   onChange: (next: readonly AttendeeInput[]) => void;
   suggestionSource?: AttendeeSuggestionSource;
+  /**
+   * Live provider RSVP keyed by lower-cased email. Display-only: chips stay
+   * AttendeeInput onChange. Missing / newly typed emails paint as awaiting.
+   */
+  statusByEmail?: ReadonlyMap<string, AttendeeResponseStatus>;
   /**
    * Rendered at the bottom of the open listbox (non-scrolling) — the slot
    * the "Enable contact suggestions" nudge lives in when the contacts
@@ -143,6 +194,7 @@ export const AttendeeField = ({
   value,
   onChange,
   suggestionSource = emptySuggestionSource,
+  statusByEmail,
   menuFooter = null,
 }: AttendeeFieldProps) => {
   const [inputValue, setInputValue] = useState("");
@@ -154,7 +206,13 @@ export const AttendeeField = ({
   const layerId = useId();
   useFloatingLayer(`attendeeField:${layerId}`, isMenuOpen);
 
-  const selectedOptions = useMemo(() => value.map(toOption), [value]);
+  const selectedOptions = useMemo(
+    () =>
+      value.map((attendee) =>
+        toOption(attendee, statusForEmail(statusByEmail, attendee.email)),
+      ),
+    [statusByEmail, value],
+  );
   const selectedEmails = useMemo(
     () => new Set(value.map((attendee) => attendee.email.toLowerCase())),
     [value],
@@ -163,7 +221,7 @@ export const AttendeeField = ({
     () =>
       suggestions
         .filter((entry) => !selectedEmails.has(entry.email.toLowerCase()))
-        .map(toOption),
+        .map((entry) => toOption(entry)),
     [selectedEmails, suggestions],
   );
 
@@ -261,6 +319,7 @@ export const AttendeeField = ({
               value: email.toLowerCase(),
               label: email,
               attendee: { email, displayName: null },
+              responseStatus: "needsAction",
             };
           }}
           formatCreateLabel={(candidate) => `Add "${candidate.trim()}"`}

--- a/packages/web/src/views/Forms/EventForm/AttendeeRsvpStatus.tsx
+++ b/packages/web/src/views/Forms/EventForm/AttendeeRsvpStatus.tsx
@@ -1,0 +1,47 @@
+import {
+  CheckIcon,
+  MinusIcon,
+  QuestionIcon,
+  XIcon,
+} from "@phosphor-icons/react";
+import { type AttendeeResponseStatus } from "@core/types/event-attendance.contracts";
+import { ATTENDEE_RSVP_LABEL } from "@web/views/Forms/EventForm/attendee-rsvp";
+
+const STATUS_ICON: Record<
+  AttendeeResponseStatus,
+  typeof CheckIcon | typeof XIcon | typeof QuestionIcon | typeof MinusIcon
+> = {
+  accepted: CheckIcon,
+  declined: XIcon,
+  tentative: QuestionIcon,
+  needsAction: MinusIcon,
+};
+
+const STATUS_CLASS: Record<AttendeeResponseStatus, string> = {
+  accepted: "bg-success text-on-accent",
+  declined: "bg-error text-on-accent",
+  tentative: "bg-warning text-on-accent",
+  needsAction: "bg-text-subtle text-on-accent",
+};
+
+/**
+ * Compact RSVP badge for guest chips and the read-only guest list. Decorative
+ * only — the parent row/chip carries the accessible name so color is never
+ * the sole signal.
+ */
+export const AttendeeRsvpStatus = ({
+  status,
+}: {
+  status: AttendeeResponseStatus;
+}) => {
+  const Icon = STATUS_ICON[status];
+  return (
+    <span
+      aria-hidden
+      title={ATTENDEE_RSVP_LABEL[status]}
+      className={`inline-flex size-3.5 shrink-0 items-center justify-center rounded-full ${STATUS_CLASS[status]}`}
+    >
+      <Icon size={10} weight="bold" />
+    </span>
+  );
+};

--- a/packages/web/src/views/Forms/EventForm/AttendeeRsvpStatus.tsx
+++ b/packages/web/src/views/Forms/EventForm/AttendeeRsvpStatus.tsx
@@ -7,15 +7,12 @@ import {
 import { type AttendeeResponseStatus } from "@core/types/event-attendance.contracts";
 import { ATTENDEE_RSVP_LABEL } from "@web/views/Forms/EventForm/attendee-rsvp";
 
-const STATUS_ICON: Record<
-  AttendeeResponseStatus,
-  typeof CheckIcon | typeof XIcon | typeof QuestionIcon | typeof MinusIcon
-> = {
+const STATUS_ICON = {
   accepted: CheckIcon,
   declined: XIcon,
   tentative: QuestionIcon,
   needsAction: MinusIcon,
-};
+} as const;
 
 const STATUS_CLASS: Record<AttendeeResponseStatus, string> = {
   accepted: "bg-success text-on-accent",

--- a/packages/web/src/views/Forms/EventForm/EventDetailsSection.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventDetailsSection.tsx
@@ -70,7 +70,11 @@ export const EventDetailsSection = ({
         >
           <div className="flex items-center gap-2 text-text-muted">
             <UsersIcon size={16} className="shrink-0" />
-            <span>{formatAttendeeRsvpTally(attendees)}</span>
+            <span>
+              {formatAttendeeRsvpTally(
+                attendees.map((attendee) => attendee.responseStatus),
+              )}
+            </span>
           </div>
           <ul className="flex flex-col gap-1 pl-6">
             {visibleAttendees.map((attendee) => {

--- a/packages/web/src/views/Forms/EventForm/EventDetailsSection.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventDetailsSection.tsx
@@ -1,9 +1,15 @@
 import { UsersIcon, VideoCameraIcon } from "@phosphor-icons/react";
 import { useState } from "react";
 import { type EventContent } from "@core/types/event.contracts";
-import { type AttendeeResponseStatus } from "@core/types/event-attendance.contracts";
+import { AttendeeRsvpStatus } from "@web/views/Forms/EventForm/AttendeeRsvpStatus";
+import {
+  ATTENDEE_RSVP_LABEL,
+  formatAttendeeRsvpTally,
+} from "@web/views/Forms/EventForm/attendee-rsvp";
 
 type EventDetails = Extract<EventContent, { kind: "details" }>;
+
+const EVENT_FORM_GUEST_LIST_ID = "event-form-guest-list";
 
 interface EventDetailsSectionProps {
   details: Pick<EventDetails, "organizer" | "attendees" | "conference">;
@@ -14,16 +20,6 @@ interface EventDetailsSectionProps {
    */
   hideAttendees?: boolean;
 }
-
-const ATTENDEE_STATUS_DOT: Record<AttendeeResponseStatus, string> = {
-  accepted: "bg-success",
-  declined: "bg-error",
-  tentative: "bg-warning",
-  needsAction: "bg-text-subtle",
-};
-
-const attendeeStatusLabel = (status: AttendeeResponseStatus): string =>
-  status === "needsAction" ? "hasn't responded" : status;
 
 const MAX_VISIBLE_ATTENDEES = 6;
 
@@ -67,33 +63,30 @@ export const EventDetailsSection = ({
       )}
 
       {hasAttendees && (
-        <div className="flex flex-col gap-1.5">
+        <div
+          id={EVENT_FORM_GUEST_LIST_ID}
+          tabIndex={-1}
+          className="c-focus-ring flex flex-col gap-1.5 rounded-xs"
+        >
           <div className="flex items-center gap-2 text-text-muted">
             <UsersIcon size={16} className="shrink-0" />
-            <span>
-              {attendees.length} {attendees.length === 1 ? "guest" : "guests"}
-            </span>
+            <span>{formatAttendeeRsvpTally(attendees)}</span>
           </div>
           <ul className="flex flex-col gap-1 pl-6">
             {visibleAttendees.map((attendee) => {
               const name = attendee.displayName ?? attendee.email;
               const isOrganizer = organizer?.email === attendee.email;
-              // The dot alone is a color-only signal (bg-success vs
-              // bg-error), invisible to colorblind users and unannounced by
-              // screen readers - title is a mouse-only tooltip, so the row's
-              // aria-label carries the same info as accessible text.
-              const statusText = attendeeStatusLabel(attendee.responseStatus);
+              // The badge is a color+icon signal; title is a mouse-only
+              // tooltip, so the row's aria-label carries the same info as
+              // accessible text.
+              const statusText = ATTENDEE_RSVP_LABEL[attendee.responseStatus];
               return (
                 <li
                   key={attendee.email}
                   className="flex items-center gap-2"
                   aria-label={`${name}, ${statusText}${isOrganizer ? ", organizer" : ""}`}
                 >
-                  <span
-                    aria-hidden
-                    title={statusText}
-                    className={`size-2.5 shrink-0 rounded-full ${ATTENDEE_STATUS_DOT[attendee.responseStatus]}`}
-                  />
+                  <AttendeeRsvpStatus status={attendee.responseStatus} />
                   <span className="min-w-0 flex-1 truncate">
                     {name}
                     {isOrganizer && " (organizer)"}

--- a/packages/web/src/views/Forms/EventForm/EventForm.attendees.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.attendees.test.tsx
@@ -1,5 +1,5 @@
-import { HotkeyManager } from "@tanstack/react-hotkeys";
-import { render, screen } from "@testing-library/react";
+import { HotkeyManager, resolveModifier } from "@tanstack/react-hotkeys";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   type Calendar,
@@ -97,6 +97,22 @@ const editDraftOrThrow = (event: Event): GridEventDraft => {
   return draft;
 };
 
+function dispatchModDigitKey(target: HTMLElement, code: string, key: string) {
+  const modifierKey = resolveModifier("Mod");
+  const isControl = modifierKey === "Control";
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    code,
+    ctrlKey: isControl,
+    key,
+    metaKey: !isControl,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
 describe("EventForm attendee editor gating", () => {
   beforeEach(() => {
     HotkeyManager.resetInstance();
@@ -110,10 +126,25 @@ describe("EventForm attendee editor gating", () => {
     renderEventForm(draft, [calendar]);
 
     expect(screen.getByRole("combobox", { name: "Guests" })).toBeEnabled();
-    // The editor owns the guest list; the legacy read-only list stands down.
-    expect(screen.queryByText(/1 guest/)).not.toBeInTheDocument();
+    // The editor owns the guest list; the read-only list stands down, but
+    // the same tally copy sits with the chips so the host still sees RSVPs.
+    expect(screen.getByText("1 guest (1 yes, 0 awaiting)")).toBeInTheDocument();
+    expect(screen.getByLabelText("Guest One, yes")).toBeInTheDocument();
     // Existing guests appear as chips (displayName preferred).
     expect(screen.getByText("Guest One")).toBeInTheDocument();
+  });
+
+  it("jumps focus to the guest combobox with Mod+8", () => {
+    const calendar = makeCalendar();
+    const draft = editDraftOrThrow(makeMeetingEvent(calendar.id));
+
+    renderEventForm(draft, [calendar]);
+
+    const titleField = screen.getByPlaceholderText("Title");
+    act(() => titleField.focus());
+    dispatchModDigitKey(titleField, "Digit8", "8");
+
+    expect(screen.getByRole("combobox", { name: "Guests" })).toHaveFocus();
   });
 
   it("keeps the read-only guest list for an event the user does not organize", () => {

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -640,7 +640,7 @@ describe("EventForm", () => {
     ).toHaveFocus();
   });
 
-  it("jumps focus to the description field with Mod+8 from the title field", () => {
+  it("jumps focus to the description field with Mod+9 from the title field", () => {
     renderWithStore(
       <EventForm
         draft={createEditDraft({ description: "Plan the launch" })}
@@ -657,7 +657,7 @@ describe("EventForm", () => {
     const titleField = screen.getByPlaceholderText("Title");
     act(() => titleField.focus());
 
-    dispatchModDigitKey(titleField, "Digit8", "8");
+    dispatchModDigitKey(titleField, "Digit9", "9");
 
     expect(screen.getByRole("textbox", { name: "Description" })).toHaveFocus();
   });
@@ -1682,17 +1682,19 @@ describe("EventForm", () => {
         />,
       );
 
-      expect(screen.getByText("2 guests")).toBeInTheDocument();
+      expect(
+        screen.getByText("2 guests (1 yes, 0 awaiting, 1 no)"),
+      ).toBeInTheDocument();
       expect(screen.getByText("Team Lead (organizer)")).toBeInTheDocument();
       expect(screen.getByText("guest@example.com")).toBeInTheDocument();
 
-      // RSVP status is otherwise a color-only dot - each row needs an
+      // RSVP status is otherwise a color+icon badge - each row needs an
       // accessible name carrying the same status text for screen readers.
       expect(
-        screen.getByLabelText("Team Lead, accepted, organizer"),
+        screen.getByLabelText("Team Lead, yes, organizer"),
       ).toBeInTheDocument();
       expect(
-        screen.getByLabelText("guest@example.com, declined"),
+        screen.getByLabelText("guest@example.com, no"),
       ).toBeInTheDocument();
     });
 

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -361,9 +361,9 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
       attendeeChips.length === 0
         ? null
         : formatAttendeeRsvpTally(
-            attendeeChips.map((chip) => ({
-              responseStatus: statusForEmail(attendeeRsvpByEmail, chip.email),
-            })),
+            attendeeChips.map((chip) =>
+              statusForEmail(attendeeRsvpByEmail, chip.email),
+            ),
           );
     const latestDraftRef = useRef(draft);
     const { startDate: eventStartDate, endDate: eventEndDate } =

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -60,6 +60,11 @@ import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 import { AttendeeField } from "@web/views/Forms/EventForm/AttendeeField/AttendeeField";
 import { EnableContactSuggestionsNudge } from "@web/views/Forms/EventForm/AttendeeField/EnableContactSuggestionsNudge";
 import { useContactSuggestions } from "@web/views/Forms/EventForm/AttendeeField/useContactSuggestions";
+import {
+  attendeeStatusByEmail,
+  formatAttendeeRsvpTally,
+  statusForEmail,
+} from "@web/views/Forms/EventForm/attendee-rsvp";
 import { CalendarSelect } from "@web/views/Forms/EventForm/CalendarSelect/CalendarSelect";
 import { DateControlsSection } from "@web/views/Forms/EventForm/DateControlsSection/DateControlsSection/DateControlsSection";
 import { getFormDates } from "@web/views/Forms/EventForm/DateControlsSection/DateTimeSection/form.datetime.util";
@@ -349,6 +354,17 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
         email,
         displayName,
       }));
+    const attendeeRsvpByEmail = attendeeStatusByEmail(
+      liveDetails?.attendees ?? sourceDetails?.attendees,
+    );
+    const attendeeChipTally =
+      attendeeChips.length === 0
+        ? null
+        : formatAttendeeRsvpTally(
+            attendeeChips.map((chip) => ({
+              responseStatus: statusForEmail(attendeeRsvpByEmail, chip.email),
+            })),
+          );
     const latestDraftRef = useRef(draft);
     const { startDate: eventStartDate, endDate: eventEndDate } =
       scheduleDateStrings(draft);
@@ -962,19 +978,29 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
                   <div className="flex items-start gap-2">
                     <UsersIcon
                       size={16}
-                      className="mt-2 shrink-0 text-text-muted"
+                      className="mt-1 shrink-0 text-text-muted"
                     />
-                    <AttendeeField
-                      id={EVENT_FORM_ATTENDEES_ID}
-                      value={attendeeChips}
-                      onChange={(next) => patchDraftFields({ attendees: next })}
-                      suggestionSource={contactSuggestionSource}
-                      menuFooter={
-                        canSuggestContacts ? null : (
-                          <EnableContactSuggestionsNudge />
-                        )
-                      }
-                    />
+                    <div className="flex min-w-0 flex-1 flex-col gap-1">
+                      {attendeeChipTally && (
+                        <p className="text-text-muted text-xs">
+                          {attendeeChipTally}
+                        </p>
+                      )}
+                      <AttendeeField
+                        id={EVENT_FORM_ATTENDEES_ID}
+                        value={attendeeChips}
+                        onChange={(next) =>
+                          patchDraftFields({ attendees: next })
+                        }
+                        statusByEmail={attendeeRsvpByEmail}
+                        suggestionSource={contactSuggestionSource}
+                        menuFooter={
+                          canSuggestContacts ? null : (
+                            <EnableContactSuggestionsNudge />
+                          )
+                        }
+                      />
+                    </div>
                   </div>
                 </FormCard>
               )}

--- a/packages/web/src/views/Forms/EventForm/attendee-rsvp.test.ts
+++ b/packages/web/src/views/Forms/EventForm/attendee-rsvp.test.ts
@@ -7,27 +7,24 @@ import { describe, expect, it } from "bun:test";
 
 describe("formatAttendeeRsvpTally", () => {
   it("always includes yes and awaiting, matching the host summary", () => {
-    expect(formatAttendeeRsvpTally([{ responseStatus: "needsAction" }])).toBe(
+    expect(formatAttendeeRsvpTally(["needsAction"])).toBe(
       "1 guest (0 yes, 1 awaiting)",
     );
   });
 
   it("pluralizes and omits zero no/maybe counts", () => {
-    expect(
-      formatAttendeeRsvpTally([
-        { responseStatus: "accepted" },
-        { responseStatus: "accepted" },
-      ]),
-    ).toBe("2 guests (2 yes, 0 awaiting)");
+    expect(formatAttendeeRsvpTally(["accepted", "accepted"])).toBe(
+      "2 guests (2 yes, 0 awaiting)",
+    );
   });
 
   it("appends no and maybe only when those counts are greater than zero", () => {
     expect(
       formatAttendeeRsvpTally([
-        { responseStatus: "accepted" },
-        { responseStatus: "declined" },
-        { responseStatus: "tentative" },
-        { responseStatus: "needsAction" },
+        "accepted",
+        "declined",
+        "tentative",
+        "needsAction",
       ]),
     ).toBe("4 guests (1 yes, 1 awaiting, 1 no, 1 maybe)");
   });

--- a/packages/web/src/views/Forms/EventForm/attendee-rsvp.test.ts
+++ b/packages/web/src/views/Forms/EventForm/attendee-rsvp.test.ts
@@ -1,0 +1,46 @@
+import {
+  attendeeStatusByEmail,
+  formatAttendeeRsvpTally,
+  statusForEmail,
+} from "@web/views/Forms/EventForm/attendee-rsvp";
+import { describe, expect, it } from "bun:test";
+
+describe("formatAttendeeRsvpTally", () => {
+  it("always includes yes and awaiting, matching the host summary", () => {
+    expect(formatAttendeeRsvpTally([{ responseStatus: "needsAction" }])).toBe(
+      "1 guest (0 yes, 1 awaiting)",
+    );
+  });
+
+  it("pluralizes and omits zero no/maybe counts", () => {
+    expect(
+      formatAttendeeRsvpTally([
+        { responseStatus: "accepted" },
+        { responseStatus: "accepted" },
+      ]),
+    ).toBe("2 guests (2 yes, 0 awaiting)");
+  });
+
+  it("appends no and maybe only when those counts are greater than zero", () => {
+    expect(
+      formatAttendeeRsvpTally([
+        { responseStatus: "accepted" },
+        { responseStatus: "declined" },
+        { responseStatus: "tentative" },
+        { responseStatus: "needsAction" },
+      ]),
+    ).toBe("4 guests (1 yes, 1 awaiting, 1 no, 1 maybe)");
+  });
+});
+
+describe("attendeeStatusByEmail", () => {
+  it("indexes by lower-cased email and defaults missing lookups to awaiting", () => {
+    const map = attendeeStatusByEmail([
+      { email: "Alex@Example.com", responseStatus: "accepted" },
+    ]);
+
+    expect(statusForEmail(map, "alex@example.com")).toBe("accepted");
+    expect(statusForEmail(map, "new@example.com")).toBe("needsAction");
+    expect(statusForEmail(undefined, "anyone@example.com")).toBe("needsAction");
+  });
+});

--- a/packages/web/src/views/Forms/EventForm/attendee-rsvp.ts
+++ b/packages/web/src/views/Forms/EventForm/attendee-rsvp.ts
@@ -1,0 +1,52 @@
+import { type AttendeeResponseStatus } from "@core/types/event-attendance.contracts";
+
+/** Observer labels for someone else's RSVP — not the user's Going/Maybe/Decline. */
+export const ATTENDEE_RSVP_LABEL: Record<AttendeeResponseStatus, string> = {
+  accepted: "yes",
+  declined: "no",
+  tentative: "maybe",
+  needsAction: "awaiting",
+};
+
+export const attendeeStatusByEmail = (
+  attendees:
+    | ReadonlyArray<{ email: string; responseStatus: AttendeeResponseStatus }>
+    | undefined,
+): ReadonlyMap<string, AttendeeResponseStatus> => {
+  const map = new Map<string, AttendeeResponseStatus>();
+  for (const attendee of attendees ?? []) {
+    map.set(attendee.email.toLowerCase(), attendee.responseStatus);
+  }
+  return map;
+};
+
+export const statusForEmail = (
+  statusByEmail: ReadonlyMap<string, AttendeeResponseStatus> | undefined,
+  email: string,
+): AttendeeResponseStatus =>
+  statusByEmail?.get(email.toLowerCase()) ?? "needsAction";
+
+/**
+ * `{n} guest(s) ({yes} yes, {awaiting} awaiting)` plus `, {n} no` /
+ * `, {n} maybe` only when those counts are greater than zero.
+ */
+export const formatAttendeeRsvpTally = (
+  attendees: ReadonlyArray<{ responseStatus: AttendeeResponseStatus }>,
+): string => {
+  const counts: Record<AttendeeResponseStatus, number> = {
+    accepted: 0,
+    declined: 0,
+    tentative: 0,
+    needsAction: 0,
+  };
+  for (const attendee of attendees) {
+    counts[attendee.responseStatus] += 1;
+  }
+
+  const guestWord = attendees.length === 1 ? "guest" : "guests";
+  const parts = [`${counts.accepted} yes`, `${counts.needsAction} awaiting`];
+  if (counts.declined > 0) parts.push(`${counts.declined} no`);
+  if (counts.tentative > 0) parts.push(`${counts.tentative} maybe`);
+
+  return `${attendees.length} ${guestWord} (${parts.join(", ")})`;
+};

--- a/packages/web/src/views/Forms/EventForm/attendee-rsvp.ts
+++ b/packages/web/src/views/Forms/EventForm/attendee-rsvp.ts
@@ -31,7 +31,7 @@ export const statusForEmail = (
  * `, {n} maybe` only when those counts are greater than zero.
  */
 export const formatAttendeeRsvpTally = (
-  attendees: ReadonlyArray<{ responseStatus: AttendeeResponseStatus }>,
+  statuses: readonly AttendeeResponseStatus[],
 ): string => {
   const counts: Record<AttendeeResponseStatus, number> = {
     accepted: 0,
@@ -39,14 +39,14 @@ export const formatAttendeeRsvpTally = (
     tentative: 0,
     needsAction: 0,
   };
-  for (const attendee of attendees) {
-    counts[attendee.responseStatus] += 1;
+  for (const status of statuses) {
+    counts[status] += 1;
   }
 
-  const guestWord = attendees.length === 1 ? "guest" : "guests";
+  const guestWord = statuses.length === 1 ? "guest" : "guests";
   const parts = [`${counts.accepted} yes`, `${counts.needsAction} awaiting`];
   if (counts.declined > 0) parts.push(`${counts.declined} no`);
   if (counts.tentative > 0) parts.push(`${counts.tentative} maybe`);
 
-  return `${attendees.length} ${guestWord} (${parts.join(", ")})`;
+  return `${statuses.length} ${guestWord} (${parts.join(", ")})`;
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hosts can see each attendee’s RSVP without profile photos: a compact yes/no/maybe/awaiting badge on organizer chips and the read-only guest list, plus a Google-style tally (`1 guest (0 yes, 1 awaiting)`). Status is looked up from the live `Attendee[]` by email; the write path stays `{email, displayName}`.

Field jumps: `e` then `a` and Mod+8 focus guests (Mod+9 is notes). The previous `a` = account letter is removed; the create-only calendar picker still uses Mod+5.

## Simplicity

Reuses the existing `responseStatus` read model and `EDIT_SEQUENCE_FIELDS` table. No contract, backend, or sync changes. Account stays digit-only instead of inventing a new letter.

Follow-up simplify commit (`54eb768e8`): tally helper takes raw statuses, new chips reuse `toOption`, attendee focus selectors dropped to two ids, `hasEditSequenceKey` is unexported, RSVP icons use `as const`. Chip `aria-label` stays on react-select `MultiValue` because a span `aria-label` failed type-check and a11y lint.

## Automated validation

`bun run verify` (merge-base `571e0163b`, detected web + e2e): **All checks passed**

- `test:web`: 2546 pass, 0 fail
- `type-check`, `lint`, `knip`: pass
- `test:a11y`: 7 passed
- `test:e2e`: 47 passed (includes `e2e/attendees`)

CI on the first commit failed e2e because `page.getByLabelText` is not a Playwright API; that locator is now `getByLabel`.

## Independent review

No confirmed findings from a pass over the simplify + feature diff: write path remains `AttendeeInput`, RSVP is display-only, Account stays Mod+5 only, guest jumps use `#event-form-attendees` then `#event-form-guest-list`.

## Test plan

- `bun run verify` → test:web, type-check, lint, knip, test:a11y, test:e2e

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f668aae4-d642-4499-ad71-fc69dce81b61?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f668aae4-d642-4499-ad71-fc69dce81b61&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

