### PR TITLE
feat(web): lower the welcome first-action bar

### DIFF
--- a/packages/web/src/components/PointerHint/PointerHint.test.tsx
+++ b/packages/web/src/components/PointerHint/PointerHint.test.tsx
@@ -62,7 +62,7 @@ describe("PointerHint", () => {
     });
 
     expect(screen.getByRole("status")).toHaveTextContent(
-      "Compass is keyboard only.",
+      "Use the keys on this screen.",
     );
     expect(screen.getByRole("status")).not.toHaveTextContent("Press");
   });
@@ -76,9 +76,38 @@ describe("PointerHint", () => {
     });
 
     expect(screen.getByRole("status")).toHaveTextContent(
-      "Compass is keyboard only.",
+      "Use the keys on this screen.",
     );
     expect(screen.getByRole("status")).not.toHaveTextContent("Press");
+  });
+
+  it("teaches the matching welcome shortcut for the attempted control", () => {
+    welcomeGuideActions.setFirstVisitOpen(true);
+    render(<PointerHint />);
+
+    act(() => {
+      pointerBlockActions.pulseBlockedClick({
+        actionId: "unknown",
+        shortcutKey: "1",
+      });
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent("Press 1");
+  });
+
+  it("keeps the welcome shortcut sentence after the session reminder threshold", () => {
+    sessionStorage.setItem(HINT_COUNT_KEY, "3");
+    welcomeGuideActions.setFirstVisitOpen(true);
+    render(<PointerHint />);
+
+    act(() => {
+      pointerBlockActions.pulseBlockedClick({
+        actionId: "unknown",
+        shortcutKey: "U",
+      });
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent("Press U");
   });
 
   it("points at the on-screen keys while the showcase is active", () => {

--- a/packages/web/src/components/PointerHint/PointerHint.tsx
+++ b/packages/web/src/components/PointerHint/PointerHint.tsx
@@ -50,7 +50,8 @@ const Key = ({ children }: { children: string }) => (
 const isContextualAttempt = (attempt: BlockedPointerAttempt | null) =>
   attempt?.actionId === POINTER_ACTIONS.sidebarClose ||
   attempt?.actionId === POINTER_ACTIONS.sidebarOpen ||
-  attempt?.actionId === POINTER_ACTIONS.eventOpen;
+  attempt?.actionId === POINTER_ACTIONS.eventOpen ||
+  Boolean(attempt?.shortcutKey);
 
 const pointerHintMessage = ({
   attempt,
@@ -96,9 +97,17 @@ const pointerHintMessage = ({
     );
   }
 
+  if (welcomeOpen && attempt?.shortcutKey) {
+    return (
+      <>
+        Press <Key>{attempt.shortcutKey}</Key>
+      </>
+    );
+  }
+
   if (isBrief) return "Keyboard only.";
 
-  if (welcomeOpen) return "Compass is keyboard only.";
+  if (welcomeOpen) return "Use the keys on this screen.";
 
   return (
     <>

--- a/packages/web/src/components/WelcomeModal/WelcomeGuideBody.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeGuideBody.test.tsx
@@ -1,11 +1,10 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   initialPointerBlockState,
   pointerBlockActions,
   usePointerBlockStore,
 } from "@web/shortcuts/keyboard-only/pointer-block.store";
-import { KEYCAP_FLASH_MS } from "./useFlashedWelcomeShortcut";
 import { WelcomeGuideBody } from "./WelcomeGuideBody";
 import { afterEach, describe, expect, it, mock } from "bun:test";
 
@@ -155,11 +154,31 @@ describe("WelcomeGuideBody", () => {
 
     expect(hintWrap?.className).toMatch(/c-keycap-flash/);
 
-    await waitFor(
-      () => {
-        expect(hintWrap?.className).not.toMatch(/c-keycap-flash/);
-      },
-      { timeout: KEYCAP_FLASH_MS + 200 },
+    act(() => {
+      pointerBlockActions.pulseBlockedClick({ actionId: "unknown" });
+    });
+
+    expect(hintWrap?.className).not.toMatch(/c-keycap-flash/);
+  });
+
+  it("does not replay a leftover flash when the guide remounts", () => {
+    const first = renderWelcomeGuide();
+
+    act(() => {
+      pointerBlockActions.pulseBlockedClick({
+        actionId: "unknown",
+        shortcutKey: "1",
+      });
+    });
+
+    first.unmount();
+    renderWelcomeGuide();
+
+    const question = screen.getByRole("button", {
+      name: "Who is Compass for?",
+    });
+    expect(question.nextElementSibling?.className).not.toMatch(
+      /c-keycap-flash/,
     );
   });
 });

--- a/packages/web/src/components/WelcomeModal/WelcomeGuideBody.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeGuideBody.test.tsx
@@ -1,23 +1,18 @@
-import { resolveModifier } from "@tanstack/react-hotkeys";
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import {
+  initialPointerBlockState,
+  pointerBlockActions,
+  usePointerBlockStore,
+} from "@web/shortcuts/keyboard-only/pointer-block.store";
+import { KEYCAP_FLASH_MS } from "./useFlashedWelcomeShortcut";
 import { WelcomeGuideBody } from "./WelcomeGuideBody";
 import { afterEach, describe, expect, it, mock } from "bun:test";
-
-const modKey = resolveModifier("Mod") === "Meta" ? "Meta" : "Control";
 
 const pressWindowKey = (init: KeyboardEventInit) => {
   act(() => {
     window.dispatchEvent(
       new KeyboardEvent("keydown", { bubbles: true, ...init }),
-    );
-  });
-};
-
-const releaseWindowKey = (init: KeyboardEventInit) => {
-  act(() => {
-    window.dispatchEvent(
-      new KeyboardEvent("keyup", { bubbles: true, ...init }),
     );
   });
 };
@@ -35,15 +30,25 @@ const captureLinkClick = (name: string) => {
 
 describe("WelcomeGuideBody", () => {
   afterEach(() => {
-    releaseWindowKey({ key: modKey });
+    usePointerBlockStore.setState(initialPointerBlockState, true);
   });
 
   it("explains that numbered shortcuts open the FAQ", () => {
     renderWelcomeGuide();
 
     expect(screen.getByText(/Tip:/)).toBeTruthy();
-    expect(screen.getByText(/to see keys, then press a number/)).toBeTruthy();
-    expect(screen.queryByText(/The same hold reveals jump keys/)).toBeNull();
+    expect(
+      screen.getByText(/Press a number to open a question or a link/),
+    ).toBeTruthy();
+  });
+
+  it("shows numbered keycaps without holding Mod", () => {
+    renderWelcomeGuide();
+
+    expect(screen.getByText("1")).toBeTruthy();
+    expect(screen.getByText("5")).toBeTruthy();
+    expect(screen.getByText("6")).toBeTruthy();
+    expect(screen.getByText("0")).toBeTruthy();
   });
 
   it("toggles a FAQ with a bare digit", async () => {
@@ -63,24 +68,6 @@ describe("WelcomeGuideBody", () => {
 
     pressWindowKey({ key: "1", code: "Digit1" });
     expect(question).toHaveAttribute("aria-expanded", "false");
-  });
-
-  it("reveals numbered keycaps while Mod is held", async () => {
-    renderWelcomeGuide();
-
-    expect(screen.queryByText("1")).toBeNull();
-
-    pressWindowKey({ key: modKey });
-
-    expect(screen.getByText("1")).toBeTruthy();
-    expect(screen.getByText("5")).toBeTruthy();
-    expect(screen.getByText("6")).toBeTruthy();
-    expect(screen.getByText("0")).toBeTruthy();
-
-    releaseWindowKey({ key: modKey });
-
-    expect(screen.queryByText("1")).toBeNull();
-    expect(screen.queryByText("6")).toBeNull();
   });
 
   it("still lets a click expand a question", async () => {
@@ -148,5 +135,31 @@ describe("WelcomeGuideBody", () => {
     expect(github).toHaveBeenCalledTimes(1);
     expect(privacy).toHaveBeenCalledTimes(1);
     expect(terms).toHaveBeenCalledTimes(1);
+  });
+
+  it("flashes the matching FAQ key after a blocked click, then clears", async () => {
+    renderWelcomeGuide();
+
+    const question = screen.getByRole("button", {
+      name: "Who is Compass for?",
+    });
+    const hintWrap = question.nextElementSibling;
+    expect(hintWrap?.className).not.toMatch(/c-keycap-flash/);
+
+    act(() => {
+      pointerBlockActions.pulseBlockedClick({
+        actionId: "unknown",
+        shortcutKey: "1",
+      });
+    });
+
+    expect(hintWrap?.className).toMatch(/c-keycap-flash/);
+
+    await waitFor(
+      () => {
+        expect(hintWrap?.className).not.toMatch(/c-keycap-flash/);
+      },
+      { timeout: KEYCAP_FLASH_MS + 200 },
+    );
   });
 });

--- a/packages/web/src/components/WelcomeModal/WelcomeGuideBody.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeGuideBody.tsx
@@ -1,14 +1,20 @@
+import classNames from "classnames";
 import { type ReactNode, useCallback, useId, useState } from "react";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
-import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
+import { pointerShortcutAttributes } from "@web/shortcuts/keyboard-only/pointer-action";
 import { ShortcutTipParts } from "@web/shortcuts/tips/ShortcutTipParts";
 import { FAQ_ITEMS } from "./faq";
+import {
+  flashedShortcutClass,
+  useFlashedWelcomeShortcut,
+} from "./useFlashedWelcomeShortcut";
 import { useWelcomeJumpShortcuts } from "./useWelcomeJumpShortcuts";
 import { WelcomeLinks } from "./WelcomeLinks";
 
 export function WelcomeGuideBody({ children }: { children?: ReactNode }) {
   const disclosureIdPrefix = useId();
   const faqHintId = `${disclosureIdPrefix}-faq-hint`;
+  const flashedKey = useFlashedWelcomeShortcut();
   const [expandedFaqs, setExpandedFaqs] = useState<Set<string>>(
     () => new Set(),
   );
@@ -35,7 +41,7 @@ export function WelcomeGuideBody({ children }: { children?: ReactNode }) {
     [toggleFaq],
   );
 
-  const isModHeld = useWelcomeJumpShortcuts(toggleFaqAt);
+  useWelcomeJumpShortcuts(toggleFaqAt);
 
   return (
     <>
@@ -57,6 +63,7 @@ export function WelcomeGuideBody({ children }: { children?: ReactNode }) {
           const isExpanded = expandedFaqs.has(item.question);
           const answerId = `${disclosureIdPrefix}-faq-answer-${index}`;
           const state = isExpanded ? "open" : "closed";
+          const digit = String(index + 1);
 
           return (
             <div key={item.question} className="py-3">
@@ -67,12 +74,18 @@ export function WelcomeGuideBody({ children }: { children?: ReactNode }) {
                   aria-expanded={isExpanded}
                   className="c-focus-ring w-full cursor-pointer select-none text-left font-medium text-sm text-text transition-colors hover:text-text-lightest"
                   onClick={() => toggleFaq(item.question)}
+                  {...pointerShortcutAttributes(digit)}
                 >
                   {item.question}
                 </button>
-                {isModHeld && (
-                  <ShortcutHint className="shrink-0">{index + 1}</ShortcutHint>
-                )}
+                <span
+                  className={classNames(
+                    "shrink-0",
+                    flashedShortcutClass(flashedKey, digit),
+                  )}
+                >
+                  <ShortcutHint>{digit}</ShortcutHint>
+                </span>
               </div>
               <div
                 id={answerId}
@@ -96,13 +109,10 @@ export function WelcomeGuideBody({ children }: { children?: ReactNode }) {
       </div>
 
       <p id={faqHintId} className="text-text-muted text-xs leading-relaxed">
-        <span className="inline-flex items-center gap-1 whitespace-nowrap">
-          Tip: Hold <ShortcutKeys keys={["Mod"]} /> to see keys, then press a
-          number.
-        </span>
+        Tip: Press a number to open a question or a link.
       </p>
       {children}
-      <WelcomeLinks isModHeld={isModHeld} />
+      <WelcomeLinks />
     </>
   );
 }

--- a/packages/web/src/components/WelcomeModal/WelcomeGuideBody.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeGuideBody.tsx
@@ -67,14 +67,16 @@ export function WelcomeGuideBody({ children }: { children?: ReactNode }) {
 
           return (
             <div key={item.question} className="py-3">
-              <div className="flex items-center justify-between gap-3">
+              <div
+                className="flex items-center justify-between gap-3"
+                {...pointerShortcutAttributes(digit)}
+              >
                 <button
                   type="button"
                   aria-controls={answerId}
                   aria-expanded={isExpanded}
                   className="c-focus-ring w-full cursor-pointer select-none text-left font-medium text-sm text-text transition-colors hover:text-text-lightest"
                   onClick={() => toggleFaq(item.question)}
-                  {...pointerShortcutAttributes(digit)}
                 >
                   {item.question}
                 </button>

--- a/packages/web/src/components/WelcomeModal/WelcomeGuideBody.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeGuideBody.tsx
@@ -112,7 +112,7 @@ export function WelcomeGuideBody({ children }: { children?: ReactNode }) {
         Tip: Press a number to open a question or a link.
       </p>
       {children}
-      <WelcomeLinks />
+      <WelcomeLinks flashedKey={flashedKey} />
     </>
   );
 }

--- a/packages/web/src/components/WelcomeModal/WelcomeLinks.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeLinks.tsx
@@ -3,9 +3,15 @@ import {
   LinkedinLogoIcon,
   XLogoIcon,
 } from "@phosphor-icons/react";
+import classNames from "classnames";
 import { type ReactNode } from "react";
 import { SOCIAL_LINKS } from "@web/common/constants/social.constants";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
+import { pointerShortcutAttributes } from "@web/shortcuts/keyboard-only/pointer-action";
+import {
+  flashedShortcutClass,
+  useFlashedWelcomeShortcut,
+} from "./useFlashedWelcomeShortcut";
 
 const SOCIAL_ICONS = {
   x: XLogoIcon,
@@ -31,7 +37,7 @@ function JumpAnchor({
   digit,
   href,
   label,
-  isModHeld,
+  flashedKey,
   className,
   children,
 }: {
@@ -39,7 +45,7 @@ function JumpAnchor({
   digit: string;
   href: string;
   label?: string;
-  isModHeld: boolean;
+  flashedKey: string | null;
   className: string;
   children: ReactNode;
 }) {
@@ -51,14 +57,24 @@ function JumpAnchor({
       aria-label={label}
       className={className}
       data-welcome-jump={String(jumpIndex)}
+      {...pointerShortcutAttributes(digit)}
     >
       {children}
-      {isModHeld && <ShortcutHint className="shrink-0">{digit}</ShortcutHint>}
+      <span
+        className={classNames(
+          "shrink-0",
+          flashedShortcutClass(flashedKey, digit),
+        )}
+      >
+        <ShortcutHint>{digit}</ShortcutHint>
+      </span>
     </a>
   );
 }
 
-export function WelcomeLinks({ isModHeld }: { isModHeld: boolean }) {
+export function WelcomeLinks() {
+  const flashedKey = useFlashedWelcomeShortcut();
+
   return (
     <div className="flex items-center justify-between border-border border-t pt-4">
       <div className="flex items-center gap-3">
@@ -71,7 +87,7 @@ export function WelcomeLinks({ isModHeld }: { isModHeld: boolean }) {
               digit={String(index + 6)}
               href={href}
               label={label}
-              isModHeld={isModHeld}
+              flashedKey={flashedKey}
               className="c-focus-ring inline-flex items-center gap-1 text-text-muted transition-colors hover:text-text"
             >
               <SocialIcon size={18} weight="bold" />
@@ -86,7 +102,7 @@ export function WelcomeLinks({ isModHeld }: { isModHeld: boolean }) {
             jumpIndex={SOCIAL_LINKS.length + index}
             digit={digit}
             href={href}
-            isModHeld={isModHeld}
+            flashedKey={flashedKey}
             className="c-focus-ring inline-flex items-center gap-1 underline-offset-4 hover:text-text hover:underline"
           >
             {label}

--- a/packages/web/src/components/WelcomeModal/WelcomeLinks.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeLinks.tsx
@@ -8,10 +8,7 @@ import { type ReactNode } from "react";
 import { SOCIAL_LINKS } from "@web/common/constants/social.constants";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 import { pointerShortcutAttributes } from "@web/shortcuts/keyboard-only/pointer-action";
-import {
-  flashedShortcutClass,
-  useFlashedWelcomeShortcut,
-} from "./useFlashedWelcomeShortcut";
+import { flashedShortcutClass } from "./useFlashedWelcomeShortcut";
 
 const SOCIAL_ICONS = {
   x: XLogoIcon,
@@ -72,9 +69,7 @@ function JumpAnchor({
   );
 }
 
-export function WelcomeLinks() {
-  const flashedKey = useFlashedWelcomeShortcut();
-
+export function WelcomeLinks({ flashedKey }: { flashedKey: string | null }) {
   return (
     <div className="flex items-center justify-between border-border border-t pt-4">
       <div className="flex items-center gap-3">

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import { useContext, useEffect, useRef, useState } from "react";
 import { SessionContext } from "@web/auth/compass/session/session.context";
 import { useStartGoogleAuthorization } from "@web/auth/google/authorization/useStartGoogleAuthorization";
@@ -11,7 +12,12 @@ import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
 import { shortcutShowcaseActions } from "@web/components/ShortcutShowcase/showcase.store";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 import { keyboardKey } from "@web/shortcuts/is-bare-letter-key";
+import { pointerShortcutAttributes } from "@web/shortcuts/keyboard-only/pointer-action";
 import { PixelPirate } from "./PixelPirate";
+import {
+  flashedShortcutClass,
+  useFlashedWelcomeShortcut,
+} from "./useFlashedWelcomeShortcut";
 import { WelcomeGuideBody } from "./WelcomeGuideBody";
 import { welcomeGuideActions } from "./welcome.guide.store";
 import { hasSeenWelcome, markWelcomeSeen } from "./welcome.modal.util";
@@ -43,6 +49,7 @@ export function WelcomeModal() {
   // focusable (now Log in) or the Google button: Enter on an OAuth redirect
   // would fling a first-time visitor off-site before they read anything.
   const signUpButtonRef = useRef<HTMLButtonElement>(null);
+  const flashedKey = useFlashedWelcomeShortcut();
 
   // The auth modal's openness lives in the URL (?auth=), so the welcome
   // screen simply hides while it is open and reappears when the browser
@@ -195,9 +202,17 @@ export function WelcomeModal() {
               type="button"
               onClick={() => handOffToAuth("log_in")}
               className="c-button-compact c-button-secondary rounded-3xl px-4 py-1.5 text-xs"
+              {...pointerShortcutAttributes("i")}
             >
               Log in
-              <ShortcutHint className="ml-2">i</ShortcutHint>
+              <ShortcutHint
+                className={classNames(
+                  "ml-2",
+                  flashedShortcutClass(flashedKey, "i"),
+                )}
+              >
+                i
+              </ShortcutHint>
             </button>
           </div>
         </div>
@@ -210,13 +225,21 @@ export function WelcomeModal() {
           <div className="flex w-full flex-col items-center gap-3">
             {isGoogleAvailable && (
               <>
-                <GoogleButton
-                  onClick={handOffToGoogle}
-                  disabled={isGoogleAuthLoading}
-                  label="Continue with Google"
-                  shortcutKey="G"
-                  style={{ width: "100%" }}
-                />
+                <div
+                  className={classNames(
+                    "w-full",
+                    flashedKey?.toLowerCase() === "g" && "c-shortcut-flash",
+                  )}
+                  {...pointerShortcutAttributes("G")}
+                >
+                  <GoogleButton
+                    onClick={handOffToGoogle}
+                    disabled={isGoogleAuthLoading}
+                    label="Continue with Google"
+                    shortcutKey="G"
+                    style={{ width: "100%" }}
+                  />
+                </div>
                 <p className="text-center text-text-muted text-xs">
                   Signs you up and connects your Google Calendar.
                 </p>
@@ -227,17 +250,33 @@ export function WelcomeModal() {
               ref={signUpButtonRef}
               onClick={() => handOffToAuth("sign_up")}
               className="c-button c-button-primary c-button-elevated inline-flex h-10 w-full items-center justify-center rounded-full"
+              {...pointerShortcutAttributes("U")}
             >
               {isGoogleAvailable ? "Sign up with email" : "Sign up"}
-              <ShortcutHint className="ml-2">U</ShortcutHint>
+              <ShortcutHint
+                className={classNames(
+                  "ml-2",
+                  flashedShortcutClass(flashedKey, "U"),
+                )}
+              >
+                U
+              </ShortcutHint>
             </button>
             <button
               type="button"
               onClick={() => dismiss("explore")}
               className="c-focus-ring inline-flex items-center rounded-md px-2 py-1 text-text-muted text-xs hover:bg-surface-overlay hover:text-text"
+              {...pointerShortcutAttributes("S")}
             >
               Explore without an account
-              <ShortcutHint className="ml-2">S</ShortcutHint>
+              <ShortcutHint
+                className={classNames(
+                  "ml-2",
+                  flashedShortcutClass(flashedKey, "S"),
+                )}
+              >
+                S
+              </ShortcutHint>
             </button>
           </div>
         </WelcomeGuideBody>

--- a/packages/web/src/components/WelcomeModal/useFlashedWelcomeShortcut.ts
+++ b/packages/web/src/components/WelcomeModal/useFlashedWelcomeShortcut.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   selectLatestPointerAttempt,
   selectPointerBlockPulse,
@@ -12,9 +12,17 @@ export function useFlashedWelcomeShortcut(): string | null {
   const pulse = usePointerBlockStore(selectPointerBlockPulse);
   const attempt = usePointerBlockStore(selectLatestPointerAttempt);
   const [flashedKey, setFlashedKey] = useState<string | null>(null);
+  // Ignore the pulse already in the store on mount so a remount does not
+  // replay a flash from an earlier blocked click.
+  const lastPulseRef = useRef(pulse);
 
   useEffect(() => {
-    if (pulse === 0 || !attempt?.shortcutKey) return;
+    if (pulse === lastPulseRef.current) return;
+    lastPulseRef.current = pulse;
+    if (!attempt?.shortcutKey) {
+      setFlashedKey(null);
+      return;
+    }
     setFlashedKey(attempt.shortcutKey);
     const timer = window.setTimeout(() => setFlashedKey(null), KEYCAP_FLASH_MS);
     return () => window.clearTimeout(timer);

--- a/packages/web/src/components/WelcomeModal/useFlashedWelcomeShortcut.ts
+++ b/packages/web/src/components/WelcomeModal/useFlashedWelcomeShortcut.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+import {
+  selectLatestPointerAttempt,
+  selectPointerBlockPulse,
+  usePointerBlockStore,
+} from "@web/shortcuts/keyboard-only/pointer-block.store";
+
+export const KEYCAP_FLASH_MS = 700;
+
+/** The shortcut key currently flashing after a blocked click, or null. */
+export function useFlashedWelcomeShortcut(): string | null {
+  const pulse = usePointerBlockStore(selectPointerBlockPulse);
+  const attempt = usePointerBlockStore(selectLatestPointerAttempt);
+  const [flashedKey, setFlashedKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (pulse === 0 || !attempt?.shortcutKey) return;
+    setFlashedKey(attempt.shortcutKey);
+    const timer = window.setTimeout(() => setFlashedKey(null), KEYCAP_FLASH_MS);
+    return () => window.clearTimeout(timer);
+  }, [pulse, attempt?.shortcutKey]);
+
+  return flashedKey;
+}
+
+export const flashedShortcutClass = (
+  flashedKey: string | null,
+  key: string,
+): string =>
+  flashedKey?.toLowerCase() === key.toLowerCase() ? "c-keycap-flash" : "";

--- a/packages/web/src/components/WelcomeModal/useWelcomeJumpShortcuts.ts
+++ b/packages/web/src/components/WelcomeModal/useWelcomeJumpShortcuts.ts
@@ -1,32 +1,19 @@
-import { resolveModifier } from "@tanstack/react-hotkeys";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
 import { physicalDigitIndex } from "@web/shortcuts/digit-pick.util";
 import { FAQ_ITEMS } from "./faq";
 
 export const WELCOME_JUMP_ATTR = "data-welcome-jump";
 
-const isPlatformModKey = (event: KeyboardEvent) =>
-  resolveModifier("Mod") === "Meta"
-    ? event.key === "Meta"
-    : event.key === "Control";
-
 /**
- * Hold Mod to reveal numbered keycaps; press a number (with or without Mod)
- * to toggle that FAQ or open a footer link. Bare digits work because
- * browsers steal Cmd/Ctrl+1–8 for tab switching.
+ * Press a number (with or without Mod) to toggle that FAQ or open a footer
+ * link. Bare digits work because browsers steal Cmd/Ctrl+1–8 for tab switching.
  *
  * 1–5 toggle FAQ items. 6–0 activate matching `[data-welcome-jump]` links.
  */
 export function useWelcomeJumpShortcuts(toggleFaqAt: (index: number) => void) {
-  const [isModHeld, setIsModHeld] = useState(false);
-
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      if (isPlatformModKey(event)) {
-        setIsModHeld(true);
-      }
-
       if (isEditableKeyboardTarget(event)) return;
 
       const index = physicalDigitIndex(event);
@@ -48,26 +35,9 @@ export function useWelcomeJumpShortcuts(toggleFaqAt: (index: number) => void) {
       el.click();
     };
 
-    const onKeyUp = (event: KeyboardEvent) => {
-      if (isPlatformModKey(event)) {
-        setIsModHeld(false);
-      }
-    };
-
-    const clearMod = () => setIsModHeld(false);
-
     window.addEventListener("keydown", onKeyDown);
-    window.addEventListener("keyup", onKeyUp);
-    window.addEventListener("blur", clearMod);
-    document.addEventListener("visibilitychange", clearMod);
-
     return () => {
       window.removeEventListener("keydown", onKeyDown);
-      window.removeEventListener("keyup", onKeyUp);
-      window.removeEventListener("blur", clearMod);
-      document.removeEventListener("visibilitychange", clearMod);
     };
   }, [toggleFaqAt]);
-
-  return isModHeld;
 }

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -156,6 +156,7 @@
   --animate-showcase-curtain: showcaseCurtain 900ms ease-in-out forwards;
   --animate-showcase-enter-stage: showcaseEnterStage 550ms
     cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  --animate-keycap-flash: keycapFlash 700ms ease-out both;
 
   @keyframes loaderSpin {
     from {
@@ -223,6 +224,17 @@
     }
     75% {
       transform: translate(6.25%, -6.25%);
+    }
+  }
+
+  @keyframes keycapFlash {
+    0%,
+    100% {
+      transform: scale(1);
+    }
+    35% {
+      transform: scale(1.2);
+      box-shadow: 0 0 0 2px var(--color-text);
     }
   }
 
@@ -478,6 +490,18 @@
     width: 1em;
     height: 1em;
     flex-shrink: 0;
+  }
+}
+
+@utility c-keycap-flash {
+  animation: var(--animate-keycap-flash);
+  @apply motion-reduce:animate-none;
+}
+
+@utility c-shortcut-flash {
+  & .c-keycap {
+    animation: var(--animate-keycap-flash);
+    @apply motion-reduce:animate-none;
   }
 }
 

--- a/packages/web/src/shortcuts/keyboard-only/pointer-action.test.ts
+++ b/packages/web/src/shortcuts/keyboard-only/pointer-action.test.ts
@@ -2,6 +2,7 @@ import {
   POINTER_ACTION_ATTRIBUTE,
   POINTER_ACTIONS,
   POINTER_EVENT_ID_ATTRIBUTE,
+  POINTER_SHORTCUT_ATTRIBUTE,
   resolveBlockedPointerAttempt,
   teachingFromBlockedPointer,
 } from "@web/shortcuts/keyboard-only/pointer-action";
@@ -25,6 +26,30 @@ describe("resolveBlockedPointerAttempt", () => {
     expect(
       resolveBlockedPointerAttempt([document.createElement("div"), document]),
     ).toEqual({ actionId: "unknown" });
+  });
+
+  it("attaches the nearest shortcut key from the composed path", () => {
+    const outer = document.createElement("div");
+    outer.setAttribute(POINTER_SHORTCUT_ATTRIBUTE, "U");
+    const inner = document.createElement("button");
+    inner.setAttribute(POINTER_SHORTCUT_ATTRIBUTE, "1");
+
+    expect(resolveBlockedPointerAttempt([inner, outer, document])).toEqual({
+      actionId: "unknown",
+      shortcutKey: "1",
+    });
+  });
+
+  it("keeps an action and a shortcut from different ancestors", () => {
+    const outer = document.createElement("div");
+    outer.setAttribute(POINTER_ACTION_ATTRIBUTE, POINTER_ACTIONS.sidebarOpen);
+    const inner = document.createElement("span");
+    inner.setAttribute(POINTER_SHORTCUT_ATTRIBUTE, "S");
+
+    expect(resolveBlockedPointerAttempt([inner, outer, document])).toEqual({
+      actionId: POINTER_ACTIONS.sidebarOpen,
+      shortcutKey: "S",
+    });
   });
 });
 

--- a/packages/web/src/shortcuts/keyboard-only/pointer-action.ts
+++ b/packages/web/src/shortcuts/keyboard-only/pointer-action.ts
@@ -1,5 +1,6 @@
 export const POINTER_ACTION_ATTRIBUTE = "data-pointer-action";
 export const POINTER_EVENT_ID_ATTRIBUTE = "data-pointer-event-id";
+export const POINTER_SHORTCUT_ATTRIBUTE = "data-pointer-shortcut";
 export const POINTER_EVENT_JUMP_REQUEST = "compass:pointer-event-jump";
 
 export const POINTER_ACTIONS = {
@@ -14,6 +15,7 @@ export type PointerActionId =
 export type BlockedPointerAttempt = {
   actionId: PointerActionId | "unknown";
   eventId?: string;
+  shortcutKey?: string;
 };
 
 const POINTER_ACTION_IDS = new Set<string>(Object.values(POINTER_ACTIONS));
@@ -24,16 +26,36 @@ const isPointerActionId = (value: string): value is PointerActionId =>
 export const resolveBlockedPointerAttempt = (
   path: EventTarget[],
 ): BlockedPointerAttempt => {
+  let actionId: PointerActionId | "unknown" = "unknown";
+  let eventId: string | undefined;
+  let shortcutKey: string | undefined;
+
   for (const target of path) {
     if (!(target instanceof HTMLElement)) continue;
-    const action = target.getAttribute(POINTER_ACTION_ATTRIBUTE);
-    if (!action || !isPointerActionId(action)) continue;
-    const eventId =
-      target.getAttribute(POINTER_EVENT_ID_ATTRIBUTE) ?? undefined;
-    return { actionId: action, ...(eventId ? { eventId } : {}) };
+    if (actionId === "unknown") {
+      const action = target.getAttribute(POINTER_ACTION_ATTRIBUTE);
+      if (action && isPointerActionId(action)) {
+        actionId = action;
+        eventId = target.getAttribute(POINTER_EVENT_ID_ATTRIBUTE) ?? undefined;
+      }
+    }
+    if (shortcutKey === undefined) {
+      const shortcut = target.getAttribute(POINTER_SHORTCUT_ATTRIBUTE);
+      if (shortcut) shortcutKey = shortcut;
+    }
+    if (actionId !== "unknown" && shortcutKey !== undefined) break;
   }
-  return { actionId: "unknown" };
+
+  return {
+    actionId,
+    ...(eventId ? { eventId } : {}),
+    ...(shortcutKey ? { shortcutKey } : {}),
+  };
 };
+
+export const pointerShortcutAttributes = (key: string) => ({
+  [POINTER_SHORTCUT_ATTRIBUTE]: key,
+});
 
 const PRIMARY_POINTER_BUTTON = 0;
 

--- a/packages/web/src/shortcuts/useGlobalShortcuts.test.tsx
+++ b/packages/web/src/shortcuts/useGlobalShortcuts.test.tsx
@@ -227,13 +227,19 @@ describe("useGlobalShortcuts", () => {
   it("does not open the command palette while first-visit welcome is open", () => {
     welcomeGuideActions.setFirstVisitOpen(true);
     const { unmount } = renderHook(() => useGlobalShortcuts(), { wrapper });
+    const keepFocus = document.createElement("button");
+    keepFocus.textContent = "Keep focus";
+    document.body.appendChild(keepFocus);
+    keepFocus.focus();
 
     act(() => {
       pressModK();
     });
 
     expect(selectIsCmdPaletteOpen(useSettingsStore.getState())).toBe(false);
+    expect(document.activeElement).toBe(keepFocus);
 
+    keepFocus.remove();
     act(() => {
       unmount();
     });

--- a/packages/web/src/shortcuts/useGlobalShortcuts.test.tsx
+++ b/packages/web/src/shortcuts/useGlobalShortcuts.test.tsx
@@ -1,12 +1,22 @@
-import { HotkeyManager, HotkeysProvider } from "@tanstack/react-hotkeys";
+import {
+  HotkeyManager,
+  HotkeysProvider,
+  resolveModifier,
+} from "@tanstack/react-hotkeys";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { type PropsWithChildren } from "react";
 import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { welcomeGuideActions } from "@web/components/WelcomeModal/welcome.guide.store";
 import {
   selectIsSidebarOpen,
   useViewStore,
 } from "@web/events/stores/view.store";
+import {
+  initialSettingsState,
+  selectIsCmdPaletteOpen,
+  useSettingsStore,
+} from "@web/settings/settings.store";
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockNavigate = mock();
@@ -49,11 +59,21 @@ function wrapper({ children }: PropsWithChildren) {
   return <HotkeysProvider>{children}</HotkeysProvider>;
 }
 
+const pressModK = () => {
+  const isMac = resolveModifier("Mod") === "Meta";
+  pressKey("k", {
+    keyDownInit: isMac ? { metaKey: true } : { ctrlKey: true },
+  });
+};
+
 describe("useGlobalShortcuts", () => {
   beforeEach(() => {
     HotkeyManager.resetInstance();
     mockNavigate.mockClear();
     mockPathname.value = "/week";
+    useSettingsStore.setState(initialSettingsState, true);
+    welcomeGuideActions.setFirstVisitOpen(false);
+    welcomeGuideActions.close();
   });
 
   it("does not navigate to Day view when a held-Cmd D keyup is replayed after a Mod+D press", async () => {
@@ -198,6 +218,35 @@ describe("useGlobalShortcuts", () => {
     });
 
     expect(mockNavigate).not.toHaveBeenCalled();
+
+    act(() => {
+      unmount();
+    });
+  });
+
+  it("does not open the command palette while first-visit welcome is open", () => {
+    welcomeGuideActions.setFirstVisitOpen(true);
+    const { unmount } = renderHook(() => useGlobalShortcuts(), { wrapper });
+
+    act(() => {
+      pressModK();
+    });
+
+    expect(selectIsCmdPaletteOpen(useSettingsStore.getState())).toBe(false);
+
+    act(() => {
+      unmount();
+    });
+  });
+
+  it("toggles the command palette after first-visit welcome is dismissed", () => {
+    const { unmount } = renderHook(() => useGlobalShortcuts(), { wrapper });
+
+    act(() => {
+      pressModK();
+    });
+
+    expect(selectIsCmdPaletteOpen(useSettingsStore.getState())).toBe(true);
 
     act(() => {
       unmount();

--- a/packages/web/src/shortcuts/useGlobalShortcuts.ts
+++ b/packages/web/src/shortcuts/useGlobalShortcuts.ts
@@ -79,7 +79,11 @@ export function useNavigationShortcuts() {
   useAppShortcut(
     "Mod+K",
     () => {
+      // Blur after this gate: first-visit welcome keys live on a focused
+      // child, and stealing focus here would leave S / Escape with nowhere
+      // to land.
       if (useWelcomeGuideStore.getState().isFirstVisitOpen) return;
+      (document.activeElement as HTMLElement | null)?.blur?.();
       const wasOpen = useSettingsStore.getState().isCmdPaletteOpen;
       settingsActions.toggleCmdPalette();
       if (!wasOpen) {
@@ -88,7 +92,6 @@ export function useNavigationShortcuts() {
     },
     {
       ignoreInputs: false,
-      blurOnTrigger: true,
       ignoreAppLock: true,
     },
   );

--- a/packages/web/src/shortcuts/useGlobalShortcuts.ts
+++ b/packages/web/src/shortcuts/useGlobalShortcuts.ts
@@ -1,6 +1,7 @@
 import { type RegisterableHotkey } from "@tanstack/react-hotkeys";
 import { useLocation, useNavigate } from "@tanstack/react-router";
 import { useRef } from "react";
+import { useWelcomeGuideStore } from "@web/components/WelcomeModal/welcome.guide.store";
 import { viewActions } from "@web/events/stores/view.store";
 import {
   settingsActions,
@@ -78,6 +79,7 @@ export function useNavigationShortcuts() {
   useAppShortcut(
     "Mod+K",
     () => {
+      if (useWelcomeGuideStore.getState().isFirstVisitOpen) return;
       const wasOpen = useSettingsStore.getState().isCmdPaletteOpen;
       settingsActions.toggleCmdPalette();
       if (!wasOpen) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

New visitors were hiding FAQ/link keycaps behind a Mod hold, getting a generic "Compass is keyboard only" pill when they clicked, and could open the live command palette with Mod+K before starting the practice arena.

This change:
- Always shows numbered shortcut keycaps on the welcome surface
- Teaches the matching key when a click is blocked, and flashes that keycap
- Keeps the live command palette closed while first-visit welcome is open, without stealing focus so `S` / Escape still work

![Welcome dialog with numbered FAQ keycaps visible](https://cursor.com/artifacts/c/art-f5349500-a4f2-417a-aade-49f1a884f3e6)
![Press 1 hint after clicking an FAQ](https://cursor.com/artifacts/c/art-79230bef-c756-4dfd-a982-ddc0ec3813fc)
![Practice arena after pressing S](https://cursor.com/artifacts/c/art-2570407b-51cc-4c9f-a8e1-fee9b26578c7)
<a href="https://cursor.com/agents/bc-0d5ee90d-34bb-4889-870e-f0e14aa30c85/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwelcome_first_action_e2e.mp4"><img src="https://cursor.com/artifacts/c/art-580f3345-8e7b-48ac-baca-d3713f37a48f" alt="welcome_first_action_e2e.mp4" /></a>

## Simplicity

Digit reveal no longer tracks Mod-hold state. Click teaching reuses the existing pointer-block pulse and `composedPath` resolution. Footer links share the FAQ flash key instead of running a second timer.

## Automated validation

`bun run verify` PASS. Selected packages: web. Checks run: `test:web`, `type-check`, `lint`, `knip`. Then `bunx playwright install chromium` and `bun run test:a11y`: 7 passed.

Browser (anonymous first visit at http://localhost:9080): numbered chips visible immediately; FAQ/Sign up clicks show `Press 1` / `Press U` and flash the keycap; Ctrl+K does not open the palette; `S` starts the practice arena.

## Independent review

Two confirmed findings (leftover flash after an unannotated click / remount replay; FAQ keycap clicks missed `data-pointer-shortcut`). Fixed in `97368a564`. Re-tested: WelcomeGuideBody 9 pass.

Handoff: `.agents/handoffs/2956.md`

## Test plan

- `bun run verify` (web, type-check, lint, knip)
- `bun run test:a11y` (7 passed)
- `bun test:web` on welcome, pointer-hint, pointer-action, and global-shortcut files
- First-visit browser pass recorded in `welcome_first_action_e2e.mp4`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d5ee90d-34bb-4889-870e-f0e14aa30c85?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d5ee90d-34bb-4889-870e-f0e14aa30c85&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

