### PR TITLE
fix(scripts): merge booking prs without auto-merge

### DIFF
--- a/.github/scripts/booking-loop-merge-guard.sh
+++ b/.github/scripts/booking-loop-merge-guard.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Deterministic re-check before squash-merging a booking-loop PR.
+# Deterministic re-check, verification wait, and squash-merge for a Booking
+# loop PR.
 # The agent's `booking-automerge` label is necessary but not sufficient —
 # this script independently re-verifies size rails and sensitive paths.
 #
@@ -41,7 +42,7 @@ fi
 downgrade() {
   local pr_number=$1
   local reason=$2
-  notify "Booking-loop PR #${pr_number} ${reason}; leaving for human review — https://github.com/${REPO}/pull/${pr_number}"
+  notify "Booking-loop PR #${pr_number} ${reason}; leaving for human review: https://github.com/${REPO}/pull/${pr_number}"
   gh pr edit "$pr_number" --repo "$REPO" \
     --remove-label "$AUTOMERGE_LABEL" --add-label "$NEEDS_HUMAN_LABEL" 2>/dev/null || true
   local issue_number
@@ -104,15 +105,16 @@ check_and_merge() {
     return 0
   fi
 
-  if ! gh pr merge "$pr_number" --repo "$REPO" --auto --squash --delete-branch; then
-    notify "Booking-loop PR #${pr_number} passed the merge guard but gh pr merge --auto failed — https://github.com/${REPO}/pull/${pr_number}"
+  if ! gh pr checks "$pr_number" --repo "$REPO" --watch --fail-fast; then
+    notify "Booking-loop PR #${pr_number} failed CI after merge-guard verification: https://github.com/${REPO}/pull/${pr_number}"
     return 0
   fi
-  printf 'enabled auto-merge on booking PR #%s\n' "$pr_number"
 
-  if ! gh pr checks "$pr_number" --repo "$REPO" --watch --fail-fast; then
-    notify "Booking-loop PR #${pr_number} failed CI after auto-merge was enabled — https://github.com/${REPO}/pull/${pr_number}"
+  if ! gh pr merge "$pr_number" --repo "$REPO" --squash --delete-branch; then
+    notify "Booking-loop PR #${pr_number} passed verification but direct squash-merge failed: https://github.com/${REPO}/pull/${pr_number}"
+    return 0
   fi
+  printf 'squash-merged booking PR #%s\n' "$pr_number"
 }
 
 main() {

--- a/.github/workflows/booking-loop.yml
+++ b/.github/workflows/booking-loop.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
-      - name: Deterministic merge guard + enable auto-merge
+      - name: Deterministic merge guard, verify, and squash-merge
         env:
           GH_TOKEN: ${{ secrets.BOOKING_LOOP_GITHUB_TOKEN || secrets.AUTOFIX_GITHUB_TOKEN }}
           DISCORD_ERRORS_WEBHOOK_URL: ${{ secrets.DISCORD_ERRORS_WEBHOOK_URL }}

--- a/docs/CI-CD/booking-loop-routine.md
+++ b/docs/CI-CD/booking-loop-routine.md
@@ -94,10 +94,9 @@ both channels are configured).
    are `booking-loop-needs-human` stops.
 3. **Agent** follows `.github/prompts/booking-loop.md`: implement the WP, run
    `bun run verify`, open a ready PR, add label `booking-automerge`.
-4. **Merge guard** (`.github/scripts/booking-loop-merge-guard.sh`): enable
-   squash auto-merge when CI is green, size is under the booking limits, and
-   no sensitive path is in the diff. Otherwise add `booking-loop-needs-human`
-   and stop.
+4. **Merge guard** (`.github/scripts/booking-loop-merge-guard.sh`): wait for
+   CI, then squash-merge when size is under the booking limits and no sensitive
+   path is in the diff. Otherwise add `booking-loop-needs-human` and stop.
 5. **Release on main** deploys staging (code paths only; docs-only merges skip
    deploy). The hourly cron is the watchdog for docs-only WPs.
 6. **Post-deploy** (`booking-loop.yml` `workflow_run`): smoke staging, strip

--- a/packages/scripts/src/testing/booking-loop-routine.test.ts
+++ b/packages/scripts/src/testing/booking-loop-routine.test.ts
@@ -59,6 +59,20 @@ describe("booking-loop Routine contract", () => {
     expect(routine).toContain("do not widen from this doc");
   });
 
+  it("waits for checks and squash-merges without GitHub auto-merge", () => {
+    const guard = readFileSync(
+      ".github/scripts/booking-loop-merge-guard.sh",
+      "utf8",
+    );
+    const checksIndex = guard.indexOf("gh pr checks");
+    const mergeIndex = guard.indexOf("gh pr merge");
+
+    expect(checksIndex).toBeGreaterThan(-1);
+    expect(mergeIndex).toBeGreaterThan(checksIndex);
+    expect(guard).toContain("--squash --delete-branch");
+    expect(guard).not.toContain("--auto --squash");
+  });
+
   it("still blocks the sensitive paths from auto-merging", () => {
     const guard = readFileSync(
       ".github/scripts/booking-loop-merge-guard.sh",


### PR DESCRIPTION
## Summary
- replace the unavailable GitHub auto-merge mutation with the existing direct squash-merge path
- wait for required checks before merging
- preserve notifications for actual CI or direct-merge failures

## Verification
- bun run verify