### PR TITLE
test(billing): cover webhook retry and unhandled-type paths

### DIFF
--- a/packages/backend/src/billing/services/billing.webhook.service.db.test.ts
+++ b/packages/backend/src/billing/services/billing.webhook.service.db.test.ts
@@ -385,4 +385,99 @@ describe("Stripe webhook", () => {
     const stored = await mongoService.user.findOne({ _id: userId });
     expect(stored?.billing?.subscriptionStatus).toBe("canceled");
   });
+  it("drops the dedupe row when the handler throws so Stripe's retry can reprocess", async () => {
+    using _env = mockEnv(stripeConfigured);
+    const userId = mongoService.objectId();
+    await mongoService.user.insertOne({
+      _id: userId,
+      email: "throw@example.com",
+      name: "Throw",
+      firstName: "Throw",
+      lastName: "User",
+      locale: "en",
+      billing: {
+        subscriptionStatus: "awaiting_checkout",
+        stripeSubscriptionId: "sub_1",
+        stripeCustomerId: "cus_1",
+      },
+    });
+
+    setStripeClientForTests({
+      subscriptions: {
+        retrieve: mock(() => Promise.reject(new Error("stripe unavailable"))),
+      },
+    } as unknown as Stripe);
+
+    const event = {
+      id: "evt_throw_1",
+      type: "customer.subscription.updated",
+      created: 1_775_000_100,
+      data: { object: { id: "sub_1" } },
+    } as unknown as Stripe.Event;
+
+    await expect(processStripeEvent(event)).rejects.toThrow(
+      "stripe unavailable",
+    );
+
+    // The row must be gone, otherwise the dedupe would swallow Stripe's retry
+    // and the write would be lost for good.
+    expect(
+      await mongoService.billingEvent.countDocuments({ _id: event.id }),
+    ).toBe(0);
+
+    const stored = await mongoService.user.findOne({ _id: userId });
+    expect(stored?.billing?.subscriptionStatus).toBe("awaiting_checkout");
+
+    // A retry after Stripe recovers is reprocessed rather than deduped away.
+    setStripeClientForTests({
+      subscriptions: { retrieve: mock(() => Promise.resolve(subscription())) },
+    } as unknown as Stripe);
+    await processStripeEvent(event);
+
+    const retried = await mongoService.user.findOne({ _id: userId });
+    expect(retried?.billing?.subscriptionStatus).toBe("trialing");
+  });
+
+  it("ignores an unhandled event type without touching the user", async () => {
+    using _env = mockEnv(stripeConfigured);
+    const userId = mongoService.objectId();
+    await mongoService.user.insertOne({
+      _id: userId,
+      email: "unhandled@example.com",
+      name: "Unhandled",
+      firstName: "Unhandled",
+      lastName: "User",
+      locale: "en",
+      billing: {
+        subscriptionStatus: "active",
+        stripeSubscriptionId: "sub_1",
+        stripeCustomerId: "cus_1",
+      },
+    });
+
+    const retrieve = mock(() => Promise.resolve(subscription()));
+    setStripeClientForTests({
+      subscriptions: { retrieve },
+    } as unknown as Stripe);
+
+    await processStripeEvent({
+      id: "evt_invoice_paid_1",
+      type: "invoice.paid",
+      created: 1_775_000_100,
+      data: { object: { id: "in_1", subscription: "sub_1" } },
+    } as unknown as Stripe.Event);
+
+    expect(retrieve).not.toHaveBeenCalled();
+    const stored = await mongoService.user.findOne({ _id: userId });
+    expect(stored?.billing?.subscriptionStatus).toBe("active");
+    expect(stored?.billing?.lastStripeEventAt).toBeUndefined();
+
+    // The dedupe row is still written: the insert precedes the handled-type
+    // check, so an unhandled redelivery is acked without re-entering handling.
+    expect(
+      await mongoService.billingEvent.countDocuments({
+        _id: "evt_invoice_paid_1",
+      }),
+    ).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary

While working the staging billing-enforcement edge-case matrix, two behaviours the rollout explicitly depends on turned out to have no test coverage in `billing.webhook.service.db.test.ts`. This adds them. Test-only — no production code changed.

- **Handler throw drops the dedupe row.** `processStripeEvent` inserts a `billingEvent` row before handling and deletes it if the handler throws. If that delete ever regressed, Stripe's retry would be swallowed by the dedupe and the write lost permanently — a silent, unrecoverable failure. The test asserts the row is gone, the user document is untouched, and a retry of the *same* event id is genuinely reprocessed rather than deduped away.
- **Unhandled event types are inert.** `invoice.paid` must not reach `subscriptions.retrieve` or write to the user. It *does* still write the dedupe row, because the insert precedes the `HANDLED_TYPES` check; the test pins that so the acking behaviour is deliberate rather than incidental.

## Simplicity

Both tests reuse the file's existing `subscription()` factory, `mockEnv`, and `setStripeClientForTests` helpers, so they add no new scaffolding. No production code needed changing — the behaviour was already correct, just unpinned.

## Automated validation

Not applicable — this PR adds tests rather than changing behaviour. The behaviours under test were verified by the test run below, not by a browser or API scenario.

## Independent review

No `/review` handoff was produced for this change. It is test-only, and the two additions were reviewed against the implementation in `billing.webhook.service.ts` (the `insertOne` / `deleteOne` pairing in `processStripeEvent` and the `HANDLED_TYPES` early return in `handleEvent`).

## Test plan

```
bun packages/scripts/src/testing/test-mongo-env.ts backend -- './packages/backend/src/billing/**/*.test.ts'
# 41 pass, 0 fail, 93 expect() calls (39 pass before this change)

bun run lint      # exit 0
bunx tsc --noEmit -p packages/backend/tsconfig.json   # clean
```

Note for reproduction in a sandboxed container: `mongodb-memory-server`'s free-port probe binds `::`, which fails where IPv6 is unavailable. That is an environment quirk, not a repo issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_014Vsm8ZP8d9X1umty1x9wu6)_