### PR TITLE
fix(web): make every form field targetable on hold-Mod

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ Internal documentation for engineers and agents working in the Compass repo.
 - Attendees, contact suggestions, or RSVP: [Attendees, Contacts, And RSVP](./features/attendees.md), [Feature File Map](./development/feature-file-map.md#attendees-contacts-and-rsvp)
 - Event caching, reads, or optimistic writes: [Event Caching](./frontend/event-caching.md)
 - Dragging/resizing events on the week grid: [Week Drag Interaction](./frontend/week-drag-interaction.md)
-- Keyboard shortcuts, event jump, or pointer suppression: [Shortcuts](./acceptance/shortcuts.md), [Contextual Pointer Guidance](./frontend/contextual-pointer-guidance.md), [Feature File Map](./development/feature-file-map.md#keyboard-shortcuts)
+- Keyboard shortcuts, event jump, or pointer suppression: [Shortcut Commandments](./frontend/shortcut-commandments.md), [Shortcuts](./acceptance/shortcuts.md), [Contextual Pointer Guidance](./frontend/contextual-pointer-guidance.md), [Feature File Map](./development/feature-file-map.md#keyboard-shortcuts)
 - Welcome, Shortcut Showcase, or the first-event handoff prompt: [Feature File Map](./development/feature-file-map.md#welcome-showcase-and-first-event-handoff), [Frontend Runtime Flow](./frontend/frontend-runtime-flow.md#welcome-showcase-and-first-event-handoff)
 - Breakpoints, sidebar collapse, or layout at different viewport sizes: [Responsive Layout](./frontend/responsive-layout.md)
 - Local-first or storage behavior: [Offline Storage And Migrations](./features/offline-storage-and-migrations.md)

--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -2,6 +2,10 @@
 
 This runbook covers keyboard shortcut parity in Compass. The principle: anything a user can do with a mouse should also be doable with the keyboard.
 
+The product rules behind those bindings — hold-Mod discovery, targeting
+any on-screen field, hints that never lie — are
+[Shortcut Commandments](../frontend/shortcut-commandments.md).
+
 ## Source of Truth
 
 Two files matter, at different depths:

--- a/docs/development/feature-file-map.md
+++ b/docs/development/feature-file-map.md
@@ -76,6 +76,9 @@ Authoritative legend data and taught bindings live under
 `packages/web/src/shortcuts`. View owners register keys; do not duplicate
 labels outside the registry.
 
+Product rules (hold-Mod discovery, "chip the field", typing always types):
+[Shortcut Commandments](../frontend/shortcut-commandments.md).
+
 - Registry (source of truth for `?` legend): `packages/web/src/shortcuts/shortcuts.registry.ts`
 - Taught bindings (handlers + Shortcut Showcase keycaps): `packages/web/src/shortcuts/keymap.ts`
 - Sidebar next-shortcut selector: `packages/web/src/shortcuts/tips/selectShortcutHint.ts`

--- a/docs/frontend/shortcut-commandments.md
+++ b/docs/frontend/shortcut-commandments.md
@@ -1,0 +1,99 @@
+# Shortcut Commandments
+
+Product rules for Compass keyboard shortcuts. The `?` legend lists every
+binding; this doc is the *why* — the constraints a new shortcut must satisfy
+so the keyboard calendar stays learnable.
+
+`Mod` is Command on Mac and Control on Windows/Linux. Users often say
+"Meta" for the same hold-to-reveal gesture.
+
+Acceptance walkthroughs live in [Shortcuts](../acceptance/shortcuts.md).
+The display registry is `packages/web/src/shortcuts/shortcuts.registry.ts`.
+
+---
+
+## 1. You can target any element any time
+
+If a control is on screen and interactive, there is a keyboard path to it
+from the current context — Day, Week, or Life; creating or editing; caret
+in a field or focus on the grid. You do not have to change views, close
+the form, or enter a special mode first.
+
+"Any element" means first-class targets (form fields, page areas, events),
+not every DOM node. Save, All-day, and RSVP are actions or modifiers on
+those targets, not their own jump digits.
+
+## 2. You can always discover the sequence by holding Mod
+
+Holding Mod (Meta/Cmd on Mac, Ctrl elsewhere) for a beat reveals the jump
+keys for whatever is currently targetable. Do not make the user memorize
+`Mod+8` for guests or `Mod+3` for Up next. If they can see it, they can
+hold Mod and read the chip.
+
+The `?` overlay is the catalog. Hold-Mod is in-the-moment discovery.
+
+## 3. Hints never lie
+
+A chip appears only when the matching key would actually do something.
+Unmounted targets get no chip and their digit is a no-op (calendar picker
+on an edit draft, collapsed sidebar, empty Up Next, guests on a calendar
+that cannot invite).
+
+Scrolled-out targets keep their shortcut but hide the chip, so a portaled
+keycap does not float over empty space.
+
+## 4. Chip the field, not a child widget
+
+Hint chips anchor on the visible control. Focus may land on a descendant
+(the caret inside a combobox, the selected color swatch). Never put the
+jump id on a hidden 2px react-select dummy input, or the chip vanishes
+even though the shortcut still works.
+
+Form fields: `getEventFormFieldAnchor` vs `getEventFormFieldElement` in
+`packages/web/src/common/utils/form/form.util.ts`. Page areas already
+split `getPageJumpAnchor` / `getPageJumpFocusElement`.
+
+## 5. Typing always types
+
+Bare letter shortcuts stand down while the caret is in an editable field.
+Mod chords stay available so discovery and jumps still work while typing:
+`Mod+digit` (jump), `Mod+E` (same field jumps as `e`…), `Mod+K` (command
+palette).
+
+## 6. One hold-Mod gesture; context chooses the map
+
+The hold is the same everywhere. Digits are a single namespace, so the
+open event form takes them over for its fields (1–9 in DOM order). With
+the form closed, the same hold numbers page areas (sidebar, month picker,
+Up next, calendars — or Life's grid/variation/details).
+
+Do not run both maps at once. Do not invent a second hold key.
+
+## 7. Leaders wait, then teach
+
+`e` then a letter within ~600ms is silent muscle memory. Hold the leader
+and the which-key menu appears. Hold-Mod uses the same cadence
+(`MOD_HOLD_HINT_MS` / `ARM_WINDOW_MS`). A new sequence should feel like
+these two, not like a third timing model.
+
+## 8. Escape peels the innermost layer
+
+Escape closes the open listbox, then the form, then event-jump, then the
+palette. A shortcut that swallows Escape while a floating layer is open
+is a bug. Floating layers register with `useFloatingLayer`.
+
+---
+
+## Adding a jump target
+
+1. Give it a stable, visible anchor (wrapper id or `pageJumpAttrs`).
+2. Make sure hold-Mod chips that anchor, and that the digit/letter focuses
+   a usable control inside it.
+3. Omit the chip when the target is not rendered or not focusable.
+4. Add a registry row only if the `?` legend should list it; hold-Mod is
+   still the way to discover the live mapping.
+
+Form field digits live in
+`packages/web/src/shortcuts/edit-sequence/edit-sequence.fields.ts` (DOM
+order, 1–9). Page-area digits live in
+`packages/web/src/shortcuts/page-jump/page-jump.targets.ts`.

--- a/packages/web/src/common/utils/form/form.util.test.ts
+++ b/packages/web/src/common/utils/form/form.util.test.ts
@@ -2,6 +2,8 @@ import { ID_EVENT_FORM } from "../../constants/web.constants";
 import {
   focusEventFormField,
   focusEventFormTitle,
+  getEventFormFieldAnchor,
+  getEventFormFieldElement,
   isComboboxInteraction,
   isEditableKeyboardTarget,
   isEventFormKeyboardTarget,
@@ -175,8 +177,11 @@ describe("form.util", () => {
       colorOther.type = "radio";
       colorOther.name = "event-color";
       color.append(colorSelected, colorOther);
-      const attendees = document.createElement("input");
+      const attendees = document.createElement("div");
       attendees.id = "event-form-attendees";
+      const attendeesInput = document.createElement("input");
+      attendeesInput.setAttribute("role", "combobox");
+      attendees.append(attendeesInput);
       form.append(
         title,
         location,
@@ -199,6 +204,7 @@ describe("form.util", () => {
         calendar,
         colorSelected,
         attendees,
+        attendeesInput,
       };
     };
 
@@ -230,7 +236,37 @@ describe("form.util", () => {
       expect(document.activeElement).toBe(fields.colorSelected);
 
       expect(focusEventFormField("attendees")).toBe(true);
-      expect(document.activeElement).toBe(fields.attendees);
+      expect(document.activeElement).toBe(fields.attendeesInput);
+    });
+
+    it("anchors guests and color chips on the visible wrapper, not the inner control", () => {
+      const fields = mountForm();
+
+      expect(getEventFormFieldAnchor("attendees")).toBe(fields.attendees);
+      expect(getEventFormFieldElement("attendees")).toBe(fields.attendeesInput);
+
+      expect(getEventFormFieldAnchor("color")?.id).toBe("event-form-color");
+      expect(getEventFormFieldElement("color")).toBe(fields.colorSelected);
+    });
+
+    it("focuses the selected color swatch even when it is not first in the group", () => {
+      const form = document.createElement("form");
+      form.setAttribute("name", ID_EVENT_FORM);
+      const color = document.createElement("fieldset");
+      color.id = "event-form-color";
+      const first = document.createElement("input");
+      first.type = "radio";
+      first.name = "event-color";
+      const selected = document.createElement("input");
+      selected.type = "radio";
+      selected.name = "event-color";
+      selected.checked = true;
+      color.append(first, selected);
+      form.append(color);
+      document.body.appendChild(form);
+
+      expect(focusEventFormField("color")).toBe(true);
+      expect(document.activeElement).toBe(selected);
     });
 
     it("falls back to start/end date inputs when time pickers are absent", () => {

--- a/packages/web/src/common/utils/form/form.util.ts
+++ b/packages/web/src/common/utils/form/form.util.ts
@@ -30,7 +30,10 @@ const findFirstMatch = (selectors: string[]): HTMLElement | null => {
   return null;
 };
 
-/** Per-field fallback selectors, in priority order. */
+/** Per-field fallback selectors, in priority order. These target the visible
+ * control (the chip anchor), not a hidden inner input. react-select's dummy
+ * input is often 2px wide — too small for a hint chip — so combobox fields
+ * put the id on the wrapper. */
 const FIELD_SELECTORS: Record<EventFormFocusField, string[]> = {
   title: [`${EVENT_FORM_SELECTOR} input[name="Event Title"]`],
   location: [
@@ -38,7 +41,7 @@ const FIELD_SELECTORS: Record<EventFormFocusField, string[]> = {
     `${EVENT_FORM_SELECTOR} input[name="Event Location"]`,
   ],
   description: [`#event-form-description`],
-  // Timed events expose a start-time combobox; all-day uses the date input.
+  // Timed events expose a start-time combobox wrapper; all-day uses the date input.
   start: [
     `${EVENT_FORM_SELECTOR} #startTimePicker`,
     `${EVENT_FORM_SELECTOR} input[title="Pick Start Date"]`,
@@ -52,22 +55,65 @@ const FIELD_SELECTORS: Record<EventFormFocusField, string[]> = {
     `${EVENT_FORM_SELECTOR} #event-form-recurrence button[aria-label="Repeat"]`,
   ],
   calendar: [`#event-form-calendar`],
-  // Prefer the selected swatch so arrow keys move from the current color.
-  color: [
-    `#event-form-color input[type="radio"]:checked`,
-    `#event-form-color input[type="radio"]`,
-  ],
+  color: [`#event-form-color`],
   attendees: [`#event-form-attendees`, `#event-form-guest-list`],
+};
+
+const FOCUSABLE_SELECTOR = [
+  "button:not([disabled])",
+  "[href]",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[contenteditable='true']",
+  "[contenteditable='']",
+  "[role='combobox']",
+  '[tabindex]:not([tabindex="-1"])',
+].join(", ");
+
+/**
+ * Visible control to chip while Mod is held. Same element as the jump
+ * target's container; focus may land on a descendant (see
+ * `getEventFormFieldElement`).
+ */
+export const getEventFormFieldAnchor = (
+  field: EventFormFocusField,
+): HTMLElement | null => findFirstMatch(FIELD_SELECTORS[field]);
+
+const resolveFocusElement = (
+  field: EventFormFocusField,
+  anchor: HTMLElement,
+): HTMLElement => {
+  // Prefer the selected swatch so arrow keys move from the current color.
+  if (field === "color") {
+    return (
+      anchor.querySelector<HTMLElement>('input[type="radio"]:checked') ??
+      anchor.querySelector<HTMLElement>('input[type="radio"]') ??
+      anchor
+    );
+  }
+
+  if (anchor.matches(FOCUSABLE_SELECTOR)) return anchor;
+
+  return (
+    anchor.querySelector<HTMLElement>('[role="combobox"]') ??
+    anchor.querySelector<HTMLElement>(FOCUSABLE_SELECTOR) ??
+    anchor
+  );
 };
 
 /**
  * The element a field jump would focus, or null if the field isn't currently
- * rendered (e.g. the calendar picker on an edit draft). Used both to focus
- * and to anchor hint chips to the same target.
+ * rendered (e.g. the calendar picker on an edit draft). Combobox wrappers
+ * resolve to the inner input so the caret lands ready to type.
  */
 export const getEventFormFieldElement = (
   field: EventFormFocusField,
-): HTMLElement | null => findFirstMatch(FIELD_SELECTORS[field]);
+): HTMLElement | null => {
+  const anchor = getEventFormFieldAnchor(field);
+  if (!anchor) return null;
+  return resolveFocusElement(field, anchor);
+};
 
 /**
  * Focus a field inside the docked event form. The grid card and sidebar form

--- a/packages/web/src/shortcuts/form-digit-jump/FormDigitHintOverlay.test.tsx
+++ b/packages/web/src/shortcuts/form-digit-jump/FormDigitHintOverlay.test.tsx
@@ -69,8 +69,11 @@ const buildForm = () => {
   location.id = "event-form-location";
   form.append(location);
 
-  const attendees = document.createElement("input");
+  const attendees = document.createElement("div");
   attendees.id = "event-form-attendees";
+  const attendeesInput = document.createElement("input");
+  attendeesInput.setAttribute("role", "combobox");
+  attendees.append(attendeesInput);
   form.append(attendees);
 
   const description = document.createElement("div");
@@ -82,7 +85,7 @@ const buildForm = () => {
     start,
     end,
     recurrenceButton,
-    radio,
+    color,
     location,
     attendees,
     description,
@@ -171,5 +174,19 @@ describe("FormDigitHintOverlay", () => {
     // No #event-form-calendar element was added (edit-draft state), so digit
     // 5 has neither a chip nor an announcement.
     expect(screen.getByRole("status").textContent).not.toContain("calendar");
+  });
+
+  it("chips the guests wrapper even when react-select's inner input is too small to chip", () => {
+    buildForm();
+    const attendees = document.getElementById("event-form-attendees");
+    const inner = attendees?.querySelector("input");
+    expect(attendees).not.toBeNull();
+    expect(inner).not.toBeNull();
+    stubRect(inner!, box(112, 90, 114, 92));
+
+    render(<FormDigitHintOverlay visible={true} />);
+
+    expect(chipDigits()).toContain("8");
+    expect(screen.getByRole("status").textContent).toContain("8 for guests");
   });
 });

--- a/packages/web/src/shortcuts/form-digit-jump/FormDigitHintOverlay.tsx
+++ b/packages/web/src/shortcuts/form-digit-jump/FormDigitHintOverlay.tsx
@@ -1,6 +1,6 @@
 import { createPortal } from "react-dom";
 import { Z_INDEX_TOOLTIP } from "@web/common/constants/web.constants";
-import { getEventFormFieldElement } from "@web/common/utils/form/form.util";
+import { getEventFormFieldAnchor } from "@web/common/utils/form/form.util";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 import { FORM_FIELD_DIGITS } from "@web/shortcuts/edit-sequence/edit-sequence.fields";
 import { getVisibleHintRect } from "@web/shortcuts/shift-hint/shift-hint-visible-rect";
@@ -18,11 +18,12 @@ export function FormDigitHintOverlay({ visible }: { visible: boolean }) {
     return null;
   }
 
-  // Only fields whose element is currently rendered get announced or
-  // chipped, e.g. the calendar picker (digit 5) isn't rendered on an edit
-  // draft, so the shortcut wouldn't do anything there.
+  // Chip the visible control, not a hidden inner input. Only fields whose
+  // anchor is currently rendered get announced or chipped, e.g. the calendar
+  // picker (digit 5) isn't rendered on an edit draft, so the shortcut
+  // wouldn't do anything there.
   const presentFields = FORM_FIELD_DIGITS.flatMap((entry) => {
-    const anchor = getEventFormFieldElement(entry.field);
+    const anchor = getEventFormFieldAnchor(entry.field);
     return anchor ? [{ ...entry, anchor }] : [];
   });
 

--- a/packages/web/src/shortcuts/form-digit-jump/useFormDigitJumpShortcut.test.tsx
+++ b/packages/web/src/shortcuts/form-digit-jump/useFormDigitJumpShortcut.test.tsx
@@ -84,8 +84,11 @@ const buildForm = () => {
   location.id = "event-form-location";
   form.append(location);
 
-  const attendees = document.createElement("input");
+  const attendees = document.createElement("div");
   attendees.id = "event-form-attendees";
+  const attendeesInput = document.createElement("input");
+  attendeesInput.setAttribute("role", "combobox");
+  attendees.append(attendeesInput);
   form.append(attendees);
 
   // Real usage sets this id on TipTap's contenteditable root, which is what
@@ -105,7 +108,7 @@ const buildForm = () => {
     calendar,
     color: radio,
     location,
-    attendees,
+    attendees: attendeesInput,
     description,
   };
 };

--- a/packages/web/src/views/Forms/EventForm/AttendeeField/AttendeeField.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/AttendeeField/AttendeeField.test.tsx
@@ -237,4 +237,21 @@ describe("AttendeeField", () => {
       screen.queryByText("Enable contact suggestions"),
     ).not.toBeInTheDocument();
   });
+
+  it("puts the jump-target id on the visible wrapper, not the dummy input", () => {
+    render(
+      <AttendeeField
+        id="event-form-attendees"
+        value={[]}
+        onChange={() => {}}
+      />,
+    );
+
+    const wrapper = document.getElementById("event-form-attendees");
+    const combobox = screen.getByRole("combobox", { name: "Guests" });
+
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.contains(combobox)).toBe(true);
+    expect(combobox.id).toBe("event-form-attendees-input");
+  });
 });

--- a/packages/web/src/views/Forms/EventForm/AttendeeField/AttendeeField.tsx
+++ b/packages/web/src/views/Forms/EventForm/AttendeeField/AttendeeField.tsx
@@ -244,10 +244,13 @@ export const AttendeeField = ({
   };
 
   return (
-    <div className="c-attendee-field">
+    // `id` belongs on this visible wrapper, not react-select's dummy input.
+    // The dummy input is often 2px wide, which fails the hold-Mod hint-chip
+    // visibility check; the wrapper is the jump-target anchor.
+    <div id={id} className="c-attendee-field">
       <AttendeeMenuFooterContext.Provider value={menuFooter}>
         <CreatableSelect<AttendeeOption, true>
-          inputId={id}
+          inputId={id ? `${id}-input` : undefined}
           aria-label="Guests"
           classNamePrefix={ATTENDEE_FIELD}
           components={attendeeFieldComponents}

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePicker.tsx
@@ -86,6 +86,8 @@ export const TimePicker = ({
   selectClassName,
   setIsMenuOpen,
   value,
+  id,
+  inputId,
   ...props
 }: Props) => {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -137,10 +139,22 @@ export const TimePicker = ({
     if (option) _onChange(option);
   };
 
+  // Jump ids live on this visible wrapper. react-select's dummy input is
+  // often 2px (hidden behind the selected value), which fails the hold-Mod
+  // hint-chip visibility check. `inputId` without a separate `id` is the
+  // jump id; the actual input then gets `${inputId}-input`.
+  const jumpId = id ?? inputId;
+  const resolvedInputId = id
+    ? inputId
+    : inputId
+      ? `${inputId}-input`
+      : undefined;
+
   return (
-    <div ref={containerRef} className="c-time-picker">
+    <div ref={containerRef} className="c-time-picker" id={jumpId}>
       <CreatableSelect
         {...props}
+        inputId={resolvedInputId}
         className={selectClassName}
         classNamePrefix={TIMEPICKER}
         styles={timePickerTextStyles}

--- a/packages/web/src/views/Forms/EventForm/EventForm.attendees.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.attendees.test.tsx
@@ -187,10 +187,6 @@ describe("EventForm attendee editor gating", () => {
     });
 
     expect(screen.getByRole("status").textContent).toContain("8 for guests");
-    const chips = document.querySelector(
-      "[data-form-digit-hints] [aria-hidden]",
-    );
-    expect(chips?.textContent).toContain("8");
   });
 
   it("keeps the read-only guest list for an event the user does not organize", () => {

--- a/packages/web/src/views/Forms/EventForm/EventForm.attendees.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.attendees.test.tsx
@@ -147,6 +147,52 @@ describe("EventForm attendee editor gating", () => {
     expect(screen.getByRole("combobox", { name: "Guests" })).toHaveFocus();
   });
 
+  it("reveals a hold-Mod chip on the guests field", async () => {
+    const calendar = makeCalendar();
+    const draft = editDraftOrThrow(makeMeetingEvent(calendar.id));
+
+    renderEventForm(draft, [calendar]);
+
+    const wrapper = document.getElementById("event-form-attendees");
+    expect(wrapper).not.toBeNull();
+    wrapper!.getBoundingClientRect = () =>
+      ({
+        top: 120,
+        left: 80,
+        bottom: 160,
+        right: 320,
+        width: 240,
+        height: 40,
+        x: 80,
+        y: 120,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    const isControl = resolveModifier("Mod") === "Control";
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          key: isControl ? "Control" : "Meta",
+          ctrlKey: isControl,
+          metaKey: !isControl,
+        }),
+      );
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 750));
+    });
+
+    expect(screen.getByRole("status").textContent).toContain("8 for guests");
+    const chips = document.querySelector(
+      "[data-form-digit-hints] [aria-hidden]",
+    );
+    expect(chips?.textContent).toContain("8");
+  });
+
   it("keeps the read-only guest list for an event the user does not organize", () => {
     const calendar = makeCalendar();
     const event = makeMeetingEvent(calendar.id, {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Holding Mod to reveal form-field jump chips skipped **Guests** (and would skip timed start/end the same way). The jump id sat on react-select's dummy input, which is often 2px wide — below the hint-chip visibility floor — so the field was on screen but had no chip.

Chips now anchor on the visible wrapper. Focus still lands on the inner combobox (or the selected color swatch). Digits stay 1–9 in DOM order; an unmounted field (guests on a local calendar, calendar picker on an edit draft) gets no chip and does not renumber the others.

Also adds [Shortcut Commandments](docs/frontend/shortcut-commandments.md): product rules from an audit of the shortcut system (target any on-screen field, discover by holding Mod, hints never lie, chip the field not a child widget, typing always types, one hold-Mod gesture, leaders wait then teach, Escape peels the innermost layer).

## Simplicity

No new shortcut engine. Form jumps already split “is it rendered?” from “focus it”; this matches page-jump’s existing anchor vs focus split (`getEventFormFieldAnchor` / `getEventFormFieldElement`).

## Automated validation

- `bun test:web` focused suites (form.util, FormDigitHintOverlay, useFormDigitJumpShortcut, AttendeeField, TimePicker, TimePickers, EventForm.attendees): pass, including “reveals a hold-Mod chip on the guests field” with a Google calendar fixture.
- `bun run lint`: pass (pre-existing warnings only).
- `bun run verify`: selected packages web; checks run test:web, type-check, lint, knip; all passed. Playwright skipped locally (Chromium missing); CI e2e/a11y cover that.
- Browser: create timed event on `/week`, hold Control → chips 1–7 and 9 on Title, start, end, Repeat, calendar, color, Location, Description. Guests (8) correctly absent in anonymous local mode. Start/end time pickers (the same dummy-input bug class) now chip.

![Hold-Mod chips on the event form, including start and end time pickers](https://cursor.com/artifacts/c/art-a06e3a10-b238-4f37-ae04-8c91123ec213)
<a href="https://cursor.com/agents/bc-87cf9c3b-07d8-4926-9d56-e5fba62b33ea/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhold_mod_form_field_chips.mp4"><img src="https://cursor.com/artifacts/c/art-dde2a69a-55ec-495b-9298-2ea8fef71377" alt="hold_mod_form_field_chips.mp4" /></a>

## Independent review

Not separately routed; this is a follow-up to merge after verification.

## Test plan

- `bun test:web --` form.util, FormDigitHintOverlay, useFormDigitJumpShortcut, AttendeeField, TimePicker, TimePickers, EventForm.attendees
- `bun run lint`
- `bun run verify`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87cf9c3b-07d8-4926-9d56-e5fba62b33ea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87cf9c3b-07d8-4926-9d56-e5fba62b33ea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

