### PR TITLE
fix(booking): clamp guest slot window to the host horizon

### DIFF
--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -85,6 +85,7 @@ export async function preparePublicBookingPage(
           durationMinutes: options.durationMinutes ?? 30,
           timeZone: "America/Chicago",
           enabled: true,
+          maxHorizonDays: 60,
         }),
       );
     }

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -3,16 +3,13 @@ import { Status } from "@core/errors/status.codes";
 import { AdminPutBookingPageInputSchema } from "@core/types/booking.contracts";
 import { BaseDriver } from "@backend/__tests__/drivers/base.driver";
 import { UserDriver } from "@backend/__tests__/drivers/user.driver";
-import { UtilDriver } from "@backend/__tests__/drivers/util.driver";
 import {
   cleanupCollections,
   cleanupTestDb,
   setupTestDb,
 } from "@backend/__tests__/helpers/mock.db.setup";
 import * as billingGuard from "@backend/billing/billing.guard";
-import { hashCancelToken } from "@backend/booking/booking-cancel-token";
 import { ensureBookingIndexes } from "@backend/booking/booking-indexes";
-import { bookingPageRepository } from "@backend/booking/booking-page.repository";
 import { bookingReservationRepository } from "@backend/booking/booking-reservation.repository";
 import bookingPageService from "@backend/booking/services/booking-page.service";
 import { type CalendarBookingPort } from "@backend/booking/services/calendar-booking.port";
@@ -281,6 +278,56 @@ describe("PublicBookingService", () => {
     expect(JSON.stringify(response)).not.toContain("intervals");
   });
 
+  it("clamps a requested window that extends past the host horizon", async () => {
+    const userId = await createNamedUser("Short Horizon Host");
+    const calendar = writableCalendar();
+    mockHealthySync([calendar]);
+    spyOn(billingGuard, "assertBillingAllowsWrites").mockResolvedValue(
+      undefined,
+    );
+    const page = await bookingPageService.putAdminPage(
+      userId,
+      samplePutInput({
+        destinationCalendarId: calendar.id,
+        blockingCalendarIds: [calendar.id],
+        maxHorizonDays: 7,
+      }),
+    );
+    const slug = "slug" in page ? page.slug : "";
+    const start = new Date();
+    const end = new Date(start.getTime() + 14 * 24 * 60 * 60 * 1000);
+
+    const response = await service.getSlots(slug, {
+      start: start.toISOString(),
+      end: end.toISOString(),
+      timeZone: "UTC",
+    });
+
+    expect(response.bookable).toBe(true);
+    const horizonMs = Date.now() + 7 * 24 * 60 * 60 * 1000;
+    for (const slot of response.slots) {
+      expect(Date.parse(slot.slotStart)).toBeLessThan(horizonMs + 1000);
+    }
+    const availabilityQuery = getAvailability.mock.calls[0]?.[1] as {
+      end: string;
+    };
+    expect(Date.parse(availabilityQuery.end)).toBeLessThanOrEqual(
+      horizonMs + 2000,
+    );
+  });
+
+  it("still rejects a slot window whose end is not after start", async () => {
+    const { slug } = await enableBookingPage();
+
+    await expect(
+      service.getSlots(slug, {
+        start: "2026-09-08T00:00:00.000Z",
+        end: "2026-09-07T00:00:00.000Z",
+        timeZone: "UTC",
+      }),
+    ).rejects.toMatchObject({ bookingCode: "INVALID_INPUT" });
+  });
+
   it("cancels idempotently", async () => {
     const { slug } = await enableBookingPage();
     const slotStart = "2026-09-07T10:00:00.000Z";
@@ -393,6 +440,7 @@ describe("Public booking routes", () => {
         hostDisplayName: "Public Host",
         durationMinutes: 30,
         enabled: true,
+        maxHorizonDays: 60,
       }),
     );
   });

