### PR TITLE
feat(booking): two-pane picker (month grid + day slot list)

### DIFF
--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -51,53 +51,82 @@ test.describe("public booking page", () => {
     await expect(page.getByLabel("Email")).toBeFocused();
   });
 
-  test("scrolls when available times overflow the viewport", async ({
+  test("scrolls later times in the selected day's slot pane", async ({
     page,
   }) => {
     await page.setViewportSize({ width: 800, height: 480 });
 
-    const origin = new Date();
-    origin.setUTCHours(origin.getUTCHours() + 1, 0, 0, 0);
-    const slots = Array.from({ length: 60 }, (_, index) => {
-      const slotStart = new Date(origin.getTime() + index * 15 * 60 * 1000);
-      return {
+    const origin = buildBookableSlot();
+    const originDate = origin.slotStart.slice(0, 10);
+    const slots: Array<{ slotStart: string; slotEnd: string }> = [];
+    for (let index = 0; index < 40; index += 1) {
+      const slotStart = new Date(
+        Date.parse(origin.slotStart) + index * 15 * 60 * 1000,
+      );
+      if (slotStart.toISOString().slice(0, 10) !== originDate) {
+        break;
+      }
+      slots.push({
         slotStart: slotStart.toISOString(),
         slotEnd: new Date(slotStart.getTime() + 30 * 60 * 1000).toISOString(),
-      };
-    });
+      });
+    }
 
     await preparePublicBookingPage(page, { slots });
 
     await expect
       .poll(async () =>
         page.evaluate(() => {
-          const scrolling = document.scrollingElement;
-          if (!scrolling) {
-            return false;
+          const heading = Array.from(document.querySelectorAll("h2")).find(
+            (node) => node.textContent === "Pick a time",
+          );
+          let node = heading?.parentElement ?? null;
+          while (node && node !== document.body) {
+            const style = getComputedStyle(node);
+            if (style.overflowY === "auto" || style.overflowY === "scroll") {
+              return node.scrollHeight > node.clientHeight + 20;
+            }
+            node = node.parentElement;
           }
-          const overflowY = getComputedStyle(
-            document.documentElement,
-          ).overflowY;
-          return (
-            (overflowY === "auto" || overflowY === "scroll") &&
-            scrolling.scrollHeight > scrolling.clientHeight + 40
+          const scrolling = document.scrollingElement;
+          return Boolean(
+            scrolling && scrolling.scrollHeight > scrolling.clientHeight + 40,
           );
         }),
       )
       .toBe(true);
 
-    await page.evaluate(() => window.scrollTo(0, 0));
-    await page.mouse.move(400, 200);
-    await page.mouse.wheel(0, 1600);
+    await page.evaluate(() => {
+      const heading = Array.from(document.querySelectorAll("h2")).find(
+        (node) => node.textContent === "Pick a time",
+      );
+      let node = heading?.parentElement ?? null;
+      while (node && node !== document.body) {
+        const style = getComputedStyle(node);
+        if (style.overflowY === "auto" || style.overflowY === "scroll") {
+          node.scrollTop = 600;
+          return;
+        }
+        node = node.parentElement;
+      }
+    });
     await expect
-      .poll(async () => page.evaluate(() => window.scrollY))
-      .toBeGreaterThan(80);
-
-    await page.evaluate(() => window.scrollTo(0, 0));
-    await page.locator("body").click({ position: { x: 16, y: 16 } });
-    await page.keyboard.press("PageDown");
-    await expect
-      .poll(async () => page.evaluate(() => window.scrollY))
+      .poll(async () =>
+        page.evaluate(() => {
+          const heading = Array.from(document.querySelectorAll("h2")).find(
+            (node) => node.textContent === "Pick a time",
+          );
+          let node = heading?.parentElement ?? null;
+          while (node && node !== document.body) {
+            const style = getComputedStyle(node);
+            if (style.overflowY === "auto" || style.overflowY === "scroll") {
+              return node.scrollTop;
+            }
+            node = node.parentElement;
+          }
+          return window.scrollY;
+        }),
+      )
       .toBeGreaterThan(80);
   });
 
@@ -214,5 +243,125 @@ test.describe("public booking page", () => {
     await dayButton.focus();
     await page.keyboard.press("ArrowRight");
     await expect(dayButton).toBeFocused();
+  });
+
+  test("shows only the selected day's times in the slot pane", async ({
+    page,
+  }) => {
+    const today = buildBookableSlot();
+    const laterTodayStart = new Date(
+      Date.parse(today.slotStart) + 30 * 60 * 1000,
+    ).toISOString();
+    const laterToday = {
+      slotStart: laterTodayStart,
+      slotEnd: new Date(
+        Date.parse(laterTodayStart) + 30 * 60 * 1000,
+      ).toISOString(),
+    };
+    const otherDayStart = new Date(
+      Date.parse(today.slotStart) + 25 * 60 * 60 * 1000,
+    ).toISOString();
+    const otherDay = {
+      slotStart: otherDayStart,
+      slotEnd: new Date(
+        Date.parse(otherDayStart) + 30 * 60 * 1000,
+      ).toISOString(),
+    };
+
+    await preparePublicBookingPage(page, {
+      slots: [today, laterToday, otherDay],
+    });
+
+    await expect(
+      page.getByRole("button", {
+        name: formatSlotButtonLabel(today.slotStart),
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", {
+        name: formatSlotButtonLabel(laterToday.slotStart),
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", {
+        name: formatSlotButtonLabel(otherDay.slotStart),
+      }),
+    ).toHaveCount(0);
+
+    const monthBox = await page
+      .getByRole("heading", { name: /20\d{2}$/ })
+      .boundingBox();
+    const slotsBox = await page
+      .getByRole("heading", { name: "Pick a time" })
+      .boundingBox();
+    expect(monthBox).toBeTruthy();
+    expect(slotsBox).toBeTruthy();
+    expect(Math.abs((monthBox?.y ?? 0) - (slotsBox?.y ?? 0))).toBeLessThan(80);
+    expect(monthBox?.x ?? 0).toBeLessThan(slotsBox?.x ?? 0);
+  });
+
+  test("jumps to the next open day in the following month", async ({
+    page,
+  }) => {
+    const now = new Date();
+    const nextMonthStart = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 2, 16, 0, 0),
+    );
+    const nextMonthSlot = {
+      slotStart: nextMonthStart.toISOString(),
+      slotEnd: new Date(
+        nextMonthStart.getTime() + 30 * 60 * 1000,
+      ).toISOString(),
+    };
+    const nextMonthHeading = new Intl.DateTimeFormat(undefined, {
+      month: "long",
+      year: "numeric",
+      timeZone: "UTC",
+    }).format(nextMonthStart);
+
+    await preparePublicBookingPage(page, { slots: [nextMonthSlot] });
+
+    await expect(page.getByText("No open times this month.")).toBeVisible();
+    await page
+      .getByRole("button", { name: "Jump to next available day" })
+      .click();
+
+    await expect(
+      page.getByRole("heading", { name: nextMonthHeading }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", {
+        name: formatSlotButtonLabel(nextMonthSlot.slotStart),
+      }),
+    ).toBeVisible();
+  });
+
+  test("stacks without horizontal scroll at 375px", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    const { slotStart } = buildBookableSlot();
+    await preparePublicBookingPage(page);
+
+    const monthHeading = page.getByRole("heading", { name: /20\d{2}$/ });
+    const slotsHeading = page.getByRole("heading", { name: "Pick a time" });
+    const monthBox = await monthHeading.boundingBox();
+    const slotsBox = await slotsHeading.boundingBox();
+    expect(monthBox).toBeTruthy();
+    expect(slotsBox).toBeTruthy();
+    expect((monthBox?.y ?? 0) + (monthBox?.height ?? 0)).toBeLessThan(
+      slotsBox?.y ?? 0,
+    );
+
+    const overflowX = await page.evaluate(() => {
+      const root = document.scrollingElement ?? document.documentElement;
+      return root.scrollWidth - root.clientWidth;
+    });
+    expect(overflowX).toBeLessThanOrEqual(1);
+
+    await page
+      .getByRole("button", { name: formatSlotButtonLabel(slotStart) })
+      .click();
+    await expect(
+      page.getByRole("button", { name: "Confirm booking" }),
+    ).toBeVisible();
   });
 });

