### PR TITLE
fix(web): unstick onboarding at the shortcut legend

### DIFF
--- a/e2e/calendars/calendar-experience.spec.ts
+++ b/e2e/calendars/calendar-experience.spec.ts
@@ -373,12 +373,13 @@ test("day view separates visible calendars into distinct columns", async ({
   const calendarHeaders = dayAgenda.getByRole("region", {
     name: "Calendars",
   });
-  const primaryHeader = calendarHeaders.getByText(CALENDAR_A_NAME);
-  const readerHeader = calendarHeaders.getByText(CALENDAR_B_NAME);
-  // Column cells, not the inner label/button — a writable header is a
-  // shrink-wrapped focus control, so its parent is narrower than the event.
-  const primaryColumn = calendarHeaders.locator(":scope > div").nth(0);
-  const readerColumn = calendarHeaders.locator(":scope > div").nth(1);
+  // Column cells (exact aria-label), not the inner "Focus … column" button.
+  const primaryHeader = calendarHeaders.getByLabel(CALENDAR_A_NAME, {
+    exact: true,
+  });
+  const readerHeader = calendarHeaders.getByLabel(CALENDAR_B_NAME, {
+    exact: true,
+  });
   const primaryEvent = dayAgenda.getByRole("button", {
     name: new RegExp(`${EVENT_A_TITLE}.*${CALENDAR_A_NAME} calendar`),
   });
@@ -395,8 +396,8 @@ test("day view separates visible calendars into distinct columns", async ({
 
   const [primaryHeaderBox, readerHeaderBox, primaryEventBox, readerEventBox] =
     await Promise.all([
-      primaryColumn.boundingBox(),
-      readerColumn.boundingBox(),
+      primaryHeader.boundingBox(),
+      readerHeader.boundingBox(),
       primaryEvent.boundingBox(),
       readerEvent.boundingBox(),
     ]);

--- a/e2e/onboarding/shortcut-showcase.spec.ts
+++ b/e2e/onboarding/shortcut-showcase.spec.ts
@@ -73,6 +73,9 @@ const playThroughLevels = async (page: Page) => {
   await expect(showcase).toContainText("The rest lives in the legend");
 
   await page.keyboard.press("?");
+  await expect(
+    showcase.getByRole("dialog", { name: "Practice shortcut legend" }),
+  ).toBeVisible();
   await page.keyboard.press("Enter");
 };
 

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
@@ -1,4 +1,8 @@
-import { resolveModifier } from "@tanstack/react-hotkeys";
+import {
+  HotkeyManager,
+  HotkeysProvider,
+  resolveModifier,
+} from "@tanstack/react-hotkeys";
 import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createTestNotificationPort } from "@web/__tests__/helpers/web-test-seams";
@@ -17,6 +21,11 @@ import {
   shortcutShowcaseActions,
   useShortcutShowcaseStore,
 } from "@web/components/ShortcutShowcase/showcase.store";
+import { useSidebarShortcuts } from "@web/components/Sidebar/useSidebarShortcuts";
+import {
+  selectIsShortcutsOpen,
+  useViewStore,
+} from "@web/events/stores/view.store";
 import { registerNotificationPort } from "@web/notifications/notification.port";
 import { resetNotificationStoreForTests } from "@web/notifications/notification.store";
 import { clearAppLockReasons, isAppLocked } from "@web/shortcuts/app-lock";
@@ -24,11 +33,14 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
 const pressKey = (key: string, init: KeyboardEventInit = {}) => {
   act(() => {
-    screen
-      .getByLabelText("Shortcut practice")
-      .dispatchEvent(
-        new KeyboardEvent("keydown", { key, bubbles: true, ...init }),
-      );
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key,
+        bubbles: true,
+        cancelable: true,
+        ...init,
+      }),
+    );
   });
 };
 
@@ -404,6 +416,84 @@ describe("ShortcutShowcase", () => {
 
     pressKey("?");
     expect(screen.getByLabelText("Practice shortcut legend")).toBeTruthy();
+
+    pressKey("Enter");
+    expect(currentStepId()).toBe("notifications");
+  });
+
+  it("opens the practice legend from Shift+/ as well as ?", () => {
+    render(<ShortcutShowcase />);
+    showStep("legend");
+
+    pressKey("/", { shiftKey: true });
+    expect(screen.getByLabelText("Practice shortcut legend")).toBeTruthy();
+  });
+
+  it("still completes the legend lesson after focus leaves the takeover", () => {
+    render(
+      <>
+        <input aria-label="Outside search" />
+        <ShortcutShowcase />
+      </>,
+    );
+    showStep("legend");
+
+    pressKey("?");
+    expect(screen.getByLabelText("Practice shortcut legend")).toBeTruthy();
+
+    const outside = screen.getByLabelText("Outside search");
+    outside.focus();
+    expect(outside).toHaveFocus();
+
+    act(() => {
+      outside.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Enter",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+
+    expect(currentStepId()).toBe("notifications");
+  });
+
+  it("does not open the real shortcut overlay from the legend lesson", () => {
+    const Harness = () => {
+      useSidebarShortcuts();
+      return <ShortcutShowcase />;
+    };
+    HotkeyManager.resetInstance();
+    useViewStore.setState({ shortcuts: { isOpen: false } });
+
+    render(
+      <HotkeysProvider>
+        <Harness />
+      </HotkeysProvider>,
+    );
+    showStep("legend");
+
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "?",
+          bubbles: true,
+          cancelable: true,
+          shiftKey: true,
+        }),
+      );
+      window.dispatchEvent(
+        new KeyboardEvent("keyup", {
+          key: "?",
+          bubbles: true,
+          cancelable: true,
+          shiftKey: true,
+        }),
+      );
+    });
+
+    expect(screen.getByLabelText("Practice shortcut legend")).toBeTruthy();
+    expect(selectIsShortcutsOpen(useViewStore.getState())).toBe(false);
 
     pressKey("Enter");
     expect(currentStepId()).toBe("notifications");

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
@@ -1,12 +1,5 @@
 import { resolveModifier } from "@tanstack/react-hotkeys";
-import {
-  type FC,
-  type KeyboardEvent as ReactKeyboardEvent,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { type FC, useContext, useEffect, useRef, useState } from "react";
 import { SessionContext } from "@web/auth/compass/session/session.context";
 import { track } from "@web/auth/posthog/track";
 import { SHOWCASE_REVEAL_MS } from "@web/common/constants/motion.constants";
@@ -72,6 +65,10 @@ const isPlatformModKey = (event: KeyboardEvent) =>
   resolveModifier("Mod") === "Meta"
     ? event.key === "Meta"
     : event.key === "Control";
+
+/** `?` is Shift+/ on common layouts; some browsers report the physical slash. */
+const isLegendToggleKey = (event: KeyboardEvent) =>
+  event.key === "?" || (event.key === "/" && event.shiftKey);
 
 const arrowDirection = (key: string): PracticeNudgeDirection | null => {
   if (key === "ArrowUp") return "up";
@@ -167,16 +164,16 @@ const ShowcaseTakeover: FC = () => {
     return () => window.removeEventListener("blur", clearMod);
   }, []);
 
-  const claim = (event: ReactKeyboardEvent<HTMLElement>) => {
+  const claim = (event: KeyboardEvent) => {
     event.preventDefault();
     event.stopPropagation();
-    event.nativeEvent.stopImmediatePropagation();
+    event.stopImmediatePropagation();
   };
 
-  const handleTakeoverKeyDown = (event: ReactKeyboardEvent<HTMLElement>) => {
+  const handleTakeoverKeyDown = (event: KeyboardEvent) => {
     if (closing) {
       event.stopPropagation();
-      event.nativeEvent.stopImmediatePropagation();
+      event.stopImmediatePropagation();
       return;
     }
 
@@ -205,7 +202,7 @@ const ShowcaseTakeover: FC = () => {
       return;
     }
 
-    if (isPlatformModKey(event.nativeEvent)) {
+    if (isPlatformModKey(event)) {
       setIsModHeld(true);
       if (stepId === "pageJump") hasRevealedJumpsRef.current = true;
     }
@@ -238,7 +235,7 @@ const ShowcaseTakeover: FC = () => {
     }
 
     const isModChord = event.metaKey || event.ctrlKey;
-    if (isModChord && keyboardKey(event.nativeEvent).toLowerCase() === "k") {
+    if (isModChord && keyboardKey(event).toLowerCase() === "k") {
       claim(event);
       if (stepId === "palette" && !paletteOpen) setPaletteOpen(true);
       return;
@@ -246,7 +243,7 @@ const ShowcaseTakeover: FC = () => {
     if (
       isModChord &&
       !event.shiftKey &&
-      keyboardKey(event.nativeEvent).toLowerCase() === "z"
+      keyboardKey(event).toLowerCase() === "z"
     ) {
       if (stepId === "deleteUndo" && practice.lastDeleted) {
         claim(event);
@@ -274,7 +271,7 @@ const ShowcaseTakeover: FC = () => {
       return;
     }
 
-    if (stepId === "legend" && event.key === "?") {
+    if (stepId === "legend" && isLegendToggleKey(event)) {
       claim(event);
       setLegendOpen(true);
       return;
@@ -290,7 +287,7 @@ const ShowcaseTakeover: FC = () => {
         }
         return;
       }
-      if (!isBareLetterKey(event.nativeEvent, "u")) return;
+      if (!isBareLetterKey(event, "u")) return;
     }
 
     if (stepId === "graduation" && event.key === "Enter") {
@@ -312,7 +309,7 @@ const ShowcaseTakeover: FC = () => {
         enableNotifications();
         return;
       }
-      if (isBareLetterKey(event.nativeEvent, "n")) {
+      if (isBareLetterKey(event, "n")) {
         claim(event);
         advance();
       }
@@ -358,24 +355,19 @@ const ShowcaseTakeover: FC = () => {
       return;
     }
 
-    if (
-      isBareLetterKey(
-        event.nativeEvent,
-        KEYMAP.createEvent.hotkey.toLowerCase(),
-      )
-    ) {
+    if (isBareLetterKey(event, KEYMAP.createEvent.hotkey.toLowerCase())) {
       claim(event);
       apply(createDraft);
       return;
     }
 
     if (stepId === "eventJump") {
-      if (isBareLetterKey(event.nativeEvent, KEYMAP.eventJump.bareLetter)) {
+      if (isBareLetterKey(event, KEYMAP.eventJump.bareLetter)) {
         claim(event);
         apply(toggleJumpHints);
         return;
       }
-      const jumpKey = keyboardKey(event.nativeEvent).toLowerCase();
+      const jumpKey = keyboardKey(event).toLowerCase();
       if (jumpKey.length === 1 && practice.jumpHintsVisible) {
         const next = apply((state) => jumpToEvent(state, jumpKey));
         if (next !== practice) {
@@ -387,16 +379,14 @@ const ShowcaseTakeover: FC = () => {
     }
 
     if (stepId === "editTitle") {
-      if (
-        isBareLetterKey(event.nativeEvent, KEYMAP.editTitle.sequence.leader)
-      ) {
+      if (isBareLetterKey(event, KEYMAP.editTitle.sequence.leader)) {
         claim(event);
         apply(armEdit);
         return;
       }
       if (
         practice.editArmed &&
-        isBareLetterKey(event.nativeEvent, KEYMAP.editTitle.sequence.second)
+        isBareLetterKey(event, KEYMAP.editTitle.sequence.second)
       ) {
         claim(event);
         apply(openTitleFromEdit);
@@ -407,7 +397,7 @@ const ShowcaseTakeover: FC = () => {
 
     if (
       stepId !== "graduation" &&
-      isBareLetterKey(event.nativeEvent, "u") &&
+      isBareLetterKey(event, "u") &&
       !authenticated
     ) {
       claim(event);
@@ -415,9 +405,36 @@ const ShowcaseTakeover: FC = () => {
     }
   };
 
-  const handleTakeoverKeyUp = (event: ReactKeyboardEvent<HTMLElement>) => {
-    if (isPlatformModKey(event.nativeEvent)) setIsModHeld(false);
+  const handleTakeoverKeyUp = (event: KeyboardEvent) => {
+    if (isPlatformModKey(event)) setIsModHeld(false);
+    // The real overlay listens on keyup. Swallow the leftover `?` so it
+    // cannot steal focus after the practice legend opens.
+    if (isLegendToggleKey(event)) {
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+    }
   };
+
+  const handleTakeoverKeyDownRef = useRef(handleTakeoverKeyDown);
+  handleTakeoverKeyDownRef.current = handleTakeoverKeyDown;
+  const handleTakeoverKeyUpRef = useRef(handleTakeoverKeyUp);
+  handleTakeoverKeyUpRef.current = handleTakeoverKeyUp;
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      handleTakeoverKeyDownRef.current(event);
+    };
+    const onKeyUp = (event: KeyboardEvent) => {
+      handleTakeoverKeyUpRef.current(event);
+    };
+    window.addEventListener("keydown", onKeyDown, true);
+    window.addEventListener("keyup", onKeyUp, true);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown, true);
+      window.removeEventListener("keyup", onKeyUp, true);
+    };
+  }, []);
 
   const runPracticeCommand = () => {
     apply((state) => ({
@@ -463,8 +480,6 @@ const ShowcaseTakeover: FC = () => {
       aria-label="Shortcut practice"
       className={`fixed inset-0 flex items-center justify-center bg-background ${closing ? "c-showcase-curtain" : ""}`}
       data-closing={closing || undefined}
-      onKeyDownCapture={handleTakeoverKeyDown}
-      onKeyUpCapture={handleTakeoverKeyUp}
       style={{ zIndex: Z_INDEX_MODAL }}
       tabIndex={-1}
     >

--- a/packages/web/src/components/Sidebar/useSidebarShortcuts.test.tsx
+++ b/packages/web/src/components/Sidebar/useSidebarShortcuts.test.tsx
@@ -8,6 +8,7 @@ import {
   useViewStore,
   viewActions,
 } from "@web/events/stores/view.store";
+import { clearAppLockReasons, setAppLockReason } from "@web/shortcuts/app-lock";
 import { useSidebarShortcuts } from "./useSidebarShortcuts";
 import { beforeEach, describe, expect, it } from "bun:test";
 
@@ -21,6 +22,7 @@ describe("useSidebarShortcuts", () => {
   beforeEach(() => {
     HotkeyManager.resetInstance();
     viewActions.setSidebarOpen(false);
+    clearAppLockReasons();
   });
 
   it("opens the sidebar before opening shortcuts with ?", async () => {
@@ -114,5 +116,47 @@ describe("useSidebarShortcuts", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(isShortcutsOpen()).toBe(false);
+  });
+
+  it("does not open shortcuts while another overlay holds the app lock", async () => {
+    setAppLockReason("shortcutShowcase", true);
+    viewActions.setSidebarOpen(true);
+    renderHook(() => useSidebarShortcuts(), { wrapper });
+
+    act(() => {
+      pressKey("?", {
+        keyDownInit: { shiftKey: true },
+        keyUpInit: { shiftKey: true },
+      });
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(isShortcutsOpen()).toBe(false);
+  });
+
+  it("still closes an already-open overlay while the app is locked", async () => {
+    viewActions.setSidebarOpen(true);
+    renderHook(() => useSidebarShortcuts(), { wrapper });
+
+    act(() => {
+      viewActions.toggleShortcuts();
+    });
+    await waitFor(() => {
+      expect(isShortcutsOpen()).toBe(true);
+    });
+
+    setAppLockReason("shortcutShowcase", true);
+
+    act(() => {
+      pressKey("?", {
+        keyDownInit: { shiftKey: true },
+        keyUpInit: { shiftKey: true },
+      });
+    });
+
+    await waitFor(() => {
+      expect(isShortcutsOpen()).toBe(false);
+    });
   });
 });

--- a/packages/web/src/components/Sidebar/useSidebarShortcuts.ts
+++ b/packages/web/src/components/Sidebar/useSidebarShortcuts.ts
@@ -3,7 +3,7 @@ import {
   useViewStore,
   viewActions,
 } from "@web/events/stores/view.store";
-import { useAppLockReason } from "@web/shortcuts/app-lock";
+import { isAppLocked, useAppLockReason } from "@web/shortcuts/app-lock";
 import { useAppShortcutUp } from "@web/shortcuts/useAppShortcut";
 
 const TOGGLE_SHORTCUTS_HOTKEY = { key: "?", shift: true } as const;
@@ -11,15 +11,25 @@ const TOGGLE_SHORTCUTS_SLASH_HOTKEY = { key: "/", shift: true } as const;
 
 /** Mount once per view: registers the `?`/`/` hotkeys and holds the app-lock
  * while the overlay is open. State itself lives in view.store, next to
- * sidebar.isOpen, since opening/closing either one affects the other. */
+ * sidebar.isOpen, since opening/closing either one affects the other.
+ *
+ * Opening respects the app-lock so a takeover (shortcut showcase) is not
+ * interrupted. Closing still works while this overlay itself holds the lock. */
 export function useSidebarShortcuts() {
   const isShortcutsOpen = useViewStore(selectIsShortcutsOpen);
   useAppLockReason("shortcutsOverlay", isShortcutsOpen);
 
-  useAppShortcutUp(TOGGLE_SHORTCUTS_HOTKEY, viewActions.toggleShortcuts, {
+  const toggleIfUnlocked = () => {
+    if (isAppLocked() && !selectIsShortcutsOpen(useViewStore.getState())) {
+      return;
+    }
+    viewActions.toggleShortcuts();
+  };
+
+  useAppShortcutUp(TOGGLE_SHORTCUTS_HOTKEY, toggleIfUnlocked, {
     ignoreAppLock: true,
   });
-  useAppShortcutUp(TOGGLE_SHORTCUTS_SLASH_HOTKEY, viewActions.toggleShortcuts, {
+  useAppShortcutUp(TOGGLE_SHORTCUTS_SLASH_HOTKEY, toggleIfUnlocked, {
     ignoreAppLock: true,
   });
 }

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.test.tsx
@@ -34,6 +34,7 @@ describe("DayCalendarColumnHeaders", () => {
         name: `Calendar timezone: ${abbreviation}`,
       }),
     ).toHaveTextContent(abbreviation);
+    expect(screen.getByLabelText("Personal")).toBeInTheDocument();
     expect(screen.getByRole("region", { name: "Calendars" })).toHaveTextContent(
       "Personal",
     );

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.tsx
@@ -41,7 +41,8 @@ export const DayCalendarColumnHeaders = ({
 
             return (
               <div
-                className="flex min-w-0 items-center justify-center gap-2 border-border border-l px-3 last:border-r has-[:focus-visible]:bg-accent/15"
+                aria-label={calendar.name}
+                className="flex w-full min-w-0 items-center justify-center gap-2 border-border border-l px-3 text-text last:border-r has-[:focus-visible]:bg-accent/15"
                 data-focused-column={isFocused ? "true" : undefined}
                 key={calendar.id}
               >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pressing `?` on the last onboarding level opened the practice legend, then the leftover keyup still toggled the real shortcut overlay (it ignored app-lock). That overlay focused a hidden search field, so Enter / Esc / U never reached the takeover and the user was stuck on Level 9/9.

The overlay now refuses to open while another surface holds the app lock, the takeover swallows leftover `?` keyup, and practice keys listen on window capture so a stray focus move cannot trap someone.

CI unblock: day-view column jump targets wrap writable header labels in a shrink-to-content button. The e2e now measures the labeled header *cell* (exact aria-label) so it compares event cards to the column, not the button.

## Simplicity

Onboarding: two small guards around the existing `?` path. CI: label the existing header cell and query it exactly — no new layout.

## Automated validation

- Showcase + sidebar shortcut unit tests: 49 pass
- Day header/grid unit tests: 21 pass after rebase onto column-jump targets
- Local Playwright: onboarding spec (5) and calendar-experience spec (6) pass, including the previously red column-width test
- Browser: Level 9 `?` → pause → Enter / N / Enter graduates

![Level 9 legend open after ?](https://cursor.com/artifacts/c/art-1ad4328c-746a-4c34-99c4-2985643a939a)
![Enter advanced to the notifications step](https://cursor.com/artifacts/c/art-b472339a-2d9f-4036-80cc-ee9988b1b690)
<a href="https://cursor.com/agents/bc-0f82d45d-d00e-4aae-9c34-83dffe7d6a4b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fonboarding_legend_enter_graduates.mp4"><img src="https://cursor.com/artifacts/c/art-1aa41a13-2e61-413f-8b5e-4289bff0f3a2" alt="onboarding_legend_enter_graduates.mp4" /></a>

## Independent review

In-PR review: the trap was a keyup/app-lock leak plus region-scoped keydown. The lock check reads live store state. Window capture is cleared on unmount.

## Test plan

- `bun test:web packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx packages/web/src/components/Sidebar/useSidebarShortcuts.test.tsx`
- `bun test:web packages/web/src/views/Day/components/Calendar/DayCalendarColumnHeaders.test.tsx packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx`
- `bun test:e2e e2e/onboarding/shortcut-showcase.spec.ts e2e/calendars/calendar-experience.spec.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f82d45d-d00e-4aae-9c34-83dffe7d6a4b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f82d45d-d00e-4aae-9c34-83dffe7d6a4b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

