### PR TITLE
feat(billing): add a trial countdown badge and let users subscribe early

### DIFF
--- a/docs/development/feature-file-map.md
+++ b/docs/development/feature-file-map.md
@@ -156,6 +156,7 @@ the full picture.
 - Shared plan/price copy: `packages/core/src/constants/billing.constants.ts`
 - Read-only look-around: `packages/web/src/billing/billing-preview.store.ts`, `packages/web/src/billing/BillingReadOnlyBanner.tsx`
 - Server access + paid gate: `packages/web/src/billing/useAppAccess.ts`, `packages/web/src/billing/BillingGateModal.tsx`
+- Trial countdown + early upgrade: `packages/web/src/billing/TrialBadge.tsx`, `packages/web/src/billing/trialDaysLeft.ts`, `packages/web/src/billing/UpgradeConfirmation/`
 - Backend billing: `packages/backend/src/billing`
 - Overview: [Billing And Trial](../features/billing.md)
 

--- a/docs/features/billing.md
+++ b/docs/features/billing.md
@@ -14,8 +14,8 @@ writes stay open.
 `billing.enforcement` is a separate, independent switch — the operator's global
 kill switch for turning the whole trial/billing product on or off, regardless
 of whether Stripe is configured. It defaults to `false` (paused): every user,
-signed in or not, sees `{kind: "open"}` from `useAppAccess`, no chip, no gate
-modal, no `localStorage` clock stamp, and `assertBillingAllowsWrites` no-ops
+signed in or not, sees `{kind: "open"}` from `useAppAccess`, no trial badge, no
+gate modal, and `assertBillingAllowsWrites` no-ops
 even with valid Stripe keys present. This lets Stripe keys and Checkout/webhook
 work stay live in an environment while the product feels free to every user.
 
@@ -90,12 +90,28 @@ production.
   `BILLING_REQUIRED` branch in `useEventMutations` exits the preview, so the
   first refused save brings the gate straight back. That refusal does not
   show the catch-all "something went wrong" toast — the gate is the feedback.
