### PR TITLE
feat(booking): confirmation permalink that survives refresh

### DIFF
--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -3,6 +3,7 @@ import {
   buildBookableSlot,
   formatSlotButtonLabel,
   preparePublicBookingCancelPage,
+  preparePublicBookingConfirmedPage,
   preparePublicBookingPage,
 } from "../booking/booking-harness";
 import { expectNoAxeViolations } from "../utils/axe-assertion";
@@ -83,65 +84,105 @@ test("the public booking conflict alert has no automatically detectable accessib
   await expectNoAxeViolations(page, { checkpoint: "public booking conflict" });
 });
 
-test.describe("public booking cancel page", () => {
-  test("confirm state has no automatically detectable accessibility violations", async ({
+test.describe("public booking confirmation page", () => {
+  test("confirmed state has no automatically detectable accessibility violations", async ({
     page,
   }) => {
-    await preparePublicBookingCancelPage(page);
+    await preparePublicBookingConfirmedPage(page);
     await expect(
-      page.getByRole("heading", { name: "Cancel this booking?" }),
+      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
     ).toBeVisible();
-    await expectNoAxeViolations(page, { checkpoint: "cancel confirm" });
-  });
-
-  test("cancelling state has no automatically detectable accessibility violations", async ({
-    page,
-  }) => {
-    let release!: () => void;
-    const holdCancel = new Promise<void>((resolve) => {
-      release = resolve;
+    await expectNoAxeViolations(page, {
+      checkpoint: "booking confirmation permalink",
     });
-    await preparePublicBookingCancelPage(page, { holdCancel });
-    await page.getByRole("button", { name: "Cancel this booking" }).click();
-    await expect(
-      page.getByRole("button", { name: "Canceling..." }),
-    ).toBeVisible();
-    await expectNoAxeViolations(page, { checkpoint: "cancel in-flight" });
-    release();
-    await expect(
-      page.getByRole("heading", { name: "Booking canceled" }),
-    ).toBeVisible();
   });
 
-  test("canceled state has no automatically detectable accessibility violations", async ({
+  test("cancelled state has no automatically detectable accessibility violations", async ({
     page,
   }) => {
-    await preparePublicBookingCancelPage(page);
-    await page.getByRole("button", { name: "Cancel this booking" }).click();
+    await preparePublicBookingConfirmedPage(page, {
+      reservationStatus: "cancelled",
+    });
     await expect(
-      page.getByRole("heading", { name: "Booking canceled" }),
+      page.getByRole("heading", { name: "This booking was canceled" }),
     ).toBeVisible();
-    await expectNoAxeViolations(page, { checkpoint: "cancel success" });
+    await expectNoAxeViolations(page, {
+      checkpoint: "booking confirmation cancelled",
+    });
   });
 
   test("not-found state has no automatically detectable accessibility violations", async ({
     page,
   }) => {
-    await preparePublicBookingCancelPage(page, { token: "" });
+    await preparePublicBookingConfirmedPage(page, {
+      reservationNotFound: true,
+    });
     await expect(
       page.getByRole("heading", { name: "Booking not found" }),
     ).toBeVisible();
-    await expectNoAxeViolations(page, { checkpoint: "cancel not found" });
-  });
-
-  test("error state has no automatically detectable accessibility violations", async ({
-    page,
-  }) => {
-    await preparePublicBookingCancelPage(page, { cancelStatus: 500 });
-    await page.getByRole("button", { name: "Cancel this booking" }).click();
-    await expect(
-      page.getByRole("heading", { name: "Could not cancel booking" }),
-    ).toBeVisible();
-    await expectNoAxeViolations(page, { checkpoint: "cancel error" });
+    await expectNoAxeViolations(page, {
+      checkpoint: "booking confirmation not found",
+    });
   });
 });
+test("confirm state has no automatically detectable accessibility violations", async ({
+  page,
+}) => {
+  await preparePublicBookingCancelPage(page);
+  await expect(
+    page.getByRole("heading", { name: "Cancel this booking?" }),
+  ).toBeVisible();
+  await expectNoAxeViolations(page, { checkpoint: "cancel confirm" });
+});
+
+test("cancelling state has no automatically detectable accessibility violations", async ({
+  page,
+}) => {
+  let release!: () => void;
+  const holdCancel = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await preparePublicBookingCancelPage(page, { holdCancel });
+  await page.getByRole("button", { name: "Cancel this booking" }).click();
+  await expect(
+    page.getByRole("button", { name: "Canceling..." }),
+  ).toBeVisible();
+  await expectNoAxeViolations(page, { checkpoint: "cancel in-flight" });
+  release();
+  await expect(
+    page.getByRole("heading", { name: "Booking canceled" }),
+  ).toBeVisible();
+});
+
+test("canceled state has no automatically detectable accessibility violations", async ({
+  page,
+}) => {
+  await preparePublicBookingCancelPage(page);
+  await page.getByRole("button", { name: "Cancel this booking" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Booking canceled" }),
+  ).toBeVisible();
+  await expectNoAxeViolations(page, { checkpoint: "cancel success" });
+});
+
+test("not-found state has no automatically detectable accessibility violations", async ({
+  page,
+}) => {
+  await preparePublicBookingCancelPage(page, { token: "" });
+  await expect(
+    page.getByRole("heading", { name: "Booking not found" }),
+  ).toBeVisible();
+  await expectNoAxeViolations(page, { checkpoint: "cancel not found" });
+});
+
+test("error state has no automatically detectable accessibility violations", async ({
+  page,
+}) => {
+  await preparePublicBookingCancelPage(page, { cancelStatus: 500 });
+  await page.getByRole("button", { name: "Cancel this booking" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Could not cancel booking" }),
+  ).toBeVisible();
+  await expectNoAxeViolations(page, { checkpoint: "cancel error" });
+});
+})

--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -125,64 +125,66 @@ test.describe("public booking confirmation page", () => {
     });
   });
 });
-test("confirm state has no automatically detectable accessibility violations", async ({
-  page,
-}) => {
-  await preparePublicBookingCancelPage(page);
-  await expect(
-    page.getByRole("heading", { name: "Cancel this booking?" }),
-  ).toBeVisible();
-  await expectNoAxeViolations(page, { checkpoint: "cancel confirm" });
-});
 
-test("cancelling state has no automatically detectable accessibility violations", async ({
-  page,
-}) => {
-  let release!: () => void;
-  const holdCancel = new Promise<void>((resolve) => {
-    release = resolve;
+test.describe("public booking cancel page", () => {
+  test("confirm state has no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await preparePublicBookingCancelPage(page);
+    await expect(
+      page.getByRole("heading", { name: "Cancel this booking?" }),
+    ).toBeVisible();
+    await expectNoAxeViolations(page, { checkpoint: "cancel confirm" });
   });
-  await preparePublicBookingCancelPage(page, { holdCancel });
-  await page.getByRole("button", { name: "Cancel this booking" }).click();
-  await expect(
-    page.getByRole("button", { name: "Canceling..." }),
-  ).toBeVisible();
-  await expectNoAxeViolations(page, { checkpoint: "cancel in-flight" });
-  release();
-  await expect(
-    page.getByRole("heading", { name: "Booking canceled" }),
-  ).toBeVisible();
-});
 
-test("canceled state has no automatically detectable accessibility violations", async ({
-  page,
-}) => {
-  await preparePublicBookingCancelPage(page);
-  await page.getByRole("button", { name: "Cancel this booking" }).click();
-  await expect(
-    page.getByRole("heading", { name: "Booking canceled" }),
-  ).toBeVisible();
-  await expectNoAxeViolations(page, { checkpoint: "cancel success" });
-});
+  test("cancelling state has no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    let release!: () => void;
+    const holdCancel = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await preparePublicBookingCancelPage(page, { holdCancel });
+    await page.getByRole("button", { name: "Cancel this booking" }).click();
+    await expect(
+      page.getByRole("button", { name: "Canceling..." }),
+    ).toBeVisible();
+    await expectNoAxeViolations(page, { checkpoint: "cancel in-flight" });
+    release();
+    await expect(
+      page.getByRole("heading", { name: "Booking canceled" }),
+    ).toBeVisible();
+  });
 
-test("not-found state has no automatically detectable accessibility violations", async ({
-  page,
-}) => {
-  await preparePublicBookingCancelPage(page, { token: "" });
-  await expect(
-    page.getByRole("heading", { name: "Booking not found" }),
-  ).toBeVisible();
-  await expectNoAxeViolations(page, { checkpoint: "cancel not found" });
-});
+  test("canceled state has no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await preparePublicBookingCancelPage(page);
+    await page.getByRole("button", { name: "Cancel this booking" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Booking canceled" }),
+    ).toBeVisible();
+    await expectNoAxeViolations(page, { checkpoint: "cancel success" });
+  });
 
-test("error state has no automatically detectable accessibility violations", async ({
-  page,
-}) => {
-  await preparePublicBookingCancelPage(page, { cancelStatus: 500 });
-  await page.getByRole("button", { name: "Cancel this booking" }).click();
-  await expect(
-    page.getByRole("heading", { name: "Could not cancel booking" }),
-  ).toBeVisible();
-  await expectNoAxeViolations(page, { checkpoint: "cancel error" });
+  test("not-found state has no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await preparePublicBookingCancelPage(page, { token: "" });
+    await expect(
+      page.getByRole("heading", { name: "Booking not found" }),
+    ).toBeVisible();
+    await expectNoAxeViolations(page, { checkpoint: "cancel not found" });
+  });
+
+  test("error state has no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await preparePublicBookingCancelPage(page, { cancelStatus: 500 });
+    await page.getByRole("button", { name: "Cancel this booking" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Could not cancel booking" }),
+    ).toBeVisible();
+    await expectNoAxeViolations(page, { checkpoint: "cancel error" });
+  });
 });
-})

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -68,6 +68,10 @@ export interface PublicBookingStubOptions {
   slotFailGate?: { fail: boolean };
   /** When set, the first slot GET waits until this resolves. */
   holdFirstSlots?: Promise<void>;
+  /** Public GET reservation status. Defaults to confirmed. */
+  reservationStatus?: "confirmed" | "cancelled";
+  /** When true, GET /reservations/:id returns 404. */
+  reservationNotFound?: boolean;
 }
 
 export interface CapturedBookingRequests {
@@ -168,6 +172,33 @@ export async function preparePublicBookingPage(
       );
     }
 
+    if (
+      /^\/api\/booking\/reservations\/[^/]+$/.test(path) &&
+      request.method() === "GET"
+    ) {
+      if (options.reservationNotFound) {
+        return route.fulfill(json({}, 404));
+      }
+      const lastPost = captured.reservationPosts.at(-1);
+      const postedSlotStart =
+        typeof lastPost?.slotStart === "string"
+          ? lastPost.slotStart
+          : slot.slotStart;
+      const postedTimeZone =
+        typeof lastPost?.guestTimeZone === "string"
+          ? lastPost.guestTimeZone
+          : "UTC";
+      return route.fulfill(
+        json({
+          slotStart: postedSlotStart,
+          guestTimeZone: postedTimeZone,
+          durationMinutes: options.durationMinutes ?? 30,
+          hostDisplayName: options.hostDisplayName ?? "Tyler Dane",
+          status: options.reservationStatus ?? "confirmed",
+        }),
+      );
+    }
+
     return route.fulfill(json({}));
   });
 
@@ -177,6 +208,51 @@ export async function preparePublicBookingPage(
   ).toBeVisible({ timeout: 15000 });
 
   return captured;
+}
+
+export async function preparePublicBookingConfirmedPage(
+  page: Page,
+  options: PublicBookingStubOptions & { reservationId?: string } = {},
+): Promise<void> {
+  const reservationId = options.reservationId ?? "000000000000000000000099";
+  const slot =
+    options.slots?.[0] ?? buildBookableSlot(options.durationMinutes ?? 30);
+
+  const json = (body: unknown, status = 200) => ({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+
+  await page.route("**/api/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname;
+
+    if (
+      /^\/api\/booking\/reservations\/[^/]+$/.test(path) &&
+      request.method() === "GET"
+    ) {
+      if (options.reservationNotFound) {
+        return route.fulfill(json({}, 404));
+      }
+      return route.fulfill(
+        json({
+          slotStart: slot.slotStart,
+          guestTimeZone: "UTC",
+          durationMinutes: options.durationMinutes ?? 30,
+          hostDisplayName: options.hostDisplayName ?? "Tyler Dane",
+          status: options.reservationStatus ?? "confirmed",
+        }),
+      );
+    }
+
+    return route.fulfill(json({}));
+  });
+
+  await page.goto(`/book/confirmed/${reservationId}`, {
+    waitUntil: "domcontentloaded",
+  });
 }
 
 export interface PublicBookingCancelStubOptions {

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 import {
   buildBookableSlot,
   formatSlotButtonLabel,
+  preparePublicBookingConfirmedPage,
   preparePublicBookingPage,
 } from "./booking-harness";
 
@@ -73,6 +74,85 @@ test.describe("public booking page", () => {
       slotStart,
       guestTimeZone: "Europe/Berlin",
     });
+  });
+
+  test("keeps confirmation details after a refresh", async ({ page }) => {
+    const { slotStart } = buildBookableSlot();
+    await preparePublicBookingPage(page);
+
+    await page
+      .getByRole("button", { name: formatSlotButtonLabel(slotStart) })
+      .click();
+    await page.getByLabel("Name").fill("Guest User");
+    await page.getByLabel("Email").fill("guest@example.com");
+    await page.getByRole("button", { name: "Confirm booking" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+    ).toBeVisible();
+    await expect(page).toHaveURL(
+      /\/book\/confirmed\/000000000000000000000099$/,
+    );
+    await expect(
+      page.getByRole("button", { name: "Copy cancel link" }),
+    ).toBeVisible();
+
+    await page.reload({ waitUntil: "domcontentloaded" });
+
+    await expect(
+      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+    ).toBeVisible();
+    await expect(page.getByText("30 minutes")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Copy cancel link" }),
+    ).toHaveCount(0);
+  });
+
+  test("copies the cancel link from the confirmation page", async ({
+    page,
+    context,
+  }) => {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    const { slotStart } = buildBookableSlot();
+    await preparePublicBookingPage(page);
+
+    await page
+      .getByRole("button", { name: formatSlotButtonLabel(slotStart) })
+      .click();
+    await page.getByLabel("Name").fill("Guest User");
+    await page.getByLabel("Email").fill("guest@example.com");
+    await page.getByRole("button", { name: "Confirm booking" }).click();
+
+    await page.getByRole("button", { name: "Copy cancel link" }).click();
+    await expect(page.getByRole("button", { name: "Copied" })).toBeVisible();
+    await expect(page.getByRole("status")).toHaveText("Copied");
+    await expect
+      .poll(async () => page.evaluate(() => navigator.clipboard.readText()))
+      .toBe(
+        "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+      );
+  });
+
+  test("shows a calm state for a cancelled confirmation permalink", async ({
+    page,
+  }) => {
+    await preparePublicBookingConfirmedPage(page, {
+      reservationStatus: "cancelled",
+    });
+    await expect(
+      page.getByRole("heading", { name: "This booking was canceled" }),
+    ).toBeVisible();
+  });
+
+  test("shows a calm state for an unknown confirmation permalink", async ({
+    page,
+  }) => {
+    await preparePublicBookingConfirmedPage(page, {
+      reservationNotFound: true,
+    });
+    await expect(
+      page.getByRole("heading", { name: "Booking not found" }),
+    ).toBeVisible();
   });
 
   test("does not POST when email is missing", async ({ page }) => {

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -103,6 +103,18 @@ test.describe("public booking page", () => {
       page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
     ).toBeVisible();
     await expect(page.getByText("30 minutes")).toBeVisible();
+    await expect(page).toHaveURL(
+      /\/book\/confirmed\/000000000000000000000099$/,
+    );
+  });
+
+  test("does not show a cancel copy button on a cold confirmation permalink", async ({
+    page,
+  }) => {
+    await preparePublicBookingConfirmedPage(page);
+    await expect(
+      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+    ).toBeVisible();
     await expect(
       page.getByRole("button", { name: "Copy cancel link" }),
     ).toHaveCount(0);

--- a/packages/backend/src/booking/booking-page.repository.ts
+++ b/packages/backend/src/booking/booking-page.repository.ts
@@ -12,6 +12,12 @@ class BookingPageRepository {
     return BookingPageRecordSchema.parse(record);
   }
 
+  async findById(id: ObjectId): Promise<BookingPageRecord | null> {
+    const record = await mongoService.bookingPage.findOne({ _id: id });
+    if (!record) return null;
+    return BookingPageRecordSchema.parse(record);
+  }
+
   async findBySlug(slug: string): Promise<BookingPageRecord | null> {
     const record = await mongoService.bookingPage.findOne({
       bookingSlug: slug,

--- a/packages/backend/src/booking/booking.routes.config.ts
+++ b/packages/backend/src/booking/booking.routes.config.ts
@@ -23,6 +23,17 @@ const publicConfirmLimiter = rateLimit({
   keyGenerator: bookingSlugKey,
 });
 
+const bookingReservationKey = (req: express.Request): string =>
+  `${req.ip ?? "unknown"}:${req.params["id"] ?? "unknown"}`;
+
+const publicReservationGetLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: bookingReservationKey,
+});
+
 /**
  * Host admin routes require a session. Public guest routes are unauthenticated.
  */
@@ -49,6 +60,10 @@ export class BookingRoutes extends CommonRoutesConfig {
     this.app
       .route(`/api/booking/pages/:slug/reservations`)
       .post(publicConfirmLimiter, bookingController.createReservation);
+
+    this.app
+      .route(`/api/booking/reservations/:id`)
+      .get(publicReservationGetLimiter, bookingController.getPublicReservation);
 
     this.app
       .route(`/api/booking/reservations/:id/cancel`)

--- a/packages/backend/src/booking/controllers/booking.controller.ts
+++ b/packages/backend/src/booking/controllers/booking.controller.ts
@@ -2,7 +2,10 @@ import { type Request, type Response } from "express";
 import { type SessionRequest } from "supertokens-node/framework/express";
 import { Status } from "@core/errors/status.codes";
 import { zObjectId } from "@core/types/type.utils";
-import { toBookingErrorResponse } from "@backend/booking/booking.error";
+import {
+  bookingError,
+  toBookingErrorResponse,
+} from "@backend/booking/booking.error";
 import bookingPageService from "@backend/booking/services/booking-page.service";
 import publicBookingService from "@backend/booking/services/public-booking.service";
 
@@ -63,6 +66,26 @@ class BookingController {
       const response = await publicBookingService.createReservation(
         req.params["slug"] ?? "",
         req.body,
+      );
+      res.status(Status.OK).json(response);
+    } catch (error) {
+      const { status, body } = toBookingErrorResponse(error);
+      res.status(status).json(body);
+    }
+  };
+
+  getPublicReservation = async (req: Request, res: Response) => {
+    try {
+      const parsedId = zObjectId.safeParse(req.params["id"]);
+      if (!parsedId.success) {
+        const { status, body } = toBookingErrorResponse(
+          bookingError("RESERVATION_NOT_FOUND", "Reservation not found"),
+        );
+        res.status(status).json(body);
+        return;
+      }
+      const response = await publicBookingService.getPublicReservation(
+        parsedId.data,
       );
       res.status(Status.OK).json(response);
     } catch (error) {

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -388,6 +388,34 @@ describe("PublicBookingService", () => {
     expect(publicReservation).not.toHaveProperty("notes");
   });
 
+  it("returns the booked slot duration after the host changes page duration", async () => {
+    const { slug, userId, calendarId } = await enableBookingPage();
+    const created = await service.createReservation(slug, {
+      slotStart: "2026-09-07T10:00:00.000Z",
+      guestName: "Ada Lovelace",
+      guestEmail: "ada@example.com",
+      notes: "secret notes",
+      guestTimeZone: "Europe/London",
+    });
+
+    spyOn(billingGuard, "assertBillingAllowsWrites").mockResolvedValue(
+      undefined,
+    );
+    await bookingPageService.putAdminPage(
+      userId,
+      samplePutInput({
+        destinationCalendarId: calendarId,
+        blockingCalendarIds: [calendarId],
+        durationMinutes: 45,
+      }),
+    );
+
+    const publicReservation = await service.getPublicReservation(
+      new ObjectId(created.reservationId),
+    );
+    expect(publicReservation.durationMinutes).toBe(30);
+  });
+
   it("returns cancelled status without leaking guest contact", async () => {
     const { slug } = await enableBookingPage();
     const created = await service.createReservation(slug, {

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -362,6 +362,58 @@ describe("PublicBookingService", () => {
     expect(stored?.status).toBe("cancelled");
   });
 
+  it("returns minimal public reservation details", async () => {
+    const { slug } = await enableBookingPage();
+    const created = await service.createReservation(slug, {
+      slotStart: "2026-09-07T10:00:00.000Z",
+      guestName: "Ada Lovelace",
+      guestEmail: "ada@example.com",
+      notes: "secret notes",
+      guestTimeZone: "Europe/London",
+    });
+
+    const publicReservation = await service.getPublicReservation(
+      new ObjectId(created.reservationId),
+    );
+
+    expect(publicReservation).toEqual({
+      slotStart: created.slotStart,
+      guestTimeZone: "Europe/London",
+      durationMinutes: 30,
+      hostDisplayName: "Host User",
+      status: "confirmed",
+    });
+    expect(publicReservation).not.toHaveProperty("guestEmail");
+    expect(publicReservation).not.toHaveProperty("cancelUrl");
+    expect(publicReservation).not.toHaveProperty("notes");
+  });
+
+  it("returns cancelled status without leaking guest contact", async () => {
+    const { slug } = await enableBookingPage();
+    const created = await service.createReservation(slug, {
+      slotStart: "2026-09-07T10:00:00.000Z",
+      guestName: "Ada Lovelace",
+      guestEmail: "ada@example.com",
+      guestTimeZone: "Europe/London",
+    });
+    const token = new URL(created.cancelUrl).searchParams.get("token");
+    await service.cancelReservation(new ObjectId(created.reservationId), {
+      token,
+    });
+
+    const publicReservation = await service.getPublicReservation(
+      new ObjectId(created.reservationId),
+    );
+    expect(publicReservation.status).toBe("cancelled");
+    expect(publicReservation).not.toHaveProperty("guestEmail");
+  });
+
+  it("throws not found for an unknown reservation", async () => {
+    await expect(
+      service.getPublicReservation(new ObjectId()),
+    ).rejects.toMatchObject({ bookingCode: "RESERVATION_NOT_FOUND" });
+  });
+
   it("rejects invalid guest email", async () => {
     const { slug } = await enableBookingPage();
     await expect(
@@ -462,6 +514,62 @@ describe("Public booking routes", () => {
       .getServer()
       .get("/api/booking/pages/notfound999")
       .expect(Status.NOT_FOUND);
+  });
+
+  it("GET public reservation returns 404 for an invalid id", async () => {
+    await baseDriver
+      .getServer()
+      .get("/api/booking/reservations/not-an-id")
+      .expect(Status.NOT_FOUND);
+  });
+
+  it("GET public reservation returns minimal fields", async () => {
+    const userId = await createNamedUser("Permalink Host");
+    const calendar = writableCalendar();
+    mockHealthySync([calendar]);
+    spyOn(billingGuard, "assertBillingAllowsWrites").mockResolvedValue(
+      undefined,
+    );
+    const page = await bookingPageService.putAdminPage(
+      userId,
+      samplePutInput({
+        destinationCalendarId: calendar.id,
+        blockingCalendarIds: [calendar.id],
+      }),
+    );
+    if (!("id" in page)) {
+      throw new Error("expected a saved booking page");
+    }
+    const reservationId = new ObjectId();
+    await bookingReservationRepository.insert({
+      _id: reservationId,
+      pageId: new ObjectId(page.id),
+      slotStart: new Date("2026-09-07T10:00:00.000Z"),
+      slotEnd: new Date("2026-09-07T10:30:00.000Z"),
+      guestName: "Ada Lovelace",
+      guestEmail: "ada@example.com",
+      notes: "secret notes",
+      guestTimeZone: "Europe/London",
+      status: "confirmed",
+      calendarEventId: "evt-1",
+      cancelTokenHash: "a".repeat(64),
+    });
+
+    const response = await baseDriver
+      .getServer()
+      .get(`/api/booking/reservations/${reservationId.toString()}`)
+      .expect(Status.OK);
+
+    expect(response.body).toEqual({
+      slotStart: "2026-09-07T10:00:00.000Z",
+      guestTimeZone: "Europe/London",
+      durationMinutes: 30,
+      hostDisplayName: "Permalink Host",
+      status: "confirmed",
+    });
+    expect(response.body).not.toHaveProperty("guestEmail");
+    expect(response.body).not.toHaveProperty("cancelUrl");
+    expect(response.body).not.toHaveProperty("notes");
   });
 
   it("POST reservation returns 409 when bookable is false", async () => {

--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -1,6 +1,7 @@
 import { MongoServerError, type ObjectId } from "mongodb";
 import { computeBookingSlots } from "@core/booking/compute-booking-slots";
 import {
+  BookingDurationMinutesSchema,
   BookingSlotsQuerySchema,
   type BookingSlotsResponse,
   BookingSlotsResponseSchema,
@@ -308,10 +309,18 @@ export class PublicBookingService {
     }
 
     const hostDisplayName = await getHostDisplayName(page.userId);
+    const fromSlot = Math.round(
+      (reservation.slotEnd.getTime() - reservation.slotStart.getTime()) /
+        60_000,
+    );
+    const durationMinutes = BookingDurationMinutesSchema.safeParse(fromSlot)
+      .success
+      ? fromSlot
+      : page.durationMinutes;
     return PublicGetBookingReservationResponseSchema.parse({
       slotStart: reservation.slotStart.toISOString(),
       guestTimeZone: reservation.guestTimeZone,
-      durationMinutes: page.durationMinutes,
+      durationMinutes,
       hostDisplayName,
       status: reservation.status,
     });

--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -9,6 +9,8 @@ import {
   CreateBookingReservationResponseSchema,
   type PublicBookingPage,
   PublicBookingPageSchema,
+  type PublicGetBookingReservationResponse,
+  PublicGetBookingReservationResponseSchema,
   toPublicBookingPage,
 } from "@core/types/booking.contracts";
 import { DateTimeSchema, type EventId } from "@core/types/domain-primitives";
@@ -289,6 +291,30 @@ export class PublicBookingService {
       }
       throw error;
     }
+  }
+
+  async getPublicReservation(
+    reservationId: ObjectId,
+  ): Promise<PublicGetBookingReservationResponse> {
+    const reservation =
+      await bookingReservationRepository.findById(reservationId);
+    if (!reservation) {
+      throw bookingError("RESERVATION_NOT_FOUND", "Reservation not found");
+    }
+
+    const page = await bookingPageRepository.findById(reservation.pageId);
+    if (!page) {
+      throw bookingError("RESERVATION_NOT_FOUND", "Reservation not found");
+    }
+
+    const hostDisplayName = await getHostDisplayName(page.userId);
+    return PublicGetBookingReservationResponseSchema.parse({
+      slotStart: reservation.slotStart.toISOString(),
+      guestTimeZone: reservation.guestTimeZone,
+      durationMinutes: page.durationMinutes,
+      hostDisplayName,
+      status: reservation.status,
+    });
   }
 
   async cancelReservation(

--- a/packages/core/src/types/booking.contracts.test.ts
+++ b/packages/core/src/types/booking.contracts.test.ts
@@ -8,6 +8,7 @@ import {
   CreateBookingReservationInputSchema,
   PublicBookingPageSchema,
   PublicGetBookingPageResponseSchema,
+  PublicGetBookingReservationResponseSchema,
   toPublicBookingPage,
   WeeklyAvailabilityIntervalSchema,
 } from "@core/types/booking.contracts";
@@ -234,5 +235,32 @@ describe("HTTP booking contracts", () => {
         guestTimeZone: "Europe/London",
       }).success,
     ).toBe(true);
+  });
+
+  it("parses a public reservation GET without guest contact fields", () => {
+    expect(
+      PublicGetBookingReservationResponseSchema.safeParse({
+        slotStart: "2026-09-01T15:00:00.000Z",
+        guestTimeZone: "Europe/London",
+        durationMinutes: 30,
+        hostDisplayName: "Tyler Dane",
+        status: "confirmed",
+      }).success,
+    ).toBe(true);
+    expect(
+      PublicGetBookingReservationResponseSchema.safeParse({
+        slotStart: "2026-09-01T15:00:00.000Z",
+        guestTimeZone: "Europe/London",
+        durationMinutes: 30,
+        hostDisplayName: "Tyler Dane",
+        status: "confirmed",
+        guestEmail: "ada@example.com",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects reserved slug confirmed", () => {
+    expect(BookingSlugSchema.safeParse("confirmed").success).toBe(false);
+    expect(BookingSlugSchema.safeParse("cancel").success).toBe(false);
   });
 });

--- a/packages/core/src/types/booking.contracts.ts
+++ b/packages/core/src/types/booking.contracts.ts
@@ -14,6 +14,8 @@ export const BOOKING_RESERVED_SLUGS = [
   "api",
   "cleanup",
   "book",
+  "cancel",
+  "confirmed",
   "p",
   "settings",
   "admin",
@@ -269,6 +271,17 @@ export const CreateBookingReservationResponseSchema = z.strictObject({
 });
 export type CreateBookingReservationResponse = z.infer<
   typeof CreateBookingReservationResponseSchema
+>;
+
+export const PublicGetBookingReservationResponseSchema = z.strictObject({
+  slotStart: DateTimeSchema,
+  guestTimeZone: TimeZoneSchema,
+  durationMinutes: BookingDurationMinutesSchema,
+  hostDisplayName: z.string().trim().min(1).max(256),
+  status: BookingReservationStatusSchema,
+});
+export type PublicGetBookingReservationResponse = z.infer<
+  typeof PublicGetBookingReservationResponseSchema
 >;
 
 export const CancelBookingReservationInputSchema = z.strictObject({

--- a/packages/web/src/api/public-booking.api.ts
+++ b/packages/web/src/api/public-booking.api.ts
@@ -11,6 +11,8 @@ import {
   CreateBookingReservationResponseSchema,
   type PublicGetBookingPageResponse,
   PublicGetBookingPageResponseSchema,
+  type PublicGetBookingReservationResponse,
+  PublicGetBookingReservationResponseSchema,
 } from "@core/types/booking.contracts";
 import { BaseApi } from "@web/api/base/base.api";
 import { getErrorStatus } from "@web/api/util/api.util";
@@ -67,6 +69,23 @@ const PublicBookingApi = {
       { skipSessionRecovery: true },
     );
     return CreateBookingReservationResponseSchema.parse(response.data);
+  },
+
+  async getReservation(
+    reservationId: string,
+  ): Promise<PublicGetBookingReservationResponse> {
+    try {
+      const response = await BaseApi.get<unknown>(
+        `/booking/reservations/${encodeURIComponent(reservationId)}`,
+        { skipSessionRecovery: true },
+      );
+      return PublicGetBookingReservationResponseSchema.parse(response.data);
+    } catch (error) {
+      if (getErrorStatus(error) === 404) {
+        throw new PublicBookingNotFoundError();
+      }
+      throw error;
+    }
   },
 
   async cancelReservation(

--- a/packages/web/src/booking/PublicBookingConfirmationView.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmationView.tsx
@@ -1,32 +1,33 @@
+import { PublicBookingCopyCancelUrl } from "@web/booking/PublicBookingCopyCancelUrl";
 import { PublicBookingLayout } from "@web/booking/PublicBookingLayout";
 import {
   formatBookingSlotLabel,
   formatDurationMinutes,
 } from "@web/booking/public-booking.format";
-import { type PublicBookingConfirmation } from "@web/booking/public-booking.query";
 
 interface PublicBookingConfirmationViewProps {
   hostDisplayName: string;
   durationMinutes: number;
-  confirmation: PublicBookingConfirmation;
+  slotStart: string;
+  timeZone: string;
+  cancelUrl?: string;
 }
 
 export function PublicBookingConfirmationView({
   hostDisplayName,
   durationMinutes,
-  confirmation,
+  slotStart,
+  timeZone,
+  cancelUrl,
 }: PublicBookingConfirmationViewProps) {
-  const when = formatBookingSlotLabel(
-    confirmation.slotStart,
-    confirmation.guestTimeZone,
-  );
+  const when = formatBookingSlotLabel(slotStart, timeZone);
 
   return (
     <PublicBookingLayout>
       <section aria-labelledby="booking-confirmation-heading">
         <h1
           id="booking-confirmation-heading"
-          className="font-semibold text-xl text-text"
+          className="font-semibold text-text text-xl"
         >
           You are booked with {hostDisplayName}
         </h1>
@@ -35,16 +36,12 @@ export function PublicBookingConfirmationView({
         </p>
         <p className="mt-4 text-sm text-text">
           A calendar invite is on its way to your email. To cancel, use the link
-          in that invite or visit:
+          in that invite
+          {cancelUrl ? " or copy it here:" : "."}
         </p>
-        <p className="mt-2 break-all text-sm text-accent">
-          <a
-            href={confirmation.cancelUrl}
-            className="underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-          >
-            {confirmation.cancelUrl}
-          </a>
-        </p>
+        {cancelUrl ? (
+          <PublicBookingCopyCancelUrl cancelUrl={cancelUrl} />
+        ) : null}
       </section>
     </PublicBookingLayout>
   );

--- a/packages/web/src/booking/PublicBookingConfirmedPage.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmedPage.tsx
@@ -1,0 +1,67 @@
+import { useParams, useRouterState } from "@tanstack/react-router";
+import { PublicBookingConfirmationView } from "@web/booking/PublicBookingConfirmationView";
+import { PublicBookingStatusMessage } from "@web/booking/PublicBookingStatusMessage";
+import { usePublicBookingReservationQuery } from "@web/booking/public-booking.query";
+
+function cancelUrlFromHistory(state: unknown): string | undefined {
+  if (
+    state &&
+    typeof state === "object" &&
+    "cancelUrl" in state &&
+    typeof state.cancelUrl === "string" &&
+    state.cancelUrl.length > 0
+  ) {
+    return state.cancelUrl;
+  }
+  return undefined;
+}
+
+export function PublicBookingConfirmedPage() {
+  const { reservationId } = useParams({
+    from: "/book/confirmed/$reservationId",
+  });
+  const cancelUrl = useRouterState({
+    select: (routerState) => cancelUrlFromHistory(routerState.location.state),
+  });
+  const reservationQuery = usePublicBookingReservationQuery(reservationId);
+
+  if (reservationQuery.isLoading) {
+    return (
+      <PublicBookingStatusMessage
+        title="Loading booking"
+        description="One moment while we load this confirmation."
+      />
+    );
+  }
+
+  if (reservationQuery.isError || !reservationQuery.data) {
+    return (
+      <PublicBookingStatusMessage
+        title="Booking not found"
+        description="This confirmation link may be incorrect or no longer available."
+      />
+    );
+  }
+
+  const reservation = reservationQuery.data;
+  if (reservation.status === "cancelled") {
+    return (
+      <PublicBookingStatusMessage
+        title="This booking was canceled"
+        description="The appointment is no longer on the host calendar. You can close this page."
+      />
+    );
+  }
+
+  return (
+    <PublicBookingConfirmationView
+      hostDisplayName={reservation.hostDisplayName}
+      durationMinutes={reservation.durationMinutes}
+      slotStart={reservation.slotStart}
+      timeZone={reservation.guestTimeZone}
+      cancelUrl={cancelUrl}
+    />
+  );
+}
+
+export default PublicBookingConfirmedPage;

--- a/packages/web/src/booking/PublicBookingConfirmedPage.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmedPage.tsx
@@ -1,4 +1,5 @@
 import { useParams, useRouterState } from "@tanstack/react-router";
+import { PublicBookingNotFoundError } from "@web/api/public-booking.api";
 import { PublicBookingConfirmationView } from "@web/booking/PublicBookingConfirmationView";
 import { PublicBookingStatusMessage } from "@web/booking/PublicBookingStatusMessage";
 import { usePublicBookingReservationQuery } from "@web/booking/public-booking.query";
@@ -34,7 +35,24 @@ export function PublicBookingConfirmedPage() {
     );
   }
 
-  if (reservationQuery.isError || !reservationQuery.data) {
+  if (reservationQuery.isError) {
+    if (reservationQuery.error instanceof PublicBookingNotFoundError) {
+      return (
+        <PublicBookingStatusMessage
+          title="Booking not found"
+          description="This confirmation link may be incorrect or no longer available."
+        />
+      );
+    }
+    return (
+      <PublicBookingStatusMessage
+        title="Could not load booking"
+        description="Please refresh and try again."
+      />
+    );
+  }
+
+  if (!reservationQuery.data) {
     return (
       <PublicBookingStatusMessage
         title="Booking not found"

--- a/packages/web/src/booking/PublicBookingCopyCancelUrl.tsx
+++ b/packages/web/src/booking/PublicBookingCopyCancelUrl.tsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import { copyText } from "@web/common/utils/clipboard/clipboard.util";
+
+interface PublicBookingCopyCancelUrlProps {
+  cancelUrl: string;
+}
+
+export function PublicBookingCopyCancelUrl({
+  cancelUrl,
+}: PublicBookingCopyCancelUrlProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    void copyText(cancelUrl).then((didCopy) => {
+      if (!didCopy) {
+        return;
+      }
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <div className="mt-4 flex flex-col gap-2">
+      <a
+        href={cancelUrl}
+        className="break-all text-accent text-sm underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+      >
+        {cancelUrl}
+      </a>
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="self-start rounded-md border border-border bg-surface px-3 py-1.5 text-sm text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+      >
+        {copied ? "Copied" : "Copy cancel link"}
+      </button>
+      <p role="status" className="sr-only">
+        {copied ? "Copied" : ""}
+      </p>
+    </div>
+  );
+}

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -1100,8 +1100,9 @@ describe("PublicBookingConfirmedPage", () => {
   it("copies the cancel URL when history state includes it", async () => {
     const user = userEvent.setup({ delay: null });
     const written: string[] = [];
-    Object.assign(navigator, {
-      clipboard: {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
         writeText: async (value: string) => {
           written.push(value);
         },

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -1097,6 +1097,21 @@ describe("PublicBookingConfirmedPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows a retryable state when the public GET fails", async () => {
+    server.use(
+      rest.get(
+        `${ENV_WEB.API_BASEURL}/booking/reservations/000000000000000000000099`,
+        (_req, res, ctx) =>
+          res(ctx.status(Status.INTERNAL_SERVER), ctx.json({})),
+      ),
+    );
+    renderBookingRoute("/book/confirmed/000000000000000000000099");
+
+    expect(
+      await screen.findByRole("heading", { name: "Could not load booking" }),
+    ).toBeInTheDocument();
+  });
+
   it("copies the cancel URL when history state includes it", async () => {
     const user = userEvent.setup({ delay: null });
     const written: string[] = [];

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -308,7 +308,7 @@ describe("PublicBookingPage", () => {
 
     await user.click(await screen.findByRole("button", { name: "Next month" }));
 
-    const utcDateKey = formatBookingSlotDateKey(slot.slotStart, guestTimeZone);
+    const utcDateKey = formatBookingDateKey(slot.slotStart, guestTimeZone);
     expect(
       await screen.findByRole("button", {
         name: formatBookingMonthDayLabel(utcDateKey, guestTimeZone),
@@ -329,7 +329,7 @@ describe("PublicBookingPage", () => {
       expect(slotTimeZones).toContain(overrideZone);
     });
 
-    const tokyoDateKey = formatBookingSlotDateKey(slot.slotStart, overrideZone);
+    const tokyoDateKey = formatBookingDateKey(slot.slotStart, overrideZone);
     expect(tokyoDateKey).not.toBe(utcDateKey);
     expect(
       await screen.findByRole("button", {

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -121,6 +121,27 @@ function slotsInWindow(
   );
 }
 
+function reservationGetHandler(
+  overrides: Record<string, unknown> = {},
+  id = "000000000000000000000099",
+) {
+  return rest.get(
+    `${ENV_WEB.API_BASEURL}/booking/reservations/${id}`,
+    (_req, res, ctx) =>
+      res(
+        ctx.status(Status.OK),
+        ctx.json({
+          slotStart: currentSlot.slotStart,
+          guestTimeZone: "UTC",
+          durationMinutes: 30,
+          hostDisplayName: "Tyler Dane",
+          status: "confirmed",
+          ...overrides,
+        }),
+      ),
+  );
+}
+
 describe("PublicBookingPage", () => {
   it("shows a generic not-found state for an unknown slug", async () => {
     renderBookingRoute("/book/unknown-host");
@@ -140,6 +161,7 @@ describe("PublicBookingPage", () => {
     server.use(
       pageHandler(),
       slotsInWindow([currentSlot]),
+      reservationGetHandler(),
       rest.post(
         `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/reservations`,
         async (req, res, ctx) => {
@@ -219,6 +241,9 @@ describe("PublicBookingPage", () => {
       guestEmail: "guest@example.com",
       guestTimeZone: "UTC",
     });
+    expect(
+      screen.getByRole("button", { name: "Copy cancel link" }),
+    ).toBeInTheDocument();
   });
 
   it("overrides the guest timezone for labels, day grouping, and submit", async () => {
@@ -252,6 +277,10 @@ describe("PublicBookingPage", () => {
           );
         },
       ),
+      reservationGetHandler({
+        slotStart: slot.slotStart,
+        guestTimeZone: overrideZone,
+      }),
       rest.post(
         `${ENV_WEB.API_BASEURL}/booking/pages/tzhost/reservations`,
         async (req, res, ctx) => {
@@ -822,6 +851,7 @@ describe("PublicBookingPage", () => {
     server.use(
       pageHandler(),
       slotsInWindow([currentSlot]),
+      reservationGetHandler(),
       rest.post(
         `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/reservations`,
         async (_req, res, ctx) => {
@@ -1023,5 +1053,99 @@ describe("PublicBookingPage", () => {
     expect(
       await screen.findByRole("heading", { name: "Pick a time" }),
     ).toBeInTheDocument();
+  });
+});
+
+describe("PublicBookingConfirmedPage", () => {
+  it("shows booking details from the public GET", async () => {
+    server.use(reservationGetHandler());
+    renderBookingRoute("/book/confirmed/000000000000000000000099");
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "You are booked with Tyler Dane",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/30 minutes/)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Copy cancel link" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows a calm state for a cancelled reservation", async () => {
+    server.use(reservationGetHandler({ status: "cancelled" }));
+    renderBookingRoute("/book/confirmed/000000000000000000000099");
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "This booking was canceled",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a calm state for an unknown reservation", async () => {
+    server.use(
+      rest.get(
+        `${ENV_WEB.API_BASEURL}/booking/reservations/000000000000000000000099`,
+        (_req, res, ctx) => res(ctx.status(Status.NOT_FOUND), ctx.json({})),
+      ),
+    );
+    renderBookingRoute("/book/confirmed/000000000000000000000099");
+
+    expect(
+      await screen.findByRole("heading", { name: "Booking not found" }),
+    ).toBeInTheDocument();
+  });
+
+  it("copies the cancel URL when history state includes it", async () => {
+    const user = userEvent.setup({ delay: null });
+    const written: string[] = [];
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: async (value: string) => {
+          written.push(value);
+        },
+      },
+    });
+
+    server.use(
+      pageHandler(),
+      slotsInWindow([currentSlot]),
+      reservationGetHandler(),
+      rest.post(
+        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/reservations`,
+        async (_req, res, ctx) =>
+          res(
+            ctx.status(Status.OK),
+            ctx.json({
+              reservationId: "000000000000000000000099",
+              slotStart: currentSlot.slotStart,
+              slotEnd: currentSlot.slotEnd,
+              guestTimeZone: "UTC",
+              cancelUrl:
+                "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+            }),
+          ),
+      ),
+    );
+
+    renderBookingRoute("/book/tylerdane");
+    await user.click(
+      await screen.findByRole("button", {
+        name: slotTimePattern(currentSlot.slotStart),
+      }),
+    );
+    await user.type(screen.getByLabelText("Name"), "Guest User");
+    await user.type(screen.getByLabelText("Email"), "guest@example.com");
+    await user.click(screen.getByRole("button", { name: "Confirm booking" }));
+    await user.click(
+      await screen.findByRole("button", { name: "Copy cancel link" }),
+    );
+
+    expect(written).toEqual([
+      "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+    ]);
+    expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Copied");
   });
 });

--- a/packages/web/src/booking/PublicBookingPage.tsx
+++ b/packages/web/src/booking/PublicBookingPage.tsx
@@ -307,7 +307,8 @@ export function PublicBookingPage() {
       await navigate({
         to: ROOT_ROUTES.BOOK_CONFIRMED,
         params: { reservationId: result.reservationId },
-        state: { cancelUrl: result.cancelUrl },
+        // Post-submit only: the public GET cannot reconstruct the cancel token.
+        state: { cancelUrl: result.cancelUrl } as never,
       });
     } catch (error) {
       if (isPublicBookingConflictError(error)) {

--- a/packages/web/src/booking/PublicBookingPage.tsx
+++ b/packages/web/src/booking/PublicBookingPage.tsx
@@ -202,10 +202,7 @@ export function PublicBookingPage() {
     const currentMonthInOldZone = formatBookingMonthKey(dayjs(), guestTimeZone);
     setGuestTimeZone(nextTimeZone);
     if (selectedSlotStart) {
-      const nextDateKey = formatBookingSlotDateKey(
-        selectedSlotStart,
-        nextTimeZone,
-      );
+      const nextDateKey = formatBookingDateKey(selectedSlotStart, nextTimeZone);
       setSelectedDateKey(nextDateKey);
       setMonthKey(nextDateKey.slice(0, 7));
       return;

--- a/packages/web/src/booking/PublicBookingPage.tsx
+++ b/packages/web/src/booking/PublicBookingPage.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useParams } from "@tanstack/react-router";
+import { useNavigate, useParams } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
 import {
   type BookingSlotsResponse,
@@ -7,7 +7,6 @@ import {
 } from "@core/types/booking.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { PublicBookingNotFoundError } from "@web/api/public-booking.api";
-import { PublicBookingConfirmationView } from "@web/booking/PublicBookingConfirmationView";
 import { PublicBookingDetailsStep } from "@web/booking/PublicBookingDetailsStep";
 import {
   type PublicBookingGuestDetails,
@@ -29,7 +28,6 @@ import {
 } from "@web/booking/public-booking.format";
 import {
   isPublicBookingConflictError,
-  type PublicBookingConfirmation,
   prefetchPublicBookingMonth,
   publicBookingQueryKeys,
   useCreatePublicBookingReservationMutation,
@@ -37,6 +35,7 @@ import {
   usePublicBookingPageQuery,
   usePublicBookingSlotsQuery,
 } from "@web/booking/public-booking.query";
+import { ROOT_ROUTES } from "@web/common/constants/routes";
 import { getBrowserTimeZone } from "@web/timezone/browser-timezone";
 
 const EMPTY_GUEST_DETAILS: PublicBookingGuestDetails = {
@@ -48,6 +47,7 @@ const EMPTY_GUEST_DETAILS: PublicBookingGuestDetails = {
 export function PublicBookingPage() {
   const { username } = useParams({ from: "/book/$username" });
   const slug = username ?? "";
+  const navigate = useNavigate();
   const [guestTimeZone, setGuestTimeZone] = useState(getBrowserTimeZone);
   const queryClient = useQueryClient();
   const [monthKey, setMonthKey] = useState(() =>
@@ -69,8 +69,6 @@ export function PublicBookingPage() {
   const [selectedDateKey, setSelectedDateKey] = useState<string | null>(null);
   const [guestDetails, setGuestDetails] =
     useState<PublicBookingGuestDetails>(EMPTY_GUEST_DETAILS);
-  const [confirmation, setConfirmation] =
-    useState<PublicBookingConfirmation | null>(null);
   const [conflictMessage, setConflictMessage] = useState<string | null>(null);
   const [step, setStep] = useState<"picker" | "details">("picker");
   const conflictAlertRef = useRef<HTMLParagraphElement>(null);
@@ -155,16 +153,6 @@ export function PublicBookingPage() {
   }
 
   const page = pageQuery.data;
-
-  if (confirmation) {
-    return (
-      <PublicBookingConfirmationView
-        hostDisplayName={page.hostDisplayName}
-        durationMinutes={page.durationMinutes}
-        confirmation={confirmation}
-      />
-    );
-  }
 
   if (slotsQuery.data && !slotsQuery.data.bookable) {
     return (
@@ -316,7 +304,11 @@ export function PublicBookingPage() {
           guestTimeZone: values.guestTimeZone,
         }),
       );
-      setConfirmation(result);
+      await navigate({
+        to: ROOT_ROUTES.BOOK_CONFIRMED,
+        params: { reservationId: result.reservationId },
+        state: { cancelUrl: result.cancelUrl },
+      });
     } catch (error) {
       if (isPublicBookingConflictError(error)) {
         setConflictMessage(

--- a/packages/web/src/booking/public-booking.query.ts
+++ b/packages/web/src/booking/public-booking.query.ts
@@ -26,6 +26,8 @@ export const publicBookingQueryKeys = {
   page: (slug: string) => ["public-booking", "page", slug] as const,
   slots: (slug: string, monthKey: string, timeZone: string) =>
     ["public-booking", "slots", slug, monthKey, timeZone] as const,
+  reservation: (reservationId: string) =>
+    ["public-booking", "reservation", reservationId] as const,
 };
 
 export function publicBookingPageQueryOptions(slug: string) {
@@ -44,6 +46,25 @@ export function publicBookingPageQueryOptions(slug: string) {
 
 export function usePublicBookingPageQuery(slug: string) {
   return useQuery(publicBookingPageQueryOptions(slug));
+}
+
+export function publicBookingReservationQueryOptions(reservationId: string) {
+  return queryOptions({
+    queryKey: publicBookingQueryKeys.reservation(reservationId),
+    queryFn: () => PublicBookingApi.getReservation(reservationId),
+    staleTime: PUBLIC_BOOKING_PAGE_STALE_TIME_MS,
+    retry: (failureCount, error) => {
+      if (error instanceof PublicBookingNotFoundError) {
+        return false;
+      }
+      return failureCount < 1;
+    },
+    enabled: Boolean(reservationId),
+  });
+}
+
+export function usePublicBookingReservationQuery(reservationId: string) {
+  return useQuery(publicBookingReservationQueryOptions(reservationId));
 }
 
 export function publicBookingSlotsQueryOptions(

--- a/packages/web/src/common/constants/routes.ts
+++ b/packages/web/src/common/constants/routes.ts
@@ -2,6 +2,7 @@ export const ROOT_ROUTES = {
   API: "/api",
   BOOK: "/book/$username",
   BOOK_CANCEL: "/book/cancel/$reservationId",
+  BOOK_CONFIRMED: "/book/confirmed/$reservationId",
   CLEANUP: "/cleanup",
   GOOGLE_AUTH_CALLBACK: "/auth/google/callback",
   LIFE: "/life",

--- a/packages/web/src/components/RootShell/isBookingPathname.test.ts
+++ b/packages/web/src/components/RootShell/isBookingPathname.test.ts
@@ -5,6 +5,7 @@ describe("isBookingPathname", () => {
   it("matches public booking and cancel paths", () => {
     expect(isBookingPathname("/book/tylerdane")).toBe(true);
     expect(isBookingPathname("/book/cancel/abc123")).toBe(true);
+    expect(isBookingPathname("/book/confirmed/abc123")).toBe(true);
   });
 
   it("does not match calendar routes", () => {

--- a/packages/web/src/routers/index.test.tsx
+++ b/packages/web/src/routers/index.test.tsx
@@ -4,6 +4,7 @@ import {
   authenticatedLayoutRoute,
   calendarShellRoute,
   lifeRoute,
+  publicBookConfirmedRoute,
   publicBookRoute,
   rootRoute,
   routeTree,
@@ -23,6 +24,13 @@ describe("routeTree", () => {
     expect(publicBookRoute.fullPath).toBe("/book/$username");
     expect(publicBookRoute.options.beforeLoad).toBeUndefined();
     expect(publicBookRoute.parentRoute).toBe(rootRoute);
+  });
+
+  it("registers /book/confirmed/$reservationId as a public route", () => {
+    expect(publicBookConfirmedRoute.fullPath).toBe(
+      "/book/confirmed/$reservationId",
+    );
+    expect(publicBookConfirmedRoute.parentRoute).toBe(rootRoute);
   });
 
   it("gates the authenticated layout behind loadAuthenticated inside the calendar shell", () => {

--- a/packages/web/src/routers/index.tsx
+++ b/packages/web/src/routers/index.tsx
@@ -27,6 +27,12 @@ declare module "@tanstack/react-router" {
   }
 }
 
+declare module "@tanstack/history" {
+  interface HistoryState {
+    cancelUrl?: string;
+  }
+}
+
 export const CompassRouterProvider = (props?: { router?: AnyRouter }) => {
   return <RouterProvider router={props?.router ?? router} />;
 };

--- a/packages/web/src/routers/index.tsx
+++ b/packages/web/src/routers/index.tsx
@@ -27,12 +27,6 @@ declare module "@tanstack/react-router" {
   }
 }
 
-declare module "@tanstack/history" {
-  interface HistoryState {
-    cancelUrl?: string;
-  }
-}
-
 export const CompassRouterProvider = (props?: { router?: AnyRouter }) => {
   return <RouterProvider router={props?.router ?? router} />;
 };

--- a/packages/web/src/routers/router.routes.tsx
+++ b/packages/web/src/routers/router.routes.tsx
@@ -53,6 +53,15 @@ export const publicBookCancelRoute = createRoute({
   ),
 });
 
+export const publicBookConfirmedRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: ROOT_ROUTES.BOOK_CONFIRMED,
+  component: lazyRouteComponent(
+    () => import("@web/booking/PublicBookingConfirmedPage"),
+    "PublicBookingConfirmedPage",
+  ),
+});
+
 export const lifeRoute = createRoute({
   getParentRoute: () => calendarShellRoute,
   path: ROOT_ROUTES.LIFE,
@@ -155,7 +164,8 @@ const calendarShellChildren = calendarShellRoute.addChildren([
 
 export const routeTree = rootRoute.addChildren([
   calendarShellChildren,
-  publicBookRoute,
+  publicBookConfirmedRoute,
   publicBookCancelRoute,
+  publicBookRoute,
   googleAuthCallbackRoute,
 ]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #3008. After a successful reservation, guests land on `/book/confirmed/$reservationId`. Refreshing that URL loads booking details from a public GET (time, duration, host display name, status) instead of in-memory component state.

The GET is rate-limited (30/min by IP + id) and returns a strict minimal payload: no guest email, notes, cancel URL, or token. Duration is taken from the stored slot start/end so a later host settings change does not rewrite the confirmation. The cancel-link copy button is only available when history state includes `cancelUrl` (post-submit, including same-tab refresh). A cold permalink visit cannot reconstruct the hashed cancel token.

Unknown ids show “Booking not found”. Cancelled ids show “This booking was canceled”. Transport failures show “Could not load booking”.

Rebased onto latest `main` after #3024 removed `formatBookingSlotDateKey` (PR merge-ref type-check was failing until that rename was applied).

## Simplicity

One public GET plus a dedicated confirmation route. Cancel URL stays in history state only. Copy feedback is a visible button label plus a `role="status"` announcement.

## Automated validation

- Core contract tests: public GET schema rejects guest email; reserved slug `confirmed`.
- Backend: GET returns minimal fields; cancelled status; invalid id 404; duration stays 30 after host changes page to 45.
- Web RTL: GET details, cancelled, unknown, 500 retryable state, copy button from post-submit history.
- Playwright: confirm, refresh permalink, cold permalink (no copy), copy + Copied, cancelled/unknown, axe on those states.

## Independent review

VERDICT: findings (then addressed)

- med: duration from mutable page settings → now derived from stored slot times (fallback to page duration if the delta is not 15/30/45/60).
- med: every GET error shown as not-found → 404 stays not-found; other errors are “Could not load booking”.
- low: no heading focus after navigation → deferred to #3005 keyboard/focus audit.

## Test plan

- `bun type-check` after merging `origin/main` (#3024 date-key rename)
- `TZ=UTC bun test` focused `PublicBookingPage.test.tsx`
- `bun run verify` on the pre-merge revision (PASS: core, web, backend, type-check, lint, knip, a11y, e2e)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e51f3b10-0faf-4d26-8e85-ef13497c1459?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e51f3b10-0faf-4d26-8e85-ef13497c1459&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

