### PR TITLE
fix(sync): tolerate unknown keys when reading sync_resources

### DIFF
--- a/packages/sync/src/storage/contracts/sync-resource.contracts.test.ts
+++ b/packages/sync/src/storage/contracts/sync-resource.contracts.test.ts
@@ -1,4 +1,8 @@
-import { ResourceBootstrapStateSchema } from "./sync-resource.contracts";
+import {
+  ResourceBootstrapStateSchema,
+  SyncResourceReadSchema,
+  SyncResourceRecordSchema,
+} from "./sync-resource.contracts";
 import { describe, expect, it } from "bun:test";
 
 describe("ResourceBootstrapStateSchema", () => {
@@ -10,5 +14,51 @@ describe("ResourceBootstrapStateSchema", () => {
 
   it("rejects a missing value - no default (backfill-bootstrap-state stamps every row explicitly instead)", () => {
     expect(() => ResourceBootstrapStateSchema.parse(undefined)).toThrow();
+  });
+});
+
+describe("SyncResourceReadSchema", () => {
+  const record = {
+    _id: "507f1f77bcf86cd799439011",
+    tenantId: "507f1f77bcf86cd799439012",
+    principalId: "507f1f77bcf86cd799439013",
+    connectionId: "507f1f77bcf86cd799439014",
+    resourceKind: "events",
+    calendarId: "507f1f77bcf86cd799439015",
+    syncCursor: null,
+    pageCursor: null,
+    importGeneration: 0,
+    activeGeneration: 0,
+    lastAttemptAt: null,
+    lastSuccessAt: null,
+    bootstrapState: "ready",
+    subscriptionId: null,
+    subscriptionResourceId: null,
+    subscriptionToken: null,
+    subscriptionExpiresAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  it("accepts a field a newer build stamped, so an old build survives a rolling deploy", () => {
+    // Production 2026-08-27: #2908 wrote lastFullListAt, then a still-running
+    // pre-#2908 pod parsed the row with strictObject and threw
+    // unrecognized_keys, taking down GET /connections and the job worker.
+    const parsed = SyncResourceReadSchema.parse({
+      ...record,
+      fieldFromNewerBuild: "value the old build never heard of",
+    });
+    expect(parsed.resourceKind).toBe("events");
+    expect("fieldFromNewerBuild" in parsed).toBe(false);
+  });
+
+  it("still rejects an unknown key on write, so this build cannot persist a typo", () => {
+    const result = SyncResourceRecordSchema.safeParse({
+      ...record,
+      typoedKey: 1,
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues[0]?.code).toBe("unrecognized_keys");
   });
 });

--- a/packages/sync/src/storage/contracts/sync-resource.contracts.ts
+++ b/packages/sync/src/storage/contracts/sync-resource.contracts.ts
@@ -158,6 +158,19 @@ export const SyncResourceRecordSchema = z.strictObject({
 });
 export type SyncResourceRecord = z.infer<typeof SyncResourceRecordSchema>;
 
+// Reads parse through this stripped variant, not the strict schema above.
+// A rolling deploy runs the old build and the new build together: the new
+// build stamps a field the old build has never heard of, the old build then
+// reads that row, and a strictObject rejects the unknown key
+// (`unrecognized_keys`) and throws. That broke GET /connections and the sync
+// job worker during the #2908 `lastFullListAt` deploy (2026-08-27). The
+// mirror-image mistake (a required field with no default) froze the fleet
+// for 23h (2026-07-31). Unknown keys are dropped from the in-memory record
+// and left untouched in Mongo — writes are field-level `$set`, so the newer
+// build's field survives. Writes stay strict, so this build still cannot
+// persist an unknown or misspelled key.
+export const SyncResourceReadSchema = SyncResourceRecordSchema.strip();
+
 export const SyncResourceUpsertSchema = SyncResourceRecordSchema.pick({
   tenantId: true,
   principalId: true,

--- a/packages/sync/src/storage/repositories/sync-resource.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.db.test.ts
@@ -1,6 +1,7 @@
 import { faker } from "@faker-js/faker";
 import { type Db } from "mongodb";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import { type SyncResourceUpsert } from "@sync/storage/contracts/sync-resource.contracts";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 
@@ -469,5 +470,34 @@ describe("SyncResourceRepository", () => {
         resource._id,
       ),
     ).toBeNull();
+  });
+
+  it("reads a row a newer build stamped with an unknown field", async () => {
+    // A rolling deploy runs the old and new builds together: the new build
+    // adds a field and stamps it on a row, then the old build reads that row.
+    // A strict read schema rejected the unknown key and broke GET
+    // /connections plus every job that re-parsed the resource (2026-08-27).
+    const resource = await repo.ensure(upsert());
+    await db
+      .collection(SYNC_COLLECTIONS.syncResources)
+      .updateOne(
+        { _id: resource._id as never },
+        { $set: { fieldFromNewerBuild: "value the old build never heard of" } },
+      );
+
+    const byId = await repo.findById(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+    );
+    expect(byId?._id).toBe(resource._id);
+
+    const byConnection = await repo.listByConnection(
+      resource.tenantId,
+      resource.principalId,
+      resource.connectionId,
+    );
+    expect(byConnection).toHaveLength(1);
+    expect(byConnection[0]?._id).toBe(resource._id);
   });
 });

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -9,8 +9,8 @@ import {
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import {
   type ResourceBootstrapState,
+  SyncResourceReadSchema,
   type SyncResourceRecord,
-  SyncResourceRecordSchema,
   type SyncResourceUpsert,
   SyncResourceUpsertSchema,
 } from "@sync/storage/contracts/sync-resource.contracts";
@@ -94,7 +94,7 @@ export class SyncResourceRepository {
         { $limit: limit },
       ])
       .toArray();
-    return records.map((r) => SyncResourceRecordSchema.parse(r));
+    return records.map((r) => SyncResourceReadSchema.parse(r));
   }
 
   async ensure(input: SyncResourceUpsert): Promise<SyncResourceRecord> {
@@ -135,7 +135,7 @@ export class SyncResourceRepository {
       { upsert: true, returnDocument: "after" },
     );
     if (!result) throw new Error("Ensure did not return a sync resource");
-    return SyncResourceRecordSchema.parse(result);
+    return SyncResourceReadSchema.parse(result);
   }
 
   async markAttempt(
@@ -409,7 +409,7 @@ export class SyncResourceRepository {
     subscriptionId: string,
   ): Promise<SyncResourceRecord | null> {
     const record = await this.collection.findOne({ subscriptionId });
-    return record ? SyncResourceRecordSchema.parse(record) : null;
+    return record ? SyncResourceReadSchema.parse(record) : null;
   }
 
   // Begin a fresh import generation for a non-destructive repair. The old
@@ -425,7 +425,7 @@ export class SyncResourceRepository {
       { returnDocument: "after" },
     );
     if (!result) throw new Error("startNewGeneration: resource not found");
-    return SyncResourceRecordSchema.parse(result).importGeneration;
+    return SyncResourceReadSchema.parse(result).importGeneration;
   }
 
   // Serve reads from the generation a repair just finished building. The flip is
@@ -519,7 +519,7 @@ export class SyncResourceRepository {
       tenantId,
       principalId,
     });
