### PR TITLE
feat(booking): type weekly hours as ranges instead of 21 tab stops

### DIFF
--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -141,6 +141,7 @@ export function BookingSettingsSection({
     buildInitialForm(undefined, effectiveTimeZone, writableCalendars),
   );
   const [enableError, setEnableError] = useState<string | null>(null);
+  const [areHoursValid, setAreHoursValid] = useState(true);
 
   // Re-seed only when the server actually answers with a different page.
   // Keying the effect on writableCalendars/effectiveTimeZone as well meant a
@@ -206,6 +207,10 @@ export function BookingSettingsSection({
   };
 
   const handleSave = () => {
+    if (!areHoursValid) {
+      setEnableError("Fix the weekly hours that could not be read.");
+      return;
+    }
     if (form.enabled && !canEnableBookingPage(form, writableCalendars)) {
       setEnableError("Choose a destination calendar before enabling booking.");
       return;
@@ -358,6 +363,7 @@ export function BookingSettingsSection({
 
       <BookingWeeklyHoursEditor
         onChange={(weeklyAvailability) => updateForm({ weeklyAvailability })}
+        onValidityChange={setAreHoursValid}
         value={form.weeklyAvailability}
       />
 

--- a/packages/web/src/booking/BookingWeeklyHoursEditor.test.tsx
+++ b/packages/web/src/booking/BookingWeeklyHoursEditor.test.tsx
@@ -1,0 +1,130 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { type WeeklyAvailability } from "@core/types/booking.contracts";
+import { BookingWeeklyHoursEditor } from "@web/booking/BookingWeeklyHoursEditor";
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+const renderEditor = (value: WeeklyAvailability = []) => {
+  const onChange = mock((_next: WeeklyAvailability) => {});
+  render(<BookingWeeklyHoursEditor onChange={onChange} value={value} />);
+  return onChange;
+};
+
+const lastCall = (onChange: ReturnType<typeof renderEditor>) =>
+  onChange.mock.calls[onChange.mock.calls.length - 1]?.[0];
+
+describe("BookingWeeklyHoursEditor", () => {
+  it("turns a typed range into availability on blur", async () => {
+    const user = userEvent.setup({ delay: null });
+    const onChange = renderEditor();
+
+    await user.type(screen.getByLabelText("Monday"), "9-5");
+    await user.tab();
+
+    expect(lastCall(onChange)).toEqual([
+      { weekday: 1, start: "09:00", end: "17:00" },
+    ]);
+  });
+
+  it("normalizes the row so the user sees what was understood", async () => {
+    const user = userEvent.setup({ delay: null });
+    renderEditor();
+
+    await user.type(screen.getByLabelText("Tuesday"), "930-5:30p");
+    await user.tab();
+
+    expect(screen.getByLabelText("Tuesday")).toHaveValue("9:30am-5:30pm");
+  });
+
+  it("treats a blank day as unavailable", async () => {
+    const user = userEvent.setup({ delay: null });
+    const onChange = renderEditor([
+      { weekday: 3, start: "09:00", end: "17:00" },
+    ]);
+
+    await user.clear(screen.getByLabelText("Wednesday"));
+    await user.tab();
+
+    expect(lastCall(onChange)).toEqual([]);
+    expect(screen.getAllByText("Unavailable").length).toBeGreaterThan(0);
+  });
+
+  it("keeps both intervals on a day with a break", () => {
+    // The old editor read the day with .find and destroyed the second
+    // interval on the next save.
+    renderEditor([
+      { weekday: 4, start: "09:00", end: "12:00" },
+      { weekday: 4, start: "13:00", end: "17:00" },
+    ]);
+
+    expect(screen.getByLabelText("Thursday")).toHaveValue("9am-12pm, 1pm-5pm");
+  });
+
+  it("reports an unreadable row without discarding what was typed", async () => {
+    const user = userEvent.setup({ delay: null });
+    const onValidityChange = mock((_valid: boolean) => {});
+    render(
+      <BookingWeeklyHoursEditor
+        onChange={() => {}}
+        onValidityChange={onValidityChange}
+        value={[]}
+      />,
+    );
+
+    await user.type(screen.getByLabelText("Friday"), "whenever");
+    await user.tab();
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      'Could not read "whenever". Try 9-5.',
+    );
+    expect(screen.getByLabelText("Friday")).toHaveValue("whenever");
+    expect(onValidityChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("applies Monday to the weekdays and leaves the weekend alone", async () => {
+    const user = userEvent.setup({ delay: null });
+    const onChange = renderEditor();
+
+    await user.type(screen.getByLabelText("Monday"), "9-5");
+    await user.click(
+      screen.getByRole("button", { name: "Apply Monday to weekdays" }),
+    );
+
+    expect(lastCall(onChange)).toEqual([
+      { weekday: 1, start: "09:00", end: "17:00" },
+      { weekday: 2, start: "09:00", end: "17:00" },
+      { weekday: 3, start: "09:00", end: "17:00" },
+      { weekday: 4, start: "09:00", end: "17:00" },
+      { weekday: 5, start: "09:00", end: "17:00" },
+    ]);
+    expect(screen.getByLabelText("Saturday")).toHaveValue("");
+  });
+
+  it("clears every day", async () => {
+    const user = userEvent.setup({ delay: null });
+    const onChange = renderEditor([
+      { weekday: 1, start: "09:00", end: "17:00" },
+      { weekday: 6, start: "10:00", end: "12:00" },
+    ]);
+
+    await user.click(screen.getByRole("button", { name: "Clear all" }));
+
+    expect(lastCall(onChange)).toEqual([]);
+    expect(screen.getByLabelText("Monday")).toHaveValue("");
+  });
+
+  it("costs 9 tab stops, not the 21 the time inputs did", () => {
+    renderEditor();
+
+    // 7 day inputs + the two bulk buttons.
+    const inputs = screen.getAllByRole("textbox");
+    const buttons = screen.getAllByRole("button");
+    expect(inputs).toHaveLength(7);
+    expect(buttons).toHaveLength(2);
+  });
+});

--- a/packages/web/src/booking/BookingWeeklyHoursEditor.tsx
+++ b/packages/web/src/booking/BookingWeeklyHoursEditor.tsx
@@ -1,119 +1,191 @@
+import { useEffect, useRef, useState } from "react";
 import {
   type WeeklyAvailability,
   type WeeklyAvailabilityInterval,
 } from "@core/types/booking.contracts";
 import { ISO_WEEKDAYS, weekdayLabel } from "@web/booking/booking.util";
+import {
+  formatHoursRanges,
+  parseHoursRanges,
+} from "@web/booking/weekly-hours.parse";
+
+type Weekday = WeeklyAvailabilityInterval["weekday"];
+
+const WEEKDAYS: readonly Weekday[] = [1, 2, 3, 4, 5];
 
 interface BookingWeeklyHoursEditorProps {
   value: WeeklyAvailability;
   onChange: (value: WeeklyAvailability) => void;
   disabled?: boolean;
+  /** Raised when a row cannot be read, so the form can block saving. */
+  onValidityChange?: (isValid: boolean) => void;
 }
 
-type WeekdayRow = {
-  weekday: WeeklyAvailabilityInterval["weekday"];
-  enabled: boolean;
-  start: string;
-  end: string;
-};
+const textForWeekday = (value: WeeklyAvailability, weekday: Weekday): string =>
+  formatHoursRanges(value.filter((entry) => entry.weekday === weekday));
 
-const defaultRowTimes = (): Pick<WeekdayRow, "start" | "end"> => ({
-  start: "09:00",
-  end: "17:00",
-});
+const textsFromAvailability = (
+  value: WeeklyAvailability,
+): Record<Weekday, string> =>
+  Object.fromEntries(
+    ISO_WEEKDAYS.map((weekday) => [weekday, textForWeekday(value, weekday)]),
+  ) as Record<Weekday, string>;
 
-const rowsFromAvailability = (value: WeeklyAvailability): WeekdayRow[] =>
-  ISO_WEEKDAYS.map((weekday) => {
-    const interval = value.find((entry) => entry.weekday === weekday);
-    return {
-      weekday,
-      enabled: interval !== undefined,
-      start: interval?.start ?? defaultRowTimes().start,
-      end: interval?.end ?? defaultRowTimes().end,
-    };
-  });
-
-const availabilityFromRows = (rows: WeekdayRow[]): WeeklyAvailability =>
-  rows
-    .filter((row) => row.enabled)
-    .map((row) => ({
-      weekday: row.weekday,
-      start: row.start,
-      end: row.end,
-    }));
-
+/**
+ * One typed range per day - "9-5", or "9-12, 1-5", or blank for unavailable.
+ *
+ * This replaced a checkbox plus two native <input type="time"> per day: 21 tab
+ * stops, each time input itself a multi-segment widget. Blankness is now the
+ * unavailable state, so the checkboxes are gone, and the parser is the same
+ * one behind the event form's time field.
+ */
 export function BookingWeeklyHoursEditor({
   value,
   onChange,
   disabled = false,
+  onValidityChange,
 }: BookingWeeklyHoursEditorProps) {
-  const rows = rowsFromAvailability(value);
+  // Raw text per row so a half-typed value is never yanked out from under the
+  // user; it only becomes availability once it parses.
+  const [texts, setTexts] = useState<Record<Weekday, string>>(() =>
+    textsFromAvailability(value),
+  );
+  const [errors, setErrors] = useState<Partial<Record<Weekday, string>>>({});
+  const [announcement, setAnnouncement] = useState("");
+  // What we last handed upward. Anything else arriving in `value` came from
+  // outside - the server response seeding the form - so the rows resync,
+  // without yanking a half-typed value out from under the user.
+  const emittedRef = useRef<WeeklyAvailability>(value);
 
-  const updateRows = (nextRows: WeekdayRow[]) => {
-    onChange(availabilityFromRows(nextRows));
+  useEffect(() => {
+    if (value === emittedRef.current) return;
+    emittedRef.current = value;
+    setTexts(textsFromAvailability(value));
+    setErrors({});
+  }, [value]);
+
+  useEffect(() => {
+    onValidityChange?.(Object.keys(errors).length === 0);
+  }, [errors, onValidityChange]);
+
+  const commit = (nextTexts: Record<Weekday, string>) => {
+    const nextErrors: Partial<Record<Weekday, string>> = {};
+    const intervals: WeeklyAvailabilityInterval[] = [];
+
+    for (const weekday of ISO_WEEKDAYS) {
+      const result = parseHoursRanges(nextTexts[weekday] ?? "");
+      if (!result.ok) {
+        nextErrors[weekday] = result.error;
+        continue;
+      }
+      for (const range of result.ranges) {
+        intervals.push({ weekday, start: range.start, end: range.end });
+      }
+    }
+
+    setErrors(nextErrors);
+    emittedRef.current = intervals;
+    onChange(intervals);
   };
 
-  const updateRow = (
-    weekday: WeeklyAvailabilityInterval["weekday"],
-    patch: Partial<WeekdayRow>,
-  ) => {
-    updateRows(
-      rows.map((row) => (row.weekday === weekday ? { ...row, ...patch } : row)),
+  const setText = (weekday: Weekday, text: string) => {
+    setTexts((current) => ({ ...current, [weekday]: text }));
+  };
+
+  const commitRow = (weekday: Weekday) => {
+    const result = parseHoursRanges(texts[weekday] ?? "");
+    const nextTexts = result.ok
+      ? { ...texts, [weekday]: formatHoursRanges(result.ranges) }
+      : texts;
+    setTexts(nextTexts);
+    commit(nextTexts);
+  };
+
+  const applyToWeekdays = () => {
+    const source = texts[1] ?? "";
+    const nextTexts = { ...texts };
+    for (const weekday of WEEKDAYS) nextTexts[weekday] = source;
+    setTexts(nextTexts);
+    commit(nextTexts);
+    setAnnouncement(
+      source.trim() === ""
+        ? "Cleared Monday through Friday"
+        : `Set Monday through Friday to ${source}`,
     );
+  };
+
+  const clearAll = () => {
+    const nextTexts = Object.fromEntries(
+      ISO_WEEKDAYS.map((weekday) => [weekday, ""]),
+    ) as Record<Weekday, string>;
+    setTexts(nextTexts);
+    commit(nextTexts);
+    setAnnouncement("Cleared every day");
   };
 
   return (
     <fieldset className="flex flex-col gap-2" disabled={disabled}>
       <legend className="mb-1 text-sm text-text">Weekly hours</legend>
-      {rows.map((row) => (
-        <div className="flex flex-wrap items-center gap-2" key={row.weekday}>
-          <label className="flex w-28 shrink-0 items-center gap-2 text-sm text-text">
+      <p className="text-text-muted text-xs" id="booking-hours-hint">
+        Type a range like 9-5, or 9-12, 1-5 for a break. Leave a day blank to be
+        unavailable.
+      </p>
+
+      <span aria-live="polite" className="sr-only" role="status">
+        {announcement}
+      </span>
+
+      {ISO_WEEKDAYS.map((weekday) => (
+        <div className="flex flex-col gap-1" key={weekday}>
+          <div className="flex items-center gap-2">
+            <label
+              className="w-28 shrink-0 text-sm text-text"
+              htmlFor={`booking-hours-${weekday}`}
+            >
+              {weekdayLabel(weekday)}
+            </label>
             <input
-              checked={row.enabled}
-              className="c-all-day-checkbox"
-              onChange={(event) =>
-                updateRow(row.weekday, { enabled: event.target.checked })
-              }
-              type="checkbox"
+              aria-describedby="booking-hours-hint"
+              aria-invalid={errors[weekday] ? true : undefined}
+              className="c-focus-ring w-40 rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text"
+              id={`booking-hours-${weekday}`}
+              onBlur={() => commitRow(weekday)}
+              onChange={(event) => setText(weekday, event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") commitRow(weekday);
+              }}
+              placeholder="9-5"
+              type="text"
+              value={texts[weekday] ?? ""}
             />
-            {weekdayLabel(row.weekday)}
-          </label>
-          {row.enabled ? (
-            <>
-              <label
-                className="sr-only"
-                htmlFor={`booking-start-${row.weekday}`}
-              >
-                {weekdayLabel(row.weekday)} start
-              </label>
-              <input
-                className="c-focus-ring rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text"
-                id={`booking-start-${row.weekday}`}
-                onChange={(event) =>
-                  updateRow(row.weekday, { start: event.target.value })
-                }
-                type="time"
-                value={row.start}
-              />
-              <span className="text-sm text-text-muted">to</span>
-              <label className="sr-only" htmlFor={`booking-end-${row.weekday}`}>
-                {weekdayLabel(row.weekday)} end
-              </label>
-              <input
-                className="c-focus-ring rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text"
-                id={`booking-end-${row.weekday}`}
-                onChange={(event) =>
-                  updateRow(row.weekday, { end: event.target.value })
-                }
-                type="time"
-                value={row.end}
-              />
-            </>
-          ) : (
-            <span className="text-sm text-text-muted">Unavailable</span>
-          )}
+            {(texts[weekday] ?? "").trim() === "" && !errors[weekday] ? (
+              <span className="text-sm text-text-muted">Unavailable</span>
+            ) : null}
+          </div>
+          {errors[weekday] ? (
+            <p className="text-error pl-30 text-xs" role="alert">
+              {errors[weekday]}
+            </p>
+          ) : null}
         </div>
       ))}
+
+      <div className="mt-1 flex gap-2">
+        <button
+          className="c-focus-ring rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text hover:bg-surface-panel"
+          onClick={applyToWeekdays}
+          type="button"
+        >
+          Apply Monday to weekdays
+        </button>
+        <button
+          className="c-focus-ring rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text hover:bg-surface-panel"
+          onClick={clearAll}
+          type="button"
+        >
+          Clear all
+        </button>
+      </div>
     </fieldset>
   );
 }

--- a/packages/web/src/booking/weekly-hours.parse.test.ts
+++ b/packages/web/src/booking/weekly-hours.parse.test.ts
@@ -1,0 +1,97 @@
+import {
+  formatHoursRanges,
+  parseHoursRanges,
+} from "@web/booking/weekly-hours.parse";
+import { describe, expect, it } from "bun:test";
+
+const ok = (input: string) => {
+  const result = parseHoursRanges(input);
+  if (!result.ok)
+    throw new Error(`expected "${input}" to parse: ${result.error}`);
+  return result.ranges;
+};
+
+describe("parseHoursRanges", () => {
+  it("reads a bare hour range as the working day", () => {
+    // The headline case: parseUserTime's meridiem inheritance would make this
+    // 9 AM to 5 AM, which the contract rejects outright.
+    expect(ok("9-5")).toEqual([{ start: "09:00", end: "17:00" }]);
+  });
+
+  it.each([
+    ["9:30-5:30p", [{ start: "09:30", end: "17:30" }]],
+    ["0930-1700", [{ start: "09:30", end: "17:00" }]],
+    ["9:00-17:00", [{ start: "09:00", end: "17:00" }]],
+    ["8a-12p", [{ start: "08:00", end: "12:00" }]],
+    ["9 to 5", [{ start: "09:00", end: "17:00" }]],
+    ["9–5", [{ start: "09:00", end: "17:00" }]],
+    ["  9 - 5  ", [{ start: "09:00", end: "17:00" }]],
+  ])("parses %p", (input, expected) => {
+    expect(ok(input as string)).toEqual(expected as never);
+  });
+
+  it("keeps an explicit AM end as AM", () => {
+    // Explicitly stated, so the PM correction must stand down. 5am is after
+    // 1am, so this is a legitimate overnight-ish early range.
+    expect(ok("1-5am")).toEqual([{ start: "01:00", end: "05:00" }]);
+  });
+
+  it("does not push an end that is already after the start", () => {
+    expect(ok("9-11")).toEqual([{ start: "09:00", end: "11:00" }]);
+  });
+
+  it("reads a comma-separated list as several intervals", () => {
+    // The contract allows this; the old editor silently dropped all but the
+    // first interval on the next save.
+    expect(ok("9-12, 1-5")).toEqual([
+      { start: "09:00", end: "12:00" },
+      { start: "13:00", end: "17:00" },
+    ]);
+  });
+
+  it("treats blank as unavailable rather than an error", () => {
+    expect(ok("")).toEqual([]);
+    expect(ok("   ")).toEqual([]);
+  });
+
+  it.each([
+    "nonsense",
+    "9",
+    "9-",
+    "-5",
+    "9-5-7",
+    "25-30",
+  ])("rejects %p", (input) => {
+    expect(parseHoursRanges(input).ok).toBe(false);
+  });
+
+  it("rejects an end at or before the start", () => {
+    // 5pm to 9am cannot be corrected into anything sensible.
+    expect(parseHoursRanges("5pm-9am").ok).toBe(false);
+    expect(parseHoursRanges("9am-9am").ok).toBe(false);
+  });
+
+  it("rejects overlapping intervals with a distinct message", () => {
+    const result = parseHoursRanges("9-12, 11-2");
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toBe(
+      "Those hours overlap each other.",
+    );
+  });
+});
+
+describe("formatHoursRanges", () => {
+  it("round-trips through the parser", () => {
+    const text = formatHoursRanges(ok("9-12, 1-5"));
+    expect(text).toBe("9am-12pm, 1pm-5pm");
+    expect(ok(text)).toEqual(ok("9-12, 1-5"));
+  });
+
+  it("renders an empty day as an empty string", () => {
+    expect(formatHoursRanges([])).toBe("");
+  });
+
+  it("keeps minutes when they are not on the hour", () => {
+    expect(formatHoursRanges(ok("9:30-5:15p"))).toBe("9:30am-5:15pm");
+  });
+});

--- a/packages/web/src/booking/weekly-hours.parse.ts
+++ b/packages/web/src/booking/weekly-hours.parse.ts
@@ -1,0 +1,138 @@
+import { type LocalTimeOfDay } from "@core/types/booking.contracts";
+import {
+  getDayjsByTimeValue,
+  parseUserTime,
+} from "@web/common/utils/datetime/web.date.util";
+
+export interface ParsedHoursRange {
+  start: LocalTimeOfDay;
+  end: LocalTimeOfDay;
+}
+
+export type ParseHoursResult =
+  | { ok: true; ranges: ParsedHoursRange[] }
+  | { ok: false; error: string };
+
+const RANGE_SEPARATOR = /\s*(?:-|–|—|\bto\b)\s*/i;
+const LIST_SEPARATOR = /[,;]/;
+const EXPLICIT_MERIDIEM = /[ap]\.?m?\.?\s*$/i;
+
+const toLocalTime = (value: string): LocalTimeOfDay =>
+  getDayjsByTimeValue(value).format("HH:mm") as LocalTimeOfDay;
+
+const minutesOf = (time: LocalTimeOfDay): number => {
+  const [hours, minutes] = time.split(":");
+  return Number(hours) * 60 + Number(minutes);
+};
+
+/** Push a bare 1-11 o'clock into the afternoon. */
+const toPm = (time: LocalTimeOfDay): LocalTimeOfDay => {
+  const [hoursText, minutes] = time.split(":");
+  return `${String(Number(hoursText) + 12).padStart(2, "0")}:${minutes}` as LocalTimeOfDay;
+};
+
+const canShiftToPm = (time: LocalTimeOfDay, raw: string): boolean => {
+  if (EXPLICIT_MERIDIEM.test(raw.trim())) return false;
+  const hour = Number(time.split(":")[0]);
+  return hour >= 1 && hour <= 11;
+};
+
+/**
+ * Parse one "9-5" style range.
+ *
+ * `parseUserTime`'s meridiem inheritance is deliberately NOT used to settle the
+ * end side: passing a 9 AM start as its current value resolves a bare "5" to
+ * 5 AM, which the contract rejects (end must be after start). A bare 1-11
+ * o'clock that lands at or before the start is pushed to PM instead, which is
+ * what "9-5" means to everyone who types it. `afterMinutes` extends the same
+ * courtesy to a later segment, so "1" after a noon break is 1 PM.
+ */
+const parseRange = (
+  text: string,
+  afterMinutes: number | null,
+): ParsedHoursRange | null => {
+  const [rawStart, rawEnd, ...rest] = text.split(RANGE_SEPARATOR);
+  if (rest.length > 0 || !rawStart || !rawEnd) return null;
+
+  const startOption = parseUserTime(rawStart.trim());
+  const endOption = parseUserTime(rawEnd.trim());
+  if (!startOption || !endOption) return null;
+
+  let start = toLocalTime(startOption.value);
+  let end = toLocalTime(endOption.value);
+
+  // A later segment continues the day, so a bare "1" after a noon break is
+  // 1 PM, not 1 AM.
+  if (
+    afterMinutes !== null &&
+    minutesOf(start) <= afterMinutes &&
+    canShiftToPm(start, rawStart)
+  ) {
+    start = toPm(start);
+  }
+
+  if (minutesOf(end) <= minutesOf(start) && canShiftToPm(end, rawEnd)) {
+    end = toPm(end);
+  }
+
+  if (minutesOf(end) <= minutesOf(start)) return null;
+  return { start, end };
+};
+
+const overlaps = (a: ParsedHoursRange, b: ParsedHoursRange): boolean =>
+  minutesOf(a.start) < minutesOf(b.end) &&
+  minutesOf(b.start) < minutesOf(a.end);
+
+/**
+ * Parse a day's hours: blank means unavailable, and a comma-separated list
+ * means several intervals ("9-12, 1-5"). The contract has always allowed
+ * multiple non-overlapping intervals per weekday; the old checkbox-plus-two-
+ * time-inputs editor could only ever show the first and dropped the rest on
+ * the next save.
+ */
+export function parseHoursRanges(input: string): ParseHoursResult {
+  const trimmed = input.trim();
+  if (trimmed === "") return { ok: true, ranges: [] };
+
+  const parts = trimmed
+    .split(LIST_SEPARATOR)
+    .map((part) => part.trim())
+    .filter((part) => part !== "");
+
+  const ranges: ParsedHoursRange[] = [];
+  for (const part of parts) {
+    const previous = ranges[ranges.length - 1];
+    // Fall back to reading the segment on its own terms when continuing the
+    // previous one yields nothing: "9-12, 11-2" is an overlap the user should
+    // hear about, not an unreadable segment.
+    const range =
+      parseRange(part, previous ? minutesOf(previous.end) : null) ??
+      parseRange(part, null);
+    if (!range) {
+      return { ok: false, error: `Could not read "${part}". Try 9-5.` };
+    }
+    if (ranges.some((existing) => overlaps(existing, range))) {
+      return { ok: false, error: "Those hours overlap each other." };
+    }
+    ranges.push(range);
+  }
+
+  return { ok: true, ranges };
+}
+
+const to12Hour = (time: LocalTimeOfDay): string => {
+  const [hoursText, minutes] = time.split(":");
+  const hours = Number(hoursText);
+  const suffix = hours >= 12 ? "pm" : "am";
+  const hour12 = hours % 12 === 0 ? 12 : hours % 12;
+  return minutes === "00"
+    ? `${hour12}${suffix}`
+    : `${hour12}:${minutes}${suffix}`;
+};
+
+/** Render stored intervals back into the compact form the field accepts. */
+export function formatHoursRanges(ranges: readonly ParsedHoursRange[]): string {
+  return ranges
+    .map((range) => `${to12Hour(range.start)}-${to12Hour(range.end)}`)
+    .join(", ");
+}


### PR DESCRIPTION
## Problem

Weekly hours were a checkbox plus two native `<input type="time">` per day — **21 tab stops**, and each native time input is itself a multi-segment widget, so a real fill-out ran to 40-odd keypresses.

## Now

One text field per day.

```
Mon  [9-5      ]
Tue  [9-5      ]
...
Sat  [         ]  Unavailable
```

`9-5` is the whole interaction. Blank means unavailable, so the checkboxes are gone. `9-12, 1-5` expresses a break. **Nine tab stops**, and the common case is `Tab`, `9-5`, one button.

## The parser

Reuses `parseUserTime` — the same parser behind the event form's time field and quick-time create — but deliberately **not** its meridiem inheritance: that resolves a bare `5` after a 9 AM start to 5 **AM**, which `WeeklyAvailabilityIntervalSchema` rejects outright (end must be after start).

Instead, a bare 1–11 o'clock that lands at or before the start is pushed to PM. A later segment continues the day, so the `1` in `9-12, 1-5` is 1 PM. When continuing yields nothing readable, it falls back to reading the segment on its own terms, so `9-12, 11-2` reports an *overlap* rather than an unreadable segment.

## Also fixes a data loss

`WeeklyAvailabilitySchema` has always allowed several non-overlapping intervals per weekday, but `rowsFromAvailability` read each day with `.find`, so a second interval was **silently destroyed on the next save**. Comma-separated ranges round-trip it.

## Errors

An unreadable row keeps what the user typed, shows an inline `role="alert"`, and blocks the save — rather than throwing away the input.

## Tests

`BookingWeeklyHoursEditor` had **no tests at all** before this. Added a table-driven parser suite (`9-5`, `9:30-5:30p`, `0930-1700`, `9-12, 1-5`, explicit-AM, overlap, end-before-start, blank) and editor tests covering typing, blanking, the two-interval round trip, the inline error, and the bulk buttons.

## Checks

- `bun test ./src/booking` — 45 pass
- `bun run type-check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)