### PR TITLE
fix(web): nest Compass calendar under matching Google account

### DIFF
--- a/docs/architecture/multi-account-sync.md
+++ b/docs/architecture/multi-account-sync.md
@@ -50,9 +50,11 @@ User-visible status hangs off one connection, never the precedence-collapsed
 aggregate. A stuck account must not pin an unattributed banner (or disable
 reconciliation) for all accounts.
 
-- The local Compass calendar is its own sidebar section (the signed-in
-  user's email) once any Google account exists. It stays visible and
-  toggleable. LCV1/LCV2 still exclude it as a create target.
+- The local Compass calendar nests under the Google account whose email
+  matches the signed-in user. When no connected account shares that
+  email, it stays its own sidebar section (the signed-in user's email)
+  once any Google account exists. It stays visible and toggleable.
+  LCV1/LCV2 still exclude it as a create target.
 - A connected-but-still-importing account keeps its section header with
   zero calendars so "Adding your calendar…" attributes to that account.
 - Day view columns are active+visible calendars, matching Week.

--- a/packages/web/src/calendars/calendar.util.test.ts
+++ b/packages/web/src/calendars/calendar.util.test.ts
@@ -457,4 +457,77 @@ describe("groupCalendarsByAccount", () => {
     expect(groups[0]?.accountEmail).toBe("old@x.com");
     expect(groups[0]?.calendars).toEqual([]);
   });
+
+  it("nests the local calendar under the Google account that matches compassEmail", () => {
+    const work = makeCalendar({
+      name: "Work",
+      provider: "google",
+      accountEmail: "old@x.com",
+    });
+    const personal = makeCalendar({
+      name: "Personal",
+      provider: "google",
+      accountEmail: "new@x.com",
+      id: "507f1f77bcf86cd799439012" as Calendar["id"],
+    });
+    const local = makeCalendar({
+      name: "Compass",
+      provider: "local",
+      id: "507f1f77bcf86cd799439013" as Calendar["id"],
+    });
+
+    const { groups, ungrouped } = groupCalendarsByAccount(
+      [personal, work, local],
+      [connection("old@x.com"), connection("new@x.com")],
+      "old@x.com",
+    );
+
+    expect(ungrouped).toEqual([]);
+    expect(groups[0]?.calendars).toEqual([work, local]);
+    expect(groups[1]?.calendars).toEqual([personal]);
+  });
+
+  it("matches compassEmail to a Google account case-insensitively", () => {
+    const work = makeCalendar({
+      name: "Work",
+      provider: "google",
+      accountEmail: "Old@X.com",
+    });
+    const local = makeCalendar({
+      name: "Compass",
+      provider: "local",
+      id: "507f1f77bcf86cd799439013" as Calendar["id"],
+    });
+
+    const { groups, ungrouped } = groupCalendarsByAccount(
+      [work, local],
+      [connection("Old@X.com")],
+      "  old@x.com  ",
+    );
+
+    expect(ungrouped).toEqual([]);
+    expect(groups[0]?.calendars).toEqual([work, local]);
+  });
+
+  it("leaves the local calendar ungrouped when compassEmail matches no Google account", () => {
+    const work = makeCalendar({
+      name: "Work",
+      provider: "google",
+      accountEmail: "old@x.com",
+    });
+    const local = makeCalendar({
+      name: "Compass",
+      provider: "local",
+      id: "507f1f77bcf86cd799439013" as Calendar["id"],
+    });
+
+    const { groups, ungrouped } = groupCalendarsByAccount(
+      [work, local],
+      [connection("old@x.com")],
+      "login@x.com",
+    );
+
+    expect(ungrouped).toEqual([local]);
+    expect(groups[0]?.calendars).toEqual([work]);
+  });
 });

