### PR TITLE
feat(web): give each calendar account a hold-Mod jump key

### DIFF
--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -310,7 +310,7 @@ Pressing `H` shows event-jump chips. Week view chips use day prefixes (`SU`/`M`/
 
 ### UX
 
-On Day view, holding Mod reveals numbered chips left to right: `1` on the view dropdown, then each **writable** calendar column (`2`, `3`, …), then the sidebar (month picker, Up next, calendars). Pressing that digit focuses the column header. Shift+Arrow then places a timed draft on that calendar; `C` / `Shift+C` honor the same focused column. Idle create (no column focused) still uses the default target calendar.
+On Day view, holding Mod reveals numbered chips left to right: `1` on the view dropdown, then each **writable** calendar column (`2`, `3`, …), then the sidebar (month picker, Up next, then each connected calendar account). Pressing that digit focuses the column header or account heading. Shift+Arrow then places a timed draft on that calendar; `C` / `Shift+C` honor the same focused column. Idle create (no column focused) still uses the default target calendar.
 
 ### Steps
 
@@ -322,7 +322,7 @@ On Day view, holding Mod reveals numbered chips left to right: `1` on the view d
 
 ### Expected Results
 
-- Hold-Mod chips on columns follow the view dropdown (`1`, then `2`…). Sidebar chips continue after the last column. Week view still uses 1–4 for view / month picker / Up next / calendars.
+- Hold-Mod chips on columns follow the view dropdown (`1`, then `2`…). Sidebar chips continue after the last column: month picker, Up next, then one chip per connected account. Collapsed accounts still get a chip; jumping to one expands it. Week view uses the same sidebar map after `1` on the view dropdown (no column chips). With no connected accounts, the last sidebar slot is the calendar list as a whole.
 - Read-only columns (for example holidays) have no chip and are not focusable via Mod+digit.
 - After focusing a column, Shift+Arrow places a form-closed timed draft in that column.
 - `C` and `Shift+C` seed the focused column's calendar. With no column focused, they still use the default create target.

--- a/docs/frontend/shortcut-commandments.md
+++ b/docs/frontend/shortcut-commandments.md
@@ -66,8 +66,10 @@ The hold is the same everywhere. Digits are a single namespace, so the
 open event form takes them over for its fields (1–9 in DOM order). With
 the form closed, the same hold numbers page areas left to right (view
 dropdown, then Day calendar columns, then month picker / Up next /
-calendars — or Life's grid/variation/details). Day view inserts writable
-columns after `1` so Shift+Arrow / C can seed a draft on a focused column.
+each connected calendar account — or Life's grid/variation/details).
+With no accounts, the last sidebar slot is the calendar list as a whole.
+Day view inserts writable columns after `1` so Shift+Arrow / C can seed
+a draft on a focused column.
 
 Do not run both maps at once. Do not invent a second hold key.
 

--- a/e2e/calendars/account-page-jump.spec.ts
+++ b/e2e/calendars/account-page-jump.spec.ts
@@ -1,5 +1,8 @@
 import { expect, type Page, test } from "@playwright/test";
-import { ensureSidebarOpen } from "../utils/event-test-utils";
+import {
+  ensureSidebarOpen,
+  getViewSwitcherButton,
+} from "../utils/event-test-utils";
 
 test.use({ viewport: { width: 1600, height: 900 } });
 
@@ -54,14 +57,12 @@ const googleCalendar = (
 });
 
 const holdMod = async (page: Page) => {
-  // Linux resolves Mod to Control; macOS to Meta. Hold both so the platform
-  // hold tracker and the chord check both fire (same as the showcase spec).
+  // This VM resolves Mod to Control. Hold only that key: a second modifier
+  // (Meta) is treated as "not pausing to look" and cancels the hold timer.
   await page.keyboard.down("Control");
-  await page.keyboard.down("Meta");
 };
 
 const releaseMod = async (page: Page) => {
-  await page.keyboard.up("Meta");
   await page.keyboard.up("Control");
 };
 
@@ -141,6 +142,10 @@ const setupTwoAccountWeek = async (page: Page) => {
   });
 
   await page.goto("/week", { waitUntil: "domcontentloaded" });
+  await getViewSwitcherButton(page).waitFor({
+    state: "visible",
+    timeout: 15000,
+  });
   await page.waitForFunction(
     () => (window as CompassE2EWindow).__COMPASS_E2E_HOOKS__ !== undefined,
   );
@@ -149,9 +154,13 @@ const setupTwoAccountWeek = async (page: Page) => {
   });
 
   await ensureSidebarOpen(page);
-  await expect(page.getByRole("heading", { name: WORK_EMAIL })).toBeVisible({
-    timeout: 10000,
-  });
+  await expect(
+    page
+      .locator("#sidebar")
+      .getByRole("button", { name: /calendar$/ })
+      .first(),
+  ).toBeVisible({ timeout: 10000 });
+  await expect(page.getByRole("heading", { name: WORK_EMAIL })).toBeVisible();
   await expect(
     page.getByRole("heading", { name: PERSONAL_EMAIL }),
   ).toBeVisible();
