### PR TITLE
fix(web): fire upcoming event alerts on Life and after tab wake

### DIFF
--- a/.agents/handoffs/2980.md
+++ b/.agents/handoffs/2980.md
@@ -1,0 +1,34 @@
+---
+schema_version: 1
+task_id: "2980"
+from: Reviewer
+to: Manager
+owner: Manager
+status: waiting
+artifact:
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/2980
+  - path: packages/web/src/notifications/upcoming-notifier.logic.ts
+  - path: packages/web/src/common/hooks/useMinuteTick.ts
+  - path: packages/web/src/components/RootShell/RootShell.tsx
+evidence:
+  - command: bun run verify
+    result: "PASS after retry. Selected web. Checks: test:web, type-check, lint, knip. test:a11y 7 passed on retry; test:e2e 48 passed on retry. Earlier type-check and useToday failures were implementer-fixed. One a11y color-contrast flake on UpNext Open button (4.14–4.28 vs 4.5) is pre-existing and not treated as a product fail."
+  - command: bun test:web
+    result: "2831 pass after useToday timeout-spy fix (was 1 fail on setInterval)"
+assumptions:
+  - "Phase 1 only: no service worker, no Web Push, no backend cron"
+  - "dayEventQueryRange stays [today, tomorrow) for day view"
+open_risks:
+  - "Closed tab and quit browser still cannot fire alerts"
+  - "Android Chrome still needs a service worker to construct Notification"
+  - "Axe color-contrast on UpNext Open can flake near 4.5:1"
+next_deadline: 2026-08-31T00:00:00Z
+retry: 1
+approval: none
+waiting_on: github-required-checks
+escalation: null
+---
+
+Verifier PASS. Simplify: no commit (diff already minimal). Review: no confirmed findings.
+
+Suggested skills: none. Next: mark PR ready, watch required checks, squash-merge.

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,6 +13,7 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 2980 | high | Manager | waiting | https://github.com/KeepSoftwareSimple/compass-calendar/pull/2980 | verify PASS (web, type-check, lint, knip, a11y, e2e); review: no confirmed findings | 2026-08-31T00:00:00Z | 1 | none |
 | 2878 | medium | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/2878 | bun run verify: web, type-check, lint, knip passed; bun test:a11y 7 passed | 2026-08-26T03:00:00Z | 0 | none |
 | 2879 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/2879 | bun run verify PASS; review: no confirmed findings | 2026-08-26T06:00:00Z | 0 | none |
 | WP-shortcut-showcase-simplify | medium | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/2890 | verifier PASS; simplify no change; independent re-review no findings | 2026-08-26T23:00:00Z | 2 | none |