-- **Trialing / active / past_due:** writable. `past_due` also shows a banner.
+- **Trialing:** writable, with a days-left badge in the sidebar month picker
+  header (`TrialBadge.tsx`, via `DatePicker`'s `headerEndContent` slot). The
+  badge carries no `tabindex`: `getPageJumpFocusElement` seats Mod+2 on the
+  first `[tabindex="0"]` inside the picker, and a tab stop here would steal
+  that jump.
+- **Active / past_due:** writable. `past_due` also shows a banner.
 - **Expired / canceled:** read-only until they subscribe again. A later
   Checkout does not grant another trial.
 
 There is no `POST /api/billing/trial/start`. A trial only begins through
 Stripe Checkout (`trial_period_days` on the first subscription).
+
+A trial can be *ended* early through `POST /api/billing/trial/end`, which calls
+`subscriptions.update(trial_end: "now")` and writes the returned Subscription
+through the webhook's own `applySubscription`, so status is fresh in the same
+response and the Stripe field mapping stays in one place. The Billing Portal
+cannot shorten a trial, which is why this endpoint exists. Three ways in, all
+gated on a running trial: the badge, a "Subscribe now" palette command, and
+bare `B`. That shortcut is registered by `UpgradeConfirmationProvider` rather
+than `useNavigationShortcuts`, which must stay usable without a QueryClient.
+A declined card lands on `past_due` (still writable), so the confirm dialog
+reports the resulting status instead of a blanket success.
 
 Existing accounts are not grandfathered. Hosted users without a Stripe
 subscription id (including missing billing, `none`, and local/backfill

--- a/packages/backend/src/billing/billing.routes.config.ts
+++ b/packages/backend/src/billing/billing.routes.config.ts
@@ -21,8 +21,8 @@ const stripeWebhookLimiter = rateLimit({
 });
 
 /**
- * Billing routes: trial status, Stripe Checkout, Billing Portal, and the
- * unauthenticated Stripe webhook.
+ * Billing routes: trial status, Stripe Checkout, ending a trial early,
+ * Billing Portal, and the unauthenticated Stripe webhook.
  */
 export class BillingRoutes extends CommonRoutesConfig {
   constructor(app: express.Application) {
@@ -39,6 +39,11 @@ export class BillingRoutes extends CommonRoutesConfig {
       .route(`/api/billing/checkout/session`)
       .all(verifySession())
       .post(sessionWriteLimiter, billingController.createCheckoutSession);
+
+    this.app
+      .route(`/api/billing/trial/end`)
+      .all(verifySession())
+      .post(sessionWriteLimiter, billingController.endTrial);
 
     this.app
       .route(`/api/billing/portal/session`)

--- a/packages/backend/src/billing/controllers/billing.controller.ts
+++ b/packages/backend/src/billing/controllers/billing.controller.ts
@@ -57,6 +57,19 @@ class BillingController {
     }
   };
 
+  endTrial = async (
+    req: Request<never, BillingStatusResponse, never, never>,
+    res: Response<BillingStatusResponse | { error: string }>,
+  ) => {
+    try {
+      const userId = zObjectId.parse(req.session?.getUserId());
+      const status = await stripeService.endTrialNow(userId.toString());
+      res.status(Status.OK).json(status);
+    } catch (e) {
+      sendBillingError(res, e);
+    }
+  };
+
   createPortalSession = async (
     req: Request<never, BillingPortalResponse, never, never>,
     res: Response<BillingPortalResponse | { error: string }>,

--- a/packages/backend/src/billing/services/billing.webhook.service.ts
+++ b/packages/backend/src/billing/services/billing.webhook.service.ts
@@ -51,7 +51,13 @@ const customerIdOf = (value: unknown): string | undefined => {
   return undefined;
 };
 
-async function applySubscription(
+/**
+ * The single place Stripe subscription fields are mapped onto `billing.*`.
+ * Exported because ending a trial early applies the Subscription that
+ * `subscriptions.update` returns through this same path, so the caller sees
+ * the new status immediately instead of waiting for the webhook to land.
+ */
+export async function applySubscription(
   userId: string,
   subscription: Stripe.Subscription,
   eventCreatedAt: Date,

--- a/packages/backend/src/billing/services/stripe.service.db.test.ts
+++ b/packages/backend/src/billing/services/stripe.service.db.test.ts
@@ -306,4 +306,161 @@ describe("StripeService", () => {
       clientMessage: "Couldn't start billing. Please try again in a moment.",
     });
   });
+  describe("endTrialNow", () => {
+    const seedTrialingUser = async (billing: Record<string, unknown> = {}) => {
+      const userId = mongoService.objectId();
+      await mongoService.user.insertOne({
+        _id: userId,
+        email: "trial@example.com",
+        name: "Trial User",
+        firstName: "Trial",
+        lastName: "User",
+        locale: "en",
+        billing: {
+          subscriptionStatus: "trialing",
+          stripeCustomerId: "cus_trial",
+          stripeSubscriptionId: "sub_trial",
+          ...billing,
+        },
+      });
+      return userId;
+    };
+
+    const stripeSubscription = (
+      status: string,
+      overrides: Record<string, unknown> = {},
+    ) =>
+      ({
+        id: "sub_trial",
+        status,
+        customer: "cus_trial",
+        cancel_at_period_end: false,
+        trial_start: 1_756_000_000,
+        trial_end: 1_756_200_000,
+        items: {
+          data: [
+            {
+              price: { id: "price_test" },
+              current_period_end: 1_758_800_000,
+            },
+          ],
+        },
+        ...overrides,
+      }) as unknown as Stripe.Subscription;
+
+    it("ends the trial now and reports the resulting active status", async () => {
+      using _env = mockEnv(stripeConfigured);
+      const userId = await seedTrialingUser();
+
+      const update = mock(() => Promise.resolve(stripeSubscription("active")));
+      setStripeClientForTests({
+        subscriptions: { update },
+      } as unknown as Stripe);
+
+      const result = await stripeService.endTrialNow(userId.toString());
+
+      expect(result).toEqual({
+        subscriptionStatus: "active",
+        trialEndsAt: new Date(1_756_200_000 * 1000).toISOString(),
+        isReadOnly: false,
+      });
+      expect(update.mock.calls[0]?.[0]).toBe("sub_trial");
+      expect(update.mock.calls[0]?.[1]).toEqual({
+        trial_end: "now",
+        proration_behavior: "none",
+      });
+      expect(update.mock.calls[0]?.[2]).toEqual({
+        idempotencyKey: "compass-end-trial-sub_trial",
+      });
+
+      const stored = await mongoService.user.findOne({ _id: userId });
+      expect(stored?.billing?.subscriptionStatus).toBe("active");
+      expect(stored?.billing?.stripePriceId).toBe("price_test");
+    });
+
+    it("reports past_due, still writable, when the charge fails", async () => {
+      using _env = mockEnv(stripeConfigured);
+      const userId = await seedTrialingUser();
+
+      setStripeClientForTests({
+        subscriptions: {
+          update: mock(() => Promise.resolve(stripeSubscription("past_due"))),
+        },
+      } as unknown as Stripe);
+
+      const result = await stripeService.endTrialNow(userId.toString());
+
+      expect(result.subscriptionStatus).toBe("past_due");
+      expect(result.isReadOnly).toBe(false);
+    });
+
+    it("still charges a trial that is set to cancel at period end", async () => {
+      using _env = mockEnv(stripeConfigured);
+      const userId = await seedTrialingUser({ cancelAtPeriodEnd: true });
+
+      setStripeClientForTests({
+        subscriptions: {
+          update: mock(() =>
+            Promise.resolve(
+              stripeSubscription("active", { cancel_at_period_end: true }),
+            ),
+          ),
+        },
+      } as unknown as Stripe);
+
+      const result = await stripeService.endTrialNow(userId.toString());
+
+      expect(result.subscriptionStatus).toBe("active");
+      const stored = await mongoService.user.findOne({ _id: userId });
+      expect(stored?.billing?.cancelAtPeriodEnd).toBe(true);
+    });
+
+    it("rejects with 409 when the account is not trialing", async () => {
+      using _env = mockEnv(stripeConfigured);
+      const userId = await seedTrialingUser({ subscriptionStatus: "active" });
+
+      const update = mock(() => Promise.resolve(stripeSubscription("active")));
+      setStripeClientForTests({
+        subscriptions: { update },
+      } as unknown as Stripe);
+
+      await expect(
+        stripeService.endTrialNow(userId.toString()),
+      ).rejects.toMatchObject({
+        name: "BillingHttpError",
+        status: 409,
+        clientMessage: "No active trial to end.",
+      });
+      expect(update).not.toHaveBeenCalled();
+    });
+
+    it("rejects with 409 when there is no Stripe subscription to end", async () => {
+      using _env = mockEnv(stripeConfigured);
+      const userId = await seedTrialingUser({
+        stripeSubscriptionId: undefined,
+      });
+
+      await expect(
+        stripeService.endTrialNow(userId.toString()),
+      ).rejects.toMatchObject({ status: 409 });
+    });
+
+    it("maps a Stripe failure to BillingHttpError", async () => {
+      using _env = mockEnv(stripeConfigured);
+      const userId = await seedTrialingUser();
+
+      const stripeError = new Stripe.errors.StripeInvalidRequestError({
+        message: "No such subscription",
+        type: "invalid_request_error",
+        statusCode: 400,
+      });
+      setStripeClientForTests({
+        subscriptions: { update: mock(() => Promise.reject(stripeError)) },
+      } as unknown as Stripe);
+
+      await expect(
+        stripeService.endTrialNow(userId.toString()),
+      ).rejects.toMatchObject({ name: "BillingHttpError", status: 400 });
+    });
+  });
 });

--- a/packages/backend/src/billing/services/stripe.service.ts
+++ b/packages/backend/src/billing/services/stripe.service.ts
@@ -1,9 +1,18 @@
-import { type BillingCheckoutResponse } from "@core/types/billing.types";
+import { Status } from "@core/errors/status.codes";
+import {
+  type BillingCheckoutResponse,
+  type BillingStatusResponse,
+} from "@core/types/billing.types";
 import {
   BILLING_PLAN,
   getStripePriceId,
 } from "@backend/billing/billing.constants";
-import { wrapStripeFailure } from "@backend/billing/billing.errors";
+import {
+  BillingHttpError,
+  wrapStripeFailure,
+} from "@backend/billing/billing.errors";
+import billingService from "@backend/billing/services/billing.service";
+import { applySubscription } from "@backend/billing/services/billing.webhook.service";
 import { getStripeClient } from "@backend/billing/services/stripe.client";
 import { CONFIG } from "@backend/common/constants/config.constants";
 import { isStripeConfigured } from "@backend/common/constants/config.util";
@@ -115,6 +124,50 @@ class StripeService {
     }
 
     return { url: session.url };
+  };
+
+  /**
+   * Ends a Stripe trial immediately, billing the card on file today. This is
+   * the only way to convert early: the Billing Portal cannot shorten a trial.
+   *
+   * The updated Subscription is written back through the webhook's
+   * `applySubscription`, so the caller's next status read is already correct
+   * and the trial badge clears without waiting for the webhook round trip.
+   * The webhook still arrives and is a no-op by way of the
+   * `lastStripeEventAt` guard.
+   *
+   * If the charge fails Stripe moves the subscription to `past_due`, which
+   * stays writable and raises the dunning banner. The caller is told the
+   * resulting status rather than a blanket success.
+   */
+  endTrialNow = async (userId: string): Promise<BillingStatusResponse> => {
+    if (!isStripeConfigured(CONFIG)) {
+      throw new Error("Stripe is not configured");
+    }
+
+    const _id = mongoService.objectId(userId);
+    const user = await mongoService.user.findOne({ _id });
+    if (!user) {
+      throw new Error("User not found");
+    }
+
+    const subscriptionId = user.billing?.stripeSubscriptionId;
+    if (!subscriptionId || user.billing?.subscriptionStatus !== "trialing") {
+      throw new BillingHttpError(Status.CONFLICT, "No active trial to end.");
+    }
+
+    const stripe = getStripeClient();
+    const subscription = await stripe.subscriptions
+      .update(
+        subscriptionId,
+        { trial_end: "now", proration_behavior: "none" },
+        { idempotencyKey: `compass-end-trial-${subscriptionId}` },
+      )
+      .catch(wrapStripeFailure);
+
+    await applySubscription(userId, subscription, new Date());
+
+    return billingService.getStatus(userId);
   };
 
   createPortalSession = async (

--- a/packages/web/src/api/billing.api.ts
+++ b/packages/web/src/api/billing.api.ts
@@ -22,6 +22,13 @@ const BillingApi = {
     return BillingCheckoutResponseSchema.parse(response.data);
   },
 
+  /** Ends the Stripe trial now, charging the card on file today. */
+  async endTrial(): Promise<BillingStatusResponse> {
+    const response =
+      await BaseApi.post<BillingStatusResponse>(`/billing/trial/end`);
+    return BillingStatusResponseSchema.parse(response.data);
+  },
+
   async createPortalSession(): Promise<BillingPortalResponse> {
     const response = await BaseApi.post<BillingPortalResponse>(
       `/billing/portal/session`,

--- a/packages/web/src/billing/TrialBadge.test.tsx
+++ b/packages/web/src/billing/TrialBadge.test.tsx
@@ -1,0 +1,146 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { type AppAccess } from "@web/billing/useAppAccess";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+
+const actualUseAppAccess = (await import("@web/billing/useAppAccess"))
+  .useAppAccess;
+let isAppAccessMocked = true;
+let access: AppAccess = { kind: "open" };
+
+mock.module("@web/billing/useAppAccess", () => ({
+  useAppAccess: (...args: Parameters<typeof actualUseAppAccess>) =>
+    isAppAccessMocked ? access : actualUseAppAccess(...args),
+}));
+
+// mock.module is process-wide: spread the real module and delegate back once
+// this file is done, or every later suite loses the other exports.
+const actualUpgradeConfirmation = {
+  ...(await import(
+    "@web/billing/UpgradeConfirmation/hooks/useUpgradeConfirmation"
+  )),
+};
+// Bound to a bare identifier so the delegate call is not a `use*` member
+// expression, which the rules-of-hooks lint reads as a conditional hook.
+const realUpgradeConfirmation =
+  actualUpgradeConfirmation.useUpgradeConfirmation;
+let isUpgradeConfirmationMocked = true;
+const openUpgradeConfirmation = mock(() => {});
+
+mock.module(
+  "@web/billing/UpgradeConfirmation/hooks/useUpgradeConfirmation",
+  () => ({
+    ...actualUpgradeConfirmation,
+    useUpgradeConfirmation: () =>
+      isUpgradeConfirmationMocked
+        ? {
+            isOpen: false,
+            openUpgradeConfirmation,
+            closeUpgradeConfirmation: () => {},
+          }
+        : realUpgradeConfirmation(),
+  }),
+);
+
+const { TrialBadge } = await import("@web/billing/TrialBadge");
+
+afterAll(() => {
+  isAppAccessMocked = false;
+  isUpgradeConfirmationMocked = false;
+});
+
+const trialEndingIn = (days: number) =>
+  new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
+
+describe("TrialBadge", () => {
+  beforeEach(() => {
+    access = { kind: "open" };
+    openUpgradeConfirmation.mockClear();
+  });
+
+  it("shows the days remaining while trialing", () => {
+    access = {
+      kind: "server",
+      status: "trialing",
+      isReadOnly: false,
+      trialEndsAt: trialEndingIn(5),
+    };
+    render(<TrialBadge />);
+
+    const badge = screen.getByRole("button", {
+      name: "5 days left in your trial. Subscribe now.",
+    });
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent("5d");
+  });
+
+  it("names the last day rather than showing 0", () => {
+    access = {
+      kind: "server",
+      status: "trialing",
+      isReadOnly: false,
+      trialEndsAt: trialEndingIn(-1),
+    };
+    render(<TrialBadge />);
+
+    expect(
+      screen.getByRole("button", {
+        name: "Last day of your trial. Subscribe now.",
+      }),
+    ).toHaveTextContent("Last day");
+  });
+
+  it("carries no tabindex, so Mod+2 still lands on the day grid", () => {
+    access = {
+      kind: "server",
+      status: "trialing",
+      isReadOnly: false,
+      trialEndsAt: trialEndingIn(3),
+    };
+    render(<TrialBadge />);
+
+    expect(screen.getByRole("button")).not.toHaveAttribute("tabindex");
+  });
+
+  it("opens the upgrade confirmation when activated", async () => {
+    access = {
+      kind: "server",
+      status: "trialing",
+      isReadOnly: false,
+      trialEndsAt: trialEndingIn(3),
+    };
+    render(<TrialBadge />);
+
+    await userEvent.click(screen.getByRole("button"));
+    expect(openUpgradeConfirmation).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders nothing for a paying subscriber", () => {
+    access = {
+      kind: "server",
+      status: "active",
+      isReadOnly: false,
+      trialEndsAt: null,
+    };
+    const { container } = render(<TrialBadge />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when billing is not enforced", () => {
+    access = { kind: "open" };
+    const { container } = render(<TrialBadge />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing for an account awaiting checkout", () => {
+    access = {
+      kind: "server",
+      status: "awaiting_checkout",
+      isReadOnly: true,
+      trialEndsAt: null,
+    };
+    const { container } = render(<TrialBadge />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/packages/web/src/billing/TrialBadge.tsx
+++ b/packages/web/src/billing/TrialBadge.tsx
@@ -1,0 +1,46 @@
+import {
+  formatTrialBadgeDescription,
+  formatTrialBadgeLabel,
+  getTrialDaysLeft,
+} from "@web/billing/trialDaysLeft";
+import { useUpgradeConfirmation } from "@web/billing/UpgradeConfirmation/hooks/useUpgradeConfirmation";
+import { useAppAccess } from "@web/billing/useAppAccess";
+import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
+
+/**
+ * Days-left pill in the month picker's header row, and the shortest path to
+ * ending the trial early.
+ *
+ * Deliberately carries no `tabindex`: `getPageJumpFocusElement` seats Mod+2 on
+ * the first `[tabindex="0"]` inside the picker, which is react-datepicker's
+ * selected day. A tab stop here would steal that jump. As a plain button it is
+ * still Tab-reachable, exactly like the prev/next arrows beside it.
+ */
+export function TrialBadge() {
+  const access = useAppAccess();
+  const { openUpgradeConfirmation } = useUpgradeConfirmation();
+
+  if (
+    access.kind !== "server" ||
+    access.status !== "trialing" ||
+    !access.trialEndsAt
+  ) {
+    return null;
+  }
+
+  const daysLeft = getTrialDaysLeft(access.trialEndsAt);
+  const description = formatTrialBadgeDescription(daysLeft);
+
+  return (
+    <TooltipWrapper description={`${description}. Press B to subscribe.`}>
+      <button
+        aria-label={`${description}. Subscribe now.`}
+        className="c-keycap c-focus-ring cursor-pointer text-xs"
+        onClick={openUpgradeConfirmation}
+        type="button"
+      >
+        {formatTrialBadgeLabel(daysLeft)}
+      </button>
+    </TooltipWrapper>
+  );
+}

--- a/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationDialog.tsx
+++ b/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationDialog.tsx
@@ -1,0 +1,63 @@
+import {
+  OverlayPanel,
+  OverlayPanelActionButton,
+  OverlayPanelActions,
+} from "@web/components/OverlayPanel/OverlayPanel";
+
+interface UpgradeConfirmationDialogProps {
+  isOpen: boolean;
+  isSubmitting: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+  onManageBilling: () => void;
+}
+
+/**
+ * Confirms ending a Stripe trial early. No amount is shown here on purpose:
+ * the price lives on the Stripe Price, not in this codebase, so operators can
+ * change it without a web deploy. "Manage billing" is the way to see the card
+ * and the exact charge before committing.
+ */
+export function UpgradeConfirmationDialog({
+  isOpen,
+  isSubmitting,
+  onCancel,
+  onConfirm,
+  onManageBilling,
+}: UpgradeConfirmationDialogProps) {
+  if (!isOpen) return null;
+
+  return (
+    <OverlayPanel
+      title="End your trial and subscribe?"
+      message="Your trial ends right away and the card on file is charged today. Your calendar keeps working, and the trial badge goes away."
+      onDismiss={onCancel}
+      align="start"
+      variant="modal"
+    >
+      <OverlayPanelActions align="start">
+        <OverlayPanelActionButton
+          variant="primary"
+          shortcut="Enter"
+          disabled={isSubmitting}
+          onClick={onConfirm}
+        >
+          {isSubmitting ? "Subscribing…" : "Subscribe now"}
+        </OverlayPanelActionButton>
+        <OverlayPanelActionButton
+          shortcut="Esc"
+          disabled={isSubmitting}
+          onClick={onCancel}
+        >
+          Cancel
+        </OverlayPanelActionButton>
+        <OverlayPanelActionButton
+          disabled={isSubmitting}
+          onClick={onManageBilling}
+        >
+          Manage billing
+        </OverlayPanelActionButton>
+      </OverlayPanelActions>
+    </OverlayPanel>
+  );
+}

--- a/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationProvider.test.tsx
+++ b/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationProvider.test.tsx
@@ -1,0 +1,170 @@
+import "@testing-library/jest-dom";
+import { HotkeysProvider } from "@tanstack/react-hotkeys";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
+import { BillingApi } from "@web/api/billing.api";
+import { useUpgradeConfirmation } from "@web/billing/UpgradeConfirmation/hooks/useUpgradeConfirmation";
+import { UpgradeConfirmationProvider } from "@web/billing/UpgradeConfirmation/UpgradeConfirmationProvider";
+import {
+  registerToastPort,
+  resetToastPort,
+} from "@web/common/utils/toast/toast.port";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+
+// Register a toast port rather than spying the toast utils: spyOn patches the
+// shared module object, so calls here would leak into other suites' spies.
+let toastMocks: ReturnType<typeof createTestToastPort>["mocks"];
+const assign = spyOn(window.location, "assign").mockImplementation(() => {});
+
+function OpenButton() {
+  const { openUpgradeConfirmation } = useUpgradeConfirmation();
+  return (
+    <button type="button" onClick={openUpgradeConfirmation}>
+      open upgrade
+    </button>
+  );
+}
+
+const renderProvider = () =>
+  render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <HotkeysProvider>
+        <UpgradeConfirmationProvider>
+          <OpenButton />
+        </UpgradeConfirmationProvider>
+      </HotkeysProvider>
+    </QueryClientProvider>,
+  );
+
+const openDialog = async () => {
+  renderProvider();
+  await userEvent.click(screen.getByRole("button", { name: "open upgrade" }));
+  return screen.getByRole("dialog", {
+    name: "End your trial and subscribe?",
+  });
+};
+
+beforeEach(() => {
+  const { port, mocks } = createTestToastPort();
+  toastMocks = mocks;
+  registerToastPort(port);
+});
+
+afterEach(() => {
+  resetToastPort();
+  assign.mockClear();
+});
+
+describe("UpgradeConfirmationProvider", () => {
+  it("does not name a price, since the price lives in Stripe", async () => {
+    const dialog = await openDialog();
+    expect(dialog.textContent).not.toMatch(/\$|\bUSD\b|\bmonth\b/);
+    expect(dialog).toHaveTextContent("the card on file is charged today");
+  });
+
+  it("ends the trial and confirms the subscription", async () => {
+    const endTrial = spyOn(BillingApi, "endTrial").mockResolvedValue({
+      subscriptionStatus: "active",
+      trialEndsAt: null,
+      isReadOnly: false,
+    });
+    await openDialog();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /Subscribe now/ }),
+    );
+
+    await waitFor(() => {
+      expect(endTrial).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(toastMocks.toast).toHaveBeenCalledWith(
+        "You're subscribed",
+        expect.objectContaining({ toastId: "billing-subscribed" }),
+      );
+    });
+    expect(toastMocks.error).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole("dialog", { name: "End your trial and subscribe?" }),
+    ).not.toBeInTheDocument();
+    endTrial.mockRestore();
+  });
+
+  it("reports a declined card instead of a false success", async () => {
+    const endTrial = spyOn(BillingApi, "endTrial").mockResolvedValue({
+      subscriptionStatus: "past_due",
+      trialEndsAt: null,
+      isReadOnly: false,
+    });
+    await openDialog();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /Subscribe now/ }),
+    );
+
+    await waitFor(() => {
+      expect(toastMocks.error).toHaveBeenCalledWith(
+        "We ended your trial, but the payment didn't go through. Check your card under Manage billing.",
+        expect.anything(),
+      );
+    });
+    expect(toastMocks.toast).not.toHaveBeenCalled();
+    endTrial.mockRestore();
+  });
+
+  it("surfaces a failed request as an error toast", async () => {
+    const endTrial = spyOn(BillingApi, "endTrial").mockRejectedValue(
+      new Error("boom"),
+    );
+    await openDialog();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /Subscribe now/ }),
+    );
+
+    await waitFor(() => {
+      expect(toastMocks.error).toHaveBeenCalledWith(
+        "Couldn't subscribe. Please try again.",
+        expect.anything(),
+      );
+    });
+    endTrial.mockRestore();
+  });
+
+  it("closes on cancel without calling Stripe", async () => {
+    const endTrial = spyOn(BillingApi, "endTrial");
+    await openDialog();
+
+    await userEvent.click(screen.getByRole("button", { name: /Cancel/ }));
+
+    expect(
+      screen.queryByRole("dialog", { name: "End your trial and subscribe?" }),
+    ).not.toBeInTheDocument();
+    expect(endTrial).not.toHaveBeenCalled();
+    endTrial.mockRestore();
+  });
+
+  it("sends Manage billing to the Stripe portal", async () => {
+    const portal = spyOn(BillingApi, "createPortalSession").mockResolvedValue({
+      url: "https://billing.stripe.com/p/session_1",
+    });
+    await openDialog();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Manage billing" }),
+    );
+
+    await waitFor(() => {
+      expect(assign).toHaveBeenCalledWith(
+        "https://billing.stripe.com/p/session_1",
+      );
+    });
+    portal.mockRestore();
+  });
+});

