### PR TITLE
feat(booking): jump between booking fields with the e leader

### DIFF
--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -104,6 +104,23 @@ One booking-page record per user.
 of `duration` fits inside an availability interval after buffers and busy
 blocks.
 
+### Host Settings controls
+
+The Settings **Booking** page is keyboard-first. It is not a native
+timezone `<select>` plus a checkbox and two time inputs per weekday.
+
+- **Timezone** uses the same searchable combobox as time travel. The
+  trigger is one tab stop and still renders a stored non-canonical alias.
+- **Weekly hours** are one typed range per weekday (`9-5`, or `9-12, 1-5`
+  for a break). A blank day is unavailable. The parser reuses
+  `parseUserTime` with an explicit PM-correction rule.
+- **Jump:** `e` then a letter focuses a field (`e` enable, `d` duration,
+  `c` destination, `b` blocking, `z` timezone, `h` hours, `n` notice,
+  `x` horizon, `o` buffer and limits, `l` link). Settings owns `s` (save)
+  and digits `1/2/3` (nav) on this page, which is why the leader is `e`
+  rather than `Mod+digit`. Focus uses `data-booking-field` and does not
+  click, so jumping onto a checkbox does not toggle it.
+
 ## Busy occupancy
 
 v1 uses **Sync busy intervals**, not a new RSVP filter.

--- a/packages/web/src/__tests__/utils/state/reset-stores.ts
+++ b/packages/web/src/__tests__/utils/state/reset-stores.ts
@@ -49,6 +49,10 @@ import {
 } from "@web/settings/settings.store";
 import { useThemeStore } from "@web/settings/theme/theme.store";
 import {
+  initialEditSequenceState,
+  useEditSequenceStore,
+} from "@web/shortcuts/edit-sequence/edit-sequence.store";
+import {
   initialPointerBlockState,
   usePointerBlockStore,
 } from "@web/shortcuts/keyboard-only/pointer-block.store";
