### PR TITLE
perf(booking): fetch slots per month with stable cache keys

### DIFF
--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -27,14 +27,29 @@ const googleCalendar = {
   accountEmail: HOST_ACCOUNT_EMAIL,
 };
 
-/** A slot two days ahead at 15:00 UTC, always inside the 14-day guest window. */
+/** A slot later in the current UTC month, inside today's remaining hours when the month is ending. */
 export function buildBookableSlot(durationMinutes = 30): {
   slotStart: string;
   slotEnd: string;
 } {
-  const start = new Date();
-  start.setUTCDate(start.getUTCDate() + 2);
+  const now = new Date();
+  const start = new Date(now);
+  start.setUTCDate(now.getUTCDate() + 2);
   start.setUTCHours(15, 0, 0, 0);
+  const sameMonth =
+    start.getUTCMonth() === now.getUTCMonth() &&
+    start.getUTCFullYear() === now.getUTCFullYear();
+  if (!sameMonth || start.getTime() <= now.getTime()) {
+    start.setTime(now.getTime());
+    start.setUTCHours(15, 0, 0, 0);
+    if (
+      start.getTime() <= now.getTime() ||
+      start.getUTCMonth() !== now.getUTCMonth()
+    ) {
+      start.setTime(now.getTime() + 2 * 60 * 60 * 1000);
+      start.setUTCMinutes(0, 0, 0);
+    }
+  }
   const end = new Date(start.getTime() + durationMinutes * 60 * 1000);
   return { slotStart: start.toISOString(), slotEnd: end.toISOString() };
 }
