### PR TITLE
feat(booking): slot-to-details flow with summary, focus, and change-time

### DIFF
--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -18,6 +18,21 @@ test("the public booking page renders with no automatically detectable accessibi
   await expectNoAxeViolations(page, { checkpoint: "public booking page" });
 });
 
+test("the public booking details step has no automatically detectable accessibility violations", async ({
+  page,
+}) => {
+  const { slotStart } = buildBookableSlot();
+  await preparePublicBookingPage(page);
+
+  await page
+    .getByRole("button", { name: formatSlotButtonLabel(slotStart) })
+    .click();
+  await expect(
+    page.getByRole("heading", { name: "Your details" }),
+  ).toBeVisible();
+  await expectNoAxeViolations(page, { checkpoint: "public booking details" });
+});
+
 test("the public booking conflict alert has no automatically detectable accessibility violations", async ({
   page,
 }) => {

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -62,6 +62,8 @@ export interface PublicBookingStubOptions {
   bookable?: boolean;
   /** When set, POST /reservations returns this status instead of 200. */
   confirmStatus?: number;
+  /** When set, the reservation POST waits until this resolves (for in-flight UI). */
+  holdConfirm?: Promise<void>;
 }
 
 export interface CapturedBookingRequests {
@@ -138,6 +140,9 @@ export async function preparePublicBookingPage(
     ) {
       const body = request.postDataJSON() as Record<string, unknown>;
       captured.reservationPosts.push(body);
+      if (options.holdConfirm) {
+        await options.holdConfirm;
+      }
       if (options.confirmStatus === 409) {
         return route.fulfill(json({}, 409));
       }

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -396,7 +396,7 @@ test.describe("public booking page", () => {
 
     await expect(
       page.getByRole("heading", { name: "Pick a time" }),
-    ).toBeVisible();
+    ).toBeFocused();
     await expect(page.getByRole("button", { name: dayName })).toHaveAttribute(
       "aria-pressed",
       "true",

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -428,6 +428,7 @@ test.describe("public booking page", () => {
     await page.getByRole("button", { name: "Confirm booking" }).click();
     const confirming = page.getByRole("button", { name: "Confirming..." });
     await expect(confirming).toHaveAttribute("aria-busy", "true");
+    await expect.poll(() => captured.reservationPosts.length).toBe(1);
     await confirming.click({ force: true });
     expect(captured.reservationPosts).toHaveLength(1);
     release();

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -22,6 +22,12 @@ test.describe("public booking page", () => {
     await page
       .getByRole("button", { name: formatSlotButtonLabel(slotStart) })
       .click();
+    await expect(
+      page.getByRole("heading", { name: "Your details" }),
+    ).toBeFocused();
+    await expect(
+      page.getByRole("button", { name: "Change time" }),
+    ).toBeVisible();
     await page.getByLabel("Name").fill("Guest User");
     await page.getByLabel("Email").fill("guest@example.com");
     await page.getByRole("button", { name: "Confirm booking" }).click();
@@ -178,13 +184,12 @@ test.describe("public booking page", () => {
       .getByRole("button", { name: formatSlotButtonLabel(second.slotStart) })
       .click();
     await expect(
-      page.getByRole("button", {
-        name: formatSlotButtonLabel(second.slotStart),
-      }),
-    ).toHaveAttribute("aria-pressed", "true");
+      page.getByRole("heading", { name: "Your details" }),
+    ).toBeVisible();
     await expect(
       page.getByRole("button", { name: "Confirm booking" }),
     ).toBeEnabled();
+    await expect(page.getByLabel("Name")).toHaveValue("Guest User");
   });
 
   test("renders a prefetched month without issuing a new slots request", async ({
@@ -363,5 +368,72 @@ test.describe("public booking page", () => {
     await expect(
       page.getByRole("button", { name: "Confirm booking" }),
     ).toBeVisible();
+  });
+
+  test("returns to the picker from Change time with the day still selected", async ({
+    page,
+  }) => {
+    const { slotStart } = buildBookableSlot();
+    await preparePublicBookingPage(page);
+
+    const dayName = await page.evaluate((iso) => {
+      const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      return new Intl.DateTimeFormat(undefined, {
+        weekday: "long",
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+        timeZone,
+      }).format(new Date(iso));
+    }, slotStart);
+
+    await page
+      .getByRole("button", { name: formatSlotButtonLabel(slotStart) })
+      .click();
+    await page.getByLabel("Name").fill("Guest User");
+    await page.getByLabel("Email").fill("guest@example.com");
+    await page.getByRole("button", { name: "Change time" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Pick a time" }),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: dayName })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await expect(
+      page.getByRole("button", { name: formatSlotButtonLabel(slotStart) }),
+    ).toHaveAttribute("aria-pressed", "true");
+
+    await page
+      .getByRole("button", { name: formatSlotButtonLabel(slotStart) })
+      .click();
+    await expect(page.getByLabel("Name")).toHaveValue("Guest User");
+    await expect(page.getByLabel("Email")).toHaveValue("guest@example.com");
+  });
+
+  test("does not POST twice while confirm is in flight", async ({ page }) => {
+    const { slotStart } = buildBookableSlot();
+    let release!: () => void;
+    const holdConfirm = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const captured = await preparePublicBookingPage(page, { holdConfirm });
+
+    await page
+      .getByRole("button", { name: formatSlotButtonLabel(slotStart) })
+      .click();
+    await page.getByLabel("Name").fill("Guest User");
+    await page.getByLabel("Email").fill("guest@example.com");
+    await page.getByRole("button", { name: "Confirm booking" }).click();
+    const confirming = page.getByRole("button", { name: "Confirming..." });
+    await expect(confirming).toHaveAttribute("aria-busy", "true");
+    await confirming.click({ force: true });
+    expect(captured.reservationPosts).toHaveLength(1);
+    release();
+    await expect(
+      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+    ).toBeVisible();
+    expect(captured.reservationPosts).toHaveLength(1);
   });
 });

--- a/packages/web/src/booking/PublicBookingDetailsStep.tsx
+++ b/packages/web/src/booking/PublicBookingDetailsStep.tsx
@@ -1,0 +1,67 @@
+import { type Ref } from "react";
+import {
+  type PublicBookingGuestDetails,
+  PublicBookingGuestForm,
+  type PublicBookingGuestFormValues,
+} from "@web/booking/PublicBookingGuestForm";
+import { PublicBookingSlotSummary } from "@web/booking/PublicBookingSlotSummary";
+
+interface PublicBookingDetailsStepProps {
+  headingRef: Ref<HTMLHeadingElement>;
+  slotStart: string;
+  durationMinutes: number;
+  timeZone: string;
+  disabled: boolean;
+  values: PublicBookingGuestDetails;
+  onChange: (values: PublicBookingGuestDetails) => void;
+  onSubmit: (values: PublicBookingGuestFormValues) => void;
+  onChangeTime: () => void;
+}
+
+export function PublicBookingDetailsStep({
+  headingRef,
+  slotStart,
+  durationMinutes,
+  timeZone,
+  disabled,
+  values,
+  onChange,
+  onSubmit,
+  onChangeTime,
+}: PublicBookingDetailsStepProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-start justify-between gap-3">
+        <h2
+          ref={headingRef}
+          id="booking-form-heading"
+          tabIndex={-1}
+          className="font-medium text-base text-text focus:outline-none focus:ring-2 focus:ring-accent"
+        >
+          Your details
+        </h2>
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={onChangeTime}
+          className="shrink-0 text-accent text-sm underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          Change time
+        </button>
+      </div>
+      <PublicBookingSlotSummary
+        slotStart={slotStart}
+        durationMinutes={durationMinutes}
+        timeZone={timeZone}
+      />
+      <PublicBookingGuestForm
+        disabled={disabled}
+        submitDisabled={false}
+        showHeading={false}
+        values={values}
+        onChange={onChange}
+        onSubmit={onSubmit}
+      />
+    </div>
+  );
+}

--- a/packages/web/src/booking/PublicBookingGuestForm.tsx
+++ b/packages/web/src/booking/PublicBookingGuestForm.tsx
@@ -15,6 +15,7 @@ export interface PublicBookingGuestFormValues
 interface PublicBookingGuestFormProps {
   disabled: boolean;
   submitDisabled: boolean;
+  showHeading?: boolean;
   values: PublicBookingGuestDetails;
   onChange: (values: PublicBookingGuestDetails) => void;
   onSubmit: (values: PublicBookingGuestFormValues) => void;
@@ -23,12 +24,16 @@ interface PublicBookingGuestFormProps {
 export function PublicBookingGuestForm({
   disabled,
   submitDisabled,
+  showHeading = true,
   values,
   onChange,
   onSubmit,
 }: PublicBookingGuestFormProps) {
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    if (disabled || submitDisabled) {
+      return;
+    }
     onSubmit({
       guestName: values.guestName.trim(),
       guestEmail: values.guestEmail.trim(),
@@ -43,9 +48,14 @@ export function PublicBookingGuestForm({
       className="flex flex-col gap-4"
       onSubmit={handleSubmit}
     >
-      <h2 id="booking-form-heading" className="font-medium text-base text-text">
-        Your details
-      </h2>
+      {showHeading ? (
+        <h2
+          id="booking-form-heading"
+          className="font-medium text-base text-text"
+        >
+          Your details
+        </h2>
+      ) : null}
       <label className="flex flex-col gap-1 text-sm">
         <span className="text-text-muted">Name</span>
         <input
@@ -89,9 +99,10 @@ export function PublicBookingGuestForm({
       <button
         type="submit"
         disabled={disabled || submitDisabled}
+        aria-busy={disabled || undefined}
         className="rounded-md bg-accent px-4 py-2 font-medium text-on-accent transition-colors hover:bg-accent-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-60"
       >
-        Confirm booking
+        {disabled ? "Confirming..." : "Confirm booking"}
       </button>
     </form>
   );

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -3,7 +3,7 @@ import {
   createRouter,
   RouterProvider,
 } from "@tanstack/react-router";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { rest } from "msw";
 import { Status } from "@core/errors/status.codes";
@@ -13,6 +13,7 @@ import {
   formatBookingMonthDayLabel,
   formatBookingMonthHeading,
   formatBookingSlotDateKey,
+  formatBookingSlotLabel,
   shiftBookingMonthKey,
 } from "@web/booking/public-booking.format";
 import { ENV_WEB } from "@web/common/constants/env.constants";
@@ -177,6 +178,23 @@ describe("PublicBookingPage", () => {
         name: slotTimePattern(currentSlot.slotStart),
       }),
     );
+    const detailsHeading = screen.getByRole("heading", {
+      name: "Your details",
+    });
+    await waitFor(() => {
+      expect(detailsHeading).toHaveFocus();
+    });
+    expect(screen.getByText("When")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        formatBookingSlotLabel(currentSlot.slotStart, guestTimeZone),
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Duration")).toBeInTheDocument();
+    expect(screen.getByText("Timezone")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Pick a time" }),
+    ).not.toBeInTheDocument();
     await user.type(screen.getByLabelText("Name"), "Guest User");
     await user.type(screen.getByLabelText("Email"), "guest@example.com");
     await user.click(screen.getByRole("button", { name: "Confirm booking" }));
@@ -259,6 +277,9 @@ describe("PublicBookingPage", () => {
     await waitFor(() => {
       expect(slotRequests).toBeGreaterThan(1);
     });
+    expect(
+      screen.getByRole("heading", { name: "Pick a time" }),
+    ).toBeInTheDocument();
 
     await user.click(
       screen.getByRole("button", {
@@ -266,8 +287,12 @@ describe("PublicBookingPage", () => {
       }),
     );
     expect(
+      await screen.findByRole("heading", { name: "Your details" }),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole("button", { name: "Confirm booking" }),
     ).toBeEnabled();
+    expect(screen.getByLabelText("Name")).toHaveValue("Guest User");
   });
 
   it("does not boot the calendar shortcut overlay on public booking routes", async () => {
@@ -512,5 +537,115 @@ describe("PublicBookingPage", () => {
         name: formatBookingMonthDayLabel(nextDateKey, guestTimeZone),
       }),
     ).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("returns to the picker with the day and typed fields intact", async () => {
+    const user = userEvent.setup({ delay: null });
+    server.use(pageHandler(), slotsInWindow([currentSlot, laterCurrentSlot]));
+
+    renderBookingRoute("/book/tylerdane");
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: slotTimePattern(currentSlot.slotStart),
+      }),
+    );
+    await user.type(screen.getByLabelText("Name"), "Guest User");
+    await user.type(screen.getByLabelText("Email"), "guest@example.com");
+    await user.type(screen.getByLabelText("Notes (optional)"), "Bring slides");
+    await user.click(screen.getByRole("button", { name: "Change time" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Pick a time" }),
+    ).toBeInTheDocument();
+    const dateKey = formatBookingSlotDateKey(
+      currentSlot.slotStart,
+      guestTimeZone,
+    );
+    expect(
+      screen.getByRole("button", {
+        name: formatBookingMonthDayLabel(dateKey, guestTimeZone),
+      }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(
+      screen.getByRole("button", {
+        name: slotTimePattern(currentSlot.slotStart),
+      }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(screen.queryByLabelText("Name")).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: slotTimePattern(laterCurrentSlot.slotStart),
+      }),
+    );
+    expect(screen.getByLabelText("Name")).toHaveValue("Guest User");
+    expect(screen.getByLabelText("Email")).toHaveValue("guest@example.com");
+    expect(screen.getByLabelText("Notes (optional)")).toHaveValue(
+      "Bring slides",
+    );
+    expect(
+      screen.getByText(
+        formatBookingSlotLabel(laterCurrentSlot.slotStart, guestTimeZone),
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("shows an in-flight confirm label and posts only once", async () => {
+    const user = userEvent.setup({ delay: null });
+    let posts = 0;
+    const delay = (ms: number) =>
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, ms);
+      });
+
+    server.use(
+      pageHandler(),
+      slotsInWindow([currentSlot]),
+      rest.post(
+        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/reservations`,
+        async (_req, res, ctx) => {
+          posts += 1;
+          await delay(80);
+          return res(
+            ctx.status(Status.OK),
+            ctx.json({
+              reservationId: "000000000000000000000099",
+              slotStart: currentSlot.slotStart,
+              slotEnd: currentSlot.slotEnd,
+              guestTimeZone: "UTC",
+              cancelUrl:
+                "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+            }),
+          );
+        },
+      ),
+    );
+
+    renderBookingRoute("/book/tylerdane");
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: slotTimePattern(currentSlot.slotStart),
+      }),
+    );
+    await user.type(screen.getByLabelText("Name"), "Guest User");
+    await user.type(screen.getByLabelText("Email"), "guest@example.com");
+    const confirm = screen.getByRole("button", { name: "Confirm booking" });
+    await user.click(confirm);
+    const confirming = await screen.findByRole("button", {
+      name: "Confirming...",
+    });
+    expect(confirming).toHaveAttribute("aria-busy", "true");
+    expect(confirming).toBeDisabled();
+    fireEvent.submit(confirming.closest("form") as HTMLFormElement);
+    expect(posts).toBe(1);
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "You are booked with Tyler Dane",
+      }),
+    ).toBeInTheDocument();
+    expect(posts).toBe(1);
   });
 });

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -555,9 +555,12 @@ describe("PublicBookingPage", () => {
     await user.type(screen.getByLabelText("Notes (optional)"), "Bring slides");
     await user.click(screen.getByRole("button", { name: "Change time" }));
 
-    expect(
-      await screen.findByRole("heading", { name: "Pick a time" }),
-    ).toBeInTheDocument();
+    const pickerHeading = await screen.findByRole("heading", {
+      name: "Pick a time",
+    });
+    await waitFor(() => {
+      expect(pickerHeading).toHaveFocus();
+    });
     const dateKey = formatBookingSlotDateKey(
       currentSlot.slotStart,
       guestTimeZone,

--- a/packages/web/src/booking/PublicBookingPage.tsx
+++ b/packages/web/src/booking/PublicBookingPage.tsx
@@ -74,7 +74,9 @@ export function PublicBookingPage() {
   const [step, setStep] = useState<"picker" | "details">("picker");
   const conflictAlertRef = useRef<HTMLParagraphElement>(null);
   const detailsHeadingRef = useRef<HTMLHeadingElement>(null);
+  const pickerHeadingRef = useRef<HTMLHeadingElement>(null);
   const submitInFlightRef = useRef(false);
+  const pendingPickerFocusRef = useRef(false);
 
   useEffect(() => {
     if (conflictMessage) {
@@ -85,6 +87,11 @@ export function PublicBookingPage() {
   useEffect(() => {
     if (step === "details") {
       detailsHeadingRef.current?.focus();
+      return;
+    }
+    if (pendingPickerFocusRef.current) {
+      pendingPickerFocusRef.current = false;
+      pickerHeadingRef.current?.focus();
     }
   }, [step]);
 
@@ -197,6 +204,7 @@ export function PublicBookingPage() {
   };
 
   const handleChangeTime = () => {
+    pendingPickerFocusRef.current = true;
     setStep("picker");
   };
 
@@ -352,6 +360,7 @@ export function PublicBookingPage() {
             }
             selectedDateKey={selectedDateKey}
             selectedSlotStart={selectedSlotStart}
+            slotsHeadingRef={pickerHeadingRef}
             onMonthChange={handleMonthChange}
             onPrefetchMonth={handlePrefetchMonth}
             onSelectDate={handleSelectDay}
@@ -371,7 +380,7 @@ export function PublicBookingPage() {
                 onSubmit={handleSubmit}
               />
             </div>
-          ) : (
+          ) : selectedSlotStart ? null : (
             <p className="text-sm text-text-muted">
               Select a time to continue.
             </p>

--- a/packages/web/src/booking/PublicBookingPage.tsx
+++ b/packages/web/src/booking/PublicBookingPage.tsx
@@ -8,6 +8,7 @@ import {
 import dayjs from "@core/util/date/dayjs";
 import { PublicBookingNotFoundError } from "@web/api/public-booking.api";
 import { PublicBookingConfirmationView } from "@web/booking/PublicBookingConfirmationView";
+import { PublicBookingDetailsStep } from "@web/booking/PublicBookingDetailsStep";
 import {
   type PublicBookingGuestDetails,
   PublicBookingGuestForm,
@@ -70,13 +71,22 @@ export function PublicBookingPage() {
   const [confirmation, setConfirmation] =
     useState<PublicBookingConfirmation | null>(null);
   const [conflictMessage, setConflictMessage] = useState<string | null>(null);
+  const [step, setStep] = useState<"picker" | "details">("picker");
   const conflictAlertRef = useRef<HTMLParagraphElement>(null);
+  const detailsHeadingRef = useRef<HTMLHeadingElement>(null);
+  const submitInFlightRef = useRef(false);
 
   useEffect(() => {
     if (conflictMessage) {
       conflictAlertRef.current?.focus();
     }
   }, [conflictMessage]);
+
+  useEffect(() => {
+    if (step === "details") {
+      detailsHeadingRef.current?.focus();
+    }
+  }, [step]);
 
   usePrefetchAdjacentBookingMonths(
     slug,
@@ -157,13 +167,15 @@ export function PublicBookingPage() {
     );
   }
 
-  const showGuestForm = selectedSlotStart !== null || conflictMessage !== null;
+  const showDetailsStep = step === "details" && selectedSlotStart !== null;
+  const showConflictForm = !showDetailsStep && conflictMessage !== null;
   const slotsPending = slotsQuery.isLoading && !slotsQuery.data;
 
   const handleSelectSlot = (slotStart: string) => {
     setSelectedSlotStart(slotStart);
     setSelectedDateKey(formatBookingSlotDateKey(slotStart, guestTimeZone));
     setConflictMessage(null);
+    setStep("details");
   };
 
   const handleSelectDay = (dateKey: string) => {
@@ -181,6 +193,11 @@ export function PublicBookingPage() {
     setSelectedSlotStart(null);
     setSelectedDateKey(null);
     setConflictMessage(null);
+    setStep("picker");
+  };
+
+  const handleChangeTime = () => {
+    setStep("picker");
   };
 
   const handlePrefetchMonth = (nextMonthKey: string) => {
@@ -228,6 +245,7 @@ export function PublicBookingPage() {
       if (next.dateKey) {
         setSelectedSlotStart(null);
         setConflictMessage(null);
+        setStep("picker");
         setMonthKey(next.monthKey);
         setSelectedDateKey(next.dateKey);
         return;
@@ -247,10 +265,11 @@ export function PublicBookingPage() {
   };
 
   const handleSubmit = async (values: PublicBookingGuestFormValues) => {
-    if (!selectedSlotStart) {
+    if (!selectedSlotStart || submitInFlightRef.current) {
       return;
     }
 
+    submitInFlightRef.current = true;
     setConflictMessage(null);
 
     try {
@@ -270,10 +289,13 @@ export function PublicBookingPage() {
           "This time is no longer available. Pick another slot.",
         );
         setSelectedSlotStart(null);
+        setStep("picker");
         await slotsQuery.refetch();
         return;
       }
       setConflictMessage("Could not confirm this booking. Please try again.");
+    } finally {
+      submitInFlightRef.current = false;
     }
   };
 
@@ -303,36 +325,58 @@ export function PublicBookingPage() {
         </p>
       ) : null}
 
-      <PublicBookingPicker
-        monthKey={monthKey}
-        timeZone={guestTimeZone}
-        maxHorizonDays={page.maxHorizonDays}
-        slots={slotsQuery.data?.slots ?? []}
-        slotsPending={slotsPending}
-        slotsError={slotsQuery.isError || (!slotsPending && !slotsQuery.data)}
-        selectedDateKey={selectedDateKey}
-        selectedSlotStart={selectedSlotStart}
-        onMonthChange={handleMonthChange}
-        onPrefetchMonth={handlePrefetchMonth}
-        onSelectDate={handleSelectDay}
-        onSelectSlot={handleSelectSlot}
-        onJumpToNextAvailable={() => {
-          void handleJumpToNextAvailable();
-        }}
-      />
-
-      {showGuestForm ? (
+      {showDetailsStep && selectedSlotStart ? (
         <div className="sticky bottom-0 z-10 -mx-4 border-border border-t bg-background px-4 py-3 sm:static sm:mx-0 sm:border-0 sm:px-0 sm:py-0">
-          <PublicBookingGuestForm
+          <PublicBookingDetailsStep
+            headingRef={detailsHeadingRef}
+            slotStart={selectedSlotStart}
+            durationMinutes={page.durationMinutes}
+            timeZone={guestTimeZone}
             disabled={createReservation.isPending}
-            submitDisabled={!selectedSlotStart}
             values={guestDetails}
             onChange={setGuestDetails}
             onSubmit={handleSubmit}
+            onChangeTime={handleChangeTime}
           />
         </div>
       ) : (
-        <p className="text-sm text-text-muted">Select a time to continue.</p>
+        <>
+          <PublicBookingPicker
+            monthKey={monthKey}
+            timeZone={guestTimeZone}
+            maxHorizonDays={page.maxHorizonDays}
+            slots={slotsQuery.data?.slots ?? []}
+            slotsPending={slotsPending}
+            slotsError={
+              slotsQuery.isError || (!slotsPending && !slotsQuery.data)
+            }
+            selectedDateKey={selectedDateKey}
+            selectedSlotStart={selectedSlotStart}
+            onMonthChange={handleMonthChange}
+            onPrefetchMonth={handlePrefetchMonth}
+            onSelectDate={handleSelectDay}
+            onSelectSlot={handleSelectSlot}
+            onJumpToNextAvailable={() => {
+              void handleJumpToNextAvailable();
+            }}
+          />
+
+          {showConflictForm ? (
+            <div className="sticky bottom-0 z-10 -mx-4 border-border border-t bg-background px-4 py-3 sm:static sm:mx-0 sm:border-0 sm:px-0 sm:py-0">
+              <PublicBookingGuestForm
+                disabled={createReservation.isPending}
+                submitDisabled={!selectedSlotStart}
+                values={guestDetails}
+                onChange={setGuestDetails}
+                onSubmit={handleSubmit}
+              />
+            </div>
+          ) : (
+            <p className="text-sm text-text-muted">
+              Select a time to continue.
+            </p>
+          )}
+        </>
       )}
     </PublicBookingLayout>
   );

--- a/packages/web/src/booking/PublicBookingPicker.tsx
+++ b/packages/web/src/booking/PublicBookingPicker.tsx
@@ -1,3 +1,4 @@
+import { type Ref } from "react";
 import { PublicBookingMonthGrid } from "@web/booking/PublicBookingMonthGrid";
 import { PublicBookingSlotPicker } from "@web/booking/PublicBookingSlotPicker";
 
@@ -10,6 +11,7 @@ interface PublicBookingPickerProps {
   slotsError: boolean;
   selectedDateKey: string | null;
   selectedSlotStart: string | null;
+  slotsHeadingRef?: Ref<HTMLHeadingElement>;
   onMonthChange: (monthKey: string) => void;
   onPrefetchMonth: (monthKey: string) => void;
   onSelectDate: (dateKey: string) => void;
@@ -26,6 +28,7 @@ export function PublicBookingPicker({
   slotsError,
   selectedDateKey,
   selectedSlotStart,
+  slotsHeadingRef,
   onMonthChange,
   onPrefetchMonth,
   onSelectDate,
@@ -59,6 +62,7 @@ export function PublicBookingPicker({
             selectedDateKey={selectedDateKey}
             guestTimeZone={timeZone}
             selectedSlotStart={selectedSlotStart}
+            headingRef={slotsHeadingRef}
             onSelectSlot={onSelectSlot}
             onJumpToNextAvailable={onJumpToNextAvailable}
           />

--- a/packages/web/src/booking/PublicBookingSlotPicker.tsx
+++ b/packages/web/src/booking/PublicBookingSlotPicker.tsx
@@ -1,3 +1,4 @@
+import { type Ref } from "react";
 import {
   formatBookingSlotDateHeading,
   formatBookingSlotDateKey,
@@ -9,6 +10,7 @@ interface PublicBookingSlotPickerProps {
   selectedDateKey: string | null;
   guestTimeZone: string;
   selectedSlotStart: string | null;
+  headingRef?: Ref<HTMLHeadingElement>;
   onSelectSlot: (slotStart: string) => void;
   onJumpToNextAvailable?: () => void;
 }
@@ -18,6 +20,7 @@ export function PublicBookingSlotPicker({
   selectedDateKey,
   guestTimeZone,
   selectedSlotStart,
+  headingRef,
   onSelectSlot,
   onJumpToNextAvailable,
 }: PublicBookingSlotPickerProps) {
@@ -33,8 +36,10 @@ export function PublicBookingSlotPicker({
     return (
       <section aria-labelledby="booking-slots-heading">
         <h2
+          ref={headingRef}
           id="booking-slots-heading"
-          className="font-medium text-base text-text"
+          tabIndex={-1}
+          className="font-medium text-base text-text focus:outline-none focus:ring-2 focus:ring-accent"
         >
           Pick a time
         </h2>
@@ -68,8 +73,10 @@ export function PublicBookingSlotPicker({
   return (
     <section aria-labelledby="booking-slots-heading">
       <h2
+        ref={headingRef}
         id="booking-slots-heading"
-        className="font-medium text-base text-text"
+        tabIndex={-1}
+        className="font-medium text-base text-text focus:outline-none focus:ring-2 focus:ring-accent"
       >
         Pick a time
       </h2>

--- a/packages/web/src/booking/PublicBookingSlotSummary.tsx
+++ b/packages/web/src/booking/PublicBookingSlotSummary.tsx
@@ -1,0 +1,34 @@
+import {
+  formatBookingSlotLabel,
+  formatDurationMinutes,
+  formatGuestTimeZoneLabel,
+} from "@web/booking/public-booking.format";
+
+interface PublicBookingSlotSummaryProps {
+  slotStart: string;
+  durationMinutes: number;
+  timeZone: string;
+}
+
+export function PublicBookingSlotSummary({
+  slotStart,
+  durationMinutes,
+  timeZone,
+}: PublicBookingSlotSummaryProps) {
+  return (
+    <dl className="rounded-md border border-border bg-surface-panel px-3 py-2 text-sm text-text">
+      <div>
+        <dt className="text-text-muted">When</dt>
+        <dd>{formatBookingSlotLabel(slotStart, timeZone)}</dd>
+      </div>
+      <div className="mt-2">
+        <dt className="text-text-muted">Duration</dt>
+        <dd>{formatDurationMinutes(durationMinutes)}</dd>
+      </div>
+      <div className="mt-2">
+        <dt className="text-text-muted">Timezone</dt>
+        <dd>{formatGuestTimeZoneLabel(timeZone)}</dd>
+      </div>
+    </dl>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Picking a time on the public booking page now opens a details step on the same `/book/$username` route. Guests see a summary of the chosen date, time, duration, and timezone, focus moves to **Your details**, and **Change time** returns to the two-pane picker with the day (and chip) still selected and typed name/email/notes preserved. Focus returns to **Pick a time**.

Confirming a booking shows **Confirming...** with `aria-busy` and cannot POST twice.

Closes #3003.

## Simplicity

Local `picker | details` step state. No extra route. Picker unmounts while details is showing so the form is not buried under the grid.

## Automated validation

- Web RTL: details heading focused after slot click, summary terms, Change time restores picker + fields + picker heading focus, in-flight confirm posts once, 409 still keeps fields and returns to the picker.
- Playwright: details focus, Change time, double-submit, 409 recovery, details-step axe checkpoint.

## Independent review

`origin/main...HEAD` (explore reviewer): two findings, both addressed:
- Change time now focuses the Pick a time heading.
- Continue hint is hidden while a slot remains selected.

## Test plan

- Focused web tests: 15 pass
- `bun run verify`: test:web, type-check, lint, knip, test:a11y passed; test:e2e failed once on a race in the double-submit spec, then passed after waiting for the first POST
- `bunx playwright test e2e/booking/public-booking.spec.ts --grep "does not POST twice"` pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e51f3b10-0faf-4d26-8e85-ef13497c1459?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e51f3b10-0faf-4d26-8e85-ef13497c1459&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

