### PR TITLE
fix(billing): retire trial stamps left by the accidental enforcement window

### DIFF
--- a/packages/web/src/billing/trial.storage.ts
+++ b/packages/web/src/billing/trial.storage.ts
@@ -11,6 +11,28 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
  * track it against. Deliberately unsophisticated — clearing storage renews
  * the trial, and that's an accepted tradeoff, not a bug to fix.
  */
+/**
+ * One-time cleanup of the pre-`.v2` trial stamp.
+ *
+ * Production briefly served `billing.enforcement: true` around 2026-08-12..14,
+ * which stamped `compass.trial.started-at` in ~19 visitors' browsers before the
+ * switch went back off. Those stamps are now months stale, so the next time
+ * enforcement is enabled anywhere those visitors would be gated instantly
+ * rather than getting the trial they never actually consumed — and
+ * `useAppAccess` reaches the anonymous-trial branch before it checks whether
+ * Stripe is configured, so an unconfigured deployment would gate them with no
+ * way to pay.
+ *
+ * Versioning the key retires every stamp written under the old name. Callers
+ * must invoke this regardless of the enforcement switch: on a paused
+ * deployment `useTrialStatus` returns before it would otherwise touch storage,
+ * which is exactly the case that needs clearing.
+ */
+export function purgeLegacyTrialStamp(): void {
+  if (!persistentBrowserStore.isAvailable()) return;
+  persistentBrowserStore.remove(STORAGE_KEYS.TRIAL_STARTED_AT_LEGACY);
+}
+
 /** Returns true the one time it actually stamps the start (a fresh trial). */
 export function ensureTrialStarted(): boolean {
   if (!persistentBrowserStore.isAvailable()) return false;

--- a/packages/web/src/billing/useTrialStatus.test.tsx
+++ b/packages/web/src/billing/useTrialStatus.test.tsx
@@ -5,6 +5,7 @@ import { type PropsWithChildren } from "react";
 import { server } from "@web/__tests__/__mocks__/server/mock.server";
 import * as authStateUtil from "@web/auth/compass/state/auth.state.util";
 import { billingQueryKeys } from "@web/billing/billing.query";
+import { TRIAL_LENGTH_DAYS } from "@web/billing/trial.storage";
 import { useTrialStatus } from "@web/billing/useTrialStatus";
 import { ENV_WEB } from "@web/common/constants/env.constants";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
@@ -134,5 +135,43 @@ describe("useTrialStatus", () => {
     expect(
       persistentBrowserStore.get(STORAGE_KEYS.TRIAL_STARTED_AT),
     ).toBeNull();
+  });
+
+  it("purges a legacy trial stamp even while enforcement is paused", async () => {
+    stubConfig(false);
+    persistentBrowserStore.set(
+      STORAGE_KEYS.TRIAL_STARTED_AT_LEGACY,
+      daysAgo(300),
+    );
+
+    await renderTrialStatus();
+
+    // The paused path is the one that matters: production sat here for months
+    // holding stamps from the brief window enforcement was accidentally on.
+    expect(
+      persistentBrowserStore.get(STORAGE_KEYS.TRIAL_STARTED_AT_LEGACY),
+    ).toBeNull();
+    expect(
+      persistentBrowserStore.get(STORAGE_KEYS.TRIAL_STARTED_AT),
+    ).toBeNull();
+  });
+
+  it("gives a visitor holding only a stale legacy stamp a full trial, not a gate", async () => {
+    stubConfig(true);
+    persistentBrowserStore.set(
+      STORAGE_KEYS.TRIAL_STARTED_AT_LEGACY,
+      daysAgo(300),
+    );
+
+    const { result } = await renderTrialStatus();
+
+    expect(result.current.isExpired).toBe(false);
+    expect(result.current.daysLeft).toBe(TRIAL_LENGTH_DAYS);
+    expect(
+      persistentBrowserStore.get(STORAGE_KEYS.TRIAL_STARTED_AT_LEGACY),
+    ).toBeNull();
+    expect(
+      persistentBrowserStore.get(STORAGE_KEYS.TRIAL_STARTED_AT),
+    ).not.toBeNull();
   });
 });

--- a/packages/web/src/billing/useTrialStatus.ts
+++ b/packages/web/src/billing/useTrialStatus.ts
@@ -6,6 +6,7 @@ import { useBillingEnforced } from "@web/billing/billing.query";
 import {
   ensureTrialStarted,
   getTrialDaysLeft,
+  purgeLegacyTrialStamp,
   TRIAL_LENGTH_DAYS,
 } from "@web/billing/trial.storage";
 
