### PR TITLE
fix(web): show Mod+R on the update-available tooltip

### DIFF
--- a/packages/web/src/components/CalendarHeader/CalendarHeader.tsx
+++ b/packages/web/src/components/CalendarHeader/CalendarHeader.tsx
@@ -1,7 +1,6 @@
-import { ArrowClockwiseIcon } from "@phosphor-icons/react";
 import { type FC } from "react";
-import { reloadLocation } from "@web/common/utils/browser/browser-navigation.util";
 import { ArrowButton } from "@web/components/Button/ArrowButton";
+import { UpdateAvailableButton } from "@web/components/CalendarHeader/UpdateAvailableButton";
 import { SelectView } from "@web/components/SelectView/SelectView";
 import { useVersionCheck } from "@web/components/Sidebar/SidebarActions/useVersionCheck";
 import { SidebarToggleButton } from "@web/components/Sidebar/SidebarToggleButton";
@@ -64,20 +63,7 @@ export const CalendarHeader: FC<Props> = ({
           </div>
         )}
         <SelectView label={label} onToday={onToday} />
-        {isUpdateAvailable ? (
-          <TooltipWrapper
-            description="Get latest version"
-            onClick={reloadLocation}
-          >
-            <button
-              aria-label="Get latest version"
-              className="flex size-7 shrink-0 items-center justify-center rounded-default text-accent transition hover:bg-surface-panel hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-              type="button"
-            >
-              <ArrowClockwiseIcon aria-hidden="true" size={16} />
-            </button>
-          </TooltipWrapper>
-        ) : null}
+        {isUpdateAvailable ? <UpdateAvailableButton /> : null}
       </div>
 
       <div className="z-2 flex shrink-0 items-center pr-5">