@@ -163,20 +172,32 @@ test("hold-Mod gives each calendar account its own jump key, including collapsed
   await setupTwoAccountWeek(page);
 
   const personalToggle = page.getByRole("button", { name: PERSONAL_EMAIL });
-  await personalToggle.click();
+  await personalToggle.focus();
+  await page.keyboard.press("Enter");
   await expect(personalToggle).toHaveAttribute("aria-expanded", "false");
 
   await holdMod(page);
-  await expect(page.locator("[data-page-jump-hints]")).toBeVisible({
-    timeout: 2000,
-  });
-  const jumpStatus = page.locator("[data-page-jump-hints]").getByRole("status");
-  await expect(jumpStatus).toContainText(`4 for ${WORK_EMAIL}`);
-  await expect(jumpStatus).toContainText(`5 for ${PERSONAL_EMAIL}`);
+  try {
+    await expect(page.locator("[data-page-jump-hints]")).toBeVisible({
+      timeout: 2000,
+    });
+    const jumpStatus = page
+      .locator("[data-page-jump-hints]")
+      .getByRole("status");
+    await expect(jumpStatus).toContainText(`4 for ${WORK_EMAIL}`);
+    await expect(jumpStatus).toContainText(`5 for ${PERSONAL_EMAIL}`);
+    await page.screenshot({
+      path: test.info().outputPath("hold-mod-account-chips.png"),
+    });
 
-  await page.keyboard.press("5");
-  await releaseMod(page);
+    await page.keyboard.press("5");
+  } finally {
+    await releaseMod(page);
+  }
 
   await expect(personalToggle).toBeFocused();
   await expect(personalToggle).toHaveAttribute("aria-expanded", "true");
+  await page.screenshot({
+    path: test.info().outputPath("mod-5-expands-collapsed-account.png"),
+  });
 });

