### PR TITLE
fix(web): style jump-mode Esc as a keycap

### DIFF
--- a/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
@@ -22,6 +22,7 @@ import {
 } from "@web/grid/shortcuts/edge-focus.store";
 import { KEYBOARD_PLACE_HINT_PARTS } from "@web/grid/shortcuts/KeyboardPlaceIndicator";
 import { settingsActions } from "@web/settings/settings.store";
+import { EVENT_JUMP_IDLE_HINT_PARTS } from "@web/shortcuts/shift-hint/EventJumpIndicator";
 import {
   eventJumpActions,
   initialEventJumpState,
@@ -115,6 +116,7 @@ const seedKeyboardPlaceDraft = () => {
 
 const KEYBOARD_PLACE_HINT = getPartsPlainText(KEYBOARD_PLACE_HINT_PARTS);
 const TIME_TRAVEL_HINT = getPartsPlainText(TIME_TRAVEL_HINT_PARTS);
+const EVENT_JUMP_IDLE_HINT = getPartsPlainText(EVENT_JUMP_IDLE_HINT_PARTS);
 const CREATE_EVENT_HINT = getHintPlainText(getShortcutHint("create-event"));
 const FIRST_EVENT_SAVE_HINT = getHintPlainText(
   getShortcutHint("first-event-save"),
@@ -395,7 +397,7 @@ describe("SidebarStatusBar", () => {
 
     render(<SidebarStatusBar />, { wrapper });
 
-    expect(screen.getByRole("status")).toHaveTextContent("Event jump · Esc");
+    expect(screen.getByRole("status")).toHaveTextContent(EVENT_JUMP_IDLE_HINT);
     expect(screen.queryByText(CREATE_EVENT_HINT)).not.toBeInTheDocument();
   });
 
@@ -406,7 +408,7 @@ describe("SidebarStatusBar", () => {
 
     render(<SidebarStatusBar />, { wrapper });
 
-    expect(screen.getByRole("status")).toHaveTextContent("Event jump · Esc");
+    expect(screen.getByRole("status")).toHaveTextContent(EVENT_JUMP_IDLE_HINT);
     expect(screen.queryByText(KEYBOARD_PLACE_HINT)).not.toBeInTheDocument();
   });
 
@@ -453,7 +455,7 @@ describe("SidebarStatusBar", () => {
 
     render(<SidebarStatusBar />, { wrapper });
 
-    expect(screen.getByRole("status")).toHaveTextContent("Event jump · Esc");
+    expect(screen.getByRole("status")).toHaveTextContent(EVENT_JUMP_IDLE_HINT);
     expect(screen.queryByText(TIME_TRAVEL_HINT)).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/shortcuts/shift-hint/EventJumpIndicator.test.tsx
+++ b/packages/web/src/shortcuts/shift-hint/EventJumpIndicator.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import {
+  EVENT_JUMP_IDLE_HINT_PARTS,
+  EventJumpIndicator,
+  eventJumpSelectionHintParts,
+} from "@web/shortcuts/shift-hint/EventJumpIndicator";
+import {
+  eventJumpActions,
+  initialEventJumpState,
+  useEventJumpStore,
+} from "@web/shortcuts/shift-hint/event-jump.store";
+import { getPartsPlainText } from "@web/shortcuts/tips/shortcut-tips.data";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+const EVENT_JUMP_IDLE_HINT = getPartsPlainText(EVENT_JUMP_IDLE_HINT_PARTS);
+
+const expectEscKeycap = () => {
+  // Query the visual chip, not the sr-only sentence that also contains "Esc".
+  const chip = screen.getByText("Esc");
+  expect(chip.closest("[aria-hidden]")).toBeTruthy();
+};
+
+describe("EventJumpIndicator", () => {
+  beforeEach(() => {
+    useEventJumpStore.setState(initialEventJumpState, true);
+  });
+
+  afterEach(() => {
+    useEventJumpStore.setState(initialEventJumpState, true);
+  });
+
+  it("renders Esc as a keycap while event jump is on", () => {
+    eventJumpActions.setActive(true);
+    render(<EventJumpIndicator />);
+
+    expect(screen.getByRole("status")).toHaveTextContent(EVENT_JUMP_IDLE_HINT);
+    expectEscKeycap();
+  });
+
+  it("keeps Esc as a keycap after a day is selected", () => {
+    eventJumpActions.setActive(true);
+    eventJumpActions.setActiveDayKeys(["2026-08-27"], "Thursday selected");
+    render(<EventJumpIndicator />);
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      getPartsPlainText(eventJumpSelectionHintParts("Thursday selected")),
+    );
+    expectEscKeycap();
+  });
+
+  it("speaks the exit announcement as plain text", () => {
+    eventJumpActions.setActive(true);
+    eventJumpActions.setActive(false);
+    render(<EventJumpIndicator />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Event jump off");
+    expect(screen.queryByText("Esc")).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/shortcuts/shift-hint/EventJumpIndicator.tsx
+++ b/packages/web/src/shortcuts/shift-hint/EventJumpIndicator.tsx
@@ -5,8 +5,24 @@ import {
   selectEventJumpAnnouncement,
   useEventJumpStore,
 } from "@web/shortcuts/shift-hint/event-jump.store";
+import { ShortcutTipParts } from "@web/shortcuts/tips/ShortcutTipParts";
+import { type ShortcutTipPart } from "@web/shortcuts/tips/shortcut-tips.data";
 
 const EXIT_ANNOUNCEMENT_LINGER_MS = 1200;
+
+export const EVENT_JUMP_IDLE_HINT_PARTS: readonly ShortcutTipPart[] = [
+  "Event jump · ",
+  { key: "Esc" },
+];
+
+export const eventJumpSelectionHintParts = (
+  announcement: string,
+): readonly ShortcutTipPart[] => [
+  "Jump · ",
+  announcement,
+  " · ",
+  { key: "Esc" },
+];
 
 /**
  * Persistent badge + live region while event-jump mode is on. Stays mounted
@@ -28,11 +44,11 @@ export const EventJumpIndicator: FC = () => {
 
   if (!isActive && !announcement) return null;
 
-  const statusText = !isActive
-    ? announcement
+  const parts: readonly ShortcutTipPart[] | null = !isActive
+    ? null
     : announcement && announcement !== "Event jump on"
-      ? `Jump · ${announcement} · Esc`
-      : "Event jump · Esc";
+      ? eventJumpSelectionHintParts(announcement)
+      : EVENT_JUMP_IDLE_HINT_PARTS;
 
   return (
     <span
@@ -41,7 +57,7 @@ export const EventJumpIndicator: FC = () => {
       data-event-jump-indicator=""
       role="status"
     >
-      {statusText}
+      {parts ? <ShortcutTipParts parts={parts} /> : announcement}
     </span>
   );
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Event jump's sidebar status used to render `Esc` as plain text (`Jump · Thursday selected · Esc`). Other mode indicators already use `ShortcutTipParts` so keys look like keycaps. This switches the jump-mode message to the same pattern.

## Simplicity

Reuses the existing `ShortcutTipParts` / `ShortcutKeys` path used by keyboard-place and time-travel hints. No new styling or components.

## Automated validation

- Focused web tests: `EventJumpIndicator.test.tsx` and `SidebarStatusBar.test.tsx` — 27 pass
- GitHub CI: lint, type-check, knip, unit (all packages), e2e, lighthouse, CodeQL — green
- Browser: press `H` then `R` on week view; status shows `Event jump · Esc` and `Jump · Thursday selected · Esc` with Esc in a `.c-keycap` chip

## Independent review

Not run. Diff is a display-only swap onto the existing keycap helper.

## Test plan

- `bun packages/scripts/src/testing/test-parallel.ts web -- packages/web/src/shortcuts/shift-hint/EventJumpIndicator.test.tsx packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx`
- Browser jump-mode check on http://localhost:9080/week (H, then R for Thursday)
- CI on PR #2927
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a922b189-15f4-4553-b9d1-313992ef6796?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a922b189-15f4-4553-b9d1-313992ef6796&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