--- a/packages/web/src/__tests__/helpers/web-test-seams.ts
+++ b/packages/web/src/__tests__/helpers/web-test-seams.ts
@@ -106,7 +106,10 @@ export function createTestNotificationPort(options?: {
   let permission: NotificationPermission = options?.permission ?? "default";
   const permissionListeners = new Set<() => void>();
 
-  const show = mock(() => options?.showSucceeds !== false);
+  const show = mock(
+    (..._args: Parameters<NotificationPort["show"]>): boolean =>
+      options?.showSucceeds !== false,
+  );
   const requestPermission = mock(async () => {
     permission = options?.respondWith ?? permission;
     return permission;

--- a/packages/web/src/__tests__/helpers/web-test-seams.ts
+++ b/packages/web/src/__tests__/helpers/web-test-seams.ts
@@ -100,11 +100,13 @@ export function createTestNotificationPort(options?: {
   /** What requestPermission resolves to; defaults to the current permission. */
   respondWith?: NotificationPermission;
   supported?: boolean;
+  /** What show returns; defaults to true so de-dupe keys burn like production. */
+  showSucceeds?: boolean;
 }) {
   let permission: NotificationPermission = options?.permission ?? "default";
   const permissionListeners = new Set<() => void>();
 
-  const show = mock();
+  const show = mock(() => options?.showSucceeds !== false);
   const requestPermission = mock(async () => {
     permission = options?.respondWith ?? permission;
     return permission;

--- a/packages/web/src/auth/posthog/track.ts
+++ b/packages/web/src/auth/posthog/track.ts
@@ -22,6 +22,8 @@ export type ProductEvent =
   | "notifications_enabled"
   | "notifications_disabled"
   | "notifications_enable_denied"
+  | "notifications_shown"
+  | "notifications_show_failed"
   | "shortcut_suggestion_shown"
   | "shortcut_invoked"
   | "shortcut_suggestion_engaged"

--- a/packages/web/src/common/hooks/useMinuteTick.test.ts
+++ b/packages/web/src/common/hooks/useMinuteTick.test.ts
@@ -1,6 +1,9 @@
 import { renderHook } from "@testing-library/react";
 import { act } from "react";
-import { useMinuteTick } from "@web/common/hooks/useMinuteTick";
+import {
+  msUntilNextMinute,
+  useMinuteTick,
+} from "@web/common/hooks/useMinuteTick";
 import {
   afterEach,
   beforeEach,
@@ -11,34 +14,53 @@ import {
   spyOn,
 } from "bun:test";
 
-const TICK_INTERVAL_MS = 60_000;
+describe("msUntilNextMinute", () => {
+  it("waits a full minute when already on a minute boundary", () => {
+    expect(msUntilNextMinute(Date.parse("2026-02-05T00:00:00.000Z"))).toBe(
+      60_000,
+    );
+  });
+
+  it("waits the remainder of the current minute", () => {
+    expect(msUntilNextMinute(Date.parse("2026-02-05T00:00:37.000Z"))).toBe(
+      23_000,
+    );
+  });
+});
 
 describe("useMinuteTick", () => {
-  let intervalCallback: (() => void) | undefined;
-  let setIntervalSpy: ReturnType<typeof spyOn>;
-  let clearIntervalSpy: ReturnType<typeof spyOn>;
+  let timeoutCallback: (() => void) | undefined;
+  let lastDelay: number | undefined;
+  let setTimeoutSpy: ReturnType<typeof spyOn>;
+  let clearTimeoutSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
     setSystemTime(new Date("2026-02-05T00:00:00.000Z"));
-    intervalCallback = undefined;
-    setIntervalSpy = spyOn(globalThis, "setInterval").mockImplementation(((
+    timeoutCallback = undefined;
+    lastDelay = undefined;
+    setTimeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(((
       callback: TimerHandler,
+      delay?: number,
     ) => {
       if (typeof callback === "function") {
-        intervalCallback = () => callback();
+        timeoutCallback = () => callback();
       }
-
-      return 1 as unknown as ReturnType<typeof setInterval>;
-    }) as unknown as typeof setInterval);
-    clearIntervalSpy = spyOn(globalThis, "clearInterval").mockImplementation(
+      lastDelay = delay;
+      return 1 as unknown as ReturnType<typeof setTimeout>;
+    }) as unknown as typeof setTimeout);
+    clearTimeoutSpy = spyOn(globalThis, "clearTimeout").mockImplementation(
       () => {},
     );
   });
 
   afterEach(() => {
     setSystemTime();
-    setIntervalSpy.mockRestore();
-    clearIntervalSpy.mockRestore();
+    setTimeoutSpy.mockRestore();
+    clearTimeoutSpy.mockRestore();
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
   });
 
   it("returns the current time on mount", () => {
@@ -47,20 +69,66 @@ describe("useMinuteTick", () => {
     expect(result.current.toISOString()).toBe("2026-02-05T00:00:00.000Z");
   });
 
+  it("schedules the first tick for the next clock minute", () => {
+    setSystemTime(new Date("2026-02-05T00:00:37.000Z"));
+    renderHook(() => useMinuteTick());
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 23_000);
+  });
+
   it("advances once per minute-tick without changing more often", () => {
     const { result } = renderHook(() => useMinuteTick());
 
-    expect(setIntervalSpy).toHaveBeenCalledWith(
-      expect.any(Function),
-      TICK_INTERVAL_MS,
-    );
+    expect(lastDelay).toBe(60_000);
 
     setSystemTime(new Date("2026-02-05T00:01:00.000Z"));
     act(() => {
-      intervalCallback?.();
+      timeoutCallback?.();
     });
 
     expect(result.current.toISOString()).toBe("2026-02-05T00:01:00.000Z");
+  });
+
+  it("catches up when the tab becomes visible", () => {
+    const { result } = renderHook(() => useMinuteTick());
+
+    setSystemTime(new Date("2026-02-05T00:04:00.000Z"));
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(result.current.toISOString()).toBe("2026-02-05T00:04:00.000Z");
+  });
+
+  it("does not catch up while the tab is hidden", () => {
+    const { result } = renderHook(() => useMinuteTick());
+    const mountedAt = result.current.toISOString();
+
+    setSystemTime(new Date("2026-02-05T00:04:00.000Z"));
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "hidden",
+    });
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(result.current.toISOString()).toBe(mountedAt);
+  });
+
+  it("catches up when the window is focused", () => {
+    const { result } = renderHook(() => useMinuteTick());
+
+    setSystemTime(new Date("2026-02-05T00:04:00.000Z"));
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    expect(result.current.toISOString()).toBe("2026-02-05T00:04:00.000Z");
   });
 
   it("stops ticking after unmount", () => {
@@ -68,6 +136,6 @@ describe("useMinuteTick", () => {
 
     unmount();
 
-    expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+    expect(clearTimeoutSpy).toHaveBeenCalled();
   });
 });

--- a/packages/web/src/common/hooks/useMinuteTick.ts
+++ b/packages/web/src/common/hooks/useMinuteTick.ts
@@ -3,14 +3,49 @@ import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 
 const TICK_INTERVAL_MS = 60_000;
 
-/** Re-renders every 60s with the current time. Shared by anything that
- * needs to notice the clock moving (today rollover, now-line, up-next). */
+/** Milliseconds until the next clock minute. A tick that lands exactly on a
+ * minute boundary waits a full minute, so we never double-fire at :00. */
+export function msUntilNextMinute(nowMs: number = Date.now()): number {
+  const remainder = nowMs % TICK_INTERVAL_MS;
+  return remainder === 0 ? TICK_INTERVAL_MS : TICK_INTERVAL_MS - remainder;
+}
+
+/** Re-renders at the next clock minute, then every minute after that.
+ * Also catches up when the tab returns to the foreground: background
+ * timers freeze, and a stale `now` would miss the upcoming-event window. */
 export function useMinuteTick(): Dayjs {
   const [now, setNow] = useState<Dayjs>(() => dayjs());
 
   useEffect(() => {
-    const interval = setInterval(() => setNow(dayjs()), TICK_INTERVAL_MS);
-    return () => clearInterval(interval);
+    let timeoutId: ReturnType<typeof setTimeout>;
+    let cancelled = false;
+
+    const tick = () => {
+      if (cancelled) return;
+      setNow(dayjs());
+      timeoutId = setTimeout(tick, msUntilNextMinute());
+    };
+
+    const catchUp = () => {
+      if (cancelled) return;
+      clearTimeout(timeoutId);
+      tick();
+    };
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") catchUp();
+    };
+
+    timeoutId = setTimeout(tick, msUntilNextMinute());
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    window.addEventListener("focus", catchUp);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timeoutId);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      window.removeEventListener("focus", catchUp);
+    };
   }, []);
 
   return now;

--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -549,4 +549,15 @@ describe("LifeCommandPalette", () => {
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
     expect(screen.queryByText("Calendar up-to-date")).not.toBeInTheDocument();
   });
+
+  it("offers event notifications in Settings", () => {
+    renderWithStore(
+      <LifeCommandPalette placeholder="Try: 'day', 'week', or 'feedback'" />,
+      { settings: { isCmdPaletteOpen: true } },
+    );
+
+    expect(
+      screen.getByRole("option", { name: "Enable event notifications" }),
+    ).toBeInTheDocument();
+  });
 });

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -413,6 +413,7 @@ export const LifeCommandPalette = ({
   const navigate = useNavigate();
   const themeCmdItems = useThemeCmdItems();
   const timezoneCmdItems = useTimezoneCmdItems();
+  const notificationCmdItems = useNotificationCmdItems();
 
   if (!open) return null;
 
@@ -434,13 +435,10 @@ export const LifeCommandPalette = ({
           heading: "Appearance",
           items: themeCmdItems,
         },
-        // No event notifications here: the Life route sits outside the
-        // authenticated layout that mounts the notifier, so offering the
-        // toggle would promise nudges this route can never deliver.
         {
           id: "settings",
           heading: "Settings",
-          items: timezoneCmdItems,
+          items: [...timezoneCmdItems, ...notificationCmdItems],
         },
         ...getMoreCommandPaletteSections("life"),
       ]}

--- a/packages/web/src/components/RootShell/RootShell.tsx
+++ b/packages/web/src/components/RootShell/RootShell.tsx
@@ -25,6 +25,7 @@ import {
   selectWelcomeGuideOpen,
   useWelcomeGuideStore,
 } from "@web/components/WelcomeModal/welcome.guide.store";
+import { UpcomingEventNotifier } from "@web/notifications/UpcomingEventNotifier";
 import { useEventContextMenuShortcut } from "@web/shortcuts/context-menu/useEventContextMenuShortcut";
 import { usePointerSuppression } from "@web/shortcuts/keyboard-only/usePointerSuppression";
 import { useFocusNoticeShortcut } from "@web/shortcuts/notice-focus/useFocusNoticeShortcut";
@@ -83,6 +84,7 @@ export function RootShell() {
       {showPastDue && <BillingPastDueBanner />}
       {showReadOnlyBanner && <BillingReadOnlyBanner />}
       <Outlet />
+      <UpcomingEventNotifier />
       <AuthModal />
       {gateStatus !== null && <BillingGateModal status={gateStatus} />}
       <CheckoutCelebrationModal />

--- a/packages/web/src/components/ShortcutShowcase/showcase.steps.ts
+++ b/packages/web/src/components/ShortcutShowcase/showcase.steps.ts
@@ -142,7 +142,7 @@ export const SHOWCASE_STEPS = [
   {
     id: "notifications",
     title: "Never miss a meeting",
-    body: "Compass can nudge you five minutes before a timed event starts, even when this tab is in the background. You can turn it off any time from the command palette.",
+    body: "Compass can nudge you five minutes before a timed event starts while this browser is open, even if the tab is in the background. You can turn it off any time from the command palette.",
   },
   {
     id: "graduation",

--- a/packages/web/src/components/Sidebar/UpNextCard/useUpNextEvent.ts
+++ b/packages/web/src/components/Sidebar/UpNextCard/useUpNextEvent.ts
@@ -4,7 +4,7 @@ import { useMinuteTick } from "@web/common/hooks/useMinuteTick";
 import { editGridEventDraft } from "@web/events/grid-event-draft.adapter";
 import { useDayEventViewModel } from "@web/events/queries/useDayEventsQuery";
 import { draftActions } from "@web/events/stores/draft.store";
-import { dayEventQueryRange } from "@web/views/Day/hooks/events/useDayEvents";
+import { notifiableEventQueryRange } from "@web/notifications/upcoming-notifier.logic";
 
 /**
  * Today's timed events with their real start/end bounds, ticking every minute.
@@ -13,7 +13,7 @@ import { dayEventQueryRange } from "@web/views/Day/hooks/events/useDayEvents";
  */
 export function useTodayTimedEvents() {
   const now = useMinuteTick();
-  const { startDate, endDate } = dayEventQueryRange(now);
+  const { startDate, endDate } = notifiableEventQueryRange(now);
   const { events, timedEvents, allDayEvents } = useDayEventViewModel({
     startDate,
     endDate,

--- a/packages/web/src/notifications/UpcomingEventNotifier.tsx
+++ b/packages/web/src/notifications/UpcomingEventNotifier.tsx
@@ -1,8 +1,8 @@
 import { useUpcomingEventNotifier } from "@web/notifications/useUpcomingEventNotifier";
 
 /**
- * Renders nothing; exists so the notifier hook has a mount point in the app
- * shell alongside the other always-on hosts.
+ * Renders nothing; exists so the notifier hook has a mount point on RootShell
+ * and keeps firing on every route, including Life.
  */
 export function UpcomingEventNotifier() {
   useUpcomingEventNotifier();

--- a/packages/web/src/notifications/notification.port.ts
+++ b/packages/web/src/notifications/notification.port.ts
@@ -18,7 +18,8 @@ export interface NotificationPort {
   isSupported(): boolean;
   getPermission(): NotificationPermission;
   requestPermission(): Promise<NotificationPermission>;
-  show(title: string, options?: ShowNotificationOptions): void;
+  /** Returns true only when the OS notification was actually constructed. */
+  show(title: string, options?: ShowNotificationOptions): boolean;
   /** Fires when the browser-level permission changes; returns an unsubscribe. */
   observePermission(onChange: () => void): () => void;
 }
@@ -43,7 +44,7 @@ const productionNotificationPort: NotificationPort = {
   },
 
   show: (title, options = {}) => {
-    if (!isSupported() || Notification.permission !== "granted") return;
+    if (!isSupported() || Notification.permission !== "granted") return false;
     try {
       const notification = new Notification(title, {
         body: options.body,
@@ -53,9 +54,12 @@ const productionNotificationPort: NotificationPort = {
         options.onClick?.();
         notification.close();
       };
+      return true;
     } catch {
       // Constructing a Notification throws on platforms that require a
-      // service worker (Android Chrome). Nothing to recover — stay silent.
+      // service worker (Android Chrome). The caller must not burn its
+      // de-dupe key, so the next tick can retry.
+      return false;
     }
   },
 

--- a/packages/web/src/notifications/notification.store.ts
+++ b/packages/web/src/notifications/notification.store.ts
@@ -55,7 +55,7 @@ export const notificationActions = {
       setPref(true, "enable");
       showStatusToast(
         NOTIFICATIONS_STATUS_TOAST_ID,
-        "Event notifications on. You'll get a heads-up 5 minutes before each event.",
+        "Event notifications on. You'll get a heads-up 5 minutes before each event while this browser is open.",
       );
       track("notifications_enabled", { source });
       return;

--- a/packages/web/src/notifications/upcoming-notifier.logic.test.ts
+++ b/packages/web/src/notifications/upcoming-notifier.logic.test.ts
@@ -4,6 +4,7 @@ import {
   announceUpcomingEvents,
   NOTIFY_LEAD_MINUTES,
   type NotifiableEvent,
+  notifiableEventQueryRange,
   notificationKey,
   pruneFiredKeys,
   selectEventsToNotify,
@@ -188,6 +189,25 @@ describe("announceUpcomingEvents", () => {
     expect(show).not.toHaveBeenCalled();
     expect([...fired]).toEqual([...existing]);
   });
+
+  it("does not burn the de-dupe key when the browser silently drops the notification", () => {
+    const { port, mocks } = createTestNotificationPort({
+      permission: "granted",
+      showSucceeds: false,
+    });
+    const event = eventAt(3);
+
+    const fired = announceUpcomingEvents(port, NOW, [event], new Set());
+
+    expect(mocks.show).toHaveBeenCalledTimes(1);
+    expect([...fired]).toEqual([]);
+
+    mocks.show.mockImplementation(() => true);
+    const retried = announceUpcomingEvents(port, NOW, [event], fired);
+
+    expect(mocks.show).toHaveBeenCalledTimes(2);
+    expect([...retried]).toEqual([notificationKey(event)]);
+  });
 });
 
 describe("pruneFiredKeys", () => {
@@ -207,5 +227,26 @@ describe("pruneFiredKeys", () => {
     const pruned = pruneFiredKeys(new Set(["broken-key-without-date"]), NOW);
 
     expect([...pruned]).toEqual([]);
+  });
+});
+
+describe("notifiableEventQueryRange", () => {
+  it("keeps today's local day and extends five minutes into tomorrow", () => {
+    setEffectiveTimeZoneForTests("America/Denver");
+    const now = dayjs.tz("2026-07-16 23:56", "America/Denver");
+
+    const { startDate, endDate } = notifiableEventQueryRange(now);
+
+    const evening = dayjs.tz("2026-07-16 21:00", "America/Denver");
+    const justAfterMidnight = dayjs.tz("2026-07-17 00:03", "America/Denver");
+    const afterLead = dayjs.tz("2026-07-17 00:06", "America/Denver");
+
+    expect(evening.valueOf()).toBeGreaterThanOrEqual(Date.parse(startDate));
+    expect(evening.valueOf()).toBeLessThan(Date.parse(endDate));
+    expect(justAfterMidnight.valueOf()).toBeGreaterThanOrEqual(
+      Date.parse(startDate),
+    );
+    expect(justAfterMidnight.valueOf()).toBeLessThan(Date.parse(endDate));
+    expect(afterLead.valueOf()).toBeGreaterThanOrEqual(Date.parse(endDate));
   });
 });

--- a/packages/web/src/notifications/upcoming-notifier.logic.ts
+++ b/packages/web/src/notifications/upcoming-notifier.logic.ts
@@ -1,4 +1,6 @@
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+import { track } from "@web/auth/posthog/track";
+import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
 import { type NotificationPort } from "@web/notifications/notification.port";
 import { inEffectiveTimeZone } from "@web/timezone/in-time-zone";
 
@@ -48,6 +50,25 @@ export function toNotifiableEvents(
  */
 export function notificationKey(event: NotifiableEvent): string {
   return `${event._id}|${event.startDate}`;
+}
+
+/**
+ * Event query range for the notifier and up-next: today's local day, plus the
+ * lead window into tomorrow so a meeting just after midnight still gets a
+ * full five-minute heads-up.
+ *
+ * Same `[start, end)` shape as `dayEventQueryRange`.
+ */
+export function notifiableEventQueryRange(now: Dayjs): {
+  startDate: string;
+  endDate: string;
+} {
+  return {
+    startDate: toUTCOffset(now.startOf("day")),
+    endDate: toUTCOffset(
+      now.startOf("day").add(1, "day").add(NOTIFY_LEAD_MINUTES, "minute"),
+    ),
+  };
 }
 
 /**
@@ -114,14 +135,20 @@ export function announceUpcomingEvents(
   const announced = pruneFiredKeys(firedKeys, now);
   for (const event of due) {
     const key = notificationKey(event);
-    port.show(event.title?.trim() || "Untitled event", {
+    const shown = port.show(event.title?.trim() || "Untitled event", {
       body: `Starts at ${inEffectiveTimeZone(event.startDate).format("h:mm A")}`,
       // Same value as the de-dupe key, so a reload inside the lead window
       // replaces the earlier notification instead of stacking a second.
       tag: key,
       onClick: () => window.focus(),
     });
-    announced.add(key);
+    if (shown) {
+      announced.add(key);
+      track("notifications_shown");
+      continue;
+    }
+    // A silent browser drop must not burn the key: the next tick retries.
+    track("notifications_show_failed");
   }
   return announced;
 }

--- a/packages/web/src/views/Root.tsx
+++ b/packages/web/src/views/Root.tsx
@@ -6,7 +6,6 @@ import { GlobalShortcutsHost } from "@web/components/CompassProvider/CompassProv
 import { DocumentTitle } from "@web/components/DocumentTitle/DocumentTitle";
 import { MobileGate } from "@web/components/MobileGate/MobileGate";
 import { UpNextBanner } from "@web/components/Sidebar/UpNextCard/UpNextBanner";
-import { UpcomingEventNotifier } from "@web/notifications/UpcomingEventNotifier";
 import SSEProvider from "@web/sse/provider/SSEProvider";
 
 export const RootView = () => {
@@ -24,7 +23,6 @@ export const RootView = () => {
         <GlobalShortcutsHost />
         <DocumentTitle />
         <UpNextBanner />
-        <UpcomingEventNotifier />
         <AuthenticatedLayout />
       </SSEProvider>
     </UserProvider>

--- a/packages/web/src/views/Week/hooks/useToday.test.ts
+++ b/packages/web/src/views/Week/hooks/useToday.test.ts
@@ -13,27 +13,31 @@ import {
 } from "bun:test";
 
 describe("useToday", () => {
-  let intervalCallback: (() => void) | undefined;
-  let setIntervalSpy: ReturnType<typeof spyOn>;
+  let timeoutCallback: (() => void) | undefined;
+  let setTimeoutSpy: ReturnType<typeof spyOn>;
+  let clearTimeoutSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
     setSystemTime(new Date("2026-02-05T23:59:00.000Z"));
-    intervalCallback = undefined;
-    setIntervalSpy = spyOn(globalThis, "setInterval").mockImplementation(((
+    timeoutCallback = undefined;
+    setTimeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(((
       callback: TimerHandler,
     ) => {
       if (typeof callback === "function") {
-        intervalCallback = () => callback();
+        timeoutCallback = () => callback();
       }
 
-      return 1 as unknown as ReturnType<typeof setInterval>;
-    }) as unknown as typeof setInterval);
-    spyOn(globalThis, "clearInterval").mockImplementation(() => {});
+      return 1 as unknown as ReturnType<typeof setTimeout>;
+    }) as unknown as typeof setTimeout);
+    clearTimeoutSpy = spyOn(globalThis, "clearTimeout").mockImplementation(
+      () => {},
+    );
   });
 
   afterEach(() => {
     setSystemTime();
-    setIntervalSpy.mockRestore();
+    setTimeoutSpy.mockRestore();
+    clearTimeoutSpy.mockRestore();
   });
 
   it("keeps the same `today` reference across a tick within the same day", () => {
@@ -42,7 +46,7 @@ describe("useToday", () => {
 
     setSystemTime(new Date("2026-02-05T23:59:30.000Z"));
     act(() => {
-      intervalCallback?.();
+      timeoutCallback?.();
     });
 
     expect(result.current.today).toBe(initialToday);
@@ -53,7 +57,7 @@ describe("useToday", () => {
 
     setSystemTime(new Date("2026-02-06T00:01:00.000Z"));
     act(() => {
-      intervalCallback?.();
+      timeoutCallback?.();
     });
 
     expect(result.current.today.isSame("2026-02-06", "day")).toBe(true);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Upcoming event alerts are client-only browser `Notification`s. They stopped working on Life because `/life` is a sibling of the authenticated layout, so `UpcomingEventNotifier` unmounted when leaving week/day. Background tabs also froze the minute tick, and a failed `Notification()` still burned the de-dupe key so the next tick never retried.

This change:

- Mounts `UpcomingEventNotifier` on `RootShell` so Life (and other sibling routes) keep firing
- Restores the Life command-palette toggle
- Aligns `useMinuteTick` to the next clock minute and refreshes `now` on `visibilitychange` / `focus`
- Queries today plus five minutes into tomorrow so a meeting just after midnight still gets a full lead
- Returns `boolean` from `show()` and only burns the fired key on success
- Tracks `notifications_shown` / `notifications_show_failed`
- Updates opt-in copy so it is clear alerts fire while this browser is open

Closed tab / quit browser still cannot fire. That remains a later Web Push / service-worker track, not this PR.

## Simplicity

No extra commit. One notifier mount point, one query helper (`notifiableEventQueryRange`), and the existing notification port. `dayEventQueryRange` is unchanged so day view still clips at midnight. No backend cron.

## Automated validation

`bun run verify` selected web, then `test:web` → `type-check` → `lint` → `knip` → `test:a11y` → `test:e2e`.

- `test:web`: 2831 pass (after driving `useToday` tests from `setTimeout`)
- `type-check`: pass (after typing the `show` mock with port arguments)
- `lint` / `knip`: pass
- `test:a11y`: 7 passed on retry
- `test:e2e`: 48 passed on retry

One axe color-contrast flake on the existing UpNext `Open` button (about 4.2:1 vs 4.5:1) is pre-existing and not treated as a product fail.

## Independent review

`.agents/handoffs/2980.md`

```
VERDICT: no confirmed findings
```

## Test plan

Commands actually run:

- `bun test:web`
- `bun run type-check`
- `bun run lint`
- `bun run knip`
- `bun run test:a11y`
- `bun run test:e2e`
- `bun run verify` (required-check subset from merge-base vs `origin/main`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-892dfd29-1233-4197-be17-ce6a4f3ccd00?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-892dfd29-1233-4197-be17-ce6a4f3ccd00&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

