### PR TITLE
docs(booking): e2e and docs closeout for the UX overhaul (#3009)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Cool things you can do with in Compass
 - Do everything from the cmd palette
 - Google Calendar sync
 - Add/remove event attendees and RSVP to invites, with optional Google-contact suggestions
-- Public booking pages at `/book/:username` (one duration per host, guest cancel link)
+- Public booking pages at `/book/:username` (month grid plus day times, one duration per host, guest timezone override, confirmation permalink, guest cancel link)
 
 Things you can't do in Compass (yet):
 

--- a/docs/architecture/glossary.md
+++ b/docs/architecture/glossary.md
@@ -177,7 +177,9 @@ _Avoid_: organizer when you mean the Compass account rather than the
 Google event organizer field
 
 **Guest** (booking):
-The unauthenticated person who picks a slot on a booking page.
+The unauthenticated person who picks a day and time on a public booking
+page (month grid plus that day's slots), then confirms. Times show in
+their timezone.
 _Avoid_: attendee when you mean the public booking user rather than a
 calendar guest-list row (the created event does add them as an
 attendee)

--- a/docs/development/feature-file-map.md
+++ b/docs/development/feature-file-map.md
@@ -58,7 +58,8 @@ Product spec: [Compass Calendar Booking (v1)](../features/booking.md).
 Work packages: [`wip/booking/`](../../wip/booking/README.md) (delete after
 docs are the source of truth).
 
-- Public URL: `/book/:username` (guest routes outside the calendar shell)
+- Public URL: `/book/:username`, confirmation `/book/confirmed/:id`,
+  cancel `/book/cancel/:id` (guest routes outside the calendar shell)
 - Shared contracts: `packages/core/src/types/booking.contracts.ts`
 - Slot engine: `packages/core/src/booking/compute-booking-slots.ts`
 - Backend admin: `packages/backend/src/booking/booking.controller.ts`,
@@ -71,9 +72,9 @@ docs are the source of truth).
   `POST /internal/availability/busy`
 - Host Settings: `packages/web/src/booking/BookingSettingsSection.tsx`
 - Public guest UI: `packages/web/src/booking/PublicBookingPage.tsx`,
-  `PublicBookingCancelPage.tsx`
+  `PublicBookingConfirmedPage.tsx`, `PublicBookingCancelPage.tsx`
 - Web API client: `packages/web/src/api/public-booking.api.ts`
-- E2e: `e2e/booking/`
+- E2e: `e2e/booking/`, `e2e/accessibility/booking-a11y.spec.ts`
 - Architecture: [Product Suite Boundaries](../architecture/product-suite-boundaries.md)
 
 ## Day / Week Views

--- a/docs/development/testing-playbook.md
+++ b/docs/development/testing-playbook.md
@@ -514,6 +514,12 @@ must inspect.
 `e2e/accessibility/datepicker-a11y.spec.ts` covers the sidebar date navigation
 region and keeps its own targeted per-date contrast regression (below).
 
+`e2e/accessibility/booking-a11y.spec.ts` covers public booking: picker and
+details (light and dark `prefers-color-scheme`), slots error, 409 conflict,
+confirmation (confirmed, cancelled, not-found, load error), and cancel
+(confirm, in-flight, success, not-found, error). CI `bun run test:e2e`
+runs the whole `e2e/` tree, including this file.
+
 #### When To Add A Targeted Regression Test
 
 Keep focused browser assertions when the failure depends on a state or visual

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -25,9 +25,14 @@ The username is a `bookingSlug` allocated from the Compass account. It
 is not editable in v1. Changing it later is a dedicated migration with
 redirects.
 
+Confirmation permalink: `/book/confirmed/:reservationId` (survives
+refresh; cancel copy is only present when the guest just confirmed).
+
+Cancel: `/book/cancel/:reservationId?token=…`.
+
 Reserved slugs (never allocated): `week`, `day`, `life`, `auth`, `api`,
-`cleanup`, `book`, `p`, `settings`, `admin`, `login`, `logout`, `signup`,
-`invite`, `calendar`.
+`cleanup`, `book`, `cancel`, `confirmed`, `p`, `settings`, `admin`,
+`login`, `logout`, `signup`, `invite`, `calendar`.
 
 ### Slug allocation
 
@@ -67,9 +72,28 @@ Host administration lives in Settings as a new page (today
 
 ### Guest
 
-The guest is unauthenticated. They open the public URL, pick a slot
-shown in **their timezone** (browser default, overridable), enter name +
-email (optional notes), and confirm. They do not need a Compass account.
+The guest is unauthenticated. They open the public URL, pick a day on
+the **month grid** and a time from that day's list, shown in **their
+timezone** (browser default, overridable), enter name + email (optional
+notes), and confirm. They do not need a Compass account.
+
+```mermaid
+flowchart TD
+  load["Open /book/:slug"]
+  picker["Two-pane: month grid + day's times"]
+  details["Your details"]
+  permalink["/book/confirmed/:id"]
+  cancel["/book/cancel/:id"]
+  load --> picker
+  picker -->|select a time| details
+  details -->|Change time| picker
+  details -->|Confirm booking| permalink
+  permalink -->|tokenized cancel URL| cancel
+```
+
+Public booking follows `prefers-color-scheme` when `compass.theme` is
+unset: a light OS uses `light-beach`, a dark OS keeps the app dark
+default. A stored theme wins over the OS.
 
 ### Guest keyboard path
 
@@ -233,10 +257,14 @@ Unauthenticated:
 - `GET /api/booking/pages/:slug` — public page (host display name,
   duration, timezone, enabled). `404` when missing or disabled.
 - `GET /api/booking/pages/:slug/slots?start=&end=&timeZone=` — bookable
-  instants in the guest timezone. Window must be within the 60-day
-  horizon.
+  instants in the guest timezone for that window. The guest UI requests
+  **one month at a time** (plus prefetch of adjacent months). Window
+  must be within the 60-day horizon.
 - `POST /api/booking/pages/:slug/reservations` — `{slotStart, guestName,
   guestEmail, notes?, guestTimeZone}`. Re-checks busy, then creates.
+- `GET /api/booking/reservations/:id` — public confirmation payload
+  (`slotStart`, `guestTimeZone`, `durationMinutes`, `hostDisplayName`,
+  `status`). `404` when missing. No guest email, notes, or cancel token.
 - `POST /api/booking/reservations/:id/cancel` — `{token}`.
 
 Authenticated (host session + writable billing, same as event writes):
@@ -282,9 +310,9 @@ Work packages and the GitHub milestone record the build history until
 | Calendar application port | `packages/backend/src/booking/calendar-booking.port.ts`, `calendar-booking.service.ts` |
 | Sync busy occupancy | `packages/sync/src/domain/occurrence-projection.ts`, `busy-query.service.ts` |
 | Host Settings UI | `packages/web/src/booking/BookingSettingsSection.tsx`, `packages/web/src/components/Settings/SettingsModal.tsx` |
-| Public guest UI | `packages/web/src/booking/PublicBookingPage.tsx`, `PublicBookingCancelPage.tsx` |
+| Public guest UI | `packages/web/src/booking/PublicBookingPage.tsx`, `PublicBookingConfirmedPage.tsx`, `PublicBookingCancelPage.tsx` |
 | Public web API client | `packages/web/src/api/public-booking.api.ts` |
-| E2e | `e2e/booking/` |
+| E2e | `e2e/booking/`, `e2e/accessibility/booking-a11y.spec.ts` |
 
 ### Named warts
 

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -82,6 +82,11 @@ export interface CapturedBookingRequests {
   slotQueries: Array<{ start: string | null; end: string | null }>;
 }
 
+/**
+ * Stub public booking APIs for the shipped two-pane picker: month-window
+ * slot GETs (filtered by `start`/`end`), day-scoped slot buttons, the
+ * details step, confirmation permalink GET, and cancel POST-on-confirm.
+ */
 export async function preparePublicBookingPage(
   page: Page,
   options: PublicBookingStubOptions = {},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #3009. Closeout for Booking UX v2: docs and the e2e harness comment now describe the shipped two-pane guest flow.

- `docs/features/booking.md`: month grid + day times, guest flow diagram, `prefers-color-scheme`, `/book/confirmed/:id`, `GET /api/booking/reservations/:id`, reserved slugs `cancel`/`confirmed`, month-window slot fetches.
- Feature-file map, glossary, README, and testing playbook list confirmation/cancel surfaces and booking axe checkpoints.
- Harness JSDoc records month-window slot stubbing, details, permalink GET, and cancel-on-confirm (behavior already in `e2e/booking/` and `e2e/accessibility/booking-a11y.spec.ts`).
- CI `e2e` job runs `bun run test:e2e` over the whole `e2e/` tree, so booking axe is already in required checks.
- Unauthenticated staging smoke: `https://staging.compasscalendar.com/`, `/book/`, and `/book/tylerdeane` all returned HTTP 200 (SPA shell; no signed-in host QA).

## Simplicity

No product-code change. Specs already covered the picker; this removes leftover v1 wording.

## Automated validation

- Staging curl 200 on `/`, `/book/`, `/book/tylerdeane`
- `bun run verify`: test:web, type-check, lint, knip, test:a11y, test:e2e all passed

## Independent review

Reviewed `origin/main...HEAD` (docs + harness JSDoc only).

```
VERDICT: no confirmed findings
FINDINGS:
(none)
```

## Test plan

- Confirm no remaining "next two weeks" / flat-list copy in booking docs
- Confirm HTTP sketch includes public reservation GET
- Confirm testing playbook states booking axe rides with CI e2e

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e51f3b10-0faf-4d26-8e85-ef13497c1459?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e51f3b10-0faf-4d26-8e85-ef13497c1459&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

