### PR TITLE
feat(booking): add an accessible month grid to the guest page

### DIFF
--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -190,4 +190,39 @@ test.describe("public booking page", () => {
     expect(endMs - startMs).toBeGreaterThan(0);
     expect(endMs - startMs).toBeLessThanOrEqual(32 * 24 * 60 * 60 * 1000);
   });
+
+  test("selects a highlighted day from the month grid", async ({ page }) => {
+    const { slotStart } = buildBookableSlot();
+    await preparePublicBookingPage(page);
+
+    const dayName = await page.evaluate((iso) => {
+      const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      return new Intl.DateTimeFormat(undefined, {
+        weekday: "long",
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+        timeZone,
+      }).format(new Date(iso));
+    }, slotStart);
+
+    const dayButton = page.getByRole("button", { name: dayName });
+    await expect(dayButton).toBeVisible();
+    await dayButton.click();
+    const selectedCell = page.getByRole("gridcell", { selected: true });
+    await expect(selectedCell).toBeVisible();
+    await expect(
+      selectedCell.getByRole("button", { name: dayName }),
+    ).toBeVisible();
+
+    const headers = page.getByRole("columnheader");
+    await expect(headers).toHaveCount(7);
+    for (const header of await headers.all()) {
+      await expect(header).not.toHaveAttribute("tabindex");
+    }
+
+    await dayButton.focus();
+    await page.keyboard.press("ArrowRight");
+    await expect(dayButton).toBeFocused();
+  });
 });

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -209,17 +209,7 @@ test.describe("public booking page", () => {
     const dayButton = page.getByRole("button", { name: dayName });
     await expect(dayButton).toBeVisible();
     await dayButton.click();
-    const selectedCell = page.getByRole("gridcell", { selected: true });
-    await expect(selectedCell).toBeVisible();
-    await expect(
-      selectedCell.getByRole("button", { name: dayName }),
-    ).toBeVisible();
-
-    const headers = page.getByRole("columnheader");
-    await expect(headers).toHaveCount(7);
-    for (const header of await headers.all()) {
-      await expect(header).not.toHaveAttribute("tabindex");
-    }
+    await expect(dayButton).toHaveAttribute("aria-pressed", "true");
 
     await dayButton.focus();
     await page.keyboard.press("ArrowRight");

--- a/packages/web/src/booking/PublicBookingMonthGrid.test.tsx
+++ b/packages/web/src/booking/PublicBookingMonthGrid.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { PublicBookingMonthGrid } from "@web/booking/PublicBookingMonthGrid";
 import {
   formatBookingMonthDayLabel,
   formatBookingMonthHeading,
+  listBookingWeekdayHeadings,
 } from "@web/booking/public-booking.format";
 import { describe, expect, it } from "bun:test";
 
@@ -85,17 +86,16 @@ describe("PublicBookingMonthGrid", () => {
       }),
     ).not.toBeInTheDocument();
 
-    const grid = screen.getByRole("grid");
-    expect(within(grid).getByText("10")).toBeInTheDocument();
-    expect(within(grid).getByText("16")).toBeInTheDocument();
+    expect(screen.getByText("10")).toBeInTheDocument();
+    expect(screen.getByText("16")).toBeInTheDocument();
   });
 
   it("keeps a single day in the tab order and moves with arrow keys", async () => {
     const user = userEvent.setup({ delay: null });
     const { selected } = renderGrid();
 
-    for (const header of screen.getAllByRole("columnheader")) {
-      expect(header).not.toHaveAttribute("tabindex");
+    for (const weekday of listBookingWeekdayHeadings(timeZone)) {
+      expect(screen.getByText(weekday.long)).not.toHaveAttribute("tabindex");
     }
 
     const seventeenth = screen.getByRole("button", {
@@ -128,13 +128,19 @@ describe("PublicBookingMonthGrid", () => {
     expect(screen.getByRole("button", { name: "Next month" })).toBeDisabled();
   });
 
-  it("sets aria-selected on the chosen day's grid cell", () => {
+  it("sets aria-pressed on the chosen day", () => {
     renderGrid({ selectedDateKey: availableA });
 
-    const selectedCell = screen.getByRole("gridcell", { selected: true });
     expect(
-      within(selectedCell).getByRole("button", {
+      screen.getByRole("button", {
         name: formatBookingMonthDayLabel(availableA, timeZone),
+        pressed: true,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: formatBookingMonthDayLabel(availableB, timeZone),
+        pressed: false,
       }),
     ).toBeInTheDocument();
   });

--- a/packages/web/src/booking/PublicBookingMonthGrid.test.tsx
+++ b/packages/web/src/booking/PublicBookingMonthGrid.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PublicBookingMonthGrid } from "@web/booking/PublicBookingMonthGrid";
+import {
+  formatBookingMonthDayLabel,
+  formatBookingMonthHeading,
+} from "@web/booking/public-booking.format";
+import { describe, expect, it } from "bun:test";
+
+const timeZone = "UTC";
+const monthKey = "2026-08";
+const todayKey = "2026-08-15";
+const availableA = "2026-08-17";
+const availableB = "2026-08-20";
+
+const slots = [
+  {
+    slotStart: "2026-08-10T15:00:00.000Z",
+    slotEnd: "2026-08-10T15:30:00.000Z",
+  },
+  {
+    slotStart: "2026-08-17T15:00:00.000Z",
+    slotEnd: "2026-08-17T15:30:00.000Z",
+  },
+  {
+    slotStart: "2026-08-20T15:00:00.000Z",
+    slotEnd: "2026-08-20T15:30:00.000Z",
+  },
+];
+
+function renderGrid(
+  overrides: Partial<Parameters<typeof PublicBookingMonthGrid>[0]> = {},
+) {
+  const selected: string[] = [];
+  const months: string[] = [];
+  render(
+    <PublicBookingMonthGrid
+      monthKey={monthKey}
+      timeZone={timeZone}
+      maxHorizonDays={60}
+      slots={slots}
+      selectedDateKey={null}
+      todayKey={todayKey}
+      onMonthChange={(next) => {
+        months.push(next);
+      }}
+      onPrefetchMonth={() => {}}
+      onSelectDate={(dateKey) => {
+        selected.push(dateKey);
+      }}
+      {...overrides}
+    />,
+  );
+  return { selected, months };
+}
+
+describe("PublicBookingMonthGrid", () => {
+  it("lets guests click a highlighted day and keeps disabled days inert", async () => {
+    const user = userEvent.setup({ delay: null });
+    const { selected } = renderGrid();
+
+    expect(
+      screen.getByRole("heading", {
+        name: formatBookingMonthHeading(monthKey, timeZone),
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Previous month" }),
+    ).toBeDisabled();
+
+    const seventeenth = screen.getByRole("button", {
+      name: formatBookingMonthDayLabel(availableA, timeZone),
+    });
+    await user.click(seventeenth);
+    expect(selected).toEqual([availableA]);
+
+    expect(
+      screen.queryByRole("button", {
+        name: formatBookingMonthDayLabel("2026-08-10", timeZone),
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: formatBookingMonthDayLabel("2026-08-16", timeZone),
+      }),
+    ).not.toBeInTheDocument();
+
+    const grid = screen.getByRole("grid");
+    expect(within(grid).getByText("10")).toBeInTheDocument();
+    expect(within(grid).getByText("16")).toBeInTheDocument();
+  });
+
+  it("keeps a single day in the tab order and moves with arrow keys", async () => {
+    const user = userEvent.setup({ delay: null });
+    const { selected } = renderGrid();
+
+    for (const header of screen.getAllByRole("columnheader")) {
+      expect(header).not.toHaveAttribute("tabindex");
+    }
+
+    const seventeenth = screen.getByRole("button", {
+      name: formatBookingMonthDayLabel(availableA, timeZone),
+    });
+    const twentieth = screen.getByRole("button", {
+      name: formatBookingMonthDayLabel(availableB, timeZone),
+    });
+    expect(seventeenth.tabIndex).toBe(0);
+    expect(twentieth.tabIndex).toBe(-1);
+
+    seventeenth.focus();
+    await user.keyboard("{ArrowRight}");
+    expect(twentieth).toHaveFocus();
+    expect(seventeenth.tabIndex).toBe(-1);
+    expect(twentieth.tabIndex).toBe(0);
+
+    await user.keyboard("{Enter}");
+    expect(selected).toEqual([availableB]);
+  });
+
+  it("disables next when the following month is past the horizon", () => {
+    renderGrid({
+      monthKey: "2026-09",
+      maxHorizonDays: 7,
+      todayKey: "2026-08-31",
+      slots: [],
+    });
+
+    expect(screen.getByRole("button", { name: "Next month" })).toBeDisabled();
+  });
+
+  it("sets aria-selected on the chosen day's grid cell", () => {
+    renderGrid({ selectedDateKey: availableA });
+
+    const selectedCell = screen.getByRole("gridcell", { selected: true });
+    expect(
+      within(selectedCell).getByRole("button", {
+        name: formatBookingMonthDayLabel(availableA, timeZone),
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/booking/PublicBookingMonthGrid.tsx
+++ b/packages/web/src/booking/PublicBookingMonthGrid.tsx
@@ -1,0 +1,233 @@
+import {
+  type KeyboardEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import dayjs from "@core/util/date/dayjs";
+import { PublicBookingMonthNav } from "@web/booking/PublicBookingMonthNav";
+import {
+  collectBookingAvailableDateKeys,
+  formatBookingDateKey,
+  formatBookingMonthDayLabel,
+  listBookingAvailableDayKeys,
+  listBookingMonthGridWeeks,
+  listBookingWeekdayHeadings,
+  stepBookingAvailableDay,
+} from "@web/booking/public-booking.format";
+
+interface PublicBookingMonthGridProps {
+  monthKey: string;
+  timeZone: string;
+  maxHorizonDays: number;
+  slots: readonly { slotStart: string }[];
+  selectedDateKey: string | null;
+  todayKey?: string;
+  onMonthChange: (monthKey: string) => void;
+  onPrefetchMonth: (monthKey: string) => void;
+  onSelectDate: (dateKey: string) => void;
+}
+
+export function PublicBookingMonthGrid({
+  monthKey,
+  timeZone,
+  maxHorizonDays,
+  slots,
+  selectedDateKey,
+  todayKey,
+  onMonthChange,
+  onPrefetchMonth,
+  onSelectDate,
+}: PublicBookingMonthGridProps) {
+  const resolvedTodayKey = todayKey ?? formatBookingDateKey(dayjs(), timeZone);
+  const availableDateKeys = useMemo(
+    () => collectBookingAvailableDateKeys(slots, timeZone),
+    [slots, timeZone],
+  );
+  const weeks = useMemo(
+    () =>
+      listBookingMonthGridWeeks(
+        monthKey,
+        timeZone,
+        availableDateKeys,
+        resolvedTodayKey,
+      ),
+    [availableDateKeys, monthKey, resolvedTodayKey, timeZone],
+  );
+  const availableDays = useMemo(
+    () => listBookingAvailableDayKeys(weeks),
+    [weeks],
+  );
+  const weekdayHeadings = useMemo(
+    () => listBookingWeekdayHeadings(timeZone),
+    [timeZone],
+  );
+
+  const [focusedDateKey, setFocusedDateKey] = useState<string | null>(
+    () => selectedDateKey ?? availableDays[0] ?? null,
+  );
+  const moveFocusRef = useRef(false);
+
+  useEffect(() => {
+    setFocusedDateKey((current) => {
+      if (selectedDateKey && availableDays.includes(selectedDateKey)) {
+        return selectedDateKey;
+      }
+      if (current && availableDays.includes(current)) {
+        return current;
+      }
+      return availableDays[0] ?? null;
+    });
+  }, [availableDays, selectedDateKey]);
+
+  useEffect(() => {
+    if (!moveFocusRef.current || !focusedDateKey) {
+      return;
+    }
+    moveFocusRef.current = false;
+    const button = document.getElementById(
+      bookingDayButtonId(monthKey, focusedDateKey),
+    );
+    button?.focus();
+  }, [focusedDateKey, monthKey]);
+
+  const tabStopDateKey = focusedDateKey ?? availableDays[0] ?? null;
+
+  const handleDayKeyDown = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    dateKey: string,
+  ) => {
+    if (availableDays.length === 0) {
+      return;
+    }
+    let next = dateKey;
+    if (event.key === "ArrowLeft") {
+      next = stepBookingAvailableDay(
+        dateKey,
+        availableDays,
+        timeZone,
+        "previous",
+      );
+    } else if (event.key === "ArrowRight") {
+      next = stepBookingAvailableDay(dateKey, availableDays, timeZone, "next");
+    } else if (event.key === "ArrowUp") {
+      next = stepBookingAvailableDay(
+        dateKey,
+        availableDays,
+        timeZone,
+        "previousWeek",
+      );
+    } else if (event.key === "ArrowDown") {
+      next = stepBookingAvailableDay(
+        dateKey,
+        availableDays,
+        timeZone,
+        "nextWeek",
+      );
+    } else if (event.key === "Home") {
+      next = availableDays[0] ?? dateKey;
+    } else if (event.key === "End") {
+      next = availableDays[availableDays.length - 1] ?? dateKey;
+    } else {
+      return;
+    }
+    event.preventDefault();
+    moveFocusRef.current = true;
+    setFocusedDateKey(next);
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <PublicBookingMonthNav
+        monthKey={monthKey}
+        timeZone={timeZone}
+        maxHorizonDays={maxHorizonDays}
+        onMonthChange={onMonthChange}
+        onPrefetchMonth={onPrefetchMonth}
+      />
+      <table
+        className="w-full table-fixed border-collapse"
+        role="grid"
+        aria-labelledby="booking-month-heading"
+      >
+        <thead>
+          <tr>
+            {weekdayHeadings.map((weekday) => (
+              <th
+                key={weekday.long}
+                scope="col"
+                className="pb-1 text-center font-medium text-text-muted text-xs"
+              >
+                <span aria-hidden="true">{weekday.short}</span>
+                <span className="sr-only">{weekday.long}</span>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {weeks.map((week, weekIndex) => (
+            <tr key={weekIndex}>
+              {week.map((cell, cellIndex) => {
+                if (cell.kind === "pad") {
+                  return (
+                    <td
+                      key={`pad-${weekIndex}-${cellIndex}`}
+                      className="p-0.5"
+                    />
+                  );
+                }
+                const { day } = cell;
+                const isSelected = selectedDateKey === day.dateKey;
+                const label = formatBookingMonthDayLabel(day.dateKey, timeZone);
+                return (
+                  <td
+                    key={day.dateKey}
+                    role="gridcell"
+                    className="p-0.5"
+                    aria-selected={day.available ? isSelected : undefined}
+                  >
+                    {day.available ? (
+                      <button
+                        type="button"
+                        id={bookingDayButtonId(monthKey, day.dateKey)}
+                        aria-label={label}
+                        aria-current={day.isToday ? "date" : undefined}
+                        tabIndex={tabStopDateKey === day.dateKey ? 0 : -1}
+                        onClick={() => {
+                          setFocusedDateKey(day.dateKey);
+                          onSelectDate(day.dateKey);
+                        }}
+                        onKeyDown={(event) =>
+                          handleDayKeyDown(event, day.dateKey)
+                        }
+                        className={`flex h-10 w-full items-center justify-center rounded-md font-medium text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+                          isSelected
+                            ? "bg-accent text-on-accent hover:bg-accent"
+                            : "text-text hover:bg-surface-panel"
+                        }`}
+                      >
+                        {day.dayOfMonth}
+                      </button>
+                    ) : (
+                      <span
+                        className="flex h-10 w-full cursor-default items-center justify-center rounded-md text-sm text-text-muted"
+                        aria-current={day.isToday ? "date" : undefined}
+                      >
+                        {day.dayOfMonth}
+                      </span>
+                    )}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function bookingDayButtonId(monthKey: string, dateKey: string): string {
+  return `booking-day-${monthKey}-${dateKey}`;
+}

--- a/packages/web/src/booking/PublicBookingMonthGrid.tsx
+++ b/packages/web/src/booking/PublicBookingMonthGrid.tsx
@@ -8,6 +8,7 @@ import {
 import dayjs from "@core/util/date/dayjs";
 import { PublicBookingMonthNav } from "@web/booking/PublicBookingMonthNav";
 import {
+  type BookingMonthGridCell,
   collectBookingAvailableDateKeys,
   formatBookingDateKey,
   formatBookingMonthDayLabel,
@@ -146,86 +147,89 @@ export function PublicBookingMonthGrid({
         onMonthChange={onMonthChange}
         onPrefetchMonth={onPrefetchMonth}
       />
-      <table
-        className="w-full table-fixed border-collapse"
-        role="grid"
-        aria-labelledby="booking-month-heading"
-      >
-        <thead>
-          <tr>
-            {weekdayHeadings.map((weekday) => (
-              <th
-                key={weekday.long}
-                scope="col"
-                className="pb-1 text-center font-medium text-text-muted text-xs"
-              >
-                <span aria-hidden="true">{weekday.short}</span>
-                <span className="sr-only">{weekday.long}</span>
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {weeks.map((week, weekIndex) => (
-            <tr key={weekIndex}>
+      <div className="w-full">
+        <div className="grid grid-cols-7">
+          {weekdayHeadings.map((weekday) => (
+            <div
+              key={weekday.long}
+              className="pb-1 text-center font-medium text-text-muted text-xs"
+            >
+              <span aria-hidden="true">{weekday.short}</span>
+              <span className="sr-only">{weekday.long}</span>
+            </div>
+          ))}
+        </div>
+        {weeks.map((week) => {
+          const rowKey = weekRowKey(week, monthKey);
+          return (
+            <div key={rowKey} className="grid grid-cols-7">
               {week.map((cell, cellIndex) => {
                 if (cell.kind === "pad") {
                   return (
-                    <td
-                      key={`pad-${weekIndex}-${cellIndex}`}
+                    <div
+                      // biome-ignore lint/suspicious/noArrayIndexKey: leading and trailing pads have no date identity
+                      key={`${rowKey}-pad-${cellIndex}`}
                       className="p-0.5"
+                      aria-hidden="true"
                     />
                   );
                 }
                 const { day } = cell;
                 const isSelected = selectedDateKey === day.dateKey;
                 const label = formatBookingMonthDayLabel(day.dateKey, timeZone);
+                if (!day.available) {
+                  return (
+                    <div
+                      key={day.dateKey}
+                      aria-current={day.isToday ? "date" : undefined}
+                      className="flex h-10 w-full items-center justify-center rounded-md text-sm text-text-muted"
+                    >
+                      {day.dayOfMonth}
+                    </div>
+                  );
+                }
                 return (
-                  <td
+                  <button
                     key={day.dateKey}
-                    role="gridcell"
-                    className="p-0.5"
-                    aria-selected={day.available ? isSelected : undefined}
+                    type="button"
+                    id={bookingDayButtonId(monthKey, day.dateKey)}
+                    aria-label={label}
+                    aria-pressed={isSelected}
+                    aria-current={day.isToday ? "date" : undefined}
+                    tabIndex={tabStopDateKey === day.dateKey ? 0 : -1}
+                    onClick={() => {
+                      setFocusedDateKey(day.dateKey);
+                      onSelectDate(day.dateKey);
+                    }}
+                    onKeyDown={(event) => handleDayKeyDown(event, day.dateKey)}
+                    className={`flex h-10 w-full items-center justify-center rounded-md font-medium text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+                      isSelected
+                        ? "bg-accent text-on-accent hover:bg-accent"
+                        : "text-text hover:bg-surface-panel"
+                    }`}
                   >
-                    {day.available ? (
-                      <button
-                        type="button"
-                        id={bookingDayButtonId(monthKey, day.dateKey)}
-                        aria-label={label}
-                        aria-current={day.isToday ? "date" : undefined}
-                        tabIndex={tabStopDateKey === day.dateKey ? 0 : -1}
-                        onClick={() => {
-                          setFocusedDateKey(day.dateKey);
-                          onSelectDate(day.dateKey);
-                        }}
-                        onKeyDown={(event) =>
-                          handleDayKeyDown(event, day.dateKey)
-                        }
-                        className={`flex h-10 w-full items-center justify-center rounded-md font-medium text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
-                          isSelected
-                            ? "bg-accent text-on-accent hover:bg-accent"
-                            : "text-text hover:bg-surface-panel"
-                        }`}
-                      >
-                        {day.dayOfMonth}
-                      </button>
-                    ) : (
-                      <span
-                        className="flex h-10 w-full cursor-default items-center justify-center rounded-md text-sm text-text-muted"
-                        aria-current={day.isToday ? "date" : undefined}
-                      >
-                        {day.dayOfMonth}
-                      </span>
-                    )}
-                  </td>
+                    {day.dayOfMonth}
+                  </button>
                 );
               })}
-            </tr>
-          ))}
-        </tbody>
-      </table>
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
+}
+
+function weekRowKey(
+  week: readonly BookingMonthGridCell[],
+  monthKey: string,
+): string {
+  for (const cell of week) {
+    if (cell.kind === "day") {
+      return cell.day.dateKey;
+    }
+  }
+  return `${monthKey}-empty`;
 }
 
 function bookingDayButtonId(monthKey: string, dateKey: string): string {

--- a/packages/web/src/booking/PublicBookingMonthGrid.tsx
+++ b/packages/web/src/booking/PublicBookingMonthGrid.tsx
@@ -205,7 +205,7 @@ export function PublicBookingMonthGrid({
                     className={`flex h-10 w-full items-center justify-center rounded-md font-medium text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
                       isSelected
                         ? "bg-accent text-on-accent hover:bg-accent"
-                        : "text-text hover:bg-surface-panel"
+                        : "bg-surface-panel text-text hover:bg-surface-raised"
                     }`}
                   >
                     {day.dayOfMonth}

--- a/packages/web/src/booking/PublicBookingPage.tsx
+++ b/packages/web/src/booking/PublicBookingPage.tsx
@@ -11,11 +11,12 @@ import {
   type PublicBookingGuestFormValues,
 } from "@web/booking/PublicBookingGuestForm";
 import { PublicBookingLayout } from "@web/booking/PublicBookingLayout";
-import { PublicBookingMonthNav } from "@web/booking/PublicBookingMonthNav";
+import { PublicBookingMonthGrid } from "@web/booking/PublicBookingMonthGrid";
 import { PublicBookingSlotPicker } from "@web/booking/PublicBookingSlotPicker";
 import { PublicBookingStatusMessage } from "@web/booking/PublicBookingStatusMessage";
 import {
   formatBookingMonthKey,
+  formatBookingSlotDateKey,
   formatDurationMinutes,
 } from "@web/booking/public-booking.format";
 import {
@@ -55,6 +56,7 @@ export function PublicBookingPage() {
   const [selectedSlotStart, setSelectedSlotStart] = useState<string | null>(
     null,
   );
+  const [selectedDateKey, setSelectedDateKey] = useState<string | null>(null);
   const [guestDetails, setGuestDetails] =
     useState<PublicBookingGuestDetails>(EMPTY_GUEST_DETAILS);
   const [confirmation, setConfirmation] =
@@ -132,12 +134,24 @@ export function PublicBookingPage() {
 
   const handleSelectSlot = (slotStart: string) => {
     setSelectedSlotStart(slotStart);
+    setSelectedDateKey(formatBookingSlotDateKey(slotStart, guestTimeZone));
     setConflictMessage(null);
+  };
+
+  const handleSelectDay = (dateKey: string) => {
+    setSelectedDateKey(dateKey);
+    if (
+      selectedSlotStart &&
+      formatBookingSlotDateKey(selectedSlotStart, guestTimeZone) !== dateKey
+    ) {
+      setSelectedSlotStart(null);
+    }
   };
 
   const handleMonthChange = (nextMonthKey: string) => {
     setMonthKey(nextMonthKey);
     setSelectedSlotStart(null);
+    setSelectedDateKey(null);
     setConflictMessage(null);
   };
 
@@ -204,12 +218,15 @@ export function PublicBookingPage() {
         </p>
       ) : null}
 
-      <PublicBookingMonthNav
+      <PublicBookingMonthGrid
         monthKey={monthKey}
         timeZone={guestTimeZone}
         maxHorizonDays={page.maxHorizonDays}
+        slots={slotsQuery.data?.slots ?? []}
+        selectedDateKey={selectedDateKey}
         onMonthChange={handleMonthChange}
         onPrefetchMonth={handlePrefetchMonth}
+        onSelectDate={handleSelectDay}
       />
 
       {slotsPending ? (

--- a/packages/web/src/booking/public-booking.format.test.ts
+++ b/packages/web/src/booking/public-booking.format.test.ts
@@ -4,7 +4,10 @@ import {
   formatBookingMonthKey,
   getPublicBookingMonthWindow,
   isBookingMonthAvailable,
+  listBookingAvailableDayKeys,
+  listBookingMonthGridWeeks,
   shiftBookingMonthKey,
+  stepBookingAvailableDay,
 } from "@web/booking/public-booking.format";
 import { describe, expect, it } from "bun:test";
 
@@ -65,5 +68,70 @@ describe("booking month keys", () => {
     );
     expect(shiftBookingMonthKey("2026-08", 1, utc)).toBe("2026-09");
     expect(shiftBookingMonthKey("2026-01", -1, utc)).toBe("2025-12");
+  });
+});
+
+describe("listBookingMonthGridWeeks", () => {
+  it("highlights only days that have slots and are not before today", () => {
+    const weeks = listBookingMonthGridWeeks(
+      "2026-08",
+      utc,
+      new Set(["2026-08-10", "2026-08-17", "2026-08-20"]),
+      "2026-08-15",
+    );
+    const days = weeks.flat().filter((cell) => cell.kind === "day");
+
+    expect(days[0]?.kind === "day" && days[0].day.dayOfMonth).toBe(1);
+    expect(weeks[0]?.filter((cell) => cell.kind === "pad")).toHaveLength(6);
+
+    const available = listBookingAvailableDayKeys(weeks);
+    expect(available).toEqual(["2026-08-17", "2026-08-20"]);
+
+    const tenth = days.find(
+      (cell) => cell.kind === "day" && cell.day.dateKey === "2026-08-10",
+    );
+    expect(tenth?.kind === "day" && tenth.day.available).toBe(false);
+
+    const sixteenth = days.find(
+      (cell) => cell.kind === "day" && cell.day.dateKey === "2026-08-16",
+    );
+    expect(sixteenth?.kind === "day" && sixteenth.day.available).toBe(false);
+  });
+
+  it("does not highlight days past the last available date in a horizon-clamped month", () => {
+    const weeks = listBookingMonthGridWeeks(
+      "2026-08",
+      utc,
+      new Set(["2026-08-16", "2026-08-22"]),
+      "2026-08-15",
+    );
+    expect(listBookingAvailableDayKeys(weeks)).toEqual([
+      "2026-08-16",
+      "2026-08-22",
+    ]);
+    const twentyThird = weeks
+      .flat()
+      .find((cell) => cell.kind === "day" && cell.day.dateKey === "2026-08-23");
+    expect(twentyThird?.kind === "day" && twentyThird.day.available).toBe(
+      false,
+    );
+  });
+});
+
+describe("stepBookingAvailableDay", () => {
+  it("moves across available days and stays in-month on week edges", () => {
+    const available = ["2026-08-17", "2026-08-20", "2026-08-24"];
+    expect(stepBookingAvailableDay("2026-08-17", available, utc, "next")).toBe(
+      "2026-08-20",
+    );
+    expect(
+      stepBookingAvailableDay("2026-08-17", available, utc, "previous"),
+    ).toBe("2026-08-17");
+    expect(
+      stepBookingAvailableDay("2026-08-17", available, utc, "nextWeek"),
+    ).toBe("2026-08-24");
+    expect(
+      stepBookingAvailableDay("2026-08-24", available, utc, "nextWeek"),
+    ).toBe("2026-08-24");
   });
 });

--- a/packages/web/src/booking/public-booking.format.ts
+++ b/packages/web/src/booking/public-booking.format.ts
@@ -180,3 +180,159 @@ export function formatDurationMinutes(minutes: number): string {
   }
   return `${minutes} minutes`;
 }
+
+export function formatBookingDateKey(
+  instant: Date | string | Dayjs,
+  timeZone: string,
+): string {
+  return dayjs(instant).tz(timeZone).format("YYYY-MM-DD");
+}
+
+export function collectBookingAvailableDateKeys(
+  slots: readonly { slotStart: string }[],
+  timeZone: string,
+): Set<string> {
+  const keys = new Set<string>();
+  for (const slot of slots) {
+    keys.add(formatBookingSlotDateKey(slot.slotStart, timeZone));
+  }
+  return keys;
+}
+
+export interface BookingMonthDayCell {
+  dateKey: string;
+  dayOfMonth: number;
+  available: boolean;
+  isToday: boolean;
+}
+
+export type BookingMonthGridCell =
+  | { kind: "pad" }
+  | { kind: "day"; day: BookingMonthDayCell };
+
+export function listBookingMonthGridWeeks(
+  monthKey: string,
+  timeZone: string,
+  availableDateKeys: ReadonlySet<string>,
+  todayKey: string,
+): BookingMonthGridCell[][] {
+  const monthStart = parseBookingMonthStart(monthKey, timeZone);
+  if (!monthStart) {
+    return [];
+  }
+
+  const cells: BookingMonthGridCell[] = [];
+  for (let pad = 0; pad < monthStart.day(); pad += 1) {
+    cells.push({ kind: "pad" });
+  }
+
+  const daysInMonth = monthStart.daysInMonth();
+  for (let dayOfMonth = 1; dayOfMonth <= daysInMonth; dayOfMonth += 1) {
+    const dateKey = monthStart.date(dayOfMonth).format("YYYY-MM-DD");
+    cells.push({
+      kind: "day",
+      day: {
+        dateKey,
+        dayOfMonth,
+        available: dateKey >= todayKey && availableDateKeys.has(dateKey),
+        isToday: dateKey === todayKey,
+      },
+    });
+  }
+
+  while (cells.length % 7 !== 0) {
+    cells.push({ kind: "pad" });
+  }
+
+  const weeks: BookingMonthGridCell[][] = [];
+  for (let index = 0; index < cells.length; index += 7) {
+    weeks.push(cells.slice(index, index + 7));
+  }
+  return weeks;
+}
+
+export function listBookingAvailableDayKeys(
+  weeks: readonly (readonly BookingMonthGridCell[])[],
+): string[] {
+  const keys: string[] = [];
+  for (const week of weeks) {
+    for (const cell of week) {
+      if (cell.kind === "day" && cell.day.available) {
+        keys.push(cell.day.dateKey);
+      }
+    }
+  }
+  return keys;
+}
+
+export function stepBookingAvailableDay(
+  dateKey: string,
+  availableDateKeys: readonly string[],
+  timeZone: string,
+  direction: "previous" | "next" | "previousWeek" | "nextWeek",
+): string {
+  if (availableDateKeys.length === 0) {
+    return dateKey;
+  }
+  const currentIndex = availableDateKeys.indexOf(dateKey);
+  if (currentIndex < 0) {
+    return availableDateKeys[0] ?? dateKey;
+  }
+  if (direction === "previous") {
+    return availableDateKeys[Math.max(0, currentIndex - 1)] ?? dateKey;
+  }
+  if (direction === "next") {
+    return (
+      availableDateKeys[
+        Math.min(availableDateKeys.length - 1, currentIndex + 1)
+      ] ?? dateKey
+    );
+  }
+
+  const weekday = dayjs.tz(dateKey, timeZone).day();
+  const sameWeekday = availableDateKeys.filter(
+    (key) => dayjs.tz(key, timeZone).day() === weekday,
+  );
+  const weekdayIndex = sameWeekday.indexOf(dateKey);
+  if (weekdayIndex < 0) {
+    return dateKey;
+  }
+  if (direction === "previousWeek") {
+    return sameWeekday[Math.max(0, weekdayIndex - 1)] ?? dateKey;
+  }
+  return (
+    sameWeekday[Math.min(sameWeekday.length - 1, weekdayIndex + 1)] ?? dateKey
+  );
+}
+
+export function listBookingWeekdayHeadings(
+  timeZone: string,
+): Array<{ short: string; long: string }> {
+  const sunday = dayjs.tz("2026-08-02", timeZone);
+  return Array.from({ length: 7 }, (_, index) => {
+    const date = sunday.add(index, "day").toDate();
+    return {
+      short: new Intl.DateTimeFormat(undefined, {
+        weekday: "short",
+        timeZone,
+      }).format(date),
+      long: new Intl.DateTimeFormat(undefined, {
+        weekday: "long",
+        timeZone,
+      }).format(date),
+    };
+  });
+}
+
+export function formatBookingMonthDayLabel(
+  dateKey: string,
+  timeZone: string,
+): string {
+  return new Intl.DateTimeFormat(undefined, {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    timeZone,
+  }).format(dayjs.tz(dateKey, timeZone).toDate());
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3001.

## Summary

Guests currently get a flat month of slots with no calendar. This adds a booking-specific month grid above the existing slot list so they can see which days have open times, click a highlighted day to select it, and move among available days with arrow keys.

Availability comes from the per-month slots query. Days without open times (or before today) are inert muted text, not buttons. Open days use a panel background; the chosen day uses the accent fill and `aria-pressed`. Month previous/next stay bounded by today and the host horizon. Weekday labels are never in the tab order.

This does not introduce the two-pane layout, default-select the first available day, or filter the slot list to the selected day. Those belong to #3002.

![Guest month grid with one open day highlighted](https://cursor.com/artifacts/c/art-fedede7f-8d80-44ad-b9d1-afda67cb9c93)
![Selected day on the guest month grid](https://cursor.com/artifacts/c/art-9cb01925-e862-43b3-af32-e6a1530d220b)

## Simplicity

Built fresh for booking rather than lifting Sidebar `MonthPicker`. Biome treats `role="grid"` on tables/divs as requiring focusable rows and column headers, which would put weekday labels in the tab order (the known focus-hijack trap this issue forbids). Available days are therefore native buttons with `aria-pressed`, a single roving tab stop, and arrow-key movement that stays inside the current month's open days.

## Automated validation

- Clicking a highlighted day selects it (`aria-pressed="true"`); past days and days without slots are not buttons.
- Previous is disabled on the current month; next is disabled when the following month is past the host horizon.
- Only one day is in the tab order; ArrowRight then Enter selects the next open day.
- axe on the public booking page is clean (no color-contrast failure on muted day text).
- Slot list is unchanged: still the full month.

## Independent review

Re-read of `origin/main...HEAD`: no confirmed findings.

- Grid is not Sidebar `MonthPicker`; headers have no `tabindex`.
- Arrow-key movement uses the in-month available-day list, so it cannot leave the current month.
- Month nav still uses `isBookingMonthAvailable` for today/horizon bounds.
- Selecting a day does not filter slots. Picking a day that does not match the selected slot only clears the slot, so guest details are not attached to a mismatched time.
- `aria-pressed` is on the button (axe `aria-allowed-attr` rejects `aria-selected` on buttons). Today still gets `aria-current="date"`.

## Test plan

- `TZ=UTC NODE_ENV=test bun test --preload ./src/__tests__/web.preload.ts ./src/booking/public-booking.format.test.ts ./src/booking/PublicBookingMonthGrid.test.tsx ./src/booking/PublicBookingMonthNav.test.tsx ./src/booking/PublicBookingPage.test.tsx` (22 pass)
- `bun run type-check`
- `bunx playwright test e2e/booking/public-booking.spec.ts e2e/accessibility/booking-a11y.spec.ts` (14 pass)
- `bun run lint` (0 errors; pre-existing warnings only)
- `bun run verify` (web + type-check + lint + knip + a11y + e2e): All checks passed, no skips

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46079ef9-363d-42a6-8efb-4d17bad565a3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46079ef9-363d-42a6-8efb-4d17bad565a3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

