### PR TITLE
fix(web,backend): delete account without a stale-login toast

### DIFF
--- a/docs/features/billing.md
+++ b/docs/features/billing.md
@@ -129,11 +129,8 @@ For an account that reached Stripe Checkout, deletion first deletes its Stripe
 Customer. That immediately cancels any trial or subscription and removes saved
 payment details; Stripe retains the financial history it is required to keep.
 If Stripe cannot confirm that deletion, Compass leaves the account intact and
-asks the user to retry, rather than risk a later charge. Previous payments are
-not refunded automatically.
-
-For security, deletion also requires a sign-in within the previous 15 minutes;
-otherwise the user must sign out and sign back in before confirming it.
+asks the user to try again from a dialog, rather than risk a later charge.
+Previous payments are not refunded automatically.
 
 Sync may be temporarily unavailable during deletion. Compass records the
 principal purge and retries it every ten minutes until Sync confirms its cached

--- a/packages/backend/src/common/errors/user/user.errors.ts
+++ b/packages/backend/src/common/errors/user/user.errors.ts
@@ -6,7 +6,6 @@ interface UserErrors {
   InvalidValue: ErrorMetadata;
   MissingGoogleRefreshToken: ErrorMetadata;
   MissingUserIdField: ErrorMetadata;
-  RecentAuthenticationRequired: ErrorMetadata;
   UserNotFound: ErrorMetadata;
 }
 
