### PR TITLE
fix(e2e): measure day column width on the cell, not the label's parent

### DIFF
--- a/e2e/calendars/calendar-experience.spec.ts
+++ b/e2e/calendars/calendar-experience.spec.ts
@@ -375,6 +375,15 @@ test("day view separates visible calendars into distinct columns", async ({
   });
   const primaryHeader = calendarHeaders.getByText(CALENDAR_A_NAME);
   const readerHeader = calendarHeaders.getByText(CALENDAR_B_NAME);
+  // Measure the grid cell, not the label's parent. A writable calendar's
+  // label is wrapped in a jump-target button that hugs its text, so the
+  // label's parent is the button for one column and the cell for the other.
+  const primaryColumn = calendarHeaders
+    .locator("> div")
+    .filter({ hasText: CALENDAR_A_NAME });
+  const readerColumn = calendarHeaders
+    .locator("> div")
+    .filter({ hasText: CALENDAR_B_NAME });
   const primaryEvent = dayAgenda.getByRole("button", {
     name: new RegExp(`${EVENT_A_TITLE}.*${CALENDAR_A_NAME} calendar`),
   });
@@ -391,8 +400,8 @@ test("day view separates visible calendars into distinct columns", async ({
 
   const [primaryHeaderBox, readerHeaderBox, primaryEventBox, readerEventBox] =
     await Promise.all([
-      primaryHeader.locator("..").boundingBox(),
-      readerHeader.locator("..").boundingBox(),
+      primaryColumn.boundingBox(),
+      readerColumn.boundingBox(),
       primaryEvent.boundingBox(),
       readerEvent.boundingBox(),
     ]);


### PR DESCRIPTION
`main`'s e2e has been red since #2942 on:

```
[chromium-desktop] › e2e/calendars/calendar-experience.spec.ts:362:5
  › day view separates visible calendars into distinct columns
Expected: <= 87
Received:    280
```

## What actually broke

**Not the layout.** #2942 wrapped each *writable* calendar's column label in a jump-target `<button>` in `DayCalendarColumnHeaders.tsx`. The test measured the header as `header.locator("..")` — the label's parent — which until then was the grid cell.

After #2942 that parent is the button for a writable calendar and still the cell for a read-only one. The button is content-sized, so the "column width" it compared against was 88px instead of the cell's 379px. That asymmetry is why only line 406 (the writable calendar) failed while line 407 (the reader) passed.

Measured on `main` with a temporary probe:

| | width |
|---|---|
| column cell | 379 |
| event | 280 |
| event x | 89 and 468 (379 apart) |

Events sit inside their columns exactly as intended. Only the anchor was wrong.

## The fix

Point the measurement at the grid cell directly rather than reshaping the markup to suit a selector that was only ever a proxy for it. The label keeps its own locator for the visibility and colour assertions.

The assertion keeps its teeth: 280 ≤ 379 passes, and an event spilling across columns would be ~758px and still fail.

## Verification

Reproduced the failure on unmodified `origin/main` locally (88 vs 280), then confirmed the test passes with this change. Full local Playwright run: **46 passed, 1 failed** — the remaining failure is `e2e/timed/mouse-inert.spec.ts › right-click is blocked; m opens the menu instead`, which presses `Shift+F10`. macOS emits no `contextmenu` event for that key, so it is a pre-existing macOS-only local failure in a spec this PR does not touch; CI runs Linux, where it passes.

## Note

#2942's own PR e2e check is recorded as **failing** and it was merged anyway; its push-to-`main` Test run was then cancelled. I could not confirm that PR's failure was this same test because those logs have since been purged, but the introducing change is confirmed by local reproduction.

This unblocks #2947.

🤖 Generated with [Claude Code](https://claude.com/claude-code)