### PR TITLE
fix(sync): strip unknown keys on resource reads

### DIFF
--- a/.agents/handoffs/2912.md
+++ b/.agents/handoffs/2912.md
@@ -1,0 +1,37 @@
+---
+schema_version: 1
+task_id: "2912"
+from: Implementer
+to: Verifier
+owner: Verifier
+status: verifying
+artifact:
+  - path: packages/sync/src/storage/contracts/sync-resource.contracts.ts
+  - path: packages/sync/src/storage/contracts/sync-resource.contracts.test.ts
+  - path: packages/sync/src/storage/repositories/sync-resource.repository.db.test.ts
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/2916
+evidence:
+  - command: bun test packages/sync/src/storage/contracts/sync-resource.contracts.test.ts
+    result: "5 pass, 0 fail (unknown key stripped; missing bootstrapState still throws)"
+  - command: bun test:sync -- packages/sync/src/storage/repositories/sync-resource.repository.db.test.ts packages/sync/src/storage/contracts/sync-resource.contracts.test.ts
+    result: "25 pass, 0 fail (listByConnection succeeds with extra Mongo field)"
+  - command: bun run verify
+    result: "Selected packages: sync; checks run test:sync, type-check, lint, knip; Checks skipped: (none); All checks passed"
+assumptions:
+  - PostHog MCP was unauthenticated in this environment; the live root_cause is taken from GitHub #2912 (Zod unrecognized_keys lastFullListAt on Failed to list/refresh connections) plus the catch-all issue history in the task text.
+  - Mongo -31800 is already fixed by #2843; this reopen is the #2908 lastFullListAt rolling-deploy parse throw.
+open_risks:
+  - JobRecordSchema and ProviderConnectionRecordSchema remain z.strictObject, so the next additive field on those collections can still take down claim/list paths during a rolling deploy.
+next_deadline: 2026-08-28T00:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+Strip unknown keys on sync resource reads so a rolling deploy of an additive
+field cannot 500 GET /connections or reopen the Sync job engine catch-all.
+
+Independent review of origin/main...HEAD: no confirmed findings.
+
+Suggested skills: `/verify-change`, `/ship`.

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -18,3 +18,4 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 | WP-shortcut-showcase-simplify | medium | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/2890 | verifier PASS; simplify no change; independent re-review no findings | 2026-08-26T23:00:00Z | 2 | none |
 | 2891 | medium | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/2893 | bun run verify PASS; review: no confirmed findings | 2026-08-27T00:00:00Z | 0 | none |
 | 2898 | medium | Manager | verifying | https://github.com/keepsoftwaresimple/compass-calendar/pull/2898 | focused web 62 pass; lint clean of new errors; review: no confirmed findings | 2026-08-27T06:00:00Z | 0 | none |
+| 2912 | high | Verifier | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/2916 | bun run verify PASS (test:sync, type-check, lint, knip); unknown-key strip tests 25 pass | 2026-08-28T00:00:00Z | 0 | none |

--- a/packages/sync/src/storage/contracts/sync-resource.contracts.test.ts
+++ b/packages/sync/src/storage/contracts/sync-resource.contracts.test.ts
@@ -1,5 +1,40 @@
-import { ResourceBootstrapStateSchema } from "./sync-resource.contracts";
+import {
+  ResourceBootstrapStateSchema,
+  SyncResourceRecordSchema,
+} from "./sync-resource.contracts";
 import { describe, expect, it } from "bun:test";
