### PR TITLE
fix(backend): preserve Stripe webhook raw body for HMAC

### DIFF
--- a/packages/backend/src/billing/billing.routes.config.ts
+++ b/packages/backend/src/billing/billing.routes.config.ts
@@ -1,4 +1,4 @@
-import type express from "express";
+import express from "express";
 import rateLimit from "express-rate-limit";
 import { verifySession } from "@backend/auth/session/session.middleware";
 import { STRIPE_WEBHOOK_PATH } from "@backend/billing/billing.constants";
@@ -21,8 +21,26 @@ const stripeWebhookLimiter = rateLimit({
 });
 
 /**
+ * Stripe HMAC is over the exact request bytes. SuperTokens and
+ * `express.json()` both parse JSON and would destroy the signature, so this
+ * route must be mounted before those middlewares. `type: "*/ *"` keeps the
+ * raw parser on this path even
+if Stripe
+'s Content-Type includes a charset.
+ */
+export function mountStripeWebhook(app: express.Application): void {
+  app.post(
+    STRIPE_WEBHOOK_PATH,
+    stripeWebhookLimiter,
+    express.raw({ type: "*/*" }),
+    billingWebhookController.handleStripe,
+  );
+}
+
+/**
  * Billing routes: trial status, Stripe Checkout, ending a trial early,
- * Billing Portal, and the unauthenticated Stripe webhook.
+ * and Billing Portal. The Stripe webhook is mounted separately, ahead of
+ * body parsers; see `mountStripeWebhook`.
  */
 export class BillingRoutes extends CommonRoutesConfig {
   constructor(app: express.Application) {
@@ -49,10 +67,6 @@ export class BillingRoutes extends CommonRoutesConfig {
       .route(`/api/billing/portal/session`)
       .all(verifySession())
       .post(sessionWriteLimiter, billingController.createPortalSession);
-
-    this.app
-      .route(STRIPE_WEBHOOK_PATH)
-      .post(stripeWebhookLimiter, billingWebhookController.handleStripe);
 
     return this.app;
   }

--- a/packages/backend/src/billing/billing.routes.config.ts
+++ b/packages/backend/src/billing/billing.routes.config.ts
@@ -23,10 +23,8 @@ const stripeWebhookLimiter = rateLimit({
 /**
  * Stripe HMAC is over the exact request bytes. SuperTokens and
  * `express.json()` both parse JSON and would destroy the signature, so this
- * route must be mounted before those middlewares. `type: "*/ *"` keeps the
- * raw parser on this path even
-if Stripe
-'s Content-Type includes a charset.
+ * route must be mounted before those middlewares. Matching every content
+ * type keeps the raw parser on this path even if Stripe includes a charset.
  */
 export function mountStripeWebhook(app: express.Application): void {
   app.post(

--- a/packages/backend/src/billing/services/billing.webhook.service.db.test.ts
+++ b/packages/backend/src/billing/services/billing.webhook.service.db.test.ts
@@ -1,12 +1,14 @@
 import { type Request, type Response } from "express";
 import Stripe from "stripe";
 import { Status } from "@core/errors/status.codes";
+import { BaseDriver } from "@backend/__tests__/drivers/base.driver";
 import {
   cleanupCollections,
   cleanupTestDb,
   setupTestDb,
 } from "@backend/__tests__/helpers/mock.db.setup";
 import { mockEnv } from "@backend/__tests__/helpers/mock.setup";
+import { STRIPE_WEBHOOK_PATH } from "@backend/billing/billing.constants";
 import billingWebhookController from "@backend/billing/controllers/billing.webhook.controller";
 import { processStripeEvent } from "@backend/billing/services/billing.webhook.service";
 import {
@@ -194,6 +196,52 @@ describe("Stripe webhook", () => {
     expect(stored?.billing?.subscriptionStatus).toBe("trialing");
     expect(stored?.billing?.stripeSubscriptionId).toBe("sub_1");
     expect(await mongoService.billingEvent.countDocuments()).toBe(1);
+  });
+
+  it("accepts a signed webhook over HTTP with pretty-printed JSON", async () => {
+    using _env = mockEnv(stripeConfigured);
+    const userId = await seedAwaitingUser("http-signed@example.com");
+    const stripe = realStripe();
+    setStripeClientForTests({
+      webhooks: stripe.webhooks,
+      subscriptions: {
+        retrieve: mock(() =>
+          Promise.resolve(
+            subscription({ metadata: { compassUserId: userId.toString() } }),
+          ),
+        ),
+      },
+    } as unknown as Stripe);
+
+    // Pretty-printed so JSON.parse + stringify would change the bytes and
+    // fail HMAC. The Express stack must hand the original payload through.
+    const payload = JSON.stringify(
+      JSON.parse(checkoutPayload(userId.toString())),
+      null,
+      2,
+    );
+    const signature = await stripe.webhooks.generateTestHeaderStringAsync({
+      payload,
+      secret: stripeConfigured.STRIPE_WEBHOOK_SECRET,
+    });
+
+    const driver = new BaseDriver();
+    try {
+      const response = await driver
+        .getServer()
+        .post(STRIPE_WEBHOOK_PATH)
+        .set("stripe-signature", signature)
+        .set("Content-Type", "application/json; charset=utf-8")
+        .send(Buffer.from(payload));
+
+      expect(response.status).toBe(Status.OK);
+      expect(response.body).toEqual({ received: true });
+      const stored = await mongoService.user.findOne({ _id: userId });
+      expect(stored?.billing?.subscriptionStatus).toBe("trialing");
+      expect(stored?.billing?.stripeSubscriptionId).toBe("sub_1");
+    } finally {
+      await driver.teardown();
+    }
   });
 
   it("rejects a payload edited after it was signed", async () => {

--- a/packages/backend/src/billing/services/billing.webhook.service.db.test.ts
+++ b/packages/backend/src/billing/services/billing.webhook.service.db.test.ts
@@ -227,15 +227,18 @@ describe("Stripe webhook", () => {
 
     const driver = new BaseDriver();
     try {
-      const response = await driver
-        .getServer()
-        .post(STRIPE_WEBHOOK_PATH)
-        .set("stripe-signature", signature)
-        .set("Content-Type", "application/json; charset=utf-8")
-        .send(Buffer.from(payload));
+      const uri = await driver.listen();
+      const response = await fetch(`${uri}${STRIPE_WEBHOOK_PATH}`, {
+        method: "POST",
+        headers: {
+          "stripe-signature": signature,
+          "Content-Type": "application/json; charset=utf-8",
+        },
+        body: payload,
+      });
 
       expect(response.status).toBe(Status.OK);
-      expect(response.body).toEqual({ received: true });
+      expect(await response.json()).toEqual({ received: true });
       const stored = await mongoService.user.findOne({ _id: userId });
       expect(stored?.billing?.subscriptionStatus).toBe("trialing");
       expect(stored?.billing?.stripeSubscriptionId).toBe("sub_1");

--- a/packages/backend/src/servers/express/express.server.ts
+++ b/packages/backend/src/servers/express/express.server.ts
@@ -5,8 +5,10 @@ import {
   middleware as supertokensMiddleware,
 } from "supertokens-node/framework/express";
 import { AuthRoutes } from "@backend/auth/auth.routes.config";
-import { STRIPE_WEBHOOK_PATH } from "@backend/billing/billing.constants";
-import { BillingRoutes } from "@backend/billing/billing.routes.config";
+import {
+  BillingRoutes,
+  mountStripeWebhook,
+} from "@backend/billing/billing.routes.config";
 import { CalendarRoutes } from "@backend/calendar/calendar.routes.config";
 import { type CommonRoutesConfig } from "@backend/common/common.routes.config";
 import corsWhitelist from "@backend/common/middleware/cors.middleware";
@@ -36,14 +38,14 @@ export const initExpressServer = () => {
   // some routes depend on them
   app.use(requestMiddleware());
   app.use(supertokensCors());
-  app.use(supertokensMiddleware());
   app.use(corsWhitelist);
   app.use(helmet());
   app.use(httpLoggingMiddleware);
-  // Stripe signs the raw bytes. express.json() would parse application/json
-  // first and every signature check would 400. Path-scoped raw parser must
-  // run before the global JSON parser.
-  app.use(STRIPE_WEBHOOK_PATH, express.raw({ type: "application/json" }));
+  // Stripe HMAC is over the exact request bytes. SuperTokens and
+  // express.json() both parse JSON and would make every signature check
+  // 400, so this route is handled before either of them.
+  mountStripeWebhook(app);
+  app.use(supertokensMiddleware());
   app.use(express.json());
 
   const routes: Array<CommonRoutesConfig> = [];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PostHog issue [01a043f1](https://us.posthog.com/project/165441/error_tracking/01a043f1-80b8-79c3-8de5-c4ee2c71a91f) (`No signatures found matching the expected signature for payload`) started firing immediately after `constructEventAsync` landed on 27 Aug. HMAC now actually runs, but SuperTokens and `express.json()` still sat in front of the webhook route, so verification could see a parsed or consumed body instead of Stripe's original bytes.

The Stripe webhook is now mounted with `express.raw()` after logging/Helmet and **before** SuperTokens middleware and the global JSON parser. Signature checks therefore receive the unmodified payload.

Google Calendar push notifications live in the sync package and authenticate with a channel token in headers, not a signed JSON body, so they are unchanged.

## Simplicity

One mount helper (`mountStripeWebhook`) owns the unauthenticated webhook path. Session billing routes stay in `BillingRoutes`. No extra `rawBody` field or dual parsers.

## Automated validation

HTTP integration test posts pretty-printed JSON (bytes that `JSON.parse` + `stringify` would change) with a real Stripe test signature through the full Express stack via `fetch`. Result: `200 { received: true }` and the user row moves to `trialing`.

`bun run verify` selected backend and passed `test:backend`, `type-check`, `lint`, and `knip`.

## Independent review

Diff reviewed against AGENTS.md. Confirmed: webhook is still unauthenticated and rate-limited; Helmet/CORS/logging still run; SuperTokens and `express.json()` no longer see this path. No confirmed findings.

## Test plan

- `bun run test:backend -- packages/backend/src/billing/services/billing.webhook.service.db.test.ts` (11 pass, including the new HTTP signed-payload case)
- `bun run verify` (test:backend, type-check, lint, knip)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1384d3b5-8f70-416a-b13a-446fd59a279b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1384d3b5-8f70-416a-b13a-446fd59a279b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

