### PR TITLE
refactor(booking): cache guest page formatters and reuse the slots query key

### DIFF
--- a/packages/web/src/booking/PublicBookingMonthGrid.tsx
+++ b/packages/web/src/booking/PublicBookingMonthGrid.tsx
@@ -178,7 +178,6 @@ export function PublicBookingMonthGrid({
                 }
                 const { day } = cell;
                 const isSelected = selectedDateKey === day.dateKey;
-                const label = formatBookingMonthDayLabel(day.dateKey, timeZone);
                 if (!day.available) {
                   return (
                     <div
@@ -195,7 +194,10 @@ export function PublicBookingMonthGrid({
                     key={day.dateKey}
                     type="button"
                     id={bookingDayButtonId(monthKey, day.dateKey)}
-                    aria-label={label}
+                    aria-label={formatBookingMonthDayLabel(
+                      day.dateKey,
+                      timeZone,
+                    )}
                     aria-pressed={isSelected}
                     aria-current={day.isToday ? "date" : undefined}
                     tabIndex={tabStopDateKey === day.dateKey ? 0 : -1}

--- a/packages/web/src/booking/public-booking.format.ts
+++ b/packages/web/src/booking/public-booking.format.ts
@@ -7,6 +7,63 @@ import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 const MONTH_KEY_PATTERN = /^\d{4}-\d{2}$/;
 const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
+/**
+ * Constructing an `Intl.DateTimeFormat` is the expensive part, and the guest
+ * page formats one label per open slot and per day cell in the month grid.
+ * Build each formatter once per timezone and reuse it. Guests only ever see a
+ * handful of zones, so the per-formatter cache stays small.
+ */
+const perTimeZoneFormatter = (
+  options: Omit<Intl.DateTimeFormatOptions, "timeZone">,
+  locale?: string,
+): ((timeZone: string) => Intl.DateTimeFormat) => {
+  const cache = new Map<string, Intl.DateTimeFormat>();
+  return (timeZone: string) => {
+    const cached = cache.get(timeZone);
+    if (cached) {
+      return cached;
+    }
+    const formatter = new Intl.DateTimeFormat(locale, { ...options, timeZone });
+    cache.set(timeZone, formatter);
+    return formatter;
+  };
+};
+
+const monthHeadingFormatter = perTimeZoneFormatter({
+  month: "long",
+  year: "numeric",
+});
+const timeZoneNameFormatter = perTimeZoneFormatter({ timeZoneName: "long" });
+const slotLabelFormatter = perTimeZoneFormatter({
+  weekday: "short",
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+});
+const slotTimeFormatter = perTimeZoneFormatter({
+  hour: "numeric",
+  minute: "2-digit",
+});
+const slotDateHeadingFormatter = perTimeZoneFormatter({
+  weekday: "long",
+  month: "long",
+  day: "numeric",
+});
+const monthDayLabelFormatter = perTimeZoneFormatter({
+  weekday: "long",
+  month: "long",
+  day: "numeric",
+  year: "numeric",
+});
+const weekdayShortFormatter = perTimeZoneFormatter({ weekday: "short" });
+const weekdayLongFormatter = perTimeZoneFormatter({ weekday: "long" });
+/** `en-CA` prints ISO date order, which is what a YYYY-MM-DD key needs. */
+const dateKeyFormatter = perTimeZoneFormatter(
+  { year: "numeric", month: "2-digit", day: "2-digit" },
+  "en-CA",
+);
+
 export const isBookingMonthKey = (value: string): boolean =>
   MONTH_KEY_PATTERN.test(value);
 
@@ -40,11 +97,7 @@ export function formatBookingMonthHeading(
   if (!monthStart) {
     return monthKey;
   }
-  return new Intl.DateTimeFormat(undefined, {
-    month: "long",
-    year: "numeric",
-    timeZone,
-  }).format(monthStart.toDate());
+  return monthHeadingFormatter(timeZone).format(monthStart.toDate());
 }
 
 function parseBookingMonthStart(
@@ -104,10 +157,7 @@ export function isBookingMonthAvailable(
 
 export function formatGuestTimeZoneLabel(timeZone: string): string {
   try {
-    const parts = new Intl.DateTimeFormat(undefined, {
-      timeZone,
-      timeZoneName: "long",
-    }).formatToParts(new Date());
+    const parts = timeZoneNameFormatter(timeZone).formatToParts(new Date());
     const name = parts.find((part) => part.type === "timeZoneName")?.value;
     return name ?? timeZone;
   } catch {
@@ -119,37 +169,21 @@ export function formatBookingSlotLabel(
   slotStart: string,
   timeZone: string,
 ): string {
-  return new Intl.DateTimeFormat(undefined, {
-    timeZone,
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  }).format(new Date(slotStart));
+  return slotLabelFormatter(timeZone).format(new Date(slotStart));
 }
 
 export function formatBookingSlotTime(
   slotStart: string,
   timeZone: string,
 ): string {
-  return new Intl.DateTimeFormat(undefined, {
-    timeZone,
-    hour: "numeric",
-    minute: "2-digit",
-  }).format(new Date(slotStart));
+  return slotTimeFormatter(timeZone).format(new Date(slotStart));
 }
 
 export function formatBookingSlotDateHeading(
   slotStart: string,
   timeZone: string,
 ): string {
-  return new Intl.DateTimeFormat(undefined, {
-    timeZone,
-    weekday: "long",
-    month: "long",
-    day: "numeric",
-  }).format(new Date(slotStart));
+  return slotDateHeadingFormatter(timeZone).format(new Date(slotStart));
 }
 
 export function formatDurationMinutes(minutes: number): string {
@@ -165,25 +199,7 @@ export function formatDurationMinutes(minutes: number): string {
   return `${hourLabel} ${remainder} minutes`;
 }
 
-/** Cache one formatter per timezone; constructing Intl is the expensive part. */
-const dateKeyFormatters = new Map<string, Intl.DateTimeFormat>();
-
-const dateKeyFormatter = (timeZone: string): Intl.DateTimeFormat => {
-  const cached = dateKeyFormatters.get(timeZone);
-  if (cached) {
-    return cached;
-  }
-  const formatter = new Intl.DateTimeFormat("en-CA", {
-    timeZone,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  });
-  dateKeyFormatters.set(timeZone, formatter);
-  return formatter;
-};
-
-/** YYYY-MM-DD in `timeZone`. `en-CA` prints ISO date order. */
+/** YYYY-MM-DD in `timeZone`. */
 export function formatBookingDateKey(
   instant: Date | string | Dayjs,
   timeZone: string,
@@ -319,14 +335,8 @@ export function listBookingWeekdayHeadings(
   return Array.from({ length: 7 }, (_, index) => {
     const date = sunday.add(index, "day").toDate();
     return {
-      short: new Intl.DateTimeFormat(undefined, {
-        weekday: "short",
-        timeZone,
-      }).format(date),
-      long: new Intl.DateTimeFormat(undefined, {
-        weekday: "long",
-        timeZone,
-      }).format(date),
+      short: weekdayShortFormatter(timeZone).format(date),
+      long: weekdayLongFormatter(timeZone).format(date),
     };
   });
 }
@@ -335,13 +345,9 @@ export function formatBookingMonthDayLabel(
   dateKey: string,
   timeZone: string,
 ): string {
-  return new Intl.DateTimeFormat(undefined, {
-    weekday: "long",
-    month: "long",
-    day: "numeric",
-    year: "numeric",
-    timeZone,
-  }).format(dayjs.tz(dateKey, timeZone).toDate());
+  return monthDayLabelFormatter(timeZone).format(
+    dayjs.tz(dateKey, timeZone).toDate(),
+  );
 }
 
 export function listBookingAvailableDateKeysInMonth(

--- a/packages/web/src/booking/public-booking.query.ts
+++ b/packages/web/src/booking/public-booking.query.ts
@@ -26,23 +26,24 @@ const PUBLIC_BOOKING_SLOTS_STALE_TIME_MS = 60_000;
 
 export const publicBookingQueryKeys = {
   page: (slug: string) => ["public-booking", "page", slug] as const,
+  /** Prefix covering every month and timezone of one host's slots. */
+  slotsAll: (slug: string) => ["public-booking", "slots", slug] as const,
   slots: (slug: string, monthKey: string, timeZone: string) =>
-    ["public-booking", "slots", slug, monthKey, timeZone] as const,
+    [...publicBookingQueryKeys.slotsAll(slug), monthKey, timeZone] as const,
   reservation: (reservationId: string) =>
     ["public-booking", "reservation", reservationId] as const,
 };
+
+/** A page or reservation that is gone stays gone; retry once for anything else. */
+const retryUnlessNotFound = (failureCount: number, error: Error): boolean =>
+  !(error instanceof PublicBookingNotFoundError) && failureCount < 1;
 
 function publicBookingPageQueryOptions(slug: string) {
   return queryOptions({
     queryKey: publicBookingQueryKeys.page(slug),
     queryFn: () => PublicBookingApi.getPage(slug),
     staleTime: PUBLIC_BOOKING_PAGE_STALE_TIME_MS,
-    retry: (failureCount, error) => {
-      if (error instanceof PublicBookingNotFoundError) {
-        return false;
-      }
-      return failureCount < 1;
-    },
+    retry: retryUnlessNotFound,
   });
 }
 
@@ -55,12 +56,7 @@ function publicBookingReservationQueryOptions(reservationId: string) {
     queryKey: publicBookingQueryKeys.reservation(reservationId),
     queryFn: () => PublicBookingApi.getReservation(reservationId),
     staleTime: PUBLIC_BOOKING_PAGE_STALE_TIME_MS,
-    retry: (failureCount, error) => {
-      if (error instanceof PublicBookingNotFoundError) {
-        return false;
-      }
-      return failureCount < 1;
-    },
+    retry: retryUnlessNotFound,
     enabled: Boolean(reservationId),
   });
 }
@@ -243,7 +239,7 @@ export function useCreatePublicBookingReservationMutation(slug: string) {
       PublicBookingApi.createReservation(slug, input),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: ["public-booking", "slots", slug],
+        queryKey: publicBookingQueryKeys.slotsAll(slug),
       });
     },
   });


### PR DESCRIPTION
## Summary

Three behavior-preserving cleanups left by the booking work packages (#3022-#3045). No user-visible change; no new exports beyond one query-key prefix.

**1. `public-booking.format.ts` cached one formatter and rebuilt six.** The file already kept a per-timezone cache for the date-key formatter, with a comment stating that constructing `Intl.DateTimeFormat` is the expensive part. The other six formatters ignored that and constructed a fresh one on every call, and they are the hot ones: `formatBookingSlotTime` runs once per open slot, `formatBookingMonthDayLabel` once per day cell, and `listBookingWeekdayHeadings` builds 14 formatters per call. Generalized the existing cache into a `perTimeZoneFormatter` helper and routed all seven through it, which also removes six near-identical option literals. Cache keys are IANA zones already validated by `validatePublicBookingSearch`, so it stays bounded.

**2. `PublicBookingMonthGrid` formatted labels it threw away.** `aria-label` was computed for every cell before the `!day.available` early return discarded it, so most of a month's ~35-42 labels were built and dropped. Moved it to where it is used.

**3. `public-booking.query.ts` hand-wrote a query key.** The reservation mutation invalidated slots with a literal `["public-booking", "slots", slug]` instead of `publicBookingQueryKeys` -- the only such call site in the web package, and one that would silently stop matching if the key factory changed shape. Added a `slotsAll` prefix, built `slots` from it, and invalidated through it. The page and reservation queries also carried the same not-found retry predicate verbatim twice; named it `retryUnlessNotFound` once.

## Simplicity

Net reduction. The formatter change removes six duplicated option literals and the bespoke `dateKeyFormatters` map in favor of one 15-line helper; the query change removes a duplicated 6-line predicate and a magic key array. Nothing new is abstracted that did not already exist in the file: `perTimeZoneFormatter` is the existing `dateKeyFormatter` cache with the option set lifted out.

## Automated validation

`bun run verify` selected the `web` package and passed `test:web`, `type-check`, `lint`, and `knip`. Because the change touches rendered guest-page output, the Playwright suites `verify` skipped for a missing browser were run explicitly after installing Chromium: all 30 `e2e/booking` specs pass, and the booking a11y specs pass.

`bun test:a11y` also surfaces 6 failures in `app-a11y.spec.ts` and `datepicker-a11y.spec.ts` (week view, event forms, sidebar datepicker). These are **pre-existing and unrelated**: re-running those two spec files on a clean `main` (00f3e00) with this branch stashed reproduces the same 6 failures. They are calendar-app color-contrast checks that touch no booking code.

## Independent review

No `/review` handoff for this change. Self-review notes on the risky edge: `formatGuestTimeZoneLabel` depends on `Intl` throwing for an invalid timezone, and the construction still happens inside its `try` (nothing is cached on throw), so the fallback-to-raw-zone behavior is preserved. `Intl` option property order is not significant, so spreading `...options` before `timeZone` is equivalent to the previous literals.

## Test plan

```
bun install
bun type-check
bun lint
bun test:web -- packages/web/src/booking/     # 126 pass, 0 fail
bun run verify                                # test:web, type-check, lint, knip passed
bunx playwright install chromium
bun test:e2e -- e2e/booking/                  # 30 passed
bun test:a11y                                 # 18 passed; 6 pre-existing app/datepicker failures, reproduced on clean main
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01FXNUAfQd2mEg5u1Q3oFzn9)_