--- a/packages/web/src/components/CalendarHeader/UpdateAvailableButton.test.tsx
+++ b/packages/web/src/components/CalendarHeader/UpdateAvailableButton.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "bun:test";
+import "@testing-library/jest-dom";
+import { expandModInShortcutDisplay } from "@web/shortcuts/shortcut.util";
+import { UpdateAvailableButton } from "./UpdateAvailableButton";
+
+describe("UpdateAvailableButton", () => {
+  it("shows the Mod+R reload shortcut on the get-latest-version tooltip", async () => {
+    const user = userEvent.setup();
+    render(<UpdateAvailableButton />);
+
+    await user.hover(
+      screen.getByRole("button", { name: "Get latest version" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Get latest version")).toBeInTheDocument();
+    });
+
+    const modifier = expandModInShortcutDisplay("Mod");
+    expect(
+      screen.getByTestId(`${modifier.toLowerCase()}-icon`),
+    ).toBeInTheDocument();
+    expect(screen.getByText("R")).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/CalendarHeader/UpdateAvailableButton.test.tsx
+++ b/packages/web/src/components/CalendarHeader/UpdateAvailableButton.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "bun:test";
 import "@testing-library/jest-dom";
@@ -14,11 +14,7 @@ describe("UpdateAvailableButton", () => {
     );
 
     const tooltip = await screen.findByRole("tooltip");
-    await waitFor(() => {
-      expect(
-        within(tooltip).getByText("Get latest version"),
-      ).toBeInTheDocument();
-    });
+    expect(within(tooltip).getByText("Get latest version")).toBeInTheDocument();
     expect(within(tooltip).getByText("R")).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/CalendarHeader/UpdateAvailableButton.test.tsx
+++ b/packages/web/src/components/CalendarHeader/UpdateAvailableButton.test.tsx
@@ -1,8 +1,7 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "bun:test";
 import "@testing-library/jest-dom";
-import { expandModInShortcutDisplay } from "@web/shortcuts/shortcut.util";
 import { UpdateAvailableButton } from "./UpdateAvailableButton";
 
 describe("UpdateAvailableButton", () => {
@@ -14,14 +13,12 @@ describe("UpdateAvailableButton", () => {
       screen.getByRole("button", { name: "Get latest version" }),
     );
 
+    const tooltip = await screen.findByRole("tooltip");
     await waitFor(() => {
-      expect(screen.getByText("Get latest version")).toBeInTheDocument();
+      expect(
+        within(tooltip).getByText("Get latest version"),
+      ).toBeInTheDocument();
     });
-
-    const modifier = expandModInShortcutDisplay("Mod");
-    expect(
-      screen.getByTestId(`${modifier.toLowerCase()}-icon`),
-    ).toBeInTheDocument();
-    expect(screen.getByText("R")).toBeInTheDocument();
+    expect(within(tooltip).getByText("R")).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/CalendarHeader/UpdateAvailableButton.tsx
+++ b/packages/web/src/components/CalendarHeader/UpdateAvailableButton.tsx
@@ -1,0 +1,27 @@
+import { ArrowClockwiseIcon } from "@phosphor-icons/react";
+import { type FC } from "react";
+import { reloadLocation } from "@web/common/utils/browser/browser-navigation.util";
+import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
+
+/**
+ * Header control shown when a newer app version is available. Clicks are
+ * blocked in keyboard-only mode, so the tooltip names the browser reload
+ * shortcut (Mod+R) rather than implying the icon itself is clickable.
+ */
+export const UpdateAvailableButton: FC = () => {
+  return (
+    <TooltipWrapper
+      description="Get latest version"
+      onClick={reloadLocation}
+      shortcut={["Mod", "R"]}
+    >
+      <button
+        aria-label="Get latest version"
+        className="flex size-7 shrink-0 items-center justify-center rounded-default text-accent transition hover:bg-surface-panel hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        type="button"
+      >
+        <ArrowClockwiseIcon aria-hidden="true" size={16} />
+      </button>
+    </TooltipWrapper>
+  );
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The new-version refresh icon in the calendar header showed “Get latest version”, but pointer clicks are blocked in keyboard-only mode, so hovering then clicking did nothing.

The tooltip now includes the browser reload shortcut (`Mod+R`: ⌘R on macOS, Ctrl+R elsewhere) so users know how to get the latest version.

![Header tooltip showing Get latest version and Ctrl+R](https://cursor.com/artifacts/c/art-5c8b4c51-5e45-419b-9978-1c63b3c1a56f)
![Close-up of the update-available tooltip with Control and R keycaps](https://cursor.com/artifacts/c/art-4c8e7d67-0539-4543-8440-10fcf4b7038b)
<a href="https://cursor.com/agents/bc-1ca69a5b-e4b1-40a1-a490-63cce74a0fb9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fupdate_available_tooltip_mod_r.mp4"><img src="https://cursor.com/artifacts/c/art-2445d178-85ec-42dc-99f0-9836e9edb377" alt="update_available_tooltip_mod_r.mp4" /></a>

## Simplicity

The refresh control is a small dedicated button so the tooltip/shortcut can be tested without mocking `useVersionCheck` (that hook is already process-mocked by other web tests). No extra state, effects, or shortcut-registry rows — browser reload is not an app binding.

## Automated validation

- Hovering the “Get latest version” button shows the description plus an `R` keycap (`UpdateAvailableButton` unit test).
- Browser: hover on the header refresh icon shows “Get latest version” and the platform Mod+R keycaps (Ctrl+R on Linux).

## Independent review

VERDICT: no confirmed findings (independent subagent review of `origin/main...HEAD`).

A11y audit of the changed control: native button, existing accessible name, focus ring unchanged, shortcut keycaps follow the existing `TooltipWrapper` + `ShortcutKeys` pattern. No confirmed accessibility findings.

## Test plan

- `bun run verify` — selected packages: web; checks run: `test:web`, `type-check`, `lint`, `knip` (passed)
- Focused: `bun run test:web -- packages/web/src/components/CalendarHeader/UpdateAvailableButton.test.tsx` (1 pass)
- `bun run test:a11y` — 7 passed
- Browser hover of the refresh icon (demo video + screenshots)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ca69a5b-e4b1-40a1-a490-63cce74a0fb9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ca69a5b-e4b1-40a1-a490-63cce74a0fb9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

