### PR TITLE
ci: let docs-only PRs satisfy their required checks

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - ".gitignore"
-      - "**/*.md"
-      - "docs/**"
   # Merge commits are never tested as merged, and nothing re-runs afterward,
   # so a red e2e used to land on main and hide until the next PR opened.
   # Scoped to main on purpose: a full Playwright run per feature-branch
@@ -22,6 +18,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: e2e-${{ github.event.pull_request.number || github.ref }}
@@ -31,7 +28,51 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Required status checks cannot come from a workflow that path filtering
+  # skipped: GitHub never creates the check run, so the context sits Pending
+  # and a docs-only PR can never merge. A job skipped by an `if:` conditional
+  # does report, and reports Success. So for pull_request the filter lives
+  # here, as a job gate, not in `on:`. The push trigger keeps its
+  # paths-ignore: push runs block nothing.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Detect non-docs changes
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files=$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename')
+          # Keep these patterns in step with the push trigger's paths-ignore
+          # above. Deliberately not `grep -q`: it exits on the first match, so
+          # printf takes a SIGPIPE that `pipefail` would turn into a non-zero
+          # pipeline on a large PR, reading as "docs only" and skipping the
+          # suite on real code. Draining into a variable cannot do that.
+          code_files=$(printf '%s\n' "$files" |
+            grep -vE '(\.md$|^docs/|^\.gitignore$)' || true)
+          # Fail open: an empty or unreadable list runs the suite rather than
+          # waving an unverified change through.
+          if [ -z "$files" ] || [ -n "$code_files" ]; then
+            code=true
+          else
+            code=false
+          fi
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          echo "Non-docs changes: $code"
+
   e2e:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - ".gitignore"
-      - "**/*.md"
-      - "docs/**"
   push:
     paths-ignore:
       - ".gitignore"
@@ -16,9 +12,54 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  # Required status checks cannot come from a workflow that path filtering
+  # skipped: GitHub never creates the check run, so the context sits Pending
+  # and a docs-only PR can never merge. A job skipped by an `if:` conditional
+  # does report, and reports Success. So for pull_request the filter lives
+  # here, as a job gate, not in `on:`. The push trigger keeps its
+  # paths-ignore: push runs block nothing.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Detect non-docs changes
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files=$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename')
+          # Keep these patterns in step with the push trigger's paths-ignore
+          # above. Deliberately not `grep -q`: it exits on the first match, so
+          # printf takes a SIGPIPE that `pipefail` would turn into a non-zero
+          # pipeline on a large PR, reading as "docs only" and skipping the
+          # suite on real code. Draining into a variable cannot do that.
+          code_files=$(printf '%s\n' "$files" |
+            grep -vE '(\.md$|^docs/|^\.gitignore$)' || true)
+          # Fail open: an empty or unreadable list runs the suite rather than
+          # waving an unverified change through.
+          if [ -z "$files" ] || [ -n "$code_files" ]; then
+            code=true
+          else
+            code=false
+          fi
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          echo "Non-docs changes: $code"
+
   lint:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -53,6 +94,8 @@ jobs:
           bun run lint
 
   knip:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -89,6 +132,8 @@ jobs:
           bun run knip
 
   type-check:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -123,6 +168,8 @@ jobs:
           bun run type-check
 
   unit:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:


### PR DESCRIPTION
## Summary

A PR touching only markdown could never merge. Both `Test` workflows carried `paths-ignore: ["**/*.md", "docs/**", ".gitignore"]`, but the `main` ruleset marks `lint`, `knip`, `type-check`, `unit (core|sync|web|backend|scripts)`, and `e2e` as **required**. GitHub never creates a check run for a workflow that path filtering skipped, so those contexts sit `Pending` forever and the PR stays `BLOCKED`.

That is why every `.agents/ledger.md` row is stuck at `verifying`: the `/ship` close-out is a markdown-only change, so it is structurally unmergeable. Hit while shipping [#2934](https://github.com/KeepSoftwareSimple/compass-calendar/pull/2934); [#2937](https://github.com/KeepSoftwareSimple/compass-calendar/pull/2937) was closed rather than bypass protection.

The fix is GitHub's documented one: move the filter out of the trigger and into a job-level conditional. **A job skipped by an `if:` reports, and reports Success**, unlike a workflow skipped by path filtering.

- `on: pull_request` loses `paths-ignore`, so the workflow always runs and always reports.
- A `changes` job resolves the PR's file list and outputs `code=true|false`.
- Every real job gains `needs: changes` + `if: needs.changes.outputs.code == 'true'`.
- The `push` triggers keep their `paths-ignore` untouched: push runs block nothing, so there is no reason to spend minutes there.

Net effect: a docs-only PR goes green in ~10s without running the suite; a code PR is unchanged.

## Simplicity

The file list comes from the PR files API via `gh`, not a third-party action (no new supply-chain surface) and not a `git diff` (no force-push, shallow-clone, or first-commit edge cases). The gate is ~20 lines of shell, duplicated across the two workflows because they are separate top-level workflows with no shared step — extracting a composite action for two call sites would cost more than it saves.

Two deliberate details, both commented in place:

- **Not `grep -q`.** It exits on the first match, so `printf` takes a SIGPIPE that `pipefail` turns into a non-zero pipeline on a large PR. That reads as "docs only" and would skip the suite on real code. Draining into a variable cannot do that.
- **Fails open.** An empty or unreadable file list runs the full suite rather than waving an unverified change through.

## Automated validation

Filter logic exercised against 12 file-list cases, all passing, including the two that matter:

| case | expected | got |
|---|---|---|
| `.agents/ledger.md` + `.agents/handoffs/2934.md` | `false` | `false` |
| `README.md` | `false` | `false` |
| `docs/features/billing.md` | `false` | `false` |
| `.gitignore` | `false` | `false` |
| `README.md` + `packages/web/src/a.ts` | `true` | `true` |
| `.github/workflows/test-unit.yml` | `true` | `true` |
| empty list (fail open) | `true` | `true` |
| `packages/web/src/md/x.ts` (md dir, not file) | `true` | `true` |
| 5001 files, one code file first (the SIGPIPE case) | `true` | `true` |
| 5001 docs files, no code | `false` | `false` |

**This PR is its own negative test:** it touches `.github/` only, so the gate must resolve `code=true` and the full suite must run and pass. A follow-up docs-only PR is the positive test.

## Test plan

```
bun test:scripts
```

72 pass — this is the suite whose contract tests reference `.github/workflows/test-unit.yml`. YAML re-parsed to confirm both workflows still declare the expected jobs, triggers, and permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)