--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -13,6 +13,7 @@ import {
 } from "@core/types/booking.contracts";
 import { DateTimeSchema, type EventId } from "@core/types/domain-primitives";
 import { BUSY_QUERY_MAX_WINDOW_MS } from "@core/types/sync/availability.contracts";
+import dayjs from "@core/util/date/dayjs";
 import { bookingError } from "@backend/booking/booking.error";
 import {
   generateCancelToken,
@@ -106,9 +107,7 @@ export class PublicBookingService {
     const now = new Date();
     const windowStart = new Date(query.start);
     const requestedEnd = new Date(query.end);
-    const horizonEnd = new Date(
-      now.getTime() + page.maxHorizonDays * 24 * 60 * 60 * 1000,
-    );
+    const horizonEnd = dayjs(now).add(page.maxHorizonDays, "day").toDate();
     const windowEnd =
       requestedEnd.getTime() > horizonEnd.getTime() ? horizonEnd : requestedEnd;
 

--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -105,12 +105,18 @@ export class PublicBookingService {
     const query = parseSlotsQuery(rawQuery);
     const now = new Date();
     const windowStart = new Date(query.start);
-    const windowEnd = new Date(query.end);
+    const requestedEnd = new Date(query.end);
     const horizonEnd = new Date(
       now.getTime() + page.maxHorizonDays * 24 * 60 * 60 * 1000,
     );
-    if (windowEnd.getTime() > horizonEnd.getTime()) {
-      throw bookingError("INVALID_INPUT", "window exceeds booking horizon");
+    const windowEnd =
+      requestedEnd.getTime() > horizonEnd.getTime() ? horizonEnd : requestedEnd;
+
+    if (windowEnd.getTime() <= windowStart.getTime()) {
+      return BookingSlotsResponseSchema.parse({
+        slots: [],
+        bookable: true,
+      });
     }
 
     const availability = await this.calendarBooking.getAvailability(
@@ -118,7 +124,7 @@ export class PublicBookingService {
       {
         calendarIds: page.blockingCalendarIds,
         start: query.start,
-        end: query.end,
+        end: DateTimeSchema.parse(windowEnd.toISOString()),
       },
     );
 

--- a/packages/core/src/types/booking.contracts.test.ts
+++ b/packages/core/src/types/booking.contracts.test.ts
@@ -115,6 +115,7 @@ describe("PublicBookingPageSchema", () => {
       "durationMinutes",
       "timeZone",
       "enabled",
+      "maxHorizonDays",
     ]);
   });
 
@@ -128,6 +129,7 @@ describe("PublicBookingPageSchema", () => {
       durationMinutes: 30,
       timeZone: "America/Denver",
       enabled: true,
+      maxHorizonDays: 60,
     });
     expect(Object.keys(pub)).not.toContain("destinationCalendarId");
     expect(Object.keys(pub)).not.toContain("blockingCalendarIds");
@@ -199,6 +201,7 @@ describe("HTTP booking contracts", () => {
         durationMinutes: admin.durationMinutes,
         timeZone: admin.timeZone,
         enabled: admin.enabled,
+        maxHorizonDays: admin.maxHorizonDays,
       }).success,
     ).toBe(true);
 

--- a/packages/core/src/types/booking.contracts.ts
+++ b/packages/core/src/types/booking.contracts.ts
@@ -181,11 +181,15 @@ export const PublicBookingPageSchema = z.strictObject({
   durationMinutes: BookingDurationMinutesSchema,
   timeZone: TimeZoneSchema,
   enabled: z.boolean(),
+  maxHorizonDays: z.number().int().positive().max(60),
 });
 export type PublicBookingPage = z.infer<typeof PublicBookingPageSchema>;
 
 export const toPublicBookingPage = (
-  page: Pick<BookingPage, "durationMinutes" | "timeZone" | "enabled">,
+  page: Pick<
+    BookingPage,
+    "durationMinutes" | "timeZone" | "enabled" | "maxHorizonDays"
+  >,
   hostDisplayName: string,
 ): PublicBookingPage =>
   PublicBookingPageSchema.parse({
@@ -193,6 +197,7 @@ export const toPublicBookingPage = (
     durationMinutes: page.durationMinutes,
     timeZone: page.timeZone,
     enabled: page.enabled,
+    maxHorizonDays: page.maxHorizonDays,
   });
 
 export const BookingReservationStatusSchema = z.enum([

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -26,6 +26,15 @@ function renderBookingRoute(path: string) {
 
 const slotStart = "2026-09-01T15:00:00.000Z";
 
+const publicPagePayload = (overrides: Record<string, unknown> = {}) => ({
+  hostDisplayName: "Tyler Dane",
+  durationMinutes: 30,
+  timeZone: "America/Chicago",
+  enabled: true,
+  maxHorizonDays: 60,
+  ...overrides,
+});
+
 describe("PublicBookingPage", () => {
   it("shows a generic not-found state for an unknown slug", async () => {
     renderBookingRoute("/book/unknown-host");
@@ -46,15 +55,7 @@ describe("PublicBookingPage", () => {
       rest.get(
         `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane`,
         (_req, res, ctx) =>
-          res(
-            ctx.status(Status.OK),
-            ctx.json({
-              hostDisplayName: "Tyler Dane",
-              durationMinutes: 30,
-              timeZone: "America/Chicago",
-              enabled: true,
-            }),
-          ),
+          res(ctx.status(Status.OK), ctx.json(publicPagePayload())),
       ),
       rest.get(
         `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/slots`,
@@ -122,15 +123,7 @@ describe("PublicBookingPage", () => {
       rest.get(
         `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane`,
         (_req, res, ctx) =>
-          res(
-            ctx.status(Status.OK),
-            ctx.json({
-              hostDisplayName: "Tyler Dane",
-              durationMinutes: 30,
-              timeZone: "America/Chicago",
-              enabled: true,
-            }),
-          ),
+          res(ctx.status(Status.OK), ctx.json(publicPagePayload())),
       ),
       rest.get(
         `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/slots`,
@@ -157,15 +150,7 @@ describe("PublicBookingPage", () => {
       rest.get(
         `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane`,
         (_req, res, ctx) =>
-          res(
-            ctx.status(Status.OK),
-            ctx.json({
-              hostDisplayName: "Tyler Dane",
-              durationMinutes: 30,
-              timeZone: "America/Chicago",
-              enabled: true,
-            }),
-          ),
+          res(ctx.status(Status.OK), ctx.json(publicPagePayload())),
       ),
       rest.get(
         `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/slots`,
@@ -209,15 +194,7 @@ describe("PublicBookingPage", () => {
       rest.get(
         `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane`,
         (_req, res, ctx) =>
-          res(
-            ctx.status(Status.OK),
-            ctx.json({
-              hostDisplayName: "Tyler Dane",
-              durationMinutes: 30,
-              timeZone: "America/Chicago",
-              enabled: true,
-            }),
-          ),
+          res(ctx.status(Status.OK), ctx.json(publicPagePayload())),
       ),
       rest.get(
         `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/slots`,
@@ -230,5 +207,56 @@ describe("PublicBookingPage", () => {
 
     await screen.findByRole("heading", { name: "Book with Tyler Dane" });
     expect(screen.queryByText(/Keyboard shortcuts/i)).not.toBeInTheDocument();
+  });
+
+  it("clamps the slot request to the host horizon and still loads times", async () => {
+    let slotStartParam: string | null = null;
+    let slotEndParam: string | null = null;
+    const inWindowStart = new Date(
+      Date.now() + 2 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    const inWindowEnd = new Date(
+      Date.parse(inWindowStart) + 30 * 60 * 1000,
+    ).toISOString();
+
+    server.use(
+      rest.get(
+        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane`,
+        (_req, res, ctx) =>
+          res(
+            ctx.status(Status.OK),
+            ctx.json(publicPagePayload({ maxHorizonDays: 7 })),
+          ),
+      ),
+      rest.get(
+        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/slots`,
+        (req, res, ctx) => {
+          slotStartParam = req.url.searchParams.get("start");
+          slotEndParam = req.url.searchParams.get("end");
+          return res(
+            ctx.status(Status.OK),
+            ctx.json({
+              bookable: true,
+              slots: [{ slotStart: inWindowStart, slotEnd: inWindowEnd }],
+            }),
+          );
+        },
+      ),
+    );
+
+    renderBookingRoute("/book/tylerdane");
+
+    expect(
+      await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Could not load times" }),
+    ).not.toBeInTheDocument();
+    expect(slotStartParam).toBeTruthy();
+    expect(slotEndParam).toBeTruthy();
+    const requestedMs =
+      Date.parse(slotEndParam ?? "") - Date.parse(slotStartParam ?? "");
+    expect(requestedMs).toBeGreaterThan(0);
+    expect(requestedMs).toBeLessThanOrEqual(7 * 24 * 60 * 60 * 1000 + 60_000);
   });
 });

--- a/packages/web/src/booking/PublicBookingPage.tsx
+++ b/packages/web/src/booking/PublicBookingPage.tsx
@@ -29,6 +29,7 @@ export function PublicBookingPage() {
   const slotsQuery = usePublicBookingSlotsQuery(
     slug,
     pageQuery.isSuccess && pageQuery.data.enabled,
+    pageQuery.data?.maxHorizonDays,
   );
   const createReservation = useCreatePublicBookingReservationMutation(slug);
 

--- a/packages/web/src/booking/public-booking.format.test.ts
+++ b/packages/web/src/booking/public-booking.format.test.ts
@@ -1,0 +1,29 @@
+import { getPublicBookingSlotWindow } from "@web/booking/public-booking.format";
+import { describe, expect, it } from "bun:test";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe("getPublicBookingSlotWindow", () => {
+  it("clamps the default 14-day window to a shorter host horizon", () => {
+    const window = getPublicBookingSlotWindow("UTC", 7);
+    const spanMs = Date.parse(window.end) - Date.parse(window.start);
+
+    expect(spanMs).toBeGreaterThan(0);
+    expect(spanMs).toBeLessThanOrEqual(7 * DAY_MS + 60_000);
+  });
+
+  it("keeps the default 14-day window when the host horizon is longer", () => {
+    const window = getPublicBookingSlotWindow("UTC", 60);
+    const spanMs = Date.parse(window.end) - Date.parse(window.start);
+
+    expect(spanMs).toBeGreaterThan(14 * DAY_MS - 60_000);
+    expect(spanMs).toBeLessThan(15 * DAY_MS);
+  });
+
+  it("does not let end-of-day padding extend past a 14-day horizon", () => {
+    const window = getPublicBookingSlotWindow("UTC", 14);
+    const spanMs = Date.parse(window.end) - Date.parse(window.start);
+
+    expect(spanMs).toBeLessThanOrEqual(14 * DAY_MS + 60_000);
+  });
+});

--- a/packages/web/src/booking/public-booking.format.ts
+++ b/packages/web/src/booking/public-booking.format.ts
@@ -9,18 +9,21 @@ const SLOT_WINDOW_DAYS = 14;
 
 export function getPublicBookingSlotWindow(
   hostTimeZone: string,
+  maxHorizonDays: number,
 ): BookingSlotsQuery {
   const guestTimeZone = getBrowserTimeZone();
-  const start = dayjs().tz(guestTimeZone).startOf("minute").toISOString();
-  const end = dayjs()
+  const start = dayjs().tz(guestTimeZone).startOf("minute");
+  const preferredEnd = dayjs()
     .tz(guestTimeZone)
     .add(SLOT_WINDOW_DAYS, "day")
-    .endOf("day")
-    .toISOString();
+    .endOf("day");
+  // Match the slot engine: horizon is now + maxHorizonDays, not end-of-day.
+  const horizonEnd = dayjs().add(maxHorizonDays, "day");
+  const end = preferredEnd.isAfter(horizonEnd) ? horizonEnd : preferredEnd;
 
   return BookingSlotsQuerySchema.parse({
-    start,
-    end,
+    start: start.toISOString(),
+    end: end.toISOString(),
     timeZone: guestTimeZone || hostTimeZone,
   });
 }

--- a/packages/web/src/booking/public-booking.query.ts
+++ b/packages/web/src/booking/public-booking.query.ts
@@ -6,7 +6,6 @@ import {
 } from "@tanstack/react-query";
 import { useMemo } from "react";
 import {
-  BookingSlotsQuerySchema,
   type CreateBookingReservationInput,
   type CreateBookingReservationResponse,
 } from "@core/types/booking.contracts";
@@ -40,8 +39,16 @@ export function usePublicBookingPageQuery(slug: string) {
   return useQuery(publicBookingPageQueryOptions(slug));
 }
 
-export function usePublicBookingSlotsQuery(slug: string, enabled: boolean) {
-  const window = useMemo(() => getPublicBookingSlotWindow("UTC"), []);
+export function usePublicBookingSlotsQuery(
+  slug: string,
+  enabled: boolean,
+  maxHorizonDays: number | undefined,
+) {
+  // Query stays disabled until maxHorizonDays is known; 60 only fills the key.
+  const window = useMemo(
+    () => getPublicBookingSlotWindow("UTC", maxHorizonDays ?? 60),
+    [maxHorizonDays],
+  );
   return useQuery({
     queryKey: publicBookingQueryKeys.slots(
       slug,
@@ -50,7 +57,7 @@ export function usePublicBookingSlotsQuery(slug: string, enabled: boolean) {
       window.timeZone,
     ),
     queryFn: () => PublicBookingApi.getSlots(slug, window),
-    enabled: enabled && Boolean(slug),
+    enabled: enabled && Boolean(slug) && maxHorizonDays != null,
   });
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3010

## Summary

Hosts with `maxHorizonDays` of 14 or less currently 400 every guest slot request, because the guest page always asks for a 14-day window (and `endOf("day")` can overshoot even a 14-day horizon). This change:

- Adds `maxHorizonDays` to `PublicBookingPageSchema` so the guest page can bound its fetch
- Clamps the default 14-day client window to `min(14 days, host horizon)`
- Clamps over-horizon slot queries on the backend instead of returning 400; still 400 when `end` is not after `start`

## Simplicity

No new helpers or config. The client takes `min(preferred end, now + horizon)`. The backend replaces the 400 with an end-date clamp and returns empty slots when the window sits entirely past the horizon. Horizon uses the same `dayjs().add(days, "day")` as the slot engine.

## Automated validation

- `bun run test:core -- packages/core/src/types/booking.contracts.test.ts` — 22 pass
- Focused web tests (`public-booking.format.test.ts`, `PublicBookingPage.test.tsx`) — 9 pass, including a 7-day horizon request clamp
- Backend `public-booking.service.db.test.ts` — 13 pass, including horizon clamp and end-before-start still 400
- `bun run type-check` — pass
- `bun run lint` — pass (pre-existing warnings only)
- `bunx playwright test e2e/booking e2e/accessibility/booking-a11y.spec.ts` — 7 passed
- `bun run verify` — selected checks passed (core, web, backend, type-check, lint, knip)

## Independent review

`VERDICT: no confirmed findings`

Reviewed the base-to-head diff against AGENTS.md (contracts in core, no em-dashes, no barrel files, semantic tests). One DST mismatch (millisecond horizon vs slot-engine dayjs days) was fixed in `b090747c0` before merge. Remaining notes, not findings: dummy `maxHorizonDays ?? 60` only fills a disabled query key; empty-state copy still says "two weeks" (out of this issue's finish line).

## Test plan

Commands above were actually run. GitHub CI is the remaining merge gate.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46079ef9-363d-42a6-8efb-4d17bad565a3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46079ef9-363d-42a6-8efb-4d17bad565a3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

