### PR TITLE
test(web): fix booking slot-loading status race in PublicBookingPage tests

### DIFF
--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -226,15 +226,24 @@ test.describe("public booking page", () => {
     await page.setViewportSize({ width: 800, height: 480 });
 
     const origin = buildBookableSlot();
+    const originMs = Date.parse(origin.slotStart);
     const originDate = origin.slotStart.slice(0, 10);
+    // Keep 40 slots on the origin UTC day. A fixed 15-minute step runs out
+    // of that day near UTC midnight, and on month-end when buildBookableSlot
+    // falls back to now+2h.
+    const remainingMinutes = Math.floor(
+      (Date.parse(`${originDate}T00:00:00.000Z`) +
+        24 * 60 * 60 * 1000 -
+        originMs) /
+        60_000,
+    );
+    const stepMinutes = Math.max(
+      1,
+      Math.min(15, Math.floor(remainingMinutes / 40)),
+    );
     const slots: Array<{ slotStart: string; slotEnd: string }> = [];
     for (let index = 0; index < 40; index += 1) {
-      const slotStart = new Date(
-        Date.parse(origin.slotStart) + index * 15 * 60 * 1000,
-      );
-      if (slotStart.toISOString().slice(0, 10) !== originDate) {
-        break;
-      }
+      const slotStart = new Date(originMs + index * stepMinutes * 60 * 1000);
       slots.push({
         slotStart: slotStart.toISOString(),
         slotEnd: new Date(slotStart.getTime() + 30 * 60 * 1000).toISOString(),

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -922,17 +922,17 @@ describe("PublicBookingPage", () => {
   });
 
   it("keeps the host heading visible and announces slot loading", async () => {
-    const delay = (ms: number) =>
-      new Promise<void>((resolve) => {
-        setTimeout(resolve, ms);
-      });
+    let releaseSlots = () => {};
+    const slotsGate = new Promise<void>((resolve) => {
+      releaseSlots = resolve;
+    });
 
     server.use(
       pageHandler(),
       rest.get(
         `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/slots`,
         async (_req, res, ctx) => {
-          await delay(80);
+          await slotsGate;
           return res(
             ctx.status(Status.OK),
             ctx.json({ bookable: true, slots: [currentSlot] }),
@@ -946,12 +946,15 @@ describe("PublicBookingPage", () => {
     expect(
       await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
     ).toBeInTheDocument();
-    expect(await screen.findByRole("status")).toHaveTextContent(
-      "Loading open times",
-    );
+    await waitFor(() => {
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "Loading open times",
+      );
+    });
     expect(
       screen.queryByRole("heading", { name: "Pick a time" }),
     ).not.toBeInTheDocument();
+    releaseSlots();
     expect(
       await screen.findByRole("heading", { name: "Pick a time" }),
     ).toBeInTheDocument();
@@ -1016,10 +1019,10 @@ describe("PublicBookingPage", () => {
 
   it("shows a slot-pane skeleton on an unfetched month without replacing the header", async () => {
     const user = userEvent.setup({ delay: null });
-    const delay = (ms: number) =>
-      new Promise<void>((resolve) => {
-        setTimeout(resolve, ms);
-      });
+    let releaseNextMonthSlots = () => {};
+    const nextMonthSlotsGate = new Promise<void>((resolve) => {
+      releaseNextMonthSlots = resolve;
+    });
     let currentMonthRequests = 0;
 
     server.use(
@@ -1036,7 +1039,7 @@ describe("PublicBookingPage", () => {
               ctx.json({ bookable: true, slots: [currentSlot] }),
             );
           }
-          await delay(80);
+          await nextMonthSlotsGate;
           return res(
             ctx.status(Status.OK),
             ctx.json({ bookable: true, slots: [nextMonthSlot] }),
@@ -1066,12 +1069,15 @@ describe("PublicBookingPage", () => {
         ),
       }),
     ).toBeInTheDocument();
-    expect(await screen.findByRole("status")).toHaveTextContent(
-      "Loading open times",
-    );
+    await waitFor(() => {
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "Loading open times",
+      );
+    });
     expect(
       screen.queryByRole("heading", { name: "Pick a time" }),
     ).not.toBeInTheDocument();
+    releaseNextMonthSlots();
     expect(
       await screen.findByRole("heading", { name: "Pick a time" }),
     ).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- The "shows a slot-pane skeleton on an unfetched month" test (and its sibling "announces slot loading" test) raced a real 80ms `setTimeout` in the MSW slots handler against RTL's status query. The `role="status"` element is a persistent aria-live region, so `findByRole("status")` resolves immediately with whatever text is current; under parallel-runner load the mocked response landed first and the status already read "Times loaded", failing the "Loading open times" assertion.
- Replace the timers with deferred promises the tests resolve only **after** asserting the loading state, so the mocked response cannot land early.
- Assert the live-region text via `waitFor(() => getByRole(...))` instead of `findByRole`, since `findBy*` waits for element presence, not text.

## Test plan
- 5 consecutive green runs of `bun packages/scripts/src/testing/test-parallel.ts web -- packages/web/src/booking/PublicBookingPage.test.tsx` (previously failed deterministically under the harness)
- `bun run type-check:web-tests` clean
- `biome check` clean on the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)