### PR TITLE
fix(web): bind discard unsaved changes to Mod+Enter

### DIFF
--- a/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
@@ -175,6 +175,43 @@ describe("OverlayPanel", () => {
     expect(screen.getByRole("button", { name: "Preferred" })).toHaveFocus();
   });
 
+  it("calls onModEnter for Mod+Enter without activating the focused button", async () => {
+    const user = userEvent.setup();
+    let confirmed = 0;
+    let cancelled = 0;
+    const onModEnter = () => {
+      confirmed += 1;
+    };
+
+    render(
+      <OverlayPanel
+        title="Confirm"
+        onDismiss={() => {
+          cancelled += 1;
+        }}
+        onModEnter={onModEnter}
+      >
+        <button
+          type="button"
+          onClick={() => {
+            cancelled += 1;
+          }}
+        >
+          Cancel
+        </button>
+        <button type="button">Discard</button>
+      </OverlayPanel>,
+    );
+
+    expect(screen.getByRole("button", { name: "Cancel" })).toHaveFocus();
+
+    await user.keyboard("{Meta>}{Enter}{/Meta}");
+    await user.keyboard("{Control>}{Enter}{/Control}");
+
+    expect(confirmed).toBe(2);
+    expect(cancelled).toBe(0);
+  });
+
   it("calls onShiftEscape for Shift+Escape and onDismiss for Escape", async () => {
     const user = userEvent.setup();
     let dismissed = 0;
@@ -243,6 +280,23 @@ describe("OverlayPanel", () => {
 
     expect(
       within(screen.getByRole("button", { name: "Cancel" })).getByText("Esc"),
+    ).toBeTruthy();
+  });
+
+  it("renders combo shortcuts as separate keycaps", () => {
+    render(
+      <OverlayPanel title="Confirm" onDismiss={() => {}}>
+        <OverlayPanelActionButton shortcut={["Mod", "Enter"]}>
+          Discard
+        </OverlayPanelActionButton>
+      </OverlayPanel>,
+    );
+
+    const discard = screen.getByRole("button", { name: "Discard" });
+    expect(within(discard).getByText("Enter")).toBeTruthy();
+    expect(
+      within(discard).queryByTestId("meta-icon") ??
+        within(discard).queryByTestId("control-icon"),
     ).toBeTruthy();
   });
 });

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
@@ -10,7 +10,7 @@ import {
 } from "react";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
 import { getFocusableElements } from "@web/common/utils/focusable-elements";
