### PR TITLE
docs(autofix): read exception environment via sql, not context groups

### DIFF
--- a/.github/prompts/error-autofix.md
+++ b/.github/prompts/error-autofix.md
@@ -23,13 +23,33 @@ like `.../error_tracking/fingerprint/<hash>?timestamp=...`). Use the PostHog
 MCP tools to pull the actual signal before doing anything else:
 
 - Stack trace and exception type/message
-- Event properties: `environment`, `service`, `version`, `result`, `errorType`
-  (these were added in a recent prep change — some historical issues predate
-  them and will be generic)
 - Occurrence count, affected users, first/last seen
+- Event properties: `environment`, `service`, `version`, `namespace`,
+  `result`, `errorType` (some historical issues predate these and will be
+  generic)
 - Whether this is `staging` or `production` (staging and prod currently
   share one PostHog project — a staging-only error is not urgent and should
   never justify an `automerge-candidate` label)
+
+The backend and sync services set `environment`/`service`/`version` as custom
+event properties, so PostHog's `environment` and `release` context groups do
+not return them — `query-error-tracking-issue-events` will look like the
+event carries nothing but `$exception_*` and `$lib`. Read them with SQL
+instead, substituting the issue's UUID:
+
+```sql
+SELECT timestamp, properties.environment, properties.service,
+       properties.version, properties.namespace, properties.errorType,
+       properties.result
+FROM events
+WHERE event = '$exception'
+  AND properties.$exception_issue_id = '<issue-uuid>'
+ORDER BY timestamp DESC
+LIMIT 10
+```
+
+An issue can span both environments, so check every row rather than the
+first one: `staging` on one occurrence does not make the issue staging-only.
 
 If the PostHog MCP cannot resolve the fingerprint, fall back to searching
 PostHog error tracking issues by the exception message/type from the GitHub


### PR DESCRIPTION
## Summary

The reported symptom is real — `query-error-tracking-issue-events` returns nothing but `$exception_*`, `$lib`, and `$lib_version` for backend exceptions — but the stated cause is not. The capture path is already correct, so there is no code change here.

`PostHogExceptionTransport.log()` (`packages/core/src/logger/posthog-exception.transport.ts:94-101`) already reads `getPostHogContext()` and attaches `environment`, `service`, and `version` to every captured backend exception, at the one shared capture point. `startOtelLogs()` sets that context in the same branch that constructs the PostHog client, so whenever a capture can happen the context exists. `posthog-node` forwards the third `additionalProperties` argument onto the `$exception` event verbatim.

The actual gap is on the read side. Those are custom, un-prefixed property names. PostHog's `environment` and `release` context groups project only reserved `$`-prefixed properties, so the include-groups that `.github/prompts/error-autofix.md` Step 1 relies on silently drop them — the properties are on the event, but invisible to the tool the triage agent was told to use.

This change points Step 1 at a SQL read that returns them, and adds the caveat that one issue can span both environments, so a single `staging` row does not make an issue staging-only.

Both issues cited in the report do in fact carry full context:

| issue | environment | service | version | namespace |
| --- | --- | --- | --- | --- |
| `01a043f1…` (Stripe signature, #2906) | `staging` | `compass-backend` | 1.1.315 | `app:billing.webhook` |
| `01a043e0…` (SSE stream, #2904) | `production` | `compass-backend` | 1.1.314 | `app:events.controller` |

The indirect inference during #2906 triage (production has no Stripe secrets, so its webhook 404s before signature verification) reached the right answer — `staging` — the hard way.

## Simplicity

Documentation only. No abstraction, no new code path, and deliberately no change to `packages/core/src/logger/**` or `packages/backend/src/logging/**` — those already do the right thing, and editing them to "fix" a working capture path would have added redundancy while tripping the no-auto-merge guard for no benefit.

I did not add a reserved `$release_id` alias to make the built-in `release` group light up: that property is meant to carry a registered PostHog release identifier, and populating it with a raw version string is a guess at semantics rather than a fix.

## Automated validation

Reproduced the reported symptom against issue `01a043f1-80b8-79c3-8de5-c4ee2c71a91f` via the PostHog MCP with `include: ["exception","environment","release","correlation"]` — response contained only `$exception_*`, `$lib`, `$lib_version`, confirming the report.

Confirmed the same event carries the properties, via SQL over `events`: `environment=staging`, `service=compass-backend`, `version=1.1.315`, `namespace=app:billing.webhook`.

Ran the exact SQL block added to the prompt against issue `01a043e0-c0d8-7553-919a-d9ee1ee00c08` — returned `production | compass-backend | 1.1.314 | app:events.controller`.

Confirmed the capture path locally by stubbing `captureException` on the client returned by `startOtelLogs()` and calling `Logger("app:billing.webhook").error(...)`; the third argument contained `environment`, `service`, `version`, and `namespace`. Scratch test removed before commit.

Fleet-wide check over 14 days: every `posthog-node` `$exception` event carries non-null `environment` and `service` (`compass-backend` / `compass-sync`, `staging` / `production`). Only `$lib: web` events have them null, which is out of scope here.

## Independent review

Not run — documentation-only change with no code paths to review.

## Test plan

- `bun run verify` — type-check, lint, knip all passed (12 pre-existing lint warnings, none in changed files).

---
_Generated by [Claude Code](https://claude.ai/code/session_01L18gKyBUwT58QPgqpFWST8)_