--- a/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationProvider.tsx
+++ b/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationProvider.tsx
@@ -1,0 +1,103 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { type PropsWithChildren, useCallback, useState } from "react";
+import { BillingApi } from "@web/api/billing.api";
+import {
+  getApiErrorMessage,
+  isSessionLevelError,
+} from "@web/api/util/api.util";
+import { track } from "@web/auth/posthog/track";
+import { billingQueryKeys } from "@web/billing/billing.query";
+import {
+  UpgradeConfirmationContext,
+  useUpgradeConfirmationState,
+} from "@web/billing/UpgradeConfirmation/hooks/useUpgradeConfirmation";
+import { UpgradeConfirmationDialog } from "@web/billing/UpgradeConfirmation/UpgradeConfirmationDialog";
+import { useIsTrialing } from "@web/billing/useIsTrialing";
+import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
+import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
+import { useAppShortcutUp } from "@web/shortcuts/useAppShortcut";
+
+const SUBSCRIBED_TOAST_ID = "billing-subscribed";
+
+export function UpgradeConfirmationProvider({ children }: PropsWithChildren) {
+  const value = useUpgradeConfirmationState();
+  const { closeUpgradeConfirmation, isOpen } = value;
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const queryClient = useQueryClient();
+  const isTrialing = useIsTrialing();
+
+  // Bare "B" for billing. The feature owns its own trigger rather than
+  // `useNavigationShortcuts`, which must stay usable without a QueryClient.
+  // Registered only while a trial runs, so the key stays free otherwise. No
+  // `ignoreAppLock`: a gate or dialog already owning the screen keeps it.
+  useAppShortcutUp(
+    "B",
+    () => {
+      value.openUpgradeConfirmation();
+    },
+    { enabled: isTrialing },
+  );
+
+  const reportFailure = useCallback((error: unknown, fallback: string) => {
+    if (isSessionLevelError(error)) return;
+    const fromApi = getApiErrorMessage(error);
+    showErrorToast(
+      fromApi && fromApi !== "Internal server error" ? fromApi : fallback,
+    );
+  }, []);
+
+  const handleConfirm = useCallback(() => {
+    setIsSubmitting(true);
+    void (async () => {
+      try {
+        const status = await BillingApi.endTrial();
+        await queryClient.invalidateQueries({
+          queryKey: billingQueryKeys.status,
+        });
+        closeUpgradeConfirmation();
+
+        // Report what actually happened. A declined card lands on past_due,
+        // which still writes but needs the user's attention, so it must not
+        // be dressed up as a successful upgrade.
+        if (status.subscriptionStatus === "active") {
+          track("trial_converted");
+          showStatusToast(SUBSCRIBED_TOAST_ID, "You're subscribed");
+        } else {
+          showErrorToast(
+            "We ended your trial, but the payment didn't go through. Check your card under Manage billing.",
+          );
+        }
+      } catch (error) {
+        reportFailure(error, "Couldn't subscribe. Please try again.");
+      } finally {
+        setIsSubmitting(false);
+      }
+    })();
+  }, [closeUpgradeConfirmation, queryClient, reportFailure]);
+
+  const handleManageBilling = useCallback(() => {
+    setIsSubmitting(true);
+    void (async () => {
+      try {
+        const { url } = await BillingApi.createPortalSession();
+        window.location.assign(url);
+      } catch (error) {
+        reportFailure(error, "Couldn't open billing. Please try again.");
+        setIsSubmitting(false);
+      }
+    })();
+  }, [reportFailure]);
+
+  return (
+    <UpgradeConfirmationContext.Provider value={value}>
+      {children}
+      <UpgradeConfirmationDialog
+        isOpen={isOpen}
+        isSubmitting={isSubmitting}
+        onCancel={closeUpgradeConfirmation}
+        onConfirm={handleConfirm}
+        onManageBilling={handleManageBilling}
+      />
+    </UpgradeConfirmationContext.Provider>
+  );
+}

