### PR TITLE
fix(web): restore scrolling on the public booking page

### DIFF
--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -51,6 +51,57 @@ test.describe("public booking page", () => {
     await expect(page.getByLabel("Email")).toBeFocused();
   });
 
+  test("scrolls when available times overflow the viewport", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 800, height: 480 });
+
+    const origin = new Date();
+    origin.setUTCDate(origin.getUTCDate() + 2);
+    origin.setUTCHours(8, 0, 0, 0);
+    const slots = Array.from({ length: 60 }, (_, index) => {
+      const slotStart = new Date(origin.getTime() + index * 15 * 60 * 1000);
+      return {
+        slotStart: slotStart.toISOString(),
+        slotEnd: new Date(slotStart.getTime() + 30 * 60 * 1000).toISOString(),
+      };
+    });
+
+    await preparePublicBookingPage(page, { slots });
+
+    await expect
+      .poll(async () =>
+        page.evaluate(() => {
+          const scrolling = document.scrollingElement;
+          if (!scrolling) {
+            return false;
+          }
+          const overflowY = getComputedStyle(
+            document.documentElement,
+          ).overflowY;
+          return (
+            (overflowY === "auto" || overflowY === "scroll") &&
+            scrolling.scrollHeight > scrolling.clientHeight + 40
+          );
+        }),
+      )
+      .toBe(true);
+
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await page.mouse.move(400, 200);
+    await page.mouse.wheel(0, 1600);
+    await expect
+      .poll(async () => page.evaluate(() => window.scrollY))
+      .toBeGreaterThan(80);
+
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await page.locator("body").click({ position: { x: 16, y: 16 } });
+    await page.keyboard.press("PageDown");
+    await expect
+      .poll(async () => page.evaluate(() => window.scrollY))
+      .toBeGreaterThan(80);
+  });
+
   test("refreshes slots and shows a conflict message on 409", async ({
     page,
   }) => {

--- a/packages/web/src/booking/PublicBookingLayout.test.tsx
+++ b/packages/web/src/booking/PublicBookingLayout.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from "@testing-library/react";
+import { PublicBookingLayout } from "@web/booking/PublicBookingLayout";
+import { describe, expect, it } from "bun:test";
+
+describe("PublicBookingLayout", () => {
+  it("opts the public booking page into document scrolling", () => {
+    render(
+      <PublicBookingLayout>
+        <p>Booking content</p>
+      </PublicBookingLayout>,
+    );
+
+    expect(document.querySelector("[data-document-scroll]")).toBeTruthy();
+    expect(screen.getByRole("main")).toHaveTextContent("Booking content");
+  });
+});

--- a/packages/web/src/booking/PublicBookingLayout.test.tsx
+++ b/packages/web/src/booking/PublicBookingLayout.test.tsx
@@ -10,7 +10,8 @@ describe("PublicBookingLayout", () => {
       </PublicBookingLayout>,
     );
 
-    expect(document.querySelector("[data-document-scroll]")).toBeTruthy();
-    expect(screen.getByRole("main")).toHaveTextContent("Booking content");
+    const main = screen.getByRole("main");
+    expect(main).toHaveTextContent("Booking content");
+    expect(main.parentElement).toHaveAttribute("data-document-scroll");
   });
 });

--- a/packages/web/src/booking/PublicBookingLayout.tsx
+++ b/packages/web/src/booking/PublicBookingLayout.tsx
@@ -1,8 +1,14 @@
 import { type PropsWithChildren } from "react";
 
