### PR TITLE
feat(web): add day-view column jump targets

### DIFF
--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -306,6 +306,29 @@ Pressing `H` shows event-jump chips. Week view chips use day prefixes (`SU`/`M`/
 
 ---
 
+## Scenario 12b: Jump Focus To A Day-View Calendar Column
+
+### UX
+
+On Day view, holding Mod reveals numbered chips on each **writable** calendar column (5, 6, … after the shared page-area digits 1–4). Pressing that digit focuses the column header. Shift+Arrow then places a timed draft on that calendar; `C` / `Shift+C` honor the same focused column. Idle create (no column focused) still uses the default target calendar.
+
+### Steps
+
+1. Navigate to `/day` with at least two writable calendars visible as columns.
+2. Hold Mod until chips appear. Note the number on a non-default calendar column.
+3. Press that digit, then Shift+ArrowDown.
+4. Press Enter to open the form and confirm the calendar picker shows that column's calendar.
+5. Discard, focus the same column again, and press `C`.
+
+### Expected Results
+
+- Hold-Mod chips on columns are numbers starting at 5, not 1. Digits 1–4 still jump to view / month picker / Up next / calendars list.
+- Read-only columns (for example holidays) have no chip and are not focusable via Mod+digit.
+- After focusing a column, Shift+Arrow places a form-closed timed draft in that column.
+- `C` and `Shift+C` seed the focused column's calendar. With no column focused, they still use the default create target.
+
+---
+
 ## Scenario 13: The Mouse Is Permanently Inert
 
 ### UX
@@ -425,3 +448,4 @@ If time is limited, run these checks before shipping shortcut-related changes:
 17. PageUp / PageDown scroll the timed grid by one viewport in Day and Week view even when an event is focused; they do not fire in a text input.
 18. Alt+ArrowUp / Alt+ArrowDown pan the timed grid by one hour in Day and Week view even when an event is focused; they do not fire in a text input.
 19. `Z` opens time travel in Day and Week view; Cmd+Z / Ctrl+Z still undoes and does not open the picker.
+20. On Day view, hold Mod then a column digit (5+) focuses that writable calendar column; Shift+Arrow / `C` seed a draft there.

--- a/docs/frontend/shortcut-commandments.md
+++ b/docs/frontend/shortcut-commandments.md
@@ -65,7 +65,9 @@ palette).
 The hold is the same everywhere. Digits are a single namespace, so the
 open event form takes them over for its fields (1–9 in DOM order). With
 the form closed, the same hold numbers page areas (sidebar, month picker,
-Up next, calendars — or Life's grid/variation/details).
+Up next, calendars — or Life's grid/variation/details). Day view then
+appends writable calendar columns at 5, 6, … so a user can land focus on
+a column and Shift+Arrow / C can seed a draft there.
 
 Do not run both maps at once. Do not invent a second hold key.
 
@@ -96,4 +98,6 @@ is a bug. Floating layers register with `useFloatingLayer`.
 Form field digits live in
 `packages/web/src/shortcuts/edit-sequence/edit-sequence.fields.ts` (DOM
 order, 1–9). Page-area digits live in
-`packages/web/src/shortcuts/page-jump/page-jump.targets.ts`.
+`packages/web/src/shortcuts/page-jump/page-jump.targets.ts`. Day-view
+calendar columns are built by `buildDayPageJumpTargets` and append after
+the shared 1–4 page areas.

--- a/packages/web/src/grid/components/AllDayGridRow.test.tsx
+++ b/packages/web/src/grid/components/AllDayGridRow.test.tsx
@@ -36,4 +36,34 @@ describe("AllDayGridRow", () => {
       `${ALL_DAY_COLUMN_TINT_PERCENT}%`,
     );
   });
