### PR TITLE
fix(booking): stop response-only keys from killing every save after the first

### DIFF
--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -182,6 +182,15 @@ export async function prepareSignedInBookingSettingsPage(
     guestsCanInviteOthers: true,
   };
 
+  const savedPageFields = {
+    id: "000000000000000000000001",
+    slug,
+    hostUserId: "000000000000000000000002",
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+    bookingUrl,
+  };
+
   await page.route("**/api/**", async (route) => {
     const request = route.request();
     const url = new URL(request.url());
@@ -196,7 +205,11 @@ export async function prepareSignedInBookingSettingsPage(
     }
 
     if (path.endsWith("/api/booking/page") && request.method() === "GET") {
-      return route.fulfill(json(bookingPagePayload));
+      // The saved-page shape, which is what the real GET returns once a slug
+      // exists. Returning the bare input shape here hid a bug where the
+      // response-only keys rode into the strict PUT schema and killed every
+      // save after the first.
+      return route.fulfill(json({ ...bookingPagePayload, ...savedPageFields }));
     }
 
     if (path.endsWith("/api/booking/page") && request.method() === "PUT") {
@@ -205,13 +218,8 @@ export async function prepareSignedInBookingSettingsPage(
       return route.fulfill(
         json({
           ...bookingPagePayload,
+          ...savedPageFields,
           ...body,
-          id: "000000000000000000000001",
-          slug,
-          hostUserId: "000000000000000000000002",
-          createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
-          bookingUrl,
         }),
       );
     }

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -25,4 +25,15 @@ test("settings booking page shows a copyable public link after save", async ({
     bookingUrl,
   );
   expect(captured.putBodies[0]).toMatchObject({ durationMinutes: 30 });
+
+  // A second save has to reach the network too. Seeding the form from the
+  // saved-page response used to smuggle response-only keys into the strict
+  // PUT schema, so every save after the first died before the request.
+  await settingsDialog.getByLabel("Duration").selectOption("15");
+  await dispatchClick(
+    settingsDialog.getByRole("button", { name: "Save booking settings" }),
+  );
+
+  await expect.poll(() => captured.putBodies.length).toBe(2);
+  expect(captured.putBodies[1]).toMatchObject({ durationMinutes: 15 });
 });

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -135,6 +135,90 @@ describe("BookingSettingsSection", () => {
     );
   });
 
+  it("saves again after the first save, sending only PUT input keys", async () => {
+    const user = userEvent.setup({ delay: null });
+    const slug = "hostuser";
+    const bookingUrl = `https://compasscalendar.com/book/${slug}`;
+    const savedBodies: Record<string, unknown>[] = [];
+
+    userMetadataActions.set(healthyGoogleMetadata);
+
+    // The saved-page shape, which is what GET really returns once a slug
+    // exists. Seeding the form from this used to poison every later save:
+    // the response-only keys rode along into the strict PUT schema.
+    const savedPage = {
+      id: createObjectIdString(),
+      slug,
+      hostUserId: createObjectIdString(),
+      enabled: false,
+      durationMinutes: 45,
+      destinationCalendarId: writableCalendar.id,
+      blockingCalendarIds: [writableCalendar.id],
+      timeZone: "America/New_York",
+      weeklyAvailability: [],
+      minNoticeHours: 4,
+      maxHorizonDays: 60,
+      bufferMinutes: null,
+      maxBookingsPerDay: null,
+      guestsCanInviteOthers: true,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      bookingUrl,
+    };
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) => res(ctx.json(savedPage))),
+      rest.put(bookingPageUrl, async (req, res, ctx) => {
+        const body = (await req.json()) as Record<string, unknown>;
+        savedBodies.push(body);
+        return res(ctx.json({ ...savedPage, ...body }));
+      }),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    await screen.findByRole("button", { name: "Save booking settings" });
+
+    await user.selectOptions(screen.getByLabelText("Duration"), "30");
+    await user.click(
+      screen.getByRole("button", { name: "Save booking settings" }),
+    );
+    await waitFor(() => {
+      expect(savedBodies).toHaveLength(1);
+    });
+
+    await user.selectOptions(screen.getByLabelText("Duration"), "15");
+    await user.click(
+      screen.getByRole("button", { name: "Save booking settings" }),
+    );
+
+    await waitFor(() => {
+      expect(savedBodies).toHaveLength(2);
+    });
+    expect(savedBodies[1]).toMatchObject({ durationMinutes: 15 });
+    expect(Object.keys(savedBodies[1] ?? {}).sort()).toEqual([
+      "blockingCalendarIds",
+      "bufferMinutes",
+      "destinationCalendarId",
+      "durationMinutes",
+      "enabled",
+      "guestsCanInviteOthers",
+      "maxBookingsPerDay",
+      "maxHorizonDays",
+      "minNoticeHours",
+      "timeZone",
+      "weeklyAvailability",
+    ]);
+  });
+
   it("blocks enable without a destination calendar", async () => {
     const user = userEvent.setup({ delay: null });
 

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -5,11 +5,7 @@ import {
   type BookingDurationMinutes,
 } from "@core/types/booking.contracts";
 import { type Calendar } from "@core/types/calendar.contracts";
-import {
-  type CalendarId,
-  type TimeZone,
-  TimeZoneSchema,
-} from "@core/types/domain-primitives";
+import { type CalendarId, TimeZoneSchema } from "@core/types/domain-primitives";
 import {
   selectGoogleConnectionState,
   selectGoogleSyncConnections,
@@ -31,6 +27,7 @@ import {
   getAvailabilityReadableCalendars,
   isPlaceholderDestinationCalendar,
   resolveWritableCalendars,
+  toBookingPageInput,
 } from "@web/booking/booking.util";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import {
@@ -61,7 +58,7 @@ const buildInitialForm = (
     durationMinutes: 30 as BookingDurationMinutes,
     destinationCalendarId: BOOKING_PLACEHOLDER_CALENDAR_ID,
     blockingCalendarIds: [BOOKING_PLACEHOLDER_CALENDAR_ID],
-    timeZone: effectiveTimeZone,
+    timeZone: TimeZoneSchema.parse(effectiveTimeZone),
     weeklyAvailability: [],
     minNoticeHours: 4,
     maxHorizonDays: 60,
@@ -87,8 +84,10 @@ const buildInitialForm = (
           writableCalendars,
         );
 
+  // toBookingPageInput, not a spread: `base` may be the saved-page response,
+  // whose response-only keys would make the strict PUT schema throw on save.
   return {
-    ...base,
+    ...toBookingPageInput(base),
     destinationCalendarId,
     blockingCalendarIds,
     timeZone: TimeZoneSchema.parse(base.timeZone || effectiveTimeZone),

--- a/packages/web/src/booking/booking.util.ts
+++ b/packages/web/src/booking/booking.util.ts
@@ -77,3 +77,31 @@ export function weekdayLabel(weekday: WeeklyAvailabilityInterval["weekday"]) {
 }
 
 export const ISO_WEEKDAYS = [1, 2, 3, 4, 5, 6, 7] as const;
+
+/**
+ * The PUT body, and only the PUT body.
+ *
+ * `GET /booking/page` answers with the saved page once a slug exists, which
+ * carries `id`, `slug`, `hostUserId`, `createdAt`, `updatedAt` and
+ * `bookingUrl` on top of the input fields. `AdminPutBookingPageInputSchema` is
+ * a `z.strictObject`, so spreading that response into form state made every
+ * save after the first throw on the unknown keys before any request went out.
+ * Pick the fields explicitly so a response-only key can never ride along.
+ */
+export function toBookingPageInput(
+  page: AdminPutBookingPageInput,
+): AdminPutBookingPageInput {
+  return {
+    enabled: page.enabled,
+    durationMinutes: page.durationMinutes,
+    destinationCalendarId: page.destinationCalendarId,
+    blockingCalendarIds: page.blockingCalendarIds,
+    timeZone: page.timeZone,
+    weeklyAvailability: page.weeklyAvailability,
+    minNoticeHours: page.minNoticeHours,
+    maxHorizonDays: page.maxHorizonDays,
+    bufferMinutes: page.bufferMinutes,
+    maxBookingsPerDay: page.maxBookingsPerDay,
+    guestsCanInviteOthers: page.guestsCanInviteOthers,
+  };
+}


### PR DESCRIPTION
## Problem

Changing anything in Settings → Booking and saving appears to do nothing, with a vague error toast. Reported as "when I try to change my timezone it doesn't work" — but it affects every field, not just the timezone.

`buildInitialForm` spread the entire `GET /booking/page` response into form state. Once a slug exists that response is the **saved page**, which carries `id`, `slug`, `hostUserId`, `createdAt`, `updatedAt` and `bookingUrl` on top of the input fields. The save path then runs `AdminPutBookingPageInputSchema.parse(form)`, and that schema is a `z.strictObject`, so it throws on the unknown keys — synchronously, inside `mutationFn`, before any request goes out. `onError` sees a ZodError rather than an ApiError and shows the generic toast.

So the **first** save works (the form is still seeded from the bare default shape), `onSuccess` writes the `bookingUrl`-bearing response into the cache, the re-seed effect copies it into `form`, and **every save after that is dead**.

## Fix

Pick the eleven PUT keys explicitly through a new `toBookingPageInput` helper instead of spreading. The strict schema stays strict — it was right; the client was feeding it garbage.

## Why no test caught it

Every existing test saved exactly once, and no GET fixture returned a `bookingUrl`. The bug lives precisely in the state the fixtures never reached.

Both fixtures now return the saved shape, and both suites save twice:
- `BookingSettingsSection.test.tsx` — new "saves again after the first save" test asserting two PUTs and that the second body's keys are exactly the eleven input keys.
- `e2e/booking/host-settings.spec.ts` — second save asserted; `booking-harness.ts` GET stub now returns the saved shape.

Verified the new jsdom test fails without the fix (1 fail) and passes with it.

## Checks

- `bun test ./src/booking` — 11 pass
- `bun run type-check` — clean
- `bun run lint` — clean in touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)