### PR TITLE
feat(web): copy and paste events with Mod+C / Mod+V

### DIFF
--- a/docs/acceptance/events.md
+++ b/docs/acceptance/events.md
@@ -193,6 +193,8 @@ With an event form open, pressing Cmd+D (Mac) or Ctrl+D (Windows) creates a copy
 - Both the original and the duplicate are present on the grid.
 - The duplicate persists after a page reload.
 
+Cmd+C / Ctrl+C and Cmd+V / Ctrl+V are the two-step version of this: copy snapshots the focused event, paste duplicates it at the same date and time (including when nothing is focused). A later copy replaces the clipboard. These chords do not fire while typing in an input.
+
 ---
 
 ## Scenario 8: Undo An Event Deletion (Cmd+Z / Ctrl+Z)

--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -425,6 +425,30 @@ Bare `Z` opens the time-travel timezone picker in Day and Week view. Cmd+Z / Ctr
 
 ---
 
+## Scenario 17: Copy And Paste An Event (Cmd+C / Cmd+V)
+
+### UX
+
+With a grid event focused (form closed, not typing in an input), Cmd+C (Mac) or Ctrl+C (Windows/Linux) copies that event into an in-app clipboard. Cmd+V / Ctrl+V then creates a duplicate at the original date and time, the same result as Cmd+D, including when nothing is focused. A later copy replaces the previous one. The clipboard lasts for the tab session with no expiry. While a text field is focused, Cmd+C / Cmd+V stay native text copy/paste.
+
+### Steps
+
+1. Navigate to `/week` (or `/day`) with at least two saved events.
+2. Focus an event (U, then arrows).
+3. Press Cmd+C (Mac) or Ctrl+C (Windows/Linux).
+4. Focus a different event and press Cmd+C again.
+5. Blur the event (click the grid background is inert; press Escape if needed so nothing is focused) and press Cmd+V.
+6. Open an event form, focus the title, select text, and press Cmd+C then Cmd+V.
+
+### Expected Results
+
+- The first Cmd+C does not create an event.
+- After the second copy, Cmd+V creates a duplicate of the *second* event at that event's original time. The two source events remain.
+- Cmd+D still duplicates the currently focused event immediately.
+- Cmd+C / Cmd+V inside the title field copy and paste text and do not duplicate an event.
+
+---
+
 ## Focused Regression Checks
 
 If time is limited, run these checks before shipping shortcut-related changes:
@@ -449,3 +473,4 @@ If time is limited, run these checks before shipping shortcut-related changes:
 18. Alt+ArrowUp / Alt+ArrowDown pan the timed grid by one hour in Day and Week view even when an event is focused; they do not fire in a text input.
 19. `Z` opens time travel in Day and Week view; Cmd+Z / Ctrl+Z still undoes and does not open the picker.
 20. On Day view, hold Mod then a column digit (2+) focuses that writable calendar column; Shift+Arrow / `C` seed a draft there.
+21. Cmd+C / Ctrl+C copies a focused event; Cmd+V / Ctrl+V pastes a duplicate at the original time without requiring focus. A later copy replaces the clipboard. Empty paste is a no-op. Copy/paste do not fire while typing in an input (native text clipboard). Cmd+D is unchanged.

--- a/packages/web/src/__tests__/utils/state/reset-stores.ts
+++ b/packages/web/src/__tests__/utils/state/reset-stores.ts
@@ -34,6 +34,10 @@ import {
   useDraftStore,
 } from "@web/events/stores/draft.store";
 import {
+  initialEventClipboardState,
+  useEventClipboardStore,
+} from "@web/events/stores/event-clipboard.store";
+import {
   initialUndoHistoryState,
   useUndoHistoryStore,
 } from "@web/events/stores/undo.store";
