### PR TITLE
feat(booking): copy the booking link automatically after a save

### DIFF
--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -120,6 +120,11 @@ timezone `<select>` plus a checkbox and two time inputs per weekday.
   and digits `1/2/3` (nav) on this page, which is why the leader is `e`
   rather than `Mod+digit`. Focus uses `data-booking-field` and does not
   click, so jumping onto a checkbox does not toggle it.
+- **Save:** a successful save that returns a booking URL copies it. A
+  page that has never been enabled has no slug yet, so the toast says to
+  enable booking instead. Safari can drop a copy that follows the save
+  round trip; the toast then names `e` then `l`, and the Copy button
+  stays.
 
 ## Busy occupancy
 

--- a/packages/web/src/booking/BookingCopyLink.test.tsx
+++ b/packages/web/src/booking/BookingCopyLink.test.tsx
@@ -1,7 +1,8 @@
 import "@testing-library/jest-dom";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { BookingCopyLink } from "@web/booking/BookingCopyLink";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { copyText } from "@web/common/utils/clipboard/clipboard.util";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
 describe("BookingCopyLink", () => {
   const mockWriteText = mock(() => Promise.resolve());
@@ -23,5 +24,43 @@ describe("BookingCopyLink", () => {
     await waitFor(() => {
       expect(mockWriteText).toHaveBeenCalledWith(bookingUrl);
     });
+  });
+});
+
+const originalClipboard = navigator.clipboard;
+
+const setClipboard = (value: unknown) => {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value,
+    writable: true,
+  });
+};
+
+afterEach(() => {
+  setClipboard(originalClipboard);
+});
+
+describe("copyText", () => {
+  it("reports success when the write lands", async () => {
+    const writeText = mock(() => Promise.resolve());
+    setClipboard({ writeText });
+
+    expect(await copyText("https://example.com/book/tyler")).toBe(true);
+    expect(writeText).toHaveBeenCalledWith("https://example.com/book/tyler");
+  });
+
+  it("reports failure instead of rejecting when permission is denied", async () => {
+    // The three call sites used to invoke writeText with no .catch(), so this
+    // surfaced as an unhandled rejection and the button just sat there.
+    setClipboard({ writeText: () => Promise.reject(new Error("denied")) });
+
+    expect(await copyText("anything")).toBe(false);
+  });
+
+  it("reports failure when there is no clipboard at all", async () => {
+    setClipboard(undefined);
+
+    expect(await copyText("anything")).toBe(false);
   });
 });

