### PR TITLE
fix(auth): request only verified google scopes

### DIFF
--- a/packages/backend/src/auth/services/google/google.auth.scopes.test.ts
+++ b/packages/backend/src/auth/services/google/google.auth.scopes.test.ts
@@ -1,6 +1,5 @@
 import {
   GOOGLE_AUTH_SCOPES,
-  GOOGLE_AUTH_SCOPES_OPTIONAL,
   GOOGLE_AUTH_SCOPES_REQUESTED,
 } from "@backend/auth/services/google/google.auth.scopes";
 import { describe, expect, it } from "bun:test";
@@ -22,18 +21,7 @@ describe("google auth scopes", () => {
     }
   });
 
-  it("requests the contacts scopes only as optional additions", () => {
-    expect(GOOGLE_AUTH_SCOPES_OPTIONAL).toEqual([
-      "https://www.googleapis.com/auth/contacts.readonly",
-      "https://www.googleapis.com/auth/contacts.other.readonly",
-    ]);
-    expect(GOOGLE_AUTH_SCOPES_REQUESTED).toEqual([
-      ...GOOGLE_AUTH_SCOPES,
-      ...GOOGLE_AUTH_SCOPES_OPTIONAL,
-    ]);
-    // No optional scope may leak into the required list.
-    for (const scope of GOOGLE_AUTH_SCOPES_OPTIONAL) {
-      expect(GOOGLE_AUTH_SCOPES).not.toContain(scope);
-    }
+  it("requests only the verified calendar scopes during sign-in", () => {
+    expect(GOOGLE_AUTH_SCOPES_REQUESTED).toEqual(GOOGLE_AUTH_SCOPES);
   });
 });

--- a/packages/backend/src/auth/services/google/google.auth.scopes.ts
+++ b/packages/backend/src/auth/services/google/google.auth.scopes.ts
@@ -1,6 +1,8 @@
 // Keep the scopes configured for SuperTokens and the scopes persisted in Sync
 // together. The browser independently verifies that Google granted this set
-// before it sends its authorization code to Compass.
+// before it sends its authorization code to Compass. Contacts permission is
+// deliberately absent: it is requested only by the explicit contacts feature
+// flow in Sync, so sign-in never includes an unapproved sensitive scope.
 //
 // This is the REQUIRED list: sign-in fails without every scope in it. It must
 // stay in lockstep with the web's GOOGLE_AUTH_SCOPES_REQUIRED and the e2e
@@ -13,19 +15,6 @@ export const GOOGLE_AUTH_SCOPES: string[] = [
   "https://www.googleapis.com/auth/calendar.events",
 ];
 
-// Optional scopes the consent screen ASKS for but sign-in never requires. The
-// user can leave them unchecked and proceed; whatever Google actually granted
-// is persisted per connection and drives capabilities (e.g. suggestContacts)
-// downstream. Approved as optional sensitive scopes 2026-08-25.
-export const GOOGLE_AUTH_SCOPES_OPTIONAL: string[] = [
-  "https://www.googleapis.com/auth/contacts.readonly",
-  "https://www.googleapis.com/auth/contacts.other.readonly",
-];
-
-// What the sign-in flow REQUESTS from Google: every required scope plus the
-// optional ones. Only ever used to build the consent request — required-scope
-// validation stays on GOOGLE_AUTH_SCOPES alone.
-export const GOOGLE_AUTH_SCOPES_REQUESTED: string[] = [
-  ...GOOGLE_AUTH_SCOPES,
-  ...GOOGLE_AUTH_SCOPES_OPTIONAL,
-];
+// What the sign-in flow requests from Google. Keep this as a named export so
+// the provider configuration declares its intent without copying the list.
+export const GOOGLE_AUTH_SCOPES_REQUESTED = GOOGLE_AUTH_SCOPES;

--- a/packages/backend/src/auth/services/google/google.auth.service.test.ts
+++ b/packages/backend/src/auth/services/google/google.auth.service.test.ts
@@ -197,22 +197,17 @@ describe("handleGoogleAuth", () => {
       expect(adoptCalls).toHaveLength(0);
     });
 
