### PR TITLE
feat(web): confirm showcase skip and resume progress

### DIFF
--- a/e2e/onboarding/first-run.spec.ts
+++ b/e2e/onboarding/first-run.spec.ts
@@ -38,6 +38,8 @@ test("welcomes a first-time user and seeds sample events", async ({
   const showcase = page.getByRole("region", { name: "Shortcut practice" });
   await expect(showcase).toBeVisible();
   await page.keyboard.press("Escape");
+  await expect(showcase).toContainText("Press Esc again to leave practice.");
+  await page.keyboard.press("Escape");
   await expect(showcase).toHaveCount(0);
 
   await expect(

--- a/e2e/onboarding/shortcut-showcase.spec.ts
+++ b/e2e/onboarding/shortcut-showcase.spec.ts
@@ -101,6 +101,9 @@ test("the welcome-started practice runs the taught keys through graduation", asy
   const showcase = page.getByRole("region", { name: "Shortcut practice" });
   await expect(showcase).toContainText("Press C to start a new event.");
   await expect(showcase.getByRole("button", { name: /^Skip$/ })).toBeVisible();
+  await expect(showcase).toContainText(
+    "C works on this sandbox. Clicks do not start an event.",
+  );
 
   await playThroughLevels(page);
 
@@ -172,12 +175,36 @@ test("Escape leaves the practice and it never auto-replays", async ({
   await expect(showcase).toContainText("Compass is keyboard-only");
 
   await page.keyboard.press("Escape");
+  await expect(showcase).toBeVisible();
+  await expect(showcase).toContainText("Press Esc again to leave practice.");
+
+  await page.keyboard.press("Escape");
   await expect(showcase).toHaveCount(0);
 
   await page.reload({ waitUntil: "domcontentloaded" });
   await expect(
     page.getByRole("region", { name: "Shortcut practice" }),
   ).toHaveCount(0);
+  await expect(
+    page.getByRole("dialog", { name: "Welcome to Compass Calendar" }),
+  ).toBeHidden();
+});
+
+test("reloading mid-practice resumes the same lesson", async ({ page }) => {
+  await page.goto("/week", { waitUntil: "domcontentloaded" });
+  await leaveWelcome(page);
+  await startLevelOne(page);
+
+  const showcase = page.getByRole("region", { name: "Shortcut practice" });
+  await page.keyboard.press("c");
+  await page.keyboard.type("Practice Event");
+  await page.keyboard.press("Enter");
+  await expect(showcase).toContainText("See where to go: reveal the jump keys");
+
+  await page.reload({ waitUntil: "domcontentloaded" });
+  const resumed = page.getByRole("region", { name: "Shortcut practice" });
+  await expect(resumed).toBeVisible();
+  await expect(resumed).toContainText("See where to go: reveal the jump keys");
   await expect(
     page.getByRole("dialog", { name: "Welcome to Compass Calendar" }),
   ).toBeHidden();

--- a/packages/web/src/common/constants/storage.constants.ts
+++ b/packages/web/src/common/constants/storage.constants.ts
@@ -7,6 +7,9 @@ type StorageKey =
   // Set when the user finishes or skips the Shortcut Showcase, so it never
   // auto-launches twice (palette replay ignores it).
   | "compass.onboarding.has-seen-shortcut-showcase"
+  // Current Shortcut Showcase step id while practice is in progress. Cleared
+  // on finish or a confirmed skip so a reload can resume instead of restarting.
+  | "compass.onboarding.shortcut-showcase-step"
   // Set when a welcome-modal exit hands off to signup before the showcase;
   // consumed once, right after signup completes, to offer it then.
   | "compass.onboarding.has-pending-showcase-offer"
@@ -55,6 +58,7 @@ export const STORAGE_KEYS: Record<
   | "HAS_DISMISSED_DEMO_EVENTS_BANNER"
   | "HAS_DISMISSED_TASKS_REMOVAL_NOTICE"
   | "HAS_SEEN_SHORTCUT_SHOWCASE"
+  | "SHORTCUT_SHOWCASE_STEP"
   | "HAS_PENDING_SHOWCASE_OFFER"
   | "FIRST_EVENT_DONE"
   | "SHORTCUT_TIPS_MUTED"
@@ -83,6 +87,7 @@ export const STORAGE_KEYS: Record<
   HAS_DISMISSED_TASKS_REMOVAL_NOTICE:
     "compass.onboarding.has-dismissed-tasks-removal-notice",
   HAS_SEEN_SHORTCUT_SHOWCASE: "compass.onboarding.has-seen-shortcut-showcase",
+  SHORTCUT_SHOWCASE_STEP: "compass.onboarding.shortcut-showcase-step",
   HAS_PENDING_SHOWCASE_OFFER: "compass.onboarding.has-pending-showcase-offer",
   FIRST_EVENT_DONE: "compass.onboarding.first-event-done",
   SHORTCUT_TIPS_MUTED: "compass.shortcuts.tips-muted",

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
@@ -61,6 +61,8 @@ describe("ShortcutShowcase", () => {
   beforeEach(() => {
     useShortcutShowcaseStore.setState(initialShortcutShowcaseState);
     persistentBrowserStore.set(STORAGE_KEYS.HAS_SEEN_SHORTCUT_SHOWCASE, "");
+    persistentBrowserStore.remove(STORAGE_KEYS.SHORTCUT_SHOWCASE_STEP);
+    persistentBrowserStore.set(STORAGE_KEYS.HAS_SEEN_WELCOME, "");
     localStorage.setItem("compass.onboarding.has-seen-onboarding-tour", "");
     clearAppLockReasons();
   });
@@ -543,7 +545,6 @@ describe("ShortcutShowcase", () => {
     act(() => shortcutShowcaseActions.replay());
     expect(currentStepId()).toBe("create");
 
-    // No confirm in the way, and no lesson to finish first.
     await user.click(screen.getByRole("button", { name: "Skip to sign up" }));
     expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
     expect(screen.queryByLabelText("Shortcut practice")).toBeNull();
@@ -552,22 +553,70 @@ describe("ShortcutShowcase", () => {
     ).toBe("true");
   });
 
-  it("Skip leaves straight away, without a confirm", async () => {
+  it("Skip arms a confirm, then Leave practice exits", async () => {
     const user = userEvent.setup();
     render(<ShortcutShowcase />);
     act(() => shortcutShowcaseActions.replay());
 
     await user.click(screen.getByRole("button", { name: /^Skip$/ }));
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
+    expect(useShortcutShowcaseStore.getState().skipPending).toBe(true);
+    expect(screen.getByText("Press Esc again to leave practice.")).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: /^Leave practice$/ }));
     expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
     expect(screen.queryByLabelText("Shortcut practice")).toBeNull();
   });
 
-  it("Escape skips the showcase outright", () => {
+  it("Escape arms a confirm, then a second Escape leaves", () => {
     render(<ShortcutShowcase />);
     act(() => shortcutShowcaseActions.replay());
 
     pressKey("Escape");
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
+    expect(useShortcutShowcaseStore.getState().skipPending).toBe(true);
+
+    pressKey("Escape");
     expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
+  });
+
+  it("a lesson keystroke cancels a pending skip", () => {
+    render(<ShortcutShowcase />);
+    act(() => shortcutShowcaseActions.replay());
+
+    pressKey("Escape");
+    expect(useShortcutShowcaseStore.getState().skipPending).toBe(true);
+
+    pressKey("c");
+    expect(useShortcutShowcaseStore.getState().skipPending).toBe(false);
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
+    expect(screen.getByLabelText("Event title")).toBeTruthy();
+  });
+
+  it("shows an inline hint on the create lesson", () => {
+    render(<ShortcutShowcase />);
+    act(() => shortcutShowcaseActions.replay());
+    expect(
+      screen.getByText(
+        "C works on this sandbox. Clicks do not start an event.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("resumes an in-progress lesson after welcome has been seen", () => {
+    persistentBrowserStore.set(STORAGE_KEYS.HAS_SEEN_WELCOME, "true");
+    persistentBrowserStore.set(
+      STORAGE_KEYS.SHORTCUT_SHOWCASE_STEP,
+      "eventJump",
+    );
+
+    render(<ShortcutShowcase />);
+
+    expect(currentStepId()).toBe("eventJump");
+    expect(screen.getByRole("heading", { name: "Pick a target" })).toBeTruthy();
+    expect(
+      screen.getByText("Tap the reveal key first, then a letter on an event."),
+    ).toBeTruthy();
   });
 
   it("Escape inside the title editor closes the editor, not the showcase", async () => {
@@ -591,7 +640,10 @@ describe("ShortcutShowcase", () => {
     pressKey("c");
     expect(screen.getByLabelText("Event title")).toBeTruthy();
 
-    // With no editor open, Escape now leaves.
+    pressKey("Escape");
+    expect(screen.queryByLabelText("Event title")).toBeNull();
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
+
     pressKey("Escape");
     pressKey("Escape");
     expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
@@ -697,7 +749,11 @@ describe("ShortcutShowcase", () => {
       // asking to leave must not raise a permission prompt instead.
       screen.getByRole("button", { name: /^Skip$/ }).focus();
       await user.keyboard("{Enter}");
+      expect(seam.mocks.requestPermission).not.toHaveBeenCalled();
+      expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
+      expect(useShortcutShowcaseStore.getState().skipPending).toBe(true);
 
+      await user.keyboard("{Enter}");
       expect(seam.mocks.requestPermission).not.toHaveBeenCalled();
       expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
     });
@@ -769,6 +825,8 @@ describe("ShortcutShowcase", () => {
       render(<ShortcutShowcase />);
       showStep("notifications");
 
+      pressKey("Escape");
+      expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
       pressKey("Escape");
       expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
     });

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
@@ -37,12 +37,14 @@ import {
 import {
   selectShowcaseActive,
   selectShowcaseStepIndex,
+  selectSkipPending,
   shortcutShowcaseActions,
   stepIdAt,
   useShortcutShowcaseStore,
 } from "@web/components/ShortcutShowcase/showcase.store";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
+import { hasSeenWelcome } from "@web/components/WelcomeModal/welcome.modal.util";
 import { getNotificationPort } from "@web/notifications/notification.port";
 import { notificationActions } from "@web/notifications/notification.store";
 import { settingsActions } from "@web/settings/settings.store";
@@ -92,6 +94,7 @@ const arrowDirection = (key: string): PracticeNudgeDirection | null => {
  */
 const ShowcaseTakeover: FC = () => {
   const stepIndex = useShortcutShowcaseStore(selectShowcaseStepIndex);
+  const skipPending = useShortcutShowcaseStore(selectSkipPending);
   const stepId = stepIdAt(stepIndex);
   const { closing, beginDismiss } = useDismissTransition(SHOWCASE_REVEAL_MS);
   const { openModal } = useAuthModal();
@@ -177,6 +180,16 @@ const ShowcaseTakeover: FC = () => {
       return;
     }
 
+    if (event.key !== "Escape") {
+      const activatingFocusedButton =
+        (event.key === "Enter" || event.key === " ") &&
+        event.target instanceof HTMLElement &&
+        Boolean(event.target.closest("button"));
+      if (!activatingFocusedButton) {
+        shortcutShowcaseActions.clearSkipPending();
+      }
+    }
+
     if (event.key === "Tab" && regionRef.current) {
       if (stepId === "edgeResize") {
         claim(event);
@@ -229,7 +242,7 @@ const ShowcaseTakeover: FC = () => {
         );
         apply((state) => commitTitle(state, input?.value ?? ""));
       } else {
-        shortcutShowcaseActions.skip();
+        shortcutShowcaseActions.requestSkip();
       }
       return;
     }
@@ -500,6 +513,7 @@ const ShowcaseTakeover: FC = () => {
               <ShortcutTipParts parts={step.body} />
             )}
           </p>
+          {step.hint && <p className="text-text-muted text-xs">{step.hint}</p>}
           {step.keycaps && <ShortcutKeys keys={[...step.keycaps]} />}
           {edgeAnnouncement && (
             <p className="text-text-muted text-xs" role="status">
@@ -573,11 +587,16 @@ const ShowcaseTakeover: FC = () => {
               <button
                 type="button"
                 className={TEXT_BUTTON_CLASS}
-                onClick={() => shortcutShowcaseActions.skip()}
+                onClick={() => shortcutShowcaseActions.requestSkip()}
               >
-                Skip
+                {skipPending ? "Leave practice" : "Skip"}
                 <ShortcutHint className="shrink-0">Esc</ShortcutHint>
               </button>
+            )}
+            {skipPending && (
+              <p className="w-full text-text-muted text-xs" role="status">
+                Press Esc again to leave practice.
+              </p>
             )}
           </div>
         </aside>
@@ -597,6 +616,12 @@ const ShowcaseTakeover: FC = () => {
 
 export const ShortcutShowcase: FC = () => {
   const isActive = useShortcutShowcaseStore(selectShowcaseActive);
+
+  useEffect(() => {
+    if (!hasSeenWelcome()) return;
+    shortcutShowcaseActions.resumeIfInProgress();
+  }, []);
+
   if (!isActive) return null;
   return <ShowcaseTakeover />;
 };

--- a/packages/web/src/components/ShortcutShowcase/showcase.steps.ts
+++ b/packages/web/src/components/ShortcutShowcase/showcase.steps.ts
@@ -24,6 +24,8 @@ export type ShowcaseStep = {
   body: string | readonly ShortcutTipPart[];
   /** One keycap per entry, rendered via ShortcutKeys. */
   keycaps?: readonly string[];
+  /** Extra context under the body so the lesson does not need a helper. */
+  hint?: string;
   level?: number;
 };
 
@@ -37,6 +39,7 @@ export const SHOWCASE_STEPS = [
     id: "create",
     title: "Drop an event on the board",
     body: "Press C to start a new event.",
+    hint: "C works on this sandbox. Clicks do not start an event.",
     keycaps: KEYMAP.createEvent.keycaps,
     level: 1,
   },
@@ -59,6 +62,7 @@ export const SHOWCASE_STEPS = [
       { key: KEYMAP.eventJump.keycaps[0] },
       " to show event keys, then press a letter to land on one.",
     ],
+    hint: "Tap the reveal key first, then a letter on an event.",
     keycaps: KEYMAP.eventJump.keycaps,
     level: 3,
   },
@@ -81,6 +85,7 @@ export const SHOWCASE_STEPS = [
       { key: "Shift" },
       " and press up or down to change just that edge.",
     ],
+    hint: "Tab until start or end is announced, then hold Shift and press up or down.",
     keycaps: [KEYMAP.edgeFocus.hotkey, ...KEYMAP.moveEvent.timedEdgeKeycaps],
     level: 5,
   },
@@ -94,6 +99,7 @@ export const SHOWCASE_STEPS = [
       { key: "T" },
       " to target the title.",
     ],
+    hint: "Press E, then T. Do not hold them together.",
     keycaps: KEYMAP.editTitle.keycaps,
     level: 6,
   },
@@ -107,6 +113,7 @@ export const SHOWCASE_STEPS = [
       { keys: KEYMAP.undo.keycaps },
       " to undo.",
     ],
+    hint: "Delete first, then undo to bring it back.",
     keycaps: ["Delete", ...KEYMAP.undo.keycaps],
     level: 7,
   },
@@ -167,10 +174,11 @@ export function getShowcaseStep(id: ShowcaseStepId): ShowcaseStep {
  */
 export function getCreateLessonPhase(
   hasOpenEditor: boolean,
-): Partial<Pick<ShowcaseStep, "body" | "keycaps">> {
+): Partial<Pick<ShowcaseStep, "body" | "keycaps" | "hint">> {
   if (!hasOpenEditor) return {};
   return {
     body: "Type a title, then press Enter to save.",
+    hint: "Enter saves the title and continues.",
     keycaps: KEYMAP.saveDraft.keycaps,
   };
 }
@@ -178,7 +186,7 @@ export function getCreateLessonPhase(
 /** After Tab lands on an edge, the hint swaps to the Shift+up/down beat. */
 export function getEdgeResizeLessonPhase(
   edge: PracticeEdge,
-): Partial<Pick<ShowcaseStep, "body" | "keycaps">> {
+): Partial<Pick<ShowcaseStep, "body" | "keycaps" | "hint">> {
   if (!edge) return {};
   return {
     body: [
@@ -186,6 +194,7 @@ export function getEdgeResizeLessonPhase(
       { key: "Shift" },
       " and press up or down to change just that edge.",
     ],
+    hint: "Hold Shift and press up or down to move just this edge.",
     keycaps: KEYMAP.moveEvent.timedEdgeKeycaps,
   };
 }
@@ -193,7 +202,7 @@ export function getEdgeResizeLessonPhase(
 /** After Delete, the hint swaps to the undo beat. */
 export function getDeleteUndoLessonPhase(
   hasDeleted: boolean,
-): Partial<Pick<ShowcaseStep, "body" | "keycaps">> {
+): Partial<Pick<ShowcaseStep, "body" | "keycaps" | "hint">> {
   if (!hasDeleted) return {};
   return {
     body: [
@@ -201,6 +210,7 @@ export function getDeleteUndoLessonPhase(
       { keys: KEYMAP.undo.keycaps },
       " to bring the event back.",
     ],
+    hint: "Now undo to bring the event back.",
     keycaps: KEYMAP.undo.keycaps,
   };
 }

--- a/packages/web/src/components/ShortcutShowcase/showcase.storage.test.ts
+++ b/packages/web/src/components/ShortcutShowcase/showcase.storage.test.ts
@@ -1,0 +1,32 @@
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import {
+  clearShowcaseProgress,
+  readShowcaseProgress,
+  writeShowcaseProgress,
+} from "@web/components/ShortcutShowcase/showcase.storage";
+import { afterEach, describe, expect, it } from "bun:test";
+
+describe("showcase progress storage", () => {
+  afterEach(() => {
+    persistentBrowserStore.remove(STORAGE_KEYS.SHORTCUT_SHOWCASE_STEP);
+  });
+
+  it("round-trips a step id and clears it", () => {
+    expect(readShowcaseProgress()).toBeNull();
+
+    writeShowcaseProgress("create");
+    expect(readShowcaseProgress()).toBe("create");
+    expect(
+      persistentBrowserStore.get(STORAGE_KEYS.SHORTCUT_SHOWCASE_STEP),
+    ).toBe("create");
+
+    clearShowcaseProgress();
+    expect(readShowcaseProgress()).toBeNull();
+  });
+
+  it("treats an empty stored value as no progress", () => {
+    persistentBrowserStore.set(STORAGE_KEYS.SHORTCUT_SHOWCASE_STEP, "");
+    expect(readShowcaseProgress()).toBeNull();
+  });
+});

--- a/packages/web/src/components/ShortcutShowcase/showcase.storage.ts
+++ b/packages/web/src/components/ShortcutShowcase/showcase.storage.ts
@@ -23,6 +23,22 @@ export function markShortcutShowcaseSeen(): void {
   persistentBrowserStore.set(STORAGE_KEYS.HAS_SEEN_SHORTCUT_SHOWCASE, "true");
 }
 
+/** Last in-progress step id, or null when there is nothing to resume. */
+export function readShowcaseProgress(): string | null {
+  if (!persistentBrowserStore.isAvailable()) return null;
+  return (
+    persistentBrowserStore.get(STORAGE_KEYS.SHORTCUT_SHOWCASE_STEP) || null
+  );
+}
+
+export function writeShowcaseProgress(stepId: string): void {
+  persistentBrowserStore.set(STORAGE_KEYS.SHORTCUT_SHOWCASE_STEP, stepId);
+}
+
+export function clearShowcaseProgress(): void {
+  persistentBrowserStore.remove(STORAGE_KEYS.SHORTCUT_SHOWCASE_STEP);
+}
+
 /** Set when a welcome-modal exit hands off to signup instead of practicing. */
 export function markShowcaseOfferPending(): void {
   persistentBrowserStore.set(STORAGE_KEYS.HAS_PENDING_SHOWCASE_OFFER, "true");

--- a/packages/web/src/components/ShortcutShowcase/showcase.store.test.ts
+++ b/packages/web/src/components/ShortcutShowcase/showcase.store.test.ts
@@ -2,6 +2,10 @@ import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 import { SHOWCASE_STEP_IDS } from "@web/components/ShortcutShowcase/showcase.steps";
 import {
+  readShowcaseProgress,
+  writeShowcaseProgress,
+} from "@web/components/ShortcutShowcase/showcase.storage";
+import {
   initialShortcutShowcaseState,
   shortcutShowcaseActions,
   stepIdAt,
@@ -16,6 +20,7 @@ describe("shortcutShowcaseActions", () => {
     useShortcutShowcaseStore.setState(initialShortcutShowcaseState);
     persistentBrowserStore.set(STORAGE_KEYS.HAS_SEEN_SHORTCUT_SHOWCASE, "");
     persistentBrowserStore.set(STORAGE_KEYS.HAS_PENDING_SHOWCASE_OFFER, "");
+    persistentBrowserStore.remove(STORAGE_KEYS.SHORTCUT_SHOWCASE_STEP);
     localStorage.setItem(LEGACY_TOUR_SEEN_KEY, "");
   });
 
@@ -36,12 +41,17 @@ describe("shortcutShowcaseActions", () => {
       expect(useShortcutShowcaseStore.getState().stepIndex).toBe(i);
     }
 
+    expect(readShowcaseProgress()).toBe(
+      SHOWCASE_STEP_IDS[SHOWCASE_STEP_IDS.length - 1],
+    );
+
     // Advancing off the last step finishes and marks seen.
     shortcutShowcaseActions.advance();
     expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
     expect(
       persistentBrowserStore.get(STORAGE_KEYS.HAS_SEEN_SHORTCUT_SHOWCASE),
     ).toBe("true");
+    expect(readShowcaseProgress()).toBeNull();
   });
 
   it("replay skips the intro and opens the first lesson", () => {
@@ -76,7 +86,7 @@ describe("shortcutShowcaseActions", () => {
     expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
   });
 
-  it("skips on the first request, from any step and either exit", () => {
+  it("skip() leaves immediately, from any step and either exit", () => {
     shortcutShowcaseActions.replay();
     shortcutShowcaseActions.advance();
     shortcutShowcaseActions.skip("signup");
@@ -84,10 +94,96 @@ describe("shortcutShowcaseActions", () => {
     expect(
       persistentBrowserStore.get(STORAGE_KEYS.HAS_SEEN_SHORTCUT_SHOWCASE),
     ).toBe("true");
+    expect(readShowcaseProgress()).toBeNull();
 
     // Skipping an inactive showcase is a no-op, not a second skip event.
     shortcutShowcaseActions.skip();
     expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
+  });
+
+  it("arms skip on the first requestSkip and leaves on the second", () => {
+    shortcutShowcaseActions.replay();
+    shortcutShowcaseActions.requestSkip();
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
+    expect(useShortcutShowcaseStore.getState().skipPending).toBe(true);
+    expect(
+      persistentBrowserStore.get(STORAGE_KEYS.HAS_SEEN_SHORTCUT_SHOWCASE),
+    ).not.toBe("true");
+    expect(readShowcaseProgress()).toBe("create");
+
+    shortcutShowcaseActions.requestSkip();
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
+    expect(useShortcutShowcaseStore.getState().skipPending).toBe(false);
+    expect(
+      persistentBrowserStore.get(STORAGE_KEYS.HAS_SEEN_SHORTCUT_SHOWCASE),
+    ).toBe("true");
+    expect(readShowcaseProgress()).toBeNull();
+  });
+
+  it("requestSkip on an inactive showcase is a no-op", () => {
+    shortcutShowcaseActions.requestSkip();
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
+    expect(useShortcutShowcaseStore.getState().skipPending).toBe(false);
+  });
+
+  it("advance clears a pending skip and keeps the practice running", () => {
+    shortcutShowcaseActions.startFromWelcome();
+    shortcutShowcaseActions.requestSkip();
+    expect(useShortcutShowcaseStore.getState().skipPending).toBe(true);
+
+    shortcutShowcaseActions.advance();
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
+    expect(useShortcutShowcaseStore.getState().skipPending).toBe(false);
+    expect(stepIdAt(useShortcutShowcaseStore.getState().stepIndex)).toBe(
+      "create",
+    );
+  });
+
+  it("persists the current step and resumes it without marking seen", () => {
+    shortcutShowcaseActions.startFromWelcome();
+    expect(readShowcaseProgress()).toBe("intro");
+    shortcutShowcaseActions.advance();
+    expect(readShowcaseProgress()).toBe("create");
+
+    useShortcutShowcaseStore.setState(initialShortcutShowcaseState);
+    shortcutShowcaseActions.resumeIfInProgress();
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
+    expect(stepIdAt(useShortcutShowcaseStore.getState().stepIndex)).toBe(
+      "create",
+    );
+    expect(
+      persistentBrowserStore.get(STORAGE_KEYS.HAS_SEEN_SHORTCUT_SHOWCASE),
+    ).not.toBe("true");
+  });
+
+  it("falls back to intro for an unknown saved step", () => {
+    writeShowcaseProgress("retiredStep");
+    shortcutShowcaseActions.resumeIfInProgress();
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
+    expect(stepIdAt(useShortcutShowcaseStore.getState().stepIndex)).toBe(
+      "intro",
+    );
+    expect(readShowcaseProgress()).toBe("intro");
+  });
+
+  it("does not resume after the showcase has been seen", () => {
+    shortcutShowcaseActions.replay();
+    shortcutShowcaseActions.skip();
+    writeShowcaseProgress("create");
+    shortcutShowcaseActions.resumeIfInProgress();
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
+  });
+
+  it("replay overwrites saved progress with the first lesson", () => {
+    shortcutShowcaseActions.startFromWelcome();
+    shortcutShowcaseActions.advance();
+    expect(readShowcaseProgress()).toBe("create");
+
+    shortcutShowcaseActions.replay();
+    expect(stepIdAt(useShortcutShowcaseStore.getState().stepIndex)).toBe(
+      "create",
+    );
+    expect(readShowcaseProgress()).toBe("create");
   });
 
   it("defers the offer through signup and redeems it exactly once", () => {

--- a/packages/web/src/components/ShortcutShowcase/showcase.store.ts
+++ b/packages/web/src/components/ShortcutShowcase/showcase.store.ts
@@ -2,10 +2,13 @@ import { create } from "zustand";
 import { track } from "@web/auth/posthog/track";
 import { SHOWCASE_STEP_IDS } from "@web/components/ShortcutShowcase/showcase.steps";
 import {
+  clearShowcaseProgress,
   consumePendingShowcaseOffer,
   hasSeenShortcutShowcase,
   markShortcutShowcaseSeen,
   markShowcaseOfferPending,
+  readShowcaseProgress,
+  writeShowcaseProgress,
 } from "@web/components/ShortcutShowcase/showcase.storage";
 
 export type ShortcutShowcaseState = {
@@ -17,12 +20,15 @@ export type ShortcutShowcaseState = {
    * durable source; readers check this OR the stored flag.
    */
   hasSeenShowcase: boolean;
+  /** First Skip/Esc arms leave; the second actually skips. */
+  skipPending: boolean;
 };
 
 export const initialShortcutShowcaseState: ShortcutShowcaseState = {
   isActive: false,
   stepIndex: 0,
   hasSeenShowcase: false,
+  skipPending: false,
 };
 
 /** Where a user who left early went next, so the funnel can tell them apart. */
@@ -35,16 +41,32 @@ export const useShortcutShowcaseStore = create<ShortcutShowcaseState>()(() => ({
 export const stepIdAt = (index: number) =>
   SHOWCASE_STEP_IDS[index] ?? SHOWCASE_STEP_IDS[0];
 
+const persistStep = (index: number) => {
+  writeShowcaseProgress(stepIdAt(index));
+};
+
+const stepIndexForSavedId = (saved: string): number => {
+  const index = SHOWCASE_STEP_IDS.indexOf(
+    saved as (typeof SHOWCASE_STEP_IDS)[number],
+  );
+  return index === -1 ? 0 : index;
+};
+
 /** Persist the seen flag and wake everyone reading it. */
 const markSeen = () => {
   markShortcutShowcaseSeen();
+  clearShowcaseProgress();
   useShortcutShowcaseStore.setState({ hasSeenShowcase: true });
 };
 
 /** Shared by finish/skip: mark seen so it never auto-launches again. */
 const endShowcase = () => {
   markSeen();
-  useShortcutShowcaseStore.setState({ isActive: false, stepIndex: 0 });
+  useShortcutShowcaseStore.setState({
+    isActive: false,
+    stepIndex: 0,
+    skipPending: false,
+  });
 };
 
 /** How the practice arena was opened, so the activation funnel can tell them apart. */
@@ -55,7 +77,12 @@ const PALETTE_START_INDEX = SHOWCASE_STEP_IDS.indexOf("create");
 
 const activate = (entry: ShowcaseEntry) => {
   const stepIndex = entry === "palette" ? PALETTE_START_INDEX : 0;
-  useShortcutShowcaseStore.setState({ isActive: true, stepIndex });
+  useShortcutShowcaseStore.setState({
+    isActive: true,
+    stepIndex,
+    skipPending: false,
+  });
+  persistStep(stepIndex);
   track("shortcut_showcase_started", { entry });
 };
 
@@ -68,6 +95,24 @@ export const shortcutShowcaseActions = {
   replay: () => {
     activate("palette");
   },
+  /**
+   * Restore an unfinished run after reload. Does not fire started: this is
+   * the same attempt, not a new activation.
+   */
+  resumeIfInProgress: () => {
+    const { isActive } = useShortcutShowcaseStore.getState();
+    if (isActive) return;
+    if (hasSeenShortcutShowcase()) return;
+    const saved = readShowcaseProgress();
+    if (!saved) return;
+    const stepIndex = stepIndexForSavedId(saved);
+    persistStep(stepIndex);
+    useShortcutShowcaseStore.setState({
+      isActive: true,
+      stepIndex,
+      skipPending: false,
+    });
+  },
   /** Graduation persists the flag before its reveal animation finishes. */
   markSeen,
   advance: () => {
@@ -78,16 +123,38 @@ export const shortcutShowcaseActions = {
       shortcutShowcaseActions.finish();
       return;
     }
-    useShortcutShowcaseStore.setState({ stepIndex: stepIndex + 1 });
+    const nextIndex = stepIndex + 1;
+    useShortcutShowcaseStore.setState({
+      stepIndex: nextIndex,
+      skipPending: false,
+    });
+    persistStep(nextIndex);
   },
   finish: () => {
     track("shortcut_showcase_finished");
     endShowcase();
   },
   /**
-   * Leaving before graduation. There is no "are you sure?" in the way: the
-   * showcase is an offer, and the flow it guards (sign up, connect a calendar)
-   * matters more than the levels.
+   * Arm, then confirm, a calendar leave. Skip and Esc call this so a stray
+   * Escape does not dump a first-time user onto the calendar. Skip to sign
+   * up still calls skip() immediately: that handoff is intentional.
+   */
+  requestSkip: (exit: ShowcaseExit = "calendar") => {
+    const { isActive, skipPending } = useShortcutShowcaseStore.getState();
+    if (!isActive) return;
+    if (skipPending) {
+      shortcutShowcaseActions.skip(exit);
+      return;
+    }
+    useShortcutShowcaseStore.setState({ skipPending: true });
+  },
+  clearSkipPending: () => {
+    if (!useShortcutShowcaseStore.getState().skipPending) return;
+    useShortcutShowcaseStore.setState({ skipPending: false });
+  },
+  /**
+   * Leave immediately and fire skipped. Used by Skip to sign up and by the
+   * second Skip/Esc after requestSkip arms the confirm.
    */
   skip: (exit: ShowcaseExit = "calendar") => {
     const { isActive, stepIndex } = useShortcutShowcaseStore.getState();
@@ -115,3 +182,6 @@ export const selectShowcaseStepIndex = (state: ShortcutShowcaseState) =>
 
 export const selectHasSeenShowcase = (state: ShortcutShowcaseState) =>
   state.hasSeenShowcase;
+
+export const selectSkipPending = (state: ShortcutShowcaseState) =>
+  state.skipPending;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Shortcut Showcase skipped too easily (one Esc or Skip click, with most skips on the first lesson) and lost in-progress runs on reload. This change:

- Arms calendar Skip/Esc with a one-step confirm (`Leave practice` / "Press Esc again to leave practice"). `shortcut_showcase_skipped` fires only on that confirm.
- Leaves **Skip to sign up** / `U` as a one-click conversion handoff.
- Persists the current step id and resumes it after reload when welcome has already been seen. Resume does not fire `shortcut_showcase_started`. Finish and confirmed skip still clear progress and fire `shortcut_showcase_finished` / `shortcut_showcase_skipped`.
- Adds inline hints on create, eventJump, edgeResize, editTitle, and deleteUndo.

![Skip confirmation on the intro](https://cursor.com/artifacts/c/art-bfbc01cb-e0d8-4f89-b0d4-a6c3aa0e3540)
![Reload resumes Level 2](https://cursor.com/artifacts/c/art-109fba62-06a6-46de-a1f7-c7259a771edb)
<a href="https://cursor.com/agents/bc-2fa793dc-4bd9-4bb1-81f9-e3cda9938a31/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fshowcase_skip_confirm_and_resume.mp4"><img src="https://cursor.com/artifacts/c/art-b6240bf6-6f87-4682-bb81-033424b95e45" alt="showcase_skip_confirm_and_resume.mp4" /></a>

## Simplicity

No Assist helper and no redo UI. Confirm is store state plus existing Skip/Esc controls. Progress is one localStorage step id, not a snapshot of practice calendar state.

## Automated validation

Focused web tests cover arm/confirm skip, immediate signup skip, persist/resume/fallback, and hint copy. Onboarding e2e covers two-Esc leave, no auto-replay after confirm, and mid-run reload resume. `first-run.spec.ts` now presses Escape twice so it can still reach sample events. Browser walkthrough: first Esc keeps practice open, reload resumes Level 2, confirmed skip then reload stays on the real calendar.

## Independent review

Pending `/review` after required checks.

## Test plan

- `bun test:web` on ShortcutShowcase, WelcomeModal, FirstEventPrompt, RootShell, and PointerHint: 132 pass
- `bun run verify`: PASS for test:web, type-check, lint, knip
- `bunx playwright test e2e/onboarding/first-run.spec.ts e2e/onboarding/shortcut-showcase.spec.ts --workers=1`: 7 passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fa793dc-4bd9-4bb1-81f9-e3cda9938a31?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fa793dc-4bd9-4bb1-81f9-e3cda9938a31&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