@@ -52,6 +67,7 @@ export interface PublicBookingStubOptions {
 export interface CapturedBookingRequests {
   reservationPosts: Array<Record<string, unknown>>;
   slotGets: number;
+  slotQueries: Array<{ start: string | null; end: string | null }>;
 }
 
 export async function preparePublicBookingPage(
@@ -62,6 +78,7 @@ export async function preparePublicBookingPage(
   const captured: CapturedBookingRequests = {
     reservationPosts: [],
     slotGets: 0,
+    slotQueries: [],
   };
   const slot =
     options.slots?.[0] ?? buildBookableSlot(options.durationMinutes ?? 30);
@@ -95,10 +112,22 @@ export async function preparePublicBookingPage(
       request.method() === "GET"
     ) {
       captured.slotGets += 1;
+      const windowStart = url.searchParams.get("start");
+      const windowEnd = url.searchParams.get("end");
+      captured.slotQueries.push({
+        start: windowStart,
+        end: windowEnd,
+      });
+      const startMs = windowStart ? Date.parse(windowStart) : Number.NaN;
+      const endMs = windowEnd ? Date.parse(windowEnd) : Number.NaN;
+      const slotsInWindow = slots.filter((entry) => {
+        const slotMs = Date.parse(entry.slotStart);
+        return slotMs >= startMs && slotMs < endMs;
+      });
       return route.fulfill(
         json({
           bookable: options.bookable ?? true,
-          slots,
+          slots: slotsInWindow,
         }),
       );
     }

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -57,8 +57,7 @@ test.describe("public booking page", () => {
     await page.setViewportSize({ width: 800, height: 480 });
 
     const origin = new Date();
-    origin.setUTCDate(origin.getUTCDate() + 2);
-    origin.setUTCHours(8, 0, 0, 0);
+    origin.setUTCHours(origin.getUTCHours() + 1, 0, 0, 0);
     const slots = Array.from({ length: 60 }, (_, index) => {
       const slotStart = new Date(origin.getTime() + index * 15 * 60 * 1000);
       return {
@@ -157,5 +156,38 @@ test.describe("public booking page", () => {
     await expect(
       page.getByRole("button", { name: "Confirm booking" }),
     ).toBeEnabled();
+  });
+
+  test("renders a prefetched month without issuing a new slots request", async ({
+    page,
+  }) => {
+    const captured = await preparePublicBookingPage(page);
+
+    await expect(
+      page.getByRole("button", { name: "Previous month" }),
+    ).toBeDisabled();
+    const next = page.getByRole("button", { name: "Next month" });
+    await expect(next).toBeEnabled();
+    await next.hover();
+    await expect.poll(() => captured.slotGets).toBeGreaterThanOrEqual(2);
+    await next.click();
+    await expect(
+      page.getByRole("button", { name: "Previous month" }),
+    ).toBeEnabled();
+    await expect(page.getByText("Loading open times...")).toHaveCount(0);
+    await expect.poll(() => captured.slotGets).toBeGreaterThanOrEqual(3);
+    const afterArrive = captured.slotGets;
+
+    await page.getByRole("button", { name: "Previous month" }).click();
+    await next.click();
+    expect(captured.slotGets).toBe(afterArrive);
+
+    const firstWindow = captured.slotQueries[0];
+    expect(firstWindow?.start).toBeTruthy();
+    expect(firstWindow?.end).toBeTruthy();
+    const startMs = Date.parse(firstWindow?.start ?? "");
+    const endMs = Date.parse(firstWindow?.end ?? "");
+    expect(endMs - startMs).toBeGreaterThan(0);
+    expect(endMs - startMs).toBeLessThanOrEqual(32 * 24 * 60 * 60 * 1000);
   });
 });

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -316,6 +316,18 @@ describe("PublicBookingService", () => {
     );
   });
 
+  it("accepts a month-length slot window within the existing 60-day cap", async () => {
+    const { slug } = await enableBookingPage();
+    const response = await service.getSlots(slug, {
+      start: "2026-08-01T00:00:00.000Z",
+      end: "2026-09-01T00:00:00.000Z",
+      timeZone: "UTC",
+    });
+
+    expect(response.bookable).toBe(true);
+    expect(Array.isArray(response.slots)).toBe(true);
+  });
+
   it("still rejects a slot window whose end is not after start", async () => {
     const { slug } = await enableBookingPage();
 

--- a/packages/web/src/api/public-booking.api.ts
+++ b/packages/web/src/api/public-booking.api.ts
@@ -41,6 +41,7 @@ const PublicBookingApi = {
   async getSlots(
     slug: string,
     query: BookingSlotsQuery,
+    signal?: AbortSignal,
   ): Promise<BookingSlotsResponse> {
     const parsed = BookingSlotsQuerySchema.parse(query);
     const params = new URLSearchParams({
@@ -50,7 +51,7 @@ const PublicBookingApi = {
     });
     const response = await BaseApi.get<unknown>(
       `/booking/pages/${encodeURIComponent(slug)}/slots?${params.toString()}`,
-      { skipSessionRecovery: true },
+      { skipSessionRecovery: true, signal },
     );
     return BookingSlotsResponseSchema.parse(response.data);
   },

--- a/packages/web/src/booking/PublicBookingMonthNav.test.tsx
+++ b/packages/web/src/booking/PublicBookingMonthNav.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import dayjs from "@core/util/date/dayjs";
+import { PublicBookingMonthNav } from "@web/booking/PublicBookingMonthNav";
+import {
+  formatBookingMonthHeading,
+  formatBookingMonthKey,
+  shiftBookingMonthKey,
+} from "@web/booking/public-booking.format";
+import { describe, expect, it } from "bun:test";
+
+const timeZone = "UTC";
+
+describe("PublicBookingMonthNav", () => {
+  it("disables previous on the current month and prefetches the next month on hover", async () => {
+    const user = userEvent.setup({ delay: null });
+    const monthKey = formatBookingMonthKey(dayjs(), timeZone);
+    const nextMonthKey = shiftBookingMonthKey(monthKey, 1, timeZone);
+    const prefetched: string[] = [];
+    const changed: string[] = [];
+
+    render(
+      <PublicBookingMonthNav
+        monthKey={monthKey}
+        timeZone={timeZone}
+        maxHorizonDays={60}
+        onMonthChange={(next) => {
+          changed.push(next);
+        }}
+        onPrefetchMonth={(next) => {
+          prefetched.push(next);
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", {
+        name: formatBookingMonthHeading(monthKey, timeZone),
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Previous month" }),
+    ).toBeDisabled();
+
+    const nextButton = screen.getByRole("button", { name: "Next month" });
+    expect(nextButton).toBeEnabled();
+    await user.hover(nextButton);
+    expect(prefetched).toEqual([nextMonthKey]);
+
+    await user.click(nextButton);
+    expect(changed).toEqual([nextMonthKey]);
+  });
+});

--- a/packages/web/src/booking/PublicBookingMonthNav.tsx
+++ b/packages/web/src/booking/PublicBookingMonthNav.tsx
@@ -1,0 +1,86 @@
+import {
+  formatBookingMonthHeading,
+  isBookingMonthAvailable,
+  shiftBookingMonthKey,
+} from "@web/booking/public-booking.format";
+
+interface PublicBookingMonthNavProps {
+  monthKey: string;
+  timeZone: string;
+  maxHorizonDays: number;
+  onMonthChange: (monthKey: string) => void;
+  onPrefetchMonth: (monthKey: string) => void;
+}
+
+export function PublicBookingMonthNav({
+  monthKey,
+  timeZone,
+  maxHorizonDays,
+  onMonthChange,
+  onPrefetchMonth,
+}: PublicBookingMonthNavProps) {
+  const previousMonthKey = shiftBookingMonthKey(monthKey, -1, timeZone);
+  const nextMonthKey = shiftBookingMonthKey(monthKey, 1, timeZone);
+  const canGoPrevious = isBookingMonthAvailable(
+    previousMonthKey,
+    timeZone,
+    maxHorizonDays,
+  );
+  const canGoNext = isBookingMonthAvailable(
+    nextMonthKey,
+    timeZone,
+    maxHorizonDays,
+  );
+
+  return (
+    <nav
+      aria-labelledby="booking-month-heading"
+      className="flex items-center justify-between gap-2"
+    >
+      <button
+        type="button"
+        aria-label="Previous month"
+        disabled={!canGoPrevious}
+        onClick={() => onMonthChange(previousMonthKey)}
+        onMouseEnter={() => {
+          if (canGoPrevious) {
+            onPrefetchMonth(previousMonthKey);
+          }
+        }}
+        onFocus={() => {
+          if (canGoPrevious) {
+            onPrefetchMonth(previousMonthKey);
+          }
+        }}
+        className="rounded-md px-3 py-2 font-medium text-sm text-text transition-colors hover:bg-surface-panel focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        Previous
+      </button>
+      <h2
+        id="booking-month-heading"
+        className="font-medium text-base text-text"
+      >
+        {formatBookingMonthHeading(monthKey, timeZone)}
+      </h2>
+      <button
+        type="button"
+        aria-label="Next month"
+        disabled={!canGoNext}
+        onClick={() => onMonthChange(nextMonthKey)}
+        onMouseEnter={() => {
+          if (canGoNext) {
+            onPrefetchMonth(nextMonthKey);
+          }
+        }}
+        onFocus={() => {
+          if (canGoNext) {
+            onPrefetchMonth(nextMonthKey);
+          }
+        }}
+        className="rounded-md px-3 py-2 font-medium text-sm text-text transition-colors hover:bg-surface-panel focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        Next
+      </button>
+    </nav>
+  );
+}

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -235,31 +235,28 @@ describe("PublicBookingPage", () => {
   });
 
   it("starts page meta and the current-month slots request in parallel", async () => {
-    let pageStarted = false;
-    let slotsStarted = false;
-    let releasePage!: () => void;
-    let releaseSlots!: () => void;
-    const holdPage = new Promise<void>((resolve) => {
-      releasePage = resolve;
-    });
-    const holdSlots = new Promise<void>((resolve) => {
-      releaseSlots = resolve;
-    });
+    const events: string[] = [];
+    const delay = (ms: number) =>
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, ms);
+      });
 
     server.use(
       rest.get(
         `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane`,
         async (_req, res, ctx) => {
-          pageStarted = true;
-          await holdPage;
+          events.push("page-start");
+          await delay(80);
+          events.push("page-end");
           return res(ctx.status(Status.OK), ctx.json(publicPagePayload()));
         },
       ),
       rest.get(
         `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/slots`,
         async (_req, res, ctx) => {
-          slotsStarted = true;
-          await holdSlots;
+          events.push("slots-start");
+          await delay(80);
+          events.push("slots-end");
           return res(
             ctx.status(Status.OK),
             ctx.json({
@@ -274,16 +271,20 @@ describe("PublicBookingPage", () => {
     renderBookingRoute("/book/tylerdane");
 
     await waitFor(() => {
-      expect(pageStarted).toBe(true);
-      expect(slotsStarted).toBe(true);
+      expect(events).toContain("page-start");
+      expect(events).toContain("slots-start");
     });
-
-    releasePage();
-    releaseSlots();
+    expect(events).not.toContain("page-end");
+    expect(events).not.toContain("slots-end");
 
     expect(
       await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
     ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Loading open times..."),
+      ).not.toBeInTheDocument();
+    });
   });
 
   it("renders a prefetched month without a new slots request", async () => {
@@ -314,6 +315,11 @@ describe("PublicBookingPage", () => {
     renderBookingRoute("/book/tylerdane");
 
     await screen.findByRole("heading", { name: "Book with Tyler Dane" });
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Loading open times..."),
+      ).not.toBeInTheDocument();
+    });
     await waitFor(() => {
       expect(slotRequests).toBeGreaterThanOrEqual(2);
     });

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -234,6 +234,103 @@ describe("PublicBookingPage", () => {
     expect(screen.queryByText(/Keyboard shortcuts/i)).not.toBeInTheDocument();
   });
 
+  it("starts page meta and the current-month slots request in parallel", async () => {
+    let pageStarted = false;
+    let slotsStarted = false;
+    let releasePage!: () => void;
+    let releaseSlots!: () => void;
+    const holdPage = new Promise<void>((resolve) => {
+      releasePage = resolve;
+    });
+    const holdSlots = new Promise<void>((resolve) => {
+      releaseSlots = resolve;
+    });
+
+    server.use(
+      rest.get(
+        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane`,
+        async (_req, res, ctx) => {
+          pageStarted = true;
+          await holdPage;
+          return res(ctx.status(Status.OK), ctx.json(publicPagePayload()));
+        },
+      ),
+      rest.get(
+        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/slots`,
+        async (_req, res, ctx) => {
+          slotsStarted = true;
+          await holdSlots;
+          return res(
+            ctx.status(Status.OK),
+            ctx.json({
+              bookable: true,
+              slots: [{ slotStart, slotEnd: "2026-09-01T15:30:00.000Z" }],
+            }),
+          );
+        },
+      ),
+    );
+
+    renderBookingRoute("/book/tylerdane");
+
+    await waitFor(() => {
+      expect(pageStarted).toBe(true);
+      expect(slotsStarted).toBe(true);
+    });
+
+    releasePage();
+    releaseSlots();
+
+    expect(
+      await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a prefetched month without a new slots request", async () => {
+    const user = userEvent.setup({ delay: null });
+    let slotRequests = 0;
+
+    server.use(
+      rest.get(
+        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane`,
+        (_req, res, ctx) =>
+          res(ctx.status(Status.OK), ctx.json(publicPagePayload())),
+      ),
+      rest.get(
+        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/slots`,
+        (_req, res, ctx) => {
+          slotRequests += 1;
+          return res(
+            ctx.status(Status.OK),
+            ctx.json({
+              bookable: true,
+              slots: [{ slotStart, slotEnd: "2026-09-01T15:30:00.000Z" }],
+            }),
+          );
+        },
+      ),
+    );
+
+    renderBookingRoute("/book/tylerdane");
+
+    await screen.findByRole("heading", { name: "Book with Tyler Dane" });
+    await waitFor(() => {
+      expect(slotRequests).toBeGreaterThanOrEqual(2);
+    });
+    const requestsAfterPrefetch = slotRequests;
+
+    await user.click(screen.getByRole("button", { name: "Next month" }));
+    expect(screen.queryByText("Loading open times...")).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(slotRequests).toBeGreaterThanOrEqual(requestsAfterPrefetch);
+    });
+    const requestsAfterArrive = slotRequests;
+
+    await user.click(screen.getByRole("button", { name: "Previous month" }));
+    await user.click(screen.getByRole("button", { name: "Next month" }));
+    expect(slotRequests).toBe(requestsAfterArrive);
+  });
+
   it("clamps the slot request to the host horizon and still loads times", async () => {
     let slotStartParam: string | null = null;
     let slotEndParam: string | null = null;
@@ -256,8 +353,10 @@ describe("PublicBookingPage", () => {
       rest.get(
         `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/slots`,
         (req, res, ctx) => {
-          slotStartParam = req.url.searchParams.get("start");
-          slotEndParam = req.url.searchParams.get("end");
+          if (slotStartParam == null) {
+            slotStartParam = req.url.searchParams.get("start");
+            slotEndParam = req.url.searchParams.get("end");
+          }
           return res(
             ctx.status(Status.OK),
             ctx.json({
@@ -282,6 +381,10 @@ describe("PublicBookingPage", () => {
     const requestedMs =
       Date.parse(slotEndParam ?? "") - Date.parse(slotStartParam ?? "");
     expect(requestedMs).toBeGreaterThan(0);
-    expect(requestedMs).toBeLessThanOrEqual(7 * 24 * 60 * 60 * 1000 + 60_000);
+    expect(requestedMs).toBeLessThanOrEqual(32 * 24 * 60 * 60 * 1000);
+    const start = new Date(slotStartParam ?? "");
+    expect(start.getUTCMinutes()).toBe(0);
+    expect(start.getUTCSeconds()).toBe(0);
+    expect(start.getUTCMilliseconds()).toBe(0);
   });
 });

--- a/packages/web/src/booking/PublicBookingPage.tsx
+++ b/packages/web/src/booking/PublicBookingPage.tsx
@@ -1,6 +1,8 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
 import { CreateBookingReservationInputSchema } from "@core/types/booking.contracts";
+import dayjs from "@core/util/date/dayjs";
 import { PublicBookingNotFoundError } from "@web/api/public-booking.api";
 import { PublicBookingConfirmationView } from "@web/booking/PublicBookingConfirmationView";
 import {
@@ -9,13 +11,19 @@ import {
   type PublicBookingGuestFormValues,
 } from "@web/booking/PublicBookingGuestForm";
 import { PublicBookingLayout } from "@web/booking/PublicBookingLayout";
+import { PublicBookingMonthNav } from "@web/booking/PublicBookingMonthNav";
 import { PublicBookingSlotPicker } from "@web/booking/PublicBookingSlotPicker";
 import { PublicBookingStatusMessage } from "@web/booking/PublicBookingStatusMessage";
-import { formatDurationMinutes } from "@web/booking/public-booking.format";
+import {
+  formatBookingMonthKey,
+  formatDurationMinutes,
+} from "@web/booking/public-booking.format";
 import {
   isPublicBookingConflictError,
   type PublicBookingConfirmation,
+  prefetchPublicBookingMonth,
   useCreatePublicBookingReservationMutation,
+  usePrefetchAdjacentBookingMonths,
   usePublicBookingPageQuery,
   usePublicBookingSlotsQuery,
 } from "@web/booking/public-booking.query";
@@ -31,11 +39,15 @@ export function PublicBookingPage() {
   const { username } = useParams({ from: "/book/$username" });
   const slug = username ?? "";
   const guestTimeZone = getBrowserTimeZone();
+  const queryClient = useQueryClient();
+  const [monthKey, setMonthKey] = useState(() =>
+    formatBookingMonthKey(dayjs(), guestTimeZone),
+  );
 
   const pageQuery = usePublicBookingPageQuery(slug);
   const slotsQuery = usePublicBookingSlotsQuery(
     slug,
-    pageQuery.isSuccess && pageQuery.data.enabled,
+    monthKey,
     pageQuery.data?.maxHorizonDays,
   );
   const createReservation = useCreatePublicBookingReservationMutation(slug);
@@ -55,6 +67,14 @@ export function PublicBookingPage() {
       conflictAlertRef.current?.focus();
     }
   }, [conflictMessage]);
+
+  usePrefetchAdjacentBookingMonths(
+    slug,
+    monthKey,
+    guestTimeZone,
+    pageQuery.data?.maxHorizonDays,
+    pageQuery.isSuccess && pageQuery.data.enabled && slotsQuery.isSuccess,
+  );
 
   if (pageQuery.isLoading) {
     return (
@@ -98,25 +118,7 @@ export function PublicBookingPage() {
     );
   }
 
-  if (slotsQuery.isLoading) {
-    return (
-      <PublicBookingStatusMessage
-        title={`Book with ${page.hostDisplayName}`}
-        description="Loading open times..."
-      />
-    );
-  }
-
-  if (slotsQuery.isError || !slotsQuery.data) {
-    return (
-      <PublicBookingStatusMessage
-        title="Could not load times"
-        description="Please refresh and try again."
-      />
-    );
-  }
-
-  if (!slotsQuery.data.bookable) {
+  if (slotsQuery.data && !slotsQuery.data.bookable) {
     return (
       <PublicBookingStatusMessage
         title="Booking temporarily unavailable"
@@ -125,12 +127,28 @@ export function PublicBookingPage() {
     );
   }
 
-  const slots = slotsQuery.data;
   const showGuestForm = selectedSlotStart !== null || conflictMessage !== null;
+  const slotsPending = slotsQuery.isLoading && !slotsQuery.data;
 
   const handleSelectSlot = (slotStart: string) => {
     setSelectedSlotStart(slotStart);
     setConflictMessage(null);
+  };
+
+  const handleMonthChange = (nextMonthKey: string) => {
+    setMonthKey(nextMonthKey);
+    setSelectedSlotStart(null);
+    setConflictMessage(null);
+  };
+
+  const handlePrefetchMonth = (nextMonthKey: string) => {
+    void prefetchPublicBookingMonth(
+      queryClient,
+      slug,
+      nextMonthKey,
+      guestTimeZone,
+      page.maxHorizonDays,
+    );
   };
 
   const handleSubmit = async (values: PublicBookingGuestFormValues) => {
@@ -186,12 +204,28 @@ export function PublicBookingPage() {
         </p>
       ) : null}
 
-      <PublicBookingSlotPicker
-        slots={slots.slots}
-        guestTimeZone={guestTimeZone}
-        selectedSlotStart={selectedSlotStart}
-        onSelectSlot={handleSelectSlot}
+      <PublicBookingMonthNav
+        monthKey={monthKey}
+        timeZone={guestTimeZone}
+        maxHorizonDays={page.maxHorizonDays}
+        onMonthChange={handleMonthChange}
+        onPrefetchMonth={handlePrefetchMonth}
       />
+
+      {slotsPending ? (
+        <p className="text-sm text-text-muted">Loading open times...</p>
+      ) : slotsQuery.isError || !slotsQuery.data ? (
+        <p className="text-sm text-text-muted">
+          Could not load times. Please refresh and try again.
+        </p>
+      ) : (
+        <PublicBookingSlotPicker
+          slots={slotsQuery.data.slots}
+          guestTimeZone={guestTimeZone}
+          selectedSlotStart={selectedSlotStart}
+          onSelectSlot={handleSelectSlot}
+        />
+      )}
 
       {showGuestForm ? (
         <PublicBookingGuestForm

--- a/packages/web/src/booking/PublicBookingSlotPicker.tsx
+++ b/packages/web/src/booking/PublicBookingSlotPicker.tsx
@@ -25,7 +25,7 @@ export function PublicBookingSlotPicker({
   if (dateKeys.length === 0) {
     return (
       <p className="text-sm text-text-muted">
-        No open times in the next two weeks. Try again later.
+        No open times this month. Try another month or check back later.
       </p>
     );
   }

--- a/packages/web/src/booking/public-booking.format.test.ts
+++ b/packages/web/src/booking/public-booking.format.test.ts
@@ -1,29 +1,69 @@
-import { getPublicBookingSlotWindow } from "@web/booking/public-booking.format";
+import { DateTimeSchema, TimeZoneSchema } from "@core/types/domain-primitives";
+import dayjs from "@core/util/date/dayjs";
+import {
+  formatBookingMonthKey,
+  getPublicBookingMonthWindow,
+  isBookingMonthAvailable,
+  shiftBookingMonthKey,
+} from "@web/booking/public-booking.format";
 import { describe, expect, it } from "bun:test";
 
-const DAY_MS = 24 * 60 * 60 * 1000;
+const utc = TimeZoneSchema.parse("UTC");
 
-describe("getPublicBookingSlotWindow", () => {
-  it("clamps the default 14-day window to a shorter host horizon", () => {
-    const window = getPublicBookingSlotWindow("UTC", 7);
-    const spanMs = Date.parse(window.end) - Date.parse(window.start);
+describe("getPublicBookingMonthWindow", () => {
+  it("starts at today and ends at the next month when the horizon allows", () => {
+    const now = dayjs("2026-08-15T12:30:00.000Z");
+    const window = getPublicBookingMonthWindow("2026-08", utc, 60, now);
 
-    expect(spanMs).toBeGreaterThan(0);
-    expect(spanMs).toBeLessThanOrEqual(7 * DAY_MS + 60_000);
+    expect(window).not.toBeNull();
+    expect(window?.start).toBe(
+      DateTimeSchema.parse("2026-08-15T00:00:00.000Z"),
+    );
+    expect(window?.end).toBe(DateTimeSchema.parse("2026-09-01T00:00:00.000Z"));
+    expect(window?.timeZone).toBe(utc);
   });
 
-  it("keeps the default 14-day window when the host horizon is longer", () => {
-    const window = getPublicBookingSlotWindow("UTC", 60);
-    const spanMs = Date.parse(window.end) - Date.parse(window.start);
+  it("clamps the month end to the host horizon", () => {
+    const now = dayjs("2026-08-15T12:00:00.000Z");
+    const window = getPublicBookingMonthWindow("2026-08", utc, 7, now);
 
-    expect(spanMs).toBeGreaterThan(14 * DAY_MS - 60_000);
-    expect(spanMs).toBeLessThan(15 * DAY_MS);
+    expect(window).not.toBeNull();
+    expect(window?.start).toBe(
+      DateTimeSchema.parse("2026-08-15T00:00:00.000Z"),
+    );
+    expect(window?.end).toBe(DateTimeSchema.parse("2026-08-22T12:00:00.000Z"));
   });
 
-  it("does not let end-of-day padding extend past a 14-day horizon", () => {
-    const window = getPublicBookingSlotWindow("UTC", 14);
-    const spanMs = Date.parse(window.end) - Date.parse(window.start);
+  it("returns a future month from the first of that month", () => {
+    const now = dayjs("2026-08-15T12:00:00.000Z");
+    const window = getPublicBookingMonthWindow("2026-09", utc, 60, now);
 
-    expect(spanMs).toBeLessThanOrEqual(14 * DAY_MS + 60_000);
+    expect(window).not.toBeNull();
+    expect(window?.start).toBe(
+      DateTimeSchema.parse("2026-09-01T00:00:00.000Z"),
+    );
+    expect(window?.end).toBe(DateTimeSchema.parse("2026-10-01T00:00:00.000Z"));
+  });
+
+  it("returns null for a past month", () => {
+    const now = dayjs("2026-08-15T12:00:00.000Z");
+    expect(getPublicBookingMonthWindow("2026-07", utc, 60, now)).toBeNull();
+    expect(isBookingMonthAvailable("2026-07", utc, 60, now)).toBe(false);
+  });
+
+  it("returns null for a month that starts after the horizon", () => {
+    const now = dayjs("2026-08-15T12:00:00.000Z");
+    expect(getPublicBookingMonthWindow("2026-09", utc, 7, now)).toBeNull();
+    expect(isBookingMonthAvailable("2026-09", utc, 7, now)).toBe(false);
+  });
+});
+
+describe("booking month keys", () => {
+  it("formats and shifts YYYY-MM keys in the guest timezone", () => {
+    expect(formatBookingMonthKey("2026-08-31T22:00:00.000Z", utc)).toBe(
+      "2026-08",
+    );
+    expect(shiftBookingMonthKey("2026-08", 1, utc)).toBe("2026-09");
+    expect(shiftBookingMonthKey("2026-01", -1, utc)).toBe("2025-12");
   });
 });

--- a/packages/web/src/booking/public-booking.format.ts
+++ b/packages/web/src/booking/public-booking.format.ts
@@ -2,30 +2,97 @@ import {
   type BookingSlotsQuery,
   BookingSlotsQuerySchema,
 } from "@core/types/booking.contracts";
-import dayjs from "@core/util/date/dayjs";
-import { getBrowserTimeZone } from "@web/timezone/browser-timezone";
+import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 
-const SLOT_WINDOW_DAYS = 14;
+const MONTH_KEY_PATTERN = /^\d{4}-\d{2}$/;
 
-export function getPublicBookingSlotWindow(
-  hostTimeZone: string,
+export function formatBookingMonthKey(
+  instant: Date | string | Dayjs,
+  timeZone: string,
+): string {
+  return dayjs(instant).tz(timeZone).format("YYYY-MM");
+}
+
+export function shiftBookingMonthKey(
+  monthKey: string,
+  delta: number,
+  timeZone: string,
+): string {
+  const monthStart = parseBookingMonthStart(monthKey, timeZone);
+  if (!monthStart) {
+    return monthKey;
+  }
+  return monthStart.add(delta, "month").format("YYYY-MM");
+}
+
+export function formatBookingMonthHeading(
+  monthKey: string,
+  timeZone: string,
+): string {
+  const monthStart = parseBookingMonthStart(monthKey, timeZone);
+  if (!monthStart) {
+    return monthKey;
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    month: "long",
+    year: "numeric",
+    timeZone,
+  }).format(monthStart.toDate());
+}
+
+function parseBookingMonthStart(
+  monthKey: string,
+  timeZone: string,
+): Dayjs | null {
+  if (!MONTH_KEY_PATTERN.test(monthKey)) {
+    return null;
+  }
+  const monthStart = dayjs.tz(`${monthKey}-01`, timeZone).startOf("month");
+  return monthStart.isValid() ? monthStart : null;
+}
+
+/**
+ * Day-rounded window for one guest-timezone month, clamped to
+ * `[today, now + maxHorizonDays]`. Null when the month is entirely in the
+ * past or past the host horizon.
+ */
+export function getPublicBookingMonthWindow(
+  monthKey: string,
+  timeZone: string,
   maxHorizonDays: number,
-): BookingSlotsQuery {
-  const guestTimeZone = getBrowserTimeZone();
-  const start = dayjs().tz(guestTimeZone).startOf("minute");
-  const preferredEnd = dayjs()
-    .tz(guestTimeZone)
-    .add(SLOT_WINDOW_DAYS, "day")
-    .endOf("day");
-  // Match the slot engine: horizon is now + maxHorizonDays, not end-of-day.
-  const horizonEnd = dayjs().add(maxHorizonDays, "day");
-  const end = preferredEnd.isAfter(horizonEnd) ? horizonEnd : preferredEnd;
+  now: Dayjs = dayjs(),
+): BookingSlotsQuery | null {
+  const monthStart = parseBookingMonthStart(monthKey, timeZone);
+  if (!monthStart) {
+    return null;
+  }
+
+  const todayStart = now.tz(timeZone).startOf("day");
+  const nextMonthStart = monthStart.add(1, "month").startOf("month");
+  const horizonEnd = now.add(maxHorizonDays, "day");
+  const start = monthStart.isBefore(todayStart) ? todayStart : monthStart;
+  const end = nextMonthStart.isAfter(horizonEnd) ? horizonEnd : nextMonthStart;
+
+  if (!end.isAfter(start)) {
+    return null;
+  }
 
   return BookingSlotsQuerySchema.parse({
     start: start.toISOString(),
     end: end.toISOString(),
-    timeZone: guestTimeZone || hostTimeZone,
+    timeZone,
   });
+}
+
+export function isBookingMonthAvailable(
+  monthKey: string,
+  timeZone: string,
+  maxHorizonDays: number,
+  now: Dayjs = dayjs(),
+): boolean {
+  return (
+    getPublicBookingMonthWindow(monthKey, timeZone, maxHorizonDays, now) != null
+  );
 }
 
 export function formatGuestTimeZoneLabel(timeZone: string): string {

--- a/packages/web/src/booking/public-booking.query.test.ts
+++ b/packages/web/src/booking/public-booking.query.test.ts
@@ -1,0 +1,91 @@
+import { QueryClient } from "@tanstack/react-query";
+import { rest } from "msw";
+import { Status } from "@core/errors/status.codes";
+import dayjs from "@core/util/date/dayjs";
+import { server } from "@web/__tests__/__mocks__/server/mock.server";
+import {
+  formatBookingMonthKey,
+  shiftBookingMonthKey,
+} from "@web/booking/public-booking.format";
+import {
+  prefetchPublicBookingMonth,
+  publicBookingSlotsQueryOptions,
+} from "@web/booking/public-booking.query";
+import { ENV_WEB } from "@web/common/constants/env.constants";
+import { describe, expect, it } from "bun:test";
+
+describe("prefetchPublicBookingMonth", () => {
+  it("does not issue a second request for a month fetched within 60s", async () => {
+    const timeZone = "UTC";
+    const monthKey = formatBookingMonthKey(dayjs(), timeZone);
+    const nextMonthKey = shiftBookingMonthKey(monthKey, 1, timeZone);
+    let slotRequests = 0;
+
+    server.use(
+      rest.get(
+        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/slots`,
+        (_req, res, ctx) => {
+          slotRequests += 1;
+          return res(
+            ctx.status(Status.OK),
+            ctx.json({ bookable: true, slots: [] }),
+          );
+        },
+      ),
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    await prefetchPublicBookingMonth(
+      queryClient,
+      "tylerdane",
+      nextMonthKey,
+      timeZone,
+      60,
+    );
+    expect(slotRequests).toBe(1);
+
+    await queryClient.fetchQuery(
+      publicBookingSlotsQueryOptions("tylerdane", nextMonthKey, timeZone, 60),
+    );
+    expect(slotRequests).toBe(1);
+  });
+
+  it("skips months that are entirely in the past", async () => {
+    const timeZone = "UTC";
+    const pastMonthKey = shiftBookingMonthKey(
+      formatBookingMonthKey(dayjs(), timeZone),
+      -1,
+      timeZone,
+    );
+    let slotRequests = 0;
+
+    server.use(
+      rest.get(
+        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/slots`,
+        (_req, res, ctx) => {
+          slotRequests += 1;
+          return res(
+            ctx.status(Status.OK),
+            ctx.json({ bookable: true, slots: [] }),
+          );
+        },
+      ),
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    await prefetchPublicBookingMonth(
+      queryClient,
+      "tylerdane",
+      pastMonthKey,
+      timeZone,
+      60,
+    );
+    expect(slotRequests).toBe(0);
+  });
+});

--- a/packages/web/src/booking/public-booking.query.ts
+++ b/packages/web/src/booking/public-booking.query.ts
@@ -4,7 +4,7 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import {
   type CreateBookingReservationInput,
   type CreateBookingReservationResponse,
@@ -14,18 +14,26 @@ import {
   PublicBookingNotFoundError,
 } from "@web/api/public-booking.api";
 import { getErrorStatus } from "@web/api/util/api.util";
-import { getPublicBookingSlotWindow } from "@web/booking/public-booking.format";
+import {
+  getPublicBookingMonthWindow,
+  shiftBookingMonthKey,
+} from "@web/booking/public-booking.format";
+import { getBrowserTimeZone } from "@web/timezone/browser-timezone";
+
+export const PUBLIC_BOOKING_PAGE_STALE_TIME_MS = 5 * 60 * 1000;
+export const PUBLIC_BOOKING_SLOTS_STALE_TIME_MS = 60_000;
 
 export const publicBookingQueryKeys = {
   page: (slug: string) => ["public-booking", "page", slug] as const,
-  slots: (slug: string, start: string, end: string, timeZone: string) =>
-    ["public-booking", "slots", slug, start, end, timeZone] as const,
+  slots: (slug: string, monthKey: string, timeZone: string) =>
+    ["public-booking", "slots", slug, monthKey, timeZone] as const,
 };
 
 export function publicBookingPageQueryOptions(slug: string) {
   return queryOptions({
     queryKey: publicBookingQueryKeys.page(slug),
     queryFn: () => PublicBookingApi.getPage(slug),
+    staleTime: PUBLIC_BOOKING_PAGE_STALE_TIME_MS,
     retry: (failureCount, error) => {
       if (error instanceof PublicBookingNotFoundError) {
         return false;
@@ -39,26 +47,109 @@ export function usePublicBookingPageQuery(slug: string) {
   return useQuery(publicBookingPageQueryOptions(slug));
 }
 
+export function publicBookingSlotsQueryOptions(
+  slug: string,
+  monthKey: string,
+  timeZone: string,
+  maxHorizonDays: number,
+) {
+  return queryOptions({
+    queryKey: publicBookingQueryKeys.slots(slug, monthKey, timeZone),
+    queryFn: () => {
+      const window = getPublicBookingMonthWindow(
+        monthKey,
+        timeZone,
+        maxHorizonDays,
+      );
+      if (!window) {
+        return { slots: [], bookable: true as const };
+      }
+      return PublicBookingApi.getSlots(slug, window);
+    },
+    staleTime: PUBLIC_BOOKING_SLOTS_STALE_TIME_MS,
+  });
+}
+
 export function usePublicBookingSlotsQuery(
   slug: string,
-  enabled: boolean,
+  monthKey: string,
   maxHorizonDays: number | undefined,
 ) {
-  // Query stays disabled until maxHorizonDays is known; 60 only fills the key.
+  const timeZone = getBrowserTimeZone();
+  // Start the first month in parallel with page meta. 60 is the schema max
+  // and only used until `maxHorizonDays` is known; the query key is the month
+  // so landing page meta does not refetch. The backend still clamps to the
+  // host horizon. Adjacent prefetch waits for the real horizon.
+  const horizon = maxHorizonDays ?? 60;
   const window = useMemo(
-    () => getPublicBookingSlotWindow("UTC", maxHorizonDays ?? 60),
-    [maxHorizonDays],
+    () => getPublicBookingMonthWindow(monthKey, timeZone, horizon),
+    [monthKey, timeZone, horizon],
   );
+
   return useQuery({
-    queryKey: publicBookingQueryKeys.slots(
-      slug,
-      window.start,
-      window.end,
-      window.timeZone,
-    ),
-    queryFn: () => PublicBookingApi.getSlots(slug, window),
-    enabled: enabled && Boolean(slug) && maxHorizonDays != null,
+    ...publicBookingSlotsQueryOptions(slug, monthKey, timeZone, horizon),
+    enabled: Boolean(slug) && window != null,
   });
+}
+
+export function prefetchPublicBookingMonth(
+  queryClient: ReturnType<typeof useQueryClient>,
+  slug: string,
+  monthKey: string,
+  timeZone: string,
+  maxHorizonDays: number,
+) {
+  const window = getPublicBookingMonthWindow(
+    monthKey,
+    timeZone,
+    maxHorizonDays,
+  );
+  if (!window || !slug) {
+    return;
+  }
+  return queryClient.prefetchQuery(
+    publicBookingSlotsQueryOptions(slug, monthKey, timeZone, maxHorizonDays),
+  );
+}
+
+export function usePrefetchAdjacentBookingMonths(
+  slug: string,
+  monthKey: string,
+  timeZone: string,
+  maxHorizonDays: number | undefined,
+  enabled: boolean,
+) {
+  const queryClient = useQueryClient();
+  const previousMonthKey = shiftBookingMonthKey(monthKey, -1, timeZone);
+  const nextMonthKey = shiftBookingMonthKey(monthKey, 1, timeZone);
+
+  useEffect(() => {
+    if (!enabled || maxHorizonDays == null || !slug) {
+      return;
+    }
+    void prefetchPublicBookingMonth(
+      queryClient,
+      slug,
+      previousMonthKey,
+      timeZone,
+      maxHorizonDays,
+    );
+    void prefetchPublicBookingMonth(
+      queryClient,
+      slug,
+      nextMonthKey,
+      timeZone,
+      maxHorizonDays,
+    );
+  }, [
+    enabled,
+    maxHorizonDays,
+    nextMonthKey,
+    previousMonthKey,
+    queryClient,
+    slug,
+    timeZone,
+  ]);
 }
 
 export function useCreatePublicBookingReservationMutation(slug: string) {

--- a/packages/web/src/booking/public-booking.query.ts
+++ b/packages/web/src/booking/public-booking.query.ts
@@ -55,7 +55,7 @@ export function publicBookingSlotsQueryOptions(
 ) {
   return queryOptions({
     queryKey: publicBookingQueryKeys.slots(slug, monthKey, timeZone),
-    queryFn: () => {
+    queryFn: ({ signal }) => {
       const window = getPublicBookingMonthWindow(
         monthKey,
         timeZone,
@@ -64,7 +64,7 @@ export function publicBookingSlotsQueryOptions(
       if (!window) {
         return { slots: [], bookable: true as const };
       }
-      return PublicBookingApi.getSlots(slug, window);
+      return PublicBookingApi.getSlots(slug, window, signal);
     },
     staleTime: PUBLIC_BOOKING_SLOTS_STALE_TIME_MS,
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3000.

## Summary

Guest slot loading was a serial waterfall (page meta, then a 14-day window keyed on a minute-resolution `start`), so the cache almost never hit and there was no way to load another month.

This fetches page meta and the current guest-timezone month in parallel, keys slot queries on `["public-booking", "slots", slug, monthKey, timeZone]` with day-rounded bounds, sets `staleTime` to 60s (page meta 5 min), and prefetches adjacent months on idle plus hover/focus of month navigation.

Minimal previous/next month controls are included so the prefetch acceptance criteria are testable. The day grid belongs to #3001.

## Simplicity

One window helper computes `[today, min(next month, now + horizon)]` or `null`. Prefetch no-ops when that window is null, so past months and months past the host horizon never hit the network. No server-side slot cache: the existing 60/min limiter already covers month-length windows.

The first slots request may start before `maxHorizonDays` is known (dummy 60, the schema max) so it stays parallel with page meta. The query key does not include the horizon, so landing page meta does not refetch. The backend still clamps to the host horizon. Adjacent prefetch waits for the real value. Slot fetches pass the query abort signal so a remount cannot leave an open XHR.

## Automated validation

- Unit: month windows are day-rounded and horizon-clamped; prefetch within 60s is a cache hit; past months are skipped; page meta and slots start together; navigating to a prefetched month does not show a loading state; back-and-forth within 60s issues no new requests.
- Backend: a month-length window is accepted inside the 60-day busy-query cap.
- Playwright: harness filters stubbed slots to the requested window; navigating to a prefetched month issues no extra GET after arrival; first window is at most one calendar month.
- Full `bun run test:web`: 2924 pass.

## Independent review

Re-read of `origin/main...HEAD`: no confirmed findings.

- Slots are no longer gated on `pageQuery.isSuccess`.
- Query keys are stable (`monthKey`, not minute-resolution `start`).
- Month nav previous is disabled on the current month; next is disabled past the host horizon.
- Prefetch is a no-op for months with a null window.
- Mutation success still invalidates `["public-booking", "slots", slug]`.

## Test plan

- `TZ=UTC NODE_ENV=test bun test --preload ./src/__tests__/web.preload.ts ./src/booking/public-booking.format.test.ts ./src/booking/public-booking.query.test.ts ./src/booking/PublicBookingMonthNav.test.tsx ./src/booking/PublicBookingPage.test.tsx` (17 pass)
- `bun run test:web` (2924 pass)
- `bun packages/scripts/src/testing/test-mongo-env.ts backend -- packages/backend/src/booking/services/public-booking.service.db.test.ts` (14 pass)
- `bunx playwright test e2e/booking/public-booking.spec.ts e2e/accessibility/booking-a11y.spec.ts` (13 pass)
- `bun run lint` and `bun run type-check`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46079ef9-363d-42a6-8efb-4d17bad565a3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46079ef9-363d-42a6-8efb-4d17bad565a3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

