### PR TITLE
feat(web): remap event jump to h and surface day prefixes

### DIFF
--- a/.agents/handoffs/2918.md
+++ b/.agents/handoffs/2918.md
@@ -1,0 +1,26 @@
+---
+schema_version: 1
+task_id: "2918"
+from: Reviewer
+to: Manager
+owner: Manager
+status: verifying
+artifact:
+  - path: packages/web/src/views/Week/components/Header/DayLabels.tsx
+  - url: https://github.com/keepsoftwaresimple/compass-calendar/pull/2918
+evidence:
+  - command: bun run verify
+    result: "PASS. Selected packages: web. Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e. Checks skipped: (none)."
+  - command: bun test:web -- packages/web/src/views/Week/components/Header/DayLabels.test.tsx
+    result: "4 pass after live-region copy fix"
+assumptions:
+  - "review finding was the Mod-hold live region implying H is a Mod chord"
+open_risks: []
+next_deadline: 2026-08-27T20:30:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+Independent review: one medium finding (misleading Mod-hold live text). Fixed in `3fa6e4a8c`. Ready to merge after CI.

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -18,3 +18,4 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 | WP-shortcut-showcase-simplify | medium | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/2890 | verifier PASS; simplify no change; independent re-review no findings | 2026-08-26T23:00:00Z | 2 | none |
 | 2891 | medium | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/2893 | bun run verify PASS; review: no confirmed findings | 2026-08-27T00:00:00Z | 0 | none |
 | 2898 | medium | Manager | verifying | https://github.com/keepsoftwaresimple/compass-calendar/pull/2898 | focused web 62 pass; lint clean of new errors; review: no confirmed findings | 2026-08-27T06:00:00Z | 0 | none |
+| 2918 | medium | Manager | verifying | https://github.com/keepsoftwaresimple/compass-calendar/pull/2918 | bun run verify PASS; review finding fixed in 3fa6e4a8c | 2026-08-27T20:30:00Z | 0 | none |

--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -21,7 +21,7 @@ Use this guide to validate:
 - creating events with keyboard shortcuts (C, A in both Day and Week view)
 - editing events with the same keys in Day and Week (Delete, Shift+arrows, draft arrows)
 - focusing events with arrow keys (chronological in Day, spatial in Week), including the first arrow when nothing is focused (nearest to now)
-- toggling event-jump chips (`S`); the mouse is permanently inert (Compass is keyboard-only)
+- toggling event-jump chips (`H`); the mouse is permanently inert (Compass is keyboard-only)
 - toggling the sidebar (])
 - undoing / redoing with the keyboard (Cmd+Z / Cmd+Shift+Z)
 - confirming that shortcuts do not fire while typing in inputs