+/**
+ * Public booking is a document-height page. The calendar shell clips
+ * `html`/`body`/`#root` with `overflow: hidden`; `data-document-scroll`
+ * opts this tree into native page scrolling so guests can reach later
+ * time slots (see `index.css`).
+ */
 export function PublicBookingLayout({ children }: PropsWithChildren) {
   return (
-    <div className="min-h-dvh bg-background text-text">
+    <div data-document-scroll className="min-h-dvh bg-background text-text">
       <main className="mx-auto flex w-full max-w-lg flex-col gap-6 px-4 py-10">
         {children}
       </main>

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -91,7 +91,9 @@ describe("PublicBookingPage", () => {
     expect(
       await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
     ).toBeInTheDocument();
-    expect(document.querySelector("[data-document-scroll]")).toBeTruthy();
+    expect(screen.getByRole("main").parentElement).toHaveAttribute(
+      "data-document-scroll",
+    );
     expect(
       await screen.findByText(/Times shown in your timezone/),
     ).toBeInTheDocument();

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -91,6 +91,7 @@ describe("PublicBookingPage", () => {
     expect(
       await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
     ).toBeInTheDocument();
+    expect(document.querySelector("[data-document-scroll]")).toBeTruthy();
     expect(
       await screen.findByText(/Times shown in your timezone/),
     ).toBeInTheDocument();

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -279,6 +279,34 @@
     height: 100%;
   }
 
+  /* Public booking is a document-height page, not a pane inside the
+     calendar shell. Opt in with data-document-scroll so guests can
+     scroll (wheel, Page Up/Down) to later time slots. */
+  html:has([data-document-scroll]) {
+    overflow-x: hidden;
+    overflow-y: auto;
+    height: auto;
+    min-height: 100dvh;
+    scrollbar-width: auto;
+  }
+
+  html:has([data-document-scroll]) body,
+  html:has([data-document-scroll]) #root {
+    overflow: visible;
+    height: auto;
+    min-height: 100dvh;
+  }
+
+  html:has([data-document-scroll])::-webkit-scrollbar {
+    display: block;
+    width: 12px;
+  }
+
+  html:has([data-document-scroll])::-webkit-scrollbar-thumb {
+    background-color: var(--color-border-strong);
+    border-radius: 6px;
+  }
+
   body {
     background-color: var(--color-background);
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Guests on `/book/:username` could not reach later time slots. Wheel, Page Up, and Page Down did nothing because the calendar shell sets `overflow: hidden` on `html`, `body`, and `#root`.

Public booking is a document-height page, not a pane inside that shell. `PublicBookingLayout` now sets `data-document-scroll`, and `index.css` uses `html:has([data-document-scroll])` to restore native document overflow. Calendar routes are unchanged.

![Booking slots cut off at the bottom of the viewport](https://cursor.com/artifacts/c/art-6905d2e9-c4c0-4f9b-9b4b-30d5bb0974dd)
<a href="https://cursor.com/agents/bc-300f4a40-a45b-4bd2-89ee-75d4f0d874aa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbooking_page_scroll_wheel_and_pagedown.mp4"><img src="https://cursor.com/artifacts/c/art-f46ca263-bdf0-49e4-babe-634027b8fdb0" alt="booking_page_scroll_wheel_and_pagedown.mp4" /></a>
![Later Thursday slots visible after scrolling](https://cursor.com/artifacts/c/art-05ae949f-436a-4672-a28c-b6928305538f)

## Simplicity

One opt-in attribute on the existing public layout plus a CSS `:has()` override. No extra scroll container, effect, or calendar-shell branching.

## Automated validation

- `bun run test:web`: 2867 pass
- `bunx playwright test e2e/booking/public-booking.spec.ts`: 5 passed, including wheel and Page Down on an overflowing slot list
- `bunx playwright test e2e/accessibility/booking-a11y.spec.ts`: passed
- `bun run lint`: pass (pre-existing biome warnings only)
- `knip --include files,exports,nsExports`: pass
- `bun run verify`: first run failed only on `web-locator` (`querySelector`); that assertion now uses `getByRole("main")`. Other verify checks had already passed (`test:web`, `type-check`, `knip`, `test:a11y`, `test:e2e` 57 passed). Lint re-run after the locator fix is pass.

Browser: local public booking page with 80 stubbed slots. Wheel and Page Down both move `window.scrollY` and reveal later dates.

## Independent review

VERDICT: no confirmed findings

FINDINGS:
no confirmed findings

A11y audit of the diff: no confirmed findings. Document scrolling restores Page Up/Down without a nested `tabIndex` region. Booking axe spec still passes.

## Test plan

- `bun run test:web`
- `bunx playwright test e2e/booking/public-booking.spec.ts`
- `bunx playwright test e2e/accessibility/booking-a11y.spec.ts`
- `bun run lint`
- `bun knip --include files,exports,nsExports`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-300f4a40-a45b-4bd2-89ee-75d4f0d874aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-300f4a40-a45b-4bd2-89ee-75d4f0d874aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

