### PR TITLE
feat(web): open the view dropdown from hold-Mod page jump

### DIFF
--- a/packages/web/src/components/CalendarHeader/CalendarHeader.tsx
+++ b/packages/web/src/components/CalendarHeader/CalendarHeader.tsx
@@ -6,7 +6,6 @@ import { SelectView } from "@web/components/SelectView/SelectView";
 import { useVersionCheck } from "@web/components/Sidebar/SidebarActions/useVersionCheck";
 import { SidebarToggleButton } from "@web/components/Sidebar/SidebarToggleButton";
 import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
-import { pageJumpAttrs } from "@web/shortcuts/page-jump/page-jump.targets";
 
 interface Props {
   /** Left-aligned heading text (e.g. "June 2026" or "Wednesday, July 1"). */
@@ -47,10 +46,7 @@ export const CalendarHeader: FC<Props> = ({
           positioned inside this cluster and must paint below the header. */}
       <div className="flex min-w-0 flex-1 items-center gap-3">
         {showNavigation && onPrev && onNext && (
-          <div
-            className="flex items-center gap-3"
-            {...pageJumpAttrs("navigation")}
-          >
+          <div className="flex items-center gap-3">
             <TooltipWrapper shortcut="J">
               <ArrowButton
                 direction="left"

--- a/packages/web/src/components/SelectView/SelectView.test.tsx
+++ b/packages/web/src/components/SelectView/SelectView.test.tsx
@@ -1,10 +1,14 @@
 import { RouterProvider } from "@tanstack/react-router";
 import { type ReactNode } from "react";
 import "@testing-library/jest-dom";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createTestRouter } from "@web/__tests__/utils/providers/createTestRouter";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
+import {
+  focusPageJumpTarget,
+  PAGE_JUMP_ATTRIBUTE,
+} from "@web/shortcuts/page-jump/page-jump.targets";
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockNavigate = mock();
@@ -504,6 +508,41 @@ describe("SelectView", () => {
         expect(todayOption).toHaveAttribute("tabindex", "0");
         expect(dayOption).toHaveAttribute("tabindex", "-1");
       });
+    });
+  });
+
+  describe("Page jump", () => {
+    it("marks the heading as the view-select jump target", async () => {
+      await renderWithRouter("July 2026");
+
+      const button = screen.getByRole("button");
+      expect(button.closest(`[${PAGE_JUMP_ATTRIBUTE}]`)).toHaveAttribute(
+        PAGE_JUMP_ATTRIBUTE,
+        "view-select",
+      );
+    });
+
+    it("opens the dropdown when the page-jump target is activated", async () => {
+      await renderWithRouter("July 2026");
+
+      const button = screen.getByRole("button");
+      expect(button).toHaveAttribute("aria-expanded", "false");
+
+      act(() => {
+        focusPageJumpTarget("view-select");
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("view-select-dropdown")).toBeInTheDocument();
+        expect(button).toHaveAttribute("aria-expanded", "true");
+      });
+      expect(screen.getByRole("option", { name: /^day/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("option", { name: /^week/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("option", { name: /^life/i }),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/packages/web/src/components/SelectView/SelectView.tsx
+++ b/packages/web/src/components/SelectView/SelectView.tsx
@@ -14,6 +14,7 @@ import { ROOT_ROUTES } from "@web/common/constants/routes";
 import { Z_INDEX_FLOATING_MENU } from "@web/common/constants/web.constants";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import { useFloatingLayer } from "@web/shortcuts/floating-layer";
+import { pageJumpAttrs } from "@web/shortcuts/page-jump/page-jump.targets";
 import {
   LIFE_SHORTCUT,
   VIEW_SHORTCUTS,
@@ -121,7 +122,7 @@ export const SelectView = ({ label, onToday }: SelectViewProps) => {
   const dropdownId = "view-select-dropdown";
 
   return (
-    <div className="relative">
+    <div className="relative" {...pageJumpAttrs("view-select")}>
       <h1 className="text-text" aria-live="polite">
         <button
           ref={refs.setReference}

--- a/packages/web/src/shortcuts/page-jump/PageJumpHintOverlay.test.tsx
+++ b/packages/web/src/shortcuts/page-jump/PageJumpHintOverlay.test.tsx
@@ -79,7 +79,7 @@ describe("PageJumpHintOverlay", () => {
   });
 
   it("renders nothing when not visible", () => {
-    addAnchor("navigation");
+    addAnchor("view-select");
     render(<PageJumpHintOverlay visible={false} />);
 
     expect(overlayRoot()).toBeNull();
@@ -92,7 +92,7 @@ describe("PageJumpHintOverlay", () => {
   });
 
   it("renders a chip for each mounted target, skipping absent ones", () => {
-    addAnchor("navigation");
+    addAnchor("view-select");
     addAnchor("month-picker");
     // No up-next / calendars anchors: e.g. the sidebar is collapsed.
     render(<PageJumpHintOverlay visible={true} />);
@@ -101,7 +101,7 @@ describe("PageJumpHintOverlay", () => {
   });
 
   it("skips a mounted target with nothing focusable", () => {
-    addAnchor("navigation");
+    addAnchor("view-select");
     // The empty Up Next card renders its section but no interactive element,
     // so its digit would do nothing and must not be advertised.
     addAnchor("up-next", { focusable: false });
@@ -112,19 +112,19 @@ describe("PageJumpHintOverlay", () => {
   });
 
   it("exposes a screen-reader summary while the visible chips stay aria-hidden", () => {
-    addAnchor("navigation");
+    addAnchor("view-select");
     addAnchor("month-picker");
     render(<PageJumpHintOverlay visible={true} />);
 
     const status = screen.getByRole("status");
     expect(status.textContent).toContain("Jump to?");
-    expect(status.textContent).toContain("1 for view navigation");
+    expect(status.textContent).toContain("1 for view dropdown");
     expect(status.textContent).toContain("2 for month picker");
     expect(chipsWrapper()?.getAttribute("aria-hidden")).not.toBeNull();
   });
 
   it("renders a custom target list, e.g. Life's, skipping absent targets", () => {
-    addAnchor("navigation");
+    addAnchor("view-select");
     addAnchor("life-grid");
     // No life-variation / life-details anchors: e.g. the sidebar is collapsed.
     render(

--- a/packages/web/src/shortcuts/page-jump/page-jump.targets.test.ts
+++ b/packages/web/src/shortcuts/page-jump/page-jump.targets.test.ts
@@ -59,14 +59,14 @@ describe("getPageJumpFocusElement", () => {
   });
 
   it("falls back to the first interactive element", () => {
-    const anchor = addAnchor("navigation");
+    const anchor = addAnchor("view-select");
     const disabled = document.createElement("button");
     disabled.disabled = true;
     anchor.append(disabled);
-    const arrow = document.createElement("button");
-    anchor.append(arrow);
+    const trigger = document.createElement("button");
+    anchor.append(trigger);
 
-    expect(getPageJumpFocusElement("navigation")).toBe(arrow);
+    expect(getPageJumpFocusElement("view-select")).toBe(trigger);
   });
 });
 
@@ -82,5 +82,48 @@ describe("focusPageJumpTarget", () => {
 
   it("reports failure when the target cannot take focus", () => {
     expect(focusPageJumpTarget("calendars")).toBe(false);
+  });
+
+  it("clicks a closed menu trigger so the dropdown opens", () => {
+    const anchor = addAnchor("view-select");
+    const trigger = document.createElement("button");
+    trigger.setAttribute("aria-haspopup", "listbox");
+    trigger.setAttribute("aria-expanded", "false");
+    trigger.addEventListener("click", () => {
+      trigger.setAttribute("aria-expanded", "true");
+    });
+    anchor.append(trigger);
+
+    expect(focusPageJumpTarget("view-select")).toBe(true);
+    expect(document.activeElement).toBe(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("does not click an already-open menu trigger", () => {
+    const anchor = addAnchor("view-select");
+    const trigger = document.createElement("button");
+    trigger.setAttribute("aria-haspopup", "listbox");
+    trigger.setAttribute("aria-expanded", "true");
+    let clicks = 0;
+    trigger.addEventListener("click", () => {
+      clicks += 1;
+    });
+    anchor.append(trigger);
+
+    expect(focusPageJumpTarget("view-select")).toBe(true);
+    expect(clicks).toBe(0);
+  });
+
+  it("does not click a plain focusable control", () => {
+    const anchor = addAnchor("calendars");
+    const toggle = document.createElement("button");
+    let clicks = 0;
+    toggle.addEventListener("click", () => {
+      clicks += 1;
+    });
+    anchor.append(toggle);
+
+    expect(focusPageJumpTarget("calendars")).toBe(true);
+    expect(clicks).toBe(0);
   });
 });

--- a/packages/web/src/shortcuts/page-jump/page-jump.targets.ts
+++ b/packages/web/src/shortcuts/page-jump/page-jump.targets.ts
@@ -7,13 +7,15 @@
  * Components opt in by spreading `pageJumpAttrs(id)` on their container;
  * digits come from this list's order, so it is the single place to add,
  * remove, or renumber a target. An unmounted anchor (collapsed sidebar,
- * empty Up Next) simply gets no chip and its digit does nothing.
+ * empty Up Next) simply gets no chip and its digit does nothing. A closed
+ * menu trigger (the view dropdown) is clicked after focus so the jump
+ * reveals Day / Week / Life instead of landing on a closed heading.
  */
 
 export const PAGE_JUMP_ATTRIBUTE = "data-page-jump";
 
 export type PageJumpTargetId =
-  | "navigation"
+  | "view-select"
   | "month-picker"
   | "up-next"
   | "calendars"
@@ -30,14 +32,14 @@ export type PageJumpTarget = {
 export type PageJumpTargets = readonly PageJumpTarget[];
 
 export const CALENDAR_PAGE_JUMP_TARGETS: PageJumpTargets = [
-  { digit: "1", id: "navigation", label: "View navigation" },
+  { digit: "1", id: "view-select", label: "View dropdown" },
   { digit: "2", id: "month-picker", label: "Month picker" },
   { digit: "3", id: "up-next", label: "Up next" },
   { digit: "4", id: "calendars", label: "Calendar list" },
 ];
 
 export const LIFE_PAGE_JUMP_TARGETS: PageJumpTargets = [
-  { digit: "1", id: "navigation", label: "View navigation" },
+  { digit: "1", id: "view-select", label: "View dropdown" },
   { digit: "2", id: "life-grid", label: "Current week" },
   { digit: "3", id: "life-variation", label: "Life variation" },
   { digit: "4", id: "life-details", label: "Life details" },
@@ -75,10 +77,22 @@ export const getPageJumpFocusElement = (
   );
 };
 
-/** Focus a page jump target; returns whether a focusable element was found. */
+const shouldOpenOnJump = (element: HTMLElement): boolean =>
+  Boolean(element.getAttribute("aria-haspopup")) &&
+  element.getAttribute("aria-expanded") !== "true";
+
+/**
+ * Focus a page jump target; returns whether a focusable element was found.
+ * Menu/listbox triggers are clicked after focus so the dropdown opens —
+ * that's what makes hold-Mod on the view switcher a discovery path for
+ * Day / Week / Life, instead of landing on a closed heading.
+ */
 export const focusPageJumpTarget = (id: PageJumpTargetId): boolean => {
   const element = getPageJumpFocusElement(id);
   if (!element) return false;
   element.focus();
+  if (shouldOpenOnJump(element)) {
+    element.click();
+  }
   return true;
 };

--- a/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.test.tsx
+++ b/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.test.tsx
@@ -63,15 +63,15 @@ const buildPage = () => {
     return anchor;
   };
 
-  const prevArrow = document.createElement("button");
-  addAnchor("navigation").append(prevArrow);
+  const viewTrigger = document.createElement("button");
+  addAnchor("view-select").append(viewTrigger);
 
   // Roving tab stop, like react-datepicker's focused day.
   const monthDay = document.createElement("div");
   monthDay.setAttribute("tabindex", "0");
   addAnchor("month-picker").append(monthDay);
 
-  return { prevArrow, monthDay };
+  return { viewTrigger, monthDay };
 };
 
 const openEventForm = () => {
@@ -129,14 +129,35 @@ describe("usePageJumpShortcut", () => {
     });
 
     it("ignores a bare digit with no modifier held", () => {
-      const { prevArrow } = buildPage();
-      prevArrow.focus();
+      const { viewTrigger } = buildPage();
+      viewTrigger.focus();
       renderHook(() => usePageJumpShortcut());
 
       const event = dispatch("keydown", { key: "2", code: "Digit2" });
 
       expect(event.defaultPrevented).toBe(false);
-      expect(prevArrow).toHaveFocus();
+      expect(viewTrigger).toHaveFocus();
+    });
+
+    it("opens a closed view-select menu trigger", () => {
+      const trigger = document.createElement("button");
+      trigger.setAttribute("aria-haspopup", "listbox");
+      trigger.setAttribute("aria-expanded", "false");
+      trigger.addEventListener("click", () => {
+        trigger.setAttribute("aria-expanded", "true");
+      });
+      const anchor = document.createElement("section");
+      anchor.setAttribute(PAGE_JUMP_ATTRIBUTE, "view-select");
+      anchor.append(trigger);
+      document.body.append(anchor);
+
+      renderHook(() => usePageJumpShortcut());
+
+      const event = pressModDigit("1");
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(trigger).toHaveFocus();
+      expect(trigger).toHaveAttribute("aria-expanded", "true");
     });
 
     it("jumps within a custom target list, e.g. Life's", () => {
@@ -192,8 +213,8 @@ describe("usePageJumpShortcut", () => {
 
   describe("while the event form is open", () => {
     it("does not dispatch: the form's digit jumps own the gesture", () => {
-      const { monthDay, prevArrow } = buildPage();
-      prevArrow.focus();
+      const { monthDay, viewTrigger } = buildPage();
+      viewTrigger.focus();
       act(() => {
         openEventForm();
       });
@@ -241,8 +262,8 @@ describe("usePageJumpShortcut", () => {
   });
 
   it("does not dispatch or arm hints while the app is locked", async () => {
-    const { monthDay, prevArrow } = buildPage();
-    prevArrow.focus();
+    const { monthDay, viewTrigger } = buildPage();
+    viewTrigger.focus();
     setAppLockReason("test-lock", true);
     const { result } = renderHook(() => usePageJumpShortcut());
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Holding Mod now shows a page-jump hint on the view dropdown (digit 1), and triggering that chord opens the menu so Day / Week / Life shortcuts are discoverable.

Previously Mod+1 focused the prev/next arrows. Those still have J/K. The view switcher is the surface that actually reveals the other views.

Closed `aria-haspopup` triggers are clicked after focus, so the jump opens the menu instead of landing on a closed heading.

## Simplicity

Reused the existing hold-Mod page-jump list instead of a new shortcut. Opening is keyed off `aria-haspopup` + `aria-expanded`, so any future menu jump target gets the same behavior without a special case for the view switcher.

## Automated validation

`bun run verify` (merge-base vs origin/main):

```
Selected packages: web
Checks run: test:web, type-check, lint, knip
Checks skipped: test:a11y (Playwright Chromium missing); test:e2e (Playwright Chromium missing)
✓ selected checks passed
```

Focused web tests (page-jump targets, overlay copy, Mod+1 dispatch, SelectView opening): 60 pass.

Browser, anonymous week view at http://localhost:9080/week (Linux, Mod = Control):

- Hold Control: a `1` chip appears on the August 2026 heading.
- Control+1: the dropdown opens with This Week (T), Day (D), Week (W), Life (L).

![Hold-Mod chip on the view heading](https://cursor.com/artifacts/c/art-7154a6d0-1f98-4028-bac1-9450660e3b00)
<a href="https://cursor.com/agents/bc-f02f6f2a-d11c-4ab2-9f51-58311c89b9be/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhold_mod_opens_view_dropdown.mp4"><img src="https://cursor.com/artifacts/c/art-c2fccf01-cb73-4306-b964-f8ad2fbeb837" alt="hold_mod_opens_view_dropdown.mp4" /></a>
![View dropdown open with Day Week Life shortcuts](https://cursor.com/artifacts/c/art-97a40008-85f7-4b01-8fa1-a908108b5fae)

## Independent review

Pending human review. Implementer did not run `/review` on their own diff.

## Test plan

- `bun test:web` on page-jump + SelectView files (60 pass)
- `bun run verify` → test:web, type-check, lint, knip passed
- Browser: hold Mod shows `1` on the date heading; Mod+1 opens Day/Week/Life
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f02f6f2a-d11c-4ab2-9f51-58311c89b9be?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f02f6f2a-d11c-4ab2-9f51-58311c89b9be&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

