### PR TITLE
Let guests be edited on repeating events

### DIFF
--- a/docs/acceptance/recurring-events.md
+++ b/docs/acceptance/recurring-events.md
@@ -27,6 +27,7 @@ Helpful notes:
 
 - Editing or deleting an occurrence applies to **This Event** immediately. A live toast offers **1 This and Following** and **2 All**; both options are clickable.
 - The scope keys work only while that toast is visible and never while typing in a form field.
+- Changing the guest list applies to **All Events** immediately, no chooser: guest edits have no per-occurrence semantics, so a save that changed guests widens to the whole series (other fields changed in that same save go with it). The guest field says so while you edit.
 - Changing the recurrence rule itself (frequency, weekdays, until) applies to This and Following immediately — "This Event" is not a valid rule-change operation. Turning Repeat off on an instance asks to convert that occurrence to a standalone event.
 - Recurring events synced with Google Calendar will push scope changes back to Google automatically.
 

--- a/docs/features/attendees.md
+++ b/docs/features/attendees.md
@@ -68,13 +68,15 @@ Source: `packages/core/src/types/event-command.contracts.ts`
   attendee-support payloads); present (including `[]`) means "replace
   membership with exactly this set." Entries are `{email, displayName}` —
   no `responseStatus` ever rides the write side.
-- The editor (`AttendeeField`) only renders for the organizer, on a writable
-  Google calendar, on a single event or a series base — never on one
-  occurrence of a series (guest edits have no per-occurrence semantics; see
-  `packages/web/src/views/Forms/EventForm/EventForm.attendees.test.tsx`).
-  A recurring series-base edit that changed the guest set is saved as
-  "All Events" automatically (`resolveRecurrenceScopeDecision`) — guest
-  replacements have no per-occurrence semantics.
+- The editor (`AttendeeField`) renders for the organizer on a writable Google
+  calendar, whether the event repeats or not — including on one occurrence of
+  a series, which is the only thing the grid ever opens for a repeating event
+  (see `packages/web/src/views/Forms/EventForm/EventForm.attendees.test.tsx`).
+  Guest edits still have no per-occurrence semantics, so any save that changed
+  the guest set on a recurring event is applied as "All Events" automatically
+  (`resolveRecurrenceScopeDecision`), and the field carries a note saying so.
+  Because the widened scope covers the whole save, other fields changed in the
+  same save go series-wide with the guests.
 - Incoming RSVP from other attendees is visible to the host without
   photos: chips and the read-only guest list show a compact status badge
   (yes / no / maybe / awaiting) looked up from the live `Attendee[]` by

--- a/e2e/attendees/attendee-editor.spec.ts
+++ b/e2e/attendees/attendee-editor.spec.ts
@@ -72,6 +72,55 @@ test("adding a guest prompts to send invitations and puts the replaced guest set
   await expect(page.getByRole("form").getByPlaceholder("Title")).toBeHidden();
 });
 
