### PR TITLE
fix(booking): keep guest details and focus the alert on slot conflict

### DIFF
--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "@playwright/test";
 import {
+  buildBookableSlot,
+  formatSlotButtonLabel,
   preparePublicBookingCancelPage,
   preparePublicBookingPage,
 } from "../booking/booking-harness";
@@ -14,6 +16,23 @@ test("the public booking page renders with no automatically detectable accessibi
     page.getByRole("heading", { name: "Pick a time" }),
   ).toBeVisible();
   await expectNoAxeViolations(page, { checkpoint: "public booking page" });
+});
+
+test("the public booking conflict alert has no automatically detectable accessibility violations", async ({
+  page,
+}) => {
+  const { slotStart } = buildBookableSlot();
+  await preparePublicBookingPage(page, { confirmStatus: 409 });
+
+  await page
+    .getByRole("button", { name: formatSlotButtonLabel(slotStart) })
+    .click();
+  await page.getByLabel("Name").fill("Guest User");
+  await page.getByLabel("Email").fill("guest@example.com");
+  await page.getByRole("button", { name: "Confirm booking" }).click();
+
+  await expect(page.getByRole("alert")).toBeVisible();
+  await expectNoAxeViolations(page, { checkpoint: "public booking conflict" });
 });
 
 test.describe("public booking cancel page", () => {

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -137,6 +137,11 @@ test.describe("public booking page", () => {
       "Bring slides",
     );
     await expect(
+      page.getByRole("button", {
+        name: formatSlotButtonLabel(first.slotStart),
+      }),
+    ).toHaveAttribute("aria-pressed", "false");
+    await expect(
       page.getByRole("button", { name: "Confirm booking" }),
     ).toBeDisabled();
     await expect.poll(() => captured.slotGets).toBeGreaterThan(1);
@@ -144,6 +149,11 @@ test.describe("public booking page", () => {
     await page
       .getByRole("button", { name: formatSlotButtonLabel(second.slotStart) })
       .click();
+    await expect(
+      page.getByRole("button", {
+        name: formatSlotButtonLabel(second.slotStart),
+      }),
+    ).toHaveAttribute("aria-pressed", "true");
     await expect(
       page.getByRole("button", { name: "Confirm booking" }),
     ).toBeEnabled();

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -105,21 +105,47 @@ test.describe("public booking page", () => {
   test("refreshes slots and shows a conflict message on 409", async ({
     page,
   }) => {
-    const { slotStart } = buildBookableSlot();
+    const first = buildBookableSlot();
+    const secondStart = new Date(
+      Date.parse(first.slotStart) + 30 * 60 * 1000,
+    ).toISOString();
+    const second = {
+      slotStart: secondStart,
+      slotEnd: new Date(Date.parse(secondStart) + 30 * 60 * 1000).toISOString(),
+    };
     const captured = await preparePublicBookingPage(page, {
       confirmStatus: 409,
+      slots: [first, second],
     });
 
     await page
-      .getByRole("button", { name: formatSlotButtonLabel(slotStart) })
+      .getByRole("button", { name: formatSlotButtonLabel(first.slotStart) })
       .click();
     await page.getByLabel("Name").fill("Guest User");
     await page.getByLabel("Email").fill("guest@example.com");
+    await page.getByLabel("Notes (optional)").fill("Bring slides");
     await page.getByRole("button", { name: "Confirm booking" }).click();
 
-    await expect(page.getByRole("alert")).toHaveText(
+    const alert = page.getByRole("alert");
+    await expect(alert).toHaveText(
       "This time is no longer available. Pick another slot.",
     );
+    await expect(alert).toBeFocused();
+    await expect(page.getByLabel("Name")).toHaveValue("Guest User");
+    await expect(page.getByLabel("Email")).toHaveValue("guest@example.com");
+    await expect(page.getByLabel("Notes (optional)")).toHaveValue(
+      "Bring slides",
+    );
+    await expect(
+      page.getByRole("button", { name: "Confirm booking" }),
+    ).toBeDisabled();
     await expect.poll(() => captured.slotGets).toBeGreaterThan(1);
+
+    await page
+      .getByRole("button", { name: formatSlotButtonLabel(second.slotStart) })
+      .click();
+    await expect(
+      page.getByRole("button", { name: "Confirm booking" }),
+    ).toBeEnabled();
   });
 });

--- a/packages/web/src/booking/PublicBookingGuestForm.tsx
+++ b/packages/web/src/booking/PublicBookingGuestForm.tsx
@@ -1,32 +1,38 @@
-import { type FormEvent, useState } from "react";
+import { type FormEvent } from "react";
 import { getBrowserTimeZone } from "@web/timezone/browser-timezone";
 
-export interface PublicBookingGuestFormValues {
+export interface PublicBookingGuestDetails {
   guestName: string;
   guestEmail: string;
   notes: string;
+}
+
+export interface PublicBookingGuestFormValues
+  extends PublicBookingGuestDetails {
   guestTimeZone: string;
 }
 
 interface PublicBookingGuestFormProps {
   disabled: boolean;
+  submitDisabled: boolean;
+  values: PublicBookingGuestDetails;
+  onChange: (values: PublicBookingGuestDetails) => void;
   onSubmit: (values: PublicBookingGuestFormValues) => void;
 }
 
 export function PublicBookingGuestForm({
   disabled,
+  submitDisabled,
+  values,
+  onChange,
   onSubmit,
 }: PublicBookingGuestFormProps) {
-  const [guestName, setGuestName] = useState("");
-  const [guestEmail, setGuestEmail] = useState("");
-  const [notes, setNotes] = useState("");
-
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     onSubmit({
-      guestName: guestName.trim(),
-      guestEmail: guestEmail.trim(),
-      notes: notes.trim(),
+      guestName: values.guestName.trim(),
+      guestEmail: values.guestEmail.trim(),
+      notes: values.notes.trim(),
       guestTimeZone: getBrowserTimeZone(),
     });
   };
@@ -46,9 +52,11 @@ export function PublicBookingGuestForm({
           required
           type="text"
           autoComplete="name"
-          value={guestName}
+          value={values.guestName}
           disabled={disabled}
-          onChange={(event) => setGuestName(event.target.value)}
+          onChange={(event) =>
+            onChange({ ...values, guestName: event.target.value })
+          }
           className="rounded-md border border-border bg-surface px-3 py-2 text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         />
       </label>
@@ -58,9 +66,11 @@ export function PublicBookingGuestForm({
           required
           type="email"
           autoComplete="email"
-          value={guestEmail}
+          value={values.guestEmail}
           disabled={disabled}
-          onChange={(event) => setGuestEmail(event.target.value)}
+          onChange={(event) =>
+            onChange({ ...values, guestEmail: event.target.value })
+          }
           className="rounded-md border border-border bg-surface px-3 py-2 text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         />
       </label>
@@ -68,15 +78,17 @@ export function PublicBookingGuestForm({
         <span className="text-text-muted">Notes (optional)</span>
         <textarea
           rows={3}
-          value={notes}
+          value={values.notes}
           disabled={disabled}
-          onChange={(event) => setNotes(event.target.value)}
+          onChange={(event) =>
+            onChange({ ...values, notes: event.target.value })
+          }
           className="rounded-md border border-border bg-surface px-3 py-2 text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         />
       </label>
       <button
         type="submit"
-        disabled={disabled}
+        disabled={disabled || submitDisabled}
         className="rounded-md bg-accent px-4 py-2 font-medium text-on-accent transition-colors hover:bg-accent-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-60"
       >
         Confirm booking

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -142,9 +142,10 @@ describe("PublicBookingPage", () => {
     expect(screen.queryByText(/week/i)).not.toBeInTheDocument();
   });
 
-  it("refreshes slots and shows a conflict message on 409", async () => {
+  it("keeps guest details and moves focus to the alert on 409", async () => {
     const user = userEvent.setup({ delay: null });
     let slotRequests = 0;
+    const laterSlotStart = "2026-09-01T15:30:00.000Z";
 
     server.use(
       rest.get(
@@ -160,7 +161,13 @@ describe("PublicBookingPage", () => {
             ctx.status(Status.OK),
             ctx.json({
               bookable: true,
-              slots: [{ slotStart, slotEnd: "2026-09-01T15:30:00.000Z" }],
+              slots: [
+                { slotStart, slotEnd: laterSlotStart },
+                {
+                  slotStart: laterSlotStart,
+                  slotEnd: "2026-09-01T16:00:00.000Z",
+                },
+              ],
             }),
           );
         },
@@ -179,14 +186,32 @@ describe("PublicBookingPage", () => {
     );
     await user.type(screen.getByLabelText("Name"), "Guest User");
     await user.type(screen.getByLabelText("Email"), "guest@example.com");
+    await user.type(screen.getByLabelText("Notes (optional)"), "Bring slides");
     await user.click(screen.getByRole("button", { name: "Confirm booking" }));
 
-    expect(await screen.findByRole("alert")).toHaveTextContent(
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(
       "This time is no longer available. Pick another slot.",
     );
     await waitFor(() => {
+      expect(alert).toHaveFocus();
+    });
+    expect(screen.getByLabelText("Name")).toHaveValue("Guest User");
+    expect(screen.getByLabelText("Email")).toHaveValue("guest@example.com");
+    expect(screen.getByLabelText("Notes (optional)")).toHaveValue(
+      "Bring slides",
+    );
+    expect(
+      screen.getByRole("button", { name: "Confirm booking" }),
+    ).toBeDisabled();
+    await waitFor(() => {
       expect(slotRequests).toBeGreaterThan(1);
     });
+
+    await user.click(screen.getByRole("button", { name: /3:30 PM|15:30/i }));
+    expect(
+      screen.getByRole("button", { name: "Confirm booking" }),
+    ).toBeEnabled();
   });
 
   it("does not boot the calendar shortcut overlay on public booking routes", async () => {

--- a/packages/web/src/booking/PublicBookingPage.tsx
+++ b/packages/web/src/booking/PublicBookingPage.tsx
@@ -1,9 +1,10 @@
 import { useParams } from "@tanstack/react-router";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { CreateBookingReservationInputSchema } from "@core/types/booking.contracts";
 import { PublicBookingNotFoundError } from "@web/api/public-booking.api";
 import { PublicBookingConfirmationView } from "@web/booking/PublicBookingConfirmationView";
 import {
+  type PublicBookingGuestDetails,
   PublicBookingGuestForm,
   type PublicBookingGuestFormValues,
 } from "@web/booking/PublicBookingGuestForm";
@@ -19,6 +20,12 @@ import {
   usePublicBookingSlotsQuery,
 } from "@web/booking/public-booking.query";
 import { getBrowserTimeZone } from "@web/timezone/browser-timezone";
+
+const EMPTY_GUEST_DETAILS: PublicBookingGuestDetails = {
+  guestName: "",
+  guestEmail: "",
+  notes: "",
+};
 
 export function PublicBookingPage() {
   const { username } = useParams({ from: "/book/$username" });
@@ -36,9 +43,18 @@ export function PublicBookingPage() {
   const [selectedSlotStart, setSelectedSlotStart] = useState<string | null>(
     null,
   );
+  const [guestDetails, setGuestDetails] =
+    useState<PublicBookingGuestDetails>(EMPTY_GUEST_DETAILS);
   const [confirmation, setConfirmation] =
     useState<PublicBookingConfirmation | null>(null);
   const [conflictMessage, setConflictMessage] = useState<string | null>(null);
+  const conflictAlertRef = useRef<HTMLParagraphElement>(null);
+
+  useEffect(() => {
+    if (conflictMessage) {
+      conflictAlertRef.current?.focus();
+    }
+  }, [conflictMessage]);
 
   if (pageQuery.isLoading) {
     return (
@@ -110,6 +126,12 @@ export function PublicBookingPage() {
   }
 
   const slots = slotsQuery.data;
+  const showGuestForm = selectedSlotStart !== null || conflictMessage !== null;
+
+  const handleSelectSlot = (slotStart: string) => {
+    setSelectedSlotStart(slotStart);
+    setConflictMessage(null);
+  };
 
   const handleSubmit = async (values: PublicBookingGuestFormValues) => {
     if (!selectedSlotStart) {
@@ -145,7 +167,7 @@ export function PublicBookingPage() {
   return (
     <PublicBookingLayout>
       <header className="flex flex-col gap-1">
-        <h1 className="font-semibold text-xl text-text">
+        <h1 className="font-semibold text-text text-xl">
           Book with {page.hostDisplayName}
         </h1>
         <p className="text-sm text-text-muted">
@@ -155,8 +177,10 @@ export function PublicBookingPage() {
 
       {conflictMessage ? (
         <p
+          ref={conflictAlertRef}
           role="alert"
-          className="rounded-md border border-warning/40 bg-surface-panel px-3 py-2 text-sm text-text"
+          tabIndex={-1}
+          className="rounded-md border border-warning/40 bg-surface-panel px-3 py-2 text-sm text-text focus:outline-none focus:ring-2 focus:ring-accent"
         >
           {conflictMessage}
         </p>
@@ -166,12 +190,15 @@ export function PublicBookingPage() {
         slots={slots.slots}
         guestTimeZone={guestTimeZone}
         selectedSlotStart={selectedSlotStart}
-        onSelectSlot={setSelectedSlotStart}
+        onSelectSlot={handleSelectSlot}
       />
 
-      {selectedSlotStart ? (
+      {showGuestForm ? (
         <PublicBookingGuestForm
           disabled={createReservation.isPending}
+          submitDisabled={!selectedSlotStart}
+          values={guestDetails}
+          onChange={setGuestDetails}
           onSubmit={handleSubmit}
         />
       ) : (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #2999.

## Summary

A slot conflict (409) used to clear the selected time, which unmounted the guest form and wiped name, email, and notes. The conflict alert was never focused, so keyboard users were left on a submit button that no longer existed.

This keeps guest details on the page, leaves the form mounted after a conflict, moves focus to the alert, and re-enables submit only after the guest picks a new time.

## Simplicity

Guest fields live on the page instead of inside a form that unmounts. No extra in-flight flags: submit is disabled whenever no slot is selected. The conflict alert is a native `role="alert"` with `tabIndex={-1}` so focus can land on it.

## Automated validation

- Unit: 409 keeps name/email/notes, focuses the alert, disables confirm, then picking another slot enables confirm.
- Playwright: same assertions on the stubbed public page; slot list is refetched; the taken slot is no longer `aria-pressed`, and the new slot is.
- Axe: conflict state checkpoint added.

## Independent review

Re-read of `origin/main...HEAD`: no confirmed findings. Lifted form state survives the 409. Focus follows `conflictMessage`. Submit stays disabled until a new slot is selected. `aria-pressed` is cleared with the selection.

## Test plan

- `TZ=UTC NODE_ENV=test bun test --preload ./src/__tests__/web.preload.ts ./src/booking/PublicBookingPage.test.tsx` (6 pass)
- `bunx playwright test e2e/booking/public-booking.spec.ts e2e/accessibility/booking-a11y.spec.ts` (12 pass)
- `bun run lint` and `bun run type-check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46079ef9-363d-42a6-8efb-4d17bad565a3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46079ef9-363d-42a6-8efb-4d17bad565a3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