-    return record ? SyncResourceRecordSchema.parse(record) : null;
+    return record ? SyncResourceReadSchema.parse(record) : null;
   }
 
   async listByConnection(
@@ -530,7 +530,7 @@ export class SyncResourceRepository {
     const records = await this.collection
       .find({ tenantId, principalId, connectionId })
       .toArray();
-    return records.map((r) => SyncResourceRecordSchema.parse(r));
+    return records.map((r) => SyncResourceReadSchema.parse(r));
   }
 
   // Events resources owned by the signed principal — input for a user-
@@ -545,7 +545,7 @@ export class SyncResourceRepository {
       .find({ tenantId, principalId, resourceKind: "events" })
       .limit(limit)
       .toArray();
-    return records.map((r) => SyncResourceRecordSchema.parse(r));
+    return records.map((r) => SyncResourceReadSchema.parse(r));
   }
 
   // Foreground freshness fallback: resources for one currently-connected
@@ -569,7 +569,7 @@ export class SyncResourceRepository {
       .sort({ lastAttemptAt: 1 })
       .limit(limit)
       .toArray();
-    return records.map((r) => SyncResourceRecordSchema.parse(r));
+    return records.map((r) => SyncResourceReadSchema.parse(r));
   }
 
   // Events resources whose last successful sync is older than `before` (or which
@@ -643,7 +643,7 @@ export class SyncResourceRepository {
       .sort({ subscriptionExpiresAt: 1 })
       .limit(limit)
       .toArray();
-    return records.map((r) => SyncResourceRecordSchema.parse(r));
+    return records.map((r) => SyncResourceReadSchema.parse(r));
   }
 
   // calendarList resources whose last FULL enumeration is older than `before`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Who is hurt:** anyone whose web client hits `GET /connections` (page load / focus refresh) or whose sync jobs re-read a `sync_resources` row while a deploy is rolling out.
- **Root cause:** `#2908` added `lastFullListAt` and stamped it on calendar-list resources. `SyncResourceRecordSchema` is a `z.strictObject`, and the repository parses every stored document through it on read. During the rolling deploy, new pods wrote a field old pods had never heard of; old pods threw `unrecognized_keys` and took down the list/refresh path (`Failed to list/refresh connections`, #2912) and the job worker (catch-all fingerprint, real cause in `root_cause`).
- **Cost:** the last occurrence was the #2908 deploy window. The same failure repeats for every future persisted field unless reads stop being strict.

## Changes

- Reads now parse through `SyncResourceReadSchema` (`SyncResourceRecordSchema.strip()`), so an old build ignores a field it does not know. Applied at all nine read sites in `sync-resource.repository.ts`.
- Writes and upsert input keep the strict `SyncResourceRecordSchema`, so this build still cannot persist an unknown or misspelled key.
- Unknown keys are dropped from the in-memory record and left untouched in Mongo (writes are field-level `$set`).

Closes #2912.

Related: draft #2913 takes the same approach with `.loose()` instead of `.strip()`. This PR prefers strip so parsed records match `SyncResourceRecord` exactly.

## Other alerts from the same window (not this PR)

- Stripe `SubtleCryptoProvider` / webhook signatures — already fixed on main by #2905.
- SuperTokens `504` on `/recipe/user/metadata` (SSE open) — upstream timeout, not a Compass code bug.
- Earlier `invalidResponse` connection/event list failures (#2899, #2901) predate `#2908`; #2900 now puts the contract-failure detail in the title.

## Simplicity

- One new schema constant plus a mechanical swap at the nine read sites. No new control flow and no per-field handling — the fix removes the failure for every future field at once.

## Automated validation

- Focused schema + repository tests: 24 pass, including the new unknown-field cases.
- `bun run verify` (test:sync, type-check, lint, knip): 1090 sync tests pass, 0 fail.

## Independent review

- No separate `/review` reviewer has run yet.

## Test plan

- `bun packages/scripts/src/testing/test-mongo-env.ts sync -- './packages/sync/src/storage/contracts/sync-resource.contracts.test.ts' './packages/sync/src/storage/repositories/sync-resource.repository.db.test.ts'` → 24 pass, 0 fail
- `bun run verify` → Selected packages: sync; Checks run: test:sync, type-check, lint, knip; 1090 pass, 0 fail

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-563532fe-3eb4-4623-8b7c-3dda6c16ad7c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-563532fe-3eb4-4623-8b7c-3dda6c16ad7c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

