### PR TITLE
fix(booking): contain overflow, cut slot keystrokes, and hide in production

### DIFF
--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -9,7 +9,9 @@ creates the calendar event with `invitation: "all"`.
 ## Status
 
 v1 is implemented in the Compass monorepo (public `/book/:username`, host
-Settings, backend APIs). A standalone Compass Booking product (separate
+Settings, backend APIs). It is enabled in development and staging
+(`runtime.nodeEnv` other than `production`) and disabled in production.
+A standalone Compass Booking product (separate
 brand, domain, or deployable) is **explicitly deferred**. The seams below
 are the extraction path; they are not a second service in v1.
 
@@ -107,9 +109,11 @@ focus uses the accent ring. Intended Tab order on the picker:
    skipping the month grid.
 2. Timezone control, then previous/next month, then one tab stop on the
    selected day (arrow keys move among days).
-3. Slot buttons for that day. Enter/Space opens **Your details** and
-   moves focus to that heading. **Skip to your details** is the first
-   tab stop on that step.
+3. One tab stop on that day's times (arrow keys move among slots, Home
+   and End jump to first and last). Enter or Space on a day moves focus
+   to the first slot. Enter or Space on a slot opens **Your details**
+   and moves focus to that heading. **Skip to your details** is the
+   first tab stop on that step.
 4. **Change time**, then name, email, notes, **Confirm booking**.
    **Change time** returns focus to **Pick a time**.
 5. After confirm, `/book/confirmed/:id` focuses **You are booked with

--- a/packages/backend/src/booking/booking.routes.config.test.ts
+++ b/packages/backend/src/booking/booking.routes.config.test.ts
@@ -1,0 +1,40 @@
+import express from "express";
+import { NodeEnv } from "@core/constants/core.constants";
+import { BookingRoutes } from "@backend/booking/booking.routes.config";
+import { CONFIG } from "@backend/common/constants/config.constants";
+import { afterEach, describe, expect, it } from "bun:test";
+
+function bookingRoutePaths(app: express.Express): string[] {
+  const router = (
+    app as unknown as {
+      _router?: { stack?: Array<{ route?: { path?: string } }> };
+    }
+  )._router;
+  return (router?.stack ?? []).flatMap((layer) => {
+    const path = layer.route?.path;
+    return path?.startsWith("/api/booking") ? [path] : [];
+  });
+}
+
+describe("BookingRoutes production gate", () => {
+  const originalNodeEnv = CONFIG.NODE_ENV;
+
+  afterEach(() => {
+    CONFIG.NODE_ENV = originalNodeEnv;
+  });
+
+  it("does not register /api/booking routes in production", () => {
+    CONFIG.NODE_ENV = NodeEnv.Production;
+    const app = express();
+    new BookingRoutes(app);
+    expect(bookingRoutePaths(app)).toEqual([]);
+  });
+
+  it("registers /api/booking routes outside production", () => {
+    CONFIG.NODE_ENV = NodeEnv.Test;
+    const app = express();
+    new BookingRoutes(app);
+    expect(bookingRoutePaths(app)).toContain("/api/booking/page");
+    expect(bookingRoutePaths(app)).toContain("/api/booking/pages/:slug");
+  });
+});

--- a/packages/backend/src/booking/booking.routes.config.ts
+++ b/packages/backend/src/booking/booking.routes.config.ts
@@ -1,8 +1,10 @@
 import type express from "express";
 import rateLimit from "express-rate-limit";
+import { isBookingEnabled } from "@core/util/env.util";
 import { verifySession } from "@backend/auth/session/session.middleware";
 import bookingController from "@backend/booking/controllers/booking.controller";
 import { CommonRoutesConfig } from "@backend/common/common.routes.config";
+import { CONFIG } from "@backend/common/constants/config.constants";
 
 const bookingSlugKey = (req: express.Request): string =>
   `${req.ip ?? "unknown"}:${req.params["slug"] ?? "unknown"}`;
