### PR TITLE
feat(booking): loading skeletons and live announcements for guest slots

### DIFF
--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -33,6 +33,18 @@ test("the public booking details step has no automatically detectable accessibil
   await expectNoAxeViolations(page, { checkpoint: "public booking details" });
 });
 
+test("the public booking slots error has no automatically detectable accessibility violations", async ({
+  page,
+}) => {
+  const slotFailGate = { fail: true };
+  await preparePublicBookingPage(page, { slotFailGate });
+
+  await expect(page.getByRole("button", { name: "Retry" })).toBeVisible();
+  await expectNoAxeViolations(page, {
+    checkpoint: "public booking slots error",
+  });
+});
+
 test("the public booking conflict alert has no automatically detectable accessibility violations", async ({
   page,
 }) => {

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -64,6 +64,10 @@ export interface PublicBookingStubOptions {
   confirmStatus?: number;
   /** When set, the reservation POST waits until this resolves (for in-flight UI). */
   holdConfirm?: Promise<void>;
+  /** When true, slot GETs return 500 until `slotFailGate.fail` is set false. */
+  slotFailGate?: { fail: boolean };
+  /** When set, the first slot GET waits until this resolves. */
+  holdFirstSlots?: Promise<void>;
 }
 
 export interface CapturedBookingRequests {
@@ -120,6 +124,12 @@ export async function preparePublicBookingPage(
         start: windowStart,
         end: windowEnd,
       });
+      if (options.holdFirstSlots && captured.slotGets === 1) {
+        await options.holdFirstSlots;
+      }
+      if (options.slotFailGate?.fail) {
+        return route.fulfill(json({}, 500));
+      }
       const startMs = windowStart ? Date.parse(windowStart) : Number.NaN;
       const endMs = windowEnd ? Date.parse(windowEnd) : Number.NaN;
       const slotsInWindow = slots.filter((entry) => {

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -208,7 +208,7 @@ test.describe("public booking page", () => {
     await expect(
       page.getByRole("button", { name: "Previous month" }),
     ).toBeEnabled();
-    await expect(page.getByText("Loading open times...")).toHaveCount(0);
+    await expect(page.getByText("Loading open times")).toHaveCount(0);
     await expect.poll(() => captured.slotGets).toBeGreaterThanOrEqual(3);
     const afterArrive = captured.slotGets;
 
@@ -436,5 +436,51 @@ test.describe("public booking page", () => {
       page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
     ).toBeVisible();
     expect(captured.reservationPosts).toHaveLength(1);
+  });
+
+  test("announces slot loading without replacing the host heading", async ({
+    page,
+  }) => {
+    let release!: () => void;
+    const holdFirstSlots = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await preparePublicBookingPage(page, { holdFirstSlots });
+
+    await expect(
+      page.getByRole("heading", { name: "Book with Tyler Dane" }),
+    ).toBeVisible();
+    await expect(page.getByRole("status")).toHaveText("Loading open times");
+    await expect(
+      page.getByRole("heading", { name: "Pick a time" }),
+    ).toHaveCount(0);
+    release();
+    await expect(
+      page.getByRole("heading", { name: "Pick a time" }),
+    ).toBeVisible();
+    await expect(page.getByRole("status")).toHaveText("Times loaded");
+  });
+
+  test("retries a failed slots request without a page reload", async ({
+    page,
+  }) => {
+    const slot = buildBookableSlot();
+    const slotFailGate = { fail: true };
+    await preparePublicBookingPage(page, {
+      slots: [slot],
+      slotFailGate,
+    });
+
+    await expect(page.getByRole("button", { name: "Retry" })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Book with Tyler Dane" }),
+    ).toBeVisible();
+    slotFailGate.fail = false;
+    await page.getByRole("button", { name: "Retry" }).click();
+    await expect(
+      page.getByRole("button", {
+        name: formatSlotButtonLabel(slot.slotStart),
+      }),
+    ).toBeVisible();
   });
 });

--- a/packages/web/src/booking/PublicBookingMonthGridSkeleton.tsx
+++ b/packages/web/src/booking/PublicBookingMonthGridSkeleton.tsx
@@ -1,0 +1,38 @@
+interface PublicBookingMonthGridSkeletonProps {
+  monthHeading: string;
+}
+
+export function PublicBookingMonthGridSkeleton({
+  monthHeading,
+}: PublicBookingMonthGridSkeletonProps) {
+  return (
+    <div className="flex flex-col gap-3" aria-hidden="true">
+      <div className="flex h-10 items-center justify-between gap-2">
+        <div className="h-9 w-20 rounded-md bg-surface-panel motion-safe:animate-pulse" />
+        <p className="font-medium text-base text-text">{monthHeading}</p>
+        <div className="h-9 w-20 rounded-md bg-surface-panel motion-safe:animate-pulse" />
+      </div>
+      <div className="w-full">
+        <div className="grid grid-cols-7">
+          {Array.from({ length: 7 }, (_, index) => (
+            <div className="pb-1" key={`weekday-${String(index)}`}>
+              <div className="mx-auto h-3 w-6 rounded-sm bg-surface-panel motion-safe:animate-pulse" />
+            </div>
+          ))}
+        </div>
+        {Array.from({ length: 6 }, (_, week) => (
+          <div className="grid grid-cols-7" key={`week-${String(week)}`}>
+            {Array.from({ length: 7 }, (_, day) => (
+              <div
+                className="p-0.5"
+                key={`cell-${String(week)}-${String(day)}`}
+              >
+                <div className="h-10 w-full rounded-md bg-surface-panel motion-safe:animate-pulse" />
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -357,11 +357,9 @@ describe("PublicBookingPage", () => {
     expect(
       await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
     ).toBeInTheDocument();
-    await waitFor(() => {
-      expect(
-        screen.queryByText("Loading open times..."),
-      ).not.toBeInTheDocument();
-    });
+    expect(
+      await screen.findByRole("heading", { name: "Pick a time" }),
+    ).toBeInTheDocument();
   });
 
   it("renders a prefetched month without a new slots request", async () => {
@@ -378,18 +376,21 @@ describe("PublicBookingPage", () => {
     renderBookingRoute("/book/tylerdane");
 
     await screen.findByRole("heading", { name: "Book with Tyler Dane" });
-    await waitFor(() => {
-      expect(
-        screen.queryByText("Loading open times..."),
-      ).not.toBeInTheDocument();
-    });
+    expect(
+      await screen.findByRole("heading", { name: "Pick a time" }),
+    ).toBeInTheDocument();
     await waitFor(() => {
       expect(slotRequests).toBeGreaterThanOrEqual(2);
     });
     const requestsAfterPrefetch = slotRequests;
 
     await user.click(screen.getByRole("button", { name: "Next month" }));
-    expect(screen.queryByText("Loading open times...")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Book with Tyler Dane" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Pick a time" }),
+    ).toBeInTheDocument();
     await waitFor(() => {
       expect(slotRequests).toBeGreaterThanOrEqual(requestsAfterPrefetch);
     });
@@ -650,5 +651,151 @@ describe("PublicBookingPage", () => {
       }),
     ).toBeInTheDocument();
     expect(posts).toBe(1);
+  });
+
+  it("keeps the host heading visible and announces slot loading", async () => {
+    const delay = (ms: number) =>
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, ms);
+      });
+
+    server.use(
+      pageHandler(),
+      rest.get(
+        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/slots`,
+        async (_req, res, ctx) => {
+          await delay(80);
+          return res(
+            ctx.status(Status.OK),
+            ctx.json({ bookable: true, slots: [currentSlot] }),
+          );
+        },
+      ),
+    );
+
+    renderBookingRoute("/book/tylerdane");
+
+    expect(
+      await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
+    ).toBeInTheDocument();
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Loading open times",
+    );
+    expect(
+      screen.queryByRole("heading", { name: "Pick a time" }),
+    ).not.toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "Pick a time" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Times loaded");
+    expect(
+      screen.getByRole("heading", { name: "Book with Tyler Dane" }),
+    ).toBeInTheDocument();
+  });
+
+  it("retries a failed slots request without leaving the page", async () => {
+    const user = userEvent.setup({ delay: null });
+    const slotFailGate = { fail: true };
+
+    server.use(
+      pageHandler(),
+      rest.get(
+        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/slots`,
+        (_req, res, ctx) => {
+          if (slotFailGate.fail) {
+            return res(ctx.status(Status.INTERNAL_SERVER), ctx.json({}));
+          }
+          return res(
+            ctx.status(Status.OK),
+            ctx.json({ bookable: true, slots: [currentSlot] }),
+          );
+        },
+      ),
+    );
+
+    renderBookingRoute("/book/tylerdane");
+
+    expect(
+      await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: "Retry" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Could not load times",
+    );
+    slotFailGate.fail = false;
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+    expect(
+      await screen.findByRole("button", {
+        name: slotTimePattern(currentSlot.slotStart),
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Book with Tyler Dane" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a slot-pane skeleton on an unfetched month without replacing the header", async () => {
+    const user = userEvent.setup({ delay: null });
+    const delay = (ms: number) =>
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, ms);
+      });
+    let currentMonthRequests = 0;
+
+    server.use(
+      pageHandler(),
+      rest.get(
+        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/slots`,
+        async (req, res, ctx) => {
+          const start = req.url.searchParams.get("start") ?? "";
+          const isCurrentMonth = start.startsWith(`${currentMonthKey}-`);
+          if (isCurrentMonth) {
+            currentMonthRequests += 1;
+            return res(
+              ctx.status(Status.OK),
+              ctx.json({ bookable: true, slots: [currentSlot] }),
+            );
+          }
+          await delay(80);
+          return res(
+            ctx.status(Status.OK),
+            ctx.json({ bookable: true, slots: [nextMonthSlot] }),
+          );
+        },
+      ),
+    );
+
+    renderBookingRoute("/book/tylerdane");
+
+    expect(
+      await screen.findByRole("heading", { name: "Pick a time" }),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(currentMonthRequests).toBeGreaterThan(0);
+    });
+
+    await user.click(screen.getByRole("button", { name: "Next month" }));
+    expect(
+      screen.getByRole("heading", { name: "Book with Tyler Dane" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        name: formatBookingMonthHeading(
+          shiftBookingMonthKey(currentMonthKey, 1, guestTimeZone),
+          guestTimeZone,
+        ),
+      }),
+    ).toBeInTheDocument();
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Loading open times",
+    );
+    expect(
+      screen.queryByRole("heading", { name: "Pick a time" }),
+    ).not.toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "Pick a time" }),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -698,9 +698,13 @@ describe("PublicBookingPage", () => {
     const slotFailGate = { fail: true };
 
     server.use(
-      pageHandler(),
       rest.get(
-        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/slots`,
+        `${ENV_WEB.API_BASEURL}/booking/pages/retryhost`,
+        (_req, res, ctx) =>
+          res(ctx.status(Status.OK), ctx.json(publicPagePayload())),
+      ),
+      rest.get(
+        `${ENV_WEB.API_BASEURL}/booking/pages/retryhost/slots`,
         (_req, res, ctx) => {
           if (slotFailGate.fail) {
             return res(ctx.status(Status.INTERNAL_SERVER), ctx.json({}));
@@ -713,7 +717,7 @@ describe("PublicBookingPage", () => {
       ),
     );
 
-    renderBookingRoute("/book/tylerdane");
+    renderBookingRoute("/book/retryhost");
 
     expect(
       await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
@@ -726,6 +730,12 @@ describe("PublicBookingPage", () => {
     );
     slotFailGate.fail = false;
     await user.click(screen.getByRole("button", { name: "Retry" }));
+    const pickTime = await screen.findByRole("heading", {
+      name: "Pick a time",
+    });
+    await waitFor(() => {
+      expect(pickTime).toHaveFocus();
+    });
     expect(
       await screen.findByRole("button", {
         name: slotTimePattern(currentSlot.slotStart),

--- a/packages/web/src/booking/PublicBookingPage.tsx
+++ b/packages/web/src/booking/PublicBookingPage.tsx
@@ -176,9 +176,11 @@ export function PublicBookingPage() {
 
   const showDetailsStep = step === "details" && selectedSlotStart !== null;
   const showConflictForm = !showDetailsStep && conflictMessage !== null;
-  const slotsPending =
-    slotsQuery.isPending || (slotsQuery.isFetching && !slotsQuery.data);
-  const slotsError = slotsQuery.isError && !slotsPending;
+  const slotsHasData = Boolean(slotsQuery.data);
+  const slotsFetching =
+    !slotsHasData && (slotsQuery.isPending || slotsQuery.isFetching);
+  const slotsError = Boolean(slotsQuery.isError && !slotsHasData);
+  const slotsPending = slotsFetching && !slotsError;
 
   const handleSelectSlot = (slotStart: string) => {
     setSelectedSlotStart(slotStart);
@@ -358,6 +360,7 @@ export function PublicBookingPage() {
             slots={slotsQuery.data?.slots ?? []}
             slotsPending={slotsPending}
             slotsError={slotsError}
+            slotsFetching={slotsFetching}
             selectedDateKey={selectedDateKey}
             selectedSlotStart={selectedSlotStart}
             slotsHeadingRef={pickerHeadingRef}

--- a/packages/web/src/booking/PublicBookingPage.tsx
+++ b/packages/web/src/booking/PublicBookingPage.tsx
@@ -176,7 +176,9 @@ export function PublicBookingPage() {
 
   const showDetailsStep = step === "details" && selectedSlotStart !== null;
   const showConflictForm = !showDetailsStep && conflictMessage !== null;
-  const slotsPending = slotsQuery.isLoading && !slotsQuery.data;
+  const slotsPending =
+    slotsQuery.isPending || (slotsQuery.isFetching && !slotsQuery.data);
+  const slotsError = slotsQuery.isError && !slotsPending;
 
   const handleSelectSlot = (slotStart: string) => {
     setSelectedSlotStart(slotStart);
@@ -355,9 +357,7 @@ export function PublicBookingPage() {
             maxHorizonDays={page.maxHorizonDays}
             slots={slotsQuery.data?.slots ?? []}
             slotsPending={slotsPending}
-            slotsError={
-              slotsQuery.isError || (!slotsPending && !slotsQuery.data)
-            }
+            slotsError={slotsError}
             selectedDateKey={selectedDateKey}
             selectedSlotStart={selectedSlotStart}
             slotsHeadingRef={pickerHeadingRef}
@@ -367,6 +367,9 @@ export function PublicBookingPage() {
             onSelectSlot={handleSelectSlot}
             onJumpToNextAvailable={() => {
               void handleJumpToNextAvailable();
+            }}
+            onRetrySlots={() => {
+              void slotsQuery.refetch();
             }}
           />
 

--- a/packages/web/src/booking/PublicBookingPicker.tsx
+++ b/packages/web/src/booking/PublicBookingPicker.tsx
@@ -13,6 +13,7 @@ interface PublicBookingPickerProps {
   slots: readonly { slotStart: string }[];
   slotsPending: boolean;
   slotsError: boolean;
+  slotsFetching: boolean;
   selectedDateKey: string | null;
   selectedSlotStart: string | null;
   slotsHeadingRef?: Ref<HTMLHeadingElement>;
@@ -55,6 +56,7 @@ export function PublicBookingPicker({
   slots,
   slotsPending,
   slotsError,
+  slotsFetching,
   selectedDateKey,
   selectedSlotStart,
   slotsHeadingRef,
@@ -66,14 +68,34 @@ export function PublicBookingPicker({
   onRetrySlots,
 }: PublicBookingPickerProps) {
   const [hasRenderedGrid, setHasRenderedGrid] = useState(false);
-  const liveMessage = useSlotsLiveMessage(slotsPending, slotsError);
+  const liveMessage = useSlotsLiveMessage(
+    slotsFetching,
+    slotsError && !slotsFetching,
+  );
   const showGridSkeleton = slotsPending && !hasRenderedGrid;
+  const restoreFocusAfterError = useRef(false);
 
   useEffect(() => {
     if (!slotsPending) {
       setHasRenderedGrid(true);
     }
   }, [slotsPending]);
+
+  useEffect(() => {
+    if (slotsError) {
+      restoreFocusAfterError.current = true;
+    }
+  }, [slotsError]);
+
+  useEffect(() => {
+    if (slotsPending || slotsError || !restoreFocusAfterError.current) {
+      return;
+    }
+    restoreFocusAfterError.current = false;
+    if (typeof slotsHeadingRef === "object" && slotsHeadingRef) {
+      slotsHeadingRef.current?.focus();
+    }
+  }, [slotsError, slotsHeadingRef, slotsPending]);
 
   return (
     <div className="flex w-full min-w-0 flex-col gap-3">
@@ -105,8 +127,10 @@ export function PublicBookingPicker({
               <p className="text-sm text-text-muted">Could not load times.</p>
               <button
                 type="button"
+                disabled={slotsFetching}
+                aria-busy={slotsFetching || undefined}
                 onClick={onRetrySlots}
-                className="rounded-md bg-surface-panel px-3 py-2 font-medium text-sm text-text transition-colors hover:bg-surface-raised focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                className="rounded-md bg-surface-panel px-3 py-2 font-medium text-sm text-text transition-colors hover:bg-surface-raised focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-60"
               >
                 Retry
               </button>

--- a/packages/web/src/booking/PublicBookingPicker.tsx
+++ b/packages/web/src/booking/PublicBookingPicker.tsx
@@ -1,6 +1,10 @@
-import { type Ref } from "react";
+import { type Ref, useEffect, useRef, useState } from "react";
 import { PublicBookingMonthGrid } from "@web/booking/PublicBookingMonthGrid";
+import { PublicBookingMonthGridSkeleton } from "@web/booking/PublicBookingMonthGridSkeleton";
+import { PublicBookingSlotPaneSkeleton } from "@web/booking/PublicBookingSlotPaneSkeleton";
 import { PublicBookingSlotPicker } from "@web/booking/PublicBookingSlotPicker";
+import { PublicBookingSlotsLiveStatus } from "@web/booking/PublicBookingSlotsLiveStatus";
+import { formatBookingMonthHeading } from "@web/booking/public-booking.format";
 
 interface PublicBookingPickerProps {
   monthKey: string;
@@ -17,6 +21,31 @@ interface PublicBookingPickerProps {
   onSelectDate: (dateKey: string) => void;
   onSelectSlot: (slotStart: string) => void;
   onJumpToNextAvailable: () => void;
+  onRetrySlots: () => void;
+}
+
+function useSlotsLiveMessage(pending: boolean, error: boolean): string {
+  const [message, setMessage] = useState("");
+  const wasPending = useRef(false);
+
+  useEffect(() => {
+    if (pending) {
+      wasPending.current = true;
+      setMessage("Loading open times");
+      return;
+    }
+    if (error) {
+      wasPending.current = false;
+      setMessage("Could not load times");
+      return;
+    }
+    if (wasPending.current) {
+      wasPending.current = false;
+      setMessage("Times loaded");
+    }
+  }, [error, pending]);
+
+  return message;
 }
 
 export function PublicBookingPicker({
@@ -34,39 +63,66 @@ export function PublicBookingPicker({
   onSelectDate,
   onSelectSlot,
   onJumpToNextAvailable,
+  onRetrySlots,
 }: PublicBookingPickerProps) {
+  const [hasRenderedGrid, setHasRenderedGrid] = useState(false);
+  const liveMessage = useSlotsLiveMessage(slotsPending, slotsError);
+  const showGridSkeleton = slotsPending && !hasRenderedGrid;
+
+  useEffect(() => {
+    if (!slotsPending) {
+      setHasRenderedGrid(true);
+    }
+  }, [slotsPending]);
+
   return (
-    <div className="grid w-full min-w-0 gap-6 sm:grid-cols-2 sm:items-start">
-      <div className="min-w-0">
-        <PublicBookingMonthGrid
-          monthKey={monthKey}
-          timeZone={timeZone}
-          maxHorizonDays={maxHorizonDays}
-          slots={slots}
-          selectedDateKey={selectedDateKey}
-          onMonthChange={onMonthChange}
-          onPrefetchMonth={onPrefetchMonth}
-          onSelectDate={onSelectDate}
-        />
-      </div>
-      <div className="min-h-64 min-w-0 sm:max-h-96 sm:overflow-y-auto">
-        {slotsPending ? (
-          <p className="text-sm text-text-muted">Loading open times...</p>
-        ) : slotsError ? (
-          <p className="text-sm text-text-muted">
-            Could not load times. Please refresh and try again.
-          </p>
-        ) : (
-          <PublicBookingSlotPicker
-            slots={slots}
-            selectedDateKey={selectedDateKey}
-            guestTimeZone={timeZone}
-            selectedSlotStart={selectedSlotStart}
-            headingRef={slotsHeadingRef}
-            onSelectSlot={onSelectSlot}
-            onJumpToNextAvailable={onJumpToNextAvailable}
-          />
-        )}
+    <div className="flex w-full min-w-0 flex-col gap-3">
+      <PublicBookingSlotsLiveStatus message={liveMessage} />
+      <div className="grid w-full min-w-0 gap-6 sm:grid-cols-2 sm:items-start">
+        <div className="min-w-0">
+          {showGridSkeleton ? (
+            <PublicBookingMonthGridSkeleton
+              monthHeading={formatBookingMonthHeading(monthKey, timeZone)}
+            />
+          ) : (
+            <PublicBookingMonthGrid
+              monthKey={monthKey}
+              timeZone={timeZone}
+              maxHorizonDays={maxHorizonDays}
+              slots={slots}
+              selectedDateKey={selectedDateKey}
+              onMonthChange={onMonthChange}
+              onPrefetchMonth={onPrefetchMonth}
+              onSelectDate={onSelectDate}
+            />
+          )}
+        </div>
+        <div className="min-h-64 min-w-0 sm:max-h-96 sm:overflow-y-auto">
+          {slotsPending ? (
+            <PublicBookingSlotPaneSkeleton />
+          ) : slotsError ? (
+            <div className="flex flex-col items-start gap-3">
+              <p className="text-sm text-text-muted">Could not load times.</p>
+              <button
+                type="button"
+                onClick={onRetrySlots}
+                className="rounded-md bg-surface-panel px-3 py-2 font-medium text-sm text-text transition-colors hover:bg-surface-raised focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              >
+                Retry
+              </button>
+            </div>
+          ) : (
+            <PublicBookingSlotPicker
+              slots={slots}
+              selectedDateKey={selectedDateKey}
+              guestTimeZone={timeZone}
+              selectedSlotStart={selectedSlotStart}
+              headingRef={slotsHeadingRef}
+              onSelectSlot={onSelectSlot}
+              onJumpToNextAvailable={onJumpToNextAvailable}
+            />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/packages/web/src/booking/PublicBookingSlotPaneSkeleton.tsx
+++ b/packages/web/src/booking/PublicBookingSlotPaneSkeleton.tsx
@@ -1,0 +1,16 @@
+export function PublicBookingSlotPaneSkeleton() {
+  return (
+    <div className="min-h-64" aria-hidden="true">
+      <div className="h-5 w-28 rounded-sm bg-surface-panel motion-safe:animate-pulse" />
+      <div className="mt-1 h-4 w-40 rounded-sm bg-surface-panel motion-safe:animate-pulse" />
+      <div className="mt-4 grid grid-cols-2 gap-2">
+        {Array.from({ length: 8 }, (_, index) => (
+          <div
+            className="h-10 rounded-md bg-surface-panel motion-safe:animate-pulse"
+            key={`slot-${String(index)}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/booking/PublicBookingSlotsLiveStatus.tsx
+++ b/packages/web/src/booking/PublicBookingSlotsLiveStatus.tsx
@@ -1,0 +1,13 @@
+interface PublicBookingSlotsLiveStatusProps {
+  message: string;
+}
+
+export function PublicBookingSlotsLiveStatus({
+  message,
+}: PublicBookingSlotsLiveStatusProps) {
+  return (
+    <p aria-live="polite" className="sr-only" role="status">
+      {message}
+    </p>
+  );
+}

--- a/packages/web/src/booking/public-booking.query.ts
+++ b/packages/web/src/booking/public-booking.query.ts
@@ -67,6 +67,7 @@ export function publicBookingSlotsQueryOptions(
       return PublicBookingApi.getSlots(slug, window, signal);
     },
     staleTime: PUBLIC_BOOKING_SLOTS_STALE_TIME_MS,
+    retry: false,
   });
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Guest slot loading no longer swaps the whole page for a status message. The host heading stays mounted. The first slots fetch can show a month-grid skeleton; later month navigation skeletons only the slot pane. A polite live region announces **Loading open times** and **Times loaded**. Failed slot fetches show **Retry**, which refetches without a reload. Retry stays mounted while in flight, then focus moves to **Pick a time**.

Closes #3004.

## Simplicity

Skeletons are static placeholders sized like the real pane. Slot queries disable automatic retries so the Retry control is the recovery path.

## Automated validation

- Web RTL: header stays during delayed slots, live status text, Retry recovers with heading focus, unfetched month keeps header and month heading while the slot pane is pending.
- Playwright: hold-first-slots announcement, Retry without reload, axe on the slots error state (23 passed, then 3 focused re-runs after the Retry focus fix).

## Independent review

`origin/main...HEAD`: Retry focus drop (med). Fixed by keeping the error pane during refetch and focusing Pick a time on success.

## Test plan

- Focused web tests: 15 pass
- `bunx typescript@7.0.2 -p packages/web/tsconfig.app.json --noEmit`
- `bunx biome check` on changed files
- `bunx playwright test e2e/booking/public-booking.spec.ts e2e/accessibility/booking-a11y.spec.ts` (23 pass) plus re-run of new specs after the focus fix

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e51f3b10-0faf-4d26-8e85-ef13497c1459?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e51f3b10-0faf-4d26-8e85-ef13497c1459&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