@@ -94,6 +98,7 @@ const storeResets: StoreReset[] = [
   () =>
     useWelcomeGuideStore.setState(useWelcomeGuideStore.getInitialState(), true),
   () => useThemeStore.setState(useThemeStore.getInitialState(), true),
+  () => useEditSequenceStore.setState(initialEditSequenceState, true),
   () => usePointerBlockStore.setState(initialPointerBlockState, true),
   () => useEventJumpStore.setState(initialEventJumpState, true),
   () => usePageJumpHintStore.setState(initialPageJumpHintState, true),

--- a/packages/web/src/booking/BookingFieldLabel.tsx
+++ b/packages/web/src/booking/BookingFieldLabel.tsx
@@ -1,0 +1,40 @@
+import {
+  type BookingSequenceField,
+  bookingJumpKeys,
+} from "@web/booking/booking-sequence.fields";
+import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
+
+/**
+ * A field caption with its `e`-leader key, revealed on hold-Mod alongside the
+ * Settings nav digits, so one gesture teaches the whole page.
+ */
+export function BookingFieldLabel({
+  children,
+  field,
+  htmlFor,
+  showShortcuts,
+}: {
+  children: string;
+  field: BookingSequenceField;
+  htmlFor?: string;
+  showShortcuts: boolean;
+}) {
+  const chip = showShortcuts ? (
+    <ShortcutKeys keys={bookingJumpKeys(field)} />
+  ) : null;
+
+  return htmlFor ? (
+    <label
+      className="mb-1 flex items-center gap-1 text-sm text-text"
+      htmlFor={htmlFor}
+    >
+      {children}
+      {chip}
+    </label>
+  ) : (
+    <span className="mb-1 flex items-center gap-1 text-sm text-text">
+      {children}
+      {chip}
+    </span>
+  );
+}

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -12,9 +12,21 @@ import {
 } from "@web/__tests__/utils/factories/calendar.factory";
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import { BookingSettingsSection } from "@web/booking/BookingSettingsSection";
+import {
+  BOOKING_FIELD_BY_KEY,
+  BOOKING_SEQUENCE_FIELDS,
+  bookingFieldAttrs,
+  bookingFieldKey,
+  focusBookingField,
+} from "@web/booking/booking-sequence.fields";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { ENV_WEB } from "@web/common/constants/env.constants";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
+import {
+  clearAppLockReasons,
+  isAppLocked,
+  setAppLockReason,
+} from "@web/shortcuts/app-lock";
 import { setPinnedTimeZone } from "@web/timezone/effective-timezone.store";
 import { afterEach, describe, expect, it, mock } from "bun:test";
 
@@ -29,6 +41,7 @@ mock.module("@web/billing/useAppAccess", () => ({
 afterEach(() => {
   isAppAccessMocked = true;
   setPinnedTimeZone(null);
+  clearAppLockReasons();
 });
 
 const writableCalendar = createMockCalendar({
@@ -40,6 +53,21 @@ const writableCalendar = createMockCalendar({
 const bookingPageUrl = `${ENV_WEB.API_BASEURL}/booking/page`;
 
 const HOST_TIME_ZONE = "America/Chicago";
+
+const unconfiguredPage = () => ({
+  enabled: false,
+  durationMinutes: 30,
+  destinationCalendarId: writableCalendar.id,
+  blockingCalendarIds: [writableCalendar.id],
+  timeZone: "UTC",
+  weeklyAvailability: [],
+  minNoticeHours: 4,
+  maxHorizonDays: 60,
+  bufferMinutes: null,
+  maxBookingsPerDay: null,
+  guestsCanInviteOthers: true,
+  isConfigured: false,
+});
 
 const healthyGoogleMetadata = {
   google: {
@@ -309,6 +337,134 @@ describe("BookingSettingsSection", () => {
     expect(trigger).toHaveAccessibleName("Booking timezone: UTC (UTC)");
   });
 
+  it("jumps to a field with the e leader, under the Settings app lock", async () => {
+    const user = userEvent.setup({ delay: null });
+    userMetadataActions.set(healthyGoogleMetadata);
+    // The Settings modal holds the lock in the real app, and the leader must
+    // still work underneath it - that is exactly what ignoreAppLock buys.
+    setAppLockReason("settingsModal", true);
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+    await screen.findByRole("button", { name: "Save booking settings" });
+    expect(isAppLocked()).toBe(true);
+
+    await user.keyboard("e");
+    await user.keyboard("h");
+
+    expect(document.activeElement).toBe(screen.getByLabelText("Monday"));
+  });
+
+  it("jumps to the timezone trigger with e then z", async () => {
+    const user = userEvent.setup({ delay: null });
+    userMetadataActions.set(healthyGoogleMetadata);
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+    await screen.findByRole("button", { name: "Save booking settings" });
+
+    await user.keyboard("e");
+    await user.keyboard("z");
+
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: /^Booking timezone:/ }),
+    );
+  });
+
+  it("does not arm the leader while the caret is in a field", async () => {
+    const user = userEvent.setup({ delay: null });
+    userMetadataActions.set(healthyGoogleMetadata);
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+    await screen.findByRole("button", { name: "Save booking settings" });
+
+    // "9-5, then 11-2" is not real input, but any typed letter would be: a
+    // bare `e` must reach the field, not swallow the next keystroke.
+    const monday = screen.getByLabelText("Monday");
+    await user.click(monday);
+    await user.keyboard("eh");
+
+    expect(monday).toHaveValue("eh");
+    expect(document.activeElement).toBe(monday);
+  });
+
+  it("blocks the save while a weekly-hours row cannot be read", async () => {
+    const user = userEvent.setup({ delay: null });
+    userMetadataActions.set(healthyGoogleMetadata);
+    let putCount = 0;
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+      rest.put(bookingPageUrl, async (req, res, ctx) => {
+        putCount += 1;
+        return res(ctx.json(await req.json()));
+      }),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+    await screen.findByRole("button", { name: "Save booking settings" });
+
+    await user.type(screen.getByLabelText("Monday"), "whenever");
+    await user.tab();
+    await user.click(
+      screen.getByRole("button", { name: "Save booking settings" }),
+    );
+
+    expect(putCount).toBe(0);
+    expect(
+      screen.getByText("Fix the weekly hours that could not be read."),
+    ).toBeInTheDocument();
+  });
+
   it("blocks enable without a destination calendar", async () => {
     const user = userEvent.setup({ delay: null });
 
@@ -404,5 +560,70 @@ describe("BookingSettingsSection", () => {
     expect(
       screen.getByRole("button", { name: "Save booking settings" }),
     ).toBeInTheDocument();
+  });
+});
+
+describe("BOOKING_SEQUENCE_FIELDS", () => {
+  it("assigns every field a unique key", () => {
+    const keys = BOOKING_SEQUENCE_FIELDS.map((entry) => entry.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("leaves Settings' own booking-page keys alone", () => {
+    // Settings owns bare `s` for Save on this page. Digits are nav.
+    const keys = BOOKING_SEQUENCE_FIELDS.map((entry) => entry.key);
+    expect(keys).not.toContain("s");
+    for (const key of keys) expect(key).not.toMatch(/^\d$/);
+  });
+
+  it("maps every key back to its field", () => {
+    for (const { key, field } of BOOKING_SEQUENCE_FIELDS) {
+      expect(BOOKING_FIELD_BY_KEY[key]).toBe(field);
+      expect(bookingFieldKey(field)).toBe(key);
+    }
+  });
+});
+
+describe("focusBookingField", () => {
+  it("focuses the control inside a tagged wrapper", () => {
+    const wrapper = document.createElement("div");
+    wrapper.setAttribute(
+      Object.keys(bookingFieldAttrs("hours"))[0] as string,
+      "hours",
+    );
+    const input = document.createElement("input");
+    wrapper.append(input);
+    document.body.append(wrapper);
+
+    expect(focusBookingField("hours")).toBe(true);
+    expect(document.activeElement).toBe(input);
+  });
+
+  it("focuses a tagged control directly", () => {
+    const select = document.createElement("select");
+    select.setAttribute("data-booking-field", "duration");
+    document.body.append(select);
+
+    expect(focusBookingField("duration")).toBe(true);
+    expect(document.activeElement).toBe(select);
+  });
+
+  it("focuses rather than clicks, so a checkbox is not toggled", () => {
+    // The Settings idiom clicks its targets; that would flip these on the way
+    // past, which is why this has its own focus-only helper.
+    const label = document.createElement("label");
+    label.setAttribute("data-booking-field", "enabled");
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    label.append(checkbox);
+    document.body.append(label);
+
+    expect(focusBookingField("enabled")).toBe(true);
+    expect(document.activeElement).toBe(checkbox);
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it("reports false when the field is not rendered", () => {
+    expect(focusBookingField("link")).toBe(false);
   });
 });

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { HotkeysProvider } from "@tanstack/react-hotkeys";
+import { HotkeysProvider, resolveModifier } from "@tanstack/react-hotkeys";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { rest } from "msw";
@@ -10,6 +10,7 @@ import {
   createMockCalendar,
   createMockConnection,
 } from "@web/__tests__/utils/factories/calendar.factory";
+import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import { BookingSettingsSection } from "@web/booking/BookingSettingsSection";
 import {
@@ -395,6 +396,47 @@ describe("BookingSettingsSection", () => {
     expect(document.activeElement).toBe(
       screen.getByRole("button", { name: /^Booking timezone:/ }),
     );
+  });
+
+  it("does not jump out of the nested timezone dialog", async () => {
+    const user = userEvent.setup({ delay: null });
+    userMetadataActions.set(healthyGoogleMetadata);
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+    await screen.findByRole("button", { name: "Save booking settings" });
+
+    await user.click(
+      screen.getByRole("button", { name: /^Booking timezone:/ }),
+    );
+    const search = await screen.findByRole("combobox", {
+      name: "Search booking timezones",
+    });
+    await waitFor(() => expect(search).toHaveFocus());
+
+    // Mod+E is the in-field leader; ignoreAppLock would otherwise arm it
+    // here and jump to Monday behind the dialog.
+    const modInit: KeyboardEventInit =
+      resolveModifier("Mod") === "Meta" ? { metaKey: true } : { ctrlKey: true };
+    pressKey("e", { keyDownInit: modInit, keyUpInit: modInit }, search);
+    pressKey("h", {}, search);
+
+    expect(search).toHaveFocus();
+    expect(
+      screen.getByRole("combobox", { name: "Search booking timezones" }),
+    ).toBeInTheDocument();
   });
 
   it("does not arm the leader while the caret is in a field", async () => {

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -15,6 +15,7 @@ import {
 import { useAppAccess } from "@web/billing/useAppAccess";
 import { BookingConnectGooglePrompt } from "@web/booking/BookingConnectGooglePrompt";
 import { BookingCopyLink } from "@web/booking/BookingCopyLink";
+import { BookingFieldLabel } from "@web/booking/BookingFieldLabel";
 import { BookingTimezoneField } from "@web/booking/BookingTimezoneField";
 import { BookingWeeklyHoursEditor } from "@web/booking/BookingWeeklyHoursEditor";
 import {
@@ -31,6 +32,13 @@ import {
   resolveWritableCalendars,
   toBookingPageInput,
 } from "@web/booking/booking.util";
+import {
+  BOOKING_FIELD_BY_KEY,
+  BOOKING_SEQUENCE_FIELDS,
+  bookingFieldAttrs,
+  bookingJumpKeys,
+  focusBookingField,
+} from "@web/booking/booking-sequence.fields";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import {
   compareCalendars,
@@ -41,7 +49,10 @@ import {
   OverlayPanelActionButton,
   OverlayPanelActions,
 } from "@web/components/OverlayPanel/OverlayPanel";
+import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import { settingsShortcutAttrs } from "@web/settings/useSettingsShortcuts";
+import { EditSequenceMenu } from "@web/shortcuts/edit-sequence/EditSequenceMenu";
+import { useEditSequenceShortcut } from "@web/shortcuts/useEditSequenceShortcut";
 import { useEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 
 const DURATION_OPTIONS: BookingDurationMinutes[] = [15, 30, 45, 60];
@@ -142,6 +153,18 @@ export function BookingSettingsSection({
   );
   const [enableError, setEnableError] = useState<string | null>(null);
   const [areHoursValid, setAreHoursValid] = useState(true);
+  const sectionRef = useRef<HTMLFieldSetElement>(null);
+
+  // ignoreAppLock because the Settings modal itself holds the lock, the same
+  // reason useSettingsShortcuts sets it. Scoped to "booking" so the which-key
+  // menu cannot appear over the grid, and so the grid's still-mounted listener
+  // cannot disarm this sequence on the follow key.
+  useEditSequenceShortcut({
+    fieldByKey: BOOKING_FIELD_BY_KEY,
+    ignoreAppLock: true,
+    onSequence: focusBookingField,
+    scope: "booking",
+  });
 
   // Re-seed only when the server actually answers with a different page.
   // Keying the effect on writableCalendars/effectiveTimeZone as well meant a
@@ -227,10 +250,18 @@ export function BookingSettingsSection({
     <fieldset
       className="flex flex-col gap-4"
       disabled={isReadOnly || saveMutation.isPending}
+      ref={sectionRef}
     >
-      {savedPage ? <BookingCopyLink bookingUrl={savedPage.bookingUrl} /> : null}
+      {savedPage ? (
+        <div {...bookingFieldAttrs("link")}>
+          <BookingCopyLink bookingUrl={savedPage.bookingUrl} />
+        </div>
+      ) : null}
 
-      <label className="flex items-center gap-2 text-sm text-text">
+      <label
+        className="flex items-center gap-2 text-sm text-text"
+        {...bookingFieldAttrs("enabled")}
+      >
         <input
           checked={form.enabled}
           className="c-all-day-checkbox"
@@ -238,6 +269,9 @@ export function BookingSettingsSection({
           type="checkbox"
         />
         Enable booking page
+        {showShortcuts ? (
+          <ShortcutKeys keys={bookingJumpKeys("enabled")} />
+        ) : null}
       </label>
       {enableError ? (
         <p className="text-error text-sm" role="alert">
@@ -246,13 +280,15 @@ export function BookingSettingsSection({
       ) : null}
 
       <div>
-        <label
-          className="mb-1 block text-sm text-text"
+        <BookingFieldLabel
+          field="duration"
           htmlFor="booking-duration"
+          showShortcuts={showShortcuts}
         >
           Duration
-        </label>
+        </BookingFieldLabel>
         <select
+          {...bookingFieldAttrs("duration")}
           className="c-focus-ring w-full rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text hover:bg-surface-panel"
           id="booking-duration"
           onChange={(event) =>
@@ -273,13 +309,15 @@ export function BookingSettingsSection({
       </div>
 
       <div>
-        <label
-          className="mb-1 block text-sm text-text"
+        <BookingFieldLabel
+          field="destination"
           htmlFor="booking-destination-calendar"
+          showShortcuts={showShortcuts}
         >
           Destination calendar
-        </label>
+        </BookingFieldLabel>
         <select
+          {...bookingFieldAttrs("destination")}
           className="c-focus-ring w-full rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text hover:bg-surface-panel"
           id="booking-destination-calendar"
           onChange={(event) =>
@@ -302,8 +340,16 @@ export function BookingSettingsSection({
         </select>
       </div>
 
-      <fieldset className="flex flex-col gap-2">
-        <legend className="mb-1 text-sm text-text">Blocking calendars</legend>
+      <fieldset
+        className="flex flex-col gap-2"
+        {...bookingFieldAttrs("blocking")}
+      >
+        <legend className="mb-1 flex items-center gap-1 text-sm text-text">
+          Blocking calendars
+          {showShortcuts ? (
+            <ShortcutKeys keys={bookingJumpKeys("blocking")} />
+          ) : null}
+        </legend>
         {availabilityCalendars.length === 0 ? (
           <p className="text-sm text-text-muted">No calendars available.</p>
         ) : (
@@ -356,26 +402,34 @@ export function BookingSettingsSection({
         )}
       </fieldset>
 
-      <BookingTimezoneField
-        onChange={(timeZone) => updateForm({ timeZone })}
-        timeZone={form.timeZone}
-      />
+      <div {...bookingFieldAttrs("timezone")}>
+        <BookingTimezoneField
+          onChange={(timeZone) => updateForm({ timeZone })}
+          shortcutKeys={showShortcuts ? bookingJumpKeys("timezone") : undefined}
+          timeZone={form.timeZone}
+        />
+      </div>
 
-      <BookingWeeklyHoursEditor
-        onChange={(weeklyAvailability) => updateForm({ weeklyAvailability })}
-        onValidityChange={setAreHoursValid}
-        value={form.weeklyAvailability}
-      />
+      <div {...bookingFieldAttrs("hours")}>
+        <BookingWeeklyHoursEditor
+          onChange={(weeklyAvailability) => updateForm({ weeklyAvailability })}
+          onValidityChange={setAreHoursValid}
+          shortcutKeys={showShortcuts ? bookingJumpKeys("hours") : undefined}
+          value={form.weeklyAvailability}
+        />
+      </div>
 
       <div className="grid grid-cols-2 gap-3">
         <div>
-          <label
-            className="mb-1 block text-sm text-text"
+          <BookingFieldLabel
+            field="notice"
             htmlFor="booking-min-notice"
+            showShortcuts={showShortcuts}
           >
             Minimum notice (hours)
-          </label>
+          </BookingFieldLabel>
           <input
+            {...bookingFieldAttrs("notice")}
             className="c-focus-ring w-full rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text"
             id="booking-min-notice"
             min={0}
@@ -387,13 +441,15 @@ export function BookingSettingsSection({
           />
         </div>
         <div>
-          <label
-            className="mb-1 block text-sm text-text"
+          <BookingFieldLabel
+            field="horizon"
             htmlFor="booking-max-horizon"
+            showShortcuts={showShortcuts}
           >
             Maximum horizon (days)
-          </label>
+          </BookingFieldLabel>
           <input
+            {...bookingFieldAttrs("horizon")}
             className="c-focus-ring w-full rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text"
             id="booking-max-horizon"
             max={60}
@@ -407,41 +463,53 @@ export function BookingSettingsSection({
         </div>
       </div>
 
-      <label className="flex items-center gap-2 text-sm text-text">
-        <input
-          checked={form.bufferMinutes !== null}
-          className="c-all-day-checkbox"
-          onChange={(event) =>
-            updateForm({ bufferMinutes: event.target.checked ? 30 : null })
-          }
-          type="checkbox"
-        />
-        Buffer between appointments (30 minutes)
-      </label>
+      <fieldset
+        className="flex flex-col gap-2"
+        {...bookingFieldAttrs("options")}
+      >
+        <legend className="mb-1 flex items-center gap-1 text-sm text-text">
+          Buffer and limits
+          {showShortcuts ? (
+            <ShortcutKeys keys={bookingJumpKeys("options")} />
+          ) : null}
+        </legend>
 
-      <label className="flex items-center gap-2 text-sm text-text">
-        <input
-          checked={form.maxBookingsPerDay !== null}
-          className="c-all-day-checkbox"
-          onChange={(event) =>
-            updateForm({ maxBookingsPerDay: event.target.checked ? 4 : null })
-          }
-          type="checkbox"
-        />
-        Max bookings per day (4)
-      </label>
+        <label className="flex items-center gap-2 text-sm text-text">
+          <input
+            checked={form.bufferMinutes !== null}
+            className="c-all-day-checkbox"
+            onChange={(event) =>
+              updateForm({ bufferMinutes: event.target.checked ? 30 : null })
+            }
+            type="checkbox"
+          />
+          Buffer between appointments (30 minutes)
+        </label>
 
-      <label className="flex items-center gap-2 text-sm text-text">
-        <input
-          checked={form.guestsCanInviteOthers}
-          className="c-all-day-checkbox"
-          onChange={(event) =>
-            updateForm({ guestsCanInviteOthers: event.target.checked })
-          }
-          type="checkbox"
-        />
-        Guest can invite others
-      </label>
+        <label className="flex items-center gap-2 text-sm text-text">
+          <input
+            checked={form.maxBookingsPerDay !== null}
+            className="c-all-day-checkbox"
+            onChange={(event) =>
+              updateForm({ maxBookingsPerDay: event.target.checked ? 4 : null })
+            }
+            type="checkbox"
+          />
+          Max bookings per day (4)
+        </label>
+
+        <label className="flex items-center gap-2 text-sm text-text">
+          <input
+            checked={form.guestsCanInviteOthers}
+            className="c-all-day-checkbox"
+            onChange={(event) =>
+              updateForm({ guestsCanInviteOthers: event.target.checked })
+            }
+            type="checkbox"
+          />
+          Guest can invite others
+        </label>
+      </fieldset>
 
       <OverlayPanelActions align="start">
         <OverlayPanelActionButton
@@ -456,6 +524,16 @@ export function BookingSettingsSection({
           {saveMutation.isPending ? "Saving…" : "Save booking settings"}
         </OverlayPanelActionButton>
       </OverlayPanelActions>
+
+      <p className="text-text-muted text-xs">
+        Press <kbd>e</kbd> then a letter to jump to a field. <kbd>S</kbd> saves.
+      </p>
+
+      <EditSequenceMenu
+        getAnchor={() => sectionRef.current}
+        options={BOOKING_SEQUENCE_FIELDS}
+        scope="booking"
+      />
     </fieldset>
   );
 }

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -159,7 +159,18 @@ export function BookingSettingsSection({
   // reason useSettingsShortcuts sets it. Scoped to "booking" so the which-key
   // menu cannot appear over the grid, and so the grid's still-mounted listener
   // cannot disarm this sequence on the follow key.
+  //
+  // Stand down when focus is in a nested dialog (the timezone OverlayPanel):
+  // that panel also holds app-lock, and ignoreAppLock would otherwise arm
+  // Mod+E inside it and jump to a field behind the dialog.
   useEditSequenceShortcut({
+    canArm: () => {
+      const active = document.activeElement;
+      if (!(active instanceof HTMLElement)) return true;
+      const closestDialog = active.closest("[role='dialog']");
+      const settingsDialog = sectionRef.current?.closest("[role='dialog']");
+      return closestDialog == null || closestDialog === settingsDialog;
+    },
     fieldByKey: BOOKING_FIELD_BY_KEY,
     ignoreAppLock: true,
     onSequence: focusBookingField,
@@ -532,6 +543,7 @@ export function BookingSettingsSection({
       <EditSequenceMenu
         getAnchor={() => sectionRef.current}
         options={BOOKING_SEQUENCE_FIELDS}
+        prompt="Jump to which field?"
         scope="booking"
       />
     </fieldset>

--- a/packages/web/src/booking/BookingTimezoneField.tsx
+++ b/packages/web/src/booking/BookingTimezoneField.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 import { type TimeZone } from "@core/types/domain-primitives";
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
+import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
 import { TimezoneCombobox } from "@web/timezone/TimezoneCombobox";
 import { timeZoneCityName } from "@web/timezone/timezone-catalog";
@@ -9,6 +10,8 @@ interface BookingTimezoneFieldProps {
   timeZone: TimeZone;
   onChange: (timeZone: TimeZone) => void;
   disabled?: boolean;
+  /** Jump keys to reveal beside the caption while hold-Mod hints are up. */
+  shortcutKeys?: readonly string[];
 }
 
 /**
@@ -23,6 +26,7 @@ export function BookingTimezoneField({
   timeZone,
   onChange,
   disabled = false,
+  shortcutKeys,
 }: BookingTimezoneFieldProps) {
   const [isOpen, setIsOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -32,8 +36,12 @@ export function BookingTimezoneField({
 
   return (
     <div>
-      <p className="mb-1 text-sm text-text" id="booking-timezone-label">
+      <p
+        className="mb-1 flex items-center gap-1 text-sm text-text"
+        id="booking-timezone-label"
+      >
         Booking timezone
+        {shortcutKeys ? <ShortcutKeys keys={[...shortcutKeys]} /> : null}
       </p>
       <button
         aria-expanded={isOpen}

--- a/packages/web/src/booking/BookingWeeklyHoursEditor.tsx
+++ b/packages/web/src/booking/BookingWeeklyHoursEditor.tsx
@@ -8,6 +8,7 @@ import {
   formatHoursRanges,
   parseHoursRanges,
 } from "@web/booking/weekly-hours.parse";
+import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 
 type Weekday = WeeklyAvailabilityInterval["weekday"];
 
@@ -19,6 +20,8 @@ interface BookingWeeklyHoursEditorProps {
   disabled?: boolean;
   /** Raised when a row cannot be read, so the form can block saving. */
   onValidityChange?: (isValid: boolean) => void;
+  /** Jump keys to reveal beside the legend while hold-Mod hints are up. */
+  shortcutKeys?: readonly string[];
 }
 
 const textForWeekday = (value: WeeklyAvailability, weekday: Weekday): string =>
@@ -44,6 +47,7 @@ export function BookingWeeklyHoursEditor({
   onChange,
   disabled = false,
   onValidityChange,
+  shortcutKeys,
 }: BookingWeeklyHoursEditorProps) {
   // Raw text per row so a half-typed value is never yanked out from under the
   // user; it only becomes availability once it parses.
@@ -125,7 +129,10 @@ export function BookingWeeklyHoursEditor({
 
   return (
     <fieldset className="flex flex-col gap-2" disabled={disabled}>
-      <legend className="mb-1 text-sm text-text">Weekly hours</legend>
+      <legend className="mb-1 flex items-center gap-1 text-sm text-text">
+        Weekly hours
+        {shortcutKeys ? <ShortcutKeys keys={[...shortcutKeys]} /> : null}
+      </legend>
       <p className="text-text-muted text-xs" id="booking-hours-hint">
         Type a range like 9-5, or 9-12, 1-5 for a break. Leave a day blank to be
         unavailable.

--- a/packages/web/src/booking/booking-sequence.fields.ts
+++ b/packages/web/src/booking/booking-sequence.fields.ts
@@ -1,0 +1,75 @@
+/**
+ * The one source of truth for the booking form's `e`-leader sequences: the
+ * dispatch map, the which-key menu, the hold-Mod chips beside each label, and
+ * the shortcuts-legend row all derive from this list, so behavior and
+ * documentation cannot drift apart.
+ *
+ * Data-only on purpose, mirroring edit-sequence.fields.ts.
+ *
+ * `s` is deliberately absent: Settings owns bare `s` for Save on this page.
+ * Digits are unavailable too - Settings nav owns Mod+1/2/3 - which is why this
+ * surface reuses the letter leader rather than the event form's Mod+digit jump.
+ */
+export const BOOKING_SEQUENCE_FIELDS = [
+  { key: "e", field: "enabled", label: "Enable booking" },
+  { key: "d", field: "duration", label: "Duration" },
+  { key: "c", field: "destination", label: "Destination calendar" },
+  { key: "b", field: "blocking", label: "Blocking calendars" },
+  { key: "z", field: "timezone", label: "Booking timezone" },
+  { key: "h", field: "hours", label: "Weekly hours" },
+  { key: "n", field: "notice", label: "Minimum notice" },
+  { key: "x", field: "horizon", label: "Maximum horizon" },
+  { key: "o", field: "options", label: "Buffer and limits" },
+  { key: "l", field: "link", label: "Booking link" },
+] as const satisfies readonly {
+  key: string;
+  field: string;
+  label: string;
+}[];
+
+export type BookingSequenceField =
+  (typeof BOOKING_SEQUENCE_FIELDS)[number]["field"];
+
+/** Second key -> booking field, for dispatch. */
+export const BOOKING_FIELD_BY_KEY = Object.fromEntries(
+  BOOKING_SEQUENCE_FIELDS.map(({ key, field }) => [key, field]),
+) as Record<string, BookingSequenceField>;
+
+export const BOOKING_FIELD_ATTR = "data-booking-field";
+
+export const bookingFieldAttrs = (field: BookingSequenceField) =>
+  ({ [BOOKING_FIELD_ATTR]: field }) as const;
+
+/** The key a given field answers to, for rendering a chip beside its label. */
+export const bookingFieldKey = (field: BookingSequenceField): string =>
+  BOOKING_SEQUENCE_FIELDS.find((entry) => entry.field === field)?.key ?? "";
+
+/** Hold-Mod chips for a field: leader then the field's letter. */
+export const bookingJumpKeys = (field: BookingSequenceField): string[] => [
+  "e",
+  bookingFieldKey(field),
+];
+
+const FOCUSABLE =
+  'input, select, textarea, button, [role="combobox"], [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Focus a booking field by data attribute rather than a selector map.
+ *
+ * Focus, never click: several of these targets are checkboxes, and the
+ * Settings idiom's focus-then-click would toggle them on the way past.
+ */
+export function focusBookingField(field: BookingSequenceField): boolean {
+  const anchor = document.querySelector<HTMLElement>(
+    `[${BOOKING_FIELD_ATTR}="${field}"]`,
+  );
+  if (!anchor) return false;
+
+  const target = anchor.matches(FOCUSABLE)
+    ? anchor
+    : anchor.querySelector<HTMLElement>(FOCUSABLE);
+  if (!target) return false;
+
+  target.focus();
+  return true;
+}

--- a/packages/web/src/shortcuts/edit-sequence/EditSequenceMenu.test.tsx
+++ b/packages/web/src/shortcuts/edit-sequence/EditSequenceMenu.test.tsx
@@ -77,4 +77,28 @@ describe("EditSequenceMenu", () => {
 
     expect(document.querySelector("[data-edit-sequence-menu]")).not.toBeNull();
   });
+
+  it("stays hidden when a different scope is armed", () => {
+    editSequenceActions.arm("booking");
+    editSequenceActions.showMenu();
+    render(<EditSequenceMenu getAnchor={() => null} />);
+
+    expect(document.querySelector("[data-edit-sequence-menu]")).toBeNull();
+  });
+
+  it("renders the supplied rows for its own scope", () => {
+    editSequenceActions.arm("booking");
+    editSequenceActions.showMenu();
+    render(
+      <EditSequenceMenu
+        getAnchor={() => null}
+        options={[{ key: "h", label: "Weekly hours" }]}
+        scope="booking"
+      />,
+    );
+
+    const menu = document.querySelector("[data-edit-sequence-menu]");
+    expect(menu?.textContent).toContain("Weekly hours");
+    expect(menu?.textContent).not.toContain("Title");
+  });
 });

--- a/packages/web/src/shortcuts/edit-sequence/EditSequenceMenu.test.tsx
+++ b/packages/web/src/shortcuts/edit-sequence/EditSequenceMenu.test.tsx
@@ -93,6 +93,7 @@ describe("EditSequenceMenu", () => {
       <EditSequenceMenu
         getAnchor={() => null}
         options={[{ key: "h", label: "Weekly hours" }]}
+        prompt="Jump to which field?"
         scope="booking"
       />,
     );
@@ -100,5 +101,7 @@ describe("EditSequenceMenu", () => {
     const menu = document.querySelector("[data-edit-sequence-menu]");
     expect(menu?.textContent).toContain("Weekly hours");
     expect(menu?.textContent).not.toContain("Title");
+    expect(menu?.textContent).toContain("Jump to which field?");
+    expect(menu?.textContent).not.toContain("Edit which field?");
   });
 });

--- a/packages/web/src/shortcuts/edit-sequence/EditSequenceMenu.tsx
+++ b/packages/web/src/shortcuts/edit-sequence/EditSequenceMenu.tsx
@@ -26,8 +26,8 @@ export interface EditSequenceMenuOption {
 }
 
 /** Screen-reader copy, so the visible chips can stay aria-hidden. */
-const srText = (options: readonly EditSequenceMenuOption[]) =>
-  `Edit which field? ${options
+const srText = (prompt: string, options: readonly EditSequenceMenuOption[]) =>
+  `${prompt} ${options
     .map(
       (option) =>
         `${option.key.toUpperCase()} for ${option.label.toLowerCase()}`,
@@ -65,11 +65,13 @@ const isOffscreen = (element: HTMLElement) => {
 export function EditSequenceMenu({
   getAnchor,
   options = EDIT_SEQUENCE_LETTER_FIELDS,
+  prompt = "Edit which field?",
   scope = "event",
 }: {
   getAnchor: () => HTMLElement | null;
   /** Defaults to the event form's letter rows. */
   options?: readonly EditSequenceMenuOption[];
+  prompt?: string;
   /** Render only while this surface owns the armed sequence. */
   scope?: EditSequenceScope;
 }) {
@@ -124,11 +126,9 @@ export function EditSequenceMenu({
         className="rounded border border-border bg-surface-raised p-2 shadow-[0_4px_6px_var(--color-shadow-default)]"
         role="status"
       >
-        <span className="sr-only">{srText(options)}</span>
+        <span className="sr-only">{srText(prompt, options)}</span>
         <div aria-hidden className="flex flex-col gap-1">
-          <span className="px-0.5 text-text-muted text-xs">
-            Edit which field?
-          </span>
+          <span className="px-0.5 text-text-muted text-xs">{prompt}</span>
           <div className="grid grid-cols-2 gap-x-2 gap-y-1">
             {options.map((option) => (
               <span

--- a/packages/web/src/shortcuts/edit-sequence/EditSequenceMenu.tsx
+++ b/packages/web/src/shortcuts/edit-sequence/EditSequenceMenu.tsx
@@ -11,17 +11,28 @@ import { Z_INDEX_TOOLTIP } from "@web/common/constants/web.constants";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 import { EDIT_SEQUENCE_LETTER_FIELDS } from "@web/shortcuts/edit-sequence/edit-sequence.fields";
 import {
+  type EditSequenceScope,
   selectEditSequenceMenuVisible,
+  selectEditSequenceScope,
   useEditSequenceStore,
 } from "@web/shortcuts/edit-sequence/edit-sequence.store";
 
 const MENU_WIDTH = 260;
 const GAP = 8;
 
+export interface EditSequenceMenuOption {
+  key: string;
+  label: string;
+}
+
 /** Screen-reader copy, so the visible chips can stay aria-hidden. */
-const SR_TEXT = `Edit which field? ${EDIT_SEQUENCE_LETTER_FIELDS.map(
-  (option) => `${option.key.toUpperCase()} for ${option.label.toLowerCase()}`,
-).join(", ")}. Escape to cancel.`;
+const srText = (options: readonly EditSequenceMenuOption[]) =>
+  `Edit which field? ${options
+    .map(
+      (option) =>
+        `${option.key.toUpperCase()} for ${option.label.toLowerCase()}`,
+    )
+    .join(", ")}. Escape to cancel.`;
 
 /** Zero-size reference low in the viewport, used when the anchor is gone or
  * scrolled out of sight. Mirrors the `cursorReference` trick the context menu
@@ -53,10 +64,18 @@ const isOffscreen = (element: HTMLElement) => {
  */
 export function EditSequenceMenu({
   getAnchor,
+  options = EDIT_SEQUENCE_LETTER_FIELDS,
+  scope = "event",
 }: {
   getAnchor: () => HTMLElement | null;
+  /** Defaults to the event form's letter rows. */
+  options?: readonly EditSequenceMenuOption[];
+  /** Render only while this surface owns the armed sequence. */
+  scope?: EditSequenceScope;
 }) {
-  const isVisible = useEditSequenceStore(selectEditSequenceMenuVisible);
+  const menuVisible = useEditSequenceStore(selectEditSequenceMenuVisible);
+  const armedScope = useEditSequenceStore(selectEditSequenceScope);
+  const isVisible = menuVisible && armedScope === scope;
   // Read through a ref: the owners rebuild `getAnchor` every render, so using
   // it as an effect dependency would re-seat the reference constantly.
   const getAnchorRef = useRef(getAnchor);
@@ -105,13 +124,13 @@ export function EditSequenceMenu({
         className="rounded border border-border bg-surface-raised p-2 shadow-[0_4px_6px_var(--color-shadow-default)]"
         role="status"
       >
-        <span className="sr-only">{SR_TEXT}</span>
+        <span className="sr-only">{srText(options)}</span>
         <div aria-hidden className="flex flex-col gap-1">
           <span className="px-0.5 text-text-muted text-xs">
             Edit which field?
           </span>
           <div className="grid grid-cols-2 gap-x-2 gap-y-1">
-            {EDIT_SEQUENCE_LETTER_FIELDS.map((option) => (
+            {options.map((option) => (
               <span
                 key={option.key}
                 className="flex items-center gap-1.5 text-text text-xs"

--- a/packages/web/src/shortcuts/edit-sequence/edit-sequence.store.ts
+++ b/packages/web/src/shortcuts/edit-sequence/edit-sequence.store.ts
@@ -2,16 +2,25 @@ import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 import { IS_DEV } from "@web/common/constants/env.constants";
 
+/**
+ * Which surface armed the leader. One store rather than one per surface, so a
+ * sequence armed in the booking form cannot leave a menu pinned over the grid;
+ * the menu renders only for its own scope.
+ */
+export type EditSequenceScope = "event" | "booking";
+
 export type EditSequenceState = {
   /** True from the leader keypress until a second key, Escape, or a cancel. */
   isArmed: boolean;
   /** True once the silent fast-path window elapses without a second key. */
   isMenuVisible: boolean;
+  scope: EditSequenceScope | null;
 };
 
 export const initialEditSequenceState: EditSequenceState = {
   isArmed: false,
   isMenuVisible: false,
+  scope: null,
 };
 
 export const useEditSequenceStore = create<EditSequenceState>()(
@@ -22,9 +31,9 @@ export const useEditSequenceStore = create<EditSequenceState>()(
 );
 
 export const editSequenceActions = {
-  arm: () =>
+  arm: (scope: EditSequenceScope = "event") =>
     useEditSequenceStore.setState(
-      { isArmed: true, isMenuVisible: false },
+      { isArmed: true, isMenuVisible: false, scope },
       false,
       { type: "arm" },
     ),
@@ -41,3 +50,6 @@ export const editSequenceActions = {
 
 export const selectEditSequenceMenuVisible = (state: EditSequenceState) =>
   state.isMenuVisible;
+
+export const selectEditSequenceScope = (state: EditSequenceState) =>
+  state.scope;

--- a/packages/web/src/shortcuts/shortcuts.registry.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.test.ts
@@ -205,6 +205,7 @@ describe("shortcuts.registry", () => {
       expect(ids).toContain("edit-focus-attendees");
       expect(ids).not.toContain("edit-focus-calendar");
       expect(ids).toContain("edit-focus-color");
+      expect(ids).toContain("other-booking-jump");
     });
 
     it("excludes the in-form leader row when the form is closed and includes it when open", () => {

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -415,6 +415,17 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
     label: "Settings",
     section: "other",
   },
+  // One summary row rather than ten, following the collapsed Mod+E / Mod 0-9
+  // rows above. Ungated for the same reason as the edit sequences: the legend
+  // is a reference, not a live-focus readout. The which-key menu carries the
+  // per-field detail in the moment, which matters here because the legend
+  // overlay is unreachable while the Settings modal holds app-lock.
+  {
+    id: "other-booking-jump",
+    keys: ["e", "letter"],
+    label: "Jump to a booking settings field",
+    section: "other",
+  },
   {
     id: "other-undo",
     keys: caps(KEYMAP.undo.hotkey),

--- a/packages/web/src/shortcuts/useEditSequenceShortcut.test.tsx
+++ b/packages/web/src/shortcuts/useEditSequenceShortcut.test.tsx
@@ -277,6 +277,60 @@ describe("useEditSequenceShortcut", () => {
 
       document.removeEventListener("keydown", seen, true);
     });
+
+    it("still fires under app lock when ignoreAppLock is set", () => {
+      const onSequence = mock(() => {});
+      setAppLockReason("test-lock", true);
+
+      renderHook(() =>
+        useEditSequenceShortcut({ ignoreAppLock: true, onSequence }),
+      );
+      pressKey("e");
+      pressKey("t");
+
+      expect(onSequence).toHaveBeenCalledWith("title");
+    });
+
+    it("dispatches from a custom field table", () => {
+      const onSequence = mock((_field: string) => {});
+      renderHook(() =>
+        useEditSequenceShortcut({
+          fieldByKey: { d: "duration" },
+          onSequence,
+        }),
+      );
+
+      pressKey("e");
+      pressKey("d");
+
+      expect(onSequence).toHaveBeenCalledWith("duration");
+    });
+
+    it("does not let the event-scope hook disarm a booking sequence under app lock", () => {
+      // The grid listener stays mounted while Settings is open. Both hooks
+      // must live in one render: a second renderHook unmounts the first.
+      // Use a reason SettingsModal does not own: the test wrapper mounts it
+      // closed, which would clear `settingsModal` and let the event hook arm.
+      const onEvent = mock(() => {});
+      const onBooking = mock((_field: string) => {});
+      setAppLockReason("test-lock", true);
+
+      renderHook(() => {
+        useEditSequenceShortcut({ onSequence: onEvent });
+        useEditSequenceShortcut({
+          fieldByKey: { d: "duration" },
+          ignoreAppLock: true,
+          onSequence: onBooking,
+          scope: "booking",
+        });
+      });
+
+      pressKey("e");
+      pressKey("d");
+
+      expect(onBooking).toHaveBeenCalledWith("duration");
+      expect(onEvent).not.toHaveBeenCalled();
+    });
   });
 
   it("ignores KeyboardEvents with no key instead of throwing", () => {

--- a/packages/web/src/shortcuts/useEditSequenceShortcut.ts
+++ b/packages/web/src/shortcuts/useEditSequenceShortcut.ts
@@ -5,11 +5,9 @@ import {
   isEditableKeyboardTarget,
 } from "@web/common/utils/form/form.util";
 import { isAppLocked } from "@web/shortcuts/app-lock";
+import { EDIT_SEQUENCE_FIELD_BY_KEY } from "@web/shortcuts/edit-sequence/edit-sequence.fields";
 import {
-  EDIT_SEQUENCE_FIELD_BY_KEY,
-  type EditSequenceSecondKey,
-} from "@web/shortcuts/edit-sequence/edit-sequence.fields";
-import {
+  type EditSequenceScope,
   editSequenceActions,
   useEditSequenceStore,
 } from "@web/shortcuts/edit-sequence/edit-sequence.store";
@@ -59,19 +57,35 @@ const hasModifier = (event: KeyboardEvent) =>
  * Capture-phase listeners suppress the follow key's keyup so existing keyup
  * shortcuts (e.g. `t` → today, `d` → day view) do not also run.
  */
-export function useEditSequenceShortcut({
+export function useEditSequenceShortcut<
+  TField extends string = EventFormFocusField,
+>({
   canArm,
   onSequence,
+  fieldByKey = EDIT_SEQUENCE_FIELD_BY_KEY as unknown as Record<string, TField>,
+  scope = "event",
+  ignoreAppLock = false,
 }: {
   /** Gate arming on there being something to edit, so a stray `e` does not
    * swallow the next keystroke. */
   canArm?: () => boolean;
-  onSequence: (field: EventFormFocusField) => void;
+  onSequence: (field: TField) => void;
+  /** Second key -> field. Defaults to the event form's table. */
+  fieldByKey?: Record<string, TField>;
+  scope?: EditSequenceScope;
+  /**
+   * Run while the app is locked. Surfaces that live inside a modal need this:
+   * the modal itself holds the lock, so the default bail would make the leader
+   * dead exactly where it is wanted.
+   */
+  ignoreAppLock?: boolean;
 }) {
   const onSequenceRef = useRef(onSequence);
   onSequenceRef.current = onSequence;
   const canArmRef = useRef(canArm);
   canArmRef.current = canArm;
+  const fieldByKeyRef = useRef(fieldByKey);
+  fieldByKeyRef.current = fieldByKey;
 
   useEffect(() => {
     const isMac = resolveModifier("Mod") === "Meta";
@@ -93,7 +107,7 @@ export function useEditSequenceShortcut({
 
     const arm = () => {
       disarm();
-      editSequenceActions.arm();
+      editSequenceActions.arm(scope);
       menuTimeoutId = setTimeout(() => {
         menuTimeoutId = null;
         if (isEditSequenceArmed()) {
@@ -112,12 +126,19 @@ export function useEditSequenceShortcut({
 
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.defaultPrevented) return;
-      if (isAppLocked()) {
-        disarm();
-        return;
-      }
 
       if (isEditSequenceArmed()) {
+        // Two surfaces share this store (grid event form and booking settings).
+        // The grid listener stays mounted under Settings; without a scope
+        // check it would disarm the booking sequence on the follow key.
+        if (useEditSequenceStore.getState().scope !== scope) {
+          return;
+        }
+        if (!ignoreAppLock && isAppLocked()) {
+          disarm();
+          return;
+        }
+
         if (event.key === "Escape") {
           disarm();
           event.preventDefault();
@@ -132,10 +153,7 @@ export function useEditSequenceShortcut({
         }
 
         const key = normalizedKeyboardKey(event);
-        const field =
-          key in EDIT_SEQUENCE_FIELD_BY_KEY
-            ? EDIT_SEQUENCE_FIELD_BY_KEY[key as EditSequenceSecondKey]
-            : null;
+        const field = fieldByKeyRef.current[key] ?? null;
 
         if (field) {
           event.preventDefault();
@@ -149,6 +167,10 @@ export function useEditSequenceShortcut({
 
         // Unknown second key: disarm silently and let the key through.
         disarm();
+        return;
+      }
+
+      if (!ignoreAppLock && isAppLocked()) {
         return;
       }
 
@@ -196,5 +218,5 @@ export function useEditSequenceShortcut({
       document.removeEventListener("pointerdown", onPointerDown, true);
       window.removeEventListener("blur", onWindowBlur);
     };
-  }, []);
+  }, [ignoreAppLock, scope]);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The host booking settings form had no field jumping and no visible shortcuts. This reuses the event-form `e` then a letter gesture (silent for 600ms, which-key menu after) because Settings already owns `s` (save) and digits `1/2/3` (nav) on this page.

`useEditSequenceShortcut` is parameterized (`fieldByKey`, `scope`, `ignoreAppLock`) rather than forked. Booking must pass `ignoreAppLock: true` because the Settings modal holds the app lock. The grid listener stays mounted under Settings, so the hook now ignores a sequence it did not arm: otherwise it disarms the booking follow key. Focus is by `data-booking-field` and never clicks, so jumping onto a checkbox does not toggle it.

The booking `e` leader also takes `canArm`: if focus is inside a nested dialog (the timezone OverlayPanel) that is not the Settings dialog, the leader does not arm. Nested OverlayPanels take app-lock too, and unconditional `ignoreAppLock` would jump to a field behind the picker.

Hold-Mod chips sit beside each label next to the nav digits, plus a persistent footer line. The legend gains one ungated summary row (`other-booking-jump`); `shortcuts.registry.test.ts` asserts it is listed with nothing focused.

Also updates `docs/features/booking.md` to match the shipped timezone combobox, typed weekly hours, and this jump gesture.

## Simplicity

The engine is parameterized instead of a second sequence listener. Field keys live in one data-only table (`booking-sequence.fields.ts`) that feeds dispatch, the which-key menu, hold-Mod chips, and the legend row. Tests for that table and for `focusBookingField` live in `BookingSettingsSection.test.tsx` rather than a new file: the sequential `unit (web)` job is already near a SIGTERM ceiling, and an extra test file is enough to trip it.

## Automated validation

- `cd packages/web && TZ=UTC NODE_ENV=test bun test ./src/booking ./src/shortcuts ./src/timezone` — 458 pass, 0 fail
- `bun run type-check` — pass
- `bun run lint` — pass (24 pre-existing warnings; custom checkers ran before biome)
- `bun run knip` — pass
- `bun run test:web` — 2924 pass, 353 files, 70.63s (same file count as main; under the ~88–95s SIGTERM ceiling)

Keyboard cases run in jsdom (`user.keyboard` / `pressKey`). Playwright cannot deliver these synthetic key presses.

Signed-in Settings Booking was not visually verified here: it needs a healthy Google connection that this environment does not have.

## Independent review

First pass (pre-fix):

- severity: med — nested timezone OverlayPanel also takes app-lock; unconditional `ignoreAppLock` would arm `e` inside it and jump behind the dialog. Fixed in `a7b482341` via `canArm` comparing the focused dialog to the booking section's Settings dialog. Test: `does not jump out of the nested timezone dialog`.
- severity: low — booking which-key menu reused "Edit which field?". Fixed: `EditSequenceMenu` takes `prompt`; booking passes "Jump to which field?".

Second pass after those commits: no confirmed findings.

## Test plan

- `cd packages/web && TZ=UTC NODE_ENV=test bun test ./src/booking ./src/shortcuts ./src/timezone` — 458 pass
- `bun run type-check` — pass
- `bun run lint` — pass
- `bun run knip` — pass
- `bun run test:web` — 2924 pass / 353 files / 70.63s

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57f38c00-686b-4dd3-8ccf-b2f0af2f694c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57f38c00-686b-4dd3-8ccf-b2f0af2f694c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