@@ -59,6 +61,10 @@ export class BookingRoutes extends CommonRoutesConfig {
   }
 
   configureRoutes(): express.Application {
+    if (!isBookingEnabled(CONFIG.NODE_ENV)) {
+      return this.app;
+    }
+
     this.app
       .route(`/api/booking/page`)
       .all(verifySession())

--- a/packages/core/src/util/env.util.test.ts
+++ b/packages/core/src/util/env.util.test.ts
@@ -1,0 +1,25 @@
+import { NodeEnv } from "@core/constants/core.constants";
+import { isBookingEnabled, isDev } from "@core/util/env.util";
+import { describe, expect, it } from "bun:test";
+
+describe("isDev", () => {
+  it("is true only for development", () => {
+    expect(isDev(NodeEnv.Development)).toBe(true);
+    expect(isDev(NodeEnv.Staging)).toBe(false);
+    expect(isDev(NodeEnv.Production)).toBe(false);
+    expect(isDev(NodeEnv.Test)).toBe(false);
+  });
+});
+
+describe("isBookingEnabled", () => {
+  it("is on in development, staging, and tests", () => {
+    expect(isBookingEnabled(NodeEnv.Development)).toBe(true);
+    expect(isBookingEnabled(NodeEnv.Staging)).toBe(true);
+    expect(isBookingEnabled(NodeEnv.Test)).toBe(true);
+  });
+
+  it("is off in production", () => {
+    expect(isBookingEnabled(NodeEnv.Production)).toBe(false);
+    expect(isBookingEnabled("production")).toBe(false);
+  });
+});

--- a/packages/core/src/util/env.util.ts
+++ b/packages/core/src/util/env.util.ts
@@ -2,3 +2,7 @@ import { NodeEnv } from "@core/constants/core.constants";
 
 export const isDev = (nodeEnv: NodeEnv | string) =>
   nodeEnv === NodeEnv.Development;
+
+/** Booking v1 is on in development, staging, and tests. Not production. */
+export const isBookingEnabled = (nodeEnv: NodeEnv | string) =>
+  nodeEnv !== NodeEnv.Production;

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -162,7 +162,10 @@ describe("BookingSettingsSection", () => {
       { wrapper },
     );
 
-    await screen.findByRole("button", { name: "Save booking settings" });
+    const save = await screen.findByRole("button", {
+      name: "Save booking settings",
+    });
+    expect(save.parentElement?.parentElement?.className).toContain("sticky");
 
     await user.selectOptions(screen.getByLabelText("Duration"), "30");
     await user.click(

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -610,19 +610,21 @@ export function BookingSettingsSection({
         </BookingCheckboxRow>
       </fieldset>
 
-      <OverlayPanelActions align="start">
-        <OverlayPanelActionButton
-          aria-busy={saveMutation.isPending || undefined}
-          disabled={saveMutation.isPending}
-          onClick={handleSave}
-          shortcut="S"
-          showShortcut={showShortcuts}
-          variant="primary"
-          {...settingsShortcutAttrs("save-booking")}
-        >
-          {saveMutation.isPending ? "Saving…" : "Save booking settings"}
-        </OverlayPanelActionButton>
-      </OverlayPanelActions>
+      <div className="sticky bottom-0 z-10 bg-surface-panel pt-3">
+        <OverlayPanelActions align="start">
+          <OverlayPanelActionButton
+            aria-busy={saveMutation.isPending || undefined}
+            disabled={saveMutation.isPending}
+            onClick={handleSave}
+            shortcut="S"
+            showShortcut={showShortcuts}
+            variant="primary"
+            {...settingsShortcutAttrs("save-booking")}
+          >
+            {saveMutation.isPending ? "Saving…" : "Save booking settings"}
+          </OverlayPanelActionButton>
+        </OverlayPanelActions>
+      </div>
 
       <p className="text-text-muted text-xs">
         Press <kbd>e</kbd> then a letter to jump to a field. <kbd>S</kbd> saves.

--- a/packages/web/src/booking/PublicBookingLayout.test.tsx
+++ b/packages/web/src/booking/PublicBookingLayout.test.tsx
@@ -3,7 +3,7 @@ import { PublicBookingLayout } from "@web/booking/PublicBookingLayout";
 import { describe, expect, it } from "bun:test";
 
 describe("PublicBookingLayout", () => {
-  it("opts the public booking page into document scrolling", () => {
+  it("keeps the public booking page inside the viewport and scrolls main", () => {
     render(
       <PublicBookingLayout>
         <p>Booking content</p>
@@ -13,6 +13,9 @@ describe("PublicBookingLayout", () => {
     const main = screen.getByRole("main");
     expect(main).toHaveTextContent("Booking content");
     expect(main.parentElement).toHaveAttribute("data-document-scroll");
+    expect(main.parentElement?.className).toContain("h-dvh");
+    expect(main.parentElement?.className).toContain("overflow-hidden");
+    expect(main.className).toContain("overflow-y-auto");
     expect(main.className).toContain("max-w-lg");
   });
 

--- a/packages/web/src/booking/PublicBookingLayout.tsx
+++ b/packages/web/src/booking/PublicBookingLayout.tsx
@@ -5,10 +5,11 @@ interface PublicBookingLayoutProps extends PropsWithChildren {
 }
 
 /**
- * Public booking is a document-height page. The calendar shell clips
- * `html`/`body`/`#root` with `overflow: hidden`; `data-document-scroll`
- * opts this tree into native page scrolling so guests can reach later
- * time slots (see `index.css`).
+ * Public booking is a viewport-height page. The calendar shell clips
+ * `html`/`body`/`#root` with `overflow: hidden`; this layout is itself
+ * the scrollport (`h-dvh` + `overflow-y-auto` on `main`) so guests can
+ * reach later time slots without the page overflowing the window.
+ * `data-document-scroll` remains a fallback (see `index.css`).
  */
 export function PublicBookingLayout({
   children,
@@ -17,10 +18,10 @@ export function PublicBookingLayout({
   return (
     <div
       data-document-scroll
-      className="relative min-h-dvh bg-background text-text"
+      className="relative flex h-dvh flex-col overflow-hidden bg-background text-text"
     >
       <main
-        className={`mx-auto flex w-full min-w-0 flex-col gap-6 px-4 py-10 ${
+        className={`mx-auto flex min-h-0 w-full min-w-0 flex-1 flex-col gap-6 overflow-y-auto px-4 py-10 ${
           wide ? "max-w-3xl" : "max-w-lg"
         }`}
       >

--- a/packages/web/src/booking/PublicBookingMonthGrid.test.tsx
+++ b/packages/web/src/booking/PublicBookingMonthGrid.test.tsx
@@ -117,6 +117,27 @@ describe("PublicBookingMonthGrid", () => {
     expect(selected).toEqual([availableB]);
   });
 
+  it("notifies keyboard day activation and ignores pointer clicks", async () => {
+    const user = userEvent.setup({ delay: null });
+    const keyboard: string[] = [];
+    const { selected } = renderGrid({
+      onKeyboardActivateDay: (dateKey) => {
+        keyboard.push(dateKey);
+      },
+    });
+
+    const seventeenth = screen.getByRole("button", {
+      name: formatBookingMonthDayLabel(availableA, timeZone),
+    });
+    await user.click(seventeenth);
+    expect(selected).toEqual([availableA]);
+    expect(keyboard).toEqual([]);
+
+    seventeenth.focus();
+    await user.keyboard("{Enter}");
+    expect(keyboard).toEqual([availableA]);
+  });
+
   it("disables next when the following month is past the horizon", () => {
     renderGrid({
       monthKey: "2026-09",

--- a/packages/web/src/booking/PublicBookingMonthGrid.tsx
+++ b/packages/web/src/booking/PublicBookingMonthGrid.tsx
@@ -28,6 +28,7 @@ interface PublicBookingMonthGridProps {
   onMonthChange: (monthKey: string) => void;
   onPrefetchMonth: (monthKey: string) => void;
   onSelectDate: (dateKey: string) => void;
+  onKeyboardActivateDay?: (dateKey: string) => void;
 }
 
 export function PublicBookingMonthGrid({
@@ -40,6 +41,7 @@ export function PublicBookingMonthGrid({
   onMonthChange,
   onPrefetchMonth,
   onSelectDate,
+  onKeyboardActivateDay,
 }: PublicBookingMonthGridProps) {
   const resolvedTodayKey = todayKey ?? formatBookingDateKey(dayjs(), timeZone);
   const availableDateKeys = useMemo(
@@ -197,9 +199,14 @@ export function PublicBookingMonthGrid({
                     aria-pressed={isSelected}
                     aria-current={day.isToday ? "date" : undefined}
                     tabIndex={tabStopDateKey === day.dateKey ? 0 : -1}
-                    onClick={() => {
+                    onClick={(event) => {
                       setFocusedDateKey(day.dateKey);
                       onSelectDate(day.dateKey);
+                      // Keyboard activation (Enter/Space) reports detail 0.
+                      // Pointer clicks must not steal focus to the slot list.
+                      if (event.detail === 0) {
+                        onKeyboardActivateDay?.(day.dateKey);
+                      }
                     }}
                     onKeyDown={(event) => handleDayKeyDown(event, day.dateKey)}
                     className={`c-focus-ring flex h-10 w-full items-center justify-center rounded-md font-medium text-sm transition-colors ${

--- a/packages/web/src/booking/PublicBookingPicker.test.tsx
+++ b/packages/web/src/booking/PublicBookingPicker.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PublicBookingPicker } from "@web/booking/PublicBookingPicker";
+import {
+  formatBookingMonthDayLabel,
+  formatBookingSlotTime,
+} from "@web/booking/public-booking.format";
+import { describe, expect, it } from "bun:test";
+
+const timeZone = "UTC";
+const monthKey = "2026-08";
+const selectedDateKey = "2026-08-17";
+const firstSlot = "2026-08-17T15:00:00.000Z";
+const secondSlot = "2026-08-17T16:00:00.000Z";
+
+const slots = [
+  { slotStart: firstSlot, slotEnd: "2026-08-17T15:30:00.000Z" },
+  { slotStart: secondSlot, slotEnd: "2026-08-17T16:30:00.000Z" },
+];
+
+function renderPicker() {
+  render(
+    <PublicBookingPicker
+      monthKey={monthKey}
+      timeZone={timeZone}
+      maxHorizonDays={60}
+      slots={slots}
+      slotsPending={false}
+      slotsError={false}
+      slotsFetching={false}
+      selectedDateKey={selectedDateKey}
+      selectedSlotStart={null}
+      onMonthChange={() => {}}
+      onPrefetchMonth={() => {}}
+      onSelectDate={() => {}}
+      onSelectSlot={() => {}}
+      onJumpToNextAvailable={() => {}}
+      onRetrySlots={() => {}}
+    />,
+  );
+}
+
+describe("PublicBookingPicker", () => {
+  it("scrolls the times list inside the pane instead of growing the page", () => {
+    renderPicker();
+
+    const first = screen.getByRole("button", {
+      name: formatBookingSlotTime(firstSlot, timeZone),
+    });
+    const pane = first.closest("div");
+    expect(pane?.className).toContain("sm:overflow-y-auto");
+    expect(pane?.className).not.toContain("sm:max-h-96");
+  });
+
+  it("moves focus to the first slot after keyboard day activation", async () => {
+    const user = userEvent.setup({ delay: null });
+    renderPicker();
+
+    const day = screen.getByRole("button", {
+      name: formatBookingMonthDayLabel(selectedDateKey, timeZone),
+    });
+    const firstSlotButton = screen.getByRole("button", {
+      name: formatBookingSlotTime(firstSlot, timeZone),
+    });
+
+    day.focus();
+    await user.keyboard("{Enter}");
+    expect(firstSlotButton).toHaveFocus();
+  });
+
+  it("does not move focus to a slot after a pointer day click", async () => {
+    const user = userEvent.setup({ delay: null });
+    renderPicker();
+
+    const day = screen.getByRole("button", {
+      name: formatBookingMonthDayLabel(selectedDateKey, timeZone),
+    });
+    await user.click(day);
+    expect(day).toHaveFocus();
+  });
+});

--- a/packages/web/src/booking/PublicBookingPicker.test.tsx
+++ b/packages/web/src/booking/PublicBookingPicker.test.tsx
@@ -8,14 +8,14 @@ import {
 import { describe, expect, it } from "bun:test";
 
 const timeZone = "UTC";
-const monthKey = "2026-08";
-const selectedDateKey = "2026-08-17";
-const firstSlot = "2026-08-17T15:00:00.000Z";
-const secondSlot = "2026-08-17T16:00:00.000Z";
+const monthKey = "2026-09";
+const selectedDateKey = "2026-09-17";
+const firstSlot = "2026-09-17T15:00:00.000Z";
+const secondSlot = "2026-09-17T16:00:00.000Z";
 
 const slots = [
-  { slotStart: firstSlot, slotEnd: "2026-08-17T15:30:00.000Z" },
-  { slotStart: secondSlot, slotEnd: "2026-08-17T16:30:00.000Z" },
+  { slotStart: firstSlot, slotEnd: "2026-09-17T15:30:00.000Z" },
+  { slotStart: secondSlot, slotEnd: "2026-09-17T16:30:00.000Z" },
 ];
 
 function renderPicker() {

--- a/packages/web/src/booking/PublicBookingPicker.tsx
+++ b/packages/web/src/booking/PublicBookingPicker.tsx
@@ -73,6 +73,8 @@ export function PublicBookingPicker({
   );
   const showGridSkeleton = slotsPending && !hasRenderedGrid;
   const restoreFocusAfterError = useRef(false);
+  const pendingSlotFocusDateRef = useRef<string | null>(null);
+  const slotPaneRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!slotsPending) {
@@ -96,12 +98,35 @@ export function PublicBookingPicker({
     }
   }, [slotsError, slotsHeadingRef, slotsPending]);
 
+  const focusFirstSlot = () => {
+    slotPaneRef.current
+      ?.querySelector<HTMLButtonElement>("[data-booking-slot]")
+      ?.focus();
+  };
+
+  useEffect(() => {
+    const pendingDate = pendingSlotFocusDateRef.current;
+    if (pendingDate === null || pendingDate !== selectedDateKey) {
+      return;
+    }
+    pendingSlotFocusDateRef.current = null;
+    focusFirstSlot();
+  }, [selectedDateKey]);
+
+  const handleKeyboardActivateDay = (dateKey: string) => {
+    if (dateKey === selectedDateKey) {
+      focusFirstSlot();
+      return;
+    }
+    pendingSlotFocusDateRef.current = dateKey;
+  };
+
   return (
-    <div className="flex w-full min-w-0 flex-col gap-3">
+    <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col gap-3">
       <p aria-live="polite" className="sr-only" role="status">
         {liveMessage}
       </p>
-      <div className="grid w-full min-w-0 gap-6 sm:grid-cols-2 sm:items-start">
+      <div className="grid min-h-0 w-full min-w-0 flex-1 gap-6 sm:grid-cols-2">
         <div className="min-w-0">
           {showGridSkeleton ? (
             <PublicBookingMonthGridSkeleton
@@ -117,10 +142,14 @@ export function PublicBookingPicker({
               onMonthChange={onMonthChange}
               onPrefetchMonth={onPrefetchMonth}
               onSelectDate={onSelectDate}
+              onKeyboardActivateDay={handleKeyboardActivateDay}
             />
           )}
         </div>
-        <div className="min-h-64 min-w-0 sm:max-h-96 sm:overflow-y-auto">
+        <div
+          ref={slotPaneRef}
+          className="min-h-64 min-w-0 sm:min-h-0 sm:overflow-y-auto"
+        >
           {slotsPending ? (
             <PublicBookingSlotPaneSkeleton />
           ) : slotsError ? (

--- a/packages/web/src/booking/PublicBookingSlotPicker.test.tsx
+++ b/packages/web/src/booking/PublicBookingSlotPicker.test.tsx
@@ -1,17 +1,24 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { PublicBookingSlotPicker } from "@web/booking/PublicBookingSlotPicker";
-import { formatBookingSlotDateHeading } from "@web/booking/public-booking.format";
+import {
+  formatBookingSlotDateHeading,
+  formatBookingSlotTime,
+} from "@web/booking/public-booking.format";
 import { describe, expect, it } from "bun:test";
 
 const timeZone = "UTC";
 const dayA = "2026-08-17T15:00:00.000Z";
 const dayALater = "2026-08-17T16:00:00.000Z";
+const dayAAfternoon = "2026-08-17T17:00:00.000Z";
+const dayAEvening = "2026-08-17T18:00:00.000Z";
 const dayB = "2026-08-20T15:00:00.000Z";
 
 const slots = [
   { slotStart: dayA, slotEnd: "2026-08-17T15:30:00.000Z" },
   { slotStart: dayALater, slotEnd: "2026-08-17T16:30:00.000Z" },
+  { slotStart: dayAAfternoon, slotEnd: "2026-08-17T17:30:00.000Z" },
+  { slotStart: dayAEvening, slotEnd: "2026-08-17T18:30:00.000Z" },
   { slotStart: dayB, slotEnd: "2026-08-20T15:30:00.000Z" },
 ];
 
@@ -83,5 +90,51 @@ describe("PublicBookingSlotPicker", () => {
     expect(
       screen.getByRole("button", { name: "Jump to next available day" }),
     ).toBeInTheDocument();
+  });
+
+  it("keeps a single slot in the tab order and moves with arrow keys", async () => {
+    const user = userEvent.setup({ delay: null });
+    render(
+      <PublicBookingSlotPicker
+        slots={slots}
+        selectedDateKey="2026-08-17"
+        guestTimeZone={timeZone}
+        selectedSlotStart={null}
+        onSelectSlot={() => {}}
+      />,
+    );
+
+    const first = screen.getByRole("button", {
+      name: formatBookingSlotTime(dayA, timeZone),
+    });
+    const second = screen.getByRole("button", {
+      name: formatBookingSlotTime(dayALater, timeZone),
+    });
+    const third = screen.getByRole("button", {
+      name: formatBookingSlotTime(dayAAfternoon, timeZone),
+    });
+    const last = screen.getByRole("button", {
+      name: formatBookingSlotTime(dayAEvening, timeZone),
+    });
+
+    expect(first.tabIndex).toBe(0);
+    expect(second.tabIndex).toBe(-1);
+    expect(third.tabIndex).toBe(-1);
+    expect(last.tabIndex).toBe(-1);
+
+    first.focus();
+    await user.keyboard("{ArrowRight}");
+    expect(second).toHaveFocus();
+    expect(first.tabIndex).toBe(-1);
+    expect(second.tabIndex).toBe(0);
+
+    await user.keyboard("{ArrowDown}");
+    expect(last).toHaveFocus();
+
+    await user.keyboard("{Home}");
+    expect(first).toHaveFocus();
+
+    await user.keyboard("{End}");
+    expect(last).toHaveFocus();
   });
 });

--- a/packages/web/src/booking/PublicBookingSlotPicker.tsx
+++ b/packages/web/src/booking/PublicBookingSlotPicker.tsx
@@ -1,4 +1,11 @@
-import { type Ref } from "react";
+import {
+  type KeyboardEvent,
+  type Ref,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   formatBookingDateKey,
   formatBookingSlotDateHeading,
@@ -15,6 +22,39 @@ interface PublicBookingSlotPickerProps {
   onJumpToNextAvailable?: () => void;
 }
 
+const SLOT_COLUMN_COUNT = 2;
+
+function stepSlotIndex(
+  index: number,
+  count: number,
+  key: string,
+): number | null {
+  if (count === 0) {
+    return null;
+  }
+  const last = count - 1;
+  switch (key) {
+    case "ArrowRight":
+      return Math.min(index + 1, last);
+    case "ArrowLeft":
+      return Math.max(index - 1, 0);
+    case "ArrowDown":
+      return Math.min(index + SLOT_COLUMN_COUNT, last);
+    case "ArrowUp":
+      return Math.max(index - SLOT_COLUMN_COUNT, 0);
+    case "Home":
+      return 0;
+    case "End":
+      return last;
+    default:
+      return null;
+  }
+}
+
+function bookingSlotButtonId(slotStart: string): string {
+  return `booking-slot-${slotStart}`;
+}
+
 export function PublicBookingSlotPicker({
   slots,
   selectedDateKey,
@@ -24,16 +64,66 @@ export function PublicBookingSlotPicker({
   onSelectSlot,
   onJumpToNextAvailable,
 }: PublicBookingSlotPickerProps) {
-  const daySlots = selectedDateKey
-    ? slots.filter(
-        (slot) =>
-          formatBookingDateKey(slot.slotStart, guestTimeZone) ===
-          selectedDateKey,
-      )
-    : [];
+  const daySlots = useMemo(
+    () =>
+      selectedDateKey
+        ? slots.filter(
+            (slot) =>
+              formatBookingDateKey(slot.slotStart, guestTimeZone) ===
+              selectedDateKey,
+          )
+        : [],
+    [guestTimeZone, selectedDateKey, slots],
+  );
 
   const empty = !selectedDateKey || daySlots.length === 0;
   const firstSlotStart = daySlots[0]?.slotStart;
+  const [focusedSlotStart, setFocusedSlotStart] = useState<string | null>(
+    () => selectedSlotStart ?? firstSlotStart ?? null,
+  );
+  const moveFocusRef = useRef(false);
+
+  useEffect(() => {
+    setFocusedSlotStart((current) => {
+      if (
+        selectedSlotStart &&
+        daySlots.some((slot) => slot.slotStart === selectedSlotStart)
+      ) {
+        return selectedSlotStart;
+      }
+      if (current && daySlots.some((slot) => slot.slotStart === current)) {
+        return current;
+      }
+      return daySlots[0]?.slotStart ?? null;
+    });
+  }, [daySlots, selectedSlotStart]);
+
+  useEffect(() => {
+    if (!moveFocusRef.current || !focusedSlotStart) {
+      return;
+    }
+    moveFocusRef.current = false;
+    document.getElementById(bookingSlotButtonId(focusedSlotStart))?.focus();
+  }, [focusedSlotStart]);
+
+  const tabStopSlotStart = focusedSlotStart ?? firstSlotStart ?? null;
+
+  const handleSlotKeyDown = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ) => {
+    const nextIndex = stepSlotIndex(index, daySlots.length, event.key);
+    if (nextIndex === null) {
+      return;
+    }
+    event.preventDefault();
+    const nextStart = daySlots[nextIndex]?.slotStart;
+    if (!nextStart) {
+      return;
+    }
+    moveFocusRef.current = true;
+    setFocusedSlotStart(nextStart);
+  };
 
   return (
     <section aria-labelledby="booking-slots-heading">
@@ -72,7 +162,7 @@ export function PublicBookingSlotPicker({
             {formatBookingSlotDateHeading(firstSlotStart, guestTimeZone)}
           </h3>
           <ul className="mt-4 grid grid-cols-2 gap-2">
-            {daySlots.map((slot) => {
+            {daySlots.map((slot, index) => {
               const isSelected = selectedSlotStart === slot.slotStart;
               const label = formatBookingSlotTime(
                 slot.slotStart,
@@ -82,8 +172,12 @@ export function PublicBookingSlotPicker({
                 <li key={slot.slotStart}>
                   <button
                     type="button"
+                    id={bookingSlotButtonId(slot.slotStart)}
+                    data-booking-slot=""
                     aria-pressed={isSelected}
+                    tabIndex={tabStopSlotStart === slot.slotStart ? 0 : -1}
                     onClick={() => onSelectSlot(slot.slotStart)}
+                    onKeyDown={(event) => handleSlotKeyDown(event, index)}
                     className="c-focus-ring w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-text transition-colors hover:border-accent hover:bg-surface-panel aria-pressed:border-accent aria-pressed:bg-surface-panel"
                   >
                     {label}

--- a/packages/web/src/common/constants/env.constants.ts
+++ b/packages/web/src/common/constants/env.constants.ts
@@ -1,5 +1,5 @@
 import { z } from "zod/v4";
-import { isDev } from "@core/util/env.util";
+import { isBookingEnabled, isDev } from "@core/util/env.util";
 
 export const getApiBaseUrl = (apiBaseUrl?: string, port?: string): string => {
   if (apiBaseUrl) {
@@ -41,3 +41,4 @@ export const ENV_WEB = webEnvSchema.parse({
 });
 
 export const IS_DEV = isDev(ENV_WEB.NODE_ENV);
+export const IS_BOOKING_ENABLED = isBookingEnabled(ENV_WEB.NODE_ENV);

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
@@ -18,6 +18,14 @@ describe("OverlayPanel", () => {
     expect(document.body.dataset.appLocked).toBeUndefined();
   });
 
+  it("keeps modal dialogs from overflowing the viewport", () => {
+    render(<OverlayPanel title="Settings" onDismiss={() => {}} />);
+
+    const dialog = screen.getByRole("dialog", { name: "Settings" });
+    expect(dialog.className).toContain("max-h-[90vh]");
+    expect(dialog.className).toContain("overflow-y-auto");
+  });
+
   it("keeps the app locked when multiple panels are stacked", () => {
     const { unmount: unmountFirst } = render(
       <OverlayPanel title="First" onDismiss={() => {}} />,

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
@@ -120,7 +120,7 @@ export const OverlayPanel = ({
     align === "start" ? "items-start" : "items-center",
     variant === "modal" && [
       widthClassName,
-      "max-w-[90vw] rounded-xl p-8",
+      "max-h-[90vh] max-w-[90vw] overflow-y-auto rounded-xl p-8",
       "transition-transform duration-400 ease-out data-closing:scale-105 motion-reduce:transition-none",
       panelClassName ??
         "gap-6 bg-surface-panel shadow-[0_20px_25px_-5px_rgba(0,0,0,0.1),0_10px_10px_-5px_rgba(0,0,0,0.04)]",

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -608,6 +608,18 @@ describe("SettingsModal", () => {
     expect(screen.queryByRole("button", { name: "Log out" })).toBeNull();
   });
 
+  it("shows Booking for a signed-in user", () => {
+    renderSettings({ authenticated: true });
+
+    expect(screen.getByRole("button", { name: "Booking" })).toBeInTheDocument();
+  });
+
+  it("hides Booking for a signed-out session", () => {
+    renderSettings({ authenticated: false });
+
+    expect(screen.queryByRole("button", { name: "Booking" })).toBeNull();
+  });
+
   it("says nothing about a plan on an install without billing", () => {
     renderSettings({ authenticated: true });
 

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -25,7 +25,6 @@ import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import { UpgradeConfirmationProvider } from "@web/billing/UpgradeConfirmation/UpgradeConfirmationProvider";
 import { type AppAccess } from "@web/billing/useAppAccess";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
-import * as realEnvConstants from "@web/common/constants/env.constants";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import {
   ACCOUNT_DISCONNECTED_TOAST_ID,
@@ -109,20 +108,6 @@ mockModuleForFile("@web/sse/hooks/useSseDegraded", realUsessedegraded, {
     isSseDegradedMocked ? isSseDegraded : actualUseSseDegraded(),
 });
 
-const bookingGate = { enabled: true, mocked: true };
-mock.module("@web/common/constants/env.constants", () => {
-  const wrapped: Record<string, unknown> = { ...realEnvConstants };
-  Object.defineProperty(wrapped, "IS_BOOKING_ENABLED", {
-    configurable: true,
-    enumerable: true,
-    get: () =>
-      bookingGate.mocked
-        ? bookingGate.enabled
-        : realEnvConstants.IS_BOOKING_ENABLED,
-  });
-  return wrapped;
-});
-
 let access: AppAccess = { kind: "open" };
 let isAppAccessMocked = true;
 const actualUseAppAccess = (await import("@web/billing/useAppAccess"))
@@ -137,8 +122,6 @@ afterAll(() => {
   isSessionMocked = false;
   isSseDegradedMocked = false;
   isAppAccessMocked = false;
-  bookingGate.mocked = false;
-  bookingGate.enabled = true;
 });
 
 afterEach(() => {
@@ -146,7 +129,6 @@ afterEach(() => {
   resetGoogleReconnectRequiredForTests();
   isSseDegraded = false;
   access = { kind: "open" };
-  bookingGate.enabled = true;
 });
 
 const settingsModalUrl = new URL(
@@ -634,13 +616,6 @@ describe("SettingsModal", () => {
 
   it("hides Booking for a signed-out session", () => {
     renderSettings({ authenticated: false });
-
-    expect(screen.queryByRole("button", { name: "Booking" })).toBeNull();
-  });
-
-  it("hides Booking when the production gate is off", () => {
-    bookingGate.enabled = false;
-    renderSettings({ authenticated: true });
 
     expect(screen.queryByRole("button", { name: "Booking" })).toBeNull();
   });

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -25,6 +25,7 @@ import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import { UpgradeConfirmationProvider } from "@web/billing/UpgradeConfirmation/UpgradeConfirmationProvider";
 import { type AppAccess } from "@web/billing/useAppAccess";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
+import * as realEnvConstants from "@web/common/constants/env.constants";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import {
   ACCOUNT_DISCONNECTED_TOAST_ID,
@@ -108,6 +109,20 @@ mockModuleForFile("@web/sse/hooks/useSseDegraded", realUsessedegraded, {
     isSseDegradedMocked ? isSseDegraded : actualUseSseDegraded(),
 });
 
+const bookingGate = { enabled: true, mocked: true };
+mock.module("@web/common/constants/env.constants", () => {
+  const wrapped: Record<string, unknown> = { ...realEnvConstants };
+  Object.defineProperty(wrapped, "IS_BOOKING_ENABLED", {
+    configurable: true,
+    enumerable: true,
+    get: () =>
+      bookingGate.mocked
+        ? bookingGate.enabled
+        : realEnvConstants.IS_BOOKING_ENABLED,
+  });
+  return wrapped;
+});
+
 let access: AppAccess = { kind: "open" };
 let isAppAccessMocked = true;
 const actualUseAppAccess = (await import("@web/billing/useAppAccess"))
@@ -122,6 +137,8 @@ afterAll(() => {
   isSessionMocked = false;
   isSseDegradedMocked = false;
   isAppAccessMocked = false;
+  bookingGate.mocked = false;
+  bookingGate.enabled = true;
 });
 
 afterEach(() => {
@@ -129,6 +146,7 @@ afterEach(() => {
   resetGoogleReconnectRequiredForTests();
   isSseDegraded = false;
   access = { kind: "open" };
+  bookingGate.enabled = true;
 });
 
 const settingsModalUrl = new URL(
@@ -616,6 +634,13 @@ describe("SettingsModal", () => {
 
   it("hides Booking for a signed-out session", () => {
     renderSettings({ authenticated: false });
+
+    expect(screen.queryByRole("button", { name: "Booking" })).toBeNull();
+  });
+
+  it("hides Booking when the production gate is off", () => {
+    bookingGate.enabled = false;
+    renderSettings({ authenticated: true });
 
     expect(screen.queryByRole("button", { name: "Booking" })).toBeNull();
   });

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -36,6 +36,7 @@ import {
   useConnectedAccountEmails,
   useDefaultTargetCalendar,
 } from "@web/calendars/useDefaultTargetCalendar";
+import { IS_BOOKING_ENABLED } from "@web/common/constants/env.constants";
 import { EXPORT_MY_DATA_TOAST_ID } from "@web/common/constants/toast.constants";
 import { runExportMyData } from "@web/common/storage/offline-data/export-user-data.util";
 import { focusOnPointerEnter } from "@web/common/utils/focus-on-pointer-enter";
@@ -95,7 +96,7 @@ export const SettingsModal: FC = () => {
   const { areHintsVisible } = useSettingsShortcuts({
     enabled: isOpen && !isUpgradeOpen,
     hasBilling,
-    hasBooking: authenticated,
+    hasBooking: authenticated && IS_BOOKING_ENABLED,
     page,
   });
 
@@ -209,7 +210,7 @@ export const SettingsModal: FC = () => {
               {areHintsVisible ? <ShortcutKeys keys="2" /> : null}
             </button>
           ) : null}
-          {authenticated ? (
+          {authenticated && IS_BOOKING_ENABLED ? (
             <button
               aria-current={page === "booking" ? "true" : undefined}
               className={navButtonClassName(page === "booking")}
@@ -227,7 +228,7 @@ export const SettingsModal: FC = () => {
         <div className="flex min-w-0 flex-1 flex-col gap-4">
           {page === "billing" ? (
             <PlanSection showShortcuts={areHintsVisible} />
-          ) : page === "booking" ? (
+          ) : page === "booking" && IS_BOOKING_ENABLED ? (
             <BookingSettingsSection showShortcuts={areHintsVisible} />
           ) : (
             <>

--- a/packages/web/src/routers/router.routes.tsx
+++ b/packages/web/src/routers/router.routes.tsx
@@ -7,7 +7,10 @@ import {
   validateBookingCancelSearch,
   validatePublicBookingSearch,
 } from "@web/booking/public-booking-search";
-import { IS_DEV } from "@web/common/constants/env.constants";
+import {
+  IS_BOOKING_ENABLED,
+  IS_DEV,
+} from "@web/common/constants/env.constants";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
 import { validateAuthSearch } from "@web/components/AuthModal/hooks/useAuthModal";
 import {
@@ -170,8 +173,8 @@ const calendarShellChildren = calendarShellRoute.addChildren([
 
 export const routeTree = rootRoute.addChildren([
   calendarShellChildren,
-  publicBookConfirmedRoute,
-  publicBookCancelRoute,
-  publicBookRoute,
+  ...(IS_BOOKING_ENABLED
+    ? [publicBookConfirmedRoute, publicBookCancelRoute, publicBookRoute]
+    : []),
   googleAuthCallbackRoute,
 ]);

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/EndsOnDate.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/components/EndsOnDate.tsx
@@ -36,6 +36,7 @@ export const EndsOnDate = ({
               calendarClassName="recurrenceUntilDatePicker"
               isOpen={open}
               minDate={miniDate.toDate()}
+              openToDate={until ?? miniDate.toDate()}
               onCalendarClose={() => setOpen(false)}
               onCalendarOpen={() => setOpen(true)}
               onChange={() => null}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The public booking page and Settings Booking form could fill the viewport and clip, so guests and hosts could not scroll to later times or Save. This keeps both surfaces inside the viewport with inner scrolling, makes the day’s slot list one tab stop (arrow keys, Home/End), and turns booking off in production while leaving it on in development, staging, and tests.

Public `/book/:username` (and confirm/cancel), Settings → Booking, and `/api/booking/**` all respect `isBookingEnabled(runtime.nodeEnv)` (`nodeEnv !== production`).

Rebased onto `main` after #3041 and #3042. The public prefetch e2e no longer requires a third slots GET; that horizon-end case is already handled on `main`.

## Simplicity

Reuse the existing `NodeEnv` gate instead of a new config flag. The slot list copies the month grid’s roving tabindex instead of adding a new widget.

## Automated validation

`bun run verify` before rebase (same booking/overflow/gate code; merge-base was `49a794772`):

```
Detected changes in: core, web, backend
Running: test:core → test:web → test:backend → type-check → lint → knip → test:a11y → test:e2e
Checks run: test:core, test:web, test:backend, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)
✓ All checks passed
```

Package totals: core 657 pass, web 3006 pass, backend 511 pass, a11y 24 passed, e2e 97 passed.

## Independent review

Read-only pass of the booking/overflow/gate diff against the plan and AGENTS.md.

```
VERDICT: no confirmed findings
FINDINGS:
(none)
```

Notes that are not findings: OverlayPanel `max-h-[90vh] overflow-y-auto` applies to every modal (as specified). Nested popovers that do not portal out of the panel can clip; Settings Booking uses the same panel scroller plus a sticky Save. `IS_BOOKING_ENABLED` is a module snapshot of `NODE_ENV`, which matches deploy (`production` vs `staging`/`test`).

## Test plan

- `bun test packages/core/src/util/env.util.test.ts` (3 pass)
- `bun test:web --` focused layout/picker/slot/month-grid/settings/overlay/recurrence files (101 pass)
- `bun test:backend -- packages/backend/src/booking/booking.routes.config.test.ts` (2 pass)
- `bun run verify` (PASS, including Playwright a11y + e2e after `bunx playwright install chromium`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62de0025-ab01-4497-ae61-68458280fed5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62de0025-ab01-4497-ae61-68458280fed5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