+
+  it("marks the highlighted calendar column", () => {
+    render(
+      <AllDayGridRow
+        allDayColumnsRef={() => {}}
+        allDayRowRef={() => {}}
+        eventsLayer={null}
+        highlightedColumnKey="work"
+        visibleDates={[
+          {
+            date: today,
+            key: "personal",
+            surfaceLabel: "Personal all-day column",
+          },
+          {
+            date: today,
+            key: "work",
+            surfaceLabel: "Work all-day column",
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByRole("columnheader", { name: "Work all-day column" }),
+    ).toHaveAttribute("data-focused-column", "true");
+    expect(
+      screen.getByRole("columnheader", { name: "Personal all-day column" }),
+    ).not.toHaveAttribute("data-focused-column");
+  });
 });

--- a/packages/web/src/grid/components/AllDayGridRow.tsx
+++ b/packages/web/src/grid/components/AllDayGridRow.tsx
@@ -26,6 +26,7 @@ interface AllDayRowProps {
   columnsId?: string;
   eventsLayer: ReactNode;
   gridOffsetTopPx?: number;
+  highlightedColumnKey?: string | null;
   rowsCount?: number;
   rowId?: string;
   visibleDates: GridVisibleDate[];
@@ -52,6 +53,7 @@ export const AllDayGridRow: FC<AllDayRowProps> = ({
   columnsId = ID_ALLDAY_COLUMNS,
   eventsLayer,
   gridOffsetTopPx = 0,
+  highlightedColumnKey = null,
   rowsCount = 0,
   rowId = ID_GRID_ALLDAY_ROW,
   visibleDates,
@@ -89,14 +91,16 @@ export const AllDayGridRow: FC<AllDayRowProps> = ({
                 ({ date, key, surfaceLabel, allDayTintColor }) => {
                   const dayKey = date.format(YEAR_MONTH_DAY_FORMAT);
                   const isJumpDay = activeDayKeys.includes(dayKey);
+                  const isFocusedColumn = key === highlightedColumnKey;
                   const tintStyle = allDayColumnTintStyle(
                     allDayTintColor,
-                    isJumpDay,
+                    isJumpDay || isFocusedColumn,
                   );
                   return (
                     <th
-                      className="relative box-border block h-full min-w-[var(--calendar-column-min-width)] border-border border-l transition-colors duration-150 data-[jump-day=true]:bg-accent/10 motion-reduce:transition-none"
+                      className="relative box-border block h-full min-w-[var(--calendar-column-min-width)] border-border border-l transition-colors duration-150 data-[focused-column=true]:bg-accent/10 data-[jump-day=true]:bg-accent/10 motion-reduce:transition-none"
                       data-all-day-tint={tintStyle ? "true" : undefined}
+                      data-focused-column={isFocusedColumn ? "true" : undefined}
                       data-jump-day={isJumpDay ? "true" : undefined}
                       aria-label={
                         surfaceLabel ?? date.format("dddd, MMMM D, YYYY")

--- a/packages/web/src/grid/components/EventGrid.tsx
+++ b/packages/web/src/grid/components/EventGrid.tsx
@@ -34,6 +34,8 @@ export interface EventGridProps {
   timedEventsLayer: ReactNode;
   today: Dayjs;
   visibleDates: GridVisibleDate[];
+  /** Day-view calendar column currently focused via hold-Mod jump. */
+  highlightedColumnKey?: string | null;
 }
 
 export const EventGrid: FC<EventGridProps> = ({
@@ -50,6 +52,7 @@ export const EventGrid: FC<EventGridProps> = ({
   timedEventsLayer,
   today,
   visibleDates,
+  highlightedColumnKey = null,
 }) => (
   <div className="relative flex min-h-0 w-full flex-1 flex-col">
     <AllDayGridRow
@@ -57,11 +60,13 @@ export const EventGrid: FC<EventGridProps> = ({
       allDayRowRef={gridRefs.allDayRowRef}
       eventsLayer={allDayEventsLayer}
       gridOffsetTopPx={allDayGridOffsetTopPx}
+      highlightedColumnKey={highlightedColumnKey}
       rowsCount={allDayRowsCount}
       visibleDates={visibleDates}
     />
     <TimedGrid
       eventsLayer={timedEventsLayer}
+      highlightedColumnKey={highlightedColumnKey}
       timedColumnsRef={gridRefs.timedColumnsElementRef}
       timedGridRef={gridRefs.mainGridElementRef}
       today={today}

--- a/packages/web/src/grid/components/TimedGrid.test.tsx
+++ b/packages/web/src/grid/components/TimedGrid.test.tsx
@@ -65,6 +65,37 @@ describe("TimedGrid", () => {
     );
   });
 
+  it("marks the highlighted calendar column", () => {
+    render(
+      <TimedGrid
+        eventsLayer={null}
+        highlightedColumnKey="work"
+        timedColumnsRef={() => {}}
+        timedGridRef={() => {}}
+        today={today}
+        visibleDates={[
+          {
+            date: today,
+            key: "personal",
+            surfaceLabel: "Personal column",
+          },
+          {
+            date: today,
+            key: "work",
+            surfaceLabel: "Work column",
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByRole("columnheader", { name: "Work column" }),
+    ).toHaveAttribute("data-focused-column", "true");
+    expect(
+      screen.getByRole("columnheader", { name: "Personal column" }),
+    ).not.toHaveAttribute("data-focused-column");
+  });
+
   it("uses the same hour-slot height for labels and timed grid rows", () => {
     render(
       <TimedGrid

--- a/packages/web/src/grid/components/TimedGrid.tsx
+++ b/packages/web/src/grid/components/TimedGrid.tsx
@@ -30,6 +30,7 @@ import {
 interface TimedGridProps {
   columnsId?: string;
   eventsLayer: ReactNode;
+  highlightedColumnKey?: string | null;
   today: Dayjs;
   timedColumnsRef: RefCallback<HTMLDivElement>;
   timedGridId?: string;
@@ -40,6 +41,7 @@ interface TimedGridProps {
 export const TimedGrid: FC<TimedGridProps> = ({
   columnsId = ID_GRID_COLUMNS_TIMED,
   eventsLayer,
+  highlightedColumnKey = null,
   timedColumnsRef,
   timedGridId = ID_GRID_MAIN,
   timedGridRef,
@@ -94,14 +96,16 @@ export const TimedGrid: FC<TimedGridProps> = ({
                 ({ date, key, surfaceLabel, allDayTintColor }) => {
                   const dayKey = date.format(YEAR_MONTH_DAY_FORMAT);
                   const isJumpDay = activeDayKeys.includes(dayKey);
+                  const isFocusedColumn = key === highlightedColumnKey;
                   const tintStyle = allDayColumnTintStyle(
                     allDayTintColor,
-                    isJumpDay,
+                    isJumpDay || isFocusedColumn,
                   );
                   return (
                     <th
-                      className="relative box-border block h-full min-w-[var(--calendar-column-min-width)] border-border border-l transition-colors duration-150 data-[past=true]:data-[jump-day=true]:bg-accent/10 data-[jump-day=true]:bg-accent/10 data-[past=true]:bg-surface motion-reduce:transition-none"
+                      className="relative box-border block h-full min-w-[var(--calendar-column-min-width)] border-border border-l transition-colors duration-150 data-[past=true]:data-[focused-column=true]:bg-accent/10 data-[past=true]:data-[jump-day=true]:bg-accent/10 data-[focused-column=true]:bg-accent/10 data-[jump-day=true]:bg-accent/10 data-[past=true]:bg-surface motion-reduce:transition-none"
                       data-all-day-tint={tintStyle ? "true" : undefined}
+                      data-focused-column={isFocusedColumn ? "true" : undefined}
                       data-jump-day={isJumpDay ? "true" : undefined}
                       data-past={date.isBefore(today, "day")}
                       aria-label={

--- a/packages/web/src/shortcuts/keymap.ts
+++ b/packages/web/src/shortcuts/keymap.ts
@@ -22,11 +22,12 @@ export const KEYMAP = {
     keycaps: ["Mod", "1-9"],
   },
   // Same hold-Mod gesture outside the form: digits follow the active view's
-  // target list order (page-jump.targets.ts).
+  // target list order (page-jump.targets.ts). Day view appends calendar
+  // columns after the shared 1–4 page areas, up to the physical top row.
   jumpPageTarget: {
     holdModifier: "Mod",
-    digits: ["1", "4"],
-    keycaps: ["Mod", "1-4"],
+    digits: ["1", "9"],
+    keycaps: ["Mod", "1-9"],
   },
   moveFocus: {
     hotkeys: {

--- a/packages/web/src/shortcuts/page-jump/PageJumpHintOverlay.test.tsx
+++ b/packages/web/src/shortcuts/page-jump/PageJumpHintOverlay.test.tsx
@@ -1,6 +1,8 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { PageJumpHintOverlay } from "@web/shortcuts/page-jump/PageJumpHintOverlay";
 import {
+  buildDayPageJumpTargets,
+  dayColumnJumpId,
   LIFE_PAGE_JUMP_TARGETS,
   PAGE_JUMP_ATTRIBUTE,
   type PageJumpTargetId,
@@ -132,5 +134,19 @@ describe("PageJumpHintOverlay", () => {
     );
 
     expect(chipDigits()).toEqual(["1", "2"]);
+  });
+
+  it("chips a Day calendar column as 5, not 1", () => {
+    addAnchor("view-select");
+    addAnchor(dayColumnJumpId("cal-work"));
+    render(
+      <PageJumpHintOverlay
+        targets={buildDayPageJumpTargets([{ id: "cal-work", name: "Work" }])}
+        visible={true}
+      />,
+    );
+
+    expect(chipDigits()).toEqual(["1", "5"]);
+    expect(screen.getByRole("status").textContent).toContain("5 for work");
   });
 });

--- a/packages/web/src/shortcuts/page-jump/page-jump.targets.test.ts
+++ b/packages/web/src/shortcuts/page-jump/page-jump.targets.test.ts
@@ -1,5 +1,8 @@
+import { PICK_KEY_LABELS } from "@web/shortcuts/digit-pick.util";
 import {
+  buildDayPageJumpTargets,
   CALENDAR_PAGE_JUMP_TARGETS,
+  dayColumnJumpId,
   focusPageJumpTarget,
   getPageJumpFocusElement,
   LIFE_PAGE_JUMP_TARGETS,
@@ -25,10 +28,48 @@ describe.each([
 ])("%s", (_name, targets) => {
   it("assigns sequential digits matching each target's list position", () => {
     // usePageJumpShortcut resolves a pressed digit by index, so the digit
-    // shown on a chip must always equal index + 1.
+    // shown on a chip must always equal the physical top-row label.
     targets.forEach((target, index) => {
-      expect(target.digit).toBe(String(index + 1));
+      expect(target.digit).toBe(PICK_KEY_LABELS[index]);
     });
+  });
+});
+
+describe("buildDayPageJumpTargets", () => {
+  it("appends writable columns after the shared 1-4 page areas", () => {
+    const personal = { id: "cal-personal", name: "Personal" };
+    const work = { id: "cal-work", name: "Work" };
+    const targets = buildDayPageJumpTargets([personal, work]);
+
+    expect(targets.slice(0, 4)).toEqual([...CALENDAR_PAGE_JUMP_TARGETS]);
+    expect(targets[4]).toEqual({
+      digit: "5",
+      id: dayColumnJumpId(personal.id),
+      label: "Personal",
+    });
+    expect(targets[5]).toEqual({
+      digit: "6",
+      id: dayColumnJumpId(work.id),
+      label: "Work",
+    });
+  });
+
+  it("keeps column digits at 5+ when earlier page areas would be unmounted", () => {
+    const targets = buildDayPageJumpTargets([{ id: "cal-1", name: "Work" }]);
+    expect(targets[4]?.digit).toBe("5");
+  });
+
+  it("omits calendars past the physical top-row keys", () => {
+    const extraSlots =
+      PICK_KEY_LABELS.length - CALENDAR_PAGE_JUMP_TARGETS.length;
+    const calendars = Array.from({ length: extraSlots + 3 }, (_, index) => ({
+      id: `cal-${index}`,
+      name: `Calendar ${index}`,
+    }));
+    const targets = buildDayPageJumpTargets(calendars);
+
+    expect(targets).toHaveLength(PICK_KEY_LABELS.length);
+    expect(targets.at(-1)?.digit).toBe(PICK_KEY_LABELS.at(-1));
   });
 });
 

--- a/packages/web/src/shortcuts/page-jump/page-jump.targets.ts
+++ b/packages/web/src/shortcuts/page-jump/page-jump.targets.ts
@@ -10,9 +10,17 @@
  * empty Up Next) simply gets no chip and its digit does nothing. A closed
  * menu trigger (the view dropdown) is clicked after focus so the jump
  * reveals Day / Week / Life instead of landing on a closed heading.
+ *
+ * Day view appends writable calendar columns after the shared 1–4 page areas
+ * (`buildDayPageJumpTargets`). Those digits stay 5+ even when the sidebar is
+ * collapsed, so muscle memory for 1–4 never shifts.
  */
 
+import { PICK_KEY_LABELS } from "@web/shortcuts/digit-pick.util";
+
 export const PAGE_JUMP_ATTRIBUTE = "data-page-jump";
+
+export const DAY_COLUMN_JUMP_ID_PREFIX = "day-column:" as const;
 
 export type PageJumpTargetId =
   | "view-select"
@@ -21,7 +29,8 @@ export type PageJumpTargetId =
   | "calendars"
   | "life-grid"
   | "life-variation"
-  | "life-details";
+  | "life-details"
+  | `${typeof DAY_COLUMN_JUMP_ID_PREFIX}${string}`;
 
 export type PageJumpTarget = {
   digit: string;
@@ -44,6 +53,39 @@ export const LIFE_PAGE_JUMP_TARGETS: PageJumpTargets = [
   { digit: "3", id: "life-variation", label: "Life variation" },
   { digit: "4", id: "life-details", label: "Life details" },
 ];
+
+export type DayColumnJumpCalendar = {
+  id: string;
+  name: string;
+};
+
+export const dayColumnJumpId = (
+  calendarId: string,
+): `${typeof DAY_COLUMN_JUMP_ID_PREFIX}${string}` =>
+  `${DAY_COLUMN_JUMP_ID_PREFIX}${calendarId}`;
+
+/**
+ * Day view's hold-Mod map: the shared calendar page areas, then one numbered
+ * target per writable displayed column. Extra calendars past the physical
+ * top-row keys (`PICK_KEY_LABELS`) are omitted — no chip, no binding.
+ */
+export const buildDayPageJumpTargets = (
+  calendars: readonly DayColumnJumpCalendar[],
+): PageJumpTargets => {
+  const columnTargets = calendars.flatMap((calendar, index) => {
+    const digit = PICK_KEY_LABELS[CALENDAR_PAGE_JUMP_TARGETS.length + index];
+    if (!digit) return [];
+    return [
+      {
+        digit,
+        id: dayColumnJumpId(calendar.id),
+        label: calendar.name,
+      },
+    ];
+  });
+
+  return [...CALENDAR_PAGE_JUMP_TARGETS, ...columnTargets];
+};
 
 /** Spread onto a component's container element to mark it as a jump target. */
 export const pageJumpAttrs = (

--- a/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.test.tsx
+++ b/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.test.tsx
@@ -16,6 +16,8 @@ import {
   usePageJumpHintStore,
 } from "@web/shortcuts/page-jump/page-jump.store";
 import {
+  buildDayPageJumpTargets,
+  dayColumnJumpId,
   LIFE_PAGE_JUMP_TARGETS,
   PAGE_JUMP_ATTRIBUTE,
   type PageJumpTargetId,
@@ -173,6 +175,27 @@ describe("usePageJumpShortcut", () => {
 
       expect(event.defaultPrevented).toBe(true);
       expect(currentWeek).toHaveFocus();
+    });
+
+    it("jumps to a Day calendar column at digit 5 without remapping 1-4", () => {
+      const { viewTrigger } = buildPage();
+      const column = document.createElement("button");
+      column.setAttribute(PAGE_JUMP_ATTRIBUTE, dayColumnJumpId("cal-work"));
+      document.body.append(column);
+
+      renderHook(() =>
+        usePageJumpShortcut(
+          buildDayPageJumpTargets([{ id: "cal-work", name: "Work" }]),
+        ),
+      );
+
+      const columnEvent = pressModDigit("5");
+      expect(columnEvent.defaultPrevented).toBe(true);
+      expect(column).toHaveFocus();
+
+      const viewEvent = pressModDigit("1");
+      expect(viewEvent.defaultPrevented).toBe(true);
+      expect(viewTrigger).toHaveFocus();
     });
   });
 

--- a/packages/web/src/shortcuts/shortcuts.menu.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.menu.test.ts
@@ -78,7 +78,7 @@ describe("shortcut menu sections", () => {
       // discoverable via the same row shown on Day/Week.
       expect(stripMetadata(sections[1]?.shortcuts ?? [])).toEqual([
         {
-          keys: ["Mod", "1-4"],
+          keys: ["Mod", "1-9"],
           label: "Jump to a page area (hold Mod for hints)",
         },
       ]);
@@ -217,7 +217,7 @@ describe("shortcut menu sections", () => {
         { keys: ["h"], label: "Toggle event jump keys" },
         { keys: ["f"], label: "Focus latest notice" },
         {
-          keys: ["Mod", "1-4"],
+          keys: ["Mod", "1-9"],
           label: "Jump to a page area (hold Mod for hints)",
         },
       ]);
@@ -228,7 +228,7 @@ describe("shortcut menu sections", () => {
         { keys: ["m"], label: "Focus a week column (M T W R F SA SU)" },
         { keys: ["f"], label: "Focus latest notice" },
         {
-          keys: ["Mod", "1-4"],
+          keys: ["Mod", "1-9"],
           label: "Jump to a page area (hold Mod for hints)",
         },
       ]);

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.test.tsx
@@ -1,15 +1,32 @@
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { createMockCalendar } from "@web/__tests__/utils/factories/calendar.factory";
+import { PAGE_JUMP_ATTRIBUTE } from "@web/shortcuts/page-jump/page-jump.targets";
 import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
 import { DayCalendarColumnHeaders } from "@web/views/Day/components/Calendar/DayCalendarColumnHeaders";
-import { describe, expect, it } from "bun:test";
+import { CALENDAR_COLUMN_ID_ATTRIBUTE } from "@web/views/Day/components/Calendar/dayCalendarColumnFocus.util";
+import { afterEach, describe, expect, it, mock } from "bun:test";
 
-const calendar = createMockCalendar({ name: "Personal" });
+const personal = createMockCalendar({ name: "Personal" });
+const holidays = createMockCalendar({
+  name: "Holidays",
+  access: "reader",
+  capabilities: {
+    canReadAvailability: true,
+    canReadDetails: true,
+    canWrite: false,
+    canManage: false,
+    canWatchEvents: true,
+  },
+});
 
 describe("DayCalendarColumnHeaders", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   it("shows the effective timezone in the grid corner", () => {
-    render(<DayCalendarColumnHeaders calendars={[calendar]} />);
+    render(<DayCalendarColumnHeaders calendars={[personal]} />);
 
     const abbreviation = formatTimeZoneAbbreviation(getEffectiveTimeZone());
     expect(
@@ -34,5 +51,44 @@ describe("DayCalendarColumnHeaders", () => {
     expect(
       screen.queryByRole("region", { name: "Calendars" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("makes writable calendars focusable jump targets", () => {
+    render(
+      <DayCalendarColumnHeaders
+        calendars={[personal, holidays]}
+        writableCalendarIds={new Set([personal.id])}
+      />,
+    );
+
+    const column = screen.getByRole("button", {
+      name: "Focus Personal column",
+    });
+    expect(column).toHaveAttribute(
+      PAGE_JUMP_ATTRIBUTE,
+      `day-column:${personal.id}`,
+    );
+    expect(column).toHaveAttribute(CALENDAR_COLUMN_ID_ATTRIBUTE, personal.id);
+    expect(
+      screen.queryByRole("button", { name: "Focus Holidays column" }),
+    ).toBeNull();
+    expect(screen.getByRole("region", { name: "Calendars" })).toHaveTextContent(
+      "Holidays",
+    );
+  });
+
+  it("reports focus changes for full-column highlight", () => {
+    const onColumnFocusChange = mock();
+    render(
+      <DayCalendarColumnHeaders
+        calendars={[personal]}
+        onColumnFocusChange={onColumnFocusChange}
+        writableCalendarIds={new Set([personal.id])}
+      />,
+    );
+
+    screen.getByRole("button", { name: "Focus Personal column" }).focus();
+
+    expect(onColumnFocusChange).toHaveBeenCalledWith(personal.id);
   });
 });

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.tsx
@@ -1,11 +1,22 @@
 import { type Calendar } from "@core/types/calendar.contracts";
 import { useGridMarginLeft } from "@web/grid/grid-margin";
+import {
+  dayColumnJumpId,
+  pageJumpAttrs,
+} from "@web/shortcuts/page-jump/page-jump.targets";
 import { GridTimezoneLabel } from "@web/timezone/GridTimezoneLabel";
+import { CALENDAR_COLUMN_ID_ATTRIBUTE } from "./dayCalendarColumnFocus.util";
 
 export const DayCalendarColumnHeaders = ({
   calendars,
+  focusedColumnKey,
+  onColumnFocusChange,
+  writableCalendarIds,
 }: {
   calendars: Calendar[];
+  focusedColumnKey?: string | null;
+  onColumnFocusChange?: (calendarId: string | null) => void;
+  writableCalendarIds?: ReadonlySet<string>;
 }) => {
   const marginLeft = useGridMarginLeft();
   return (
@@ -24,23 +35,68 @@ export const DayCalendarColumnHeaders = ({
             gridTemplateColumns: `repeat(${calendars.length}, minmax(0, 1fr))`,
           }}
         >
-          {calendars.map((calendar) => (
-            <div
-              className="flex min-w-0 items-center justify-center gap-2 border-border border-l px-3 last:border-r"
-              key={calendar.id}
-            >
-              <span
-                aria-hidden="true"
-                className="size-2 shrink-0 rounded-full"
-                style={{ backgroundColor: calendar.backgroundColor }}
-              />
-              <span className="truncate text-sm text-text">
-                {calendar.name}
-              </span>
-            </div>
-          ))}
+          {calendars.map((calendar) => {
+            const isWritable = writableCalendarIds?.has(calendar.id) ?? false;
+            const isFocused = focusedColumnKey === calendar.id;
+
+            return (
+              <div
+                className="flex min-w-0 items-center justify-center gap-2 border-border border-l px-3 last:border-r has-[:focus-visible]:bg-accent/15"
+                data-focused-column={isFocused ? "true" : undefined}
+                key={calendar.id}
+              >
+                {isWritable ? (
+                  <button
+                    aria-label={`Focus ${calendar.name} column`}
+                    className="c-focus-ring flex min-w-0 items-center justify-center gap-2 rounded-sm"
+                    onBlur={(event) => {
+                      const next = event.relatedTarget;
+                      if (
+                        next instanceof HTMLElement &&
+                        next.closest(`[${CALENDAR_COLUMN_ID_ATTRIBUTE}]`)
+                      ) {
+                        return;
+                      }
+                      onColumnFocusChange?.(null);
+                    }}
+                    onFocus={() => onColumnFocusChange?.(calendar.id)}
+                    type="button"
+                    {...pageJumpAttrs(dayColumnJumpId(calendar.id))}
+                    {...{ [CALENDAR_COLUMN_ID_ATTRIBUTE]: calendar.id }}
+                  >
+                    <ColumnLabel
+                      backgroundColor={calendar.backgroundColor}
+                      name={calendar.name}
+                    />
+                  </button>
+                ) : (
+                  <ColumnLabel
+                    backgroundColor={calendar.backgroundColor}
+                    name={calendar.name}
+                  />
+                )}
+              </div>
+            );
+          })}
         </section>
       ) : null}
     </div>
   );
 };
+
+const ColumnLabel = ({
+  backgroundColor,
+  name,
+}: {
+  backgroundColor: string;
+  name: string;
+}) => (
+  <>
+    <span
+      aria-hidden="true"
+      className="size-2 shrink-0 rounded-full"
+      style={{ backgroundColor }}
+    />
+    <span className="truncate text-sm text-text">{name}</span>
+  </>
+);

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -15,6 +15,7 @@ import {
 } from "@web/__tests__/__mocks__/mock.render";
 import { server } from "@web/__tests__/__mocks__/server/mock.server";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
 import { createCompassQueryClient } from "@web/api/query-client";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { setCalendarVisibility } from "@web/calendars/calendar-visibility.store";
@@ -673,5 +674,77 @@ describe("DayCalendarGrid", () => {
         top: expect.any(Number),
       }),
     );
+  });
+
+  it("seeds a keyboardPlace draft on the focused writable column", async () => {
+    const personal = makeCalendar("Personal");
+    const work = makeCalendar("Work", { isPrimary: true });
+    renderDayCalendarGrid([personal, work]);
+
+    const personalColumn = await screen.findByRole("button", {
+      name: "Focus Personal column",
+    });
+    act(() => {
+      personalColumn.focus();
+    });
+
+    pressKey("ArrowDown", {
+      keyDownInit: { shiftKey: true },
+      keyUpInit: { shiftKey: true },
+    });
+
+    await waitFor(() => {
+      expect(getGridDraft()?.values.calendarId).toBe(personal.id);
+    });
+    expect(getIsFormOpen()).toBe(false);
+    expect(useDraftStore.getState().status?.activity).toBe("keyboardPlace");
+  });
+
+  it("seeds CREATE_TIMED_DRAFT on the focused writable column", async () => {
+    const personal = makeCalendar("Personal");
+    const work = makeCalendar("Work", { isPrimary: true });
+    renderDayCalendarGrid([personal, work]);
+
+    const personalColumn = await screen.findByRole("button", {
+      name: "Focus Personal column",
+    });
+    act(() => {
+      personalColumn.focus();
+    });
+
+    act(() => {
+      emitViewCommand("CREATE_TIMED_DRAFT");
+    });
+
+    await waitFor(() => {
+      expect(getGridDraft()?.values.calendarId).toBe(personal.id);
+      expect(getIsFormOpen()).toBe(true);
+    });
+  });
+
+  it("highlights the focused calendar column on the timed and all-day grids", async () => {
+    const personal = makeCalendar("Personal");
+    const work = makeCalendar("Work", { isPrimary: true });
+    renderDayCalendarGrid([personal, work]);
+
+    const personalColumn = await screen.findByRole("button", {
+      name: "Focus Personal column",
+    });
+    act(() => {
+      personalColumn.focus();
+    });
+
+    await waitFor(() => {
+      expect(
+        within(getTimedGrid())
+          .getByRole("columnheader", { name: /Personal, / })
+          .getAttribute("data-focused-column"),
+      ).toBe("true");
+      expect(
+        within(getAllDayRegion())
+          .getByRole("columnheader", { name: /Personal, / })
+          .getAttribute("data-focused-column"),
+      ).toBe("true");
+    });
   });
 });

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -1,4 +1,8 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  type CalendarId,
+  CalendarIdSchema,
+} from "@core/types/domain-primitives";
 import { shouldShowContextualLoadError } from "@web/api/util/api.util";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import {
@@ -6,7 +10,11 @@ import {
   isFirstImportInProgress,
 } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
-import { useDefaultTargetCalendar } from "@web/calendars/useDefaultTargetCalendar";
+import { getWritableCalendars } from "@web/calendars/calendar.util";
+import {
+  useConnectedAccountEmails,
+  useDefaultTargetCalendar,
+} from "@web/calendars/useDefaultTargetCalendar";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { onViewCommand } from "@web/common/utils/dom/view-command-bus";
 import {
@@ -28,6 +36,8 @@ import { EventGrid, isEventGridLoading } from "@web/grid/components/EventGrid";
 import { useGridMeasurements } from "@web/grid/hooks/useGridMeasurements";
 import { withAllDayColumnTints } from "@web/grid/utils/allDayColumnTint.util";
 import { EditSequenceMenu } from "@web/shortcuts/edit-sequence/EditSequenceMenu";
+import { PageJumpHints } from "@web/shortcuts/page-jump/PageJumpHints";
+import { buildDayPageJumpTargets } from "@web/shortcuts/page-jump/page-jump.targets";
 import { ShiftHintOverlay } from "@web/shortcuts/shift-hint/ShiftHintOverlay";
 import { dayEventQueryRange } from "@web/views/Day/hooks/events/useDayEvents";
 import { useDateInView } from "@web/views/Day/hooks/navigation/useDateInView";
@@ -42,6 +52,7 @@ import {
   DayCalendarTimedEventsLayer,
 } from "./DayCalendarEventLayers";
 import { assignDayAllDayEventRows } from "./dayAllDayRows.util";
+import { getFocusedDayColumnCalendarId } from "./dayCalendarColumnFocus.util";
 import {
   addVisibleDraftEvent,
   getCalendarEventIdSet,
@@ -102,6 +113,26 @@ export function DayCalendarGrid() {
     isDisplayedEvent,
     visibleDates,
   } = useDayCalendarColumns({ allDayEvents, dateInView, timedEvents });
+  const connectedAccountEmails = useConnectedAccountEmails();
+  const writableDisplayedCalendars = useMemo(
+    () =>
+      getWritableCalendars(displayedCalendars, {
+        hasConnectedAccount: connectedAccountEmails.length > 0,
+      }),
+    [connectedAccountEmails.length, displayedCalendars],
+  );
+  const writableCalendarIds = useMemo(
+    () =>
+      new Set<string>(
+        writableDisplayedCalendars.map((calendar) => calendar.id),
+      ),
+    [writableDisplayedCalendars],
+  );
+  const pageJumpTargets = useMemo(
+    () => buildDayPageJumpTargets(writableDisplayedCalendars),
+    [writableDisplayedCalendars],
+  );
+  const [focusedColumnKey, setFocusedColumnKey] = useState<string | null>(null);
   const { gridRefs, measurements } = useGridMeasurements({
     visibleDateCount: visibleDates.length,
   });
@@ -193,6 +224,15 @@ export function DayCalendarGrid() {
     onOpenEvent: openEventFormForEvent,
   });
 
+  const resolveShortcutCalendarId = useCallback((): CalendarId | null => {
+    const focusedColumnId = getFocusedDayColumnCalendarId();
+    if (focusedColumnId && writableCalendarIds.has(focusedColumnId)) {
+      const parsed = CalendarIdSchema.safeParse(focusedColumnId);
+      if (parsed.success) return parsed.data;
+    }
+    return defaultTargetCalendarId;
+  }, [defaultTargetCalendarId, writableCalendarIds]);
+
   const openShortcutDraft = useCallback(
     (createDraft: () => void, openForm = true) => {
       if (gridDraft) {
@@ -219,10 +259,10 @@ export function DayCalendarGrid() {
           dateInView,
           dateInView,
           "createShortcut",
-          defaultTargetCalendarId,
+          resolveShortcutCalendarId(),
         ),
       ),
-    [dateInView, defaultTargetCalendarId, openShortcutDraft],
+    [dateInView, openShortcutDraft, resolveShortcutCalendarId],
   );
 
   const createTimedDraftFromShortcut = useCallback(
@@ -232,10 +272,10 @@ export function DayCalendarGrid() {
           dateInView.isSame(today, "day"),
           dateInView,
           "createShortcut",
-          defaultTargetCalendarId,
+          resolveShortcutCalendarId(),
         ),
       ),
-    [dateInView, defaultTargetCalendarId, openShortcutDraft, today],
+    [dateInView, openShortcutDraft, resolveShortcutCalendarId, today],
   );
 
   // Form stays closed so Shift+Arrow can keep repositioning; Enter opens it.
@@ -248,11 +288,11 @@ export function DayCalendarGrid() {
             dateInView.isSame(today, "day"),
             dateInView,
             "keyboardPlace",
-            defaultTargetCalendarId,
+            resolveShortcutCalendarId(),
           ),
         false,
       ),
-    [dateInView, defaultTargetCalendarId, openShortcutDraft, today],
+    [dateInView, openShortcutDraft, resolveShortcutCalendarId, today],
   );
   const { getEditSequenceAnchor, shiftHints } = useDayEventNudgeShortcuts({
     allDayEvents: displayedAllDayEvents,
@@ -333,11 +373,17 @@ export function DayCalendarGrid() {
       className="flex h-full min-w-xs flex-1 flex-col bg-background px-0.5 pb-0.5"
       onContextMenu={handleContextMenu}
     >
-      <DayCalendarColumnHeaders calendars={displayedCalendars} />
+      <DayCalendarColumnHeaders
+        calendars={displayedCalendars}
+        focusedColumnKey={focusedColumnKey}
+        onColumnFocusChange={setFocusedColumnKey}
+        writableCalendarIds={writableCalendarIds}
+      />
       <EventGrid
         allDayEventsLayer={allDayEventsLayer}
         allDayRowsCount={allDayRowsCount}
         gridRefs={gridRefs}
+        highlightedColumnKey={focusedColumnKey}
         isErrorEvents={showEventsLoadError}
         isImportFailed={isImportFailed}
         isImportingEmpty={isImportingEmpty}
@@ -351,6 +397,7 @@ export function DayCalendarGrid() {
       {contextMenu}
       <ShiftHintOverlay hints={shiftHints} />
       <EditSequenceMenu getAnchor={getEditSequenceAnchor} />
+      <PageJumpHints targets={pageJumpTargets} />
     </section>
   );
 }

--- a/packages/web/src/views/Day/components/Calendar/dayCalendarColumnFocus.util.test.ts
+++ b/packages/web/src/views/Day/components/Calendar/dayCalendarColumnFocus.util.test.ts
@@ -1,0 +1,28 @@
+import {
+  CALENDAR_COLUMN_ID_ATTRIBUTE,
+  getFocusedDayColumnCalendarId,
+} from "./dayCalendarColumnFocus.util";
+import { afterEach, describe, expect, it } from "bun:test";
+
+describe("getFocusedDayColumnCalendarId", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("returns null when focus is not inside a column header", () => {
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    outside.focus();
+
+    expect(getFocusedDayColumnCalendarId()).toBeNull();
+  });
+
+  it("reads the calendar id from the focused column header", () => {
+    const column = document.createElement("button");
+    column.setAttribute(CALENDAR_COLUMN_ID_ATTRIBUTE, "cal-work");
+    document.body.append(column);
+    column.focus();
+
+    expect(getFocusedDayColumnCalendarId()).toBe("cal-work");
+  });
+});

--- a/packages/web/src/views/Day/components/Calendar/dayCalendarColumnFocus.util.ts
+++ b/packages/web/src/views/Day/components/Calendar/dayCalendarColumnFocus.util.ts
@@ -1,0 +1,16 @@
+export const CALENDAR_COLUMN_ID_ATTRIBUTE = "data-calendar-column-id";
+
+/**
+ * Calendar id of the Day-view column header that currently has focus, or
+ * null when focus is anywhere else. Place-create reads this at keydown so a
+ * Mod+digit jump into a column seeds that calendar instead of the default.
+ */
+export const getFocusedDayColumnCalendarId = (): string | null => {
+  const active = document.activeElement;
+  if (!(active instanceof HTMLElement)) return null;
+  return (
+    active
+      .closest(`[${CALENDAR_COLUMN_ID_ATTRIBUTE}]`)
+      ?.getAttribute(CALENDAR_COLUMN_ID_ATTRIBUTE) ?? null
+  );
+};

--- a/packages/web/src/views/Day/view/DayViewContent.tsx
+++ b/packages/web/src/views/Day/view/DayViewContent.tsx
@@ -23,7 +23,6 @@ import {
   viewActions,
 } from "@web/events/stores/view.store";
 import { useCalendarViewShortcuts } from "@web/grid/shortcuts/useCalendarViewShortcuts";
-import { PageJumpHints } from "@web/shortcuts/page-jump/PageJumpHints";
 import { getShortcutMenuSections } from "@web/shortcuts/shortcuts.registry";
 import { TimezoneMismatchBannerGate } from "@web/timezone/TimezoneMismatchBannerGate";
 import { DayCalendarGrid } from "@web/views/Day/components/Calendar/DayCalendarGrid";
@@ -119,7 +118,6 @@ export const DayViewContent = memo(() => {
         placeholder={getCommandPalettePlaceholder("day")}
       />
       <Dedication />
-      <PageJumpHints />
 
       <div
         id={ID_MAIN}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hold-Mod on Day view now numbers writable calendar columns after the shared page-area digits 1–4. Pressing that digit focuses the column header (not an event), highlights the full column, and Shift+Arrow / `C` / `Shift+C` seed a draft on that calendar instead of always using the default target.

Digits 1–4 stay stable (view / month picker / Up next / calendars). Extra calendars past the physical top-row keys get no chip. Read-only columns stay visible for `H` event-jump but get no Mod chip.

## Simplicity

Reuses the existing page-jump map (`buildDayPageJumpTargets` appends after `CALENDAR_PAGE_JUMP_TARGETS`) and native header buttons as anchors. Place-create reads `document.activeElement` for the focused column id; no new shortcut engine.

## Automated validation

- `bun run test:web` focused files: 79 pass / 0 fail (page-jump targets, overlay chip `5`, headers, grid highlight, Shift+Arrow / `C` seed the focused calendar).
- `bun run verify`: selected packages `web`; checks `test:web`, `type-check`, `lint`, `knip` passed. Playwright was missing at verify time.
- After `bunx playwright install chromium`: `bun run test:a11y` — 7 passed.
- Browser, anonymous `/day` with the local Compass column: hold Control shows chip `5` on the column (1–4 remain page areas); focusing the header then Shift+ArrowDown places a timed draft; Enter opens the form on `Compass (primary)`.

![Hold-Mod chips: 1 on view, 5 on Compass column](https://cursor.com/artifacts/c/art-13d0e1fc-f49d-4104-82de-1284aeede912)
![Event form seeded on Compass (primary)](https://cursor.com/artifacts/c/art-802158fd-c07f-4fe0-b708-da7f17c20950)
<a href="https://cursor.com/agents/bc-090cda98-1093-4fb8-9d16-7deffd6d2b08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fday_column_focus_place_create_form.mp4"><img src="https://cursor.com/artifacts/c/art-63887b09-aa41-4464-a850-676d7545a1de" alt="day_column_focus_place_create_form.mp4" /></a>

## Independent review

Not run on this PR. Use `/review` against `cursor/day-column-jump-2b08`.

## Test plan

- `bun run test:web --` focused page-jump / Day header / Day grid / TimedGrid / AllDayGridRow files — 79 pass
- `bun run type-check`
- `bun run lint` (exit 0; pre-existing repo warnings only)
- `bun run verify` — test:web, type-check, lint, knip passed
- `bun run test:a11y` — 7 passed
- Manual: `bun run dev:web` → `/day` → hold Mod → chip 5 on Compass → focus header → Shift+ArrowDown → Enter

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-090cda98-1093-4fb8-9d16-7deffd6d2b08?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-090cda98-1093-4fb8-9d16-7deffd6d2b08&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