--- a/packages/web/src/booking/PublicBookingLayout.test.tsx
+++ b/packages/web/src/booking/PublicBookingLayout.test.tsx
@@ -13,5 +13,16 @@ describe("PublicBookingLayout", () => {
     const main = screen.getByRole("main");
     expect(main).toHaveTextContent("Booking content");
     expect(main.parentElement).toHaveAttribute("data-document-scroll");
+    expect(main.className).toContain("max-w-lg");
+  });
+
+  it("widens the two-pane picker page", () => {
+    render(
+      <PublicBookingLayout wide>
+        <p>Picker</p>
+      </PublicBookingLayout>,
+    );
+
+    expect(screen.getByRole("main").className).toContain("max-w-3xl");
   });
 });

--- a/packages/web/src/booking/PublicBookingLayout.tsx
+++ b/packages/web/src/booking/PublicBookingLayout.tsx
@@ -1,15 +1,26 @@
 import { type PropsWithChildren } from "react";
 
+interface PublicBookingLayoutProps extends PropsWithChildren {
+  wide?: boolean;
+}
+
 /**
  * Public booking is a document-height page. The calendar shell clips
  * `html`/`body`/`#root` with `overflow: hidden`; `data-document-scroll`
  * opts this tree into native page scrolling so guests can reach later
  * time slots (see `index.css`).
  */