+test("adding a guest on one occurrence of a series saves the whole series", async ({
+  page,
+}) => {
+  const seriesId = "evt-series-guests";
+  const captured = await prepareSignedInGooglePage(page, {
+    events: [
+      buildEventFixture({
+        id: `${seriesId}::20260601T100000Z`,
+        title: "Weekly Sync",
+        recurrence: { kind: "occurrence", seriesId },
+        attendees: [
+          {
+            email: ACCOUNT_EMAIL,
+            displayName: null,
+            responseStatus: "accepted",
+          },
+        ],
+      }),
+    ],
+  });
+
+  await openEventForm(page, "Weekly Sync");
+
+  // The editor renders on an occurrence, and says where the edit lands.
+  await expect(
+    page.getByText("Guest changes apply to all events in this series."),
+  ).toBeVisible();
+
+  const combobox = getGuestCombobox(page);
+  await combobox.fill("dana@example.com");
+  await page.keyboard.press("Enter");
+
+  await clickSave(page);
+  await dispatchClick(page.getByRole("button", { name: "Send", exact: true }));
+
+  await expect.poll(() => captured.replaceRequests.length).toBe(1);
+  const { eventId, body } = captured.replaceRequests[0];
+  // The composite occurrence id still addresses the request; the backend
+  // collapses it to the series master because the scope is "all".
+  expect(eventId).toBe(`${seriesId}::20260601T100000Z`);
+  expect(body.scope).toBe("all");
+  const content = body.content as Record<string, unknown>;
+  expect(content.attendees).toEqual([
+    { email: ACCOUNT_EMAIL, displayName: null },
+    { email: "dana@example.com", displayName: null },
+  ]);
+  expect(body.invitation).toBe("all");
+});
+
 test("choosing Don't send saves the guest edit with invitation none", async ({
   page,
 }) => {

--- a/packages/web/src/__tests__/utils/mock-module.test.util.ts
+++ b/packages/web/src/__tests__/utils/mock-module.test.util.ts
@@ -1,0 +1,71 @@
+import { afterAll, mock } from "bun:test";
+
+/**
+ * `mock.module` is process-wide and permanent. A factory registered by one
+ * test file keeps answering that specifier for every file bun runs after it,
+ * so a factory returning only the exports one file cares about silently
+ * deletes the rest for everyone downstream — and the module's own test file
+ * then exercises the mock instead of the implementation. The failure lands in
+ * an unrelated file and only for some file orderings, which is why it reads as
+ * flakiness rather than as a mock that was never cleaned up.
+ *
+ * This registers the mock the way that survives: spread the real namespace so
+ * untouched exports keep working, and route each override through a flag that
+ * this file's `afterAll` flips back off.
+ *
+ * Callers pass the real namespace rather than a specifier so the capture is a
+ * plain static import — `await import(someVariable)` resolves relative to this
+ * file, not the caller, and would silently miss relative specifiers.
+ *
+ *     import * as realSseClient from "@web/sse/client/sse.client";
+ *
+ *     mockModuleForFile("@web/sse/client/sse.client", realSseClient, {
+ *       openStream,
+ *       closeStream,
+ *     });
+ *
+ * Function overrides delegate at call time, so even a consumer that imported
+ * during this file recovers the real behavior afterwards. Non-function
+ * overrides (constants, contexts) can only swap back for consumers importing
+ * after the flip — prefer wrapping the tree in a real provider over mocking a
+ * context module at all.
+ */
+export function mockModuleForFile<T extends Record<string, unknown>>(
+  specifier: string,
+  actualNamespace: T,
+  overrides: Partial<Record<keyof T | (string & {}), unknown>>,
+): void {
+  const actual = { ...actualNamespace } as Record<string, unknown>;
+  let isMocked = true;
+
+  afterAll(() => {
+    isMocked = false;
+  });
+
+  const wrapped: Record<string, unknown> = { ...actual };
+
+  for (const [key, override] of Object.entries(overrides)) {
+    if (typeof override === "function") {
+      wrapped[key] = (...args: unknown[]) => {
+        if (isMocked)
+          return (override as (...a: unknown[]) => unknown)(...args);
+        const real = actual[key];
+        if (typeof real !== "function") {
+          throw new Error(
+            `mockModuleForFile: ${specifier} has no callable export "${key}" to restore`,
+          );
+        }
+        return (real as (...a: unknown[]) => unknown)(...args);
+      };
+      continue;
+    }
+
+    Object.defineProperty(wrapped, key, {
+      configurable: true,
+      enumerable: true,
+      get: () => (isMocked ? override : actual[key]),
+    });
+  }
+
+  mock.module(specifier, () => wrapped);
+}

--- a/packages/web/src/common/utils/toast/google-delayed.toast.test.tsx
+++ b/packages/web/src/common/utils/toast/google-delayed.toast.test.tsx
@@ -2,15 +2,19 @@ import { HotkeyManager, HotkeysProvider } from "@tanstack/react-hotkeys";
 import { render, screen, within } from "@testing-library/react";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
+import * as realConnectGoogle from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import { GoogleDelayedToast } from "@web/common/utils/toast/google-delayed.toast";
 import { registerToastPort } from "@web/common/utils/toast/toast.port";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockRefresh = mock();
 
-mock.module("@web/auth/google/hooks/useConnectGoogle/useConnectGoogle", () => ({
-  useConnectGoogle: () => ({ refresh: mockRefresh }),
-}));
+mockModuleForFile(
+  "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle",
+  realConnectGoogle,
+  { useConnectGoogle: () => ({ refresh: mockRefresh }) },
+);
 
 describe("GoogleDelayedToast", () => {
   const { port, mocks } = createTestToastPort();

--- a/packages/web/src/common/utils/toast/google-reconnect.toast.test.tsx
+++ b/packages/web/src/common/utils/toast/google-reconnect.toast.test.tsx
@@ -2,6 +2,8 @@ import { HotkeyManager, HotkeysProvider } from "@tanstack/react-hotkeys";
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
+import * as realConnectGoogle from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import {
   GoogleReconnectToast,
   showGoogleReconnectToast,
@@ -19,9 +21,11 @@ const mockUseConnectGoogle = mock(() => ({ connect: mockConnect }));
 // directly). Mocking the hook keeps this file testing only what it owns —
 // that a click dismisses the toast and calls connect() — not re-deriving
 // useConnectGoogle's own behavior.
-mock.module("@web/auth/google/hooks/useConnectGoogle/useConnectGoogle", () => ({
-  useConnectGoogle: mockUseConnectGoogle,
-}));
+mockModuleForFile(
+  "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle",
+  realConnectGoogle,
+  { useConnectGoogle: mockUseConnectGoogle },
+);
 
 describe("GoogleReconnectToast", () => {
   const { port, mocks } = createTestToastPort();

--- a/packages/web/src/components/Sidebar/CalendarList/AnonymousCalendarRow.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AnonymousCalendarRow.test.tsx
@@ -5,7 +5,10 @@ import {
   getCalendarCapabilities,
 } from "@core/types/calendar.contracts";
 import { CalendarIdSchema } from "@core/types/domain-primitives";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
+import * as realAuthStateUtil from "@web/auth/compass/state/auth.state.util";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
+import * as realAuthModal from "@web/components/AuthModal/hooks/useAuthModal";
 import { AnonymousCalendarRow } from "./AnonymousCalendarRow";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
@@ -15,19 +18,23 @@ beforeEach(() => {
   mockOpenModal.mockClear();
 });
 
-mock.module("@web/components/AuthModal/hooks/useAuthModal", () => ({
-  useAuthModal: () => ({
-    openModal: mockOpenModal,
-  }),
-}));
+mockModuleForFile(
+  "@web/components/AuthModal/hooks/useAuthModal",
+  realAuthModal,
+  { useAuthModal: () => ({ openModal: mockOpenModal }) },
+);
 
-mock.module("@web/auth/compass/state/auth.state.util", () => ({
-  shouldShowAnonymousCalendarChangeSignUpPrompt: () => false,
-  subscribeToAuthState: (callback: () => void) => {
-    callback();
-    return () => {};
+mockModuleForFile(
+  "@web/auth/compass/state/auth.state.util",
+  realAuthStateUtil,
+  {
+    shouldShowAnonymousCalendarChangeSignUpPrompt: () => false,
+    subscribeToAuthState: (callback: () => void) => {
+      callback();
+      return () => {};
+    },
   },
-}));
+);
 
 describe("AnonymousCalendarRow", () => {
   const mockCalendar: Calendar = {

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
@@ -2,9 +2,14 @@ import "@testing-library/jest-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
+import * as realAuthStateUtil from "@web/auth/compass/state/auth.state.util";
+import * as realUserHook from "@web/auth/compass/user/hooks/useUser";
+import * as realConnectGoogle from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import { type GoogleUiState } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.types";
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
-import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import * as realAuthModal from "@web/components/AuthModal/hooks/useAuthModal";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockOpenModal = mock();
 let mockEmail: string | undefined;
@@ -36,44 +41,30 @@ const mockUseConnectGoogle = mock(() => ({
   commandAction: googleCommandActionFor(mockGoogleState),
 }));
 
-mock.module("@web/auth/compass/state/auth.state.util", () => ({
-  shouldShowAnonymousCalendarChangeSignUpPrompt: () => mockIsAnonymousDirty,
-  subscribeToAuthState: () => () => {},
-}));
+mockModuleForFile(
+  "@web/auth/compass/state/auth.state.util",
+  realAuthStateUtil,
+  {
+    shouldShowAnonymousCalendarChangeSignUpPrompt: () => mockIsAnonymousDirty,
+    subscribeToAuthState: () => () => {},
+  },
+);
 
-mock.module("@web/auth/compass/user/hooks/useUser", () => ({
-  useUser: () => ({
-    email: mockEmail,
-  }),
-}));
-
-mock.module("@web/auth/google/hooks/useConnectGoogle/useConnectGoogle", () => ({
-  useConnectGoogle: mockUseConnectGoogle,
-}));
-
-// mock.module is process-wide, not scoped to this file, and isn't reliably
-// "restorable" afterward (another file's top-level dynamic import can race
-// with this file's afterAll). So the factory spreads the real module's other
-// exports (AuthModalContext, useAuthModalState, validateAuthSearch - needed
-// by AuthModalProvider/router code elsewhere) and checks a flag on every
-// useAuthModal() call instead of freezing the mock in at registration time.
-const actualAuthModal = {
-  ...(await import("@web/components/AuthModal/hooks/useAuthModal")),
-};
-let isAuthModalMocked = true;
-
-mock.module("@web/components/AuthModal/hooks/useAuthModal", () => ({
-  ...actualAuthModal,
-  useAuthModal: (...args: unknown[]) =>
-    isAuthModalMocked
-      ? { openModal: mockOpenModal }
-      : // biome-ignore lint/correctness/useHookAtTopLevel: this is a mock.module factory, not a component - the flag is stable for the lifetime of any given render (it only flips once, in afterAll, after this file's components have unmounted).
-        actualAuthModal.useAuthModal(...(args as [])),
-}));
-
-afterAll(() => {
-  isAuthModalMocked = false;
+mockModuleForFile("@web/auth/compass/user/hooks/useUser", realUserHook, {
+  useUser: () => ({ email: mockEmail }),
 });
+
+mockModuleForFile(
+  "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle",
+  realConnectGoogle,
+  { useConnectGoogle: mockUseConnectGoogle },
+);
+
+mockModuleForFile(
+  "@web/components/AuthModal/hooks/useAuthModal",
+  realAuthModal,
+  { useAuthModal: () => ({ openModal: mockOpenModal }) },
+);
 
 // CalendarListHeader.tsx is already cached by the time this file runs -
 // CalendarList.test.tsx (which sorts before this file) imports

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -7,9 +7,7 @@ import {
   within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { createContext } from "react";
 import { dispatchMissingKey } from "@web/__tests__/utils/keyboard.test.util";
-import { type CompassSession } from "@web/auth/compass/session/session.types";
 import {
   registerUseStartGoogleAuthorizationForTests,
   resetUseStartGoogleAuthorizationForTests,
@@ -32,15 +30,6 @@ const mockOpenModal = mock();
 const mockCloseModal = mock();
 const mockSetView = mock();
 const authModalState = { isOpen: false };
-const SessionContext = createContext<CompassSession>({
-  authenticated: false,
-  setAuthenticated: mock(),
-});
-
-mock.module("@web/auth/compass/session/session.context", () => ({
-  SessionContext,
-}));
-
 // mock.module is process-wide, not scoped to this file, and isn't reliably
 // "restorable" afterward (another file's top-level dynamic import can race
 // with this file's afterAll). So the factory spreads the real module's other

--- a/packages/web/src/events/queries/useDayEventsQuery.test.ts
+++ b/packages/web/src/events/queries/useDayEventsQuery.test.ts
@@ -2,7 +2,9 @@ import { waitFor } from "@testing-library/react";
 import { EventScheduleSchema } from "@core/types/event.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
 import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
+import * as realDayQuery from "@web/events/queries/day.event.query";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { normalizeEventList } from "@web/events/queries/event.query.normalize";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
@@ -18,9 +20,9 @@ const dayEvent = createMockEvent({
 
 const fetchDayEvents = mock(async () => normalizeEventList([dayEvent]));
 
-mock.module("@web/events/queries/day.event.query", () => ({
+mockModuleForFile("@web/events/queries/day.event.query", realDayQuery, {
   fetchDayEvents,
-}));
+});
 
 const { renderHook } =
   require("@web/__tests__/__mocks__/mock.render") as typeof import("@web/__tests__/__mocks__/mock.render");

--- a/packages/web/src/events/queries/usePrefetchAdjacentEvents.test.ts
+++ b/packages/web/src/events/queries/usePrefetchAdjacentEvents.test.ts
@@ -1,5 +1,7 @@
 import { waitFor } from "@testing-library/react";
 import dayjs from "@core/util/date/dayjs";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
+import * as realWeekQuery from "@web/events/queries/week.event.query";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 const fetchWeekEvents = mock(async () => ({
@@ -14,9 +16,9 @@ const fetchWeekEvents = mock(async () => ({
   },
 }));
 
-mock.module("@web/events/queries/week.event.query", () => ({
+mockModuleForFile("@web/events/queries/week.event.query", realWeekQuery, {
   fetchWeekEvents,
-}));
+});
 
 const { renderHook } =
   require("@web/__tests__/__mocks__/mock.render") as typeof import("@web/__tests__/__mocks__/mock.render");

--- a/packages/web/src/events/queries/useWeekEventsQuery.test.ts
+++ b/packages/web/src/events/queries/useWeekEventsQuery.test.ts
@@ -2,9 +2,11 @@ import { waitFor } from "@testing-library/react";
 import { EventScheduleSchema } from "@core/types/event.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
 import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { normalizeEventList } from "@web/events/queries/event.query.normalize";
+import * as realWeekQuery from "@web/events/queries/week.event.query";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 const weekEvent = createMockEvent({
@@ -18,9 +20,9 @@ const weekEvent = createMockEvent({
 
 const fetchWeekEvents = mock(async () => normalizeEventList([weekEvent]));
 
-mock.module("@web/events/queries/week.event.query", () => ({
+mockModuleForFile("@web/events/queries/week.event.query", realWeekQuery, {
   fetchWeekEvents,
-}));
+});
 
 const { renderHook } =
   require("@web/__tests__/__mocks__/mock.render") as typeof import("@web/__tests__/__mocks__/mock.render");

--- a/packages/web/src/events/recurrence/recurrence-scope-decision.test.ts
+++ b/packages/web/src/events/recurrence/recurrence-scope-decision.test.ts
@@ -289,6 +289,96 @@ describe("resolveRecurrenceScopeDecision", () => {
       });
     });
 
+    it("applies ALL_EVENTS when an occurrence's guest set changes", () => {
+      const baseEventId = new ObjectId().toString();
+      const baseEvent = createMockEvent({
+        id: EventIdSchema.parse(baseEventId),
+        recurrence: { kind: "series", rules: ["FREQ=WEEKLY;COUNT=4"] },
+        schedule: SCHEDULE,
+      });
+      const draft = buildEditDraft({
+        recurrence: {
+          kind: "occurrence",
+          seriesId: EventIdSchema.parse(baseEventId),
+        },
+      });
+      if (draft.kind !== "edit") throw new Error("Expected an edit draft");
+      draft.values.attendees = [
+        { email: "guest@example.com", displayName: null },
+      ];
+
+      expect(
+        resolveRecurrenceScopeDecision({
+          action: "save",
+          baseEvent,
+          draft,
+          isInstance: true,
+          isRecurring: true,
+        }),
+      ).toEqual({
+        kind: "apply",
+        scope: RecurringEventUpdateScope.ALL_EVENTS,
+      });
+    });
+
+    // The series base is a cache scan away and is absent whenever the loaded
+    // week misses the first occurrence, so the guest rule must not need it.
+    it("applies ALL_EVENTS for an occurrence guest change with no series base loaded", () => {
+      const draft = buildEditDraft({
+        recurrence: {
+          kind: "occurrence",
+          seriesId: EventIdSchema.parse(new ObjectId().toString()),
+        },
+      });
+      if (draft.kind !== "edit") throw new Error("Expected an edit draft");
+      draft.values.attendees = [
+        { email: "guest@example.com", displayName: null },
+      ];
+
+      expect(
+        resolveRecurrenceScopeDecision({
+          action: "save",
+          baseEvent: null,
+          draft,
+          isInstance: true,
+          isRecurring: true,
+        }),
+      ).toEqual({
+        kind: "apply",
+        scope: RecurringEventUpdateScope.ALL_EVENTS,
+      });
+    });
+
+    it("still converts to standalone when repeat is cleared alongside a guest change", () => {
+      const baseEventId = new ObjectId().toString();
+      const baseEvent = createMockEvent({
+        id: EventIdSchema.parse(baseEventId),
+        recurrence: { kind: "series", rules: ["FREQ=WEEKLY;COUNT=4"] },
+        schedule: SCHEDULE,
+      });
+      const draft = buildEditDraft({
+        recurrence: {
+          kind: "occurrence",
+          seriesId: EventIdSchema.parse(baseEventId),
+        },
+        liveRecurrence: { kind: "single" },
+      });
+      if (draft.kind !== "edit") throw new Error("Expected an edit draft");
+      draft.values.attendees = [
+        { email: "guest@example.com", displayName: null },
+      ];
+
+      expect(
+        resolveRecurrenceScopeDecision({
+          action: "save",
+          baseEvent,
+          draft,
+          isInstance: true,
+          isRecurring: true,
+        }),
+      ).toEqual({ kind: "convertToStandalone" });
+    });
+
     it("applies THIS_AND_FOLLOWING when the recurrence rule changes", () => {
       const baseEventId = new ObjectId().toString();
       const baseEvent = createMockEvent({

--- a/packages/web/src/events/recurrence/recurrence-scope-decision.ts
+++ b/packages/web/src/events/recurrence/recurrence-scope-decision.ts
@@ -91,6 +91,26 @@ export const resolveRecurrenceScopeDecision = (
     return { kind: "apply", scope: RecurringEventUpdateScope.THIS_EVENT };
   }
 
+  const rule = getScopeDecisionRecurrenceRule(draft, baseEvent);
+  const toStandAlone = isInstance && rule === null;
+
+  // Ahead of both rules below: turning Repeat off detaches this instance, so
+  // it must never be reinterpreted as a series-wide edit. Only an explicit
+  // "single" choice yields a null rule (a "preserve" occurrence whose series
+  // base is not in cache returns undefined), so checking this first cannot
+  // swallow an ordinary occurrence edit.
+  if (toStandAlone) {
+    return { kind: "convertToStandalone" };
+  }
+
+  // Ahead of the instance rule below: guest replacements have no
+  // per-occurrence semantics (sync refuses attendees at "this" /
+  // "thisAndFollowing"), so a guest change widens the whole save to the
+  // series no matter which instance it started from.
+  if (isRecurring && gridDraftGuestsChanged(draft)) {
+    return { kind: "apply", scope: RecurringEventUpdateScope.ALL_EVENTS };
+  }
+
   // Ordinary occurrence changes stay in flow: apply to this instance now
   // and let the live toast promote the exact mutation to following/all.
   if (
@@ -99,19 +119,6 @@ export const resolveRecurrenceScopeDecision = (
     draft.values.recurrence.kind === "preserve"
   ) {
     return { kind: "apply", scope: RecurringEventUpdateScope.THIS_EVENT };
-  }
-
-  const rule = getScopeDecisionRecurrenceRule(draft, baseEvent);
-  const toStandAlone = isInstance && rule === null;
-
-  if (toStandAlone) {
-    return { kind: "convertToStandalone" };
-  }
-
-  // Guest replacements have no per-occurrence semantics; sync refuses
-  // attendees at "this" / "thisAndFollowing".
-  if (isRecurring && gridDraftGuestsChanged(draft)) {
-    return { kind: "apply", scope: RecurringEventUpdateScope.ALL_EVENTS };
   }
 
   // Changing the RRULE itself is not a valid "this" operation, and the

--- a/packages/web/src/sse/hooks/useSSEConnection.test.tsx
+++ b/packages/web/src/sse/hooks/useSSEConnection.test.tsx
@@ -1,8 +1,13 @@
 import { QueryClientProvider } from "@tanstack/react-query";
 import { render, waitFor } from "@testing-library/react";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
 import { createCompassQueryClient } from "@web/api/query-client";
+import * as realSessionHook from "@web/auth/compass/session/useSession";
+import * as realUserHook from "@web/auth/compass/user/hooks/useUser";
+import * as realUserMetadata from "@web/auth/compass/user/util/user-metadata.util";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
+import * as realSseClient from "@web/sse/client/sse.client";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockUseSession = mock();
@@ -18,20 +23,22 @@ const onStreamReopen = mock((handler: () => void) => {
   };
 });
 
-mock.module("@web/auth/compass/session/useSession", () => ({
+mockModuleForFile("@web/auth/compass/session/useSession", realSessionHook, {
   useSession: mockUseSession,
-}));
-mock.module("@web/auth/compass/user/hooks/useUser", () => ({
+});
+mockModuleForFile("@web/auth/compass/user/hooks/useUser", realUserHook, {
   useUser: mockUseUser,
-}));
-mock.module("@web/auth/compass/user/util/user-metadata.util", () => ({
-  refreshUserMetadata: mockRefreshUserMetadata,
-}));
-mock.module("../client/sse.client", () => ({
+});
+mockModuleForFile(
+  "@web/auth/compass/user/util/user-metadata.util",
+  realUserMetadata,
+  { refreshUserMetadata: mockRefreshUserMetadata },
+);
+mockModuleForFile("@web/sse/client/sse.client", realSseClient, {
   openStream,
   closeStream,
   onStreamReopen,
-}));
+});
 
 const { useSSEConnection } =
   require("./useSSEConnection") as typeof import("./useSSEConnection");

--- a/packages/web/src/sse/hooks/useSyncFocusRefresh.test.ts
+++ b/packages/web/src/sse/hooks/useSyncFocusRefresh.test.ts
@@ -1,5 +1,7 @@
 import { renderHook } from "@testing-library/react";
 import { act } from "react";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
+import * as realUserMetadata from "@web/auth/compass/user/util/user-metadata.util";
 import { type UseConnectGoogleResult } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.types";
 import {
   afterEach,
@@ -14,9 +16,11 @@ import {
 const MIN_HIDDEN_DURATION_MS = 30_000;
 const mockRefreshUserMetadata = mock().mockResolvedValue(undefined);
 
-mock.module("@web/auth/compass/user/util/user-metadata.util", () => ({
-  refreshUserMetadata: mockRefreshUserMetadata,
-}));
+mockModuleForFile(
+  "@web/auth/compass/user/util/user-metadata.util",
+  realUserMetadata,
+  { refreshUserMetadata: mockRefreshUserMetadata },
+);
 
 const { useSyncFocusRefresh } =
   require("./useSyncFocusRefresh") as typeof import("./useSyncFocusRefresh");

--- a/packages/web/src/sse/provider/SSEProvider.test.tsx
+++ b/packages/web/src/sse/provider/SSEProvider.test.tsx
@@ -1,7 +1,13 @@
 import { QueryClientProvider } from "@tanstack/react-query";
 import { render, waitFor } from "@testing-library/react";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
 import { createFakeServerMessageBus } from "@web/__tests__/utils/sse-message-bus.test.util";
 import { createCompassQueryClient } from "@web/api/query-client";
+import * as realSessionHook from "@web/auth/compass/session/useSession";
+import * as realUserHook from "@web/auth/compass/user/hooks/useUser";
+import * as realUserMetadata from "@web/auth/compass/user/util/user-metadata.util";
+import * as realConnectGoogle from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
+import * as realSseClient from "@web/sse/client/sse.client";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockUseSession = mock();
@@ -9,14 +15,9 @@ const mockUseUser = mock();
 const openStream = mock();
 const closeStream = mock();
 const getStream = mock(() => null);
-// SSEProvider mounts useSyncFocusRefresh, which calls the real
-// useConnectGoogle() by default. mock.module leaks process-wide across the
-// full test suite (not scoped to this file), so without an explicit mock
-// here this file is at the mercy of whichever OTHER file's useConnectGoogle
-// mock happened to load last — e.g. CalendarListHeader.test.tsx's mock omits
-// `refresh` entirely, which throws when useSyncFocusRefresh calls it. This
-// test isn't about Google/sync behavior, so give it its own stable, complete
-// fake rather than relying on load order.
+// SSEProvider mounts useSyncFocusRefresh, which calls useConnectGoogle().
+// This test isn't about Google/sync behavior, so give it a stable, complete
+// fake of its own rather than inheriting whatever another file installed.
 const mockUseConnectGoogle = mock(() => ({
   commandAction: null,
   isAvailable: false,
@@ -27,25 +28,29 @@ const mockUseConnectGoogle = mock(() => ({
   refresh: mock(),
 }));
 
-mock.module("@web/auth/compass/session/useSession", () => ({
+mockModuleForFile("@web/auth/compass/session/useSession", realSessionHook, {
   useSession: mockUseSession,
-}));
-mock.module("@web/auth/compass/user/hooks/useUser", () => ({
+});
+mockModuleForFile("@web/auth/compass/user/hooks/useUser", realUserHook, {
   useUser: mockUseUser,
-}));
-mock.module("@web/auth/compass/user/util/user-metadata.util", () => ({
-  refreshUserMetadata: mock().mockResolvedValue(undefined),
-}));
-mock.module("@web/auth/google/hooks/useConnectGoogle/useConnectGoogle", () => ({
-  useConnectGoogle: mockUseConnectGoogle,
-}));
-mock.module("../client/sse.client", () => ({
+});
+mockModuleForFile(
+  "@web/auth/compass/user/util/user-metadata.util",
+  realUserMetadata,
+  { refreshUserMetadata: mock().mockResolvedValue(undefined) },
+);
+mockModuleForFile(
+  "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle",
+  realConnectGoogle,
+  { useConnectGoogle: mockUseConnectGoogle },
+);
+mockModuleForFile("@web/sse/client/sse.client", realSseClient, {
   openStream,
   closeStream,
   getStream,
   onServerMessage: createFakeServerMessageBus().onServerMessage,
   onStreamReopen: () => () => undefined,
-}));
+});
 
 const { default: SSEProvider } =
   require("./SSEProvider") as typeof import("./SSEProvider");

--- a/packages/web/src/views/Day/hooks/events/useDayEvents.test.ts
+++ b/packages/web/src/views/Day/hooks/events/useDayEvents.test.ts
@@ -1,6 +1,8 @@
 import { type QueryClient } from "@tanstack/react-query";
 import { waitFor } from "@testing-library/react";
 import dayjs from "@core/util/date/dayjs";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
+import * as realDayQuery from "@web/events/queries/day.event.query";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
@@ -16,9 +18,9 @@ const fetchDayEvents = mock(async () => ({
   },
 }));
 
-mock.module("@web/events/queries/day.event.query", () => ({
+mockModuleForFile("@web/events/queries/day.event.query", realDayQuery, {
   fetchDayEvents,
-}));
+});
 
 const { renderHook } =
   require("@web/__tests__/__mocks__/mock.render") as typeof import("@web/__tests__/__mocks__/mock.render");

--- a/packages/web/src/views/Forms/EventForm/EventForm.attendees.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.attendees.test.tsx
@@ -16,11 +16,12 @@ import { editGridEventDraft } from "@web/events/grid-event-draft.adapter";
 import { EventForm } from "@web/views/Forms/EventForm/EventForm";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
-// WP-04 attendee-editor gating: the guest combobox renders only where the
-// whole write path can deliver a guest edit — a writable Google calendar, an
-// event the user organizes, never a single occurrence of a series. Everyone
-// else keeps the read-only guest list. Sibling to EventForm.readOnly.test.tsx
-// (full form, no subcomponent mocks) for the same isolation reasons.
+// WP-04 attendee-editor gating: the guest combobox renders wherever the whole
+// write path can deliver a guest edit — a writable Google calendar and an
+// event the user organizes — repeating events included, where the edit is
+// series-wide and the field says so. Everyone else keeps the read-only guest
+// list. Sibling to EventForm.readOnly.test.tsx (full form, no subcomponent
+// mocks) for the same isolation reasons.
 
 const ACCOUNT_EMAIL = "me@example.com";
 
@@ -247,7 +248,7 @@ describe("EventForm attendee editor gating", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("hides the editor for a single occurrence of a series (guest edits are series-wide only)", () => {
+  it("shows the editor for a single occurrence of a series, noting the edit is series-wide", () => {
     const calendar = makeCalendar();
     const seriesId = EventIdSchema.parse(createObjectIdString());
     const event = makeMeetingEvent(calendar.id, {
@@ -257,9 +258,11 @@ describe("EventForm attendee editor gating", () => {
     renderEventForm(editDraftOrThrow(event), [calendar]);
 
     expect(
-      screen.queryByRole("combobox", { name: "Guests" }),
-    ).not.toBeInTheDocument();
-    expect(screen.getByText(/1 guest/)).toBeInTheDocument();
+      screen.getByRole("combobox", { name: "Guests" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Guest changes apply to all events in this series."),
+    ).toBeInTheDocument();
   });
 
   it("shows the editor when editing the series base itself", () => {
@@ -273,6 +276,23 @@ describe("EventForm attendee editor gating", () => {
     expect(
       screen.getByRole("combobox", { name: "Guests" }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText("Guest changes apply to all events in this series."),
+    ).toBeInTheDocument();
+  });
+
+  it("omits the series-wide note on a non-recurring event", () => {
+    const calendar = makeCalendar();
+    const event = makeMeetingEvent(calendar.id);
+
+    renderEventForm(editDraftOrThrow(event), [calendar]);
+
+    expect(
+      screen.getByRole("combobox", { name: "Guests" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Guest changes apply to all events in this series."),
+    ).not.toBeInTheDocument();
   });
 
   it("treats an event with no organizer as organized by the account (Compass-created)", () => {

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -292,11 +292,12 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
       draft.kind === "edit" ? (liveSource ?? draft.source) : null;
     const liveDetails =
       rsvpSource?.content.kind === "details" ? rsvpSource.content : undefined;
-    // Attendee-editor gate (WP-04): guests are editable only where the whole
-    // write path can deliver them — a writable Google calendar, an event the
-    // user organizes, and never a single occurrence of a series (sync
-    // refuses per-occurrence guest replacements; series-wide edits go
-    // through the "all"-scope path via the scope dialog's narrowing).
+    // Attendee-editor gate (WP-04): guests are editable everywhere the whole
+    // write path can deliver them — a writable Google calendar and an event
+    // the user organizes. Repeating events included: sync refuses
+    // per-occurrence guest replacements, so a guest change on any instance
+    // is saved series-wide (resolveRecurrenceScopeDecision widens the whole
+    // save to "all"), and the field says so.
     const { data: allCalendars } = useCalendarsQuery();
     const defaultTargetCalendar = useDefaultTargetCalendar(allCalendars ?? []);
     const attendeeCalendar =
@@ -320,9 +321,9 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
       !isReadOnly &&
       attendeeCalendar?.provider === "google" &&
       attendeeCalendar.capabilities.canWrite &&
-      organizesEvent &&
-      (draft.kind === "create" ||
-        draft.source.recurrence.kind !== "occurrence");
+      organizesEvent;
+    const guestEditIsSeriesWide =
+      draft.kind === "edit" && draft.source.recurrence.kind !== "single";
     // RSVP gate (WP-08): show Going / Maybe / Decline when the calendar's
     // connected account email appears in the attendee list (organizer
     // included — organizers can answer their own event). Hidden when self is
@@ -980,6 +981,11 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
                       {attendeeChipTally && (
                         <p className="text-text-muted text-xs">
                           {attendeeChipTally}
+                        </p>
+                      )}
+                      {guestEditIsSeriesWide && (
+                        <p className="text-text-muted text-xs">
+                          Guest changes apply to all events in this series.
                         </p>
                       )}
                       <AttendeeField

--- a/packages/web/src/views/Forms/hooks/useSaveEventForm.attendees.test.tsx
+++ b/packages/web/src/views/Forms/hooks/useSaveEventForm.attendees.test.tsx
@@ -5,7 +5,7 @@ import {
   type Calendar,
   getCalendarCapabilities,
 } from "@core/types/calendar.contracts";
-import { CalendarIdSchema } from "@core/types/domain-primitives";
+import { CalendarIdSchema, EventIdSchema } from "@core/types/domain-primitives";
 import { type Event } from "@core/types/event.contracts";
 import {
   type CreateEventInput,
@@ -280,6 +280,40 @@ describe("useSaveEventForm guest edits", () => {
     const draft = editDraftOrThrow(
       meetingEvent({
         recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY"] },
+      }),
+    );
+    draft.values.attendees = [
+      { email: "guest@example.com", displayName: null },
+      { email: "new-guest@example.com", displayName: null },
+    ];
+
+    act(() => {
+      result.current.saveEventForm(draft, RecurringEventUpdateScope.ALL_EVENTS);
+    });
+    act(() => {
+      result.current.invitationPrompt?.onSend();
+    });
+
+    const variables = replaceVariables(queryClient);
+    expect(variables?.input.scope).toBe("all");
+    expect(variables?.input.content.attendees).toHaveLength(2);
+    expect(variables?.input.invitation).toBe("all");
+  });
+
+  // The grid only ever opens occurrences of a series, so this is the path a
+  // real guest edit on a repeating event takes: resolveRecurrenceScopeDecision
+  // widens it to "all" and normalizeGuestEdit must let it through intact.
+  it("keeps a guest edit made on one occurrence of a series", () => {
+    const { queryClient, Wrapper } = createWrapper();
+    const { result } = renderHook(() => useSaveEventForm(), {
+      wrapper: Wrapper,
+    });
+    const draft = editDraftOrThrow(
+      meetingEvent({
+        recurrence: {
+          kind: "occurrence",
+          seriesId: EventIdSchema.parse("aaaaaaaaaaaaaaaaaaaaaaaa"),
+        },
       }),
     );
     draft.values.attendees = [

--- a/packages/web/src/views/Forms/hooks/useSaveEventForm.ts
+++ b/packages/web/src/views/Forms/hooks/useSaveEventForm.ts
@@ -47,10 +47,10 @@ export function useSaveEventForm() {
   // Belt behind the editor's own render gates: a guest edit that could never
   // deliver is dropped back to preserve semantics instead of submitting a
   // command sync/backend will refuse. The UI cannot reach these states — the
-  // editor only renders on writable Google calendars the user organizes,
-  // occurrence drafts never render it, and a guest-changed recurring edit
-  // is saved as "all" automatically — so this only defends replayed or
-  // hand-built drafts.
+  // editor only renders on writable Google calendars the user organizes, and
+  // a guest-changed recurring edit is saved as "all" automatically, whether
+  // it started from the series base or from one occurrence — so this only
+  // defends replayed or hand-built drafts.
   const normalizeGuestEdit = useCallback(
     (
       draft: GridEventDraft,

--- a/packages/web/src/views/GoogleAuthCallback/GoogleAuthCallback.test.ts
+++ b/packages/web/src/views/GoogleAuthCallback/GoogleAuthCallback.test.ts
@@ -1,19 +1,24 @@
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
+import { AuthApi } from "@web/api/auth.api";
 import { GOOGLE_AUTH_SCOPES_REQUIRED } from "@web/auth/google/authorization/google-authorization.constants";
 import {
   readGoogleAuthorizationIntent,
   writeGoogleAuthorizationIntent,
 } from "@web/auth/google/authorization/google-authorization.storage";
 import { registerToastPort } from "@web/common/utils/toast/toast.port";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
+// Patch the one method on the real AuthApi object rather than replacing the
+// module: mock.module is process-wide and permanent, and an AuthApi carrying
+// only loginOrSignup breaks every later file that reaches for another method
+// (useConnectGoogle.scope.test.tsx spies on beginGoogleConnection).
 const mockLoginOrSignup = mock();
+const realLoginOrSignup = AuthApi.loginOrSignup;
+AuthApi.loginOrSignup = mockLoginOrSignup as typeof AuthApi.loginOrSignup;
 
-mock.module("@web/api/auth.api", () => ({
-  AuthApi: {
-    loginOrSignup: mockLoginOrSignup,
-  },
-}));
+afterAll(() => {
+  AuthApi.loginOrSignup = realLoginOrSignup;
+});
 
 const { port, mocks } = createTestToastPort();
 


### PR DESCRIPTION
## Why

Opening a repeating event from the week grid showed no Guests field. Every card the grid renders for a repeating event is an *occurrence* (the series base is filtered out of rendering), and the editor's gate excluded occurrences outright — so no recurring event's guest list could be edited at all, regardless of permissions.

## What changed

**Feature** — the guest editor now renders wherever the write path can deliver a guest edit: a writable Google calendar on an event you organize, repeating or not. Organizer-only stays the rule; `guestsCanModify` is still out of scope.

- `resolveRecurrenceScopeDecision` now runs the convert-to-standalone and guests-changed rules *ahead* of the ordinary-occurrence early return. Previously a guest change from an instance resolved to `"this"`, and `normalizeGuestEdit` silently stripped the attendees — a save that looked successful and changed nothing.
- The guest field says where the edit lands: "Guest changes apply to all events in this series."
- No backend or contract work: `resolveCommandTarget` already collapses a composite `eventId::recurrenceId` to the series master at scope `"all"`, and sync already merges guests by email against freshly-fetched provider state.

**Test-suite fixes** — two process-wide `mock.module` leaks, found while verifying the above.

- `WelcomeModal.test.tsx` installed its own `SessionContext` over the real module permanently. The replacement was identical in shape and default value and the test never read it, so the mock bought nothing while leaving later files with a context whose identity no longer matched their provider. AuthModal was the casualty.
- Added `mockModuleForFile` — spread the real namespace, route overrides through a flag the file's `afterAll` flips off — and converted the mocks that were demonstrably leaking. `GoogleAuthCallback` drops its module mock entirely: `AuthApi` is a plain mutable object, so patching one method and restoring it is simpler and leaves nothing behind.

## Verification

- `bun run test:web`: 2842 pass, 0 fail, 58s (was 2523s with 3 failures).
- `CalendarList → AuthModal` ordering: 0 failures in 2.7s (was 42 failures in 211s).
- `bun run lint` and `bun run type-check` clean.
- `e2e/attendees`: 9 passed, including a new spec that adds a guest from an occurrence and asserts the PUT carries `scope: "all"` with the attendee array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)