--- a/e2e/calendars/account-page-jump.spec.ts
+++ b/e2e/calendars/account-page-jump.spec.ts
@@ -1,0 +1,182 @@
+import { expect, type Page, test } from "@playwright/test";
+import { ensureSidebarOpen } from "../utils/event-test-utils";
+
+test.use({ viewport: { width: 1600, height: 900 } });
+
+const WORK_EMAIL = "work@example.com";
+const PERSONAL_EMAIL = "personal@example.com";
+const WORK_CALENDAR_ID = "a".repeat(24);
+const PERSONAL_CALENDAR_ID = "b".repeat(24);
+
+type CompassE2EWindow = Window & {
+  __COMPASS_E2E_TEST__?: boolean;
+  __COMPASS_E2E_HOOKS__?: { setAuthenticated: (value: boolean) => void };
+};
+
+const ownerCapabilities = {
+  canReadAvailability: true,
+  canReadDetails: true,
+  canWrite: true,
+  canManage: true,
+  canWatchEvents: true,
+};
+
+const connection = (id: string, accountEmail: string) => ({
+  id,
+  state: "healthy",
+  stateReason: null,
+  lastSyncedAt: null,
+  lastHealthyAt: null,
+  accountEmail,
+  connectionState: "HEALTHY",
+  canSuggestContacts: false,
+});
+
+const googleCalendar = (
+  id: string,
+  name: string,
+  accountEmail: string,
+  backgroundColor: string,
+) => ({
+  id,
+  name,
+  description: "",
+  timeZone: "Etc/UTC",
+  foregroundColor: "#ffffff",
+  backgroundColor,
+  provider: "google",
+  access: "owner",
+  capabilities: ownerCapabilities,
+  isPrimary: true,
+  isVisible: true,
+  isActive: true,
+  accountEmail,
+});
+
+const holdMod = async (page: Page) => {
+  // Linux resolves Mod to Control; macOS to Meta. Hold both so the platform
+  // hold tracker and the chord check both fire (same as the showcase spec).
+  await page.keyboard.down("Control");
+  await page.keyboard.down("Meta");
+};
+
+const releaseMod = async (page: Page) => {
+  await page.keyboard.up("Meta");
+  await page.keyboard.up("Control");
+};
+
+const setupTwoAccountWeek = async (page: Page) => {
+  await page.addInitScript(() => {
+    (window as CompassE2EWindow).__COMPASS_E2E_TEST__ = true;
+    window.alert = () => undefined;
+    window.confirm = () => true;
+    window.prompt = () => null;
+    localStorage.setItem(
+      "compass.auth",
+      JSON.stringify({
+        hasAuthenticated: true,
+        lastKnownEmail: "e2e@example.com",
+        shouldPromptSignUpAfterAnonymousCalendarChange: false,
+      }),
+    );
+  });
+
+  await page.route("**/api/**", async (route) => {
+    const url = new URL(route.request().url());
+    const { pathname } = url;
+    const method = route.request().method();
+    const json = (body: unknown, status = 200) =>
+      route.fulfill({
+        status,
+        contentType: "application/json",
+        body: JSON.stringify(body),
+      });
+
+    if (pathname.endsWith("/api/user/profile")) {
+      return json({
+        userId: "e2e-user",
+        email: "e2e@example.com",
+        firstName: "E2E",
+        lastName: "User",
+        name: "E2E User",
+        locale: "en",
+        picture: "",
+      });
+    }
+    if (pathname.endsWith("/api/user/metadata")) {
+      return json({
+        google: {
+          connectionState: "HEALTHY",
+          connections: [
+            connection("conn-work", WORK_EMAIL),
+            connection("conn-personal", PERSONAL_EMAIL),
+          ],
+        },
+      });
+    }
+    if (pathname.endsWith("/api/config")) {
+      return json({ google: { isConfigured: true } });
+    }
+    if (pathname.endsWith("/api/calendars/availability")) {
+      return json({ busyPeriods: [] });
+    }
+    if (pathname.endsWith("/api/calendars") && method === "GET") {
+      return json({
+        calendars: [
+          googleCalendar(WORK_CALENDAR_ID, "Work", WORK_EMAIL, "#4285f4"),
+          googleCalendar(
+            PERSONAL_CALENDAR_ID,
+            "Personal",
+            PERSONAL_EMAIL,
+            "#34a853",
+          ),
+        ],
+      });
+    }
+    if (pathname.endsWith("/api/event") && method === "GET") {
+      return json({ events: [] });
+    }
+
+    return json({});
+  });
+
+  await page.goto("/week", { waitUntil: "domcontentloaded" });
+  await page.waitForFunction(
+    () => (window as CompassE2EWindow).__COMPASS_E2E_HOOKS__ !== undefined,
+  );
+  await page.evaluate(() => {
+    (window as CompassE2EWindow).__COMPASS_E2E_HOOKS__?.setAuthenticated(true);
+  });
+
+  await ensureSidebarOpen(page);
+  await expect(page.getByRole("heading", { name: WORK_EMAIL })).toBeVisible({
+    timeout: 10000,
+  });
+  await expect(
+    page.getByRole("heading", { name: PERSONAL_EMAIL }),
+  ).toBeVisible();
+};
+
+test("hold-Mod gives each calendar account its own jump key, including collapsed ones", async ({
+  page,
+}) => {
+  await setupTwoAccountWeek(page);
+
+  const personalToggle = page.getByRole("button", { name: PERSONAL_EMAIL });
+  await personalToggle.click();
+  await expect(personalToggle).toHaveAttribute("aria-expanded", "false");
+
+  await holdMod(page);
+  await expect(page.locator("[data-page-jump-hints]")).toBeVisible({
+    timeout: 2000,
+  });
+  const jumpStatus = page.locator("[data-page-jump-hints]").getByRole("status");
+  await expect(jumpStatus).toContainText(`4 for ${WORK_EMAIL}`);
+  await expect(jumpStatus).toContainText(`5 for ${PERSONAL_EMAIL}`);
+
+  await page.keyboard.press("5");
+  await releaseMod(page);
+
+  await expect(personalToggle).toBeFocused();
+  await expect(personalToggle).toHaveAttribute("aria-expanded", "true");
+});

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -398,6 +398,34 @@ describe("CalendarList", () => {
     ).toBeInTheDocument();
   });
 
