### PR TITLE
feat(web): expand shortcut practice with edge resize, undo, and legend

### DIFF
--- a/e2e/onboarding/shortcut-showcase.spec.ts
+++ b/e2e/onboarding/shortcut-showcase.spec.ts
@@ -21,7 +21,7 @@ const startLevelOne = async (page: Page) => {
   await expect(showcase).toContainText("Compass is keyboard-only");
   await page.keyboard.press("Enter");
   await expect(showcase).toContainText("Drop an event on the board");
-  await expect(showcase).toContainText("Level 1/6");
+  await expect(showcase).toContainText("Level 1/9");
 };
 
 const holdModAndPress = async (page: Page, key: string) => {
@@ -42,7 +42,7 @@ const playThroughLevels = async (page: Page) => {
   await page.keyboard.type("Practice Event");
   await page.keyboard.press("Enter");
   await expect(showcase).toContainText("Practice Event");
-  await expect(showcase).toContainText("Level 2/6");
+  await expect(showcase).toContainText("Level 2/9");
   await expect(showcase).toContainText("See where to go: reveal the jump keys");
 
   await holdModAndPress(page, "1");
@@ -53,14 +53,26 @@ const playThroughLevels = async (page: Page) => {
   await expect(showcase).toContainText("Nudge it into place");
 
   await page.keyboard.press("Shift+ArrowRight");
+  await expect(showcase).toContainText("Change just one edge");
+
+  await page.keyboard.press("Tab");
+  await page.keyboard.press("Shift+ArrowDown");
   await expect(showcase).toContainText("Grab the title");
 
   await page.keyboard.press("e");
   await page.keyboard.press("t");
   await page.keyboard.press("Enter");
+  await expect(showcase).toContainText("Delete, then take it back");
+
+  await page.keyboard.press("Delete");
+  await holdModAndPress(page, "z");
   await expect(showcase).toContainText("When you forget, ask the palette");
 
   await holdModAndPress(page, "k");
+  await page.keyboard.press("Enter");
+  await expect(showcase).toContainText("The rest lives in the legend");
+
+  await page.keyboard.press("?");
   await page.keyboard.press("Enter");
 };
 
@@ -91,7 +103,7 @@ test("the welcome-started practice runs the taught keys through graduation", asy
 
   // Not a level, so it carries no chip; N passes without prompting.
   await expect(showcase).toContainText("Never miss a meeting");
-  await expect(showcase).not.toContainText("Level 7/");
+  await expect(showcase).not.toContainText("Level ");
   await page.keyboard.press("n");
 
   await expect(showcase).toContainText("you've got this");

--- a/packages/web/src/components/ShortcutShowcase/PracticeCalendar.tsx
+++ b/packages/web/src/components/ShortcutShowcase/PracticeCalendar.tsx
@@ -14,6 +14,7 @@ import {
   SHOWCASE_GRID_START_HOUR,
 } from "@web/components/ShortcutShowcase/practice.state";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
+import { eventEdgeFocusShadow } from "@web/grid/components/calendar-accent.util";
 
 const DAY_LABELS = ["Mon", "Tue", "Wed"];
 const GRID_START_MIN = SHOWCASE_GRID_START_HOUR * 60;
@@ -36,24 +37,38 @@ const PracticeBlock: FC<{
   const contentColor = theme.getContrastText(base);
   const isFocused = state.focusedId === block.id;
   const isEditing = state.editor?.eventId === block.id;
+  const focusedEdge = isFocused ? state.edge : null;
   const top = ((block.startMin - GRID_START_MIN) / TOTAL_MIN) * 100;
   const height = ((block.endMin - block.startMin) / TOTAL_MIN) * 100;
 
   const focusShadow = isFocused
     ? "0 0 0 1px var(--background), 0 0 0 3px color-mix(in srgb, var(--text) 70%, transparent)"
     : "";
+  const edgeFocusShadow =
+    focusedEdge === "start"
+      ? eventEdgeFocusShadow("startDate", "vertical", "var(--text)")
+      : focusedEdge === "end"
+        ? eventEdgeFocusShadow("endDate", "vertical", "var(--text)")
+        : "";
+  const edgeFocusAttr =
+    focusedEdge === "start"
+      ? "startDate"
+      : focusedEdge === "end"
+        ? "endDate"
+        : undefined;
 
   return (
     <div
       className="absolute inset-x-1 rounded-md px-2 py-1 text-xs transition-all duration-200"
       data-practice-event-id={block.id}
       data-practice-focused={isFocused ? "" : undefined}
+      data-edge-focus={edgeFocusAttr}
       style={{
         top: `${top}%`,
         height: `${height}%`,
         backgroundColor: base,
         color: contentColor,
-        boxShadow: focusShadow,
+        boxShadow: [focusShadow, edgeFocusShadow].filter(Boolean).join(", "),
       }}
     >
       {isEditing ? (

--- a/packages/web/src/components/ShortcutShowcase/PracticeLegend.tsx
+++ b/packages/web/src/components/ShortcutShowcase/PracticeLegend.tsx
@@ -1,0 +1,39 @@
+import { type FC } from "react";
+import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
+import { KEYMAP } from "@web/shortcuts/keymap";
+
+const LEGEND_ROWS = [
+  { keys: KEYMAP.createEvent.keycaps, label: "Create event" },
+  { keys: KEYMAP.eventJump.keycaps, label: "Show event jump keys" },
+  { keys: KEYMAP.moveEvent.keycaps, label: "Move focused event" },
+  { keys: KEYMAP.edgeFocus.keycaps, label: "Cycle start or end" },
+  { keys: KEYMAP.commandPalette.keycaps, label: "Command palette" },
+] as const;
+
+/**
+ * Sandbox-only legend for the showcase `?` level. The real overlay stays
+ * locked behind the takeover's app-lock; this list teaches the key without
+ * dumping the full registry.
+ */
+export const PracticeLegend: FC = () => {
+  return (
+    <div
+      role="dialog"
+      aria-label="Practice shortcut legend"
+      className="absolute inset-x-4 top-8 z-10 rounded-xl border border-border bg-surface-raised p-3 shadow-xl"
+    >
+      <p className="mb-2 text-text-muted text-xs">Shortcut legend</p>
+      <ul className="flex flex-col gap-1">
+        {LEGEND_ROWS.map((row) => (
+          <li
+            key={row.label}
+            className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 text-sm text-text"
+          >
+            {row.label}
+            <ShortcutKeys className="shrink-0" keys={[...row.keys]} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
@@ -119,7 +119,7 @@ describe("ShortcutShowcase", () => {
     expect(
       screen.getByText(/That takes a little practice to get the muscle memory/),
     ).toBeTruthy();
-    expect(screen.queryByText("Level 1/6")).toBeNull();
+    expect(screen.queryByText("Level 1/9")).toBeNull();
     expect(
       screen.getByRole("button", { name: "Start practicing" }),
     ).toBeTruthy();
@@ -130,7 +130,7 @@ describe("ShortcutShowcase", () => {
 
     pressKey("Enter");
     expect(currentStepId()).toBe("create");
-    expect(screen.getByText("Level 1/6")).toBeTruthy();
+    expect(screen.getByText("Level 1/9")).toBeTruthy();
     expect(screen.getByText("Press C to start a new event.")).toBeTruthy();
   });
 
@@ -140,7 +140,7 @@ describe("ShortcutShowcase", () => {
     act(() => shortcutShowcaseActions.replay());
     expect(currentStepId()).toBe("create");
     expect(screen.getByText("Press C to start a new event.")).toBeTruthy();
-    expect(screen.getByText("Level 1/6")).toBeTruthy();
+    expect(screen.getByText("Level 1/9")).toBeTruthy();
 
     pressKey("c");
     expect(currentStepId()).toBe("create");
@@ -152,7 +152,7 @@ describe("ShortcutShowcase", () => {
     );
     expect(currentStepId()).toBe("pageJump");
     expect(screen.getByText("Coffee with Alex")).toBeTruthy();
-    expect(screen.getByText("Level 2/6")).toBeTruthy();
+    expect(screen.getByText("Level 2/9")).toBeTruthy();
     expect(
       screen.getByText("See where to go: reveal the jump keys"),
     ).toBeTruthy();
@@ -303,7 +303,33 @@ describe("ShortcutShowcase", () => {
     showStep("nudge");
 
     pressKey("ArrowRight", { shiftKey: true });
+    expect(currentStepId()).toBe("edgeResize");
+  });
+
+  it("teaches Tab then Shift+arrow to resize one edge", () => {
+    render(<ShortcutShowcase />);
+    showStep("edgeResize");
+
+    pressKey("ArrowDown", { shiftKey: true });
+    expect(currentStepId()).toBe("edgeResize");
+
+    pressKey("Tab");
+    expect(screen.getByRole("status")).toHaveTextContent("Editing start time");
+
+    pressKey("ArrowDown", { shiftKey: true });
     expect(currentStepId()).toBe("editTitle");
+  });
+
+  it("keeps Tab on the focused event during the edge-resize lesson", () => {
+    render(<ShortcutShowcase />);
+    showStep("edgeResize");
+
+    pressKey("Tab");
+    expect(screen.getByRole("status")).toHaveTextContent("Editing start time");
+    pressKey("Tab");
+    expect(screen.getByRole("status")).toHaveTextContent("Editing end time");
+    pressKey("Tab");
+    expect(screen.queryByRole("status")).toBeNull();
   });
 
   it("teaches E then T to target the title", async () => {
@@ -317,6 +343,21 @@ describe("ShortcutShowcase", () => {
     expect(screen.getByLabelText("Event title")).toBeTruthy();
 
     await user.type(screen.getByLabelText("Event title"), "{Enter}");
+    expect(currentStepId()).toBe("deleteUndo");
+  });
+
+  it("teaches Delete then undo", () => {
+    const isMac = resolveModifier("Mod") === "Meta";
+    render(<ShortcutShowcase />);
+    showStep("deleteUndo");
+
+    expect(screen.getByText("Team sync")).toBeTruthy();
+    pressKey("Delete");
+    expect(screen.queryByText("Team sync")).toBeNull();
+    expect(currentStepId()).toBe("deleteUndo");
+
+    pressKey("z", isMac ? { metaKey: true } : { ctrlKey: true });
+    expect(screen.getByText("Team sync")).toBeTruthy();
     expect(currentStepId()).toBe("palette");
   });
 
@@ -329,8 +370,31 @@ describe("ShortcutShowcase", () => {
     expect(screen.getByLabelText("Practice command palette")).toBeTruthy();
 
     pressKey("Enter");
-    // The last level hands off to the notifications offer, then graduation.
+    expect(currentStepId()).toBe("legend");
+  });
+
+  it("opens a practice legend with ? and completes on Enter", () => {
+    render(<ShortcutShowcase />);
+    showStep("legend");
+
+    pressKey("?");
+    expect(screen.getByLabelText("Practice shortcut legend")).toBeTruthy();
+
+    pressKey("Enter");
     expect(currentStepId()).toBe("notifications");
+  });
+
+  it("Escape closes the practice legend and stays on the legend level", () => {
+    render(<ShortcutShowcase />);
+    showStep("legend");
+
+    pressKey("?");
+    expect(screen.getByLabelText("Practice shortcut legend")).toBeTruthy();
+
+    pressKey("Escape");
+    expect(screen.queryByLabelText("Practice shortcut legend")).toBeNull();
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
+    expect(currentStepId()).toBe("legend");
   });
 
   it("does not open the practice palette on Mod+K before the palette level", () => {

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
@@ -15,11 +15,14 @@ import { useDismissTransition } from "@web/common/hooks/useDismissTransition";
 import { getFocusableElements } from "@web/common/utils/focusable-elements";
 import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
 import { PracticeCalendar } from "@web/components/ShortcutShowcase/PracticeCalendar";
+import { PracticeLegend } from "@web/components/ShortcutShowcase/PracticeLegend";
 import { PracticePalette } from "@web/components/ShortcutShowcase/PracticePalette";
 import {
   armEdit,
   commitTitle,
   createDraft,
+  cycleEdgeFocus,
+  deleteFocused,
   disarmEdit,
   ensureFocused,
   initialPracticeState,
@@ -29,9 +32,12 @@ import {
   PRACTICE_TEAM_SYNC_ID,
   type PracticeNudgeDirection,
   toggleJumpHints,
+  undoDelete,
 } from "@web/components/ShortcutShowcase/practice.state";
 import {
   getCreateLessonPhase,
+  getDeleteUndoLessonPhase,
+  getEdgeResizeLessonPhase,
   getShowcaseStep,
   SHOWCASE_LEVEL_IDS,
 } from "@web/components/ShortcutShowcase/showcase.steps";
@@ -82,7 +88,8 @@ const arrowDirection = (key: string): PracticeNudgeDirection | null => {
  * practice state, so nothing here touches storage or the real grid stores.
  *
  * An unnumbered intro gates first-time entry, then levels teach create,
- * hold-Mod jumps, event jump, nudge, the E-then-T edit sequence, and Cmd+K.
+ * hold-Mod jumps, event jump, whole-event nudge, Tab-then-Shift+arrow edge
+ * resize, the E-then-T edit sequence, delete-then-undo, Cmd+K, and `?`.
  * Graduation hands off to a prompt on the real calendar. Skip is always
  * offered.
  */
@@ -95,6 +102,7 @@ const ShowcaseTakeover: FC = () => {
   const [isModHeld, setIsModHeld] = useState(false);
   const hasRevealedJumpsRef = useRef(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [legendOpen, setLegendOpen] = useState(false);
   const [practice, setPractice] = useState(initialPracticeState);
   const [offerPending, setOfferPending] = useState(false);
   const offerTakenRef = useRef(false);
@@ -151,7 +159,7 @@ const ShowcaseTakeover: FC = () => {
   // biome-ignore lint/correctness/useExhaustiveDependencies: lesson transitions reseat focus after transient controls unmount.
   useEffect(() => {
     seatFocus();
-  }, [stepId, practice.editor, paletteOpen]);
+  }, [stepId, practice.editor, paletteOpen, legendOpen]);
 
   useEffect(() => {
     const clearMod = () => setIsModHeld(false);
@@ -173,6 +181,13 @@ const ShowcaseTakeover: FC = () => {
     }
 
     if (event.key === "Tab" && regionRef.current) {
+      if (stepId === "edgeResize") {
+        claim(event);
+        apply((state) =>
+          cycleEdgeFocus(state, event.shiftKey ? "backward" : "forward"),
+        );
+        return;
+      }
       const root = regionRef.current;
       const focusables = getFocusableElements(root);
       if (focusables.length > 0) {
@@ -209,6 +224,8 @@ const ShowcaseTakeover: FC = () => {
       settingsActions.closeCmdPalette();
       if (paletteOpen) {
         setPaletteOpen(false);
+      } else if (legendOpen) {
+        setLegendOpen(false);
       } else if (practice.editor) {
         const input = document.querySelector<HTMLInputElement>(
           "[data-practice-title-input]",
@@ -226,6 +243,18 @@ const ShowcaseTakeover: FC = () => {
       if (stepId === "palette" && !paletteOpen) setPaletteOpen(true);
       return;
     }
+    if (
+      isModChord &&
+      !event.shiftKey &&
+      keyboardKey(event.nativeEvent).toLowerCase() === "z"
+    ) {
+      if (stepId === "deleteUndo" && practice.lastDeleted) {
+        claim(event);
+        apply(undoDelete);
+        advance();
+      }
+      return;
+    }
 
     if (paletteOpen) {
       if (event.key === "Enter") {
@@ -233,6 +262,21 @@ const ShowcaseTakeover: FC = () => {
         setPaletteOpen(false);
         if (stepId === "palette") advance();
       }
+      return;
+    }
+
+    if (legendOpen) {
+      if (event.key === "Enter") {
+        claim(event);
+        setLegendOpen(false);
+        if (stepId === "legend") advance();
+      }
+      return;
+    }
+
+    if (stepId === "legend" && event.key === "?") {
+      claim(event);
+      setLegendOpen(true);
       return;
     }
 
@@ -292,6 +336,26 @@ const ShowcaseTakeover: FC = () => {
         if (next !== practice) advance();
         return;
       }
+    }
+
+    if (stepId === "edgeResize") {
+      const direction = arrowDirection(event.key);
+      if (
+        event.shiftKey &&
+        direction &&
+        (practice.edge === "start" || practice.edge === "end")
+      ) {
+        claim(event);
+        const next = apply((state) => nudgeFocused(state, direction));
+        if (next !== practice) advance();
+        return;
+      }
+    }
+
+    if (stepId === "deleteUndo" && event.key === "Delete") {
+      claim(event);
+      apply(deleteFocused);
+      return;
     }
 
     if (
@@ -370,7 +434,24 @@ const ShowcaseTakeover: FC = () => {
           ...getShowcaseStep("create"),
           ...getCreateLessonPhase(Boolean(practice.editor)),
         }
-      : getShowcaseStep(stepId);
+      : stepId === "edgeResize"
+        ? {
+            ...getShowcaseStep("edgeResize"),
+            ...getEdgeResizeLessonPhase(practice.edge),
+          }
+        : stepId === "deleteUndo"
+          ? {
+              ...getShowcaseStep("deleteUndo"),
+              ...getDeleteUndoLessonPhase(Boolean(practice.lastDeleted)),
+            }
+          : getShowcaseStep(stepId);
+
+  const edgeAnnouncement =
+    stepId === "edgeResize" && practice.edge === "start"
+      ? "Editing start time"
+      : stepId === "edgeResize" && practice.edge === "end"
+        ? "Editing end time"
+        : null;
 
   const levelLabel =
     "level" in step ? `Level ${step.level}/${SHOWCASE_LEVEL_IDS.length}` : null;
@@ -405,6 +486,11 @@ const ShowcaseTakeover: FC = () => {
             )}
           </p>
           {step.keycaps && <ShortcutKeys keys={[...step.keycaps]} />}
+          {edgeAnnouncement && (
+            <p className="text-text-muted text-xs" role="status">
+              {edgeAnnouncement}
+            </p>
+          )}
           <div className="flex flex-wrap items-center gap-2 pt-2">
             {stepId === "intro" && (
               <div className="flex items-center gap-2">
@@ -482,6 +568,7 @@ const ShowcaseTakeover: FC = () => {
         </aside>
         <div className="relative min-w-0 flex-1 rounded-xl border border-border bg-surface p-4 shadow-xl">
           {paletteOpen && <PracticePalette onRun={runPracticeCommand} />}
+          {legendOpen && <PracticeLegend />}
           <PracticeCalendar
             state={practice}
             onTitleCommit={handleTitleCommit}

--- a/packages/web/src/components/ShortcutShowcase/practice.state.test.ts
+++ b/packages/web/src/components/ShortcutShowcase/practice.state.test.ts
@@ -2,13 +2,17 @@ import {
   armEdit,
   commitTitle,
   createDraft,
+  cycleEdgeFocus,
+  deleteFocused,
   ensureFocused,
   initialPracticeState,
   jumpToEvent,
   nudgeFocused,
   openTitleFromEdit,
+  PRACTICE_NUDGE_MIN,
   PRACTICE_TEAM_SYNC_ID,
   toggleJumpHints,
+  undoDelete,
 } from "@web/components/ShortcutShowcase/practice.state";
 import { describe, expect, it } from "bun:test";
 
@@ -62,6 +66,56 @@ describe("practice state transitions", () => {
     const moved = nudgeFocused(focused, "right");
     const next = moved.events.find((event) => event.id === focused.focusedId);
     expect(next?.dayIndex).toBe((team?.dayIndex ?? 0) + 1);
+  });
+
+  it("cycles edge focus and resizes only the focused edge", () => {
+    const focused = ensureFocused(initialPracticeState);
+    const team = focused.events.find((event) => event.id === focused.focusedId);
+    expect(team).toBeTruthy();
+
+    const startEdge = cycleEdgeFocus(focused, "forward");
+    expect(startEdge.edge).toBe("start");
+
+    const laterStart = nudgeFocused(startEdge, "down");
+    const resized = laterStart.events.find(
+      (event) => event.id === focused.focusedId,
+    );
+    expect(resized?.startMin).toBe((team?.startMin ?? 0) + PRACTICE_NUDGE_MIN);
+    expect(resized?.endMin).toBe(team?.endMin);
+
+    const wholeMove = nudgeFocused(focused, "down");
+    const translated = wholeMove.events.find(
+      (event) => event.id === focused.focusedId,
+    );
+    expect(translated?.startMin).toBe(
+      (team?.startMin ?? 0) + PRACTICE_NUDGE_MIN,
+    );
+    expect(translated?.endMin).toBe((team?.endMin ?? 0) + PRACTICE_NUDGE_MIN);
+  });
+
+  it("ignores left/right while an edge is focused", () => {
+    const startEdge = cycleEdgeFocus(
+      ensureFocused(initialPracticeState),
+      "forward",
+    );
+    expect(nudgeFocused(startEdge, "right")).toBe(startEdge);
+  });
+
+  it("deletes the focused event and restores it on undo", () => {
+    const focused = ensureFocused(initialPracticeState);
+    const deletedId = focused.focusedId;
+    expect(deletedId).toBeTruthy();
+
+    const afterDelete = deleteFocused(focused);
+    expect(afterDelete.events.some((event) => event.id === deletedId)).toBe(
+      false,
+    );
+    expect(afterDelete.lastDeleted?.id).toBe(deletedId);
+
+    const restored = undoDelete(afterDelete);
+    expect(restored.events.some((event) => event.id === deletedId)).toBe(true);
+    expect(restored.focusedId).toBe(deletedId);
+    expect(restored.lastDeleted).toBeNull();
   });
 
   it("opens the title field from an armed edit sequence", () => {

--- a/packages/web/src/components/ShortcutShowcase/practice.state.test.ts
+++ b/packages/web/src/components/ShortcutShowcase/practice.state.test.ts
@@ -105,6 +105,7 @@ describe("practice state transitions", () => {
     const focused = ensureFocused(initialPracticeState);
     const deletedId = focused.focusedId;
     expect(deletedId).toBeTruthy();
+    if (!deletedId) throw new Error("expected a focused event");
 
     const afterDelete = deleteFocused(focused);
     expect(afterDelete.events.some((event) => event.id === deletedId)).toBe(

--- a/packages/web/src/components/ShortcutShowcase/practice.state.ts
+++ b/packages/web/src/components/ShortcutShowcase/practice.state.ts
@@ -22,6 +22,9 @@ export type PracticeEventBlock = {
 
 export type PracticeNudgeDirection = "up" | "down" | "left" | "right";
 
+/** Start or end of the focused block; `null` means the whole event. */
+export type PracticeEdge = "start" | "end" | null;
+
 export type PracticeState = {
   events: PracticeEventBlock[];
   focusedId: string | null;
@@ -30,6 +33,10 @@ export type PracticeState = {
   jumpHintsVisible: boolean;
   /** `e` leader is armed; `t` opens the title field. */
   editArmed: boolean;
+  /** Tab-cycled edge on the focused event; `null` is the whole block. */
+  edge: PracticeEdge;
+  /** Last deleted block, so the delete/undo lesson can restore it. */
+  lastDeleted: PracticeEventBlock | null;
 };
 
 export const SHOWCASE_GRID_START_HOUR = 8;
@@ -75,6 +82,8 @@ export const initialPracticeState: PracticeState = {
   editor: null,
   jumpHintsVisible: false,
   editArmed: false,
+  edge: null,
+  lastDeleted: null,
 };
 
 export const createDraft = (state: PracticeState): PracticeState => {
@@ -93,6 +102,7 @@ export const createDraft = (state: PracticeState): PracticeState => {
     focusedId: draft.id,
     editor: { eventId: draft.id, isNew: true },
     editArmed: false,
+    edge: null,
   };
 };
 
@@ -107,7 +117,7 @@ export const commitTitle = (
       ? { ...event, title: title.trim() || "New event" }
       : event,
   );
-  return { ...state, events, editor: null, editArmed: false };
+  return { ...state, events, editor: null, editArmed: false, edge: null };
 };
 
 export const toggleJumpHints = (state: PracticeState): PracticeState => ({
@@ -124,7 +134,12 @@ export const jumpToEvent = (
     (event) => event.jumpKey === jumpKey.toLowerCase(),
   );
   if (!match) return state;
-  return { ...state, focusedId: match.id, jumpHintsVisible: false };
+  return {
+    ...state,
+    focusedId: match.id,
+    jumpHintsVisible: false,
+    edge: null,
+  };
 };
 
 export const ensureFocused = (state: PracticeState): PracticeState => {
@@ -138,7 +153,32 @@ export const ensureFocused = (state: PracticeState): PracticeState => {
     state.events.find((event) => event.id === PRACTICE_TEAM_SYNC_ID) ??
     state.events[0];
   if (!fallback) return state;
-  return { ...state, focusedId: fallback.id };
+  return { ...state, focusedId: fallback.id, edge: null };
+};
+
+const nudgeFocusedEdge = (
+  event: PracticeEventBlock,
+  edge: Exclude<PracticeEdge, null>,
+  direction: PracticeNudgeDirection,
+): PracticeEventBlock | null => {
+  // Timed edges only move in time, matching the real grid (left/right is a
+  // day shift and would push the block off this 3-day sandbox).
+  if (direction === "left" || direction === "right") return null;
+  const delta = direction === "down" ? PRACTICE_NUDGE_MIN : -PRACTICE_NUDGE_MIN;
+  if (edge === "start") {
+    const startMin = Math.max(
+      GRID_START_MIN,
+      Math.min(event.endMin - PRACTICE_NUDGE_MIN, event.startMin + delta),
+    );
+    if (startMin === event.startMin) return null;
+    return { ...event, startMin };
+  }
+  const endMin = Math.min(
+    GRID_END_MIN,
+    Math.max(event.startMin + PRACTICE_NUDGE_MIN, event.endMin + delta),
+  );
+  if (endMin === event.endMin) return null;
+  return { ...event, endMin };
 };
 
 export const nudgeFocused = (
@@ -151,6 +191,12 @@ export const nudgeFocused = (
   let moved = false;
   const events = focused.events.map((event) => {
     if (event.id !== focused.focusedId) return event;
+    if (focused.edge) {
+      const next = nudgeFocusedEdge(event, focused.edge, direction);
+      if (!next) return event;
+      moved = true;
+      return next;
+    }
     if (direction === "left" || direction === "right") {
       const dayIndex = Math.max(
         0,
@@ -179,10 +225,58 @@ export const nudgeFocused = (
   return { ...focused, events };
 };
 
+const EDGE_CYCLE: PracticeEdge[] = [null, "start", "end"];
+
+export const cycleEdgeFocus = (
+  state: PracticeState,
+  direction: "forward" | "backward",
+): PracticeState => {
+  const focused = ensureFocused(state);
+  if (!focused.focusedId) return state;
+  const index = EDGE_CYCLE.indexOf(focused.edge);
+  const step = direction === "forward" ? 1 : -1;
+  const nextEdge =
+    EDGE_CYCLE[(index + step + EDGE_CYCLE.length) % EDGE_CYCLE.length] ?? null;
+  return { ...focused, edge: nextEdge };
+};
+
+export const deleteFocused = (state: PracticeState): PracticeState => {
+  const focused = ensureFocused(state);
+  if (!focused.focusedId) return state;
+  const deleted = focused.events.find(
+    (event) => event.id === focused.focusedId,
+  );
+  if (!deleted) return state;
+  const events = focused.events.filter(
+    (event) => event.id !== focused.focusedId,
+  );
+  return {
+    ...focused,
+    events,
+    focusedId: events[0]?.id ?? null,
+    lastDeleted: deleted,
+    edge: null,
+    editor: null,
+    editArmed: false,
+  };
+};
+
+export const undoDelete = (state: PracticeState): PracticeState => {
+  if (!state.lastDeleted) return state;
+  const restored = state.lastDeleted;
+  return {
+    ...state,
+    events: [...state.events, restored],
+    focusedId: restored.id,
+    lastDeleted: null,
+    edge: null,
+  };
+};
+
 export const armEdit = (state: PracticeState): PracticeState => {
   const focused = ensureFocused(state);
   if (!focused.focusedId || focused.editor) return state;
-  return { ...focused, editArmed: true };
+  return { ...focused, editArmed: true, edge: null };
 };
 
 export const openTitleFromEdit = (state: PracticeState): PracticeState => {
@@ -191,6 +285,7 @@ export const openTitleFromEdit = (state: PracticeState): PracticeState => {
     ...state,
     editArmed: false,
     editor: { eventId: state.focusedId, isNew: false },
+    edge: null,
   };
 };
 

--- a/packages/web/src/components/ShortcutShowcase/showcase.steps.ts
+++ b/packages/web/src/components/ShortcutShowcase/showcase.steps.ts
@@ -1,3 +1,4 @@
+import { type PracticeEdge } from "@web/components/ShortcutShowcase/practice.state";
 import { KEYMAP } from "@web/shortcuts/keymap";
 import { type ShortcutTipPart } from "@web/shortcuts/tips/shortcut-tips.data";
 
@@ -73,6 +74,17 @@ export const SHOWCASE_STEPS = [
     level: 4,
   },
   {
+    id: "edgeResize",
+    title: "Change just one edge",
+    body: [
+      "Tab to the start or end of the focused event, then hold ",
+      { key: "Shift" },
+      " and press an arrow to change just that edge.",
+    ],
+    keycaps: [KEYMAP.edgeFocus.hotkey, ...KEYMAP.moveEvent.keycaps],
+    level: 5,
+  },
+  {
     id: "editTitle",
     title: "Grab the title",
     body: [
@@ -83,7 +95,20 @@ export const SHOWCASE_STEPS = [
       " to target the title.",
     ],
     keycaps: KEYMAP.editTitle.keycaps,
-    level: 5,
+    level: 6,
+  },
+  {
+    id: "deleteUndo",
+    title: "Delete, then take it back",
+    body: [
+      "Press ",
+      { key: "Delete" },
+      " to remove the focused event, then ",
+      { keys: KEYMAP.undo.keycaps },
+      " to undo.",
+    ],
+    keycaps: ["Delete", ...KEYMAP.undo.keycaps],
+    level: 7,
   },
   {
     id: "palette",
@@ -94,7 +119,18 @@ export const SHOWCASE_STEPS = [
       " to open the command palette. Enter runs the highlighted command.",
     ],
     keycaps: KEYMAP.commandPalette.keycaps,
-    level: 6,
+    level: 8,
+  },
+  {
+    id: "legend",
+    title: "The rest lives in the legend",
+    body: [
+      "Press ",
+      { key: "?" },
+      " to open the shortcut legend. Enter closes it.",
+    ],
+    keycaps: ["?"],
+    level: 9,
   },
   {
     id: "notifications",
@@ -136,5 +172,35 @@ export function getCreateLessonPhase(
   return {
     body: "Type a title, then press Enter to save.",
     keycaps: KEYMAP.saveDraft.keycaps,
+  };
+}
+
+/** After Tab lands on an edge, the hint swaps to the Shift+arrow beat. */
+export function getEdgeResizeLessonPhase(
+  edge: PracticeEdge,
+): Partial<Pick<ShowcaseStep, "body" | "keycaps">> {
+  if (!edge) return {};
+  return {
+    body: [
+      "Hold ",
+      { key: "Shift" },
+      " and press an arrow to change just that edge.",
+    ],
+    keycaps: KEYMAP.moveEvent.keycaps,
+  };
+}
+
+/** After Delete, the hint swaps to the undo beat. */
+export function getDeleteUndoLessonPhase(
+  hasDeleted: boolean,
+): Partial<Pick<ShowcaseStep, "body" | "keycaps">> {
+  if (!hasDeleted) return {};
+  return {
+    body: [
+      "Press ",
+      { keys: KEYMAP.undo.keycaps },
+      " to bring the event back.",
+    ],
+    keycaps: KEYMAP.undo.keycaps,
   };
 }

--- a/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
@@ -357,6 +357,7 @@ export function useGridEventEditShortcuts({
       event,
       keyboardEvent,
       onNudge: (nudgedEvent, nextEdge) => {
+        shortcutHintProgressActions.demonstrate("edge-focus");
         commit(nudgedEvent);
         edgeFocusActions.setEdge(
           event._id!,

--- a/packages/web/src/shortcuts/tips/selectShortcutHint.test.ts
+++ b/packages/web/src/shortcuts/tips/selectShortcutHint.test.ts
@@ -125,6 +125,15 @@ describe("selectShortcutHint", () => {
     ).toBe("nudge");
   });
 
+  it("teaches edge focus after nudge once an event is focused", () => {
+    expect(
+      selectShortcutHint({ ...afterFirstEvent, eventFocused: true }, [
+        "edit-sequence",
+        "nudge",
+      ]).id,
+    ).toBe("edge-focus");
+  });
+
   it("falls through to the command palette after save-draft is demonstrated", () => {
     expect(
       selectShortcutHint({ ...afterFirstEvent, isFormOpen: true }, [

--- a/packages/web/src/shortcuts/tips/selectShortcutHint.ts
+++ b/packages/web/src/shortcuts/tips/selectShortcutHint.ts
@@ -22,6 +22,7 @@ const IDLE_POOL = [
 const FOCUSED_POOL = [
   "edit-sequence",
   "nudge",
+  "edge-focus",
   ...IDLE_POOL,
 ] as const satisfies readonly ShortcutHintId[];
 

--- a/packages/web/src/shortcuts/tips/shortcut-tips.data.test.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-tips.data.test.ts
@@ -37,6 +37,9 @@ describe("getHintPlainText", () => {
       "On week view, press H then M to focus Monday",
     );
     expect(plainTextById.nudge).toBe("Hold Shift and press an arrow to move");
+    expect(plainTextById["edge-focus"]).toBe(
+      "Press Tab to the start or end, then hold Shift and press an arrow",
+    );
     expect(plainTextById["command-palette"]).toBe(
       `Press ${mod}+K to open the command palette`,
     );

--- a/packages/web/src/shortcuts/tips/shortcut-tips.data.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-tips.data.ts
@@ -7,6 +7,7 @@ export type ShortcutHintId =
   | "life-this-week"
   | "edit-sequence"
   | "nudge"
+  | "edge-focus"
   | "create-event"
   | "page-jump"
   | "event-jump"
@@ -109,6 +110,16 @@ export const SHORTCUT_HINTS: Record<ShortcutHintId, ShortcutHint> = {
   nudge: {
     id: "nudge",
     parts: ["Hold ", { key: nudgeModifier }, " and press an arrow to move"],
+  },
+  "edge-focus": {
+    id: "edge-focus",
+    parts: [
+      "Press ",
+      { key: KEYMAP.edgeFocus.hotkey },
+      " to the start or end, then hold ",
+      { key: nudgeModifier },
+      " and press an arrow",
+    ],
   },
   "command-palette": {
     id: "command-palette",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Shortcut Showcase still taught six levels, but `KEYMAP.edgeFocus` (Tab to start/end, then Shift+arrow to resize) was never practiced. This expands the sandbox to nine skippable levels:

1. Create (`C`)
2. Hold-Mod page jump
3. Event jump (`H`)
4. Whole-event nudge (Shift+arrow)
5. **Resize one edge** (Tab, then Shift+arrow)
6. Edit title (`E` then `T`)
7. **Delete, then undo**
8. Command palette
9. **`?` legend**

Tab on the edge-resize lesson cycles the focused event's start/end instead of trapping focus in the takeover. The practice block draws the same top/bottom accent as the real grid. After graduation, a new `edge-focus` sidebar tip rotates in once an event is focused.

Form-field Mod+digit jump is left to the real-calendar `save-draft` tip; the fake editor is still title-only.

## Simplicity

Practice state stays a pure in-memory grid. Edge resize, delete, and undo are small transitions on that state — no real form, undo stack, or legend overlay is mounted. The `?` lesson uses a five-row sandbox list.

## Automated validation

- `bun test:web` on showcase, practice-state, and shortcut-tip files: 82 pass
- `bunx playwright test e2e/onboarding/shortcut-showcase.spec.ts`: 5 passed, including the full taught-key playthrough through graduation
- `bun run lint`: clean for this diff (existing repo warnings only)
- Browser walkthrough of the first-run practice completed all nine levels, including Tab → "Editing start time" → Shift+arrow, Delete then undo, and the `?` legend

![Level 5 after Tab focuses the start edge](https://cursor.com/artifacts/c/art-49311686-fb20-4a97-bf6a-9cf19fc51966)
![Level 7 after Delete removes the focused event](https://cursor.com/artifacts/c/art-487050ec-0f91-4796-87d9-4ed0ad190b26)
![Level 9 practice shortcut legend](https://cursor.com/artifacts/c/art-3bd0a425-ff98-4459-9618-f65beec90770)
<a href="https://cursor.com/agents/bc-5425836c-4922-46bf-a1ef-d8b826952781/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpractice_new_levels_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-d70e9e97-9cfe-40de-8a34-fbc4e0df87a4" alt="practice_new_levels_walkthrough.mp4" /></a>

## Independent review

Pending `/review` after the first CI pass.

## Test plan

- `bun test:web packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx packages/web/src/components/ShortcutShowcase/practice.state.test.ts packages/web/src/shortcuts/tips/shortcut-tips.data.test.ts packages/web/src/shortcuts/tips/selectShortcutHint.test.ts packages/web/src/components/ShortcutShowcase/showcase.store.test.ts packages/web/src/shortcuts/tips/useShortcutHintContext.test.tsx`
- `bunx playwright test e2e/onboarding/shortcut-showcase.spec.ts`
- `bun run lint`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5425836c-4922-46bf-a1ef-d8b826952781?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5425836c-4922-46bf-a1ef-d8b826952781&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

