### PR TITLE
feat(web): join up next meeting with v from anywhere

### DIFF
--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -35,6 +35,15 @@ const googleCalendar = {
   accountEmail: HOST_ACCOUNT_EMAIL,
 };
 
+function monthKeyInZone(date: Date, timeZone: string): string {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+  }).formatToParts(date);
+  return `${parts.find((part) => part.type === "year")?.value}-${parts.find((part) => part.type === "month")?.value}`;
+}
+
 /** A slot later in the current UTC month, inside today's remaining hours when the month is ending. */
 export function buildBookableSlot(durationMinutes = 30): {
   slotStart: string;
@@ -43,19 +52,54 @@ export function buildBookableSlot(durationMinutes = 30): {
   const now = new Date();
   const start = new Date(now);
   start.setUTCDate(now.getUTCDate() + 2);
-  start.setUTCHours(15, 0, 0, 0);
-  const sameMonth =
+  start.setUTCHours(12, 0, 0, 0);
+  const sameUtcMonth =
     start.getUTCMonth() === now.getUTCMonth() &&
     start.getUTCFullYear() === now.getUTCFullYear();
-  if (!sameMonth || start.getTime() <= now.getTime()) {
-    start.setTime(now.getTime());
-    start.setUTCHours(15, 0, 0, 0);
+  if (!sameUtcMonth || start.getTime() <= now.getTime()) {
+    start.setTime(
+      Date.UTC(
+        now.getUTCFullYear(),
+        now.getUTCMonth(),
+        now.getUTCDate(),
+        12,
+        0,
+        0,
+        0,
+      ),
+    );
     if (
       start.getTime() <= now.getTime() ||
       start.getUTCMonth() !== now.getUTCMonth()
     ) {
-      start.setTime(now.getTime() + 2 * 60 * 60 * 1000);
-      start.setUTCMinutes(0, 0, 0);
+      // Noon UTC is past. Stay on today rather than +2h, which is 12:00 AM
+      // the next Berlin day on month-end evenings.
+      start.setTime(now.getTime() + 20 * 60 * 1000);
+      start.setUTCSeconds(0, 0);
+      start.setUTCMilliseconds(0);
+      const berlinNow = monthKeyInZone(now, "Europe/Berlin");
+      if (
+        start.getUTCMonth() === now.getUTCMonth() &&
+        monthKeyInZone(start, "Europe/Berlin") !== berlinNow &&
+        berlinNow === monthKeyInZone(now, "UTC")
+      ) {
+        start.setTime(now.getTime() + 60 * 1000);
+        start.setUTCSeconds(0, 0);
+        start.setUTCMilliseconds(0);
+      }
+      if (start.getUTCMonth() !== now.getUTCMonth()) {
+        start.setTime(
+          Date.UTC(
+            now.getUTCFullYear(),
+            now.getUTCMonth(),
+            now.getUTCDate(),
+            23,
+            59,
+            0,
+            0,
+          ),
+        );
+      }
     }
   }
   const end = new Date(start.getTime() + durationMinutes * 60 * 1000);

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -13,6 +13,7 @@ import {
   formatBookingDateKey,
   formatBookingMonthDayLabel,
   formatBookingMonthHeading,
+  formatBookingMonthKey,
   formatBookingSlotLabel,
   formatBookingSlotTime,
   shiftBookingMonthKey,
@@ -32,32 +33,108 @@ function renderBookingRoute(path: string) {
   return { ...result, router };
 }
 
-function bookableSlotInCurrentMonth(minuteOffset = 0) {
-  const now = new Date();
-  const start = new Date(now);
-  start.setUTCHours(15, minuteOffset, 0, 0);
-  if (
-    start.getTime() <= now.getTime() ||
-    start.getUTCMonth() !== now.getUTCMonth()
-  ) {
-    start.setTime(now.getTime() + 2 * 60 * 60 * 1000);
-    start.setUTCMinutes(minuteOffset, 0, 0);
-  }
+function monthKeyInZone(date: Date, timeZone: string): string {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+  }).formatToParts(date);
+  return `${parts.find((part) => part.type === "year")?.value}-${parts.find((part) => part.type === "month")?.value}`;
+}
+
+function slotAround(start: Date) {
   return {
     slotStart: start.toISOString(),
     slotEnd: new Date(start.getTime() + 30 * 60 * 1000).toISOString(),
   };
 }
 
+function utcTodayAt(now: Date, hours: number, minutes: number) {
+  return new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate(),
+      hours,
+      minutes,
+      0,
+      0,
+    ),
+  );
+}
+
+/**
+ * Future slot in the current UTC month. Prefers 12:00 UTC so the calendar
+ * date matches Europe/Berlin. After noon, stay on today instead of +2h,
+ * which becomes 12:00 AM the next Berlin day on month-end evenings.
+ */
+function bookableSlotInCurrentMonth(minuteOffset = 0) {
+  const now = new Date();
+  const berlinMonthNow = monthKeyInZone(now, "Europe/Berlin");
+  const noon = utcTodayAt(now, 12, minuteOffset);
+  if (
+    noon.getTime() > now.getTime() &&
+    noon.getUTCMonth() === now.getUTCMonth()
+  ) {
+    return slotAround(noon);
+  }
+
+  const evening = utcTodayAt(now, 20, minuteOffset);
+  if (
+    evening.getTime() > now.getTime() &&
+    monthKeyInZone(evening, "Europe/Berlin") === berlinMonthNow
+  ) {
+    return slotAround(evening);
+  }
+
+  const soon = new Date(now.getTime() + (20 + minuteOffset) * 60 * 1000);
+  soon.setUTCSeconds(0, 0);
+  soon.setUTCMilliseconds(0);
+  if (soon.getUTCMonth() === now.getUTCMonth()) {
+    if (monthKeyInZone(soon, "Europe/Berlin") === berlinMonthNow) {
+      return slotAround(soon);
+    }
+    const stillThisBerlinMonth = berlinMonthNow === monthKeyInZone(now, "UTC");
+    if (stillThisBerlinMonth) {
+      const beforeBerlinMidnight = new Date(now.getTime() + 60 * 1000);
+      beforeBerlinMidnight.setUTCSeconds(0, 0);
+      if (
+        monthKeyInZone(beforeBerlinMidnight, "Europe/Berlin") ===
+          berlinMonthNow &&
+        beforeBerlinMidnight.getUTCMonth() === now.getUTCMonth()
+      ) {
+        return slotAround(beforeBerlinMidnight);
+      }
+    }
+    return slotAround(soon);
+  }
+
+  const late = utcTodayAt(now, 23, 59);
+  if (late.getTime() > now.getTime()) {
+    return slotAround(late);
+  }
+
+  return slotAround(soon);
+}
+
+function bookableSlotOnSecondOfUtcMonth(year: number, monthIndex: number) {
+  return slotAround(new Date(Date.UTC(year, monthIndex, 2, 16, 0, 0)));
+}
+
 function bookableSlotInNextMonth() {
   const now = new Date();
-  const start = new Date(
-    Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 2, 16, 0, 0),
+  return bookableSlotOnSecondOfUtcMonth(
+    now.getUTCFullYear(),
+    now.getUTCMonth() + 1,
   );
-  return {
-    slotStart: start.toISOString(),
-    slotEnd: new Date(start.getTime() + 30 * 60 * 1000).toISOString(),
-  };
+}
+
+/** Day 2 of the month after `now` in `timeZone`, at 16:00 UTC. */
+function bookableSlotAfterCurrentMonthInZone(timeZone: string) {
+  const [year, month] = monthKeyInZone(new Date(), timeZone)
+    .split("-")
+    .map(Number);
+  return bookableSlotOnSecondOfUtcMonth(year, month);
 }
 
 function slotButtonName(iso: string, timeZone = "UTC") {
@@ -74,7 +151,19 @@ async function selectGuestTimeZone(
 }
 
 const currentSlot = bookableSlotInCurrentMonth();
-const laterCurrentSlot = bookableSlotInCurrentMonth(30);
+const laterCurrentSlot = (() => {
+  const later = bookableSlotInCurrentMonth(30);
+  if (later.slotStart.slice(0, 10) === currentSlot.slotStart.slice(0, 10)) {
+    return later;
+  }
+  const currentMs = Date.parse(currentSlot.slotStart);
+  const endOfUtcDay = Date.parse(
+    `${currentSlot.slotStart.slice(0, 10)}T23:59:00.000Z`,
+  );
+  return slotAround(
+    new Date(Math.min(currentMs + 15 * 60 * 1000, endOfUtcDay)),
+  );
+})();
 const nextMonthSlot = bookableSlotInNextMonth();
 const guestTimeZone = "UTC";
 const currentMonthKey = new Date().toISOString().slice(0, 7);
@@ -401,6 +490,7 @@ describe("PublicBookingPage", () => {
   it("keeps the guest timezone across month navigation and the details step", async () => {
     const user = userEvent.setup({ delay: null });
     const overrideZone = "Europe/Berlin";
+    const persistNextSlot = bookableSlotAfterCurrentMonthInZone(overrideZone);
 
     server.use(
       rest.get(
@@ -415,7 +505,7 @@ describe("PublicBookingPage", () => {
           const end = req.url.searchParams.get("end");
           const startMs = start ? Date.parse(start) : Number.NEGATIVE_INFINITY;
           const endMs = end ? Date.parse(end) : Number.POSITIVE_INFINITY;
-          const slots = [currentSlot, nextMonthSlot].filter((slot) => {
+          const slots = [currentSlot, persistNextSlot].filter((slot) => {
             const at = Date.parse(slot.slotStart);
             return at >= startMs && at < endMs;
           });
@@ -443,7 +533,11 @@ describe("PublicBookingPage", () => {
     ).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Next month" }));
-    const nextMonthKey = shiftBookingMonthKey(currentMonthKey, 1, overrideZone);
+    const nextMonthKey = shiftBookingMonthKey(
+      formatBookingMonthKey(new Date(), overrideZone),
+      1,
+      overrideZone,
+    );
     expect(
       await screen.findByRole("heading", {
         name: formatBookingMonthHeading(nextMonthKey, overrideZone),
@@ -454,7 +548,7 @@ describe("PublicBookingPage", () => {
     ).toBeInTheDocument();
     expect(
       await screen.findByRole("button", {
-        name: slotButtonName(nextMonthSlot.slotStart, overrideZone),
+        name: slotButtonName(persistNextSlot.slotStart, overrideZone),
       }),
     ).toBeInTheDocument();
 

--- a/packages/web/src/components/Sidebar/UpNextCard/UpNextBanner.test.tsx
+++ b/packages/web/src/components/Sidebar/UpNextCard/UpNextBanner.test.tsx
@@ -120,6 +120,28 @@ describe("UpNextBanner", () => {
     );
   });
 
+  it("pressing v opens the meeting link when the banner is not showing", async () => {
+    const user = userEvent.setup();
+    render(<UpNextBanner />, {
+      events: [
+        timedEvent(LATER_EVENT_ID, "Later Standup", 30, {
+          url: "https://meet.google.com/abc-defg-hij",
+          label: null,
+        }),
+      ],
+    });
+
+    expect(screen.queryByRole("status")).toBeNull();
+
+    await user.keyboard("v");
+
+    expect(mockWindowOpen).toHaveBeenCalledWith(
+      "https://meet.google.com/abc-defg-hij",
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+
   it("pressing n opens the event details form even when Join is shown", async () => {
     const user = userEvent.setup();
     render(<UpNextBanner />, {

--- a/packages/web/src/components/Sidebar/UpNextCard/UpNextBanner.tsx
+++ b/packages/web/src/components/Sidebar/UpNextCard/UpNextBanner.tsx
@@ -12,8 +12,10 @@ const MINUTES_BEFORE_START = 2;
 
 /**
  * A centered banner that surfaces the next timed event when it is about to
- * start, mirroring Vimcal. N opens the event's details; when the event has a
- * meeting link, the primary action switches to V for "Join" instead.
+ * start, mirroring Vimcal. N opens the event's details from anywhere. V joins
+ * the Up Next meeting whenever that event has a conference URL, not only
+ * while this banner is visible. The banner's primary action switches to Join
+ * when a link exists.
  */
 export const UpNextBanner: FC = () => {
   const { now, openEventDetails, upNext, conferenceUrl, isCurrentEvent } =
@@ -39,7 +41,7 @@ export const UpNextBanner: FC = () => {
 
   useAppShortcutUp("N", () => openEventDetails("keyboardEdit"));
   useAppShortcutUp("V", openConference, {
-    enabled: Boolean(conferenceUrl) && isWithinWindow,
+    enabled: Boolean(conferenceUrl),
   });
   // Only active while the banner itself is showing. Fires alongside any
   // other Escape handling (e.g. useEscapeToCloseForm closing the event form)

--- a/packages/web/src/components/Sidebar/UpNextCard/UpNextCard.test.tsx
+++ b/packages/web/src/components/Sidebar/UpNextCard/UpNextCard.test.tsx
@@ -227,6 +227,8 @@ describe("UpNextCard", () => {
     );
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    expect(screen.getByText("V")).toBeInTheDocument();
+    expect(screen.queryByText("N")).toBeNull();
   });
 
   it("shows no Join link when the event has no conference", () => {
@@ -235,6 +237,7 @@ describe("UpNextCard", () => {
     });
 
     expect(screen.queryByRole("link", { name: "Join" })).toBeNull();
+    expect(screen.getByText("N")).toBeInTheDocument();
   });
 });
 

--- a/packages/web/src/components/Sidebar/UpNextCard/UpNextCard.tsx
+++ b/packages/web/src/components/Sidebar/UpNextCard/UpNextCard.tsx
@@ -48,7 +48,8 @@ export function formatEventStatus(
  * for them.
  */
 export const UpNextCard: FC = () => {
-  const { now, openEventDetails, upNext, isCurrentEvent } = useUpNextEvent();
+  const { now, openEventDetails, upNext, conferenceUrl, isCurrentEvent } =
+    useUpNextEvent();
   const countdown = upNext
     ? formatEventStatus(
         dayjs(upNext.startDate),
@@ -80,7 +81,7 @@ export const UpNextCard: FC = () => {
               .group), not .group itself, so a plain :focus-visible variant
               on the group never matches. */}
           <ShortcutHint className="absolute top-2 right-2 opacity-0 transition-opacity group-hover:opacity-100 group-has-[:focus-visible]:opacity-100">
-            N
+            {conferenceUrl ? "V" : "N"}
           </ShortcutHint>
           <span className="min-w-0 truncate font-medium text-sm text-text">
             {upNext.title}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`v` now joins the Up Next meeting whenever that event has a conference URL, not only while the 2-minute banner is visible. The sidebar Up Next card chips `V` instead of `N` when a meeting link exists. `n` still opens the event details.

This is the one-key path into a meeting: press `v` from Day or Week (while not typing) and the conference URL opens in a new tab.

## Simplicity

One existing binding in `UpNextBanner` (already mounted on Root). Ungated `enabled` from the banner window to `Boolean(conferenceUrl)`. The card reuses `conferenceUrl` from `useUpNextEvent` for the hint. No second handler, no registry change (`nav-join-meeting` already listed `v`).

## Automated validation

- Focused: `bun run test:web -- packages/web/src/components/Sidebar/UpNextCard/UpNextBanner.test.tsx packages/web/src/components/Sidebar/UpNextCard/UpNextCard.test.tsx` — 21 pass, 0 fail. Includes `pressing v opens the meeting link when the banner is not showing`.
- Booking helpers: `bun run test:web -- packages/web/src/booking/PublicBookingPage.test.tsx` — 23 pass, 0 fail, including `keeps the guest timezone across month navigation and the details step` at 20:40 UTC on 2026-08-31.
- `bun run verify`: selected packages `web`; checks run `test:web`, `type-check`, `lint`, `knip`. Playwright a11y/e2e skipped (Chromium not installed locally).

Browser: seeded a local event starting ~25 minutes out (banner hidden). Pressing `v` opened `https://meet.google.com/abc-defg-hij` in a new tab. `n` still opened the event form.

CI after merging `main` failed on public booking timezone tests: `now+2h` snapped to 22:00 UTC, which is 12:00 AM the next day in Europe/Berlin, so the slot left the current-month picker. Helpers now prefer noon UTC, then a same-day evening slot, and the persist test's next month follows Berlin after the timezone switch.

## Independent review

VERDICT: no confirmed findings
FINDINGS: none

## Test plan

- `bun run test:web -- packages/web/src/components/Sidebar/UpNextCard/UpNextBanner.test.tsx packages/web/src/components/Sidebar/UpNextCard/UpNextCard.test.tsx`
- `bun run test:web -- packages/web/src/booking/PublicBookingPage.test.tsx`
- `bun run verify`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e17b8bd6-90ac-4195-8069-faaef892787c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e17b8bd6-90ac-4195-8069-faaef892787c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

