### PR TITLE
feat(web): teach day columns with Shift and stop truncating the tip

### DIFF
--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -283,7 +283,7 @@ After deleting or moving an event, pressing Cmd+Z (Mac) or Ctrl+Z (Windows/Linux
 
 ### UX
 
-Pressing `H` shows event-jump chips. Week view chips use day prefixes (`SU`/`M`/`T`/`W`/`R`/`F`/`SA`) plus a per-day index (`W4`, `SU1`). Day view uses numeric chips (`1`, `2`, …). Pressing a day letter highlights that column and focuses its first event; a following digit focuses that index. Memorized tokens (`SA`, `SU`, `W`, `W2`, day-view `1`) also work without first pressing `H`, except where a competing command still applies: bare `T` stays “go to today”, focused `M` stays “open event menu”, and `F` stays “focus latest notice” while a notice is visible. `Esc` exits (a second `H` also toggles off). Holding Mod reveals the same day prefixes on week column headers. Bare Shift and Shift+Tab do not show jump chips.
+Pressing `H` shows event-jump chips. Week view chips use day prefixes (`SU`/`M`/`T`/`W`/`R`/`F`/`SA`) plus a per-day index (`W4`, `SU1`). Day view uses numeric chips (`1`, `2`, …). Pressing a day letter highlights that column and focuses its first event; a following digit focuses that index. From idle, a column is entered with Shift and its day letter (`Shift+W`, `Shift+S` then `U`/`A` for the weekend), which always works: bare `T` stays “go to today”, bare `M` stays “open event menu”, and bare `F` stays “focus latest notice”. Day view keeps bare digits, since `Shift+1` is `!`. `Esc` exits (a second `H` also toggles off). Holding Mod reveals the same day prefixes on week column headers, shown as `⇧W` while jump mode is off. Bare Shift and Shift+Tab do not show jump chips.
 
 ### Steps
 
@@ -291,15 +291,15 @@ Pressing `H` shows event-jump chips. Week view chips use day prefixes (`SU`/`M`/
 2. Press `H` once; chips should appear.
 3. Press the day letter on a chip (for example `W` for Wednesday), then optionally a digit (`2`) or use arrow keys.
 4. Press `Esc` to exit.
-5. Without pressing `H`, type a claimable day token (for example `SA`, `W`, or `W2`) and confirm the matching event is focused.
+5. Without pressing `H`, press `Shift+W` (or `Shift+S` then `A`) and confirm the matching event is focused; a following digit still refines to `W2`.
 6. Press Shift alone or Shift+Tab and confirm jump mode does not activate.
 
 ### Expected Results
 
 - Chips appear on events currently visible in the grid when `H` is pressed and stay until Esc. Scrolled-off events keep their jump keys but hide their chips.
 - A day letter highlights that column and focuses the first event; digits refine to `Wn`.
-- The same day letter / digit tokens work without a prior `H` when no competing command applies; `H` remains available to reveal every chip. Weekend columns use `SA` / `SU` from idle.
-- Bare `T` still goes to today while jump is off. With an event focused, `M` still opens the event menu. With a visible notice, `F` still focuses that notice.
+- Shift + the day letter enters a column from idle, including while an event is focused; `H` remains available to reveal every chip. Weekend columns use `Shift+S` then `A` / `U`.
+- Bare `T` still goes to today while jump is off. With an event focused, bare `M` still opens the event menu. With a visible notice, bare `F` still focuses that notice.
 - Arrow keys keep jump mode on so letter-then-arrows works.
 - Shift alone / Shift+Tab / Shift+J do not toggle jump mode.
 - While a modal holds the app lock, or focus is in an editable field, `H` and leaderless jump tokens do not activate jump mode.
@@ -443,7 +443,7 @@ If time is limited, run these checks before shipping shortcut-related changes:
 12. With no event focused and no particular control focused (document body), any Arrow key focuses the timed event nearest now in the current Day/Week view (in-progress, else next upcoming, else most recently ended; today preferred in Week; all-day only if no timed events). Further arrows then follow the existing rules. `U` still focuses the first DOM-order event. With a focused event and no draft open: in Week view ArrowUp/ArrowDown stay on the same day and ArrowLeft/Right jump to the time-nearest event on the previous/next non-empty day; in Day view all four arrows move chronological focus.
 13. Cmd+D / Ctrl+D duplicates a focused event in Day and Week view.
 14. With a focused event, `E` then `T` opens the form with the title focused; `E` then `A` / `C` jump to guests / color; bare `E` alone does nothing.
-15. Pressing `H` shows event jump chips; a day letter + digit focuses that event; the same tokens work without a prior `H` when no competing command applies; Shift+Tab does not show chips.
+15. Pressing `H` shows event jump chips; a day letter + digit focuses that event; `Shift` + the day letter enters a column without a prior `H`; Shift+Tab does not show chips.
 16. Mouse clicks, right-clicks, and double-clicks are inert everywhere; a blocked click shows the keyboard-only hint. `M` opens the focused event's menu; `F` focuses the newest notice.
 17. PageUp / PageDown scroll the timed grid by one viewport in Day and Week view even when an event is focused; they do not fire in a text input.
 18. Alt+ArrowUp / Alt+ArrowDown pan the timed grid by one hour in Day and Week view even when an event is focused; they do not fire in a text input.

--- a/e2e/timed/shift-hold-event-hints.spec.ts
+++ b/e2e/timed/shift-hold-event-hints.spec.ts
@@ -20,6 +20,8 @@ const DAY_PREFIX_KEYS: Record<string, string[]> = {
   SA: ["s", "a"],
 };
 
+const WEEKDAY_PREFIXES = ["SU", "M", "T", "W", "R", "F", "SA"];
+
 /**
  * Creates a timed event on today via `c`, then nudges it by quarter-hour
  * steps so the trio gets distinct start times for chronological jump
@@ -125,7 +127,7 @@ test("tap h shows day-prefix jump keys and focuses the assigned event", async ({
   await expect(shiftHintOverlay(page)).toHaveCount(0);
 });
 
-test("day prefix focuses an event without first pressing h", async ({
+test("Shift and the day letter focuses an event without first pressing h", async ({
   page,
 }) => {
   await prepareCalendarPage(page);
@@ -136,16 +138,12 @@ test("day prefix focuses an event without first pressing h", async ({
 
   const [saved] = await getSavedEventsByTitle(page, title);
   const weekday = new Date(saved.startDate).getDay();
-  const key = weekday === 3 ? "w" : weekday === 4 ? "r" : null;
-  if (!key) {
-    test.skip(
-      true,
-      "leaderless e2e uses Wednesday/Thursday prefixes; other days are covered by unit tests",
-    );
-    return;
-  }
+  const keys = DAY_PREFIX_KEYS[WEEKDAY_PREFIXES[weekday]!]!;
 
-  await page.keyboard.press(key);
+  // Shift enters the column from idle; the weekend's second letter is typed
+  // bare, because jump mode is already on by then.
+  await page.keyboard.press(`Shift+${keys[0]}`);
+  if (keys[1]) await page.keyboard.press(keys[1]);
 
   await expect(
     page.locator("#mainGrid").getByRole("button", { name: title }),

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
@@ -174,6 +174,17 @@ describe("SidebarStatusBar", () => {
     expect(screen.getByRole("status")).toHaveTextContent(CREATE_EVENT_HINT);
   });
 
+  it("wraps the shortcut instead of clipping it, so no hint ends in an ellipsis", () => {
+    const { wrapper } = createStoreWrapper();
+
+    render(<SidebarStatusBar />, { wrapper });
+
+    const status = screen.getByRole("status");
+    expect(status.className).not.toContain("truncate");
+    expect(status.className).toContain("break-words");
+    expect(status.className).toContain("text-center");
+  });
+
   it("renders exactly one save status region, regardless of account count", () => {
     const { queryClient, wrapper } = createStoreWrapper();
     seedPendingEventMutations(queryClient, ["event-1"]);

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
@@ -34,7 +34,7 @@ import { useTimeTravelZone } from "@web/timezone/time-travel.store";
 
 /**
  * Pinned status bar at the bottom of the sidebar, just above the actions bar.
- * Always occupies a fixed height so nothing in the sidebar can shift when a
+ * Always occupies at least one line so nothing in the sidebar can shift when a
  * mutation goes in/out of flight, or an account's Google sync status changes -
  * that status used to render inline under each account's heading, where it
  * pushed the calendar rows below it up and down as accounts synced.
@@ -98,9 +98,9 @@ export const SidebarStatusBar: FC = () => {
   ) : null;
 
   return (
-    <div className="flex h-6 shrink-0 items-center px-4">
+    <div className="flex min-h-6 shrink-0 items-center justify-center px-4 py-0.5">
       {indicator ? (
-        <div className="flex h-full min-w-0 flex-1 items-center">
+        <div className="flex min-w-0 flex-1 items-center justify-center">
           {indicator}
         </div>
       ) : (
@@ -108,14 +108,14 @@ export const SidebarStatusBar: FC = () => {
           aria-label={
             text ? `${text}. Open account settings` : "Open account settings"
           }
-          className="c-focus-ring flex h-full min-w-0 flex-1 items-center rounded-xs text-left"
+          className="c-focus-ring flex min-w-0 flex-1 items-center justify-center self-stretch rounded-xs"
           onClick={settingsActions.openSettings}
           title={text || undefined}
           type="button"
         >
           <span
             aria-live="polite"
-            className={`truncate text-xs ${status ? SYNC_STATUS_VARIANT_CLASSNAME[status.variant] : ""}`}
+            className={`break-words text-center text-xs leading-5 ${status ? SYNC_STATUS_VARIANT_CLASSNAME[status.variant] : ""}`}
             role="status"
           >
             {text}

--- a/packages/web/src/grid/shortcuts/EdgeFocusIndicator.tsx
+++ b/packages/web/src/grid/shortcuts/EdgeFocusIndicator.tsx
@@ -16,7 +16,7 @@ export const EdgeFocusIndicator: FC = () => {
   return (
     <span
       aria-live="polite"
-      className="truncate text-text-muted text-xs opacity-80"
+      className="block w-full text-pretty break-words text-center text-text-muted text-xs leading-5 opacity-80"
       data-edge-focus-indicator=""
       role="status"
     >

--- a/packages/web/src/grid/shortcuts/KeyboardPlaceIndicator.tsx
+++ b/packages/web/src/grid/shortcuts/KeyboardPlaceIndicator.tsx
@@ -18,7 +18,7 @@ export const KeyboardPlaceIndicator: FC = () => {
   return (
     <span
       aria-live="polite"
-      className="truncate text-text-muted text-xs opacity-80"
+      className="block w-full text-pretty break-words text-center text-text-muted text-xs leading-5 opacity-80"
       data-keyboard-place-indicator=""
       role="status"
     >

--- a/packages/web/src/shortcuts/shift-hint/EventJumpIndicator.tsx
+++ b/packages/web/src/shortcuts/shift-hint/EventJumpIndicator.tsx
@@ -53,7 +53,7 @@ export const EventJumpIndicator: FC = () => {
   return (
     <span
       aria-live="polite"
-      className="truncate text-text-muted text-xs opacity-80"
+      className="block w-full text-pretty break-words text-center text-text-muted text-xs leading-5 opacity-80"
       data-event-jump-indicator=""
       role="status"
     >

--- a/packages/web/src/shortcuts/shift-hint/assign-shift-hint-keys.test.ts
+++ b/packages/web/src/shortcuts/shift-hint/assign-shift-hint-keys.test.ts
@@ -1,6 +1,7 @@
 import {
   assignDayJumpKeys,
   DAY_JUMP_PREFIX_BY_WEEKDAY,
+  dayJumpPrefixesForWeekdays,
   filterHintsByPrefix,
   matchDayJumpKeystroke,
 } from "@web/shortcuts/shift-hint/assign-shift-hint-keys";
@@ -387,5 +388,19 @@ describe("matchDayJumpKeystroke", () => {
       dayKey: "2026-08-05",
       buffer: "2",
     });
+  });
+});
+
+describe("dayJumpPrefixesForWeekdays", () => {
+  it("returns the prefixes for the days that have events, in weekday order", () => {
+    expect(dayJumpPrefixesForWeekdays([5, 3, 3, 0])).toEqual(["su", "w", "f"]);
+  });
+
+  it("has no letters in day view, where events are numbered", () => {
+    expect(dayJumpPrefixesForWeekdays([1, 2], "day")).toEqual([]);
+  });
+
+  it("is empty when nothing is scheduled", () => {
+    expect(dayJumpPrefixesForWeekdays([])).toEqual([]);
   });
 });

--- a/packages/web/src/shortcuts/shift-hint/assign-shift-hint-keys.ts
+++ b/packages/web/src/shortcuts/shift-hint/assign-shift-hint-keys.ts
@@ -41,6 +41,21 @@ export type DayJumpAssignment = {
 
 export type DayJumpLabelMode = "week" | "day";
 
+/**
+ * Day prefixes that currently have somewhere to land, in weekday order. Day
+ * view labels events numerically, so no letter is live there.
+ */
+export function dayJumpPrefixesForWeekdays(
+  weekdays: readonly number[],
+  mode: DayJumpLabelMode = "week",
+): string[] {
+  if (mode === "day") return [];
+  const present = new Set(weekdays);
+  return Object.entries(DAY_JUMP_PREFIX_BY_WEEKDAY)
+    .filter(([weekday]) => present.has(Number(weekday)))
+    .map(([, prefix]) => prefix);
+}
+
 /** Wait before committing a digit that could still grow (F1 vs F10). */
 export const DIGIT_AMBIGUOUS_COMMIT_MS = 400;
 

--- a/packages/web/src/shortcuts/shift-hint/event-jump.store.ts
+++ b/packages/web/src/shortcuts/shift-hint/event-jump.store.ts
@@ -13,6 +13,9 @@ export type EventJumpState = {
   pointerHintKey: string | null;
   /** Event that owns `pointerHintKey`, so rebuilds can refresh the token. */
   pointerHintEventId: string | null;
+  /** Day prefixes with somewhere to land right now, in weekday order. Read by
+   * the sidebar tip so it only teaches a key that would work. */
+  jumpableDayPrefixes: string[];
 };
 
 export const initialEventJumpState: EventJumpState = {
@@ -21,6 +24,7 @@ export const initialEventJumpState: EventJumpState = {
   announcement: "",
   pointerHintKey: null,
   pointerHintEventId: null,
+  jumpableDayPrefixes: [],
 };
 
 export const useEventJumpStore = create<EventJumpState>()(
@@ -71,6 +75,18 @@ export const eventJumpActions = {
       false,
       { type: "setPointerHint" },
     ),
+  setJumpableDayPrefixes: (jumpableDayPrefixes: string[]) => {
+    const current = useEventJumpStore.getState().jumpableDayPrefixes;
+    if (
+      current.length === jumpableDayPrefixes.length &&
+      current.every((prefix, i) => prefix === jumpableDayPrefixes[i])
+    ) {
+      return;
+    }
+    useEventJumpStore.setState({ jumpableDayPrefixes }, false, {
+      type: "setJumpableDayPrefixes",
+    });
+  },
   reset: () =>
     useEventJumpStore.setState(initialEventJumpState, false, { type: "reset" }),
 };
@@ -89,3 +105,6 @@ export const selectEventJumpAnnouncement = (state: EventJumpState) =>
 
 export const selectEventJumpPointerHintKey = (state: EventJumpState) =>
   state.pointerHintKey;
+
+export const selectJumpableDayPrefixes = (state: EventJumpState) =>
+  state.jumpableDayPrefixes;

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx
@@ -39,6 +39,12 @@ const dispatch = (
   );
 };
 
+/** The idle entry gesture: Shift + the day letter (browsers report it upper). */
+const pressDayJump = (letter: string) => {
+  dispatch("keydown", letter.toUpperCase(), { shiftKey: true });
+  dispatch("keyup", letter.toUpperCase(), { shiftKey: true });
+};
+
 const pressEventJump = () => {
   dispatch("keydown", KEYMAP.eventJump.bareLetter);
   dispatch("keyup", KEYMAP.eventJump.bareLetter);
@@ -151,14 +157,15 @@ describe("useShiftHoldEventHints", () => {
     expect(useEventJumpStore.getState().isActive).toBe(true);
   });
 
-  it("focuses a day prefix without first pressing h", () => {
+  it("focuses a day prefix with Shift and the day letter", () => {
     const { focus, result, elements } = mountHints();
 
     const event = new KeyboardEvent("keydown", {
       bubbles: true,
       cancelable: true,
       composed: true,
-      key: "w",
+      key: "W",
+      shiftKey: true,
     });
     act(() => {
       document.dispatchEvent(event);
@@ -173,11 +180,11 @@ describe("useShiftHoldEventHints", () => {
     expect(result.current.hints.map((hint) => hint.hint)).toEqual(["w1", "w2"]);
   });
 
-  it("refines a leaderless day prefix with a following digit", () => {
+  it("refines a Shift-entered day prefix with a following digit", () => {
     const { focus, elements } = mountHints();
 
     act(() => {
-      dispatch("keydown", "w");
+      pressDayJump("w");
       dispatch("keydown", "2");
     });
 
@@ -200,7 +207,8 @@ describe("useShiftHoldEventHints", () => {
       bubbles: true,
       cancelable: true,
       composed: true,
-      key: "w",
+      key: "W",
+      shiftKey: true,
     });
     act(() => {
       document.dispatchEvent(event);
@@ -245,7 +253,7 @@ describe("useShiftHoldEventHints", () => {
     expect(focus).not.toHaveBeenCalled();
   });
 
-  it("does not claim m while a calendar event is focused", () => {
+  it("leaves bare m to the event menu while an event is focused", () => {
     const { focus, elements } = mountHints("week", [
       timedFixture(EVENT_A, "2026-08-03T09:00:00.000Z"),
     ]);
@@ -267,13 +275,15 @@ describe("useShiftHoldEventHints", () => {
     expect(focus).not.toHaveBeenCalled();
   });
 
-  it("claims m when no calendar event is focused", () => {
+  it("claims Shift+M even while a calendar event is focused", () => {
     const { focus, elements } = mountHints("week", [
       timedFixture(EVENT_A, "2026-08-03T09:00:00.000Z"),
     ]);
+    elements[0]!.setAttribute(WEEK_INTERACTION_EVENT_ID_ATTRIBUTE, EVENT_A);
+    elements[0]!.focus();
 
     act(() => {
-      dispatch("keydown", "m");
+      pressDayJump("m");
     });
 
     expect(useEventJumpStore.getState().isActive).toBe(true);
@@ -282,7 +292,23 @@ describe("useShiftHoldEventHints", () => {
     );
   });
 
-  it("does not claim f while a notice is visible", () => {
+  it("claims Shift+T for Tuesday while bare t still goes to today", () => {
+    const { focus, elements } = mountHints("week", [
+      timedFixture(EVENT_A, "2026-08-04T09:00:00.000Z"),
+    ]);
+
+    act(() => {
+      pressDayJump("t");
+    });
+
+    expect(useEventJumpStore.getState().isActive).toBe(true);
+    expect(focus).toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: EVENT_A, element: elements[0] }),
+    );
+    expect(useEventJumpStore.getState().activeDayKeys).toEqual(["2026-08-04"]);
+  });
+
+  it("leaves bare f to notice focus while a notice is visible", () => {
     const { focus } = mountHints("week", [
       timedFixture(EVENT_A, "2026-08-07T09:00:00.000Z"),
     ]);
@@ -308,13 +334,13 @@ describe("useShiftHoldEventHints", () => {
     expect(focus).not.toHaveBeenCalled();
   });
 
-  it("claims f when no notice is visible", () => {
+  it("claims Shift+F for Friday", () => {
     const { focus, elements } = mountHints("week", [
       timedFixture(EVENT_A, "2026-08-07T09:00:00.000Z"),
     ]);
 
     act(() => {
-      dispatch("keydown", "f");
+      pressDayJump("f");
     });
 
     expect(useEventJumpStore.getState().isActive).toBe(true);
@@ -595,6 +621,35 @@ describe("useShiftHoldEventHints", () => {
     expect(useEventJumpStore.getState().pointerHintKey).toBe("W3");
   });
 
+  it("publishes the columns a day key can currently land on", () => {
+    mountHints("week", [
+      timedFixture(EVENT_A, "2026-08-05T09:00:00.000Z"),
+      timedFixture(EVENT_B, "2026-08-08T11:00:00.000Z"),
+    ]);
+
+    expect(useEventJumpStore.getState().jumpableDayPrefixes).toEqual([
+      "w",
+      "sa",
+    ]);
+  });
+
+  it("publishes no columns in day view, where events are numbered", () => {
+    mountHints("day");
+
+    expect(useEventJumpStore.getState().jumpableDayPrefixes).toEqual([]);
+  });
+
+  it("clears the published columns when the grid unmounts", () => {
+    mountHints();
+    expect(
+      useEventJumpStore.getState().jumpableDayPrefixes.length,
+    ).toBeGreaterThan(0);
+
+    cleanup();
+
+    expect(useEventJumpStore.getState().jumpableDayPrefixes).toEqual([]);
+  });
+
   it("does not activate on bare Shift or Shift+Tab", () => {
     const { result } = mountHints();
 
@@ -682,14 +737,14 @@ describe("useShiftHoldEventHints", () => {
     expect(result.current.hints).toEqual([]);
   });
 
-  it("focuses Saturday from idle with sa", () => {
+  it("focuses Saturday from idle with Shift+S then a", () => {
     const { focus, elements } = mountHints("week", [
       timedFixture(EVENT_A, "2026-08-02T09:00:00.000Z"),
       timedFixture(EVENT_B, "2026-08-08T11:00:00.000Z"),
     ]);
 
     act(() => {
-      dispatch("keydown", "s");
+      pressDayJump("s");
       dispatch("keydown", "a");
     });
 

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
@@ -2,10 +2,8 @@ import { useEffect, useRef, useState } from "react";
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import dayjs from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
-import { getCalendarEventIdFromElement } from "@web/common/utils/event/event.util";
 import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
 import { isAppLocked } from "@web/shortcuts/app-lock";
-import { EVENT_MENU_LETTER } from "@web/shortcuts/context-menu/useEventContextMenuShortcut";
 import { isHigherEscapeOwner } from "@web/shortcuts/escape-ownership";
 import {
   isBareLetterKey,
@@ -18,16 +16,12 @@ import {
 } from "@web/shortcuts/keyboard-only/pointer-action";
 import { KEYMAP } from "@web/shortcuts/keymap";
 import {
-  findNextNoticeTarget,
-  getVisibleNotices,
-} from "@web/shortcuts/notice-focus/notice-focus";
-import { FOCUS_NOTICE_LETTER } from "@web/shortcuts/notice-focus/useFocusNoticeShortcut";
-import {
   assignDayJumpKeys,
   type DayJumpAssignment,
   type DayJumpLabelMode,
   type DayJumpMatchResult,
   DIGIT_AMBIGUOUS_COMMIT_MS,
+  dayJumpPrefixesForWeekdays,
   filterHintsByPrefix,
   matchDayJumpKeystroke,
 } from "@web/shortcuts/shift-hint/assign-shift-hint-keys";
@@ -63,30 +57,6 @@ const DAY_NAME_BY_PREFIX: Record<string, string> = {
   sa: "Saturday",
 };
 
-/** Bare `t` stays "go to today" while jump is off. */
-const TODAY_LETTER = "t";
-
-/**
- * Competing single-letter commands that still apply while jump is off.
- * `t` always wins (today). `f` / `m` win only when their action has a target.
- */
-const competingShortcutApplies = (key: string): boolean => {
-  if (key === TODAY_LETTER) return true;
-  if (key === FOCUS_NOTICE_LETTER) {
-    return (
-      findNextNoticeTarget(getVisibleNotices(), document.activeElement) !== null
-    );
-  }
-  if (key === EVENT_MENU_LETTER) {
-    const active = document.activeElement;
-    return (
-      active instanceof HTMLElement &&
-      getCalendarEventIdFromElement(active) !== null
-    );
-  }
-  return false;
-};
-
 const isUnmodifiedSingleChar = (event: KeyboardEvent) => {
   const key = keyboardKey(event);
   return (
@@ -95,6 +65,21 @@ const isUnmodifiedSingleChar = (event: KeyboardEvent) => {
     !event.ctrlKey &&
     !event.altKey &&
     !event.shiftKey
+  );
+};
+
+/**
+ * Day columns are entered with Shift so they never race the bare-letter
+ * commands they used to lose to (`t` today, `f` notice focus, `m` event menu).
+ */
+const isShiftedSingleChar = (event: KeyboardEvent) => {
+  const key = keyboardKey(event);
+  return (
+    key.length === 1 &&
+    event.shiftKey &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.altKey
   );
 };
 
@@ -163,11 +148,13 @@ const buildDayJumpAssignments = (
 };
 
 /**
- * Press `h` to show day-prefix jump labels, or type a jump token (`sa`,
- * `w`, `w1`, day-view `1`…) without `h` when no competing command still
- * applies. Esc exits. Day letters (and digits after a day) win over global
- * shortcuts while active. A second `h` toggles off. In week view `s` is only
- * the Sunday/Saturday prefix.
+ * Press `h` to show day-prefix jump labels, or Shift+<day letter> to enter
+ * jump mode straight onto that column (`Shift+W`, `Shift+S` then `u`/`a`).
+ * Shift is what makes the day columns always available: bare `t`, `f`, and
+ * `m` keep their own commands. Once jump mode is on, the labels are typed
+ * bare (`w`, `w1`, day-view `1`…) and win over global shortcuts. Esc exits,
+ * a second `h` toggles off. In week view `s` is only the Sunday/Saturday
+ * prefix.
  */
 export function useShiftHoldEventHints({
   allDayEvents = [],
@@ -197,6 +184,7 @@ export function useShiftHoldEventHints({
   const allDayEventsRef = useRef(allDayEvents);
   const timedEventsRef = useRef(timedEvents);
   const modeRef = useRef(mode);
+  const publishedPrefixesRef = useRef<string[]>([]);
 
   focusRef.current = focus;
   listVisibleRef.current = listVisible;
@@ -373,7 +361,6 @@ export function useShiftHoldEventHints({
       if (!isActiveRef.current) {
         if (isAppLocked() || isEditableKeyboardTarget(event)) return;
         if (isEditSequenceArmed()) return;
-        if (!isUnmodifiedSingleChar(event)) return;
 
         if (isBareLetterKey(event, KEYMAP.eventJump.bareLetter)) {
           event.preventDefault();
@@ -385,7 +372,17 @@ export function useShiftHoldEventHints({
           return;
         }
 
+        // Shift+day enters jump mode straight onto that column. Any other
+        // shifted letter (Shift+J, Shift+C) falls through to its own handler.
+        // Day view is numbered, and Shift+1 is "!", so its digits stay bare.
         const key = normalizedKeyboardKey(event);
+        const isDigit = /^\d$/.test(key);
+        if (
+          isDigit ? !isUnmodifiedSingleChar(event) : !isShiftedSingleChar(event)
+        ) {
+          return;
+        }
+
         const assignments = rebuildAssignments();
         if (assignments.length === 0) return;
 
@@ -395,7 +392,7 @@ export function useShiftHoldEventHints({
           buffer: "",
           mode: modeRef.current,
         });
-        if (!match || competingShortcutApplies(key)) return;
+        if (!match) return;
 
         event.preventDefault();
         event.stopPropagation();
@@ -561,6 +558,36 @@ export function useShiftHoldEventHints({
       : assignments;
     setHints(toActiveHints(source, visibleById));
   }, [eventIdsKey, isActive]);
+
+  // Publish the day columns that have a live jump key, so the sidebar tip only
+  // teaches a keystroke that would actually land somewhere. Derived from the
+  // event props rather than the DOM registry so it is current before any
+  // keypress. Events without a start date would otherwise advertise the
+  // FALLBACK_SCHEDULE's phantom Sunday.
+  useEffect(() => {
+    void eventIdsKey;
+    const weekdays = [...allDayEventsRef.current, ...timedEventsRef.current]
+      .filter((event) => Boolean(event.startDate))
+      .map((event) => scheduleMeta(event).weekday);
+    const next = dayJumpPrefixesForWeekdays(weekdays, mode);
+    publishedPrefixesRef.current = next;
+    eventJumpActions.setJumpableDayPrefixes(next);
+  }, [eventIdsKey, mode]);
+
+  // Only clear what this grid published: switching Day -> Week can mount the
+  // new grid before the old one unmounts, and a blind clear there would blank
+  // the incoming view's columns for the rest of the session.
+  useEffect(
+    () => () => {
+      const published = publishedPrefixesRef.current;
+      const current = useEventJumpStore.getState().jumpableDayPrefixes;
+      const isOurs =
+        current.length === published.length &&
+        current.every((prefix, i) => prefix === published[i]);
+      if (isOurs) eventJumpActions.setJumpableDayPrefixes([]);
+    },
+    [],
+  );
 
   return { hints };
 }

--- a/packages/web/src/shortcuts/shortcuts.menu.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.menu.test.ts
@@ -233,7 +233,11 @@ describe("shortcut menu sections", () => {
         { keys: ["i"], label: "Focus sidebar" },
         { keys: ["u"], label: "Focus calendar event" },
         { keys: ["h"], label: "Toggle event jump keys" },
-        { keys: ["m"], label: "Focus a week column (M T W R F SA SU)" },
+        {
+          keys: ["Shift", "m"],
+          label:
+            "Focus a week column (Shift + M T W R F, Shift + S then U or A)",
+        },
         { keys: ["f"], label: "Focus latest notice" },
         {
           keys: ["Mod", "1-9"],

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -194,8 +194,8 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
   },
   {
     id: "focus-week-day",
-    keys: ["m"],
-    label: "Focus a week column (M T W R F SA SU)",
+    keys: ["Shift", "m"],
+    label: "Focus a week column (Shift + M T W R F, Shift + S then U or A)",
     section: "focus",
     when: { weekView: true },
   },

--- a/packages/web/src/shortcuts/tips/ShortcutTipIndicator.tsx
+++ b/packages/web/src/shortcuts/tips/ShortcutTipIndicator.tsx
@@ -25,7 +25,7 @@ export const ShortcutTipIndicator: FC<{ hint: RankedShortcutHint }> = ({
   return (
     <span
       aria-live="polite"
-      className="truncate text-text-muted text-xs opacity-80"
+      className="block w-full text-pretty break-words text-center text-text-muted text-xs leading-5 opacity-80"
       role="status"
     >
       <ShortcutTipParts parts={hint.parts} />

--- a/packages/web/src/shortcuts/tips/ShortcutTipParts.tsx
+++ b/packages/web/src/shortcuts/tips/ShortcutTipParts.tsx
@@ -30,7 +30,7 @@ export const ShortcutTipParts: FC<{
             // biome-ignore lint/suspicious/noArrayIndexKey: parts are a fixed, order-stable literal
             <span
               key={i}
-              className="inline-flex whitespace-nowrap align-text-bottom"
+              className="inline-flex whitespace-nowrap align-middle"
             >
               <ShortcutKeys keys={[...partKeycaps(part)]} />
             </span>

--- a/packages/web/src/shortcuts/tips/rankShortcutHints.test.ts
+++ b/packages/web/src/shortcuts/tips/rankShortcutHints.test.ts
@@ -70,6 +70,56 @@ describe("shortcut hint personalization", () => {
     expect(hint.reasonCode).toBe("local_recency");
   });
 
+  it("cools down after two impressions in the window", () => {
+    const hint = selectShortcutHint(
+      calendarIdle,
+      [],
+      profile({
+        "calendar.page_jump": {
+          invocations: 0,
+          lastShownAt: NOW,
+          recentImpressions: 2,
+        },
+      }),
+      NOW,
+    );
+
+    expect(hint.id).toBe("event-jump");
+    expect(hint.reasonCode).toBe("local_fatigue");
+  });
+
+  it("stops teaching a shortcut the user has clearly learned", () => {
+    const hint = selectShortcutHint(
+      calendarIdle,
+      [],
+      profile({
+        "calendar.page_jump": { invocations: 5, recentImpressions: 0 },
+      }),
+      NOW,
+    );
+
+    expect(hint.id).toBe("event-jump");
+  });
+
+  it("keeps teaching the pool once every shortcut in it is learned", () => {
+    const hint = selectShortcutHint(
+      calendarIdle,
+      [],
+      profile({
+        "calendar.page_jump": { invocations: 9, recentImpressions: 0 },
+        "calendar.event_jump": { invocations: 9, recentImpressions: 0 },
+        "command_palette.open": { invocations: 9, recentImpressions: 0 },
+        "calendar.create_timed_event": {
+          invocations: 9,
+          recentImpressions: 0,
+        },
+      }),
+      NOW,
+    );
+
+    expect(hint.id).toBe("page-jump");
+  });
+
   it("never promotes an ineligible focused-event action into an idle calendar", () => {
     const hint = selectShortcutHint(
       calendarIdle,

--- a/packages/web/src/shortcuts/tips/rankShortcutHints.ts
+++ b/packages/web/src/shortcuts/tips/rankShortcutHints.ts
@@ -8,7 +8,11 @@ import {
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 export const SHORTCUT_FATIGUE_COOLDOWN_MS = 6 * 60 * 60 * 1000;
-export const SHORTCUT_FATIGUE_IMPRESSIONS = 3;
+export const SHORTCUT_FATIGUE_IMPRESSIONS = 2;
+/** Invocations after which a shortcut counts as learned and stops being
+ * taught, so the bar spends its one line on something the user has not
+ * adopted yet. */
+export const SHORTCUT_MASTERED_INVOCATIONS = 5;
 
 type RankedCandidate = {
   fatigued: boolean;
@@ -54,7 +58,7 @@ function scoreCandidate(
     lastShownAge < SHORTCUT_FATIGUE_COOLDOWN_MS;
 
   let score = untried ? 80 : 0;
-  score += Math.max(0, 20 - invocations * 4);
+  score += Math.max(-24, 20 - invocations * 8);
   if (lastInvokedAge !== null && lastInvokedAge < DAY_MS) score -= 24;
   else if (lastInvokedAge !== null && lastInvokedAge < 7 * DAY_MS) score -= 12;
   else if (lastInvokedAge !== null && lastInvokedAge > 30 * DAY_MS) score += 12;
@@ -77,9 +81,10 @@ function personalizedReason(
 
 /**
  * Ranks only the deterministic context pool. With no local history, the first
- * item is exactly the legacy deterministic pick. History adds three small,
- * explainable signals: untried actions, invocation recency, and repeated-tip
- * fatigue. The deterministic order remains the tie-breaker.
+ * item is exactly the legacy deterministic pick. History adds four small,
+ * explainable signals: mastered actions drop out of the pool entirely, and
+ * untried actions, invocation recency, and repeated-tip fatigue score the
+ * rest. The deterministic order remains the tie-breaker.
  */
 export function rankShortcutHints(
   pool: readonly ShortcutHintId[],
@@ -87,7 +92,14 @@ export function rankShortcutHints(
   profile: ShortcutUsageProfile,
   now = Date.now(),
 ): RankedShortcutHint {
-  const fallbackOrder = deterministicFallbackOrder(pool, demonstratedIds);
+  const unmastered = pool.filter((id) => {
+    const usage = profile.actions[getShortcutHint(id).actionId];
+    return (usage?.invocations ?? 0) < SHORTCUT_MASTERED_INVOCATIONS;
+  });
+  const fallbackOrder = deterministicFallbackOrder(
+    unmastered.length > 0 ? unmastered : pool,
+    demonstratedIds,
+  );
   const candidates = fallbackOrder.map((id) =>
     scoreCandidate(id, demonstratedIds, profile, now),
   );

--- a/packages/web/src/shortcuts/tips/selectShortcutHint.test.ts
+++ b/packages/web/src/shortcuts/tips/selectShortcutHint.test.ts
@@ -1,4 +1,5 @@
 import { selectShortcutHint } from "@web/shortcuts/tips/selectShortcutHint";
+import { getHintPlainText } from "@web/shortcuts/tips/shortcut-tips.data";
 import { describe, expect, it } from "bun:test";
 
 const calendarIdle = {
@@ -78,11 +79,65 @@ describe("selectShortcutHint", () => {
 
   it("teaches week-column letters after event jump on week view", () => {
     expect(
-      selectShortcutHint({ ...afterFirstEvent, isWeekView: true }, [
-        "page-jump",
-        "event-jump",
-      ]).id,
+      selectShortcutHint(
+        {
+          ...afterFirstEvent,
+          isWeekView: true,
+          jumpableDayPrefixes: ["m", "w"],
+        },
+        ["page-jump", "event-jump"],
+      ).id,
     ).toBe("week-day-focus");
+  });
+
+  it("names the first jumpable column at or after tomorrow", () => {
+    const hint = selectShortcutHint(
+      {
+        ...afterFirstEvent,
+        isWeekView: true,
+        jumpableDayPrefixes: ["m", "w", "sa"],
+        // Monday, so Wednesday is the next taught column, not Monday again.
+        todayWeekday: 1,
+      },
+      ["page-jump", "event-jump"],
+    );
+    expect(getHintPlainText(hint)).toBe("Shift+W jumps to Wednesday");
+  });
+
+  it("wraps past the end of the week when nothing later is jumpable", () => {
+    const hint = selectShortcutHint(
+      {
+        ...afterFirstEvent,
+        isWeekView: true,
+        jumpableDayPrefixes: ["m"],
+        todayWeekday: 5,
+      },
+      ["page-jump", "event-jump"],
+    );
+    expect(getHintPlainText(hint)).toBe("Shift+M jumps to Monday");
+  });
+
+  it("teaches the column even while an event is focused, since Shift always works", () => {
+    expect(
+      selectShortcutHint(
+        {
+          ...afterFirstEvent,
+          eventFocused: true,
+          isWeekView: true,
+          jumpableDayPrefixes: ["m"],
+        },
+        ["edit-sequence", "nudge", "edge-focus", "page-jump", "event-jump"],
+      ).id,
+    ).toBe("week-day-focus");
+  });
+
+  it("skips the column tip when no day has a jump key", () => {
+    expect(
+      selectShortcutHint(
+        { ...afterFirstEvent, isWeekView: true, jumpableDayPrefixes: [] },
+        ["page-jump", "event-jump"],
+      ).id,
+    ).toBe("command-palette");
   });
 
   it("walks the idle pool in showcase order as primitives are demonstrated", () => {

--- a/packages/web/src/shortcuts/tips/selectShortcutHint.ts
+++ b/packages/web/src/shortcuts/tips/selectShortcutHint.ts
@@ -1,9 +1,12 @@
 import { rankShortcutHints } from "@web/shortcuts/tips/rankShortcutHints";
 import { type ShortcutUsageProfile } from "@web/shortcuts/tips/shortcut-personalization.storage";
 import {
+  DAY_JUMP_PREFIXES,
+  type DayJumpPrefix,
   getShortcutHint,
   type RankedShortcutHint,
   type ShortcutHintId,
+  weekDayFocusHint,
 } from "@web/shortcuts/tips/shortcut-tips.data";
 
 export type ShortcutHintContext = {
@@ -12,6 +15,10 @@ export type ShortcutHintContext = {
   isWeekView?: boolean;
   eventFocused: boolean;
   firstEventDone: boolean;
+  /** Day prefixes the jump engine can currently land on. */
+  jumpableDayPrefixes?: readonly string[];
+  /** 0=Sunday … 6=Saturday, used to teach the week forward from today. */
+  todayWeekday?: number;
 };
 
 const IDLE_POOL = [
@@ -27,6 +34,22 @@ const FOCUSED_POOL = [
   "edge-focus",
   ...IDLE_POOL,
 ] as const satisfies readonly ShortcutHintId[];
+
+/**
+ * The day column to teach next: the first jumpable one at or after tomorrow,
+ * wrapping through the week. Days with no events have no jump key, so teaching
+ * them would advertise a dead keystroke.
+ */
+function pickWeekDayPrefix(ctx: ShortcutHintContext): DayJumpPrefix | null {
+  const jumpable = new Set(ctx.jumpableDayPrefixes ?? []);
+  if (jumpable.size === 0) return null;
+  const start = ((ctx.todayWeekday ?? 0) + 1) % DAY_JUMP_PREFIXES.length;
+  const ordered = [
+    ...DAY_JUMP_PREFIXES.slice(start),
+    ...DAY_JUMP_PREFIXES.slice(0, start),
+  ];
+  return ordered.find((prefix) => jumpable.has(prefix)) ?? null;
+}
 
 /** Week view inserts the column-letter tip after event-jump. */
 function withWeekDayFocus(
@@ -74,8 +97,13 @@ export function selectShortcutHint(
   profile: ShortcutUsageProfile = EMPTY_USAGE_PROFILE,
   now = Date.now(),
 ): RankedShortcutHint {
-  const pick = (pool: readonly ShortcutHintId[]) =>
-    rankShortcutHints(pool, demonstratedIds, profile, now);
+  const dayPrefix = pickWeekDayPrefix(ctx);
+  const showWeekDay = Boolean(ctx.isWeekView) && dayPrefix !== null;
+  const pick = (pool: readonly ShortcutHintId[]) => {
+    const winner = rankShortcutHints(pool, demonstratedIds, profile, now);
+    if (winner.id !== "week-day-focus" || !dayPrefix) return winner;
+    return { ...weekDayFocusHint(dayPrefix), reasonCode: winner.reasonCode };
+  };
 
   if (ctx.isFormOpen && !ctx.firstEventDone) {
     return ranked("first-event-save");
@@ -87,10 +115,10 @@ export function selectShortcutHint(
     return pick(LIFE_POOL);
   }
   if (ctx.eventFocused) {
-    return pick(withWeekDayFocus(FOCUSED_POOL, ctx.isWeekView));
+    return pick(withWeekDayFocus(FOCUSED_POOL, showWeekDay));
   }
   if (!ctx.firstEventDone) {
     return ranked("create-event", "first_event");
   }
-  return pick(withWeekDayFocus(IDLE_POOL, ctx.isWeekView));
+  return pick(withWeekDayFocus(IDLE_POOL, showWeekDay));
 }

--- a/packages/web/src/shortcuts/tips/shortcut-tips.data.test.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-tips.data.test.ts
@@ -3,6 +3,7 @@ import {
   getHintPlainText,
   getPartsPlainText,
   SHORTCUT_HINTS,
+  weekDayFocusHint,
 } from "@web/shortcuts/tips/shortcut-tips.data";
 import { describe, expect, it } from "bun:test";
 
@@ -18,31 +19,52 @@ describe("getHintPlainText", () => {
 
     expect(plainTextById["first-event-save"]).toBe("Type a title, then Enter");
     expect(plainTextById["save-draft"]).toBe(
-      `Enter to save · hold ${mod} to jump fields`,
+      `Enter saves · hold ${mod} to jump fields`,
     );
-    expect(plainTextById["life-this-week"]).toBe(
-      "Press T to jump to this week",
-    );
-    expect(plainTextById["edit-sequence"]).toBe(
-      "Press E then T to jump to the title",
-    );
-    expect(plainTextById["create-event"]).toBe("Press C to add an event");
-    expect(plainTextById["page-jump"]).toBe(
-      `Hold ${mod} to see where you can jump`,
-    );
-    expect(plainTextById["event-jump"]).toBe(
-      "Press H to show event keys, or a day key to jump",
-    );
-    expect(plainTextById["week-day-focus"]).toBe(
-      "On week view, press H then M to focus Monday",
-    );
-    expect(plainTextById.nudge).toBe("Hold Shift and press an arrow to move");
+    expect(plainTextById["life-this-week"]).toBe("T jumps to this week");
+    expect(plainTextById["edit-sequence"]).toBe("E then T edits the title");
+    expect(plainTextById["create-event"]).toBe("C creates an event");
+    expect(plainTextById["page-jump"]).toBe(`Hold ${mod} to see jump targets`);
+    expect(plainTextById["event-jump"]).toBe("H labels events to jump to");
+    expect(plainTextById["week-day-focus"]).toBe("Shift+M jumps to Monday");
+    expect(plainTextById.nudge).toBe("Shift and an arrow moves the event");
     expect(plainTextById["edge-focus"]).toBe(
-      "Press Tab to the start or end, then hold Shift and press up or down",
+      "Tab picks an edge, then Shift and up or down",
     );
     expect(plainTextById["command-palette"]).toBe(
-      `Press ${mod}+K to open the command palette`,
+      `${mod}+K opens the command palette`,
     );
+  });
+
+  it("names the day the sidebar picked, weekends as a two-key chord", () => {
+    expect(getHintPlainText(weekDayFocusHint("w"))).toBe(
+      "Shift+W jumps to Wednesday",
+    );
+    expect(getHintPlainText(weekDayFocusHint("r"))).toBe(
+      "Shift+R jumps to Thursday",
+    );
+    expect(getHintPlainText(weekDayFocusHint("su"))).toBe(
+      "Shift+S then U jumps to Sunday",
+    );
+    expect(getHintPlainText(weekDayFocusHint("sa"))).toBe(
+      "Shift+S then A jumps to Saturday",
+    );
+  });
+
+  it("keeps every tip short enough to wrap into the sidebar's two lines", () => {
+    // The status bar is one line tall at SIDEBAR_MIN_WIDTH and may grow to
+    // two. Nothing is ever clipped, so the budget lives here instead.
+    for (const hint of Object.values(SHORTCUT_HINTS)) {
+      const text = getHintPlainText(hint);
+      expect({ id: hint.id, length: text.length <= 48 }).toEqual({
+        id: hint.id,
+        length: true,
+      });
+      expect(text).not.toContain("—");
+      expect(text).not.toContain("–");
+      expect(text.startsWith("Press ")).toBe(false);
+      expect(text).not.toContain("On week view");
+    }
   });
 
   it("joins a chord's keys with + and speaks Mod as Cmd or Ctrl", () => {

--- a/packages/web/src/shortcuts/tips/shortcut-tips.data.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-tips.data.ts
@@ -86,6 +86,45 @@ const [editLeader, editSecond] = KEYMAP.editTitle.keycaps;
 const [eventJumpKey] = KEYMAP.eventJump.keycaps;
 const [nudgeModifier] = KEYMAP.moveEvent.keycaps;
 
+/** Day-column jump prefixes, in weekday order. */
+export const DAY_JUMP_PREFIXES = ["su", "m", "t", "w", "r", "f", "sa"] as const;
+
+export type DayJumpPrefix = (typeof DAY_JUMP_PREFIXES)[number];
+
+const DAY_NAME_BY_PREFIX: Record<DayJumpPrefix, string> = {
+  su: "Sunday",
+  m: "Monday",
+  t: "Tuesday",
+  w: "Wednesday",
+  r: "Thursday",
+  f: "Friday",
+  sa: "Saturday",
+};
+
+/** Weekend prefixes are a two-key chord: Shift+S selects the pair, then the
+ * second letter picks the day. */
+function weekDayFocusParts(prefix: DayJumpPrefix): readonly ShortcutTipPart[] {
+  const dayName = DAY_NAME_BY_PREFIX[prefix];
+  const [first, second] = prefix;
+  const shifted = { keys: ["Shift", first.toUpperCase()] } as const;
+  if (!second) return [shifted, ` jumps to ${dayName}`];
+  return [
+    shifted,
+    " then ",
+    { key: second.toUpperCase() },
+    ` jumps to ${dayName}`,
+  ];
+}
+
+/** The weekday tip names whichever column the sidebar picked, so it teaches the
+ * whole week over time instead of Monday forever. */
+export function weekDayFocusHint(prefix: DayJumpPrefix): ShortcutHint {
+  return {
+    ...SHORTCUT_HINTS["week-day-focus"],
+    parts: weekDayFocusParts(prefix),
+  };
+}
+
 export const SHORTCUT_HINTS: Record<ShortcutHintId, ShortcutHint> = {
   "first-event-save": {
     id: "first-event-save",
@@ -100,7 +139,7 @@ export const SHORTCUT_HINTS: Record<ShortcutHintId, ShortcutHint> = {
     featureArea: "event_editing",
     parts: [
       { key: saveKey },
-      " to save · hold ",
+      " saves · hold ",
       { key: KEYMAP.jumpFormField.holdModifier },
       " to jump fields",
     ],
@@ -110,7 +149,7 @@ export const SHORTCUT_HINTS: Record<ShortcutHintId, ShortcutHint> = {
     id: "life-this-week",
     actionId: "life.focus_current_week",
     featureArea: "life_navigation",
-    parts: ["Press ", { key: "T" }, " to jump to this week"],
+    parts: [{ key: "T" }, " jumps to this week"],
     suggestionReason: "life_view",
   },
   "edit-sequence": {
@@ -118,11 +157,10 @@ export const SHORTCUT_HINTS: Record<ShortcutHintId, ShortcutHint> = {
     actionId: "event.edit_title",
     featureArea: "event_editing",
     parts: [
-      "Press ",
       { key: editLeader },
       " then ",
       { key: editSecond },
-      " to jump to the title",
+      " edits the title",
     ],
     suggestionReason: "event_focused",
   },
@@ -130,7 +168,7 @@ export const SHORTCUT_HINTS: Record<ShortcutHintId, ShortcutHint> = {
     id: "create-event",
     actionId: "calendar.create_timed_event",
     featureArea: "event_creation",
-    parts: ["Press ", { key: createKey }, " to add an event"],
+    parts: [{ key: createKey }, " creates an event"],
     suggestionReason: "calendar_idle",
   },
   "page-jump": {
@@ -140,7 +178,7 @@ export const SHORTCUT_HINTS: Record<ShortcutHintId, ShortcutHint> = {
     parts: [
       "Hold ",
       { key: KEYMAP.jumpPageTarget.holdModifier },
-      " to see where you can jump",
+      " to see jump targets",
     ],
     suggestionReason: "calendar_idle",
   },
@@ -148,31 +186,21 @@ export const SHORTCUT_HINTS: Record<ShortcutHintId, ShortcutHint> = {
     id: "event-jump",
     actionId: "calendar.event_jump",
     featureArea: "calendar_navigation",
-    parts: [
-      "Press ",
-      { key: eventJumpKey },
-      " to show event keys, or a day key to jump",
-    ],
+    parts: [{ key: eventJumpKey }, " labels events to jump to"],
     suggestionReason: "calendar_idle",
   },
   "week-day-focus": {
     id: "week-day-focus",
     actionId: "calendar.focus_week_day",
     featureArea: "calendar_navigation",
-    parts: [
-      "On week view, press ",
-      { key: eventJumpKey },
-      " then ",
-      { key: "M" },
-      " to focus Monday",
-    ],
+    parts: weekDayFocusParts("m"),
     suggestionReason: "week_view",
   },
   nudge: {
     id: "nudge",
     actionId: "event.move",
     featureArea: "event_editing",
-    parts: ["Hold ", { key: nudgeModifier }, " and press an arrow to move"],
+    parts: [{ key: nudgeModifier }, " and an arrow moves the event"],
     suggestionReason: "event_focused",
   },
   "edge-focus": {
@@ -180,11 +208,10 @@ export const SHORTCUT_HINTS: Record<ShortcutHintId, ShortcutHint> = {
     actionId: "event.edge_focus",
     featureArea: "event_editing",
     parts: [
-      "Press ",
       { key: KEYMAP.edgeFocus.hotkey },
-      " to the start or end, then hold ",
+      " picks an edge, then ",
       { key: nudgeModifier },
-      " and press up or down",
+      " and up or down",
     ],
     suggestionReason: "event_focused",
   },
@@ -193,9 +220,8 @@ export const SHORTCUT_HINTS: Record<ShortcutHintId, ShortcutHint> = {
     actionId: "command_palette.open",
     featureArea: "command_palette",
     parts: [
-      "Press ",
       { keys: KEYMAP.commandPalette.keycaps },
-      " to open the command palette",
+      " opens the command palette",
     ],
     suggestionReason: "calendar_idle",
   },

--- a/packages/web/src/shortcuts/tips/useShortcutHintContext.test.tsx
+++ b/packages/web/src/shortcuts/tips/useShortcutHintContext.test.tsx
@@ -9,6 +9,8 @@ import {
 } from "@web/events/grid-event-draft.adapter";
 import { draftActions } from "@web/events/stores/draft.store";
 import { CALENDAR_VIEW_INTERACTION_ID_ATTRIBUTES } from "@web/grid/interaction/view-event-registry";
+import { eventJumpActions } from "@web/shortcuts/shift-hint/event-jump.store";
+import { getHintPlainText } from "@web/shortcuts/tips/shortcut-tips.data";
 import {
   resetShortcutHintProgressStoreForTests,
   shortcutHintProgressActions,
@@ -34,6 +36,7 @@ describe("useShortcutHintContext", () => {
   afterEach(() => {
     draftActions.discard();
     useFirstEventPromptStore.setState(initialFirstEventPromptState, true);
+    eventJumpActions.reset();
     resetShortcutHintProgressStoreForTests();
     document.body.innerHTML = "";
     window.history.replaceState({}, "", "/");
@@ -97,9 +100,26 @@ describe("useShortcutHintContext", () => {
     act(() => {
       shortcutHintProgressActions.demonstrate("page-jump");
       shortcutHintProgressActions.demonstrate("event-jump");
+      // Exactly one jumpable column, so the assertion does not depend on
+      // which weekday the suite runs on.
+      eventJumpActions.setJumpableDayPrefixes(["w"]);
     });
 
     const { result } = renderHook(() => useShortcutHintContext());
     expect(result.current.id).toBe("week-day-focus");
+    expect(getHintPlainText(result.current)).toBe("Shift+W jumps to Wednesday");
+  });
+
+  it("falls through the column tip when no day has a jump key", () => {
+    window.history.replaceState({}, "", "/week");
+    useFirstEventPromptStore.setState({ isDone: true }, false);
+    act(() => {
+      shortcutHintProgressActions.demonstrate("page-jump");
+      shortcutHintProgressActions.demonstrate("event-jump");
+      eventJumpActions.setJumpableDayPrefixes([]);
+    });
+
+    const { result } = renderHook(() => useShortcutHintContext());
+    expect(result.current.id).toBe("command-palette");
   });
 });

--- a/packages/web/src/shortcuts/tips/useShortcutHintContext.ts
+++ b/packages/web/src/shortcuts/tips/useShortcutHintContext.ts
@@ -1,3 +1,5 @@
+import { useEffect, useState } from "react";
+import dayjs from "@core/util/date/dayjs";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
 import {
   selectFirstEventCelebrating,
@@ -9,10 +11,19 @@ import {
   selectIsEventFormOpen,
   useDraftStore,
 } from "@web/events/stores/draft.store";
+import {
+  selectJumpableDayPrefixes,
+  useEventJumpStore,
+} from "@web/shortcuts/shift-hint/event-jump.store";
 import { selectShortcutHint } from "@web/shortcuts/tips/selectShortcutHint";
 import { readShortcutUsageProfile } from "@web/shortcuts/tips/shortcut-personalization.storage";
 import { useShortcutHintProgress } from "@web/shortcuts/tips/shortcut-tips.progress.store";
 import { useIsAnyCalendarEventFocused } from "@web/shortcuts/tips/useIsAnyCalendarEventFocused";
+
+/** Re-rank this often so a tip that nothing else disturbs still gives way.
+ * Impressions are only recorded when the rendered tip changes, so without a
+ * tick one tip can hold the bar for a whole session and never fatigue. */
+export const SHORTCUT_HINT_ROTATION_MS = 90 * 1000;
 
 /**
  * Reads onboarding + current-doing stores and returns the sidebar's next
@@ -30,6 +41,16 @@ export function useShortcutHintContext() {
     pathname === ROOT_ROUTES.WEEK ||
     pathname.startsWith(`${ROOT_ROUTES.WEEK}/`);
   const progress = useShortcutHintProgress();
+  const jumpableDayPrefixes = useEventJumpStore(selectJumpableDayPrefixes);
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const tick = setInterval(
+      () => setNow(Date.now()),
+      SHORTCUT_HINT_ROTATION_MS,
+    );
+    return () => clearInterval(tick);
+  }, []);
 
   return selectShortcutHint(
     {
@@ -38,8 +59,11 @@ export function useShortcutHintContext() {
       isWeekView,
       eventFocused,
       firstEventDone: firstEventDone || isCelebrating,
+      jumpableDayPrefixes,
+      todayWeekday: dayjs().day(),
     },
     progress,
     readShortcutUsageProfile(),
+    now,
   );
 }

--- a/packages/web/src/shortcuts/useAppShortcut.test.ts
+++ b/packages/web/src/shortcuts/useAppShortcut.test.ts
@@ -54,6 +54,19 @@ describe("useAppShortcut", () => {
     });
   });
 
+  it("leaves a shifted key to its own binding, so Shift+W is not week view", async () => {
+    // Day columns are entered with Shift+<day letter>; the bare-letter view
+    // shortcuts share those letters and must not fire alongside them.
+    renderHook(() => useAppShortcutUp("W", mockHandler));
+
+    dispatchKeyEvent("W", "keydown", { shiftKey: true });
+    dispatchKeyEvent("W", "keyup", { shiftKey: true });
+
+    await waitFor(() => {
+      expect(mockHandler).not.toHaveBeenCalled();
+    });
+  });
+
   it("supports modifier hotkeys", async () => {
     const modifierKey = resolveModifier("Mod");
     const isCtrl = modifierKey === "Control";

--- a/packages/web/src/timezone/TimeTravelIndicator.tsx
+++ b/packages/web/src/timezone/TimeTravelIndicator.tsx
@@ -16,7 +16,7 @@ export const TimeTravelIndicator: FC = () => {
   return (
     <span
       aria-live="polite"
-      className="truncate text-text-muted text-xs opacity-80"
+      className="block w-full text-pretty break-words text-center text-text-muted text-xs leading-5 opacity-80"
       role="status"
     >
       <ShortcutTipParts parts={TIME_TRAVEL_HINT_PARTS} />

--- a/packages/web/src/views/Week/components/Header/DayLabels.test.tsx
+++ b/packages/web/src/views/Week/components/Header/DayLabels.test.tsx
@@ -74,11 +74,12 @@ describe("DayLabels", () => {
     pageJumpHintActions.setHintsVisible(true);
     renderLabels();
 
-    expect(screen.getByText("M")).toBeTruthy();
-    expect(screen.getByText("R")).toBeTruthy();
+    // Jump mode is off here, so the column chip advertises the Shift entry.
+    expect(screen.getByText("⇧M")).toBeTruthy();
+    expect(screen.getByText("⇧R")).toBeTruthy();
     expect(screen.queryByText("Mon")).toBeNull();
     expect(screen.getByRole("status").textContent).toContain(
-      "These are typed after H, not with Mod.",
+      "Hold Shift and press the day key to focus that column.",
     );
   });
 });

--- a/packages/web/src/views/Week/components/Header/DayLabels.tsx
+++ b/packages/web/src/views/Week/components/Header/DayLabels.tsx
@@ -10,7 +10,6 @@ import {
 } from "@web/events/stores/draft.store";
 import { EVENT_WIDTH_MINIMUM } from "@web/grid/grid.constants";
 import { useGridMarginLeft } from "@web/grid/grid-margin";
-import { KEYMAP } from "@web/shortcuts/keymap";
 import {
   selectPageJumpHintsVisible,
   usePageJumpHintStore,
@@ -51,10 +50,9 @@ export const DayLabels: FC<Props> = ({
   const showDayJumpPrefixes =
     !isEventFormOpen && (pageJumpHintsVisible || isEventJumpActive);
   const marginLeft = useGridMarginLeft();
-  const jumpKey = KEYMAP.eventJump.keycaps[0];
   const dayJumpHowTo = isEventJumpActive
     ? "Type the day key to focus that column."
-    : `These are typed after ${jumpKey}, not with Mod.`;
+    : "Hold Shift and press the day key to focus that column.";
   const dayJumpAnnouncement = showDayJumpPrefixes
     ? `Day jump keys: ${weekDays
         .map((day) => `${day.format("dddd")} ${dayJumpPrefix(day)}`)
@@ -126,7 +124,11 @@ export const DayLabels: FC<Props> = ({
                 {dayNumber}
               </span>
               {showDayJumpPrefixes ? (
-                <ShortcutHint>{prefix}</ShortcutHint>
+                // Jump mode takes the letter bare; from idle the column is
+                // entered with Shift, so the chip has to say so.
+                <ShortcutHint>
+                  {isEventJumpActive ? prefix : `⇧${prefix}`}
+                </ShortcutHint>
               ) : (
                 <span className="relative text-[clamp(var(--font-size-m),2cqw,var(--font-size-l))] leading-none">
                   {day.format("ddd")}


### PR DESCRIPTION
## Why

The sidebar shortcut tip read **"On week view, press H then M to focus Monday"**. The prelude repeated where the user already was, the `H` was not required, it only ever named Monday, and the line was clipped with an ellipsis when it did not fit. Underneath the wording, the shortcut itself was the problem: bare day letters lost to other single-letter commands, so the tip was sometimes simply wrong.

## What

**Day columns enter with Shift.** `Shift+M`/`T`/`W`/`R`/`F`, and `Shift+S` then `U`/`A` for the weekend. Every weekday is now reachable, including while an event is focused, and `competingShortcutApplies` is deleted: bare `t` keeps "go to today", bare `f` keeps notice focus, bare `m` keeps the event menu. Once jump mode is on (via `H`, a Shift+day, or a blocked click) labels are still typed bare, so the on-screen `W2` chips and the pointer hint stay accurate. Day view keeps bare digits, because `Shift+1` is `!`. Week column headers show `⇧W` while jump mode is off.

**The tip teaches a key that works.** The grid publishes which columns actually have events; the tip names the first one at or after tomorrow, so it walks the week instead of repeating Monday, and never advertises a dead keystroke (it disappears entirely in day view).

**Less repetition.** Shortcuts with 5+ invocations drop out of the pool, familiarity decays faster, and a tip fatigues after 2 impressions instead of 3. A slow rotation tick makes that fatigue reachable at all — impressions were only recorded when the rendered tip changed, so a tip nothing disturbed could hold the bar for a whole session.

**Copy and layout.** All eleven tips rewritten keycap-first with no "Press" prelude, guarded by a test at ≤48 characters with no em-dashes. The status bar centers the line and grows to a second line rather than clipping.

## Verification

- 2709 web unit tests, type-check, biome clean (12 warnings, all pre-existing).
- `e2e/timed/shift-hold-event-hints.spec.ts` passes with trusted input, including `Shift+Tab` and `Shift+J` still falling through to their own handlers.
- New `useAppShortcut` test pins the load-bearing assumption: a bare `"W"` registration does **not** fire on `Shift+W`, so the week-view shortcut and the Wednesday column cannot both trigger.
- Measured live at the 240px minimum sidebar: the longest tip wraps to exactly two lines (bar 24px → 44px) with no horizontal overflow, left/right gaps identical at 55.2px, and the keycap chip's center within 1px of the text center.

🤖 Generated with [Claude Code](https://claude.com/claude-code)