### PR TITLE
fix(web): teach Shift+up/down for timed edge resize

### DIFF
--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
@@ -306,15 +306,29 @@ describe("ShortcutShowcase", () => {
     expect(currentStepId()).toBe("edgeResize");
   });
 
-  it("teaches Tab then Shift+arrow to resize one edge", () => {
+  it("teaches Tab then Shift+up/down to resize one edge", () => {
     render(<ShortcutShowcase />);
     showStep("edgeResize");
+
+    expect(
+      screen.getByText(/press up or down to change just that edge/),
+    ).toBeTruthy();
+    expect(screen.getByTestId("arrowup-icon")).toBeTruthy();
+    expect(screen.getByTestId("arrowdown-icon")).toBeTruthy();
+    expect(screen.queryByTestId("arrowleft-icon")).toBeNull();
+    expect(screen.queryByTestId("arrowright-icon")).toBeNull();
 
     pressKey("ArrowDown", { shiftKey: true });
     expect(currentStepId()).toBe("edgeResize");
 
     pressKey("Tab");
     expect(screen.getByRole("status")).toHaveTextContent("Editing start time");
+    expect(
+      screen.getByText(/press up or down to change just that edge/),
+    ).toBeTruthy();
+
+    pressKey("ArrowLeft", { shiftKey: true });
+    expect(currentStepId()).toBe("edgeResize");
 
     pressKey("ArrowDown", { shiftKey: true });
     expect(currentStepId()).toBe("editTitle");

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
@@ -310,9 +310,10 @@ describe("ShortcutShowcase", () => {
     render(<ShortcutShowcase />);
     showStep("edgeResize");
 
-    expect(
-      screen.getByText(/press up or down to change just that edge/),
-    ).toBeTruthy();
+    const practice = screen.getByLabelText("Shortcut practice");
+    expect(practice).toHaveTextContent(
+      /press up or down to change just that edge/,
+    );
     expect(screen.getByTestId("arrowup-icon")).toBeTruthy();
     expect(screen.getByTestId("arrowdown-icon")).toBeTruthy();
     expect(screen.queryByTestId("arrowleft-icon")).toBeNull();
@@ -323,9 +324,9 @@ describe("ShortcutShowcase", () => {
 
     pressKey("Tab");
     expect(screen.getByRole("status")).toHaveTextContent("Editing start time");
-    expect(
-      screen.getByText(/press up or down to change just that edge/),
-    ).toBeTruthy();
+    expect(practice).toHaveTextContent(
+      /press up or down to change just that edge/,
+    );
 
     pressKey("ArrowLeft", { shiftKey: true });
     expect(currentStepId()).toBe("edgeResize");

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
@@ -7,6 +7,8 @@ import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 import { ShortcutShowcase } from "@web/components/ShortcutShowcase/ShortcutShowcase";
 import {
+  getEdgeResizeLessonPhase,
+  getShowcaseStep,
   SHOWCASE_STEP_IDS,
   type ShowcaseStepId,
 } from "@web/components/ShortcutShowcase/showcase.steps";
@@ -310,14 +312,22 @@ describe("ShortcutShowcase", () => {
     render(<ShortcutShowcase />);
     showStep("edgeResize");
 
+    expect(getShowcaseStep("edgeResize").keycaps).toEqual([
+      "Tab",
+      "Shift",
+      "ArrowUp",
+      "ArrowDown",
+    ]);
+    expect(getEdgeResizeLessonPhase("start").keycaps).toEqual([
+      "Shift",
+      "ArrowUp",
+      "ArrowDown",
+    ]);
+
     const practice = screen.getByLabelText("Shortcut practice");
     expect(practice).toHaveTextContent(
       /press up or down to change just that edge/,
     );
-    expect(screen.getByTestId("arrowup-icon")).toBeTruthy();
-    expect(screen.getByTestId("arrowdown-icon")).toBeTruthy();
-    expect(screen.queryByTestId("arrowleft-icon")).toBeNull();
-    expect(screen.queryByTestId("arrowright-icon")).toBeNull();
 
     pressKey("ArrowDown", { shiftKey: true });
     expect(currentStepId()).toBe("edgeResize");

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
@@ -88,7 +88,7 @@ const arrowDirection = (key: string): PracticeNudgeDirection | null => {
  * practice state, so nothing here touches storage or the real grid stores.
  *
  * An unnumbered intro gates first-time entry, then levels teach create,
- * hold-Mod jumps, event jump, whole-event nudge, Tab-then-Shift+arrow edge
+ * hold-Mod jumps, event jump, whole-event nudge, Tab-then-Shift+up/down edge
  * resize, the E-then-T edit sequence, delete-then-undo, Cmd+K, and `?`.
  * Graduation hands off to a prompt on the real calendar. Skip is always
  * offered.
@@ -342,7 +342,7 @@ const ShowcaseTakeover: FC = () => {
       const direction = arrowDirection(event.key);
       if (
         event.shiftKey &&
-        direction &&
+        (direction === "up" || direction === "down") &&
         (practice.edge === "start" || practice.edge === "end")
       ) {
         claim(event);

--- a/packages/web/src/components/ShortcutShowcase/showcase.steps.ts
+++ b/packages/web/src/components/ShortcutShowcase/showcase.steps.ts
@@ -79,9 +79,9 @@ export const SHOWCASE_STEPS = [
     body: [
       "Tab to the start or end of the focused event, then hold ",
       { key: "Shift" },
-      " and press an arrow to change just that edge.",
+      " and press up or down to change just that edge.",
     ],
-    keycaps: [KEYMAP.edgeFocus.hotkey, ...KEYMAP.moveEvent.keycaps],
+    keycaps: [KEYMAP.edgeFocus.hotkey, ...KEYMAP.moveEvent.timedEdgeKeycaps],
     level: 5,
   },
   {
@@ -175,7 +175,7 @@ export function getCreateLessonPhase(
   };
 }
 
-/** After Tab lands on an edge, the hint swaps to the Shift+arrow beat. */
+/** After Tab lands on an edge, the hint swaps to the Shift+up/down beat. */
 export function getEdgeResizeLessonPhase(
   edge: PracticeEdge,
 ): Partial<Pick<ShowcaseStep, "body" | "keycaps">> {
@@ -184,9 +184,9 @@ export function getEdgeResizeLessonPhase(
     body: [
       "Hold ",
       { key: "Shift" },
-      " and press an arrow to change just that edge.",
+      " and press up or down to change just that edge.",
     ],
-    keycaps: KEYMAP.moveEvent.keycaps,
+    keycaps: KEYMAP.moveEvent.timedEdgeKeycaps,
   };
 }
 

--- a/packages/web/src/shortcuts/keymap.ts
+++ b/packages/web/src/shortcuts/keymap.ts
@@ -48,6 +48,9 @@ export const KEYMAP = {
       right: "Shift+ArrowRight",
     },
     keycaps: ["Shift", "ArrowRight"],
+    // Timed start/end edges only move in time. Left/right stay whole-event
+    // day shifts; the practice and edge-focus tip teach the vertical axis.
+    timedEdgeKeycaps: ["Shift", "ArrowUp", "ArrowDown"],
   },
   edgeFocus: { hotkey: "Tab", keycaps: ["Tab"] },
   undo: { hotkey: "Mod+Z", keycaps: ["Mod", "Z"] },

--- a/packages/web/src/shortcuts/tips/shortcut-tips.data.test.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-tips.data.test.ts
@@ -38,7 +38,7 @@ describe("getHintPlainText", () => {
     );
     expect(plainTextById.nudge).toBe("Hold Shift and press an arrow to move");
     expect(plainTextById["edge-focus"]).toBe(
-      "Press Tab to the start or end, then hold Shift and press an arrow",
+      "Press Tab to the start or end, then hold Shift and press up or down",
     );
     expect(plainTextById["command-palette"]).toBe(
       `Press ${mod}+K to open the command palette`,

--- a/packages/web/src/shortcuts/tips/shortcut-tips.data.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-tips.data.ts
@@ -227,7 +227,7 @@ export const SHORTCUT_HINTS: Record<ShortcutHintId, ShortcutHint> = {
       { key: KEYMAP.edgeFocus.hotkey },
       " to the start or end, then hold ",
       { key: nudgeModifier },
-      " and press an arrow",
+      " and press up or down",
     ],
     suggestionReason: "event_focused",
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Level 5 of shortcut practice was showing Shift+left/right (the whole-event day move) as the way to change start/end time. Timed start/end edges only move with Shift+up/down.

The level 5 copy and keycaps now teach Tab, then Shift+up/down. After Tab, Shift+left/right no longer complete the lesson. The same wording is used on the in-app edge-focus hint.

![Level 5 tip with Tab, Shift, and up/down arrows](https://cursor.com/artifacts/c/art-b16c704a-c4dd-475f-83f4-85f7a76ad6cd)

<a href="https://cursor.com/agents/bc-746cddc1-7e60-4d85-be59-96a637655283/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flevel5_edge_resize_shift_up_down.mp4"><img src="https://cursor.com/artifacts/c/art-1279505c-04b1-4d9a-894f-908f5be6f633" alt="level5_edge_resize_shift_up_down.mp4" /></a>

## Simplicity

Taught keycaps live next to the existing `moveEvent` binding as `timedEdgeKeycaps`, so the practice, the hint, and a remap stay in one place. No new step or handler path.

## Automated validation

`bun run verify` selected packages: web.

- `test:web`: pass (2628 tests)
- `type-check`: pass
- `lint`: pass
- `knip`: pass
- `test:a11y`: pass
- Focused showcase tests: pass, including `teaches Tab then Shift+up/down to resize one edge`
- `e2e/onboarding/shortcut-showcase.spec.ts`: 5/5 pass

`test:e2e` as a whole failed on an unrelated spec: `day view separates visible calendars into distinct columns` (`primaryEventBox.width` 280 vs header 87). That assertion is outside this diff and is also red on other current PRs / recent `main` e2e runs.

Browser: Level 5 shows “press up or down” with Tab / Shift / ↑ / ↓ chips. After Tab, Shift+Left stays on level 5; Shift+Up/Down advances to level 6.

## Independent review

Read the complete `origin/main...HEAD` diff against AGENTS.md.

```
VERDICT: no confirmed findings
FINDINGS:
(none)
```

Note, not a finding: the in-app edge-focus tip now says “up or down”, which matches timed start/end time. All-day edge resize still uses left/right in the real grid; the practice calendar is timed-only.

## Test plan

- `bun packages/scripts/src/testing/test-parallel.ts web -- packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx packages/web/src/shortcuts/tips/shortcut-tips.data.test.ts`
- `bun run lint`
- `bun run verify` (web, type-check, lint, knip, a11y; e2e run with the unrelated calendar-column failure above)
- Browser walkthrough of Level 5/9 on `http://localhost:9080`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-746cddc1-7e60-4d85-be59-96a637655283?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-746cddc1-7e60-4d85-be59-96a637655283&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

