### PR TITLE
feat(web): lead the upgrade dialog with one Premium call to action

### DIFF
--- a/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationDialog.tsx
+++ b/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationDialog.tsx
@@ -13,10 +13,11 @@ interface UpgradeConfirmationDialogProps {
 }
 
 /**
- * Confirms ending a Stripe trial early. No amount is shown here on purpose:
- * the price lives on the Stripe Price, not in this codebase, so operators can
- * change it without a web deploy. "Manage billing" is the way to see the card
- * and the exact charge before committing.
+ * Confirms starting a Stripe subscription before the trial runs out. No amount
+ * is shown here on purpose: the price lives on the Stripe Price, not in this
+ * codebase, so operators can change it without a web deploy. "Manage billing"
+ * is the way to see the card and the exact charge before committing, so it sits
+ * apart from the two real choices rather than competing with them.
  */
 export function UpgradeConfirmationDialog({
   isOpen,
@@ -29,35 +30,38 @@ export function UpgradeConfirmationDialog({
 
   return (
     <OverlayPanel
-      title="End your trial and subscribe?"
-      message="Your trial ends right away and the card on file is charged today. Your calendar keeps working, and the trial badge goes away."
+      title="Start Premium now?"
+      message="Premium starts right away and the card on file is charged today. Everything in your calendar keeps working, and the trial badge goes away."
       onDismiss={onCancel}
       align="start"
       variant="modal"
     >
-      <OverlayPanelActions align="start">
+      <div className="flex w-full flex-col items-start gap-4">
+        <OverlayPanelActions align="start">
+          <OverlayPanelActionButton
+            variant="primary"
+            shortcut="Enter"
+            disabled={isSubmitting}
+            onClick={onConfirm}
+          >
+            {isSubmitting ? "Starting Premium…" : "Start Premium"}
+          </OverlayPanelActionButton>
+          <OverlayPanelActionButton
+            shortcut="Esc"
+            disabled={isSubmitting}
+            onClick={onCancel}
+          >
+            Cancel
+          </OverlayPanelActionButton>
+        </OverlayPanelActions>
         <OverlayPanelActionButton
-          variant="primary"
-          shortcut="Enter"
-          disabled={isSubmitting}
-          onClick={onConfirm}
-        >
-          {isSubmitting ? "Subscribing…" : "Subscribe now"}
-        </OverlayPanelActionButton>
-        <OverlayPanelActionButton
-          shortcut="Esc"
-          disabled={isSubmitting}
-          onClick={onCancel}
-        >
-          Cancel
-        </OverlayPanelActionButton>
-        <OverlayPanelActionButton
+          variant="ghost"
           disabled={isSubmitting}
           onClick={onManageBilling}
         >
           Manage billing
         </OverlayPanelActionButton>
-      </OverlayPanelActions>
+      </div>
     </OverlayPanel>
   );
 }

--- a/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationProvider.test.tsx
+++ b/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationProvider.test.tsx
@@ -46,7 +46,7 @@ const openDialog = async () => {
   renderProvider();
   await userEvent.click(screen.getByRole("button", { name: "open upgrade" }));
   return screen.getByRole("dialog", {
-    name: "End your trial and subscribe?",
+    name: "Start Premium now?",
   });
 };
 
@@ -77,7 +77,7 @@ describe("UpgradeConfirmationProvider", () => {
     await openDialog();
 
     await userEvent.click(
-      screen.getByRole("button", { name: /Subscribe now/ }),
+      screen.getByRole("button", { name: /Start Premium/ }),
     );
 
     await waitFor(() => {
@@ -91,7 +91,7 @@ describe("UpgradeConfirmationProvider", () => {
     });
     expect(toastMocks.error).not.toHaveBeenCalled();
     expect(
-      screen.queryByRole("dialog", { name: "End your trial and subscribe?" }),
+      screen.queryByRole("dialog", { name: "Start Premium now?" }),
     ).not.toBeInTheDocument();
     endTrial.mockRestore();
   });
@@ -105,7 +105,7 @@ describe("UpgradeConfirmationProvider", () => {
     await openDialog();
 
     await userEvent.click(
-      screen.getByRole("button", { name: /Subscribe now/ }),
+      screen.getByRole("button", { name: /Start Premium/ }),
     );
 
     await waitFor(() => {
@@ -125,7 +125,7 @@ describe("UpgradeConfirmationProvider", () => {
     await openDialog();
 
     await userEvent.click(
-      screen.getByRole("button", { name: /Subscribe now/ }),
+      screen.getByRole("button", { name: /Start Premium/ }),
     );
 
     await waitFor(() => {
@@ -144,7 +144,7 @@ describe("UpgradeConfirmationProvider", () => {
     await userEvent.click(screen.getByRole("button", { name: /Cancel/ }));
 
     expect(
-      screen.queryByRole("dialog", { name: "End your trial and subscribe?" }),
+      screen.queryByRole("dialog", { name: "Start Premium now?" }),
     ).not.toBeInTheDocument();
     expect(endTrial).not.toHaveBeenCalled();
     endTrial.mockRestore();

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
@@ -251,7 +251,7 @@ export const OverlayPanelActions = ({
 
 interface OverlayPanelActionButtonProps
   extends ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: "primary" | "secondary" | "destructive";
+  variant?: "primary" | "secondary" | "destructive" | "ghost";
   /** Visible keycap(s) for the action. */
   shortcut?: string | string[];
 }
@@ -274,13 +274,18 @@ export const OverlayPanelActionButton = forwardRef<
     <button
       ref={ref}
       className={classNames(
-        "inline-flex h-11 items-center justify-center rounded px-4 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface-panel disabled:pointer-events-none disabled:opacity-50",
+        "inline-flex items-center justify-center rounded text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface-panel disabled:pointer-events-none disabled:opacity-50",
+        // The ghost variant skips the button box entirely so it reads as a
+        // quiet link next to the real actions.
+        variant !== "ghost" && "h-11 px-4",
         variant === "primary" &&
-          "bg-accent text-on-accent transition hover:brightness-110",
+          "bg-accent font-medium text-on-accent transition hover:brightness-110",
         variant === "destructive" &&
           "bg-error text-on-accent transition hover:brightness-110",
         variant === "secondary" &&
           "border border-border bg-surface-overlay text-text transition-colors hover:bg-surface-panel",
+        variant === "ghost" &&
+          "text-text-muted underline-offset-4 transition-colors hover:text-text hover:underline",
         className,
       )}
       type={type}


### PR DESCRIPTION
## What

The trial upgrade confirmation had three same-weight buttons on one row, so nothing read as *the* action. Now there is a single primary call to action, and the copy frames the choice as starting Premium rather than ending a trial.

- **Button hierarchy** — "Start Premium" is the only filled/accent button. "Cancel" sits beside it as a plain outline. "Manage billing" drops to a quiet ghost link on its own row below, since it is an escape hatch for checking the card, not a third decision.
- **Copy** — title is now "Start Premium now?" and the confirm button reads "Start Premium" / "Starting Premium…". The message still spells out that the card on file is charged today and that the trial badge goes away, so the friendlier framing hides nothing.
- **`OverlayPanelActionButton`** gains a `ghost` variant. It has to *skip* the shared `h-11 px-4` box rather than override it: the classes are concatenated with `classnames`, so a later `px-0` would win or lose on Tailwind's CSS source order rather than string order.

"Premium" is the plan name already used by the plan badge, settings, and the checkout celebration, so this brings the dialog in line with the rest of billing.

## Verification

- `bun test:web` — 2689 pass, 0 fail
- `bun run type-check` and `biome check` clean
- Rendered the dialog against the dev server's stylesheet to confirm the hierarchy reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)