### PR TITLE
fix(web): left-to-right hold-Mod chips and month-picker nav

### DIFF
--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -310,7 +310,7 @@ Pressing `H` shows event-jump chips. Week view chips use day prefixes (`SU`/`M`/
 
 ### UX
 
-On Day view, holding Mod reveals numbered chips on each **writable** calendar column (5, 6, … after the shared page-area digits 1–4). Pressing that digit focuses the column header. Shift+Arrow then places a timed draft on that calendar; `C` / `Shift+C` honor the same focused column. Idle create (no column focused) still uses the default target calendar.
+On Day view, holding Mod reveals numbered chips left to right: `1` on the view dropdown, then each **writable** calendar column (`2`, `3`, …), then the sidebar (month picker, Up next, calendars). Pressing that digit focuses the column header. Shift+Arrow then places a timed draft on that calendar; `C` / `Shift+C` honor the same focused column. Idle create (no column focused) still uses the default target calendar.
 
 ### Steps
 
@@ -322,7 +322,7 @@ On Day view, holding Mod reveals numbered chips on each **writable** calendar co
 
 ### Expected Results
 
-- Hold-Mod chips on columns are numbers starting at 5, not 1. Digits 1–4 still jump to view / month picker / Up next / calendars list.
+- Hold-Mod chips on columns follow the view dropdown (`1`, then `2`…). Sidebar chips continue after the last column. Week view still uses 1–4 for view / month picker / Up next / calendars.
 - Read-only columns (for example holidays) have no chip and are not focusable via Mod+digit.
 - After focusing a column, Shift+Arrow places a form-closed timed draft in that column.
 - `C` and `Shift+C` seed the focused column's calendar. With no column focused, they still use the default create target.
@@ -448,4 +448,4 @@ If time is limited, run these checks before shipping shortcut-related changes:
 17. PageUp / PageDown scroll the timed grid by one viewport in Day and Week view even when an event is focused; they do not fire in a text input.
 18. Alt+ArrowUp / Alt+ArrowDown pan the timed grid by one hour in Day and Week view even when an event is focused; they do not fire in a text input.
 19. `Z` opens time travel in Day and Week view; Cmd+Z / Ctrl+Z still undoes and does not open the picker.
-20. On Day view, hold Mod then a column digit (5+) focuses that writable calendar column; Shift+Arrow / `C` seed a draft there.
+20. On Day view, hold Mod then a column digit (2+) focuses that writable calendar column; Shift+Arrow / `C` seed a draft there.

--- a/docs/features/billing.md
+++ b/docs/features/billing.md
@@ -88,7 +88,8 @@ production.
   `billing-preview.store.ts` and is deliberately in-memory, so a reload puts
   the trial ask back. Writes still fail server-side, and the
   `BILLING_REQUIRED` branch in `useEventMutations` exits the preview, so the
-  first refused save brings the gate straight back.
+  first refused save brings the gate straight back. That refusal does not
+  show the catch-all "something went wrong" toast — the gate is the feedback.
 - **Trialing / active / past_due:** writable. `past_due` also shows a banner.
 - **Expired / canceled:** read-only until they subscribe again. A later
   Checkout does not grant another trial.

--- a/docs/frontend/shortcut-commandments.md
+++ b/docs/frontend/shortcut-commandments.md
@@ -64,10 +64,10 @@ palette).
 
 The hold is the same everywhere. Digits are a single namespace, so the
 open event form takes them over for its fields (1–9 in DOM order). With
