### PR TITLE
feat(web): guest timezone override on public booking

### DIFF
--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -440,9 +440,12 @@ export const dispatchClick = async (
   });
 };
 
-export function formatSlotButtonLabel(slotStart: string): RegExp {
+export function formatSlotButtonLabel(
+  slotStart: string,
+  timeZone = "UTC",
+): RegExp {
   const time = new Intl.DateTimeFormat(undefined, {
-    timeZone: "UTC",
+    timeZone,
     hour: "numeric",
     minute: "2-digit",
   }).format(new Date(slotStart));

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -43,6 +43,38 @@ test.describe("public booking page", () => {
     });
   });
 
+  test("overrides the guest timezone on the reservation", async ({ page }) => {
+    const { slotStart } = buildBookableSlot();
+    const captured = await preparePublicBookingPage(page);
+
+    await expect(
+      page.getByRole("button", { name: /^Timezone:/ }),
+    ).toBeVisible();
+    await page.getByRole("button", { name: /^Timezone:/ }).click();
+    await page.getByRole("combobox").fill("berlin");
+    await page.keyboard.press("Enter");
+    await expect(
+      page.getByRole("button", { name: /^Timezone: Berlin/ }),
+    ).toBeVisible();
+    await page
+      .getByRole("button", {
+        name: formatSlotButtonLabel(slotStart, "Europe/Berlin"),
+      })
+      .click();
+    await page.getByLabel("Name").fill("Guest User");
+    await page.getByLabel("Email").fill("guest@example.com");
+    await page.getByRole("button", { name: "Confirm booking" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+    ).toBeVisible();
+    expect(captured.reservationPosts).toHaveLength(1);
+    expect(captured.reservationPosts[0]).toMatchObject({
+      slotStart,
+      guestTimeZone: "Europe/Berlin",
+    });
+  });
+
   test("does not POST when email is missing", async ({ page }) => {
     const { slotStart } = buildBookableSlot();
     const captured = await preparePublicBookingPage(page);

--- a/packages/web/src/booking/PublicBookingDetailsStep.tsx
+++ b/packages/web/src/booking/PublicBookingDetailsStep.tsx
@@ -58,6 +58,7 @@ export function PublicBookingDetailsStep({
         disabled={disabled}
         submitDisabled={false}
         showHeading={false}
+        guestTimeZone={timeZone}
         values={values}
         onChange={onChange}
         onSubmit={onSubmit}

--- a/packages/web/src/booking/PublicBookingGuestForm.tsx
+++ b/packages/web/src/booking/PublicBookingGuestForm.tsx
@@ -1,5 +1,4 @@
 import { type FormEvent } from "react";
-import { getBrowserTimeZone } from "@web/timezone/browser-timezone";
 
 export interface PublicBookingGuestDetails {
   guestName: string;
@@ -16,6 +15,7 @@ interface PublicBookingGuestFormProps {
   disabled: boolean;
   submitDisabled: boolean;
   showHeading?: boolean;
+  guestTimeZone: string;
   values: PublicBookingGuestDetails;
   onChange: (values: PublicBookingGuestDetails) => void;
   onSubmit: (values: PublicBookingGuestFormValues) => void;
@@ -25,6 +25,7 @@ export function PublicBookingGuestForm({
   disabled,
   submitDisabled,
   showHeading = true,
+  guestTimeZone,
   values,
   onChange,
   onSubmit,
@@ -38,7 +39,7 @@ export function PublicBookingGuestForm({
       guestName: values.guestName.trim(),
       guestEmail: values.guestEmail.trim(),
       notes: values.notes.trim(),
-      guestTimeZone: getBrowserTimeZone(),
+      guestTimeZone,
     });
   };
 

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -226,6 +226,7 @@ describe("PublicBookingPage", () => {
     let postedBody: unknown;
     const slotTimeZones: string[] = [];
     const overrideZone = "Asia/Tokyo";
+    const slot = nextMonthSlot;
 
     server.use(
       rest.get(
@@ -241,8 +242,10 @@ describe("PublicBookingPage", () => {
           const end = req.url.searchParams.get("end");
           const startMs = start ? Date.parse(start) : Number.NEGATIVE_INFINITY;
           const endMs = end ? Date.parse(end) : Number.POSITIVE_INFINITY;
-          const at = Date.parse(currentSlot.slotStart);
-          const slots = at >= startMs && at < endMs ? [currentSlot] : [];
+          const slots = [slot].filter((item) => {
+            const at = Date.parse(item.slotStart);
+            return at >= startMs && at < endMs;
+          });
           return res(
             ctx.status(Status.OK),
             ctx.json({ bookable: true, slots }),
@@ -257,8 +260,8 @@ describe("PublicBookingPage", () => {
             ctx.status(Status.OK),
             ctx.json({
               reservationId: "000000000000000000000099",
-              slotStart: currentSlot.slotStart,
-              slotEnd: currentSlot.slotEnd,
+              slotStart: slot.slotStart,
+              slotEnd: slot.slotEnd,
               guestTimeZone: overrideZone,
               cancelUrl:
                 "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
@@ -277,10 +280,9 @@ describe("PublicBookingPage", () => {
       screen.getByRole("button", { name: /^Timezone: UTC/ }),
     ).toBeInTheDocument();
 
-    const utcDateKey = formatBookingSlotDateKey(
-      currentSlot.slotStart,
-      guestTimeZone,
-    );
+    await user.click(await screen.findByRole("button", { name: "Next month" }));
+
+    const utcDateKey = formatBookingSlotDateKey(slot.slotStart, guestTimeZone);
     expect(
       await screen.findByRole("button", {
         name: formatBookingMonthDayLabel(utcDateKey, guestTimeZone),
@@ -288,7 +290,7 @@ describe("PublicBookingPage", () => {
     ).toHaveAttribute("aria-pressed", "true");
     expect(
       await screen.findByRole("button", {
-        name: slotTimePattern(currentSlot.slotStart, guestTimeZone),
+        name: slotTimePattern(slot.slotStart, guestTimeZone),
       }),
     ).toBeInTheDocument();
 
@@ -301,10 +303,8 @@ describe("PublicBookingPage", () => {
       expect(slotTimeZones).toContain(overrideZone);
     });
 
-    const tokyoDateKey = formatBookingSlotDateKey(
-      currentSlot.slotStart,
-      overrideZone,
-    );
+    const tokyoDateKey = formatBookingSlotDateKey(slot.slotStart, overrideZone);
+    expect(tokyoDateKey).not.toBe(utcDateKey);
     expect(
       await screen.findByRole("button", {
         name: formatBookingMonthDayLabel(tokyoDateKey, overrideZone),
@@ -312,24 +312,22 @@ describe("PublicBookingPage", () => {
     ).toHaveAttribute("aria-pressed", "true");
     expect(
       await screen.findByRole("button", {
-        name: slotTimePattern(currentSlot.slotStart, overrideZone),
+        name: slotTimePattern(slot.slotStart, overrideZone),
       }),
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("button", {
-        name: slotTimePattern(currentSlot.slotStart, guestTimeZone),
+        name: slotTimePattern(slot.slotStart, guestTimeZone),
       }),
     ).not.toBeInTheDocument();
 
     await user.click(
       screen.getByRole("button", {
-        name: slotTimePattern(currentSlot.slotStart, overrideZone),
+        name: slotTimePattern(slot.slotStart, overrideZone),
       }),
     );
     expect(
-      screen.getByText(
-        formatBookingSlotLabel(currentSlot.slotStart, overrideZone),
-      ),
+      screen.getByText(formatBookingSlotLabel(slot.slotStart, overrideZone)),
     ).toBeInTheDocument();
     await user.type(screen.getByLabelText("Name"), "Guest User");
     await user.type(screen.getByLabelText("Email"), "guest@example.com");
@@ -341,7 +339,7 @@ describe("PublicBookingPage", () => {
       }),
     ).toBeInTheDocument();
     expect(postedBody).toMatchObject({
-      slotStart: currentSlot.slotStart,
+      slotStart: slot.slotStart,
       guestTimeZone: overrideZone,
     });
   });

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -59,13 +59,22 @@ function bookableSlotInNextMonth() {
   };
 }
 
-function slotTimePattern(iso: string) {
+function slotTimePattern(iso: string, timeZone = "UTC") {
   const label = new Intl.DateTimeFormat(undefined, {
-    timeZone: "UTC",
+    timeZone,
     hour: "numeric",
     minute: "2-digit",
   }).format(new Date(iso));
   return new RegExp(label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i");
+}
+
+async function selectGuestTimeZone(
+  user: ReturnType<typeof userEvent.setup>,
+  query: string,
+) {
+  await user.click(screen.getByRole("button", { name: /^Timezone:/ }));
+  await user.type(screen.getByRole("combobox"), query);
+  await user.keyboard("{Enter}");
 }
 
 const currentSlot = bookableSlotInCurrentMonth();
@@ -208,7 +217,216 @@ describe("PublicBookingPage", () => {
       slotStart: currentSlot.slotStart,
       guestName: "Guest User",
       guestEmail: "guest@example.com",
+      guestTimeZone: "UTC",
     });
+  });
+
+  it("overrides the guest timezone for labels, day grouping, and submit", async () => {
+    const user = userEvent.setup({ delay: null });
+    let postedBody: unknown;
+    const slotTimeZones: string[] = [];
+    const overrideZone = "Asia/Tokyo";
+
+    server.use(
+      rest.get(
+        `${ENV_WEB.API_BASEURL}/booking/pages/tzhost`,
+        (_req, res, ctx) =>
+          res(ctx.status(Status.OK), ctx.json(publicPagePayload())),
+      ),
+      rest.get(
+        `${ENV_WEB.API_BASEURL}/booking/pages/tzhost/slots`,
+        (req, res, ctx) => {
+          slotTimeZones.push(req.url.searchParams.get("timeZone") ?? "");
+          const start = req.url.searchParams.get("start");
+          const end = req.url.searchParams.get("end");
+          const startMs = start ? Date.parse(start) : Number.NEGATIVE_INFINITY;
+          const endMs = end ? Date.parse(end) : Number.POSITIVE_INFINITY;
+          const at = Date.parse(currentSlot.slotStart);
+          const slots = at >= startMs && at < endMs ? [currentSlot] : [];
+          return res(
+            ctx.status(Status.OK),
+            ctx.json({ bookable: true, slots }),
+          );
+        },
+      ),
+      rest.post(
+        `${ENV_WEB.API_BASEURL}/booking/pages/tzhost/reservations`,
+        async (req, res, ctx) => {
+          postedBody = await req.json();
+          return res(
+            ctx.status(Status.OK),
+            ctx.json({
+              reservationId: "000000000000000000000099",
+              slotStart: currentSlot.slotStart,
+              slotEnd: currentSlot.slotEnd,
+              guestTimeZone: overrideZone,
+              cancelUrl:
+                "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+            }),
+          );
+        },
+      ),
+    );
+
+    renderBookingRoute("/book/tzhost");
+
+    expect(
+      await screen.findByText(/Times shown in your timezone/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^Timezone: UTC/ }),
+    ).toBeInTheDocument();
+
+    const utcDateKey = formatBookingSlotDateKey(
+      currentSlot.slotStart,
+      guestTimeZone,
+    );
+    expect(
+      await screen.findByRole("button", {
+        name: formatBookingMonthDayLabel(utcDateKey, guestTimeZone),
+      }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(
+      await screen.findByRole("button", {
+        name: slotTimePattern(currentSlot.slotStart, guestTimeZone),
+      }),
+    ).toBeInTheDocument();
+
+    await selectGuestTimeZone(user, "tokyo");
+
+    expect(
+      await screen.findByRole("button", { name: /^Timezone: Tokyo/ }),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(slotTimeZones).toContain(overrideZone);
+    });
+
+    const tokyoDateKey = formatBookingSlotDateKey(
+      currentSlot.slotStart,
+      overrideZone,
+    );
+    expect(
+      await screen.findByRole("button", {
+        name: formatBookingMonthDayLabel(tokyoDateKey, overrideZone),
+      }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(
+      await screen.findByRole("button", {
+        name: slotTimePattern(currentSlot.slotStart, overrideZone),
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: slotTimePattern(currentSlot.slotStart, guestTimeZone),
+      }),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: slotTimePattern(currentSlot.slotStart, overrideZone),
+      }),
+    );
+    expect(
+      screen.getByText(
+        formatBookingSlotLabel(currentSlot.slotStart, overrideZone),
+      ),
+    ).toBeInTheDocument();
+    await user.type(screen.getByLabelText("Name"), "Guest User");
+    await user.type(screen.getByLabelText("Email"), "guest@example.com");
+    await user.click(screen.getByRole("button", { name: "Confirm booking" }));
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "You are booked with Tyler Dane",
+      }),
+    ).toBeInTheDocument();
+    expect(postedBody).toMatchObject({
+      slotStart: currentSlot.slotStart,
+      guestTimeZone: overrideZone,
+    });
+  });
+
+  it("keeps the guest timezone across month navigation and the details step", async () => {
+    const user = userEvent.setup({ delay: null });
+    const overrideZone = "Europe/Berlin";
+
+    server.use(
+      rest.get(
+        `${ENV_WEB.API_BASEURL}/booking/pages/tzpersist`,
+        (_req, res, ctx) =>
+          res(ctx.status(Status.OK), ctx.json(publicPagePayload())),
+      ),
+      rest.get(
+        `${ENV_WEB.API_BASEURL}/booking/pages/tzpersist/slots`,
+        (req, res, ctx) => {
+          const start = req.url.searchParams.get("start");
+          const end = req.url.searchParams.get("end");
+          const startMs = start ? Date.parse(start) : Number.NEGATIVE_INFINITY;
+          const endMs = end ? Date.parse(end) : Number.POSITIVE_INFINITY;
+          const slots = [currentSlot, nextMonthSlot].filter((slot) => {
+            const at = Date.parse(slot.slotStart);
+            return at >= startMs && at < endMs;
+          });
+          return res(
+            ctx.status(Status.OK),
+            ctx.json({ bookable: true, slots }),
+          );
+        },
+      ),
+    );
+
+    renderBookingRoute("/book/tzpersist");
+
+    await screen.findByRole("button", {
+      name: slotTimePattern(currentSlot.slotStart, guestTimeZone),
+    });
+    await selectGuestTimeZone(user, "berlin");
+    expect(
+      await screen.findByRole("button", { name: /^Timezone: Berlin/ }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", {
+        name: slotTimePattern(currentSlot.slotStart, overrideZone),
+      }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Next month" }));
+    const nextMonthKey = shiftBookingMonthKey(currentMonthKey, 1, overrideZone);
+    expect(
+      await screen.findByRole("heading", {
+        name: formatBookingMonthHeading(nextMonthKey, overrideZone),
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^Timezone: Berlin/ }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", {
+        name: slotTimePattern(nextMonthSlot.slotStart, overrideZone),
+      }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Previous month" }));
+    await user.click(
+      await screen.findByRole("button", {
+        name: slotTimePattern(currentSlot.slotStart, overrideZone),
+      }),
+    );
+    expect(
+      screen.getByRole("button", { name: /^Timezone: Berlin/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        formatBookingSlotLabel(currentSlot.slotStart, overrideZone),
+      ),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Change time" }));
+    expect(
+      await screen.findByRole("heading", { name: "Pick a time" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^Timezone: Berlin/ }),
+    ).toBeInTheDocument();
   });
 
   it("shows unavailable when bookable is false", async () => {

--- a/packages/web/src/booking/PublicBookingPage.tsx
+++ b/packages/web/src/booking/PublicBookingPage.tsx
@@ -17,13 +17,13 @@ import {
 import { PublicBookingLayout } from "@web/booking/PublicBookingLayout";
 import { PublicBookingPicker } from "@web/booking/PublicBookingPicker";
 import { PublicBookingStatusMessage } from "@web/booking/PublicBookingStatusMessage";
+import { PublicBookingTimezoneControl } from "@web/booking/PublicBookingTimezoneControl";
 import {
   findNextAvailableBookingDate,
   formatBookingDateKey,
   formatBookingMonthKey,
   formatBookingSlotDateKey,
   formatDurationMinutes,
-  formatGuestTimeZoneLabel,
   listBookingAvailableDateKeysInMonth,
   shiftBookingMonthKey,
 } from "@web/booking/public-booking.format";
@@ -48,10 +48,10 @@ const EMPTY_GUEST_DETAILS: PublicBookingGuestDetails = {
 export function PublicBookingPage() {
   const { username } = useParams({ from: "/book/$username" });
   const slug = username ?? "";
-  const guestTimeZone = getBrowserTimeZone();
+  const [guestTimeZone, setGuestTimeZone] = useState(getBrowserTimeZone);
   const queryClient = useQueryClient();
   const [monthKey, setMonthKey] = useState(() =>
-    formatBookingMonthKey(dayjs(), guestTimeZone),
+    formatBookingMonthKey(dayjs(), getBrowserTimeZone()),
   );
 
   const pageQuery = usePublicBookingPageQuery(slug);
@@ -59,6 +59,7 @@ export function PublicBookingPage() {
     slug,
     monthKey,
     pageQuery.data?.maxHorizonDays,
+    guestTimeZone,
   );
   const createReservation = useCreatePublicBookingReservationMutation(slug);
 
@@ -207,6 +208,27 @@ export function PublicBookingPage() {
     setStep("picker");
   };
 
+  const handleTimeZoneChange = (nextTimeZone: string) => {
+    if (nextTimeZone === guestTimeZone) {
+      return;
+    }
+    const currentMonthInOldZone = formatBookingMonthKey(dayjs(), guestTimeZone);
+    setGuestTimeZone(nextTimeZone);
+    if (selectedSlotStart) {
+      const nextDateKey = formatBookingSlotDateKey(
+        selectedSlotStart,
+        nextTimeZone,
+      );
+      setSelectedDateKey(nextDateKey);
+      setMonthKey(nextDateKey.slice(0, 7));
+      return;
+    }
+    if (monthKey === currentMonthInOldZone) {
+      setMonthKey(formatBookingMonthKey(dayjs(), nextTimeZone));
+    }
+    setSelectedDateKey(null);
+  };
+
   const handleChangeTime = () => {
     pendingPickerFocusRef.current = true;
     setStep("picker");
@@ -320,10 +342,13 @@ export function PublicBookingPage() {
         <p className="text-sm text-text-muted">
           {formatDurationMinutes(page.durationMinutes)} meeting
         </p>
-        <p className="text-sm text-text-muted">
-          Times shown in your timezone (
-          {formatGuestTimeZoneLabel(guestTimeZone)}).
-        </p>
+        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-sm text-text-muted">
+          <p>Times shown in your timezone</p>
+          <PublicBookingTimezoneControl
+            timeZone={guestTimeZone}
+            onChange={handleTimeZoneChange}
+          />
+        </div>
       </header>
 
       {conflictMessage ? (
@@ -381,6 +406,7 @@ export function PublicBookingPage() {
               <PublicBookingGuestForm
                 disabled={createReservation.isPending}
                 submitDisabled={!selectedSlotStart}
+                guestTimeZone={guestTimeZone}
                 values={guestDetails}
                 onChange={setGuestDetails}
                 onSubmit={handleSubmit}

--- a/packages/web/src/booking/PublicBookingTimezoneControl.tsx
+++ b/packages/web/src/booking/PublicBookingTimezoneControl.tsx
@@ -1,0 +1,59 @@
+import { useRef, useState } from "react";
+import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
+import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
+import { TimezoneCombobox } from "@web/timezone/TimezoneCombobox";
+import { timeZoneCityName } from "@web/timezone/timezone-catalog";
+
+interface PublicBookingTimezoneControlProps {
+  timeZone: string;
+  onChange: (timeZone: string) => void;
+}
+
+export function PublicBookingTimezoneControl({
+  timeZone,
+  onChange,
+}: PublicBookingTimezoneControlProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const label = `${timeZoneCityName(timeZone)} (${formatTimeZoneAbbreviation(timeZone)})`;
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
+        aria-label={`Timezone: ${label}`}
+        className="rounded-md text-left text-sm text-text underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        onClick={() => setIsOpen(true)}
+      >
+        {label}
+      </button>
+      {isOpen ? (
+        <OverlayPanel
+          align="start"
+          initialFocusRef={searchRef}
+          onDismiss={() => setIsOpen(false)}
+          restoreFocus={() => triggerRef.current?.focus()}
+          title="Timezone"
+          variant="modal"
+          widthClassName="w-120"
+        >
+          <TimezoneCombobox
+            inputRef={searchRef}
+            onSelect={(nextTimeZone) => {
+              if (nextTimeZone) {
+                onChange(nextTimeZone);
+              }
+              setIsOpen(false);
+            }}
+            searchLabel="Search timezones"
+            value={timeZone}
+          />
+        </OverlayPanel>
+      ) : null}
+    </>
+  );
+}

--- a/packages/web/src/booking/public-booking.query.ts
+++ b/packages/web/src/booking/public-booking.query.ts
@@ -18,7 +18,6 @@ import {
   getPublicBookingMonthWindow,
   shiftBookingMonthKey,
 } from "@web/booking/public-booking.format";
-import { getBrowserTimeZone } from "@web/timezone/browser-timezone";
 
 export const PUBLIC_BOOKING_PAGE_STALE_TIME_MS = 5 * 60 * 1000;
 export const PUBLIC_BOOKING_SLOTS_STALE_TIME_MS = 60_000;
@@ -75,8 +74,8 @@ export function usePublicBookingSlotsQuery(
   slug: string,
   monthKey: string,
   maxHorizonDays: number | undefined,
+  timeZone: string,
 ) {
-  const timeZone = getBrowserTimeZone();
   // Start the first month in parallel with page meta. 60 is the schema max
   // and only used until `maxHorizonDays` is known; the query key is the month
   // so landing page meta does not refetch. The backend still clamps to the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3006.

Guests can change the display timezone next to “Times shown in your timezone”. That value is the single source of truth for slot labels, day grouping, per-month slot queries, and `guestTimeZone` on the reservation POST. It defaults to the browser zone and persists across month navigation and the details step.

## Simplicity

Reuses `TimezoneCombobox` and `OverlayPanel` from the host booking field. Page state owns one `guestTimeZone`; the slots hook no longer reads the browser zone on its own.

## Automated validation

- `PublicBookingPage` override test: Tokyo labels, day grouping on a next-month slot, POST `guestTimeZone`
- Persist test: Berlin survives month nav, details, and Change time
- Playwright: `overrides the guest timezone on the reservation` (15/15 in `public-booking.spec.ts`)
- `bun run verify`: test:web, type-check, lint, knip, test:a11y, test:e2e all passed

## Independent review

`origin/main...HEAD`: no confirmed findings.

## Test plan

```
TZ=UTC NODE_ENV=test bun test --preload ./src/__tests__/web.preload.ts ./src/booking/PublicBookingPage.test.tsx
bunx playwright test e2e/booking/public-booking.spec.ts
bun run verify
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e51f3b10-0faf-4d26-8e85-ef13497c1459?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e51f3b10-0faf-4d26-8e85-ef13497c1459&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

