### PR TITLE
feat(web): teach t shortcut on month picker today control

### DIFF
--- a/packages/web/src/components/DatePicker/DatePicker.tsx
+++ b/packages/web/src/components/DatePicker/DatePicker.tsx
@@ -13,6 +13,7 @@ import { ChevronLeftIcon } from "@web/components/Icons/ChevronLeftIcon";
 import { ChevronRightIcon } from "@web/components/Icons/ChevronRightIcon";
 import { selectTheme, useThemeStore } from "@web/settings/theme/theme.store";
 import { useFloatingLayer } from "@web/shortcuts/floating-layer";
+import { POINTER_ACTIONS } from "@web/shortcuts/keyboard-only/pointer-action";
 import { Focusable, INPUT_RESET_CLASSNAME } from "../Focusable/Focusable";
 import { CircleIcon } from "../Icons/CircleIcon";
 import { TooltipWrapper } from "../Tooltip/TooltipWrapper";
@@ -224,7 +225,10 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
                   </MonthNavButton>
                 </div>
                 {withTodayButton && (
-                  <TooltipWrapper description={currentMonth}>
+                  <TooltipWrapper
+                    description={currentMonth}
+                    shortcut={view === "sidebar" ? "T" : undefined}
+                  >
                     <button
                       type="button"
                       aria-label="Go to this month"
@@ -232,6 +236,11 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
                         "flex h-6 w-6 cursor-pointer items-center justify-center rounded-full transition-colors hover:bg-text/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
                         currentMonth === selectedMonth && "invisible",
                       )}
+                      data-pointer-action={
+                        view === "sidebar"
+                          ? POINTER_ACTIONS.goToToday
+                          : undefined
+                      }
                       style={{ color: headerColor }}
                       onClick={() => {
                         headerProps.changeMonth(dayjs().month());

--- a/packages/web/src/components/PointerHint/PointerHint.test.tsx
+++ b/packages/web/src/components/PointerHint/PointerHint.test.tsx
@@ -137,6 +137,20 @@ describe("PointerHint", () => {
     );
   });
 
+  it("teaches the today shortcut for the month picker today control", () => {
+    render(<PointerHint />);
+
+    act(() => {
+      pointerBlockActions.pulseBlockedClick({
+        actionId: POINTER_ACTIONS.goToToday,
+      });
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Press T to go to today.",
+    );
+  });
+
   it("teaches the assigned sequence for the attempted event", () => {
     render(<PointerHint />);
 
@@ -177,6 +191,21 @@ describe("PointerHint", () => {
 
     expect(screen.getByRole("status")).toHaveTextContent(
       "Press ] to close the sidebar.",
+    );
+  });
+
+  it("keeps the today shortcut sentence after the session reminder threshold", () => {
+    sessionStorage.setItem(HINT_COUNT_KEY, "3");
+    render(<PointerHint />);
+
+    act(() => {
+      pointerBlockActions.pulseBlockedClick({
+        actionId: POINTER_ACTIONS.goToToday,
+      });
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Press T to go to today.",
     );
   });
 });

--- a/packages/web/src/components/PointerHint/PointerHint.tsx
+++ b/packages/web/src/components/PointerHint/PointerHint.tsx
@@ -50,6 +50,7 @@ const Key = ({ children }: { children: string }) => (
 const isContextualAttempt = (attempt: BlockedPointerAttempt | null) =>
   attempt?.actionId === POINTER_ACTIONS.sidebarClose ||
   attempt?.actionId === POINTER_ACTIONS.sidebarOpen ||
+  attempt?.actionId === POINTER_ACTIONS.goToToday ||
   attempt?.actionId === POINTER_ACTIONS.eventOpen ||
   Boolean(attempt?.shortcutKey);
 
@@ -77,6 +78,14 @@ const pointerHintMessage = ({
     return (
       <>
         Press <Key>]</Key> to {verb} the sidebar.
+      </>
+    );
+  }
+
+  if (attempt?.actionId === POINTER_ACTIONS.goToToday) {
+    return (
+      <>
+        Press <Key>T</Key> to go to today.
       </>
     );
   }

--- a/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.test.tsx
+++ b/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.test.tsx
@@ -10,6 +10,7 @@ import { act, type PropsWithChildren, type ReactElement } from "react";
 import dayjs from "@core/util/date/dayjs";
 import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
 import { MonthPicker } from "@web/components/Sidebar/MonthPicker/MonthPicker";
+import { POINTER_ACTIONS } from "@web/shortcuts/keyboard-only/pointer-action";
 import {
   pageJumpHintActions,
   usePageJumpHintStore,
@@ -254,5 +255,24 @@ describe("MonthPicker", () => {
     expect(picker.textContent).not.toContain("Shift");
     expect(picker.textContent).not.toContain(",");
     expect(picker.textContent).not.toContain(".");
+  });
+
+  it("labels the today control with the t shortcut and pointer-teaching action", async () => {
+    const user = userEvent.setup();
+    renderPicker(<MonthPicker onSelectDate={mock()} {...pickerProps} />);
+
+    const todayButton = screen.getByRole("button", {
+      name: "Go to this month",
+    });
+    expect(todayButton).toHaveAttribute(
+      "data-pointer-action",
+      POINTER_ACTIONS.goToToday,
+    );
+
+    await user.hover(todayButton);
+
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveTextContent(dayjs().format("MMM YYYY"));
+    expect(tooltip).toHaveTextContent("T");
   });
 });

--- a/packages/web/src/shortcuts/keyboard-only/pointer-action.test.ts
+++ b/packages/web/src/shortcuts/keyboard-only/pointer-action.test.ts
@@ -83,4 +83,12 @@ describe("teachingFromBlockedPointer", () => {
       attempt: { actionId: POINTER_ACTIONS.sidebarClose },
     });
   });
+
+  it("teaches go-to-today from the annotated month picker control", () => {
+    const target = document.createElement("button");
+    target.setAttribute(POINTER_ACTION_ATTRIBUTE, POINTER_ACTIONS.goToToday);
+    expect(teachingFromBlockedPointer([target, document], 0)).toEqual({
+      attempt: { actionId: POINTER_ACTIONS.goToToday },
+    });
+  });
 });