-export function PublicBookingLayout({ children }: PropsWithChildren) {
+export function PublicBookingLayout({
+  children,
+  wide = false,
+}: PublicBookingLayoutProps) {
   return (
     <div data-document-scroll className="min-h-dvh bg-background text-text">
-      <main className="mx-auto flex w-full max-w-lg flex-col gap-6 px-4 py-10">
+      <main
+        className={`mx-auto flex w-full min-w-0 flex-col gap-6 px-4 py-10 ${
+          wide ? "max-w-3xl" : "max-w-lg"
+        }`}
+      >
         {children}
       </main>
     </div>

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -9,6 +9,12 @@ import { rest } from "msw";
 import { Status } from "@core/errors/status.codes";
 import { server } from "@web/__tests__/__mocks__/server/mock.server";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
+import {
+  formatBookingMonthDayLabel,
+  formatBookingMonthHeading,
+  formatBookingSlotDateKey,
+  shiftBookingMonthKey,
+} from "@web/booking/public-booking.format";
 import { ENV_WEB } from "@web/common/constants/env.constants";
 import { routeTree } from "@web/routers/router.routes";
 import { describe, expect, it } from "bun:test";
@@ -24,7 +30,48 @@ function renderBookingRoute(path: string) {
   return { ...result, router };
 }
 
-const slotStart = "2026-09-01T15:00:00.000Z";
+function bookableSlotInCurrentMonth(minuteOffset = 0) {
+  const now = new Date();
+  const start = new Date(now);
+  start.setUTCHours(15, minuteOffset, 0, 0);
+  if (
+    start.getTime() <= now.getTime() ||
+    start.getUTCMonth() !== now.getUTCMonth()
+  ) {
+    start.setTime(now.getTime() + 2 * 60 * 60 * 1000);
+    start.setUTCMinutes(minuteOffset, 0, 0);
+  }
+  return {
+    slotStart: start.toISOString(),
+    slotEnd: new Date(start.getTime() + 30 * 60 * 1000).toISOString(),
+  };
+}
+
+function bookableSlotInNextMonth() {
+  const now = new Date();
+  const start = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 2, 16, 0, 0),
+  );
+  return {
+    slotStart: start.toISOString(),
+    slotEnd: new Date(start.getTime() + 30 * 60 * 1000).toISOString(),
+  };
+}
+
+function slotTimePattern(iso: string) {
+  const label = new Intl.DateTimeFormat(undefined, {
+    timeZone: "UTC",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(iso));
+  return new RegExp(label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i");
+}
+
+const currentSlot = bookableSlotInCurrentMonth();
+const laterCurrentSlot = bookableSlotInCurrentMonth(30);
+const nextMonthSlot = bookableSlotInNextMonth();
+const guestTimeZone = "UTC";
+const currentMonthKey = new Date().toISOString().slice(0, 7);
 
 const publicPagePayload = (overrides: Record<string, unknown> = {}) => ({
   hostDisplayName: "Tyler Dane",
@@ -34,6 +81,35 @@ const publicPagePayload = (overrides: Record<string, unknown> = {}) => ({
   maxHorizonDays: 60,
   ...overrides,
 });
+
+function pageHandler() {
+  return rest.get(
+    `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane`,
+    (_req, res, ctx) =>
+      res(ctx.status(Status.OK), ctx.json(publicPagePayload())),
+  );
+}
+
+function slotsInWindow(
+  allSlots: Array<{ slotStart: string; slotEnd: string }>,
+  onRequest?: () => void,
+) {
+  return rest.get(
+    `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/slots`,
+    (req, res, ctx) => {
+      onRequest?.();
+      const start = req.url.searchParams.get("start");
+      const end = req.url.searchParams.get("end");
+      const startMs = start ? Date.parse(start) : Number.NEGATIVE_INFINITY;
+      const endMs = end ? Date.parse(end) : Number.POSITIVE_INFINITY;
+      const slots = allSlots.filter((slot) => {
+        const at = Date.parse(slot.slotStart);
+        return at >= startMs && at < endMs;
+      });
+      return res(ctx.status(Status.OK), ctx.json({ bookable: true, slots }));
+    },
+  );
+}
 
 describe("PublicBookingPage", () => {
   it("shows a generic not-found state for an unknown slug", async () => {
@@ -52,22 +128,8 @@ describe("PublicBookingPage", () => {
     let postedBody: unknown;
 
     server.use(
-      rest.get(
-        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane`,
-        (_req, res, ctx) =>
-          res(ctx.status(Status.OK), ctx.json(publicPagePayload())),
-      ),
-      rest.get(
-        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/slots`,
-        (_req, res, ctx) =>
-          res(
-            ctx.status(Status.OK),
-            ctx.json({
-              bookable: true,
-              slots: [{ slotStart, slotEnd: "2026-09-01T15:30:00.000Z" }],
-            }),
-          ),
-      ),
+      pageHandler(),
+      slotsInWindow([currentSlot]),
       rest.post(
         `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/reservations`,
         async (req, res, ctx) => {
@@ -76,8 +138,8 @@ describe("PublicBookingPage", () => {
             ctx.status(Status.OK),
             ctx.json({
               reservationId: "000000000000000000000099",
-              slotStart,
-              slotEnd: "2026-09-01T15:30:00.000Z",
+              slotStart: currentSlot.slotStart,
+              slotEnd: currentSlot.slotEnd,
               guestTimeZone: "UTC",
               cancelUrl:
                 "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
@@ -95,12 +157,25 @@ describe("PublicBookingPage", () => {
     expect(screen.getByRole("main").parentElement).toHaveAttribute(
       "data-document-scroll",
     );
+    expect(screen.getByRole("main").className).toContain("max-w-3xl");
     expect(
       await screen.findByText(/Times shown in your timezone/),
     ).toBeInTheDocument();
 
+    const dateKey = formatBookingSlotDateKey(
+      currentSlot.slotStart,
+      guestTimeZone,
+    );
+    expect(
+      await screen.findByRole("button", {
+        name: formatBookingMonthDayLabel(dateKey, guestTimeZone),
+      }),
+    ).toHaveAttribute("aria-pressed", "true");
+
     await user.click(
-      await screen.findByRole("button", { name: /3:00 PM|15:00/i }),
+      await screen.findByRole("button", {
+        name: slotTimePattern(currentSlot.slotStart),
+      }),
     );
     await user.type(screen.getByLabelText("Name"), "Guest User");
     await user.type(screen.getByLabelText("Email"), "guest@example.com");
@@ -112,7 +187,7 @@ describe("PublicBookingPage", () => {
       }),
     ).toBeInTheDocument();
     expect(postedBody).toMatchObject({
-      slotStart,
+      slotStart: currentSlot.slotStart,
       guestName: "Guest User",
       guestEmail: "guest@example.com",
     });
@@ -120,11 +195,7 @@ describe("PublicBookingPage", () => {
 
   it("shows unavailable when bookable is false", async () => {
     server.use(
-      rest.get(
-        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane`,
-        (_req, res, ctx) =>
-          res(ctx.status(Status.OK), ctx.json(publicPagePayload())),
-      ),
+      pageHandler(),
       rest.get(
         `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/slots`,
         (_req, res, ctx) =>
@@ -145,33 +216,12 @@ describe("PublicBookingPage", () => {
   it("keeps guest details and moves focus to the alert on 409", async () => {
     const user = userEvent.setup({ delay: null });
     let slotRequests = 0;
-    const laterSlotStart = "2026-09-01T15:30:00.000Z";
 
     server.use(
-      rest.get(
-        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane`,
-        (_req, res, ctx) =>
-          res(ctx.status(Status.OK), ctx.json(publicPagePayload())),
-      ),
-      rest.get(
-        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/slots`,
-        (_req, res, ctx) => {
-          slotRequests += 1;
-          return res(
-            ctx.status(Status.OK),
-            ctx.json({
-              bookable: true,
-              slots: [
-                { slotStart, slotEnd: laterSlotStart },
-                {
-                  slotStart: laterSlotStart,
-                  slotEnd: "2026-09-01T16:00:00.000Z",
-                },
-              ],
-            }),
-          );
-        },
-      ),
+      pageHandler(),
+      slotsInWindow([currentSlot, laterCurrentSlot], () => {
+        slotRequests += 1;
+      }),
       rest.post(
         `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/reservations`,
         (_req, res, ctx) => res(ctx.status(Status.CONFLICT), ctx.json({})),
@@ -182,7 +232,9 @@ describe("PublicBookingPage", () => {
 
     await screen.findByRole("heading", { name: "Book with Tyler Dane" });
     await user.click(
-      await screen.findByRole("button", { name: /3:00 PM|15:00/i }),
+      await screen.findByRole("button", {
+        name: slotTimePattern(currentSlot.slotStart),
+      }),
     );
     await user.type(screen.getByLabelText("Name"), "Guest User");
     await user.type(screen.getByLabelText("Email"), "guest@example.com");
@@ -208,7 +260,11 @@ describe("PublicBookingPage", () => {
       expect(slotRequests).toBeGreaterThan(1);
     });
 
-    await user.click(screen.getByRole("button", { name: /3:30 PM|15:30/i }));
+    await user.click(
+      screen.getByRole("button", {
+        name: slotTimePattern(laterCurrentSlot.slotStart),
+      }),
+    );
     expect(
       screen.getByRole("button", { name: "Confirm booking" }),
     ).toBeEnabled();
@@ -216,11 +272,7 @@ describe("PublicBookingPage", () => {
 
   it("does not boot the calendar shortcut overlay on public booking routes", async () => {
     server.use(
-      rest.get(
-        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane`,
-        (_req, res, ctx) =>
-          res(ctx.status(Status.OK), ctx.json(publicPagePayload())),
-      ),
+      pageHandler(),
       rest.get(
         `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/slots`,
         (_req, res, ctx) =>
@@ -261,7 +313,7 @@ describe("PublicBookingPage", () => {
             ctx.status(Status.OK),
             ctx.json({
               bookable: true,
-              slots: [{ slotStart, slotEnd: "2026-09-01T15:30:00.000Z" }],
+              slots: [currentSlot],
             }),
           );
         },
@@ -292,24 +344,10 @@ describe("PublicBookingPage", () => {
     let slotRequests = 0;
 
     server.use(
-      rest.get(
-        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane`,
-        (_req, res, ctx) =>
-          res(ctx.status(Status.OK), ctx.json(publicPagePayload())),
-      ),
-      rest.get(
-        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/slots`,
-        (_req, res, ctx) => {
-          slotRequests += 1;
-          return res(
-            ctx.status(Status.OK),
-            ctx.json({
-              bookable: true,
-              slots: [{ slotStart, slotEnd: "2026-09-01T15:30:00.000Z" }],
-            }),
-          );
-        },
-      ),
+      pageHandler(),
+      slotsInWindow([currentSlot, nextMonthSlot], () => {
+        slotRequests += 1;
+      }),
     );
 
     renderBookingRoute("/book/tylerdane");
@@ -392,5 +430,87 @@ describe("PublicBookingPage", () => {
     expect(start.getUTCMinutes()).toBe(0);
     expect(start.getUTCSeconds()).toBe(0);
     expect(start.getUTCMilliseconds()).toBe(0);
+  });
+
+  it("scopes the slot list to the selected day and swaps it when the month changes", async () => {
+    const user = userEvent.setup({ delay: null });
+    server.use(pageHandler(), slotsInWindow([currentSlot, nextMonthSlot]));
+
+    renderBookingRoute("/book/tylerdane");
+
+    expect(
+      await screen.findByRole("button", {
+        name: slotTimePattern(currentSlot.slotStart),
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: slotTimePattern(nextMonthSlot.slotStart),
+      }),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Next month" }));
+
+    const nextMonthKey = shiftBookingMonthKey(
+      currentMonthKey,
+      1,
+      guestTimeZone,
+    );
+    expect(
+      await screen.findByRole("heading", {
+        name: formatBookingMonthHeading(nextMonthKey, guestTimeZone),
+      }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", {
+        name: slotTimePattern(nextMonthSlot.slotStart),
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: slotTimePattern(currentSlot.slotStart),
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("jumps across a month boundary to the next open day", async () => {
+    const user = userEvent.setup({ delay: null });
+    server.use(pageHandler(), slotsInWindow([nextMonthSlot]));
+
+    renderBookingRoute("/book/tylerdane");
+
+    await screen.findByRole("heading", { name: "Book with Tyler Dane" });
+    expect(
+      await screen.findByText("No open times this month."),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Jump to next available day" }),
+    );
+
+    const nextMonthKey = shiftBookingMonthKey(
+      currentMonthKey,
+      1,
+      guestTimeZone,
+    );
+    expect(
+      await screen.findByRole("heading", {
+        name: formatBookingMonthHeading(nextMonthKey, guestTimeZone),
+      }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", {
+        name: slotTimePattern(nextMonthSlot.slotStart),
+      }),
+    ).toBeInTheDocument();
+    const nextDateKey = formatBookingSlotDateKey(
+      nextMonthSlot.slotStart,
+      guestTimeZone,
+    );
+    expect(
+      screen.getByRole("button", {
+        name: formatBookingMonthDayLabel(nextDateKey, guestTimeZone),
+      }),
+    ).toHaveAttribute("aria-pressed", "true");
   });
 });

--- a/packages/web/src/booking/PublicBookingPage.tsx
+++ b/packages/web/src/booking/PublicBookingPage.tsx
@@ -1,7 +1,10 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
-import { CreateBookingReservationInputSchema } from "@core/types/booking.contracts";
+import {
+  type BookingSlotsResponse,
+  CreateBookingReservationInputSchema,
+} from "@core/types/booking.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { PublicBookingNotFoundError } from "@web/api/public-booking.api";
 import { PublicBookingConfirmationView } from "@web/booking/PublicBookingConfirmationView";
@@ -11,18 +14,23 @@ import {
   type PublicBookingGuestFormValues,
 } from "@web/booking/PublicBookingGuestForm";
 import { PublicBookingLayout } from "@web/booking/PublicBookingLayout";
-import { PublicBookingMonthGrid } from "@web/booking/PublicBookingMonthGrid";
-import { PublicBookingSlotPicker } from "@web/booking/PublicBookingSlotPicker";
+import { PublicBookingPicker } from "@web/booking/PublicBookingPicker";
 import { PublicBookingStatusMessage } from "@web/booking/PublicBookingStatusMessage";
 import {
+  findNextAvailableBookingDate,
+  formatBookingDateKey,
   formatBookingMonthKey,
   formatBookingSlotDateKey,
   formatDurationMinutes,
+  formatGuestTimeZoneLabel,
+  listBookingAvailableDateKeysInMonth,
+  shiftBookingMonthKey,
 } from "@web/booking/public-booking.format";
 import {
   isPublicBookingConflictError,
   type PublicBookingConfirmation,
   prefetchPublicBookingMonth,
+  publicBookingQueryKeys,
   useCreatePublicBookingReservationMutation,
   usePrefetchAdjacentBookingMonths,
   usePublicBookingPageQuery,
@@ -77,6 +85,26 @@ export function PublicBookingPage() {
     pageQuery.data?.maxHorizonDays,
     pageQuery.isSuccess && pageQuery.data.enabled && slotsQuery.isSuccess,
   );
+
+  useEffect(() => {
+    if (!slotsQuery.data?.bookable) {
+      return;
+    }
+    const todayKey = formatBookingDateKey(dayjs(), guestTimeZone);
+    const available = listBookingAvailableDateKeysInMonth(
+      slotsQuery.data.slots,
+      monthKey,
+      guestTimeZone,
+      todayKey,
+    );
+    if (selectedDateKey && available.includes(selectedDateKey)) {
+      return;
+    }
+    if (selectedDateKey?.startsWith(monthKey)) {
+      return;
+    }
+    setSelectedDateKey(available[0] ?? null);
+  }, [guestTimeZone, monthKey, selectedDateKey, slotsQuery.data]);
 
   if (pageQuery.isLoading) {
     return (
@@ -165,6 +193,59 @@ export function PublicBookingPage() {
     );
   };
 
+  const handleJumpToNextAvailable = async () => {
+    const todayKey = formatBookingDateKey(dayjs(), guestTimeZone);
+    const slotsByMonth = new Map<
+      string,
+      BookingSlotsResponse["slots"] | undefined
+    >();
+    let cursor = monthKey;
+    for (let step = 0; step < 14; step += 1) {
+      const cached = queryClient.getQueryData<BookingSlotsResponse>(
+        publicBookingQueryKeys.slots(slug, cursor, guestTimeZone),
+      );
+      if (cached) {
+        slotsByMonth.set(cursor, cached.slots);
+      }
+      cursor = shiftBookingMonthKey(cursor, 1, guestTimeZone);
+    }
+    if (slotsQuery.data && !slotsByMonth.has(monthKey)) {
+      slotsByMonth.set(monthKey, slotsQuery.data.slots);
+    }
+
+    for (let attempt = 0; attempt < 14; attempt += 1) {
+      const next = findNextAvailableBookingDate(
+        monthKey,
+        selectedDateKey,
+        slotsByMonth,
+        guestTimeZone,
+        todayKey,
+        page.maxHorizonDays,
+      );
+      if (!next) {
+        return;
+      }
+      if (next.dateKey) {
+        setSelectedSlotStart(null);
+        setConflictMessage(null);
+        setMonthKey(next.monthKey);
+        setSelectedDateKey(next.dateKey);
+        return;
+      }
+      await prefetchPublicBookingMonth(
+        queryClient,
+        slug,
+        next.monthKey,
+        guestTimeZone,
+        page.maxHorizonDays,
+      );
+      const fetched = queryClient.getQueryData<BookingSlotsResponse>(
+        publicBookingQueryKeys.slots(slug, next.monthKey, guestTimeZone),
+      );
+      slotsByMonth.set(next.monthKey, fetched?.slots ?? []);
+    }
+  };
+
   const handleSubmit = async (values: PublicBookingGuestFormValues) => {
     if (!selectedSlotStart) {
       return;
@@ -197,13 +278,17 @@ export function PublicBookingPage() {
   };
 
   return (
-    <PublicBookingLayout>
+    <PublicBookingLayout wide>
       <header className="flex flex-col gap-1">
         <h1 className="font-semibold text-text text-xl">
           Book with {page.hostDisplayName}
         </h1>
         <p className="text-sm text-text-muted">
           {formatDurationMinutes(page.durationMinutes)} meeting
+        </p>
+        <p className="text-sm text-text-muted">
+          Times shown in your timezone (
+          {formatGuestTimeZoneLabel(guestTimeZone)}).
         </p>
       </header>
 
@@ -218,40 +303,34 @@ export function PublicBookingPage() {
         </p>
       ) : null}
 
-      <PublicBookingMonthGrid
+      <PublicBookingPicker
         monthKey={monthKey}
         timeZone={guestTimeZone}
         maxHorizonDays={page.maxHorizonDays}
         slots={slotsQuery.data?.slots ?? []}
+        slotsPending={slotsPending}
+        slotsError={slotsQuery.isError || (!slotsPending && !slotsQuery.data)}
         selectedDateKey={selectedDateKey}
+        selectedSlotStart={selectedSlotStart}
         onMonthChange={handleMonthChange}
         onPrefetchMonth={handlePrefetchMonth}
         onSelectDate={handleSelectDay}
+        onSelectSlot={handleSelectSlot}
+        onJumpToNextAvailable={() => {
+          void handleJumpToNextAvailable();
+        }}
       />
 
-      {slotsPending ? (
-        <p className="text-sm text-text-muted">Loading open times...</p>
-      ) : slotsQuery.isError || !slotsQuery.data ? (
-        <p className="text-sm text-text-muted">
-          Could not load times. Please refresh and try again.
-        </p>
-      ) : (
-        <PublicBookingSlotPicker
-          slots={slotsQuery.data.slots}
-          guestTimeZone={guestTimeZone}
-          selectedSlotStart={selectedSlotStart}
-          onSelectSlot={handleSelectSlot}
-        />
-      )}
-
       {showGuestForm ? (
-        <PublicBookingGuestForm
-          disabled={createReservation.isPending}
-          submitDisabled={!selectedSlotStart}
-          values={guestDetails}
-          onChange={setGuestDetails}
-          onSubmit={handleSubmit}
-        />
+        <div className="sticky bottom-0 z-10 -mx-4 border-border border-t bg-background px-4 py-3 sm:static sm:mx-0 sm:border-0 sm:px-0 sm:py-0">
+          <PublicBookingGuestForm
+            disabled={createReservation.isPending}
+            submitDisabled={!selectedSlotStart}
+            values={guestDetails}
+            onChange={setGuestDetails}
+            onSubmit={handleSubmit}
+          />
+        </div>
       ) : (
         <p className="text-sm text-text-muted">Select a time to continue.</p>
       )}

--- a/packages/web/src/booking/PublicBookingPicker.tsx
+++ b/packages/web/src/booking/PublicBookingPicker.tsx
@@ -1,0 +1,69 @@
+import { PublicBookingMonthGrid } from "@web/booking/PublicBookingMonthGrid";
+import { PublicBookingSlotPicker } from "@web/booking/PublicBookingSlotPicker";
+
+interface PublicBookingPickerProps {
+  monthKey: string;
+  timeZone: string;
+  maxHorizonDays: number;
+  slots: readonly { slotStart: string }[];
+  slotsPending: boolean;
+  slotsError: boolean;
+  selectedDateKey: string | null;
+  selectedSlotStart: string | null;
+  onMonthChange: (monthKey: string) => void;
+  onPrefetchMonth: (monthKey: string) => void;
+  onSelectDate: (dateKey: string) => void;
+  onSelectSlot: (slotStart: string) => void;
+  onJumpToNextAvailable: () => void;
+}
+
+export function PublicBookingPicker({
+  monthKey,
+  timeZone,
+  maxHorizonDays,
+  slots,
+  slotsPending,
+  slotsError,
+  selectedDateKey,
+  selectedSlotStart,
+  onMonthChange,
+  onPrefetchMonth,
+  onSelectDate,
+  onSelectSlot,
+  onJumpToNextAvailable,
+}: PublicBookingPickerProps) {
+  return (
+    <div className="grid w-full min-w-0 gap-6 sm:grid-cols-2 sm:items-start">
+      <div className="min-w-0">
+        <PublicBookingMonthGrid
+          monthKey={monthKey}
+          timeZone={timeZone}
+          maxHorizonDays={maxHorizonDays}
+          slots={slots}
+          selectedDateKey={selectedDateKey}
+          onMonthChange={onMonthChange}
+          onPrefetchMonth={onPrefetchMonth}
+          onSelectDate={onSelectDate}
+        />
+      </div>
+      <div className="min-h-64 min-w-0 sm:max-h-96 sm:overflow-y-auto">
+        {slotsPending ? (
+          <p className="text-sm text-text-muted">Loading open times...</p>
+        ) : slotsError ? (
+          <p className="text-sm text-text-muted">
+            Could not load times. Please refresh and try again.
+          </p>
+        ) : (
+          <PublicBookingSlotPicker
+            slots={slots}
+            selectedDateKey={selectedDateKey}
+            guestTimeZone={timeZone}
+            selectedSlotStart={selectedSlotStart}
+            onSelectSlot={onSelectSlot}
+            onJumpToNextAvailable={onJumpToNextAvailable}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/booking/PublicBookingSlotPicker.test.tsx
+++ b/packages/web/src/booking/PublicBookingSlotPicker.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PublicBookingSlotPicker } from "@web/booking/PublicBookingSlotPicker";
+import { formatBookingSlotDateHeading } from "@web/booking/public-booking.format";
+import { describe, expect, it } from "bun:test";
+
+const timeZone = "UTC";
+const dayA = "2026-08-17T15:00:00.000Z";
+const dayALater = "2026-08-17T16:00:00.000Z";
+const dayB = "2026-08-20T15:00:00.000Z";
+
+const slots = [
+  { slotStart: dayA, slotEnd: "2026-08-17T15:30:00.000Z" },
+  { slotStart: dayALater, slotEnd: "2026-08-17T16:30:00.000Z" },
+  { slotStart: dayB, slotEnd: "2026-08-20T15:30:00.000Z" },
+];
+
+describe("PublicBookingSlotPicker", () => {
+  it("shows only the selected day's times", () => {
+    const selected: string[] = [];
+    render(
+      <PublicBookingSlotPicker
+        slots={slots}
+        selectedDateKey="2026-08-17"
+        guestTimeZone={timeZone}
+        selectedSlotStart={null}
+        onSelectSlot={(slotStart) => {
+          selected.push(slotStart);
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", {
+        name: formatBookingSlotDateHeading(dayA, timeZone),
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /3:00 PM|15:00/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /4:00 PM|16:00/i })).toBeTruthy();
+    expect(
+      screen.queryByRole("heading", {
+        name: formatBookingSlotDateHeading(dayB, timeZone),
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("offers a jump when the selected day has no times", async () => {
+    const user = userEvent.setup({ delay: null });
+    const jumped: number[] = [];
+    render(
+      <PublicBookingSlotPicker
+        slots={slots}
+        selectedDateKey="2026-08-18"
+        guestTimeZone={timeZone}
+        selectedSlotStart={null}
+        onSelectSlot={() => {}}
+        onJumpToNextAvailable={() => {
+          jumped.push(1);
+        }}
+      />,
+    );
+
+    expect(screen.getByText("No open times on this day.")).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: "Jump to next available day" }),
+    );
+    expect(jumped).toHaveLength(1);
+  });
+
+  it("offers a jump when the month has no open days", () => {
+    render(
+      <PublicBookingSlotPicker
+        slots={[]}
+        selectedDateKey={null}
+        guestTimeZone={timeZone}
+        selectedSlotStart={null}
+        onSelectSlot={() => {}}
+        onJumpToNextAvailable={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("No open times this month.")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Jump to next available day" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/booking/PublicBookingSlotPicker.tsx
+++ b/packages/web/src/booking/PublicBookingSlotPicker.tsx
@@ -1,84 +1,97 @@
-import { type BookingSlot } from "@core/types/booking.contracts";
 import {
   formatBookingSlotDateHeading,
+  formatBookingSlotDateKey,
   formatBookingSlotTime,
-  formatGuestTimeZoneLabel,
-  groupSlotsByGuestDate,
 } from "@web/booking/public-booking.format";
 
 interface PublicBookingSlotPickerProps {
-  slots: readonly BookingSlot[];
+  slots: readonly { slotStart: string }[];
+  selectedDateKey: string | null;
   guestTimeZone: string;
   selectedSlotStart: string | null;
   onSelectSlot: (slotStart: string) => void;
+  onJumpToNextAvailable?: () => void;
 }
 
 export function PublicBookingSlotPicker({
   slots,
+  selectedDateKey,
   guestTimeZone,
   selectedSlotStart,
   onSelectSlot,
+  onJumpToNextAvailable,
 }: PublicBookingSlotPickerProps) {
-  const grouped = groupSlotsByGuestDate(slots, guestTimeZone);
-  const dateKeys = [...grouped.keys()];
+  const daySlots = selectedDateKey
+    ? slots.filter(
+        (slot) =>
+          formatBookingSlotDateKey(slot.slotStart, guestTimeZone) ===
+          selectedDateKey,
+      )
+    : [];
 
-  if (dateKeys.length === 0) {
+  if (!selectedDateKey || daySlots.length === 0) {
     return (
-      <p className="text-sm text-text-muted">
-        No open times this month. Try another month or check back later.
-      </p>
-    );
-  }
-
-  return (
-    <section aria-labelledby="booking-slots-heading">
-      <div className="flex flex-col gap-1">
+      <section aria-labelledby="booking-slots-heading">
         <h2
           id="booking-slots-heading"
           className="font-medium text-base text-text"
         >
           Pick a time
         </h2>
-        <p className="text-sm text-text-muted">
-          Times shown in your timezone (
-          {formatGuestTimeZoneLabel(guestTimeZone)}).
+        <p className="mt-2 text-sm text-text-muted">
+          {selectedDateKey
+            ? "No open times on this day."
+            : "No open times this month."}
         </p>
-      </div>
-      <div className="mt-4 flex flex-col gap-5">
-        {dateKeys.map((dateKey) => {
-          const daySlots = grouped.get(dateKey) ?? [];
-          const heading = formatBookingSlotDateHeading(
-            daySlots[0]?.slotStart ?? dateKey,
-            guestTimeZone,
-          );
+        {onJumpToNextAvailable ? (
+          <button
+            type="button"
+            onClick={onJumpToNextAvailable}
+            className="mt-3 rounded-md bg-surface-panel px-3 py-2 font-medium text-sm text-text transition-colors hover:bg-surface-raised focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            Jump to next available day
+          </button>
+        ) : (
+          <p className="mt-2 text-sm text-text-muted">
+            Try another month or check back later.
+          </p>
+        )}
+      </section>
+    );
+  }
+
+  const heading = formatBookingSlotDateHeading(
+    daySlots[0]?.slotStart ?? selectedDateKey,
+    guestTimeZone,
+  );
+
+  return (
+    <section aria-labelledby="booking-slots-heading">
+      <h2
+        id="booking-slots-heading"
+        className="font-medium text-base text-text"
+      >
+        Pick a time
+      </h2>
+      <h3 className="mt-1 font-medium text-sm text-text-muted">{heading}</h3>
+      <ul className="mt-4 grid grid-cols-2 gap-2">
+        {daySlots.map((slot) => {
+          const isSelected = selectedSlotStart === slot.slotStart;
+          const label = formatBookingSlotTime(slot.slotStart, guestTimeZone);
           return (
-            <div key={dateKey} className="flex flex-col gap-2">
-              <h3 className="font-medium text-sm text-text-muted">{heading}</h3>
-              <ul className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-                {daySlots.map((slot) => {
-                  const isSelected = selectedSlotStart === slot.slotStart;
-                  const label = formatBookingSlotTime(
-                    slot.slotStart,
-                    guestTimeZone,
-                  );
-                  return (
-                    <li key={slot.slotStart}>
-                      <button
-                        type="button"
-                        aria-pressed={isSelected}
-                        onClick={() => onSelectSlot(slot.slotStart)}
-                        className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-text transition-colors hover:border-accent hover:bg-surface-panel focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent aria-pressed:border-accent aria-pressed:bg-surface-panel"
-                      >
-                        {label}
-                      </button>
-                    </li>
-                  );
-                })}
-              </ul>
-            </div>
+            <li key={slot.slotStart}>
+              <button
+                type="button"
+                aria-pressed={isSelected}
+                onClick={() => onSelectSlot(slot.slotStart)}
+                className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-text transition-colors hover:border-accent hover:bg-surface-panel focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent aria-pressed:border-accent aria-pressed:bg-surface-panel"
+              >
+                {label}
+              </button>
+            </li>
           );
         })}
-      </div>
+      </ul>
     </section>
   );
 }

--- a/packages/web/src/booking/public-booking.format.test.ts
+++ b/packages/web/src/booking/public-booking.format.test.ts
@@ -1,9 +1,11 @@
 import { DateTimeSchema, TimeZoneSchema } from "@core/types/domain-primitives";
 import dayjs from "@core/util/date/dayjs";
 import {
+  findNextAvailableBookingDate,
   formatBookingMonthKey,
   getPublicBookingMonthWindow,
   isBookingMonthAvailable,
+  listBookingAvailableDateKeysInMonth,
   listBookingAvailableDayKeys,
   listBookingMonthGridWeeks,
   shiftBookingMonthKey,
@@ -133,5 +135,91 @@ describe("stepBookingAvailableDay", () => {
     expect(
       stepBookingAvailableDay("2026-08-24", available, utc, "nextWeek"),
     ).toBe("2026-08-24");
+  });
+});
+
+describe("findNextAvailableBookingDate", () => {
+  const augustSlots = [
+    { slotStart: "2026-08-17T15:00:00.000Z" },
+    { slotStart: "2026-08-20T15:00:00.000Z" },
+  ];
+  const septemberSlots = [{ slotStart: "2026-09-02T15:00:00.000Z" }];
+  const now = dayjs("2026-08-15T12:00:00.000Z");
+
+  it("returns the next open day later in the same month", () => {
+    const slotsByMonth = new Map<
+      string,
+      readonly { slotStart: string }[] | undefined
+    >([["2026-08", augustSlots]]);
+
+    expect(
+      findNextAvailableBookingDate(
+        "2026-08",
+        "2026-08-17",
+        slotsByMonth,
+        utc,
+        "2026-08-15",
+        60,
+        now,
+      ),
+    ).toEqual({ monthKey: "2026-08", dateKey: "2026-08-20" });
+  });
+
+  it("crosses into a prefetched month when the current month is exhausted", () => {
+    const slotsByMonth = new Map<
+      string,
+      readonly { slotStart: string }[] | undefined
+    >([
+      ["2026-08", augustSlots],
+      ["2026-09", septemberSlots],
+    ]);
+
+    expect(
+      findNextAvailableBookingDate(
+        "2026-08",
+        "2026-08-20",
+        slotsByMonth,
+        utc,
+        "2026-08-15",
+        60,
+        now,
+      ),
+    ).toEqual({ monthKey: "2026-09", dateKey: "2026-09-02" });
+  });
+
+  it("asks the caller to fetch a month that is not in cache", () => {
+    const slotsByMonth = new Map<
+      string,
+      readonly { slotStart: string }[] | undefined
+    >([["2026-08", []]]);
+
+    expect(
+      findNextAvailableBookingDate(
+        "2026-08",
+        null,
+        slotsByMonth,
+        utc,
+        "2026-08-15",
+        60,
+        now,
+      ),
+    ).toEqual({ monthKey: "2026-09", dateKey: null });
+  });
+});
+
+describe("listBookingAvailableDateKeysInMonth", () => {
+  it("keeps only in-month days that have slots and are not before today", () => {
+    expect(
+      listBookingAvailableDateKeysInMonth(
+        [
+          { slotStart: "2026-08-10T15:00:00.000Z" },
+          { slotStart: "2026-08-17T15:00:00.000Z" },
+          { slotStart: "2026-09-02T15:00:00.000Z" },
+        ],
+        "2026-08",
+        utc,
+        "2026-08-15",
+      ),
+    ).toEqual(["2026-08-17"]);
   });
 });

--- a/packages/web/src/booking/public-booking.format.ts
+++ b/packages/web/src/booking/public-booking.format.ts
@@ -157,23 +157,6 @@ export function formatBookingSlotDateHeading(
   }).format(new Date(slotStart));
 }
 
-export function groupSlotsByGuestDate<T extends { slotStart: string }>(
-  slots: readonly T[],
-  timeZone: string,
-): Map<string, T[]> {
-  const grouped = new Map<string, T[]>();
-  for (const slot of slots) {
-    const key = formatBookingSlotDateKey(slot.slotStart, timeZone);
-    const existing = grouped.get(key);
-    if (existing) {
-      existing.push(slot);
-    } else {
-      grouped.set(key, [slot]);
-    }
-  }
-  return grouped;
-}
-
 export function formatDurationMinutes(minutes: number): string {
   if (minutes === 60) {
     return "1 hour";
@@ -335,4 +318,59 @@ export function formatBookingMonthDayLabel(
     year: "numeric",
     timeZone,
   }).format(dayjs.tz(dateKey, timeZone).toDate());
+}
+
+export function listBookingAvailableDateKeysInMonth(
+  slots: readonly { slotStart: string }[],
+  monthKey: string,
+  timeZone: string,
+  todayKey: string,
+): string[] {
+  return listBookingAvailableDayKeys(
+    listBookingMonthGridWeeks(
+      monthKey,
+      timeZone,
+      collectBookingAvailableDateKeys(slots, timeZone),
+      todayKey,
+    ),
+  );
+}
+
+export function findNextAvailableBookingDate(
+  monthKey: string,
+  afterDateKey: string | null,
+  slotsByMonth: ReadonlyMap<
+    string,
+    readonly { slotStart: string }[] | undefined
+  >,
+  timeZone: string,
+  todayKey: string,
+  maxHorizonDays: number,
+  now?: Dayjs,
+): { monthKey: string; dateKey: string | null } | null {
+  let month = monthKey;
+  let after = afterDateKey;
+  for (let step = 0; step < 14; step += 1) {
+    if (!isBookingMonthAvailable(month, timeZone, maxHorizonDays, now)) {
+      return null;
+    }
+    if (!slotsByMonth.has(month)) {
+      return { monthKey: month, dateKey: null };
+    }
+    const days = listBookingAvailableDateKeysInMonth(
+      slotsByMonth.get(month) ?? [],
+      month,
+      timeZone,
+      todayKey,
+    );
+    const afterKey = after;
+    const next =
+      afterKey == null ? days[0] : days.find((dateKey) => dateKey > afterKey);
+    if (next) {
+      return { monthKey: month, dateKey: next };
+    }
+    month = shiftBookingMonthKey(month, 1, timeZone);
+    after = null;
+  }
+  return null;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #3002.

The guest booking page now uses a two-pane picker: month grid on the left, the selected day's times on the right. Below `sm` (375px) the panes stack, grid first, with no horizontal scroll. The page defaults to the first open day in the current month. An empty month offers **Jump to next available day**, which can cross a month boundary using prefetched or then-fetched slot data.

Host name, duration, and timezone stay in the page header. Confirmation and cancel pages stay at `max-w-lg`; only the picker page uses `max-w-3xl`.

Out of scope: slot-to-details summary (#3003) and loading skeletons (#3004).

![Desktop two-pane picker, August 31 selected](https://cursor.com/artifacts/c/art-22300ea0-321b-4e0a-9649-2fc5b5e3cbf2)
![Selected 3:00 PM slot with guest form](https://cursor.com/artifacts/c/art-cb98e191-2d82-4a10-8a2d-b53935403912)
![Jump lands on September 2 with 4:00 PM](https://cursor.com/artifacts/c/art-35147a55-7225-4dd8-a2c9-76e98bff6eab)
![375px stacked layout, no horizontal scroll](https://cursor.com/artifacts/c/art-11a3c7bc-becb-4e70-8a03-b9b57b6da5d5)

<a href="https://cursor.com/agents/bc-46079ef9-363d-42a6-8efb-4d17bad565a3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbooking_two_pane_desktop_select.mp4"><img src="https://cursor.com/artifacts/c/art-98cc0281-2379-4811-b06a-e82651aec198" alt="booking_two_pane_desktop_select.mp4" /></a>

## Simplicity

The slot list is a date filter over the existing month payload. Jump walks cached months, then prefetches the next missing month instead of adding a new API.

## Automated validation

- Focused web tests (page, slot picker, layout, format): 28 pass
- `bun run type-check` pass
- `bun run lint` pass (repo-wide nursery warnings only, unchanged)
- `bun run verify`: web, type-check, lint, knip, a11y pass. First e2e pass reused a stale `:9150` server from the previous month-grid session and failed three new specs. After stopping that process and re-running against a fresh server: **17/17** booking e2e + booking a11y pass, including day-scoped slots, jump across months, 375px stack, and slot-pane scroll.

## Independent review

Read `origin/main...HEAD` (10 files). No confirmed findings.

- Two-pane uses `sm:grid-cols-2` and `min-w-0`; mobile stack is the default grid.
- Default day is the first in-month available key; month nav still clears the date so the new month can default.
- Jump does not go through `handleMonthChange`, so month and date land together.
- No em-dashes in new copy. Slot buttons keep `focus-visible:ring-2 focus-visible:ring-accent`.
- Confirmation/cancel layouts stay narrow.

## Test plan

- `cd packages/web && TZ=UTC NODE_ENV=test bun test --preload ./src/__tests__/web.preload.ts` on booking page, slot picker, layout, and format tests: 28 pass
- `bun run type-check`
- `bun run lint`
- `bunx playwright test e2e/booking/public-booking.spec.ts e2e/accessibility/booking-a11y.spec.ts`: 17 pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46079ef9-363d-42a6-8efb-4d17bad565a3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46079ef9-363d-42a6-8efb-4d17bad565a3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

