### PR TITLE
refactor(booking): remove duplication left by the WP-01..WP-09 booking merges

### DIFF
--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -1,5 +1,8 @@
 import { MongoServerError, type ObjectId } from "mongodb";
-import { computeBookingSlots } from "@core/booking/compute-booking-slots";
+import {
+  type ComputeBookingSlotsInput,
+  computeBookingSlots,
+} from "@core/booking/compute-booking-slots";
 import {
   BookingSlotsQuerySchema,
   type BookingSlotsResponse,
@@ -12,7 +15,10 @@ import {
   toPublicBookingPage,
 } from "@core/types/booking.contracts";
 import { DateTimeSchema, type EventId } from "@core/types/domain-primitives";
-import { BUSY_QUERY_MAX_WINDOW_MS } from "@core/types/sync/availability.contracts";
+import {
+  BUSY_QUERY_MAX_WINDOW_MS,
+  type BusyAvailabilityResponse,
+} from "@core/types/sync/availability.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { bookingError } from "@backend/booking/booking.error";
 import {
@@ -83,6 +89,37 @@ const parseSlotsQuery = (rawQuery: unknown) => {
 const slotEndForStart = (slotStart: Date, durationMinutes: number): Date =>
   new Date(slotStart.getTime() + durationMinutes * 60_000);
 
+/**
+ * Every page-derived knob the slot engine reads, in one place.
+ *
+ * `getSlots` and `createReservation` must agree exactly on what the engine is
+ * told, or a slot the guest was offered could be rejected (or, worse, accepted)
+ * by the re-check. Building both inputs here removes the chance of the two
+ * eleven-field literals drifting apart.
+ */
+const slotEngineInputForPage = (
+  page: BookingPageRecord,
+  availability: BusyAvailabilityResponse,
+  confirmedReservationStarts: readonly Date[],
+  window: { now: Date; windowStart: Date; windowEnd: Date },
+): ComputeBookingSlotsInput => ({
+  timeZone: page.timeZone,
+  durationMinutes: page.durationMinutes,
+  weeklyAvailability: page.weeklyAvailability,
+  minNoticeHours: page.minNoticeHours,
+  maxHorizonDays: page.maxHorizonDays,
+  bufferMinutes: page.bufferMinutes,
+  maxBookingsPerDay: page.maxBookingsPerDay,
+  busyIntervals: availability.intervals.map((interval) => ({
+    start: new Date(interval.start),
+    end: new Date(interval.end),
+  })),
+  confirmedReservationStarts,
+  now: window.now,
+  windowStart: window.windowStart,
+  windowEnd: window.windowEnd,
+});
+
 export class PublicBookingService {
   constructor(private readonly calendarBookingPort?: CalendarBookingPort) {}
 
@@ -136,23 +173,13 @@ export class PublicBookingService {
 
     const confirmedStarts =
       await bookingReservationRepository.listConfirmedStartsByPageId(page._id);
-    const slotStarts = computeBookingSlots({
-      timeZone: page.timeZone,
-      durationMinutes: page.durationMinutes,
-      weeklyAvailability: page.weeklyAvailability,
-      minNoticeHours: page.minNoticeHours,
-      maxHorizonDays: page.maxHorizonDays,
-      bufferMinutes: page.bufferMinutes,
-      maxBookingsPerDay: page.maxBookingsPerDay,
-      busyIntervals: availability.intervals.map((interval) => ({
-        start: new Date(interval.start),
-        end: new Date(interval.end),
-      })),
-      confirmedReservationStarts: confirmedStarts,
-      now,
-      windowStart,
-      windowEnd,
-    });
+    const slotStarts = computeBookingSlots(
+      slotEngineInputForPage(page, availability, confirmedStarts, {
+        now,
+        windowStart,
+        windowEnd,
+      }),
+    );
 
     return BookingSlotsResponseSchema.parse({
       bookable: true,
@@ -200,23 +227,13 @@ export class PublicBookingService {
     const confirmedStarts =
       await bookingReservationRepository.listConfirmedStartsByPageId(page._id);
     const allowedStarts = new Set(
-      computeBookingSlots({
-        timeZone: page.timeZone,
-        durationMinutes: page.durationMinutes,
-        weeklyAvailability: page.weeklyAvailability,
-        minNoticeHours: page.minNoticeHours,
-        maxHorizonDays: page.maxHorizonDays,
-        bufferMinutes: page.bufferMinutes,
-        maxBookingsPerDay: page.maxBookingsPerDay,
-        busyIntervals: availability.intervals.map((interval) => ({
-          start: new Date(interval.start),
-          end: new Date(interval.end),
-        })),
-        confirmedReservationStarts: confirmedStarts,
-        now,
-        windowStart: slotStart,
-        windowEnd: slotEnd,
-      }).map((start) => Date.parse(start)),
+      computeBookingSlots(
+        slotEngineInputForPage(page, availability, confirmedStarts, {
+          now,
+          windowStart: slotStart,
+          windowEnd: slotEnd,
+        }),
+      ).map((start) => Date.parse(start)),
     );
 
     if (!allowedStarts.has(slotStart.getTime())) {

--- a/packages/core/src/booking/compute-booking-slots.ts
+++ b/packages/core/src/booking/compute-booking-slots.ts
@@ -103,14 +103,22 @@ const isSlotBlocked = (
 const localDateKey = (instant: Date, timeZone: string): string =>
   dayjs(instant).tz(timeZone).format("YYYY-MM-DD");
 
-const countReservationsOnLocalDate = (
+/**
+ * Reservations tallied by their local date, in one pass. The day loop below
+ * would otherwise re-scan every reservation - and pay a timezone conversion
+ * for each - once per day in the window.
+ */
+const countReservationsByLocalDate = (
   reservationStarts: readonly Date[],
-  localDate: string,
   timeZone: string,
-): number =>
-  reservationStarts.filter(
-    (start) => localDateKey(start, timeZone) === localDate,
-  ).length;
+): Map<string, number> => {
+  const counts = new Map<string, number>();
+  for (const start of reservationStarts) {
+    const localDate = localDateKey(start, timeZone);
+    counts.set(localDate, (counts.get(localDate) ?? 0) + 1);
+  }
+  return counts;
+};
 
 const availabilityForWeekday = (
   weeklyAvailability: WeeklyAvailability,
@@ -159,6 +167,11 @@ export const computeBookingSlots = (
     ...reservationIntervals,
   ]);
 
+  const reservationsPerLocalDate =
+    maxBookingsPerDay === null
+      ? null
+      : countReservationsByLocalDate(confirmedReservationStarts, timeZone);
+
   const slots: string[] = [];
   const seenStarts = new Set<number>();
 
@@ -172,11 +185,7 @@ export const computeBookingSlots = (
 
     if (
       maxBookingsPerDay !== null &&
-      countReservationsOnLocalDate(
-        confirmedReservationStarts,
-        localDate,
-        timeZone,
-      ) >= maxBookingsPerDay
+      (reservationsPerLocalDate?.get(localDate) ?? 0) >= maxBookingsPerDay
     ) {
       dayCursor = dayCursor.add(1, "day");
       continue;

--- a/packages/web/src/booking/BookingCheckboxRow.tsx
+++ b/packages/web/src/booking/BookingCheckboxRow.tsx
@@ -1,0 +1,31 @@
+import { type ReactNode } from "react";
+
+interface BookingCheckboxRowProps {
+  checked: boolean;
+  children: ReactNode;
+  onChange: (checked: boolean) => void;
+}
+
+/**
+ * The checkbox-and-label row the booking settings use five times over: every
+ * blocking calendar (grouped and ungrouped alike) and each buffer/limit
+ * option. They were five copies of the same markup, so a class tweak on one
+ * silently left the others behind.
+ */
+export function BookingCheckboxRow({
+  checked,
+  children,
+  onChange,
+}: BookingCheckboxRowProps) {
+  return (
+    <label className="flex items-center gap-2 text-sm text-text">
+      <input
+        checked={checked}
+        className="c-all-day-checkbox"
+        onChange={(event) => onChange(event.target.checked)}
+        type="checkbox"
+      />
+      {children}
+    </label>
+  );
+}

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -13,6 +13,7 @@ import {
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
 import { useAppAccess } from "@web/billing/useAppAccess";
+import { BookingCheckboxRow } from "@web/booking/BookingCheckboxRow";
 import { BookingConnectGooglePrompt } from "@web/booking/BookingConnectGooglePrompt";
 import { BookingCopyLink } from "@web/booking/BookingCopyLink";
 import { BookingFieldLabel } from "@web/booking/BookingFieldLabel";
@@ -58,6 +59,11 @@ import { useEditSequenceShortcut } from "@web/shortcuts/useEditSequenceShortcut"
 import { useEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 
 const DURATION_OPTIONS: BookingDurationMinutes[] = [15, 30, 45, 60];
+
+// Named so the value the checkbox writes and the value its label promises can
+// only ever be the same number.
+const DEFAULT_BUFFER_MINUTES = 30;
+const DEFAULT_MAX_BOOKINGS_PER_DAY = 4;
 
 const isSavedBookingPage = (
   page: AdminPutBookingPageInput | AdminGetBookingPageResponse,
@@ -204,7 +210,6 @@ export function BookingSettingsSection({
     availabilityCalendars,
     connections,
   );
-
   const updateForm = (patch: Partial<AdminPutBookingPageInput>) => {
     setForm((current) => ({ ...current, ...patch }));
     setEnableError(null);
@@ -233,6 +238,16 @@ export function BookingSettingsSection({
       };
     });
   };
+
+  const renderBlockingCalendar = (calendar: Calendar) => (
+    <BookingCheckboxRow
+      checked={blockingSet.has(calendar.id)}
+      key={calendar.id}
+      onChange={(checked) => toggleBlockingCalendar(calendar.id, checked)}
+    >
+      {calendar.name}
+    </BookingCheckboxRow>
+  );
 
   const handleEnableChange = (enabled: boolean) => {
     if (enabled && !canEnableBookingPage(form, writableCalendars)) {
@@ -396,43 +411,10 @@ export function BookingSettingsSection({
                   <p className="text-text-muted text-xs">
                     {group.accountEmail}
                   </p>
-                  {group.calendars.map((calendar) => (
-                    <label
-                      className="flex items-center gap-2 text-sm text-text"
-                      key={calendar.id}
-                    >
-                      <input
-                        checked={blockingSet.has(calendar.id)}
-                        className="c-all-day-checkbox"
-                        onChange={(event) =>
-                          toggleBlockingCalendar(
-                            calendar.id,
-                            event.target.checked,
-                          )
-                        }
-                        type="checkbox"
-                      />
-                      {calendar.name}
-                    </label>
-                  ))}
+                  {group.calendars.map(renderBlockingCalendar)}
                 </div>
               ))}
-            {ungrouped.map((calendar) => (
-              <label
-                className="flex items-center gap-2 text-sm text-text"
-                key={calendar.id}
-              >
-                <input
-                  checked={blockingSet.has(calendar.id)}
-                  className="c-all-day-checkbox"
-                  onChange={(event) =>
-                    toggleBlockingCalendar(calendar.id, event.target.checked)
-                  }
-                  type="checkbox"
-                />
-                {calendar.name}
-              </label>
-            ))}
+            {ungrouped.map(renderBlockingCalendar)}
           </>
         )}
       </fieldset>
@@ -509,41 +491,36 @@ export function BookingSettingsSection({
           ) : null}
         </legend>
 
-        <label className="flex items-center gap-2 text-sm text-text">
-          <input
-            checked={form.bufferMinutes !== null}
-            className="c-all-day-checkbox"
-            onChange={(event) =>
-              updateForm({ bufferMinutes: event.target.checked ? 30 : null })
-            }
-            type="checkbox"
-          />
-          Buffer between appointments (30 minutes)
-        </label>
+        <BookingCheckboxRow
+          checked={form.bufferMinutes !== null}
+          onChange={(checked) =>
+            updateForm({
+              bufferMinutes: checked ? DEFAULT_BUFFER_MINUTES : null,
+            })
+          }
+        >
+          Buffer between appointments ({DEFAULT_BUFFER_MINUTES} minutes)
+        </BookingCheckboxRow>
 
-        <label className="flex items-center gap-2 text-sm text-text">
-          <input
-            checked={form.maxBookingsPerDay !== null}
-            className="c-all-day-checkbox"
-            onChange={(event) =>
-              updateForm({ maxBookingsPerDay: event.target.checked ? 4 : null })
-            }
-            type="checkbox"
-          />
-          Max bookings per day (4)
-        </label>
+        <BookingCheckboxRow
+          checked={form.maxBookingsPerDay !== null}
+          onChange={(checked) =>
+            updateForm({
+              maxBookingsPerDay: checked ? DEFAULT_MAX_BOOKINGS_PER_DAY : null,
+            })
+          }
+        >
+          Max bookings per day ({DEFAULT_MAX_BOOKINGS_PER_DAY})
+        </BookingCheckboxRow>
 
-        <label className="flex items-center gap-2 text-sm text-text">
-          <input
-            checked={form.guestsCanInviteOthers}
-            className="c-all-day-checkbox"
-            onChange={(event) =>
-              updateForm({ guestsCanInviteOthers: event.target.checked })
-            }
-            type="checkbox"
-          />
+        <BookingCheckboxRow
+          checked={form.guestsCanInviteOthers}
+          onChange={(guestsCanInviteOthers) =>
+            updateForm({ guestsCanInviteOthers })
+          }
+        >
           Guest can invite others
-        </label>
+        </BookingCheckboxRow>
       </fieldset>
 
       <OverlayPanelActions align="start">

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -10,9 +10,9 @@ import { Status } from "@core/errors/status.codes";
 import { server } from "@web/__tests__/__mocks__/server/mock.server";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
 import {
+  formatBookingDateKey,
   formatBookingMonthDayLabel,
   formatBookingMonthHeading,
-  formatBookingSlotDateKey,
   shiftBookingMonthKey,
 } from "@web/booking/public-booking.format";
 import { ENV_WEB } from "@web/common/constants/env.constants";
@@ -162,10 +162,7 @@ describe("PublicBookingPage", () => {
       await screen.findByText(/Times shown in your timezone/),
     ).toBeInTheDocument();
 
-    const dateKey = formatBookingSlotDateKey(
-      currentSlot.slotStart,
-      guestTimeZone,
-    );
+    const dateKey = formatBookingDateKey(currentSlot.slotStart, guestTimeZone);
     expect(
       await screen.findByRole("button", {
         name: formatBookingMonthDayLabel(dateKey, guestTimeZone),
@@ -503,7 +500,7 @@ describe("PublicBookingPage", () => {
         name: slotTimePattern(nextMonthSlot.slotStart),
       }),
     ).toBeInTheDocument();
-    const nextDateKey = formatBookingSlotDateKey(
+    const nextDateKey = formatBookingDateKey(
       nextMonthSlot.slotStart,
       guestTimeZone,
     );

--- a/packages/web/src/booking/PublicBookingPage.tsx
+++ b/packages/web/src/booking/PublicBookingPage.tsx
@@ -20,7 +20,6 @@ import {
   findNextAvailableBookingDate,
   formatBookingDateKey,
   formatBookingMonthKey,
-  formatBookingSlotDateKey,
   formatDurationMinutes,
   formatGuestTimeZoneLabel,
   listBookingAvailableDateKeysInMonth,
@@ -162,7 +161,7 @@ export function PublicBookingPage() {
 
   const handleSelectSlot = (slotStart: string) => {
     setSelectedSlotStart(slotStart);
-    setSelectedDateKey(formatBookingSlotDateKey(slotStart, guestTimeZone));
+    setSelectedDateKey(formatBookingDateKey(slotStart, guestTimeZone));
     setConflictMessage(null);
   };
 
@@ -170,7 +169,7 @@ export function PublicBookingPage() {
     setSelectedDateKey(dateKey);
     if (
       selectedSlotStart &&
-      formatBookingSlotDateKey(selectedSlotStart, guestTimeZone) !== dateKey
+      formatBookingDateKey(selectedSlotStart, guestTimeZone) !== dateKey
     ) {
       setSelectedSlotStart(null);
     }

--- a/packages/web/src/booking/PublicBookingSlotPicker.tsx
+++ b/packages/web/src/booking/PublicBookingSlotPicker.tsx
@@ -1,6 +1,6 @@
 import {
+  formatBookingDateKey,
   formatBookingSlotDateHeading,
-  formatBookingSlotDateKey,
   formatBookingSlotTime,
 } from "@web/booking/public-booking.format";
 
@@ -24,7 +24,7 @@ export function PublicBookingSlotPicker({
   const daySlots = selectedDateKey
     ? slots.filter(
         (slot) =>
-          formatBookingSlotDateKey(slot.slotStart, guestTimeZone) ===
+          formatBookingDateKey(slot.slotStart, guestTimeZone) ===
           selectedDateKey,
       )
     : [];

--- a/packages/web/src/booking/public-booking.format.ts
+++ b/packages/web/src/booking/public-booking.format.ts
@@ -133,18 +133,6 @@ export function formatBookingSlotTime(
   }).format(new Date(slotStart));
 }
 
-export function formatBookingSlotDateKey(
-  slotStart: string,
-  timeZone: string,
-): string {
-  return new Intl.DateTimeFormat("en-CA", {
-    timeZone,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  }).format(new Date(slotStart));
-}
-
 export function formatBookingSlotDateHeading(
   slotStart: string,
   timeZone: string,
@@ -164,6 +152,11 @@ export function formatDurationMinutes(minutes: number): string {
   return `${minutes} minutes`;
 }
 
+/**
+ * The one YYYY-MM-DD-in-a-timezone key. Slot starts used to go through a
+ * separate `Intl` "en-CA" formatter, which is a second way to be right about
+ * the same thing, and so a second thing to keep right.
+ */
 export function formatBookingDateKey(
   instant: Date | string | Dayjs,
   timeZone: string,
@@ -177,7 +170,7 @@ export function collectBookingAvailableDateKeys(
 ): Set<string> {
   const keys = new Set<string>();
   for (const slot of slots) {
-    keys.add(formatBookingSlotDateKey(slot.slotStart, timeZone));
+    keys.add(formatBookingDateKey(slot.slotStart, timeZone));
   }
   return keys;
 }


### PR DESCRIPTION
## Summary

A scheduled tech-debt sweep over the last 7 days of merged commits (#2959 through #3022, mostly the booking work packages and their follow-ups). Four duplication/complexity items found, each its own commit:

**1. `perf(core)` — reservations tallied once, not once per day** (`compute-booking-slots.ts`)
`computeBookingSlots` re-filtered the entire confirmed-reservation list, paying a timezone conversion per reservation, once for every day in the window: O(days x reservations) where O(reservations) will do. Now built as a `Map` in a single pass before the loop, and only when a max-per-day cap is actually set. Keyed by the same `dayjs(instant).tz(timeZone)` YYYY-MM-DD string the loop already compared against, so the result is identical.

**2. `refactor(backend)` — one slot-engine input** (`public-booking.service.ts`)
`getSlots` and `createReservation` each spelled out the same eleven-field `computeBookingSlots` literal, differing only in the window. These two must agree exactly: if they drift, a slot the guest was offered gets rejected by the reservation re-check (or worse, the other way). Extracted `slotEngineInputForPage`, which also folds the repeated busy-interval `Date` mapping into one place.

**3. `refactor(web)` — one date-key formatter** (`public-booking.format.ts`)
`formatBookingSlotDateKey` (via `Intl` `"en-CA"`) and `formatBookingDateKey` (via dayjs) both produced a YYYY-MM-DD key for an instant in a timezone, and `PublicBookingPage` called both, a few lines apart, for the same purpose. Dropped the `Intl` copy and pointed the slot call sites at `formatBookingDateKey`.

**4. `refactor(web)` — shared checkbox row** (new `BookingCheckboxRow.tsx`)
`BookingSettingsSection` repeated the same label-wraps-checkbox markup five times: once per blocking calendar in the grouped branch, again in the ungrouped branch, and once for each of the three buffer/limit options. A class tweak on one copy would quietly leave the other four behind. Also named `DEFAULT_BUFFER_MINUTES` / `DEFAULT_MAX_BOOKINGS_PER_DAY`, which were previously written twice each: once as the value the checkbox sets, once as the number its label promises ("(30 minutes)", "(4)").

## Simplicity

Behavior-preserving throughout. Net -139/+162 lines, and the additions are mostly the extracted helpers plus the comments explaining what each one prevents. No new abstractions beyond the three named above, and each replaces two or more existing copies rather than anticipating a future caller.

The one deliberate non-change: the "Enable booking page" checkbox keeps its inline markup, because it carries `bookingFieldAttrs` on the label element. Threading arbitrary label props through `BookingCheckboxRow` to absorb that single case would cost more than the copy saves.

## Automated validation

No user-visible behavior changes to exercise; the guest booking page and host settings render exactly as before. Covered by the existing suites below, which include the booking page/settings/slot-picker component tests and the slot-engine unit tests.

## Independent review

Not run: this is an unattended scheduled sweep with no `/review` specialist verdict to point at. Reviewer's eyes are the check here, which is part of why this is not on auto-merge (see Test plan).

## Test plan

```
bun install
bun run lint          # clean; the 19 warnings are pre-existing on main
bun type-check        # pass
bun test:core         # 652 pass, 0 fail
bun test:web          # 2963 pass, 0 fail
bun test:backend      # could not run in this environment
```

`bun test:backend` fails before any test body executes: `mongodb-memory-server` cannot bind a port (`Failed to listen at ::`) in this sandbox. Verified the same failure on a clean `main` checkout with the changes stashed, so it is environmental, not from this diff. CI runs it.

Left off auto-merge deliberately: at 8 files and 301 changed lines this exceeds the sweep's own auto-merge caps (under 8 files, under 250 lines), so it wants a human look before landing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcZ9oq2KuDxEV3HZQUL853)_