--- a/packages/web/src/billing/UpgradeConfirmation/hooks/useUpgradeConfirmation.ts
+++ b/packages/web/src/billing/UpgradeConfirmation/hooks/useUpgradeConfirmation.ts
@@ -1,0 +1,47 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+
+interface UpgradeConfirmationContextValue {
+  isOpen: boolean;
+  closeUpgradeConfirmation: () => void;
+  openUpgradeConfirmation: () => void;
+}
+
+const defaultContextValue: UpgradeConfirmationContextValue = {
+  isOpen: false,
+  closeUpgradeConfirmation: () => {},
+  openUpgradeConfirmation: () => {},
+};
+
+export const UpgradeConfirmationContext =
+  createContext<UpgradeConfirmationContextValue>(defaultContextValue);
+
+export function useUpgradeConfirmation(): UpgradeConfirmationContextValue {
+  return useContext(UpgradeConfirmationContext);
+}
+
+export function useUpgradeConfirmationState(): UpgradeConfirmationContextValue {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const openUpgradeConfirmation = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  const closeUpgradeConfirmation = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  return useMemo(
+    () => ({
+      isOpen,
+      closeUpgradeConfirmation,
+      openUpgradeConfirmation,
+    }),
+    [isOpen, closeUpgradeConfirmation, openUpgradeConfirmation],
+  );
+}