-import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
+import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import { useAppLockReason } from "@web/shortcuts/app-lock";
 
 interface Props {
@@ -30,6 +30,8 @@ interface Props {
   onDismiss?: () => void;
   /** Called when pressing Shift+Escape; falls back to onDismiss when omitted. */
   onShiftEscape?: () => void;
+  /** Called when pressing Mod+Enter (Cmd/Ctrl+Enter). */
+  onModEnter?: () => void;
   /** Focus this element on open instead of the first focusable in the panel. */
   initialFocusRef?: RefObject<HTMLElement | null>;
   /** Overrides the element that receives focus when the dialog closes. */
@@ -67,6 +69,7 @@ export const OverlayPanel = ({
   children,
   onDismiss,
   onShiftEscape,
+  onModEnter,
   initialFocusRef,
   restoreFocus,
   skipFocusRestoreRef,
@@ -155,6 +158,13 @@ export const OverlayPanel = ({
         return;
       }
     }
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && onModEnter) {
+      // Prevent the focused button (often Cancel) from activating on Enter.
+      e.preventDefault();
+      e.stopPropagation();
+      onModEnter();
+      return;
+    }
     if (e.key !== "Tab" || !panelRef.current) return;
     const focusables = getFocusableElements(panelRef.current);
     if (focusables.length === 0) return;
@@ -242,8 +252,8 @@ export const OverlayPanelActions = ({
 interface OverlayPanelActionButtonProps
   extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: "primary" | "secondary" | "destructive";
-  /** Visible keycap; OverlayPanel already binds Escape / focused Enter. */
-  shortcut?: string;
+  /** Visible keycap(s) for the action. */
+  shortcut?: string | string[];
 }
 
 export const OverlayPanelActionButton = forwardRef<
@@ -277,9 +287,7 @@ export const OverlayPanelActionButton = forwardRef<
       {...buttonProps}
     >
       {children}
-      {shortcut ? (
-        <ShortcutHint className="ml-2">{shortcut}</ShortcutHint>
-      ) : null}
+      {shortcut ? <ShortcutKeys className="ml-2" keys={shortcut} /> : null}
     </button>
   );
 });

--- a/packages/web/src/views/Forms/EventForm/DiscardUnsavedChangesDialog.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DiscardUnsavedChangesDialog.test.tsx
@@ -1,5 +1,6 @@
+import { resolveModifier } from "@tanstack/react-hotkeys";
 import userEvent from "@testing-library/user-event";
-import { render, screen } from "@web/__tests__/__mocks__/mock.render";
+import { render, screen, within } from "@web/__tests__/__mocks__/mock.render";
 import { DiscardUnsavedChangesDialog } from "@web/views/Forms/EventForm/DiscardUnsavedChangesDialog";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
@@ -86,5 +87,47 @@ describe("DiscardUnsavedChangesDialog", () => {
     await user.keyboard("{Shift>}{Escape}{/Shift}");
     expect(onDiscard).toHaveBeenCalledTimes(1);
     expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("cancels on Enter while Cancel is focused", async () => {
+    const user = userEvent.setup();
+    renderDialog(true);
+
+    expect(screen.getByRole("button", { name: "Cancel" })).toHaveFocus();
+
+    await user.keyboard("{Enter}");
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onDiscard).not.toHaveBeenCalled();
+  });
+
+  it("discards on Mod+Enter while Cancel is focused", async () => {
+    const user = userEvent.setup();
+    renderDialog(true);
+
+    expect(screen.getByRole("button", { name: "Cancel" })).toHaveFocus();
+
+    const chord =
+      resolveModifier("Mod") === "Control"
+        ? "{Control>}{Enter}{/Control}"
+        : "{Meta>}{Enter}{/Meta}";
+    await user.keyboard(chord);
+
+    expect(onDiscard).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("shows Mod+Enter on Discard instead of Enter", () => {
+    renderDialog(true);
+
+    const discard = screen.getByRole("button", { name: "Discard" });
+    expect(discard).toHaveAttribute(
+      "aria-keyshortcuts",
+      "Meta+Enter Control+Enter",
+    );
+    expect(within(discard).getByText("Enter")).toBeInTheDocument();
+    expect(
+      within(discard).queryByTestId("meta-icon") ??
+        within(discard).queryByTestId("control-icon"),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/web/src/views/Forms/EventForm/DiscardUnsavedChangesDialog.tsx
+++ b/packages/web/src/views/Forms/EventForm/DiscardUnsavedChangesDialog.tsx
@@ -36,6 +36,7 @@ export function DiscardUnsavedChangesDialog({
       }
       onDismiss={onCancel}
       onShiftEscape={onDiscard}
+      onModEnter={onDiscard}
       initialFocusRef={cancelButtonRef}
       align="start"
       variant="modal"
@@ -50,7 +51,8 @@ export function DiscardUnsavedChangesDialog({
         </OverlayPanelActionButton>
         <OverlayPanelActionButton
           variant="primary"
-          shortcut="Enter"
+          shortcut={["Mod", "Enter"]}
+          aria-keyshortcuts="Meta+Enter Control+Enter"
           onClick={onDiscard}
         >
           Discard


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The discard-unsaved-changes dialog advertised Enter on Discard, but Cancel is focused by default, so Enter cancelled instead of discarding.

Discard now uses Mod+Enter (Cmd on macOS, Ctrl elsewhere). Plain Enter still activates the focused button (Cancel by default). Escape still cancels; Shift+Escape still discards.

![Discard dialog with Mod+Enter shortcut](https://cursor.com/artifacts/c/art-16bbc61d-0ea4-49bb-b1eb-764f02a39842)

<a href="https://cursor.com/agents/bc-366780a4-5025-4db3-a3fc-7f037be1846b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdiscard_enter_cancels_ctrl_enter_discards.mp4"><img src="https://cursor.com/artifacts/c/art-b69367a8-d83c-4be8-bf5e-71d01c2c3493" alt="discard_enter_cancels_ctrl_enter_discards.mp4" /></a>

## Simplicity

Reuses OverlayPanel's existing key-handling (same pattern as Shift+Escape) and ShortcutKeys for the combo hint. No extra document listeners or hooks. Simplify pass found nothing further to extract.

## Automated validation

- `bun test:web -- packages/web/src/views/Forms/EventForm/DiscardUnsavedChangesDialog.test.tsx packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx` — 25 pass
- `bun run verify` — selected packages: web; checks run: test:web, type-check, lint, knip; Playwright a11y/e2e skipped locally (Chromium missing); GitHub e2e succeeded
- Browser: Enter with Cancel focused keeps the form open; Ctrl+Enter discards and restores the original title

![Enter cancels; form stays open with edited title](https://cursor.com/artifacts/c/art-4637d017-ab6d-4e30-9bf6-714b984cdd30)
![After Ctrl+Enter, original title restored](https://cursor.com/artifacts/c/art-81c485ea-647b-4a5f-b187-767e208726e8)

## Independent review

VERDICT: no confirmed findings

FINDINGS: none. Keyboard preventDefault on Mod+Enter stops the focused Cancel button from activating; tests cover that path. Shortcut chips stay aria-hidden; the Discard button name remains "Discard". Other Enter-hint dialogs are out of scope.

## Test plan

- `bun test:web -- packages/web/src/views/Forms/EventForm/DiscardUnsavedChangesDialog.test.tsx packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx`
- `bun run verify`
- Browser keyboard demo of Enter vs Ctrl+Enter on the live discard dialog
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-366780a4-5025-4db3-a3fc-7f037be1846b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-366780a4-5025-4db3-a3fc-7f037be1846b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