--- a/packages/web/src/calendars/calendar.util.ts
+++ b/packages/web/src/calendars/calendar.util.ts
@@ -122,10 +122,16 @@ export interface AccountGroup {
  * Empty groups are kept so a connected-but-still-importing account still
  * renders its section header. Callers that cannot show an empty optgroup
  * (the Settings default-calendar select) skip those groups inline.
+ *
+ * When `compassEmail` matches a group's account email (case-insensitive),
+ * nest the local Compass calendar under that Google section instead of
+ * leaving it ungrouped. Callers that paint a second "Compass email" parent
+ * then only do so when no Google account shares the login address.
  */
 export function groupCalendarsByAccount(
   calendars: Calendar[],
   connections: GoogleSyncConnectionSummary[],
+  compassEmail?: string | null,
 ): { groups: AccountGroup[]; ungrouped: Calendar[] } {
   const groups: AccountGroup[] = [];
   const byEmail = new Map<string, AccountGroup>();
@@ -158,8 +164,36 @@ export function groupCalendarsByAccount(
     group.calendars.push(calendar);
   }
 
-  return { groups, ungrouped };
+  return nestLocalCalendarInMatchingGroup(groups, ungrouped, compassEmail);
 }
+
+const nestLocalCalendarInMatchingGroup = (
+  groups: AccountGroup[],
+  ungrouped: Calendar[],
+  compassEmail: string | null | undefined,
+): { groups: AccountGroup[]; ungrouped: Calendar[] } => {
+  const normalizedCompassEmail = compassEmail?.trim().toLowerCase();
+  if (!normalizedCompassEmail) return { groups, ungrouped };
+
+  // Connection order is already the group order; first match wins if two
+  // accounts somehow share an email.
+  const matchingGroup = groups.find(
+    (group) =>
+      group.accountEmail.trim().toLowerCase() === normalizedCompassEmail,
+  );
+  if (!matchingGroup) return { groups, ungrouped };
+
+  const stillUngrouped: Calendar[] = [];
+  for (const calendar of ungrouped) {
+    if (calendar.provider === "local") {
+      matchingGroup.calendars.push(calendar);
+    } else {
+      stillUngrouped.push(calendar);
+    }
+  }
+
+  return { groups, ungrouped: stillUngrouped };
+};
 
 export interface DefaultTargetCalendarOptions {
   /**

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -643,6 +643,61 @@ describe("CalendarList", () => {
     expect(screen.getByText("Work")).toBeInTheDocument();
   });
 
+  it("nests Compass under the Google account that matches the Compass login email", () => {
+    mockUserEmail = "ahab@pequod.com";
+    const work = makeCalendar({
+      name: "Work",
+      accountEmail: "ahab@pequod.com",
+    });
+    const personal = makeCalendar({
+      name: "Personal",
+      accountEmail: "ahab@gmail.com",
+    });
+    const local = makeCalendar({ name: "Compass", provider: "local" });
+
+    renderCalendarList([work, personal, local], {
+      connections: [
+        makeConnection("ahab@pequod.com"),
+        makeConnection("ahab@gmail.com"),
+      ],
+    });
+
+    const matchingSection = screen.getByRole("region", {
+      name: "Calendars for ahab@pequod.com",
+    });
+    expect(within(matchingSection).getByText("Work")).toBeInTheDocument();
+    expect(within(matchingSection).getByText("Compass")).toBeInTheDocument();
+    expect(
+      screen.queryAllByRole("region", {
+        name: "Calendars for ahab@pequod.com",
+      }),
+    ).toHaveLength(1);
+    expect(
+      within(
+        screen.getByRole("region", { name: "Calendars for ahab@gmail.com" }),
+      ).queryByText("Compass"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides Compass with the matching Google account when that section collapses", async () => {
+    mockUserEmail = "ahab@pequod.com";
+    const work = makeCalendar({
+      name: "Work",
+      accountEmail: "ahab@pequod.com",
+    });
+    const local = makeCalendar({ name: "Compass", provider: "local" });
+
+    const user = userEvent.setup({ delay: null });
+    renderCalendarList([work, local], {
+      connections: [makeConnection("ahab@pequod.com")],
+    });
+
+    expect(screen.getByText("Compass")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "ahab@pequod.com" }));
+    expect(screen.queryByText("Compass")).not.toBeInTheDocument();
+    expect(screen.queryByText("Work")).not.toBeInTheDocument();
+  });
+
   it("keeps the local Compass section visible when Google accounts are collapsed", async () => {
     const work = makeCalendar({
       name: "Work",

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
@@ -51,8 +51,8 @@ export const CalendarList: FC = () => {
     [data, accountEmailOrder],
   );
   const { groups, ungrouped } = useMemo(
-    () => groupCalendarsByAccount(calendars, connections),
-    [calendars, connections],
+    () => groupCalendarsByAccount(calendars, connections, email),
+    [calendars, connections, email],
   );
 
   const renderRows = (rows: Calendar[], id?: string) => (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When the Compass login email matches a connected Google account, the sidebar currently paints two parent rows with the same address: Google calendars under one, and the local Compass calendar under a second copy of that email.

This change nests Compass under the matching Google account (case-insensitive) so users see one parent. If no connected account shares the login email, Compass stays its own section.

Grouping is UI-only. The local calendar still has no `accountEmail` on the wire, and it remains excluded as a create/default target while Google is connected.

## Simplicity

`/simplify`: no commit. Nesting stays a second pass after grouping so local appends after that account's Google calendars regardless of calendar order. CalendarList only threads `useUser().email` into the existing helper.

## Automated validation

`/verify-change` VERDICT: PASS

```
Selected packages: web
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)
All checks passed
```

Focused web tests (56 pass) cover match, case-insensitive/trim match, no-match fallback, one sidebar region when emails match, and collapse with the matching account.

GitHub CI: 24/24 SUCCESS on `e1e1c2c5e`.

## Independent review

`.agents/handoffs/2953.md` plus reviewer output:

```
VERDICT: no confirmed findings
FINDINGS: (none)
```

## Test plan

- `bun run verify` (test:web, type-check, lint, knip, test:a11y, test:e2e)
- `bun test:web -- packages/web/src/calendars/calendar.util.test.ts packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx` (56 pass)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9b3c691-de86-4503-887d-d4b61f27df54?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9b3c691-de86-4503-887d-d4b61f27df54&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