@@ -279,26 +279,26 @@ After deleting or moving an event, pressing Cmd+Z (Mac) or Ctrl+Z (Windows/Linux
 
 ### UX
 
-Pressing `S` shows event-jump chips. Week view chips use day prefixes (`SU`/`M`/`T`/`W`/`R`/`F`/`SA`) plus a per-day index (`W4`, `SU1`). Day view uses numeric chips (`1`, `2`, …). Pressing a day letter highlights that column and focuses its first event; a following digit focuses that index. Memorized tokens (`W`, `W2`, day-view `1`) also work without first pressing `S`, except where a competing command still applies: bare `T` stays “go to today”, focused `M` stays “open event menu”, and `F` stays “focus latest notice” while a notice is visible. `Esc` exits (in day view a second `S` also toggles off). Bare Shift and Shift+Tab do not show jump chips.
+Pressing `H` shows event-jump chips. Week view chips use day prefixes (`SU`/`M`/`T`/`W`/`R`/`F`/`SA`) plus a per-day index (`W4`, `SU1`). Day view uses numeric chips (`1`, `2`, …). Pressing a day letter highlights that column and focuses its first event; a following digit focuses that index. Memorized tokens (`SA`, `SU`, `W`, `W2`, day-view `1`) also work without first pressing `H`, except where a competing command still applies: bare `T` stays “go to today”, focused `M` stays “open event menu”, and `F` stays “focus latest notice” while a notice is visible. `Esc` exits (a second `H` also toggles off). Holding Mod reveals the same day prefixes on week column headers. Bare Shift and Shift+Tab do not show jump chips.
 
 ### Steps
 
 1. Navigate to `/week` with timed events on at least two different days.
-2. Press `S` once; chips should appear.
+2. Press `H` once; chips should appear.
 3. Press the day letter on a chip (for example `W` for Wednesday), then optionally a digit (`2`) or use arrow keys.
 4. Press `Esc` to exit.
-5. Without pressing `S`, type a claimable day token (for example `W` or `W2`) and confirm the matching event is focused.
+5. Without pressing `H`, type a claimable day token (for example `SA`, `W`, or `W2`) and confirm the matching event is focused.
 6. Press Shift alone or Shift+Tab and confirm jump mode does not activate.
 
 ### Expected Results
 
-- Chips appear on events currently visible in the grid when `S` is pressed and stay until Esc. Scrolled-off events keep their jump keys but hide their chips.
+- Chips appear on events currently visible in the grid when `H` is pressed and stay until Esc. Scrolled-off events keep their jump keys but hide their chips.
 - A day letter highlights that column and focuses the first event; digits refine to `Wn`.
-- The same day letter / digit tokens work without a prior `S` when no competing command applies; `S` remains available to reveal every chip.
+- The same day letter / digit tokens work without a prior `H` when no competing command applies; `H` remains available to reveal every chip. Weekend columns use `SA` / `SU` from idle.
 - Bare `T` still goes to today while jump is off. With an event focused, `M` still opens the event menu. With a visible notice, `F` still focuses that notice.
 - Arrow keys keep jump mode on so letter-then-arrows works.
 - Shift alone / Shift+Tab / Shift+J do not toggle jump mode.
-- While a modal holds the app lock, or focus is in an editable field, `S` and leaderless jump tokens do not activate jump mode.
+- While a modal holds the app lock, or focus is in an editable field, `H` and leaderless jump tokens do not activate jump mode.
 
 ---
 
@@ -306,7 +306,7 @@ Pressing `S` shows event-jump chips. Week view chips use day prefixes (`SU`/`M`/
 
 ### UX
 
-Compass is the keyboard calendar: pointer clicks, right-clicks, and double-clicks do not perform the clicked action (scroll and hover still work). A blocked click on a known action shows a transient, contextual hint with the keyboard path for that action. Clicking an event also activates its jump assignments and selects that event, so the displayed token plus Enter works immediately without first pressing `S`. Keyboard activation is unaffected: Enter/Space on a native button still works, Shift+F10 still opens the focused event's context menu, and `M` opens it directly.
+Compass is the keyboard calendar: pointer clicks, right-clicks, and double-clicks do not perform the clicked action (scroll and hover still work). A blocked click on a known action shows a transient, contextual hint with the keyboard path for that action. Clicking an event also activates its jump assignments and selects that event, so the displayed token plus Enter works immediately without first pressing `H`. Keyboard activation is unaffected: Enter/Space on a native button still works, Shift+F10 still opens the focused event's context menu, and `M` opens it directly.
 
 ### Steps
 
@@ -318,7 +318,7 @@ Compass is the keyboard calendar: pointer clicks, right-clicks, and double-click
 
 ### Expected Results
 
-- Clicking an event does not open it, but jump chips appear, the event is selected, and the hint identifies that event's exact token plus `Enter`; the shown sequence opens the event without an initial `S`.
+- Clicking an event does not open it, but jump chips appear, the event is selected, and the hint identifies that event's exact token plus `Enter`; the shown sequence opens the event without an initial `H`.
 - Clicking either sidebar control does not toggle the sidebar; the hint says to press `]` and uses open/close language matching the current state.
 - Unannotated controls retain the generic keyboard-only fallback while contextual coverage is expanded.
 - Right-click does not open the context menu; `M` (or Shift+F10) on a focused event does.
@@ -416,7 +416,7 @@ If time is limited, run these checks before shipping shortcut-related changes:
 12. With no event focused and no particular control focused (document body), any Arrow key focuses the timed event nearest now in the current Day/Week view (in-progress, else next upcoming, else most recently ended; today preferred in Week; all-day only if no timed events). Further arrows then follow the existing rules. `U` still focuses the first DOM-order event. With a focused event and no draft open: in Week view ArrowUp/ArrowDown stay on the same day and ArrowLeft/Right jump to the time-nearest event on the previous/next non-empty day; in Day view all four arrows move chronological focus.
 13. Cmd+D / Ctrl+D duplicates a focused event in Day and Week view.
 14. With a focused event, `E` then `T` opens the form with the title focused; `E` then `A` / `C` jump to guests / color; bare `E` alone does nothing.
-15. Pressing `S` shows event jump chips; a day letter + digit focuses that event; the same tokens work without a prior `S` when no competing command applies; Shift+Tab does not show chips.
+15. Pressing `H` shows event jump chips; a day letter + digit focuses that event; the same tokens work without a prior `H` when no competing command applies; Shift+Tab does not show chips.
 16. Mouse clicks, right-clicks, and double-clicks are inert everywhere; a blocked click shows the keyboard-only hint. `M` opens the focused event's menu; `F` focuses the newest notice.
 17. PageUp / PageDown scroll the timed grid by one viewport in Day and Week view even when an event is focused; they do not fire in a text input.
 18. Alt+ArrowUp / Alt+ArrowDown pan the timed grid by one hour in Day and Week view even when an event is focused; they do not fire in a text input.

--- a/docs/development/common-change-recipes.md
+++ b/docs/development/common-change-recipes.md
@@ -82,11 +82,11 @@ consistent.
    - day/week view keys: `packages/web/src/grid/shortcuts/useCalendarViewShortcuts.ts`
      (behavior in `useWeekShortcutOwner.ts` / `DayCalendarGrid.tsx`)
    - shared grid edit/focus: `packages/web/src/grid/shortcuts/`
-   - event jump (`S`): `packages/web/src/shortcuts/shift-hint/`
+   - event jump (`H`): `packages/web/src/shortcuts/shift-hint/`
    - Pointer suppression (mouse permanently inert): `packages/web/src/shortcuts/keyboard-only/`
 4. Respect `app-lock`, `escape-ownership`, and “do not fire while typing in
    inputs” (use the existing `useAppShortcut` helpers; do not attach bare
-   `window` listeners for new app shortcuts). Bare-letter shortcuts (`S`, `F`,
+   `window` listeners for new app shortcuts). Bare-letter shortcuts (`H`, `F`,
    `M`, `E`…) must yield to an armed edit sequence.
 5. Add or update registry/data tests and the owning hook tests. Update
    [Shortcuts acceptance](../acceptance/shortcuts.md) when user-visible

--- a/docs/development/feature-file-map.md
+++ b/docs/development/feature-file-map.md
@@ -81,7 +81,7 @@ labels outside the registry.
 - Sidebar next-shortcut selector: `packages/web/src/shortcuts/tips/selectShortcutHint.ts`
 - Sidebar tip progress (demonstrated primitives): `packages/web/src/shortcuts/tips/shortcut-tips.progress.store.ts`
 - Global shell shortcuts (sidebar `]`, palette, settings, navigation): `packages/web/src/shortcuts/useGlobalShortcuts.ts`
-- Event-jump chips (`S`): `packages/web/src/shortcuts/shift-hint/`
+- Event-jump chips (`H`): `packages/web/src/shortcuts/shift-hint/`
 - Pointer suppression (mouse permanently inert; keyboard clicks pass): `packages/web/src/shortcuts/keyboard-only/`
 - Escape ownership (modals/form before lower handlers): `packages/web/src/shortcuts/escape-ownership.ts`
 - App lock (suppress shortcuts while a modal owns the UI): `packages/web/src/shortcuts/app-lock.ts`

--- a/e2e/onboarding/shortcut-showcase.spec.ts
+++ b/e2e/onboarding/shortcut-showcase.spec.ts
@@ -40,7 +40,7 @@ const playThroughLevels = async (page: Page) => {
   await holdModAndPress(page, "1");
   await expect(showcase).toContainText("Pick a target");
 
-  await page.keyboard.press("s");
+  await page.keyboard.press("h");
   await page.keyboard.press("f");
   await expect(showcase).toContainText("Nudge it into place");
 

--- a/e2e/timed/shift-hold-event-hints.spec.ts
+++ b/e2e/timed/shift-hold-event-hints.spec.ts
@@ -64,7 +64,7 @@ const blurActive = (page: CalendarPage) =>
     }
   });
 