@@ -44,6 +45,9 @@ export function useTrialStatus(): TrialStatus {
   const [daysLeft, setDaysLeft] = useState(() => getTrialDaysLeft());
 
   useEffect(() => {
+    // Before the enforcement gate: a paused deployment is precisely where a
+    // stale pre-.v2 stamp would sit undisturbed until someone flips the switch.
+    purgeLegacyTrialStamp();
     if (!enforced) return;
     if (ensureTrialStarted()) {
       track("trial_started");

--- a/packages/web/src/common/constants/storage.constants.ts
+++ b/packages/web/src/common/constants/storage.constants.ts
@@ -13,7 +13,10 @@ type StorageKey =
   // "completed" | "dismissed": the first-event prompt's terminal state.
   // Absent means it is still live (or never shown).
   | "compass.onboarding.first-event-done"
+  // Superseded by the .v2 key below. Only ever read to be deleted — see
+  // purgeLegacyTrialStamp in trial.storage.ts.
   | "compass.trial.started-at"
+  | "compass.trial.started-at.v2"
   | "compass.shortcuts.tips-muted"
   // Demonstrated sidebar shortcut-tip ids (JSON). Device-local; an unknown
   // id is skipped on read, not an error.
@@ -56,6 +59,7 @@ export const STORAGE_KEYS: Record<
   | "HAS_PENDING_SHOWCASE_OFFER"
   | "FIRST_EVENT_DONE"
   | "TRIAL_STARTED_AT"
+  | "TRIAL_STARTED_AT_LEGACY"
   | "SHORTCUT_TIPS_MUTED"
   | "SHORTCUT_TIPS_DEMONSTRATED"
   | "LIFE_PREFERENCES"
@@ -83,7 +87,8 @@ export const STORAGE_KEYS: Record<
   HAS_SEEN_SHORTCUT_SHOWCASE: "compass.onboarding.has-seen-shortcut-showcase",
   HAS_PENDING_SHOWCASE_OFFER: "compass.onboarding.has-pending-showcase-offer",
   FIRST_EVENT_DONE: "compass.onboarding.first-event-done",
-  TRIAL_STARTED_AT: "compass.trial.started-at",
+  TRIAL_STARTED_AT: "compass.trial.started-at.v2",
+  TRIAL_STARTED_AT_LEGACY: "compass.trial.started-at",
   SHORTCUT_TIPS_MUTED: "compass.shortcuts.tips-muted",
   SHORTCUT_TIPS_DEMONSTRATED: "compass.shortcuts.tips-demonstrated",
   LIFE_PREFERENCES: "compass.life.preferences",


### PR DESCRIPTION
## Summary

Production briefly served `billing.enforcement: true` around **2026-08-12..14**. PostHog records 20 `trial_started` events across 19 distinct people on `compasscalendar.com` in that window (`environment=production`), and `trial_started` fires only *past* the `if (!enforced) return` guard in `useTrialStatus` — and `isBillingEnforced` is fail-open, so a pending or errored config cannot produce it. The switch really was on.

It is off again now (`production /api/config` → `isConfigured:false, enforcement:false`), but ~19 browsers still hold a `compass.trial.started-at` stamp that is months stale.

The stamp only bites when enforcement is next enabled — at which point those visitors are gated **immediately**, having never actually consumed a trial. Worse, `useAppAccess` reaches its anonymous-trial branch *before* it checks `billing.isConfigured`:

```js
if (!enforced) return { kind: "open" };
if (trial.isAnonymousTrial) return { kind: "anonymous-trial", isExpired, ... };  // ← before the isConfigured bail-out
```

So a deployment with enforcement on and Stripe unconfigured — production's exact shape today — would gate them with no way to subscribe.

This versions the storage key to `compass.trial.started-at.v2` and deletes the old key on load. The purge runs *before* the enforcement check, because a paused deployment is precisely where a stale stamp sits untouched until someone flips the switch. A visitor holding only a legacy stamp gets a full trial rather than a gate.

Note this only takes effect for a given visitor once they load a build containing it — there is no server-side record of these stamps to clear, so a production deploy is what actually retires them.

## Simplicity

Key versioning rather than a date-cutoff heuristic: one `remove()` call, no clock comparison, no window to get wrong, and it is self-evidently exhaustive. The purge is a single function called from the one hook that already owns the trial clock.

Deliberately **not** included: reordering the `isConfigured` check above the anonymous-trial branch in `useAppAccess`. That would change anonymous-gate behaviour for any Stripe-less deployment and deserves its own decision rather than riding along here.

## Automated validation

No browser scenario was run — staging-cloud is reachable by API from the working environment but browser navigations to `*.compasscalendar.com` are reset at the egress gateway, so the gate UI could not be driven. The behaviour is covered by the unit tests below instead, exercising both the paused and enforced paths.

## Independent review

No `/review` handoff. The change was reviewed against `useAppAccess.ts` (branch ordering), `useTrialStatus.ts` (the `!enforced` early return the purge must precede), and `trial.storage.ts`.

## Test plan

```
bun packages/scripts/src/testing/test-parallel.ts web -- './packages/web/src/billing/**/*.test.tsx'
# 31 pass, 0 fail

bun run test:web
# 2566 pass, 0 fail across 329 files

bun run lint    # exit 0
```

Two tests added to `useTrialStatus.test.tsx`:
- purges a legacy stamp **while enforcement is paused** (the production case)
- a visitor holding only a stale legacy stamp gets a full trial, not a gate

---
_Generated by [Claude Code](https://claude.ai/code/session_014Vsm8ZP8d9X1umty1x9wu6)_