### PR TITLE
Stop the remaining test module mocks and spies from leaking

### DIFF
--- a/packages/web/src/auth/compass/hooks/useLogout.test.ts
+++ b/packages/web/src/auth/compass/hooks/useLogout.test.ts
@@ -1,6 +1,8 @@
 import { renderHook } from "@testing-library/react";
 import { act } from "react";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
 import { session } from "@web/auth/compass/session/Session";
+import * as realUsesession from "@web/auth/compass/session/useSession";
 import {
   afterAll,
   afterEach,
@@ -35,9 +37,9 @@ const actualPosthogBootstrap = {
 };
 let isLogoutMocked = true;
 
-mock.module("@web/auth/compass/session/useSession", () => ({
+mockModuleForFile("@web/auth/compass/session/useSession", realUsesession, {
   useSession: mockUseSession,
-}));
+});
 
 mock.module("@web/auth/compass/state/auth.state.util", () => ({
   ...actualAuthStateUtil,

--- a/packages/web/src/auth/compass/session/SessionProvider.test.tsx
+++ b/packages/web/src/auth/compass/session/SessionProvider.test.tsx
@@ -1,6 +1,8 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { act, useContext } from "react";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
 import { session } from "@web/auth/compass/session/Session";
+import * as realAuthStateUtil from "@web/auth/compass/state/auth.state.util";
 import { DEFAULT_AUTH_STATE } from "@web/auth/compass/state/auth.state.util";
 import * as userMetadataUtil from "@web/auth/compass/user/util/user-metadata.util";
 import {
@@ -50,18 +52,22 @@ const subscribeToAuthState = mock();
 const updateAuthState = mock();
 const doesSessionExist = spyOn(session, "doesSessionExist");
 
-mock.module("@web/auth/compass/state/auth.state.util", () => ({
-  clearAnonymousCalendarChangeSignUpPrompt,
-  clearAuthenticationState,
-  getAuthState,
-  getLastKnownEmail,
-  hasUserEverAuthenticated,
-  markUserAsAuthenticated,
-  markAnonymousCalendarChangeForSignUpPrompt,
-  shouldShowAnonymousCalendarChangeSignUpPrompt,
-  subscribeToAuthState,
-  updateAuthState,
-}));
+mockModuleForFile(
+  "@web/auth/compass/state/auth.state.util",
+  realAuthStateUtil,
+  {
+    clearAnonymousCalendarChangeSignUpPrompt,
+    clearAuthenticationState,
+    getAuthState,
+    getLastKnownEmail,
+    hasUserEverAuthenticated,
+    markUserAsAuthenticated,
+    markAnonymousCalendarChangeForSignUpPrompt,
+    shouldShowAnonymousCalendarChangeSignUpPrompt,
+    subscribeToAuthState,
+    updateAuthState,
+  },
+);
 
 const { SessionContext } =
   require("./session.context") as typeof import("./session.context");

--- a/packages/web/src/auth/compass/session/session.util.test.ts
+++ b/packages/web/src/auth/compass/session/session.util.test.ts
@@ -1,13 +1,20 @@
 import { UNAUTHENTICATED_USER } from "@web/auth/compass/session/session.util";
 import { session } from "./Session";
 import { getUserId } from "./session.util";
-import { beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { afterAll, beforeEach, describe, expect, it, spyOn } from "bun:test";
 
 const mockDoesSessionExist = spyOn(session, "doesSessionExist");
 const mockGetAccessTokenPayloadSecurely = spyOn(
   session,
   "getAccessTokenPayloadSecurely",
 );
+
+// bun never restores a spy on its own, and these live at module scope: without
+// this they stay installed on supertokens' session module for every later file.
+afterAll(() => {
+  mockDoesSessionExist.mockRestore();
+  mockGetAccessTokenPayloadSecurely.mockRestore();
+});
 
 describe("session.util", () => {
   beforeEach(() => {

--- a/packages/web/src/auth/compass/user/hooks/useLoadProfile.test.ts
+++ b/packages/web/src/auth/compass/user/hooks/useLoadProfile.test.ts
@@ -1,6 +1,8 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { Status } from "@core/errors/status.codes";
 import { type UserProfile } from "@core/types/user.types";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
+import * as realAuthStateUtil from "@web/auth/compass/state/auth.state.util";
 import { type UseLoadProfileResult } from "@web/auth/compass/user/hooks/useLoadProfile";
 import * as errorToast from "@web/common/utils/toast/error-toast.util";
 import {
@@ -31,11 +33,15 @@ const mockProfile: UserProfile = {
 
 const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
 
-mock.module("@web/auth/compass/state/auth.state.util", () => ({
-  getLastKnownEmail,
-  hasUserEverAuthenticated,
-  markUserAsAuthenticated,
-}));
+mockModuleForFile(
+  "@web/auth/compass/state/auth.state.util",
+  realAuthStateUtil,
+  {
+    getLastKnownEmail,
+    hasUserEverAuthenticated,
+    markUserAsAuthenticated,
+  },
+);
 
 // mock.module is process-wide and not reliably restorable, so the real
 // UserApi is captured up front and a flag (flipped off in afterAll) decides

--- a/packages/web/src/common/utils/event/event.util.test.ts
+++ b/packages/web/src/common/utils/event/event.util.test.ts
@@ -2,7 +2,9 @@ import { ObjectId } from "bson";
 import { Status } from "@core/errors/status.codes";
 import { createMockStandaloneEvent } from "@core/util/test/ccal.event.factory";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
 import { type ApiError, type ApiResponse } from "@web/api/api.types";
+import * as realPosthogBootstrap from "@web/auth/posthog/posthog.bootstrap";
 import {
   EVENT_SAVE_UNAVAILABLE_TOAST_ID,
   GENERIC_ERROR_TOAST_ID,
@@ -32,13 +34,13 @@ const mockCaptureException = mock();
 // `capture` is a no-op here (not a mock) so a `track()` call elsewhere in the
 // same test run - the module registration is process-global - doesn't crash
 // on a stubbed client shaped only for captureException.
-mock.module("@web/auth/posthog/posthog.bootstrap", () => ({
+mockModuleForFile("@web/auth/posthog/posthog.bootstrap", realPosthogBootstrap, {
   getPosthogClient: () => ({
     captureException: mockCaptureException,
     capture: () => undefined,
     reset: () => undefined,
   }),
-}));
+});
 
 const { handleError } = await import("@web/common/utils/event/event.util");
 

--- a/packages/web/src/common/utils/toast/session-expired.toast.test.tsx
+++ b/packages/web/src/common/utils/toast/session-expired.toast.test.tsx
@@ -2,15 +2,17 @@ import { HotkeyManager, HotkeysProvider } from "@tanstack/react-hotkeys";
 import { render, screen, within } from "@testing-library/react";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
 import { SessionExpiredToast } from "@web/common/utils/toast/session-expired.toast";
 import { registerToastPort } from "@web/common/utils/toast/toast.port";
+import * as realRouters from "@web/routers";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockNavigate = mock();
 
-mock.module("@web/routers", () => ({
+mockModuleForFile("@web/routers", realRouters, {
   router: { navigate: mockNavigate },
-}));
+});
 
 describe("SessionExpiredToast", () => {
   const { port, mocks } = createTestToastPort();

--- a/packages/web/src/components/CommandPalette/hooks/useAuthCmdItems.test.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useAuthCmdItems.test.ts
@@ -1,5 +1,7 @@
 import { renderHook } from "@testing-library/react";
 import { act } from "react";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
+import * as realUsesession from "@web/auth/compass/session/useSession";
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockOpenModal = mock();
@@ -7,9 +9,9 @@ const mockUseAuthModal = mock();
 const mockUseAuthFeatureFlag = mock();
 const mockUseSession = mock();
 
-mock.module("@web/auth/compass/session/useSession", () => ({
+mockModuleForFile("@web/auth/compass/session/useSession", realUsesession, {
   useSession: mockUseSession,
-}));
+});
 
 // mock.module is process-wide, not scoped to this file, and isn't reliably
 // "restorable" afterward (another file's top-level dynamic import can race

--- a/packages/web/src/components/CommandPalette/hooks/useLogoutCmdItems.test.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useLogoutCmdItems.test.ts
@@ -1,14 +1,16 @@
 import { renderHook } from "@testing-library/react";
 import { act } from "react";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
+import * as realUsesession from "@web/auth/compass/session/useSession";
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockOpenLogoutConfirmation = mock();
 const mockUseLogoutConfirmation = mock();
 const mockUseSession = mock();
 
-mock.module("@web/auth/compass/session/useSession", () => ({
+mockModuleForFile("@web/auth/compass/session/useSession", realUsesession, {
   useSession: mockUseSession,
-}));
+});
 
 // mock.module is process-wide, so the factory must keep the module's other
 // exports (LogoutConfirmationContext, useLogoutConfirmationState - the

--- a/packages/web/src/components/CommandPalette/hooks/useShowAccountsCmdItems.test.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useShowAccountsCmdItems.test.ts
@@ -1,6 +1,8 @@
 import { UsersIcon } from "@phosphor-icons/react";
 import { renderHook } from "@testing-library/react";
 import { act } from "react";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
+import * as realUsesession from "@web/auth/compass/session/useSession";
 import {
   selectIsSettingsOpen,
   selectSettingsPage,
@@ -10,9 +12,9 @@ import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockUseSession = mock();
 
-mock.module("@web/auth/compass/session/useSession", () => ({
+mockModuleForFile("@web/auth/compass/session/useSession", realUsesession, {
   useSession: mockUseSession,
-}));
+});
 
 const { useShowAccountsCmdItems } = await import("./useShowAccountsCmdItems");
 

--- a/packages/web/src/components/CommandPalette/hooks/useShowBillingCmdItems.test.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useShowBillingCmdItems.test.ts
@@ -1,5 +1,8 @@
 import { renderHook } from "@testing-library/react";
 import { act } from "react";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
+import * as realUsesession from "@web/auth/compass/session/useSession";
+import * as realUseappaccess from "@web/billing/useAppAccess";
 import { type AppAccess } from "@web/billing/useAppAccess";
 import {
   selectIsSettingsOpen,
@@ -10,14 +13,14 @@ import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockUseSession = mock();
 
-mock.module("@web/auth/compass/session/useSession", () => ({
+mockModuleForFile("@web/auth/compass/session/useSession", realUsesession, {
   useSession: mockUseSession,
-}));
+});
 
 let access: AppAccess = { kind: "open" };
-mock.module("@web/billing/useAppAccess", () => ({
+mockModuleForFile("@web/billing/useAppAccess", realUseappaccess, {
   useAppAccess: () => access,
-}));
+});
 
 const { useShowBillingCmdItems } = await import("./useShowBillingCmdItems");
 

--- a/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationProvider.test.tsx
+++ b/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationProvider.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import { afterAll, afterEach, describe, expect, it, spyOn } from "bun:test";
 import "@testing-library/jest-dom";
 import { UserApi } from "@web/api/user.api";
 import * as authState from "@web/auth/compass/state/auth.state.util";
@@ -25,6 +25,18 @@ const getPosthogClient = spyOn(
   posthogBootstrap,
   "getPosthogClient",
 ).mockReturnValue(posthog as never);
+
+// These spies live at module scope so the requires below see them, and bun
+// never restores a spy on its own: without this every later file in the run
+// would keep the fakes (a getPosthogClient with no capture(), a stubbed
+// location.assign), and fail somewhere unrelated.
+afterAll(() => {
+  deleteAccount.mockRestore();
+  clearAllBrowserStorage.mockRestore();
+  getLastKnownEmail.mockRestore();
+  assign.mockRestore();
+  getPosthogClient.mockRestore();
+});
 
 const { DeleteAccountConfirmationProvider } =
   require("./DeleteAccountConfirmationProvider") as typeof import("./DeleteAccountConfirmationProvider");

--- a/packages/web/src/components/DocumentTitle/useDocumentTitle.test.tsx
+++ b/packages/web/src/components/DocumentTitle/useDocumentTitle.test.tsx
@@ -1,5 +1,7 @@
 import { renderHook } from "@testing-library/react";
 import dayjs from "@core/util/date/dayjs";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
+import * as realUseupnextevent from "@web/components/Sidebar/UpNextCard/useUpNextEvent";
 import { initialViewState, useViewStore } from "@web/events/stores/view.store";
 import {
   DEFAULT_DOCUMENT_TITLE,
@@ -38,13 +40,17 @@ const actualUpNext = {
   ...(await import("@web/components/Sidebar/UpNextCard/useUpNextEvent")),
 };
 let isUpNextMocked = true;
-mock.module("@web/components/Sidebar/UpNextCard/useUpNextEvent", () => ({
-  useUpNextEvent: () =>
-    isUpNextMocked
-      ? upNextState
-      : // biome-ignore lint/correctness/useHookAtTopLevel: mock.module factory, not a component
-        actualUpNext.useUpNextEvent(),
-}));
+mockModuleForFile(
+  "@web/components/Sidebar/UpNextCard/useUpNextEvent",
+  realUseupnextevent,
+  {
+    useUpNextEvent: () =>
+      isUpNextMocked
+        ? upNextState
+        : // biome-ignore lint/correctness/useHookAtTopLevel: mock.module factory, not a component
+          actualUpNext.useUpNextEvent(),
+  },
+);
 
 const actualTanstackRouter = { ...(await import("@tanstack/react-router")) };
 const locationState = { pathname: "/week/2026-08-02" };

--- a/packages/web/src/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/packages/web/src/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,5 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
+import * as realPosthogBootstrap from "@web/auth/posthog/posthog.bootstrap";
+import * as realBrowserNavigationUtil from "@web/common/utils/browser/browser-navigation.util";
 import { ErrorBoundary } from "@web/components/ErrorBoundary/ErrorBoundary";
 import {
   afterEach,
@@ -19,17 +22,21 @@ const mockReload = mock();
 // `capture` is a no-op here (not a mock) so a `track()` call elsewhere in the
 // same test run - the module registration is process-global - doesn't crash
 // on a stubbed client shaped only for captureException.
-mock.module("@web/auth/posthog/posthog.bootstrap", () => ({
+mockModuleForFile("@web/auth/posthog/posthog.bootstrap", realPosthogBootstrap, {
   getPosthogClient: () => ({
     captureException: mockCaptureException,
     capture: () => undefined,
     reset: () => undefined,
   }),
-}));
+});
 
-mock.module("@web/common/utils/browser/browser-navigation.util", () => ({
-  reloadLocation: mockReload,
-}));
+mockModuleForFile(
+  "@web/common/utils/browser/browser-navigation.util",
+  realBrowserNavigationUtil,
+  {
+    reloadLocation: mockReload,
+  },
+);
 
 const Boom = () => {
   throw new Error("render exploded");

--- a/packages/web/src/components/LogoutConfirmation/LogoutConfirmationProvider.test.tsx
+++ b/packages/web/src/components/LogoutConfirmation/LogoutConfirmationProvider.test.tsx
@@ -66,6 +66,15 @@ mock.module("@web/auth/compass/session/useSession", () => ({
 afterAll(() => {
   isTeardownMocked = false;
   isSessionMocked = false;
+  // bun never restores a spy on its own, and these live at module scope, so
+  // without this the toast and auth-state fakes stay installed for every
+  // later file in the run.
+  clearAuthenticationState.mockRestore();
+  showStatusToast.mockRestore();
+  showErrorToast.mockRestore();
+  settingsActionsMock.closeSettings.mockRestore();
+  settingsActionsMock.closeCmdPalette.mockRestore();
+  signOut.mockRestore();
 });
 
 const { LogoutConfirmationProvider } =

--- a/packages/web/src/components/SelectView/SelectView.test.tsx
+++ b/packages/web/src/components/SelectView/SelectView.test.tsx
@@ -1,5 +1,7 @@
 import { RouterProvider } from "@tanstack/react-router";
 import { type ReactNode } from "react";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
+import * as realShortcuthint from "@web/components/Shortcuts/ShortcutHint";
 import "@testing-library/jest-dom";
 import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -37,13 +39,13 @@ afterAll(() => {
   isNavigateMocked = false;
 });
 
-mock.module("@web/components/Shortcuts/ShortcutHint", () => ({
+mockModuleForFile("@web/components/Shortcuts/ShortcutHint", realShortcuthint, {
   ShortcutHint: ({ children }: { children: ReactNode }) => (
     <span aria-hidden data-testid="shortcut-hint">
       {children}
     </span>
   ),
-}));
+});
 
 const { SelectView } = await import("./SelectView");
 

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -14,6 +14,7 @@ import dayjs from "@core/util/date/dayjs";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
 import { createMockCalendar } from "@web/__tests__/utils/factories/calendar.factory";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
 import { AuthApi } from "@web/api/auth.api";
 import { BillingApi } from "@web/api/billing.api";
 import {
@@ -39,6 +40,7 @@ import {
   settingsActions,
   useSettingsStore,
 } from "@web/settings/settings.store";
+import * as realUsessedegraded from "@web/sse/hooks/useSseDegraded";
 import {
   afterAll,
   afterEach,
@@ -101,10 +103,10 @@ let isSseDegraded = false;
 let isSseDegradedMocked = true;
 const actualUseSseDegraded = (await import("@web/sse/hooks/useSseDegraded"))
   .useSseDegraded;
-mock.module("@web/sse/hooks/useSseDegraded", () => ({
+mockModuleForFile("@web/sse/hooks/useSseDegraded", realUsessedegraded, {
   useSseDegraded: () =>
     isSseDegradedMocked ? isSseDegraded : actualUseSseDegraded(),
-}));
+});
 
 let access: AppAccess = { kind: "open" };
 let isAppAccessMocked = true;

--- a/packages/web/src/components/Sidebar/SidebarActions/SidebarActions.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarActions/SidebarActions.test.tsx
@@ -1,9 +1,11 @@
 import { act, render, screen } from "@testing-library/react";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
 import {
   resetGoogleSyncUIStateForTests,
   setSyncingSyncIndicatorOverride,
 } from "@web/auth/google/state/google.sync.state";
+import * as realUseversioncheck from "@web/components/Sidebar/SidebarActions/useVersionCheck";
 import { viewActions } from "@web/events/stores/view.store";
 import { afterAll, afterEach, describe, expect, it, mock } from "bun:test";
 
@@ -17,12 +19,16 @@ const actualUseVersionCheck = (
 ).useVersionCheck;
 let isVersionCheckMocked = true;
 
-mock.module("@web/components/Sidebar/SidebarActions/useVersionCheck", () => ({
-  useVersionCheck: () =>
-    isVersionCheckMocked
-      ? { isUpdateAvailable: false }
-      : actualUseVersionCheck(),
-}));
+mockModuleForFile(
+  "@web/components/Sidebar/SidebarActions/useVersionCheck",
+  realUseversioncheck,
+  {
+    useVersionCheck: () =>
+      isVersionCheckMocked
+        ? { isUpdateAvailable: false }
+        : actualUseVersionCheck(),
+  },
+);
 
 afterAll(() => {
   isVersionCheckMocked = false;

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
@@ -4,6 +4,7 @@ import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
 import { seedPendingEventMutations } from "@web/__tests__/utils/event-query-test-data";
 import { createMockConnection } from "@web/__tests__/utils/factories/calendar.factory";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
 import { type GoogleUiState } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.types";
 import {
   initialFirstEventPromptState,
@@ -34,6 +35,7 @@ import {
   getShortcutHint,
 } from "@web/shortcuts/tips/shortcut-tips.data";
 import { shortcutHintProgressActions } from "@web/shortcuts/tips/shortcut-tips.progress.store";
+import * as realUsessedegraded from "@web/sse/hooks/useSseDegraded";
 import { TIME_TRAVEL_HINT_PARTS } from "@web/timezone/TimeTravelIndicator";
 import {
   resetTimeTravelStoreForTests,
@@ -84,10 +86,10 @@ let isSseDegraded = false;
 let isSseDegradedMocked = true;
 const actualUseSseDegraded = (await import("@web/sse/hooks/useSseDegraded"))
   .useSseDegraded;
-mock.module("@web/sse/hooks/useSseDegraded", () => ({
+mockModuleForFile("@web/sse/hooks/useSseDegraded", realUsessedegraded, {
   useSseDegraded: () =>
     isSseDegradedMocked ? isSseDegraded : actualUseSseDegraded(),
-}));
+});
 
 afterAll(() => {
   isConnectGoogleMocked = false;

--- a/packages/web/src/components/Sidebar/TasksRemovalNotice/TasksRemovalNotice.test.tsx
+++ b/packages/web/src/components/Sidebar/TasksRemovalNotice/TasksRemovalNotice.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { act } from "react";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
+import * as realUsesession from "@web/auth/compass/session/useSession";
 import { createTasksRemovalNotice } from "./TasksRemovalNotice";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
@@ -8,9 +10,9 @@ import { beforeEach, describe, expect, it, mock } from "bun:test";
 // function, injected via createTasksRemovalNotice below — no mock.module,
 // no cache-busting.
 const mockUseSession = mock();
-mock.module("@web/auth/compass/session/useSession", () => ({
+mockModuleForFile("@web/auth/compass/session/useSession", realUsesession, {
   useSession: mockUseSession,
-}));
+});
 
 describe("TasksRemovalNotice", () => {
   const mockUseTasksRemovalNotice = mock();

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -16,6 +16,7 @@ import {
 import { server } from "@web/__tests__/__mocks__/server/mock.server";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
 import { createCompassQueryClient } from "@web/api/query-client";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { setCalendarVisibility } from "@web/calendars/calendar-visibility.store";
@@ -36,7 +37,9 @@ import {
   useDraftStore,
 } from "@web/events/stores/draft.store";
 import { TIMED_EVENT_FAN_INDENT } from "@web/grid/grid.constants";
+import * as realUsegridmeasurements from "@web/grid/hooks/useGridMeasurements";
 import { type GridMeasurements } from "@web/grid/types/grid.types";
+import * as realUsedateinview from "@web/views/Day/hooks/navigation/useDateInView";
 import {
   afterEach,
   beforeEach,
@@ -76,36 +79,44 @@ const measurements = {
   },
 } satisfies GridMeasurements;
 
-mock.module("@web/views/Day/hooks/navigation/useDateInView", () => ({
-  useDateInView: () => dayjs("2026-05-20T00:00:00.000"),
-}));
-
-mock.module("@web/grid/hooks/useGridMeasurements", () => ({
-  useGridMeasurements: () => {
-    const allDayColumnsRef = { current: null as HTMLDivElement | null };
-    const mainGridRef = { current: null as HTMLDivElement | null };
-    const timedColumnsRef = { current: null as HTMLDivElement | null };
-
-    return {
-      gridRefs: {
-        allDayColumnsRef,
-        allDayRef: (node: HTMLDivElement | null) => {
-          allDayColumnsRef.current = node;
-        },
-        allDayRowRef: mock(),
-        mainGridElementRef: (node: HTMLDivElement | null) => {
-          mainGridRef.current = node;
-        },
-        mainGridRef,
-        timedColumnsElementRef: (node: HTMLDivElement | null) => {
-          timedColumnsRef.current = node;
-        },
-        timedColumnsRef,
-      },
-      measurements,
-    };
+mockModuleForFile(
+  "@web/views/Day/hooks/navigation/useDateInView",
+  realUsedateinview,
+  {
+    useDateInView: () => dayjs("2026-05-20T00:00:00.000"),
   },
-}));
+);
+
+mockModuleForFile(
+  "@web/grid/hooks/useGridMeasurements",
+  realUsegridmeasurements,
+  {
+    useGridMeasurements: () => {
+      const allDayColumnsRef = { current: null as HTMLDivElement | null };
+      const mainGridRef = { current: null as HTMLDivElement | null };
+      const timedColumnsRef = { current: null as HTMLDivElement | null };
+
+      return {
+        gridRefs: {
+          allDayColumnsRef,
+          allDayRef: (node: HTMLDivElement | null) => {
+            allDayColumnsRef.current = node;
+          },
+          allDayRowRef: mock(),
+          mainGridElementRef: (node: HTMLDivElement | null) => {
+            mainGridRef.current = node;
+          },
+          mainGridRef,
+          timedColumnsElementRef: (node: HTMLDivElement | null) => {
+            timedColumnsRef.current = node;
+          },
+          timedColumnsRef,
+        },
+        measurements,
+      };
+    },
+  },
+);
 
 // Stand-in for the sidebar-docked event details panel: DayCalendarGrid no
 // longer renders any form itself — it only toggles the draft store — so the

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -17,6 +17,7 @@ import {
 } from "@web/__tests__/render-with-store";
 import { toNormalizedEventQueryData } from "@web/__tests__/utils/event-query-test-data";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
 import { ID_GRID_MAIN } from "@web/common/constants/web.constants";
 import { Categories_Event } from "@web/common/types/web.event.types";
 import { focusEventFormField } from "@web/common/utils/form/form.util";
@@ -31,6 +32,7 @@ import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { useEditSequenceShortcut } from "@web/shortcuts/useEditSequenceShortcut";
 import { type Props as DateTimeSectionProps } from "@web/views/Forms/EventForm/DateControlsSection/DateTimeSection/DateTimeSection";
 import { getFormDates } from "@web/views/Forms/EventForm/DateControlsSection/DateTimeSection/form.datetime.util";
+import * as realSavesection from "@web/views/Forms/EventForm/SaveSection";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 /**
@@ -91,13 +93,13 @@ mock.module(
   }),
 );
 
-mock.module("@web/views/Forms/EventForm/SaveSection", () => ({
+mockModuleForFile("@web/views/Forms/EventForm/SaveSection", realSavesection, {
   SaveSection: ({ onSubmit }: { onSubmit: () => void }) => (
     <button type="button" onClick={onSubmit}>
       Save
     </button>
   ),
-}));
+});
 
 const { EventForm } = require("./EventForm") as typeof import("./EventForm");
 

--- a/packages/web/src/views/Week/WeekView.render.test.tsx
+++ b/packages/web/src/views/Week/WeekView.render.test.tsx
@@ -17,5 +17,7 @@ describe("Scroll", () => {
     render(<ScrollHarness />);
 
     expect(scrollSpy).toHaveBeenCalled();
+    // A prototype spy outlives this file unless it is put back.
+    scrollSpy.mockRestore();
   });
 });


### PR DESCRIPTION
Follow-up to #2989, which added `mockModuleForFile` and converted the mocks that were then breaking the suite. This converts the rest.

## Why

bun's `mock.module` is process-wide and permanent. A factory returning only the exports one file cares about deletes the rest for every file that runs after it, so the module's own test exercises the mock instead of the implementation. The failure lands somewhere unrelated and only for some file orderings, which reads as flakiness rather than as a mock that was never cleaned up.

## What changed

**Module mocks.** Converted the remaining non-spreading `mock.module` factories to `mockModuleForFile` across 18 files — `useSession`, `auth.state.util`, `posthog.bootstrap`, `useSseDegraded`, `useAppAccess`, `useUpNextEvent`, `useVersionCheck`, `browser-navigation.util`, `ShortcutHint`, `useDateInView`, `useGridMeasurements`, the EventForm section components, and others. Each now spreads the real namespace and hands behavior back in `afterAll`.

**Unrestored spies — the same bug class, easier to miss.** bun never restores a spy on its own, and a `spyOn` at module scope looks local while behaving globally.

- `DeleteAccountConfirmationProvider.test.tsx` had five, including `spyOn(getPosthogClient)` returning a fake with no `capture()`. It only stopped breaking `sse.client` because two other files leaked a posthog mock over the top of it — converting those exposed it.
- Also restored spies in `LogoutConfirmationProvider`, `session.util`, and `WeekView.render` (a `HTMLElement.prototype.scroll` spy that outlived its file).

## Verification

- `bun run test:web`: 2876 pass, 0 fail, 58s.
- `bun run lint` and `bun run type-check` clean.

## Known, not addressed here

Running the suite with the file list reversed stalls around the EventForm tests. I reproduced the same stall on a clean checkout of `main`, so it predates this change and is not a mock leak. Worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)