### PR TITLE
fix(web): close Start Premium dialog on Escape

### DIFF
--- a/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationDialog.tsx
+++ b/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationDialog.tsx
@@ -31,6 +31,21 @@ export function UpgradeConfirmationDialog({
   onManageBilling,
 }: UpgradeConfirmationDialogProps) {
   const manageBillingRef = useRef<HTMLButtonElement>(null);
+  const overlayShortcut = {
+    enabled: isOpen,
+    ignoreAppLock: true,
+    ignoreInputs: false,
+    preventDefault: true,
+  } as const;
+
+  useAppShortcut(
+    "Escape",
+    () => {
+      if (isSubmitting) return;
+      onCancel();
+    },
+    overlayShortcut,
+  );
 
   useAppShortcut(
     "M",
@@ -39,12 +54,7 @@ export function UpgradeConfirmationDialog({
       manageBillingRef.current?.focus({ preventScroll: true });
       onManageBilling();
     },
-    {
-      enabled: isOpen,
-      ignoreAppLock: true,
-      ignoreInputs: false,
-      preventDefault: true,
-    },
+    overlayShortcut,
   );
 
   if (!isOpen) return null;

--- a/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationProvider.test.tsx
+++ b/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationProvider.test.tsx
@@ -161,6 +161,30 @@ describe("UpgradeConfirmationProvider", () => {
     endTrial.mockRestore();
   });
 
+  it("closes on Escape without calling Stripe", async () => {
+    const endTrial = spyOn(BillingApi, "endTrial");
+    await openDialog();
+
+    await userEvent.keyboard("{Escape}");
+
+    expect(
+      screen.queryByRole("dialog", { name: "Start Premium now?" }),
+    ).not.toBeInTheDocument();
+    expect(endTrial).not.toHaveBeenCalled();
+    endTrial.mockRestore();
+  });
+
+  it("closes on Escape even when focus is outside the dialog", async () => {
+    await openDialog();
+    document.body.focus();
+
+    await userEvent.keyboard("{Escape}");
+
+    expect(
+      screen.queryByRole("dialog", { name: "Start Premium now?" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("sends Manage billing to the Stripe portal in a new tab", async () => {
     const portal = spyOn(BillingApi, "createPortalSession").mockResolvedValue({
       url: "https://billing.stripe.com/p/session_1",

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -906,4 +906,29 @@ describe("SettingsModal", () => {
       screen.getByRole("dialog", { name: "Start Premium now?" }),
     ).toBeInTheDocument();
   });
+
+  it("closes the upgrade confirmation on Escape and leaves Settings open", async () => {
+    access = {
+      kind: "server",
+      status: "trialing",
+      isReadOnly: false,
+      trialEndsAt: dayjs().add(3, "day").toISOString(),
+    };
+    const user = userEvent.setup({ delay: null });
+    renderSettings({ authenticated: true, page: "billing" });
+
+    await user.keyboard("b");
+    expect(
+      screen.getByRole("dialog", { name: "Start Premium now?" }),
+    ).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+
+    expect(
+      screen.queryByRole("dialog", { name: "Start Premium now?" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("dialog", { name: "Settings" }),
+    ).toBeInTheDocument();
+  });
 });

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -135,6 +135,10 @@ export const SettingsModal: FC = () => {
   if (!isOpen) return null;
 
   const handleDismiss = () => {
+    // The upgrade dialog stacks on top of Settings (unlike delete/logout,
+    // which close Settings first). Escape must not dismiss this panel while
+    // the confirmation still owns the screen.
+    if (isUpgradeOpen) return;
     if (confirmingId !== null) {
       setConfirmingId(null);
       return;

--- a/packages/web/src/shortcuts/useGlobalShortcuts.test.tsx
+++ b/packages/web/src/shortcuts/useGlobalShortcuts.test.tsx
@@ -258,4 +258,38 @@ describe("useGlobalShortcuts", () => {
       unmount();
     });
   });
+
+  it("closes the command palette on Escape", () => {
+    useSettingsStore.setState({ isCmdPaletteOpen: true });
+    const { unmount } = renderHook(() => useGlobalShortcuts(), { wrapper });
+
+    act(() => {
+      pressKey("Escape");
+    });
+
+    expect(selectIsCmdPaletteOpen(useSettingsStore.getState())).toBe(false);
+
+    act(() => {
+      unmount();
+    });
+  });
+
+  it("does not blur the focused control on Escape when the palette is closed", () => {
+    const keepFocus = document.createElement("button");
+    keepFocus.textContent = "Keep focus";
+    document.body.appendChild(keepFocus);
+    keepFocus.focus();
+    const { unmount } = renderHook(() => useGlobalShortcuts(), { wrapper });
+
+    act(() => {
+      pressKey("Escape");
+    });
+
+    expect(document.activeElement).toBe(keepFocus);
+
+    keepFocus.remove();
+    act(() => {
+      unmount();
+    });
+  });
 });

--- a/packages/web/src/shortcuts/useGlobalShortcuts.ts
+++ b/packages/web/src/shortcuts/useGlobalShortcuts.ts
@@ -4,6 +4,7 @@ import { useRef } from "react";
 import { useWelcomeGuideStore } from "@web/components/WelcomeModal/welcome.guide.store";
 import { viewActions } from "@web/events/stores/view.store";
 import {
+  selectIsCmdPaletteOpen,
   settingsActions,
   useSettingsStore,
 } from "@web/settings/settings.store";
@@ -29,6 +30,7 @@ export function useGlobalShortcuts() {
 export function useNavigationShortcuts() {
   const navigate = useNavigate();
   const location = useLocation();
+  const isCmdPaletteOpen = useSettingsStore(selectIsCmdPaletteOpen);
   const dayHotkey = VIEW_SHORTCUTS.day.key.toUpperCase() as RegisterableHotkey;
   const weekHotkey =
     VIEW_SHORTCUTS.week.key.toUpperCase() as RegisterableHotkey;
@@ -96,12 +98,17 @@ export function useNavigationShortcuts() {
     },
   );
 
+  // Armed only while the palette is open. The handler ignoreAppLocks (so
+  // Escape can close the palette over a modal) and blurs on trigger. If it
+  // stayed registered while closed, every Escape would blur the focused
+  // overlay control and advertised Esc actions would no-op.
   useAppShortcut(
     "Escape",
     () => {
       settingsActions.closeCmdPalette();
     },
     {
+      enabled: isCmdPaletteOpen,
       ignoreInputs: false,
       blurOnTrigger: true,
       ignoreAppLock: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pressing Escape on the "Start Premium now?" dialog did nothing, even though Cancel advertises an Esc keycap.

Two things were fighting the advertised shortcut:

1. The global command-palette Escape handler stayed armed while the palette was closed (`ignoreAppLock` + `blurOnTrigger`). Every Escape blurred the focused overlay control and never reached Cancel.
2. The upgrade dialog stacked on top of Settings (unlike delete/logout, which close Settings first) and did not register Escape itself. OverlayPanel only dismisses when the key bubbles from inside the panel.

This binds Escape on the upgrade dialog the same way M is bound, ignores Settings dismiss while that confirmation is open, and only runs the palette Escape handler when the palette is actually open.

## Simplicity

No new overlay stack or focus machinery. The dialog already used `useAppShortcut` for M; Escape now shares that path. The palette shortcut is a one-line `enabled` gate.

## Automated validation

`bun run verify` from merge-base vs `origin/main`:

```
Selected packages: web
Checks run: test:web, type-check, lint, knip
✓ selected checks passed
```

Focused web tests (61 pass / 0 fail):

- `UpgradeConfirmationProvider` closes on Escape, including when focus is on `document.body`, and does not call Stripe
- `SettingsModal` opens the confirmation with B, then Escape closes it and leaves Settings open
- `useGlobalShortcuts` still closes the palette on Escape, and does not blur a focused control when the palette is closed

## Independent review

Local verify PASS for the web subset (test:web, type-check, lint, knip).

## Test plan

```bash
bun run verify
bun packages/scripts/src/testing/test-parallel.ts web -- \
  packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationProvider.test.tsx \
  packages/web/src/components/Settings/SettingsModal.test.tsx \
  packages/web/src/shortcuts/useGlobalShortcuts.test.tsx
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-372c57ca-1089-4638-a6fc-919d9d0eb504?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-372c57ca-1089-4638-a6fc-919d9d0eb504&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