-    it("signs up successfully when the optional contacts scopes are not granted", async () => {
-      // The consent screen REQUESTS the contacts scopes
-      // (GOOGLE_AUTH_SCOPES_REQUESTED), but the user can uncheck them: the
-      // grant then carries exactly the required scopes and sign-in must
-      // succeed — required-scope validation checks GOOGLE_AUTH_SCOPES only.
+    it("signs up successfully with the verified calendar scopes", async () => {
+      // Sign-in requests only the verified Calendar scopes. Contacts, when
+      // enabled, are authorized separately through the Sync feature flow.
       const providerUser = makeProviderUser();
-      const withoutContacts = GOOGLE_AUTH_SCOPES_REQUESTED.filter(
-        (scope) => !scope.includes("contacts"),
-      );
-      expect(withoutContacts).toEqual(GOOGLE_AUTH_SCOPES);
+      expect(GOOGLE_AUTH_SCOPES_REQUESTED).toEqual(GOOGLE_AUTH_SCOPES);
       const success: GoogleSignInSuccess = {
         providerUser,
         oAuthTokens: {
           access_token: faker.internet.jwt(),
           refresh_token: faker.string.uuid(),
-          scope: withoutContacts.join(" "),
+          scope: GOOGLE_AUTH_SCOPES.join(" "),
         },
         createdNewRecipeUser: true,
         recipeUserId: faker.database.mongodbObjectId(),

--- a/packages/backend/src/common/middleware/supertokens.middleware.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.ts
@@ -35,8 +35,8 @@ const createGoogleProvider = (
         clientType: "web",
         clientId,
         clientSecret,
-        // Requested (required + optional contacts) — the REQUIRED validation
-        // lives in google.auth.service.ts against GOOGLE_AUTH_SCOPES only.
+        // Contacts are authorized only when the user explicitly enables that
+        // feature through the Sync connection flow.
         scope: GOOGLE_AUTH_SCOPES_REQUESTED,
       },
     ],

--- a/packages/web/src/auth/google/authorization/google-authorization.constants.ts
+++ b/packages/web/src/auth/google/authorization/google-authorization.constants.ts
@@ -15,21 +15,10 @@ export const GOOGLE_AUTH_SCOPES_REQUIRED = [
   "https://www.googleapis.com/auth/calendar.events",
 ];
 
-// Optional scopes the consent screen asks for but sign-in never verifies. The
-// user can leave them unchecked and proceed; the backend stores whatever was
-// actually granted. Approved as optional sensitive scopes 2026-08-25.
-export const GOOGLE_AUTH_SCOPES_OPTIONAL = [
-  "https://www.googleapis.com/auth/contacts.readonly",
-  "https://www.googleapis.com/auth/contacts.other.readonly",
-];
-
-// What the sign-in flow REQUESTS from Google: required plus optional. Only for
-// building the consent request — callback verification stays on
-// GOOGLE_AUTH_SCOPES_REQUIRED alone.
-export const GOOGLE_AUTH_SCOPES_REQUESTED = [
-  ...GOOGLE_AUTH_SCOPES_REQUIRED,
-  ...GOOGLE_AUTH_SCOPES_OPTIONAL,
-];
+// Contacts are requested only by the explicit contacts feature flow in Sync.
+// Keeping sign-in to the verified Calendar scopes prevents Google from
+// treating the login request as unverified.
+export const GOOGLE_AUTH_SCOPES_REQUESTED = GOOGLE_AUTH_SCOPES_REQUIRED;
 
 export const GOOGLE_AUTHORIZATION_ERROR_MESSAGE =
   "We couldn't connect your Google account. Please try again.";

--- a/packages/web/src/auth/google/authorization/google-authorization.test.ts
+++ b/packages/web/src/auth/google/authorization/google-authorization.test.ts
@@ -1,6 +1,5 @@
 import { completeGoogleAuthorization } from "./complete-google-authorization";
 import {
-  GOOGLE_AUTH_SCOPES_OPTIONAL,
   GOOGLE_AUTH_SCOPES_REQUESTED,
   GOOGLE_AUTH_SCOPES_REQUIRED,
 } from "./google-authorization.constants";
@@ -70,14 +69,8 @@ describe("completeGoogleAuthorization", () => {
     expect(readGoogleAuthorizationIntent("state-1")).toBeNull();
   });
 
-  it("completes sign-in when the optional contacts scopes are not granted", async () => {
-    // The consent screen REQUESTS the contacts scopes but never requires
-    // them: a callback granting exactly the required list (contacts left
-    // unchecked) must complete like any other sign-in.
-    const withoutContacts = GOOGLE_AUTH_SCOPES_REQUESTED.filter(
-      (scope) => !GOOGLE_AUTH_SCOPES_OPTIONAL.includes(scope),
-    );
-    expect(withoutContacts).toEqual(GOOGLE_AUTH_SCOPES_REQUIRED);
+  it("completes sign-in with the verified Calendar scopes", async () => {
+    expect(GOOGLE_AUTH_SCOPES_REQUESTED).toEqual(GOOGLE_AUTH_SCOPES_REQUIRED);
     const deps = makeDeps();
     writeGoogleAuthorizationIntent("state-optional", {
       intent: "signIn",
@@ -88,7 +81,10 @@ describe("completeGoogleAuthorization", () => {
     await expect(
       completeGoogleAuthorization({
         ...deps,
-        search: callbackSearch("state-optional", withoutContacts.join(" ")),
+        search: callbackSearch(
+          "state-optional",
+          GOOGLE_AUTH_SCOPES_REQUIRED.join(" "),
+        ),
       }),
     ).resolves.toEqual({
       status: "completed",
@@ -98,24 +94,13 @@ describe("completeGoogleAuthorization", () => {
     expect(deps.authApi.loginOrSignup).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps the required scope list free of the optional contacts scopes", () => {
-    // GOOGLE_AUTH_SCOPES_REQUIRED is what verification checks — a contacts
-    // scope here would brick sign-in for every user who declines it. The
-    // literal pin guards the split: required unchanged, contacts requested
-    // only as optional additions.
+  it("requests only verified Calendar scopes during sign-in", () => {
     expect(GOOGLE_AUTH_SCOPES_REQUIRED).toEqual([
       "https://www.googleapis.com/auth/userinfo.email",
       "https://www.googleapis.com/auth/calendar.readonly",
       "https://www.googleapis.com/auth/calendar.events",
     ]);
-    expect(GOOGLE_AUTH_SCOPES_REQUESTED).toEqual([
-      ...GOOGLE_AUTH_SCOPES_REQUIRED,
-      "https://www.googleapis.com/auth/contacts.readonly",
-      "https://www.googleapis.com/auth/contacts.other.readonly",
-    ]);
-    for (const scope of GOOGLE_AUTH_SCOPES_OPTIONAL) {
-      expect(GOOGLE_AUTH_SCOPES_REQUIRED).not.toContain(scope);
-    }
+    expect(GOOGLE_AUTH_SCOPES_REQUESTED).toEqual(GOOGLE_AUTH_SCOPES_REQUIRED);
   });
 
   it("rejects callbacks that are missing required Google Calendar scopes", async () => {

--- a/packages/web/src/auth/google/authorization/useStartGoogleAuthorization.impl.ts
+++ b/packages/web/src/auth/google/authorization/useStartGoogleAuthorization.impl.ts
@@ -35,9 +35,8 @@ export const useStartGoogleAuthorizationImpl = ({
   >(
     () => ({
       flow: "auth-code",
-      // Requested = required + optional contacts. Callback verification
-      // (complete-google-authorization) checks REQUIRED only, so leaving the
-      // contacts boxes unchecked still signs in.
+      // Contacts are requested separately only after the user enables the
+      // contacts feature. Login asks solely for verified Calendar scopes.
       scope: GOOGLE_AUTH_SCOPES_REQUESTED.join(" "),
       prompt,
       state,


### PR DESCRIPTION
## Summary
- request only the already verified Google Calendar scopes during sign-in
- keep Contacts authorization confined to its explicit Sync feature flow
- cover the verified scope set with backend and web regression tests

## Validation
- bun test:backend -- packages/backend/src/auth/services/google/google.auth.scopes.test.ts packages/backend/src/auth/services/google/google.auth.service.test.ts
- bun test:web -- packages/web/src/auth/google/authorization/google-authorization.test.ts
- bun type-check
- bun lint