-the form closed, the same hold numbers page areas (sidebar, month picker,
-Up next, calendars — or Life's grid/variation/details). Day view then
-appends writable calendar columns at 5, 6, … so a user can land focus on
-a column and Shift+Arrow / C can seed a draft there.
+the form closed, the same hold numbers page areas left to right (view
+dropdown, then Day calendar columns, then month picker / Up next /
+calendars — or Life's grid/variation/details). Day view inserts writable
+columns after `1` so Shift+Arrow / C can seed a draft on a focused column.
 
 Do not run both maps at once. Do not invent a second hold key.
 
@@ -99,5 +99,5 @@ Form field digits live in
 `packages/web/src/shortcuts/edit-sequence/edit-sequence.fields.ts` (DOM
 order, 1–9). Page-area digits live in
 `packages/web/src/shortcuts/page-jump/page-jump.targets.ts`. Day-view
-calendar columns are built by `buildDayPageJumpTargets` and append after
-the shared 1–4 page areas.
+calendar columns are built by `buildDayPageJumpTargets` in left-to-right
+order (view, columns, sidebar).

--- a/e2e/calendars/calendar-experience.spec.ts
+++ b/e2e/calendars/calendar-experience.spec.ts
@@ -375,6 +375,10 @@ test("day view separates visible calendars into distinct columns", async ({
   });
   const primaryHeader = calendarHeaders.getByText(CALENDAR_A_NAME);
   const readerHeader = calendarHeaders.getByText(CALENDAR_B_NAME);
+  // Column cells, not the inner label/button — a writable header is a
+  // shrink-wrapped focus control, so its parent is narrower than the event.
+  const primaryColumn = calendarHeaders.locator(":scope > div").nth(0);
+  const readerColumn = calendarHeaders.locator(":scope > div").nth(1);
   const primaryEvent = dayAgenda.getByRole("button", {
     name: new RegExp(`${EVENT_A_TITLE}.*${CALENDAR_A_NAME} calendar`),
   });
@@ -391,8 +395,8 @@ test("day view separates visible calendars into distinct columns", async ({
 
   const [primaryHeaderBox, readerHeaderBox, primaryEventBox, readerEventBox] =
     await Promise.all([
-      primaryHeader.locator("..").boundingBox(),
-      readerHeader.locator("..").boundingBox(),
+      primaryColumn.boundingBox(),
+      readerColumn.boundingBox(),
       primaryEvent.boundingBox(),
       readerEvent.boundingBox(),
     ]);

--- a/packages/web/src/common/utils/event/event.util.test.ts
+++ b/packages/web/src/common/utils/event/event.util.test.ts
@@ -211,6 +211,24 @@ describe("handleError", () => {
       "Something went wrong behind the scenes. Please try again later.",
     );
   });
+
+  it("does not toast a BILLING_REQUIRED refusal — the gate is the feedback", () => {
+    const error = createServerError(Status.FORBIDDEN);
+    error.response = {
+      status: Status.FORBIDDEN,
+      data: {
+        code: "BILLING_REQUIRED",
+        message: "A trial or subscription is required to change events",
+        retryable: false,
+      },
+    } as ApiResponse<unknown>;
+
+    handleError(error);
+
+    expect(mockCaptureException).not.toHaveBeenCalled();
+    expect(mocks.error).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe("isEventInRange", () => {

--- a/packages/web/src/common/utils/event/event.util.ts
+++ b/packages/web/src/common/utils/event/event.util.ts
@@ -259,6 +259,11 @@ export const handleError = (error: Error) => {
 
   const mutationError = parseExpectedMutationError(error);
   if (mutationError) {
+    // Look-around writes are refused on purpose: the billing gate is the
+    // feedback. A catch-all toast on top of it reads as an unexpected crash.
+    if (mutationError.code === "BILLING_REQUIRED") {
+      return;
+    }
     // The backend authored a known mutation failure: tell the user what
     // actually happened when we have copy for it (a generic toast on a
     // deterministic refusal reads as "try again", which can never work).

--- a/packages/web/src/components/DatePicker/DatePicker.tsx
+++ b/packages/web/src/components/DatePicker/DatePicker.tsx
@@ -11,7 +11,6 @@ import { theme } from "@web/common/styles/theme";
 import { MonthNavButton } from "@web/components/DatePicker/MonthNavButton";
 import { ChevronLeftIcon } from "@web/components/Icons/ChevronLeftIcon";
 import { ChevronRightIcon } from "@web/components/Icons/ChevronRightIcon";
-import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import { selectTheme, useThemeStore } from "@web/settings/theme/theme.store";
 import { useFloatingLayer } from "@web/shortcuts/floating-layer";
 import { Focusable, INPUT_RESET_CLASSNAME } from "../Focusable/Focusable";
@@ -28,13 +27,10 @@ export interface Props extends Omit<ReactDatePickerProps, "autoFocus"> {
   inputColor?: string;
   isOpen?: boolean;
   monthTextClassName?: string;
-  /** Sidebar-only: hover keycaps and hold-Mod chips on the month chevrons. */
+  /** Sidebar-only: hover keycaps on the month chevrons. */
   monthNav?: {
     prevShortcut: readonly string[];
     nextShortcut: readonly string[];
-    prevHoldHint: readonly string[];
-    nextHoldHint: readonly string[];
-    showHoldHints: boolean;
   };
   withUnderline?: boolean;
   view: "sidebar" | "grid";
@@ -226,12 +222,6 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
                   >
                     <ChevronRightIcon />
                   </MonthNavButton>
-                  {monthNav?.showHoldHints ? (
-                    <span className="ml-1 flex items-center gap-1.5">
-                      <ShortcutKeys keys={[...monthNav.prevHoldHint]} />
-                      <ShortcutKeys keys={[...monthNav.nextHoldHint]} />
-                    </span>
-                  ) : null}
                 </div>
                 {withTodayButton && (
                   <TooltipWrapper description={currentMonth}>

--- a/packages/web/src/components/DatePicker/MonthNavButton.test.tsx
+++ b/packages/web/src/components/DatePicker/MonthNavButton.test.tsx
@@ -37,22 +37,4 @@ describe("MonthNavButton", () => {
 
     expect(onClick).toHaveBeenCalledTimes(1);
   });
-
-  it("shows remaining hold-Mod keys next to the chevron", () => {
-    render(
-      <MonthNavButton
-        ariaLabel="Previous month"
-        color="#fff"
-        holdHintKeys={["Shift", "J"]}
-        onClick={() => {}}
-        showHoldHints
-      >
-        <span>‹</span>
-      </MonthNavButton>,
-    );
-
-    const button = screen.getByRole("button", { name: "Previous month" });
-    expect(button.parentElement?.textContent).toContain("Shift");
-    expect(button.parentElement?.textContent).toContain("J");
-  });
 });

--- a/packages/web/src/components/DatePicker/MonthNavButton.tsx
+++ b/packages/web/src/components/DatePicker/MonthNavButton.tsx
@@ -1,5 +1,4 @@
 import type React from "react";
-import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
 
 const MONTH_NAV_BUTTON_HOVER_COLOR = "rgba(255,255,255,0.2)";
@@ -11,8 +10,6 @@ type MonthNavButtonProps = {
   isSidebarStyle?: boolean;
   onClick: () => void;
   shortcut?: string | string[];
-  holdHintKeys?: readonly string[];
-  showHoldHints?: boolean;
 };
 
 export const MonthNavButton = ({
@@ -22,8 +19,6 @@ export const MonthNavButton = ({
   isSidebarStyle = false,
   onClick,
   shortcut,
-  holdHintKeys,
-  showHoldHints = false,
 }: MonthNavButtonProps) => {
   const button = (
     <button
@@ -70,19 +65,7 @@ export const MonthNavButton = ({
     </button>
   );
 
-  const withHoldHint =
-    showHoldHints && holdHintKeys && holdHintKeys.length > 0 ? (
-      <span className="relative inline-flex">
-        {button}
-        <span className="pointer-events-none absolute top-full left-1/2 z-10 mt-0.5 -translate-x-1/2">
-          <ShortcutKeys keys={[...holdHintKeys]} />
-        </span>
-      </span>
-    ) : (
-      button
-    );
+  if (!shortcut) return button;
 
-  if (!shortcut) return withHoldHint;
-
-  return <TooltipWrapper shortcut={shortcut}>{withHoldHint}</TooltipWrapper>;
+  return <TooltipWrapper shortcut={shortcut}>{button}</TooltipWrapper>;
 };

--- a/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.test.tsx
+++ b/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.test.tsx
@@ -205,7 +205,7 @@ describe("MonthPicker", () => {
     expect(screen.getByText("May 2026")).toBeInTheDocument();
 
     act(() => {
-      pressMonthChord("J");
+      pressMonthChord(",");
     });
 
     await waitFor(() => {
@@ -215,7 +215,7 @@ describe("MonthPicker", () => {
     expect(onSelectDate).not.toHaveBeenCalled();
 
     act(() => {
-      pressMonthChord("K");
+      pressMonthChord(".");
     });
 
     await waitFor(() => {
@@ -224,20 +224,27 @@ describe("MonthPicker", () => {
     expect(onSelectDate).not.toHaveBeenCalled();
   });
 
-  it("reveals Shift+J and Shift+K chips on the chevrons while Mod-hold hints are visible", () => {
+  it("steps the month when Shift+, produces < (US QWERTY)", async () => {
+    const onSelectDate = mock();
+    renderPicker(<MonthPicker onSelectDate={onSelectDate} {...pickerProps} />);
+
+    act(() => {
+      pressMonthChord("<");
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Apr 2026")).toBeInTheDocument();
+    });
+    expect(onSelectDate).not.toHaveBeenCalled();
+  });
+
+  it("does not show remaining-key chips on the chevrons while Mod-hold hints are visible", () => {
     usePageJumpHintStore.setState({ areHintsVisible: true });
     renderPicker(<MonthPicker onSelectDate={mock()} {...pickerProps} />);
 
     const picker = screen.getByRole("group", { name: "Date navigation" });
-    expect(picker.textContent).toContain("Shift");
-    expect(picker.textContent).toContain("J");
-    expect(picker.textContent).toContain("K");
-  });
-
-  it("hides month-nav hold chips when Mod-hold hints are off", () => {
-    renderPicker(<MonthPicker onSelectDate={mock()} {...pickerProps} />);
-
-    const prev = screen.getByRole("button", { name: "Previous month" });
-    expect(prev.parentElement?.textContent).not.toContain("Shift");
+    expect(picker.textContent).not.toContain("Shift");
+    expect(picker.textContent).not.toContain(",");
+    expect(picker.textContent).not.toContain(".");
   });
 });

--- a/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.tsx
+++ b/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.tsx
@@ -2,16 +2,10 @@ import { type FC, useEffect, useRef, useState } from "react";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { ID_DATEPICKER_SIDEBAR } from "@web/common/constants/web.constants";
 import { DatePicker } from "@web/components/DatePicker/DatePicker";
-import {
-  selectPageJumpHintsVisible,
-  usePageJumpHintStore,
-} from "@web/shortcuts/page-jump/page-jump.store";
 import { pageJumpAttrs } from "@web/shortcuts/page-jump/page-jump.targets";
 import { getMonthPickerDayClassName } from "./monthPickerDayClassName";
 import {
-  MONTH_PICKER_NEXT_HOLD_KEYCAPS,
   MONTH_PICKER_NEXT_KEYCAPS,
-  MONTH_PICKER_PREV_HOLD_KEYCAPS,
   MONTH_PICKER_PREV_KEYCAPS,
   useMonthPickerShortcuts,
 } from "./useMonthPickerShortcuts";
@@ -44,7 +38,6 @@ export const MonthPicker: FC<Props> = ({
   const [displayedMonth, setDisplayedMonth] = useState(() =>
     selectedDate.startOf("month"),
   );
-  const showHoldHints = usePageJumpHintStore(selectPageJumpHintsVisible);
 
   useMonthPickerShortcuts({
     onPrevMonth: () => setDisplayedMonth((month) => month.subtract(1, "month")),
@@ -94,9 +87,6 @@ export const MonthPicker: FC<Props> = ({
         monthNav={{
           prevShortcut: MONTH_PICKER_PREV_KEYCAPS,
           nextShortcut: MONTH_PICKER_NEXT_KEYCAPS,
-          prevHoldHint: MONTH_PICKER_PREV_HOLD_KEYCAPS,
-          nextHoldHint: MONTH_PICKER_NEXT_HOLD_KEYCAPS,
-          showHoldHints,
         }}
         monthTextClassName="text-[14px] font-medium"
         monthsShown={monthsShown}

--- a/packages/web/src/components/Sidebar/MonthPicker/useMonthPickerShortcuts.ts
+++ b/packages/web/src/components/Sidebar/MonthPicker/useMonthPickerShortcuts.ts
@@ -1,18 +1,24 @@
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 
-export const MONTH_PICKER_PREV_HOTKEY = "Mod+Shift+J";
-export const MONTH_PICKER_NEXT_HOTKEY = "Mod+Shift+K";
+export const MONTH_PICKER_PREV_HOTKEY = "Mod+Shift+,";
+export const MONTH_PICKER_NEXT_HOTKEY = "Mod+Shift+.";
 
-export const MONTH_PICKER_PREV_KEYCAPS = ["Mod", "Shift", "J"] as const;
-export const MONTH_PICKER_NEXT_KEYCAPS = ["Mod", "Shift", "K"] as const;
+export const MONTH_PICKER_PREV_KEYCAPS = ["Mod", "Shift", ","] as const;
+export const MONTH_PICKER_NEXT_KEYCAPS = ["Mod", "Shift", "."] as const;
 
-/** Remaining keys once Mod is already held (hold-Mod hint chips). */
-export const MONTH_PICKER_PREV_HOLD_KEYCAPS = ["Shift", "J"] as const;
-export const MONTH_PICKER_NEXT_HOLD_KEYCAPS = ["Shift", "K"] as const;
+const MONTH_PICKER_SHORTCUT_OPTIONS = {
+  ignoreInputs: true,
+  preventDefault: true,
+  stopPropagation: true,
+} as const;
 
 /**
- * Mod+Shift+J / Mod+Shift+K step the sidebar month picker's displayed month
+ * Mod+Shift+, / Mod+Shift+. step the sidebar month picker's displayed month
  * the same way the chevrons do. Registered only while the picker is mounted.
+ * Avoids Chrome/Edge's reserved Mod+Shift+J (Downloads / Console).
+ *
+ * US QWERTY reports Shift+, / Shift+. as `<` / `>`, so those aliases are
+ * registered too and match the real KeyboardEvent.
  */
 export function useMonthPickerShortcuts({
   onPrevMonth,
@@ -21,14 +27,16 @@ export function useMonthPickerShortcuts({
   onPrevMonth: () => void;
   onNextMonth: () => void;
 }) {
-  useAppShortcut(MONTH_PICKER_PREV_HOTKEY, onPrevMonth, {
-    ignoreInputs: true,
-    preventDefault: true,
-    stopPropagation: true,
-  });
-  useAppShortcut(MONTH_PICKER_NEXT_HOTKEY, onNextMonth, {
-    ignoreInputs: true,
-    preventDefault: true,
-    stopPropagation: true,
-  });
+  useAppShortcut(
+    MONTH_PICKER_PREV_HOTKEY,
+    onPrevMonth,
+    MONTH_PICKER_SHORTCUT_OPTIONS,
+  );
+  useAppShortcut("Mod+Shift+<", onPrevMonth, MONTH_PICKER_SHORTCUT_OPTIONS);
+  useAppShortcut(
+    MONTH_PICKER_NEXT_HOTKEY,
+    onNextMonth,
+    MONTH_PICKER_SHORTCUT_OPTIONS,
+  );
+  useAppShortcut("Mod+Shift+>", onNextMonth, MONTH_PICKER_SHORTCUT_OPTIONS);
 }

--- a/packages/web/src/components/Sidebar/MonthPicker/useMonthPickerShortcuts.ts
+++ b/packages/web/src/components/Sidebar/MonthPicker/useMonthPickerShortcuts.ts
@@ -1,8 +1,5 @@
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 
-export const MONTH_PICKER_PREV_HOTKEY = "Mod+Shift+,";
-export const MONTH_PICKER_NEXT_HOTKEY = "Mod+Shift+.";
-
 export const MONTH_PICKER_PREV_KEYCAPS = ["Mod", "Shift", ","] as const;
 export const MONTH_PICKER_NEXT_KEYCAPS = ["Mod", "Shift", "."] as const;
 
@@ -17,8 +14,9 @@ const MONTH_PICKER_SHORTCUT_OPTIONS = {
  * the same way the chevrons do. Registered only while the picker is mounted.
  * Avoids Chrome/Edge's reserved Mod+Shift+J (Downloads / Console).
  *
- * US QWERTY reports Shift+, / Shift+. as `<` / `>`, so those aliases are
- * registered too and match the real KeyboardEvent.
+ * Registered as RawHotkey objects because tanstack's string Hotkey type
+ * excludes Shift+punctuation (layout-dependent event.key). US QWERTY
+ * reports those chords as `<` / `>`, so both shapes are bound.
  */
 export function useMonthPickerShortcuts({
   onPrevMonth,
@@ -28,15 +26,23 @@ export function useMonthPickerShortcuts({
   onNextMonth: () => void;
 }) {
   useAppShortcut(
-    MONTH_PICKER_PREV_HOTKEY,
+    { key: ",", mod: true, shift: true },
     onPrevMonth,
     MONTH_PICKER_SHORTCUT_OPTIONS,
   );
-  useAppShortcut("Mod+Shift+<", onPrevMonth, MONTH_PICKER_SHORTCUT_OPTIONS);
   useAppShortcut(
-    MONTH_PICKER_NEXT_HOTKEY,
+    { key: "<", mod: true, shift: true },
+    onPrevMonth,
+    MONTH_PICKER_SHORTCUT_OPTIONS,
+  );
+  useAppShortcut(
+    { key: ".", mod: true, shift: true },
     onNextMonth,
     MONTH_PICKER_SHORTCUT_OPTIONS,
   );
-  useAppShortcut("Mod+Shift+>", onNextMonth, MONTH_PICKER_SHORTCUT_OPTIONS);
+  useAppShortcut(
+    { key: ">", mod: true, shift: true },
+    onNextMonth,
+    MONTH_PICKER_SHORTCUT_OPTIONS,
+  );
 }

--- a/packages/web/src/shortcuts/keymap.ts
+++ b/packages/web/src/shortcuts/keymap.ts
@@ -22,8 +22,8 @@ export const KEYMAP = {
     keycaps: ["Mod", "1-9"],
   },
   // Same hold-Mod gesture outside the form: digits follow the active view's
-  // target list order (page-jump.targets.ts). Day view appends calendar
-  // columns after the shared 1–4 page areas, up to the physical top row.
+  // target list order (page-jump.targets.ts). Day view numbers left to right
+  // (view, columns, sidebar), up to the physical top row.
   jumpPageTarget: {
     holdModifier: "Mod",
     digits: ["1", "9"],

--- a/packages/web/src/shortcuts/page-jump/PageJumpHintOverlay.test.tsx
+++ b/packages/web/src/shortcuts/page-jump/PageJumpHintOverlay.test.tsx
@@ -136,7 +136,7 @@ describe("PageJumpHintOverlay", () => {
     expect(chipDigits()).toEqual(["1", "2"]);
   });
 
-  it("chips a Day calendar column as 5, not 1", () => {
+  it("chips a Day calendar column as 2, after the view dropdown", () => {
     addAnchor("view-select");
     addAnchor(dayColumnJumpId("cal-work"));
     render(
@@ -146,7 +146,7 @@ describe("PageJumpHintOverlay", () => {
       />,
     );
 
-    expect(chipDigits()).toEqual(["1", "5"]);
-    expect(screen.getByRole("status").textContent).toContain("5 for work");
+    expect(chipDigits()).toEqual(["1", "2"]);
+    expect(screen.getByRole("status").textContent).toContain("2 for work");
   });
 });

--- a/packages/web/src/shortcuts/page-jump/page-jump.targets.test.ts
+++ b/packages/web/src/shortcuts/page-jump/page-jump.targets.test.ts
@@ -36,40 +36,57 @@ describe.each([
 });
 
 describe("buildDayPageJumpTargets", () => {
-  it("appends writable columns after the shared 1-4 page areas", () => {
+  it("numbers left to right: view, columns, then sidebar", () => {
     const personal = { id: "cal-personal", name: "Personal" };
     const work = { id: "cal-work", name: "Work" };
     const targets = buildDayPageJumpTargets([personal, work]);
 
-    expect(targets.slice(0, 4)).toEqual([...CALENDAR_PAGE_JUMP_TARGETS]);
-    expect(targets[4]).toEqual({
-      digit: "5",
-      id: dayColumnJumpId(personal.id),
-      label: "Personal",
-    });
-    expect(targets[5]).toEqual({
-      digit: "6",
-      id: dayColumnJumpId(work.id),
+    expect(
+      targets.map(({ digit, id, label }) => ({ digit, id, label })),
+    ).toEqual([
+      { digit: "1", id: "view-select", label: "View dropdown" },
+      { digit: "2", id: dayColumnJumpId(personal.id), label: "Personal" },
+      { digit: "3", id: dayColumnJumpId(work.id), label: "Work" },
+      { digit: "4", id: "month-picker", label: "Month picker" },
+      { digit: "5", id: "up-next", label: "Up next" },
+      { digit: "6", id: "calendars", label: "Calendar list" },
+    ]);
+  });
+
+  it("starts the first column at 2 so sidebar digits follow the columns", () => {
+    const targets = buildDayPageJumpTargets([{ id: "cal-1", name: "Work" }]);
+    expect(targets.map((target) => target.digit)).toEqual([
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+    ]);
+    expect(targets[1]).toEqual({
+      digit: "2",
+      id: dayColumnJumpId("cal-1"),
       label: "Work",
     });
+    expect(targets.at(-1)).toMatchObject({ id: "calendars", digit: "5" });
   });
 
-  it("keeps column digits at 5+ when earlier page areas would be unmounted", () => {
-    const targets = buildDayPageJumpTargets([{ id: "cal-1", name: "Work" }]);
-    expect(targets[4]?.digit).toBe("5");
-  });
-
-  it("omits calendars past the physical top-row keys", () => {
-    const extraSlots =
-      PICK_KEY_LABELS.length - CALENDAR_PAGE_JUMP_TARGETS.length;
-    const calendars = Array.from({ length: extraSlots + 3 }, (_, index) => ({
+  it("omits calendars that would overflow the reserved sidebar slots", () => {
+    const sidebarCount = CALENDAR_PAGE_JUMP_TARGETS.length - 1;
+    const maxColumns = PICK_KEY_LABELS.length - 1 - sidebarCount;
+    const calendars = Array.from({ length: maxColumns + 3 }, (_, index) => ({
       id: `cal-${index}`,
       name: `Calendar ${index}`,
     }));
     const targets = buildDayPageJumpTargets(calendars);
 
     expect(targets).toHaveLength(PICK_KEY_LABELS.length);
-    expect(targets.at(-1)?.digit).toBe(PICK_KEY_LABELS.at(-1));
+    expect(targets.at(-1)).toMatchObject({
+      id: "calendars",
+      digit: PICK_KEY_LABELS.at(-1),
+    });
+    expect(
+      targets.filter((target) => target.id.startsWith("day-column:")),
+    ).toHaveLength(maxColumns);
   });
 });
 

--- a/packages/web/src/shortcuts/page-jump/page-jump.targets.ts
+++ b/packages/web/src/shortcuts/page-jump/page-jump.targets.ts
@@ -11,9 +11,10 @@
  * menu trigger (the view dropdown) is clicked after focus so the jump
  * reveals Day / Week / Life instead of landing on a closed heading.
  *
- * Day view appends writable calendar columns after the shared 1–4 page areas
- * (`buildDayPageJumpTargets`). Those digits stay 5+ even when the sidebar is
- * collapsed, so muscle memory for 1–4 never shifts.
+ * Day view numbers left to right (`buildDayPageJumpTargets`): view dropdown,
+ * then writable calendar columns, then the sidebar (month picker, Up next,
+ * calendars). Extra columns that would overflow the physical top-row keys
+ * are omitted so the three sidebar slots still get chips when mounted.
  */
 
 import { PICK_KEY_LABELS } from "@web/shortcuts/digit-pick.util";
@@ -65,26 +66,29 @@ export const dayColumnJumpId = (
   `${DAY_COLUMN_JUMP_ID_PREFIX}${calendarId}`;
 
 /**
- * Day view's hold-Mod map: the shared calendar page areas, then one numbered
- * target per writable displayed column. Extra calendars past the physical
- * top-row keys (`PICK_KEY_LABELS`) are omitted — no chip, no binding.
+ * Day view's hold-Mod map in visual left-to-right order: the view dropdown,
+ * then one numbered target per writable displayed column, then the sidebar
+ * page areas. Extra calendars that would crowd out the reserved sidebar
+ * slots are omitted — no chip, no binding.
  */
 export const buildDayPageJumpTargets = (
   calendars: readonly DayColumnJumpCalendar[],
 ): PageJumpTargets => {
-  const columnTargets = calendars.flatMap((calendar, index) => {
-    const digit = PICK_KEY_LABELS[CALENDAR_PAGE_JUMP_TARGETS.length + index];
-    if (!digit) return [];
-    return [
-      {
-        digit,
-        id: dayColumnJumpId(calendar.id),
-        label: calendar.name,
-      },
-    ];
-  });
+  const [viewSelect, ...sidebarTargets] = CALENDAR_PAGE_JUMP_TARGETS;
+  const maxColumns = PICK_KEY_LABELS.length - 1 - sidebarTargets.length;
+  const columnTargets = calendars
+    .slice(0, Math.max(0, maxColumns))
+    .map((calendar) => ({
+      id: dayColumnJumpId(calendar.id),
+      label: calendar.name,
+    }));
 
-  return [...CALENDAR_PAGE_JUMP_TARGETS, ...columnTargets];
+  return [viewSelect, ...columnTargets, ...sidebarTargets].map(
+    (target, index) => ({
+      ...target,
+      digit: PICK_KEY_LABELS[index] ?? "",
+    }),
+  );
 };
 
 /** Spread onto a component's container element to mark it as a jump target. */

--- a/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.test.tsx
+++ b/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.test.tsx
@@ -177,7 +177,7 @@ describe("usePageJumpShortcut", () => {
       expect(currentWeek).toHaveFocus();
     });
 
-    it("jumps to a Day calendar column at digit 5 without remapping 1-4", () => {
+    it("jumps to a Day calendar column at digit 2 after the view dropdown", () => {
       const { viewTrigger } = buildPage();
       const column = document.createElement("button");
       column.setAttribute(PAGE_JUMP_ATTRIBUTE, dayColumnJumpId("cal-work"));
@@ -189,7 +189,7 @@ describe("usePageJumpShortcut", () => {
         ),
       );
 
-      const columnEvent = pressModDigit("5");
+      const columnEvent = pressModDigit("2");
       expect(columnEvent.defaultPrevented).toBe(true);
       expect(column).toHaveFocus();
 

--- a/packages/web/src/shortcuts/shortcuts.menu.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.menu.test.ts
@@ -38,11 +38,11 @@ describe("shortcut menu sections", () => {
         label: "Go to Day view",
       });
       expect(stripMetadata(navigate.shortcuts)).toContainEqual({
-        keys: ["Mod", "Shift", "J"],
+        keys: ["Mod", "Shift", ","],
         label: "Previous month in picker",
       });
       expect(stripMetadata(navigate.shortcuts)).toContainEqual({
-        keys: ["Mod", "Shift", "K"],
+        keys: ["Mod", "Shift", "."],
         label: "Next month in picker",
       });
       expect(stripMetadata(navigate.shortcuts)).not.toContainEqual({

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.test.tsx
@@ -69,6 +69,7 @@ describe("DayCalendarColumnHeaders", () => {
       `day-column:${personal.id}`,
     );
     expect(column).toHaveAttribute(CALENDAR_COLUMN_ID_ATTRIBUTE, personal.id);
+    expect(column).toHaveClass("w-full");
     expect(
       screen.queryByRole("button", { name: "Focus Holidays column" }),
     ).toBeNull();

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.tsx
@@ -48,7 +48,7 @@ export const DayCalendarColumnHeaders = ({
                 {isWritable ? (
                   <button
                     aria-label={`Focus ${calendar.name} column`}
-                    className="c-focus-ring flex min-w-0 items-center justify-center gap-2 rounded-sm"
+                    className="c-focus-ring flex w-full min-w-0 items-center justify-center gap-2 rounded-sm"
                     onBlur={(event) => {
                       const next = event.relatedTarget;
                       if (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hold-Mod chips on Day view now number left to right: view dropdown, then calendar columns, then the sidebar. Month-picker navigation is remapped to `Mod+Shift+,` / `Mod+Shift+.` so previous-month works in Chrome (Cmd+Shift+J is reserved), and the noisy Shift+J/K hold-Mod chips next to the chevrons are gone. Look-around writes that return `BILLING_REQUIRED` still bring the trial gate back, but no longer show the catch-all "Something went wrong behind the scenes" toast.

Also fixes the Day calendar e2e that started measuring the shrink-wrapped writable column focus button instead of the column cell after the page-jump digit work.

## Simplicity

Reorders `buildDayPageJumpTargets` and remaps existing month-picker chords as tanstack `RawHotkey` objects (string `Mod+Shift+,` is not in the typed Hotkey union). No new shortcut engine. Billing toast skip is one expected-code early return in `handleError`. E2e now measures the column cells directly.

## Automated validation

- Focused web tests: 97 pass (page-jump targets/overlay/shortcut, MonthPicker chords including US `<`, no hold-Mod Shift chips, registry/menu, `handleError` skips `BILLING_REQUIRED`).
- `bun run verify`: selected package `web`; checks `test:web`, `type-check`, `lint`, `knip` passed. Playwright Chromium was not installed, so `test:a11y` / `test:e2e` were skipped.
- Browser (anonymous `/day/2026-08-28`): `Ctrl+Shift+,` stepped the sidebar picker Aug → Jul and `Ctrl+Shift+.` restored Aug; the day header stayed Friday, August 28. No Shift+J/K pills appeared next to the chevrons.

## Independent review

Not run.

## Test plan

- `bun packages/scripts/src/testing/test-parallel.ts web --` focused files above
- `bun run type-check`
- `bun run verify`
- Browser: Day view month-picker `Mod+Shift+,` / `Mod+Shift+.`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d8a9318-4ce6-49a6-8b6f-0f38ca29a6d0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d8a9318-4ce6-49a6-8b6f-0f38ca29a6d0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

