### PR TITLE
feat(web): respect prefers-color-scheme on public pages

### DIFF
--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -7,30 +7,51 @@ import {
 } from "../booking/booking-harness";
 import { expectNoAxeViolations } from "../utils/axe-assertion";
 
-test("the public booking page renders with no automatically detectable accessibility violations", async ({
-  page,
-}) => {
-  await preparePublicBookingPage(page);
+test.describe("public booking page color scheme", () => {
+  (["light", "dark"] as const).forEach((colorScheme) => {
+    test.describe(`${colorScheme} OS`, () => {
+      test.use({ colorScheme });
 
-  await expect(
-    page.getByRole("heading", { name: "Pick a time" }),
-  ).toBeVisible();
-  await expectNoAxeViolations(page, { checkpoint: "public booking page" });
-});
+      test("the picker has no automatically detectable accessibility violations", async ({
+        page,
+      }) => {
+        await preparePublicBookingPage(page);
+        await expect(
+          page.getByRole("heading", { name: "Pick a time" }),
+        ).toBeVisible();
+        if (colorScheme === "light") {
+          await expect(page.locator("html")).toHaveAttribute(
+            "data-theme",
+            "light-beach",
+          );
+        } else {
+          await expect(page.locator("html")).not.toHaveAttribute(
+            "data-theme",
+            "light-beach",
+          );
+        }
+        await expectNoAxeViolations(page, {
+          checkpoint: `public booking page ${colorScheme}`,
+        });
+      });
 
-test("the public booking details step has no automatically detectable accessibility violations", async ({
-  page,
-}) => {
-  const { slotStart } = buildBookableSlot();
-  await preparePublicBookingPage(page);
-
-  await page
-    .getByRole("button", { name: formatSlotButtonLabel(slotStart) })
-    .click();
-  await expect(
-    page.getByRole("heading", { name: "Your details" }),
-  ).toBeVisible();
-  await expectNoAxeViolations(page, { checkpoint: "public booking details" });
+      test("the details step has no automatically detectable accessibility violations", async ({
+        page,
+      }) => {
+        const { slotStart } = buildBookableSlot();
+        await preparePublicBookingPage(page);
+        await page
+          .getByRole("button", { name: formatSlotButtonLabel(slotStart) })
+          .click();
+        await expect(
+          page.getByRole("heading", { name: "Your details" }),
+        ).toBeVisible();
+        await expectNoAxeViolations(page, {
+          checkpoint: `public booking details ${colorScheme}`,
+        });
+      });
+    });
+  });
 });
 
 test("the public booking slots error has no automatically detectable accessibility violations", async ({

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -516,3 +516,39 @@ test.describe("public booking page", () => {
     ).toBeVisible();
   });
 });
+
+test.describe("public booking theme", () => {
+  test("uses the light theme when OS is light and nothing is stored", async ({
+    page,
+  }) => {
+    await page.emulateMedia({ colorScheme: "light" });
+    await preparePublicBookingPage(page);
+    await expect(page.locator("html")).toHaveAttribute(
+      "data-theme",
+      "light-beach",
+    );
+  });
+
+  test("keeps the dark default when OS is dark and nothing is stored", async ({
+    page,
+  }) => {
+    await page.emulateMedia({ colorScheme: "dark" });
+    await preparePublicBookingPage(page);
+    await expect(page.locator("html")).not.toHaveAttribute(
+      "data-theme",
+      "light-beach",
+    );
+  });
+
+  test("keeps a stored dark theme when OS is light", async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem("compass.theme", "dark-abyss");
+    });
+    await page.emulateMedia({ colorScheme: "light" });
+    await preparePublicBookingPage(page);
+    await expect(page.locator("html")).not.toHaveAttribute(
+      "data-theme",
+      "light-beach",
+    );
+  });
+});

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -7,15 +7,23 @@
     <meta name="theme-color" content="#06090f" />
 
     <!--
