### PR TITLE
fix(scripts): retry booking loop after quota reset

### DIFF
--- a/.github/scripts/booking-loop-launch.sh
+++ b/.github/scripts/booking-loop-launch.sh
@@ -21,6 +21,8 @@ prompt_file="${BOOKING_LOOP_SCRIPT_DIR}/../prompts/booking-loop.md"
 gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "$RUNNING_LABEL" \
   --remove-label "$NEEDS_HUMAN_LABEL" 2>/dev/null || \
   gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "$RUNNING_LABEL"
+gh issue edit "$ISSUE_NUMBER" --repo "$REPO" \
+  --remove-label "$QUOTA_WAITING_LABEL" 2>/dev/null || true
 
 if [ -n "${CURSOR_API_KEY:-}" ]; then
   prompt_text=$(cat <<EOF
@@ -32,7 +34,7 @@ Issue URL: ${issue_url}
 Read ${prompt_file##*/} at .github/prompts/booking-loop.md and follow it exactly.
 Also read .agents/skills/booking-loop/SKILL.md, wip/booking/README.md, wip/booking/TRACKING.md, and docs/features/booking.md.
 
-Take only this issue's work package from origin/main to a ready PR with Fixes #${ISSUE_NUMBER}, then squash-merge. Label the PR ${AUTOMERGE_LABEL}. Do not wait for a human. Never enter credentials on staging.
+Take only the work package for this issue from origin/main to a ready PR with Fixes #${ISSUE_NUMBER}, then squash-merge. Label the PR ${AUTOMERGE_LABEL}. Do not wait for a human. Never enter credentials on staging.
 EOF
 )
 
@@ -40,16 +42,17 @@ EOF
     jq -n \
       --arg text "$prompt_text" \
       --arg repo "$(github_repo_url)" \
-      '{
-        prompt: {text: $text},
-        source: {repository: $repo, ref: "main"},
+      "{
+        prompt: {text: \$text},
+        source: {repository: \$repo, ref: \"main\"},
         target: {autoCreatePr: false}
-      }'
+      }"
   )
 
   tmp=$(mktemp)
+  headers=$(mktemp)
   http_code=$(
-    curl -sS -o "$tmp" -w "%{http_code}" \
+    curl -sS -D "$headers" -o "$tmp" -w "%{http_code}" \
       --request POST \
       --url https://api.cursor.com/v0/agents \
       -u "${CURSOR_API_KEY}:" \
@@ -57,9 +60,46 @@ EOF
       --data "$payload"
   ) || http_code="000"
 
+  if [ "$http_code" = "429" ]; then
+    retry_after_seconds=$(awk 'BEGIN { IGNORECASE = 1 } /^retry-after:/ {
+      gsub("\\r", "", $2)
+      if ($2 ~ /^[0-9]+$/) print $2
+      exit
+    }' "$headers")
+    retry_after_seconds=${retry_after_seconds:-3600}
+    if [ "$retry_after_seconds" -lt 3600 ]; then
+      retry_after_seconds=3600
+    fi
+    if [ "$retry_after_seconds" -gt 86400 ]; then
+      retry_after_seconds=86400
+    fi
+    next_retry_at=$(python3 - "$retry_after_seconds" <<'PY'
+from datetime import datetime, timedelta, timezone
+import sys
+
+print((datetime.now(timezone.utc) + timedelta(seconds=int(sys.argv[1]))).isoformat().replace("+00:00", "Z"))
+PY
+)
+    rm -f "$tmp" "$headers"
+    gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "$(cat <<BODY
+booking-loop: Cursor quota exhausted (HTTP 429). Waiting until ${next_retry_at}, then the hourly watchdog will retry this WP.
+
+<!-- booking-loop-quota-retry-at=${next_retry_at} -->
+BODY
+)"
+    gh issue edit "$ISSUE_NUMBER" --repo "$REPO" \
+      --add-label "$QUOTA_WAITING_LABEL" --remove-label "$RUNNING_LABEL" \
+      --remove-label "$NEEDS_HUMAN_LABEL"
+    notify "booking-loop: Cursor quota exhausted for #${ISSUE_NUMBER}; retrying after ${next_retry_at}"
+    echo "Cursor quota exhausted for #${ISSUE_NUMBER}; retry after ${next_retry_at}."
+    set_output launch_mode quota-wait
+    set_output retry_after_seconds "$retry_after_seconds"
+    exit 0
+  fi
+
   if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
     body=$(head -c 800 "$tmp" || true)
