### PR TITLE
feat(booking): default the booking timezone to the host's own zone

### DIFF
--- a/packages/backend/src/booking/services/booking-page.service.db.test.ts
+++ b/packages/backend/src/booking/services/booking-page.service.db.test.ts
@@ -139,9 +139,47 @@ describe("BookingPageService", () => {
         enabled: false,
         durationMinutes: 30,
         weeklyAvailability: [],
+        // Nothing saved, so the timeZone is a placeholder the client replaces.
+        isConfigured: false,
       }),
     );
     expect(await bookingPageRepository.findByUserId(user._id)).toBeNull();
+  });
+
+  it("reports a saved-but-never-enabled page as configured", async () => {
+    const userId = await createNamedUser("Draft User");
+
+    // Saved while disabled, so no slug is allocated and the response is the
+    // bare input shape - indistinguishable from "never saved" without the
+    // flag. The stored timezone here is a real choice the client must keep.
+    await bookingPageService.putAdminPage(
+      userId,
+      samplePutInput({ enabled: false }),
+    );
+
+    const page = await bookingPageService.getAdminPage(userId);
+
+    expect("bookingUrl" in page).toBe(false);
+    expect(page).toEqual(
+      expect.objectContaining({
+        isConfigured: true,
+        timeZone: "America/Denver",
+      }),
+    );
+  });
+
+  it("marks a disabled PUT response as configured too", async () => {
+    const userId = await createNamedUser("Disabled Saver");
+
+    // The PUT answer for a page with no slug is the same bare shape as GET's,
+    // so it needs the flag as well - the client parses both with one schema.
+    const saved = await bookingPageService.putAdminPage(
+      userId,
+      samplePutInput({ enabled: false }),
+    );
+
+    expect("bookingUrl" in saved).toBe(false);
+    expect(saved).toEqual(expect.objectContaining({ isConfigured: true }));
   });
 
   it("allocates a slug once and keeps it on later PUTs", async () => {

--- a/packages/backend/src/booking/services/booking-page.service.ts
+++ b/packages/backend/src/booking/services/booking-page.service.ts
@@ -1,6 +1,7 @@
 import { MongoServerError, type ObjectId } from "mongodb";
 import {
   type AdminGetBookingPageResponse,
+  type AdminGetBookingPageSetupResponse,
   type AdminPutBookingPageInput,
   AdminPutBookingPageInputSchema,
   allocateBookingSlug,
@@ -111,13 +112,15 @@ const isDuplicateSlugError = (error: unknown): boolean =>
 
 export type HostBookingPageGetResponse =
   | AdminGetBookingPageResponse
-  | AdminPutBookingPageInput;
+  | AdminGetBookingPageSetupResponse;
 
 class BookingPageService {
   async getAdminPage(userId: ObjectId): Promise<HostBookingPageGetResponse> {
     const record = await bookingPageRepository.findByUserId(userId);
     if (!record) {
-      return buildDefaultAdminPutInput();
+      // Nothing saved yet, so the timeZone below is only a placeholder - the
+      // client seeds the real one off isConfigured: false.
+      return { ...buildDefaultAdminPutInput(), isConfigured: false };
     }
 
     if (!record.bookingSlug) {
@@ -136,10 +139,15 @@ class BookingPageService {
           guestsCanInviteOthers: record.guestsCanInviteOthers,
         }),
       );
-      return AdminPutBookingPageInputSchema.parse({
-        enabled,
-        ...rest,
-      });
+      return {
+        ...AdminPutBookingPageInputSchema.parse({
+          enabled,
+          ...rest,
+        }),
+        // Saved, just never enabled, so no slug exists. The host's stored
+        // timezone is a real choice and must not be re-seeded.
+        isConfigured: true,
+      };
     }
 
     return mapBookingPageRecordToAdminResponse({
@@ -151,7 +159,7 @@ class BookingPageService {
   async putAdminPage(
     userId: ObjectId,
     rawInput: unknown,
-  ): Promise<AdminGetBookingPageResponse | AdminPutBookingPageInput> {
+  ): Promise<HostBookingPageGetResponse> {
     const input = AdminPutBookingPageInputSchema.parse(rawInput);
 
     if (input.enabled) {
@@ -180,19 +188,24 @@ class BookingPageService {
         });
 
         if (!saved.bookingSlug) {
-          return AdminPutBookingPageInputSchema.parse({
-            enabled: saved.enabled,
-            durationMinutes: saved.durationMinutes,
-            destinationCalendarId: saved.destinationCalendarId,
-            blockingCalendarIds: saved.blockingCalendarIds,
-            timeZone: saved.timeZone,
-            weeklyAvailability: saved.weeklyAvailability,
-            minNoticeHours: saved.minNoticeHours,
-            maxHorizonDays: saved.maxHorizonDays,
-            bufferMinutes: saved.bufferMinutes,
-            maxBookingsPerDay: saved.maxBookingsPerDay,
-            guestsCanInviteOthers: saved.guestsCanInviteOthers,
-          });
+          // Saved but never enabled, so no slug exists yet. Mark it configured
+          // so the client keeps the host's stored timezone.
+          return {
+            ...AdminPutBookingPageInputSchema.parse({
+              enabled: saved.enabled,
+              durationMinutes: saved.durationMinutes,
+              destinationCalendarId: saved.destinationCalendarId,
+              blockingCalendarIds: saved.blockingCalendarIds,
+              timeZone: saved.timeZone,
+              weeklyAvailability: saved.weeklyAvailability,
+              minNoticeHours: saved.minNoticeHours,
+              maxHorizonDays: saved.maxHorizonDays,
+              bufferMinutes: saved.bufferMinutes,
+              maxBookingsPerDay: saved.maxBookingsPerDay,
+              guestsCanInviteOthers: saved.guestsCanInviteOthers,
+            }),
+            isConfigured: true,
+          };
         }
 
         return mapBookingPageRecordToAdminResponse({

--- a/packages/core/src/types/booking.contracts.ts
+++ b/packages/core/src/types/booking.contracts.ts
@@ -297,6 +297,25 @@ export type AdminPutBookingPageInput = z.infer<
   typeof AdminPutBookingPageInputSchema
 >;
 
+/**
+ * GET response for a page with no public link yet: either never saved, or
+ * saved but never enabled (so no slug was allocated). `isConfigured` tells
+ * those two apart, which the wire otherwise could not - both came back as a
+ * bare input object. The client needs the distinction to know whether it may
+ * seed the timezone from the browser: the server has no user timezone and can
+ * only fill in a placeholder.
+ */
+export const AdminGetBookingPageSetupResponseSchema =
+  AdminPutBookingPageInputSchema.extend({ isConfigured: z.boolean() });
+export type AdminGetBookingPageSetupResponse = z.infer<
+  typeof AdminGetBookingPageSetupResponseSchema
+>;
+
+/** Everything `GET /booking/page` can answer with. */
+export type AdminGetBookingPageResult =
+  | AdminGetBookingPageResponse
+  | AdminGetBookingPageSetupResponse;
+
 const slugifyBookingCandidate = (value: string): string =>
   value.toLowerCase().replace(/[^a-z0-9]/g, "");
 

--- a/packages/web/src/__tests__/__mocks__/server/mock.handlers.ts
+++ b/packages/web/src/__tests__/__mocks__/server/mock.handlers.ts
@@ -93,6 +93,7 @@ export const globalHandlers = [
         bufferMinutes: null,
         maxBookingsPerDay: null,
         guestsCanInviteOthers: true,
+        isConfigured: false,
       }),
     );
   }),

--- a/packages/web/src/api/booking.api.ts
+++ b/packages/web/src/api/booking.api.ts
@@ -1,40 +1,38 @@
 import {
   type AdminGetBookingPageResponse,
   AdminGetBookingPageResponseSchema,
+  type AdminGetBookingPageSetupResponse,
+  AdminGetBookingPageSetupResponseSchema,
   type AdminPutBookingPageInput,
-  AdminPutBookingPageInputSchema,
 } from "@core/types/booking.contracts";
 import { BaseApi } from "@web/api/base/base.api";
 
 export type HostBookingPageResponse =
-  | AdminPutBookingPageInput
+  | AdminGetBookingPageSetupResponse
   | AdminGetBookingPageResponse;
 
 const isAdminGetBookingPageResponse = (
-  page: HostBookingPageResponse,
-): page is AdminGetBookingPageResponse => "bookingUrl" in page;
+  page: unknown,
+): page is AdminGetBookingPageResponse =>
+  typeof page === "object" && page !== null && "bookingUrl" in page;
 
 const BookingApi = {
   async getPage(): Promise<HostBookingPageResponse> {
     const response = await BaseApi.get<unknown>(`/booking/page`);
-    if (
-      isAdminGetBookingPageResponse(response.data as HostBookingPageResponse)
-    ) {
+    if (isAdminGetBookingPageResponse(response.data)) {
       return AdminGetBookingPageResponseSchema.parse(response.data);
     }
-    return AdminPutBookingPageInputSchema.parse(response.data);
+    return AdminGetBookingPageSetupResponseSchema.parse(response.data);
   },
 
   async putPage(
     input: AdminPutBookingPageInput,
   ): Promise<HostBookingPageResponse> {
     const response = await BaseApi.put<unknown>(`/booking/page`, input);
-    if (
-      isAdminGetBookingPageResponse(response.data as HostBookingPageResponse)
-    ) {
+    if (isAdminGetBookingPageResponse(response.data)) {
       return AdminGetBookingPageResponseSchema.parse(response.data);
     }
-    return AdminPutBookingPageInputSchema.parse(response.data);
+    return AdminGetBookingPageSetupResponseSchema.parse(response.data);
   },
 };
 

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -15,6 +15,7 @@ import { BookingSettingsSection } from "@web/booking/BookingSettingsSection";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { ENV_WEB } from "@web/common/constants/env.constants";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
+import { setPinnedTimeZone } from "@web/timezone/effective-timezone.store";
 import { afterEach, describe, expect, it, mock } from "bun:test";
 
 const actualUseAppAccess = (await import("@web/billing/useAppAccess"))
@@ -27,6 +28,7 @@ mock.module("@web/billing/useAppAccess", () => ({
 
 afterEach(() => {
   isAppAccessMocked = true;
+  setPinnedTimeZone(null);
 });
 
 const writableCalendar = createMockCalendar({
@@ -36,6 +38,8 @@ const writableCalendar = createMockCalendar({
 });
 
 const bookingPageUrl = `${ENV_WEB.API_BASEURL}/booking/page`;
+
+const HOST_TIME_ZONE = "America/Chicago";
 
 const healthyGoogleMetadata = {
   google: {
@@ -217,6 +221,88 @@ describe("BookingSettingsSection", () => {
       "timeZone",
       "weeklyAvailability",
     ]);
+  });
+
+  it("seeds the booking timezone from the user's zone when never configured", async () => {
+    userMetadataActions.set(healthyGoogleMetadata);
+    // Pinned rather than relying on the browser zone: CI runs at TZ=UTC, where
+    // a browser-zone assertion would pass even against the "UTC" placeholder.
+    setPinnedTimeZone(HOST_TIME_ZONE);
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(
+          ctx.json({
+            enabled: false,
+            durationMinutes: 30,
+            destinationCalendarId: writableCalendar.id,
+            blockingCalendarIds: [writableCalendar.id],
+            // The server placeholder: it has no user timezone to offer.
+            timeZone: "UTC",
+            weeklyAvailability: [],
+            minNoticeHours: 4,
+            maxHorizonDays: 60,
+            bufferMinutes: null,
+            maxBookingsPerDay: null,
+            guestsCanInviteOthers: true,
+            isConfigured: false,
+          }),
+        ),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    const field = await screen.findByLabelText("Booking timezone");
+    expect(field).toHaveValue(HOST_TIME_ZONE);
+  });
+
+  it("keeps a configured page's stored timezone even when it is UTC", async () => {
+    userMetadataActions.set(healthyGoogleMetadata);
+    setPinnedTimeZone(HOST_TIME_ZONE);
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(
+          ctx.json({
+            enabled: false,
+            durationMinutes: 30,
+            destinationCalendarId: writableCalendar.id,
+            blockingCalendarIds: [writableCalendar.id],
+            timeZone: "UTC",
+            weeklyAvailability: [],
+            minNoticeHours: 4,
+            maxHorizonDays: 60,
+            bufferMinutes: null,
+            maxBookingsPerDay: null,
+            guestsCanInviteOthers: true,
+            // Saved, never enabled. UTC here is a deliberate choice.
+            isConfigured: true,
+          }),
+        ),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    const field = await screen.findByLabelText("Booking timezone");
+    expect(field).toHaveValue("UTC");
   });
 
   it("blocks enable without a destination calendar", async () => {

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   type AdminGetBookingPageResponse,
   type AdminPutBookingPageInput,
@@ -6,6 +6,7 @@ import {
 } from "@core/types/booking.contracts";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId, TimeZoneSchema } from "@core/types/domain-primitives";
+import { type HostBookingPageResponse } from "@web/api/booking.api";
 import {
   selectGoogleConnectionState,
   selectGoogleSyncConnections,
@@ -26,6 +27,7 @@ import {
   defaultBlockingCalendarIdsForDestination,
   getAvailabilityReadableCalendars,
   isPlaceholderDestinationCalendar,
+  isUnconfiguredBookingPage,
   resolveWritableCalendars,
   toBookingPageInput,
 } from "@web/booking/booking.util";
@@ -49,7 +51,7 @@ const isSavedBookingPage = (
 ): page is AdminGetBookingPageResponse => "bookingUrl" in page;
 
 const buildInitialForm = (
-  page: AdminPutBookingPageInput | undefined,
+  page: HostBookingPageResponse | undefined,
   effectiveTimeZone: string,
   writableCalendars: Calendar[],
 ): AdminPutBookingPageInput => {
@@ -84,13 +86,21 @@ const buildInitialForm = (
           writableCalendars,
         );
 
+  // The server has no user timezone, so an unconfigured page carries a "UTC"
+  // placeholder. Seed the browser's zone there, but leave a configured page's
+  // stored zone alone - a host who deliberately picked UTC must keep it.
+  const timeZone =
+    page && !isUnconfiguredBookingPage(page)
+      ? base.timeZone
+      : effectiveTimeZone;
+
   // toBookingPageInput, not a spread: `base` may be the saved-page response,
   // whose response-only keys would make the strict PUT schema throw on save.
   return {
     ...toBookingPageInput(base),
     destinationCalendarId,
     blockingCalendarIds,
-    timeZone: TimeZoneSchema.parse(base.timeZone || effectiveTimeZone),
+    timeZone: TimeZoneSchema.parse(timeZone || effectiveTimeZone),
   };
 };
 
@@ -132,8 +142,13 @@ export function BookingSettingsSection({
   );
   const [enableError, setEnableError] = useState<string | null>(null);
 
+  // Re-seed only when the server actually answers with a different page.
+  // Keying the effect on writableCalendars/effectiveTimeZone as well meant a
+  // calendars refetch or a timezone-store change wiped edits mid-typing.
+  const seededPageRef = useRef<HostBookingPageResponse | undefined>(undefined);
   useEffect(() => {
-    if (!serverPage) return;
+    if (!serverPage || seededPageRef.current === serverPage) return;
+    seededPageRef.current = serverPage;
     setForm(buildInitialForm(serverPage, effectiveTimeZone, writableCalendars));
   }, [effectiveTimeZone, serverPage, writableCalendars]);
 

--- a/packages/web/src/booking/booking.util.ts
+++ b/packages/web/src/booking/booking.util.ts
@@ -1,4 +1,5 @@
 import {
+  type AdminGetBookingPageResult,
   type AdminPutBookingPageInput,
   type WeeklyAvailabilityInterval,
 } from "@core/types/booking.contracts";
@@ -104,4 +105,16 @@ export function toBookingPageInput(
     maxBookingsPerDay: page.maxBookingsPerDay,
     guestsCanInviteOthers: page.guestsCanInviteOthers,
   };
+}
+
+/**
+ * A page the host has never saved. `GET /booking/page` answers with the same
+ * bare input shape whether the host never saved or saved without ever
+ * enabling, so the explicit flag is the only way to tell them apart - and the
+ * difference decides whether the client may overwrite the timezone.
+ */
+export function isUnconfiguredBookingPage(
+  page: AdminGetBookingPageResult,
+): boolean {
+  return "isConfigured" in page && page.isConfigured === false;
 }


### PR DESCRIPTION
## Problem

A host who had never configured booking saw **UTC**, not their own timezone.

`buildDefaultAdminPutInput()` hardcodes `timeZone: "UTC"` — the server has no user timezone to offer — and the client's `base.timeZone || effectiveTimeZone` fallback treated that placeholder as a real answer, so the fallback was dead code.

## Why this needed a wire change

The client can't simply overwrite any `"UTC"` it sees: a host may legitimately work in UTC.

And it couldn't tell **"never saved"** from **"saved but never enabled"** — `GET /booking/page` answered both with the same bare input shape. Since configure-then-enable-later is a normal flow, seeding on the absence of `bookingUrl` would have silently eaten a deliberately chosen timezone. That would be a timezone fix that still eats your timezone.

So: `isConfigured` is added to the GET/PUT responses that carry no public link, and the client seeds the browser zone only when it's `false`. `AdminPutBookingPageInputSchema` is deliberately untouched — it's the PUT input and must not grow a field, so the setup response gets its own schema (`AdminGetBookingPageSetupResponseSchema`).

Note the PUT path needed the flag too: a **disabled** save also returns the bare shape, and the client parses both responses with the one schema.

## Also fixed: the re-seed effect was clobbering edits

The effect keyed on `writableCalendars` and `effectiveTimeZone`, so a calendars refetch or a timezone-store change re-ran it and wiped what the host was typing mid-edit. It now re-seeds only when the server actually answers with a different page.

## Tests

- Unconfigured response → the field shows the host's zone (pinned to `America/Chicago` rather than asserting the browser zone, since CI runs at `TZ=UTC` where that assertion would pass against the placeholder).
- Configured response with `timeZone: "UTC"` → stays UTC.
- Backend: saved-but-never-enabled GET reports `isConfigured: true` and keeps its stored zone; a disabled PUT carries the flag too.

Verified the seeding test fails without the fix and passes with it.

## Checks

- `bun run test:web` — 2869 pass
- `bun run test:core` — pass
- backend booking db tests — 20 pass
- `bun run type-check`, `bun run lint`, `bun run knip` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)