### PR TITLE
refactor(web): drop the Shift+F10 row from the shortcuts legend

### DIFF
--- a/packages/web/src/shortcuts/shortcuts.registry.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.test.ts
@@ -65,18 +65,30 @@ describe("shortcuts.registry", () => {
       expect(ids).toContain("edit-save");
     });
 
-    it("lists f, m, and Shift+F10 in the legend", () => {
-      const shortcuts = filterShortcutsByContext({
+    it("lists f and m, and never advertises F10, in the legend", () => {
+      const week = filterShortcutsByContext({
         view: "week",
         isViewingCurrentPeriod: true,
       });
       const byId = Object.fromEntries(
-        shortcuts.map((shortcut) => [shortcut.id, shortcut]),
+        week.map((shortcut) => [shortcut.id, shortcut]),
       );
 
       expect(byId["focus-notice"]?.keys).toEqual(["f"]);
       expect(byId["edit-menu"]?.keys).toEqual(["m"]);
-      expect(byId["edit-menu-shift-f10"]?.keys).toEqual(["Shift", "F10"]);
+      expect(byId["edit-menu"]?.label).toBe("Open event menu");
+
+      // Shift+F10 still opens the menu where the OS has that key; it is just
+      // not advertised, since it would duplicate the m row's label.
+      for (const view of ["day", "week", "life"] as const) {
+        const shortcuts = filterShortcutsByContext({
+          view,
+          isViewingCurrentPeriod: true,
+        });
+        expect(
+          shortcuts.filter((shortcut) => shortcut.keys.includes("F10")),
+        ).toEqual([]);
+      }
     });
 
     it("lists h event jump toggle in day and week focus sections", () => {

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -230,14 +230,12 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
     section: "edit",
   },
   {
+    // Shift+F10 also opens this menu on platforms that have a context-menu key
+    // (the browser turns it into a contextmenu event, which pointer-block lets
+    // through). It is deliberately not listed here: it would be a second row
+    // with this exact label, and m already teaches the capability.
     id: "edit-menu",
     keys: ["m"],
-    label: "Open event menu",
-    section: "edit",
-  },
-  {
-    id: "edit-menu-shift-f10",
-    keys: ["Shift", "F10"],
     label: "Open event menu",
     section: "edit",
   },


### PR DESCRIPTION
## What

The keyboard shortcuts legend listed two rows with the identical label **"Open event menu"** — one for `m`, one for `Shift+F10`. This drops the `Shift+F10` row.

`m` already teaches the capability; a second row with the same label teaches nothing new.

## The behavior is retained

The row was **documentation, not implementation**. Removing it changes nothing at runtime.

Shift+F10 still opens the menu on platforms that have a context-menu key (Windows, Linux):

1. the browser turns the key into a `contextmenu` event,
2. `packages/web/src/shortcuts/keyboard-only/pointer-block.ts` deliberately lets that event through while blocking real right-clicks,
3. `GridContextMenuWrapper` handles it.

Anyone whose fingers expect Shift+F10 still gets the menu, and it costs us nothing because the browser does the work. A comment on the `edit-menu` registry entry records why the row is intentionally absent, so it doesn't get "restored" later.

macOS has no such key and Chromium there emits no `contextmenu` event for it at all, so the row was outright dead there.

## Changes

- `shortcuts.registry.ts` — delete the `edit-menu-shift-f10` entry; comment the `edit-menu` entry.
- `shortcuts.registry.test.ts` — replace the F10 assertion with one asserting `focus-notice` is `["f"]`, `edit-menu` is `["m"]` labelled "Open event menu", and that **no** shortcut advertises `F10` in any view. Whole key arrays are asserted, not just presence.

`e2e/timed/mouse-inert.spec.ts` and `pointer-block.ts` are deliberately untouched — they are what keep Shift+F10 working and guard against a future change silently killing it.

## Verification

`bun run verify`: `test:web`, `type-check`, `lint`, `knip`, `test:a11y` all pass. All 257 shortcut tests pass.

Browser-checked against the running app: the legend dialog contains exactly one "Open event menu / M" row and no `F10` string anywhere.

### One pre-existing e2e failure, not from this change

`mouse-inert.spec.ts:82` — the `Shift+F10` assertion in "right-click is blocked; m opens the menu instead" — fails **on macOS only**, because macOS has no context-menu key so no `contextmenu` event fires. It is unguarded on `main`, so it fails deterministically on any macOS dev machine and passes in CI (Linux).

Confirmed pre-existing by reverting both files to HEAD, running the full suite (identical single failure), then restoring and re-running (same failure). The `m` assertion immediately above it passes, confirming the retained behavior.

Worth noting for reviewers: adding a platform guard to that assertion would fix the macOS-local red test. It's out of scope here, but it's the other half of the same macOS gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)