-    rm -f "$tmp"
+    rm -f "$tmp" "$headers"
     gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "$(cat <<BODY
 booking-loop: Cursor API launch failed (HTTP ${http_code}). Not commenting \`${PICKUP_PHRASE}\` because \`CURSOR_API_KEY\` is set (dual-launch rule).
 
@@ -79,7 +119,7 @@ BODY
 
   agent_url=$(jq -r '.target.url // .id // empty' "$tmp")
   agent_id=$(jq -r '.id // empty' "$tmp")
-  rm -f "$tmp"
+  rm -f "$tmp" "$headers"
 
   gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "$(cat <<BODY
 booking-loop: launched Cursor cloud agent \`${agent_id}\`.

--- a/.github/scripts/booking-loop-lib.sh
+++ b/.github/scripts/booking-loop-lib.sh
@@ -7,6 +7,7 @@ MILESTONE="${BOOKING_LOOP_MILESTONE:-Compass Booking v1}"
 STAGING_URL="${BOOKING_LOOP_STAGING_URL:-https://staging.compasscalendar.com}"
 PICKUP_PHRASE="booking-loop: pickup"
 RUNNING_LABEL="booking-loop-running"
+QUOTA_WAITING_LABEL="booking-loop-waiting-for-credits"
 NEEDS_HUMAN_LABEL="booking-loop-needs-human"
 AUTOMERGE_LABEL="booking-automerge"
 

--- a/.github/scripts/booking-loop-next.sh
+++ b/.github/scripts/booking-loop-next.sh
@@ -10,6 +10,60 @@ if [ -z "$REPO" ]; then
   exit 1
 fi
 
+quota_waiting_json=$(
+  gh issue list --repo "$REPO" --milestone "$MILESTONE" --state open \
+    --label "$QUOTA_WAITING_LABEL" --limit 10 --json number,title,url
+)
+
+if [ "$quota_waiting_json" != "[]" ]; then
+  quota_waiting_number=$(python3 -c '
+import json, sys
+issues = json.loads(sys.stdin.read())
+issues.sort(key=lambda issue: issue["number"])
+print(issues[0]["number"])
+' <<<"$quota_waiting_json")
+  quota_retry_at=$(gh api "repos/${REPO}/issues/${quota_waiting_number}/comments" \
+    --paginate --jq '[.[].body | select(test("booking-loop-quota-retry-at="))] | last // ""' \
+    | sed -n 's/.*booking-loop-quota-retry-at=\([^ >]*\).*/\1/p' | tail -n 1)
+  quota_retry_due=$(RETRY_AT="$quota_retry_at" python3 - <<'PY'
+from datetime import datetime, timezone
+import os
+
+retry_at = os.environ["RETRY_AT"]
+if not retry_at:
+    print("true")
+else:
+    try:
+        timestamp = datetime.fromisoformat(retry_at.replace("Z", "+00:00"))
+        print("true" if timestamp <= datetime.now(timezone.utc) else "false")
+    except ValueError:
+        print("true")
+PY
+)
+
+  if [ "$quota_retry_due" != "true" ]; then
+    echo "Booking loop is waiting for Cursor credits on #${quota_waiting_number} until ${quota_retry_at:-the next hourly retry}."
+    set_output found false
+    exit 0
+  fi
+
+  quota_waiting_selected=$(python3 -c '
+import json, sys
+issues = json.loads(sys.stdin.read())
+issues.sort(key=lambda issue: issue["number"])
+print(json.dumps(issues[0]))
+' <<<"$quota_waiting_json")
+  number=$(python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["number"])' <<<"$quota_waiting_selected")
+  title=$(python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["title"])' <<<"$quota_waiting_selected")
+  url=$(python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["url"])' <<<"$quota_waiting_selected")
+  echo "Retrying Booking issue: #${number} ${title}"
+  set_output found true
+  set_output issue_number "$number"
+  set_output issue_title "$title"
+  set_output issue_url "$url"
+  exit 0
+fi
+
 running_json=$(
   gh issue list --repo "$REPO" --milestone "$MILESTONE" --state open \
     --label "$RUNNING_LABEL" --limit 10 --json number,updatedAt
@@ -78,13 +132,14 @@ prs_json=$(
 
 selected=$(
   ISSUES_JSON="$issues_json" PRS_JSON="$prs_json" \
-  SKIP_LABEL="$NEEDS_HUMAN_LABEL" RUNNING_LABEL="$RUNNING_LABEL" python3 - <<'PY'
+  SKIP_LABEL="$NEEDS_HUMAN_LABEL" RUNNING_LABEL="$RUNNING_LABEL" QUOTA_WAITING_LABEL="$QUOTA_WAITING_LABEL" python3 - <<'PY'
 import json, os, re
 
 issues = json.loads(os.environ["ISSUES_JSON"])
 prs = json.loads(os.environ["PRS_JSON"])
 skip_label = os.environ["SKIP_LABEL"]
 skip_also = os.environ["RUNNING_LABEL"]
+quota_waiting_label = os.environ["QUOTA_WAITING_LABEL"]
 
 issues.sort(key=lambda i: i["number"])
 
@@ -101,7 +156,7 @@ def has_open_pr(number: int) -> bool:
 
 for issue in issues:
     labels = {lab["name"] for lab in issue.get("labels") or []}
-    if skip_label in labels or skip_also in labels:
+    if skip_label in labels or skip_also in labels or quota_waiting_label in labels:
         continue
     if has_open_pr(issue["number"]):
         continue

--- a/docs/CI-CD/booking-loop-routine.md
+++ b/docs/CI-CD/booking-loop-routine.md
@@ -18,7 +18,8 @@ INPUT: GitHub issue in milestone Compass Booking v1
 SKILL/PROMPT: .github/prompts/booking-loop.md
 OUTPUT: ready PR with Fixes #<n>, squash-merge, staging smoke, next WP launched
 IDEMPOTENCY: one in-flight agent; booking-loop-running; skip issues with an open Fixes PR
-RETRY: dispatch a fresh run (do not “Re-run jobs” on a failed snapshot)
+RETRY: HTTP 429 waits for credits and retries on the hourly watchdog; dispatch a
+  fresh run for all other retryable investigation (do not “Re-run jobs” on a failed snapshot)
 APPROVAL: booking-automerge + merge-guard; bun run verify PASS + required checks
 STOP: repo var BOOKING_LOOP_ENABLED (must be string "true"; default off)
 HEARTBEAT: hourly cron watchdog when idle; Discord on merge-guard / smoke failure
@@ -59,7 +60,7 @@ required for WP-01 through WP-09.
    squash-merge commits trigger `release-on-main` (the default
    `GITHUB_TOKEN` does not).
 4. Labels `booking-automerge`, `booking-loop-running`,
-   `booking-loop-needs-human` on this repo (create with
+   `booking-loop-waiting-for-credits`, `booking-loop-needs-human` on this repo (create with
    `gh label create` if missing).
 
 Org Project "Compass Booking" is optional. Milestone
@@ -87,7 +88,10 @@ both channels are configured).
    3 hours are treated as abandoned and cleared.
 2. **Launch** (`.github/scripts/booking-loop-launch.sh`): POST the Cloud
    Agents API when `CURSOR_API_KEY` is set; otherwise comment
-   `booking-loop: pickup`. Never both.
+   `booking-loop: pickup`. Never both. HTTP 429 records the provider's retry
+   time, labels the issue `booking-loop-waiting-for-credits`, and exits
+   successfully so the hourly watchdog can resume it. Other launch failures
+   are `booking-loop-needs-human` stops.
 3. **Agent** follows `.github/prompts/booking-loop.md`: implement the WP, run
    `bun run verify`, open a ready PR, add label `booking-automerge`.
 4. **Merge guard** (`.github/scripts/booking-loop-merge-guard.sh`): enable
@@ -152,6 +156,7 @@ When the agent opens a PR, it writes `.agents/handoffs/<issue-number>.md`
 | --- | --- |
 | `booking-automerge` | Agent finished; merge-guard may squash-merge. |
 | `booking-loop-running` | An agent is in flight for this issue. |
+| `booking-loop-waiting-for-credits` | Cursor returned HTTP 429; retry only after the recorded time. |
 | `booking-loop-needs-human` | Kill this issue's loop; do not pick it again. |
 
 ## Drills (documented, not run)

--- a/packages/scripts/src/testing/booking-loop-launch.test.ts
+++ b/packages/scripts/src/testing/booking-loop-launch.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+function writeExecutable(path: string, contents: string) {
+  writeFileSync(path, contents, { mode: 0o755 });
+}
+
+function runLaunch(status: string, retryAfter = "") {
+  const directory = mkdtempSync(join(tmpdir(), "booking-loop-launch-"));
+  temporaryDirectories.push(directory);
+  const bin = join(directory, "bin");
+  const log = join(directory, "commands.log");
+  const output = join(directory, "github-output");
+  mkdirSync(bin);
+
+  writeExecutable(
+    join(bin, "gh"),
+    `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> "$BOOKING_LOOP_TEST_LOG"\n`,
+  );
+  writeExecutable(
+    join(bin, "curl"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+response_file=""
+headers_file=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) response_file="$2"; shift 2 ;;
+    -D) headers_file="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+printf '{"error":"simulated"}' > "$response_file"
+if [ -n "$headers_file" ]; then
+  printf 'retry-after: %s\\r\\n' "$BOOKING_LOOP_TEST_RETRY_AFTER" > "$headers_file"
+fi
+printf '%s' "$BOOKING_LOOP_TEST_STATUS"
+`,
+  );
+
+  const result = spawnSync(
+    "bash",
+    [".github/scripts/booking-loop-launch.sh", "42"],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        BOOKING_LOOP_TEST_LOG: log,
+        BOOKING_LOOP_TEST_RETRY_AFTER: retryAfter,
+        BOOKING_LOOP_TEST_STATUS: status,
+        CURSOR_API_KEY: "test-key",
+        GITHUB_OUTPUT: output,
+        GITHUB_REPOSITORY: "example/compass",
+        PATH: `${bin}:${process.env.PATH}`,
+      },
+    },
+  );
+
+  return {
+    ...result,
+    commands: readFileSync(log, "utf8"),
+    output: existsSync(output) ? readFileSync(output, "utf8") : "",
+  };
+}
+
+function runPicker(retryAt: string) {
+  const directory = mkdtempSync(join(tmpdir(), "booking-loop-picker-"));
+  temporaryDirectories.push(directory);
+  const bin = join(directory, "bin");
+  const output = join(directory, "github-output");
+  mkdirSync(bin);
+
+  writeExecutable(
+    join(bin, "gh"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "issue" ]; then
+  printf '[{"number":42,"title":"Booking contracts","url":"https://example.test/issues/42"}]'
+  exit 0
+fi
+if [ "$1" = "api" ]; then
+  printf '<!-- booking-loop-quota-retry-at=%s -->\\n' "$BOOKING_LOOP_TEST_RETRY_AT"
+  exit 0
+fi
+exit 1
+`,
+  );
+
+  const result = spawnSync("bash", [".github/scripts/booking-loop-next.sh"], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      BOOKING_LOOP_TEST_RETRY_AT: retryAt,
+      GITHUB_OUTPUT: output,
+      GITHUB_REPOSITORY: "example/compass",
+      PATH: `${bin}:${process.env.PATH}`,
+    },
+  });
+
+  return {
+    ...result,
+    output: existsSync(output) ? readFileSync(output, "utf8") : "",
+  };
+}
+
+describe("booking-loop launch quota recovery", () => {
+  it("records HTTP 429 as an hourly-retryable credit wait", () => {
+    const result = runLaunch("429", "120");
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.commands).toContain("booking-loop-waiting-for-credits");
+    expect(result.commands).toContain("booking-loop-quota-retry-at=");
+    expect(result.commands).not.toContain(
+      "--add-label booking-loop-needs-human",
+    );
+    expect(result.output).toContain("launch_mode=quota-wait");
+    expect(result.output).toContain("retry_after_seconds=3600");
+  });
+
+  it("keeps non-quota launch failures as human stops", () => {
+    const result = runLaunch("403");
+
+    expect(result.status, result.stderr).toBe(1);
+    expect(result.commands).toContain("--add-label booking-loop-needs-human");
+    expect(result.commands).not.toContain(
+      "--add-label booking-loop-waiting-for-credits",
+    );
+  });
+
+  it("does not launch before the recorded credit retry time", () => {
+    const result = runPicker("2999-01-01T00:00:00Z");
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.output).toContain("found=false");
+  });
+
+  it("retries the waiting issue after the recorded credit retry time", () => {
+    const result = runPicker("2000-01-01T00:00:00Z");
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.output).toContain("found=true");
+    expect(result.output).toContain("issue_number=42");
+  });
+});

--- a/packages/scripts/src/testing/booking-loop-routine.test.ts
+++ b/packages/scripts/src/testing/booking-loop-routine.test.ts
@@ -21,7 +21,7 @@ describe("booking-loop Routine contract", () => {
     );
     expect(routine).toContain("STOP: repo var BOOKING_LOOP_ENABLED");
     expect(routine).toContain(
-      "RETRY: dispatch a fresh run (do not “Re-run jobs” on a failed snapshot)",
+      "RETRY: HTTP 429 waits for credits and retries on the hourly watchdog",
     );
     expect(routine).toContain(
       "VERIFIER: .github/scripts/booking-loop-merge-guard.sh",
@@ -49,8 +49,8 @@ describe("booking-loop Routine contract", () => {
       "utf8",
     );
     expect(guard).toContain("NO_AUTOMERGE_PATH_PATTERNS=(");
-    expect(guard).toContain("MAX_FILES=${BOOKING_LOOP_MAX_FILES:-60}");
-    expect(guard).toContain("MAX_LINES=${BOOKING_LOOP_MAX_LINES:-4000}");
+    expect(guard).toContain(`MAX_FILES=\${BOOKING_LOOP_MAX_FILES:-60}`);
+    expect(guard).toContain(`MAX_LINES=\${BOOKING_LOOP_MAX_LINES:-4000}`);
 
     const routine = readFileSync("docs/CI-CD/booking-loop-routine.md", "utf8");
     expect(routine).toContain("MAX_FILES=60");
@@ -85,9 +85,17 @@ describe("booking-loop Routine contract", () => {
     );
     expect(launch).toContain("https://api.cursor.com/v0/agents");
     expect(launch).toContain("booking-loop: pickup");
-    expect(launch).toContain('if [ -n "${CURSOR_API_KEY:-}" ]');
+    expect(launch).toContain(`if [ -n "\${CURSOR_API_KEY:-}" ]`);
     expect(launch).toContain("Not commenting");
     expect(launch).toContain("dual-launch");
+    expect(launch).toContain('if [ "$http_code" = "429" ]');
+    const helpers = readFileSync(".github/scripts/booking-loop-lib.sh", "utf8");
+    expect(helpers).toContain("booking-loop-waiting-for-credits");
+    expect(launch).toContain("booking-loop-quota-retry-at=");
+
+    const next = readFileSync(".github/scripts/booking-loop-next.sh", "utf8");
+    expect(next).toContain("QUOTA_WAITING_LABEL");
+    expect(next).toContain("Booking loop is waiting for Cursor credits");
 
     const workflow = readFileSync(".github/workflows/booking-loop.yml", "utf8");
     expect(workflow).toContain("vars.BOOKING_LOOP_ENABLED == 'true'");


### PR DESCRIPTION
## Summary
- classify Cursor HTTP 429 as a persisted credit wait rather than a human stop
- retry the waiting work package only after its recorded retry time
- cover 429, wait, resume, and non-quota-stop behavior

## Verification
- bun run verify