### PR TITLE
fix(backend): close the SSE stream when the initial replay fails

### DIFF
--- a/packages/backend/src/servers/sse/events-stream.controller.db.test.ts
+++ b/packages/backend/src/servers/sse/events-stream.controller.db.test.ts
@@ -6,7 +6,9 @@ import {
 } from "@backend/__tests__/helpers/mock.db.setup";
 import { initSupertokens } from "@backend/common/middleware/supertokens.middleware";
 import eventsController from "@backend/servers/sse/events-stream.controller";
+import { sseServer } from "@backend/servers/sse/sse.server";
 import userService from "@backend/user/services/user.service";
+import userMetadataService from "@backend/user/services/user-metadata.service";
 import {
   afterAll,
   beforeAll,
@@ -73,5 +75,32 @@ describe("EventsController", () => {
     // Let the fire-and-forget rejection's .catch handler settle so it
     // doesn't surface as an unhandled rejection in a later test.
     await new Promise((resolve) => setImmediate(resolve));
+  });
+
+  it("closes and unsubscribes the stream when the initial metadata replay fails", async () => {
+    const userId = "507f1f77bcf86cd799439015";
+    spyOn(userMetadataService, "fetchUserMetadata").mockImplementation(() =>
+      Promise.reject(new Error("simulated metadata failure")),
+    );
+
+    const req = {
+      session: { getUserId: () => userId },
+      on: mock(),
+    } as unknown as Request;
+    const res = {
+      setHeader: mock(),
+      flushHeaders: mock(),
+      write: mock(),
+      status: mock().mockReturnThis(),
+      end: mock(),
+      // subscribe() flushes the headers before the fetch, so by the time it
+      // rejects the response is already committed.
+      headersSent: true,
+    } as unknown as Response;
+
+    await eventsController.streamEvents(req, res);
+
+    expect(res.end).toHaveBeenCalled();
+    expect(sseServer.subscriberCount(userId)).toBe(0);
   });
 });

--- a/packages/backend/src/servers/sse/events-stream.controller.ts
+++ b/packages/backend/src/servers/sse/events-stream.controller.ts
@@ -9,6 +9,7 @@ const logger = Logger("app:events.controller");
 class EventsController {
   streamEvents = async (req: Request, res: Response): Promise<void> => {
     const userId = req.session!.getUserId();
+    let unsubscribe: (() => void) | undefined;
 
     try {
       // Subscribe immediately so no events are missed during the metadata fetch.
@@ -16,7 +17,7 @@ class EventsController {
       // (a single global poller for the whole process, not one per user) and
       // fans out to whoever is subscribed, so no per-connection wiring is
       // needed here beyond the subscription itself.
-      const unsubscribe = sseServer.subscribe(userId, res);
+      unsubscribe = sseServer.subscribe(userId, res);
       req.on("close", unsubscribe);
 
       // Replay current state after subscribing — client is never stuck on reconnect.
@@ -34,7 +35,15 @@ class EventsController {
       });
     } catch (err) {
       logger.error(`Failed to open SSE stream for user ${userId}:`, err);
-      if (!res.headersSent) {
+      if (res.headersSent) {
+        // subscribe() already flushed the headers, so the client is holding an
+        // open stream that never got its initial replay. Close it instead of
+        // leaving it open: EventSource reconnects on its own when the
+        // connection ends. Unsubscribe explicitly rather than relying on
+        // req "close", which is not guaranteed to have fired by then.
+        unsubscribe?.();
+        res.end();
+      } else {
         res.status(500).end();
       }
     }


### PR DESCRIPTION
## Summary

`sseServer.subscribe()` calls `res.flushHeaders()`, so by the time `fetchUserMetadata` rejects in `streamEvents`, `res.headersSent` is already `true`. The `if (!res.headersSent)` guard in the catch block could therefore never fire on that path: the handler logged the error and returned, leaving the client holding an open, still-subscribed stream that never received its initial `userMetadataChanged` replay and had no reason to reconnect. The user sat with stale metadata until a page reload.

This is not theoretical. PostHog error-tracking issue `01a043e0-c0d8-7553-919a-d9ee1ee00c08` (#2904) recorded it at 2026-08-27T15:39:56Z, when SuperTokens returned a 504 for `GET /recipe/user/metadata`. The 504 itself is transient infrastructure and needs no code change; only the handling of it did.

The catch block now branches the other way. When headers are already sent, the response is ended so the browser's `EventSource` reconnects on its own, and `unsubscribe()` is called explicitly so the connection map does not leak an entry (`res.end()` on its own is not guaranteed to have fired `req`'s `"close"` by that point). The pre-existing `res.status(500).end()` behavior is kept for the case where headers genuinely have not been sent.

Closes #2904

## Simplicity

Inline, no new abstraction. The only structural change is hoisting `unsubscribe` to a `let` outside the `try` so the catch block can reach it. Net change to the controller is 8 added lines, 5 of them a comment.

## Automated validation

Not applicable: this path is an error branch in an SSE handler, exercised by the regression test below rather than by a browser or CLI scenario.

## Independent review

Not run.

## Test plan

- Added `closes and unsubscribes the stream when the initial metadata replay fails` to `packages/backend/src/servers/sse/events-stream.controller.db.test.ts`. It mocks the response with `headersSent: true`, makes `fetchUserMetadata` reject, and asserts the response was ended and `sseServer.subscriberCount(userId)` is `0`. Confirmed it fails against the unfixed controller (`expect(res.end).toHaveBeenCalled()`, received 0 calls) and passes with the fix.
- `bun run verify`: `type-check`, `lint`, and `knip` pass on the backend package.
- `test:backend` could not run through `verify` in this environment because `mongodb-memory-server` binds to `::` and the container has no IPv6 stack. Ran the full backend suite against the same in-memory replica set with an IPv4 bind instead: 437 pass / 8 fail, against a 436 pass / 8 fail baseline on `main` with the same command. The 8 failures are pre-existing and unrelated (`GET /api/config`, `UserController`); the extra pass is the new test.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xj8pDC4QpCHMPU4pjhpaVG)_