### PR TITLE
fix(web): keep e then t on title while event jump is on

### DIFF
--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx
@@ -742,6 +742,81 @@ describe("useShiftHoldEventHints", () => {
     expect(result.current.hints.length).toBeGreaterThan(0);
   });
 
+  it("edits the title with e then t after focusing a Monday event in jump mode", () => {
+    const onSequence = mock(() => {});
+    renderHook(() => useEditSequenceShortcut({ onSequence }));
+    const { focus } = mountHints([
+      timedFixture(EVENT_A, "2026-08-03T09:00:00.000Z"),
+      timedFixture(EVENT_B, "2026-08-04T09:00:00.000Z"),
+    ]);
+
+    act(() => {
+      pressEventJump();
+      dispatch("keydown", "m");
+    });
+    expect(focus).toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: EVENT_A }),
+    );
+    focus.mockClear();
+
+    act(() => {
+      dispatch("keydown", "e");
+      dispatch("keydown", "t");
+    });
+
+    expect(onSequence).toHaveBeenCalledWith("title");
+    expect(focus).not.toHaveBeenCalled();
+    expect(useEventJumpStore.getState().isActive).toBe(false);
+  });
+
+  it("edits the title with e then t even when jump's listener is registered first", () => {
+    const onSequence = mock(() => {});
+    const { focus } = mountHints([
+      timedFixture(EVENT_A, "2026-08-03T09:00:00.000Z"),
+      timedFixture(EVENT_B, "2026-08-04T09:00:00.000Z"),
+    ]);
+    renderHook(() => useEditSequenceShortcut({ onSequence }));
+
+    act(() => {
+      pressEventJump();
+      dispatch("keydown", "m");
+      dispatch("keydown", "e");
+      dispatch("keydown", "t");
+    });
+
+    expect(onSequence).toHaveBeenCalledWith("title");
+    expect(focus).toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: EVENT_A }),
+    );
+    expect(focus).not.toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: EVENT_B }),
+    );
+  });
+
+  it("still jumps to Tuesday with t when nothing can arm the edit sequence", () => {
+    renderHook(() =>
+      useEditSequenceShortcut({
+        canArm: () => false,
+        onSequence: mock(() => {}),
+      }),
+    );
+    const { focus } = mountHints([
+      timedFixture(EVENT_A, "2026-08-03T09:00:00.000Z"),
+      timedFixture(EVENT_B, "2026-08-04T09:00:00.000Z"),
+    ]);
+
+    act(() => {
+      pressEventJump();
+      dispatch("keydown", "e");
+      dispatch("keydown", "t");
+    });
+
+    expect(focus).toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: EVENT_B }),
+    );
+    expect(useEventJumpStore.getState().isActive).toBe(true);
+  });
+
   it("does not steal s while the e edit sequence is armed", () => {
     const onSequence = mock(() => {});
     renderHook(() => useEditSequenceShortcut({ onSequence }));

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
@@ -134,7 +134,9 @@ const buildDayJumpAssignments = (
  * Shift is what makes the day columns always available: bare `t`, `f`, and
  * `m` keep their own commands. Once jump mode is on, the labels are typed
  * bare (`w`, `w1`…) and win over global shortcuts. Esc exits, a second `h`
- * toggles off. `s` is only the Sunday/Saturday prefix.
+ * toggles off. `s` is only the Sunday/Saturday prefix. `e` is not a day
+ * prefix: jump yields to an armed (or about-to-arm) edit sequence so `e`
+ * then `t` edits the title instead of selecting Tuesday.
  *
  * Day view uses the same scheme on the one date it shows, so a bare digit is
  * never an event label on an empty buffer in either view - that keystroke
@@ -340,10 +342,13 @@ export function useShiftHoldEventHints({
 
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.defaultPrevented) return;
+      // Armed `e`… sequences own the follow key (`t` title vs Tuesday). Check
+      // in both on and off states: jump stays on after focusing a card, and
+      // the two capture listeners can register in either order.
+      if (isEditSequenceArmed()) return;
 
       if (!isActiveRef.current) {
         if (isAppLocked() || isEditableKeyboardTarget(event)) return;
-        if (isEditSequenceArmed()) return;
 
         // An empty-grid click parks a short-lived teaching target. Escape and
         // calendar navigation abandon it without claiming the key - the digits
@@ -449,6 +454,12 @@ export function useShiftHoldEventHints({
       if (!match) {
         clearAmbiguousCommitTimer();
         stripDigitBuffer();
+        // `e` is not a day prefix. Leave it unclaimed so a later-registered
+        // edit-sequence listener can still arm (`e` then `t` on a focused
+        // event). Other unmatched letters stay swallowed so j/k/c cannot fire.
+        if (key === KEYMAP.editTitle.sequence.leader) {
+          return;
+        }
         event.preventDefault();
         event.stopPropagation();
         keyupSwallow.add(key);

--- a/packages/web/src/shortcuts/useEditSequenceShortcut.test.tsx
+++ b/packages/web/src/shortcuts/useEditSequenceShortcut.test.tsx
@@ -9,7 +9,10 @@ import {
   selectEditSequenceMenuVisible,
   useEditSequenceStore,
 } from "@web/shortcuts/edit-sequence/edit-sequence.store";
-import { eventJumpActions } from "@web/shortcuts/shift-hint/event-jump.store";
+import {
+  eventJumpActions,
+  useEventJumpStore,
+} from "@web/shortcuts/shift-hint/event-jump.store";
 import {
   isEditSequenceArmed,
   resetEditSequenceArm,
@@ -240,19 +243,20 @@ describe("useEditSequenceShortcut", () => {
       expect(onSequence).not.toHaveBeenCalled();
     });
 
-    it("yields to event jump mode instead of arming underneath it", () => {
-      // Event jump already stands down for an armed sequence; without the
-      // mirror check a stray `e` would arm under the jump hints and swallow
-      // the next day letter.
+    it("arms while event jump is on so e then t can still edit the title", () => {
+      // Jump stays on after focusing a card. `e` is not a day prefix, so
+      // arming (and turning jump off) is what keeps `t` on title instead of
+      // Tuesday.
       const onSequence = mock(() => {});
       eventJumpActions.setActive(true);
       renderHook(() => useEditSequenceShortcut({ onSequence }));
 
       pressKey("e");
-      expect(isEditSequenceArmed()).toBe(false);
+      expect(isEditSequenceArmed()).toBe(true);
+      expect(useEventJumpStore.getState().isActive).toBe(false);
 
       pressKey("t");
-      expect(onSequence).not.toHaveBeenCalled();
+      expect(onSequence).toHaveBeenCalledWith("title");
     });
 
     it("does not arm when canArm is false, so the next key passes through", () => {
@@ -276,6 +280,21 @@ describe("useEditSequenceShortcut", () => {
       );
 
       document.removeEventListener("keydown", seen, true);
+    });
+
+    it("leaves jump on when canArm is false, so a following t can still be a day jump", () => {
+      const onSequence = mock(() => {});
+      eventJumpActions.setActive(true);
+      renderHook(() =>
+        useEditSequenceShortcut({ canArm: () => false, onSequence }),
+      );
+
+      pressKey("e");
+      expect(isEditSequenceArmed()).toBe(false);
+      expect(useEventJumpStore.getState().isActive).toBe(true);
+
+      pressKey("t");
+      expect(onSequence).not.toHaveBeenCalled();
     });
 
     it("still fires under app lock when ignoreAppLock is set", () => {

--- a/packages/web/src/shortcuts/useEditSequenceShortcut.ts
+++ b/packages/web/src/shortcuts/useEditSequenceShortcut.ts
@@ -17,7 +17,10 @@ import {
   normalizedKeyboardKey,
 } from "@web/shortcuts/is-bare-letter-key";
 import { KEYMAP } from "@web/shortcuts/keymap";
-import { isEventJumpActive } from "@web/shortcuts/shift-hint/event-jump.store";
+import {
+  eventJumpActions,
+  isEventJumpActive,
+} from "@web/shortcuts/shift-hint/event-jump.store";
 import { createKeyupSwallow } from "@web/shortcuts/swallow-next-keyup";
 import { shortcutHintProgressActions } from "@web/shortcuts/tips/shortcut-tips.progress.store";
 
@@ -53,6 +56,10 @@ const hasModifier = (event: KeyboardEvent) =>
  * targets. Both land in the same arm/dispatch path, which is why this is one
  * listener rather than two: a second listener claiming `Mod+E` would fire the
  * sequence twice.
+ *
+ * Jump mode can still be on after focusing a card (`h` then a day letter).
+ * Arming turns jump off so the follow key (`t` title vs Tuesday) cannot be
+ * stolen. A stray `e` with nothing to edit does not arm (`canArm`).
  *
  * Capture-phase listeners suppress the follow key's keyup so existing keyup
  * shortcuts (e.g. `t` → today, `d` → day view) do not also run.
@@ -183,11 +190,15 @@ export function useEditSequenceShortcut<
           !isEditableKeyboardTarget(event));
 
       if (!isLeader) return;
-      // Event jump owns the letter keys while it is on, and it already stands
-      // down for an armed sequence. Yield back, or a stray `e` would arm
-      // underneath the jump hints and steal the next day letter.
-      if (isEventJumpActive()) return;
+      // `canArm` is the stray-`e` gate (nothing focused → do not swallow the
+      // next key). Jump mode staying on after a focused card used to block
+      // this path entirely, so `e` then `t` selected Tuesday instead of the
+      // title. Drop jump once we are actually arming so the follow key cannot
+      // be read as a day prefix.
       if (canArmRef.current && !canArmRef.current()) return;
+      if (isEventJumpActive()) {
+        eventJumpActions.setActive(false);
+      }
 
       if (isMod) {
         event.preventDefault();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After focusing a calendar event with `h` (event jump), `e` then `t` selected Tuesday instead of editing the title. Jump mode stays on after a card is focused, the edit leader refused to arm while jump was active, and bare `t` is Tuesday's day prefix.

The edit sequence now arms whenever there is something to edit, turns jump off, and jump leaves unmatched `e` unclaimed so the follow key cannot be stolen regardless of capture-listener order. A stray `e` with nothing focused still leaves jump on, so `t` remains Tuesday.

![Edit-which-field menu after h then m then e on Monday](https://cursor.com/artifacts/c/art-57cb16dc-0a53-494b-b646-d041944c16df)
![Title field focused for Monday Deep work day after e then t](https://cursor.com/artifacts/c/art-444068c0-4f53-4291-967e-be448220511f)
<a href="https://cursor.com/agents/bc-10d37976-989d-4ec3-922e-fcef2ec05dca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fedit_title_after_event_jump.mp4"><img src="https://cursor.com/artifacts/c/art-17cc6b36-fcb9-4301-b1f0-9644f529eef5" alt="edit_title_after_event_jump.mp4" /></a>

## Simplicity

Two capture listeners and the existing `canArm` gate. No new mode or keymap.

## Automated validation

Browser: week view, `h` then `m` focused Monday "Deep work day", `e` then `t` opened that event's form with the title caret (typed `!`). Separate check: `h` then `t` still focuses Tuesday "Design review".

`bun run verify` (web): test:web, type-check, lint, knip, test:a11y, test:e2e. Checks skipped: none. All passed.

## Independent review

```
VERDICT: no confirmed findings
FINDINGS:
```

Reviewed the full `origin/main...HEAD` diff. `canArm` still gates stray `e`. Jump's armed-sequence yield covers a stale `isActiveRef` until React syncs `setActive(false)`. Unmatched `e` is left unclaimed so a later-registered edit listener can arm; other unmatched letters stay swallowed.

## Test plan

- `bun test:web packages/web/src/shortcuts/useEditSequenceShortcut.test.tsx packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx` (55 pass)
- `bun run verify` (test:web, type-check, lint, knip, test:a11y, test:e2e; none skipped)
- Browser: `h` `m` `e` `t` edits Monday title; `h` `t` still jumps to Tuesday
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10d37976-989d-4ec3-922e-fcef2ec05dca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10d37976-989d-4ec3-922e-fcef2ec05dca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

