### PR TITLE
Split Settings billing and fix subscribe shortcuts

### DIFF
--- a/docs/features/billing.md
+++ b/docs/features/billing.md
@@ -94,7 +94,11 @@ production.
   header (`TrialBadge.tsx`, via `DatePicker`'s `headerEndContent` slot). The
   badge carries no `tabindex`: `getPageJumpFocusElement` seats Mod+2 on the
   first `[tabindex="0"]` inside the picker, and a tab stop here would steal
-  that jump.
+  that jump. Press `B` (keycap-styled in the badge tooltip and on Settings →
+  Billing) to subscribe early. That shortcut is registered by
+  `UpgradeConfirmationProvider` and keeps working while Settings is open.
+- **Active / past_due:** writable. `past_due` also shows a banner. Settings
+  splits Accounts and Billing; Billing is hidden on installs with no plan.
 - **Active / past_due:** writable. `past_due` also shows a banner.
 - **Expired / canceled:** read-only until they subscribe again. A later
   Checkout does not grant another trial.
@@ -108,8 +112,10 @@ through the webhook's own `applySubscription`, so status is fresh in the same
 response and the Stripe field mapping stays in one place. The Billing Portal
 cannot shorten a trial, which is why this endpoint exists. Three ways in, all
 gated on a running trial: the badge, a "Subscribe now" palette command, and
-bare `B`. That shortcut is registered by `UpgradeConfirmationProvider` rather
-than `useNavigationShortcuts`, which must stay usable without a QueryClient.
+bare `B`. "Manage billing" is a different action: it opens the Stripe Customer
+Portal in a new tab (popup-blocked fallback: same-tab, returning to
+`?settings=billing`). Portal return reopens Settings on Billing and refetches
+status on window focus so a trial that became Premium is visible immediately.
 A declined card lands on `past_due` (still writable), so the confirm dialog
 reports the resulting status instead of a blanket success.
 

--- a/packages/backend/src/billing/services/stripe.service.db.test.ts
+++ b/packages/backend/src/billing/services/stripe.service.db.test.ts
@@ -266,7 +266,7 @@ describe("StripeService", () => {
     expect(result.url).toBe("https://billing.stripe.com/p/session_1");
     expect(portalCreate.mock.calls[0]?.[0]).toEqual({
       customer: "cus_portal",
-      return_url: "http://localhost:9080",
+      return_url: "http://localhost:9080/?settings=billing",
     });
   });
 

--- a/packages/backend/src/billing/services/stripe.service.ts
+++ b/packages/backend/src/billing/services/stripe.service.ts
@@ -27,6 +27,12 @@ const checkoutReturnUrl = (outcome: "success" | "cancel"): string => {
   return url.toString();
 };
 
+const portalReturnUrl = (): string => {
+  const url = new URL(CONFIG.FRONTEND_URL);
+  url.searchParams.set("settings", "billing");
+  return url.toString();
+};
+
 class StripeService {
   createCheckoutSession = async (
     userId: string,
@@ -192,7 +198,7 @@ class StripeService {
     const session = await stripe.billingPortal.sessions
       .create({
         customer: customerId,
-        return_url: CONFIG.FRONTEND_URL,
+        return_url: portalReturnUrl(),
       })
       .catch(wrapStripeFailure);
 

--- a/packages/web/src/billing/BillingGateModal.test.tsx
+++ b/packages/web/src/billing/BillingGateModal.test.tsx
@@ -13,7 +13,15 @@ import {
 } from "@web/billing/billing-preview.store";
 import { registerToastPort } from "@web/common/utils/toast/toast.port";
 import { BillingGateModal } from "./BillingGateModal";
-import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
 
 const assign = spyOn(window.location, "assign").mockImplementation(() => {});
 
@@ -188,6 +196,11 @@ describe("BillingGateModal", () => {
     ).mockResolvedValue({ url: "https://billing.stripe.com/p/ok" });
     const { port } = createTestToastPort();
     registerToastPort(port);
+    const replace = mock(() => {});
+    const popup = { closed: false, location: { replace }, opener: {} };
+    const open = spyOn(window, "open").mockReturnValue(
+      popup as unknown as Window,
+    );
     const user = userEvent.setup();
     renderGate("canceled");
 
@@ -200,7 +213,12 @@ describe("BillingGateModal", () => {
     await user.keyboard("m");
 
     expect(createPortalSession).toHaveBeenCalled();
-    expect(assign).toHaveBeenCalledWith("https://billing.stripe.com/p/ok");
+    await waitFor(() => {
+      expect(open).toHaveBeenCalledWith("about:blank", "_blank");
+      expect(replace).toHaveBeenCalledWith("https://billing.stripe.com/p/ok");
+    });
+    expect(assign).not.toHaveBeenCalled();
     createPortalSession.mockRestore();
+    open.mockRestore();
   });
 });

--- a/packages/web/src/billing/BillingGateModal.test.tsx
+++ b/packages/web/src/billing/BillingGateModal.test.tsx
@@ -1,6 +1,12 @@
 import "@testing-library/jest-dom";
 import { HotkeyManager, HotkeysProvider } from "@tanstack/react-hotkeys";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Status } from "@core/errors/status.codes";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
@@ -227,5 +233,35 @@ describe("BillingGateModal", () => {
     ).toHaveFocus();
     createPortalSession.mockRestore();
     open.mockRestore();
+  });
+
+  it("activates Manage billing on hover then Enter instead of Subscribe", async () => {
+    const createPortalSession = spyOn(
+      BillingApi,
+      "createPortalSession",
+    ).mockResolvedValue({ url: "https://billing.stripe.com/p/ok" });
+    const createCheckoutSession = spyOn(
+      BillingApi,
+      "createCheckoutSession",
+    ).mockResolvedValue({ url: "https://checkout.stripe.com/c/ok" });
+    const { port } = createTestToastPort();
+    registerToastPort(port);
+    const replace = mock(() => {});
+    const popup = { closed: false, location: { replace }, opener: {} };
+    spyOn(window, "open").mockReturnValue(popup as unknown as Window);
+    const user = userEvent.setup({ delay: null });
+    renderGate("canceled");
+
+    const manage = screen.getByRole("button", { name: "Manage billing" });
+    fireEvent.pointerEnter(manage, { pointerType: "mouse" });
+    expect(manage).toHaveFocus();
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith("https://billing.stripe.com/p/ok");
+    });
+    expect(createCheckoutSession).not.toHaveBeenCalled();
+    createPortalSession.mockRestore();
+    createCheckoutSession.mockRestore();
   });
 });

--- a/packages/web/src/billing/BillingGateModal.test.tsx
+++ b/packages/web/src/billing/BillingGateModal.test.tsx
@@ -218,6 +218,13 @@ describe("BillingGateModal", () => {
       expect(replace).toHaveBeenCalledWith("https://billing.stripe.com/p/ok");
     });
     expect(assign).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", {
+        name: (accessibleName) =>
+          accessibleName.includes("Manage billing") ||
+          accessibleName.includes("Opening Stripe"),
+      }),
+    ).toHaveFocus();
     createPortalSession.mockRestore();
     open.mockRestore();
   });