--- a/packages/web/src/billing/trialDaysLeft.test.ts
+++ b/packages/web/src/billing/trialDaysLeft.test.ts
@@ -1,0 +1,48 @@
+import dayjs from "@core/util/date/dayjs";
+import {
+  formatTrialBadgeDescription,
+  formatTrialBadgeLabel,
+  getTrialDaysLeft,
+} from "@web/billing/trialDaysLeft";
+import { describe, expect, it } from "bun:test";
+
+const now = dayjs("2026-08-27T12:00:00.000Z");
+
+describe("getTrialDaysLeft", () => {
+  it("rounds a partial final day up to 1", () => {
+    expect(getTrialDaysLeft("2026-08-27T18:00:00.000Z", now)).toBe(1);
+  });
+
+  it("counts a full seven-day trial", () => {
+    expect(getTrialDaysLeft("2026-09-03T12:00:00.000Z", now)).toBe(7);
+  });
+
+  it("rounds a partial day up rather than down", () => {
+    expect(getTrialDaysLeft("2026-09-03T13:00:00.000Z", now)).toBe(8);
+  });
+
+  it("clamps a past end date to 0", () => {
+    expect(getTrialDaysLeft("2026-08-20T12:00:00.000Z", now)).toBe(0);
+  });
+
+  it("returns 0 for an unparseable date rather than NaN", () => {
+    expect(getTrialDaysLeft("not-a-date", now)).toBe(0);
+  });
+});
+
+describe("trial badge copy", () => {
+  it("labels the last day without a number", () => {
+    expect(formatTrialBadgeLabel(0)).toBe("Last day");
+    expect(formatTrialBadgeDescription(0)).toBe("Last day of your trial");
+  });
+
+  it("uses a compact label and a full description", () => {
+    expect(formatTrialBadgeLabel(7)).toBe("7d");
+    expect(formatTrialBadgeDescription(7)).toBe("7 days left in your trial");
+  });
+
+  it("singularizes one day", () => {
+    expect(formatTrialBadgeLabel(1)).toBe("1d");
+    expect(formatTrialBadgeDescription(1)).toBe("1 day left in your trial");
+  });
+});