@@ -30,13 +29,6 @@ export const UserError: UserErrors = {
     description: "Failed to access the userId",
     status: Status.BAD_REQUEST,
     isOperational: true,
-  },
-  RecentAuthenticationRequired: {
-    description:
-      "For security, sign out and sign back in before deleting your account",
-    status: Status.FORBIDDEN,
-    isOperational: true,
-    code: "RECENT_AUTHENTICATION_REQUIRED",
   },
   UserNotFound: {
     description: "User not found",

--- a/packages/backend/src/user/services/user.service.db.test.ts
+++ b/packages/backend/src/user/services/user.service.db.test.ts
@@ -525,19 +525,28 @@ describe("UserService", () => {
       cancellation.mockRestore();
     });
 
-    it("requires a fresh sign-in before deleting an account", async () => {
+    it("deletes the account when lastLoggedInAt was never stamped", async () => {
+      const user = await UserDriver.createUser();
+      await mongoService.user.updateOne(
+        { _id: user._id },
+        { $unset: { lastLoggedInAt: "" } },
+      );
+
+      await userService.deleteAccount(user._id.toString());
+
+      expect(await mongoService.user.findOne({ _id: user._id })).toBeNull();
+    });
+
+    it("deletes the account when the last sign-in was not recent", async () => {
       const user = await UserDriver.createUser();
       await mongoService.user.updateOne(
         { _id: user._id },
         { $set: { lastLoggedInAt: new Date(Date.now() - 16 * 60_000) } },
       );
 
-      await expect(
-        userService.deleteAccount(user._id.toString()),
-      ).rejects.toThrow(
-        "For security, sign out and sign back in before deleting your account",
-      );
-      expect(await mongoService.user.findOne({ _id: user._id })).not.toBeNull();
+      await userService.deleteAccount(user._id.toString());
+
+      expect(await mongoService.user.findOne({ _id: user._id })).toBeNull();
     });
 
     it("retries local cleanup after Stripe cancellation has succeeded", async () => {

--- a/packages/backend/src/user/services/user.service.ts
+++ b/packages/backend/src/user/services/user.service.ts
@@ -18,7 +18,6 @@ import { syncPrincipalDeletionRetry } from "@backend/user/services/sync-principa
 import { type Summary_Delete } from "@backend/user/types/user.types";
 
 const logger = Logger("app:user.service");
-const RECENT_AUTHENTICATION_MS = 15 * 60_000;
 const ACCOUNT_DELETION_RETRY_INTERVAL_MS = 10 * 60_000;
 const ACCOUNT_DELETION_RETRY_BATCH_SIZE = 100;
 
@@ -260,20 +259,6 @@ class UserService {
    * credential/cache purge succeeds.
    */
   deleteAccount = async (userId: string): Promise<Summary_Delete> => {
-    const user = await mongoService.user.findOne(
-      { _id: zObjectId.parse(userId) },
-      { projection: { lastLoggedInAt: 1 } },
-    );
-    const isRecent =
-      user?.lastLoggedInAt != null &&
-      Date.now() - user.lastLoggedInAt.getTime() <= RECENT_AUTHENTICATION_MS;
-    if (!isRecent) {
-      throw error(
-        UserError.RecentAuthenticationRequired,
-        "Recent authentication required to delete account",
-      );
-    }
-
     await mongoService.pendingAccountDeletion.updateOne(
       { _id: userId },
       { $setOnInsert: { createdAt: new Date() } },

--- a/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationDialog.test.tsx
+++ b/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationDialog.test.tsx
@@ -82,6 +82,24 @@ describe("DeleteAccountConfirmationDialog", () => {
     expect(onConfirm).toHaveBeenCalledTimes(1);
   });
 
+  it("confirms from the keyboard with Enter after the phrase is typed", async () => {
+    const { input, onConfirm, user } = setup();
+
+    await user.type(input, DELETE_ACCOUNT_PHRASE);
+    await user.keyboard("{Enter}");
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not confirm on Enter until the phrase matches", async () => {
+    const { input, onConfirm, user } = setup();
+
+    await user.type(input, "not the phrase");
+    await user.keyboard("{Enter}");
+
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
   it("blocks pasting the phrase, so it has to be typed", async () => {
     const { confirmButton, input, user } = setup();
 

--- a/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationDialog.tsx
+++ b/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationDialog.tsx
@@ -38,37 +38,48 @@ export function DeleteAccountConfirmationDialog({
       variant="modal"
       widthClassName="w-[480px]"
     >
-      <div className="flex w-full flex-col gap-2">
-        <label htmlFor={inputId} className="text-sm text-text">
-          Type <span className="text-text-muted">{DELETE_ACCOUNT_PHRASE}</span>{" "}
-          to confirm
-        </label>
-        <input
-          id={inputId}
-          type="text"
-          value={typedPhrase}
-          autoComplete="off"
-          className="w-full rounded border border-border bg-transparent px-3 py-2 text-text outline-none placeholder:text-text-muted focus-visible:border-accent"
-          onChange={(event) => setTypedPhrase(event.target.value)}
-          // Typing the phrase out is the whole point of the confirmation,
-          // so it can't be pasted or dragged in.
-          onPaste={(event) => event.preventDefault()}
-          onDrop={(event) => event.preventDefault()}
-        />
-      </div>
+      <form
+        className="flex w-full flex-col gap-6"
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (typedPhrase === DELETE_ACCOUNT_PHRASE) onConfirm();
+        }}
+      >
+        <div className="flex w-full flex-col gap-2">
+          <label htmlFor={inputId} className="text-sm text-text">
+            Type{" "}
+            <span className="text-text-muted">{DELETE_ACCOUNT_PHRASE}</span> to
+            confirm
+          </label>
+          <input
+            id={inputId}
+            type="text"
+            value={typedPhrase}
+            autoComplete="off"
+            className="w-full rounded border border-border bg-transparent px-3 py-2 text-text outline-none placeholder:text-text-muted focus-visible:border-accent"
+            onChange={(event) => setTypedPhrase(event.target.value)}
+            // Typing the phrase out is the whole point of the confirmation,
+            // so it can't be pasted or dragged in.
+            onPaste={(event) => event.preventDefault()}
+            onDrop={(event) => event.preventDefault()}
+          />
+        </div>
 
-      <OverlayPanelActions align="start">
-        <OverlayPanelActionButton
-          variant="destructive"
-          disabled={typedPhrase !== DELETE_ACCOUNT_PHRASE}
-          onClick={onConfirm}
-        >
-          Delete account
-        </OverlayPanelActionButton>
-        <OverlayPanelActionButton onClick={onCancel}>
-          Cancel
-        </OverlayPanelActionButton>
-      </OverlayPanelActions>
+        <OverlayPanelActions align="start">
+          <OverlayPanelActionButton
+            type="submit"
+            variant="destructive"
+            shortcut="Enter"
+            showShortcut={typedPhrase === DELETE_ACCOUNT_PHRASE}
+            disabled={typedPhrase !== DELETE_ACCOUNT_PHRASE}
+          >
+            Delete account
+          </OverlayPanelActionButton>
+          <OverlayPanelActionButton shortcut="Esc" onClick={onCancel}>
+            Cancel
+          </OverlayPanelActionButton>
+        </OverlayPanelActions>
+      </form>
     </OverlayPanel>
   );
 }

--- a/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationProvider.test.tsx
+++ b/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationProvider.test.tsx
@@ -206,4 +206,29 @@ describe("DeleteAccountConfirmationProvider", () => {
 
     consoleError.mockRestore();
   });
+
+  it("does not stack a retry dialog on top of session recovery", async () => {
+    deleteAccount.mockImplementationOnce(
+      () =>
+        Promise.reject({
+          config: {},
+          response: { status: 401 },
+        }) as never,
+    );
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
+
+    await confirmDeletion();
+
+    await waitFor(() => {
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("dialog", {
+        name: /couldn't delete your account/i,
+      }),
+    ).not.toBeInTheDocument();
+    expect(assign).not.toHaveBeenCalled();
+
+    consoleError.mockRestore();
+  });
 });

--- a/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationProvider.test.tsx
+++ b/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationProvider.test.tsx
@@ -65,6 +65,21 @@ const confirmDeletion = async () => {
   await user.click(screen.getByRole("button", { name: "open" }));
   await user.type(screen.getByRole("textbox"), DELETE_ACCOUNT_PHRASE);
   await user.click(screen.getByRole("button", { name: "Delete account" }));
+  return user;
+};
+
+const flushFarewellTimer = async (run: () => Promise<void> | void) => {
+  const setTimeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(((
+    callback: TimerHandler,
+  ) => {
+    if (typeof callback === "function") callback();
+    return 0;
+  }) as typeof setTimeout);
+  try {
+    await run();
+  } finally {
+    setTimeoutSpy.mockRestore();
+  }
 };
 
 afterEach(() => {
@@ -78,50 +93,29 @@ afterEach(() => {
 
 describe("DeleteAccountConfirmationProvider", () => {
   it("resets the analytics identity after deleting the account", async () => {
-    await confirmDeletion();
-
-    const setTimeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(((
-      callback: TimerHandler,
-    ) => {
-      if (typeof callback === "function") callback();
-      return 0;
-    }) as typeof setTimeout);
-    try {
-      await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
-      expect(posthog.reset).toHaveBeenCalledTimes(1);
-    } finally {
-      setTimeoutSpy.mockRestore();
-    }
+    await flushFarewellTimer(async () => {
+      await confirmDeletion();
+      await waitFor(() => {
+        expect(posthog.reset).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 
   it("resets analytics even when browser storage cleanup fails", async () => {
     clearAllBrowserStorage.mockRejectedValueOnce(
       new Error("IndexedDB blocked"),
     );
-    await confirmDeletion();
-
-    const setTimeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(((
-      callback: TimerHandler,
-    ) => {
-      if (typeof callback === "function") callback();
-      return 0;
-    }) as typeof setTimeout);
-    try {
-      await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
-      expect(posthog.reset).toHaveBeenCalledTimes(1);
-    } finally {
-      setTimeoutSpy.mockRestore();
-    }
+    await flushFarewellTimer(async () => {
+      await confirmDeletion();
+      await waitFor(() => {
+        expect(posthog.reset).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 
-  // Deleting spans a Mongo transaction and a Google grant revocation. The
-  // farewell used to wait for that to finish, so the user sat looking at the
-  // calendar of the account they'd just deleted with nothing to say it was
-  // working.
+  // Deleting spans a Mongo transaction and a Google grant revocation. Until
+  // the working overlay covers the screen the user is looking at the calendar
+  // of the account they just asked to delete, with nothing to say it's working.
   it("covers the calendar while the account is still being deleted", async () => {
     let finishDelete = () => {};
     deleteAccount.mockImplementationOnce(
@@ -133,44 +127,63 @@ describe("DeleteAccountConfirmationProvider", () => {
 
     await confirmDeletion();
 
-    // Still in flight: the request has not resolved yet.
-    const farewell = await screen.findByRole("status");
-    expect(farewell).toHaveTextContent(/so long captain@example.com/i);
-    // aria-busy on a live region withholds the announcement until it flips
-    // false, and this one never does - it lives until the reload, so a screen
-    // reader user got silence where everyone else got the farewell.
-    expect(farewell).not.toHaveAttribute("aria-busy");
+    const deleting = await screen.findByRole("status");
+    expect(deleting).toHaveTextContent(/deleting your account/i);
+    expect(deleting).not.toHaveAttribute("aria-busy");
     expect(assign).not.toHaveBeenCalled();
 
-    // Resolve the one production timer immediately. This keeps the production
-    // API unchanged and prevents a real timer from leaking into later files.
-    const setTimeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(((
-      callback: TimerHandler,
-    ) => {
-      if (typeof callback === "function") callback();
-      return 0;
-    }) as typeof setTimeout);
-    try {
+    await flushFarewellTimer(async () => {
       finishDelete();
-      await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
-
-      expect(assign).toHaveBeenCalled();
-    } finally {
-      setTimeoutSpy.mockRestore();
-    }
+      await waitFor(() => {
+        expect(screen.getByRole("status")).toHaveTextContent(
+          /so long captain@example.com/i,
+        );
+        expect(assign).toHaveBeenCalled();
+      });
+    });
   });
 
-  it("takes the farewell back down if the account could not be deleted", async () => {
+  it("keeps the user in a keyboard dialog if the account could not be deleted", async () => {
     deleteAccount.mockImplementationOnce(
       () => Promise.reject(new Error("nope")) as never,
     );
 
-    await confirmDeletion();
+    const user = await confirmDeletion();
+
+    const failure = await screen.findByRole("dialog", {
+      name: /couldn't delete your account/i,
+    });
+    expect(failure).toHaveTextContent(/your account is still here/i);
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(assign).not.toHaveBeenCalled();
+
+    await flushFarewellTimer(async () => {
+      await user.keyboard("{Enter}");
+      await waitFor(() => {
+        expect(deleteAccount).toHaveBeenCalledTimes(2);
+        expect(assign).toHaveBeenCalled();
+      });
+    });
+  });
+
+  it("lets the user dismiss a failed delete with Escape", async () => {
+    deleteAccount.mockImplementationOnce(
+      () => Promise.reject(new Error("nope")) as never,
+    );
+
+    const user = await confirmDeletion();
+
+    await screen.findByRole("dialog", {
+      name: /couldn't delete your account/i,
+    });
+    await user.keyboard("{Escape}");
 
     await waitFor(() => {
-      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("dialog", {
+          name: /couldn't delete your account/i,
+        }),
+      ).not.toBeInTheDocument();
     });
     expect(assign).not.toHaveBeenCalled();
   });

--- a/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationProvider.test.tsx
+++ b/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationProvider.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterAll, afterEach, describe, expect, it, spyOn } from "bun:test";
 import "@testing-library/jest-dom";
@@ -68,7 +68,9 @@ const confirmDeletion = async () => {
   return user;
 };
 
-const flushFarewellTimer = async (run: () => Promise<void> | void) => {
+// Spy setTimeout only after user-event is done. Testing Library treats a
+// mocked setTimeout as fake timers and then user-event/waitFor crash.
+const flushPendingDelete = async (finishDelete: () => void) => {
   const setTimeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(((
     callback: TimerHandler,
   ) => {
@@ -76,7 +78,12 @@ const flushFarewellTimer = async (run: () => Promise<void> | void) => {
     return 0;
   }) as typeof setTimeout);
   try {
-    await run();
+    await act(async () => {
+      finishDelete();
+      for (let i = 0; i < 30; i++) {
+        await Promise.resolve();
+      }
+    });
   } finally {
     setTimeoutSpy.mockRestore();
   }
@@ -93,24 +100,36 @@ afterEach(() => {
 
 describe("DeleteAccountConfirmationProvider", () => {
   it("resets the analytics identity after deleting the account", async () => {
-    await flushFarewellTimer(async () => {
-      await confirmDeletion();
-      await waitFor(() => {
-        expect(posthog.reset).toHaveBeenCalledTimes(1);
-      });
-    });
+    let finishDelete = () => {};
+    deleteAccount.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishDelete = () => resolve({} as never);
+        }) as never,
+    );
+
+    await confirmDeletion();
+    await flushPendingDelete(finishDelete);
+
+    expect(posthog.reset).toHaveBeenCalledTimes(1);
   });
 
   it("resets analytics even when browser storage cleanup fails", async () => {
     clearAllBrowserStorage.mockRejectedValueOnce(
       new Error("IndexedDB blocked"),
     );
-    await flushFarewellTimer(async () => {
-      await confirmDeletion();
-      await waitFor(() => {
-        expect(posthog.reset).toHaveBeenCalledTimes(1);
-      });
-    });
+    let finishDelete = () => {};
+    deleteAccount.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishDelete = () => resolve({} as never);
+        }) as never,
+    );
+
+    await confirmDeletion();
+    await flushPendingDelete(finishDelete);
+
+    expect(posthog.reset).toHaveBeenCalledTimes(1);
   });
 
   // Deleting spans a Mongo transaction and a Google grant revocation. Until
@@ -132,21 +151,19 @@ describe("DeleteAccountConfirmationProvider", () => {
     expect(deleting).not.toHaveAttribute("aria-busy");
     expect(assign).not.toHaveBeenCalled();
 
-    await flushFarewellTimer(async () => {
-      finishDelete();
-      await waitFor(() => {
-        expect(screen.getByRole("status")).toHaveTextContent(
-          /so long captain@example.com/i,
-        );
-        expect(assign).toHaveBeenCalled();
-      });
-    });
+    await flushPendingDelete(finishDelete);
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      /so long captain@example.com/i,
+    );
+    expect(assign).toHaveBeenCalled();
   });
 
   it("keeps the user in a keyboard dialog if the account could not be deleted", async () => {
     deleteAccount.mockImplementationOnce(
       () => Promise.reject(new Error("nope")) as never,
     );
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
 
     const user = await confirmDeletion();
 
@@ -157,19 +174,19 @@ describe("DeleteAccountConfirmationProvider", () => {
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
     expect(assign).not.toHaveBeenCalled();
 
-    await flushFarewellTimer(async () => {
-      await user.keyboard("{Enter}");
-      await waitFor(() => {
-        expect(deleteAccount).toHaveBeenCalledTimes(2);
-        expect(assign).toHaveBeenCalled();
-      });
+    await user.keyboard("{Enter}");
+    await waitFor(() => {
+      expect(deleteAccount).toHaveBeenCalledTimes(2);
     });
+
+    consoleError.mockRestore();
   });
 
   it("lets the user dismiss a failed delete with Escape", async () => {
     deleteAccount.mockImplementationOnce(
       () => Promise.reject(new Error("nope")) as never,
     );
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
 
     const user = await confirmDeletion();
 
@@ -186,5 +203,7 @@ describe("DeleteAccountConfirmationProvider", () => {
       ).not.toBeInTheDocument();
     });
     expect(assign).not.toHaveBeenCalled();
+
+    consoleError.mockRestore();
   });
 });

--- a/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationProvider.tsx
+++ b/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationProvider.tsx
@@ -1,5 +1,6 @@
 import { type PropsWithChildren, useCallback, useState } from "react";
 import { UserApi } from "@web/api/user.api";
+import { isSessionLevelError } from "@web/api/util/api.util";
 import { getLastKnownEmail } from "@web/auth/compass/state/auth.state.util";
 import { getPosthogClient } from "@web/auth/posthog/posthog.bootstrap";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
@@ -20,21 +21,20 @@ export function DeleteAccountConfirmationProvider({
 }: PropsWithChildren) {
   const value = useDeleteAccountConfirmationState();
   const { closeDeleteAccountConfirmation, isOpen } = value;
-  const [farewell, setFarewell] = useState<string | null>(null);
-  const [isDeleting, setIsDeleting] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [hasFailed, setHasFailed] = useState(false);
 
   const deleteAccount = useCallback(async () => {
     setHasFailed(false);
-    setFarewell(null);
-    setIsDeleting(true);
+    setStatusMessage("Deleting your account.");
 
     try {
       await UserApi.deleteAccount();
     } catch (e) {
       console.error("Failed to delete account", e);
-      setIsDeleting(false);
-      setHasFailed(true);
+      setStatusMessage(null);
+      // Session recovery already showed its own sign-in UI.
+      if (!isSessionLevelError(e)) setHasFailed(true);
       return;
     }
 
@@ -51,8 +51,7 @@ export function DeleteAccountConfirmationProvider({
       getPosthogClient()?.reset();
     }
 
-    setIsDeleting(false);
-    setFarewell(email);
+    setStatusMessage(`Until our sails cross paths again, so long ${email}.`);
 
     await new Promise((resolve) => setTimeout(resolve, FAREWELL_MS));
     window.location.assign(ROOT_ROUTES.ROOT);
@@ -80,19 +79,8 @@ export function DeleteAccountConfirmationProvider({
         onCancel={handleFailureCancel}
         onRetry={deleteAccount}
       />
-      {isDeleting && (
-        <OverlayPanel
-          role="status"
-          variant="status"
-          message="Deleting your account."
-        />
-      )}
-      {farewell && (
-        <OverlayPanel
-          role="status"
-          variant="status"
-          message={`Until our sails cross paths again, so long ${farewell}.`}
-        />
+      {statusMessage && (
+        <OverlayPanel role="status" variant="status" message={statusMessage} />
       )}
     </DeleteAccountConfirmationContext.Provider>
   );

--- a/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationProvider.tsx
+++ b/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationProvider.tsx
@@ -1,12 +1,11 @@
 import { type PropsWithChildren, useCallback, useState } from "react";
 import { UserApi } from "@web/api/user.api";
-import { getApiErrorCode, isApiError } from "@web/api/util/api.util";
 import { getLastKnownEmail } from "@web/auth/compass/state/auth.state.util";
 import { getPosthogClient } from "@web/auth/posthog/posthog.bootstrap";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
 import { clearAllBrowserStorage } from "@web/common/utils/cleanup/browser.cleanup.util";
-import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import { DeleteAccountConfirmationDialog } from "@web/components/DeleteAccountConfirmation/DeleteAccountConfirmationDialog";
+import { DeleteAccountFailureDialog } from "@web/components/DeleteAccountConfirmation/DeleteAccountFailureDialog";
 import {
   DeleteAccountConfirmationContext,
   useDeleteAccountConfirmationState,
@@ -22,65 +21,51 @@ export function DeleteAccountConfirmationProvider({
   const value = useDeleteAccountConfirmationState();
   const { closeDeleteAccountConfirmation, isOpen } = value;
   const [farewell, setFarewell] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [hasFailed, setHasFailed] = useState(false);
+
+  const deleteAccount = useCallback(async () => {
+    setHasFailed(false);
+    setFarewell(null);
+    setIsDeleting(true);
+
+    try {
+      await UserApi.deleteAccount();
+    } catch (e) {
+      console.error("Failed to delete account", e);
+      setIsDeleting(false);
+      setHasFailed(true);
+      return;
+    }
+
+    const email = getLastKnownEmail() ?? "friend";
+
+    try {
+      await clearAllBrowserStorage();
+    } catch {
+      // Already logged by clearAllBrowserStorage. The account is gone
+      // either way, so still send them off as an anonymous user.
+    } finally {
+      // Match deliberate logout: do not let a later anonymous visitor or
+      // newly-created account inherit this deleted account's device identity.
+      getPosthogClient()?.reset();
+    }
+
+    setIsDeleting(false);
+    setFarewell(email);
+
+    await new Promise((resolve) => setTimeout(resolve, FAREWELL_MS));
+    window.location.assign(ROOT_ROUTES.ROOT);
+  }, []);
 
   const handleConfirm = useCallback(() => {
     closeDeleteAccountConfirmation();
+    void deleteAccount();
+  }, [closeDeleteAccountConfirmation, deleteAccount]);
 
-    // Up before the request, not after it: deleting spans a Mongo
-    // transaction and a Google grant revocation, and until this covers the
-    // screen the user is looking at the calendar of the account they just
-    // deleted, with nothing to say it's working. Reading the email has to
-    // happen first too, since the cleanup below wipes it from storage.
-    setFarewell(getLastKnownEmail() ?? "friend");
-    // Monotonic: a wall clock that steps backwards mid-delete (NTP, resume
-    // from sleep) would make the wait below longer than the step.
-    const shownAt = performance.now();
-
-    void (async () => {
-      try {
-        await UserApi.deleteAccount();
-      } catch (e) {
-        console.error("Failed to delete account", e);
-        setFarewell(null);
-        if (
-          isApiError(e) &&
-          getApiErrorCode(e) === "RECENT_AUTHENTICATION_REQUIRED"
-        ) {
-          showErrorToast(
-            "For security, sign out and sign back in before deleting your account.",
-          );
-          return;
-        }
-        showErrorToast("Couldn't delete your account. Please try again.");
-        return;
-      }
-
-      try {
-        await clearAllBrowserStorage();
-      } catch {
-        // Already logged by clearAllBrowserStorage. The account is gone
-        // either way, so still send them off as an anonymous user.
-      } finally {
-        // Match deliberate logout: do not let a later anonymous visitor or
-        // newly-created account inherit this deleted account's device identity.
-        getPosthogClient()?.reset();
-      }
-
-      // Hold the farewell for its full span measured from when it appeared,
-      // so a slow delete doesn't add to the wait and a fast one doesn't
-      // flash it.
-      const remaining = FAREWELL_MS - (performance.now() - shownAt);
-      if (remaining > 0) {
-        await new Promise((resolve) => setTimeout(resolve, remaining));
-      }
-
-      // Reload rather than just flipping session state: it's the only way to
-      // be sure nothing of the deleted account survives in memory (query
-      // caches, the open IndexedDB connection). They land back in the app,
-      // anonymous.
-      window.location.assign(ROOT_ROUTES.ROOT);
-    })();
-  }, [closeDeleteAccountConfirmation]);
+  const handleFailureCancel = useCallback(() => {
+    setHasFailed(false);
+  }, []);
 
   return (
     <DeleteAccountConfirmationContext.Provider value={value}>
@@ -90,6 +75,18 @@ export function DeleteAccountConfirmationProvider({
         onCancel={closeDeleteAccountConfirmation}
         onConfirm={handleConfirm}
       />
+      <DeleteAccountFailureDialog
+        isOpen={hasFailed}
+        onCancel={handleFailureCancel}
+        onRetry={deleteAccount}
+      />
+      {isDeleting && (
+        <OverlayPanel
+          role="status"
+          variant="status"
+          message="Deleting your account."
+        />
+      )}
       {farewell && (
         <OverlayPanel
           role="status"

--- a/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountFailureDialog.test.tsx
+++ b/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountFailureDialog.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, mock } from "bun:test";
+import "@testing-library/jest-dom";
+import { DeleteAccountFailureDialog } from "./DeleteAccountFailureDialog";
+
+describe("DeleteAccountFailureDialog", () => {
+  it("does not render when closed", () => {
+    render(
+      <DeleteAccountFailureDialog
+        isOpen={false}
+        onCancel={mock()}
+        onRetry={mock()}
+      />,
+    );
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("retries from the keyboard with Enter", async () => {
+    const user = userEvent.setup();
+    const onCancel = mock();
+    const onRetry = mock();
+
+    render(
+      <DeleteAccountFailureDialog
+        isOpen
+        onCancel={onCancel}
+        onRetry={onRetry}
+      />,
+    );
+
+    expect(
+      screen.getByRole("dialog", { name: /couldn't delete your account/i }),
+    ).toHaveTextContent(/your account is still here/i);
+
+    await user.keyboard("{Enter}");
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("cancels from the keyboard with Escape", async () => {
+    const user = userEvent.setup();
+    const onCancel = mock();
+    const onRetry = mock();
+
+    render(
+      <DeleteAccountFailureDialog
+        isOpen
+        onCancel={onCancel}
+        onRetry={onRetry}
+      />,
+    );
+
+    await user.keyboard("{Escape}");
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountFailureDialog.tsx
+++ b/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountFailureDialog.tsx
@@ -1,0 +1,42 @@
+import {
+  OverlayPanel,
+  OverlayPanelActionButton,
+  OverlayPanelActions,
+} from "@web/components/OverlayPanel/OverlayPanel";
+
+interface DeleteAccountFailureDialogProps {
+  isOpen: boolean;
+  onCancel: () => void;
+  onRetry: () => void;
+}
+
+export function DeleteAccountFailureDialog({
+  isOpen,
+  onCancel,
+  onRetry,
+}: DeleteAccountFailureDialogProps) {
+  if (!isOpen) return null;
+
+  return (
+    <OverlayPanel
+      title="Couldn't delete your account"
+      message="Something went wrong, and your account is still here."
+      onDismiss={onCancel}
+      align="start"
+      variant="modal"
+    >
+      <OverlayPanelActions align="start">
+        <OverlayPanelActionButton
+          variant="primary"
+          shortcut="Enter"
+          onClick={onRetry}
+        >
+          Try again
+        </OverlayPanelActionButton>
+        <OverlayPanelActionButton shortcut="Esc" onClick={onCancel}>
+          Cancel
+        </OverlayPanelActionButton>
+      </OverlayPanelActions>
+    </OverlayPanel>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Account deletion was blocked by a 15-minute `lastLoggedInAt` check added in #2958. That timestamp is only stamped on a real sign-in, not on an active SuperTokens session. Anyone with a persistent session (including existing users who never logged out after that deploy, so `lastLoggedInAt` is missing) got a temporary toast: "For security, sign out and sign back in before deleting your account."

That is the toast Tyler hit on prod with `tyler@switchback.tech`. He was signed in and using the app. The session was valid. The confirmation phrase had already been typed.

This change:

- Deletes the account when the caller has a valid session and has typed the confirmation phrase. Stripe-safe deletion and the 3/15-minute rate limit stay.
- Covers the calendar with "Deleting your account." while the request is in flight, and only shows the farewell after success.
- If deletion still fails (Stripe, network, 500), shows a persistent keyboard dialog instead of a toast: Try again (Enter) / Cancel (Esc).
- Lets Enter confirm deletion after the phrase is typed.

<a href="https://cursor.com/agents/bc-efdc0ace-7e14-4dcc-bcd0-966c103c1b72/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdelete_account_keyboard_failure_dialog.mp4"><img src="https://cursor.com/artifacts/c/art-82a4d8fe-f773-4f90-962e-ae63ee6b8d95" alt="delete_account_keyboard_failure_dialog.mp4" /></a>
![Delete-account failure dialog with Try again Enter and Cancel Esc](https://cursor.com/artifacts/c/art-459f83b9-596b-41eb-8fe8-3b6e9d2a9057)

## Simplicity

Removed the recency gate instead of adding a Google re-auth detour. A valid session plus the typed confirmation is enough. The remaining failure UI reuses the same OverlayPanel pattern as logout.

## Automated validation

Local `bun run verify` selected web + backend. Passed: web, backend, type-check, lint, knip, a11y. Failed: test:e2e on unrelated public-booking skip-link/scroll tests (not in this diff).

GitHub CI on this PR: lint, knip, type-check, unit (core/web/backend/sync/scripts), e2e, lighthouse, CodeQL all green.

Keyboard walkthrough: Ctrl+, then Settings `d`, type the phrase, Enter. No backend in this environment, so the failure dialog appears. Esc returns to the calendar. No logout toast.

## Independent review

`.agents/handoffs/3037.md`. Reviewer verdict: no confirmed findings. Remaining controls are a valid session, the typed confirmation phrase, Stripe-safe deletion, and the 3/15-minute rate limit.

## Test plan

- `bun test:web -- packages/web/src/components/DeleteAccountConfirmation/` (18 pass)
- `bun test:backend -- packages/backend/src/user/services/user.service.db.test.ts` (32 pass)
- `bun run verify` (web, backend, type-check, lint, knip, a11y pass; local e2e unrelated public-booking fail)
- GitHub Test workflow: e2e pass on this PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efdc0ace-7e14-4dcc-bcd0-966c103c1b72?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efdc0ace-7e14-4dcc-bcd0-966c103c1b72&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

