### PR TITLE
feat(web): create events at a typed time

### DIFF
--- a/packages/web/src/common/utils/datetime/web.date.util.ts
+++ b/packages/web/src/common/utils/datetime/web.date.util.ts
@@ -53,7 +53,7 @@ export const getColorsByHour = (currentHour: number) => {
   return colors;
 };
 
-const getDayjsByTimeValue = (timeValue: string) => {
+export const getDayjsByTimeValue = (timeValue: string) => {
   return dayjs(`2000-01-01 ${timeValue}`, YMDHAM_FORMAT);
 };
 

--- a/packages/web/src/common/utils/draft/draft.util.ts
+++ b/packages/web/src/common/utils/draft/draft.util.ts
@@ -30,6 +30,21 @@ export const createTimedDraft = (
   calendarId: CalendarId | null = null,
 ) => {
   const { startDate, endDate } = getDraftTimes(isCurrentWeek, startOfView);
+
+  startTimedDraftAt(startDate, endDate, activity, calendarId);
+};
+
+/**
+ * Seed and start a timed draft at an already-decided time. Shared by the
+ * near-now defaults above and by quick-time create, which picks its own start
+ * from a typed digit sequence.
+ */
+export const startTimedDraftAt = (
+  startDate: string,
+  endDate: string,
+  activity: "createShortcut" | "keyboardPlace",
+  calendarId: CalendarId | null = null,
+) => {
   // Stable grid identity so place-create can focus the card and Enter can
   // open the live draft without reseeding.
   const clientId = EventIdSchema.parse(createObjectIdString());
@@ -46,6 +61,21 @@ export const createTimedDraft = (
   if (activity === "keyboardPlace") {
     focusCalendarEventElement(clientId);
   }
+};
+
+/**
+ * One hour after `start`, clamped to midnight: a draft that crossed into the
+ * next day would render in the all-day row (multi-day timed display), which is
+ * a surprising place for "create an event" to land. Ending exactly at midnight
+ * still counts as inside the day, so the draft stays in the timed grid.
+ */
+export const timedDraftEnd = (start: Dayjs): Dayjs => {
+  const midnightAfterStart = start.add(1, "day").startOf("day");
+  const oneHourEnd = start.add(1, "hour");
+
+  return oneHourEnd.isAfter(midnightAfterStart)
+    ? midnightAfterStart
+    : oneHourEnd;
 };
 
 export const createAlldayDraft = (
@@ -81,18 +111,8 @@ export const getDraftTimes = (isCurrentWeek: boolean, startOfWeek: Dayjs) => {
 
   const fullStart = isCurrentWeek ? now : startOfWeek.hour(now.hour());
   const _start = fullStart.minute(nextMinuteInterval).second(0);
-
-  // Clamp to midnight: a default that crossed into the next day would render
-  // in the all-day row (multi-day timed display), which is a surprising place
-  // for "create an event now" to land. Ending exactly at midnight still
-  // counts as inside the day, so the draft stays in the timed grid.
-  const midnightAfterStart = _start.add(1, "day").startOf("day");
-  const oneHourEnd = _start.add(1, "hour");
-  const _end = oneHourEnd.isAfter(midnightAfterStart)
-    ? midnightAfterStart
-    : oneHourEnd;
   const startDate = _start.format();
-  const endDate = _end.format();
+  const endDate = timedDraftEnd(_start).format();
 
   return { startDate, endDate };
 };

--- a/packages/web/src/common/utils/draft/draft.util.ts
+++ b/packages/web/src/common/utils/draft/draft.util.ts
@@ -83,11 +83,16 @@ export const createAlldayDraft = (
   endOfView: Dayjs,
   activity: "createShortcut",
   calendarId: CalendarId | null = null,
+  /** Day a blocked pointer click picked, which wins over the today-first
+   * default so the draft lands on the day the user actually aimed at. */
+  startAt?: Dayjs,
 ) => {
   const today = dayjs().tz(getEffectiveTimeZone());
-  const start = today.isBetween(startOfView, endOfView, "day", "[]")
-    ? today.startOf("day")
-    : startOfView.startOf("day");
+  const start =
+    startAt?.startOf("day") ??
+    (today.isBetween(startOfView, endOfView, "day", "[]")
+      ? today.startOf("day")
+      : startOfView.startOf("day"));
   // Same stable identity as timed shortcut drafts so save can reuse it as
   // CreateEventInput.id and restore focus to the new card.
   const clientId = EventIdSchema.parse(createObjectIdString());

--- a/packages/web/src/components/PointerHint/PointerHint.test.tsx
+++ b/packages/web/src/components/PointerHint/PointerHint.test.tsx
@@ -179,4 +179,36 @@ describe("PointerHint", () => {
       "Press ] to close the sidebar.",
     );
   });
+
+  it("names the quarter-hour an empty timed-grid click aimed at", () => {
+    render(<PointerHint />);
+
+    act(() => {
+      pointerBlockActions.pulseBlockedClick({
+        actionId: "grid.timed",
+        gridDate: "2026-08-29",
+        gridTimeKey: "1130",
+        gridTimeLabel: "11:30 AM",
+      });
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Press 1130 to create at 11:30 AM.",
+    );
+  });
+
+  it("teaches Shift+C for a click on the all-day row", () => {
+    render(<PointerHint />);
+
+    act(() => {
+      pointerBlockActions.pulseBlockedClick({
+        actionId: "grid.all-day",
+        gridDate: "2026-08-29",
+      });
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Press Shift+C to create an all-day event here.",
+    );
+  });
 });

--- a/packages/web/src/components/PointerHint/PointerHint.tsx
+++ b/packages/web/src/components/PointerHint/PointerHint.tsx
@@ -51,6 +51,8 @@ const isContextualAttempt = (attempt: BlockedPointerAttempt | null) =>
   attempt?.actionId === POINTER_ACTIONS.sidebarClose ||
   attempt?.actionId === POINTER_ACTIONS.sidebarOpen ||
   attempt?.actionId === POINTER_ACTIONS.eventOpen ||
+  attempt?.actionId === "grid.timed" ||
+  attempt?.actionId === "grid.all-day" ||
   Boolean(attempt?.shortcutKey);
 
 const pointerHintMessage = ({
@@ -93,6 +95,23 @@ const pointerHintMessage = ({
       <>
         Press <Key>{eventJumpKey}</Key>, then <Key>Enter</Key> to open this
         event.
+      </>
+    );
+  }
+
+  if (attempt?.actionId === "grid.timed" && attempt.gridTimeKey) {
+    return (
+      <>
+        Press <Key>{attempt.gridTimeKey}</Key> to create at{" "}
+        {attempt.gridTimeLabel ?? attempt.gridTimeKey}.
+      </>
+    );
+  }
+
+  if (attempt?.actionId === "grid.all-day") {
+    return (
+      <>
+        Press <Key>Shift+C</Key> to create an all-day event here.
       </>
     );
   }

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
@@ -613,7 +613,9 @@ describe("ShortcutShowcase", () => {
     render(<ShortcutShowcase />);
 
     expect(currentStepId()).toBe("eventJump");
-    expect(screen.getByRole("heading", { name: "Pick a target" })).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { name: "Pick a target or time" }),
+    ).toBeTruthy();
     expect(
       screen.getByText("Tap the reveal key first, then a letter on an event."),
     ).toBeTruthy();

--- a/packages/web/src/components/ShortcutShowcase/showcase.steps.ts
+++ b/packages/web/src/components/ShortcutShowcase/showcase.steps.ts
@@ -56,11 +56,11 @@ export const SHOWCASE_STEPS = [
   },
   {
     id: "eventJump",
-    title: "Pick a target",
+    title: "Pick a target or time",
     body: [
       "Tap ",
       { key: KEYMAP.eventJump.keycaps[0] },
-      " to show event keys, then press a letter to land on one.",
+      " to show event keys and open times. Type 1130 to create at 11:30.",
     ],
     hint: "Tap the reveal key first, then a letter on an event.",
     keycaps: KEYMAP.eventJump.keycaps,

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
@@ -20,6 +20,11 @@ import {
 } from "@web/grid/shortcuts/edge-focus.store";
 import { KeyboardPlaceIndicator } from "@web/grid/shortcuts/KeyboardPlaceIndicator";
 import { settingsActions } from "@web/settings/settings.store";
+import { QuickTimeIndicator } from "@web/shortcuts/quick-time/QuickTimeIndicator";
+import {
+  selectQuickTimeDigits,
+  useQuickTimeStore,
+} from "@web/shortcuts/quick-time/quick-time.store";
 import { EventJumpIndicator } from "@web/shortcuts/shift-hint/EventJumpIndicator";
 import {
   selectEventJumpActive,
@@ -45,6 +50,7 @@ import { useTimeTravelZone } from "@web/timezone/time-travel.store";
  */
 export const SidebarStatusBar: FC = () => {
   const hint = useShortcutHintContext();
+  const quickTimeDigits = useQuickTimeStore(selectQuickTimeDigits);
   const isEventJump = useEventJumpStore(selectEventJumpActive);
   const eventJumpAnnouncement = useEventJumpStore(selectEventJumpAnnouncement);
   const showEventJump = isEventJump || Boolean(eventJumpAnnouncement);
@@ -83,7 +89,11 @@ export const SidebarStatusBar: FC = () => {
 
   // Highest-priority active indicator wins the bar; the next-shortcut hint
   // is the idle default. Operational status uses the settings button.
-  const indicator = showEventJump ? (
+  // A half-typed time is the most transient state on the bar, and it lapses on
+  // its own in well under a second, so it outranks every mode indicator.
+  const indicator = quickTimeDigits ? (
+    <QuickTimeIndicator />
+  ) : showEventJump ? (
     <EventJumpIndicator />
   ) : showEdgeFocus ? (
     <EdgeFocusIndicator />

--- a/packages/web/src/grid/components/AllDayGridRow.tsx
+++ b/packages/web/src/grid/components/AllDayGridRow.tsx
@@ -102,6 +102,7 @@ export const AllDayGridRow: FC<AllDayRowProps> = ({
                       data-all-day-tint={tintStyle ? "true" : undefined}
                       data-focused-column={isFocusedColumn ? "true" : undefined}
                       data-jump-day={isJumpDay ? "true" : undefined}
+                      data-grid-date={dayKey}
                       aria-label={
                         surfaceLabel ?? date.format("dddd, MMMM D, YYYY")
                       }

--- a/packages/web/src/grid/components/TimedGrid.tsx
+++ b/packages/web/src/grid/components/TimedGrid.tsx
@@ -107,6 +107,7 @@ export const TimedGrid: FC<TimedGridProps> = ({
                       data-all-day-tint={tintStyle ? "true" : undefined}
                       data-focused-column={isFocusedColumn ? "true" : undefined}
                       data-jump-day={isJumpDay ? "true" : undefined}
+                      data-grid-date={dayKey}
                       data-past={date.isBefore(today, "day")}
                       aria-label={
                         surfaceLabel ?? date.format("dddd, MMMM D, YYYY")

--- a/packages/web/src/shortcuts/keyboard-only/pointer-action.test.ts
+++ b/packages/web/src/shortcuts/keyboard-only/pointer-action.test.ts
@@ -1,11 +1,18 @@
+import dayjs from "@core/util/date/dayjs";
+import {
+  ID_GRID_COLUMNS_TIMED,
+  ID_GRID_MAIN,
+} from "@web/common/constants/web.constants";
 import {
   POINTER_ACTION_ATTRIBUTE,
   POINTER_ACTIONS,
   POINTER_EVENT_ID_ATTRIBUTE,
   POINTER_SHORTCUT_ATTRIBUTE,
+  pointerGridIntentFromPointer,
   resolveBlockedPointerAttempt,
   teachingFromBlockedPointer,
 } from "@web/shortcuts/keyboard-only/pointer-action";
+import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 import { describe, expect, it } from "bun:test";
 
 describe("resolveBlockedPointerAttempt", () => {
@@ -82,5 +89,40 @@ describe("teachingFromBlockedPointer", () => {
     expect(teachingFromBlockedPointer([target, document], 2)).toEqual({
       attempt: { actionId: POINTER_ACTIONS.sidebarClose },
     });
+  });
+});
+
+describe("pointerGridIntentFromPointer", () => {
+  it("keeps the exact effective-zone quarter-hour selected by a timed click", () => {
+    const grid = document.createElement("div");
+    grid.id = ID_GRID_MAIN;
+    Object.defineProperty(grid, "scrollHeight", { value: 1440 });
+    grid.getBoundingClientRect = () =>
+      ({ top: 0, left: 0, right: 200, bottom: 400 }) as DOMRect;
+    const columns = document.createElement("div");
+    columns.id = ID_GRID_COLUMNS_TIMED;
+    const column = document.createElement("div");
+    column.dataset.gridDate = "2026-08-29";
+    column.getBoundingClientRect = () =>
+      ({ top: 0, left: 0, right: 200, bottom: 1440 }) as DOMRect;
+    columns.appendChild(column);
+    document.body.append(grid, columns);
+
+    const intent = pointerGridIntentFromPointer(
+      [column, columns, document],
+      100,
+      690,
+    );
+
+    expect(intent).toMatchObject({
+      date: "2026-08-29",
+      kind: "timed",
+      timeKey: "1130",
+    });
+    expect(
+      dayjs(intent?.start).tz(getEffectiveTimeZone()).format("HH:mm"),
+    ).toBe("11:30");
+    grid.remove();
+    columns.remove();
   });
 });

--- a/packages/web/src/shortcuts/keyboard-only/pointer-action.ts
+++ b/packages/web/src/shortcuts/keyboard-only/pointer-action.ts
@@ -1,7 +1,19 @@
+import dayjs from "@core/util/date/dayjs";
+import {
+  ID_ALLDAY_COLUMNS,
+  ID_GRID_COLUMNS_TIMED,
+  ID_GRID_EVENTS_ALLDAY,
+  ID_GRID_EVENTS_TIMED,
+  ID_GRID_MAIN,
+} from "@web/common/constants/web.constants";
+import { GRID_TIME_STEP } from "@web/grid/grid.constants";
+import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
+
 export const POINTER_ACTION_ATTRIBUTE = "data-pointer-action";
 export const POINTER_EVENT_ID_ATTRIBUTE = "data-pointer-event-id";
 export const POINTER_SHORTCUT_ATTRIBUTE = "data-pointer-shortcut";
 export const POINTER_EVENT_JUMP_REQUEST = "compass:pointer-event-jump";
+export const POINTER_GRID_CREATE_REQUEST = "compass:pointer-grid-create";
 
 export const POINTER_ACTIONS = {
   eventOpen: "event.open",
@@ -13,9 +25,12 @@ export type PointerActionId =
   (typeof POINTER_ACTIONS)[keyof typeof POINTER_ACTIONS];
 
 export type BlockedPointerAttempt = {
-  actionId: PointerActionId | "unknown";
+  actionId: PointerActionId | "grid.timed" | "grid.all-day" | "unknown";
   eventId?: string;
   shortcutKey?: string;
+  gridDate?: string;
+  gridTimeKey?: string;
+  gridTimeLabel?: string;
 };
 
 const POINTER_ACTION_IDS = new Set<string>(Object.values(POINTER_ACTIONS));
@@ -94,6 +109,97 @@ export const requestPointerEventJump = (eventId: string) => {
   document.dispatchEvent(
     new CustomEvent(POINTER_EVENT_JUMP_REQUEST, { detail: { eventId } }),
   );
+};
+
+export type PointerGridIntent = {
+  date: string;
+  kind: "all-day" | "timed";
+  /** Exact effective-zone instant selected by the pointer. */
+  start?: string;
+  timeKey?: string;
+  timeLabel?: string;
+};
+
+export const requestPointerGridCreate = (intent: PointerGridIntent) => {
+  document.dispatchEvent(
+    new CustomEvent(POINTER_GRID_CREATE_REQUEST, { detail: intent }),
+  );
+};
+
+export const pointerGridIntent = (event: Event): PointerGridIntent | null => {
+  if (!(event instanceof CustomEvent)) return null;
+  const detail = event.detail;
+  if (
+    !detail ||
+    typeof detail.date !== "string" ||
+    (detail.kind !== "all-day" && detail.kind !== "timed")
+  ) {
+    return null;
+  }
+  return {
+    date: detail.date,
+    kind: detail.kind,
+    ...(typeof detail.timeKey === "string" ? { timeKey: detail.timeKey } : {}),
+    ...(typeof detail.start === "string" ? { start: detail.start } : {}),
+    ...(typeof detail.timeLabel === "string"
+      ? { timeLabel: detail.timeLabel }
+      : {}),
+  };
+};
+
+export const pointerGridIntentFromPointer = (
+  path: EventTarget[],
+  clientX: number,
+  clientY: number,
+): PointerGridIntent | null => {
+  let date: string | undefined;
+  let kind: PointerGridIntent["kind"] | undefined;
+  for (const target of path) {
+    if (!(target instanceof HTMLElement)) continue;
+    date ??= target.dataset.gridDate;
+    if (target.id === ID_ALLDAY_COLUMNS) kind = "all-day";
+    if (target.id === ID_GRID_COLUMNS_TIMED) kind = "timed";
+    if (target.id === ID_GRID_EVENTS_ALLDAY) kind = "all-day";
+    if (target.id === ID_GRID_EVENTS_TIMED) kind = "timed";
+  }
+  if (!kind) return null;
+  if (!date) {
+    const columns = document.getElementById(
+      kind === "all-day" ? ID_ALLDAY_COLUMNS : ID_GRID_COLUMNS_TIMED,
+    );
+    date = [
+      ...(columns?.querySelectorAll<HTMLElement>("[data-grid-date]") ?? []),
+    ].find((column) => {
+      const rect = column.getBoundingClientRect();
+      return clientX >= rect.left && clientX <= rect.right;
+    })?.dataset.gridDate;
+  }
+  if (!date) return null;
+  if (kind === "all-day") return { date, kind };
+
+  const grid = document.getElementById(ID_GRID_MAIN);
+  if (!grid) return null;
+  const rect = grid.getBoundingClientRect();
+  const relative = grid.scrollTop + clientY - rect.top;
+  const rawMinute = (relative / grid.scrollHeight) * 1440;
+  const minute = Math.min(
+    24 * 60 - GRID_TIME_STEP,
+    Math.max(0, Math.round(rawMinute / GRID_TIME_STEP) * GRID_TIME_STEP),
+  );
+  const hour = Math.floor(minute / 60);
+  const minutes = minute % 60;
+  const timeKey = `${String(hour).padStart(2, "0")}${String(minutes).padStart(2, "0")}`;
+  const timeLabel = new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(2000, 0, 1, hour, minutes));
+  const start = dayjs
+    .tz(
+      `${date}T${String(hour).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`,
+      getEffectiveTimeZone(),
+    )
+    .format();
+  return { date, kind, start, timeKey, timeLabel };
 };
 
 export const pointerEventJumpId = (event: Event): string | undefined => {

--- a/packages/web/src/shortcuts/keyboard-only/pointer-block.ts
+++ b/packages/web/src/shortcuts/keyboard-only/pointer-block.ts
@@ -54,6 +54,8 @@ export interface PointerBlockEvent {
   detail?: number;
   button?: number;
   pointerType?: string;
+  clientX?: number;
+  clientY?: number;
   composedPath?(): EventTarget[];
   preventDefault(): void;
   stopPropagation(): void;

--- a/packages/web/src/shortcuts/keyboard-only/usePointerSuppression.ts
+++ b/packages/web/src/shortcuts/keyboard-only/usePointerSuppression.ts
@@ -1,6 +1,9 @@
 import { useEffect } from "react";
 import {
+  type BlockedPointerAttempt,
+  pointerGridIntentFromPointer,
   requestPointerEventJump,
+  requestPointerGridCreate,
   teachingFromBlockedPointer,
 } from "@web/shortcuts/keyboard-only/pointer-action";
 import {
@@ -22,11 +25,34 @@ export function usePointerSuppression() {
   useEffect(() => {
     const { onPointerEvent, onKeyDown } = createPointerBlockListener({
       onBlockedGesture: (event) => {
-        const { attempt, jumpEventId } = teachingFromBlockedPointer(
-          event.composedPath?.() ?? [],
-          event.button ?? 0,
-        );
+        const { attempt: baseAttempt, jumpEventId } =
+          teachingFromBlockedPointer(
+            event.composedPath?.() ?? [],
+            event.button ?? 0,
+          );
+        const gridIntent =
+          baseAttempt.actionId === "unknown"
+            ? pointerGridIntentFromPointer(
+                event.composedPath?.() ?? [],
+                event.clientX ?? 0,
+                event.clientY ?? 0,
+              )
+            : null;
+        const attempt: BlockedPointerAttempt = gridIntent
+          ? {
+              actionId:
+                gridIntent.kind === "timed" ? "grid.timed" : "grid.all-day",
+              gridDate: gridIntent.date,
+              gridTimeKey: gridIntent.timeKey,
+              gridTimeLabel: gridIntent.timeLabel,
+            }
+          : baseAttempt;
         pointerBlockActions.pulseBlockedClick(attempt);
+        if (gridIntent) {
+          eventJumpActions.setActive(false);
+          requestPointerGridCreate(gridIntent);
+          return;
+        }
         if (jumpEventId) {
           // Never let a prior event's assignment flash for a new/locked target.
           eventJumpActions.setPointerHint(null);

--- a/packages/web/src/shortcuts/quick-time/QuickTimeIndicator.tsx
+++ b/packages/web/src/shortcuts/quick-time/QuickTimeIndicator.tsx
@@ -1,0 +1,39 @@
+import { type FC } from "react";
+import {
+  selectQuickTimeDigits,
+  useQuickTimeStore,
+} from "@web/shortcuts/quick-time/quick-time.store";
+import { ShortcutTipParts } from "@web/shortcuts/tips/ShortcutTipParts";
+import { type ShortcutTipPart } from "@web/shortcuts/tips/shortcut-tips.data";
+
+export const quickTimeHintParts = (
+  digits: string,
+): readonly ShortcutTipPart[] => [
+  "New event at ",
+  digits.padEnd(4, "_"),
+  " · ",
+  { key: "Esc" },
+];
+
+/**
+ * Echoes a half-typed start time so `11` is visibly waiting for its minutes
+ * rather than looking like a dropped keystroke. Separate from
+ * EventJumpIndicator because typing a time never requires `h`, and that
+ * indicator only renders while jump mode is on.
+ */
+export const QuickTimeIndicator: FC = () => {
+  const digits = useQuickTimeStore(selectQuickTimeDigits);
+
+  if (!digits) return null;
+
+  return (
+    <span
+      aria-live="polite"
+      className="block w-full text-pretty break-words text-center text-text-muted text-xs leading-5 opacity-80"
+      data-quick-time-indicator=""
+      role="status"
+    >
+      <ShortcutTipParts parts={quickTimeHintParts(digits)} />
+    </span>
+  );
+};

--- a/packages/web/src/shortcuts/quick-time/QuickTimeSlots.test.tsx
+++ b/packages/web/src/shortcuts/quick-time/QuickTimeSlots.test.tsx
@@ -47,30 +47,29 @@ describe("QuickTimeSlots", () => {
   it("stays hidden until event jump reveals the open slots", () => {
     renderSlots();
 
-    expect(document.querySelector("[data-quick-time-slot]")).toBeNull();
+    expect(screen.queryByText("1700")).toBeNull();
   });
 
   it("advertises each open slot's sequence once jump mode is on", () => {
     eventJumpActions.setActive(true);
     renderSlots();
 
-    const slot = document.querySelector("[data-quick-time-slot]");
+    const slot = screen.getByText("1700").closest("[data-quick-time-slot]");
     expect(slot?.getAttribute("data-quick-time-slot")).toBe("1700");
-    expect(screen.getByText("1700")).toBeTruthy();
   });
 
   it("renders nothing when every hour is taken", () => {
     eventJumpActions.setActive(true);
-    renderSlots({ slots: [] });
+    const { container } = renderSlots({ slots: [] });
 
-    expect(document.getElementById("quickTimeSlots")).toBeNull();
+    expect(container.firstChild).toBeNull();
   });
 
   it("is inert decoration the keyboard and pointer cannot reach", () => {
     eventJumpActions.setActive(true);
     renderSlots();
 
-    const slot = document.querySelector("[data-quick-time-slot]");
+    const slot = screen.getByText("1700").closest("[data-quick-time-slot]");
     expect(slot?.getAttribute("aria-hidden")).toBe("true");
     expect(slot?.className).toContain("pointer-events-none");
   });

--- a/packages/web/src/shortcuts/quick-time/QuickTimeSlots.test.tsx
+++ b/packages/web/src/shortcuts/quick-time/QuickTimeSlots.test.tsx
@@ -1,0 +1,77 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import dayjs from "@core/util/date/dayjs";
+import {
+  type GridMeasurements,
+  type GridVisibleDate,
+} from "@web/grid/types/grid.types";
+import { QuickTimeSlots } from "@web/shortcuts/quick-time/QuickTimeSlots";
+import { type QuickTimeSlot } from "@web/shortcuts/quick-time/quick-time.util";
+import { eventJumpActions } from "@web/shortcuts/shift-hint/event-jump.store";
+import { afterEach, describe, expect, it } from "bun:test";
+
+const DAY = dayjs("2026-08-05T00:00:00");
+
+const visibleDates: GridVisibleDate[] = [
+  { date: DAY, key: "2026-08-05" },
+  { date: DAY.add(1, "day"), key: "2026-08-06" },
+];
+
+const measurements = {
+  colWidths: [140, 140],
+  hourHeight: 60,
+} as unknown as GridMeasurements;
+
+const slots: QuickTimeSlot[] = [
+  {
+    start: DAY.hour(17).format(),
+    end: DAY.hour(18).format(),
+    sequence: "1700",
+  },
+];
+
+const renderSlots = (props?: { slots?: QuickTimeSlot[] }) =>
+  render(
+    <QuickTimeSlots
+      measurements={measurements}
+      slots={props?.slots ?? slots}
+      visibleDates={visibleDates}
+    />,
+  );
+
+describe("QuickTimeSlots", () => {
+  afterEach(() => {
+    cleanup();
+    eventJumpActions.reset();
+  });
+
+  it("stays hidden until event jump reveals the open slots", () => {
+    renderSlots();
+
+    expect(document.querySelector("[data-quick-time-slot]")).toBeNull();
+  });
+
+  it("advertises each open slot's sequence once jump mode is on", () => {
+    eventJumpActions.setActive(true);
+    renderSlots();
+
+    const slot = document.querySelector("[data-quick-time-slot]");
+    expect(slot?.getAttribute("data-quick-time-slot")).toBe("1700");
+    expect(screen.getByText("1700")).toBeTruthy();
+  });
+
+  it("renders nothing when every hour is taken", () => {
+    eventJumpActions.setActive(true);
+    renderSlots({ slots: [] });
+
+    expect(document.getElementById("quickTimeSlots")).toBeNull();
+  });
+
+  it("is inert decoration the keyboard and pointer cannot reach", () => {
+    eventJumpActions.setActive(true);
+    renderSlots();
+
+    const slot = document.querySelector("[data-quick-time-slot]");
+    expect(slot?.getAttribute("aria-hidden")).toBe("true");
+    expect(slot?.className).toContain("pointer-events-none");
+  });
+});

--- a/packages/web/src/shortcuts/quick-time/QuickTimeSlots.tsx
+++ b/packages/web/src/shortcuts/quick-time/QuickTimeSlots.tsx
@@ -1,0 +1,89 @@
+import { ZIndex } from "@web/common/constants/web.constants";
+import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
+import { getBusyPeriodPosition } from "@web/grid/layout/event.position";
+import {
+  type EventPosition,
+  type GridMeasurements,
+  type GridVisibleDate,
+} from "@web/grid/types/grid.types";
+import { type QuickTimeSlot } from "@web/shortcuts/quick-time/quick-time.util";
+import {
+  selectEventJumpActive,
+  useEventJumpStore,
+} from "@web/shortcuts/shift-hint/event-jump.store";
+
+const ID_QUICK_TIME_SLOTS = "quickTimeSlots";
+
+interface Props {
+  /** Day view pins every slot to the target calendar's column. */
+  columnIndex?: number;
+  measurements: GridMeasurements;
+  slots: QuickTimeSlot[];
+  visibleDates: GridVisibleDate[];
+}
+
+/**
+ * Placeholder blocks in the open hours of the quick-time target day, shown
+ * while event-jump mode is on so `h` reveals where a typed time would land as
+ * well as where the existing events are.
+ *
+ * Inert decoration in the same sense as BusyPeriodBlock: no handlers, nothing
+ * for the drag/resize engine to grab, and ZIndex.BUSY_PERIOD so it can never
+ * paint over a real card. The chips are aria-hidden because they are a visual
+ * affordance for a keystroke - the jump indicator's live region carries the
+ * spoken story.
+ */
+export const QuickTimeSlots = ({
+  columnIndex,
+  measurements,
+  slots,
+  visibleDates,
+}: Props) => {
+  const isActive = useEventJumpStore(selectEventJumpActive);
+
+  if (!isActive || slots.length === 0) return null;
+
+  return (
+    <div id={ID_QUICK_TIME_SLOTS}>
+      {slots.map((slot) => {
+        const position = getBusyPeriodPosition(slot, {
+          columnIndex,
+          measurements,
+          visibleDates,
+        });
+        if (position.width <= 0 || position.height <= 0) return null;
+
+        return (
+          <QuickTimeSlotBlock
+            key={slot.sequence}
+            position={position}
+            sequence={slot.sequence}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+const QuickTimeSlotBlock = ({
+  position,
+  sequence,
+}: {
+  position: EventPosition;
+  sequence: string;
+}) => (
+  <div
+    aria-hidden
+    className="pointer-events-none absolute flex items-start justify-end overflow-hidden rounded-xs border border-border-strong border-dashed p-0.5"
+    data-quick-time-slot={sequence}
+    style={{
+      height: position.height,
+      left: position.left,
+      top: position.top,
+      width: position.width,
+      zIndex: position.zIndex ?? ZIndex.BUSY_PERIOD,
+    }}
+  >
+    <ShortcutHint>{sequence}</ShortcutHint>
+  </div>
+);

--- a/packages/web/src/shortcuts/quick-time/quick-time.store.ts
+++ b/packages/web/src/shortcuts/quick-time/quick-time.store.ts
@@ -1,0 +1,28 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import { IS_DEV } from "@web/common/constants/env.constants";
+
+export type QuickTimeState = {
+  /** Digits typed toward a start time so far; "" when idle. */
+  digits: string;
+};
+
+export const initialQuickTimeState: QuickTimeState = { digits: "" };
+
+export const useQuickTimeStore = create<QuickTimeState>()(
+  devtools(() => initialQuickTimeState, {
+    name: "compass/quick-time",
+    enabled: IS_DEV,
+  }),
+);
+
+export const quickTimeActions = {
+  setDigits: (digits: string) =>
+    useQuickTimeStore.setState({ digits }, false, { type: "setDigits" }),
+  clear: () => {
+    if (useQuickTimeStore.getState().digits === "") return;
+    useQuickTimeStore.setState(initialQuickTimeState, false, { type: "clear" });
+  },
+};
+
+export const selectQuickTimeDigits = (state: QuickTimeState) => state.digits;

--- a/packages/web/src/shortcuts/quick-time/quick-time.util.test.ts
+++ b/packages/web/src/shortcuts/quick-time/quick-time.util.test.ts
@@ -1,0 +1,153 @@
+import dayjs from "@core/util/date/dayjs";
+import {
+  buildQuickTimeSlots,
+  canQuickTimeBufferGrow,
+  quickTimeSequenceForHour,
+  quickTimeTargetDay,
+  resolveQuickTimeStart,
+} from "@web/shortcuts/quick-time/quick-time.util";
+import { describe, expect, it } from "bun:test";
+
+const DAY = dayjs("2026-08-05T00:00:00");
+const at = (time: string) => dayjs(`2026-08-05T${time}`);
+const resolve = (digits: string, now: string) =>
+  resolveQuickTimeStart(digits, at(now), DAY)?.format("HH:mm") ?? null;
+
+describe("resolveQuickTimeStart", () => {
+  it("reads a four-digit time on the morning side of the clock", () => {
+    expect(resolve("1130", "09:00")).toBe("11:30");
+  });
+
+  it("inherits the evening meridiem from the current time", () => {
+    expect(resolve("1130", "21:00")).toBe("23:30");
+  });
+
+  it("takes a 24-hour hour literally, whatever the time of day", () => {
+    expect(resolve("1700", "09:00")).toBe("17:00");
+    expect(resolve("1700", "21:00")).toBe("17:00");
+  });
+
+  it("expands one and two digits to the top of the hour", () => {
+    expect(resolve("9", "08:00")).toBe("09:00");
+    expect(resolve("11", "08:00")).toBe("11:00");
+  });
+
+  it("lands on the target day, not today", () => {
+    const start = resolveQuickTimeStart(
+      "1700",
+      at("09:00"),
+      dayjs("2026-08-09T00:00:00"),
+    );
+
+    expect(start?.format("YYYY-MM-DD HH:mm")).toBe("2026-08-09 17:00");
+  });
+
+  it("rejects sequences that are not a clock time", () => {
+    expect(resolve("99", "09:00")).toBeNull();
+    expect(resolve("2599", "09:00")).toBeNull();
+    expect(resolve("", "09:00")).toBeNull();
+    expect(resolve("11305", "09:00")).toBeNull();
+  });
+});
+
+describe("canQuickTimeBufferGrow", () => {
+  it("stops at four digits, where the buffer commits on its own", () => {
+    expect(canQuickTimeBufferGrow("113")).toBe(true);
+    expect(canQuickTimeBufferGrow("1130")).toBe(false);
+  });
+});
+
+describe("quickTimeSequenceForHour", () => {
+  it("advertises the 24-hour sequence for a reachable hour", () => {
+    expect(quickTimeSequenceForHour(17, at("09:00"), DAY)).toBe("1700");
+    expect(quickTimeSequenceForHour(9, at("09:00"), DAY)).toBe("0900");
+  });
+
+  it("declines an hour no digits can reach from now", () => {
+    // In the evening, meridiem inheritance pulls "0900" to 9 PM, so the
+    // morning hour has no sequence of its own.
+    expect(quickTimeSequenceForHour(9, at("21:00"), DAY)).toBeNull();
+  });
+});
+
+describe("quickTimeTargetDay", () => {
+  const startOfView = dayjs("2026-08-02T00:00:00");
+  const endOfView = dayjs("2026-08-08T23:59:59");
+
+  it("uses today when the view contains it", () => {
+    const now = dayjs("2026-08-05T09:00:00");
+
+    expect(
+      quickTimeTargetDay(startOfView, endOfView, now).format("YYYY-MM-DD"),
+    ).toBe("2026-08-05");
+  });
+
+  it("falls back to the first visible day on another week", () => {
+    const now = dayjs("2026-09-20T09:00:00");
+
+    expect(
+      quickTimeTargetDay(startOfView, endOfView, now).format("YYYY-MM-DD"),
+    ).toBe("2026-08-02");
+  });
+});
+
+describe("buildQuickTimeSlots", () => {
+  const now = at("00:30");
+
+  it("offers every open hour of the target day", () => {
+    const slots = buildQuickTimeSlots({ busy: [], now, targetDay: DAY });
+    const sequences = slots.map((slot) => slot.sequence);
+
+    expect(sequences[0]).toBe("0000");
+    expect(sequences.at(-1)).toBe("2300");
+    expect(sequences).toContain("0900");
+    expect(sequences).toContain("1700");
+  });
+
+  it("skips noon in the morning, which no sequence reaches", () => {
+    // parseUserTime reads "1200" as 12 AM while the current time is AM (the
+    // event form's time field behaves the same way), so noon has no sequence
+    // of its own before midday and gets no chip rather than a lying one.
+    const morning = buildQuickTimeSlots({ busy: [], now, targetDay: DAY });
+    const afternoon = buildQuickTimeSlots({
+      busy: [],
+      now: at("13:00"),
+      targetDay: DAY,
+    });
+
+    expect(morning.map((slot) => slot.sequence)).not.toContain("1200");
+    expect(afternoon.map((slot) => slot.sequence)).toContain("1200");
+  });
+
+  it("drops the hours an event already covers", () => {
+    const slots = buildQuickTimeSlots({
+      busy: [
+        {
+          startMs: at("09:30").valueOf(),
+          endMs: at("10:15").valueOf(),
+        },
+      ],
+      now,
+      targetDay: DAY,
+    });
+
+    const sequences = slots.map((slot) => slot.sequence);
+    expect(sequences).not.toContain("0900");
+    expect(sequences).not.toContain("1000");
+    expect(sequences).toContain("0800");
+    expect(sequences).toContain("1100");
+  });
+
+  it("keeps an hour an event only touches at the boundary", () => {
+    const slots = buildQuickTimeSlots({
+      busy: [{ startMs: at("10:00").valueOf(), endMs: at("11:00").valueOf() }],
+      now,
+      targetDay: DAY,
+    });
+
+    const sequences = slots.map((slot) => slot.sequence);
+    expect(sequences).toContain("0900");
+    expect(sequences).not.toContain("1000");
+    expect(sequences).toContain("1100");
+  });
+});

--- a/packages/web/src/shortcuts/quick-time/quick-time.util.ts
+++ b/packages/web/src/shortcuts/quick-time/quick-time.util.ts
@@ -1,0 +1,122 @@
+import { type Dayjs } from "@core/util/date/dayjs";
+import {
+  getDayjsByTimeValue,
+  getTimeOptionByValue,
+  parseUserTime,
+} from "@web/common/utils/datetime/web.date.util";
+
+/** Longest sequence a typed time can be: HHMM. */
+export const QUICK_TIME_MAX_DIGITS = 4;
+
+const DIGITS_ONLY = /^\d{1,4}$/;
+
+export const isQuickTimeDigit = (key: string) => /^\d$/.test(key);
+
+/** False once the buffer is HHMM, which is when it can commit immediately. */
+export const canQuickTimeBufferGrow = (digits: string) =>
+  digits.length < QUICK_TIME_MAX_DIGITS;
+
+/**
+ * Resolve a typed digit sequence to a start time on `targetDay`.
+ *
+ * The 12-hour ambiguity ("1130" at 9am vs 9pm) is settled by `parseUserTime`'s
+ * meridiem inheritance: passing `now` as its current value shifts an hour in
+ * 1-12 into PM when now is PM, and leaves 13-23 ("1700") alone. Reusing it
+ * keeps a typed time on the grid identical to the same digits typed into the
+ * event form's time field, warts included - notably that "1200" typed in the
+ * morning resolves to 12 AM, not noon (see quickTimeSequenceForHour, which
+ * declines to advertise a sequence that would not land where its chip says).
+ */
+export function resolveQuickTimeStart(
+  digits: string,
+  now: Dayjs,
+  targetDay: Dayjs,
+): Dayjs | null {
+  if (!DIGITS_ONLY.test(digits)) return null;
+
+  const parsed = parseUserTime(digits, getTimeOptionByValue(now).value);
+  if (!parsed) return null;
+
+  const time = getDayjsByTimeValue(parsed.value);
+  if (!time.isValid()) return null;
+
+  return targetDay.startOf("day").hour(time.hour()).minute(time.minute());
+}
+
+/**
+ * The sequence a slot chip advertises for `hour`, or null when no digits-only
+ * sequence reaches that hour from `now`.
+ *
+ * Round-tripping the 24-hour form through `resolveQuickTimeStart` is what makes
+ * that guarantee: in the evening, meridiem inheritance pulls "0900" to 9 PM, so
+ * the morning slots (already past) simply get no chip rather than one that
+ * lands somewhere else.
+ */
+export function quickTimeSequenceForHour(
+  hour: number,
+  now: Dayjs,
+  targetDay: Dayjs,
+): string | null {
+  const sequence = `${String(hour).padStart(2, "0")}00`;
+  const resolved = resolveQuickTimeStart(sequence, now, targetDay);
+
+  return resolved?.hour() === hour ? sequence : null;
+}
+
+/**
+ * The day a typed time lands on: today when the view contains it, else the
+ * first day of the view. Mirrors createAlldayDraft's fallback so "create an
+ * event" means the same day whichever gesture started it.
+ */
+export const quickTimeTargetDay = (
+  startOfView: Dayjs,
+  endOfView: Dayjs,
+  now: Dayjs,
+): Dayjs =>
+  now.isBetween(startOfView, endOfView, "day", "[]")
+    ? now.startOf("day")
+    : startOfView.startOf("day");
+
+export type QuickTimeSlot = {
+  /** Offset-formatted, so getBusyPeriodPosition can place it like any segment. */
+  start: string;
+  end: string;
+  /** Digits the chip advertises, and that create this slot when typed. */
+  sequence: string;
+};
+
+/**
+ * One placeholder per open hour of `targetDay`: hours already covered by an
+ * event are dropped so chips never pile onto a card, and hours with no
+ * reachable sequence are dropped by quickTimeSequenceForHour.
+ */
+export function buildQuickTimeSlots({
+  busy,
+  now,
+  targetDay,
+}: {
+  busy: readonly { startMs: number; endMs: number }[];
+  now: Dayjs;
+  targetDay: Dayjs;
+}): QuickTimeSlot[] {
+  const day = targetDay.startOf("day");
+  const slots: QuickTimeSlot[] = [];
+
+  for (let hour = 0; hour < 24; hour += 1) {
+    const sequence = quickTimeSequenceForHour(hour, now, day);
+    if (!sequence) continue;
+
+    const start = day.hour(hour);
+    const end = start.add(1, "hour");
+    const startMs = start.valueOf();
+    const endMs = end.valueOf();
+    const isTaken = busy.some(
+      (period) => period.startMs < endMs && period.endMs > startMs,
+    );
+    if (isTaken) continue;
+
+    slots.push({ start: start.format(), end: end.format(), sequence });
+  }
+
+  return slots;
+}

--- a/packages/web/src/shortcuts/quick-time/quick-time.util.ts
+++ b/packages/web/src/shortcuts/quick-time/quick-time.util.ts
@@ -10,8 +10,6 @@ export const QUICK_TIME_MAX_DIGITS = 4;
 
 const DIGITS_ONLY = /^\d{1,4}$/;
 
-export const isQuickTimeDigit = (key: string) => /^\d$/.test(key);
-
 /** False once the buffer is HHMM, which is when it can commit immediately. */
 export const canQuickTimeBufferGrow = (digits: string) =>
   digits.length < QUICK_TIME_MAX_DIGITS;

--- a/packages/web/src/shortcuts/quick-time/useQuickTimeCreate.test.tsx
+++ b/packages/web/src/shortcuts/quick-time/useQuickTimeCreate.test.tsx
@@ -11,6 +11,10 @@ import {
 } from "@web/shortcuts/quick-time/quick-time.store";
 import { useQuickTimeCreate } from "@web/shortcuts/quick-time/useQuickTimeCreate";
 import { DIGIT_AMBIGUOUS_COMMIT_MS } from "@web/shortcuts/shift-hint/assign-shift-hint-keys";
+import {
+  eventJumpActions,
+  useEventJumpStore,
+} from "@web/shortcuts/shift-hint/event-jump.store";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const TARGET_DAY = dayjs().startOf("day");
@@ -176,6 +180,7 @@ describe("useQuickTimeCreate deferred commit", () => {
   afterEach(() => {
     cleanup();
     quickTimeActions.clear();
+    eventJumpActions.setPointerDraftIntent(null);
   });
 
   it("commits a still-growable sequence once the window lapses", async () => {
@@ -192,5 +197,41 @@ describe("useQuickTimeCreate deferred commit", () => {
     );
 
     expect(startedAt(createAt)).toBe("00:00");
+  });
+
+  describe("with an empty-grid click parked", () => {
+    const CLICKED_DAY = TARGET_DAY.add(2, "day");
+
+    const parkIntent = (timeKey: string, hour: number) =>
+      eventJumpActions.setPointerDraftIntent({
+        date: CLICKED_DAY.format("YYYY-MM-DD"),
+        start: CLICKED_DAY.hour(hour).minute(30).format(),
+        timeKey,
+      });
+
+    it("lands on the clicked instant, not a re-resolved one", () => {
+      // 1130 clicked in the evening parks 23:30. Re-resolving those digits
+      // could pick the morning instead, moving the draft off the slot the
+      // hint pointed at.
+      parkIntent("1130", 23);
+      const { createAt, type } = mountConsumer();
+
+      type(["1", "1", "3", "0"]);
+
+      expect(startedAt(createAt)).toBe("23:30");
+      expect(useEventJumpStore.getState().pointerDraftDateKey).toBeNull();
+    });
+
+    it("retargets a different sequence to the clicked day", () => {
+      parkIntent("1130", 23);
+      const { createAt, type } = mountConsumer();
+
+      type(["1", "7", "0", "0"]);
+
+      const start = createAt.mock.calls[0]?.[0] as Dayjs;
+      expect(start.format("YYYY-MM-DD HH:mm")).toBe(
+        `${CLICKED_DAY.format("YYYY-MM-DD")} 17:00`,
+      );
+    });
   });
 });

--- a/packages/web/src/shortcuts/quick-time/useQuickTimeCreate.test.tsx
+++ b/packages/web/src/shortcuts/quick-time/useQuickTimeCreate.test.tsx
@@ -1,0 +1,196 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+import { clearAppLockReasons, setAppLockReason } from "@web/shortcuts/app-lock";
+import {
+  clearFloatingLayerReasons,
+  setFloatingLayerReason,
+} from "@web/shortcuts/floating-layer";
+import {
+  quickTimeActions,
+  useQuickTimeStore,
+} from "@web/shortcuts/quick-time/quick-time.store";
+import { useQuickTimeCreate } from "@web/shortcuts/quick-time/useQuickTimeCreate";
+import { DIGIT_AMBIGUOUS_COMMIT_MS } from "@web/shortcuts/shift-hint/assign-shift-hint-keys";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+const TARGET_DAY = dayjs().startOf("day");
+
+const keydown = (key: string, init: KeyboardEventInit = {}) =>
+  new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    key,
+    ...init,
+  });
+
+/** Digits are matched by physical code, so a digit press must carry one. */
+const digit = (value: string) => keydown(value, { code: `Digit${value}` });
+
+const mountConsumer = () => {
+  const createAt = mock((_start: Dayjs) => {});
+  const { result } = renderHook(() =>
+    useQuickTimeCreate({
+      createAt: (start) => createAt(start),
+      getTargetDay: () => TARGET_DAY,
+    }),
+  );
+
+  const type = (keys: string[]) =>
+    act(() => {
+      for (const key of keys) result.current.tryConsumeKey(digit(key));
+    });
+
+  return { createAt, result, type };
+};
+
+const startedAt = (createAt: ReturnType<typeof mock>) =>
+  (createAt.mock.calls[0]?.[0] as Dayjs | undefined)?.format("HH:mm") ?? null;
+
+describe("useQuickTimeCreate", () => {
+  beforeEach(() => {
+    clearAppLockReasons();
+    clearFloatingLayerReasons();
+    quickTimeActions.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    clearAppLockReasons();
+    clearFloatingLayerReasons();
+    quickTimeActions.clear();
+  });
+
+  it("creates on the fourth digit, which cannot grow further", () => {
+    const { createAt, type } = mountConsumer();
+
+    type(["1", "7", "0", "0"]);
+
+    expect(createAt).toHaveBeenCalledTimes(1);
+    expect(startedAt(createAt)).toBe("17:00");
+    expect(useQuickTimeStore.getState().digits).toBe("");
+  });
+
+  it("consumes each digit so it reaches no other handler", () => {
+    const { result } = mountConsumer();
+
+    act(() => {
+      expect(result.current.tryConsumeKey(digit("1"))).toBe(true);
+    });
+    expect(useQuickTimeStore.getState().digits).toBe("1");
+  });
+
+  it("commits a short sequence on Enter without waiting", () => {
+    const { createAt, result, type } = mountConsumer();
+
+    type(["1", "7"]);
+    act(() => {
+      expect(result.current.tryConsumeKey(keydown("Enter"))).toBe(true);
+    });
+
+    expect(startedAt(createAt)).toBe("17:00");
+  });
+
+  it("abandons the sequence on Escape", () => {
+    const { createAt, result, type } = mountConsumer();
+
+    type(["1", "7"]);
+    act(() => {
+      expect(result.current.tryConsumeKey(keydown("Escape"))).toBe(true);
+    });
+
+    expect(createAt).not.toHaveBeenCalled();
+    expect(useQuickTimeStore.getState().digits).toBe("");
+  });
+
+  it("leaves Escape alone when nothing is buffered, so jump mode still exits", () => {
+    const { result } = mountConsumer();
+
+    act(() => {
+      expect(result.current.tryConsumeKey(keydown("Escape"))).toBe(false);
+    });
+  });
+
+  it("lets another command run after abandoning a half-typed time", () => {
+    const { createAt, result, type } = mountConsumer();
+
+    type(["1", "1"]);
+    act(() => {
+      expect(result.current.tryConsumeKey(keydown("h"))).toBe(false);
+    });
+
+    expect(createAt).not.toHaveBeenCalled();
+    expect(useQuickTimeStore.getState().digits).toBe("");
+  });
+
+  it("ignores a bare Shift so shifted digit layouts still buffer", () => {
+    const { result, type } = mountConsumer();
+
+    type(["1"]);
+    act(() => {
+      expect(
+        result.current.tryConsumeKey(keydown("Shift", { shiftKey: true })),
+      ).toBe(false);
+    });
+
+    expect(useQuickTimeStore.getState().digits).toBe("1");
+  });
+
+  it("stands down while the app is locked", () => {
+    const { result } = mountConsumer();
+
+    setAppLockReason("commandPalette", true);
+    act(() => {
+      expect(result.current.tryConsumeKey(digit("1"))).toBe(false);
+    });
+
+    expect(useQuickTimeStore.getState().digits).toBe("");
+  });
+
+  it("stands down while a floating layer owns the keyboard", () => {
+    const { result } = mountConsumer();
+
+    setFloatingLayerReason("contextMenu", true);
+    act(() => {
+      expect(result.current.tryConsumeKey(digit("1"))).toBe(false);
+    });
+
+    expect(useQuickTimeStore.getState().digits).toBe("");
+  });
+
+  it("ignores a Mod chord, which belongs to page jump", () => {
+    const { result } = mountConsumer();
+
+    act(() => {
+      expect(
+        result.current.tryConsumeKey(
+          keydown("1", { code: "Digit1", metaKey: true }),
+        ),
+      ).toBe(false);
+    });
+
+    expect(useQuickTimeStore.getState().digits).toBe("");
+  });
+});
+
+describe("useQuickTimeCreate deferred commit", () => {
+  afterEach(() => {
+    cleanup();
+    quickTimeActions.clear();
+  });
+
+  it("commits a still-growable sequence once the window lapses", async () => {
+    const { createAt, type } = mountConsumer();
+
+    type(["0"]);
+    expect(createAt).not.toHaveBeenCalled();
+
+    await act(
+      () =>
+        new Promise<void>((resolve) => {
+          setTimeout(resolve, DIGIT_AMBIGUOUS_COMMIT_MS + 50);
+        }),
+    );
+
+    expect(startedAt(createAt)).toBe("00:00");
+  });
+});

--- a/packages/web/src/shortcuts/quick-time/useQuickTimeCreate.ts
+++ b/packages/web/src/shortcuts/quick-time/useQuickTimeCreate.ts
@@ -1,0 +1,155 @@
+import { useCallback, useEffect, useRef } from "react";
+import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
+import { isEventFormOpen } from "@web/events/stores/draft.store";
+import { isAppLocked } from "@web/shortcuts/app-lock";
+import {
+  digitPickIndex,
+  PICK_KEY_LABELS,
+} from "@web/shortcuts/digit-pick.util";
+import { isFloatingLayerOpen } from "@web/shortcuts/floating-layer";
+import { quickTimeActions } from "@web/shortcuts/quick-time/quick-time.store";
+import {
+  canQuickTimeBufferGrow,
+  resolveQuickTimeStart,
+} from "@web/shortcuts/quick-time/quick-time.util";
+import { DIGIT_AMBIGUOUS_COMMIT_MS } from "@web/shortcuts/shift-hint/assign-shift-hint-keys";
+import { eventJumpActions } from "@web/shortcuts/shift-hint/event-jump.store";
+import { isEditSequenceArmed } from "@web/shortcuts/useEditSequenceShortcut";
+import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
+
+/** Digit keys only: PICK_KEY_LABELS' last two entries are "-" and "=". */
+const DIGIT_PICK_COUNT = 10;
+
+const MODIFIER_KEYS = new Set(["Alt", "Control", "Meta", "Shift"]);
+
+export type QuickTimeConsumer = {
+  /** True when the key was consumed and must not reach another handler. */
+  tryConsumeKey: (event: KeyboardEvent) => boolean;
+};
+
+/**
+ * Buffers a typed digit sequence ("1130") and creates a timed draft at that
+ * time on `getTargetDay()`.
+ *
+ * The keystrokes arrive from useShiftHoldEventHints' capture listener rather
+ * than a second document listener of our own: both features read bare digits,
+ * and one listener with an explicit precedence rule beats two whose order
+ * depends on React mount order. This hook lives with the view owner instead,
+ * because that is the only place that knows which day a draft should land on.
+ *
+ * Commit timing mirrors the event-jump digit buffer (DIGIT_AMBIGUOUS_COMMIT_MS)
+ * so the two feel the same: "1130" commits on the 4th digit, "9" commits once
+ * the window lapses, Enter commits now, Escape abandons.
+ */
+export function useQuickTimeCreate({
+  createAt,
+  getTargetDay,
+}: {
+  createAt: (start: Dayjs) => void;
+  getTargetDay: () => Dayjs;
+}): QuickTimeConsumer {
+  const digitsRef = useRef("");
+  const commitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const createAtRef = useRef(createAt);
+  const getTargetDayRef = useRef(getTargetDay);
+
+  createAtRef.current = createAt;
+  getTargetDayRef.current = getTargetDay;
+
+  const clearCommitTimer = useCallback(() => {
+    if (commitTimerRef.current === null) return;
+    clearTimeout(commitTimerRef.current);
+    commitTimerRef.current = null;
+  }, []);
+
+  const reset = useCallback(() => {
+    clearCommitTimer();
+    digitsRef.current = "";
+    quickTimeActions.clear();
+  }, [clearCommitTimer]);
+
+  const commit = useCallback(() => {
+    const digits = digitsRef.current;
+    reset();
+    if (!digits) return;
+
+    const now = dayjs().tz(getEffectiveTimeZone());
+    const start = resolveQuickTimeStart(digits, now, getTargetDayRef.current());
+    if (!start) return;
+
+    // The slot placeholders have answered their question, and leaving them up
+    // would strew chips across the draft that just arrived. Dropped before the
+    // create so both land in one commit rather than flashing chips over it.
+    eventJumpActions.setActive(false);
+    createAtRef.current(start);
+  }, [reset]);
+
+  useEffect(() => reset, [reset]);
+
+  const tryConsumeKey = useCallback(
+    (event: KeyboardEvent): boolean => {
+      // A bare Shift keydown precedes every digit on layouts where the top row
+      // is shifted, so it must never count as abandoning the buffer.
+      if (MODIFIER_KEYS.has(event.key)) return false;
+
+      // isEditableKeyboardTarget misses role-less buttons (the closed
+      // CalendarSelect trigger) and the context menu's color row, so the form
+      // and floating-layer checks carry those. isEditSequenceArmed yields to a
+      // half-typed `e`… sequence, which disarms only on keys it sees itself.
+      if (
+        isAppLocked() ||
+        isEditableKeyboardTarget(event) ||
+        isEventFormOpen() ||
+        isFloatingLayerOpen() ||
+        isEditSequenceArmed()
+      ) {
+        reset();
+        return false;
+      }
+
+      const buffered = digitsRef.current !== "";
+
+      if (event.key === "Escape") {
+        if (!buffered) return false;
+        reset();
+        return true;
+      }
+
+      if (event.key === "Enter") {
+        if (!buffered) return false;
+        commit();
+        return true;
+      }
+
+      const pickIndex = digitPickIndex(event);
+      if (pickIndex === null || pickIndex >= DIGIT_PICK_COUNT) {
+        // Anything else abandons a half-typed time but still runs its own
+        // command, so `11` then `h` still toggles event jump.
+        if (buffered) reset();
+        return false;
+      }
+
+      const next = `${digitsRef.current}${PICK_KEY_LABELS[pickIndex]}`;
+      digitsRef.current = next;
+      quickTimeActions.setDigits(next);
+
+      if (!canQuickTimeBufferGrow(next)) {
+        commit();
+        return true;
+      }
+
+      clearCommitTimer();
+      commitTimerRef.current = setTimeout(() => {
+        commitTimerRef.current = null;
+        if (digitsRef.current !== next) return;
+        commit();
+      }, DIGIT_AMBIGUOUS_COMMIT_MS);
+
+      return true;
+    },
+    [clearCommitTimer, commit, reset],
+  );
+
+  return { tryConsumeKey };
+}

--- a/packages/web/src/shortcuts/quick-time/useQuickTimeCreate.ts
+++ b/packages/web/src/shortcuts/quick-time/useQuickTimeCreate.ts
@@ -14,7 +14,10 @@ import {
   resolveQuickTimeStart,
 } from "@web/shortcuts/quick-time/quick-time.util";
 import { DIGIT_AMBIGUOUS_COMMIT_MS } from "@web/shortcuts/shift-hint/assign-shift-hint-keys";
-import { eventJumpActions } from "@web/shortcuts/shift-hint/event-jump.store";
+import {
+  eventJumpActions,
+  useEventJumpStore,
+} from "@web/shortcuts/shift-hint/event-jump.store";
 import { isEditSequenceArmed } from "@web/shortcuts/useEditSequenceShortcut";
 import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 
@@ -26,6 +29,29 @@ const MODIFIER_KEYS = new Set(["Alt", "Control", "Meta", "Shift"]);
 export type QuickTimeConsumer = {
   /** True when the key was consumed and must not reach another handler. */
   tryConsumeKey: (event: KeyboardEvent) => boolean;
+};
+
+/**
+ * A blocked empty-grid click parks the exact instant it aimed at, and
+ * PointerHint teaches that instant's own digits. Typing them back must land
+ * there exactly - resolving them again could pick the other meridiem and move
+ * the draft off the slot the user clicked.
+ */
+const pointerDraftStart = (digits: string): Dayjs | null => {
+  const { pointerDraftStart: start, pointerDraftTimeKey } =
+    useEventJumpStore.getState();
+  if (!start || pointerDraftTimeKey !== digits) return null;
+
+  return dayjs(start).tz(getEffectiveTimeZone());
+};
+
+/** A click on another day retargets the sequence to that day. */
+const pointerDraftDay = (): Dayjs | null => {
+  const { pointerDraftDateKey } = useEventJumpStore.getState();
+
+  return pointerDraftDateKey
+    ? dayjs(pointerDraftDateKey).tz(getEffectiveTimeZone(), true)
+    : null;
 };
 
 /**
@@ -75,8 +101,16 @@ export function useQuickTimeCreate({
     if (!digits) return;
 
     const now = dayjs().tz(getEffectiveTimeZone());
-    const start = resolveQuickTimeStart(digits, now, getTargetDayRef.current());
+    const start =
+      pointerDraftStart(digits) ??
+      resolveQuickTimeStart(
+        digits,
+        now,
+        pointerDraftDay() ?? getTargetDayRef.current(),
+      );
     if (!start) return;
+
+    eventJumpActions.setPointerDraftIntent(null);
 
     // The slot placeholders have answered their question, and leaving them up
     // would strew chips across the draft that just arrived. Dropped before the

--- a/packages/web/src/shortcuts/shift-hint/assign-shift-hint-keys.test.ts
+++ b/packages/web/src/shortcuts/shift-hint/assign-shift-hint-keys.test.ts
@@ -11,32 +11,29 @@ import { describe, expect, it } from "bun:test";
 
 describe("assignDayJumpKeys", () => {
   it("assigns weekday prefixes and per-day indices chronologically", () => {
-    const assignments = assignDayJumpKeys(
-      [
-        {
-          eventId: "wed-2",
-          startMs: 200,
-          eventType: "timed",
-          dayKey: "2026-08-05",
-          weekday: 3,
-        },
-        {
-          eventId: "wed-1",
-          startMs: 100,
-          eventType: "timed",
-          dayKey: "2026-08-05",
-          weekday: 3,
-        },
-        {
-          eventId: "mon-1",
-          startMs: 50,
-          eventType: "timed",
-          dayKey: "2026-08-03",
-          weekday: 1,
-        },
-      ],
-      "week",
-    );
+    const assignments = assignDayJumpKeys([
+      {
+        eventId: "wed-2",
+        startMs: 200,
+        eventType: "timed",
+        dayKey: "2026-08-05",
+        weekday: 3,
+      },
+      {
+        eventId: "wed-1",
+        startMs: 100,
+        eventType: "timed",
+        dayKey: "2026-08-05",
+        weekday: 3,
+      },
+      {
+        eventId: "mon-1",
+        startMs: 50,
+        eventType: "timed",
+        dayKey: "2026-08-03",
+        weekday: 1,
+      },
+    ]);
 
     expect(assignments).toEqual([
       {
@@ -74,56 +71,50 @@ describe("assignDayJumpKeys", () => {
     expect(dayNameForPrefix("w")).toBe("Wednesday");
     expect(dayNameForPrefix("unknown")).toBe("unknown");
 
-    const assignments = assignDayJumpKeys(
-      [
-        {
-          eventId: "sun",
-          startMs: 1,
-          eventType: "timed",
-          dayKey: "2026-08-02",
-          weekday: 0,
-        },
-        {
-          eventId: "sat",
-          startMs: 1,
-          eventType: "timed",
-          dayKey: "2026-08-08",
-          weekday: 6,
-        },
-        {
-          eventId: "fri-10",
-          startMs: 10,
-          eventType: "timed",
-          dayKey: "2026-08-07",
-          weekday: 5,
-        },
-      ],
-      "week",
-    );
+    const assignments = assignDayJumpKeys([
+      {
+        eventId: "sun",
+        startMs: 1,
+        eventType: "timed",
+        dayKey: "2026-08-02",
+        weekday: 0,
+      },
+      {
+        eventId: "sat",
+        startMs: 1,
+        eventType: "timed",
+        dayKey: "2026-08-08",
+        weekday: 6,
+      },
+      {
+        eventId: "fri-10",
+        startMs: 10,
+        eventType: "timed",
+        dayKey: "2026-08-07",
+        weekday: 5,
+      },
+    ]);
 
     expect(assignments.map((item) => item.hint)).toEqual(["su1", "f1", "sa1"]);
   });
 
   it("prefers all-day before timed on equal start within a day", () => {
-    const assignments = assignDayJumpKeys(
-      [
-        {
-          eventId: "timed",
-          startMs: 100,
-          eventType: "timed",
-          dayKey: "2026-08-03",
-          weekday: 1,
-        },
-        {
-          eventId: "allday",
-          startMs: 100,
-          eventType: "all-day",
-          dayKey: "2026-08-03",
-          weekday: 1,
-        },
-      ],
-      "week",
-    );
+    const assignments = assignDayJumpKeys([
+      {
+        eventId: "timed",
+        startMs: 100,
+        eventType: "timed",
+        dayKey: "2026-08-03",
+        weekday: 1,
+      },
+      {
+        eventId: "allday",
+        startMs: 100,
+        eventType: "all-day",
+        dayKey: "2026-08-03",
+        weekday: 1,
+      },
+    ]);
     expect(assignments.map((item) => item.hint)).toEqual(["m1", "m2"]);
     expect(assignments.map((item) => item.eventId)).toEqual([
       "allday",
@@ -131,39 +122,36 @@ describe("assignDayJumpKeys", () => {
     ]);
   });
 
-  it("uses bare numeric hints in day mode", () => {
-    const assignments = assignDayJumpKeys(
-      [
-        {
-          eventId: "b",
-          startMs: 200,
-          eventType: "timed",
-          dayKey: "2026-08-05",
-          weekday: 3,
-        },
-        {
-          eventId: "a",
-          startMs: 100,
-          eventType: "timed",
-          dayKey: "2026-08-05",
-          weekday: 3,
-        },
-      ],
-      "day",
-    );
+  it("labels a single day's events with that weekday's prefix", () => {
+    const assignments = assignDayJumpKeys([
+      {
+        eventId: "b",
+        startMs: 200,
+        eventType: "timed",
+        dayKey: "2026-08-05",
+        weekday: 3,
+      },
+      {
+        eventId: "a",
+        startMs: 100,
+        eventType: "timed",
+        dayKey: "2026-08-05",
+        weekday: 3,
+      },
+    ]);
     expect(assignments).toEqual([
       {
         eventId: "a",
-        hint: "1",
+        hint: "w1",
         dayKey: "2026-08-05",
-        dayPrefix: "",
+        dayPrefix: "w",
         index: 1,
       },
       {
         eventId: "b",
-        hint: "2",
+        hint: "w2",
         dayKey: "2026-08-05",
-        dayPrefix: "",
+        dayPrefix: "w",
         index: 2,
       },
     ]);
@@ -177,66 +165,63 @@ describe("assignDayJumpKeys", () => {
       dayKey: "2026-08-07",
       weekday: 5,
     }));
-    const assignments = assignDayJumpKeys(targets, "week");
+    const assignments = assignDayJumpKeys(targets);
     expect(assignments[9]?.hint).toBe("f10");
   });
 });
 
 describe("matchDayJumpKeystroke", () => {
-  const weekAssignments = assignDayJumpKeys(
-    [
-      {
-        eventId: "sun-event",
-        startMs: 1,
-        eventType: "timed",
-        dayKey: "2026-08-02",
-        weekday: 0,
-      },
-      {
-        eventId: "wed-1",
-        startMs: 1,
-        eventType: "timed",
-        dayKey: "2026-08-05",
-        weekday: 3,
-      },
-      {
-        eventId: "wed-2",
-        startMs: 2,
-        eventType: "timed",
-        dayKey: "2026-08-05",
-        weekday: 3,
-      },
-      {
-        eventId: "wed-3",
-        startMs: 3,
-        eventType: "timed",
-        dayKey: "2026-08-05",
-        weekday: 3,
-      },
-      {
-        eventId: "wed-4",
-        startMs: 4,
-        eventType: "timed",
-        dayKey: "2026-08-05",
-        weekday: 3,
-      },
-      {
-        eventId: "sat-event",
-        startMs: 1,
-        eventType: "timed",
-        dayKey: "2026-08-08",
-        weekday: 6,
-      },
-      ...Array.from({ length: 10 }, (_, index) => ({
-        eventId: `fri-${index + 1}`,
-        startMs: index + 1,
-        eventType: "timed" as const,
-        dayKey: "2026-08-07",
-        weekday: 5,
-      })),
-    ],
-    "week",
-  );
+  const weekAssignments = assignDayJumpKeys([
+    {
+      eventId: "sun-event",
+      startMs: 1,
+      eventType: "timed",
+      dayKey: "2026-08-02",
+      weekday: 0,
+    },
+    {
+      eventId: "wed-1",
+      startMs: 1,
+      eventType: "timed",
+      dayKey: "2026-08-05",
+      weekday: 3,
+    },
+    {
+      eventId: "wed-2",
+      startMs: 2,
+      eventType: "timed",
+      dayKey: "2026-08-05",
+      weekday: 3,
+    },
+    {
+      eventId: "wed-3",
+      startMs: 3,
+      eventType: "timed",
+      dayKey: "2026-08-05",
+      weekday: 3,
+    },
+    {
+      eventId: "wed-4",
+      startMs: 4,
+      eventType: "timed",
+      dayKey: "2026-08-05",
+      weekday: 3,
+    },
+    {
+      eventId: "sat-event",
+      startMs: 1,
+      eventType: "timed",
+      dayKey: "2026-08-08",
+      weekday: 6,
+    },
+    ...Array.from({ length: 10 }, (_, index) => ({
+      eventId: `fri-${index + 1}`,
+      startMs: index + 1,
+      eventType: "timed" as const,
+      dayKey: "2026-08-07",
+      weekday: 5,
+    })),
+  ]);
 
   it("selects a unique day and focuses its first event", () => {
     expect(
@@ -361,50 +346,20 @@ describe("matchDayJumpKeystroke", () => {
     ).toEqual(["w1", "w2", "w3", "w4"]);
   });
 
-  it("matches day-mode digits", () => {
-    const dayAssignments = assignDayJumpKeys(
-      [
-        {
-          eventId: "a",
-          startMs: 1,
-          eventType: "timed",
-          dayKey: "2026-08-05",
-          weekday: 3,
-        },
-        {
-          eventId: "b",
-          startMs: 2,
-          eventType: "timed",
-          dayKey: "2026-08-05",
-          weekday: 3,
-        },
-      ],
-      "day",
-    );
-
+  it("leaves a digit on an empty buffer for quick-time create", () => {
     expect(
       matchDayJumpKeystroke({
-        assignments: dayAssignments,
+        assignments: weekAssignments,
         key: "2",
         buffer: "",
-        mode: "day",
       }),
-    ).toEqual({
-      kind: "focus",
-      eventId: "b",
-      dayKey: "2026-08-05",
-      buffer: "2",
-    });
+    ).toBeNull();
   });
 });
 
 describe("dayJumpPrefixesForWeekdays", () => {
   it("returns the prefixes for the days that have events, in weekday order", () => {
     expect(dayJumpPrefixesForWeekdays([5, 3, 3, 0])).toEqual(["su", "w", "f"]);
-  });
-
-  it("has no letters in day view, where events are numbered", () => {
-    expect(dayJumpPrefixesForWeekdays([1, 2], "day")).toEqual([]);
   });
 
   it("is empty when nothing is scheduled", () => {

--- a/packages/web/src/shortcuts/shift-hint/assign-shift-hint-keys.ts
+++ b/packages/web/src/shortcuts/shift-hint/assign-shift-hint-keys.ts
@@ -1,8 +1,10 @@
 /**
  * Day-prefix event jump labels.
  *
- * Week: SU/M/T/W/R/F/SA + per-day chronological index (W4, SU1, F10).
- * Day view: numeric index only (1, 2, …).
+ * SU/M/T/W/R/F/SA + per-day chronological index (W4, SU1, F10), in both week
+ * and day view. Day view groups on the single date it shows, so its labels are
+ * that weekday's prefix (W1, W2, …). One scheme for both views is what keeps a
+ * bare digit free everywhere for quick-time create (shortcuts/quick-time).
  */
 
 export const DAY_JUMP_PREFIX_BY_WEEKDAY = {
@@ -67,17 +69,10 @@ export type DayJumpAssignment = {
   index: number;
 };
 
-export type DayJumpLabelMode = "week" | "day";
-
-/**
- * Day prefixes that currently have somewhere to land, in weekday order. Day
- * view labels events numerically, so no letter is live there.
- */
+/** Day prefixes that currently have somewhere to land, in weekday order. */
 export function dayJumpPrefixesForWeekdays(
   weekdays: readonly number[],
-  mode: DayJumpLabelMode = "week",
 ): string[] {
-  if (mode === "day") return [];
   const present = new Set(weekdays);
   return Object.entries(DAY_JUMP_PREFIX_BY_WEEKDAY)
     .filter(([weekday]) => present.has(Number(weekday)))
@@ -96,25 +91,11 @@ const compareTargets = (a: DayJumpTarget, b: DayJumpTarget) => {
   return a.eventId.localeCompare(b.eventId);
 };
 
-/**
- * Assign day-prefix (week) or numeric (day) hints. Same targets → same keys.
- */
+/** Assign day-prefix hints. Same targets → same keys. */
 export function assignDayJumpKeys(
   targets: DayJumpTarget[],
-  mode: DayJumpLabelMode = "week",
 ): DayJumpAssignment[] {
   if (targets.length === 0) return [];
-
-  if (mode === "day") {
-    const sorted = [...targets].sort(compareTargets);
-    return sorted.map((target, index) => ({
-      eventId: target.eventId,
-      hint: String(index + 1),
-      dayKey: target.dayKey,
-      dayPrefix: "",
-      index: index + 1,
-    }));
-  }
 
   const byDay = new Map<string, DayJumpTarget[]>();
   for (const target of targets) {
@@ -180,25 +161,21 @@ const UNIQUE_DAY_LETTERS = new Set(["m", "t", "w", "r", "f"]);
  * Unique day letters select the day and focus the first event without requiring
  * a digit. Digits append and focus when the buffer uniquely identifies a hint
  * (exact match with no longer sibling prefixes).
+ *
+ * A digit on an empty buffer is deliberately unmatched: no day is selected yet,
+ * so it belongs to quick-time create (shortcuts/quick-time) instead.
  */
 export function matchDayJumpKeystroke({
   assignments,
   key,
   buffer,
-  mode = "week",
 }: {
   assignments: DayJumpAssignment[];
   key: string;
   buffer: string;
-  mode?: DayJumpLabelMode;
 }): DayJumpMatchResult {
   if (key.length !== 1) return null;
   const lower = key.toLowerCase();
-
-  if (mode === "day") {
-    if (!/^\d$/.test(lower)) return null;
-    return matchDigitBuffer(assignments, `${buffer}${lower}`);
-  }
 
   // Digit after a day is selected (buffer is day prefix or day+digits).
   if (/^\d$/.test(lower)) {

--- a/packages/web/src/shortcuts/shift-hint/event-jump.store.ts
+++ b/packages/web/src/shortcuts/shift-hint/event-jump.store.ts
@@ -13,6 +13,10 @@ export type EventJumpState = {
   pointerHintKey: string | null;
   /** Event that owns `pointerHintKey`, so rebuilds can refresh the token. */
   pointerHintEventId: string | null;
+  /** Date selected by the latest blocked empty-grid click. */
+  pointerDraftDateKey: string | null;
+  pointerDraftStart: string | null;
+  pointerDraftTimeKey: string | null;
   /** Day prefixes with somewhere to land right now, in weekday order. Read by
    * the sidebar tip so it only teaches a key that would work. */
   jumpableDayPrefixes: string[];
@@ -24,6 +28,9 @@ export const initialEventJumpState: EventJumpState = {
   announcement: "",
   pointerHintKey: null,
   pointerHintEventId: null,
+  pointerDraftDateKey: null,
+  pointerDraftStart: null,
+  pointerDraftTimeKey: null,
   jumpableDayPrefixes: [],
 };
 
@@ -74,6 +81,18 @@ export const eventJumpActions = {
       },
       false,
       { type: "setPointerHint" },
+    ),
+  setPointerDraftIntent: (
+    pointerDraft: { date: string; start?: string; timeKey?: string } | null,
+  ) =>
+    useEventJumpStore.setState(
+      {
+        pointerDraftDateKey: pointerDraft?.date ?? null,
+        pointerDraftStart: pointerDraft?.start ?? null,
+        pointerDraftTimeKey: pointerDraft?.timeKey ?? null,
+      },
+      false,
+      { type: "setPointerDraftIntent" },
     ),
   setJumpableDayPrefixes: (jumpableDayPrefixes: string[]) => {
     const current = useEventJumpStore.getState().jumpableDayPrefixes;

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx
@@ -74,10 +74,7 @@ describe("useShiftHoldEventHints", () => {
     document.body.innerHTML = "";
   });
 
-  const mountHints = (
-    mode: "week" | "day" = "week",
-    timedEvents?: GridEvent[],
-  ) => {
+  const mountHints = (timedEvents?: GridEvent[]) => {
     const focus = mock((_target: { eventId: string }) => {});
     const events = timedEvents ?? [
       timedFixture(EVENT_A, "2026-08-05T09:00:00.000Z"),
@@ -113,7 +110,6 @@ describe("useShiftHoldEventHints", () => {
             eventType: "timed" as const,
             element: elements[index]!,
           })),
-        mode,
         timedEvents: events,
       }),
     );
@@ -199,7 +195,7 @@ describe("useShiftHoldEventHints", () => {
   });
 
   it("does not claim a day letter with no events that day", () => {
-    const { focus, result } = mountHints("week", [
+    const { focus, result } = mountHints([
       timedFixture(EVENT_C, "2026-08-06T13:00:00.000Z"),
     ]);
 
@@ -220,21 +216,19 @@ describe("useShiftHoldEventHints", () => {
     expect(result.current.hints).toEqual([]);
   });
 
-  it("focuses a day-view index without first pressing h", () => {
-    const { focus, elements } = mountHints("day");
+  it("leaves a bare digit alone so quick-time create can read it", () => {
+    const { focus } = mountHints();
 
     act(() => {
       dispatch("keydown", "1");
     });
 
-    expect(useEventJumpStore.getState().isActive).toBe(true);
-    expect(focus).toHaveBeenCalledWith(
-      expect.objectContaining({ eventId: EVENT_A, element: elements[0] }),
-    );
+    expect(useEventJumpStore.getState().isActive).toBe(false);
+    expect(focus).not.toHaveBeenCalled();
   });
 
   it("does not claim t while jump is off so today still works", () => {
-    const { focus } = mountHints("week", [
+    const { focus } = mountHints([
       timedFixture(EVENT_A, "2026-08-04T09:00:00.000Z"),
     ]);
 
@@ -254,7 +248,7 @@ describe("useShiftHoldEventHints", () => {
   });
 
   it("leaves bare m to the event menu while an event is focused", () => {
-    const { focus, elements } = mountHints("week", [
+    const { focus, elements } = mountHints([
       timedFixture(EVENT_A, "2026-08-03T09:00:00.000Z"),
     ]);
     elements[0]!.setAttribute(WEEK_INTERACTION_EVENT_ID_ATTRIBUTE, EVENT_A);
@@ -276,7 +270,7 @@ describe("useShiftHoldEventHints", () => {
   });
 
   it("claims Shift+M even while a calendar event is focused", () => {
-    const { focus, elements } = mountHints("week", [
+    const { focus, elements } = mountHints([
       timedFixture(EVENT_A, "2026-08-03T09:00:00.000Z"),
     ]);
     elements[0]!.setAttribute(WEEK_INTERACTION_EVENT_ID_ATTRIBUTE, EVENT_A);
@@ -293,7 +287,7 @@ describe("useShiftHoldEventHints", () => {
   });
 
   it("claims Shift+T for Tuesday while bare t still goes to today", () => {
-    const { focus, elements } = mountHints("week", [
+    const { focus, elements } = mountHints([
       timedFixture(EVENT_A, "2026-08-04T09:00:00.000Z"),
     ]);
 
@@ -309,7 +303,7 @@ describe("useShiftHoldEventHints", () => {
   });
 
   it("leaves bare f to notice focus while a notice is visible", () => {
-    const { focus } = mountHints("week", [
+    const { focus } = mountHints([
       timedFixture(EVENT_A, "2026-08-07T09:00:00.000Z"),
     ]);
     const notice = document.createElement("div");
@@ -335,7 +329,7 @@ describe("useShiftHoldEventHints", () => {
   });
 
   it("claims Shift+F for Friday", () => {
-    const { focus, elements } = mountHints("week", [
+    const { focus, elements } = mountHints([
       timedFixture(EVENT_A, "2026-08-07T09:00:00.000Z"),
     ]);
 
@@ -489,7 +483,6 @@ describe("useShiftHoldEventHints", () => {
             eventType: "timed" as const,
             element: elements[index]!,
           })),
-        mode: "week",
         timedEvents,
       }),
     );
@@ -598,7 +591,6 @@ describe("useShiftHoldEventHints", () => {
                 },
               ];
             }),
-          mode: "week",
           timedEvents,
         }),
       { initialProps: { timedEvents: events } },
@@ -622,7 +614,7 @@ describe("useShiftHoldEventHints", () => {
   });
 
   it("publishes the columns a day key can currently land on", () => {
-    mountHints("week", [
+    mountHints([
       timedFixture(EVENT_A, "2026-08-05T09:00:00.000Z"),
       timedFixture(EVENT_B, "2026-08-08T11:00:00.000Z"),
     ]);
@@ -631,12 +623,6 @@ describe("useShiftHoldEventHints", () => {
       "w",
       "sa",
     ]);
-  });
-
-  it("publishes no columns in day view, where events are numbered", () => {
-    mountHints("day");
-
-    expect(useEventJumpStore.getState().jumpableDayPrefixes).toEqual([]);
   });
 
   it("clears the published columns when the grid unmounts", () => {
@@ -705,23 +691,7 @@ describe("useShiftHoldEventHints", () => {
     expect(result.current.hints).toEqual([]);
   });
 
-  it("toggles off with a second h in day view", () => {
-    const { result } = mountHints("day");
-
-    act(() => {
-      pressEventJump();
-    });
-    expect(useEventJumpStore.getState().isActive).toBe(true);
-    expect(result.current.hints).toHaveLength(3);
-
-    act(() => {
-      pressEventJump();
-    });
-    expect(useEventJumpStore.getState().isActive).toBe(false);
-    expect(result.current.hints).toEqual([]);
-  });
-
-  it("toggles off with a second h in week view", () => {
+  it("toggles off with a second h", () => {
     const { result } = mountHints();
 
     act(() => {
@@ -738,7 +708,7 @@ describe("useShiftHoldEventHints", () => {
   });
 
   it("focuses Saturday from idle with Shift+S then a", () => {
-    const { focus, elements } = mountHints("week", [
+    const { focus, elements } = mountHints([
       timedFixture(EVENT_A, "2026-08-02T09:00:00.000Z"),
       timedFixture(EVENT_B, "2026-08-08T11:00:00.000Z"),
     ]);

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
@@ -12,7 +12,9 @@ import {
 } from "@web/shortcuts/is-bare-letter-key";
 import {
   POINTER_EVENT_JUMP_REQUEST,
+  POINTER_GRID_CREATE_REQUEST,
   pointerEventJumpId,
+  pointerGridIntent,
 } from "@web/shortcuts/keyboard-only/pointer-action";
 import { KEYMAP } from "@web/shortcuts/keymap";
 import { type QuickTimeConsumer } from "@web/shortcuts/quick-time/useQuickTimeCreate";
@@ -249,6 +251,7 @@ export function useShiftHoldEventHints({
       isActiveRef.current = false;
       bufferRef.current = "";
       clearHints();
+      eventJumpActions.setPointerDraftIntent(null);
       eventJumpActions.setActive(false);
     };
 
@@ -351,6 +354,21 @@ export function useShiftHoldEventHints({
       if (!isActiveRef.current) {
         if (isAppLocked() || isEditableKeyboardTarget(event)) return;
         if (isEditSequenceArmed()) return;
+
+        // An empty-grid click parks a short-lived teaching target. Escape and
+        // calendar navigation abandon it without claiming the key - the digits
+        // themselves are read by the quick-time consumer below.
+        if (useEventJumpStore.getState().pointerDraftDateKey) {
+          const inputKey = normalizedKeyboardKey(event);
+          const isViewNavigation =
+            !event.metaKey &&
+            !event.ctrlKey &&
+            !event.altKey &&
+            ["j", "k", "t"].includes(inputKey);
+          if (event.key === "Escape" || isViewNavigation) {
+            eventJumpActions.setPointerDraftIntent(null);
+          }
+        }
 
         if (quickTimeRef.current?.tryConsumeKey(event)) {
           event.preventDefault();
@@ -487,12 +505,22 @@ export function useShiftHoldEventHints({
       focusEvent(eventId);
     };
 
+    const onPointerGridCreateRequest = (event: Event) => {
+      const intent = pointerGridIntent(event);
+      if (!intent) return;
+      eventJumpActions.setPointerDraftIntent(intent);
+    };
+
     document.addEventListener("keydown", onKeyDown, true);
     document.addEventListener("keyup", onKeyUp, true);
     window.addEventListener("blur", onBlur);
     document.addEventListener(
       POINTER_EVENT_JUMP_REQUEST,
       onPointerEventJumpRequest,
+    );
+    document.addEventListener(
+      POINTER_GRID_CREATE_REQUEST,
+      onPointerGridCreateRequest,
     );
 
     return () => {
@@ -505,6 +533,11 @@ export function useShiftHoldEventHints({
         POINTER_EVENT_JUMP_REQUEST,
         onPointerEventJumpRequest,
       );
+      document.removeEventListener(
+        POINTER_GRID_CREATE_REQUEST,
+        onPointerGridCreateRequest,
+      );
+      eventJumpActions.setPointerDraftIntent(null);
       if (isActiveRef.current) {
         eventJumpActions.reset();
       }

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
@@ -15,10 +15,10 @@ import {
   pointerEventJumpId,
 } from "@web/shortcuts/keyboard-only/pointer-action";
 import { KEYMAP } from "@web/shortcuts/keymap";
+import { type QuickTimeConsumer } from "@web/shortcuts/quick-time/useQuickTimeCreate";
 import {
   assignDayJumpKeys,
   type DayJumpAssignment,
-  type DayJumpLabelMode,
   type DayJumpMatchResult,
   DIGIT_AMBIGUOUS_COMMIT_MS,
   dayJumpPrefixesForWeekdays,
@@ -48,15 +48,14 @@ export type EventJumpHintsResult = {
   hints: ActiveShiftHint[];
 };
 
-const isUnmodifiedSingleChar = (event: KeyboardEvent) => {
-  const key = keyboardKey(event);
-  return (
-    key.length === 1 &&
-    !event.metaKey &&
-    !event.ctrlKey &&
-    !event.altKey &&
-    !event.shiftKey
-  );
+const DAY_NAME_BY_PREFIX: Record<string, string> = {
+  su: "Sunday",
+  m: "Monday",
+  t: "Tuesday",
+  w: "Wednesday",
+  r: "Thursday",
+  f: "Friday",
+  sa: "Saturday",
 };
 
 /**
@@ -110,7 +109,6 @@ const toActiveHints = (
 const buildDayJumpAssignments = (
   visible: ShiftHintFocusTarget[],
   events: GridEvent[],
-  mode: DayJumpLabelMode,
 ): {
   assignments: DayJumpAssignment[];
   visibleById: Map<string, ShiftHintFocusTarget>;
@@ -133,7 +131,7 @@ const buildDayJumpAssignments = (
   });
 
   return {
-    assignments: assignDayJumpKeys(targets, mode),
+    assignments: assignDayJumpKeys(targets),
     visibleById: new Map(visible.map((target) => [target.eventId, target])),
   };
 };
@@ -143,21 +141,27 @@ const buildDayJumpAssignments = (
  * jump mode straight onto that column (`Shift+W`, `Shift+S` then `u`/`a`).
  * Shift is what makes the day columns always available: bare `t`, `f`, and
  * `m` keep their own commands. Once jump mode is on, the labels are typed
- * bare (`w`, `w1`, day-view `1`…) and win over global shortcuts. Esc exits,
- * a second `h` toggles off. In week view `s` is only the Sunday/Saturday
- * prefix.
+ * bare (`w`, `w1`…) and win over global shortcuts. Esc exits, a second `h`
+ * toggles off. `s` is only the Sunday/Saturday prefix.
+ *
+ * Day view uses the same scheme on the one date it shows, so a bare digit is
+ * never an event label on an empty buffer in either view - that keystroke
+ * belongs to `quickTime` instead, which this listener offers every key before
+ * reading it as a jump label. Both features read bare digits, so they share one
+ * listener with an explicit precedence rule rather than racing two whose order
+ * would depend on React mount order.
  */
 export function useShiftHoldEventHints({
   allDayEvents = [],
   focus,
   listVisible,
-  mode = "week",
+  quickTime,
   timedEvents,
 }: {
   allDayEvents?: GridEvent[];
   focus: (target: ShiftHintFocusTarget) => void;
   listVisible: () => ShiftHintFocusTarget[];
-  mode?: DayJumpLabelMode;
+  quickTime?: QuickTimeConsumer;
   timedEvents: GridEvent[];
 }): EventJumpHintsResult {
   const [hints, setHints] = useState<ActiveShiftHint[]>([]);
@@ -172,16 +176,16 @@ export function useShiftHoldEventHints({
   );
   const focusRef = useRef(focus);
   const listVisibleRef = useRef(listVisible);
+  const quickTimeRef = useRef(quickTime);
   const allDayEventsRef = useRef(allDayEvents);
   const timedEventsRef = useRef(timedEvents);
-  const modeRef = useRef(mode);
   const publishedPrefixesRef = useRef<string[]>([]);
 
   focusRef.current = focus;
   listVisibleRef.current = listVisible;
+  quickTimeRef.current = quickTime;
   allDayEventsRef.current = allDayEvents;
   timedEventsRef.current = timedEvents;
-  modeRef.current = mode;
   isActiveRef.current = isActive;
 
   useEffect(() => {
@@ -208,7 +212,6 @@ export function useShiftHoldEventHints({
       const { assignments, visibleById } = buildDayJumpAssignments(
         listVisibleRef.current(),
         [...allDayEventsRef.current, ...timedEventsRef.current],
-        modeRef.current,
       );
       assignmentsRef.current = assignments;
       visibleByIdRef.current = visibleById;
@@ -230,10 +233,11 @@ export function useShiftHoldEventHints({
       publishFiltered(dayPrefix);
     };
 
+    // Activates even with nothing to label: the quick-time slot placeholders
+    // are the whole point of `h` on an empty day.
     const activate = () => {
       if (isAppLocked()) return;
       const assignments = rebuildAssignments();
-      if (assignments.length === 0) return;
       isActiveRef.current = true;
       bufferRef.current = "";
       eventJumpActions.setActive(true);
@@ -259,12 +263,7 @@ export function useShiftHoldEventHints({
       clearAmbiguousCommitTimer();
       eventJumpActions.setActiveDayKeys([dayKey]);
       focusEvent(eventId);
-      // Day view clears the buffer; week keeps the day prefix for the next index.
-      if (modeRef.current === "day") {
-        bufferRef.current = "";
-        publishFiltered("");
-        return;
-      }
+      // Keep the day prefix so the next digit indexes within the same day.
       const dayPrefix = buffer.replace(/\d+$/, "") || buffer;
       bufferRef.current = dayPrefix;
       publishFiltered(dayPrefix);
@@ -353,6 +352,12 @@ export function useShiftHoldEventHints({
         if (isAppLocked() || isEditableKeyboardTarget(event)) return;
         if (isEditSequenceArmed()) return;
 
+        if (quickTimeRef.current?.tryConsumeKey(event)) {
+          event.preventDefault();
+          event.stopPropagation();
+          return;
+        }
+
         if (isBareLetterKey(event, KEYMAP.eventJump.bareLetter)) {
           event.preventDefault();
           event.stopPropagation();
@@ -365,14 +370,8 @@ export function useShiftHoldEventHints({
 
         // Shift+day enters jump mode straight onto that column. Any other
         // shifted letter (Shift+J, Shift+C) falls through to its own handler.
-        // Day view is numbered, and Shift+1 is "!", so its digits stay bare.
         const key = normalizedKeyboardKey(event);
-        const isDigit = /^\d$/.test(key);
-        if (
-          isDigit ? !isUnmodifiedSingleChar(event) : !isShiftedSingleChar(event)
-        ) {
-          return;
-        }
+        if (!isShiftedSingleChar(event)) return;
 
         const assignments = rebuildAssignments();
         if (assignments.length === 0) return;
@@ -381,7 +380,6 @@ export function useShiftHoldEventHints({
           assignments,
           key,
           buffer: "",
-          mode: modeRef.current,
         });
         if (!match) return;
 
@@ -396,6 +394,18 @@ export function useShiftHoldEventHints({
 
       if (isAppLocked() || isEditableKeyboardTarget(event)) {
         deactivate();
+        return;
+      }
+
+      // Only on an empty buffer: once a day letter is typed ("w"), the digits
+      // that follow are that day's event index. Esc or a second `h` clears the
+      // buffer and puts quick-time back within reach.
+      if (
+        bufferRef.current === "" &&
+        quickTimeRef.current?.tryConsumeKey(event)
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
         return;
       }
 
@@ -426,7 +436,6 @@ export function useShiftHoldEventHints({
         assignments: assignmentsRef.current,
         key,
         buffer: bufferRef.current,
-        mode: modeRef.current,
       });
 
       if (!match) {
@@ -523,7 +532,6 @@ export function useShiftHoldEventHints({
     const { assignments, visibleById } = buildDayJumpAssignments(
       listVisibleRef.current(),
       [...allDayEventsRef.current, ...timedEventsRef.current],
-      modeRef.current,
     );
     assignmentsRef.current = assignments;
     visibleByIdRef.current = visibleById;
@@ -560,10 +568,10 @@ export function useShiftHoldEventHints({
     const weekdays = [...allDayEventsRef.current, ...timedEventsRef.current]
       .filter((event) => Boolean(event.startDate))
       .map((event) => scheduleMeta(event).weekday);
-    const next = dayJumpPrefixesForWeekdays(weekdays, mode);
+    const next = dayJumpPrefixesForWeekdays(weekdays);
     publishedPrefixesRef.current = next;
     eventJumpActions.setJumpableDayPrefixes(next);
-  }, [eventIdsKey, mode]);
+  }, [eventIdsKey]);
 
   // Only clear what this grid published: switching Day -> Week can mount the
   // new grid before the old one unmounts, and a blind clear there would blank

--- a/packages/web/src/shortcuts/shortcuts.menu.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.menu.test.ts
@@ -223,6 +223,11 @@ describe("shortcut menu sections", () => {
         { keys: ["i"], label: "Focus sidebar" },
         { keys: ["u"], label: "Focus calendar event" },
         { keys: ["h"], label: "Toggle event jump keys" },
+        {
+          keys: ["Shift", "m"],
+          label:
+            "Focus a day's events (Shift + M T W R F, Shift + S then U or A)",
+        },
         { keys: ["f"], label: "Focus latest notice" },
         {
           keys: ["Mod", "1-9"],
@@ -236,7 +241,7 @@ describe("shortcut menu sections", () => {
         {
           keys: ["Shift", "m"],
           label:
-            "Focus a week column (Shift + M T W R F, Shift + S then U or A)",
+            "Focus a day's events (Shift + M T W R F, Shift + S then U or A)",
         },
         { keys: ["f"], label: "Focus latest notice" },
         {

--- a/packages/web/src/shortcuts/shortcuts.registry.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.test.ts
@@ -134,19 +134,13 @@ describe("shortcuts.registry", () => {
       expect(life).not.toContain("focus-shift-hold");
     });
 
-    it("lists week-column focus only in week view", () => {
-      const week = filterShortcutsByContext({
-        view: "week",
-        isViewingCurrentPeriod: true,
-      }).map((shortcut) => shortcut.id);
-      expect(week).toContain("focus-week-day");
-
-      for (const view of ["day", "life"] as const) {
+    it("lists day-letter focus in both calendar views", () => {
+      for (const view of ["week", "day"] as const) {
         const ids = filterShortcutsByContext({
           view,
           isViewingCurrentPeriod: true,
         }).map((shortcut) => shortcut.id);
-        expect(ids).not.toContain("focus-week-day");
+        expect(ids).toContain("focus-week-day");
       }
     });
 

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -167,6 +167,12 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
     section: "create",
   },
   {
+    id: "create-typed-time",
+    keys: ["1130"],
+    label: "Create draft at a typed time (press H to see open slots)",
+    section: "create",
+  },
+  {
     id: "create-place-discard",
     keys: ["Escape"],
     label: "Discard placed draft",
@@ -195,9 +201,8 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
   {
     id: "focus-week-day",
     keys: ["Shift", "m"],
-    label: "Focus a week column (Shift + M T W R F, Shift + S then U or A)",
+    label: "Focus a day's events (Shift + M T W R F, Shift + S then U or A)",
     section: "focus",
-    when: { weekView: true },
   },
   {
     id: "focus-notice",

--- a/packages/web/src/shortcuts/tips/shortcut-tips.data.test.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-tips.data.test.ts
@@ -25,7 +25,9 @@ describe("getHintPlainText", () => {
     expect(plainTextById["edit-sequence"]).toBe("E then T edits the title");
     expect(plainTextById["create-event"]).toBe("C creates an event");
     expect(plainTextById["page-jump"]).toBe(`Hold ${mod} to see jump targets`);
-    expect(plainTextById["event-jump"]).toBe("H labels events to jump to");
+    expect(plainTextById["event-jump"]).toBe(
+      "H shows event and open-time shortcuts",
+    );
     expect(plainTextById["week-day-focus"]).toBe("Shift+M jumps to Monday");
     expect(plainTextById.nudge).toBe("Shift and an arrow moves the event");
     expect(plainTextById["edge-focus"]).toBe(

--- a/packages/web/src/shortcuts/tips/shortcut-tips.data.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-tips.data.ts
@@ -195,7 +195,7 @@ export const SHORTCUT_HINTS: Record<ShortcutHintId, ShortcutHint> = {
     id: "event-jump",
     actionId: "calendar.event_jump",
     featureArea: "calendar_navigation",
-    parts: [{ key: eventJumpKey }, " labels events to jump to"],
+    parts: [{ key: eventJumpKey }, " shows event and open-time shortcuts"],
     suggestionReason: "calendar_idle",
   },
   "week-day-focus": {

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -3,6 +3,7 @@ import {
   type CalendarId,
   CalendarIdSchema,
 } from "@core/types/domain-primitives";
+import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { shouldShowContextualLoadError } from "@web/api/util/api.util";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import {
@@ -20,6 +21,8 @@ import { onViewCommand } from "@web/common/utils/dom/view-command-bus";
 import {
   createAlldayDraft,
   createTimedDraft,
+  startTimedDraftAt,
+  timedDraftEnd,
 } from "@web/common/utils/draft/draft.util";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import {
@@ -38,7 +41,10 @@ import { withAllDayColumnTints } from "@web/grid/utils/allDayColumnTint.util";
 import { EditSequenceMenu } from "@web/shortcuts/edit-sequence/EditSequenceMenu";
 import { PageJumpHints } from "@web/shortcuts/page-jump/PageJumpHints";
 import { buildDayPageJumpTargets } from "@web/shortcuts/page-jump/page-jump.targets";
+import { QuickTimeSlots } from "@web/shortcuts/quick-time/QuickTimeSlots";
+import { buildQuickTimeSlots } from "@web/shortcuts/quick-time/quick-time.util";
 import { ShiftHintOverlay } from "@web/shortcuts/shift-hint/ShiftHintOverlay";
+import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 import { dayEventQueryRange } from "@web/views/Day/hooks/events/useDayEvents";
 import { useDateInView } from "@web/views/Day/hooks/navigation/useDateInView";
 import { useDateNavigation } from "@web/views/Day/hooks/navigation/useDateNavigation";
@@ -294,12 +300,58 @@ export function DayCalendarGrid() {
       ),
     [dateInView, openShortcutDraft, resolveShortcutCalendarId, today],
   );
+  // Typed-time create lands on the day being viewed, form closed and card
+  // focused, matching placeTimedDraftFromShortcut above.
+  const createDraftAtTime = useCallback(
+    (start: Dayjs) =>
+      openShortcutDraft(
+        () =>
+          startTimedDraftAt(
+            start.format(),
+            timedDraftEnd(start).format(),
+            "keyboardPlace",
+            resolveShortcutCalendarId(),
+          ),
+        false,
+      ),
+    [openShortcutDraft, resolveShortcutCalendarId],
+  );
+
+  const getQuickTimeDay = useCallback(() => dateInView, [dateInView]);
+
   const { getEditSequenceAnchor, shiftHints } = useDayEventNudgeShortcuts({
     allDayEvents: displayedAllDayEvents,
+    createDraftAtTime,
+    getQuickTimeDay,
     navigateToDate,
     placeTimedDraft: placeTimedDraftFromShortcut,
     timedEvents: displayedTimedEvents,
   });
+
+  // The placeholder sits in the column the draft would land in - the calendar
+  // resolveShortcutCalendarId picks. Occupancy is checked across every column,
+  // so a slot busy on any calendar shows no chip; conservative, and it keeps
+  // chips off cards regardless of which column they are in.
+  const quickTimeSlots = useMemo(() => {
+    const now = dayjs().tz(getEffectiveTimeZone());
+    const busy = displayedTimedEvents.flatMap((event) =>
+      event.startDate && event.endDate
+        ? [
+            {
+              startMs: dayjs(event.startDate).valueOf(),
+              endMs: dayjs(event.endDate).valueOf(),
+            },
+          ]
+        : [],
+    );
+
+    return buildQuickTimeSlots({ busy, now, targetDay: dateInView });
+  }, [dateInView, displayedTimedEvents]);
+
+  const quickTimeCalendarId = resolveShortcutCalendarId();
+  const quickTimeColumnIndex = quickTimeCalendarId
+    ? calendarColumnIndexById.get(quickTimeCalendarId)
+    : undefined;
 
   // onViewCommand returns its own unsubscribe and emitViewCommand reads the
   // listener set at emit time, so re-subscribing when the handler identity
@@ -343,6 +395,12 @@ export function DayCalendarGrid() {
           measurements={measurements}
           visibleDates={visibleDates}
         />
+        <QuickTimeSlots
+          columnIndex={quickTimeColumnIndex}
+          measurements={measurements}
+          slots={quickTimeSlots}
+          visibleDates={visibleDates}
+        />
         <DayCalendarTimedEventsLayer
           events={displayedTimedEvents}
           getCalendarColumnIndex={getCalendarColumnIndex}
@@ -363,6 +421,8 @@ export function DayCalendarGrid() {
       isDisplayedEvent,
       measurements,
       openEventFormForEvent,
+      quickTimeColumnIndex,
+      quickTimeSlots,
       visibleDates,
     ],
   );

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -43,6 +43,10 @@ import { PageJumpHints } from "@web/shortcuts/page-jump/PageJumpHints";
 import { buildDayPageJumpTargets } from "@web/shortcuts/page-jump/page-jump.targets";
 import { QuickTimeSlots } from "@web/shortcuts/quick-time/QuickTimeSlots";
 import { buildQuickTimeSlots } from "@web/shortcuts/quick-time/quick-time.util";
+import {
+  eventJumpActions,
+  useEventJumpStore,
+} from "@web/shortcuts/shift-hint/event-jump.store";
 import { ShiftHintOverlay } from "@web/shortcuts/shift-hint/ShiftHintOverlay";
 import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 import { dayEventQueryRange } from "@web/views/Day/hooks/events/useDayEvents";
@@ -258,18 +262,25 @@ export function DayCalendarGrid() {
     [defaultTargetCalendarId, gridDraft, isCalendarsPending],
   );
 
-  const createAllDayDraftFromShortcut = useCallback(
-    () =>
-      openShortcutDraft(() =>
-        createAlldayDraft(
-          dateInView,
-          dateInView,
-          "createShortcut",
-          resolveShortcutCalendarId(),
-        ),
+  const createAllDayDraftFromShortcut = useCallback(() => {
+    // A blocked click on the all-day row aimed at a specific day; honor it
+    // over the day in view, then spend the intent.
+    const pointerDateKey = useEventJumpStore.getState().pointerDraftDateKey;
+    const start = pointerDateKey
+      ? dayjs(pointerDateKey).tz(getEffectiveTimeZone(), true)
+      : dateInView;
+
+    openShortcutDraft(() =>
+      createAlldayDraft(
+        start,
+        start,
+        "createShortcut",
+        resolveShortcutCalendarId(),
+        start,
       ),
-    [dateInView, openShortcutDraft, resolveShortcutCalendarId],
-  );
+    );
+    eventJumpActions.setPointerDraftIntent(null);
+  }, [dateInView, openShortcutDraft, resolveShortcutCalendarId]);
 
   const createTimedDraftFromShortcut = useCallback(
     () =>

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.test.tsx
@@ -149,11 +149,13 @@ const addReadOnlyCalendarTarget = (
 
 const renderEditShortcuts = ({
   allDayEvents = [],
+  createDraftAtTime = () => {},
   navigateToDate,
   placeTimedDraft,
   timedEvents = [timedEvent],
 }: {
   allDayEvents?: GridEvent[];
+  createDraftAtTime?: (start: Dayjs) => void;
   navigateToDate?: (date: Dayjs) => void;
   placeTimedDraft?: () => void;
   timedEvents?: GridEvent[];
@@ -200,7 +202,9 @@ const renderEditShortcuts = ({
     () =>
       useDayEventNudgeShortcuts({
         allDayEvents,
+        createDraftAtTime,
         dependencies,
+        getQuickTimeDay: () => dayjs("2026-08-05"),
         navigateToDate,
         placeTimedDraft,
         timedEvents,

--- a/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.ts
+++ b/packages/web/src/views/Day/hooks/shortcuts/useDayEventNudgeShortcuts.ts
@@ -5,6 +5,7 @@ import { type EventMutationDependencies } from "@web/events/mutations/useEventMu
 import { draftActions, useDraftStore } from "@web/events/stores/draft.store";
 import { useGridEventEditShortcuts } from "@web/grid/shortcuts/useGridEventEditShortcuts";
 import { useGridEventFormFieldSequences } from "@web/grid/shortcuts/useGridEventFormFieldSequences";
+import { useQuickTimeCreate } from "@web/shortcuts/quick-time/useQuickTimeCreate";
 import {
   type ActiveShiftHint,
   useShiftHoldEventHints,
@@ -20,13 +21,19 @@ import { dayEventTargeting } from "@web/views/Day/interaction/registry/day-event
  */
 export function useDayEventNudgeShortcuts({
   allDayEvents = [],
+  createDraftAtTime,
   dependencies = {},
+  getQuickTimeDay,
   navigateToDate,
   placeTimedDraft,
   timedEvents,
 }: {
   allDayEvents?: GridEvent[];
+  /** Quick-time create: place a draft at a typed start time. */
+  createDraftAtTime: (start: Dayjs) => void;
   dependencies?: EventMutationDependencies;
+  /** The day a typed time lands on - the date currently in view. */
+  getQuickTimeDay: () => Dayjs;
   /** Follow draft Left/Right moves so the draft stays on screen. */
   navigateToDate?: (date: Dayjs) => void;
   /** Shift+Arrow place-create when nothing is focused and no draft can move. */
@@ -86,11 +93,16 @@ export function useDayEventNudgeShortcuts({
       timedEvents,
     });
 
+  const quickTime = useQuickTimeCreate({
+    createAt: createDraftAtTime,
+    getTargetDay: getQuickTimeDay,
+  });
+
   const { hints: shiftHints } = useShiftHoldEventHints({
     allDayEvents,
     focus: targeting.focus,
     listVisible: targeting.listNavigable,
-    mode: "day",
+    quickTime,
     timedEvents,
   });
 

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGrid.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGrid.tsx
@@ -4,6 +4,7 @@ import { type Dayjs } from "@core/util/date/dayjs";
 import { TimedGrid } from "@web/grid/components/TimedGrid";
 import { MainGridBusyPeriods } from "@web/views/Week/components/Grid/MainGrid/MainGridBusyPeriods";
 import { MainGridEvents } from "@web/views/Week/components/Grid/MainGrid/MainGridEvents";
+import { MainGridQuickTimeSlots } from "@web/views/Week/components/Grid/MainGrid/MainGridQuickTimeSlots";
 import { type Measurements_Grid } from "@web/views/Week/hooks/grid/useGridLayout";
 import { type WeekProps } from "@web/views/Week/hooks/useWeek";
 
@@ -69,6 +70,10 @@ const MainGridChildren: FC<MainGridChildrenProps> = ({
           measurements={measurements}
           weekProps={weekProps}
         />
+        <MainGridQuickTimeSlots
+          measurements={measurements}
+          weekProps={weekProps}
+        />
         <MainGridEvents measurements={measurements} weekProps={weekProps} />
       </>
     ),
@@ -105,6 +110,10 @@ const MainGridCalendar: FC<MainGridCalendarProps> = ({
     () => (
       <>
         <MainGridBusyPeriods
+          measurements={measurements}
+          weekProps={weekProps}
+        />
+        <MainGridQuickTimeSlots
           measurements={measurements}
           weekProps={weekProps}
         />

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGridQuickTimeSlots.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGridQuickTimeSlots.tsx
@@ -1,0 +1,72 @@
+import { useMemo } from "react";
+import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
+import dayjs from "@core/util/date/dayjs";
+import { useWeekEventViewModel } from "@web/events/queries/useWeekEventsQuery";
+import { type GridVisibleDate } from "@web/grid/types/grid.types";
+import { QuickTimeSlots } from "@web/shortcuts/quick-time/QuickTimeSlots";
+import {
+  buildQuickTimeSlots,
+  quickTimeTargetDay,
+} from "@web/shortcuts/quick-time/quick-time.util";
+import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
+import { type Measurements_Grid } from "@web/views/Week/hooks/grid/useGridLayout";
+import { type WeekProps } from "@web/views/Week/hooks/useWeek";
+
+interface Props {
+  measurements: Measurements_Grid;
+  weekProps: WeekProps;
+}
+
+/**
+ * Week-grid host for the quick-time placeholders. Sources events from the same
+ * cached week query MainGridEvents reads, the way MainGridBusyPeriods sources
+ * its own availability query, so no new props thread through the grid.
+ */
+export const MainGridQuickTimeSlots = ({ measurements, weekProps }: Props) => {
+  const { component } = weekProps;
+  // Same args as MainGridEvents so this shares that query's cache entry rather
+  // than opening a second one.
+  const { timedEvents } = useWeekEventViewModel({
+    startOfView: weekProps.query.startOfView,
+    endOfView: weekProps.query.endOfView,
+  });
+  const visibleDates: GridVisibleDate[] = useMemo(
+    () =>
+      component.weekDays.map((date) => ({
+        date,
+        key: date.format(YEAR_MONTH_DAY_FORMAT),
+      })),
+    [component.weekDays],
+  );
+
+  const slots = useMemo(() => {
+    const now = dayjs().tz(getEffectiveTimeZone());
+    const targetDay = quickTimeTargetDay(
+      component.startOfView,
+      component.endOfView,
+      now,
+    );
+    // All-day events live in their own row, so only timed cards can collide
+    // with a placeholder.
+    const busy = timedEvents.flatMap((event) =>
+      event.startDate && event.endDate
+        ? [
+            {
+              startMs: dayjs(event.startDate).valueOf(),
+              endMs: dayjs(event.endDate).valueOf(),
+            },
+          ]
+        : [],
+    );
+
+    return buildQuickTimeSlots({ busy, now, targetDay });
+  }, [component.endOfView, component.startOfView, timedEvents]);
+
+  return (
+    <QuickTimeSlots
+      measurements={measurements}
+      slots={slots}
+      visibleDates={visibleDates}
+    />
+  );
+};

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
@@ -24,6 +24,10 @@ import { useGridEventFormFieldSequences } from "@web/grid/shortcuts/useGridEvent
 import { quickTimeTargetDay } from "@web/shortcuts/quick-time/quick-time.util";
 import { useQuickTimeCreate } from "@web/shortcuts/quick-time/useQuickTimeCreate";
 import {
+  eventJumpActions,
+  useEventJumpStore,
+} from "@web/shortcuts/shift-hint/event-jump.store";
+import {
   type ActiveShiftHint,
   useShiftHoldEventHints,
 } from "@web/shortcuts/shift-hint/useShiftHoldEventHints";
@@ -110,12 +114,20 @@ export const useWeekShortcutOwner = ({
   const createAllDayDraftEvent = useCallback(() => {
     if (!canSeedDraft) return;
 
+    // A blocked click on the all-day row aimed at a specific day; honor it
+    // over the today-first default, then spend the intent.
+    const pointerDateKey = useEventJumpStore.getState().pointerDraftDateKey;
+
     void createAlldayDraft(
       startOfView,
       endOfView,
       "createShortcut",
       defaultTargetCalendarId,
+      pointerDateKey
+        ? dayjs(pointerDateKey).tz(getEffectiveTimeZone(), true)
+        : undefined,
     );
+    eventJumpActions.setPointerDraftIntent(null);
   }, [canSeedDraft, defaultTargetCalendarId, endOfView, startOfView]);
 
   const createTimedDraftEvent = useCallback(() => {

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
@@ -6,6 +6,8 @@ import { onViewCommand } from "@web/common/utils/dom/view-command-bus";
 import {
   createAlldayDraft,
   createTimedDraft,
+  startTimedDraftAt,
+  timedDraftEnd,
 } from "@web/common/utils/draft/draft.util";
 import { repositionDraftByKeyboard } from "@web/common/utils/draft/reposition-draft-by-keyboard.util";
 import { focusCalendarEventElement } from "@web/common/utils/event/event.util";
@@ -19,10 +21,13 @@ import {
 import { useCalendarViewShortcuts } from "@web/grid/shortcuts/useCalendarViewShortcuts";
 import { useGridEventEditShortcuts } from "@web/grid/shortcuts/useGridEventEditShortcuts";
 import { useGridEventFormFieldSequences } from "@web/grid/shortcuts/useGridEventFormFieldSequences";
+import { quickTimeTargetDay } from "@web/shortcuts/quick-time/quick-time.util";
+import { useQuickTimeCreate } from "@web/shortcuts/quick-time/useQuickTimeCreate";
 import {
   type ActiveShiftHint,
   useShiftHoldEventHints,
 } from "@web/shortcuts/shift-hint/useShiftHoldEventHints";
+import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 import { type Util_Scroll } from "@web/views/Week/hooks/grid/useScroll";
 import { goToTodayInWeek } from "@web/views/Week/hooks/shortcuts/weekShortcuts.util";
 import { type WeekProps } from "@web/views/Week/hooks/useWeek";
@@ -247,11 +252,43 @@ export const useWeekShortcutOwner = ({
     onFocusCalendar: focusFirstCalendarEvent,
   });
 
+  // Typed-time create. Same guards and same form-closed/card-focused landing
+  // as Shift+Arrow place-create, so the two gestures produce the same draft.
+  const getQuickTimeDay = useCallback(
+    () =>
+      quickTimeTargetDay(
+        startOfView,
+        endOfView,
+        dayjs().tz(getEffectiveTimeZone()),
+      ),
+    [endOfView, startOfView],
+  );
+
+  const createDraftAtTime = useCallback(
+    (start: Dayjs) => {
+      if (!canSeedDraft) return;
+      if (useDraftStore.getState().gridDraft) return;
+
+      startTimedDraftAt(
+        start.format(),
+        timedDraftEnd(start).format(),
+        "keyboardPlace",
+        defaultTargetCalendarId,
+      );
+    },
+    [canSeedDraft, defaultTargetCalendarId],
+  );
+
+  const quickTime = useQuickTimeCreate({
+    createAt: createDraftAtTime,
+    getTargetDay: getQuickTimeDay,
+  });
+
   const { hints: shiftHints } = useShiftHoldEventHints({
     allDayEvents,
     focus: targeting.focus,
     listVisible: targeting.listNavigable,
-    mode: "week",
+    quickTime,
     timedEvents,
   });
 


### PR DESCRIPTION
## Summary

Type a digit sequence anywhere on the grid to drop a timed draft at that time on the current day. `1130` at 9am creates 11:30 AM; the same keys at 9pm create 11:30 PM. Pressing `H` is optional - it paints dashed placeholder chips in every open hour so the sequences are discoverable, skipping any hour an event already covers.

The draft lands form-closed and focused, so `Shift+Arrow` still nudges it and `Enter` opens the form.

A blocked empty-grid click now teaches the quarter-hour it aimed at ("Press 1130 to create at 11:30 AM") and parks that exact instant, so typing the sequence back lands there rather than re-resolving to the other meridiem. A blocked click on the all-day row teaches `Shift+C` and targets that day.

## Simplicity

Net deletion in the labeling layer: Day view's separate numeric event labels are gone, so both views share one scheme (`w1`, `w2`) and a bare digit means the same thing everywhere. Time parsing reuses `parseUserTime`, so typed times on the grid behave identically to the event form's time field. Placeholder chips are positioned with the grid's own `getBusyPeriodPosition` rather than a second geometry path, and each chip round-trips through the parser so an unreachable hour gets no chip instead of a chip that lies.

## Known wart

`parseUserTime` maps `1200` typed in the morning to 12:00 **AM** - the event form's existing behavior. Noon therefore gets no chip before midday. Diverging here would make the grid and the form disagree, so this is asserted in a test rather than special-cased.

## Test plan

- `bun run test:web` - 2817 pass, 0 fail
- `bun run type-check` (both web tsconfigs), `bun run lint`, `bun run knip`
- 32 new unit tests across `shortcuts/quick-time` covering parsing, commit timing, guard precedence, slot building, and the pointer-intent seam
