### PR TITLE
feat(core): booking Zod contracts (WP-01)

### DIFF
--- a/.agents/handoffs/2970.md
+++ b/.agents/handoffs/2970.md
@@ -1,0 +1,34 @@
+---
+schema_version: 1
+task_id: "2970"
+from: Implementer
+to: Manager
+owner: Manager
+status: verifying
+artifact:
+  - path: packages/core/src/types/booking.contracts.ts
+  - path: packages/core/src/types/booking.contracts.test.ts
+evidence:
+  - command: bun test:core
+    result: pass (22 booking contract tests)
+  - command: bun run type-check
+    result: pass
+  - command: bun lint
+    result: pass
+  - command: bun knip
+    result: pass
+  - command: bun run verify
+    result: pass
+assumptions:
+  - "WP-01 is contracts-only with zero runtime wiring"
+open_risks: []
+next_deadline: 2026-08-30T23:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-01 Zod booking contracts for Compass Booking v1. Public projection
+strips calendar ids via `toPublicBookingPage`. Slug allocation follows
+the five-step spec algorithm with reserved-slug and collision handling.

--- a/packages/core/src/types/booking.contracts.test.ts
+++ b/packages/core/src/types/booking.contracts.test.ts
@@ -1,0 +1,235 @@
+import { faker } from "@faker-js/faker";
+import {
+  AdminGetBookingPageResponseSchema,
+  AdminPutBookingPageInputSchema,
+  allocateBookingSlug,
+  BookingPageSchema,
+  BookingSlugSchema,
+  CreateBookingReservationInputSchema,
+  PublicBookingPageSchema,
+  PublicGetBookingPageResponseSchema,
+  toPublicBookingPage,
+  WeeklyAvailabilityIntervalSchema,
+} from "@core/types/booking.contracts";
+import { describe, expect, it } from "bun:test";
+
+const calendarId = () => faker.database.mongodbObjectId();
+const objectId = () => faker.database.mongodbObjectId();
+const dateTime = () => "2026-08-30T12:00:00.000Z";
+
+const fullAdminPage = () => ({
+  id: objectId(),
+  slug: "tylerdane",
+  hostUserId: objectId(),
+  enabled: true,
+  durationMinutes: 30 as const,
+  destinationCalendarId: calendarId(),
+  blockingCalendarIds: [calendarId()],
+  timeZone: "America/Denver",
+  weeklyAvailability: [
+    { weekday: 1 as const, start: "09:00", end: "17:00" },
+    { weekday: 3 as const, start: "10:00", end: "12:00" },
+  ],
+  minNoticeHours: 4,
+  maxHorizonDays: 60,
+  bufferMinutes: null,
+  maxBookingsPerDay: null,
+  guestsCanInviteOthers: true,
+  createdAt: dateTime(),
+  updatedAt: dateTime(),
+});
+
+describe("BookingSlugSchema", () => {
+  it("accepts a valid slug", () => {
+    expect(BookingSlugSchema.safeParse("tylerdane").success).toBe(true);
+  });
+
+  it("rejects an empty slug", () => {
+    expect(BookingSlugSchema.safeParse("").success).toBe(false);
+  });
+
+  it("rejects reserved slug week", () => {
+    expect(BookingSlugSchema.safeParse("week").success).toBe(false);
+  });
+
+  it("rejects uppercase characters", () => {
+    expect(BookingSlugSchema.safeParse("TylerDane").success).toBe(false);
+  });
+});
+
+describe("BookingPageSchema", () => {
+  it("parses a full admin page JSON", () => {
+    expect(BookingPageSchema.safeParse(fullAdminPage()).success).toBe(true);
+  });
+
+  it("rejects duration 20", () => {
+    expect(
+      BookingPageSchema.safeParse({
+        ...fullAdminPage(),
+        durationMinutes: 20,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects weekday 0 on weekly availability", () => {
+    expect(
+      BookingPageSchema.safeParse({
+        ...fullAdminPage(),
+        weeklyAvailability: [{ weekday: 0, start: "09:00", end: "17:00" }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects maxHorizonDays above 60", () => {
+    expect(
+      BookingPageSchema.safeParse({
+        ...fullAdminPage(),
+        maxHorizonDays: 61,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects overlapping intervals on the same weekday", () => {
+    expect(
+      BookingPageSchema.safeParse({
+        ...fullAdminPage(),
+        weeklyAvailability: [
+          { weekday: 2, start: "09:00", end: "12:00" },
+          { weekday: 2, start: "11:00", end: "13:00" },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("allows non-overlapping intervals on different weekdays", () => {
+    const page = fullAdminPage();
+    expect(BookingPageSchema.safeParse(page).success).toBe(true);
+  });
+});
+
+describe("PublicBookingPageSchema", () => {
+  it("has no calendar ids in the shape", () => {
+    const keys = PublicBookingPageSchema.keyof().options;
+    expect(keys).toEqual([
+      "hostDisplayName",
+      "durationMinutes",
+      "timeZone",
+      "enabled",
+    ]);
+  });
+
+  it("projects an admin page without calendar ids", () => {
+    const admin = BookingPageSchema.parse(fullAdminPage());
+    const pub = toPublicBookingPage(admin, "Tyler Dane");
+
+    expect(PublicBookingPageSchema.safeParse(pub).success).toBe(true);
+    expect(pub).toEqual({
+      hostDisplayName: "Tyler Dane",
+      durationMinutes: 30,
+      timeZone: "America/Denver",
+      enabled: true,
+    });
+    expect(Object.keys(pub)).not.toContain("destinationCalendarId");
+    expect(Object.keys(pub)).not.toContain("blockingCalendarIds");
+  });
+});
+
+describe("WeeklyAvailabilityIntervalSchema", () => {
+  it("rejects end before start", () => {
+    expect(
+      WeeklyAvailabilityIntervalSchema.safeParse({
+        weekday: 1,
+        start: "17:00",
+        end: "09:00",
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("allocateBookingSlug", () => {
+  it("allocates tylerdane for Tyler Dane when free", () => {
+    expect(
+      allocateBookingSlug("Tyler Dane", "tyler", "abcdef123456", new Set()),
+    ).toBe("tylerdane");
+  });
+
+  it("uses the email local-part when the name slugifies too short", () => {
+    expect(
+      allocateBookingSlug("Al", "ada.lovelace", "abcdef123456", new Set()),
+    ).toBe("adalovelace");
+  });
+
+  it("uses user plus the user id suffix when still too short", () => {
+    expect(allocateBookingSlug("Al", "a", "abcdef123456", new Set())).toBe(
+      "user123456",
+    );
+  });
+
+  it("appends a numeric suffix when the candidate is taken", () => {
+    expect(
+      allocateBookingSlug(
+        "Tyler Dane",
+        "tyler",
+        "abcdef123456",
+        new Set(["tylerdane"]),
+      ),
+    ).toBe("tylerdane2");
+  });
+
+  it("appends a numeric suffix when the candidate is reserved", () => {
+    expect(allocateBookingSlug("Week", "week", "abcdef123456", new Set())).toBe(
+      "week2",
+    );
+  });
+
+  it("truncates long candidates to 32 characters before suffixing", () => {
+    const longName = "abcdefghijklmnopqrstuvwxyz1234567890extra";
+    const slug = allocateBookingSlug(longName, "x", "abcdef123456", new Set());
+    expect(slug.length).toBeLessThanOrEqual(32);
+    expect(slug).toBe("abcdefghijklmnopqrstuvwxyz123456");
+  });
+});
+
+describe("HTTP booking contracts", () => {
+  it("parses public page and admin responses", () => {
+    const admin = fullAdminPage();
+    expect(
+      PublicGetBookingPageResponseSchema.safeParse({
+        hostDisplayName: "Tyler Dane",
+        durationMinutes: admin.durationMinutes,
+        timeZone: admin.timeZone,
+        enabled: admin.enabled,
+      }).success,
+    ).toBe(true);
+
+    expect(
+      AdminGetBookingPageResponseSchema.safeParse({
+        ...admin,
+        bookingUrl: "https://compasscalendar.com/book/tylerdane",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("parses admin replace input without server-managed fields", () => {
+    const admin = fullAdminPage();
+    const { id, slug, hostUserId, createdAt, updatedAt, ...replaceInput } =
+      admin;
+
+    expect(AdminPutBookingPageInputSchema.safeParse(replaceInput).success).toBe(
+      true,
+    );
+    expect(id).toBeDefined();
+    expect(slug).toBeDefined();
+  });
+
+  it("parses create reservation input", () => {
+    expect(
+      CreateBookingReservationInputSchema.safeParse({
+        slotStart: "2026-09-01T15:00:00.000Z",
+        guestName: "Ada Lovelace",
+        guestEmail: "ada@example.com",
+        guestTimeZone: "Europe/London",
+      }).success,
+    ).toBe(true);
+  });
+});

--- a/packages/core/src/types/booking.contracts.ts
+++ b/packages/core/src/types/booking.contracts.ts
@@ -1,0 +1,336 @@
+import { z } from "zod/v4";
+import {
+  CalendarIdSchema,
+  DateTimeSchema,
+  TimeZoneSchema,
+} from "@core/types/domain-primitives";
+import { ObjectIdStringSchema } from "@core/types/type.utils";
+
+export const BOOKING_RESERVED_SLUGS = [
+  "week",
+  "day",
+  "life",
+  "auth",
+  "api",
+  "cleanup",
+  "book",
+  "p",
+  "settings",
+  "admin",
+  "login",
+  "logout",
+  "signup",
+  "invite",
+  "calendar",
+] as const;
+
+export type BookingReservedSlug = (typeof BOOKING_RESERVED_SLUGS)[number];
+
+export const BookingPageIdSchema =
+  ObjectIdStringSchema.brand<"BookingPageId">();
+export type BookingPageId = z.infer<typeof BookingPageIdSchema>;
+
+export const BookingUserIdSchema =
+  ObjectIdStringSchema.brand<"BookingUserId">();
+export type BookingUserId = z.infer<typeof BookingUserIdSchema>;
+
+export const BookingReservationIdSchema =
+  ObjectIdStringSchema.brand<"BookingReservationId">();
+export type BookingReservationId = z.infer<typeof BookingReservationIdSchema>;
+
+export const BookingSlugSchema = z
+  .string()
+  .trim()
+  .regex(/^[a-z0-9]{3,32}$/, {
+    message: "Slug must be 3-32 lowercase letters or digits",
+  })
+  .refine(
+    (slug) => !BOOKING_RESERVED_SLUGS.includes(slug as BookingReservedSlug),
+    { message: "Slug is reserved" },
+  );
+export type BookingSlug = z.infer<typeof BookingSlugSchema>;
+
+export const BookingDurationMinutesSchema = z.union([
+  z.literal(15),
+  z.literal(30),
+  z.literal(45),
+  z.literal(60),
+]);
+export type BookingDurationMinutes = z.infer<
+  typeof BookingDurationMinutesSchema
+>;
+
+const HH_MM_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+export const LocalTimeOfDaySchema = z
+  .string()
+  .trim()
+  .regex(HH_MM_PATTERN, { message: 'Time must be "HH:mm" in 24-hour form' });
+export type LocalTimeOfDay = z.infer<typeof LocalTimeOfDaySchema>;
+
+const localTimeToMinutes = (time: string): number => {
+  const [hoursText, minutesText] = time.split(":");
+  const hours = Number(hoursText);
+  const minutes = Number(minutesText);
+  return hours * 60 + minutes;
+};
+
+export const IsoWeekdaySchema = z.union([
+  z.literal(1),
+  z.literal(2),
+  z.literal(3),
+  z.literal(4),
+  z.literal(5),
+  z.literal(6),
+  z.literal(7),
+]);
+export type IsoWeekday = z.infer<typeof IsoWeekdaySchema>;
+
+export const WeeklyAvailabilityIntervalSchema = z
+  .strictObject({
+    weekday: IsoWeekdaySchema,
+    start: LocalTimeOfDaySchema,
+    end: LocalTimeOfDaySchema,
+  })
+  .refine(
+    ({ start, end }) => localTimeToMinutes(end) > localTimeToMinutes(start),
+    { message: "Availability end must be after start", path: ["end"] },
+  );
+export type WeeklyAvailabilityInterval = z.infer<
+  typeof WeeklyAvailabilityIntervalSchema
+>;
+
+const intervalsOverlap = (
+  a: WeeklyAvailabilityInterval,
+  b: WeeklyAvailabilityInterval,
+): boolean => {
+  if (a.weekday !== b.weekday) {
+    return false;
+  }
+  const aStart = localTimeToMinutes(a.start);
+  const aEnd = localTimeToMinutes(a.end);
+  const bStart = localTimeToMinutes(b.start);
+  const bEnd = localTimeToMinutes(b.end);
+  return aStart < bEnd && bStart < aEnd;
+};
+
+export const WeeklyAvailabilitySchema = z
+  .array(WeeklyAvailabilityIntervalSchema)
+  .readonly()
+  .superRefine((intervals, ctx) => {
+    for (let i = 0; i < intervals.length; i += 1) {
+      const left = intervals[i];
+      if (!left) {
+        continue;
+      }
+      for (let j = i + 1; j < intervals.length; j += 1) {
+        const right = intervals[j];
+        if (!right) {
+          continue;
+        }
+        if (intervalsOverlap(left, right)) {
+          ctx.addIssue({
+            code: "custom",
+            message: "Weekly availability intervals must not overlap",
+            path: [j],
+          });
+        }
+      }
+    }
+  });
+export type WeeklyAvailability = z.infer<typeof WeeklyAvailabilitySchema>;
+
+export const BookingBufferMinutesSchema = z
+  .int()
+  .positive()
+  .nullable()
+  .default(null);
+export type BookingBufferMinutes = z.infer<typeof BookingBufferMinutesSchema>;
+
+export const BookingMaxBookingsPerDaySchema = z
+  .int()
+  .positive()
+  .nullable()
+  .default(null);
+export type BookingMaxBookingsPerDay = z.infer<
+  typeof BookingMaxBookingsPerDaySchema
+>;
+
+export const BookingPageSchema = z.strictObject({
+  id: BookingPageIdSchema,
+  slug: BookingSlugSchema,
+  hostUserId: BookingUserIdSchema,
+  enabled: z.boolean(),
+  durationMinutes: BookingDurationMinutesSchema,
+  destinationCalendarId: CalendarIdSchema,
+  blockingCalendarIds: z.array(CalendarIdSchema).min(1).readonly(),
+  timeZone: TimeZoneSchema,
+  weeklyAvailability: WeeklyAvailabilitySchema,
+  minNoticeHours: z.number().int().nonnegative().default(4),
+  maxHorizonDays: z.number().int().positive().max(60).default(60),
+  bufferMinutes: BookingBufferMinutesSchema,
+  maxBookingsPerDay: BookingMaxBookingsPerDaySchema,
+  guestsCanInviteOthers: z.boolean().default(true),
+  createdAt: DateTimeSchema,
+  updatedAt: DateTimeSchema,
+});
+export type BookingPage = z.infer<typeof BookingPageSchema>;
+
+export const PublicBookingPageSchema = z.strictObject({
+  hostDisplayName: z.string().trim().min(1).max(256),
+  durationMinutes: BookingDurationMinutesSchema,
+  timeZone: TimeZoneSchema,
+  enabled: z.boolean(),
+});
+export type PublicBookingPage = z.infer<typeof PublicBookingPageSchema>;
+
+export const toPublicBookingPage = (
+  page: Pick<BookingPage, "durationMinutes" | "timeZone" | "enabled">,
+  hostDisplayName: string,
+): PublicBookingPage =>
+  PublicBookingPageSchema.parse({
+    hostDisplayName,
+    durationMinutes: page.durationMinutes,
+    timeZone: page.timeZone,
+    enabled: page.enabled,
+  });
+
+export const BookingReservationStatusSchema = z.enum([
+  "confirmed",
+  "cancelled",
+]);
+export type BookingReservationStatus = z.infer<
+  typeof BookingReservationStatusSchema
+>;
+
+export const ReservationSchema = z.strictObject({
+  id: BookingReservationIdSchema,
+  pageId: BookingPageIdSchema,
+  slotStart: DateTimeSchema,
+  slotEnd: DateTimeSchema,
+  guestName: z.string().trim().min(1).max(256),
+  guestEmail: z.string().trim().min(1).max(320),
+  notes: z.string().trim().max(4000).nullable(),
+  guestTimeZone: TimeZoneSchema,
+  status: BookingReservationStatusSchema,
+  calendarEventId: z.string().trim().min(1).max(256).nullable(),
+  cancelTokenHash: z.string().trim().min(1).max(256),
+  createdAt: DateTimeSchema,
+  updatedAt: DateTimeSchema,
+});
+export type Reservation = z.infer<typeof ReservationSchema>;
+
+export const PublicGetBookingPageResponseSchema = PublicBookingPageSchema;
+export type PublicGetBookingPageResponse = z.infer<
+  typeof PublicGetBookingPageResponseSchema
+>;
+
+export const BookingSlotsQuerySchema = z.strictObject({
+  start: DateTimeSchema,
+  end: DateTimeSchema,
+  timeZone: TimeZoneSchema,
+});
+export type BookingSlotsQuery = z.infer<typeof BookingSlotsQuerySchema>;
+
+export const BookingSlotSchema = z.strictObject({
+  slotStart: DateTimeSchema,
+  slotEnd: DateTimeSchema,
+});
+export type BookingSlot = z.infer<typeof BookingSlotSchema>;
+
+export const BookingSlotsResponseSchema = z.strictObject({
+  slots: z.array(BookingSlotSchema).readonly(),
+});
+export type BookingSlotsResponse = z.infer<typeof BookingSlotsResponseSchema>;
+
+export const CreateBookingReservationInputSchema = z.strictObject({
+  slotStart: DateTimeSchema,
+  guestName: z.string().trim().min(1).max(256),
+  guestEmail: z.string().trim().min(1).max(320),
+  notes: z.string().trim().max(4000).optional(),
+  guestTimeZone: TimeZoneSchema,
+});
+export type CreateBookingReservationInput = z.infer<
+  typeof CreateBookingReservationInputSchema
+>;
+
+export const CreateBookingReservationResponseSchema = z.strictObject({
+  reservationId: BookingReservationIdSchema,
+  slotStart: DateTimeSchema,
+  slotEnd: DateTimeSchema,
+  guestTimeZone: TimeZoneSchema,
+  cancelUrl: z.url(),
+});
+export type CreateBookingReservationResponse = z.infer<
+  typeof CreateBookingReservationResponseSchema
+>;
+
+export const CancelBookingReservationInputSchema = z.strictObject({
+  token: z.string().trim().min(1).max(256),
+});
+export type CancelBookingReservationInput = z.infer<
+  typeof CancelBookingReservationInputSchema
+>;
+
+export const AdminGetBookingPageResponseSchema = BookingPageSchema.extend({
+  bookingUrl: z.url(),
+});
+export type AdminGetBookingPageResponse = z.infer<
+  typeof AdminGetBookingPageResponseSchema
+>;
+
+export const AdminPutBookingPageInputSchema = z.strictObject({
+  enabled: z.boolean(),
+  durationMinutes: BookingDurationMinutesSchema,
+  destinationCalendarId: CalendarIdSchema,
+  blockingCalendarIds: z.array(CalendarIdSchema).min(1).readonly(),
+  timeZone: TimeZoneSchema,
+  weeklyAvailability: WeeklyAvailabilitySchema,
+  minNoticeHours: z.number().int().nonnegative().default(4),
+  maxHorizonDays: z.number().int().positive().max(60).default(60),
+  bufferMinutes: BookingBufferMinutesSchema,
+  maxBookingsPerDay: BookingMaxBookingsPerDaySchema,
+  guestsCanInviteOthers: z.boolean().default(true),
+});
+export type AdminPutBookingPageInput = z.infer<
+  typeof AdminPutBookingPageInputSchema
+>;
+
+const slugifyBookingCandidate = (value: string): string =>
+  value.toLowerCase().replace(/[^a-z0-9]/g, "");
+
+export const allocateBookingSlug = (
+  name: string,
+  emailLocalPart: string,
+  userIdSuffix: string,
+  taken: ReadonlySet<string>,
+): string => {
+  let candidate = slugifyBookingCandidate(name);
+
+  if (candidate.length < 3) {
+    candidate = slugifyBookingCandidate(emailLocalPart);
+  }
+
+  if (candidate.length < 3) {
+    candidate = `user${userIdSuffix.slice(-6)}`;
+  }
+
+  candidate = candidate.slice(0, 32);
+
+  const isUnavailable = (slug: string): boolean =>
+    BOOKING_RESERVED_SLUGS.includes(slug as BookingReservedSlug) ||
+    taken.has(slug);
+
+  if (!isUnavailable(candidate)) {
+    return candidate;
+  }
+
+  for (let suffix = 2; ; suffix += 1) {
+    const suffixText = String(suffix);
+    const baseMaxLength = Math.max(0, 32 - suffixText.length);
+    const nextCandidate = `${candidate.slice(0, baseMaxLength)}${suffixText}`;
+    if (!isUnavailable(nextCandidate)) {
+      return nextCandidate;
+    }
+  }
+};

--- a/wip/booking/TRACKING.md
+++ b/wip/booking/TRACKING.md
@@ -20,7 +20,7 @@ Org project create is blocked on `project` scope; see
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | PACK-WRITE | high | planning-session | done | `wip/booking/` + `docs/features/booking.md` | this directory exists; WPs have finish lines and session prompts; spec approved by product owner 2026-08-30; issues #2970–#2978; milestone 7 | — | 0 | user, 2026-08-30 |
-| WP-01 | high | — | queued | [WP-01-booking-contracts.md](WP-01-booking-contracts.md) [#2970](https://github.com/KeepSoftwareSimple/compass-calendar/issues/2970) | | | 0 | none |
+| WP-01 | high | cursor/booking-wp-01-booking-contracts-893c | running | [WP-01-booking-contracts.md](WP-01-booking-contracts.md) [#2970](https://github.com/KeepSoftwareSimple/compass-calendar/issues/2970) | started_at: 2026-08-30T21:52:00Z | | 0 | none |
 | WP-02 | high | — | queued | [WP-02-occupancy-honesty.md](WP-02-occupancy-honesty.md) [#2971](https://github.com/KeepSoftwareSimple/compass-calendar/issues/2971) | | | 0 | none |
 | WP-03 | high | — | queued | [WP-03-persistence-and-slug.md](WP-03-persistence-and-slug.md) [#2972](https://github.com/KeepSoftwareSimple/compass-calendar/issues/2972) | | | 0 | none |
 | WP-04 | high | — | queued | [WP-04-slot-engine.md](WP-04-slot-engine.md) [#2973](https://github.com/KeepSoftwareSimple/compass-calendar/issues/2973) | | | 0 | none |

--- a/wip/booking/TRACKING.md
+++ b/wip/booking/TRACKING.md
@@ -20,7 +20,7 @@ Org project create is blocked on `project` scope; see
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | PACK-WRITE | high | planning-session | done | `wip/booking/` + `docs/features/booking.md` | this directory exists; WPs have finish lines and session prompts; spec approved by product owner 2026-08-30; issues #2970–#2978; milestone 7 | — | 0 | user, 2026-08-30 |
-| WP-01 | high | cursor/booking-wp-01-booking-contracts-893c | running | [WP-01-booking-contracts.md](WP-01-booking-contracts.md) [#2970](https://github.com/KeepSoftwareSimple/compass-calendar/issues/2970) | started_at: 2026-08-30T21:52:00Z | | 0 | none |
+| WP-01 | high | cursor/booking-wp-01-booking-contracts-893c | done | [WP-01-booking-contracts.md](WP-01-booking-contracts.md) [#2970](https://github.com/KeepSoftwareSimple/compass-calendar/issues/2970) | booking.contracts.ts + tests; bun test:core/type-check/lint/knip/verify PASS | | 0 | none |
 | WP-02 | high | — | queued | [WP-02-occupancy-honesty.md](WP-02-occupancy-honesty.md) [#2971](https://github.com/KeepSoftwareSimple/compass-calendar/issues/2971) | | | 0 | none |
 | WP-03 | high | — | queued | [WP-03-persistence-and-slug.md](WP-03-persistence-and-slug.md) [#2972](https://github.com/KeepSoftwareSimple/compass-calendar/issues/2972) | | | 0 | none |
 | WP-04 | high | — | queued | [WP-04-slot-engine.md](WP-04-slot-engine.md) [#2973](https://github.com/KeepSoftwareSimple/compass-calendar/issues/2973) | | | 0 | none |

--- a/wip/booking/WP-01-booking-contracts.md
+++ b/wip/booking/WP-01-booking-contracts.md
@@ -2,7 +2,7 @@
 
 **task_id:** WP-01
 **github:** [#2970](https://github.com/KeepSoftwareSimple/compass-calendar/issues/2970)
-**status:** queued
+**status:** done
 **owner:** Implementer (core)
 **depends on:** none
 **next owner after done:** WP-03, WP-04, WP-05 may start (WP-02 is
@@ -81,7 +81,13 @@ Key files (create):
 
 ## Evidence
 
-Fill when implementing.
+- Added `packages/core/src/types/booking.contracts.ts` with Zod schemas for
+  booking slugs, durations, weekly availability, admin/public pages,
+  reservations, HTTP shapes, and `allocateBookingSlug`.
+- Colocated tests in `booking.contracts.test.ts` cover acceptance cases:
+  full admin parse, public projection without calendar ids, invalid slug/duration/weekday/horizon,
+  reserved slug rejection, overlapping intervals, and slug allocation.
+- `bun test:core`, `bun run type-check`, `bun lint`, `bun knip`, `bun run verify` PASS.
 
 ## Out of scope
 


### PR DESCRIPTION
Fixes #2970

## Summary

Adds shared Zod booking contracts in `packages/core` for Compass Booking v1 (WP-01): slug rules with reserved-name rejection, duration enum, weekly ISO availability with overlap checks, admin/public page shapes, reservation schema, public/admin HTTP request/response shapes, and pure `allocateBookingSlug` per the product spec. Includes colocated tests; zero runtime wiring.

## Simplicity

Single contracts file plus tests. Public projection is a small `toPublicBookingPage` helper. No backend, web, or persistence changes in this WP.

## Automated validation

- Full admin page JSON parses; `toPublicBookingPage` yields no calendar ids.
- Empty slug, duration `20`, weekday `0`, `maxHorizonDays: 61` rejected.
- Reserved slug `week` rejected; `Tyler Dane` allocates `tylerdane` when free.
- Overlapping weekday intervals rejected.

## Independent review

Handoff: `.agents/handoffs/2970.md`. Contracts-only diff; no behavior change outside schema validation and slug allocation helper.

## Test plan

- `bun test:core`
- `bun run type-check`
- `bun lint`
- `bun knip`
- `bun run verify`