### PR TITLE
feat(web): drop hardcoded price and export from billing gate

### DIFF
--- a/.agents/handoffs/2922.md
+++ b/.agents/handoffs/2922.md
@@ -1,0 +1,28 @@
+---
+schema_version: 1
+task_id: "2922"
+from: Manager
+to: Verifier
+owner: Verifier
+status: running
+artifact:
+  - path: packages/web/src/billing/BillingGateModal.tsx
+  - url: https://github.com/keepsoftwaresimple/compass-calendar/pull/2922
+evidence:
+  - command: git diff origin/main...HEAD --stat
+    result: "13 files, +32/-61. BillingGateModal drops price copy and Export my data. CI checks on pre-main-sync head were SUCCESS."
+assumptions:
+  - "User asked to simplify and merge PR 2922"
+  - "origin/main moved (billing bypass #2921, day-prefix #2918); docs/features/billing.md changed in both"
+open_risks:
+  - "Need to merge origin/main before squash-merge; billing.md likely auto-merges"
+next_deadline: 2026-08-27T21:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+Ship 2922: keyboard-first price-free billing gate. Next: merge main, verify, simplify, review, squash-merge.
+
+Suggested skills: `/verify-change`, `/simplify`, `/review`.

--- a/.agents/handoffs/2922.md
+++ b/.agents/handoffs/2922.md
@@ -1,19 +1,22 @@
 ---
 schema_version: 1
 task_id: "2922"
-from: Simplifier
-to: Verifier
-owner: Verifier
+from: Reviewer
+to: Manager
+owner: Manager
 status: verifying
 artifact:
   - path: packages/web/src/billing/BillingGateModal.tsx
-  - path: packages/core/src/constants/billing.constants.ts
+  - path: .agents/handoffs/2922.md
   - url: https://github.com/keepsoftwaresimple/compass-calendar/pull/2922
 evidence:
+  - command: bun run verify
+    result: "PASS. Selected packages: core, web, backend. Checks run: test:core, test:web, test:backend, type-check, lint, knip. Checks skipped: test:a11y, test:e2e (Playwright Chromium missing)."
   - command: bun test:web -- packages/web/src/billing/BillingGateModal.test.tsx
     result: "8 pass, 0 fail"
 assumptions:
-  - "Simplify kept shortcut mutation (boring) and hardcoded 7-day title copy"
+  - "Removing Export from the signed-in gate is the requested product behavior; Settings is unmounted while the gate is up"
+  - "Anonymous TrialGateModal still showing Export is out of this request"
 open_risks: []
 next_deadline: 2026-08-27T21:00:00Z
 retry: 0
@@ -22,4 +25,11 @@ waiting_on: null
 escalation: null
 ---
 
-Simplify: KeyboardEvent import + BILLING_PLAN comment. No hook-count change. Next: `/verify-change`.
+Independent review of `origin/main...HEAD` product files.
+
+```
+VERDICT: no confirmed findings
+FINDINGS:
+```
+
+Suggested skills: none. Manager squash-merges after required GitHub checks are green.

--- a/.agents/handoffs/2922.md
+++ b/.agents/handoffs/2922.md
@@ -1,21 +1,20 @@
 ---
 schema_version: 1
 task_id: "2922"
-from: Manager
+from: Simplifier
 to: Verifier
 owner: Verifier
-status: running
+status: verifying
 artifact:
   - path: packages/web/src/billing/BillingGateModal.tsx
+  - path: packages/core/src/constants/billing.constants.ts
   - url: https://github.com/keepsoftwaresimple/compass-calendar/pull/2922
 evidence:
-  - command: git diff origin/main...HEAD --stat
-    result: "13 files, +32/-61. BillingGateModal drops price copy and Export my data. CI checks on pre-main-sync head were SUCCESS."
+  - command: bun test:web -- packages/web/src/billing/BillingGateModal.test.tsx
+    result: "8 pass, 0 fail"
 assumptions:
-  - "User asked to simplify and merge PR 2922"
-  - "origin/main moved (billing bypass #2921, day-prefix #2918); docs/features/billing.md changed in both"
-open_risks:
-  - "Need to merge origin/main before squash-merge; billing.md likely auto-merges"
+  - "Simplify kept shortcut mutation (boring) and hardcoded 7-day title copy"
+open_risks: []
 next_deadline: 2026-08-27T21:00:00Z
 retry: 0
 approval: none
