### PR TITLE
fix(backend): keep the reason a Sync 200 body failed the contract on event reads

### DIFF
--- a/packages/backend/src/event/controllers/event.controller.test.ts
+++ b/packages/backend/src/event/controllers/event.controller.test.ts
@@ -10,7 +10,10 @@ import {
   eventMutationError,
   toEventMutationError,
 } from "@backend/event/event.error";
-import eventController, { logLevelForEventFailure } from "./event.controller";
+import eventController, {
+  logLevelForEventFailure,
+  syncFailureLogContext,
+} from "./event.controller";
 import {
   afterEach,
   beforeEach,
@@ -942,6 +945,42 @@ describe("logLevelForEventFailure", () => {
         correlationId: "corr-2",
       }),
     ).toBe("error");
+  });
+});
+
+describe("syncFailureLogContext", () => {
+  it("adds nothing when the failure did not come from Sync", () => {
+    expect(syncFailureLogContext()).toBe("");
+  });
+
+  it("names the kind, status and correlation id", () => {
+    expect(
+      syncFailureLogContext({
+        kind: "unexpectedStatus",
+        status: 500,
+        correlationId: "corr-1",
+      }),
+    ).toBe(" (unexpectedStatus) [status=500] [correlationId=corr-1]");
+  });
+
+  // The point of the fix. Issue #2901 fired seven times reporting only that a
+  // 200 body failed the contract, never which field failed it, because this
+  // line dropped the detail #2900 had already collected.
+  it("names the field a rejected 200 body broke", () => {
+    expect(
+      syncFailureLogContext({
+        kind: "invalidResponse",
+        status: 200,
+        correlationId: "corr-2",
+        detail:
+          "issues=<root>: unrecognized_keys [addedByNewerSync]; " +
+          "keys=instances,nextCursor; content-type=application/json",
+      }),
+    ).toBe(
+      " (invalidResponse) [status=200] [correlationId=corr-2] " +
+        "issues=<root>: unrecognized_keys [addedByNewerSync]; " +
+        "keys=instances,nextCursor; content-type=application/json",
+    );
   });
 });
 

--- a/packages/backend/src/event/controllers/event.controller.ts
+++ b/packages/backend/src/event/controllers/event.controller.ts
@@ -79,6 +79,31 @@ export const logLevelForEventFailure = (
   return status === Status.SERVICE_UNAVAILABLE ? "warn" : "error";
 };
 
+// The Sync-failure context appended to the logged message, never to `body`.
+// The correlation id goes here rather than into `body.message`: PostHog groups
+// issues by the message, so a per-request id in it would split one defect into
+// an issue per occurrence.
+//
+// `detail` is the log-safe SyncClientError.detail: the failing Zod field paths
+// with their issue code, the body's top-level keys, and the content-type —
+// field names and codes only, never a field value. Without it an
+// `invalidResponse` reports only that the contract broke, not which field
+// broke it, which is how issue #2901 stayed undiagnosable through seven
+// occurrences. `unwrap-sync-result` already appends it on the proxy routes;
+// this is the same line for the event routes, which reach neither
+// `unwrapSyncResult` nor `throwSyncProxyFailure`.
+//
+// Exported for tests, for the same reason logLevelForEventFailure is: the
+// module-level `logger` cannot be spied on.
+export const syncFailureLogContext = (syncError?: SyncClientError): string => {
+  if (!syncError) return "";
+  return (
+    ` (${syncError.kind}) [status=${syncError.status}] ` +
+    `[correlationId=${syncError.correlationId}]` +
+    (syncError.detail ? ` ${syncError.detail}` : "")
+  );
+};
+
 const send = (res: Response, e: unknown) => {
   const { status, body } = toEventMutationError(e);
   const syncError =
@@ -86,14 +111,9 @@ const send = (res: Response, e: unknown) => {
   const level = logLevelForEventFailure(status, syncError);
 
   if (level) {
-    // The correlation id goes here rather than into `body.message`: PostHog
-    // groups issues by the message, so a per-request id in it would split one
-    // defect into an issue per occurrence.
-    const detail = syncError
-      ? ` (${syncError.kind}) [status=${syncError.status}] ` +
-        `[correlationId=${syncError.correlationId}]`
-      : "";
-    logger[level](`${body.code}: ${body.message}${detail}`);
+    logger[level](
+      `${body.code}: ${body.message}${syncFailureLogContext(syncError)}`,
+    );
   }
 
   res.status(status).json(body);


### PR DESCRIPTION
## Problem

#2900 taught the Sync client to collect a log-safe `detail` when a 200 response fails its schema: the failing Zod field paths with their issue code, the body's top-level keys, and the `content-type` header. Field names and codes only, never a field value.

It threaded that through `throwSyncProxyFailure` and `unwrapSyncResult`. **The event routes reach neither.** `listAllFullEvents` raises `eventMutationError("PROVIDER_FAILURE", ..., result.error)`, and the log line that becomes the PostHog issue is assembled in this controller's own `send`:

```ts
const detail = syncError
  ? ` (${syncError.kind}) [status=${syncError.status}] ` +
    `[correlationId=${syncError.correlationId}]`
  : "";
logger[level](`${body.code}: ${body.message}${detail}`);
```

`syncError.detail` is present on the object and dropped here. The local name `detail` shadowing the field it omits is what makes this read like the opposite at a glance.

## Evidence

#2901 has fired **7** times in production, from PostHog (project 165441), all `status=200`, kind `invalidResponse`, `Failed to list events from sync`:

| timestamp | version |
|---|---|
| 2026-08-27T10:13:57.729Z | 1.1.295 |
| 2026-08-27T10:13:57.865Z | 1.1.295 |
| 2026-08-27T10:14:04.788Z | 1.1.295 |
| 2026-08-27T11:29:14.401Z | 1.1.295 |
| 2026-08-27T17:32:14.285Z | **1.1.317** |
| 2026-08-27T17:32:14.286Z | **1.1.317** |
| 2026-08-27T17:32:14.286Z | **1.1.317** |

`v1.1.317` (571e0163b) already contains #2900, so the last three should have named the failing field. They did not. `root_cause`, `cause_chain` and `detail` are null on every one, which is why #2901 could not be closed or diagnosed.

## Change

Extract the context into `syncFailureLogContext` and append `detail` the way `unwrapSyncResult` already does. Log line only, so nothing Sync-internal reaches the browser, and `body.message` is untouched (PostHog groups issues by message).

The extraction follows this file's own precedent for `logLevelForEventFailure`: the module-level `logger` cannot be spied on, because `Logger()` builds a new winston instance per call, so the assembled string is exported and pinned directly.

## Explicitly not done

Relaxing `EventInstanceListResponseSchema` off `z.strictObject`. The strict read schema is what detected this; stripping it would turn a loud contract break into silent data loss. Fix whichever field `detail` names, once `detail` reaches us.

## Verification

- `test-parallel backend-fast`: 348 pass, 0 fail across 41 files
- `event.controller.test.ts`: 37 pass, including 3 new cases
- `typescript@7.0.2 --noEmit`: clean
- `biome check`: clean

Refs #2901

🤖 Generated with [Claude Code](https://claude.com/claude-code)
