### PR TITLE
fix(web): let tab reach every event form action

### DIFF
--- a/e2e/accessibility/app-a11y.spec.ts
+++ b/e2e/accessibility/app-a11y.spec.ts
@@ -40,21 +40,21 @@ test("the all-day event form is accessible when open", async ({ page }) => {
   await expectNoAxeViolations(page, { checkpoint: "all-day event form open" });
 });
 
-test("the event action toolbar is accessible", async ({ page }) => {
+test("the event action row is accessible", async ({ page }) => {
   await prepareCalendarPage(page);
   const title = createEventTitle("A11y Checkpoint");
   await openTimedEventFormWithKeyboard(page);
   await fillTitleAndSaveEventForm(page, title);
   await openEventForEditingWithKeyboard(page, title);
 
-  const toolbar = page
+  const actionRow = page
     .getByRole("form")
-    .getByRole("toolbar", { name: "Event actions" });
-  await expect(toolbar).toBeVisible();
-  await toolbar.getByRole("button", { name: "Duplicate" }).focus();
+    .getByRole("group", { name: "Event actions" });
+  await expect(actionRow).toBeVisible();
+  await actionRow.getByRole("button", { name: "Duplicate" }).focus();
 
   await expectNoAxeViolations(page, {
-    checkpoint: "event action toolbar",
+    checkpoint: "event action row",
   });
 });
 

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -371,7 +371,9 @@ test.describe("public booking page", () => {
       page.getByRole("button", { name: "Previous month" }),
     ).toBeEnabled();
     await expect(page.getByText("Loading open times")).toHaveCount(0);
-    await expect.poll(() => captured.slotGets).toBeGreaterThanOrEqual(3);
+    // Horizon can omit the month after next (60 days from 1 Sep does not
+    // cover November), so do not require a third fetch. Revisiting the
+    // prefetched month must not issue another request.
     const afterArrive = captured.slotGets;
 
     await page.getByRole("button", { name: "Previous month" }).click();

--- a/e2e/utils/event-test-utils.ts
+++ b/e2e/utils/event-test-utils.ts
@@ -323,7 +323,7 @@ export const openEventForEditingWithKeyboard = async (
 };
 
 /**
- * Deletes the event whose form is open, driving the action toolbar above the
+ * Deletes the event whose form is open, driving the action row above the
  * title by keyboard (focus + Enter on a native button, so this doubles as
  * coverage that keyboard activation works).
  */
@@ -332,7 +332,7 @@ export const deleteEventWithKeyboard = async (page: Page) => {
   await expect(form).toBeVisible();
   page.once("dialog", (dialog) => dialog.accept());
   const deleteButton = form
-    .getByRole("toolbar", { name: "Event actions" })
+    .getByRole("group", { name: "Event actions" })
     .getByRole("button", { name: "Delete" });
   await deleteButton.waitFor({ state: "visible", timeout: FORM_TIMEOUT });
   await deleteButton.focus();

--- a/packages/web/src/common/utils/form/form.util.ts
+++ b/packages/web/src/common/utils/form/form.util.ts
@@ -36,8 +36,8 @@ const findFirstMatch = (selectors: string[]): HTMLElement | null => {
  * input is often 2px wide — too small for a hint chip — so combobox fields
  * put the id on the wrapper. */
 const FIELD_SELECTORS: Record<EventFormFocusField, string[]> = {
-  // The action toolbar above the title. Its roving tabindex means exactly one
-  // button is tabbable at a time, which is the one FOCUSABLE_SELECTOR finds.
+  // The action toolbar above the title. FOCUSABLE_SELECTOR lands on the
+  // first button (Duplicate when present, otherwise Delete or Close).
   actions: [`${EVENT_FORM_SELECTOR} #event-form-actions`],
   title: [`${EVENT_FORM_SELECTOR} input[name="Event Title"]`],
   location: [

--- a/packages/web/src/components/Sidebar/EventDetails/SidebarEventDetails.test.tsx
+++ b/packages/web/src/components/Sidebar/EventDetails/SidebarEventDetails.test.tsx
@@ -62,14 +62,15 @@ describe("SidebarEventDetails", () => {
     const title = await screen.findByPlaceholderText("Title");
     await waitFor(() => expect(title).toHaveFocus());
 
-    // The toolbar renders above the title, so it sits behind Shift+Tab
+    // The action row renders above the title, so it sits behind Shift+Tab
     // instead of taking the first forward Tab out of the title. Each action
     // is its own tab stop so Delete and Close are reachable without arrows.
-    const toolbar = screen.getByRole("toolbar", { name: "Event actions" });
+    const actionRow = screen.getByRole("group", { name: "Event actions" });
     expect(
-      toolbar.compareDocumentPosition(title) & Node.DOCUMENT_POSITION_FOLLOWING,
+      actionRow.compareDocumentPosition(title) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
-    const actionButtons = within(toolbar).getAllByRole("button");
+    const actionButtons = within(actionRow).getAllByRole("button");
     expect(actionButtons.length).toBeGreaterThan(1);
     expect(
       actionButtons.every((button) => button.getAttribute("tabindex") !== "-1"),

--- a/packages/web/src/components/Sidebar/EventDetails/SidebarEventDetails.test.tsx
+++ b/packages/web/src/components/Sidebar/EventDetails/SidebarEventDetails.test.tsx
@@ -63,17 +63,17 @@ describe("SidebarEventDetails", () => {
     await waitFor(() => expect(title).toHaveFocus());
 
     // The toolbar renders above the title, so it sits behind Shift+Tab
-    // instead of taking the first forward Tab out of the title, and its
-    // roving tabindex makes the whole row one stop.
+    // instead of taking the first forward Tab out of the title. Each action
+    // is its own tab stop so Delete and Close are reachable without arrows.
     const toolbar = screen.getByRole("toolbar", { name: "Event actions" });
     expect(
       toolbar.compareDocumentPosition(title) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+    const actionButtons = within(toolbar).getAllByRole("button");
+    expect(actionButtons.length).toBeGreaterThan(1);
     expect(
-      within(toolbar)
-        .getAllByRole("button")
-        .filter((button) => button.getAttribute("tabindex") === "0"),
-    ).toHaveLength(1);
+      actionButtons.every((button) => button.getAttribute("tabindex") !== "-1"),
+    ).toBe(true);
   });
 
   it("prompts before discarding a dirty existing event from the Close action", async () => {

--- a/packages/web/src/shortcuts/form-digit-jump/FormDigitHintOverlay.test.tsx
+++ b/packages/web/src/shortcuts/form-digit-jump/FormDigitHintOverlay.test.tsx
@@ -82,7 +82,7 @@ const buildForm = () => {
 
   const actions = document.createElement("div");
   actions.id = "event-form-actions";
-  actions.setAttribute("role", "toolbar");
+  actions.setAttribute("role", "group");
   form.append(actions);
 
   const elements = [

--- a/packages/web/src/shortcuts/form-digit-jump/useFormDigitJumpShortcut.test.tsx
+++ b/packages/web/src/shortcuts/form-digit-jump/useFormDigitJumpShortcut.test.tsx
@@ -98,7 +98,7 @@ const buildForm = () => {
   // focuses the first one, which is the one FIELD_SELECTORS resolves to.
   const actions = document.createElement("div");
   actions.id = "event-form-actions";
-  actions.setAttribute("role", "toolbar");
+  actions.setAttribute("role", "group");
   const duplicate = document.createElement("button");
   actions.append(duplicate);
   form.append(actions);

--- a/packages/web/src/shortcuts/form-digit-jump/useFormDigitJumpShortcut.test.tsx
+++ b/packages/web/src/shortcuts/form-digit-jump/useFormDigitJumpShortcut.test.tsx
@@ -94,13 +94,12 @@ const buildForm = () => {
   // Real usage sets this id on TipTap's contenteditable root, which is what
   // makes it focusable; jsdom doesn't treat contenteditable as focusable on
   // its own, so tabIndex is also set to reproduce that here.
-  // The action toolbar above the title, with a roving tabindex: exactly one
-  // button is tabbable, which is the one FIELD_SELECTORS resolves to.
+  // The action toolbar above the title. Each button is tabbable; Mod+0
+  // focuses the first one, which is the one FIELD_SELECTORS resolves to.
   const actions = document.createElement("div");
   actions.id = "event-form-actions";
   actions.setAttribute("role", "toolbar");
   const duplicate = document.createElement("button");
-  duplicate.tabIndex = 0;
   actions.append(duplicate);
   form.append(actions);
 

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.test.tsx
@@ -173,7 +173,14 @@ describe("RecurrenceSection", () => {
     await user.click(screen.getByRole("button", { name: /edit recurrence/i }));
     await user.click(await screen.findByRole("textbox"));
 
-    const ownDate = await screen.findByLabelText(/Monday, August 3rd, 2026/);
+    // The picker opens on today. Walk back to the event's month so the
+    // assertion does not depend on this test running in August.
+    const ownDateLabel = /Monday, August 3rd, 2026/;
+    for (let i = 0; i < 12 && !screen.queryByLabelText(ownDateLabel); i += 1) {
+      await user.click(screen.getByRole("button", { name: "Previous month" }));
+    }
+
+    const ownDate = await screen.findByLabelText(ownDateLabel);
     expect(ownDate.getAttribute("aria-label")).toMatch(/^Choose /);
     expect(ownDate).not.toHaveClass("react-datepicker__day--disabled");
     expect(ownDate.getAttribute("aria-disabled")).not.toBe("true");

--- a/packages/web/src/views/Forms/EventForm/EventForm.readOnly.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.readOnly.test.tsx
@@ -100,7 +100,7 @@ describe("EventForm read-only gate", () => {
     // The action toolbar stays, minus Delete: read-only events can be
     // duplicated (that creates a new, independent event) and closed, but
     // never mutated in place.
-    const actions = screen.getByRole("toolbar", { name: "Event actions" });
+    const actions = screen.getByRole("group", { name: "Event actions" });
     expect(
       within(actions).queryByRole("button", { name: "Delete" }),
     ).not.toBeInTheDocument();
@@ -198,7 +198,7 @@ describe("EventForm read-only gate", () => {
       screen.getByRole("toolbar", { name: "Description formatting" }),
     ).toBeInTheDocument();
     expect(
-      within(screen.getByRole("toolbar", { name: "Event actions" })).getByRole(
+      within(screen.getByRole("group", { name: "Event actions" })).getByRole(
         "button",
         { name: "Delete" },
       ),

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -293,22 +293,23 @@ describe("EventForm", () => {
     );
 
     const title = screen.getByPlaceholderText("Title");
-    const toolbar = screen.getByRole("toolbar", { name: "Event actions" });
+    const actionRow = screen.getByRole("group", { name: "Event actions" });
 
     // Above the title in DOM order, so the title keeps the form's opening
-    // focus and the toolbar sits behind Shift+Tab rather than stealing the
+    // focus and the action row sits behind Shift+Tab rather than stealing the
     // first forward Tab the way the old kebab menu did.
     expect(
-      toolbar.compareDocumentPosition(title) & Node.DOCUMENT_POSITION_FOLLOWING,
+      actionRow.compareDocumentPosition(title) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(
-      within(toolbar).getByRole("button", { name: "Duplicate" }),
+      within(actionRow).getByRole("button", { name: "Duplicate" }),
     ).toBeInTheDocument();
     expect(
-      within(toolbar).getByRole("button", { name: "Delete" }),
+      within(actionRow).getByRole("button", { name: "Delete" }),
     ).toBeInTheDocument();
     expect(
-      within(toolbar).getByRole("button", { name: "Close" }),
+      within(actionRow).getByRole("button", { name: "Close" }),
     ).toBeInTheDocument();
   });
 

--- a/packages/web/src/views/Forms/EventForm/FormActionsRow.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/FormActionsRow.test.tsx
@@ -44,69 +44,30 @@ describe("FormActionsRow", () => {
     ).toEqual(["Duplicate", "Close"]);
   });
 
-  it("is a single tab stop: exactly one button is tabbable", () => {
+  it("puts every action in the tab order", () => {
     renderRow();
 
-    const tabbable = buttons().filter(
-      (button) => button.getAttribute("tabindex") === "0",
-    );
-    expect(tabbable).toHaveLength(1);
-    expect(tabbable[0]).toHaveAttribute("aria-label", "Duplicate");
+    expect(buttons().map((button) => button.getAttribute("tabindex"))).toEqual([
+      null,
+      null,
+      null,
+    ]);
   });
 
-  it("moves focus with arrow keys, wrapping at both ends", async () => {
+  it("tabs through duplicate, delete, and close in DOM order", async () => {
     const user = userEvent.setup();
     renderRow();
     const [duplicate, deleteButton, close] = buttons();
 
     duplicate.focus();
-    await user.keyboard("{ArrowRight}");
+    await user.tab();
     expect(deleteButton).toHaveFocus();
 
-    await user.keyboard("{ArrowRight}{ArrowRight}");
-    expect(duplicate).toHaveFocus();
-
-    await user.keyboard("{ArrowLeft}");
-    expect(close).toHaveFocus();
-  });
-
-  it("jumps to the ends with Home and End", async () => {
-    const user = userEvent.setup();
-    renderRow();
-    const [duplicate, , close] = buttons();
-
-    duplicate.focus();
-    await user.keyboard("{End}");
+    await user.tab();
     expect(close).toHaveFocus();
 
-    await user.keyboard("{Home}");
-    expect(duplicate).toHaveFocus();
-  });
-
-  it("keeps the roving index in range when duplicate disappears", async () => {
-    const user = userEvent.setup();
-    const { rerender } = renderRow();
-
-    buttons()[2].focus();
-    await user.keyboard("{ArrowLeft}");
-    expect(buttons()[1]).toHaveFocus();
-
-    // A saved event reverting to a draft drops Duplicate, shortening the row
-    // under a roving index that was pointing at the old last item.
-    rerender(
-      <FormActionsRow
-        isExistingEvent={false}
-        onClose={mock()}
-        onDelete={mock()}
-        onDuplicate={mock()}
-      />,
-    );
-
-    const remaining = buttons();
-    expect(remaining).toHaveLength(2);
-    expect(
-      remaining.filter((button) => button.getAttribute("tabindex") === "0"),
-    ).toHaveLength(1);
+    await user.tab({ shift: true });
+    expect(deleteButton).toHaveFocus();
   });
 
   it("calls the matching handler when a button is activated", async () => {

--- a/packages/web/src/views/Forms/EventForm/FormActionsRow.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/FormActionsRow.test.tsx
@@ -70,6 +70,20 @@ describe("FormActionsRow", () => {
     expect(deleteButton).toHaveFocus();
   });
 
+  it("activates the focused action with Enter after tabbing to it", async () => {
+    const user = userEvent.setup();
+    const onDelete = mock();
+    renderRow({ onDelete });
+    const [duplicate, deleteButton] = buttons();
+
+    duplicate.focus();
+    await user.tab();
+    expect(deleteButton).toHaveFocus();
+
+    await user.keyboard("{Enter}");
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
   it("calls the matching handler when a button is activated", async () => {
     const user = userEvent.setup();
     const onDuplicate = mock();

--- a/packages/web/src/views/Forms/EventForm/FormActionsRow.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/FormActionsRow.test.tsx
@@ -14,8 +14,8 @@ const renderRow = (props: Partial<Parameters<typeof FormActionsRow>[0]> = {}) =>
     />,
   );
 
-const toolbar = () => screen.getByRole("toolbar", { name: "Event actions" });
-const buttons = () => within(toolbar()).getAllByRole("button");
+const actionRow = () => screen.getByRole("group", { name: "Event actions" });
+const buttons = () => within(actionRow()).getAllByRole("button");
 
 afterEach(cleanup);
 

--- a/packages/web/src/views/Forms/EventForm/FormActionsRow.tsx
+++ b/packages/web/src/views/Forms/EventForm/FormActionsRow.tsx
@@ -26,8 +26,8 @@ type ActionItem = {
 };
 
 /**
- * Always-visible event-form toolbar above the title. Sits before the title in
- * the DOM so opening the form still lands on the title; Shift+Tab reaches
+ * Always-visible event-form action row above the title. Sits before the title
+ * in the DOM so opening the form still lands on the title; Shift+Tab reaches
  * these actions. Each action is its own tab stop. Mod+0 jumps here.
  */
 export const FormActionsRow: React.FC<Props> = ({
@@ -66,7 +66,7 @@ export const FormActionsRow: React.FC<Props> = ({
       aria-label="Event actions"
       className="flex items-center justify-end gap-1"
       id={EVENT_FORM_ACTIONS_ID}
-      role="toolbar"
+      role="group"
     >
       {items.map((item) => (
         <TooltipWrapper

--- a/packages/web/src/views/Forms/EventForm/FormActionsRow.tsx
+++ b/packages/web/src/views/Forms/EventForm/FormActionsRow.tsx
@@ -1,6 +1,5 @@
 import { Copy, Trash, X } from "@phosphor-icons/react";
 import type React from "react";
-import { type KeyboardEvent, useState } from "react";
 import IconButton from "@web/components/IconButton/IconButton";
 import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
 
@@ -29,7 +28,7 @@ type ActionItem = {
 /**
  * Always-visible event-form toolbar above the title. Sits before the title in
  * the DOM so opening the form still lands on the title; Shift+Tab reaches
- * these actions. One tab stop (roving tabindex); Mod+0 jumps here.
+ * these actions. Each action is its own tab stop. Mod+0 jumps here.
  */
 export const FormActionsRow: React.FC<Props> = ({
   isExistingEvent,
@@ -38,8 +37,6 @@ export const FormActionsRow: React.FC<Props> = ({
   onDelete,
   onDuplicate,
 }) => {
-  const [activeIndex, setActiveIndex] = useState(0);
-
   const items: ActionItem[] = [];
   if (isExistingEvent) {
     items.push({
@@ -64,49 +61,14 @@ export const FormActionsRow: React.FC<Props> = ({
     shortcut: "Esc",
   });
 
-  // Duplicate appears after a draft saves, so the stored index can go stale.
-  const tabbableIndex = Math.min(activeIndex, items.length - 1);
-
-  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    const last = items.length - 1;
-    const move = (index: number) => {
-      setActiveIndex(index);
-      event.currentTarget
-        .querySelectorAll<HTMLButtonElement>("button")
-        [index]?.focus();
-    };
-
-    switch (event.key) {
-      case "ArrowRight":
-        event.preventDefault();
-        move(tabbableIndex === last ? 0 : tabbableIndex + 1);
-        break;
-      case "ArrowLeft":
-        event.preventDefault();
-        move(tabbableIndex === 0 ? last : tabbableIndex - 1);
-        break;
-      case "Home":
-        event.preventDefault();
-        move(0);
-        break;
-      case "End":
-        event.preventDefault();
-        move(last);
-        break;
-      default:
-        break;
-    }
-  };
-
   return (
     <div
       aria-label="Event actions"
       className="flex items-center justify-end gap-1"
       id={EVENT_FORM_ACTIONS_ID}
-      onKeyDown={onKeyDown}
       role="toolbar"
     >
-      {items.map((item, index) => (
+      {items.map((item) => (
         <TooltipWrapper
           key={item.label}
           description={item.label}
@@ -115,9 +77,7 @@ export const FormActionsRow: React.FC<Props> = ({
           <IconButton
             aria-label={item.label}
             onClick={item.onClick}
-            onFocus={() => setActiveIndex(index)}
             size="small"
-            tabIndex={index === tabbableIndex ? 0 : -1}
           >
             {item.icon}
           </IconButton>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The event form action row (Duplicate, Delete, Close) used a single-stop roving tabindex. Tab landed only on Duplicate, so keyboard users could not reach Delete or Close.

Each action is now its own tab stop. The row is a named `group` rather than a `toolbar`, so screen readers do not expect arrow-key movement. Opening the form still focuses the title; Shift+Tab still reaches the row. Mod+0 still jumps to the first action.

Browser check: from the title, Shift+Tab reaches Close, then Delete, then Duplicate. Tab walks Duplicate → Delete → Close → title.

<a href="https://cursor.com/agents/bc-2d74e613-0e2c-4901-a084-726766f30036/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftab_through_event_form_actions.mp4"><img src="https://cursor.com/artifacts/c/art-0c58c4a6-7798-49e7-94d7-706319535571" alt="tab_through_event_form_actions.mp4" /></a>

## Simplicity

Removed the roving index, arrow/Home/End handler, and the stale-index clamp. Native tab order is the whole keyboard model.

## Automated validation

- Focused `bun test:web` on `FormActionsRow`, `EventForm`, `EventForm.readOnly`, `SidebarEventDetails`, `useFormDigitJumpShortcut`, `FormDigitHintOverlay`, `form.util`, and `RecurrenceSection`.
- `bunx playwright test e2e/accessibility/app-a11y.spec.ts` (event action row checkpoint).
- `bunx playwright test e2e/booking/public-booking.spec.ts -g "prefetched month"`.
- Browser: Tab/Shift+Tab through Duplicate, Delete, and Close on a saved event.

CI on 1 Sep also failed two date-boundary suites unrelated to this UI change. Those tests now walk to the event month (recurrence Ends-on) and no longer require a third booking slots fetch when the 60-day horizon does not cover month+2.

## Independent review

Quoted FINDINGS from a read-only `/review` of the first commit:

```
[low] FormActionsRow.tsx:69 — role="toolbar" advertised arrow-key movement after the roving handler was removed.
Fix: role="group" with the same accessible name.
```

Addressed in `fix(web): name the event action row as a group`.

## Test plan

- `bun test:web -- packages/web/src/views/Forms/EventForm/FormActionsRow.test.tsx packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.test.tsx`
- `bunx playwright test e2e/accessibility/app-a11y.spec.ts`
- `bunx playwright test e2e/booking/public-booking.spec.ts -g "prefetched month"`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d74e613-0e2c-4901-a084-726766f30036?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d74e613-0e2c-4901-a084-726766f30036&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