@@ -23,6 +22,4 @@ waiting_on: null
 escalation: null
 ---
 
-Ship 2922: keyboard-first price-free billing gate. Next: merge main, verify, simplify, review, squash-merge.
-
-Suggested skills: `/verify-change`, `/simplify`, `/review`.
+Simplify: KeyboardEvent import + BILLING_PLAN comment. No hook-count change. Next: `/verify-change`.

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -19,4 +19,4 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 | 2891 | medium | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/2893 | bun run verify PASS; review: no confirmed findings | 2026-08-27T00:00:00Z | 0 | none |
 | 2898 | medium | Manager | verifying | https://github.com/keepsoftwaresimple/compass-calendar/pull/2898 | focused web 62 pass; lint clean of new errors; review: no confirmed findings | 2026-08-27T06:00:00Z | 0 | none |
 | 2918 | medium | Manager | verifying | https://github.com/keepsoftwaresimple/compass-calendar/pull/2918 | bun run verify PASS; review finding fixed in 3fa6e4a8c | 2026-08-27T20:30:00Z | 0 | none |
-| 2922 | medium | Verifier | verifying | https://github.com/keepsoftwaresimple/compass-calendar/pull/2922 | bun test:web BillingGateModal 8 pass; simplify c4cbe8696 | 2026-08-27T21:00:00Z | 0 | none |
+| 2922 | medium | Manager | verifying | https://github.com/keepsoftwaresimple/compass-calendar/pull/2922 | bun run verify PASS; simplify c4cbe8696; review: no confirmed findings | 2026-08-27T21:00:00Z | 0 | none |

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -19,4 +19,4 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 | 2891 | medium | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/2893 | bun run verify PASS; review: no confirmed findings | 2026-08-27T00:00:00Z | 0 | none |
 | 2898 | medium | Manager | verifying | https://github.com/keepsoftwaresimple/compass-calendar/pull/2898 | focused web 62 pass; lint clean of new errors; review: no confirmed findings | 2026-08-27T06:00:00Z | 0 | none |
 | 2918 | medium | Manager | verifying | https://github.com/keepsoftwaresimple/compass-calendar/pull/2918 | bun run verify PASS; review finding fixed in 3fa6e4a8c | 2026-08-27T20:30:00Z | 0 | none |
-| 2922 | medium | Simplifier | running | https://github.com/keepsoftwaresimple/compass-calendar/pull/2922 | origin/main merged; billing.md auto-merged | 2026-08-27T21:00:00Z | 0 | none |
+| 2922 | medium | Verifier | verifying | https://github.com/keepsoftwaresimple/compass-calendar/pull/2922 | bun test:web BillingGateModal 8 pass; simplify c4cbe8696 | 2026-08-27T21:00:00Z | 0 | none |

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -19,3 +19,4 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 | 2891 | medium | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/2893 | bun run verify PASS; review: no confirmed findings | 2026-08-27T00:00:00Z | 0 | none |
 | 2898 | medium | Manager | verifying | https://github.com/keepsoftwaresimple/compass-calendar/pull/2898 | focused web 62 pass; lint clean of new errors; review: no confirmed findings | 2026-08-27T06:00:00Z | 0 | none |
 | 2918 | medium | Manager | verifying | https://github.com/keepsoftwaresimple/compass-calendar/pull/2918 | bun run verify PASS; review finding fixed in 3fa6e4a8c | 2026-08-27T20:30:00Z | 0 | none |
+| 2922 | medium | Simplifier | running | https://github.com/keepsoftwaresimple/compass-calendar/pull/2922 | origin/main merged; billing.md auto-merged | 2026-08-27T21:00:00Z | 0 | none |

--- a/docs/Config/README.md
+++ b/docs/Config/README.md
@@ -100,4 +100,4 @@ database and must not share the backend's database user/data.
 | `posthog.host` | No | PostHog host injected into the web bundle. |
 | `stripe.secretKey` | No | Stripe secret (`sk_test_...` is fine on staging). All three Stripe keys are required together; omit the whole `stripe:` block on self-host. |
 | `stripe.webhookSecret` | No | Stripe webhook signing secret. |
-| `stripe.priceId` | No | Stripe Price id for the $7.99/month plan. |
+| `stripe.priceId` | No | Stripe Price id for the hosted subscription. The amount lives on that Price in Stripe. |