+
+const objectId = "64a0a0a0a0a0a0a0a0a0a0a0";
+
+const validRecord = {
+  _id: objectId,
+  tenantId: objectId,
+  principalId: objectId,
+  connectionId: objectId,
+  resourceKind: "calendarList" as const,
+  calendarId: null,
+  syncCursor: null,
+  pageCursor: null,
+  importGeneration: 0,
+  activeGeneration: 0,
+  lastAttemptAt: null,
+  lastSuccessAt: null,
+  lastFullListAt: new Date("2026-08-27T17:19:51.000Z"),
+  lastReadFailureAt: null,
+  lastReadFailureDetail: null,
+  bootstrapState: "ready" as const,
+  watchUnsupportedAt: null,
+  subscriptionId: null,
+  subscriptionResourceId: null,
+  subscriptionToken: null,
+  subscriptionExpiresAt: null,
+  changeNotifiedAt: null,
+  pushLastReceivedAt: null,
+  cursorExpiredStreak: 0,
+  cursorExpiredBackoffUntil: null,
+  createdAt: new Date("2026-08-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-08-27T17:19:51.000Z"),
+};
 
 describe("ResourceBootstrapStateSchema", () => {
   it("parses every known state", () => {
@@ -10,5 +45,31 @@ describe("ResourceBootstrapStateSchema", () => {
 
   it("rejects a missing value - no default (backfill-bootstrap-state stamps every row explicitly instead)", () => {
     expect(() => ResourceBootstrapStateSchema.parse(undefined)).toThrow();
+  });
+});
+
+describe("SyncResourceRecordSchema", () => {
+  it("parses a complete resource", () => {
+    const parsed = SyncResourceRecordSchema.parse(validRecord);
+    expect(parsed.lastFullListAt).toEqual(validRecord.lastFullListAt);
+    expect(parsed.bootstrapState).toBe("ready");
+  });
+
+  it("strips a newer writer's unknown key instead of failing the whole read", () => {
+    // 2026-08-27: lastFullListAt was the key that 500'd GET /connections and
+    // reopened the Sync-job-engine catch-all during #2908's rolling deploy.
+    // The next additive field must not repeat that. Missing required fields
+    // still throw — see the bootstrapState test below.
+    const parsed = SyncResourceRecordSchema.parse({
+      ...validRecord,
+      addedByNewerWriter: "must-not-brick-older-replicas",
+    });
+    expect(parsed.lastFullListAt).toEqual(validRecord.lastFullListAt);
+    expect("addedByNewerWriter" in parsed).toBe(false);
+  });
+
+  it("still rejects a row missing a required field", () => {
+    const { bootstrapState: _dropped, ...withoutBootstrap } = validRecord;
+    expect(() => SyncResourceRecordSchema.parse(withoutBootstrap)).toThrow();
   });
 });

--- a/packages/sync/src/storage/contracts/sync-resource.contracts.ts
+++ b/packages/sync/src/storage/contracts/sync-resource.contracts.ts
@@ -30,7 +30,17 @@ export type ResourceBootstrapState = z.infer<
 // subscription. A calendar-list resource has no calendarId (there is one per
 // connection); an events resource is keyed to one provider calendar. Holds no
 // event content.
-export const SyncResourceRecordSchema = z.strictObject({
+//
+// `z.object` (strip unknown keys), not `z.strictObject`. Additive fields are
+// written in the same deploy that teaches the schema about them, so during a
+// rolling deploy a newer replica stamps a key an older replica cannot name.
+// Strict parse then throws on every read of that row: GET /connections
+// (listByConnection inside refreshConnectionState) 500s the whole calendar
+// list, and every job that ensure()/finds the resource throws into #runJob's
+// catch-all ("Sync job engine failed"). 2026-08-27: lastFullListAt from #2908
+// did exactly that. Missing required fields still fail — that is the
+// 2026-07-31 freeze we still want (a row silently missing watchUnsupportedAt).
+export const SyncResourceRecordSchema = z.object({
   _id: ObjectIdStringSchema,
   tenantId: TenantIdSchema,
   principalId: PrincipalIdSchema,

--- a/packages/sync/src/storage/repositories/sync-resource.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.db.test.ts
@@ -1,6 +1,7 @@
 import { faker } from "@faker-js/faker";
 import { type Db } from "mongodb";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import { type SyncResourceUpsert } from "@sync/storage/contracts/sync-resource.contracts";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 
@@ -469,5 +470,30 @@ describe("SyncResourceRepository", () => {
         resource._id,
       ),
     ).toBeNull();
+  });
+
+  it("lists a resource that already carries a newer writer's unknown key", async () => {
+    // GET /connections refresh-parses every resource for the principal. A
+    // strict schema turned one additive field (lastFullListAt, #2908) into a
+    // 500 for the whole calendar list, and the same throw from a job's
+    // ensure()/find reopened the Sync-job-engine catch-all.
+    const resource = await repo.ensure(
+      upsert({ resourceKind: "calendarList" }),
+    );
+    await db
+      .collection(SYNC_COLLECTIONS.syncResources)
+      .updateOne(
+        { _id: resource._id },
+        { $set: { addedByNewerWriter: "rolling-deploy-field" } },
+      );
+
+    const listed = await repo.listByConnection(
+      resource.tenantId,
+      resource.principalId,
+      resource.connectionId,
+    );
+    expect(listed).toHaveLength(1);
+    expect(listed[0]?._id).toBe(resource._id);
+    expect("addedByNewerWriter" in (listed[0] ?? {})).toBe(false);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- The PostHog "Sync job engine failed" catch-all reopened. The live `root_cause` is not Mongo `-31800` (that wave ended with #2843/#2848). It is Zod `unrecognized_keys: lastFullListAt` on `sync_resources` parse, matching GitHub #2912 (`Failed to list/refresh connections`).
- #2908 added `lastFullListAt` and started writing it in the same deploy. During a rolling deploy, a newer replica stamps the field; an older replica's `z.strictObject` parse then throws on every read of that row.
- That throw 500s `GET /connections` (refresh-state lists every resource for the principal) and any job that `ensure()`/`find`s the resource, which fingerprints as the `#runJob` catch-all.
- Persistence reads now use `z.object` (strip unknown keys). Missing required fields still fail — that is the 2026-07-31 freeze we still want.

Fixes #2912

## Simplicity

- One schema flag change. No new helper, no per-call-site try/catch, no wire-contract relaxation. #2900 already made the backend diagnostic name the broken field; this stops the sync-side parse from throwing on the next additive field.

## Automated validation

- `bun test packages/sync/src/storage/contracts/sync-resource.contracts.test.ts` — 5 pass (unknown key stripped; missing `bootstrapState` still throws)
- `bun test:sync -- packages/sync/src/storage/repositories/sync-resource.repository.db.test.ts packages/sync/src/storage/contracts/sync-resource.contracts.test.ts` — 25 pass (`listByConnection` succeeds when Mongo already has an extra field)
- `bun run verify` — selected sync; `test:sync`, type-check, lint, knip all passed

## Independent review

- origin/main...HEAD: no confirmed findings. Follow-up (not in this PR): `JobRecordSchema` and `ProviderConnectionRecordSchema` are still `z.strictObject`, so the next additive field on those collections can still take down claim/list during a rolling deploy.

## Test plan

- `bun test packages/sync/src/storage/contracts/sync-resource.contracts.test.ts` — 5 pass, 0 fail
- `bun test:sync -- packages/sync/src/storage/repositories/sync-resource.repository.db.test.ts packages/sync/src/storage/contracts/sync-resource.contracts.test.ts` — 25 pass, 0 fail
- `bun run verify` — All checks passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab0ddea9-c744-453e-860f-db64ee540755?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab0ddea9-c744-453e-860f-db64ee540755&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