--- a/packages/web/src/shortcuts/keyboard-only/pointer-action.ts
+++ b/packages/web/src/shortcuts/keyboard-only/pointer-action.ts
@@ -5,6 +5,7 @@ export const POINTER_EVENT_JUMP_REQUEST = "compass:pointer-event-jump";
 
 export const POINTER_ACTIONS = {
   eventOpen: "event.open",
+  goToToday: "calendar.today",
   sidebarClose: "sidebar.close",
   sidebarOpen: "sidebar.open",
 } as const;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The month picker today control (the dotted circle next to the month chevrons) only showed the current month name on hover, so users had no cue that `t` jumps back to today.

This change:
- Adds the `T` keycap to that hover tip on the sidebar month picker.
- Annotates the control as `calendar.today` so a blocked mouse click shows `Press T to go to today.` instead of the generic keyboard-only reminder.

Event-form / grid date pickers are unchanged: `t` is a calendar navigation shortcut, not a picker-month jump.

Merged latest `main` (grid pointer-hint teaching) so this branch can squash-merge cleanly.

## Simplicity

Reuses the existing `TooltipWrapper` shortcut slot and `POINTER_ACTIONS` / `PointerHint` teaching path used by the sidebar toggle. No new stores or hint types.

## Automated validation

Browser (anonymous IndexedDB, http://localhost:9080):
- Hovering the month picker today control shows `Aug 2026` plus a `T` keycap.
- Clicking it shows the top-center hint `Press T to go to today.`

![Month picker today hover tip with T shortcut](https://cursor.com/artifacts/c/art-e09aba77-ed1c-4cd5-96e3-b35079f7b0b8)
<a href="https://cursor.com/agents/bc-c7ab8d87-e9b2-429f-b1f6-9e4ddd95e21f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmonth_picker_today_shortcut.mp4"><img src="https://cursor.com/artifacts/c/art-9a4f6b50-6f4b-424b-ae80-e0fab28dc25e" alt="month_picker_today_shortcut.mp4" /></a>

## Independent review

Local review of the base-to-head diff: no confirmed findings. Reuses existing tooltip and pointer-hint patterns; sidebar-only so form date pickers do not advertise `t`.

## Test plan

- `bun test:web` (focused files: PointerHint, MonthPicker, pointer-action) — 33 pass after merging main
- `bun run verify` — test:web, type-check, lint, knip passed
- `bun run test:a11y` — 7 passed
- `bunx playwright test e2e/timed/mouse-inert.spec.ts e2e/accessibility/datepicker-a11y.spec.ts` — 4 passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7ab8d87-e9b2-429f-b1f6-9e4ddd95e21f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7ab8d87-e9b2-429f-b1f6-9e4ddd95e21f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