--- a/docs/features/billing.md
+++ b/docs/features/billing.md
@@ -1,8 +1,9 @@
 # Billing And Trial
 
-Hosted Compass uses Stripe Checkout (subscription mode, 7-day trial, $7.99/month)
-and the Stripe Billing Portal. There is no Stripe.js and no publishable key in
-the web bundle.
+Hosted Compass uses Stripe Checkout (subscription mode, 7-day trial)
+and the Stripe Billing Portal. The subscription amount lives on the Stripe
+Price behind `stripe.priceId`, so operators can change it in Stripe without
+a web deploy. There is no Stripe.js and no publishable key in the web bundle.
 
 Self-host installs omit the `stripe:` config block. `/api/config` then reports
 `billing.isConfigured: false`, the web never shows a paid gate, and event
@@ -91,7 +92,7 @@ calculates zero tax rather than erroring, so a missing one is silent.
 
 ## Key files
 
-- Plan/price copy: `packages/core/src/constants/billing.constants.ts`
+- Trial length: `packages/core/src/constants/billing.constants.ts`
 - Status derivation: `packages/backend/src/billing/services/billing.service.ts`
 - Checkout / portal: `packages/backend/src/billing/services/stripe.service.ts`
 - Webhook: `packages/backend/src/billing/services/billing.webhook.service.ts`

--- a/docs/self-hosting/README.md
+++ b/docs/self-hosting/README.md
@@ -6,7 +6,7 @@ Start with [Run Compass on a server](./server-guide.md). It walks through a smal
 
 If you only want to run Compass on your own computer, use the normal local development flow with Bun instead of the self-host installer.
 
-Self-host does not require Stripe. Omit the `stripe:` block so billing stays off and every account remains writable. Hosted Compass uses a 7-day trial then $7.99/month; see [Billing And Trial](../features/billing.md).
+Self-host does not require Stripe. Omit the `stripe:` block so billing stays off and every account remains writable. Hosted Compass uses a 7-day trial then a paid subscription; see [Billing And Trial](../features/billing.md).
 
 ## Compass architecture
 

--- a/packages/backend/src/config/config.route.test.ts
+++ b/packages/backend/src/config/config.route.test.ts
@@ -29,7 +29,6 @@ describe("GET /api/config", () => {
         billing: {
           isConfigured: false,
           enforcement: false,
-          priceDisplay: "$7.99/month",
           trialLengthDays: 7,
         },
       });
@@ -62,7 +61,6 @@ describe("GET /api/config", () => {
         billing: {
           isConfigured: false,
           enforcement: false,
-          priceDisplay: "$7.99/month",
           trialLengthDays: 7,
         },
       });

--- a/packages/backend/src/config/controllers/config.controller.test.ts
+++ b/packages/backend/src/config/controllers/config.controller.test.ts
@@ -45,7 +45,6 @@ describe("ConfigController.get sync cutover posture", () => {
     expect(config.billing).toEqual({
       isConfigured: false,
       enforcement: false,
-      priceDisplay: "$7.99/month",
       trialLengthDays: 7,
     });
   });

--- a/packages/backend/src/config/controllers/config.controller.ts
+++ b/packages/backend/src/config/controllers/config.controller.ts
@@ -23,7 +23,6 @@ class ConfigController {
         billing: {
           isConfigured: isStripeConfigured(CONFIG),
           enforcement: isBillingEnforced(CONFIG),
-          priceDisplay: BILLING_PLAN.PRICE_DISPLAY,
           trialLengthDays: BILLING_PLAN.TRIAL_LENGTH_DAYS,
         },
       }),

