### PR TITLE
feat(web): celebrate the checkout return and surface the plan

### DIFF
--- a/packages/web/src/auth/posthog/track.ts
+++ b/packages/web/src/auth/posthog/track.ts
@@ -16,6 +16,7 @@ export type ProductEvent =
   | "first_event_prompt_completed"
   | "first_event_prompt_dismissed"
   | "trial_converted"
+  | "trial_celebration_shown"
   | "billing_gate_shown"
   | "billing_gate_cta_clicked"
   | "notifications_enabled"

--- a/packages/web/src/billing/CheckoutCelebrationModal.test.tsx
+++ b/packages/web/src/billing/CheckoutCelebrationModal.test.tsx
@@ -1,0 +1,97 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  checkoutCelebrationActions,
+  initialCheckoutCelebrationState,
+  useCheckoutCelebrationStore,
+} from "@web/billing/checkout-celebration.store";
+import { type AppAccess } from "@web/billing/useAppAccess";
+import { afterAll, afterEach, describe, expect, it, mock } from "bun:test";
+
+const actualUseAppAccess = (await import("@web/billing/useAppAccess"))
+  .useAppAccess;
+let isAppAccessMocked = true;
+let access: AppAccess = { kind: "open" };
+
+mock.module("@web/billing/useAppAccess", () => ({
+  useAppAccess: (...args: Parameters<typeof actualUseAppAccess>) =>
+    isAppAccessMocked ? access : actualUseAppAccess(...args),
+}));
+
+const { CheckoutCelebrationModal } = await import("./CheckoutCelebrationModal");
+
+const server = (
+  status: Extract<AppAccess, { kind: "server" }>["status"],
+  trialEndsAt: string | null = null,
+): AppAccess => ({ kind: "server", status, isReadOnly: false, trialEndsAt });
+
+afterAll(() => {
+  isAppAccessMocked = false;
+});
+
+describe("CheckoutCelebrationModal", () => {
+  afterEach(() => {
+    access = { kind: "open" };
+    useCheckoutCelebrationStore.setState(initialCheckoutCelebrationState);
+  });
+
+  it("stays out of the way until a checkout returns", () => {
+    render(<CheckoutCelebrationModal />);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("celebrates the trial a checkout just started", () => {
+    access = server("trialing", "2026-09-03T00:00:00.000Z");
+    checkoutCelebrationActions.celebrate();
+    render(<CheckoutCelebrationModal />);
+
+    expect(
+      screen.getByRole("dialog", { name: "You're aboard!" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Your 7-day trial has started. Full access, nothing held back.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: /pixel pirate/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("names the membership once the subscription is active", () => {
+    access = server("active");
+    checkoutCelebrationActions.celebrate();
+    render(<CheckoutCelebrationModal />);
+
+    expect(
+      screen.getByText("You're a Compass Premium member."),
+    ).toBeInTheDocument();
+  });
+
+  // The webhook can land after the redirect, so the modal must say something
+  // true rather than claim a plan it cannot yet see.
+  it("holds a neutral line while the webhook is still in flight", () => {
+    access = server("awaiting_checkout");
+    checkoutCelebrationActions.celebrate();
+    render(<CheckoutCelebrationModal />);
+
+    expect(
+      screen.getByText("Setting up your subscription..."),
+    ).toBeInTheDocument();
+  });
+
+  it("clears the celebration when dismissed", async () => {
+    access = server("trialing", "2026-09-03T00:00:00.000Z");
+    checkoutCelebrationActions.celebrate();
+    const user = userEvent.setup();
+    render(<CheckoutCelebrationModal />);
+
+    await user.click(screen.getByRole("button", { name: /Start planning/ }));
+
+    await waitFor(() => {
+      expect(useCheckoutCelebrationStore.getState().isCelebrating).toBe(false);
+    });
+  });
+});

--- a/packages/web/src/billing/CheckoutCelebrationModal.test.tsx
+++ b/packages/web/src/billing/CheckoutCelebrationModal.test.tsx
@@ -82,6 +82,37 @@ describe("CheckoutCelebrationModal", () => {
     ).toBeInTheDocument();
   });
 
+  // The button advertises an Enter hint, and Escape is the app's universal
+  // step-back; both must really close it, not just the click.
+  it("closes on Enter from the button it seats focus on", async () => {
+    access = server("trialing", "2026-09-03T00:00:00.000Z");
+    checkoutCelebrationActions.celebrate();
+    const user = userEvent.setup();
+    render(<CheckoutCelebrationModal />);
+
+    expect(
+      screen.getByRole("button", { name: /Start planning/ }),
+    ).toHaveFocus();
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(useCheckoutCelebrationStore.getState().isCelebrating).toBe(false);
+    });
+  });
+
+  it("closes on Escape", async () => {
+    access = server("trialing", "2026-09-03T00:00:00.000Z");
+    checkoutCelebrationActions.celebrate();
+    const user = userEvent.setup();
+    render(<CheckoutCelebrationModal />);
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(useCheckoutCelebrationStore.getState().isCelebrating).toBe(false);
+    });
+  });
+
   it("clears the celebration when dismissed", async () => {
     access = server("trialing", "2026-09-03T00:00:00.000Z");
     checkoutCelebrationActions.celebrate();

--- a/packages/web/src/billing/CheckoutCelebrationModal.tsx
+++ b/packages/web/src/billing/CheckoutCelebrationModal.tsx
@@ -1,0 +1,88 @@
+import { type FC, useEffect, useRef } from "react";
+import { track } from "@web/auth/posthog/track";
+import {
+  checkoutCelebrationActions,
+  selectIsCelebrating,
+  useCheckoutCelebrationStore,
+} from "@web/billing/checkout-celebration.store";
+import { type AppAccess, useAppAccess } from "@web/billing/useAppAccess";
+import { MODAL_DISMISS_MS } from "@web/common/constants/motion.constants";
+import { useDismissTransition } from "@web/common/hooks/useDismissTransition";
+import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
+import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
+import { PixelPirate } from "@web/components/WelcomeModal/PixelPirate";
+
+const PANEL_CLASSNAME =
+  "max-w-full gap-4 border border-border bg-surface text-center text-text shadow-xl";
+
+const TITLE = "You're aboard!";
+
+/**
+ * The status is read live rather than captured on mount: `useCheckoutReturn`
+ * polls billing status for 15s after the return, so a user who lands before
+ * the Stripe webhook does sees "Setting up" sharpen into the real plan
+ * without the modal remounting.
+ */
+const getBody = (access: AppAccess): string => {
+  if (access.kind !== "server") return "Setting up your subscription...";
+  if (access.status === "trialing") {
+    return "Your 7-day trial has started. Full access, nothing held back.";
+  }
+  if (access.status === "active") return "You're a Compass Premium member.";
+  return "Setting up your subscription...";
+};
+
+/**
+ * The moment the anonymous -> trial transition is finally acknowledged.
+ * Raised by `useCheckoutReturn` on `?checkout=success`; `RootShell` suppresses
+ * the billing gate while it is up, so the two never fight for the screen
+ * during the webhook gap.
+ */
+export const CheckoutCelebrationModal: FC = () => {
+  const isCelebrating = useCheckoutCelebrationStore(selectIsCelebrating);
+  const access = useAppAccess();
+  const { closing, beginDismiss } = useDismissTransition(MODAL_DISMISS_MS);
+  const primaryButtonRef = useRef<HTMLButtonElement>(null);
+  const shownRef = useRef(false);
+
+  const status = access.kind === "server" ? access.status : "unknown";
+
+  useEffect(() => {
+    if (!isCelebrating || shownRef.current) return;
+    shownRef.current = true;
+    track("trial_celebration_shown", { status });
+  }, [isCelebrating, status]);
+
+  if (!isCelebrating) return null;
+
+  const dismiss = () => {
+    beginDismiss(checkoutCelebrationActions.dismiss);
+  };
+
+  return (
+    <OverlayPanel
+      align="center"
+      ariaLabel={TITLE}
+      closing={closing}
+      initialFocusRef={primaryButtonRef}
+      onDismiss={dismiss}
+      panelClassName={PANEL_CLASSNAME}
+      widthClassName="w-120"
+    >
+      <div className="flex w-full flex-col items-center gap-4">
+        <PixelPirate className="c-pirate-cheer h-20 w-20" />
+        <h1 className="font-medium text-xl">{TITLE}</h1>
+        <p className="text-sm text-text-muted">{getBody(access)}</p>
+        <button
+          className="c-button c-button-primary c-button-elevated mt-2 inline-flex items-center justify-center rounded-full px-6 py-2"
+          onClick={dismiss}
+          ref={primaryButtonRef}
+          type="button"
+        >
+          Start planning
+          <ShortcutHint className="ml-2">Enter</ShortcutHint>
+        </button>
+      </div>
+    </OverlayPanel>
+  );
+};

--- a/packages/web/src/billing/PlanSection.tsx
+++ b/packages/web/src/billing/PlanSection.tsx
@@ -1,0 +1,62 @@
+import { type FC } from "react";
+import dayjs from "@core/util/date/dayjs";
+import {
+  getPlanBadge,
+  PLAN_BADGE_TONE_CLASSNAME,
+} from "@web/billing/planBadge";
+import { useAppAccess } from "@web/billing/useAppAccess";
+import { useBillingRedirect } from "@web/billing/useBillingRedirect";
+
+const OUTLINE_BUTTON_CLASSNAME =
+  "c-focus-ring shrink-0 rounded border border-border bg-surface-overlay px-2 py-1 text-xs text-text transition-colors hover:bg-surface-panel disabled:pointer-events-none disabled:opacity-60";
+
+/**
+ * The account view's answer to "what am I paying for?". Until this existed,
+ * every billing surface in the app was a gate or a warning, so a happy
+ * subscriber had no way to confirm their own standing.
+ *
+ * Renders nothing when there is no plan to report (self-hosted, enforcement
+ * paused, anonymous), rather than inventing billing chrome for installs that
+ * have no billing.
+ */
+export const PlanSection: FC = () => {
+  const access = useAppAccess();
+  const { isRedirecting, redirectTo } = useBillingRedirect();
+  const badge = getPlanBadge(access);
+
+  if (!badge) return null;
+
+  const trialEndsAt =
+    access.kind === "server" && access.status === "trialing"
+      ? access.trialEndsAt
+      : null;
+
+  return (
+    <div>
+      <p className="mb-1 block text-sm text-text">Plan</p>
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0">
+          <span
+            className={`shrink-0 rounded border border-border px-1.5 text-xs ${PLAN_BADGE_TONE_CLASSNAME[badge.tone]}`}
+          >
+            {badge.label}
+          </span>
+          {trialEndsAt ? (
+            <p className="mt-1 text-text-muted text-xs">
+              Your trial ends {dayjs(trialEndsAt).format("MMM D, YYYY")}. Press
+              B to subscribe now.
+            </p>
+          ) : null}
+        </div>
+        <button
+          className={OUTLINE_BUTTON_CLASSNAME}
+          disabled={isRedirecting}
+          onClick={() => void redirectTo("portal", "settings_portal")}
+          type="button"
+        >
+          Manage billing
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/packages/web/src/billing/billing.query.ts
+++ b/packages/web/src/billing/billing.query.ts
@@ -5,6 +5,7 @@ import { type BillingStatusResponse } from "@core/types/billing.types";
 import { AppConfigApi } from "@web/api/app-config.api";
 import { BillingApi } from "@web/api/billing.api";
 import { track } from "@web/auth/posthog/track";
+import { checkoutCelebrationActions } from "@web/billing/checkout-celebration.store";
 
 export const billingQueryKeys = {
   status: ["billing", "status"] as const,
@@ -50,8 +51,10 @@ export function isBillingEnforced(
 }
 
 /**
- * After Stripe Checkout returns `?checkout=success`, keep refetching billing
- * status for a short window so a late webhook does not leave the gate up.
+ * After Stripe Checkout returns `?checkout=success`, raise the celebration and
+ * keep refetching billing status for a short window so a late webhook does not
+ * leave the gate up. The polling is also what lets the celebration's copy
+ * sharpen from "setting up" to the real status while it is on screen.
  */
 export function useCheckoutReturn() {
   const queryClient = useQueryClient();
@@ -66,6 +69,7 @@ export function useCheckoutReturn() {
     };
     invalidate();
     track("trial_converted");
+    checkoutCelebrationActions.celebrate();
     const interval = window.setInterval(invalidate, 1500);
     const timeout = window.setTimeout(() => {
       window.clearInterval(interval);

--- a/packages/web/src/billing/checkout-celebration.store.ts
+++ b/packages/web/src/billing/checkout-celebration.store.ts
@@ -1,0 +1,36 @@
+import { create } from "zustand";
+
+export type CheckoutCelebrationState = {
+  /**
+   * True from the moment the user lands back from a successful Stripe
+   * Checkout until they dismiss the celebration.
+   */
+  isCelebrating: boolean;
+};
+
+export const initialCheckoutCelebrationState: CheckoutCelebrationState = {
+  isCelebrating: false,
+};
+
+/**
+ * Deliberately in-memory, with no "already seen" stamp. A persisted flag
+ * would suppress the celebration for someone who cancels and subscribes
+ * again later, which is exactly the moment worth marking. The router strips
+ * `?checkout=success` with `replace: true`, so the only way to see it twice
+ * is to reload a stale URL by hand -- a wart worth living with.
+ */
+export const useCheckoutCelebrationStore = create<CheckoutCelebrationState>()(
+  () => ({ ...initialCheckoutCelebrationState }),
+);
+
+export const checkoutCelebrationActions = {
+  celebrate: () => {
+    useCheckoutCelebrationStore.setState({ isCelebrating: true });
+  },
+  dismiss: () => {
+    useCheckoutCelebrationStore.setState({ isCelebrating: false });
+  },
+};
+
+export const selectIsCelebrating = (state: CheckoutCelebrationState) =>
+  state.isCelebrating;

--- a/packages/web/src/billing/planBadge.test.ts
+++ b/packages/web/src/billing/planBadge.test.ts
@@ -1,0 +1,74 @@
+import dayjs from "@core/util/date/dayjs";
+import { getPlanBadge } from "@web/billing/planBadge";
+import { type AppAccess } from "@web/billing/useAppAccess";
+import { describe, expect, it } from "bun:test";
+
+const server = (
+  status: Extract<AppAccess, { kind: "server" }>["status"],
+  trialEndsAt: string | null = null,
+): AppAccess => ({ kind: "server", status, isReadOnly: false, trialEndsAt });
+
+describe("getPlanBadge", () => {
+  it("reports nothing for an open install", () => {
+    expect(getPlanBadge({ kind: "open" })).toBeNull();
+  });
+
+  it("reports nothing for an account with no billing state", () => {
+    expect(getPlanBadge(server("none"))).toBeNull();
+  });
+
+  it("labels an active subscription Premium", () => {
+    expect(getPlanBadge(server("active"))).toEqual({
+      label: "Premium",
+      tone: "premium",
+    });
+  });
+
+  it("counts down the days left on a trial", () => {
+    const endsAt = dayjs().add(3, "day").toISOString();
+
+    expect(getPlanBadge(server("trialing", endsAt))).toEqual({
+      label: "Trial · 3d",
+      tone: "trial",
+    });
+  });
+
+  it("reads the final trial day as Last day", () => {
+    const endsAt = dayjs().subtract(1, "hour").toISOString();
+
+    expect(getPlanBadge(server("trialing", endsAt))).toEqual({
+      label: "Trial · Last day",
+      tone: "trial",
+    });
+  });
+
+  it("falls back to a bare Trial label with no end date", () => {
+    expect(getPlanBadge(server("trialing", null))).toEqual({
+      label: "Trial",
+      tone: "trial",
+    });
+  });
+
+  it("flags a failed payment", () => {
+    expect(getPlanBadge(server("past_due"))).toEqual({
+      label: "Payment due",
+      tone: "attention",
+    });
+  });
+
+  it("labels an account that has not checked out yet Free", () => {
+    expect(getPlanBadge(server("awaiting_checkout"))).toEqual({
+      label: "Free",
+      tone: "neutral",
+    });
+  });
+
+  it("labels both spent states Expired", () => {
+    for (const status of ["expired", "canceled"] as const) {
+      expect(getPlanBadge(server(status))).toEqual({
+        label: "Expired",
+        tone: "attention",
+      });
+    }
+  });
+});

--- a/packages/web/src/billing/planBadge.ts
+++ b/packages/web/src/billing/planBadge.ts
@@ -1,0 +1,52 @@
+import {
+  formatTrialBadgeLabel,
+  getTrialDaysLeft,
+} from "@web/billing/trialDaysLeft";
+import { type AppAccess } from "@web/billing/useAppAccess";
+
+export type PlanBadgeTone = "premium" | "trial" | "attention" | "neutral";
+
+export type PlanBadge = { label: string; tone: PlanBadgeTone };
+
+// Tone only decorates a label that already says what the plan is; the pill is
+// never colour alone. Same contract as SYNC_STATUS_VARIANT_CLASSNAME.
+export const PLAN_BADGE_TONE_CLASSNAME: Record<PlanBadgeTone, string> = {
+  premium: "text-success",
+  trial: "text-text",
+  attention: "text-warning",
+  neutral: "text-text-muted",
+};
+
+/**
+ * The one mapping from access state to the plan pill, shared by the Settings
+ * panel and the command palette row so the two surfaces a user compares in
+ * the same breath cannot drift.
+ *
+ * Returns null wherever there is no plan to speak of: self-hosted installs,
+ * a paused enforcement switch, and anonymous visitors all read `open`, and
+ * showing them billing chrome would invent a product they do not have.
+ */
+export function getPlanBadge(access: AppAccess): PlanBadge | null {
+  if (access.kind !== "server") return null;
+
+  switch (access.status) {
+    case "active":
+      return { label: "Premium", tone: "premium" };
+    case "trialing":
+      return {
+        label: access.trialEndsAt
+          ? `Trial · ${formatTrialBadgeLabel(getTrialDaysLeft(access.trialEndsAt))}`
+          : "Trial",
+        tone: "trial",
+      };
+    case "past_due":
+      return { label: "Payment due", tone: "attention" };
+    case "awaiting_checkout":
+      return { label: "Free", tone: "neutral" };
+    case "expired":
+    case "canceled":
+      return { label: "Expired", tone: "attention" };
+    case "none":
+      return null;
+  }
+}

--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -7,8 +7,10 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
+import dayjs from "@core/util/date/dayjs";
 import { renderWithStore } from "@web/__tests__/render-with-store";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import { type AppAccess } from "@web/billing/useAppAccess";
 import { onViewCommand } from "@web/common/utils/dom/view-command-bus";
 import { type EventMutationDependencies } from "@web/events/mutations/useEventMutations";
 import { type EventRepository } from "@web/events/repositories/event.repository.types";
@@ -44,8 +46,32 @@ mock.module("@tanstack/react-router", () => ({
         actualTanstackRouter.useNavigate(...(args as [])),
 }));
 
+// Defaults to false so every pre-existing test in this file keeps the
+// signed-out palette it was written against; only the plan-pill tests flip it.
+let authenticated = false;
+let isSessionMocked = true;
+const actualUseSession = (await import("@web/auth/compass/session/useSession"))
+  .useSession;
+mock.module("@web/auth/compass/session/useSession", () => ({
+  useSession: (...args: Parameters<typeof actualUseSession>) =>
+    isSessionMocked
+      ? { authenticated, setAuthenticated: mock() }
+      : actualUseSession(...args),
+}));
+
+let access: AppAccess = { kind: "open" };
+let isAppAccessMocked = true;
+const actualUseAppAccess = (await import("@web/billing/useAppAccess"))
+  .useAppAccess;
+mock.module("@web/billing/useAppAccess", () => ({
+  useAppAccess: (...args: Parameters<typeof actualUseAppAccess>) =>
+    isAppAccessMocked ? access : actualUseAppAccess(...args),
+}));
+
 afterAll(() => {
   isNavigateMocked = false;
+  isAppAccessMocked = false;
+  isSessionMocked = false;
 });
 
 const { CommandPalette, LifeCommandPalette } = await import("./CommandPalette");
@@ -98,6 +124,35 @@ describe("CommandPalette", () => {
     mockNavigate.mockClear();
     onGoToToday.mockClear();
     onShowShortcuts.mockClear();
+    access = { kind: "open" };
+    authenticated = false;
+  });
+
+  // The plan pill shares the row's end slot with the shortcut chips, so both
+  // have to survive together.
+  it("shows the plan beside the account row without dropping its shortcut", () => {
+    authenticated = true;
+    access = {
+      kind: "server",
+      status: "trialing",
+      isReadOnly: false,
+      trialEndsAt: dayjs().add(5, "day").toISOString(),
+    };
+    renderPalette();
+
+    const row = rowLabel("Manage Accounts").closest("button") as HTMLElement;
+
+    expect(within(row).getByText("Trial \u00b7 5d")).toBeInTheDocument();
+    expect(within(row).getByText(",")).toBeInTheDocument();
+  });
+
+  it("leaves the account row bare when there is no plan to report", () => {
+    authenticated = true;
+    renderPalette();
+
+    const row = rowLabel("Manage Accounts").closest("button") as HTMLElement;
+
+    expect(within(row).queryByText(/Trial|Premium|Free/)).toBeNull();
   });
 
   it("renders all sections with items and focuses the input on mount", () => {

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -223,9 +223,14 @@ const CommandPaletteContent = ({
                             item.label
                           )}
                         </span>
+                        {item.badge && (
+                          <span className="ml-auto shrink-0 rounded border border-border px-1.5 text-text-muted text-xs">
+                            {item.badge}
+                          </span>
+                        )}
                         {item.shortcut && (
                           <ShortcutKeys
-                            className="ml-auto shrink-0"
+                            className={`shrink-0 ${item.badge ? "" : "ml-auto"}`}
                             keys={item.shortcut}
                           />
                         )}

--- a/packages/web/src/components/CommandPalette/command-palette.types.ts
+++ b/packages/web/src/components/CommandPalette/command-palette.types.ts
@@ -8,6 +8,8 @@ export interface CommandItem {
   disabled?: boolean;
   /** A single key (`"?"`) or one key per combo entry (`["Shift", "W"]`), rendered as keycap chips. */
   shortcut?: string | string[];
+  /** Status pill shown at the end of the row (e.g. the account row's plan). Decoration only: never searched. */
+  badge?: string;
   /** Extra search terms (synonyms) matched by the palette's fuzzy filter; never rendered. */
   keywords?: string[];
 }

--- a/packages/web/src/components/CommandPalette/hooks/useShowAccountsCmdItems.test.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useShowAccountsCmdItems.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from "@testing-library/react";
 import { act } from "react";
+import { type AppAccess } from "@web/billing/useAppAccess";
 import {
   selectIsSettingsOpen,
   useSettingsStore,
@@ -12,11 +13,20 @@ mock.module("@web/auth/compass/session/useSession", () => ({
   useSession: mockUseSession,
 }));
 
+// Mocked rather than wrapped in a QueryClient: the badge is the only thing
+// this hook reads billing for, and driving the access state directly is what
+// the assertions are about.
+let access: AppAccess = { kind: "open" };
+mock.module("@web/billing/useAppAccess", () => ({
+  useAppAccess: () => access,
+}));
+
 const { useShowAccountsCmdItems } = await import("./useShowAccountsCmdItems");
 
 describe("useShowAccountsCmdItems", () => {
   beforeEach(() => {
     useSettingsStore.setState({ isSettingsOpen: false });
+    access = { kind: "open" };
     mockUseSession.mockReset();
     mockUseSession.mockReturnValue({
       authenticated: true,
@@ -46,5 +56,24 @@ describe("useShowAccountsCmdItems", () => {
     });
 
     expect(selectIsSettingsOpen(useSettingsStore.getState())).toBe(true);
+  });
+
+  it("carries no badge on an install without billing", () => {
+    const { result } = renderHook(() => useShowAccountsCmdItems());
+
+    expect(result.current[0].badge).toBeUndefined();
+  });
+
+  it("shows the plan on the row so it is visible without opening Settings", () => {
+    access = {
+      kind: "server",
+      status: "active",
+      isReadOnly: false,
+      trialEndsAt: null,
+    };
+
+    const { result } = renderHook(() => useShowAccountsCmdItems());
+
+    expect(result.current[0].badge).toBe("Premium");
   });
 });

--- a/packages/web/src/components/CommandPalette/hooks/useShowAccountsCmdItems.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useShowAccountsCmdItems.ts
@@ -1,5 +1,7 @@
 import { UsersIcon } from "@phosphor-icons/react";
 import { useSession } from "@web/auth/compass/session/useSession";
+import { getPlanBadge } from "@web/billing/planBadge";
+import { useAppAccess } from "@web/billing/useAppAccess";
 import { type CommandItem } from "@web/components/CommandPalette/command-palette.types";
 import { settingsActions } from "@web/settings/settings.store";
 
@@ -13,6 +15,9 @@ import { settingsActions } from "@web/settings/settings.store";
  */
 export const useShowAccountsCmdItems = (): CommandItem[] => {
   const { authenticated } = useSession();
+  // Reads billing status, so this hook now needs a QueryClient in scope. Both
+  // palettes mount inside CompassProvider, but bare hook tests must wrap.
+  const access = useAppAccess();
 
   if (!authenticated) {
     return [];
@@ -36,7 +41,13 @@ export const useShowAccountsCmdItems = (): CommandItem[] => {
         "remove account",
         "export data",
         "delete account",
+        "plan",
+        "billing",
+        "subscription",
+        "premium",
+        "trial",
       ],
+      badge: getPlanBadge(access)?.label,
       onClick: settingsActions.openSettings,
     },
   ];

--- a/packages/web/src/components/RootShell/RootShell.tsx
+++ b/packages/web/src/components/RootShell/RootShell.tsx
@@ -7,6 +7,11 @@ import {
   selectBillingPreviewing,
   useBillingPreviewStore,
 } from "@web/billing/billing-preview.store";
+import { CheckoutCelebrationModal } from "@web/billing/CheckoutCelebrationModal";
+import {
+  selectIsCelebrating,
+  useCheckoutCelebrationStore,
+} from "@web/billing/checkout-celebration.store";
 import { useAppAccess } from "@web/billing/useAppAccess";
 import { AuthModal } from "@web/components/AuthModal/AuthModal";
 import { AuthModalProvider } from "@web/components/AuthModal/AuthModalProvider";
@@ -40,6 +45,7 @@ export function RootShell() {
   const isWelcomeGuideOpen = useWelcomeGuideStore(selectWelcomeGuideOpen);
   const access = useAppAccess();
   const isPreviewing = useBillingPreviewStore(selectBillingPreviewing);
+  const isCelebrating = useCheckoutCelebrationStore(selectIsCelebrating);
   useCheckoutReturn();
   useNavigationShortcuts();
   useCalendarShellShortcuts();
@@ -55,7 +61,12 @@ export function RootShell() {
   // banner pitching a trial they can no longer take.
   const isPreviewable = readOnlyStatus === "awaiting_checkout";
   const showReadOnlyBanner = isPreviewable && isPreviewing;
-  const gateStatus = showReadOnlyBanner ? null : readOnlyStatus;
+  // The gate must yield to the celebration. Between the Checkout return and
+  // the webhook landing, status can still read awaiting_checkout, and the gate
+  // is a full app-lock overlay -- it would take the screen at exactly the
+  // moment the user has just paid.
+  const gateStatus =
+    showReadOnlyBanner || isCelebrating ? null : readOnlyStatus;
   const showPastDue = access.kind === "server" && access.status === "past_due";
 
   // The gate owns the screen: the onboarding cards sit at Z_INDEX_TOOLTIP
@@ -70,6 +81,7 @@ export function RootShell() {
       <Outlet />
       <AuthModal />
       {gateStatus !== null && <BillingGateModal status={gateStatus} />}
+      <CheckoutCelebrationModal />
       {gateStatus === null && !deferCalendarOnboarding && <WelcomeModal />}
       {gateStatus === null && !deferCalendarOnboarding && <ShortcutShowcase />}
       {gateStatus === null && !deferCalendarOnboarding && <FirstEventPrompt />}

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -2,15 +2,18 @@ import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
+import dayjs from "@core/util/date/dayjs";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
 import { createMockCalendar } from "@web/__tests__/utils/factories/calendar.factory";
 import { AuthApi } from "@web/api/auth.api";
+import { BillingApi } from "@web/api/billing.api";
 import {
   markAccountReconnectRequired,
   resetGoogleReconnectRequiredForTests,
 } from "@web/auth/google/state/google.reconnect.state";
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
+import { type AppAccess } from "@web/billing/useAppAccess";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import {
@@ -90,16 +93,27 @@ mock.module("@web/sse/hooks/useSseDegraded", () => ({
     isSseDegradedMocked ? isSseDegraded : actualUseSseDegraded(),
 }));
 
+let access: AppAccess = { kind: "open" };
+let isAppAccessMocked = true;
+const actualUseAppAccess = (await import("@web/billing/useAppAccess"))
+  .useAppAccess;
+mock.module("@web/billing/useAppAccess", () => ({
+  useAppAccess: (...args: Parameters<typeof actualUseAppAccess>) =>
+    isAppAccessMocked ? access : actualUseAppAccess(...args),
+}));
+
 afterAll(() => {
   isLogoutConfirmationMocked = false;
   isSessionMocked = false;
   isSseDegradedMocked = false;
+  isAppAccessMocked = false;
 });
 
 afterEach(() => {
   mockOpenLogoutConfirmation.mockClear();
   resetGoogleReconnectRequiredForTests();
   isSseDegraded = false;
+  access = { kind: "open" };
 });
 
 const settingsModalUrl = new URL(
@@ -565,5 +579,71 @@ describe("SettingsModal", () => {
     renderSettings({ authenticated: false });
 
     expect(screen.queryByRole("button", { name: "Log out" })).toBeNull();
+  });
+
+  it("says nothing about a plan on an install without billing", () => {
+    renderSettings({ authenticated: true });
+
+    expect(screen.queryByText("Plan")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Manage billing" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("tells a subscriber they are on Premium", () => {
+    access = {
+      kind: "server",
+      status: "active",
+      isReadOnly: false,
+      trialEndsAt: null,
+    };
+    renderSettings({ authenticated: true });
+
+    expect(screen.getByText("Plan")).toBeInTheDocument();
+    expect(screen.getByText("Premium")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Manage billing" }),
+    ).toBeInTheDocument();
+  });
+
+  it("counts down the trial and points at the early-upgrade shortcut", () => {
+    access = {
+      kind: "server",
+      status: "trialing",
+      isReadOnly: false,
+      trialEndsAt: dayjs().add(3, "day").toISOString(),
+    };
+    renderSettings({ authenticated: true });
+
+    expect(screen.getByText("Trial \u00b7 3d")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Press\s+B to subscribe now\./),
+    ).toBeInTheDocument();
+  });
+
+  it("opens the billing portal from Manage billing", async () => {
+    const createPortalSession = spyOn(
+      BillingApi,
+      "createPortalSession",
+    ).mockResolvedValue({ url: "https://billing.stripe.com/p/ok" });
+    const assign = spyOn(window.location, "assign").mockImplementation(
+      () => {},
+    );
+    access = {
+      kind: "server",
+      status: "active",
+      isReadOnly: false,
+      trialEndsAt: null,
+    };
+    const user = userEvent.setup();
+    renderSettings({ authenticated: true });
+
+    await user.click(screen.getByRole("button", { name: "Manage billing" }));
+
+    await waitFor(() => {
+      expect(assign).toHaveBeenCalledWith("https://billing.stripe.com/p/ok");
+    });
+    createPortalSession.mockRestore();
+    assign.mockRestore();
   });
 });

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -16,6 +16,7 @@ import {
   selectGoogleSyncConnections,
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
+import { PlanSection } from "@web/billing/PlanSection";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import {
   compareCalendars,
@@ -143,6 +144,7 @@ export const SettingsModal: FC = () => {
           </button>
         </nav>
         <div className="flex min-w-0 flex-1 flex-col gap-4">
+          <PlanSection />
           <DefaultTimezonePicker />
           <DefaultCalendarPicker
             calendars={writableCalendars}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -152,6 +152,7 @@
   --animate-sync-icon-wave: syncIconWave 2.4s linear infinite;
   --animate-loader-spin: loaderSpin 1.1s linear infinite;
   --animate-pirate-scout: pirateScout 2.2s ease-in-out infinite;
+  --animate-pirate-cheer: pirateCheer 700ms cubic-bezier(0.16, 1, 0.3, 1) both;
   --animate-showcase-curtain: showcaseCurtain 900ms ease-in-out forwards;
   --animate-showcase-enter-stage: showcaseEnterStage 550ms
     cubic-bezier(0.16, 1, 0.3, 1) forwards;
@@ -222,6 +223,25 @@
     }
     75% {
       transform: translate(6.25%, -6.25%);
+    }
+  }
+
+  /* One celebratory leap, then settle. Punctuates rather than loops. */
+  @keyframes pirateCheer {
+    0% {
+      transform: scale(0.4) translateY(25%);
+      opacity: 0;
+    }
+    55% {
+      transform: scale(1.15) translateY(-12.5%);
+      opacity: 1;
+    }
+    75% {
+      transform: scale(0.95) translateY(0);
+    }
+    100% {
+      transform: scale(1) translateY(0);
+      opacity: 1;
     }
   }
 }
@@ -376,6 +396,14 @@
 
 @utility c-pirate-scout {
   animation: var(--animate-pirate-scout);
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}
+
+@utility c-pirate-cheer {
+  animation: var(--animate-pirate-cheer);
 
   @media (prefers-reduced-motion: reduce) {
     animation: none;


### PR DESCRIPTION
> **Stacked on #2947.** Base branch is `claude/trial-badge-countdown-rebased`, not `main`. Merge #2947 first; this PR's diff will then reduce to its own two commits.

Coming back from Stripe Checkout dropped the user straight onto their calendar with no acknowledgement at all, which made the moment they committed feel like nothing had happened. And no surface anywhere told a signed-in user what plan they were on: every billing element in the app was a gate (`BillingGateModal`) or a warning (`BillingReadOnlyBanner`, `BillingPastDueBanner`), so a happy subscriber had no way to confirm their own standing.

## Celebration

A full-screen overlay raised by the existing `useCheckoutReturn` hook on `?checkout=success`, built on the cheering `PixelPirate` that until now only appeared on the welcome and error screens.

Its copy reads access state **live** rather than capturing it on mount. `useCheckoutReturn` already polls billing status for 15s to cover a late webhook, so "Setting up your subscription" sharpens into the real plan without the modal remounting:

| status | body |
|---|---|
| `trialing` | Your 7-day trial has started. Full access, nothing held back. |
| `active` | You're a Compass Premium member. |
| pending / open | Setting up your subscription... |

Note that a card-required trial lands on `trialing`, not `active`, so that is the branch nearly every new subscriber actually sees.

**`RootShell` suppresses the billing gate while the celebration is up.** During the webhook gap the status can still read `awaiting_checkout`, and the gate is a full app-lock overlay, so without this it would throw a paywall over someone who has just paid. `isCelebrating` folds into the existing `gateStatus` computation the same way `showReadOnlyBanner` already does.

The store is deliberately in-memory with **no seen-stamp**. A persisted flag would suppress the moment for someone who cancels and subscribes again later, which is exactly when it is worth marking. The router strips the param with `replace: true`, so the only way to see it twice is to reload a stale URL by hand.

New `c-pirate-cheer` animation follows the existing three-part convention (`--animate-*` token, `@keyframes`, `@utility` with a `prefers-reduced-motion` guard). It is a single 700ms leap rather than a loop: `pirateScout` loops because it signals ongoing work, this one punctuates.

## Plan visibility

One shared `getPlanBadge` mapping feeds both surfaces, so the two things a user compares in the same breath cannot drift (same reasoning as the existing `SYNC_STATUS_VARIANT_CLASSNAME` map):

- **`PlanSection`** at the top of Settings (`Mod+,`, the palette's "Manage Accounts" row): status pill, trial countdown, and a "Manage billing" button into the Stripe portal with its own `cta` string so this call site stays separable from the past-due banner's in the funnel.
- **A pill on the palette's account row**, so the plan is visible without opening Settings. `CommandItem` gained an optional `badge`, which shares the row's end slot with the shortcut chips.

Both render nothing when there is no plan to report, so self-hosted and enforcement-paused installs get no billing chrome for a product they do not have.

## Verification

- `bun run type-check` clean; backend 451 pass, 0 fail; web 2665 pass
- Browser-verified the celebration: renders, seats focus on its button, dismisses, uses semantic tokens correctly in both themes, and `pirateCheer` plus its reduced-motion guard compile into the served CSS
- Enter and Escape dismissal are asserted in jsdom rather than the browser, because the preview pane silently drops synthetic key events (no keydown reaches the page at all)
- The 14 remaining web failures reproduce on untouched `origin/main` and touch none of this code

**Not verified locally:** the Settings pill and palette badge. Local dev has `enforcement: false` and no Stripe keys, so `useAppAccess` correctly returns `open` and both surfaces render nothing by design. They are covered by unit tests; visual confirmation needs staging, where enforcement is already on. The real Stripe round trip likewise needs staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)