-      Apply the saved theme before first paint so light-theme users don't flash
-      the default dark palette while the app boots (index.tsx awaits IndexedDB
-      first). Runs pre-module, so the key + colors are hard-coded here; keep them
-      in sync with settings/theme/theme.constants.ts. Dark is the CSS default,
-      so only a non-default choice needs touching.
+      Apply the theme before first paint so light visitors don't flash the
+      default dark palette while the app boots (index.tsx awaits IndexedDB
+      first). Runs pre-module, so the key + colors are hard-coded here; keep
+      them in sync with settings/theme/theme.constants.ts and
+      settings/theme/theme.util.ts. Dark is the CSS default, so only light
+      needs touching. An explicit stored choice wins; otherwise follow
+      prefers-color-scheme.
     -->
     <script>
       try {
-        if (localStorage.getItem("compass.theme") === "light-beach") {
+        var stored = localStorage.getItem("compass.theme");
+        var useLight =
+          stored === "light-beach" ||
+          (stored === null &&
+            window.matchMedia &&
+            window.matchMedia("(prefers-color-scheme: light)").matches);
+        if (useLight) {
           document.documentElement.setAttribute("data-theme", "light-beach");
           document
             .querySelector('meta[name="theme-color"]')

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -17,8 +17,8 @@
     -->
     <script>
       try {
-        var stored = localStorage.getItem("compass.theme");
-        var useLight =
+        const stored = localStorage.getItem("compass.theme");
+        const useLight =
           stored === "light-beach" ||
           (stored === null &&
             window.matchMedia &&

--- a/packages/web/src/settings/theme/theme.constants.ts
+++ b/packages/web/src/settings/theme/theme.constants.ts
@@ -12,7 +12,11 @@ export const THEMES = {
 
 export type ThemeName = keyof typeof THEMES;
 
-/** Dark is the default (also the index.css :root fallback). */
+/**
+ * Dark is the CSS :root fallback and the value used when
+ * `prefers-color-scheme` is dark or unavailable. Light is applied only when
+ * the visitor stored `light-beach` or the OS is light and nothing is stored.
+ */
 export const DEFAULT_THEME: ThemeName = "dark-abyss";
 
 /**

--- a/packages/web/src/settings/theme/theme.store.test.ts
+++ b/packages/web/src/settings/theme/theme.store.test.ts
@@ -2,25 +2,65 @@ import { persistentBrowserStore } from "@web/common/storage/browser-key-value.st
 import { THEME_STORAGE_KEY } from "./theme.constants";
 import { themeActions, useThemeStore } from "./theme.store";
 import { readStoredTheme } from "./theme.util";
-import { beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+function stubColorScheme(light: boolean) {
+  const original = window.matchMedia;
+  window.matchMedia = ((query: string) => ({
+    matches: light && query.includes("prefers-color-scheme: light"),
+    media: query,
+    onchange: null,
+    addListener() {},
+    removeListener() {},
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent() {
+      return true;
+    },
+  })) as typeof window.matchMedia;
+  return () => {
+    window.matchMedia = original;
+  };
+}
 
 describe("theme store + util", () => {
+  let restoreMatchMedia: (() => void) | undefined;
+
   beforeEach(() => {
     persistentBrowserStore.remove(THEME_STORAGE_KEY);
     document.documentElement.removeAttribute("data-theme");
     useThemeStore.setState({ theme: "dark-abyss" });
   });
 
-  it("falls back to the default theme when nothing is stored", () => {
+  afterEach(() => {
+    restoreMatchMedia?.();
+    restoreMatchMedia = undefined;
+  });
+
+  it("falls back to the default theme when nothing is stored and OS is dark", () => {
+    restoreMatchMedia = stubColorScheme(false);
     expect(readStoredTheme()).toBe("dark-abyss");
   });
 
+  it("follows prefers-color-scheme light when nothing is stored", () => {
+    restoreMatchMedia = stubColorScheme(true);
+    expect(readStoredTheme()).toBe("light-beach");
+  });
+
   it("falls back to the default theme for an unknown stored value", () => {
+    restoreMatchMedia = stubColorScheme(true);
     persistentBrowserStore.set(THEME_STORAGE_KEY, "neon-swamp");
     expect(readStoredTheme()).toBe("dark-abyss");
   });
 
   it("reads back a valid stored theme", () => {
+    restoreMatchMedia = stubColorScheme(true);
+    persistentBrowserStore.set(THEME_STORAGE_KEY, "dark-abyss");
+    expect(readStoredTheme()).toBe("dark-abyss");
+  });
+
+  it("reads a stored light theme even when OS is dark", () => {
+    restoreMatchMedia = stubColorScheme(false);
     persistentBrowserStore.set(THEME_STORAGE_KEY, "light-beach");
     expect(readStoredTheme()).toBe("light-beach");
   });

--- a/packages/web/src/settings/theme/theme.util.ts
+++ b/packages/web/src/settings/theme/theme.util.ts
@@ -9,9 +9,29 @@ import {
 export const isThemeName = (value: string | null): value is ThemeName =>
   value !== null && value in THEMES;
 
-/** The persisted theme, falling back to the default when unset/unknown. */
+/**
+ * OS light/dark when the visitor has never stored a theme. Guests on public
+ * pages hit this path; signed-in users who picked a theme do not.
+ */
+export const readPreferredColorSchemeTheme = (): ThemeName => {
+  if (typeof window.matchMedia !== "function") {
+    return DEFAULT_THEME;
+  }
+  return window.matchMedia("(prefers-color-scheme: light)").matches
+    ? "light-beach"
+    : DEFAULT_THEME;
+};
+
+/**
+ * The persisted theme. An explicit stored choice always wins. When the key is
+ * missing, follow `prefers-color-scheme`. Unknown stored values keep the
+ * dark default so a corrupt key does not flip the palette on every visit.
+ */
 export const readStoredTheme = (): ThemeName => {
   const stored = persistentBrowserStore.get(THEME_STORAGE_KEY);
+  if (stored === null) {
+    return readPreferredColorSchemeTheme();
+  }
   return isThemeName(stored) ? stored : DEFAULT_THEME;
 };
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,6 +18,9 @@ export default defineConfig({
   },
   use: {
     baseURL: `http://localhost:${TEST_PORT}`,
+    // Historic app tests assume Dark Abyss tokens. Guest booking specs that
+    // cover prefers-color-scheme override this per test.
+    colorScheme: "dark",
     trace: "on-first-retry",
   },
   projects: [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3007.

When `localStorage["compass.theme"]` is unset, the pre-paint script and `readStoredTheme` follow `prefers-color-scheme` so guests on a light OS see `light-beach` with no dark flash. A signed-in user’s stored `dark-abyss` or `light-beach` still wins.

## Simplicity

One extra branch in the existing no-flash script and theme reader. OS fallback is not persisted, so a later explicit `setTheme` remains the only write.

## Automated validation

- Theme util: OS light/dark, unknown stored key, stored dark wins over OS light
- Playwright: light/dark `data-theme` on the booking page; stored dark wins
- Axe on picker and details in both color schemes
- Playwright default `colorScheme` stays dark so existing app token assertions are unchanged

## Independent review

`origin/main...HEAD` (pre Playwright default): no confirmed findings.

## Test plan

```
TZ=UTC NODE_ENV=test bun test --preload ./src/__tests__/web.preload.ts ./src/settings/theme/theme.store.test.ts
bunx playwright test e2e/booking/public-booking.spec.ts e2e/accessibility/booking-a11y.spec.ts
bun run verify
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e51f3b10-0faf-4d26-8e85-ef13497c1459?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e51f3b10-0faf-4d26-8e85-ef13497c1459&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