--- a/packages/web/src/billing/trialDaysLeft.ts
+++ b/packages/web/src/billing/trialDaysLeft.ts
@@ -1,0 +1,30 @@
+import dayjs from "@core/util/date/dayjs";
+
+/**
+ * Whole days remaining before `trialEndsAt`, for the sidebar trial badge.
+ *
+ * Rounded up so the final partial day still reads as "1 day left" rather than
+ * "0": the trial is live until Stripe says otherwise, and a badge showing 0
+ * while the app still works is a lie. Clamped at 0 for a past date, which the
+ * badge treats as its last day.
+ */
+export function getTrialDaysLeft(
+  trialEndsAt: string,
+  now: dayjs.Dayjs = dayjs(),
+): number {
+  const end = dayjs(trialEndsAt);
+  if (!end.isValid()) return 0;
+  return Math.max(0, Math.ceil(end.diff(now, "day", true)));
+}
+
+/** Badge text. Compact, because the month picker header row is narrow. */
+export function formatTrialBadgeLabel(daysLeft: number): string {
+  return daysLeft <= 0 ? "Last day" : `${daysLeft}d`;
+}
+
+/** The full sentence, for screen readers and the tooltip. */
+export function formatTrialBadgeDescription(daysLeft: number): string {
+  if (daysLeft <= 0) return "Last day of your trial";
+  if (daysLeft === 1) return "1 day left in your trial";
+  return `${daysLeft} days left in your trial`;
+}

--- a/packages/web/src/billing/useAppAccess.test.tsx
+++ b/packages/web/src/billing/useAppAccess.test.tsx
@@ -69,6 +69,27 @@ describe("useAppAccess", () => {
     });
   });
 