+  it("gives each account section its own page-jump target", () => {
+    const work = makeCalendar({
+      name: "Work",
+      accountEmail: "ahab@pequod.com",
+    });
+    const personal = makeCalendar({
+      name: "Personal",
+      accountEmail: "ahab@gmail.com",
+    });
+
+    renderCalendarList([work, personal], {
+      connections: [
+        makeConnection("ahab@pequod.com"),
+        makeConnection("ahab@gmail.com"),
+      ],
+    });
+
+    expect(
+      screen.getByRole("region", { name: "Calendars for ahab@pequod.com" }),
+    ).toHaveAttribute("data-page-jump", "calendar-account:ahab@pequod.com");
+    expect(
+      screen.getByRole("region", { name: "Calendars for ahab@gmail.com" }),
+    ).toHaveAttribute("data-page-jump", "calendar-account:ahab@gmail.com");
+    expect(
+      screen.getByRole("region", { name: "Calendars" }),
+    ).not.toHaveAttribute("data-page-jump");
+  });
+
   it("hides the generic header as soon as any account section exists", () => {
     // Found live on staging: the Compass login's own Google account (A7
     // adopts it as a connection at sign-up) is always one of the sections
@@ -424,6 +452,10 @@ describe("CalendarList", () => {
 
     expect(screen.getByText(HEADER_EMAIL)).toBeInTheDocument();
     expect(screen.getByText("Compass")).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "Calendars" })).toHaveAttribute(
+      "data-page-jump",
+      "calendars",
+    );
   });
 
   it("orders sections by connection order, not calendar order", () => {

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
@@ -19,7 +19,10 @@ import {
 } from "@web/calendars/collapsed-accounts.store";
 import { useCalendarVisibility } from "@web/calendars/useCalendarVisibility";
 import { useConnectedAccountEmails } from "@web/calendars/useDefaultTargetCalendar";
-import { pageJumpAttrs } from "@web/shortcuts/page-jump/page-jump.targets";
+import {
+  calendarAccountJumpId,
+  pageJumpAttrs,
+} from "@web/shortcuts/page-jump/page-jump.targets";
 import { AccountSectionHeader } from "./AccountSectionHeader";
 import { AnonymousCalendarRow } from "./AnonymousCalendarRow";
 import { CalendarListHeader } from "./CalendarListHeader";
@@ -76,7 +79,10 @@ export const CalendarList: FC = () => {
       : renderRows(rows, accountCalendarListId(key));
 
   return (
-    <section aria-label="Calendars" {...pageJumpAttrs("calendars")}>
+    <section
+      aria-label="Calendars"
+      {...(groups.length === 0 ? pageJumpAttrs("calendars") : {})}
+    >
       {/* Every connected account carries its own heading below, so the generic
           banner is only for users who have none yet and are signed in. Anonymous
           users get a single calendar row instead. Showing it alongside account
@@ -107,6 +113,7 @@ export const CalendarList: FC = () => {
             <section
               aria-label={`Calendars for ${group.accountEmail}`}
               key={group.accountEmail}
+              {...pageJumpAttrs(calendarAccountJumpId(group.accountEmail))}
             >
               <AccountSectionHeader
                 accountEmail={group.accountEmail}

--- a/packages/web/src/shortcuts/page-jump/PageJumpHintOverlay.test.tsx
+++ b/packages/web/src/shortcuts/page-jump/PageJumpHintOverlay.test.tsx
@@ -1,7 +1,9 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { PageJumpHintOverlay } from "@web/shortcuts/page-jump/PageJumpHintOverlay";
 import {
+  buildCalendarPageJumpTargets,
   buildDayPageJumpTargets,
+  calendarAccountJumpId,
   dayColumnJumpId,
   LIFE_PAGE_JUMP_TARGETS,
   PAGE_JUMP_ATTRIBUTE,
@@ -148,5 +150,30 @@ describe("PageJumpHintOverlay", () => {
 
     expect(chipDigits()).toEqual(["1", "2"]);
     expect(screen.getByRole("status").textContent).toContain("2 for work");
+  });
+
+  it("chips each connected account after Up next", () => {
+    addAnchor("view-select");
+    addAnchor("month-picker");
+    addAnchor("up-next");
+    addAnchor(calendarAccountJumpId("ahab@pequod.com"));
+    addAnchor(calendarAccountJumpId("ahab@gmail.com"));
+    render(
+      <PageJumpHintOverlay
+        targets={buildCalendarPageJumpTargets([
+          "ahab@pequod.com",
+          "ahab@gmail.com",
+        ])}
+        visible={true}
+      />,
+    );
+
+    expect(chipDigits()).toEqual(["1", "2", "3", "4", "5"]);
+    expect(screen.getByRole("status").textContent).toContain(
+      "4 for ahab@pequod.com",
+    );
+    expect(screen.getByRole("status").textContent).toContain(
+      "5 for ahab@gmail.com",
+    );
   });
 });

--- a/packages/web/src/shortcuts/page-jump/PageJumpHints.tsx
+++ b/packages/web/src/shortcuts/page-jump/PageJumpHints.tsx
@@ -1,20 +1,27 @@
+import { useMemo } from "react";
+import { useConnectedAccountEmails } from "@web/calendars/useDefaultTargetCalendar";
 import { PageJumpHintOverlay } from "@web/shortcuts/page-jump/PageJumpHintOverlay";
 import {
-  CALENDAR_PAGE_JUMP_TARGETS,
+  buildCalendarPageJumpTargets,
   type PageJumpTargets,
 } from "@web/shortcuts/page-jump/page-jump.targets";
 import { usePageJumpShortcut } from "@web/shortcuts/page-jump/usePageJumpShortcut";
 
 /**
  * Self-contained mount for the page-level hold-Mod jump gesture: hook plus
- * hint overlay. Rendered once per view (Day, Week, Life), each passing its
- * own jump targets.
+ * hint overlay. Rendered once per view (Day, Week, Life). Week uses the
+ * default calendar map (one chip per connected account); Day and Life pass
+ * their own lists.
  */
-export function PageJumpHints({
-  targets = CALENDAR_PAGE_JUMP_TARGETS,
-}: {
-  targets?: PageJumpTargets;
-}) {
-  const { areHintsVisible } = usePageJumpShortcut(targets);
-  return <PageJumpHintOverlay targets={targets} visible={areHintsVisible} />;
+export function PageJumpHints({ targets }: { targets?: PageJumpTargets }) {
+  const accountEmails = useConnectedAccountEmails();
+  const calendarTargets = useMemo(
+    () => buildCalendarPageJumpTargets(accountEmails),
+    [accountEmails],
+  );
+  const resolvedTargets = targets ?? calendarTargets;
+  const { areHintsVisible } = usePageJumpShortcut(resolvedTargets);
+  return (
+    <PageJumpHintOverlay targets={resolvedTargets} visible={areHintsVisible} />
+  );
 }

--- a/packages/web/src/shortcuts/page-jump/page-jump.targets.test.ts
+++ b/packages/web/src/shortcuts/page-jump/page-jump.targets.test.ts
@@ -1,7 +1,9 @@
 import { PICK_KEY_LABELS } from "@web/shortcuts/digit-pick.util";
 import {
+  buildCalendarPageJumpTargets,
   buildDayPageJumpTargets,
   CALENDAR_PAGE_JUMP_TARGETS,
+  calendarAccountJumpId,
   dayColumnJumpId,
   focusPageJumpTarget,
   getPageJumpFocusElement,
@@ -32,6 +34,44 @@ describe.each([
     targets.forEach((target, index) => {
       expect(target.digit).toBe(PICK_KEY_LABELS[index]);
     });
+  });
+});
+
+describe("buildCalendarPageJumpTargets", () => {
+  it("matches the no-account Week map when no emails are given", () => {
+    expect(buildCalendarPageJumpTargets()).toEqual(CALENDAR_PAGE_JUMP_TARGETS);
+  });
+
+  it("replaces the list-level calendars slot with one target per account", () => {
+    const work = "ahab@pequod.com";
+    const personal = "ahab@gmail.com";
+    const targets = buildCalendarPageJumpTargets([work, personal]);
+
+    expect(
+      targets.map(({ digit, id, label }) => ({ digit, id, label })),
+    ).toEqual([
+      { digit: "1", id: "view-select", label: "View dropdown" },
+      { digit: "2", id: "month-picker", label: "Month picker" },
+      { digit: "3", id: "up-next", label: "Up next" },
+      { digit: "4", id: calendarAccountJumpId(work), label: work },
+      { digit: "5", id: calendarAccountJumpId(personal), label: personal },
+    ]);
+  });
+
+  it("omits extra accounts that would overflow the top-row keys", () => {
+    const emails = Array.from(
+      { length: PICK_KEY_LABELS.length },
+      (_, index) => `account${index}@x.com`,
+    );
+    const targets = buildCalendarPageJumpTargets(emails);
+
+    expect(targets).toHaveLength(PICK_KEY_LABELS.length);
+    expect(targets[0]).toMatchObject({ id: "view-select" });
+    expect(targets[1]).toMatchObject({ id: "month-picker" });
+    expect(targets[2]).toMatchObject({ id: "up-next" });
+    expect(
+      targets.filter((target) => target.id.startsWith("calendar-account:")),
+    ).toHaveLength(PICK_KEY_LABELS.length - 3);
   });
 });
 
@@ -82,6 +122,46 @@ describe("buildDayPageJumpTargets", () => {
     expect(targets).toHaveLength(PICK_KEY_LABELS.length);
     expect(targets.at(-1)).toMatchObject({
       id: "calendars",
+      digit: PICK_KEY_LABELS.at(-1),
+    });
+    expect(
+      targets.filter((target) => target.id.startsWith("day-column:")),
+    ).toHaveLength(maxColumns);
+  });
+
+  it("replaces the list-level calendars slot with one target per account", () => {
+    const work = "ahab@pequod.com";
+    const personal = "ahab@gmail.com";
+    const targets = buildDayPageJumpTargets(
+      [{ id: "cal-work", name: "Work" }],
+      [work, personal],
+    );
+
+    expect(
+      targets.map(({ digit, id, label }) => ({ digit, id, label })),
+    ).toEqual([
+      { digit: "1", id: "view-select", label: "View dropdown" },
+      { digit: "2", id: dayColumnJumpId("cal-work"), label: "Work" },
+      { digit: "3", id: "month-picker", label: "Month picker" },
+      { digit: "4", id: "up-next", label: "Up next" },
+      { digit: "5", id: calendarAccountJumpId(work), label: work },
+      { digit: "6", id: calendarAccountJumpId(personal), label: personal },
+    ]);
+  });
+
+  it("omits extra columns so per-account sidebar slots still fit", () => {
+    const emails = ["a@x.com", "b@x.com", "c@x.com"];
+    const sidebarCount = buildCalendarPageJumpTargets(emails).length - 1;
+    const maxColumns = PICK_KEY_LABELS.length - 1 - sidebarCount;
+    const calendars = Array.from({ length: maxColumns + 3 }, (_, index) => ({
+      id: `cal-${index}`,
+      name: `Calendar ${index}`,
+    }));
+    const targets = buildDayPageJumpTargets(calendars, emails);
+
+    expect(targets).toHaveLength(PICK_KEY_LABELS.length);
+    expect(targets.at(-1)).toMatchObject({
+      id: calendarAccountJumpId("c@x.com"),
       digit: PICK_KEY_LABELS.at(-1),
     });
     expect(
@@ -183,5 +263,46 @@ describe("focusPageJumpTarget", () => {
 
     expect(focusPageJumpTarget("calendars")).toBe(true);
     expect(clicks).toBe(0);
+  });
+
+  it("expands a collapsed account heading so its calendars are revealed", () => {
+    const id = calendarAccountJumpId("ahab@gmail.com");
+    const anchor = addAnchor(id);
+    const toggle = document.createElement("button");
+    toggle.setAttribute("aria-controls", "account-calendars");
+    toggle.setAttribute("aria-expanded", "false");
+    toggle.addEventListener("click", () => {
+      toggle.setAttribute("aria-expanded", "true");
+    });
+    anchor.append(toggle);
+
+    expect(focusPageJumpTarget(id)).toBe(true);
+    expect(document.activeElement).toBe(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("does not collapse an already-expanded account heading", () => {
+    const id = calendarAccountJumpId("ahab@gmail.com");
+    const anchor = addAnchor(id);
+    const toggle = document.createElement("button");
+    toggle.setAttribute("aria-expanded", "true");
+    let clicks = 0;
+    toggle.addEventListener("click", () => {
+      clicks += 1;
+    });
+    anchor.append(toggle);
+
+    expect(focusPageJumpTarget(id)).toBe(true);
+    expect(clicks).toBe(0);
+  });
+
+  it("finds an account anchor whose email contains CSS-significant characters", () => {
+    const id = calendarAccountJumpId("tyler+work@gmail.com");
+    const anchor = addAnchor(id);
+    const toggle = document.createElement("button");
+    anchor.append(toggle);
+
+    expect(focusPageJumpTarget(id)).toBe(true);
+    expect(document.activeElement).toBe(toggle);
   });
 });

--- a/packages/web/src/shortcuts/page-jump/page-jump.targets.ts
+++ b/packages/web/src/shortcuts/page-jump/page-jump.targets.ts
@@ -8,13 +8,19 @@
  * digits come from this list's order, so it is the single place to add,
  * remove, or renumber a target. An unmounted anchor (collapsed sidebar,
  * empty Up Next) simply gets no chip and its digit does nothing. A closed
- * menu trigger (the view dropdown) is clicked after focus so the jump
- * reveals Day / Week / Life instead of landing on a closed heading.
+ * menu trigger (the view dropdown) or collapsed account heading is clicked
+ * after focus so the jump reveals the contents instead of landing on a
+ * closed control.
+ *
+ * Week view numbers the sidebar after the view dropdown (`buildCalendarPageJumpTargets`):
+ * month picker, Up next, then one target per connected account. With no
+ * accounts, a single "calendars" slot covers the list. Extra accounts that
+ * would overflow the physical top-row keys are omitted.
  *
  * Day view numbers left to right (`buildDayPageJumpTargets`): view dropdown,
- * then writable calendar columns, then the sidebar (month picker, Up next,
- * calendars). Extra columns that would overflow the physical top-row keys
- * are omitted so the three sidebar slots still get chips when mounted.
+ * then writable calendar columns, then that same sidebar map. Extra columns
+ * that would crowd out the reserved sidebar slots (month picker, Up next,
+ * and each account) are omitted so those chips still appear when mounted.
  */
 
 import { PICK_KEY_LABELS } from "@web/shortcuts/digit-pick.util";
@@ -22,6 +28,8 @@ import { PICK_KEY_LABELS } from "@web/shortcuts/digit-pick.util";
 export const PAGE_JUMP_ATTRIBUTE = "data-page-jump";
 
 export const DAY_COLUMN_JUMP_ID_PREFIX = "day-column:" as const;
+
+export const CALENDAR_ACCOUNT_JUMP_ID_PREFIX = "calendar-account:" as const;
 
 export type PageJumpTargetId =
   | "view-select"
@@ -31,7 +39,8 @@ export type PageJumpTargetId =
   | "life-grid"
   | "life-variation"
   | "life-details"
-  | `${typeof DAY_COLUMN_JUMP_ID_PREFIX}${string}`;
+  | `${typeof DAY_COLUMN_JUMP_ID_PREFIX}${string}`
+  | `${typeof CALENDAR_ACCOUNT_JUMP_ID_PREFIX}${string}`;
 
 export type PageJumpTarget = {
   digit: string;
@@ -41,12 +50,75 @@ export type PageJumpTarget = {
 
 export type PageJumpTargets = readonly PageJumpTarget[];
 
-export const CALENDAR_PAGE_JUMP_TARGETS: PageJumpTargets = [
-  { digit: "1", id: "view-select", label: "View dropdown" },
-  { digit: "2", id: "month-picker", label: "Month picker" },
-  { digit: "3", id: "up-next", label: "Up next" },
-  { digit: "4", id: "calendars", label: "Calendar list" },
-];
+type PageJumpTargetDraft = Omit<PageJumpTarget, "digit">;
+
+const VIEW_SELECT_TARGET: PageJumpTargetDraft = {
+  id: "view-select",
+  label: "View dropdown",
+};
+
+const MONTH_PICKER_TARGET: PageJumpTargetDraft = {
+  id: "month-picker",
+  label: "Month picker",
+};
+
+const UP_NEXT_TARGET: PageJumpTargetDraft = {
+  id: "up-next",
+  label: "Up next",
+};
+
+const CALENDARS_LIST_TARGET: PageJumpTargetDraft = {
+  id: "calendars",
+  label: "Calendar list",
+};
+
+const withPickDigits = (
+  targets: readonly PageJumpTargetDraft[],
+): PageJumpTargets =>
+  targets.slice(0, PICK_KEY_LABELS.length).map((target, index) => ({
+    ...target,
+    digit: PICK_KEY_LABELS[index] ?? "",
+  }));
+
+export const calendarAccountJumpId = (
+  accountEmail: string,
+): `${typeof CALENDAR_ACCOUNT_JUMP_ID_PREFIX}${string}` =>
+  `${CALENDAR_ACCOUNT_JUMP_ID_PREFIX}${accountEmail}`;
+
+/**
+ * Sidebar calendar slots after month picker / Up next: one numbered target
+ * per connected account so hold-Mod jumps straight to that heading. With no
+ * accounts, keep a single list-level slot for the anonymous / disconnected
+ * calendar rows.
+ */
+const calendarListJumpTargets = (
+  accountEmails: readonly string[],
+): PageJumpTargetDraft[] =>
+  accountEmails.length === 0
+    ? [CALENDARS_LIST_TARGET]
+    : accountEmails.map((accountEmail) => ({
+        id: calendarAccountJumpId(accountEmail),
+        label: accountEmail,
+      }));
+
+/**
+ * Week (and the Day sidebar suffix): view dropdown, month picker, Up next,
+ * then each connected account. Extra accounts that would overflow the
+ * physical top-row keys are omitted — no chip, no binding.
+ */
+export const buildCalendarPageJumpTargets = (
+  accountEmails: readonly string[] = [],
+): PageJumpTargets =>
+  withPickDigits([
+    VIEW_SELECT_TARGET,
+    MONTH_PICKER_TARGET,
+    UP_NEXT_TARGET,
+    ...calendarListJumpTargets(accountEmails),
+  ]);
+
+/** No-account Week map. Prefer `buildCalendarPageJumpTargets` when accounts exist. */
+export const CALENDAR_PAGE_JUMP_TARGETS: PageJumpTargets =
+  buildCalendarPageJumpTargets();
 
 export const LIFE_PAGE_JUMP_TARGETS: PageJumpTargets = [
   { digit: "1", id: "view-select", label: "View dropdown" },
@@ -68,13 +140,16 @@ export const dayColumnJumpId = (
 /**
  * Day view's hold-Mod map in visual left-to-right order: the view dropdown,
  * then one numbered target per writable displayed column, then the sidebar
- * page areas. Extra calendars that would crowd out the reserved sidebar
- * slots are omitted — no chip, no binding.
+ * page areas (month picker, Up next, each account). Extra calendars that
+ * would crowd out the reserved sidebar slots are omitted — no chip, no
+ * binding.
  */
 export const buildDayPageJumpTargets = (
   calendars: readonly DayColumnJumpCalendar[],
+  accountEmails: readonly string[] = [],
 ): PageJumpTargets => {
-  const [viewSelect, ...sidebarTargets] = CALENDAR_PAGE_JUMP_TARGETS;
+  const [viewSelect, ...sidebarTargets] =
+    buildCalendarPageJumpTargets(accountEmails);
   const maxColumns = PICK_KEY_LABELS.length - 1 - sidebarTargets.length;
   const columnTargets = calendars
     .slice(0, Math.max(0, maxColumns))
@@ -83,12 +158,7 @@ export const buildDayPageJumpTargets = (
       label: calendar.name,
     }));
 
-  return [viewSelect, ...columnTargets, ...sidebarTargets].map(
-    (target, index) => ({
-      ...target,
-      digit: PICK_KEY_LABELS[index] ?? "",
-    }),
-  );
+  return withPickDigits([viewSelect, ...columnTargets, ...sidebarTargets]);
 };
 
 /** Spread onto a component's container element to mark it as a jump target. */
@@ -98,8 +168,20 @@ export const pageJumpAttrs = (
   [PAGE_JUMP_ATTRIBUTE]: id,
 });
 
-export const getPageJumpAnchor = (id: PageJumpTargetId): HTMLElement | null =>
-  document.querySelector<HTMLElement>(`[${PAGE_JUMP_ATTRIBUTE}="${id}"]`);
+/**
+ * Match by attribute value rather than interpolating `id` into a selector:
+ * account emails can contain CSS-significant characters (`+`, `.`).
+ */
+export const getPageJumpAnchor = (id: PageJumpTargetId): HTMLElement | null => {
+  for (const element of document.querySelectorAll<HTMLElement>(
+    `[${PAGE_JUMP_ATTRIBUTE}]`,
+  )) {
+    if (element.getAttribute(PAGE_JUMP_ATTRIBUTE) === id) {
+      return element;
+    }
+  }
+  return null;
+};
 
 const INTERACTIVE_SELECTOR =
   'button:not([disabled]), [href], input:not([disabled]), [tabindex]:not([tabindex="-1"])';
@@ -124,14 +206,12 @@ export const getPageJumpFocusElement = (
 };
 
 const shouldOpenOnJump = (element: HTMLElement): boolean =>
-  Boolean(element.getAttribute("aria-haspopup")) &&
-  element.getAttribute("aria-expanded") !== "true";
+  element.getAttribute("aria-expanded") === "false";
 
 /**
  * Focus a page jump target; returns whether a focusable element was found.
- * Menu/listbox triggers are clicked after focus so the dropdown opens —
- * that's what makes hold-Mod on the view switcher a discovery path for
- * Day / Week / Life, instead of landing on a closed heading.
+ * Closed menus and collapsed account headings are clicked after focus so
+ * the jump reveals their contents instead of landing on a closed control.
  */
 export const focusPageJumpTarget = (id: PageJumpTargetId): boolean => {
   const element = getPageJumpFocusElement(id);

--- a/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.test.tsx
+++ b/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.test.tsx
@@ -16,7 +16,9 @@ import {
   usePageJumpHintStore,
 } from "@web/shortcuts/page-jump/page-jump.store";
 import {
+  buildCalendarPageJumpTargets,
   buildDayPageJumpTargets,
+  calendarAccountJumpId,
   dayColumnJumpId,
   LIFE_PAGE_JUMP_TARGETS,
   PAGE_JUMP_ATTRIBUTE,
@@ -196,6 +198,37 @@ describe("usePageJumpShortcut", () => {
       const viewEvent = pressModDigit("1");
       expect(viewEvent.defaultPrevented).toBe(true);
       expect(viewTrigger).toHaveFocus();
+    });
+
+    it("jumps to a specific calendar account instead of the first in the list", () => {
+      const first = document.createElement("button");
+      const firstAnchor = document.createElement("section");
+      firstAnchor.setAttribute(
+        PAGE_JUMP_ATTRIBUTE,
+        calendarAccountJumpId("ahab@pequod.com"),
+      );
+      firstAnchor.append(first);
+      document.body.append(firstAnchor);
+
+      const second = document.createElement("button");
+      const secondAnchor = document.createElement("section");
+      secondAnchor.setAttribute(
+        PAGE_JUMP_ATTRIBUTE,
+        calendarAccountJumpId("ahab@gmail.com"),
+      );
+      secondAnchor.append(second);
+      document.body.append(secondAnchor);
+
+      renderHook(() =>
+        usePageJumpShortcut(
+          buildCalendarPageJumpTargets(["ahab@pequod.com", "ahab@gmail.com"]),
+        ),
+      );
+
+      const event = pressModDigit("5");
+      expect(event.defaultPrevented).toBe(true);
+      expect(second).toHaveFocus();
+      expect(first).not.toHaveFocus();
     });
   });
 

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -139,8 +139,12 @@ export function DayCalendarGrid() {
     [writableDisplayedCalendars],
   );
   const pageJumpTargets = useMemo(
-    () => buildDayPageJumpTargets(writableDisplayedCalendars),
-    [writableDisplayedCalendars],
+    () =>
+      buildDayPageJumpTargets(
+        writableDisplayedCalendars,
+        connectedAccountEmails,
+      ),
+    [connectedAccountEmails, writableDisplayedCalendars],
   );
   const [focusedColumnKey, setFocusedColumnKey] = useState<string | null>(null);
   const { gridRefs, measurements } = useGridMeasurements({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Holding Mod numbered the whole calendar list as one target (`4`), so reaching a collapsed account meant tabbing through every heading after that. Each connected account now has its own jump key (after the month picker and Up next), including when that section is collapsed. Jumping to a collapsed heading expands it.

Anonymous / disconnected lists keep the single list-level `calendars` slot.

![Hold-Mod chips on each account, including a collapsed heading](https://cursor.com/artifacts/c/art-3cebd89d-5333-4362-8124-1072afa30540)
![Mod+5 focuses and expands the collapsed personal account](https://cursor.com/artifacts/c/art-1ccd5bf1-7763-44ce-8626-a21ca9f24361)

## Simplicity

Reuses the existing page-jump map: `buildCalendarPageJumpTargets` swaps the last sidebar slot for one target per account, and Day view still omits extra columns so those sidebar slots stay reserved. No second hold gesture.

## Automated validation

- Hold-Mod shows `4` on `work@example.com` and `5` on collapsed `personal@example.com`
- Mod+5 focuses that heading and expands its calendars
- `bun run verify` PASS: test:web, type-check, lint, knip, test:a11y, test:e2e

## Independent review

Not run as a separate `/review` pass. Local verify is green.

## Test plan

- `bun test:web` (2848 tests)
- `bunx playwright test e2e/calendars/account-page-jump.spec.ts`
- `bun run verify` (test:web, type-check, lint, knip, test:a11y, test:e2e)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f04df78-8b53-4f37-ad1d-53a105630b6c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f04df78-8b53-4f37-ad1d-53a105630b6c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