--- a/packages/web/src/booking/BookingCopyLink.tsx
+++ b/packages/web/src/booking/BookingCopyLink.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { copyText } from "@web/common/utils/clipboard/clipboard.util";
 import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
 
 interface BookingCopyLinkProps {
@@ -9,7 +10,14 @@ export function BookingCopyLink({ bookingUrl }: BookingCopyLinkProps) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = () => {
-    void navigator.clipboard.writeText(bookingUrl).then(() => {
+    void copyText(bookingUrl).then((didCopy) => {
+      if (!didCopy) {
+        showStatusToast(
+          "booking-link-copied",
+          "Could not copy. Select the link to copy it.",
+        );
+        return;
+      }
       setCopied(true);
       showStatusToast("booking-link-copied", "Booking link copied");
       window.setTimeout(() => setCopied(false), 2000);

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -43,6 +43,7 @@ afterEach(() => {
   isAppAccessMocked = true;
   setPinnedTimeZone(null);
   clearAppLockReasons();
+  setClipboard(originalClipboard);
 });
 
 const writableCalendar = createMockCalendar({
@@ -54,6 +55,15 @@ const writableCalendar = createMockCalendar({
 const bookingPageUrl = `${ENV_WEB.API_BASEURL}/booking/page`;
 
 const HOST_TIME_ZONE = "America/Chicago";
+
+const originalClipboard = navigator.clipboard;
+const setClipboard = (value: unknown) => {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value,
+    writable: true,
+  });
+};
 
 const unconfiguredPage = () => ({
   enabled: false,
@@ -505,6 +515,92 @@ describe("BookingSettingsSection", () => {
     expect(
       screen.getByText("Fix the weekly hours that could not be read."),
     ).toBeInTheDocument();
+  });
+
+  it("copies the booking link after a save that returns one", async () => {
+    const user = userEvent.setup({ delay: null });
+    userMetadataActions.set(healthyGoogleMetadata);
+    const slug = "hostuser";
+    const bookingUrl = `https://compasscalendar.com/book/${slug}`;
+    const writeText = mock(() => Promise.resolve());
+    setClipboard({ writeText });
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+      rest.put(bookingPageUrl, async (req, res, ctx) =>
+        res(
+          ctx.json({
+            ...((await req.json()) as Record<string, unknown>),
+            id: createObjectIdString(),
+            slug,
+            hostUserId: createObjectIdString(),
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            bookingUrl,
+          }),
+        ),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+    await screen.findByRole("button", { name: "Save booking settings" });
+
+    await user.click(
+      screen.getByRole("button", { name: "Save booking settings" }),
+    );
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(bookingUrl);
+    });
+  });
+
+  it("does not claim a copy when the page has no link yet", async () => {
+    const user = userEvent.setup({ delay: null });
+    userMetadataActions.set(healthyGoogleMetadata);
+    const writeText = mock(() => Promise.resolve());
+    setClipboard({ writeText });
+    let putCount = 0;
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+      // Saving while disabled allocates no slug, so the response carries no
+      // bookingUrl and there is nothing to copy.
+      rest.put(bookingPageUrl, async (req, res, ctx) => {
+        putCount += 1;
+        const body = (await req.json()) as Record<string, unknown>;
+        return res(ctx.json({ ...body, isConfigured: true }));
+      }),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+    await screen.findByRole("button", { name: "Save booking settings" });
+
+    await user.click(
+      screen.getByRole("button", { name: "Save booking settings" }),
+    );
+
+    await waitFor(() => {
+      expect(putCount).toBe(1);
+    });
+    expect(writeText).not.toHaveBeenCalled();
   });
 
   it("blocks enable without a destination calendar", async () => {

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -45,6 +45,8 @@ import {
   groupCalendarsByAccount,
 } from "@web/calendars/calendar.util";
 import { useConnectedAccountEmails } from "@web/calendars/useDefaultTargetCalendar";
+import { copyText } from "@web/common/utils/clipboard/clipboard.util";
+import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
 import {
   OverlayPanelActionButton,
   OverlayPanelActions,
@@ -254,7 +256,29 @@ export function BookingSettingsSection({
       return;
     }
     setEnableError(null);
-    saveMutation.mutate(form);
+    // Auto-copy lives here, not in the mutation: the mutation owns the query
+    // cache, and putting clipboard UX there would also bury the no-link case.
+    saveMutation.mutate(form, {
+      onSuccess: (page) => {
+        if (!("bookingUrl" in page)) {
+          // No slug is allocated until the page is enabled, so there is no
+          // link to copy yet - say so rather than claiming one was copied.
+          showStatusToast(
+            "booking-link-copied",
+            "Saved. Enable booking to get your link.",
+          );
+          return;
+        }
+        void copyText(page.bookingUrl).then((didCopy) => {
+          showStatusToast(
+            "booking-link-copied",
+            didCopy
+              ? "Saved. Booking link copied."
+              : "Saved. Press e then l to copy your link.",
+          );
+        });
+      },
+    });
   };
 
   return (

--- a/packages/web/src/common/utils/clipboard/clipboard.util.ts
+++ b/packages/web/src/common/utils/clipboard/clipboard.util.ts
@@ -1,0 +1,23 @@
+/**
+ * Copy text, reporting whether it landed.
+ *
+ * `navigator.clipboard.writeText` rejects on a denied permission or a
+ * non-secure context, and it is absent entirely in some environments. Callers
+ * used to invoke it directly with no `.catch()`, so a refusal surfaced as an
+ * unhandled rejection and left the UI claiming nothing had happened.
+ *
+ * Note for callers that copy after an await: Safari ends the user-gesture
+ * chain at the first await, so a copy that follows a network round trip can
+ * fail there even with permission granted. Always leave a manual path.
+ */
+export async function copyText(text: string): Promise<boolean> {
+  try {
+    // Not `clipboard?.writeText(...)`: optional chaining yields undefined,
+    // which awaits successfully and would report a copy that never happened.
+    if (!navigator.clipboard) return false;
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/web/src/components/About/AboutModal.tsx
+++ b/packages/web/src/components/About/AboutModal.tsx
@@ -6,6 +6,7 @@ import {
 import { type FC, useState } from "react";
 import { SOCIAL_LINKS } from "@web/common/constants/social.constants";
 import { APP_VERSION } from "@web/common/constants/version.constants";
+import { copyText } from "@web/common/utils/clipboard/clipboard.util";
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
 import {
   selectIsAboutOpen,
@@ -34,7 +35,8 @@ export const AboutModal: FC = () => {
   if (!isOpen) return null;
 
   const handleCopyVersion = () => {
-    void navigator.clipboard.writeText(APP_VERSION).then(() => {
+    void copyText(APP_VERSION).then((didCopy) => {
+      if (!didCopy) return;
       setCopied(true);
       window.setTimeout(() => setCopied(false), COPIED_LABEL_DURATION_MS);
     });

--- a/packages/web/src/components/MobileGate/MobileGate.tsx
+++ b/packages/web/src/components/MobileGate/MobileGate.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
+import { copyText } from "@web/common/utils/clipboard/clipboard.util";
 import { useAppLockReason } from "@web/shortcuts/app-lock";
 
 const WAITLIST_URL = "https://tylerdane.kit.com/compass-mobile";
@@ -23,20 +24,19 @@ export const MobileGate: React.FC = () => {
 
   const handleCopyLink = async () => {
     const url = window.location.href;
-    try {
-      await navigator.clipboard.writeText(url);
-      setCopied(true);
-      if (copiedResetTimeoutRef.current !== null) {
-        window.clearTimeout(copiedResetTimeoutRef.current);
-      }
-      copiedResetTimeoutRef.current = window.setTimeout(() => {
-        copiedResetTimeoutRef.current = null;
-        setCopied(false);
-      }, 2000);
-    } catch {
+    if (!(await copyText(url))) {
       // Fallback for older mobile browsers without clipboard permission.
       window.prompt("Copy this link and open it on a computer:", url);
+      return;
     }
+    setCopied(true);
+    if (copiedResetTimeoutRef.current !== null) {
+      window.clearTimeout(copiedResetTimeoutRef.current);
+    }
+    copiedResetTimeoutRef.current = window.setTimeout(() => {
+      copiedResetTimeoutRef.current = null;
+      setCopied(false);
+    }, 2000);
   };
 
   return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Saving booking settings left the host to find the public link and click Copy. A save that returns a `bookingUrl` now copies it and says so.

The copy lives in `handleSave`'s per-call `onSuccess`, not the mutation's: the mutation owns the query cache, and putting clipboard UX there would also bury the no-link case. A page that has never been enabled has no slug, so the response carries no `bookingUrl`. That toast says to enable booking rather than claiming a copy that did not happen.

Safari ends the user-gesture chain at the first await, so a copy after the save round trip can fail even with permission granted. The toast then names `e` then `l`, and the Copy button stays.

Extract `copyText` while here. `navigator.clipboard.writeText` was duplicated across BookingCopyLink, AboutModal, and MobileGate with no `.catch()`, so a denied permission or a non-secure context surfaced as an unhandled rejection. MobileGate keeps its `window.prompt` fallback, now driven by the util's boolean.

Also documents auto-copy in `docs/features/booking.md`.

## Simplicity

One util, three call sites, one per-call `onSuccess`. `copyText` tests live in `BookingCopyLink.test.tsx` rather than a new file: the sequential `unit (web)` job is already near a SIGTERM ceiling.

## Automated validation

- `cd packages/web && TZ=UTC NODE_ENV=test bun test ./src/booking ./src/shortcuts ./src/timezone ./src/components/About ./src/components/MobileGate` — 483 pass, 0 fail
- `bun run type-check` — pass
- `bun run lint` — pass (pre-existing warnings; custom checkers ran before biome)
- `bun run knip` — pass
- `bun run test:web` — 2938 pass, 355 files, 71.21s (no new test file)

Signed-in Settings Booking was not visually verified here: it needs a healthy Google connection that this environment does not have.

## Independent review

VERDICT: no confirmed findings

Question (not a defect): `e` then `l` focuses the readonly URL input rather than clicking Copy. That matches the original design (toast names the jump; Copy stays as a fresh user gesture).

## Test plan

- `cd packages/web && TZ=UTC NODE_ENV=test bun test ./src/booking ./src/shortcuts ./src/timezone ./src/components/About ./src/components/MobileGate` — 483 pass
- `bun run type-check` — pass
- `bun run lint` — pass
- `bun run knip` — pass
- `bun run test:web` — 2938 pass / 355 files / 71.21s

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57f38c00-686b-4dd3-8ccf-b2f0af2f694c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57f38c00-686b-4dd3-8ccf-b2f0af2f694c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

