### PR TITLE
fix(web): keep billing-gate L from opening Life view

### DIFF
--- a/packages/web/src/billing/BillingGateModal.test.tsx
+++ b/packages/web/src/billing/BillingGateModal.test.tsx
@@ -1,4 +1,5 @@
 import "@testing-library/jest-dom";
+import { HotkeyManager, HotkeysProvider } from "@tanstack/react-hotkeys";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Status } from "@core/errors/status.codes";
@@ -12,7 +13,7 @@ import {
 } from "@web/billing/billing-preview.store";
 import { registerToastPort } from "@web/common/utils/toast/toast.port";
 import { BillingGateModal } from "./BillingGateModal";
-import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 
 const assign = spyOn(window.location, "assign").mockImplementation(() => {});
 
@@ -33,14 +34,21 @@ const checkoutFailed = (): ApiError => {
 
 const renderGate = (status = "awaiting_checkout") =>
   render(
-    <SessionContext.Provider
-      value={{ authenticated: true, setAuthenticated: () => {} }}
-    >
-      <BillingGateModal status={status} />
-    </SessionContext.Provider>,
+    <HotkeysProvider>
+      <SessionContext.Provider
+        value={{ authenticated: true, setAuthenticated: () => {} }}
+      >
+        <BillingGateModal status={status} />
+      </SessionContext.Provider>
+    </HotkeysProvider>,
   );
 
 describe("BillingGateModal", () => {
+  beforeEach(() => {
+    HotkeyManager.resetInstance();
+    document.body.removeAttribute("data-app-locked");
+  });
+
   afterEach(() => {
     assign.mockClear();
     useBillingPreviewStore.setState(initialBillingPreviewState);

--- a/packages/web/src/billing/BillingGateModal.tsx
+++ b/packages/web/src/billing/BillingGateModal.tsx
@@ -1,10 +1,4 @@
-import {
-  type FC,
-  type KeyboardEvent,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { type FC, useEffect, useRef } from "react";
 import { track } from "@web/auth/posthog/track";
 import { billingPreviewActions } from "@web/billing/billing-preview.store";
 import { useBillingRedirect } from "@web/billing/useBillingRedirect";
@@ -12,12 +6,19 @@ import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 import { PixelPirateScouting } from "@web/components/WelcomeModal/PixelPirateScouting";
 import { useAppLockReason } from "@web/shortcuts/app-lock";
-import { keyboardKey } from "@web/shortcuts/is-bare-letter-key";
+import { swallowNextKeyup } from "@web/shortcuts/swallow-next-keyup";
+import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 
 const PANEL_CLASSNAME =
   "max-w-full gap-4 border border-border bg-surface text-center text-text shadow-xl";
 const SECONDARY_BUTTON_CLASSNAME =
   "c-button c-button-secondary inline-flex items-center justify-center rounded-full px-6 py-2";
+
+const OVERLAY_LETTER_SHORTCUT = {
+  ignoreAppLock: true,
+  ignoreInputs: false,
+  preventDefault: true,
+} as const;
 
 type BillingGateModalProps = {
   status: string;
@@ -65,19 +66,35 @@ export const BillingGateModal: FC<BillingGateModalProps> = ({ status }) => {
         onClick: () => void redirectTo("portal"),
       };
 
-  // Welcome-style letter bindings: unmodified keys, preventDefault, then run.
-  const handleShortcutKey = (event: KeyboardEvent) => {
-    if (isRedirecting) return;
-    if (event.metaKey || event.ctrlKey || event.altKey) return;
-    const actions: Record<string, () => void> = {
-      s: () => void redirectTo("checkout"),
-      [secondary.key.toLowerCase()]: secondary.onClick,
-    };
-    const action = actions[keyboardKey(event).toLowerCase()];
-    if (!action) return;
-    event.preventDefault();
-    action();
-  };
+  useAppShortcut(
+    "S",
+    () => {
+      if (isRedirecting) return;
+      void redirectTo("checkout");
+    },
+    OVERLAY_LETTER_SHORTCUT,
+  );
+
+  useAppShortcut(
+    "L",
+    () => {
+      if (isRedirecting) return;
+      // Look-around unmounts this overlay and drops app-lock before keyup.
+      // Life view is bound on that keyup — swallow it so L only means preview.
+      swallowNextKeyup("l");
+      lookAround();
+    },
+    { ...OVERLAY_LETTER_SHORTCUT, enabled: isAwaitingCheckout },
+  );
+
+  useAppShortcut(
+    "M",
+    () => {
+      if (isRedirecting) return;
+      void redirectTo("portal");
+    },
+    { ...OVERLAY_LETTER_SHORTCUT, enabled: !isAwaitingCheckout },
+  );
 
   return (
     <OverlayPanel
@@ -87,11 +104,7 @@ export const BillingGateModal: FC<BillingGateModalProps> = ({ status }) => {
       panelClassName={PANEL_CLASSNAME}
       widthClassName="w-120"
     >
-      {/* biome-ignore lint/a11y/noStaticElementInteractions: keydown here is a modal-scoped shortcut layer, not an interactive element in its own right */}
-      <div
-        className="flex w-full flex-col items-center gap-4"
-        onKeyDown={handleShortcutKey}
-      >
+      <div className="flex w-full flex-col items-center gap-4">
         <PixelPirateScouting className="h-14 w-14" />
         <h1 className="font-medium text-xl">{title}</h1>
         <p className="text-sm text-text-muted">{body}</p>

--- a/packages/web/src/components/RootShell/RootShell.test.tsx
+++ b/packages/web/src/components/RootShell/RootShell.test.tsx
@@ -2,7 +2,9 @@ import "@testing-library/jest-dom";
 import userEvent from "@testing-library/user-event";
 import { act, type ReactElement } from "react";
 import { render, screen } from "@web/__tests__/__mocks__/mock.render";
+import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { createTestRouter } from "@web/__tests__/utils/providers/createTestRouter";
+import { BillingApi } from "@web/api/billing.api";
 import { SessionContext } from "@web/auth/compass/session/session.context";
 import {
   billingPreviewActions,
@@ -12,6 +14,7 @@ import {
 import { type AppAccess } from "@web/billing/useAppAccess";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import { registerToastPort } from "@web/common/utils/toast/toast.port";
 import { RootShell } from "@web/components/RootShell/RootShell";
 import {
   afterAll,
@@ -21,6 +24,7 @@ import {
   expect,
   it,
   mock,
+  spyOn,
 } from "bun:test";
 
 const actualUseAppAccess = (await import("@web/billing/useAppAccess"))
@@ -54,6 +58,7 @@ const renderShell = async (
   });
   render(<div />, { router });
   await router.load();
+  return router;
 };
 
 afterAll(() => {
@@ -140,6 +145,44 @@ describe("RootShell billing gates", () => {
     expect(
       screen.getByRole("dialog", { name: "Start your 7-day trial" }),
     ).toBeInTheDocument();
+  });
+
+  it("looks around with L without navigating to Life", async () => {
+    access = awaitingCheckout;
+    const router = await renderShell("/week");
+    const user = userEvent.setup();
+
+    await user.keyboard("l");
+
+    expect(
+      screen.queryByRole("dialog", { name: "Start your 7-day trial" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "You're looking around in read-only mode.",
+    );
+    expect(router.state.location.pathname).toBe("/week");
+  });
+
+  it("starts checkout with S from the billing gate", async () => {
+    const createCheckoutSession = spyOn(
+      BillingApi,
+      "createCheckoutSession",
+    ).mockResolvedValue({ url: "https://checkout.stripe.com/c/ok" });
+    const assign = spyOn(window.location, "assign").mockImplementation(
+      () => {},
+    );
+    const { port } = createTestToastPort();
+    registerToastPort(port);
+    access = awaitingCheckout;
+    await renderShell("/week");
+    const user = userEvent.setup();
+
+    await user.keyboard("s");
+
+    expect(createCheckoutSession).toHaveBeenCalled();
+    expect(assign).toHaveBeenCalledWith("https://checkout.stripe.com/c/ok");
+    createCheckoutSession.mockRestore();
+    assign.mockRestore();
   });
 });
 

--- a/packages/web/src/shortcuts/swallow-next-keyup.test.ts
+++ b/packages/web/src/shortcuts/swallow-next-keyup.test.ts
@@ -1,0 +1,55 @@
+import { swallowNextKeyup } from "@web/shortcuts/swallow-next-keyup";
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+const dispatchKeyup = (
+  key: string,
+  target: Window | Document = window,
+): KeyboardEvent => {
+  const event = new KeyboardEvent("keyup", {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    key,
+  });
+  target.dispatchEvent(event);
+  return event;
+};
+
+describe("swallowNextKeyup", () => {
+  afterEach(() => {
+    // Drain any leftover capture listener from a case that did not fire
+    // the matching key (the helper times out at 1s).
+    dispatchKeyup("l");
+    dispatchKeyup("s");
+  });
+
+  it("preventsDefault the matching keyup and stops it reaching document", () => {
+    const seen = mock((_event: KeyboardEvent) => {});
+    document.addEventListener("keyup", seen, true);
+    swallowNextKeyup("l");
+
+    const event = dispatchKeyup("l");
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(seen).not.toHaveBeenCalled();
+    document.removeEventListener("keyup", seen, true);
+  });
+
+  it("ignores a different letter and still swallows the target", () => {
+    swallowNextKeyup("l");
+
+    const other = dispatchKeyup("s");
+    expect(other.defaultPrevented).toBe(false);
+
+    const target = dispatchKeyup("l");
+    expect(target.defaultPrevented).toBe(true);
+  });
+
+  it("swallows only the next matching keyup", () => {
+    swallowNextKeyup("l");
+    dispatchKeyup("l");
+
+    const second = dispatchKeyup("l");
+    expect(second.defaultPrevented).toBe(false);
+  });
+});

--- a/packages/web/src/shortcuts/swallow-next-keyup.ts
+++ b/packages/web/src/shortcuts/swallow-next-keyup.ts
@@ -1,0 +1,30 @@
+import { keyboardKey } from "@web/shortcuts/is-bare-letter-key";
+
+const SWALLOW_MS = 1000;
+
+/**
+ * Overlay letter shortcuts run on keydown and may unmount (and drop app-lock)
+ * before the matching keyup. View navigation is bound on keyup, so that leftover
+ * release would otherwise navigate. Capture-phase on `window` runs before
+ * document-level hotkeys.
+ */
+export function swallowNextKeyup(key: string): void {
+  const target = key.toLowerCase();
+  let done = false;
+
+  const finish = () => {
+    if (done) return;
+    done = true;
+    window.removeEventListener("keyup", onKeyUp, true);
+  };
+
+  const onKeyUp = (event: KeyboardEvent) => {
+    if (keyboardKey(event).toLowerCase() !== target) return;
+    event.preventDefault();
+    event.stopPropagation();
+    finish();
+  };
+
+  window.addEventListener("keyup", onKeyUp, true);
+  window.setTimeout(finish, SWALLOW_MS);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The billing gate advertises `L` for “Look around first” and `S` for “Start trial”. `L` dismissed the overlay on keydown, which dropped app-lock before the leftover keyup, so the Life view shortcut (`keyup` `L`) then navigated away from `/week`. `S` only fired if the keydown bubbled from a focused descendant of the panel, so it could miss after a refused write remounted the gate.

This binds `S` / `L` / `M` through `useAppShortcut` (`ignoreAppLock`, works without panel focus) and swallows the matching keyup in the capture phase before look-around unmounts the gate.

## Simplicity

One small `swallowNextKeyup` helper (same leftover-keyup idea as the existing Cmd+D suppression) plus document-level overlay bindings. The Life shortcut itself is unchanged.

## Automated validation

Focused web tests (23 pass, 0 fail):

- `BillingGateModal` — `S` starts checkout, `L` enters look-around, `M` opens the portal
- `RootShell` on `/week` — `L` dismisses the gate, shows the read-only banner, and stays on `/week` (does not navigate to `/life`); `S` calls `createCheckoutSession`
- `swallowNextKeyup` — matching keyup is prevented and does not reach `document`

`bun run verify` (merge-base `origin/main`):

- Detected changes in: web
- Checks run: `test:web`, `type-check`, `lint`, `knip` — passed
- Skipped: `test:a11y`, `test:e2e` (Playwright Chromium not installed)

## Independent review

Not run yet.

## Test plan

- `bun test:web -- packages/web/src/billing/BillingGateModal.test.tsx packages/web/src/components/RootShell/RootShell.test.tsx packages/web/src/shortcuts/swallow-next-keyup.test.ts` — 23 pass, 0 fail
- `bun run verify` — selected checks passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c454dc0d-1a5b-4d41-ab1a-dda55be624ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c454dc0d-1a5b-4d41-ab1a-dda55be624ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