--- a/packages/core/src/constants/billing.constants.ts
+++ b/packages/core/src/constants/billing.constants.ts
@@ -1,8 +1,8 @@
 /**
- * Trial terms. Kept in core so web copy and backend Checkout share one
- * source. The Stripe price id and amount live in Stripe (and the
- * `stripe.priceId` secret), not here, so operators can change the price
- * without a deploy.
+ * Trial length and backfill cutoff. Backend Checkout reads
+ * `TRIAL_LENGTH_DAYS`. The Stripe price id and amount live in Stripe
+ * (and the `stripe.priceId` secret), not here, so operators can change
+ * the price without a deploy.
  *
  * BACKFILL_CUTOFF bounds which rows `backfill-billing` stamps: only
  * accounts with `signedUpAt <= cutoff` (or missing `signedUpAt`) are

--- a/packages/core/src/constants/billing.constants.ts
+++ b/packages/core/src/constants/billing.constants.ts
@@ -1,7 +1,8 @@
 /**
- * Trial and pricing terms. Kept in core so web copy and backend Checkout
- * share one source. The Stripe price id is a deployment secret and lives
- * in config, not here.
+ * Trial terms. Kept in core so web copy and backend Checkout share one
+ * source. The Stripe price id and amount live in Stripe (and the
+ * `stripe.priceId` secret), not here, so operators can change the price
+ * without a deploy.
  *
  * BACKFILL_CUTOFF bounds which rows `backfill-billing` stamps: only
  * accounts with `signedUpAt <= cutoff` (or missing `signedUpAt`) are
@@ -12,9 +13,5 @@
  */
 export const BILLING_PLAN = {
   TRIAL_LENGTH_DAYS: 7,
-  PLAN_NAME: "Compass",
-  PRICE_AMOUNT_CENTS: 799,
-  PRICE_CURRENCY: "usd",
-  PRICE_DISPLAY: "$7.99/month",
   BACKFILL_CUTOFF: "2099-12-31T23:59:59.000Z",
 } as const;

--- a/packages/core/src/types/config.types.ts
+++ b/packages/core/src/types/config.types.ts
@@ -30,13 +30,11 @@ export const AppConfigSchema = z.object({
     .object({
       isConfigured: z.boolean(),
       enforcement: z.boolean().default(false),
-      priceDisplay: z.string(),
       trialLengthDays: z.number(),
     })
     .default({
       isConfigured: false,
       enforcement: false,
-      priceDisplay: BILLING_PLAN.PRICE_DISPLAY,
       trialLengthDays: BILLING_PLAN.TRIAL_LENGTH_DAYS,
     }),
 });

--- a/packages/web/src/__tests__/__mocks__/server/mock.handlers.ts
+++ b/packages/web/src/__tests__/__mocks__/server/mock.handlers.ts
@@ -86,7 +86,6 @@ export const globalHandlers = [
         billing: {
           isConfigured: false,
           enforcement: true,
-          priceDisplay: "$7.99/month",
           trialLengthDays: 7,
         },
       }),

--- a/packages/web/src/billing/BillingGateModal.test.tsx
+++ b/packages/web/src/billing/BillingGateModal.test.tsx
@@ -6,7 +6,6 @@ import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { type ApiError } from "@web/api/api.types";
 import { BillingApi } from "@web/api/billing.api";
 import { SessionContext } from "@web/auth/compass/session/session.context";