-test("tap s shows day-prefix jump keys and focuses the assigned event", async ({
+test("tap h shows day-prefix jump keys and focuses the assigned event", async ({
   page,
 }) => {
   await prepareCalendarPage(page);
@@ -93,7 +93,7 @@ test("tap s shows day-prefix jump keys and focuses the assigned event", async ({
     .getByRole("button", { name: secondTitle });
 
   await blurActive(page);
-  await page.keyboard.press("s");
+  await page.keyboard.press("h");
 
   const overlay = shiftHintOverlay(page);
   await expect(overlay.locator(":scope > span")).toHaveCount(3);
@@ -125,7 +125,7 @@ test("tap s shows day-prefix jump keys and focuses the assigned event", async ({
   await expect(shiftHintOverlay(page)).toHaveCount(0);
 });
 
-test("day prefix focuses an event without first pressing s", async ({
+test("day prefix focuses an event without first pressing h", async ({
   page,
 }) => {
   await prepareCalendarPage(page);

--- a/packages/web/src/__tests__/utils/state/reset-stores.ts
+++ b/packages/web/src/__tests__/utils/state/reset-stores.ts
@@ -45,6 +45,10 @@ import {
   usePointerBlockStore,
 } from "@web/shortcuts/keyboard-only/pointer-block.store";
 import {
+  initialPageJumpHintState,
+  usePageJumpHintStore,
+} from "@web/shortcuts/page-jump/page-jump.store";
+import {
   initialEventJumpState,
   useEventJumpStore,
 } from "@web/shortcuts/shift-hint/event-jump.store";
@@ -82,6 +86,7 @@ const storeResets: StoreReset[] = [
   () => useThemeStore.setState(useThemeStore.getInitialState(), true),
   () => usePointerBlockStore.setState(initialPointerBlockState, true),
   () => useEventJumpStore.setState(initialEventJumpState, true),
+  () => usePageJumpHintStore.setState(initialPageJumpHintState, true),
   resetShortcutHintProgressStoreForTests,
 ];
 

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
@@ -261,11 +261,11 @@ describe("ShortcutShowcase", () => {
     expect(currentStepId()).toBe("eventJump");
   });
 
-  it("teaches S then a letter to land on an event", () => {
+  it("teaches H then a letter to land on an event", () => {
     render(<ShortcutShowcase />);
     showStep("eventJump");
 
-    pressKey("s");
+    pressKey("h");
     expect(screen.getByText("F")).toBeTruthy();
 
     pressKey("f");

--- a/packages/web/src/components/ShortcutShowcase/showcase.steps.ts
+++ b/packages/web/src/components/ShortcutShowcase/showcase.steps.ts
@@ -49,7 +49,7 @@ export const SHOWCASE_STEPS = [
     title: "Pick a target",
     body: [
       "Tap ",
-      { key: "S" },
+      { key: KEYMAP.eventJump.keycaps[0] },
       " to show event keys, then press a letter to land on one.",
     ],
     keycaps: KEYMAP.eventJump.keycaps,

--- a/packages/web/src/shortcuts/global.shortcut.types.ts
+++ b/packages/web/src/shortcuts/global.shortcut.types.ts
@@ -1,6 +1,7 @@
 export interface ShortcutContext {
   isFormOpen?: boolean;
   lifeView?: boolean;
+  weekView?: boolean;
 }
 
 export interface Shortcut {

--- a/packages/web/src/shortcuts/keymap.ts
+++ b/packages/web/src/shortcuts/keymap.ts
@@ -5,7 +5,7 @@
  * remap here propagates to the real handlers, the showcase, and its hint
  * chips in one edit. Bindings come in four shapes because the app has four
  * dispatch styles: tanstack hotkey strings, the bespoke `e`… sequence engine,
- * bare-letter capture listeners (`s`, `f`, `m`), and the hold-Mod + digit-chord
+ * bare-letter capture listeners (`h`, `f`, `m`), and the hold-Mod + digit-chord
  * engine (`jumpFormField`).
  *
  * Only taught bindings live here — this is not a registry of every shortcut.
@@ -38,7 +38,7 @@ export const KEYMAP = {
     keycaps: ["ArrowLeft", "ArrowUp", "ArrowDown", "ArrowRight"],
   },
   editTitle: { sequence: { leader: "e", second: "t" }, keycaps: ["E", "T"] },
-  eventJump: { bareLetter: "s", keycaps: ["S"] },
+  eventJump: { bareLetter: "h", keycaps: ["H"] },
   moveEvent: {
     hotkeys: {
       up: "Shift+ArrowUp",

--- a/packages/web/src/shortcuts/mod-hold/useModHoldHintShortcut.ts
+++ b/packages/web/src/shortcuts/mod-hold/useModHoldHintShortcut.ts
@@ -30,21 +30,31 @@ export function useModHoldHintShortcut({
   enabled = true,
   onModChord,
   onHintsRevealed,
+  onVisibilityChange,
 }: {
   enabled?: boolean;
   onModChord: (event: KeyboardEvent) => boolean;
   /** Fires once when hold-Mod chips actually appear, not on a bare Mod tap. */
   onHintsRevealed?: () => void;
+  /** Fires whenever hint visibility flips, including disable and unmount. */
+  onVisibilityChange?: (visible: boolean) => void;
 }): { areHintsVisible: boolean } {
   const [areHintsVisible, setAreHintsVisible] = useState(false);
   const onModChordRef = useRef(onModChord);
   onModChordRef.current = onModChord;
   const onHintsRevealedRef = useRef(onHintsRevealed);
   onHintsRevealedRef.current = onHintsRevealed;
+  const onVisibilityChangeRef = useRef(onVisibilityChange);
+  onVisibilityChangeRef.current = onVisibilityChange;
 
   useEffect(() => {
+    const publishVisibility = (visible: boolean) => {
+      setAreHintsVisible(visible);
+      onVisibilityChangeRef.current?.(visible);
+    };
+
     if (!enabled) {
-      setAreHintsVisible(false);
+      publishVisibility(false);
       return;
     }
 
@@ -65,7 +75,7 @@ export function useModHoldHintShortcut({
       clearHoldTimer();
       if (hintsVisible) {
         hintsVisible = false;
-        setAreHintsVisible(false);
+        publishVisibility(false);
       }
     };
 
@@ -73,7 +83,7 @@ export function useModHoldHintShortcut({
       holdTimeoutId = setTimeout(() => {
         holdTimeoutId = null;
         hintsVisible = true;
-        setAreHintsVisible(true);
+        publishVisibility(true);
         onHintsRevealedRef.current?.();
       }, MOD_HOLD_HINT_MS);
     };

--- a/packages/web/src/shortcuts/page-jump/page-jump.store.ts
+++ b/packages/web/src/shortcuts/page-jump/page-jump.store.ts
@@ -1,0 +1,32 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import { IS_DEV } from "@web/common/constants/env.constants";
+
+export type PageJumpHintState = {
+  areHintsVisible: boolean;
+};
+
+export const initialPageJumpHintState: PageJumpHintState = {
+  areHintsVisible: false,
+};
+
+export const usePageJumpHintStore = create<PageJumpHintState>()(
+  devtools(() => initialPageJumpHintState, {
+    name: "compass/page-jump-hint",
+    enabled: IS_DEV,
+  }),
+);
+
+export const pageJumpHintActions = {
+  setHintsVisible: (areHintsVisible: boolean) =>
+    usePageJumpHintStore.setState({ areHintsVisible }, false, {
+      type: "setHintsVisible",
+    }),
+  reset: () =>
+    usePageJumpHintStore.setState(initialPageJumpHintState, false, {
+      type: "reset",
+    }),
+};
+
+export const selectPageJumpHintsVisible = (state: PageJumpHintState) =>
+  state.areHintsVisible;

--- a/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.test.tsx
+++ b/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.test.tsx
@@ -12,6 +12,10 @@ import {
 import { clearAppLockReasons, setAppLockReason } from "@web/shortcuts/app-lock";
 import { MOD_HOLD_HINT_MS } from "@web/shortcuts/mod-hold/useModHoldHintShortcut";
 import {
+  pageJumpHintActions,
+  usePageJumpHintStore,
+} from "@web/shortcuts/page-jump/page-jump.store";
+import {
   LIFE_PAGE_JUMP_TARGETS,
   PAGE_JUMP_ATTRIBUTE,
   type PageJumpTargetId,
@@ -90,6 +94,7 @@ describe("usePageJumpShortcut", () => {
   afterEach(() => {
     clearAppLockReasons();
     useDraftStore.setState(initialDraftState, true);
+    pageJumpHintActions.reset();
     document.body.innerHTML = "";
   });
 
@@ -163,6 +168,7 @@ describe("usePageJumpShortcut", () => {
       await waitFor(() => {
         expect(result.current.areHintsVisible).toBe(true);
       });
+      expect(usePageJumpHintStore.getState().areHintsVisible).toBe(true);
       expect(getShortcutHintProgress()).toContain("page-jump");
     });
 

--- a/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.ts
+++ b/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.ts
@@ -1,9 +1,11 @@
+import { useEffect } from "react";
 import {
   selectIsEventFormOpen,
   useDraftStore,
 } from "@web/events/stores/draft.store";
 import { physicalDigitIndex } from "@web/shortcuts/digit-pick.util";
 import { useModHoldHintShortcut } from "@web/shortcuts/mod-hold/useModHoldHintShortcut";
+import { pageJumpHintActions } from "@web/shortcuts/page-jump/page-jump.store";
 import {
   CALENDAR_PAGE_JUMP_TARGETS,
   focusPageJumpTarget,
@@ -24,7 +26,7 @@ export function usePageJumpShortcut(
 ): { areHintsVisible: boolean } {
   const isEventFormOpen = useDraftStore(selectIsEventFormOpen);
 
-  return useModHoldHintShortcut({
+  const result = useModHoldHintShortcut({
     enabled: !isEventFormOpen,
     onHintsRevealed: () => shortcutHintProgressActions.demonstrate("page-jump"),
     onModChord: (event) => {
@@ -34,4 +36,11 @@ export function usePageJumpShortcut(
       return focusPageJumpTarget(target.id);
     },
   });
+
+  useEffect(() => {
+    pageJumpHintActions.setHintsVisible(result.areHintsVisible);
+    return () => pageJumpHintActions.setHintsVisible(false);
+  }, [result.areHintsVisible]);
+
+  return result;
 }

--- a/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.ts
+++ b/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.ts
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import {
   selectIsEventFormOpen,
   useDraftStore,
@@ -26,9 +25,10 @@ export function usePageJumpShortcut(
 ): { areHintsVisible: boolean } {
   const isEventFormOpen = useDraftStore(selectIsEventFormOpen);
 
-  const result = useModHoldHintShortcut({
+  return useModHoldHintShortcut({
     enabled: !isEventFormOpen,
     onHintsRevealed: () => shortcutHintProgressActions.demonstrate("page-jump"),
+    onVisibilityChange: pageJumpHintActions.setHintsVisible,
     onModChord: (event) => {
       const index = physicalDigitIndex(event);
       const target = index !== null ? targets[index] : undefined;
@@ -36,11 +36,4 @@ export function usePageJumpShortcut(
       return focusPageJumpTarget(target.id);
     },
   });
-
-  useEffect(() => {
-    pageJumpHintActions.setHintsVisible(result.areHintsVisible);
-    return () => pageJumpHintActions.setHintsVisible(false);
-  }, [result.areHintsVisible]);
-
-  return result;
 }

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx
@@ -4,6 +4,7 @@ import { dispatchMissingKey } from "@web/__tests__/utils/keyboard.test.util";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { clearAppLockReasons, setAppLockReason } from "@web/shortcuts/app-lock";
 import { requestPointerEventJump } from "@web/shortcuts/keyboard-only/pointer-action";
+import { KEYMAP } from "@web/shortcuts/keymap";
 import {
   eventJumpActions,
   useEventJumpStore,
@@ -37,9 +38,9 @@ const dispatch = (
   );
 };
 
-const pressS = () => {
-  dispatch("keydown", "s");
-  dispatch("keyup", "s");
+const pressEventJump = () => {
+  dispatch("keydown", KEYMAP.eventJump.bareLetter);
+  dispatch("keyup", KEYMAP.eventJump.bareLetter);
 };
 
 const timedFixture = (id: string, startDate: string): GridEvent =>
@@ -113,11 +114,11 @@ describe("useShiftHoldEventHints", () => {
     return { focus, result, elements, ids };
   };
 
-  it("toggles hints on s and focuses via day prefix", () => {
+  it("toggles hints on h and focuses via day prefix", () => {
     const { focus, result, elements } = mountHints();
 
     act(() => {
-      pressS();
+      pressEventJump();
     });
 
     expect(useEventJumpStore.getState().isActive).toBe(true);
@@ -148,7 +149,7 @@ describe("useShiftHoldEventHints", () => {
     expect(useEventJumpStore.getState().isActive).toBe(true);
   });
 
-  it("focuses a day prefix without first pressing s", () => {
+  it("focuses a day prefix without first pressing h", () => {
     const { focus, result, elements } = mountHints();
 
     const event = new KeyboardEvent("keydown", {
@@ -209,7 +210,7 @@ describe("useShiftHoldEventHints", () => {
     expect(result.current.hints).toEqual([]);
   });
 
-  it("focuses a day-view index without first pressing s", () => {
+  it("focuses a day-view index without first pressing h", () => {
     const { focus, elements } = mountHints("day");
 
     act(() => {
@@ -625,7 +626,7 @@ describe("useShiftHoldEventHints", () => {
     const { result } = mountHints();
 
     act(() => {
-      pressS();
+      pressEventJump();
     });
 
     expect(useEventJumpStore.getState().isActive).toBe(false);
@@ -636,7 +637,7 @@ describe("useShiftHoldEventHints", () => {
     const { result } = mountHints();
 
     act(() => {
-      pressS();
+      pressEventJump();
     });
     expect(result.current.hints).toHaveLength(3);
 
@@ -647,27 +648,61 @@ describe("useShiftHoldEventHints", () => {
     expect(result.current.hints).toEqual([]);
   });
 
-  it("toggles off with a second s in day view", () => {
+  it("toggles off with a second h in day view", () => {
     const { result } = mountHints("day");
 
     act(() => {
-      pressS();
+      pressEventJump();
     });
     expect(useEventJumpStore.getState().isActive).toBe(true);
     expect(result.current.hints).toHaveLength(3);
 
     act(() => {
-      pressS();
+      pressEventJump();
     });
     expect(useEventJumpStore.getState().isActive).toBe(false);
     expect(result.current.hints).toEqual([]);
+  });
+
+  it("toggles off with a second h in week view", () => {
+    const { result } = mountHints();
+
+    act(() => {
+      pressEventJump();
+    });
+    expect(useEventJumpStore.getState().isActive).toBe(true);
+    expect(result.current.hints).toHaveLength(3);
+
+    act(() => {
+      pressEventJump();
+    });
+    expect(useEventJumpStore.getState().isActive).toBe(false);
+    expect(result.current.hints).toEqual([]);
+  });
+
+  it("focuses Saturday from idle with sa", () => {
+    const { focus, elements } = mountHints("week", [
+      timedFixture(EVENT_A, "2026-08-02T09:00:00.000Z"),
+      timedFixture(EVENT_B, "2026-08-08T11:00:00.000Z"),
+    ]);
+
+    act(() => {
+      dispatch("keydown", "s");
+      dispatch("keydown", "a");
+    });
+
+    expect(useEventJumpStore.getState().isActive).toBe(true);
+    expect(focus).toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: EVENT_B, element: elements[1] }),
+    );
+    expect(useEventJumpStore.getState().activeDayKeys).toEqual(["2026-08-08"]);
   });
 
   it("keeps mode on when arrows are pressed after selecting a day", () => {
     const { focus, result } = mountHints();
 
     act(() => {
-      pressS();
+      pressEventJump();
       dispatch("keydown", "w");
     });
     expect(focus).toHaveBeenCalled();

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
@@ -161,11 +161,11 @@ const buildDayJumpAssignments = (
 };
 
 /**
- * Press `s` to show day-prefix jump labels, or type a jump token (`w`, `w1`,
- * day-view `1`…) without `s` when no competing command still applies. Esc
- * exits. Day letters (and digits after a day) win over global shortcuts while
- * active. In day view, a second `s` toggles off; in week view `s` keeps
- * Sunday/Saturday prefix meaning.
+ * Press `h` to show day-prefix jump labels, or type a jump token (`sa`,
+ * `w`, `w1`, day-view `1`…) without `h` when no competing command still
+ * applies. Esc exits. Day letters (and digits after a day) win over global
+ * shortcuts while active. A second `h` toggles off. In week view `s` is only
+ * the Sunday/Saturday prefix.
  */
 export function useShiftHoldEventHints({
   allDayEvents = [],
@@ -376,7 +376,7 @@ export function useShiftHoldEventHints({
           event.stopPropagation();
           activate();
           if (isActiveRef.current) {
-            suppressKeyUpRef.current.add("s");
+            suppressKeyUpRef.current.add(KEYMAP.eventJump.bareLetter);
           }
           return;
         }
@@ -443,8 +443,7 @@ export function useShiftHoldEventHints({
         event.preventDefault();
         event.stopPropagation();
         suppressKeyUpRef.current.add(key);
-        // Day view has no letter prefixes; a second `s` toggles off.
-        if (modeRef.current === "day" && key === "s") {
+        if (key === KEYMAP.eventJump.bareLetter) {
           deactivate();
         }
         return;

--- a/packages/web/src/shortcuts/shortcuts.menu.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.menu.test.ts
@@ -214,7 +214,7 @@ describe("shortcut menu sections", () => {
       expect(stripMetadata(findFocus("day")?.shortcuts ?? [])).toEqual([
         { keys: ["i"], label: "Focus sidebar" },
         { keys: ["u"], label: "Focus calendar event" },
-        { keys: ["s"], label: "Toggle event jump keys" },
+        { keys: ["h"], label: "Toggle event jump keys" },
         { keys: ["f"], label: "Focus latest notice" },
         {
           keys: ["Mod", "1-4"],
@@ -224,7 +224,8 @@ describe("shortcut menu sections", () => {
       expect(stripMetadata(findFocus("week")?.shortcuts ?? [])).toEqual([
         { keys: ["i"], label: "Focus sidebar" },
         { keys: ["u"], label: "Focus calendar event" },
-        { keys: ["s"], label: "Toggle event jump keys" },
+        { keys: ["h"], label: "Toggle event jump keys" },
+        { keys: ["m"], label: "Focus a week column (M T W R F SA SU)" },
         { keys: ["f"], label: "Focus latest notice" },
         {
           keys: ["Mod", "1-4"],

--- a/packages/web/src/shortcuts/shortcuts.registry.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.test.ts
@@ -79,7 +79,7 @@ describe("shortcuts.registry", () => {
       expect(byId["edit-menu-shift-f10"]?.keys).toEqual(["Shift", "F10"]);
     });
 
-    it("lists s event jump toggle in day and week focus sections", () => {
+    it("lists h event jump toggle in day and week focus sections", () => {
       for (const view of ["day", "week"] as const) {
         const shortcuts = filterShortcutsByContext({
           view,
@@ -95,6 +95,22 @@ describe("shortcuts.registry", () => {
         isViewingCurrentPeriod: true,
       }).map((shortcut) => shortcut.id);
       expect(life).not.toContain("focus-shift-hold");
+    });
+
+    it("lists week-column focus only in week view", () => {
+      const week = filterShortcutsByContext({
+        view: "week",
+        isViewingCurrentPeriod: true,
+      }).map((shortcut) => shortcut.id);
+      expect(week).toContain("focus-week-day");
+
+      for (const view of ["day", "life"] as const) {
+        const ids = filterShortcutsByContext({
+          view,
+          isViewingCurrentPeriod: true,
+        }).map((shortcut) => shortcut.id);
+        expect(ids).not.toContain("focus-week-day");
+      }
     });
 
     it("lists the page jump shortcut in day, week, and life", () => {

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -177,6 +177,13 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
     section: "focus",
   },
   {
+    id: "focus-week-day",
+    keys: ["m"],
+    label: "Focus a week column (M T W R F SA SU)",
+    section: "focus",
+    when: { weekView: true },
+  },
+  {
     id: "focus-notice",
     keys: ["f"],
     label: "Focus latest notice",
@@ -443,6 +450,9 @@ export const filterShortcutsByContext = (
     } else {
       // Day/week view excludes life-specific shortcuts
       if (shortcut.when?.lifeView === true) {
+        return false;
+      }
+      if (shortcut.when?.weekView === true && view !== "week") {
         return false;
       }
       // Exclude current view switcher (show only alternate view)

--- a/packages/web/src/shortcuts/tips/selectShortcutHint.test.ts
+++ b/packages/web/src/shortcuts/tips/selectShortcutHint.test.ts
@@ -76,6 +76,15 @@ describe("selectShortcutHint", () => {
     );
   });
 
+  it("teaches week-column letters after event jump on week view", () => {
+    expect(
+      selectShortcutHint({ ...afterFirstEvent, isWeekView: true }, [
+        "page-jump",
+        "event-jump",
+      ]).id,
+    ).toBe("week-day-focus");
+  });
+
   it("walks the idle pool in showcase order as primitives are demonstrated", () => {
     expect(
       selectShortcutHint(afterFirstEvent, ["page-jump", "event-jump"]).id,

--- a/packages/web/src/shortcuts/tips/selectShortcutHint.ts
+++ b/packages/web/src/shortcuts/tips/selectShortcutHint.ts
@@ -7,6 +7,7 @@ import {
 export type ShortcutHintContext = {
   isFormOpen: boolean;
   isLifeView: boolean;
+  isWeekView?: boolean;
   eventFocused: boolean;
   firstEventDone: boolean;
 };
@@ -18,10 +19,24 @@ const IDLE_POOL = [
   "create-event",
 ] as const satisfies readonly ShortcutHintId[];
 
+const WEEK_IDLE_POOL = [
+  "page-jump",
+  "event-jump",
+  "week-day-focus",
+  "command-palette",
+  "create-event",
+] as const satisfies readonly ShortcutHintId[];
+
 const FOCUSED_POOL = [
   "edit-sequence",
   "nudge",
   ...IDLE_POOL,
+] as const satisfies readonly ShortcutHintId[];
+
+const WEEK_FOCUSED_POOL = [
+  "edit-sequence",
+  "nudge",
+  ...WEEK_IDLE_POOL,
 ] as const satisfies readonly ShortcutHintId[];
 
 const FORM_POOL = [
@@ -70,10 +85,10 @@ export function selectShortcutHint(
     return pick(LIFE_POOL);
   }
   if (ctx.eventFocused) {
-    return pick(FOCUSED_POOL);
+    return pick(ctx.isWeekView ? WEEK_FOCUSED_POOL : FOCUSED_POOL);
   }
   if (!ctx.firstEventDone) {
     return getShortcutHint("create-event");
   }
-  return pick(IDLE_POOL);
+  return pick(ctx.isWeekView ? WEEK_IDLE_POOL : IDLE_POOL);
 }

--- a/packages/web/src/shortcuts/tips/selectShortcutHint.ts
+++ b/packages/web/src/shortcuts/tips/selectShortcutHint.ts
@@ -19,25 +19,25 @@ const IDLE_POOL = [
   "create-event",
 ] as const satisfies readonly ShortcutHintId[];
 
-const WEEK_IDLE_POOL = [
-  "page-jump",
-  "event-jump",
-  "week-day-focus",
-  "command-palette",
-  "create-event",
-] as const satisfies readonly ShortcutHintId[];
-
 const FOCUSED_POOL = [
   "edit-sequence",
   "nudge",
   ...IDLE_POOL,
 ] as const satisfies readonly ShortcutHintId[];
 
-const WEEK_FOCUSED_POOL = [
-  "edit-sequence",
-  "nudge",
-  ...WEEK_IDLE_POOL,
-] as const satisfies readonly ShortcutHintId[];
+/** Week view inserts the column-letter tip after event-jump. */
+function withWeekDayFocus(
+  pool: readonly ShortcutHintId[],
+  isWeekView?: boolean,
+): readonly ShortcutHintId[] {
+  if (!isWeekView) return pool;
+  const insertAt = pool.indexOf("event-jump") + 1;
+  return [
+    ...pool.slice(0, insertAt),
+    "week-day-focus",
+    ...pool.slice(insertAt),
+  ];
+}
 
 const FORM_POOL = [
   "save-draft",
@@ -85,10 +85,10 @@ export function selectShortcutHint(
     return pick(LIFE_POOL);
   }
   if (ctx.eventFocused) {
-    return pick(ctx.isWeekView ? WEEK_FOCUSED_POOL : FOCUSED_POOL);
+    return pick(withWeekDayFocus(FOCUSED_POOL, ctx.isWeekView));
   }
   if (!ctx.firstEventDone) {
     return getShortcutHint("create-event");
   }
-  return pick(ctx.isWeekView ? WEEK_IDLE_POOL : IDLE_POOL);
+  return pick(withWeekDayFocus(IDLE_POOL, ctx.isWeekView));
 }

--- a/packages/web/src/shortcuts/tips/shortcut-tips.data.test.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-tips.data.test.ts
@@ -31,7 +31,10 @@ describe("getHintPlainText", () => {
       `Hold ${mod} to see where you can jump`,
     );
     expect(plainTextById["event-jump"]).toBe(
-      "Press S to show event keys, or a day key to jump",
+      "Press H to show event keys, or a day key to jump",
+    );
+    expect(plainTextById["week-day-focus"]).toBe(
+      "On week view, press H then M to focus Monday",
     );
     expect(plainTextById.nudge).toBe("Hold Shift and press an arrow to move");
     expect(plainTextById["command-palette"]).toBe(

--- a/packages/web/src/shortcuts/tips/shortcut-tips.data.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-tips.data.ts
@@ -10,6 +10,7 @@ export type ShortcutHintId =
   | "create-event"
   | "page-jump"
   | "event-jump"
+  | "week-day-focus"
   | "command-palette";
 
 export type ShortcutTipPart =
@@ -93,6 +94,16 @@ export const SHORTCUT_HINTS: Record<ShortcutHintId, ShortcutHint> = {
       "Press ",
       { key: eventJumpKey },
       " to show event keys, or a day key to jump",
+    ],
+  },
+  "week-day-focus": {
+    id: "week-day-focus",
+    parts: [
+      "On week view, press ",
+      { key: eventJumpKey },
+      " then ",
+      { key: "M" },
+      " to focus Monday",
     ],
   },
   nudge: {

--- a/packages/web/src/shortcuts/tips/useShortcutHintContext.test.tsx
+++ b/packages/web/src/shortcuts/tips/useShortcutHintContext.test.tsx
@@ -9,7 +9,10 @@ import {
 } from "@web/events/grid-event-draft.adapter";
 import { draftActions } from "@web/events/stores/draft.store";
 import { CALENDAR_VIEW_INTERACTION_ID_ATTRIBUTES } from "@web/grid/interaction/view-event-registry";
-import { shortcutHintProgressActions } from "@web/shortcuts/tips/shortcut-tips.progress.store";
+import {
+  resetShortcutHintProgressStoreForTests,
+  shortcutHintProgressActions,
+} from "@web/shortcuts/tips/shortcut-tips.progress.store";
 import { useShortcutHintContext } from "@web/shortcuts/tips/useShortcutHintContext";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
@@ -31,6 +34,7 @@ describe("useShortcutHintContext", () => {
   afterEach(() => {
     draftActions.discard();
     useFirstEventPromptStore.setState(initialFirstEventPromptState, true);
+    resetShortcutHintProgressStoreForTests();
     document.body.innerHTML = "";
     window.history.replaceState({}, "", "/");
   });
@@ -85,5 +89,17 @@ describe("useShortcutHintContext", () => {
     act(() => shortcutHintProgressActions.demonstrate("page-jump"));
 
     expect(result.current.id).toBe("event-jump");
+  });
+
+  it("teaches week-column letters on /week after event jump is demonstrated", () => {
+    window.history.replaceState({}, "", "/week");
+    useFirstEventPromptStore.setState({ isDone: true }, false);
+    act(() => {
+      shortcutHintProgressActions.demonstrate("page-jump");
+      shortcutHintProgressActions.demonstrate("event-jump");
+    });
+
+    const { result } = renderHook(() => useShortcutHintContext());
+    expect(result.current.id).toBe("week-day-focus");
   });
 });

--- a/packages/web/src/shortcuts/tips/useShortcutHintContext.ts
+++ b/packages/web/src/shortcuts/tips/useShortcutHintContext.ts
@@ -1,3 +1,4 @@
+import { ROOT_ROUTES } from "@web/common/constants/routes";
 import {
   selectFirstEventCelebrating,
   selectFirstEventDone,
@@ -22,13 +23,18 @@ export function useShortcutHintContext() {
   const isCelebrating = useFirstEventPromptStore(selectFirstEventCelebrating);
   const isFormOpen = useDraftStore(selectIsEventFormOpen);
   const eventFocused = useIsAnyCalendarEventFocused();
-  const isLifeView = isLifePathname(window.location.pathname);
+  const pathname = window.location.pathname;
+  const isLifeView = isLifePathname(pathname);
+  const isWeekView =
+    pathname === ROOT_ROUTES.WEEK ||
+    pathname.startsWith(`${ROOT_ROUTES.WEEK}/`);
   const progress = useShortcutHintProgress();
 
   return selectShortcutHint(
     {
       isFormOpen,
       isLifeView,
+      isWeekView,
       eventFocused,
       firstEventDone: firstEventDone || isCelebrating,
     },

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
@@ -248,7 +248,7 @@ describe("useDayEventNudgeShortcuts", () => {
     const { rendered } = renderEditShortcuts();
 
     act(() => {
-      pressKey("s");
+      pressKey("h");
     });
 
     // Compare ids, never the nodes: a failed toEqual on a jsdom element

--- a/packages/web/src/views/Week/components/Header/DayLabels.test.tsx
+++ b/packages/web/src/views/Week/components/Header/DayLabels.test.tsx
@@ -65,7 +65,9 @@ describe("DayLabels", () => {
     expect(screen.queryByText("Mon")).toBeNull();
     expect(screen.getByRole("status").textContent).toContain("Monday M");
     expect(screen.getByRole("status").textContent).toContain("Thursday R");
-    expect(screen.getByRole("status").textContent).toContain("Press H");
+    expect(screen.getByRole("status").textContent).toContain(
+      "Type the day key to focus that column.",
+    );
   });
 
   it("shows day-jump prefixes while page-jump Mod-hold hints are visible", () => {
@@ -75,5 +77,8 @@ describe("DayLabels", () => {
     expect(screen.getByText("M")).toBeTruthy();
     expect(screen.getByText("R")).toBeTruthy();
     expect(screen.queryByText("Mon")).toBeNull();
+    expect(screen.getByRole("status").textContent).toContain(
+      "These are typed after H, not with Mod.",
+    );
   });
 });

--- a/packages/web/src/views/Week/components/Header/DayLabels.test.tsx
+++ b/packages/web/src/views/Week/components/Header/DayLabels.test.tsx
@@ -1,22 +1,39 @@
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import dayjs from "@core/util/date/dayjs";
+import { pageJumpHintActions } from "@web/shortcuts/page-jump/page-jump.store";
+import { eventJumpActions } from "@web/shortcuts/shift-hint/event-jump.store";
 import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
 import { DayLabels } from "@web/views/Week/components/Header/DayLabels";
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 
 const monday = dayjs("2026-08-17T12:00:00.000Z");
+const weekDays = [
+  monday,
+  monday.add(1, "day"),
+  monday.add(2, "day"),
+  monday.add(3, "day"),
+];
+
+const renderLabels = () =>
+  render(
+    <DayLabels
+      startOfView={monday.startOf("week")}
+      today={monday}
+      week={monday.week()}
+      weekDays={weekDays}
+    />,
+  );
 
 describe("DayLabels", () => {
+  afterEach(() => {
+    cleanup();
+    eventJumpActions.reset();
+    pageJumpHintActions.reset();
+  });
+
   it("shows the effective timezone in the grid corner", () => {
-    render(
-      <DayLabels
-        startOfView={monday.startOf("week")}
-        today={monday}
-        week={monday.week()}
-        weekDays={[monday, monday.add(1, "day"), monday.add(2, "day")]}
-      />,
-    );
+    renderLabels();
 
     const abbreviation = formatTimeZoneAbbreviation(getEffectiveTimeZone());
     expect(
@@ -24,5 +41,39 @@ describe("DayLabels", () => {
         name: `Calendar timezone: ${abbreviation}`,
       }),
     ).toHaveTextContent(abbreviation);
+  });
+
+  it("shows weekday abbreviations until jump hints are visible", () => {
+    renderLabels();
+
+    expect(screen.getByText("Mon")).toBeTruthy();
+    expect(screen.getByText("Tue")).toBeTruthy();
+    expect(screen.getByText("Wed")).toBeTruthy();
+    expect(screen.getByText("Thu")).toBeTruthy();
+    expect(screen.queryByText("M")).toBeNull();
+    expect(screen.queryByText("R")).toBeNull();
+  });
+
+  it("swaps weekday abbreviations for day-jump prefixes while event jump is on", () => {
+    eventJumpActions.setActive(true);
+    renderLabels();
+
+    expect(screen.getByText("M")).toBeTruthy();
+    expect(screen.getByText("T")).toBeTruthy();
+    expect(screen.getByText("W")).toBeTruthy();
+    expect(screen.getByText("R")).toBeTruthy();
+    expect(screen.queryByText("Mon")).toBeNull();
+    expect(screen.getByRole("status").textContent).toContain("Monday M");
+    expect(screen.getByRole("status").textContent).toContain("Thursday R");
+    expect(screen.getByRole("status").textContent).toContain("Press H");
+  });
+
+  it("shows day-jump prefixes while page-jump Mod-hold hints are visible", () => {
+    pageJumpHintActions.setHintsVisible(true);
+    renderLabels();
+
+    expect(screen.getByText("M")).toBeTruthy();
+    expect(screen.getByText("R")).toBeTruthy();
+    expect(screen.queryByText("Mon")).toBeNull();
   });
 });

--- a/packages/web/src/views/Week/components/Header/DayLabels.tsx
+++ b/packages/web/src/views/Week/components/Header/DayLabels.tsx
@@ -3,13 +3,33 @@ import { type FC } from "react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type Dayjs } from "@core/util/date/dayjs";
 import { getWeekDayLabel } from "@web/common/utils/event/event.util";
+import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
+import {
+  selectIsEventFormOpen,
+  useDraftStore,
+} from "@web/events/stores/draft.store";
 import { EVENT_WIDTH_MINIMUM } from "@web/grid/grid.constants";
 import { useGridMarginLeft } from "@web/grid/grid-margin";
+import { KEYMAP } from "@web/shortcuts/keymap";
 import {
+  selectPageJumpHintsVisible,
+  usePageJumpHintStore,
+} from "@web/shortcuts/page-jump/page-jump.store";
+import {
+  DAY_JUMP_PREFIX_BY_WEEKDAY,
+  type DayJumpWeekday,
+} from "@web/shortcuts/shift-hint/assign-shift-hint-keys";
+import {
+  selectEventJumpActive,
   selectEventJumpActiveDayKeys,
   useEventJumpStore,
 } from "@web/shortcuts/shift-hint/event-jump.store";
 import { GridTimezoneLabel } from "@web/timezone/GridTimezoneLabel";
+
+const dayJumpPrefix = (day: Dayjs) => {
+  const weekday = day.day() as DayJumpWeekday;
+  return DAY_JUMP_PREFIX_BY_WEEKDAY[weekday].toUpperCase();
+};
 
 interface Props {
   today: Dayjs;
@@ -25,7 +45,18 @@ export const DayLabels: FC<Props> = ({
   weekDays,
 }) => {
   const activeDayKeys = useEventJumpStore(selectEventJumpActiveDayKeys);
+  const isEventJumpActive = useEventJumpStore(selectEventJumpActive);
+  const pageJumpHintsVisible = usePageJumpHintStore(selectPageJumpHintsVisible);
+  const isEventFormOpen = useDraftStore(selectIsEventFormOpen);
+  const showDayJumpPrefixes =
+    !isEventFormOpen && (pageJumpHintsVisible || isEventJumpActive);
   const marginLeft = useGridMarginLeft();
+  const jumpKey = KEYMAP.eventJump.keycaps[0];
+  const dayJumpAnnouncement = showDayJumpPrefixes
+    ? `Day jump keys: ${weekDays
+        .map((day) => `${day.format("dddd")} ${dayJumpPrefix(day)}`)
+        .join(", ")}. Press ${jumpKey} then the day key.`
+    : "";
   const getColor = (day: Dayjs) => {
     const isCurrentWeek = today.week() === week;
     const isToday = isCurrentWeek && today.format("DD") === day.format("DD");
@@ -70,6 +101,7 @@ export const DayLabels: FC<Props> = ({
           const { isToday, color } = getColor(day);
           const dayKey = day.format(YEAR_MONTH_DAY_FORMAT);
           const isJumpDay = activeDayKeys.includes(dayKey);
+          const prefix = dayJumpPrefix(day);
 
           return (
             <div
@@ -90,13 +122,22 @@ export const DayLabels: FC<Props> = ({
               >
                 {dayNumber}
               </span>
-              <span className="relative text-[clamp(var(--font-size-m),2cqw,var(--font-size-l))] leading-none">
-                {day.format("ddd")}
-              </span>
+              {showDayJumpPrefixes ? (
+                <ShortcutHint>{prefix}</ShortcutHint>
+              ) : (
+                <span className="relative text-[clamp(var(--font-size-m),2cqw,var(--font-size-l))] leading-none">
+                  {day.format("ddd")}
+                </span>
+              )}
             </div>
           );
         })}
       </div>
+      {dayJumpAnnouncement ? (
+        <span aria-live="polite" className="sr-only" role="status">
+          {dayJumpAnnouncement}
+        </span>
+      ) : null}
     </div>
   );
 };

--- a/packages/web/src/views/Week/components/Header/DayLabels.tsx
+++ b/packages/web/src/views/Week/components/Header/DayLabels.tsx
@@ -52,10 +52,13 @@ export const DayLabels: FC<Props> = ({
     !isEventFormOpen && (pageJumpHintsVisible || isEventJumpActive);
   const marginLeft = useGridMarginLeft();
   const jumpKey = KEYMAP.eventJump.keycaps[0];
+  const dayJumpHowTo = isEventJumpActive
+    ? "Type the day key to focus that column."
+    : `These are typed after ${jumpKey}, not with Mod.`;
   const dayJumpAnnouncement = showDayJumpPrefixes
     ? `Day jump keys: ${weekDays
         .map((day) => `${day.format("dddd")} ${dayJumpPrefix(day)}`)
-        .join(", ")}. Press ${jumpKey} then the day key.`
+        .join(", ")}. ${dayJumpHowTo}`
     : "";
   const getColor = (day: Dayjs) => {
     const isCurrentWeek = today.week() === week;

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
@@ -369,7 +369,7 @@ describe("useWeekShortcutOwner calendar event targeting", () => {
     });
 
     act(() => {
-      pressKey("s");
+      pressKey("h");
     });
 
     // Compare ids, never the nodes: a failed toEqual on a jsdom element


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Event jump used `s`, which consumed the first keystroke of `sa`/`su` and forced a pause before focusing Saturday or Sunday.

- Remap the event-jump activator from `s` to `h` (`KEYMAP.eventJump`). Help stays on `?`.
- Weekend prefixes (`sa`/`su`) and other claimable day tokens work from idle without waiting.
- A second `h` toggles jump off in both day and week views.
- Week-only `?` legend row and sidebar tip teach column letters (`M T W R F SA SU`).
- Holding Mod (or entering jump mode) swaps week header `ddd` labels for those prefixes so the mapping can be discovered in place.

## Simplicity

- Hold-Mod engine publishes visibility directly (`onVisibilityChange`); no store-sync `useEffect`.
- Week tip pools collapse to one insert helper instead of duplicated idle/focused lists.
- Live region distinguishes jump-mode (“type the day key”) from Mod-hold discovery (“typed after H, not with Mod”).

## Automated validation

- Focused web tests on shortcut/header files: 219 pass (pre-simplify); 51 pass after simplify; 4 pass after live-region fix
- `bun run verify`: test:web, type-check, lint, knip, test:a11y, test:e2e — all passed
- Playwright: event-jump and showcase specs plus full `test:e2e` via verify

## Independent review

`.agents/handoffs/2918.md` — one medium finding (Mod-hold live region implied H is a Mod chord). Fixed in `3fa6e4a8c`.

## Test plan

- `bun test:web --` focused shortcut/header files
- `bun run verify` (web, type-check, lint, knip, a11y, e2e)
- Browser walkthrough on http://localhost:9080/week

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c1cdcfe-4e44-4a11-b861-bb27178eefc3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c1cdcfe-4e44-4a11-b861-bb27178eefc3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