--- a/packages/web/src/billing/BillingGateModal.tsx
+++ b/packages/web/src/billing/BillingGateModal.tsx
@@ -33,6 +33,7 @@ type BillingGateModalProps = {
 export const BillingGateModal: FC<BillingGateModalProps> = ({ status }) => {
   useAppLockReason("billingGate", true);
   const primaryButtonRef = useRef<HTMLButtonElement>(null);
+  const secondaryButtonRef = useRef<HTMLButtonElement>(null);
   const { isRedirecting, redirectTo } = useBillingRedirect();
   const shownRef = useRef(false);
 
@@ -91,6 +92,7 @@ export const BillingGateModal: FC<BillingGateModalProps> = ({ status }) => {
     "M",
     () => {
       if (isRedirecting) return;
+      secondaryButtonRef.current?.focus({ preventScroll: true });
       void redirectTo("portal");
     },
     { ...OVERLAY_LETTER_SHORTCUT, enabled: !isAwaitingCheckout },
@@ -124,6 +126,7 @@ export const BillingGateModal: FC<BillingGateModalProps> = ({ status }) => {
             <ShortcutHint className="ml-2">S</ShortcutHint>
           </button>
           <button
+            ref={secondaryButtonRef}
             className={SECONDARY_BUTTON_CLASSNAME}
             disabled={isRedirecting}
             onClick={secondary.onClick}

--- a/packages/web/src/billing/BillingGateModal.tsx
+++ b/packages/web/src/billing/BillingGateModal.tsx
@@ -116,7 +116,11 @@ export const BillingGateModal: FC<BillingGateModalProps> = ({ status }) => {
             onClick={() => void redirectTo("checkout")}
             type="button"
           >
-            {isAwaitingCheckout ? "Start trial" : "Subscribe"}
+            {isRedirecting
+              ? "Opening Stripe…"
+              : isAwaitingCheckout
+                ? "Start trial"
+                : "Subscribe"}
             <ShortcutHint className="ml-2">S</ShortcutHint>
           </button>
           <button
@@ -125,7 +129,9 @@ export const BillingGateModal: FC<BillingGateModalProps> = ({ status }) => {
             onClick={secondary.onClick}
             type="button"
           >
-            {secondary.label}
+            {isRedirecting && secondary.key === "M"
+              ? "Opening Stripe…"
+              : secondary.label}
             <ShortcutHint className="ml-2">{secondary.key}</ShortcutHint>
           </button>
         </div>

--- a/packages/web/src/billing/BillingGateModal.tsx
+++ b/packages/web/src/billing/BillingGateModal.tsx
@@ -2,6 +2,7 @@ import { type FC, useEffect, useRef } from "react";
 import { track } from "@web/auth/posthog/track";
 import { billingPreviewActions } from "@web/billing/billing-preview.store";
 import { useBillingRedirect } from "@web/billing/useBillingRedirect";
+import { focusOnPointerEnter } from "@web/common/utils/focus-on-pointer-enter";
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 import { PixelPirateScouting } from "@web/components/WelcomeModal/PixelPirateScouting";
@@ -116,6 +117,7 @@ export const BillingGateModal: FC<BillingGateModalProps> = ({ status }) => {
             className="c-button c-button-primary c-button-elevated inline-flex items-center justify-center rounded-full px-6 py-2"
             disabled={isRedirecting}
             onClick={() => void redirectTo("checkout")}
+            onPointerEnter={focusOnPointerEnter}
             type="button"
           >
             {isRedirecting
@@ -130,6 +132,7 @@ export const BillingGateModal: FC<BillingGateModalProps> = ({ status }) => {
             className={SECONDARY_BUTTON_CLASSNAME}
             disabled={isRedirecting}
             onClick={secondary.onClick}
+            onPointerEnter={focusOnPointerEnter}
             type="button"
           >
             {isRedirecting && secondary.key === "M"

--- a/packages/web/src/billing/PlanSection.tsx
+++ b/packages/web/src/billing/PlanSection.tsx
@@ -6,9 +6,12 @@ import {
 } from "@web/billing/planBadge";
 import { useAppAccess } from "@web/billing/useAppAccess";
 import { useBillingRedirect } from "@web/billing/useBillingRedirect";
+import { focusOnPointerEnter } from "@web/common/utils/focus-on-pointer-enter";
+import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
+import { settingsShortcutAttrs } from "@web/settings/useSettingsShortcuts";
 
 const OUTLINE_BUTTON_CLASSNAME =
-  "c-focus-ring shrink-0 rounded border border-border bg-surface-overlay px-2 py-1 text-xs text-text transition-colors hover:bg-surface-panel disabled:pointer-events-none disabled:opacity-60";
+  "c-focus-ring inline-flex shrink-0 items-center rounded border border-border bg-surface-overlay px-2 py-1 text-xs text-text transition-colors hover:bg-surface-panel disabled:pointer-events-none disabled:opacity-60";
 
 /**
  * The account view's answer to "what am I paying for?". Until this existed,
@@ -19,7 +22,9 @@ const OUTLINE_BUTTON_CLASSNAME =
  * paused, anonymous), rather than inventing billing chrome for installs that
  * have no billing.
  */
-export const PlanSection: FC = () => {
+export const PlanSection: FC<{
+  showShortcuts?: boolean;
+}> = ({ showShortcuts = false }) => {
   const access = useAppAccess();
   const { isRedirecting, redirectTo } = useBillingRedirect();
   const badge = getPlanBadge(access);
@@ -43,8 +48,8 @@ export const PlanSection: FC = () => {
           </span>
           {trialEndsAt ? (
             <p className="mt-1 text-text-muted text-xs">
-              Your trial ends {dayjs(trialEndsAt).format("MMM D, YYYY")}. Press
-              B to subscribe now.
+              Your trial ends {dayjs(trialEndsAt).format("MMM D, YYYY")}. Press{" "}
+              <ShortcutKeys keys="B" /> to subscribe now.
             </p>
           ) : null}
         </div>
@@ -52,9 +57,12 @@ export const PlanSection: FC = () => {
           className={OUTLINE_BUTTON_CLASSNAME}
           disabled={isRedirecting}
           onClick={() => void redirectTo("portal", "settings_portal")}
+          onPointerEnter={focusOnPointerEnter}
           type="button"
+          {...settingsShortcutAttrs("manage-billing")}
         >
-          Manage billing
+          {isRedirecting ? "Opening Stripe…" : "Manage billing"}
+          {showShortcuts ? <ShortcutKeys className="ml-2" keys="M" /> : null}
         </button>
       </div>
     </div>

--- a/packages/web/src/billing/TrialBadge.tsx
+++ b/packages/web/src/billing/TrialBadge.tsx
@@ -32,7 +32,7 @@ export function TrialBadge() {
   const description = formatTrialBadgeDescription(daysLeft);
 
   return (
-    <TooltipWrapper description={`${description}. Press B to subscribe.`}>
+    <TooltipWrapper description={description} shortcut="B">
       <button
         aria-label={`${description}. Subscribe now.`}
         className="c-keycap c-focus-ring cursor-pointer text-xs"

--- a/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationDialog.tsx
+++ b/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationDialog.tsx
@@ -7,6 +7,7 @@ import {
 interface UpgradeConfirmationDialogProps {
   isOpen: boolean;
   isSubmitting: boolean;
+  isOpeningPortal: boolean;
   onCancel: () => void;
   onConfirm: () => void;
   onManageBilling: () => void;
@@ -16,12 +17,13 @@ interface UpgradeConfirmationDialogProps {
  * Confirms starting a Stripe subscription before the trial runs out. No amount
  * is shown here on purpose: the price lives on the Stripe Price, not in this
  * codebase, so operators can change it without a web deploy. "Manage billing"
- * is the way to see the card and the exact charge before committing, so it sits
- * apart from the two real choices rather than competing with them.
+ * opens the Stripe portal (card, invoices, cancel) and does not charge today;
+ * Start Premium is the only way to end the trial early.
  */
 export function UpgradeConfirmationDialog({
   isOpen,
   isSubmitting,
+  isOpeningPortal,
   onCancel,
   onConfirm,
   onManageBilling,
@@ -31,7 +33,7 @@ export function UpgradeConfirmationDialog({
   return (
     <OverlayPanel
       title="Start Premium now?"
-      message="Premium starts right away and the card on file is charged today. Everything in your calendar keeps working, and the trial badge goes away."
+      message="Premium starts right away and the card on file is charged today. Everything in your calendar keeps working, and the trial badge goes away. Manage billing opens your invoices and card on file. It does not charge you or end the trial."
       onDismiss={onCancel}
       align="start"
       variant="modal"
@@ -44,7 +46,9 @@ export function UpgradeConfirmationDialog({
             disabled={isSubmitting}
             onClick={onConfirm}
           >
-            {isSubmitting ? "Starting Premium…" : "Start Premium"}
+            {isSubmitting && !isOpeningPortal
+              ? "Starting Premium…"
+              : "Start Premium"}
           </OverlayPanelActionButton>
           <OverlayPanelActionButton
             shortcut="Esc"
@@ -56,10 +60,11 @@ export function UpgradeConfirmationDialog({
         </OverlayPanelActions>
         <OverlayPanelActionButton
           variant="ghost"
+          shortcut="M"
           disabled={isSubmitting}
           onClick={onManageBilling}
         >
-          Manage billing
+          {isOpeningPortal ? "Opening Stripe…" : "Manage billing"}
         </OverlayPanelActionButton>
       </div>
     </OverlayPanel>

--- a/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationDialog.tsx
+++ b/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationDialog.tsx
@@ -1,3 +1,4 @@
+import { type RefObject } from "react";
 import {
   OverlayPanel,
   OverlayPanelActionButton,
@@ -8,6 +9,7 @@ interface UpgradeConfirmationDialogProps {
   isOpen: boolean;
   isSubmitting: boolean;
   isOpeningPortal: boolean;
+  manageBillingRef: RefObject<HTMLButtonElement | null>;
   onCancel: () => void;
   onConfirm: () => void;
   onManageBilling: () => void;
@@ -24,6 +26,7 @@ export function UpgradeConfirmationDialog({
   isOpen,
   isSubmitting,
   isOpeningPortal,
+  manageBillingRef,
   onCancel,
   onConfirm,
   onManageBilling,
@@ -59,6 +62,7 @@ export function UpgradeConfirmationDialog({
           </OverlayPanelActionButton>
         </OverlayPanelActions>
         <OverlayPanelActionButton
+          ref={manageBillingRef}
           variant="ghost"
           shortcut="M"
           disabled={isSubmitting}

--- a/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationDialog.tsx
+++ b/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationDialog.tsx
@@ -1,15 +1,15 @@
-import { type RefObject } from "react";
+import { useState } from "react";
 import {
   OverlayPanel,
   OverlayPanelActionButton,
   OverlayPanelActions,
 } from "@web/components/OverlayPanel/OverlayPanel";
+import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 
 interface UpgradeConfirmationDialogProps {
   isOpen: boolean;
   isSubmitting: boolean;
   isOpeningPortal: boolean;
-  manageBillingRef: RefObject<HTMLButtonElement | null>;
   onCancel: () => void;
   onConfirm: () => void;
   onManageBilling: () => void;
@@ -26,11 +26,28 @@ export function UpgradeConfirmationDialog({
   isOpen,
   isSubmitting,
   isOpeningPortal,
-  manageBillingRef,
   onCancel,
   onConfirm,
   onManageBilling,
 }: UpgradeConfirmationDialogProps) {
+  const [manageBillingEl, setManageBillingEl] =
+    useState<HTMLButtonElement | null>(null);
+
+  useAppShortcut(
+    "M",
+    () => {
+      if (isSubmitting) return;
+      manageBillingEl?.focus({ preventScroll: true });
+      onManageBilling();
+    },
+    {
+      enabled: isOpen,
+      ignoreAppLock: true,
+      ignoreInputs: false,
+      preventDefault: true,
+    },
+  );
+
   if (!isOpen) return null;
 
   return (
@@ -62,7 +79,7 @@ export function UpgradeConfirmationDialog({
           </OverlayPanelActionButton>
         </OverlayPanelActions>
         <OverlayPanelActionButton
-          ref={manageBillingRef}
+          ref={setManageBillingEl}
           variant="ghost"
           shortcut="M"
           disabled={isSubmitting}

--- a/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationProvider.test.tsx
+++ b/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationProvider.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
 import { HotkeysProvider } from "@tanstack/react-hotkeys";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { BillingApi } from "@web/api/billing.api";
@@ -11,7 +11,15 @@ import {
   registerToastPort,
   resetToastPort,
 } from "@web/common/utils/toast/toast.port";
-import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
 
 // Register a toast port rather than spying the toast utils: spyOn patches the
 // shared module object, so calls here would leak into other suites' spies.
@@ -66,6 +74,9 @@ describe("UpgradeConfirmationProvider", () => {
     const dialog = await openDialog();
     expect(dialog.textContent).not.toMatch(/\$|\bUSD\b|\bmonth\b/);
     expect(dialog).toHaveTextContent("the card on file is charged today");
+    expect(dialog).toHaveTextContent(
+      "It does not charge you or end the trial.",
+    );
   });
 
   it("ends the trial and confirms the subscription", async () => {
@@ -150,10 +161,15 @@ describe("UpgradeConfirmationProvider", () => {
     endTrial.mockRestore();
   });
 
-  it("sends Manage billing to the Stripe portal", async () => {
+  it("sends Manage billing to the Stripe portal in a new tab", async () => {
     const portal = spyOn(BillingApi, "createPortalSession").mockResolvedValue({
       url: "https://billing.stripe.com/p/session_1",
     });
+    const replace = mock(() => {});
+    const popup = { closed: false, location: { replace }, opener: {} };
+    const open = spyOn(window, "open").mockReturnValue(
+      popup as unknown as Window,
+    );
     await openDialog();
 
     await userEvent.click(
@@ -161,10 +177,60 @@ describe("UpgradeConfirmationProvider", () => {
     );
 
     await waitFor(() => {
-      expect(assign).toHaveBeenCalledWith(
+      expect(open).toHaveBeenCalledWith("about:blank", "_blank");
+      expect(replace).toHaveBeenCalledWith(
         "https://billing.stripe.com/p/session_1",
       );
     });
+    expect(assign).not.toHaveBeenCalled();
     portal.mockRestore();
+    open.mockRestore();
+  });
+
+  it("opens the portal with M and does not end the trial", async () => {
+    const endTrial = spyOn(BillingApi, "endTrial");
+    const portal = spyOn(BillingApi, "createPortalSession").mockResolvedValue({
+      url: "https://billing.stripe.com/p/session_1",
+    });
+    const replace = mock(() => {});
+    const popup = { closed: false, location: { replace }, opener: {} };
+    spyOn(window, "open").mockReturnValue(popup as unknown as Window);
+    await openDialog();
+
+    await userEvent.keyboard("m");
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith(
+        "https://billing.stripe.com/p/session_1",
+      );
+    });
+    expect(endTrial).not.toHaveBeenCalled();
+    portal.mockRestore();
+    endTrial.mockRestore();
+  });
+
+  it("activates Manage billing on hover then Enter instead of Start Premium", async () => {
+    const endTrial = spyOn(BillingApi, "endTrial");
+    const portal = spyOn(BillingApi, "createPortalSession").mockResolvedValue({
+      url: "https://billing.stripe.com/p/session_1",
+    });
+    const replace = mock(() => {});
+    const popup = { closed: false, location: { replace }, opener: {} };
+    spyOn(window, "open").mockReturnValue(popup as unknown as Window);
+    await openDialog();
+
+    const manage = screen.getByRole("button", { name: "Manage billing" });
+    fireEvent.pointerEnter(manage, { pointerType: "mouse" });
+    expect(manage).toHaveFocus();
+    await userEvent.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith(
+        "https://billing.stripe.com/p/session_1",
+      );
+    });
+    expect(endTrial).not.toHaveBeenCalled();
+    portal.mockRestore();
+    endTrial.mockRestore();
   });
 });

--- a/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationProvider.test.tsx
+++ b/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationProvider.test.tsx
@@ -205,8 +205,45 @@ describe("UpgradeConfirmationProvider", () => {
       );
     });
     expect(endTrial).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", {
+        name: (accessibleName) =>
+          accessibleName.includes("Manage billing") ||
+          accessibleName.includes("Opening Stripe"),
+      }),
+    ).toHaveFocus();
+    await userEvent.keyboard("{Enter}");
+    expect(endTrial).not.toHaveBeenCalled();
     portal.mockRestore();
     endTrial.mockRestore();
+  });
+
+  it("stays in Compass if the portal tab is closed before the URL lands", async () => {
+    const popup = {
+      closed: false,
+      close: mock(),
+      location: { replace: mock() },
+      opener: {},
+    };
+    spyOn(window, "open").mockReturnValue(popup as unknown as Window);
+    const portal = spyOn(BillingApi, "createPortalSession").mockImplementation(
+      async () => {
+        popup.closed = true;
+        return { url: "https://billing.stripe.com/p/session_1" };
+      },
+    );
+    await openDialog();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Manage billing" }),
+    );
+
+    await waitFor(() => {
+      expect(portal).toHaveBeenCalled();
+    });
+    expect(assign).not.toHaveBeenCalled();
+    expect(popup.location.replace).not.toHaveBeenCalled();
+    portal.mockRestore();
   });
 
   it("activates Manage billing on hover then Enter instead of Start Premium", async () => {

--- a/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationProvider.tsx
+++ b/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationProvider.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { type PropsWithChildren, useCallback, useRef, useState } from "react";
+import { type PropsWithChildren, useCallback, useState } from "react";
 import { BillingApi } from "@web/api/billing.api";
 import {
   getApiErrorMessage,
@@ -21,10 +21,7 @@ import {
   selectIsSettingsOpen,
   useSettingsStore,
 } from "@web/settings/settings.store";
-import {
-  useAppShortcut,
-  useAppShortcutUp,
-} from "@web/shortcuts/useAppShortcut";
+import { useAppShortcutUp } from "@web/shortcuts/useAppShortcut";
 
 export function UpgradeConfirmationProvider({ children }: PropsWithChildren) {
   const value = useUpgradeConfirmationState();
@@ -35,10 +32,8 @@ export function UpgradeConfirmationProvider({ children }: PropsWithChildren) {
   const isSettingsOpen = useSettingsStore(selectIsSettingsOpen);
   const { isRedirecting, redirectTo } = useBillingRedirect();
   const busy = isSubmitting || isRedirecting;
-  const manageBillingRef = useRef<HTMLButtonElement>(null);
   const handleManageBilling = () => {
     if (busy) return;
-    manageBillingRef.current?.focus({ preventScroll: true });
     void redirectTo("portal", "upgrade_portal");
   };
 
@@ -55,13 +50,6 @@ export function UpgradeConfirmationProvider({ children }: PropsWithChildren) {
     },
     { enabled: isTrialing, ignoreAppLock: isSettingsOpen },
   );
-
-  useAppShortcut("M", handleManageBilling, {
-    enabled: isOpen,
-    ignoreAppLock: true,
-    ignoreInputs: false,
-    preventDefault: true,
-  });
 
   const reportFailure = useCallback((error: unknown, fallback: string) => {
     if (isSessionLevelError(error)) return;
@@ -107,7 +95,6 @@ export function UpgradeConfirmationProvider({ children }: PropsWithChildren) {
         isOpen={isOpen}
         isSubmitting={busy}
         isOpeningPortal={isRedirecting}
-        manageBillingRef={manageBillingRef}
         onCancel={closeUpgradeConfirmation}
         onConfirm={handleConfirm}
         onManageBilling={handleManageBilling}

--- a/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationProvider.tsx
+++ b/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationProvider.tsx
@@ -12,12 +12,19 @@ import {
   useUpgradeConfirmationState,
 } from "@web/billing/UpgradeConfirmation/hooks/useUpgradeConfirmation";
 import { UpgradeConfirmationDialog } from "@web/billing/UpgradeConfirmation/UpgradeConfirmationDialog";
+import { useBillingRedirect } from "@web/billing/useBillingRedirect";
 import { useIsTrialing } from "@web/billing/useIsTrialing";
+import { BILLING_SUBSCRIBED_TOAST_ID } from "@web/common/constants/toast.constants";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
-import { useAppShortcutUp } from "@web/shortcuts/useAppShortcut";
-
-const SUBSCRIBED_TOAST_ID = "billing-subscribed";
+import {
+  selectIsSettingsOpen,
+  useSettingsStore,
+} from "@web/settings/settings.store";
+import {
+  useAppShortcut,
+  useAppShortcutUp,
+} from "@web/shortcuts/useAppShortcut";
 
 export function UpgradeConfirmationProvider({ children }: PropsWithChildren) {
   const value = useUpgradeConfirmationState();
@@ -25,17 +32,36 @@ export function UpgradeConfirmationProvider({ children }: PropsWithChildren) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const queryClient = useQueryClient();
   const isTrialing = useIsTrialing();
+  const isSettingsOpen = useSettingsStore(selectIsSettingsOpen);
+  const { isRedirecting, redirectTo } = useBillingRedirect();
+  const busy = isSubmitting || isRedirecting;
 
   // Bare "B" for billing. The feature owns its own trigger rather than
   // `useNavigationShortcuts`, which must stay usable without a QueryClient.
-  // Registered only while a trial runs, so the key stays free otherwise. No
-  // `ignoreAppLock`: a gate or dialog already owning the screen keeps it.
+  // Registered only while a trial runs, so the key stays free otherwise.
+  // `ignoreAppLock` while Settings is open: that modal is exactly where
+  // "Press B to subscribe" is written, and OverlayPanel would otherwise
+  // swallow the key.
   useAppShortcutUp(
     "B",
     () => {
       value.openUpgradeConfirmation();
     },
-    { enabled: isTrialing },
+    { enabled: isTrialing, ignoreAppLock: isSettingsOpen },
+  );
+
+  useAppShortcut(
+    "M",
+    () => {
+      if (busy) return;
+      void redirectTo("portal", "upgrade_portal");
+    },
+    {
+      enabled: isOpen,
+      ignoreAppLock: true,
+      ignoreInputs: false,
+      preventDefault: true,
+    },
   );
 
   const reportFailure = useCallback((error: unknown, fallback: string) => {
@@ -61,7 +87,7 @@ export function UpgradeConfirmationProvider({ children }: PropsWithChildren) {
         // be dressed up as a successful upgrade.
         if (status.subscriptionStatus === "active") {
           track("trial_converted");
-          showStatusToast(SUBSCRIBED_TOAST_ID, "You're subscribed");
+          showStatusToast(BILLING_SUBSCRIBED_TOAST_ID, "You're subscribed");
         } else {
           showErrorToast(
             "We ended your trial, but the payment didn't go through. Check your card under Manage billing.",
@@ -76,24 +102,17 @@ export function UpgradeConfirmationProvider({ children }: PropsWithChildren) {
   }, [closeUpgradeConfirmation, queryClient, reportFailure]);
 
   const handleManageBilling = useCallback(() => {
-    setIsSubmitting(true);
-    void (async () => {
-      try {
-        const { url } = await BillingApi.createPortalSession();
-        window.location.assign(url);
-      } catch (error) {
-        reportFailure(error, "Couldn't open billing. Please try again.");
-        setIsSubmitting(false);
-      }
-    })();
-  }, [reportFailure]);
+    if (busy) return;
+    void redirectTo("portal", "upgrade_portal");
+  }, [busy, redirectTo]);
 
   return (
     <UpgradeConfirmationContext.Provider value={value}>
       {children}
       <UpgradeConfirmationDialog
         isOpen={isOpen}
-        isSubmitting={isSubmitting}
+        isSubmitting={busy}
+        isOpeningPortal={isRedirecting}
         onCancel={closeUpgradeConfirmation}
         onConfirm={handleConfirm}
         onManageBilling={handleManageBilling}

--- a/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationProvider.tsx
+++ b/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationProvider.tsx
@@ -35,6 +35,10 @@ export function UpgradeConfirmationProvider({ children }: PropsWithChildren) {
   const isSettingsOpen = useSettingsStore(selectIsSettingsOpen);
   const { isRedirecting, redirectTo } = useBillingRedirect();
   const busy = isSubmitting || isRedirecting;
+  const handleManageBilling = () => {
+    if (busy) return;
+    void redirectTo("portal", "upgrade_portal");
+  };
 
   // Bare "B" for billing. The feature owns its own trigger rather than
   // `useNavigationShortcuts`, which must stay usable without a QueryClient.
@@ -50,19 +54,12 @@ export function UpgradeConfirmationProvider({ children }: PropsWithChildren) {
     { enabled: isTrialing, ignoreAppLock: isSettingsOpen },
   );
 
-  useAppShortcut(
-    "M",
-    () => {
-      if (busy) return;
-      void redirectTo("portal", "upgrade_portal");
-    },
-    {
-      enabled: isOpen,
-      ignoreAppLock: true,
-      ignoreInputs: false,
-      preventDefault: true,
-    },
-  );
+  useAppShortcut("M", handleManageBilling, {
+    enabled: isOpen,
+    ignoreAppLock: true,
+    ignoreInputs: false,
+    preventDefault: true,
+  });
 
   const reportFailure = useCallback((error: unknown, fallback: string) => {
     if (isSessionLevelError(error)) return;
@@ -100,11 +97,6 @@ export function UpgradeConfirmationProvider({ children }: PropsWithChildren) {
       }
     })();
   }, [closeUpgradeConfirmation, queryClient, reportFailure]);
-
-  const handleManageBilling = useCallback(() => {
-    if (busy) return;
-    void redirectTo("portal", "upgrade_portal");
-  }, [busy, redirectTo]);
 
   return (
     <UpgradeConfirmationContext.Provider value={value}>

--- a/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationProvider.tsx
+++ b/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationProvider.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { type PropsWithChildren, useCallback, useState } from "react";
+import { type PropsWithChildren, useCallback, useRef, useState } from "react";
 import { BillingApi } from "@web/api/billing.api";
 import {
   getApiErrorMessage,
@@ -35,8 +35,10 @@ export function UpgradeConfirmationProvider({ children }: PropsWithChildren) {
   const isSettingsOpen = useSettingsStore(selectIsSettingsOpen);
   const { isRedirecting, redirectTo } = useBillingRedirect();
   const busy = isSubmitting || isRedirecting;
+  const manageBillingRef = useRef<HTMLButtonElement>(null);
   const handleManageBilling = () => {
     if (busy) return;
+    manageBillingRef.current?.focus({ preventScroll: true });
     void redirectTo("portal", "upgrade_portal");
   };
 
@@ -105,6 +107,7 @@ export function UpgradeConfirmationProvider({ children }: PropsWithChildren) {
         isOpen={isOpen}
         isSubmitting={busy}
         isOpeningPortal={isRedirecting}
+        manageBillingRef={manageBillingRef}
         onCancel={closeUpgradeConfirmation}
         onConfirm={handleConfirm}
         onManageBilling={handleManageBilling}

--- a/packages/web/src/billing/billing.query.ts
+++ b/packages/web/src/billing/billing.query.ts
@@ -1,4 +1,9 @@
-import { queryOptions, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  type QueryClient,
+  queryOptions,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useEffect } from "react";
 import { type BillingStatusResponse } from "@core/types/billing.types";
@@ -59,6 +64,25 @@ export function isBillingEnforced(
 const STATUS_POLL_MS = 1500;
 const STATUS_POLL_WINDOW_MS = 15_000;
 
+function startBillingStatusPoll(
+  queryClient: QueryClient,
+  onWindowEnd: () => void,
+): () => void {
+  const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: billingQueryKeys.status });
+  };
+  invalidate();
+  const interval = window.setInterval(invalidate, STATUS_POLL_MS);
+  const timeout = window.setTimeout(() => {
+    window.clearInterval(interval);
+    onWindowEnd();
+  }, STATUS_POLL_WINDOW_MS);
+  return () => {
+    window.clearInterval(interval);
+    window.clearTimeout(timeout);
+  };
+}
+
 /**
  * After Stripe Checkout returns `?checkout=success`, raise the celebration and
  * keep refetching billing status for a short window so a late webhook does not
@@ -74,62 +98,37 @@ export function useCheckoutReturn() {
   const { checkout, settings } = useSearch({ from: "__root__" });
 
   useEffect(() => {
-    if (checkout !== "success") return;
-
-    const invalidate = () => {
-      void queryClient.invalidateQueries({ queryKey: billingQueryKeys.status });
-    };
-    invalidate();
-    track("trial_converted");
-    checkoutCelebrationActions.celebrate();
-    const interval = window.setInterval(invalidate, STATUS_POLL_MS);
-    const timeout = window.setTimeout(() => {
-      window.clearInterval(interval);
+    const stripCheckout = () => {
       void navigate({
         to: ".",
         search: (prev) => ({ ...prev, checkout: undefined }),
         replace: true,
       });
-    }, STATUS_POLL_WINDOW_MS);
-
-    return () => {
-      window.clearInterval(interval);
-      window.clearTimeout(timeout);
     };
+
+    if (checkout === "cancel") {
+      showStatusToast(BILLING_CHECKOUT_CANCELED_TOAST_ID, "Checkout canceled");
+      stripCheckout();
+      return;
+    }
+
+    if (checkout !== "success") return;
+
+    track("trial_converted");
+    checkoutCelebrationActions.celebrate();
+    return startBillingStatusPoll(queryClient, stripCheckout);
   }, [checkout, navigate, queryClient]);
-
-  useEffect(() => {
-    if (checkout !== "cancel") return;
-
-    showStatusToast(BILLING_CHECKOUT_CANCELED_TOAST_ID, "Checkout canceled");
-    void navigate({
-      to: ".",
-      search: (prev) => ({ ...prev, checkout: undefined }),
-      replace: true,
-    });
-  }, [checkout, navigate]);
 
   useEffect(() => {
     if (settings !== "billing") return;
 
     settingsActions.openSettings("billing");
-    const invalidate = () => {
-      void queryClient.invalidateQueries({ queryKey: billingQueryKeys.status });
-    };
-    invalidate();
-    const interval = window.setInterval(invalidate, STATUS_POLL_MS);
-    const timeout = window.setTimeout(() => {
-      window.clearInterval(interval);
+    return startBillingStatusPoll(queryClient, () => {
       void navigate({
         to: ".",
         search: (prev) => ({ ...prev, settings: undefined }),
         replace: true,
       });
-    }, STATUS_POLL_WINDOW_MS);
-
-    return () => {
-      window.clearInterval(interval);
-      window.clearTimeout(timeout);
-    };
+    });
   }, [navigate, queryClient, settings]);
 }

--- a/packages/web/src/billing/billing.query.ts
+++ b/packages/web/src/billing/billing.query.ts
@@ -6,6 +6,9 @@ import { AppConfigApi } from "@web/api/app-config.api";
 import { BillingApi } from "@web/api/billing.api";
 import { track } from "@web/auth/posthog/track";
 import { checkoutCelebrationActions } from "@web/billing/checkout-celebration.store";
+import { BILLING_CHECKOUT_CANCELED_TOAST_ID } from "@web/common/constants/toast.constants";
+import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
+import { settingsActions } from "@web/settings/settings.store";
 
 export const billingQueryKeys = {
   status: ["billing", "status"] as const,
@@ -32,6 +35,9 @@ export function useBillingStatusQuery(enabled: boolean) {
   return useQuery({
     ...billingStatusQueryOptions(),
     enabled,
+    // Portal upgrades happen in another tab; always refetch when Compass
+    // becomes visible again rather than waiting out staleTime.
+    refetchOnWindowFocus: "always",
   });
 }
 
@@ -50,16 +56,22 @@ export function isBillingEnforced(
   return config?.billing.enforcement === true;
 }
 
+const STATUS_POLL_MS = 1500;
+const STATUS_POLL_WINDOW_MS = 15_000;
+
 /**
  * After Stripe Checkout returns `?checkout=success`, raise the celebration and
  * keep refetching billing status for a short window so a late webhook does not
  * leave the gate up. The polling is also what lets the celebration's copy
  * sharpen from "setting up" to the real status while it is on screen.
+ *
+ * `?checkout=cancel` is stripped with a quiet toast. `?settings=billing` is
+ * the portal return: reopen Settings on Billing and poll until status lands.
  */
 export function useCheckoutReturn() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const { checkout } = useSearch({ from: "__root__" });
+  const { checkout, settings } = useSearch({ from: "__root__" });
 
   useEffect(() => {
     if (checkout !== "success") return;
@@ -70,7 +82,7 @@ export function useCheckoutReturn() {
     invalidate();
     track("trial_converted");
     checkoutCelebrationActions.celebrate();
-    const interval = window.setInterval(invalidate, 1500);
+    const interval = window.setInterval(invalidate, STATUS_POLL_MS);
     const timeout = window.setTimeout(() => {
       window.clearInterval(interval);
       void navigate({
@@ -78,11 +90,46 @@ export function useCheckoutReturn() {
         search: (prev) => ({ ...prev, checkout: undefined }),
         replace: true,
       });
-    }, 15_000);
+    }, STATUS_POLL_WINDOW_MS);
 
     return () => {
       window.clearInterval(interval);
       window.clearTimeout(timeout);
     };
   }, [checkout, navigate, queryClient]);
+
+  useEffect(() => {
+    if (checkout !== "cancel") return;
+
+    showStatusToast(BILLING_CHECKOUT_CANCELED_TOAST_ID, "Checkout canceled");
+    void navigate({
+      to: ".",
+      search: (prev) => ({ ...prev, checkout: undefined }),
+      replace: true,
+    });
+  }, [checkout, navigate]);
+
+  useEffect(() => {
+    if (settings !== "billing") return;
+
+    settingsActions.openSettings("billing");
+    const invalidate = () => {
+      void queryClient.invalidateQueries({ queryKey: billingQueryKeys.status });
+    };
+    invalidate();
+    const interval = window.setInterval(invalidate, STATUS_POLL_MS);
+    const timeout = window.setTimeout(() => {
+      window.clearInterval(interval);
+      void navigate({
+        to: ".",
+        search: (prev) => ({ ...prev, settings: undefined }),
+        replace: true,
+      });
+    }, STATUS_POLL_WINDOW_MS);
+
+    return () => {
+      window.clearInterval(interval);
+      window.clearTimeout(timeout);
+    };
+  }, [navigate, queryClient, settings]);
 }

--- a/packages/web/src/billing/useBillingRedirect.ts
+++ b/packages/web/src/billing/useBillingRedirect.ts
@@ -32,13 +32,16 @@ const navigateToBillingUrl = (
     window.location.assign(url);
     return;
   }
-  if (popup && !popup.closed) {
-    popup.opener = null;
-    popup.location.replace(url);
+  // A non-null handle that is already closed means the user dismissed the
+  // blank tab. Stay in Compass. Same-tab assign is only for a blocked popup
+  // (`window.open` returned null).
+  if (!popup) {
+    window.location.assign(url);
     return;
   }
-  popup?.close();
-  window.location.assign(url);
+  if (popup.closed) return;
+  popup.opener = null;
+  popup.location.replace(url);
 };
 
 /**

--- a/packages/web/src/billing/useBillingRedirect.ts
+++ b/packages/web/src/billing/useBillingRedirect.ts
@@ -7,7 +7,39 @@ import {
 import { track } from "@web/auth/posthog/track";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 
-type BillingRedirectKind = "checkout" | "portal";
+export type BillingRedirectKind = "checkout" | "portal";
+
+const fallbackMessage = (kind: BillingRedirectKind): string =>
+  kind === "portal"
+    ? "Couldn't open billing. Please try again."
+    : "Couldn't start checkout. Please try again.";
+
+/**
+ * Checkout stays same-tab so `?checkout=success` can raise the celebration.
+ * Portal opens in a new tab so Settings (or the gate) is still there when
+ * the user comes back; a blocked popup falls back to same-tab assign, whose
+ * `return_url` reopens Settings on Billing.
+ *
+ * The blank popup is opened before the await so the click/key gesture still
+ * counts as a user activation for popup blockers.
+ */
+const navigateToBillingUrl = (
+  kind: BillingRedirectKind,
+  url: string,
+  popup: Window | null,
+): void => {
+  if (kind === "checkout") {
+    window.location.assign(url);
+    return;
+  }
+  if (popup && !popup.closed) {
+    popup.opener = null;
+    popup.location.replace(url);
+    return;
+  }
+  popup?.close();
+  window.location.assign(url);
+};
 
 /**
  * The one way out of Compass and into Stripe. Owns the in-flight latch (a
@@ -25,19 +57,22 @@ export function useBillingRedirect() {
     if (isRedirecting) return;
     setIsRedirecting(true);
     track("billing_gate_cta_clicked", { cta });
+    const popup =
+      kind === "portal" ? window.open("about:blank", "_blank") : null;
     try {
       const { url } =
         kind === "checkout"
           ? await BillingApi.createCheckoutSession()
           : await BillingApi.createPortalSession();
-      window.location.assign(url);
+      navigateToBillingUrl(kind, url, popup);
     } catch (error) {
+      popup?.close();
       if (!isSessionLevelError(error)) {
         const fromApi = getApiErrorMessage(error);
         showErrorToast(
           fromApi && fromApi !== "Internal server error"
             ? fromApi
-            : "Couldn't start checkout. Please try again.",
+            : fallbackMessage(kind),
         );
       }
     } finally {

--- a/packages/web/src/billing/useBillingRedirect.ts
+++ b/packages/web/src/billing/useBillingRedirect.ts
@@ -7,7 +7,7 @@ import {
 import { track } from "@web/auth/posthog/track";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 
-export type BillingRedirectKind = "checkout" | "portal";
+type BillingRedirectKind = "checkout" | "portal";
 
 const fallbackMessage = (kind: BillingRedirectKind): string =>
   kind === "portal"

--- a/packages/web/src/billing/usePlanChangeToasts.test.ts
+++ b/packages/web/src/billing/usePlanChangeToasts.test.ts
@@ -1,0 +1,84 @@
+import { renderHook } from "@testing-library/react";
+import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
+import { type AppAccess } from "@web/billing/useAppAccess";
+import { BILLING_SUBSCRIBED_TOAST_ID } from "@web/common/constants/toast.constants";
+import {
+  registerToastPort,
+  resetToastPort,
+} from "@web/common/utils/toast/toast.port";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+} from "bun:test";
+
+const actualUseAppAccess = (await import("@web/billing/useAppAccess"))
+  .useAppAccess;
+let isAppAccessMocked = true;
+let access: AppAccess = { kind: "open" };
+
+mock.module("@web/billing/useAppAccess", () => ({
+  useAppAccess: (...args: Parameters<typeof actualUseAppAccess>) =>
+    isAppAccessMocked ? access : actualUseAppAccess(...args),
+}));
+
+const { usePlanChangeToasts } = await import("./usePlanChangeToasts");
+
+describe("usePlanChangeToasts", () => {
+  let toastMocks: ReturnType<typeof createTestToastPort>["mocks"];
+
+  afterAll(() => {
+    isAppAccessMocked = false;
+  });
+
+  beforeEach(() => {
+    access = { kind: "open" };
+    const { port, mocks } = createTestToastPort();
+    toastMocks = mocks;
+    registerToastPort(port);
+  });
+
+  afterEach(() => {
+    resetToastPort();
+  });
+
+  it("toasts when a trial becomes an active subscription", () => {
+    access = {
+      kind: "server",
+      status: "trialing",
+      isReadOnly: false,
+      trialEndsAt: "2099-01-01T00:00:00.000Z",
+    };
+    const { rerender } = renderHook(() => usePlanChangeToasts());
+
+    access = {
+      kind: "server",
+      status: "active",
+      isReadOnly: false,
+      trialEndsAt: null,
+    };
+    rerender();
+
+    expect(toastMocks.toast).toHaveBeenCalledWith(
+      "You're subscribed",
+      expect.objectContaining({ toastId: BILLING_SUBSCRIBED_TOAST_ID }),
+    );
+  });
+
+  it("does not toast when the status was already active", () => {
+    access = {
+      kind: "server",
+      status: "active",
+      isReadOnly: false,
+      trialEndsAt: null,
+    };
+    const { rerender } = renderHook(() => usePlanChangeToasts());
+    rerender();
+
+    expect(toastMocks.toast).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/billing/usePlanChangeToasts.ts
+++ b/packages/web/src/billing/usePlanChangeToasts.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from "react";
+import { type AppAccess, useAppAccess } from "@web/billing/useAppAccess";
+import { BILLING_SUBSCRIBED_TOAST_ID } from "@web/common/constants/toast.constants";
+import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
+
+const isTrialingAccess = (access: AppAccess): boolean =>
+  access.kind === "server" && access.status === "trialing";
+
+const isActiveAccess = (access: AppAccess): boolean =>
+  access.kind === "server" && access.status === "active";
+
+/**
+ * When a trial becomes a paid subscription (portal return, webhook, in-app
+ * end-trial), say so. The toast id matches the in-app upgrade so rapid
+ * duplicate reports collapse to one chip.
+ */
+export function usePlanChangeToasts() {
+  const access = useAppAccess();
+  const previousRef = useRef(access);
+
+  useEffect(() => {
+    const previous = previousRef.current;
+    previousRef.current = access;
+    if (isTrialingAccess(previous) && isActiveAccess(access)) {
+      showStatusToast(BILLING_SUBSCRIBED_TOAST_ID, "You're subscribed");
+    }
+  }, [access]);
+}

--- a/packages/web/src/common/constants/toast.constants.ts
+++ b/packages/web/src/common/constants/toast.constants.ts
@@ -18,6 +18,9 @@ export const EXPORT_MY_DATA_TOAST_ID: Id = "export-my-data";
 export const LOGGED_OUT_TOAST_ID: Id = "logged-out";
 export const EVENT_SAVE_UNAVAILABLE_TOAST_ID: Id = "event-save-unavailable";
 export const NOTIFICATIONS_STATUS_TOAST_ID: Id = "notifications-status";
+export const BILLING_SUBSCRIBED_TOAST_ID: Id = "billing-subscribed";
+export const BILLING_CHECKOUT_CANCELED_TOAST_ID: Id =
+  "billing-checkout-canceled";
 
 const toastPalette: Record<
   ThemeName,

--- a/packages/web/src/common/utils/focus-on-pointer-enter.ts
+++ b/packages/web/src/common/utils/focus-on-pointer-enter.ts
@@ -1,11 +1,22 @@
 import { type PointerEvent } from "react";
+import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
 
 /**
  * Seats focus on the hovered control so Enter activates that element rather
  * than whichever sibling was focused on open. Touch/pen are skipped: those
  * already activate on tap, and a focus move would steal from the real target.
+ * Text fields keep focus: hovering Cancel while typing must not make Enter
+ * dismiss the dialog.
  */
 export const focusOnPointerEnter = (event: PointerEvent<HTMLElement>): void => {
   if (event.pointerType !== "mouse") return;
+  const active = document.activeElement;
+  if (
+    active instanceof HTMLElement &&
+    active !== event.currentTarget &&
+    isEditableKeyboardTarget({ target: active })
+  ) {
+    return;
+  }
   event.currentTarget.focus({ preventScroll: true });
 };

--- a/packages/web/src/common/utils/focus-on-pointer-enter.ts
+++ b/packages/web/src/common/utils/focus-on-pointer-enter.ts
@@ -1,0 +1,11 @@
+import { type PointerEvent } from "react";
+
+/**
+ * Seats focus on the hovered control so Enter activates that element rather
+ * than whichever sibling was focused on open. Touch/pen are skipped: those
+ * already activate on tap, and a focus move would steal from the real target.
+ */
+export const focusOnPointerEnter = (event: PointerEvent<HTMLElement>): void => {
+  if (event.pointerType !== "mouse") return;
+  event.currentTarget.focus({ preventScroll: true });
+};

--- a/packages/web/src/components/AuthModal/hooks/useAuthModal.ts
+++ b/packages/web/src/components/AuthModal/hooks/useAuthModal.ts
@@ -38,6 +38,7 @@ export interface AuthSearch {
   auth?: string;
   token?: string;
   checkout?: string;
+  settings?: string;
 }
 
 export function validateAuthSearch(
@@ -47,6 +48,7 @@ export function validateAuthSearch(
     auth: typeof search.auth === "string" ? search.auth : undefined,
     token: typeof search.token === "string" ? search.token : undefined,
     checkout: typeof search.checkout === "string" ? search.checkout : undefined,
+    settings: search.settings === "billing" ? "billing" : undefined,
   };
 }
 

--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -130,7 +130,7 @@ describe("CommandPalette", () => {
 
   // The plan pill shares the row's end slot with the shortcut chips, so both
   // have to survive together.
-  it("shows the plan beside the account row without dropping its shortcut", () => {
+  it("shows the plan beside the billing row", () => {
     authenticated = true;
     access = {
       kind: "server",
@@ -140,10 +140,14 @@ describe("CommandPalette", () => {
     };
     renderPalette();
 
-    const row = rowLabel("Manage Accounts").closest("button") as HTMLElement;
+    const accounts = rowLabel("Manage Accounts").closest(
+      "button",
+    ) as HTMLElement;
+    expect(within(accounts).queryByText(/Trial|Premium|Free/)).toBeNull();
+    expect(within(accounts).getByText(",")).toBeInTheDocument();
 
-    expect(within(row).getByText("Trial \u00b7 5d")).toBeInTheDocument();
-    expect(within(row).getByText(",")).toBeInTheDocument();
+    const billing = rowLabel("Manage Billing").closest("button") as HTMLElement;
+    expect(within(billing).getByText("Trial \u00b7 5d")).toBeInTheDocument();
   });
 
   it("leaves the account row bare when there is no plan to report", () => {
@@ -153,6 +157,7 @@ describe("CommandPalette", () => {
     const row = rowLabel("Manage Accounts").closest("button") as HTMLElement;
 
     expect(within(row).queryByText(/Trial|Premium|Free/)).toBeNull();
+    expect(screen.queryByText("Manage Billing")).toBeNull();
   });
 
   it("renders all sections with items and focuses the input on mount", () => {

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -20,6 +20,7 @@ import { useAuthCmdItems } from "@web/components/CommandPalette/hooks/useAuthCmd
 import { useDemoEventsCmdItems } from "@web/components/CommandPalette/hooks/useDemoEventsCmdItems";
 import { useLogoutCmdItems } from "@web/components/CommandPalette/hooks/useLogoutCmdItems";
 import { useShowAccountsCmdItems } from "@web/components/CommandPalette/hooks/useShowAccountsCmdItems";
+import { useShowBillingCmdItems } from "@web/components/CommandPalette/hooks/useShowBillingCmdItems";
 import { useThemeCmdItems } from "@web/components/CommandPalette/hooks/useThemeCmdItems";
 import { useUpgradeCmdItems } from "@web/components/CommandPalette/hooks/useUpgradeCmdItems";
 import { getMoreCommandPaletteSections } from "@web/components/CommandPalette/more.cmd.constants";
@@ -301,6 +302,7 @@ export const CommandPalette = ({
   const demoEventsCmdItems = useDemoEventsCmdItems();
   const authCmdItems = useAuthCmdItems();
   const showAccountsCmdItems = useShowAccountsCmdItems();
+  const showBillingCmdItems = useShowBillingCmdItems();
   const logoutCmdItems = useLogoutCmdItems();
   const themeCmdItems = useThemeCmdItems();
   const upgradeCmdItems = useUpgradeCmdItems();
@@ -365,6 +367,7 @@ export const CommandPalette = ({
         ...notificationCmdItems,
         ...authCmdItems,
         ...showAccountsCmdItems,
+        ...showBillingCmdItems,
         ...logoutCmdItems,
       ],
     },

--- a/packages/web/src/components/CommandPalette/hooks/useShowAccountsCmdItems.test.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useShowAccountsCmdItems.test.ts
@@ -1,8 +1,9 @@
+import { UsersIcon } from "@phosphor-icons/react";
 import { renderHook } from "@testing-library/react";
 import { act } from "react";
-import { type AppAccess } from "@web/billing/useAppAccess";
 import {
   selectIsSettingsOpen,
+  selectSettingsPage,
   useSettingsStore,
 } from "@web/settings/settings.store";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
@@ -13,20 +14,14 @@ mock.module("@web/auth/compass/session/useSession", () => ({
   useSession: mockUseSession,
 }));
 
-// Mocked rather than wrapped in a QueryClient: the badge is the only thing
-// this hook reads billing for, and driving the access state directly is what
-// the assertions are about.
-let access: AppAccess = { kind: "open" };
-mock.module("@web/billing/useAppAccess", () => ({
-  useAppAccess: () => access,
-}));
-
 const { useShowAccountsCmdItems } = await import("./useShowAccountsCmdItems");
 
 describe("useShowAccountsCmdItems", () => {
   beforeEach(() => {
-    useSettingsStore.setState({ isSettingsOpen: false });
-    access = { kind: "open" };
+    useSettingsStore.setState({
+      isSettingsOpen: false,
+      settingsPage: "accounts",
+    });
     mockUseSession.mockReset();
     mockUseSession.mockReturnValue({
       authenticated: true,
@@ -45,35 +40,19 @@ describe("useShowAccountsCmdItems", () => {
     expect(result.current).toEqual([]);
   });
 
-  it("opens the settings modal from the command palette item", () => {
+  it("opens Settings on Accounts from the command palette item", () => {
     const { result } = renderHook(() => useShowAccountsCmdItems());
 
     expect(result.current[0].label).toBe("Manage Accounts");
+    expect(result.current[0].icon).toBe(UsersIcon);
     expect(result.current[0].keywords).toContain("accounts");
+    expect(result.current[0].keywords).not.toContain("billing");
 
     act(() => {
       result.current[0].onClick?.();
     });
 
     expect(selectIsSettingsOpen(useSettingsStore.getState())).toBe(true);
-  });
-
-  it("carries no badge on an install without billing", () => {
-    const { result } = renderHook(() => useShowAccountsCmdItems());
-
-    expect(result.current[0].badge).toBeUndefined();
-  });
-
-  it("shows the plan on the row so it is visible without opening Settings", () => {
-    access = {
-      kind: "server",
-      status: "active",
-      isReadOnly: false,
-      trialEndsAt: null,
-    };
-
-    const { result } = renderHook(() => useShowAccountsCmdItems());
-
-    expect(result.current[0].badge).toBe("Premium");
+    expect(selectSettingsPage(useSettingsStore.getState())).toBe("accounts");
   });
 });

--- a/packages/web/src/components/CommandPalette/hooks/useShowAccountsCmdItems.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useShowAccountsCmdItems.ts
@@ -1,23 +1,17 @@
 import { UsersIcon } from "@phosphor-icons/react";
 import { useSession } from "@web/auth/compass/session/useSession";
-import { getPlanBadge } from "@web/billing/planBadge";
-import { useAppAccess } from "@web/billing/useAppAccess";
 import { type CommandItem } from "@web/components/CommandPalette/command-palette.types";
 import { settingsActions } from "@web/settings/settings.store";
 
 /**
- * The single palette entry for account management: opens Settings, which
- * holds adding/disconnecting a Google account, exporting data, and deleting
- * the Compass account. Those used to also be separate top-level palette
- * items (add-account, delete-account, export-my-data), which cluttered any
- * "acc"-ish search with four near-duplicate rows - they're covered here via
- * keywords instead.
+ * The single palette entry for account management: opens Settings on the
+ * Accounts page. Adding/disconnecting a Google account, exporting data, and
+ * deleting the Compass account used to also be separate top-level palette
+ * items, which cluttered any "acc"-ish search with four near-duplicate rows
+ * - they're covered here via keywords instead.
  */
 export const useShowAccountsCmdItems = (): CommandItem[] => {
   const { authenticated } = useSession();
-  // Reads billing status, so this hook now needs a QueryClient in scope. Both
-  // palettes mount inside CompassProvider, but bare hook tests must wrap.
-  const access = useAppAccess();
 
   if (!authenticated) {
     return [];
@@ -41,14 +35,8 @@ export const useShowAccountsCmdItems = (): CommandItem[] => {
         "remove account",
         "export data",
         "delete account",
-        "plan",
-        "billing",
-        "subscription",
-        "premium",
-        "trial",
       ],
-      badge: getPlanBadge(access)?.label,
-      onClick: settingsActions.openSettings,
+      onClick: () => settingsActions.openSettings("accounts"),
     },
   ];
 };

--- a/packages/web/src/components/CommandPalette/hooks/useShowBillingCmdItems.test.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useShowBillingCmdItems.test.ts
@@ -1,0 +1,75 @@
+import { renderHook } from "@testing-library/react";
+import { act } from "react";
+import { type AppAccess } from "@web/billing/useAppAccess";
+import {
+  selectIsSettingsOpen,
+  selectSettingsPage,
+  useSettingsStore,
+} from "@web/settings/settings.store";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const mockUseSession = mock();
+
+mock.module("@web/auth/compass/session/useSession", () => ({
+  useSession: mockUseSession,
+}));
+
+let access: AppAccess = { kind: "open" };
+mock.module("@web/billing/useAppAccess", () => ({
+  useAppAccess: () => access,
+}));
+
+const { useShowBillingCmdItems } = await import("./useShowBillingCmdItems");
+
+describe("useShowBillingCmdItems", () => {
+  beforeEach(() => {
+    useSettingsStore.setState({
+      isSettingsOpen: false,
+      settingsPage: "accounts",
+    });
+    access = { kind: "open" };
+    mockUseSession.mockReset();
+    mockUseSession.mockReturnValue({
+      authenticated: true,
+      setAuthenticated: mock(),
+    });
+  });
+
+  it("returns no items when logged out", () => {
+    mockUseSession.mockReturnValue({
+      authenticated: false,
+      setAuthenticated: mock(),
+    });
+
+    const { result } = renderHook(() => useShowBillingCmdItems());
+
+    expect(result.current).toEqual([]);
+  });
+
+  it("returns no items on an install without billing", () => {
+    const { result } = renderHook(() => useShowBillingCmdItems());
+
+    expect(result.current).toEqual([]);
+  });
+
+  it("opens Settings on Billing and shows the plan badge", () => {
+    access = {
+      kind: "server",
+      status: "active",
+      isReadOnly: false,
+      trialEndsAt: null,
+    };
+
+    const { result } = renderHook(() => useShowBillingCmdItems());
+
+    expect(result.current[0].label).toBe("Manage Billing");
+    expect(result.current[0].badge).toBe("Premium");
+
+    act(() => {
+      result.current[0].onClick?.();
+    });
+
+    expect(selectIsSettingsOpen(useSettingsStore.getState())).toBe(true);
+    expect(selectSettingsPage(useSettingsStore.getState())).toBe("billing");
+  });
+});

--- a/packages/web/src/components/CommandPalette/hooks/useShowBillingCmdItems.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useShowBillingCmdItems.ts
@@ -1,0 +1,37 @@
+import { CreditCardIcon } from "@phosphor-icons/react";
+import { useSession } from "@web/auth/compass/session/useSession";
+import { getPlanBadge } from "@web/billing/planBadge";
+import { useAppAccess } from "@web/billing/useAppAccess";
+import { type CommandItem } from "@web/components/CommandPalette/command-palette.types";
+import { settingsActions } from "@web/settings/settings.store";
+
+/** Opens Settings on Billing when the install actually has a plan to report. */
+export const useShowBillingCmdItems = (): CommandItem[] => {
+  const { authenticated } = useSession();
+  const access = useAppAccess();
+  const badge = getPlanBadge(access);
+
+  if (!authenticated || !badge) {
+    return [];
+  }
+
+  return [
+    {
+      id: "show-billing",
+      label: "Manage Billing",
+      icon: CreditCardIcon,
+      keywords: [
+        "plan",
+        "billing",
+        "subscription",
+        "premium",
+        "trial",
+        "payment",
+        "invoice",
+        "card",
+      ],
+      badge: badge.label,
+      onClick: () => settingsActions.openSettings("billing"),
+    },
+  ];
+};

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
@@ -1,11 +1,11 @@
 import "@testing-library/jest-dom";
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   OverlayPanel,
   OverlayPanelActionButton,
 } from "@web/components/OverlayPanel/OverlayPanel";
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, mock } from "bun:test";
 
 describe("OverlayPanel", () => {
   it("locks app shortcuts while mounted and clears on unmount", () => {
@@ -283,20 +283,42 @@ describe("OverlayPanel", () => {
     ).toBeTruthy();
   });
 
-  it("renders combo shortcuts as separate keycaps", () => {
+  it("hides a shortcut chip when showShortcut is false", () => {
     render(
       <OverlayPanel title="Confirm" onDismiss={() => {}}>
-        <OverlayPanelActionButton shortcut={["Mod", "Enter"]}>
-          Discard
+        <OverlayPanelActionButton shortcut="E" showShortcut={false}>
+          Export data
         </OverlayPanelActionButton>
       </OverlayPanel>,
     );
 
-    const discard = screen.getByRole("button", { name: "Discard" });
-    expect(within(discard).getByText("Enter")).toBeTruthy();
     expect(
-      within(discard).queryByTestId("meta-icon") ??
-        within(discard).queryByTestId("control-icon"),
-    ).toBeTruthy();
+      within(screen.getByRole("button", { name: "Export data" })).queryByText(
+        "E",
+      ),
+    ).toBeNull();
+  });
+
+  it("focuses a hovered action so Enter activates that button", async () => {
+    const onPrimary = mock();
+    const onSecondary = mock();
+    const user = userEvent.setup({ delay: null });
+    render(
+      <OverlayPanel title="Confirm" onDismiss={() => {}}>
+        <OverlayPanelActionButton onClick={onPrimary}>
+          Primary
+        </OverlayPanelActionButton>
+        <OverlayPanelActionButton onClick={onSecondary}>
+          Secondary
+        </OverlayPanelActionButton>
+      </OverlayPanel>,
+    );
+
+    const secondary = screen.getByRole("button", { name: "Secondary" });
+    fireEvent.pointerEnter(secondary, { pointerType: "mouse" });
+    expect(secondary).toHaveFocus();
+    await user.keyboard("{Enter}");
+    expect(onSecondary).toHaveBeenCalled();
+    expect(onPrimary).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
@@ -299,6 +299,30 @@ describe("OverlayPanel", () => {
     ).toBeNull();
   });
 
+  it("does not steal focus from a text field when hovering an action", async () => {
+    const onCancel = mock();
+    const user = userEvent.setup({ delay: null });
+    render(
+      <OverlayPanel title="Share feedback" onDismiss={() => {}}>
+        <textarea aria-label="What would you like to share?" />
+        <OverlayPanelActionButton onClick={onCancel}>
+          Cancel
+        </OverlayPanelActionButton>
+      </OverlayPanel>,
+    );
+
+    const notes = screen.getByRole("textbox", {
+      name: "What would you like to share?",
+    });
+    expect(notes).toHaveFocus();
+    fireEvent.pointerEnter(screen.getByRole("button", { name: "Cancel" }), {
+      pointerType: "mouse",
+    });
+    expect(notes).toHaveFocus();
+    await user.keyboard("{Enter}");
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
   it("focuses a hovered action so Enter activates that button", async () => {
     const onPrimary = mock();
     const onSecondary = mock();

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
@@ -9,6 +9,7 @@ import {
   useRef,
 } from "react";
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
+import { focusOnPointerEnter } from "@web/common/utils/focus-on-pointer-enter";
 import { getFocusableElements } from "@web/common/utils/focusable-elements";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import { useAppLockReason } from "@web/shortcuts/app-lock";
@@ -254,6 +255,8 @@ interface OverlayPanelActionButtonProps
   variant?: "primary" | "secondary" | "destructive" | "ghost";
   /** Visible keycap(s) for the action. */
   shortcut?: string | string[];
+  /** When false, the shortcut still belongs to the action but the chip is hidden. */
+  showShortcut?: boolean;
 }
 
 export const OverlayPanelActionButton = forwardRef<
@@ -264,8 +267,10 @@ export const OverlayPanelActionButton = forwardRef<
     children,
     className,
     shortcut,
+    showShortcut = true,
     type = "button",
     variant = "secondary",
+    onPointerEnter,
     ...buttonProps
   },
   ref,
@@ -289,10 +294,16 @@ export const OverlayPanelActionButton = forwardRef<
         className,
       )}
       type={type}
+      onPointerEnter={(event) => {
+        focusOnPointerEnter(event);
+        onPointerEnter?.(event);
+      }}
       {...buttonProps}
     >
       {children}
-      {shortcut ? <ShortcutKeys className="ml-2" keys={shortcut} /> : null}
+      {shortcut && showShortcut ? (
+        <ShortcutKeys className="ml-2" keys={shortcut} />
+      ) : null}
     </button>
   );
 });

--- a/packages/web/src/components/RootShell/RootShell.test.tsx
+++ b/packages/web/src/components/RootShell/RootShell.test.tsx
@@ -216,6 +216,14 @@ describe("RootShell billing gates", () => {
     expect(selectSettingsPage(useSettingsStore.getState())).toBe("billing");
   });
 
+  it("keeps Billing open when portal return lands before plan data", async () => {
+    access = { kind: "open" };
+    await renderShell("/week?settings=billing");
+
+    expect(selectIsSettingsOpen(useSettingsStore.getState())).toBe(true);
+    expect(selectSettingsPage(useSettingsStore.getState())).toBe("billing");
+  });
+
   it("toasts and strips a canceled checkout", async () => {
     const { port, mocks } = createTestToastPort();
     registerToastPort(port);

--- a/packages/web/src/components/RootShell/RootShell.test.tsx
+++ b/packages/web/src/components/RootShell/RootShell.test.tsx
@@ -14,8 +14,16 @@ import {
 import { type AppAccess } from "@web/billing/useAppAccess";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
-import { registerToastPort } from "@web/common/utils/toast/toast.port";
+import {
+  registerToastPort,
+  resetToastPort,
+} from "@web/common/utils/toast/toast.port";
 import { RootShell } from "@web/components/RootShell/RootShell";
+import {
+  selectIsSettingsOpen,
+  selectSettingsPage,
+  useSettingsStore,
+} from "@web/settings/settings.store";
 import {
   afterAll,
   afterEach,
@@ -76,6 +84,11 @@ describe("RootShell billing gates", () => {
   afterEach(() => {
     access = { kind: "open" };
     useBillingPreviewStore.setState(initialBillingPreviewState);
+    useSettingsStore.setState({
+      isSettingsOpen: false,
+      settingsPage: "accounts",
+    });
+    resetToastPort();
   });
 
   it("never gates an anonymous visitor", async () => {
@@ -183,6 +196,38 @@ describe("RootShell billing gates", () => {
     expect(assign).toHaveBeenCalledWith("https://checkout.stripe.com/c/ok");
     createCheckoutSession.mockRestore();
     assign.mockRestore();
+  });
+
+  it("reopens Settings on Billing after returning from the portal", async () => {
+    access = {
+      kind: "server",
+      status: "active",
+      isReadOnly: false,
+      trialEndsAt: null,
+    };
+    spyOn(BillingApi, "getStatus").mockResolvedValue({
+      subscriptionStatus: "active",
+      trialEndsAt: null,
+      isReadOnly: false,
+    });
+    await renderShell("/week?settings=billing");
+
+    expect(selectIsSettingsOpen(useSettingsStore.getState())).toBe(true);
+    expect(selectSettingsPage(useSettingsStore.getState())).toBe("billing");
+  });
+
+  it("toasts and strips a canceled checkout", async () => {
+    const { port, mocks } = createTestToastPort();
+    registerToastPort(port);
+    const router = await renderShell("/week?checkout=cancel");
+
+    expect(mocks.toast).toHaveBeenCalledWith(
+      "Checkout canceled",
+      expect.objectContaining({ toastId: "billing-checkout-canceled" }),
+    );
+    expect(
+      (router.state.location.search as { checkout?: string }).checkout,
+    ).toBeUndefined();
   });
 });
 

--- a/packages/web/src/components/RootShell/RootShell.tsx
+++ b/packages/web/src/components/RootShell/RootShell.tsx
@@ -13,6 +13,7 @@ import {
   useCheckoutCelebrationStore,
 } from "@web/billing/checkout-celebration.store";
 import { useAppAccess } from "@web/billing/useAppAccess";
+import { usePlanChangeToasts } from "@web/billing/usePlanChangeToasts";
 import { AuthModal } from "@web/components/AuthModal/AuthModal";
 import { AuthModalProvider } from "@web/components/AuthModal/AuthModalProvider";
 import { FirstEventPrompt } from "@web/components/FirstEventPrompt/FirstEventPrompt";
@@ -47,6 +48,7 @@ export function RootShell() {
   const isPreviewing = useBillingPreviewStore(selectBillingPreviewing);
   const isCelebrating = useCheckoutCelebrationStore(selectIsCelebrating);
   useCheckoutReturn();
+  usePlanChangeToasts();
   useNavigationShortcuts();
   useCalendarShellShortcuts();
   usePointerSuppression();

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -34,7 +34,11 @@ import {
   registerToastPort,
   resetToastPort,
 } from "@web/common/utils/toast/toast.port";
-import { settingsActions } from "@web/settings/settings.store";
+import {
+  selectSettingsPage,
+  settingsActions,
+  useSettingsStore,
+} from "@web/settings/settings.store";
 import {
   afterAll,
   afterEach,
@@ -610,6 +614,42 @@ describe("SettingsModal", () => {
     expect(
       screen.queryByRole("button", { name: "Manage billing" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("stays on Billing while plan data is still fail-open", () => {
+    access = { kind: "open" };
+    renderSettings({ authenticated: true, page: "billing" });
+
+    expect(selectSettingsPage(useSettingsStore.getState())).toBe("billing");
+    expect(screen.getByRole("button", { name: "Billing" })).toHaveAttribute(
+      "aria-current",
+      "true",
+    );
+  });
+
+  it("leaves Billing when the server reports no plan", () => {
+    access = {
+      kind: "server",
+      status: "none",
+      isReadOnly: false,
+      trialEndsAt: null,
+    };
+    renderSettings({ authenticated: true, page: "billing" });
+
+    expect(selectSettingsPage(useSettingsStore.getState())).toBe("accounts");
+    expect(screen.queryByRole("button", { name: "Billing" })).toBeNull();
+  });
+
+  it("seats focus on Billing when Settings opens on that page", () => {
+    access = {
+      kind: "server",
+      status: "active",
+      isReadOnly: false,
+      trialEndsAt: null,
+    };
+    renderSettings({ authenticated: true, page: "billing" });
+
+    expect(screen.getByRole("button", { name: "Billing" })).toHaveFocus();
   });
 
   it("keeps timezone and accounts off the Billing page", () => {

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -642,6 +642,7 @@ describe("SettingsModal", () => {
 
     expect(selectSettingsPage(useSettingsStore.getState())).toBe("accounts");
     expect(screen.queryByRole("button", { name: "Billing" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Accounts" })).toHaveFocus();
   });
 
   it("seats focus on Billing when Settings opens on that page", () => {

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -792,6 +792,9 @@ describe("SettingsModal", () => {
 
     await user.keyboard("2");
     expect(screen.getByText("Plan")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Billing" })).toHaveFocus();
+    await user.keyboard("{Enter}");
+    expect(screen.getByText("Plan")).toBeInTheDocument();
     await user.keyboard("1");
     expect(screen.getByText("Default timezone")).toBeInTheDocument();
   });

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -616,8 +616,9 @@ describe("SettingsModal", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("stays on Billing while plan data is still fail-open", () => {
+  it("stays on Billing while plan data is still fail-open", async () => {
     access = { kind: "open" };
+    const user = userEvent.setup({ delay: null });
     renderSettings({ authenticated: true, page: "billing" });
 
     expect(selectSettingsPage(useSettingsStore.getState())).toBe("billing");
@@ -625,6 +626,9 @@ describe("SettingsModal", () => {
       "aria-current",
       "true",
     );
+    await user.keyboard("2");
+    expect(selectSettingsPage(useSettingsStore.getState())).toBe("billing");
+    expect(screen.getByRole("button", { name: "Billing" })).toHaveFocus();
   });
 
   it("leaves Billing when the server reports no plan", () => {

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -1,4 +1,12 @@
-import { act, render, screen, waitFor, within } from "@testing-library/react";
+import { HotkeysProvider, resolveModifier } from "@tanstack/react-hotkeys";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
@@ -13,6 +21,7 @@ import {
   resetGoogleReconnectRequiredForTests,
 } from "@web/auth/google/state/google.reconnect.state";
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
+import { UpgradeConfirmationProvider } from "@web/billing/UpgradeConfirmation/UpgradeConfirmationProvider";
 import { type AppAccess } from "@web/billing/useAppAccess";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
@@ -143,11 +152,13 @@ const renderSettings = ({
   connections = [connection()],
   calendars = [],
   open = true,
+  page = "accounts",
 }: {
   authenticated?: boolean;
   connections?: GoogleSyncConnectionSummary[];
   calendars?: Calendar[];
   open?: boolean;
+  page?: "accounts" | "billing";
 } = {}) => {
   authenticated = isAuthenticated;
   userMetadataActions.set({
@@ -155,9 +166,19 @@ const renderSettings = ({
   });
   const { queryClient, wrapper } = createStoreWrapper();
   queryClient.setQueryData(calendarQueryKeys.all, calendars);
-  if (open) settingsActions.openSettings();
+  if (open) settingsActions.openSettings(page);
 
-  return { queryClient, ...render(<SettingsModal />, { wrapper }) };
+  return {
+    queryClient,
+    ...render(
+      <HotkeysProvider>
+        <UpgradeConfirmationProvider>
+          <SettingsModal />
+        </UpgradeConfirmationProvider>
+      </HotkeysProvider>,
+      { wrapper },
+    ),
+  };
 };
 
 describe("SettingsModal", () => {
@@ -585,9 +606,47 @@ describe("SettingsModal", () => {
     renderSettings({ authenticated: true });
 
     expect(screen.queryByText("Plan")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Billing" })).toBeNull();
     expect(
       screen.queryByRole("button", { name: "Manage billing" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("keeps timezone and accounts off the Billing page", () => {
+    access = {
+      kind: "server",
+      status: "active",
+      isReadOnly: false,
+      trialEndsAt: null,
+    };
+    renderSettings({ authenticated: true, page: "billing" });
+
+    expect(screen.getByRole("button", { name: "Billing" })).toHaveAttribute(
+      "aria-current",
+      "true",
+    );
+    expect(screen.queryByText("Default timezone")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Export data" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("switches between Accounts and Billing", async () => {
+    access = {
+      kind: "server",
+      status: "active",
+      isReadOnly: false,
+      trialEndsAt: null,
+    };
+    const user = userEvent.setup({ delay: null });
+    renderSettings({ authenticated: true });
+
+    expect(screen.getByText("Default timezone")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Billing" }));
+    expect(screen.getByText("Plan")).toBeInTheDocument();
+    expect(screen.queryByText("Default timezone")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Accounts" }));
+    expect(screen.getByText("Default timezone")).toBeInTheDocument();
   });
 
   it("tells a subscriber they are on Premium", () => {
@@ -597,7 +656,7 @@ describe("SettingsModal", () => {
       isReadOnly: false,
       trialEndsAt: null,
     };
-    renderSettings({ authenticated: true });
+    renderSettings({ authenticated: true, page: "billing" });
 
     expect(screen.getByText("Plan")).toBeInTheDocument();
     expect(screen.getByText("Premium")).toBeInTheDocument();
@@ -613,19 +672,52 @@ describe("SettingsModal", () => {
       isReadOnly: false,
       trialEndsAt: dayjs().add(3, "day").toISOString(),
     };
-    renderSettings({ authenticated: true });
+    renderSettings({ authenticated: true, page: "billing" });
 
     expect(screen.getByText("Trial \u00b7 3d")).toBeInTheDocument();
+    expect(screen.getByText(/to subscribe now/)).toBeInTheDocument();
     expect(
-      screen.getByText(/Press\s+B to subscribe now\./),
-    ).toBeInTheDocument();
+      within(
+        screen.getByText(/to subscribe now/).closest("p") as HTMLElement,
+      ).getByText("B"),
+    ).toBeTruthy();
   });
 
-  it("opens the billing portal from Manage billing", async () => {
+  it("opens the billing portal from Manage billing in a new tab", async () => {
     const createPortalSession = spyOn(
       BillingApi,
       "createPortalSession",
     ).mockResolvedValue({ url: "https://billing.stripe.com/p/ok" });
+    const replace = mock(() => {});
+    const popup = { closed: false, location: { replace }, opener: {} };
+    const open = spyOn(window, "open").mockReturnValue(
+      popup as unknown as Window,
+    );
+    access = {
+      kind: "server",
+      status: "active",
+      isReadOnly: false,
+      trialEndsAt: null,
+    };
+    const user = userEvent.setup();
+    renderSettings({ authenticated: true, page: "billing" });
+
+    await user.click(screen.getByRole("button", { name: "Manage billing" }));
+
+    await waitFor(() => {
+      expect(open).toHaveBeenCalledWith("about:blank", "_blank");
+      expect(replace).toHaveBeenCalledWith("https://billing.stripe.com/p/ok");
+    });
+    createPortalSession.mockRestore();
+    open.mockRestore();
+  });
+
+  it("falls back to the same tab when the portal popup is blocked", async () => {
+    const createPortalSession = spyOn(
+      BillingApi,
+      "createPortalSession",
+    ).mockResolvedValue({ url: "https://billing.stripe.com/p/ok" });
+    const open = spyOn(window, "open").mockReturnValue(null);
     const assign = spyOn(window.location, "assign").mockImplementation(
       () => {},
     );
@@ -636,7 +728,7 @@ describe("SettingsModal", () => {
       trialEndsAt: null,
     };
     const user = userEvent.setup();
-    renderSettings({ authenticated: true });
+    renderSettings({ authenticated: true, page: "billing" });
 
     await user.click(screen.getByRole("button", { name: "Manage billing" }));
 
@@ -644,6 +736,126 @@ describe("SettingsModal", () => {
       expect(assign).toHaveBeenCalledWith("https://billing.stripe.com/p/ok");
     });
     createPortalSession.mockRestore();
+    open.mockRestore();
     assign.mockRestore();
+  });
+
+  it("jumps to Billing with 2 and back to Accounts with 1", async () => {
+    access = {
+      kind: "server",
+      status: "active",
+      isReadOnly: false,
+      trialEndsAt: null,
+    };
+    const user = userEvent.setup({ delay: null });
+    renderSettings({ authenticated: true });
+
+    await user.keyboard("2");
+    expect(screen.getByText("Plan")).toBeInTheDocument();
+    await user.keyboard("1");
+    expect(screen.getByText("Default timezone")).toBeInTheDocument();
+  });
+
+  it("opens the portal with M from the Billing page", async () => {
+    const createPortalSession = spyOn(
+      BillingApi,
+      "createPortalSession",
+    ).mockResolvedValue({ url: "https://billing.stripe.com/p/ok" });
+    const replace = mock(() => {});
+    const popup = { closed: false, location: { replace }, opener: {} };
+    const open = spyOn(window, "open").mockReturnValue(
+      popup as unknown as Window,
+    );
+    access = {
+      kind: "server",
+      status: "active",
+      isReadOnly: false,
+      trialEndsAt: null,
+    };
+    const user = userEvent.setup({ delay: null });
+    renderSettings({ authenticated: true, page: "billing" });
+
+    await user.keyboard("m");
+
+    await waitFor(() => {
+      expect(open).toHaveBeenCalledWith("about:blank", "_blank");
+      expect(replace).toHaveBeenCalledWith("https://billing.stripe.com/p/ok");
+    });
+    createPortalSession.mockRestore();
+    open.mockRestore();
+  });
+
+  it("reveals shortcut chips while Mod is held", async () => {
+    access = {
+      kind: "server",
+      status: "active",
+      isReadOnly: false,
+      trialEndsAt: null,
+    };
+    const user = userEvent.setup({ delay: null });
+    renderSettings({ authenticated: true });
+
+    expect(
+      within(screen.getByRole("button", { name: "Accounts" })).queryByText("1"),
+    ).toBeNull();
+
+    const modKey = resolveModifier("Mod") === "Meta" ? "Meta" : "Control";
+    await user.keyboard(`{${modKey}>}`);
+    expect(
+      within(screen.getByRole("button", { name: "Accounts" })).getByText("1"),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByRole("button", { name: "Billing" })).getByText("2"),
+    ).toBeInTheDocument();
+
+    await user.keyboard(`{/${modKey}}`);
+    expect(
+      within(screen.getByRole("button", { name: "Accounts" })).queryByText("1"),
+    ).toBeNull();
+  });
+
+  it("activates Manage billing on hover then Enter, without leaving Accounts focused", async () => {
+    const createPortalSession = spyOn(
+      BillingApi,
+      "createPortalSession",
+    ).mockResolvedValue({ url: "https://billing.stripe.com/p/ok" });
+    const replace = mock(() => {});
+    const popup = { closed: false, location: { replace }, opener: {} };
+    spyOn(window, "open").mockReturnValue(popup as unknown as Window);
+    access = {
+      kind: "server",
+      status: "active",
+      isReadOnly: false,
+      trialEndsAt: null,
+    };
+    const user = userEvent.setup({ delay: null });
+    renderSettings({ authenticated: true, page: "billing" });
+
+    const manage = screen.getByRole("button", { name: "Manage billing" });
+    fireEvent.pointerEnter(manage, { pointerType: "mouse" });
+    expect(manage).toHaveFocus();
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith("https://billing.stripe.com/p/ok");
+    });
+    createPortalSession.mockRestore();
+  });
+
+  it("opens the upgrade confirmation with B while Settings is open", async () => {
+    access = {
+      kind: "server",
+      status: "trialing",
+      isReadOnly: false,
+      trialEndsAt: dayjs().add(3, "day").toISOString(),
+    };
+    const user = userEvent.setup({ delay: null });
+    renderSettings({ authenticated: true, page: "billing" });
+
+    await user.keyboard("b");
+
+    expect(
+      screen.getByRole("dialog", { name: "Start Premium now?" }),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -82,6 +82,7 @@ export const SettingsModal: FC = () => {
   const isOpen = useSettingsStore(selectIsSettingsOpen);
   const page = useSettingsStore(selectSettingsPage);
   const initialFocusRef = useRef<HTMLButtonElement>(null);
+  const reseatFocusOnAccountsRef = useRef(false);
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
   useAppLockReason("settingsModal", isOpen);
   const { openDeleteAccountConfirmation } = useDeleteAccountConfirmation();
@@ -106,11 +107,20 @@ export const SettingsModal: FC = () => {
   // Fail-open and in-flight status both look like `kind: "open"` (no badge).
   // Bounce only once the server says there is no plan; otherwise a portal
   // return (`?settings=billing`) would snap to Accounts before status lands.
+  // The Billing nav unmounts on that bounce, so reseat focus on Accounts or
+  // it falls to document.body and Escape no longer dismisses the dialog.
   useEffect(() => {
     if (page === "billing" && access.kind === "server" && !hasBilling) {
+      reseatFocusOnAccountsRef.current = true;
       settingsActions.setSettingsPage("accounts");
     }
   }, [access.kind, hasBilling, page]);
+
+  useEffect(() => {
+    if (!reseatFocusOnAccountsRef.current || page !== "accounts") return;
+    reseatFocusOnAccountsRef.current = false;
+    initialFocusRef.current?.focus();
+  }, [page]);
 
   const { data } = useCalendarsQuery();
   const connections = useUserMetadataStore(selectGoogleSyncConnections);

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -81,6 +81,7 @@ const navButtonClassName = (current: boolean) =>
 export const SettingsModal: FC = () => {
   const isOpen = useSettingsStore(selectIsSettingsOpen);
   const page = useSettingsStore(selectSettingsPage);
+  const initialFocusRef = useRef<HTMLButtonElement>(null);
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
   useAppLockReason("settingsModal", isOpen);
   const { openDeleteAccountConfirmation } = useDeleteAccountConfirmation();
@@ -102,11 +103,14 @@ export const SettingsModal: FC = () => {
     if (!isOpen) setConfirmingId(null);
   }, [isOpen]);
 
+  // Fail-open and in-flight status both look like `kind: "open"` (no badge).
+  // Bounce only once the server says there is no plan; otherwise a portal
+  // return (`?settings=billing`) would snap to Accounts before status lands.
   useEffect(() => {
-    if (page === "billing" && !hasBilling) {
+    if (page === "billing" && access.kind === "server" && !hasBilling) {
       settingsActions.setSettingsPage("accounts");
     }
-  }, [hasBilling, page]);
+  }, [access.kind, hasBilling, page]);
 
   const { data } = useCalendarsQuery();
   const connections = useUserMetadataStore(selectGoogleSyncConnections);
@@ -155,6 +159,7 @@ export const SettingsModal: FC = () => {
   return (
     <OverlayPanel
       align="start"
+      initialFocusRef={initialFocusRef}
       onDismiss={handleDismiss}
       title="Settings"
       variant="modal"
@@ -167,18 +172,20 @@ export const SettingsModal: FC = () => {
             className={navButtonClassName(page === "accounts")}
             onClick={() => settingsActions.setSettingsPage("accounts")}
             onPointerEnter={focusOnPointerEnter}
+            ref={page === "accounts" ? initialFocusRef : undefined}
             type="button"
             {...settingsShortcutAttrs("nav-accounts")}
           >
             Accounts
             {areHintsVisible ? <ShortcutKeys keys="1" /> : null}
           </button>
-          {hasBilling ? (
+          {hasBilling || page === "billing" ? (
             <button
               aria-current={page === "billing" ? "true" : undefined}
               className={navButtonClassName(page === "billing")}
               onClick={() => settingsActions.setSettingsPage("billing")}
               onPointerEnter={focusOnPointerEnter}
+              ref={page === "billing" ? initialFocusRef : undefined}
               type="button"
               {...settingsShortcutAttrs("nav-billing")}
             >

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -17,6 +17,9 @@ import {
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
 import { PlanSection } from "@web/billing/PlanSection";
+import { getPlanBadge } from "@web/billing/planBadge";
+import { useUpgradeConfirmation } from "@web/billing/UpgradeConfirmation/hooks/useUpgradeConfirmation";
+import { useAppAccess } from "@web/billing/useAppAccess";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import {
   compareCalendars,
@@ -34,6 +37,7 @@ import {
 } from "@web/calendars/useDefaultTargetCalendar";
 import { EXPORT_MY_DATA_TOAST_ID } from "@web/common/constants/toast.constants";
 import { runExportMyData } from "@web/common/storage/offline-data/export-user-data.util";
+import { focusOnPointerEnter } from "@web/common/utils/focus-on-pointer-enter";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
 import { useDeleteAccountConfirmation } from "@web/components/DeleteAccountConfirmation/hooks/useDeleteAccountConfirmation";
@@ -43,11 +47,17 @@ import {
   OverlayPanelActionButton,
   OverlayPanelActions,
 } from "@web/components/OverlayPanel/OverlayPanel";
+import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import {
   selectIsSettingsOpen,
+  selectSettingsPage,
   settingsActions,
   useSettingsStore,
 } from "@web/settings/settings.store";
+import {
+  settingsShortcutAttrs,
+  useSettingsShortcuts,
+} from "@web/settings/useSettingsShortcuts";
 import { useAppLockReason } from "@web/shortcuts/app-lock";
 import { useSseDegraded } from "@web/sse/hooks/useSseDegraded";
 import { DefaultTimezonePicker } from "@web/timezone/DefaultTimezonePicker";
@@ -55,24 +65,35 @@ import { DefaultTimezonePicker } from "@web/timezone/DefaultTimezonePicker";
 const OUTLINE_BUTTON_CLASSNAME =
   "c-focus-ring shrink-0 rounded border border-border bg-surface-overlay px-2 py-1 text-xs text-text transition-colors hover:bg-surface-panel disabled:pointer-events-none disabled:opacity-60";
 
+const navButtonClassName = (current: boolean) =>
+  current
+    ? "c-focus-ring flex w-full items-center justify-between rounded bg-surface-overlay px-2 py-1 text-left text-sm text-text"
+    : "c-focus-ring flex w-full items-center justify-between rounded px-2 py-1 text-left text-sm text-text-muted transition-colors hover:bg-surface-overlay hover:text-text";
+
 /**
- * The app's Settings menu (Mod+,): a nav shell (one item today - Accounts)
- * holding default-calendar choice, connected-account management, and the
- * signed-in user's own Log out action (which stays reachable from the
- * Command Palette too - see useLogoutCmdItems). Default-calendar and
- * account management used to live scattered across the sidebar (the
- * default-calendar star) and a dedicated "manage accounts" dialog. ESC steps
- * back a level - out of an open disconnect confirmation first, then out of
- * the modal - via `handleDismiss`, since OverlayPanel already routes both
- * ESC and a backdrop click through `onDismiss`.
+ * The app's Settings menu (Mod+,): Accounts (timezone, calendars, Google
+ * connections, export / delete / log out) and Billing (plan + portal) as
+ * sibling pages. ESC steps back a level - out of an open disconnect
+ * confirmation first, then out of the modal - via `handleDismiss`, since
+ * OverlayPanel already routes both ESC and a backdrop click through
+ * `onDismiss`.
  */
 export const SettingsModal: FC = () => {
   const isOpen = useSettingsStore(selectIsSettingsOpen);
+  const page = useSettingsStore(selectSettingsPage);
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
   useAppLockReason("settingsModal", isOpen);
   const { openDeleteAccountConfirmation } = useDeleteAccountConfirmation();
   const { authenticated } = useSession();
   const { openLogoutConfirmation } = useLogoutConfirmation();
+  const { isOpen: isUpgradeOpen } = useUpgradeConfirmation();
+  const access = useAppAccess();
+  const hasBilling = getPlanBadge(access) !== null;
+  const { areHintsVisible } = useSettingsShortcuts({
+    enabled: isOpen && !isUpgradeOpen,
+    hasBilling,
+    page,
+  });
 
   // The modal stays mounted (self-reads the store) so a stray close path
   // that skips handleDismiss (e.g. the Mod+, toggle) can't leave a
@@ -80,6 +101,12 @@ export const SettingsModal: FC = () => {
   useEffect(() => {
     if (!isOpen) setConfirmingId(null);
   }, [isOpen]);
+
+  useEffect(() => {
+    if (page === "billing" && !hasBilling) {
+      settingsActions.setSettingsPage("accounts");
+    }
+  }, [hasBilling, page]);
 
   const { data } = useCalendarsQuery();
   const connections = useUserMetadataStore(selectGoogleSyncConnections);
@@ -136,48 +163,82 @@ export const SettingsModal: FC = () => {
       <div className="flex w-full gap-6">
         <nav className="w-32 shrink-0">
           <button
-            aria-current="true"
-            className="w-full rounded bg-surface-overlay px-2 py-1 text-left text-sm text-text"
+            aria-current={page === "accounts" ? "true" : undefined}
+            className={navButtonClassName(page === "accounts")}
+            onClick={() => settingsActions.setSettingsPage("accounts")}
+            onPointerEnter={focusOnPointerEnter}
             type="button"
+            {...settingsShortcutAttrs("nav-accounts")}
           >
             Accounts
+            {areHintsVisible ? <ShortcutKeys keys="1" /> : null}
           </button>
+          {hasBilling ? (
+            <button
+              aria-current={page === "billing" ? "true" : undefined}
+              className={navButtonClassName(page === "billing")}
+              onClick={() => settingsActions.setSettingsPage("billing")}
+              onPointerEnter={focusOnPointerEnter}
+              type="button"
+              {...settingsShortcutAttrs("nav-billing")}
+            >
+              Billing
+              {areHintsVisible ? <ShortcutKeys keys="2" /> : null}
+            </button>
+          ) : null}
         </nav>
         <div className="flex min-w-0 flex-1 flex-col gap-4">
-          <PlanSection />
-          <DefaultTimezonePicker />
-          <DefaultCalendarPicker
-            calendars={writableCalendars}
-            connections={connections}
-            resolvedDefault={resolvedDefault}
-          />
-          <AccountsSection
-            confirmingId={confirmingId}
-            connections={connections}
-            resolvedDefault={resolvedDefault}
-            setConfirmingId={setConfirmingId}
-          />
-          <div className="mt-2 border-border border-t pt-3">
-            <OverlayPanelActions align="start">
-              <OverlayPanelActionButton
-                onClick={handleExport}
-                variant="secondary"
-              >
-                Export data
-              </OverlayPanelActionButton>
-              <OverlayPanelActionButton
-                onClick={handleDeleteAccount}
-                variant="destructive"
-              >
-                Delete account
-              </OverlayPanelActionButton>
-              {authenticated ? (
-                <OverlayPanelActionButton onClick={handleLogout}>
-                  Log out
-                </OverlayPanelActionButton>
-              ) : null}
-            </OverlayPanelActions>
-          </div>
+          {page === "billing" ? (
+            <PlanSection showShortcuts={areHintsVisible} />
+          ) : (
+            <>
+              <DefaultTimezonePicker />
+              <DefaultCalendarPicker
+                calendars={writableCalendars}
+                connections={connections}
+                resolvedDefault={resolvedDefault}
+              />
+              <AccountsSection
+                confirmingId={confirmingId}
+                connections={connections}
+                resolvedDefault={resolvedDefault}
+                setConfirmingId={setConfirmingId}
+                showShortcuts={areHintsVisible}
+              />
+              <div className="mt-2 border-border border-t pt-3">
+                <OverlayPanelActions align="start">
+                  <OverlayPanelActionButton
+                    onClick={handleExport}
+                    shortcut="E"
+                    showShortcut={areHintsVisible}
+                    variant="secondary"
+                    {...settingsShortcutAttrs("export")}
+                  >
+                    Export data
+                  </OverlayPanelActionButton>
+                  <OverlayPanelActionButton
+                    onClick={handleDeleteAccount}
+                    shortcut="D"
+                    showShortcut={areHintsVisible}
+                    variant="destructive"
+                    {...settingsShortcutAttrs("delete-account")}
+                  >
+                    Delete account
+                  </OverlayPanelActionButton>
+                  {authenticated ? (
+                    <OverlayPanelActionButton
+                      onClick={handleLogout}
+                      shortcut="O"
+                      showShortcut={areHintsVisible}
+                      {...settingsShortcutAttrs("log-out")}
+                    >
+                      Log out
+                    </OverlayPanelActionButton>
+                  ) : null}
+                </OverlayPanelActions>
+              </div>
+            </>
+          )}
         </div>
       </div>
     </OverlayPanel>
@@ -242,6 +303,7 @@ interface AccountsSectionProps {
   connections: GoogleSyncConnectionSummary[];
   resolvedDefault: Calendar | undefined;
   setConfirmingId: (id: string | null) => void;
+  showShortcuts: boolean;
 }
 
 const AccountsSection: FC<AccountsSectionProps> = ({
@@ -249,6 +311,7 @@ const AccountsSection: FC<AccountsSectionProps> = ({
   connections,
   resolvedDefault,
   setConfirmingId,
+  showShortcuts,
 }) => {
   const { connect, isAvailable, isConnecting } = useConnectGoogle({
     newAccount: true,
@@ -285,7 +348,10 @@ const AccountsSection: FC<AccountsSectionProps> = ({
             aria-busy={isConnecting || undefined}
             disabled={isConnecting}
             onClick={connect}
+            shortcut="A"
+            showShortcut={showShortcuts}
             variant="primary"
+            {...settingsShortcutAttrs("add-account")}
           >
             {isConnecting ? "Opening Google…" : "Add account"}
           </OverlayPanelActionButton>
@@ -397,6 +463,7 @@ const AccountRow: FC<AccountRowProps> = ({
                 setConfirming(false),
               )
             }
+            onPointerEnter={focusOnPointerEnter}
             ref={confirmButtonRef}
             type="button"
           >
@@ -406,6 +473,7 @@ const AccountRow: FC<AccountRowProps> = ({
             className={OUTLINE_BUTTON_CLASSNAME}
             disabled={isDisconnecting}
             onClick={() => setConfirming(false)}
+            onPointerEnter={focusOnPointerEnter}
             type="button"
           >
             Cancel
@@ -416,6 +484,7 @@ const AccountRow: FC<AccountRowProps> = ({
           aria-label={`Disconnect ${accountEmail}`}
           className={OUTLINE_BUTTON_CLASSNAME}
           onClick={() => setConfirming(true)}
+          onPointerEnter={focusOnPointerEnter}
           ref={disconnectButtonRef}
           type="button"
         >

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
@@ -109,7 +109,7 @@ export const SidebarStatusBar: FC = () => {
             text ? `${text}. Open account settings` : "Open account settings"
           }
           className="c-focus-ring flex min-w-0 flex-1 items-center justify-center self-stretch rounded-xs"
-          onClick={settingsActions.openSettings}
+          onClick={() => settingsActions.openSettings()}
           title={text || undefined}
           type="button"
         >

--- a/packages/web/src/settings/settings.store.ts
+++ b/packages/web/src/settings/settings.store.ts
@@ -2,16 +2,20 @@ import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 import { IS_DEV } from "@web/common/constants/env.constants";
 
+export type SettingsPage = "accounts" | "billing";
+
 interface SettingsState {
   isCmdPaletteOpen: boolean;
   isSettingsOpen: boolean;
   isAboutOpen: boolean;
+  settingsPage: SettingsPage;
 }
 
 export const initialSettingsState: SettingsState = {
   isCmdPaletteOpen: false,
   isSettingsOpen: false,
   isAboutOpen: false,
+  settingsPage: "accounts",
 };
 
 // Selectors passed to this hook must return primitives or stable references;
@@ -39,16 +43,31 @@ export const settingsActions = {
       { type: "toggleCmdPalette" },
     ),
   closeSettings: () =>
-    useSettingsStore.setState({ isSettingsOpen: false }, false, {
-      type: "closeSettings",
-    }),
-  openSettings: () =>
-    useSettingsStore.setState({ isSettingsOpen: true }, false, {
-      type: "openSettings",
+    useSettingsStore.setState(
+      { isSettingsOpen: false, settingsPage: "accounts" },
+      false,
+      {
+        type: "closeSettings",
+      },
+    ),
+  openSettings: (page: SettingsPage = "accounts") =>
+    useSettingsStore.setState(
+      { isSettingsOpen: true, settingsPage: page },
+      false,
+      {
+        type: "openSettings",
+      },
+    ),
+  setSettingsPage: (settingsPage: SettingsPage) =>
+    useSettingsStore.setState({ settingsPage }, false, {
+      type: "setSettingsPage",
     }),
   toggleSettings: () =>
     useSettingsStore.setState(
-      (state) => ({ isSettingsOpen: !state.isSettingsOpen }),
+      (state) =>
+        state.isSettingsOpen
+          ? { isSettingsOpen: false, settingsPage: "accounts" }
+          : { isSettingsOpen: true, settingsPage: "accounts" },
       false,
       { type: "toggleSettings" },
     ),
@@ -69,3 +88,5 @@ export const selectIsSettingsOpen = (state: SettingsState) =>
   state.isSettingsOpen;
 
 export const selectIsAboutOpen = (state: SettingsState) => state.isAboutOpen;
+
+export const selectSettingsPage = (state: SettingsState) => state.settingsPage;

--- a/packages/web/src/settings/useSettingsShortcuts.ts
+++ b/packages/web/src/settings/useSettingsShortcuts.ts
@@ -35,7 +35,8 @@ const shortcutIdForEvent = (
 ): string | null => {
   const digit = physicalDigitIndex(event);
   if (digit === 0) return "nav-accounts";
-  if (digit === 1) return hasBilling ? "nav-billing" : null;
+  if (digit === 1)
+    return hasBilling || page === "billing" ? "nav-billing" : null;
 
   const key = normalizedKeyboardKey(event);
   if (page === "billing" && key === "m") return "manage-billing";

--- a/packages/web/src/settings/useSettingsShortcuts.ts
+++ b/packages/web/src/settings/useSettingsShortcuts.ts
@@ -1,0 +1,92 @@
+import { useEffect } from "react";
+import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
+import { type SettingsPage } from "@web/settings/settings.store";
+import { physicalDigitIndex } from "@web/shortcuts/digit-pick.util";
+import { normalizedKeyboardKey } from "@web/shortcuts/is-bare-letter-key";
+import { useModHoldHintShortcut } from "@web/shortcuts/mod-hold/useModHoldHintShortcut";
+
+export const SETTINGS_SHORTCUT_ATTR = "data-settings-shortcut";
+
+export const settingsShortcutAttrs = (id: string) =>
+  ({ [SETTINGS_SHORTCUT_ATTR]: id }) as const;
+
+const clickSettingsShortcut = (id: string): boolean => {
+  const el = document.querySelector<HTMLElement>(
+    `[${SETTINGS_SHORTCUT_ATTR}="${id}"]`,
+  );
+  if (!el || el.hasAttribute("disabled")) return false;
+  el.click();
+  return true;
+};
+
+/**
+ * Maps a key to a Settings control. Nav digits 1/2 always win over in-page
+ * actions so a user looking at Accounts can still jump to Billing. Disconnect
+ * rows therefore have no digit shortcut (hover + Enter activates them).
+ */
+const shortcutIdForEvent = (
+  event: KeyboardEvent,
+  page: SettingsPage,
+  hasBilling: boolean,
+): string | null => {
+  const digit = physicalDigitIndex(event);
+  if (digit === 0) return "nav-accounts";
+  if (digit === 1) return hasBilling ? "nav-billing" : null;
+
+  const key = normalizedKeyboardKey(event);
+  if (page === "billing" && key === "m") return "manage-billing";
+  if (page !== "accounts") return null;
+  if (key === "a") return "add-account";
+  if (key === "e") return "export";
+  if (key === "d") return "delete-account";
+  if (key === "o") return "log-out";
+  return null;
+};
+
+/**
+ * Page-local Settings shortcuts. Calendar letter keys are free while the
+ * modal holds app-lock; chips appear on Mod down (no 600ms delay) so the
+ * gesture matches the welcome modal rather than page-jump.
+ */
+export function useSettingsShortcuts({
+  enabled,
+  hasBilling,
+  page,
+}: {
+  enabled: boolean;
+  hasBilling: boolean;
+  page: SettingsPage;
+}): { areHintsVisible: boolean } {
+  const { areHintsVisible } = useModHoldHintShortcut({
+    enabled,
+    holdMs: 0,
+    ignoreAppLock: true,
+    onModChord: (event) => {
+      const id = shortcutIdForEvent(event, page, hasBilling);
+      if (!id) return false;
+      return clickSettingsShortcut(id);
+    },
+  });
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.repeat) return;
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      if (isEditableKeyboardTarget(event)) return;
+
+      const id = shortcutIdForEvent(event, page, hasBilling);
+      if (!id) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      clickSettingsShortcut(id);
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [enabled, hasBilling, page]);
+
+  return { areHintsVisible };
+}

--- a/packages/web/src/settings/useSettingsShortcuts.ts
+++ b/packages/web/src/settings/useSettingsShortcuts.ts
@@ -15,6 +15,10 @@ const clickSettingsShortcut = (id: string): boolean => {
     `[${SETTINGS_SHORTCUT_ATTR}="${id}"]`,
   );
   if (!el || el.hasAttribute("disabled")) return false;
+  // Programmatic click does not move focus. Seat it on the target so a
+  // following Enter activates this control instead of the previous one
+  // (Accounts stays focused after 2, which would jump back).
+  el.focus({ preventScroll: true });
   el.click();
   return true;
 };

--- a/packages/web/src/shortcuts/mod-hold/useModHoldHintShortcut.ts
+++ b/packages/web/src/shortcuts/mod-hold/useModHoldHintShortcut.ts
@@ -29,11 +29,21 @@ export const MOD_HOLD_HINT_MS = 600;
  */
 export function useModHoldHintShortcut({
   enabled = true,
+  ignoreAppLock = false,
+  holdMs = MOD_HOLD_HINT_MS,
   onModChord,
   onHintsRevealed,
   onVisibilityChange,
 }: {
   enabled?: boolean;
+  /**
+   * Settings (and other app-lock overlays) still want hold-Mod chips. Page
+   * jump and form-field jump must keep the default, which hides the gesture
+   * while a dialog owns the screen.
+   */
+  ignoreAppLock?: boolean;
+  /** 0 reveals chips on the initial Mod press instead of waiting. */
+  holdMs?: number;
   onModChord: (event: KeyboardEvent) => boolean;
   /** Fires once when hold-Mod chips actually appear, not on a bare Mod tap. */
   onHintsRevealed?: () => void;
@@ -81,12 +91,17 @@ export function useModHoldHintShortcut({
     };
 
     const armHoldTimer = () => {
-      holdTimeoutId = setTimeout(() => {
+      const reveal = () => {
         holdTimeoutId = null;
         hintsVisible = true;
         publishVisibility(true);
         onHintsRevealedRef.current?.();
-      }, MOD_HOLD_HINT_MS);
+      };
+      if (holdMs <= 0) {
+        reveal();
+        return;
+      }
+      holdTimeoutId = setTimeout(reveal, holdMs);
     };
 
     const isModOnly = (event: KeyboardEvent) =>
@@ -96,7 +111,7 @@ export function useModHoldHintShortcut({
 
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.defaultPrevented) return;
-      if (isAppLocked()) {
+      if (!ignoreAppLock && isAppLocked()) {
         hideHints();
         return;
       }
@@ -160,7 +175,7 @@ export function useModHoldHintShortcut({
       window.removeEventListener("blur", onWindowBlur);
       document.removeEventListener("visibilitychange", onVisibilityChange);
     };
-  }, [enabled]);
+  }, [enabled, holdMs, ignoreAppLock]);
 
   return { areHintsVisible };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Settings is now two pages, Accounts and Billing, so plan and portal actions are no longer mixed into timezone and Google account chrome. `B` subscribes while Settings is open, shortcut copy uses keycaps, hover plus Enter activates the hovered billing action instead of Start Premium, and Manage billing opens Stripe in a new tab with `?settings=billing` restoring the Billing page and fresh plan data.

## Simplicity

Shared the 15s billing-status poll and the Manage billing handler (`7a0d58acd`). Dropped an unused `BillingRedirectKind` export. Left Settings nav and palette items duplicated: they gate and keyword differently.

## Automated validation

`bun run verify` PASS on `origin/main...HEAD` at `1405940f1`.

Selected packages: web, backend.
Checks run: test:web (2732 pass), test:backend (449 pass, 1 skip), type-check, lint, knip, test:a11y (7 passed), test:e2e (47 passed).
Checks skipped: none.

`bun run lint`: exit 0, 13 pre-existing warnings, none in this diff.

## Independent review

`.agents/handoffs/2955.md` at `1405940f1`:

```
VERDICT: no confirmed findings
FINDINGS:
```

Earlier review findings (portal bounce, hover stealing text-field focus, shortcut focus, closed portal tab) were fixed in follow-up commits on this branch, then re-reviewed.

## Test plan

- `bun run verify`
- `bun run lint`
- `bun test:web -- packages/web/src/components/Settings/SettingsModal.test.tsx packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationProvider.test.tsx packages/web/src/billing/BillingGateModal.test.tsx packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx packages/web/src/components/RootShell/RootShell.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-adb0de7b-e93f-4d3b-ab3e-ee7343a087c2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-adb0de7b-e93f-4d3b-ab3e-ee7343a087c2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