-import * as exportUtil from "@web/common/storage/offline-data/export-user-data.util";
 import { registerToastPort } from "@web/common/utils/toast/toast.port";
 import { BillingGateModal } from "./BillingGateModal";
 import {
@@ -113,13 +112,29 @@ describe("BillingGateModal", () => {
     expect(screen.getByRole("button", { name: "Start trial" })).toHaveFocus();
     for (const [name, key] of [
       ["Start trial", "S"],
-      ["Export my data", "E"],
       ["Log out", "L"],
     ] as const) {
       expect(
         within(screen.getByRole("button", { name })).getByText(key),
       ).toBeTruthy();
     }
+    expect(
+      screen.queryByRole("button", { name: "Export my data" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not mention a price on the start-trial or subscribe copy", () => {
+    const { unmount } = renderGate();
+
+    expect(
+      screen.getByText("A card is required to start."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/\$|\/month/i)).not.toBeInTheDocument();
+    unmount();
+
+    renderGate("canceled");
+    expect(screen.getByText("Your trial has ended.")).toBeInTheDocument();
+    expect(screen.queryByText(/\$|\/month/i)).not.toBeInTheDocument();
   });
 
   it("starts checkout with S and does not dismiss on Escape", async () => {
@@ -145,19 +160,12 @@ describe("BillingGateModal", () => {
     createCheckoutSession.mockRestore();
   });
 
-  it("exports with E and logs out with L", async () => {
-    const exportSpy = spyOn(exportUtil, "runExportMyData").mockResolvedValue();
+  it("logs out with L", async () => {
     const user = userEvent.setup();
     renderGate();
 
-    await user.keyboard("e");
-    await waitFor(() => {
-      expect(exportSpy).toHaveBeenCalled();
-    });
-
     await user.keyboard("l");
     expect(mockLogout).toHaveBeenCalled();
-    exportSpy.mockRestore();
   });
 
   it("traps Tab within the dialog", async () => {

--- a/packages/web/src/billing/BillingGateModal.tsx
+++ b/packages/web/src/billing/BillingGateModal.tsx
@@ -1,5 +1,4 @@
 import { type FC, useEffect, useRef, useState } from "react";
-import { BILLING_PLAN } from "@core/constants/billing.constants";
 import { BillingApi } from "@web/api/billing.api";
 import {
   getApiErrorMessage,
@@ -11,7 +10,6 @@ import {
   GATE_PANEL_CLASSNAME,
   handleOverlayLetterShortcut,
 } from "@web/billing/gate-overlay";
-import { runExportMyData } from "@web/common/storage/offline-data/export-user-data.util";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
@@ -30,7 +28,6 @@ export const BillingGateModal: FC<BillingGateModalProps> = ({ status }) => {
   useAppLockReason("billingGate", true);
   const logout = useLogout();
   const primaryButtonRef = useRef<HTMLButtonElement>(null);
-  const [isExporting, setIsExporting] = useState(false);
   const [isRedirecting, setIsRedirecting] = useState(false);
   const shownRef = useRef(false);
 
@@ -39,8 +36,8 @@ export const BillingGateModal: FC<BillingGateModalProps> = ({ status }) => {
     ? "Start your 7-day trial"
     : "Subscribe to keep using Compass";
   const body = isAwaitingCheckout
-    ? `Compass is ${BILLING_PLAN.PRICE_DISPLAY} after a ${BILLING_PLAN.TRIAL_LENGTH_DAYS}-day trial. A card is required to start.`
-    : `Your trial has ended. Compass is ${BILLING_PLAN.PRICE_DISPLAY}.`;
+    ? "A card is required to start."
+    : "Your trial has ended.";
 
   useEffect(() => {
     if (!shownRef.current) {
@@ -72,16 +69,6 @@ export const BillingGateModal: FC<BillingGateModalProps> = ({ status }) => {
     }
   };
 
-  const handleExport = async () => {
-    setIsExporting(true);
-    track("billing_gate_cta_clicked", { cta: "export" });
-    try {
-      await runExportMyData();
-    } finally {
-      setIsExporting(false);
-    }
-  };
-
   const handleLogout = () => {
     track("billing_gate_cta_clicked", { cta: "logout" });
     void logout();
@@ -91,9 +78,6 @@ export const BillingGateModal: FC<BillingGateModalProps> = ({ status }) => {
     const actions: Record<string, () => void> = {
       s: () => {
         void redirectTo("checkout");
-      },
-      e: () => {
-        if (!isExporting) void handleExport();
       },
       l: handleLogout,
     };
@@ -145,16 +129,7 @@ export const BillingGateModal: FC<BillingGateModalProps> = ({ status }) => {
           )}
         </div>
         <button
-          className="c-focus-ring inline-flex items-center text-text-muted text-xs underline-offset-4 hover:text-text hover:underline"
-          disabled={isExporting}
-          onClick={() => void handleExport()}
-          type="button"
-        >
-          {isExporting ? "Exporting…" : "Export my data"}
-          {isExporting ? null : <ShortcutHint className="ml-2">E</ShortcutHint>}
-        </button>
-        <button
-          className="c-focus-ring inline-flex items-center text-text-muted text-xs underline-offset-4 hover:text-text hover:underline"
+          className="c-focus-ring inline-flex items-center text-text-muted text-xs underline underline-offset-4"
           onClick={handleLogout}
           type="button"
         >

--- a/packages/web/src/billing/BillingGateModal.tsx
+++ b/packages/web/src/billing/BillingGateModal.tsx
@@ -1,4 +1,10 @@
-import { type FC, useEffect, useRef, useState } from "react";
+import {
+  type FC,
+  type KeyboardEvent,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { BillingApi } from "@web/api/billing.api";
 import {
   getApiErrorMessage,
@@ -74,7 +80,7 @@ export const BillingGateModal: FC<BillingGateModalProps> = ({ status }) => {
     void logout();
   };
 
-  const handleShortcutKey = (e: React.KeyboardEvent) => {
+  const handleShortcutKey = (e: KeyboardEvent) => {
     const actions: Record<string, () => void> = {
       s: () => {
         void redirectTo("checkout");

--- a/packages/web/src/billing/useAppAccess.test.tsx
+++ b/packages/web/src/billing/useAppAccess.test.tsx
@@ -39,7 +39,6 @@ const stubConfig = (isConfigured: boolean, enforcement = true) => {
           billing: {
             isConfigured,
             enforcement,
-            priceDisplay: "$7.99/month",
             trialLengthDays: 7,
           },
         }),
@@ -246,7 +245,6 @@ describe("useAppAccess", () => {
             billing: {
               isConfigured: true,
               enforcement: true,
-              priceDisplay: "$7.99/month",
               trialLengthDays: 7,
             },
           }),

--- a/packages/web/src/billing/useTrialStatus.test.tsx
+++ b/packages/web/src/billing/useTrialStatus.test.tsx
@@ -24,7 +24,6 @@ const stubConfig = (enforcement: boolean) => {
           billing: {
             isConfigured: true,
             enforcement,
-            priceDisplay: "$7.99/month",
             trialLengthDays: 7,
           },
         }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The signed-in trial overlay (`BillingGateModal`) is keyboard-first and price-free:

- Copy no longer names a subscription amount (`A card is required to start.` / `Your trial has ended.`).
- Log out is always underlined with a focus ring; hover no longer restyles it.
- Export my data is gone from this overlay (shortcuts are S / L, plus M on the subscribe state).
- `/api/config` no longer ships a hardcoded `priceDisplay`. Checkout already uses `stripe.priceId`, so changing the amount in Stripe does not require a web deploy.

## Simplicity

Implementation already deleted price copy, unused `PRICE_*` constants, and the export path. Follow-up `c4cbe8696` types the shortcut handler via `KeyboardEvent` and documents that `BILLING_PLAN` no longer supplies web price copy. Hook count unchanged (`isRedirecting`, `shownRef` + `useEffect` remain for Stripe redirect disable and one-shot analytics). Title still says `7-day` as product copy rather than re-importing the trial-length constant into web.

## Automated validation

Verifier (`bun run verify` vs `origin/main`):

```
Selected packages: core, web, backend
Checks run: test:core, test:web, test:backend, type-check, lint, knip
Checks skipped: test:a11y (Playwright Chromium missing); test:e2e (Playwright Chromium missing)
selected checks passed
```

`VERDICT: PASS` (local Playwright skipped; GitHub e2e/a11y remain the CI parity).

Focused: `bun test:web -- packages/web/src/billing/BillingGateModal.test.tsx` — 8 pass.

Browser (forced overlay locally, not committed): title `Start your 7-day trial`, body `A card is required to start.`, no `$7.99`, no Export my data, Tab cycles Start trial ↔ Log out, Esc does not dismiss, Log out stays underlined on hover.

![Billing gate with price-free copy and no export](https://cursor.com/artifacts/c/art-64e22c18-3459-4798-aa06-24e4d2f305d7)
![Log out focused via keyboard Tab](https://cursor.com/artifacts/c/art-0f728f36-a42b-4e08-90b8-5ead136f4e30)
<a href="https://cursor.com/agents/bc-c0c98654-005a-45ab-a033-50df1210061b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbilling_gate_keyboard_first.mp4"><img src="https://cursor.com/artifacts/c/art-3d01fb97-d02f-4e02-b50d-e3c6f5585213" alt="billing_gate_keyboard_first.mp4" /></a>

## Independent review

`.agents/handoffs/2922.md`

```
VERDICT: no confirmed findings
FINDINGS:
```

## Test plan

- `bun test:web -- packages/web/src/billing/BillingGateModal.test.tsx` — 8 pass
- `bun test:backend:fast -- packages/backend/src/config/controllers/config.controller.test.ts` — 3 pass
- `bun test:backend -- packages/backend/src/config/config.route.test.ts` — 3 pass
- `bun run verify` — test:core, test:web, test:backend, type-check, lint, knip passed; Playwright a11y/e2e skipped locally

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0c98654-005a-45ab-a033-50df1210061b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0c98654-005a-45ab-a033-50df1210061b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