@@ -69,6 +73,7 @@ const storeResets: StoreReset[] = [
   () => useViewStore.setState(initialViewState, true),
   () => useUserMetadataStore.setState(initialUserMetadataState, true),
   () => useDraftStore.setState(initialDraftState, true),
+  () => useEventClipboardStore.setState(initialEventClipboardState, true),
   () => useUndoHistoryStore.setState(initialUndoHistoryState, true),
   recurrenceScopeOpportunityActions.reset,
   resetEventRepositorySourceForTests,

--- a/packages/web/src/__tests__/utils/state/seed-stores.ts
+++ b/packages/web/src/__tests__/utils/state/seed-stores.ts
@@ -1,3 +1,4 @@
+import { type Event } from "@core/types/event.contracts";
 import {
   type UserMetadataState,
   useUserMetadataStore,
@@ -6,6 +7,7 @@ import {
   type State_DraftEvent,
   useDraftStore,
 } from "@web/events/stores/draft.store";
+import { eventClipboardActions } from "@web/events/stores/event-clipboard.store";
 import { useViewStore } from "@web/events/stores/view.store";
 import { useSettingsStore } from "@web/settings/settings.store";
 
@@ -16,7 +18,10 @@ type ViewState = ReturnType<typeof useViewStore.getState>;
  * State shape accepted by the render helpers' `state` option.
  */
 export type TestAppState = {
-  events?: { draft?: Partial<State_DraftEvent> };
+  events?: {
+    draft?: Partial<State_DraftEvent>;
+    clipboard?: Event | null;
+  };
   settings?: Partial<SettingsState>;
   userMetadata?: Partial<UserMetadataState>;
   view?: Partial<ViewState>;
@@ -28,6 +33,8 @@ export function seedStoresFromState(state?: TestAppState): void {
 
   const { events, settings, userMetadata, view } = state;
   if (events?.draft) useDraftStore.setState(events.draft);
+  if (events?.clipboard) eventClipboardActions.copy(events.clipboard);
+  if (events?.clipboard === null) eventClipboardActions.clear();
   if (settings) useSettingsStore.setState(settings);
   if (userMetadata) useUserMetadataStore.setState(userMetadata);
   if (view) useViewStore.setState(view);

--- a/packages/web/src/events/stores/event-clipboard.store.test.ts
+++ b/packages/web/src/events/stores/event-clipboard.store.test.ts
@@ -1,0 +1,62 @@
+import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import {
+  eventClipboardActions,
+  initialEventClipboardState,
+  useEventClipboardStore,
+} from "@web/events/stores/event-clipboard.store";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+describe("event-clipboard.store", () => {
+  beforeEach(() => {
+    useEventClipboardStore.setState(initialEventClipboardState, true);
+  });
+
+  it("snapshots the event so later mutations of the source do not change the clipboard", () => {
+    const source = createMockEvent({
+      content: { kind: "details", title: "Original", description: "" },
+    });
+
+    eventClipboardActions.copy(source);
+    const live = source as {
+      content: { kind: "details"; title: string; description: string };
+    };
+    live.content.title = "Edited";
+
+    expect(useEventClipboardStore.getState().event?.content).toEqual({
+      kind: "details",
+      title: "Original",
+      description: "",
+    });
+  });
+
+  it("overwrites the clipboard with the latest copy", () => {
+    const first = createMockEvent({
+      content: { kind: "details", title: "First", description: "" },
+    });
+    const second = createMockEvent({
+      content: { kind: "details", title: "Second", description: "" },
+    });
+
+    eventClipboardActions.copy(first);
+    eventClipboardActions.copy(second);
+
+    expect(useEventClipboardStore.getState().event?.content).toEqual({
+      kind: "details",
+      title: "Second",
+      description: "",
+    });
+  });
+
+  it("keeps the snapshot until the next copy or clear: no TTL", () => {
+    const source = createMockEvent({
+      content: { kind: "details", title: "Kept", description: "" },
+    });
+
+    eventClipboardActions.copy(source);
+
+    expect(useEventClipboardStore.getState().event?.id).toBe(source.id);
+
+    eventClipboardActions.clear();
+    expect(useEventClipboardStore.getState().event).toBeNull();
+  });
+});

--- a/packages/web/src/events/stores/event-clipboard.store.ts
+++ b/packages/web/src/events/stores/event-clipboard.store.ts
@@ -1,0 +1,31 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import { type Event } from "@core/types/event.contracts";
+import { IS_DEV } from "@web/common/constants/env.constants";
+
+export type EventClipboardState = {
+  event: Event | null;
+};
+
+export const initialEventClipboardState: EventClipboardState = {
+  event: null,
+};
+
+export const useEventClipboardStore = create<EventClipboardState>()(
+  devtools(() => initialEventClipboardState, {
+    name: "compass/event-clipboard",
+    enabled: IS_DEV,
+  }),
+);
+
+export const eventClipboardActions = {
+  /** Snapshot `event` so later edits or deletes of the original do not change what pastes. */
+  copy: (event: Event) =>
+    useEventClipboardStore.setState({ event: structuredClone(event) }, false, {
+      type: "copy",
+    }),
+  clear: () =>
+    useEventClipboardStore.setState(initialEventClipboardState, false, {
+      type: "clear",
+    }),
+};

--- a/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
@@ -1,5 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
+import { type Event } from "@core/types/event.contracts";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import {
@@ -52,6 +53,10 @@ import {
   useDraftStore,
 } from "@web/events/stores/draft.store";
 import {
+  eventClipboardActions,
+  useEventClipboardStore,
+} from "@web/events/stores/event-clipboard.store";
+import {
   edgeFocusActions,
   useEdgeFocusStore,
 } from "@web/grid/shortcuts/edge-focus.store";
@@ -65,6 +70,7 @@ import {
 } from "@web/grid/shortcuts/focus-adjacent-grid-event";
 import { isHigherEscapeOwner } from "@web/shortcuts/escape-ownership";
 import { KEYMAP } from "@web/shortcuts/keymap";
+import { swallowNextKeyup } from "@web/shortcuts/swallow-next-keyup";
 import { shortcutHintProgressActions } from "@web/shortcuts/tips/shortcut-tips.progress.store";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 import { deleteEventAndDiscardDraft } from "@web/views/Forms/hooks/useDeleteEvent";
@@ -172,10 +178,10 @@ export type GridEventEditDayBoundary =
     };
 
 /**
- * Shared Delete / Mod+D / Shift+arrow nudge / draft Arrow reposition / focus
- * traversal shortcuts for Day and Week. Targeting, day-boundary policy, and
- * draft reposition stay view-specific (Day follows across midnight; Week
- * clamps to weekDays).
+ * Shared Delete / Mod+D / Mod+C+V copy-paste / Shift+arrow nudge / draft Arrow
+ * reposition / focus traversal shortcuts for Day and Week. Targeting,
+ * day-boundary policy, and draft reposition stay view-specific (Day follows
+ * across midnight; Week clamps to weekDays).
  *
  * Handlers close over latest render values; TanStack Hotkeys syncs the
  * callback each render, so event-list refs are unnecessary.
@@ -261,6 +267,23 @@ export function useGridEventEditShortcuts({
     deleteEventAndDiscardDraft(deleteEvent, event);
   };
 
+  const duplicateSourceEvent = (sourceEvent: Event) => {
+    const committed = commitDuplicateEvent({
+      source: sourceEvent,
+      calendars: calendars ?? [],
+      defaultCalendarId: defaultCalendar?.id,
+      create: createEvent,
+    });
+    if (committed) return;
+
+    // No writable calendar could be resolved for the copy - fall back to
+    // the create-draft form so the user can pick one.
+    const duplicate = duplicateGridEventDraft(sourceEvent, calendars ?? []);
+    if (!duplicate) return;
+
+    draftActions.startGridDraft({ activity: "gridClick", draft: duplicate });
+  };
+
   const duplicateFocusedCalendarEvent = (keyboardEvent: KeyboardEvent) => {
     if (isEventFormOpen() || isEventFormKeyboardTarget(keyboardEvent)) {
       return;
@@ -274,24 +297,50 @@ export function useGridEventEditShortcuts({
     const sourceEvent = findEventInCache(queryClient, gridEvent._id);
     if (!sourceEvent) return;
 
-    const committed = commitDuplicateEvent({
-      source: sourceEvent,
-      calendars: calendars ?? [],
-      defaultCalendarId: defaultCalendar?.id,
-      create: createEvent,
-    });
+    keyboardEvent.preventDefault();
+    keyboardEvent.stopPropagation();
+    duplicateSourceEvent(sourceEvent);
+  };
+
+  const copyFocusedCalendarEvent = (keyboardEvent: KeyboardEvent) => {
+    // Always swallow: macOS replays a meta-released C keyup that would
+    // otherwise match the create-event shortcut.
+    swallowNextKeyup("c");
+
+    if (isEventFormOpen() || isEventFormKeyboardTarget(keyboardEvent)) {
+      return;
+    }
+
+    if (isFocusInSidebar()) return;
+
+    const eventId = targeting.getFocusedNavigable()?.eventId;
+    if (!eventId) return;
+
+    const sourceEvent = findEventInCache(queryClient, eventId);
+    if (!sourceEvent) return;
 
     keyboardEvent.preventDefault();
     keyboardEvent.stopPropagation();
+    eventClipboardActions.copy(sourceEvent);
+  };
 
-    if (committed) return;
+  const pasteCopiedCalendarEvent = (keyboardEvent: KeyboardEvent) => {
+    // Always swallow: macOS replays a meta-released V keyup that would
+    // otherwise match Join Up Next.
+    swallowNextKeyup("v");
 
-    // No writable calendar could be resolved for the copy - fall back to
-    // the create-draft form so the user can pick one.
-    const duplicate = duplicateGridEventDraft(sourceEvent, calendars ?? []);
-    if (!duplicate) return;
+    if (isEventFormOpen() || isEventFormKeyboardTarget(keyboardEvent)) {
+      return;
+    }
 
-    draftActions.startGridDraft({ activity: "gridClick", draft: duplicate });
+    if (isFocusInSidebar()) return;
+
+    const sourceEvent = useEventClipboardStore.getState().event;
+    if (!sourceEvent) return;
+
+    keyboardEvent.preventDefault();
+    keyboardEvent.stopPropagation();
+    duplicateSourceEvent(sourceEvent);
   };
 
   const describeEdgeDate = (event: GridEvent, edge: EventEdge) => {
@@ -665,6 +714,12 @@ export function useGridEventEditShortcuts({
   });
   useAppShortcut("Mod+D", duplicateFocusedCalendarEvent, {
     ignoreInputs: false,
+  });
+  useAppShortcut("Mod+C", copyFocusedCalendarEvent, {
+    ignoreInputs: true,
+  });
+  useAppShortcut("Mod+V", pasteCopiedCalendarEvent, {
+    ignoreInputs: true,
   });
   useAppShortcut(
     KEYMAP.moveFocus.hotkeys.up,

--- a/packages/web/src/shortcuts/shortcuts.menu.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.menu.test.ts
@@ -262,6 +262,14 @@ describe("shortcut menu sections", () => {
           label: "Duplicate focused event",
         });
         expect(stripMetadata(edit?.shortcuts ?? [])).toContainEqual({
+          keys: ["Mod", "C"],
+          label: "Copy focused event",
+        });
+        expect(stripMetadata(edit?.shortcuts ?? [])).toContainEqual({
+          keys: ["Mod", "V"],
+          label: "Paste copied event",
+        });
+        expect(stripMetadata(edit?.shortcuts ?? [])).toContainEqual({
           keys: ["ArrowUp"],
           label:
             view === "week"

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -246,6 +246,18 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
     section: "edit",
   },
   {
+    id: "edit-copy",
+    keys: ["Mod", "C"],
+    label: "Copy focused event",
+    section: "edit",
+  },
+  {
+    id: "edit-paste",
+    keys: ["Mod", "V"],
+    label: "Paste copied event",
+    section: "edit",
+  },
+  {
     // Shift+F10 also opens this menu on platforms that have a context-menu key
     // (the browser turns it into a contextmenu event, which pointer-block lets
     // through). It is deliberately not listed here: it would be a second row

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -401,6 +401,30 @@ describe("EventForm", () => {
     });
   });
 
+  it("does not duplicate the event with Mod+C while the title field is focused", () => {
+    const onDuplicate = mock();
+
+    renderWithStore(
+      <EventForm
+        draft={createEditDraft()}
+        isDraft={false}
+        isExistingEvent={true}
+        onClose={mock()}
+        onDelete={mock()}
+        onDuplicate={onDuplicate}
+        onSubmit={mock()}
+        setDraft={mock()}
+      />,
+    );
+
+    const titleField = screen.getByPlaceholderText("Title");
+    act(() => titleField.focus());
+
+    dispatchModKey(titleField, "c");
+
+    expect(onDuplicate).not.toHaveBeenCalled();
+  });
+
   it("jumps focus to the location field with Mod+E then L from the title field", () => {
     renderWithStore(
       <WithEditLeader>

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
@@ -28,6 +28,10 @@ import {
 } from "@web/events/grid-event-draft.adapter";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { draftActions, useDraftStore } from "@web/events/stores/draft.store";
+import {
+  initialEventClipboardState,
+  useEventClipboardStore,
+} from "@web/events/stores/event-clipboard.store";
 import { initialViewState, useViewStore } from "@web/events/stores/view.store";
 import {
   initialEdgeFocusState,
@@ -172,6 +176,7 @@ const getEditMutation = (queryClient: QueryClient) =>
 beforeEach(() => {
   HotkeyManager.resetInstance();
   useEdgeFocusStore.setState(initialEdgeFocusState, true);
+  useEventClipboardStore.setState(initialEventClipboardState, true);
   draftActions.discard();
 });
 
@@ -182,8 +187,16 @@ afterEach(() => {
   weekEventRegistry.clear();
   useViewStore.setState(initialViewState);
   useEdgeFocusStore.setState(initialEdgeFocusState, true);
+  useEventClipboardStore.setState(initialEventClipboardState, true);
   draftActions.discard();
   setSystemTime();
+  // Drain leftover swallowNextKeyup capture listeners from Mod+C / Mod+V.
+  window.dispatchEvent(
+    new KeyboardEvent("keyup", { bubbles: true, cancelable: true, key: "c" }),
+  );
+  window.dispatchEvent(
+    new KeyboardEvent("keyup", { bubbles: true, cancelable: true, key: "v" }),
+  );
 });
 
 const addCalendarTarget = (
@@ -511,6 +524,240 @@ describe("useWeekShortcutOwner calendar event targeting", () => {
     const state = useDraftStore.getState();
     expect(state.status?.isFormOpen).toBe(false);
     expect(state.gridDraft).toBeNull();
+  });
+
+  it("copies a focused event with Mod+C and pastes a duplicate at the original time with Mod+V", () => {
+    const button = addCalendarTarget();
+    button.focus();
+    const { queryClient } = renderShortcuts();
+
+    pressKey("c", {
+      keyDownInit: { ctrlKey: true },
+      keyUpInit: { ctrlKey: true },
+    });
+    expect(queryClient.getMutationCache().getAll()).toHaveLength(0);
+
+    button.blur();
+    pressKey("v", {
+      keyDownInit: { ctrlKey: true },
+      keyUpInit: { ctrlKey: true },
+    });
+
+    const created = queryClient
+      .getMutationCache()
+      .getAll()
+      .find((mutation) => mutation.options.mutationKey?.[2] === "create");
+    const { input } = created?.state.variables as {
+      input: { calendarId: string; content: { title: string } };
+    };
+    expect(input.calendarId).toBe(editableEvent.calendarId);
+    expect(input.content.title).toBe("Editable event");
+    expect(useDraftStore.getState().gridDraft).toBeNull();
+  });
+
+  it("pastes the latest copied event when the user copies a second event before pasting", () => {
+    const first = addCalendarTarget();
+    const second = addCalendarTarget(leftmostEvent.id);
+    first.focus();
+    const { queryClient } = renderShortcuts({ includeLeftmostEvent: true });
+
+    pressKey("c", {
+      keyDownInit: { ctrlKey: true },
+      keyUpInit: { ctrlKey: true },
+    });
+    second.focus();
+    pressKey("c", {
+      keyDownInit: { ctrlKey: true },
+      keyUpInit: { ctrlKey: true },
+    });
+    pressKey("v", {
+      keyDownInit: { ctrlKey: true },
+      keyUpInit: { ctrlKey: true },
+    });
+
+    const created = queryClient
+      .getMutationCache()
+      .getAll()
+      .find((mutation) => mutation.options.mutationKey?.[2] === "create");
+    const { input } = created?.state.variables as {
+      input: { content: { title: string } };
+    };
+    expect(input.content.title).toBe("Leftmost event");
+  });
+
+  it("does not create an event when pasting with an empty clipboard", () => {
+    const { queryClient } = renderShortcuts();
+
+    pressKey("v", {
+      keyDownInit: { ctrlKey: true },
+      keyUpInit: { ctrlKey: true },
+    });
+
+    expect(queryClient.getMutationCache().getAll()).toHaveLength(0);
+  });
+
+  it("does not copy when nothing is focused", () => {
+    addCalendarTarget();
+    renderShortcuts();
+
+    pressKey("c", {
+      keyDownInit: { ctrlKey: true },
+      keyUpInit: { ctrlKey: true },
+    });
+
+    expect(useEventClipboardStore.getState().event).toBeNull();
+  });
+
+  it("still pastes after the keyup-swallow window: the clipboard has no TTL", () => {
+    const button = addCalendarTarget();
+    button.focus();
+    const { queryClient } = renderShortcuts();
+
+    pressKey("c", {
+      keyDownInit: { ctrlKey: true },
+      keyUpInit: { ctrlKey: true },
+    });
+    button.blur();
+
+    expect(useEventClipboardStore.getState().event?.id).toBe(editableEvent.id);
+
+    pressKey("v", {
+      keyDownInit: { ctrlKey: true },
+      keyUpInit: { ctrlKey: true },
+    });
+
+    expect(
+      queryClient
+        .getMutationCache()
+        .getAll()
+        .some((mutation) => mutation.options.mutationKey?.[2] === "create"),
+    ).toBe(true);
+  });
+
+  it("does not open a create draft from a meta-released C keyup after Mod+C", () => {
+    const button = addCalendarTarget();
+    button.focus();
+    renderShortcuts();
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          key: "c",
+          ctrlKey: true,
+        }),
+      );
+    });
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keyup", {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          key: "c",
+          ctrlKey: false,
+        }),
+      );
+    });
+
+    expect(useDraftStore.getState().status?.activity).not.toBe(
+      "createShortcut",
+    );
+    expect(useEventClipboardStore.getState().event?.id).toBe(editableEvent.id);
+  });
+
+  it("swallows a meta-released V keyup after Mod+V so it cannot join a meeting", () => {
+    const button = addCalendarTarget();
+    button.focus();
+    renderShortcuts();
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          key: "c",
+          ctrlKey: true,
+        }),
+      );
+    });
+    button.blur();
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          key: "v",
+          ctrlKey: true,
+        }),
+      );
+    });
+
+    const replayed = new KeyboardEvent("keyup", {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      key: "v",
+      ctrlKey: false,
+    });
+    act(() => {
+      window.dispatchEvent(replayed);
+    });
+
+    expect(replayed.defaultPrevented).toBe(true);
+  });
+
+  it("does not copy an event with Mod+C while a text input is focused", () => {
+    addCalendarTarget();
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+    renderShortcuts();
+
+    pressKey(
+      "c",
+      {
+        keyDownInit: { ctrlKey: true },
+        keyUpInit: { ctrlKey: true },
+      },
+      input,
+    );
+
+    expect(useEventClipboardStore.getState().event).toBeNull();
+  });
+
+  it("copies a focused read-only event so paste can duplicate it onto a writable calendar", () => {
+    const readOnlyButton = addReadOnlyCalendarTarget(readOnlyEvent.id);
+    readOnlyButton.focus();
+    const { queryClient } = renderShortcuts({
+      extraEvents: [readOnlyEvent],
+      calendars: [writableCalendar, readOnlyCalendar],
+    });
+
+    pressKey("c", {
+      keyDownInit: { ctrlKey: true },
+      keyUpInit: { ctrlKey: true },
+    });
+    readOnlyButton.blur();
+    pressKey("v", {
+      keyDownInit: { ctrlKey: true },
+      keyUpInit: { ctrlKey: true },
+    });
+
+    const created = queryClient
+      .getMutationCache()
+      .getAll()
+      .find((mutation) => mutation.options.mutationKey?.[2] === "create");
+    const { input } = created?.state.variables as {
+      input: { calendarId: string; content: { title: string } };
+    };
+    expect(input.content.title).toBe("Read-only event");
+    expect(input.calendarId).toBe(writableCalendar.id);
   });
 
   it("keeps ArrowDown on the same day when a later event exists that day", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Mod+C / Mod+V as a two-step duplicate of a focused calendar event ([#402](https://github.com/KeepSoftwareSimple/compass-calendar/issues/402)).

- Mod+C snapshots the focused saved event into an in-memory clipboard (last copy wins, including read-only events).
- Mod+V runs the existing `commitDuplicateEvent` path at the original datetime. No focus is required to paste.
- The clipboard lasts for the tab session with no TTL and does not touch `navigator.clipboard`.
- Native text copy/paste is left alone in form fields (`ignoreInputs: true`). Mod+D is unchanged.
- macOS meta-released C/V keyups are swallowed so they cannot create an event or join Up Next.

## Simplicity

Reuses `commitDuplicateEvent` / `duplicateGridEventDraft` instead of a second duplicate implementation. The only new state is a small Zustand snapshot store.

## Automated validation

- `bun test:web` on clipboard store, week shortcut owner, shortcut menu, and EventForm tests: 125 pass.
- `bun run lint`: 0 errors (pre-existing warnings only).
- `bun run verify`: selected checks passed (`test:web`, `type-check`, `lint`, `knip`). Playwright Chromium was not installed, so e2e/a11y were skipped.

## Independent review

Not requested. Local verify is the gate.

## Test plan

- `bun test:web packages/web/src/events/stores/event-clipboard.store.test.ts packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx packages/web/src/shortcuts/shortcuts.menu.test.ts packages/web/src/views/Forms/EventForm/EventForm.test.tsx`
- `bun run lint`
- `bun run verify`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53f14fc3-1131-4333-9c3f-0b0173b4983a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53f14fc3-1131-4333-9c3f-0b0173b4983a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