+  it("returns server trialing status with the trial end date", async () => {
+    stubConfig(true);
+    stubBilling({
+      subscriptionStatus: "trialing",
+      trialEndsAt: "2026-09-03T00:00:00.000Z",
+      isReadOnly: false,
+    });
+
+    const { result } = renderHook(() => useAppAccess(), {
+      wrapper: createWrapper(true),
+    });
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        kind: "server",
+        status: "trialing",
+        isReadOnly: false,
+        trialEndsAt: "2026-09-03T00:00:00.000Z",
+      });
+    });
+  });
+
   it("fails open while authenticated billing status is loading", () => {
     stubConfig(true);
     server.use(

--- a/packages/web/src/billing/useIsTrialing.ts
+++ b/packages/web/src/billing/useIsTrialing.ts
@@ -1,0 +1,11 @@
+import { useAppAccess } from "@web/billing/useAppAccess";
+
+/**
+ * True only while a Stripe trial is running. Gates the surfaces that offer an
+ * early upgrade: the sidebar badge, the palette command, the "B" shortcut, and
+ * that shortcut's row in the `?` legend.
+ */
+export function useIsTrialing(): boolean {
+  const access = useAppAccess();
+  return access.kind === "server" && access.status === "trialing";
+}

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -21,6 +21,7 @@ import { useDemoEventsCmdItems } from "@web/components/CommandPalette/hooks/useD
 import { useLogoutCmdItems } from "@web/components/CommandPalette/hooks/useLogoutCmdItems";
 import { useShowAccountsCmdItems } from "@web/components/CommandPalette/hooks/useShowAccountsCmdItems";
 import { useThemeCmdItems } from "@web/components/CommandPalette/hooks/useThemeCmdItems";
+import { useUpgradeCmdItems } from "@web/components/CommandPalette/hooks/useUpgradeCmdItems";
 import { getMoreCommandPaletteSections } from "@web/components/CommandPalette/more.cmd.constants";
 import {
   getNavigationCommandItems,
@@ -297,6 +298,7 @@ export const CommandPalette = ({
   const showAccountsCmdItems = useShowAccountsCmdItems();
   const logoutCmdItems = useLogoutCmdItems();
   const themeCmdItems = useThemeCmdItems();
+  const upgradeCmdItems = useUpgradeCmdItems();
   const timezoneCmdItems = useTimezoneCmdItems();
   const notificationCmdItems = useNotificationCmdItems();
   const { undo, redo, canUndo, canRedo } = useUndoRedo(mutationDependencies);
@@ -353,6 +355,7 @@ export const CommandPalette = ({
       id: "settings",
       heading: "Settings",
       items: [
+        ...upgradeCmdItems,
         ...timezoneCmdItems,
         ...notificationCmdItems,
         ...authCmdItems,

--- a/packages/web/src/components/CommandPalette/hooks/useUpgradeCmdItems.test.tsx
+++ b/packages/web/src/components/CommandPalette/hooks/useUpgradeCmdItems.test.tsx
@@ -1,0 +1,87 @@
+import { renderHook } from "@testing-library/react";
+import { type AppAccess } from "@web/billing/useAppAccess";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+
+// mock.module is process-wide: spread the real modules and delegate back once
+// this file is done, or every later suite loses the other exports.
+const actualAppAccess = { ...(await import("@web/billing/useAppAccess")) };
+const actualUpgradeConfirmation = {
+  ...(await import(
+    "@web/billing/UpgradeConfirmation/hooks/useUpgradeConfirmation"
+  )),
+};
+// Bound to bare identifiers so the delegate calls are not `use*` member
+// expressions, which the rules-of-hooks lint reads as conditional hooks.
+const realAppAccess = actualAppAccess.useAppAccess;
+const realUpgradeConfirmation =
+  actualUpgradeConfirmation.useUpgradeConfirmation;
+let isMocked = true;
+let access: AppAccess = { kind: "open" };
+const openUpgradeConfirmation = mock(() => {});
+
+mock.module("@web/billing/useAppAccess", () => ({
+  ...actualAppAccess,
+  useAppAccess: (...args: Parameters<typeof realAppAccess>) =>
+    isMocked ? access : realAppAccess(...args),
+}));
+
+mock.module(
+  "@web/billing/UpgradeConfirmation/hooks/useUpgradeConfirmation",
+  () => ({
+    ...actualUpgradeConfirmation,
+    useUpgradeConfirmation: () =>
+      isMocked
+        ? {
+            isOpen: false,
+            openUpgradeConfirmation,
+            closeUpgradeConfirmation: () => {},
+          }
+        : realUpgradeConfirmation(),
+  }),
+);
+
+const { useUpgradeCmdItems } = await import(
+  "@web/components/CommandPalette/hooks/useUpgradeCmdItems"
+);
+
+afterAll(() => {
+  isMocked = false;
+});
+
+describe("useUpgradeCmdItems", () => {
+  beforeEach(() => {
+    access = { kind: "open" };
+    openUpgradeConfirmation.mockClear();
+  });
+
+  it("offers Subscribe now while trialing", () => {
+    access = {
+      kind: "server",
+      status: "trialing",
+      isReadOnly: false,
+      trialEndsAt: "2026-09-03T00:00:00.000Z",
+    };
+    const { result } = renderHook(() => useUpgradeCmdItems());
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]?.label).toBe("Subscribe now");
+    result.current[0]?.onClick?.();
+    expect(openUpgradeConfirmation).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers nothing to a paying subscriber", () => {
+    access = {
+      kind: "server",
+      status: "active",
+      isReadOnly: false,
+      trialEndsAt: null,
+    };
+    const { result } = renderHook(() => useUpgradeCmdItems());
+    expect(result.current).toEqual([]);
+  });
+
+  it("offers nothing when billing is not enforced", () => {
+    const { result } = renderHook(() => useUpgradeCmdItems());
+    expect(result.current).toEqual([]);
+  });
+});

--- a/packages/web/src/components/CommandPalette/hooks/useUpgradeCmdItems.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useUpgradeCmdItems.ts
@@ -1,0 +1,32 @@
+import { CreditCardIcon } from "@phosphor-icons/react";
+import { useUpgradeConfirmation } from "@web/billing/UpgradeConfirmation/hooks/useUpgradeConfirmation";
+import { useIsTrialing } from "@web/billing/useIsTrialing";
+import { type CommandItem } from "@web/components/CommandPalette/command-palette.types";
+
+/** Only offered while a Stripe trial is actually running. */
+export const useUpgradeCmdItems = (): CommandItem[] => {
+  const isTrialing = useIsTrialing();
+  const { openUpgradeConfirmation } = useUpgradeConfirmation();
+
+  if (!isTrialing) {
+    return [];
+  }
+
+  return [
+    {
+      id: "subscribe-now",
+      label: "Subscribe now",
+      icon: CreditCardIcon,
+      keywords: [
+        "billing",
+        "subscribe",
+        "trial",
+        "pay",
+        "premium",
+        "upgrade",
+        "payment",
+      ],
+      onClick: openUpgradeConfirmation,
+    },
+  ];
+};

--- a/packages/web/src/components/CompassProvider/CompassProvider.tsx
+++ b/packages/web/src/components/CompassProvider/CompassProvider.tsx
@@ -8,6 +8,7 @@ import { queryClient as defaultQueryClient } from "@web/api/query-client";
 import { SessionProvider } from "@web/auth/compass/session/SessionProvider";
 import { getPosthogClient } from "@web/auth/posthog/posthog.bootstrap";
 import { PostHogProvider } from "@web/auth/posthog/posthog-react";
+import { UpgradeConfirmationProvider } from "@web/billing/UpgradeConfirmation/UpgradeConfirmationProvider";
 import { ENV_WEB } from "@web/common/constants/env.constants";
 import { useEscapeToDismissToast } from "@web/common/utils/toast/useEscapeToDismissToast";
 import { AboutModal } from "@web/components/About/AboutModal";
@@ -70,10 +71,12 @@ export const CompassRequiredProviders = ({
           <IconProvider>
             <LogoutConfirmationProvider>
               <DeleteAccountConfirmationProvider>
-                {children}
-                <SettingsModal />
-                <TimezoneDialogHost />
-                <AboutModal />
+                <UpgradeConfirmationProvider>
+                  {children}
+                  <SettingsModal />
+                  <TimezoneDialogHost />
+                  <AboutModal />
+                </UpgradeConfirmationProvider>
               </DeleteAccountConfirmationProvider>
               <ThemeAwareToastContainer />
             </LogoutConfirmationProvider>

--- a/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.test.tsx
+++ b/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.test.tsx
@@ -3,6 +3,7 @@ import {
   HotkeysProvider,
   resolveModifier,
 } from "@tanstack/react-hotkeys";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { act, type PropsWithChildren, type ReactElement } from "react";
@@ -21,8 +22,15 @@ const getSelectedDay = () =>
 
 const dayNamed = (label: string) => screen.getByLabelText(label);
 
+// The header's TrialBadge reads billing status through react-query, so the
+// picker needs a client the way it does in the real app, on top of the
+// hotkeys provider the month chords already required.
 const wrapper = ({ children }: PropsWithChildren) => (
-  <HotkeysProvider>{children}</HotkeysProvider>
+  <QueryClientProvider
+    client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+  >
+    <HotkeysProvider>{children}</HotkeysProvider>
+  </QueryClientProvider>
 );
 
 const renderPicker = (ui: ReactElement) => render(ui, { wrapper });

--- a/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.tsx
+++ b/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.tsx
@@ -1,5 +1,6 @@
 import { type FC, useEffect, useRef, useState } from "react";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+import { TrialBadge } from "@web/billing/TrialBadge";
 import { ID_DATEPICKER_SIDEBAR } from "@web/common/constants/web.constants";
 import { DatePicker } from "@web/components/DatePicker/DatePicker";
 import { pageJumpAttrs } from "@web/shortcuts/page-jump/page-jump.targets";
@@ -82,6 +83,7 @@ export const MonthPicker: FC<Props> = ({
         dayClassName={getDayClassName}
         headerActionsClassName={headerActionsClassName}
         headerClassName="!relative !justify-start !px-0 !pb-3"
+        headerEndContent={<TrialBadge />}
         inline
         isOpen={true}
         monthNav={{

--- a/packages/web/src/shortcuts/global.shortcut.types.ts
+++ b/packages/web/src/shortcuts/global.shortcut.types.ts
@@ -2,6 +2,8 @@ export interface ShortcutContext {
   isFormOpen?: boolean;
   lifeView?: boolean;
   weekView?: boolean;
+  /** Only listed while a Stripe trial is running. */
+  isTrialing?: boolean;
 }
 
 export interface Shortcut {

--- a/packages/web/src/shortcuts/shortcuts.registry.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.test.ts
@@ -67,6 +67,29 @@ describe("shortcuts.registry", () => {
       expect(ids).toContain("edit-save");
     });
 
+    it("hides the subscribe row unless a trial is running", () => {
+      const ids = filterShortcutsByContext({
+        view: "week",
+        isViewingCurrentPeriod: true,
+        isTrialing: false,
+      }).map((s) => s.id);
+
+      expect(ids).not.toContain("other-subscribe");
+    });
+
+    it("lists the subscribe row in every view while trialing", () => {
+      for (const view of ["day", "week", "life"] as const) {
+        const shortcut = filterShortcutsByContext({
+          view,
+          isViewingCurrentPeriod: true,
+          isTrialing: true,
+        }).find((s) => s.id === "other-subscribe");
+
+        expect(shortcut?.keys).toEqual(["b"]);
+        expect(shortcut?.label).toBe("Subscribe now");
+      }
+    });
+
     it("lists f and m, and never advertises F10, in the legend", () => {
       const week = filterShortcutsByContext({
         view: "week",

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -376,6 +376,13 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
     section: "other",
   },
   {
+    id: "other-subscribe",
+    keys: ["b"],
+    label: "Subscribe now",
+    section: "other",
+    when: { isTrialing: true },
+  },
+  {
     id: "other-settings",
     keys: ["Mod", ","],
     label: "Settings",
@@ -405,6 +412,7 @@ interface FilterOptions {
   view: "day" | "week" | "life";
   isViewingCurrentPeriod: boolean;
   isFormOpen?: boolean;
+  isTrialing?: boolean;
 }
 
 // Context-sensitive display labels, keyed by shortcut id. Each override lives
@@ -433,7 +441,7 @@ const LABEL_OVERRIDES: Record<string, (options: FilterOptions) => string> = {
 export const filterShortcutsByContext = (
   options: FilterOptions,
 ): Shortcut[] => {
-  const { view, isFormOpen } = options;
+  const { view, isFormOpen, isTrialing } = options;
 
   return SHORTCUTS_REGISTRY.map((shortcut) => ({
     ...shortcut,
@@ -487,6 +495,9 @@ export const filterShortcutsByContext = (
 
     // Filter by context predicates
     if (shortcut.when?.isFormOpen && !isFormOpen) {
+      return false;
+    }
+    if (shortcut.when?.isTrialing && !isTrialing) {
       return false;
     }
 

--- a/packages/web/src/views/Day/view/DayViewContent.tsx
+++ b/packages/web/src/views/Day/view/DayViewContent.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useMemo, useRef } from "react";
+import { useIsTrialing } from "@web/billing/useIsTrialing";
 import { ID_MAIN } from "@web/common/constants/web.constants";
 import { useHorizontalNavigation } from "@web/common/hooks/useHorizontalNavigation";
 import { emitViewCommand } from "@web/common/utils/dom/view-command-bus";
@@ -62,14 +63,16 @@ export const DayViewContent = memo(() => {
   useFocusSidebarShortcut();
   useSidebarShortcuts();
 
+  const isTrialing = useIsTrialing();
   const shortcutSections = useMemo(
     () =>
       getShortcutMenuSections({
         view: "day",
         isViewingCurrentPeriod: isViewingToday,
         isFormOpen: isEventDetailsOpen,
+        isTrialing,
       }),
-    [isEventDetailsOpen, isViewingToday],
+    [isEventDetailsOpen, isTrialing, isViewingToday],
   );
 
   const handleGoToToday = useCallback(() => {

--- a/packages/web/src/views/Life/LifeView.tsx
+++ b/packages/web/src/views/Life/LifeView.tsx
@@ -1,5 +1,6 @@
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useIsTrialing } from "@web/billing/useIsTrialing";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
 import { ID_MAIN } from "@web/common/constants/web.constants";
 import { useResponsiveLayout } from "@web/components/AuthenticatedLayout/useResponsiveLayout";
@@ -107,10 +108,15 @@ export function LifeView({ today }: LifeViewProps) {
   }, [navigate, preferences.lifespan, preferences.variation]);
 
   useSidebarShortcuts();
+  const isTrialing = useIsTrialing();
   const shortcutSections = useMemo(
     () =>
-      getShortcutMenuSections({ view: "life", isViewingCurrentPeriod: true }),
-    [],
+      getShortcutMenuSections({
+        view: "life",
+        isViewingCurrentPeriod: true,
+        isTrialing,
+      }),
+    [isTrialing],
   );
   const onPreferencesChange = useCallback(
     (update: (current: LifePreferences) => LifePreferences) => {

--- a/packages/web/src/views/Week/WeekView.tsx
+++ b/packages/web/src/views/Week/WeekView.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useRef } from "react";
+import { useIsTrialing } from "@web/billing/useIsTrialing";
 import { ID_MAIN } from "@web/common/constants/web.constants";
 import { useHorizontalNavigation } from "@web/common/hooks/useHorizontalNavigation";
 import { CalendarConnectionBannerGate } from "@web/components/CalendarConnectionBanner/CalendarConnectionBannerGate";
@@ -100,14 +101,16 @@ export const WeekView = () => {
     });
   }, [scrollUtil, util]);
 
+  const isTrialing = useIsTrialing();
   const shortcutSections = useMemo(
     () =>
       getShortcutMenuSections({
         view: "week",
         isViewingCurrentPeriod: isCurrentWeek,
         isFormOpen: isEventDetailsOpen,
+        isTrialing,
       }),
-    [isCurrentWeek, isEventDetailsOpen],
+    [isCurrentWeek, isEventDetailsOpen, isTrialing],
   );
 
   const { calendarDate, goToDateFromSidebar } = useSidebarCalendarDate({


### PR DESCRIPTION
A signed-in trial user had no signal they were on a clock: the trial was invisible until the day it expired and `BillingGateModal` took the screen. There was also no way to convert early, because the Stripe Billing Portal cannot shorten a trial.

## What this does

- **Days-left badge** in the sidebar month picker header, reusing `DatePicker`'s existing (previously unused) `headerEndContent` slot, so no layout changes were needed. The badge deliberately carries no `tabindex`: `getPageJumpFocusElement` seats Mod+2 on the first `[tabindex="0"]` inside the picker, and a tab stop here would steal that jump.
- **`POST /api/billing/trial/end`** calls `subscriptions.update(trial_end: "now")` and writes the returned Subscription through the webhook's own `applySubscription`, so the badge clears without waiting for the webhook round trip and the Stripe field mapping stays in one place. A declined card lands on `past_due`, which is still writable, so the confirm dialog reports the resulting status instead of a blanket success.
- **Three ways in**, all gated on an actually-running trial: the badge, a "Subscribe now" palette command, and bare `B`. The shortcut is registered by `UpgradeConfirmationProvider` rather than `useNavigationShortcuts`, which must stay usable without a QueryClient.
- The confirm dialog names **no price**. The amount lives on the Stripe Price so operators can change it without a deploy (#2922); "Manage billing" is the path to seeing the card and the charge.

## Note on provenance

This work was authored earlier but never opened as a PR. It has been rebased onto current `main`, which required real conflict resolution:

- It was cut before #2934, so it still deleted `TrialGateModal.tsx` / `useTrialStatus.ts` that `main` has already replaced with `BillingGateModal.tsx`. Those deletions are now `main`'s.
- Its two Shift+F10 commits were superseded by #2941, which dropped the legend row outright, so they were dropped rather than replayed.
- `MonthPicker.test.tsx` needed **both** `main`'s `HotkeysProvider` wrapper and this branch's `QueryClient` provider, nested.
- Docs now describe the badge and the trial/end endpoint, which the original commit never documented (it only recorded the anonymous-trial removal).

## Verification

- `bun run type-check` clean
- backend: 451 pass, 0 fail
- web: full suite green apart from 14 failures reproduced on untouched `origin/main` (`sse.client`, `useConnectGoogle`, `fetchDayEvents`, `refreshUserMetadata`, plus a `ContextMenuItems` timeout that passes in isolation)

Stacked: [the celebration + plan visibility PR](https://github.com/KeepSoftwareSimple/compass-calendar/tree/claude/trial-celebration-visibility) builds on this branch. Merge this one first, and do **not** use `--delete-branch` until the dependent PR has merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)