### PR TITLE
feat(onboarding): rework Schedule Rush into Block Party

### DIFF
--- a/docs/development/feature-file-map.md
+++ b/docs/development/feature-file-map.md
@@ -116,12 +116,13 @@ Product rules (hold-Mod discovery, "chip the field", typing always types):
 
 ## Welcome, Showcase, And First-Event Handoff
 
-Anonymous calendar onboarding (welcome modal, the Schedule Rush practice game,
+Anonymous calendar onboarding (welcome modal, the Block Party practice game,
 first-event prompt) lives under
 `packages/web/src/components/{WelcomeModal,ShortcutShowcase,FirstEventPrompt}`.
 Game pieces: `game.tasks.ts` (task queue, scoring constants, seed board),
 `game.state.ts` (pure run reducer), `practice.state.ts` (sandbox board),
-`GameHud.tsx` / `GameEndScreen.tsx` (HUD and scoreboard).
+`GameHud.tsx` / `GameEndScreen.tsx` (HUD and scoreboard),
+`GameSimOverlays.tsx` (simulated legend / page-jump / palette overlays).
 The flow, its entry points, and the storage contract are documented in
 [Frontend Runtime Flow](../frontend/frontend-runtime-flow.md#welcome-showcase-and-first-event-handoff).
 

--- a/docs/frontend/frontend-runtime-flow.md
+++ b/docs/frontend/frontend-runtime-flow.md
@@ -81,20 +81,25 @@ Welcome → signup → first-event contract:
   returning user is not handed the practice or the first-event prompt
 - signing up (either route) defers a showcase offer via `showcase.storage.ts`;
   `offerAfterSignupIfPending()` redeems it once, right after signup completes
-- the Shortcut Showcase is **Schedule Rush**: an always-escapable, practice-only
-  game whose state never reaches real calendar storage. One 90-second run
-  clears a fixed queue of ten scheduling tasks (create, typed quick-times,
-  nudge, edge resize, delete, undo) against a ghost target slot, with scoring
-  and streaks; task keycaps derive from the application's keymap. Time-up and
-  a full clear land on the same end screen, where anonymous players get signup
-  as the primary CTA and graduation hands off to `FirstEventPrompt`. A reload
-  mid-run re-offers a fresh run from the one-screen how-to card (the old
-  per-lesson resume point is now just an in-progress marker)
+- the Shortcut Showcase is **Block Party**: a practice-only game whose state
+  never reaches real calendar storage. A run clears a fixed queue of
+  scheduling tasks (create, typed quick-times, nudge, edge resize, delete,
+  undo, plus discovery beats for the `?` legend, `H` event jump, Mod-hold
+  page jump, and `Mod+K` palette, all simulated inside the arena) against a
+  ghost target slot, with scoring and streaks; task keycaps derive from the
+  application's keymap and the exact next key pulses on the task card. The
+  first run is untimed; the end screen offers a timed rematch, and a timed
+  run whose clock expires keeps going with the score frozen at the buzzer.
+  Esc skips the current task (leaving mid-run is the two-click Leave button),
+  anonymous players get signup as the end screen's primary CTA, and
+  graduation hands off to `FirstEventPrompt`. A reload mid-run re-offers a
+  fresh run from the one-screen how-to card, and `?play=1` on any URL is a
+  shareable deep link straight into the game (consumed, then stripped)
 - `FirstEventPrompt` is a non-blocking real-calendar card. It stays hidden
   while the auth modal is open and retires after the first genuine create.
   Users who finished or dismissed the retired onboarding checklist are read
   as already done via a legacy storage key, so they never see it
-- command palette can reopen practice (“Play Schedule Rush”) or the welcome
+- command palette can reopen practice (“Play Block Party”) or the welcome
   guide (“Show welcome guide”)
 - users who already finished or skipped the retired guided tour are treated as
   having seen the showcase so it does not ambush them

--- a/e2e/onboarding/shortcut-showcase.spec.ts
+++ b/e2e/onboarding/shortcut-showcase.spec.ts
@@ -16,14 +16,17 @@ const leaveWelcome = async (page: Page) => {
   await expect(welcomeDialog).toBeHidden();
 };
 
-const startTheClock = async (page: Page) => {
+const startPracticing = async (page: Page) => {
   const showcase = page.getByRole("region", { name: "Shortcut practice" });
-  await expect(showcase).toContainText("Schedule Rush");
+  await expect(showcase).toContainText("Block Party");
   await expect(
-    showcase.getByRole("button", { name: "Start the clock" }),
+    showcase.getByRole("button", { name: "Start practicing" }),
   ).toBeVisible();
   await page.keyboard.press("Enter");
-  await expect(showcase).toContainText("Task 1/10");
+  await expect(showcase).toContainText("Task 1/14");
+  // The first run is untimed practice: no countdown anywhere.
+  await expect(showcase.getByRole("timer")).toHaveCount(0);
+  await expect(showcase).toContainText("Practice");
 };
 
 const holdModAndPress = async (page: Page, key: string) => {
@@ -42,7 +45,7 @@ const pressTimes = async (page: Page, key: string, times: number) => {
   }
 };
 
-/** The winning script: clears all ten tasks with the taught keys. */
+/** The winning script: clears all fourteen tasks with the taught keys. */
 const clearTheQueue = async (page: Page) => {
   const showcase = page.getByRole("region", { name: "Shortcut practice" });
 
@@ -50,43 +53,69 @@ const clearTheQueue = async (page: Page) => {
   await page.keyboard.press("c");
   await page.keyboard.press("ArrowLeft");
   await page.keyboard.press("Enter");
-  await expect(showcase).toContainText("Task 2/10");
+  await expect(showcase).toContainText("Task 2/14");
 
   // quicktime-lunch: type the time, lock.
   await page.keyboard.type("1230");
   await page.keyboard.press("Enter");
-  await expect(showcase).toContainText("Task 3/10");
+  await expect(showcase).toContainText("Task 3/14");
 
   // place-review: two days right, lock.
   await page.keyboard.press("c");
   await pressTimes(page, "ArrowRight", 2);
   await page.keyboard.press("Enter");
-  await expect(showcase).toContainText("Task 4/10");
+  await expect(showcase).toContainText("Task 4/14");
 
   // nudge-standup: 9:00 -> 10:00 in 15-minute steps.
   await pressTimes(page, "Shift+ArrowDown", 4);
-  await expect(showcase).toContainText("Task 5/10");
+  await expect(showcase).toContainText("Task 5/14");
 
   // resize-one-on-one: Tab to the end edge, stretch 10:30 -> 11:00.
   await page.keyboard.press("Tab");
   await page.keyboard.press("Tab");
   await pressTimes(page, "Shift+ArrowDown", 2);
-  await expect(showcase).toContainText("Task 6/10");
+  await expect(showcase).toContainText("Task 6/14");
 
   // quicktime-focus
   await page.keyboard.type("1600");
   await page.keyboard.press("Enter");
-  await expect(showcase).toContainText("Task 7/10");
+  await expect(showcase).toContainText("Task 7/14");
 
   // delete-gym, undo-gym
   await page.keyboard.press("Delete");
-  await expect(showcase).toContainText("Task 8/10");
+  await expect(showcase).toContainText("Task 8/14");
   await holdModAndPress(page, "z");
-  await expect(showcase).toContainText("Task 9/10");
+  await expect(showcase).toContainText("Task 9/14");
+
+  // legend-peek: ? opens the practice legend, ? closes it again.
+  await page.keyboard.press("?");
+  await expect(showcase).toContainText("Shortcuts");
+  await page.keyboard.press("?");
+  await expect(showcase).toContainText("Task 10/14");
+
+  // jump-to-kickoff: H reveals jump letters, S is on Team kickoff.
+  await page.keyboard.press("h");
+  await page.keyboard.press("s");
+  await expect(showcase).toContainText("Task 11/14");
+
+  // page-jump-peek: hold Mod alone until the numbers appear, then Mod+1.
+  await page.keyboard.down("Control");
+  await page.keyboard.down("Meta");
+  await page.waitForTimeout(800);
+  await page.keyboard.press("1");
+  await page.keyboard.up("Meta");
+  await page.keyboard.up("Control");
+  await expect(showcase).toContainText("Task 12/14");
+
+  // palette-peek: Mod+K opens the practice palette, Esc closes it.
+  await holdModAndPress(page, "k");
+  await expect(showcase).toContainText("Type a command...");
+  await page.keyboard.press("Escape");
+  await expect(showcase).toContainText("Task 13/14");
 
   // nudge-review: one day left.
   await page.keyboard.press("Shift+ArrowLeft");
-  await expect(showcase).toContainText("Task 10/10");
+  await expect(showcase).toContainText("Task 14/14");
 
   // place-party: down to 5pm, lock.
   await page.keyboard.press("c");
@@ -103,7 +132,7 @@ test("exploring without an account offers the game's how-to card", async ({
 
   const showcase = page.getByRole("region", { name: "Shortcut practice" });
   await expect(showcase).toBeVisible();
-  await expect(showcase).toContainText("Schedule Rush");
+  await expect(showcase).toContainText("Block Party");
   await expect(showcase).toContainText("keyboard-only");
 });
 
@@ -112,19 +141,27 @@ test("a full run clears the queue, shows the score, and graduates", async ({
 }) => {
   await page.goto("/week", { waitUntil: "domcontentloaded" });
   await leaveWelcome(page);
-  await startTheClock(page);
+  await startPracticing(page);
 
   const showcase = page.getByRole("region", { name: "Shortcut practice" });
-  await expect(showcase.getByRole("timer")).toBeVisible();
-  await expect(showcase.getByRole("button", { name: /^Skip$/ })).toBeVisible();
+  await expect(
+    showcase.getByRole("button", { name: "Leave practice" }),
+  ).toBeVisible();
 
   await clearTheQueue(page);
 
-  await expect(showcase).toContainText("10/10 tasks cleared");
+  await expect(showcase).toContainText("14/14 tasks cleared");
   await expect(showcase).toContainText("Moves you learned");
   await expect(
     showcase.getByRole("button", { name: /Sign up to keep your calendar/ }),
   ).toBeVisible();
+  // The untimed run's rematch is the timed challenge; reminders are gone.
+  await expect(
+    showcase.getByRole("button", { name: /Race the clock/ }),
+  ).toBeVisible();
+  await expect(
+    showcase.getByRole("button", { name: /Enable reminders/ }),
+  ).toHaveCount(0);
 
   // O opens the calendar for anonymous players; Enter belongs to signup.
   await page.keyboard.press("o");
@@ -135,33 +172,20 @@ test("a full run clears the queue, shows the score, and graduates", async ({
   ).toBeVisible();
 });
 
-test("the end screen's reminders button opts in without leaving", async ({
+test("T races the clock and the buzzer never ends the run", async ({
   page,
-  context,
 }) => {
-  // Granted up front so the offer resolves without a real browser prompt,
-  // which Playwright cannot click.
-  await context.grantPermissions(["notifications"]);
   await page.goto("/week", { waitUntil: "domcontentloaded" });
   await leaveWelcome(page);
-  await startTheClock(page);
-  await clearTheQueue(page);
 
   const showcase = page.getByRole("region", { name: "Shortcut practice" });
   await expect(
-    showcase.getByRole("button", { name: /Enable reminders/ }),
+    showcase.getByRole("button", { name: "Race the clock" }),
   ).toBeVisible();
-  // Keyboard, not click: pointer events are suppressed app-wide.
-  await page.keyboard.press("n");
-
-  await expect(showcase).toContainText("You cleared the week!");
-  await expect
-    .poll(() =>
-      page.evaluate(() =>
-        localStorage.getItem("compass.notifications.enabled"),
-      ),
-    )
-    .toBe("true");
+  await page.keyboard.press("t");
+  await expect(showcase).toContainText("Task 1/14");
+  await expect(showcase.getByRole("timer")).toBeVisible();
+  await expect(showcase.getByRole("timer")).toContainText("2:00");
 });
 
 test("Enter on the end screen hands an anonymous player to signup", async ({
@@ -169,7 +193,7 @@ test("Enter on the end screen hands an anonymous player to signup", async ({
 }) => {
   await page.goto("/week", { waitUntil: "domcontentloaded" });
   await leaveWelcome(page);
-  await startTheClock(page);
+  await startPracticing(page);
   await clearTheQueue(page);
 
   await page.keyboard.press("Enter");
@@ -186,7 +210,7 @@ test("Skip to sign up leaves the game for the signup form", async ({
   await leaveWelcome(page);
 
   const showcase = page.getByRole("region", { name: "Shortcut practice" });
-  await expect(showcase).toContainText("Schedule Rush");
+  await expect(showcase).toContainText("Block Party");
 
   await expect(
     showcase.getByRole("button", { name: /Skip to sign up/ }),
@@ -196,12 +220,28 @@ test("Skip to sign up leaves the game for the signup form", async ({
   await expect(page).toHaveURL(/auth=signup/);
 });
 
-test("Escape leaves the game and it never auto-replays", async ({ page }) => {
+test("Escape mid-run skips one task and keeps the game up", async ({
+  page,
+}) => {
+  await page.goto("/week", { waitUntil: "domcontentloaded" });
+  await leaveWelcome(page);
+  await startPracticing(page);
+
+  const showcase = page.getByRole("region", { name: "Shortcut practice" });
+  // Mid-run, Escape skips the current task and the game stays up.
+  await page.keyboard.press("Escape");
+  await expect(showcase).toContainText("Task 2/14");
+  await expect(showcase).toBeVisible();
+});
+
+test("Escape leaves from the how-to card and it never auto-replays", async ({
+  page,
+}) => {
   await page.goto("/week", { waitUntil: "domcontentloaded" });
   await leaveWelcome(page);
 
   const showcase = page.getByRole("region", { name: "Shortcut practice" });
-  await expect(showcase).toContainText("Schedule Rush");
+  await expect(showcase).toContainText("Block Party");
 
   await page.keyboard.press("Escape");
   await expect(showcase).toBeVisible();
@@ -224,23 +264,38 @@ test("reloading mid-game re-offers a fresh run from the how-to card", async ({
 }) => {
   await page.goto("/week", { waitUntil: "domcontentloaded" });
   await leaveWelcome(page);
-  await startTheClock(page);
+  await startPracticing(page);
 
   const showcase = page.getByRole("region", { name: "Shortcut practice" });
   await page.keyboard.press("c");
   await page.keyboard.press("ArrowLeft");
   await page.keyboard.press("Enter");
-  await expect(showcase).toContainText("Task 2/10");
+  await expect(showcase).toContainText("Task 2/14");
 
   await page.reload({ waitUntil: "domcontentloaded" });
   const resumed = page.getByRole("region", { name: "Shortcut practice" });
   await expect(resumed).toBeVisible();
-  // A 90-second run has no mid-run resume: the attempt re-offers whole.
-  await expect(resumed).toContainText("Schedule Rush");
+  // A run has no mid-run resume: the attempt re-offers whole.
+  await expect(resumed).toContainText("Block Party");
   await expect(
-    resumed.getByRole("button", { name: "Start the clock" }),
+    resumed.getByRole("button", { name: "Start practicing" }),
   ).toBeVisible();
   await expect(
     page.getByRole("dialog", { name: "Welcome to Compass Calendar" }),
   ).toBeHidden();
+});
+
+test("a ?play=1 link starts the game directly, skipping the welcome modal", async ({
+  page,
+}) => {
+  await page.goto("/week?play=1", { waitUntil: "domcontentloaded" });
+
+  await expect(
+    page.getByRole("dialog", { name: "Welcome to Compass Calendar" }),
+  ).toBeHidden();
+  const showcase = page.getByRole("region", { name: "Shortcut practice" });
+  await expect(showcase).toBeVisible();
+  await expect(showcase).toContainText("Block Party");
+  // Consumed and stripped, so a reload does not restart the run.
+  await expect(page).not.toHaveURL(/play=/);
 });

--- a/packages/web/src/auth/posthog/track.ts
+++ b/packages/web/src/auth/posthog/track.ts
@@ -15,6 +15,7 @@ export type ProductEvent =
   | "shortcut_game_run_started"
   | "shortcut_game_task_shown"
   | "shortcut_game_task_completed"
+  | "shortcut_game_task_skipped"
   | "shortcut_game_replayed"
   | "first_event_prompt_shown"
   | "first_event_prompt_completed"

--- a/packages/web/src/components/AuthModal/hooks/useAuthModal.ts
+++ b/packages/web/src/components/AuthModal/hooks/useAuthModal.ts
@@ -39,6 +39,8 @@ export interface AuthSearch {
   token?: string;
   checkout?: string;
   settings?: string;
+  /** ?play=1 launches the Block Party practice game directly (any value). */
+  play?: string | number | boolean;
 }
 
 export function validateAuthSearch(
@@ -49,6 +51,14 @@ export function validateAuthSearch(
     token: typeof search.token === "string" ? search.token : undefined,
     checkout: typeof search.checkout === "string" ? search.checkout : undefined,
     settings: search.settings === "billing" ? "billing" : undefined,
+    // The router JSON-parses search values, so ?play=1 arrives as a number
+    // and ?play as a boolean. Any present value counts.
+    play:
+      typeof search.play === "string" ||
+      typeof search.play === "number" ||
+      typeof search.play === "boolean"
+        ? search.play
+        : undefined,
   };
 }
 

--- a/packages/web/src/components/CommandPalette/navigation.cmd.constants.test.ts
+++ b/packages/web/src/components/CommandPalette/navigation.cmd.constants.test.ts
@@ -31,7 +31,7 @@ describe("getNavigationCommandItems", () => {
       onShowWelcomeGuide: () => {},
     }).map((item) => item.label);
 
-    expect(labels).toContain("Play Schedule Rush (practice shortcuts)");
+    expect(labels).toContain("Play Block Party (practice shortcuts)");
     expect(labels).toContain("Show welcome guide");
     expect(labels.indexOf("Practice shortcuts")).toBeLessThan(
       labels.indexOf("Show welcome guide"),

--- a/packages/web/src/components/CommandPalette/navigation.cmd.constants.ts
+++ b/packages/web/src/components/CommandPalette/navigation.cmd.constants.ts
@@ -121,7 +121,7 @@ export const getNavigationCommandItems = ({
   if (onPracticeShortcuts) {
     calendarItems.push({
       id: "practice-shortcuts",
-      label: "Play Schedule Rush (practice shortcuts)",
+      label: "Play Block Party (practice shortcuts)",
       icon: CompassIcon,
       keywords: [
         "onboarding",
@@ -134,7 +134,7 @@ export const getNavigationCommandItems = ({
         "practice",
         "shortcuts",
         "game",
-        "schedule rush",
+        "block party",
       ],
       onClick: onPracticeShortcuts,
     });

--- a/packages/web/src/components/RootShell/RootShell.tsx
+++ b/packages/web/src/components/RootShell/RootShell.tsx
@@ -20,6 +20,7 @@ import { AuthModal } from "@web/components/AuthModal/AuthModal";
 import { AuthModalProvider } from "@web/components/AuthModal/AuthModalProvider";
 import { FirstEventPrompt } from "@web/components/FirstEventPrompt/FirstEventPrompt";
 import { PointerHint } from "@web/components/PointerHint/PointerHint";
+import { ShowcasePlayLink } from "@web/components/ShortcutShowcase/play-link";
 import { ShortcutShowcase } from "@web/components/ShortcutShowcase/ShortcutShowcase";
 import { WelcomeGuideModal } from "@web/components/WelcomeModal/WelcomeGuideModal";
 import { WelcomeModal } from "@web/components/WelcomeModal/WelcomeModal";
@@ -95,6 +96,7 @@ export function RootShell() {
       {gateStatus !== null && <BillingGateModal status={gateStatus} />}
       <CheckoutCelebrationModal />
       {showCalendarOnboarding && <WelcomeModal />}
+      {showCalendarOnboarding && <ShowcasePlayLink />}
       {showCalendarOnboarding && <ShortcutShowcase />}
       {showCalendarOnboarding && <FirstEventPrompt />}
       {gateStatus === null && isWelcomeGuideOpen && <WelcomeGuideModal />}

--- a/packages/web/src/components/ShortcutShowcase/GameEndScreen.tsx
+++ b/packages/web/src/components/ShortcutShowcase/GameEndScreen.tsx
@@ -1,5 +1,5 @@
 import { type FC } from "react";
-import { type GameOutcome } from "@web/components/ShortcutShowcase/game.state";
+import { type GameState } from "@web/components/ShortcutShowcase/game.state";
 import {
   getLearnedMoves,
   RUN_TASKS,
@@ -7,7 +7,6 @@ import {
 } from "@web/components/ShortcutShowcase/game.tasks";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
-import { KEYMAP } from "@web/shortcuts/keymap";
 
 const PRIMARY_BUTTON_CLASS =
   "c-button c-button-primary inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-xs";
@@ -15,54 +14,56 @@ const SECONDARY_BUTTON_CLASS =
   "c-button c-button-secondary inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-xs";
 
 /**
- * The run's scoreboard, shown on a clear and on time-up alike (time-up is a
- * soft landing, not a failure). For anonymous players the loudest button is
- * signup — the moment right after the game lands is the highest-intent
- * moment onboarding gets, and the old lesson flow never asked.
+ * The run's scoreboard. Every run finishes the queue now (the buzzer only
+ * freezes the timed score), so the screen celebrates and offers a timed
+ * rematch. For anonymous players the loudest button is signup: the moment
+ * right after the game lands is the highest-intent moment onboarding gets.
  */
 export const GameEndScreen: FC<{
-  outcome: GameOutcome;
+  outcome: GameState["outcome"];
   score: number;
   tasksDone: number;
+  tasksSkipped: number;
   timeBonus: number;
+  timed: boolean;
+  buzzer: GameState["buzzer"];
   authenticated: boolean;
-  notificationsSupported: boolean;
-  notificationsPending: boolean;
   closing: boolean;
   onSignUp: () => void;
   onGraduate: () => void;
   onReplay: () => void;
-  onEnableNotifications: () => void;
 }> = ({
   outcome,
   score,
   tasksDone,
+  tasksSkipped,
   timeBonus,
+  timed,
+  buzzer,
   authenticated,
-  notificationsSupported,
-  notificationsPending,
   closing,
   onSignUp,
   onGraduate,
   onReplay,
-  onEnableNotifications,
 }) => {
-  const cleared = outcome === "cleared";
   const learnedMoves = getLearnedMoves(tasksDone);
+  const heading = !timed
+    ? "You cleared the week!"
+    : buzzer
+      ? "Cleared it. The clock just blinked first."
+      : "You beat the clock!";
 
   return (
     <div
       className="flex w-full max-w-lg flex-col gap-5 rounded-xl border border-border bg-surface p-8 shadow-xl"
-      data-game-end-screen={outcome}
+      data-game-end-screen={outcome ?? "cleared"}
     >
       <div className="flex flex-col gap-1">
-        <h2 className="font-semibold text-text text-xl">
-          {cleared ? "You cleared the week!" : "Time! Nice run."}
-        </h2>
+        <h2 className="font-semibold text-text text-xl">{heading}</h2>
         <p className="text-sm text-text-muted">
-          {cleared
-            ? "Every one of those moves works the same on your real calendar."
-            : "The moves you made work the same on your real calendar — the rest will come."}
+          {tasksSkipped > 0
+            ? "The moves you made work the same on your real calendar. The rest will come."
+            : "Every one of those moves works the same on your real calendar."}
         </p>
       </div>
 
@@ -79,10 +80,16 @@ export const GameEndScreen: FC<{
           <p>
             {tasksDone}/{RUN_TASKS.length} tasks cleared
           </p>
+          {tasksSkipped > 0 && <p>{tasksSkipped} skipped</p>}
           {timeBonus > 0 && (
             <p>
               +{timeBonus} time bonus ({timeBonus / TIME_BONUS_PER_SECOND}s
               left)
+            </p>
+          )}
+          {buzzer && (
+            <p>
+              At the buzzer: {buzzer.score} ({buzzer.tasksDone} tasks)
             </p>
           )}
         </div>
@@ -104,12 +111,6 @@ export const GameEndScreen: FC<{
           ))}
         </div>
       )}
-
-      <p className="text-text-muted text-xs">
-        There's more: <ShortcutKeys keys="?" /> opens the full shortcut legend
-        anytime, and <ShortcutKeys keys={KEYMAP.eventJump.keycaps[0]} /> jumps
-        straight to any event.
-      </p>
 
       <div className="flex flex-wrap items-center gap-2">
         {!authenticated && (
@@ -142,20 +143,9 @@ export const GameEndScreen: FC<{
           disabled={closing}
           onClick={onReplay}
         >
-          Play again
+          {timed ? "Play again" : "Race the clock"}
           <ShortcutHint className="shrink-0">P</ShortcutHint>
         </button>
-        {notificationsSupported && (
-          <button
-            type="button"
-            className={SECONDARY_BUTTON_CLASS}
-            disabled={closing || notificationsPending}
-            onClick={onEnableNotifications}
-          >
-            Enable reminders
-            <ShortcutHint className="shrink-0">N</ShortcutHint>
-          </button>
-        )}
       </div>
     </div>
   );

--- a/packages/web/src/components/ShortcutShowcase/GameHud.tsx
+++ b/packages/web/src/components/ShortcutShowcase/GameHud.tsx
@@ -6,7 +6,8 @@ import {
   STREAK_X2_AT,
   STREAK_X3_AT,
 } from "@web/components/ShortcutShowcase/game.tasks";
-import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
+import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
+import { ShortCutLabel } from "@web/components/Shortcuts/ShortcutLabel";
 
 const formatClock = (remainingSeconds: number) => {
   const minutes = Math.floor(remainingSeconds / 60);
@@ -16,31 +17,48 @@ const formatClock = (remainingSeconds: number) => {
 
 const TIMER_WARNING_SECONDS = 15;
 
-/** Countdown, score, and streak strip above the practice grid. */
+/** Countdown (timed runs only), score, and streak strip above the grid. */
 export const GameHud: FC<{
   remainingSeconds: number;
   score: number;
   streak: number;
   award: GameAward | null;
-}> = ({ remainingSeconds, score, streak, award }) => {
-  const warning = remainingSeconds <= TIMER_WARNING_SECONDS;
+  timed: boolean;
+  /** A timed run whose clock already hit zero: pin 0:00 and keep playing. */
+  overtime: boolean;
+}> = ({ remainingSeconds, score, streak, award, timed, overtime }) => {
+  const warning =
+    timed && !overtime && remainingSeconds <= TIMER_WARNING_SECONDS;
   const multiplier =
     streak >= STREAK_X3_AT ? 3 : streak >= STREAK_X2_AT ? 2 : null;
 
   return (
     <div className="flex items-center justify-between pb-3">
-      <span
-        aria-label="Time left"
-        aria-live="off"
-        className={`font-semibold text-lg tabular-nums ${
-          warning
-            ? "motion-reduce:animate-none animate-pulse text-error"
-            : "text-text"
-        }`}
-        role="timer"
-      >
-        {formatClock(remainingSeconds)}
-      </span>
+      {timed ? (
+        <span className="flex items-baseline gap-2">
+          <span
+            aria-label="Time left"
+            aria-live="off"
+            className={`font-semibold text-lg tabular-nums ${
+              overtime
+                ? "text-error"
+                : warning
+                  ? "motion-reduce:animate-none animate-pulse text-error"
+                  : "text-text"
+            }`}
+            role="timer"
+          >
+            {formatClock(overtime ? 0 : remainingSeconds)}
+          </span>
+          {overtime && (
+            <span className="font-medium text-error text-xs">overtime</span>
+          )}
+        </span>
+      ) : (
+        <span className="font-medium text-text-muted text-xs uppercase tracking-wide">
+          Practice
+        </span>
+      )}
       <div className="relative flex items-center gap-2">
         {multiplier && (
           <span className="rounded-full bg-accent px-2 py-0.5 font-semibold text-background text-xs">
@@ -69,12 +87,24 @@ export const GameHud: FC<{
 
 /**
  * The piece queue: the current task as a big card with its keycaps, and the
- * next two peeking underneath — the tetris "next piece" preview.
+ * next two peeking underneath (the "next piece" preview). Chips ahead of
+ * `nextKeycapIndex` are still to come, the chip at it pulses as the exact
+ * next key, and chips behind it dim as done.
  */
-export const GameTaskQueue: FC<{ taskIndex: number }> = ({ taskIndex }) => {
+export const GameTaskQueue: FC<{
+  taskIndex: number;
+  nextKeycapIndex: number;
+}> = ({ taskIndex, nextKeycapIndex }) => {
   const task: GameTask | undefined = RUN_TASKS[taskIndex];
   if (!task) return null;
   const upNext = RUN_TASKS.slice(taskIndex + 1, taskIndex + 3);
+  // Shift/Mod lead a chord, so their partner chip pulses too. The page-jump
+  // task is the exception: Mod is held alone first, the digit comes later.
+  const nextKey = task.keycaps[nextKeycapIndex];
+  const chordPartnerIndex =
+    task.type !== "pageJump" && (nextKey === "Shift" || nextKey === "Mod")
+      ? nextKeycapIndex + 1
+      : -1;
 
   return (
     <div className="flex flex-col gap-3">
@@ -87,8 +117,22 @@ export const GameTaskQueue: FC<{ taskIndex: number }> = ({ taskIndex }) => {
       >
         <h3 className="font-semibold text-lg text-text">{task.title}</h3>
         <p className="pt-1 text-sm text-text-muted">{task.instruction}</p>
-        <div className="pt-3">
-          <ShortcutKeys keys={[...task.keycaps]} />
+        <div className="flex items-center gap-1 pt-3">
+          {task.keycaps.map((key, index) => (
+            <ShortcutHint
+              key={`${key}-${index}`}
+              variant="keycap"
+              className={
+                index === nextKeycapIndex || index === chordPartnerIndex
+                  ? "c-keycap-next"
+                  : index < nextKeycapIndex
+                    ? "opacity-40"
+                    : ""
+              }
+            >
+              <ShortCutLabel k={key} />
+            </ShortcutHint>
+          ))}
         </div>
       </div>
       {upNext.length > 0 && (

--- a/packages/web/src/components/ShortcutShowcase/GameSimOverlays.tsx
+++ b/packages/web/src/components/ShortcutShowcase/GameSimOverlays.tsx
@@ -1,0 +1,81 @@
+import { type FC } from "react";
+import { type GameSimOverlay } from "@web/components/ShortcutShowcase/game.state";
+import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
+import { KEYMAP } from "@web/shortcuts/keymap";
+
+const LEGEND_ROWS: readonly { label: string; keys: readonly string[] }[] = [
+  { label: "Create event", keys: KEYMAP.createEvent.keycaps },
+  { label: "Lock it in", keys: KEYMAP.saveDraft.keycaps },
+  { label: "Move event", keys: KEYMAP.moveEvent.keycaps },
+  { label: "Focus an edge", keys: KEYMAP.edgeFocus.keycaps },
+  { label: "Command palette", keys: KEYMAP.commandPalette.keycaps },
+];
+
+const PALETTE_ROWS = ["Go to today", "Show shortcuts", "Play Block Party"];
+
+/**
+ * Simulated overlays for the discovery tasks: small stand-ins for the real
+ * shortcut legend, page-jump numbers, and command palette, drawn inside the
+ * arena. The real components stay closed behind the takeover on purpose, so
+ * a timed run can never end up buried under an app overlay.
+ */
+export const GameSimOverlays: FC<{ overlay: GameSimOverlay }> = ({
+  overlay,
+}) => {
+  if (overlay === "pagejump") {
+    // Numbered chips pinned roughly over the grid and the sidebar, matching
+    // the real reveal's "every region gets a digit" shape.
+    return (
+      <div aria-hidden className="pointer-events-none absolute inset-0">
+        <span className="c-keycap -translate-x-1/2 absolute top-1/2 left-[45%] scale-150">
+          1
+        </span>
+        <span className="c-keycap absolute top-1/2 right-8 scale-150">2</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="absolute inset-0 flex items-center justify-center rounded-xl bg-background/60">
+      {overlay === "legend" ? (
+        <div
+          className="flex w-72 flex-col gap-2 rounded-xl border border-border bg-surface-raised p-5 shadow-xl"
+          data-game-sim-overlay="legend"
+        >
+          <p className="font-medium text-text-muted text-xs uppercase tracking-wide">
+            Shortcuts
+          </p>
+          {LEGEND_ROWS.map((row) => (
+            <div
+              key={row.label}
+              className="flex items-center justify-between gap-3 text-sm text-text"
+            >
+              <span>{row.label}</span>
+              <ShortcutKeys keys={[...row.keys]} />
+            </div>
+          ))}
+          <p className="pt-1 text-text-muted text-xs">
+            Press <ShortcutKeys keys="?" /> or Esc to close.
+          </p>
+        </div>
+      ) : (
+        <div
+          className="flex w-80 flex-col gap-1 rounded-xl border border-border bg-surface-raised p-3 shadow-xl"
+          data-game-sim-overlay="palette"
+        >
+          <div className="rounded-md bg-surface-overlay px-3 py-2 text-sm text-text-muted">
+            Type a command...
+          </div>
+          {PALETTE_ROWS.map((row) => (
+            <div key={row} className="px-3 py-1.5 text-sm text-text">
+              {row}
+            </div>
+          ))}
+          <p className="px-3 pt-1 text-text-muted text-xs">
+            Press Esc to close.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/web/src/components/ShortcutShowcase/PracticeCalendar.tsx
+++ b/packages/web/src/components/ShortcutShowcase/PracticeCalendar.tsx
@@ -14,7 +14,6 @@ import {
   SHOWCASE_GRID_END_HOUR,
   SHOWCASE_GRID_START_HOUR,
 } from "@web/components/ShortcutShowcase/practice.state";
-import { eventEdgeFocusShadow } from "@web/grid/components/calendar-accent.util";
 
 const DAY_LABELS = ["Mon", "Tue", "Wed"];
 const GRID_START_MIN = SHOWCASE_GRID_START_HOUR * 60;
@@ -41,7 +40,9 @@ const PracticeBlock: FC<{
   state: PracticeState;
   flashing: boolean;
   pulsing: boolean;
-}> = ({ block, state, flashing, pulsing }) => {
+  jumpLetter?: string;
+  jumpLetterActive?: boolean;
+}> = ({ block, state, flashing, pulsing, jumpLetter, jumpLetterActive }) => {
   const { base } = useEventPalette(block.color);
   const contentColor = theme.getContrastText(base);
   const isFocused = state.focusedId === block.id;
@@ -49,14 +50,18 @@ const PracticeBlock: FC<{
   const focusedEdge = isFocused ? state.edge : null;
   const height = ((block.endMin - block.startMin) / TOTAL_MIN) * 100;
 
+  // With an edge focused, the edge bar carries the focus: the whole-block
+  // ring dims so a thick border cannot be mistaken for the focused edge.
   const focusShadow = isFocused
-    ? "0 0 0 1px var(--background), 0 0 0 3px color-mix(in srgb, var(--text) 70%, transparent)"
+    ? focusedEdge
+      ? "0 0 0 1px color-mix(in srgb, var(--text) 35%, transparent)"
+      : "0 0 0 1px var(--background), 0 0 0 3px color-mix(in srgb, var(--text) 70%, transparent)"
     : "";
   const edgeFocusShadow =
     focusedEdge === "start"
-      ? eventEdgeFocusShadow("startDate", "vertical", "var(--text)")
+      ? "0 -4px 0 0 var(--color-accent)"
       : focusedEdge === "end"
-        ? eventEdgeFocusShadow("endDate", "vertical", "var(--text)")
+        ? "0 4px 0 0 var(--color-accent)"
         : "";
   const edgeFocusAttr =
     focusedEdge === "start"
@@ -69,7 +74,7 @@ const PracticeBlock: FC<{
     <div
       className={`absolute inset-x-1 rounded-md px-2 py-1 text-xs transition-all duration-200 ${
         flashing ? "c-game-lock-flash" : ""
-      } ${pulsing && isFocused ? "c-game-focus-pulse" : ""} ${
+      } ${pulsing && isFocused && !focusedEdge ? "c-game-focus-pulse" : ""} ${
         isPlacing ? "opacity-90" : ""
       }`}
       data-practice-event-id={block.id}
@@ -90,6 +95,17 @@ const PracticeBlock: FC<{
         <div className="truncate opacity-80">
           {formatTime(block.startMin)} to {formatTime(block.endMin)}
         </div>
+      )}
+      {jumpLetter && (
+        <span
+          aria-hidden
+          className={`c-keycap absolute top-1 right-1 ${
+            jumpLetterActive ? "c-keycap-next" : ""
+          }`}
+          data-practice-jump-letter={jumpLetter}
+        >
+          {jumpLetter.toUpperCase()}
+        </span>
       )}
     </div>
   );
@@ -131,7 +147,18 @@ export const PracticeCalendar: FC<{
   flash?: PracticeFlash | null;
   /** Pulse the focused block so an auto-focused task target stands out. */
   pulseFocused?: boolean;
-}> = ({ state, targetSlot = null, flash = null, pulseFocused = false }) => {
+  /** Jump-letter chips by event id, shown while the H reveal is active. */
+  jumpLetters?: Record<string, string> | null;
+  /** The event whose chip pulses as the exact next key to press. */
+  jumpTargetId?: string | null;
+}> = ({
+  state,
+  targetSlot = null,
+  flash = null,
+  pulseFocused = false,
+  jumpLetters = null,
+  jumpTargetId = null,
+}) => {
   const hours: number[] = [];
   for (let h = SHOWCASE_GRID_START_HOUR; h < SHOWCASE_GRID_END_HOUR; h += 1) {
     hours.push(h);
@@ -200,6 +227,8 @@ export const PracticeCalendar: FC<{
                   state={state}
                   flashing={flash?.eventId === block.id}
                   pulsing={pulseFocused}
+                  jumpLetter={jumpLetters?.[block.id]}
+                  jumpLetterActive={block.id === jumpTargetId}
                 />
               ))}
           </div>

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
@@ -1,7 +1,6 @@
 import { resolveModifier } from "@tanstack/react-hotkeys";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { createTestNotificationPort } from "@web/__tests__/helpers/web-test-seams";
 import { dispatchMissingKey } from "@web/__tests__/utils/keyboard.test.util";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
@@ -12,8 +11,6 @@ import {
   shortcutShowcaseActions,
   useShortcutShowcaseStore,
 } from "@web/components/ShortcutShowcase/showcase.store";
-import { registerNotificationPort } from "@web/notifications/notification.port";
-import { resetNotificationStoreForTests } from "@web/notifications/notification.store";
 import { clearAppLockReasons, isAppLocked } from "@web/shortcuts/app-lock";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
@@ -30,6 +27,19 @@ const pressKey = (key: string, init: KeyboardEventInit = {}) => {
   });
 };
 
+const releaseKey = (key: string, init: KeyboardEventInit = {}) => {
+  act(() => {
+    window.dispatchEvent(
+      new KeyboardEvent("keyup", {
+        key,
+        bubbles: true,
+        cancelable: true,
+        ...init,
+      }),
+    );
+  });
+};
+
 const modInit = () =>
   resolveModifier("Mod") === "Meta" ? { metaKey: true } : { ctrlKey: true };
 
@@ -37,8 +47,16 @@ const typeDigits = (digits: string) => {
   for (const digit of digits) pressKey(digit);
 };
 
-/** Starts the clock from the how-to card and clears the whole queue. */
-const playWinningRun = () => {
+/** Hold a bare Control long enough for the page-jump reveal to fire. */
+const holdModForReveal = async () => {
+  pressKey("Control", { ctrlKey: true });
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 700));
+  });
+};
+
+/** Starts an untimed run from the how-to card and clears the whole queue. */
+const playWinningRun = async () => {
   pressKey("Enter");
   // place-standup
   pressKey("c");
@@ -65,6 +83,19 @@ const playWinningRun = () => {
   // delete-gym, undo-gym
   pressKey("Delete");
   pressKey("z", modInit());
+  // legend-peek: open the practice legend, close it again
+  pressKey("?", { shiftKey: true });
+  pressKey("?", { shiftKey: true });
+  // jump-to-kickoff: reveal jump letters, take the kickoff one
+  pressKey("h");
+  pressKey("s");
+  // page-jump-peek: hold Mod for the reveal, then Mod+1
+  await holdModForReveal();
+  pressKey("1", { ctrlKey: true });
+  releaseKey("Control");
+  // palette-peek: open the practice palette, Esc closes it
+  pressKey("k", modInit());
+  pressKey("Escape");
   // nudge-review
   pressKey("ArrowLeft", { shiftKey: true });
   // place-party
@@ -116,7 +147,7 @@ describe("ShortcutShowcase", () => {
 
     act(() => shortcutShowcaseActions.replay());
 
-    const first = screen.getByRole("button", { name: "Start the clock" });
+    const first = screen.getByRole("button", { name: "Start practicing" });
     expect(first).toHaveFocus();
 
     await user.tab({ shift: true });
@@ -140,31 +171,42 @@ describe("ShortcutShowcase", () => {
     expect(screen.getByLabelText("Shortcut practice")).toBeTruthy();
   });
 
-  it("shows the how-to card, and Enter starts the clock on task 1", () => {
+  it("shows the how-to card, and Enter starts an untimed run on task 1", () => {
     render(<ShortcutShowcase />);
     act(() => shortcutShowcaseActions.startFromWelcome());
 
-    expect(screen.getByText("Schedule Rush")).toBeTruthy();
+    expect(screen.getByText("Block Party")).toBeTruthy();
     expect(
-      screen.getByRole("button", { name: "Start the clock" }),
+      screen.getByRole("button", { name: "Start practicing" }),
     ).toBeTruthy();
-    expect(screen.queryByRole("timer")).toBeNull();
 
-    // Game keys do nothing before the clock starts.
+    // Game keys do nothing before the run starts.
     pressKey("c");
-    expect(screen.queryByRole("timer")).toBeNull();
+    expect(screen.queryByText(/^Task 1\//)).toBeNull();
 
     pressKey("Enter");
-    expect(screen.getByRole("timer")).toBeTruthy();
     expect(screen.getByText(`Task 1/${RUN_TASKS.length}`)).toBeTruthy();
     expect(screen.getByText("Standup")).toBeTruthy();
+    // The first run is practice: no countdown anywhere.
+    expect(screen.queryByRole("timer")).toBeNull();
+    expect(screen.getByText("Practice")).toBeTruthy();
   });
 
-  it("clears the queue with the taught keys and reaches the end screen", () => {
+  it("T races the clock from the how-to card", () => {
     render(<ShortcutShowcase />);
     act(() => shortcutShowcaseActions.startFromWelcome());
 
-    playWinningRun();
+    pressKey("t");
+    expect(screen.getByText(`Task 1/${RUN_TASKS.length}`)).toBeTruthy();
+    expect(screen.getByRole("timer")).toBeTruthy();
+    expect(screen.getByRole("timer").textContent).toBe("2:00");
+  });
+
+  it("clears the queue with the taught keys and reaches the end screen", async () => {
+    render(<ShortcutShowcase />);
+    act(() => shortcutShowcaseActions.startFromWelcome());
+
+    await playWinningRun();
 
     expect(screen.getByText("You cleared the week!")).toBeTruthy();
     expect(
@@ -180,7 +222,7 @@ describe("ShortcutShowcase", () => {
   it("graduates from the end screen and fades out before unmounting", async () => {
     render(<ShortcutShowcase />);
     act(() => shortcutShowcaseActions.startFromWelcome());
-    playWinningRun();
+    await playWinningRun();
 
     // O opens the calendar for anonymous players (Enter belongs to signup).
     pressKey("o");
@@ -218,7 +260,7 @@ describe("ShortcutShowcase", () => {
     try {
       render(<ShortcutShowcase />);
       act(() => shortcutShowcaseActions.startFromWelcome());
-      playWinningRun();
+      await playWinningRun();
       pressKey("o");
       await waitFor(() => {
         expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
@@ -229,10 +271,10 @@ describe("ShortcutShowcase", () => {
     }
   });
 
-  it("Enter on the end screen hands an anonymous player to signup", () => {
+  it("Enter on the end screen hands an anonymous player to signup", async () => {
     render(<ShortcutShowcase />);
     act(() => shortcutShowcaseActions.startFromWelcome());
-    playWinningRun();
+    await playWinningRun();
 
     pressKey("Enter");
     expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
@@ -241,11 +283,13 @@ describe("ShortcutShowcase", () => {
     ).toBe("true");
   });
 
-  it("replays from the end screen with a fresh board and score", () => {
+  it("offers a timed rematch from the end screen with a fresh board", async () => {
     render(<ShortcutShowcase />);
     act(() => shortcutShowcaseActions.startFromWelcome());
-    playWinningRun();
+    await playWinningRun();
     expect(screen.getByText("You cleared the week!")).toBeTruthy();
+    // After an untimed run the replay slot is the timed challenge.
+    expect(screen.getByRole("button", { name: /Race the clock/ })).toBeTruthy();
 
     pressKey("p");
     expect(screen.getByRole("timer")).toBeTruthy();
@@ -269,7 +313,7 @@ describe("ShortcutShowcase", () => {
     expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
   });
 
-  it("Escape arms a confirm, then a second Escape leaves", () => {
+  it("on the how-to card, Escape arms a confirm and a second Escape leaves", () => {
     render(<ShortcutShowcase />);
     act(() => shortcutShowcaseActions.replay());
 
@@ -282,20 +326,70 @@ describe("ShortcutShowcase", () => {
     expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
   });
 
-  it("a game keystroke cancels a pending skip", () => {
+  it("Escape mid-run skips the current task, never the game", () => {
+    render(<ShortcutShowcase />);
+    act(() => shortcutShowcaseActions.replay());
+    pressKey("Enter");
+    expect(screen.getByText(`Task 1/${RUN_TASKS.length}`)).toBeTruthy();
+
+    pressKey("Escape");
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
+    expect(useShortcutShowcaseStore.getState().skipPending).toBe(false);
+    expect(screen.getByText(`Task 2/${RUN_TASKS.length}`)).toBeTruthy();
+  });
+
+  it("Escape closes an open practice overlay before it skips anything", () => {
+    render(<ShortcutShowcase />);
+    act(() => shortcutShowcaseActions.replay());
+    pressKey("Enter");
+    // Esc through the board tasks until the legend task is up.
+    for (let i = 0; i < 8; i += 1) pressKey("Escape");
+    expect(screen.getByText("Blanking on a move?")).toBeTruthy();
+
+    pressKey("?", { shiftKey: true });
+    expect(screen.getByText("Shortcuts")).toBeTruthy();
+
+    // Esc closes the legend; closing it is the lesson, so the task clears.
+    pressKey("Escape");
+    expect(screen.queryByText("Shortcuts")).toBeNull();
+    expect(screen.getByText("Fly across the board")).toBeTruthy();
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
+  });
+
+  it("Escape leaves from the end screen once the run is over", async () => {
+    render(<ShortcutShowcase />);
+    act(() => shortcutShowcaseActions.replay());
+    await playWinningRun();
+
+    pressKey("Escape");
+    expect(screen.getByLabelText("Shortcut practice")).toHaveAttribute(
+      "data-closing",
+    );
+    expect(
+      persistentBrowserStore.get(STORAGE_KEYS.HAS_SEEN_SHORTCUT_SHOWCASE),
+    ).toBe("true");
+  });
+
+  it("the Leave button needs two clicks; a game keystroke cancels the first", async () => {
+    const user = userEvent.setup();
     render(<ShortcutShowcase />);
     act(() => shortcutShowcaseActions.replay());
     pressKey("Enter");
 
-    pressKey("Escape");
+    await user.click(screen.getByRole("button", { name: "Leave practice" }));
     expect(useShortcutShowcaseStore.getState().skipPending).toBe(true);
+    expect(screen.getByText("Click Leave now to confirm.")).toBeTruthy();
 
     pressKey("c");
     expect(useShortcutShowcaseStore.getState().skipPending).toBe(false);
     expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
+
+    await user.click(screen.getByRole("button", { name: "Leave practice" }));
+    await user.click(screen.getByRole("button", { name: "Leave now" }));
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
   });
 
-  it("swallows the palette and legend triggers during the game", () => {
+  it("claims the real palette and legend keys; sims open only on their tasks", () => {
     render(<ShortcutShowcase />);
     act(() => shortcutShowcaseActions.replay());
     pressKey("Enter");
@@ -303,7 +397,10 @@ describe("ShortcutShowcase", () => {
     pressKey("k", modInit());
     pressKey("?", { shiftKey: true });
     expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
-    expect(screen.getByRole("timer")).toBeTruthy();
+    // Task 1 teaches placing, so neither key opens a practice overlay.
+    expect(screen.queryByText("Shortcuts")).toBeNull();
+    expect(screen.queryByText("Type a command...")).toBeNull();
+    expect(screen.getByText(`Task 1/${RUN_TASKS.length}`)).toBeTruthy();
   });
 
   it("re-offers an unfinished attempt from the how-to card after reload", () => {
@@ -318,7 +415,7 @@ describe("ShortcutShowcase", () => {
 
     expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
     expect(
-      screen.getByRole("button", { name: "Start the clock" }),
+      screen.getByRole("button", { name: "Start practicing" }),
     ).toBeTruthy();
     expect(
       persistentBrowserStore.get(STORAGE_KEYS.HAS_SEEN_SHORTCUT_SHOWCASE),
@@ -336,46 +433,13 @@ describe("ShortcutShowcase", () => {
     ).not.toBe(0);
   });
 
-  describe("the reminders offer on the end screen", () => {
-    const installPort = (
-      options?: Parameters<typeof createTestNotificationPort>[0],
-    ) => {
-      const seam = createTestNotificationPort(options);
-      registerNotificationPort(seam.port);
-      act(() => {
-        resetNotificationStoreForTests();
-      });
-      return seam;
-    };
+  it("never offers a reminders button on the end screen", async () => {
+    render(<ShortcutShowcase />);
+    act(() => shortcutShowcaseActions.replay());
+    await playWinningRun();
 
-    it("asks the browser once, even when pressed twice", async () => {
-      const user = userEvent.setup();
-      const seam = installPort({ respondWith: "granted" });
-      render(<ShortcutShowcase />);
-      act(() => shortcutShowcaseActions.replay());
-      playWinningRun();
-
-      const button = screen.getByRole("button", { name: /Enable reminders/ });
-      await user.click(button);
-      await user.click(button);
-
-      await waitFor(() => {
-        expect(seam.mocks.requestPermission).toHaveBeenCalledTimes(1);
-      });
-      // The end screen stays put: enabling reminders is not an exit.
-      expect(useShortcutShowcaseStore.getState().isActive).toBe(true);
-      expect(screen.getByText("You cleared the week!")).toBeTruthy();
-    });
-
-    it("offers no reminders button where the API is missing", () => {
-      installPort({ supported: false });
-      render(<ShortcutShowcase />);
-      act(() => shortcutShowcaseActions.replay());
-      playWinningRun();
-
-      expect(
-        screen.queryByRole("button", { name: /Enable reminders/ }),
-      ).toBeNull();
-    });
+    expect(
+      screen.queryByRole("button", { name: /Enable reminders/ }),
+    ).toBeNull();
   });
 });

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
@@ -11,11 +11,15 @@ import {
   GameHud,
   GameTaskQueue,
 } from "@web/components/ShortcutShowcase/GameHud";
+import { GameSimOverlays } from "@web/components/ShortcutShowcase/GameSimOverlays";
 import {
   createInitialGameState,
   currentTask,
   type GameKey,
+  getJumpLetters,
+  getNextKeycapIndex,
   handleGameKey,
+  skipCurrentTask,
   startRun,
   tick,
 } from "@web/components/ShortcutShowcase/game.state";
@@ -25,6 +29,7 @@ import {
   RUN_DURATION_MS,
 } from "@web/components/ShortcutShowcase/game.tasks";
 import { PracticeCalendar } from "@web/components/ShortcutShowcase/PracticeCalendar";
+import { hasPlayDeepLink } from "@web/components/ShortcutShowcase/play-link";
 import { type PracticeNudgeDirection } from "@web/components/ShortcutShowcase/practice.state";
 import {
   selectShowcaseActive,
@@ -36,8 +41,6 @@ import {
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import { hasSeenWelcome } from "@web/components/WelcomeModal/welcome.modal.util";
-import { getNotificationPort } from "@web/notifications/notification.port";
-import { notificationActions } from "@web/notifications/notification.store";
 import { settingsActions } from "@web/settings/settings.store";
 import { useAppLockReason } from "@web/shortcuts/app-lock";
 import {
@@ -67,17 +70,22 @@ const arrowDirection = (key: string): PracticeNudgeDirection | null => {
 
 const HUD_TICK_MS = 250;
 
+/** How long a bare Mod hold takes to reveal the practice page-jump numbers. */
+const MOD_HOLD_REVEAL_MS = 600;
+
 /**
- * Schedule Rush: the full-screen practice arena shown before a new user
- * ever sees the real calendar. One 90-second run against a fixed queue of
- * scheduling tasks, played entirely with the app's real keyboard verbs —
- * bindings come from KEYMAP (shared with the real handlers); behavior is a
- * deliberately simplified reimplementation against ephemeral practice
- * state, so nothing here touches storage or the real grid stores.
+ * Block Party: the full-screen practice arena shown before a new user ever
+ * sees the real calendar. One run against a fixed queue of scheduling
+ * tasks, played entirely with the app's real keyboard verbs. Bindings come
+ * from KEYMAP (shared with the real handlers); behavior is a deliberately
+ * simplified reimplementation against ephemeral practice state, so nothing
+ * here touches storage or the real grid stores.
  *
- * A one-screen how-to card gates the clock, the end screen is a soft
- * landing either way (cleared or time-up), and graduation hands off to a
- * prompt on the real calendar. Skip is always offered.
+ * The first run is untimed practice; the end screen offers a race against
+ * the clock, and a timed run that outlives its clock keeps going with the
+ * timed score frozen at the buzzer. Esc skips the current task; leaving
+ * mid-run is the two-click Leave button, so no single keypress can dump a
+ * first-time user onto the calendar.
  */
 const ShowcaseTakeover: FC = () => {
   const skipPending = useShortcutShowcaseStore(selectSkipPending);
@@ -89,8 +97,6 @@ const ShowcaseTakeover: FC = () => {
   const [remainingSeconds, setRemainingSeconds] = useState(
     RUN_DURATION_MS / 1000,
   );
-  const [offerPending, setOfferPending] = useState(false);
-  const offerTakenRef = useRef(false);
   const regionRef = useRef<HTMLElement>(null);
 
   useAppLockReason("shortcutShowcase", true);
@@ -102,16 +108,25 @@ const ShowcaseTakeover: FC = () => {
     setGame((state) => handleGameKey(state, key, Date.now()));
   };
 
-  const begin = () => {
+  const begin = (timed: boolean) => {
     setRemainingSeconds(RUN_DURATION_MS / 1000);
-    setGame((state) => startRun(state, Date.now()));
+    setGame((state) => startRun({ ...state, timed }, Date.now()));
   };
 
-  const replay = () => {
+  const replay = (timed: boolean) => {
     const nextRunCount = gameRef.current.runCount + 1;
-    track("shortcut_game_replayed", { run_count: nextRunCount });
+    track("shortcut_game_replayed", { run_count: nextRunCount, timed });
     setRemainingSeconds(RUN_DURATION_MS / 1000);
-    setGame(startRun(createInitialGameState(nextRunCount), Date.now()));
+    setGame(startRun(createInitialGameState(nextRunCount, timed), Date.now()));
+  };
+
+  // The page-jump task's reveal: hold Mod alone briefly, mirroring the real
+  // mod-hold hint engine. The timer lives here so the reducer stays pure.
+  const modHoldTimerRef = useRef<number | null>(null);
+  const cancelModHold = () => {
+    if (modHoldTimerRef.current === null) return;
+    window.clearTimeout(modHoldTimerRef.current);
+    modHoldTimerRef.current = null;
   };
 
   /** Funnel context attached to skip events so drop-off is measurable. */
@@ -147,19 +162,6 @@ const ShowcaseTakeover: FC = () => {
     openModal("signUp");
   };
 
-  const notificationsSupported = getNotificationPort().isSupported();
-
-  // The permission prompt may outlive the end screen. Deduplicate it so
-  // replays cannot stack a second request.
-  const enableNotifications = () => {
-    if (offerTakenRef.current) return;
-    offerTakenRef.current = true;
-    setOfferPending(true);
-    void notificationActions.enable("showcase").finally(() => {
-      setOfferPending(false);
-    });
-  };
-
   // Run-started, per-task, and finished events fire from effects (not the
   // setState updater) keyed by run count so each fires exactly once per run.
   const reportedRunRef = useRef(0);
@@ -170,8 +172,9 @@ const ShowcaseTakeover: FC = () => {
     track("shortcut_game_run_started", {
       entry: entry ?? "resume",
       run_count: game.runCount,
+      timed: game.timed,
     });
-  }, [game.phase, game.runCount, entry]);
+  }, [game.phase, game.runCount, game.timed, entry]);
 
   const reportedTaskRef = useRef("");
   useEffect(() => {
@@ -208,19 +211,28 @@ const ShowcaseTakeover: FC = () => {
     if (reportedEndRef.current === game.runCount) return;
     reportedEndRef.current = game.runCount;
     shortcutShowcaseActions.recordRunFinished({
-      outcome: game.outcome ?? "time_up",
+      outcome: game.outcome ?? "cleared",
       score: game.score,
       tasks_done: game.tasksDone,
+      tasks_skipped: game.tasksSkipped,
+      timed: game.timed,
+      ...(game.buzzer
+        ? {
+            buzzer_score: game.buzzer.score,
+            buzzer_tasks_done: game.buzzer.tasksDone,
+          }
+        : {}),
       duration_ms: game.endedAtMs - game.startedAtMs,
       run_count: game.runCount,
     });
   }, [game]);
 
-  // The countdown. The reducer stays pure: the interval feeds it wall-clock
-  // timestamps and keeps a display clock for the HUD, re-rendering only when
-  // the visible second actually changes.
+  // The countdown, for timed runs only. The reducer stays pure: the interval
+  // feeds it wall-clock timestamps and keeps a display clock for the HUD,
+  // re-rendering only when the visible second actually changes. Once the
+  // buzzer snapshots the score the clock is pinned and the interval stops.
   useEffect(() => {
-    if (game.phase !== "running") return;
+    if (game.phase !== "running" || !game.timed || game.buzzer) return;
     const id = window.setInterval(() => {
       const now = Date.now();
       setGame((state) => tick(state, now));
@@ -231,7 +243,7 @@ const ShowcaseTakeover: FC = () => {
       setRemainingSeconds((prev) => (prev === next ? prev : next));
     }, HUD_TICK_MS);
     return () => window.clearInterval(id);
-  }, [game.phase]);
+  }, [game.phase, game.timed, game.buzzer]);
 
   const seatFocus = () => {
     const root = regionRef.current;
@@ -279,6 +291,25 @@ const ShowcaseTakeover: FC = () => {
       }
     }
 
+    // A bare Mod press starts the page-jump reveal hold; any other keydown
+    // means a chord, which breaks the hold.
+    if (event.key === "Meta" || event.key === "Control") {
+      if (
+        phase === "running" &&
+        !event.repeat &&
+        currentTask(gameRef.current)?.type === "pageJump" &&
+        gameRef.current.simOverlay !== "pagejump"
+      ) {
+        cancelModHold();
+        modHoldTimerRef.current = window.setTimeout(() => {
+          modHoldTimerRef.current = null;
+          dispatchKey({ type: "modHoldReveal" });
+        }, MOD_HOLD_REVEAL_MS);
+      }
+      return;
+    }
+    cancelModHold();
+
     if (event.key === "Tab" && regionRef.current) {
       // Mid-run, Tab is the edge-focus verb it teaches; the takeover's
       // buttons stay reachable outside the run.
@@ -307,19 +338,42 @@ const ShowcaseTakeover: FC = () => {
     if (event.key === "Escape") {
       claim(event);
       settingsActions.closeCmdPalette();
+      if (phase === "running") {
+        shortcutShowcaseActions.clearSkipPending();
+        // Esc closes an open sim overlay first; otherwise it skips the task.
+        if (gameRef.current.simOverlay) {
+          dispatchKey({ type: "closeOverlay" });
+          return;
+        }
+        const task = currentTask(gameRef.current);
+        track("shortcut_game_task_skipped", {
+          task_id: task?.id ?? "none",
+          index: gameRef.current.taskIndex,
+        });
+        setGame((state) => skipCurrentTask(state, Date.now()));
+        return;
+      }
+      if (phase === "ended") {
+        // The run already finished; Esc is just another way out.
+        graduate();
+        return;
+      }
       shortcutShowcaseActions.requestSkip("calendar", gameContext());
       return;
     }
 
-    // The real palette and legend ignore the app lock; swallow their
-    // triggers so neither overlay can land on top of a timed run.
+    // The real palette and legend ignore the app lock; claim their triggers
+    // so neither overlay can land on top of a run. Mid-run the same keys
+    // drive the simulated versions the discovery tasks teach.
     const isModChord = event.metaKey || event.ctrlKey;
     if (isModChord && keyboardKey(event).toLowerCase() === "k") {
       claim(event);
+      if (phase === "running") dispatchKey({ type: "palette" });
       return;
     }
     if (isLegendToggleKey(event)) {
       claim(event);
+      if (phase === "running") dispatchKey({ type: "legend" });
       return;
     }
 
@@ -335,10 +389,22 @@ const ShowcaseTakeover: FC = () => {
       return;
     }
 
+    // Mod+digit lands the page-jump task while its reveal is up.
+    if (phase === "running" && isModChord && /^[0-9]$/.test(event.key)) {
+      claim(event);
+      dispatchKey({ type: "pageJumpDigit", digit: event.key });
+      return;
+    }
+
     if (phase === "howto") {
       if (event.key === "Enter" && !event.repeat && !focusedButton) {
         claim(event);
-        begin();
+        begin(false);
+        return;
+      }
+      if (isBareLetterKey(event, "t") && !event.repeat) {
+        claim(event);
+        begin(true);
         return;
       }
       if (isBareLetterKey(event, "u") && !authenticated) {
@@ -369,12 +435,7 @@ const ShowcaseTakeover: FC = () => {
       }
       if (isBareLetterKey(event, "p") && !event.repeat) {
         claim(event);
-        replay();
-        return;
-      }
-      if (isBareLetterKey(event, "n") && notificationsSupported) {
-        claim(event);
-        enableNotifications();
+        replay(true);
       }
       return;
     }
@@ -398,6 +459,24 @@ const ShowcaseTakeover: FC = () => {
       claim(event);
       dispatchKey({ type: "delete" });
       return;
+    }
+
+    if (isBareLetterKey(event, KEYMAP.eventJump.bareLetter)) {
+      claim(event);
+      dispatchKey({ type: "jump" });
+      return;
+    }
+
+    // While jump chips are up, bare letters are jump targets. This branch
+    // sits above the create and signup letters on purpose: no letter may
+    // fling the player elsewhere mid-jump.
+    if (gameRef.current.jumpChipsShown) {
+      const letter = keyboardKey(event).toLowerCase();
+      if (/^[a-z]$/.test(letter) && !event.altKey) {
+        claim(event);
+        dispatchKey({ type: "letter", letter });
+        return;
+      }
     }
 
     if (isBareLetterKey(event, KEYMAP.createEvent.hotkey.toLowerCase())) {
@@ -424,6 +503,12 @@ const ShowcaseTakeover: FC = () => {
   };
 
   const handleTakeoverKeyUp = (event: KeyboardEvent) => {
+    // Releasing Mod ends the page-jump hold, revealed or not.
+    if (event.key === "Meta" || event.key === "Control") {
+      cancelModHold();
+      dispatchKey({ type: "modHoldEnd" });
+      return;
+    }
     // The real legend overlay listens on keyup. Swallow the leftover `?` so
     // it cannot open on top of the takeover.
     if (isLegendToggleKey(event)) {
@@ -450,14 +535,22 @@ const ShowcaseTakeover: FC = () => {
     return () => {
       window.removeEventListener("keydown", onKeyDown, true);
       window.removeEventListener("keyup", onKeyUp, true);
+      if (modHoldTimerRef.current !== null) {
+        window.clearTimeout(modHoldTimerRef.current);
+      }
     };
   }, []);
 
   const task = currentTask(game);
   const isRunning = game.phase === "running";
   const ghost = isRunning && task ? getTaskGhost(task) : null;
+  // eventJump leaves its target unfocused on purpose: the jump is the task.
   const pulseFocused = Boolean(
-    isRunning && task && "targetEventId" in task && task.type !== "undo",
+    isRunning &&
+      task &&
+      "targetEventId" in task &&
+      task.type !== "undo" &&
+      task.type !== "eventJump",
   );
   const awardBlockId = game.lastAward
     ? getTaskBlockId(game.lastAward.taskId)
@@ -470,16 +563,26 @@ const ShowcaseTakeover: FC = () => {
   const skipControls = (
     <div className="flex flex-wrap items-center gap-2 pt-2">
       {game.phase === "howto" && (
-        <div className="flex items-center gap-2">
+        <>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              className={PRIMARY_BUTTON_CLASS}
+              onClick={() => begin(false)}
+            >
+              Start practicing
+            </button>
+            <ShortcutHint className="shrink-0">Enter</ShortcutHint>
+          </div>
           <button
             type="button"
-            className={PRIMARY_BUTTON_CLASS}
-            onClick={begin}
+            className={SECONDARY_BUTTON_CLASS}
+            onClick={() => begin(true)}
           >
-            Start the clock
+            Race the clock
+            <ShortcutHint className="shrink-0">T</ShortcutHint>
           </button>
-          <ShortcutHint className="shrink-0">Enter</ShortcutHint>
-        </div>
+        </>
       )}
       {!authenticated && (
         <button
@@ -498,12 +601,25 @@ const ShowcaseTakeover: FC = () => {
           shortcutShowcaseActions.requestSkip("calendar", gameContext())
         }
       >
-        {skipPending ? "Leave practice" : "Skip"}
-        <ShortcutHint className="shrink-0">Esc</ShortcutHint>
+        {skipPending
+          ? "Leave now"
+          : game.phase === "running"
+            ? "Leave practice"
+            : "Skip"}
+        {game.phase === "howto" && (
+          <ShortcutHint className="shrink-0">Esc</ShortcutHint>
+        )}
       </button>
       {skipPending && (
         <p className="w-full text-text-muted text-xs" role="status">
-          Press Esc again to leave practice.
+          {game.phase === "running"
+            ? "Click Leave now to confirm."
+            : "Press Esc again to leave practice."}
+        </p>
+      )}
+      {game.phase === "running" && !skipPending && (
+        <p className="flex w-full items-center gap-1.5 text-text-muted text-xs">
+          <ShortcutHint className="shrink-0">Esc</ShortcutHint> skips this task
         </p>
       )}
     </div>
@@ -523,18 +639,18 @@ const ShowcaseTakeover: FC = () => {
           className={`flex items-center justify-center px-8 ${closing ? "c-showcase-enter-stage" : ""}`}
         >
           <GameEndScreen
-            outcome={game.outcome ?? "time_up"}
+            outcome={game.outcome}
             score={game.score}
             tasksDone={game.tasksDone}
+            tasksSkipped={game.tasksSkipped}
             timeBonus={game.timeBonus}
+            timed={game.timed}
+            buzzer={game.buzzer}
             authenticated={authenticated}
-            notificationsSupported={notificationsSupported}
-            notificationsPending={offerPending}
             closing={closing}
             onSignUp={signUpFromEndScreen}
             onGraduate={graduate}
-            onReplay={replay}
-            onEnableNotifications={enableNotifications}
+            onReplay={() => replay(true)}
           />
         </div>
       ) : (
@@ -545,15 +661,15 @@ const ShowcaseTakeover: FC = () => {
             {game.phase === "howto" ? (
               <>
                 <p className="font-medium text-accent text-xs uppercase tracking-wide">
-                  Schedule Rush
+                  Block Party
                 </p>
                 <h2 className="font-semibold text-lg text-text">
                   Compass is keyboard-only. Ready?
                 </h2>
                 <p className="text-sm text-text-muted">
-                  Your week needs scheduling: clear the queue of ten tasks
-                  before the clock runs out. Ninety seconds — the cards teach
-                  each move as it comes, and nothing here is saved.
+                  Your week needs scheduling. Work through the queue of tasks;
+                  each card teaches the move as it comes, and nothing here is
+                  saved. No clock on your first run.
                 </p>
                 <div className="flex flex-col gap-1.5 text-sm text-text">
                   <span className="flex items-center gap-2">
@@ -571,7 +687,10 @@ const ShowcaseTakeover: FC = () => {
                 </div>
               </>
             ) : (
-              <GameTaskQueue taskIndex={game.taskIndex} />
+              <GameTaskQueue
+                taskIndex={game.taskIndex}
+                nextKeycapIndex={task ? getNextKeycapIndex(task, game) : 0}
+              />
             )}
             {skipControls}
           </aside>
@@ -582,6 +701,8 @@ const ShowcaseTakeover: FC = () => {
                 score={game.score}
                 streak={game.streak}
                 award={game.lastAward}
+                timed={game.timed}
+                overtime={Boolean(game.buzzer)}
               />
             )}
             <div className="relative min-h-0 flex-1 rounded-xl border border-border bg-surface p-4 shadow-xl">
@@ -590,7 +711,14 @@ const ShowcaseTakeover: FC = () => {
                 targetSlot={ghost}
                 flash={flash}
                 pulseFocused={pulseFocused}
+                jumpLetters={
+                  game.jumpChipsShown ? getJumpLetters(game.practice) : null
+                }
+                jumpTargetId={
+                  task?.type === "eventJump" ? task.targetEventId : null
+                }
               />
+              {game.simOverlay && <GameSimOverlays overlay={game.simOverlay} />}
             </div>
           </div>
         </div>
@@ -603,6 +731,9 @@ export const ShortcutShowcase: FC = () => {
   const isActive = useShortcutShowcaseStore(selectShowcaseActive);
 
   useEffect(() => {
+    // A ?play= deep link owns activation (ShowcasePlayLink); resuming too
+    // would double-activate the run.
+    if (hasPlayDeepLink()) return;
     if (!hasSeenWelcome()) return;
     shortcutShowcaseActions.resumeIfInProgress();
   }, []);

--- a/packages/web/src/components/ShortcutShowcase/game.state.test.ts
+++ b/packages/web/src/components/ShortcutShowcase/game.state.test.ts
@@ -3,9 +3,12 @@ import {
   currentTask,
   type GameKey,
   type GameState,
+  getJumpLetters,
+  getNextKeycapIndex,
   handleGameKey,
   isTaskComplete,
   resolveTypedTime,
+  skipCurrentTask,
   startRun,
   tick,
 } from "@web/components/ShortcutShowcase/game.state";
@@ -26,6 +29,14 @@ const key = {
   del: { type: "delete" } as GameKey,
   undo: { type: "undo" } as GameKey,
   tab: { type: "tab", backward: false } as GameKey,
+  legend: { type: "legend" } as GameKey,
+  palette: { type: "palette" } as GameKey,
+  jump: { type: "jump" } as GameKey,
+  modHoldReveal: { type: "modHoldReveal" } as GameKey,
+  modHoldEnd: { type: "modHoldEnd" } as GameKey,
+  closeOverlay: { type: "closeOverlay" } as GameKey,
+  letter: (letter: string): GameKey => ({ type: "letter", letter }),
+  pageJumpDigit: (digit: string): GameKey => ({ type: "pageJumpDigit", digit }),
   digit: (digit: string): GameKey => ({ type: "digit", digit }),
   arrow: (
     direction: "up" | "down" | "left" | "right",
@@ -69,6 +80,18 @@ const WINNING_SCRIPT: GameKey[] = [
   // delete-gym, undo-gym
   key.del,
   key.undo,
+  // legend-peek: open, then close
+  key.legend,
+  key.legend,
+  // jump-to-kickoff: reveal chips, jump by letter (kickoff is "s" by board order)
+  key.jump,
+  key.letter("s"),
+  // page-jump-peek: the hold reveals, the digit lands
+  key.modHoldReveal,
+  key.pageJumpDigit("1"),
+  // palette-peek: open, then Esc closes
+  key.palette,
+  key.closeOverlay,
   // nudge-review: Wed -> Tue
   key.arrow("left", true),
   // place-party: spawn Wed 4pm, walk down to 5pm, lock
@@ -97,12 +120,17 @@ describe("run lifecycle", () => {
 
     const running = startRun(initial, T0);
     expect(running.phase).toBe("running");
-    expect(running.endsAtMs).toBe(T0 + RUN_DURATION_MS);
+    // The default run is untimed practice: no clock is armed.
+    expect(running.timed).toBe(false);
+    expect(running.endsAtMs).toBe(0);
     expect(currentTask(running)?.id).toBe("place-standup");
+
+    const timed = startRun(createInitialGameState(1, true), T0);
+    expect(timed.endsAtMs).toBe(T0 + RUN_DURATION_MS);
   });
 
-  it("clears the whole queue with the winning script and pays the time bonus", () => {
-    let state = startRun(createInitialGameState(), T0);
+  it("clears the whole queue with the winning script and pays the timed bonus", () => {
+    let state = startRun(createInitialGameState(1, true), T0);
     state = playKeys(state, WINNING_SCRIPT, T0 + 1_000);
 
     expect(state.phase).toBe("ended");
@@ -113,18 +141,68 @@ describe("run lifecycle", () => {
     expect(state.score).toBeGreaterThan(state.timeBonus);
   });
 
-  it("ends with time_up when the clock runs out mid-queue", () => {
+  it("pays no time bonus on an untimed run and never ticks", () => {
     let state = startRun(createInitialGameState(), T0);
+    expect(tick(state, T0 + RUN_DURATION_MS * 10)).toBe(state);
+
+    state = playKeys(state, WINNING_SCRIPT, T0 + RUN_DURATION_MS * 10);
+    expect(state.phase).toBe("ended");
+    expect(state.outcome).toBe("cleared");
+    expect(state.timeBonus).toBe(0);
+  });
+
+  it("freezes the score at the buzzer and keeps the run going", () => {
+    let state = startRun(createInitialGameState(1, true), T0);
     state = playKeys(state, WINNING_SCRIPT.slice(0, 3), T0 + 1_000);
     expect(state.tasksDone).toBe(1);
 
-    const ended = tick(state, T0 + RUN_DURATION_MS);
-    expect(ended.phase).toBe("ended");
-    expect(ended.outcome).toBe("time_up");
-    expect(ended.tasksDone).toBe(1);
-    expect(ended.score).toBe(state.score);
+    const buzzed = tick(state, T0 + RUN_DURATION_MS);
+    expect(buzzed.phase).toBe("running");
+    expect(buzzed.buzzer).toEqual({ score: state.score, tasksDone: 1 });
+    // A second tick does not re-snapshot.
+    expect(tick(buzzed, T0 + RUN_DURATION_MS + 1_000)).toBe(buzzed);
 
-    expect(handleGameKey(ended, key.create, T0 + RUN_DURATION_MS)).toBe(ended);
+    // Finishing after the buzzer is overtime: full run, no time bonus.
+    const finished = playKeys(
+      buzzed,
+      WINNING_SCRIPT.slice(3),
+      T0 + RUN_DURATION_MS + 5_000,
+    );
+    expect(finished.phase).toBe("ended");
+    expect(finished.outcome).toBe("overtime");
+    expect(finished.tasksDone).toBe(RUN_TASKS.length);
+    expect(finished.timeBonus).toBe(0);
+    expect(finished.buzzer).toEqual(buzzed.buzzer);
+  });
+});
+
+describe("task skip", () => {
+  it("advances with no points, resets the streak, and re-enters the next task", () => {
+    let state = startRun(createInitialGameState(), T0);
+    state = playKeys(state, WINNING_SCRIPT.slice(0, 3), T0);
+    expect(state.streak).toBe(1);
+    const scoreBefore = state.score;
+
+    const skipped = skipCurrentTask(state, T0 + 1_000);
+    expect(currentTask(skipped)?.id).toBe("place-review");
+    expect(skipped.score).toBe(scoreBefore);
+    expect(skipped.tasksSkipped).toBe(1);
+    expect(skipped.streak).toBe(0);
+  });
+
+  it("skipping every task ends the run with no points and no bonus", () => {
+    let state = startRun(createInitialGameState(1, true), T0);
+    for (let i = 0; i < RUN_TASKS.length; i += 1) {
+      state = skipCurrentTask(state, T0 + i);
+    }
+    expect(state.phase).toBe("ended");
+    expect(state.outcome).toBe("cleared");
+    expect(state.tasksDone).toBe(0);
+    expect(state.tasksSkipped).toBe(RUN_TASKS.length);
+    expect(state.score).toBe(0);
+    expect(state.timeBonus).toBe(0);
+    // Ended runs ignore further skips.
+    expect(skipCurrentTask(state, T0)).toBe(state);
   });
 });
 
@@ -210,8 +288,119 @@ describe("task validation", () => {
     expect(state.practice.events.some((e) => e.id === "game-gym")).toBe(false);
 
     state = handleGameKey(state, key.undo, T0);
-    expect(currentTask(state)?.id).toBe("nudge-review");
+    expect(currentTask(state)?.id).toBe("legend-peek");
     expect(state.practice.events.some((e) => e.id === "game-gym")).toBe(true);
+  });
+});
+
+describe("discovery tasks", () => {
+  /** Play up to (and including) undo-gym so legend-peek is current. */
+  const reachLegend = () =>
+    playKeys(
+      startRun(createInitialGameState(), T0),
+      WINNING_SCRIPT.slice(0, 27),
+      T0,
+    );
+
+  it("completes the legend by opening with ? and closing with Esc", () => {
+    let state = reachLegend();
+    expect(currentTask(state)?.id).toBe("legend-peek");
+
+    state = handleGameKey(state, key.legend, T0);
+    expect(state.simOverlay).toBe("legend");
+    expect(currentTask(state)?.id).toBe("legend-peek");
+
+    state = handleGameKey(state, key.closeOverlay, T0);
+    expect(currentTask(state)?.id).toBe("jump-to-kickoff");
+  });
+
+  it("jumps by letter; wrong letters leave the task open for another try", () => {
+    let state = playKeys(reachLegend(), [key.legend, key.legend], T0);
+    expect(currentTask(state)?.id).toBe("jump-to-kickoff");
+    // The undo beat left Gym focused; being focused is not the task.
+    expect(state.practice.focusedId).toBe("game-gym");
+
+    state = handleGameKey(state, key.jump, T0);
+    expect(state.jumpChipsShown).toBe(true);
+    expect(getJumpLetters(state.practice)["game-kickoff"]).toBe("s");
+
+    // A letter with no block is a no-op; a wrong block closes the chips
+    // but leaves the task open.
+    expect(handleGameKey(state, key.letter("z"), T0)).toBe(state);
+    state = handleGameKey(state, key.letter("j"), T0);
+    expect(currentTask(state)?.id).toBe("jump-to-kickoff");
+
+    state = playKeys(state, [key.jump, key.letter("s")], T0);
+    expect(currentTask(state)?.id).toBe("page-jump-peek");
+    expect(state.practice.focusedId).toBe("game-kickoff");
+  });
+
+  it("aborts the page-jump reveal when Mod is released without a digit", () => {
+    let state = playKeys(
+      reachLegend(),
+      [key.legend, key.legend, key.jump, key.letter("s")],
+      T0,
+    );
+    expect(currentTask(state)?.id).toBe("page-jump-peek");
+
+    state = playKeys(state, [key.modHoldReveal, key.modHoldEnd], T0);
+    expect(currentTask(state)?.id).toBe("page-jump-peek");
+    expect(state.simOverlay).toBeNull();
+
+    state = playKeys(state, [key.modHoldReveal, key.pageJumpDigit("1")], T0);
+    expect(currentTask(state)?.id).toBe("palette-peek");
+  });
+});
+
+describe("keycap progress", () => {
+  it("walks the place chips: create, arrow while placing, enter on target", () => {
+    let state = startRun(createInitialGameState(), T0);
+    const task = currentTask(state) as NonNullable<
+      ReturnType<typeof currentTask>
+    >;
+    expect(getNextKeycapIndex(task, state)).toBe(0);
+
+    state = handleGameKey(state, key.create, T0);
+    expect(getNextKeycapIndex(task, state)).toBe(1);
+
+    state = handleGameKey(state, key.arrow("left"), T0);
+    expect(getNextKeycapIndex(task, state)).toBe(2);
+  });
+
+  it("tracks typed digits and points at Enter once the piece spawns", () => {
+    let state = playKeys(
+      startRun(createInitialGameState(), T0),
+      WINNING_SCRIPT.slice(0, 3),
+      T0,
+    );
+    const task = currentTask(state) as NonNullable<
+      ReturnType<typeof currentTask>
+    >;
+    expect(task.id).toBe("quicktime-lunch");
+    expect(getNextKeycapIndex(task, state)).toBe(0);
+
+    state = playKeys(state, [key.digit("1"), key.digit("2")], T0);
+    expect(getNextKeycapIndex(task, state)).toBe(2);
+
+    state = playKeys(state, [key.digit("3"), key.digit("0")], T0);
+    // Spawned at 12:30, still placing: Enter is the last chip.
+    expect(getNextKeycapIndex(task, state)).toBe(task.keycaps.length - 1);
+  });
+
+  it("moves from Tab to Shift+Down once the resize edge is focused", () => {
+    let state = playKeys(
+      startRun(createInitialGameState(), T0),
+      WINNING_SCRIPT.slice(0, 16),
+      T0,
+    );
+    const task = currentTask(state) as NonNullable<
+      ReturnType<typeof currentTask>
+    >;
+    expect(task.id).toBe("resize-one-on-one");
+    expect(getNextKeycapIndex(task, state)).toBe(0);
+
+    state = playKeys(state, [key.tab, key.tab], T0);
+    expect(getNextKeycapIndex(task, state)).toBe(1);
   });
 });
 
@@ -260,7 +449,7 @@ describe("winning script sanity", () => {
   it("every task in the queue has a reachable, well-formed target", () => {
     const state = startRun(createInitialGameState(), T0);
     for (const task of RUN_TASKS) {
-      expect(isTaskComplete(task, state.practice)).toBe(
+      expect(isTaskComplete(task, state)).toBe(
         // Only already-satisfied tasks would be undo of something present.
         task.type === "undo",
       );

--- a/packages/web/src/components/ShortcutShowcase/game.state.ts
+++ b/packages/web/src/components/ShortcutShowcase/game.state.ts
@@ -27,13 +27,17 @@ import {
 } from "@web/components/ShortcutShowcase/practice.state";
 
 /**
- * The Schedule Rush reducer. Every function is pure and every timestamp
- * arrives as an argument — no Date.now() in here — so a full run scripts
+ * The Block Party reducer. Every function is pure and every timestamp
+ * arrives as an argument (no Date.now() in here), so a full run scripts
  * cleanly in tests without fake timers.
  */
 
 export type GamePhase = "howto" | "running" | "ended";
-export type GameOutcome = "cleared" | "time_up";
+/** Overtime: the queue was finished after a timed run's clock hit zero. */
+export type GameOutcome = "cleared" | "overtime";
+
+/** A simulated overlay for the discovery tasks; never the real component. */
+export type GameSimOverlay = "legend" | "pagejump" | "palette";
 
 /** Keyboard input, already translated from the DOM event by the component. */
 export type GameKey =
@@ -43,7 +47,15 @@ export type GameKey =
   | { type: "tab"; backward: boolean }
   | { type: "enter" }
   | { type: "delete" }
-  | { type: "undo" };
+  | { type: "undo" }
+  | { type: "legend" }
+  | { type: "palette" }
+  | { type: "jump" }
+  | { type: "letter"; letter: string }
+  | { type: "modHoldReveal" }
+  | { type: "modHoldEnd" }
+  | { type: "pageJumpDigit"; digit: string }
+  | { type: "closeOverlay" };
 
 export type GameAward = {
   seq: number;
@@ -73,9 +85,24 @@ export type GameState = {
   /** Seq bumps on every award so the UI can key the score popup. */
   lastAward: GameAward | null;
   runCount: number;
+  /** False on a practice run: no clock, no time bonus. */
+  timed: boolean;
+  /** Timed-run score frozen the moment the clock hit zero. */
+  buzzer: { score: number; tasksDone: number } | null;
+  /** Tasks skipped with Esc; shown on the end screen, worth no points. */
+  tasksSkipped: number;
+  /** Simulated overlay for the discovery tasks. */
+  simOverlay: GameSimOverlay | null;
+  /** True once the current task's reveal step happened; reset per task. */
+  simOverlayOpened: boolean;
+  /** Jump-letter chips visible on the practice blocks (the H task). */
+  jumpChipsShown: boolean;
 };
 
-export const createInitialGameState = (runCount = 1): GameState => ({
+export const createInitialGameState = (
+  runCount = 1,
+  timed = false,
+): GameState => ({
   phase: "howto",
   outcome: null,
   practice: createPracticeState(
@@ -93,6 +120,12 @@ export const createInitialGameState = (runCount = 1): GameState => ({
   taskStartedAtMs: 0,
   lastAward: null,
   runCount,
+  timed,
+  buzzer: null,
+  tasksSkipped: 0,
+  simOverlay: null,
+  simOverlayOpened: false,
+  jumpChipsShown: false,
 });
 
 export const currentTask = (state: GameState): GameTask | null =>
@@ -101,8 +134,20 @@ export const currentTask = (state: GameState): GameTask | null =>
 /** Pin focus to a task's target so Shift+Arrow/Delete land without hunting. */
 const enterTask = (state: GameState): GameState => {
   const task = currentTask(state);
-  const next = { ...state, digitBuffer: "" };
-  if (task && "targetEventId" in task && task.type !== "undo") {
+  const next = {
+    ...state,
+    digitBuffer: "",
+    simOverlay: null,
+    simOverlayOpened: false,
+    jumpChipsShown: false,
+  };
+  // undo needs the block gone; eventJump would self-complete if pre-focused.
+  if (
+    task &&
+    "targetEventId" in task &&
+    task.type !== "undo" &&
+    task.type !== "eventJump"
+  ) {
     return { ...next, practice: focusEvent(next.practice, task.targetEventId) };
   }
   return next;
@@ -114,19 +159,50 @@ export const startRun = (state: GameState, nowMs: number): GameState => {
     ...state,
     phase: "running",
     startedAtMs: nowMs,
-    endsAtMs: nowMs + RUN_DURATION_MS,
+    endsAtMs: state.timed ? nowMs + RUN_DURATION_MS : 0,
     taskStartedAtMs: nowMs,
   });
 };
 
-/** Time-up is a soft landing: the score stands and the end screen shows. */
+/**
+ * The buzzer is a soft landing, not an exit: when a timed run's clock hits
+ * zero the score freezes into `buzzer` and play continues untimed, so the
+ * player never loses their run to the clock.
+ */
 export const tick = (state: GameState, nowMs: number): GameState =>
-  state.phase === "running" && nowMs >= state.endsAtMs
-    ? { ...state, phase: "ended", outcome: "time_up", endedAtMs: nowMs }
+  state.phase === "running" &&
+  state.timed &&
+  !state.buzzer &&
+  nowMs >= state.endsAtMs
+    ? { ...state, buzzer: { score: state.score, tasksDone: state.tasksDone } }
     : state;
 
 const blockById = (practice: PracticeState, id: string) =>
   practice.events.find((event) => event.id === id);
+
+/**
+ * Letters shown on the blocks while jump chips are up, keyed by event id and
+ * ordered by board position. The pool avoids letters the takeover already
+ * binds (c create, h jump, u signup, plus the end screen's o/p and the e/t
+ * edit sequence).
+ */
+const JUMP_LETTER_POOL = "asdfgjkl";
+
+export const getJumpLetters = (
+  practice: PracticeState,
+): Record<string, string> => {
+  const ordered = [...practice.events].sort(
+    (a, b) =>
+      a.dayIndex - b.dayIndex ||
+      a.startMin - b.startMin ||
+      a.id.localeCompare(b.id),
+  );
+  const letters: Record<string, string> = {};
+  ordered.slice(0, JUMP_LETTER_POOL.length).forEach((event, index) => {
+    letters[event.id] = JUMP_LETTER_POOL[index] as string;
+  });
+  return letters;
+};
 
 const matchesSlot = (
   block: { dayIndex: number; startMin: number; endMin: number },
@@ -136,10 +212,8 @@ const matchesSlot = (
   block.startMin === slot.startMin &&
   block.endMin === slot.endMin;
 
-export const isTaskComplete = (
-  task: GameTask,
-  practice: PracticeState,
-): boolean => {
+export const isTaskComplete = (task: GameTask, state: GameState): boolean => {
+  const { practice } = state;
   switch (task.type) {
     case "place":
     case "quickTime": {
@@ -163,6 +237,17 @@ export const isTaskComplete = (
       return !blockById(practice, task.targetEventId);
     case "undo":
       return Boolean(blockById(practice, task.targetEventId));
+    // Opened, then closed: the reveal-and-dismiss is the whole lesson.
+    case "legend":
+    case "pageJump":
+    case "palette":
+      return state.simOverlayOpened && state.simOverlay === null;
+    case "eventJump":
+      return (
+        state.simOverlayOpened &&
+        !state.jumpChipsShown &&
+        practice.focusedId === task.targetEventId
+      );
   }
 };
 
@@ -295,12 +380,66 @@ const applyKey = (state: GameState, key: GameKey): GameState => {
       const next = undoDelete(practice);
       return next === practice ? state : { ...state, practice: next };
     }
+    case "legend": {
+      if (state.simOverlay === "legend") return { ...state, simOverlay: null };
+      if (task.type !== "legend" || state.simOverlay) return state;
+      return { ...state, simOverlay: "legend", simOverlayOpened: true };
+    }
+    case "palette": {
+      if (state.simOverlay === "palette") return { ...state, simOverlay: null };
+      if (task.type !== "palette" || state.simOverlay) return state;
+      return { ...state, simOverlay: "palette", simOverlayOpened: true };
+    }
+    case "jump": {
+      if (task.type !== "eventJump") return state;
+      return {
+        ...state,
+        jumpChipsShown: !state.jumpChipsShown,
+        simOverlayOpened: true,
+      };
+    }
+    case "letter": {
+      if (!state.jumpChipsShown) return state;
+      const letters = getJumpLetters(practice);
+      const targetId = Object.keys(letters).find(
+        (id) => letters[id] === key.letter,
+      );
+      if (!targetId) return state;
+      return {
+        ...state,
+        jumpChipsShown: false,
+        practice: focusEvent(practice, targetId),
+      };
+    }
+    case "modHoldReveal": {
+      if (task.type !== "pageJump" || state.simOverlay) return state;
+      return { ...state, simOverlay: "pagejump", simOverlayOpened: true };
+    }
+    case "modHoldEnd": {
+      // Releasing Mod without a digit closes the reveal and resets the
+      // opened flag: the taught gesture is hold, then digit.
+      if (state.simOverlay !== "pagejump") return state;
+      return { ...state, simOverlay: null, simOverlayOpened: false };
+    }
+    case "pageJumpDigit": {
+      if (state.simOverlay !== "pagejump") return state;
+      if (key.digit !== "1" && key.digit !== "2") return state;
+      return { ...state, simOverlay: null };
+    }
+    case "closeOverlay": {
+      if (!state.simOverlay) return state;
+      // Esc aborts the page-jump reveal (Mod is still held); on the legend
+      // and palette it is a taught way to close them, so it completes.
+      return state.simOverlay === "pagejump"
+        ? { ...state, simOverlay: null, simOverlayOpened: false }
+        : { ...state, simOverlay: null };
+    }
   }
 };
 
 const completeIfDone = (state: GameState, nowMs: number): GameState => {
   const task = currentTask(state);
-  if (!task || !isTaskComplete(task, state.practice)) return state;
+  if (!task || !isTaskComplete(task, state)) return state;
 
   const elapsed = nowMs - state.taskStartedAtMs;
   const speedy = elapsed <= SPEED_BONUS_MS;
@@ -326,18 +465,45 @@ const completeIfDone = (state: GameState, nowMs: number): GameState => {
   };
 
   if (advanced.taskIndex >= RUN_TASKS.length) {
-    const remainingSeconds = Math.max(
-      0,
-      Math.floor((state.endsAtMs - nowMs) / 1000),
-    );
+    // The time bonus needs a timed run finished before the buzzer with no
+    // skips, or Esc-ing through tasks would farm remaining seconds.
+    const fullClear =
+      state.timed && !state.buzzer && advanced.tasksDone === RUN_TASKS.length;
+    const remainingSeconds = fullClear
+      ? Math.max(0, Math.floor((state.endsAtMs - nowMs) / 1000))
+      : 0;
     const timeBonus = remainingSeconds * TIME_BONUS_PER_SECOND;
     return {
       ...advanced,
       phase: "ended",
-      outcome: "cleared",
+      outcome: state.buzzer ? "overtime" : "cleared",
       endedAtMs: nowMs,
       timeBonus,
       score: advanced.score + timeBonus,
+    };
+  }
+  return enterTask(advanced);
+};
+
+/**
+ * Esc mid-run: advance past the current task with no points. Skipping the
+ * last task ends the run through the same outcome logic as a clear.
+ */
+export const skipCurrentTask = (state: GameState, nowMs: number): GameState => {
+  if (state.phase !== "running" || !currentTask(state)) return state;
+  const advanced: GameState = {
+    ...state,
+    taskIndex: state.taskIndex + 1,
+    tasksSkipped: state.tasksSkipped + 1,
+    streak: 0,
+    taskStartedAtMs: nowMs,
+  };
+  if (advanced.taskIndex >= RUN_TASKS.length) {
+    return {
+      ...advanced,
+      phase: "ended",
+      outcome: state.buzzer ? "overtime" : "cleared",
+      endedAtMs: nowMs,
     };
   }
   return enterTask(advanced);
@@ -352,4 +518,47 @@ export const handleGameKey = (
   const next = applyKey(state, key);
   if (next === state) return state;
   return completeIfDone(next, nowMs);
+};
+
+/**
+ * Which chip in `task.keycaps` the player should press next, so the task
+ * card can dim what's done and pulse what's expected. Derived entirely from
+ * the board, so a wrong turn self-corrects. `keycaps.length` means every
+ * chip is behind the player (e.g. the H task, where the next key is the
+ * letter on a block, not a card chip).
+ */
+export const getNextKeycapIndex = (
+  task: GameTask,
+  state: GameState,
+): number => {
+  const { practice } = state;
+  switch (task.type) {
+    case "place": {
+      const block = blockById(practice, task.piece.id);
+      if (!block) return 0;
+      if (
+        practice.placingId === task.piece.id &&
+        !matchesSlot(block, task.target)
+      ) {
+        return 1;
+      }
+      return task.keycaps.length - 1;
+    }
+    case "quickTime": {
+      const enterIndex = task.keycaps.length - 1;
+      if (blockById(practice, task.piece.id)) return enterIndex;
+      return Math.min(state.digitBuffer.length, enterIndex - 1);
+    }
+    case "resize":
+      return practice.focusedId === task.targetEventId &&
+        practice.edge === "end"
+        ? 1
+        : 0;
+    case "eventJump":
+      return state.jumpChipsShown ? task.keycaps.length : 0;
+    case "pageJump":
+      return state.simOverlay === "pagejump" ? 1 : 0;
+    default:
+      return 0;
+  }
 };

--- a/packages/web/src/components/ShortcutShowcase/game.tasks.ts
+++ b/packages/web/src/components/ShortcutShowcase/game.tasks.ts
@@ -3,13 +3,14 @@ import { type PracticeEventBlock } from "@web/components/ShortcutShowcase/practi
 import { KEYMAP } from "@web/shortcuts/keymap";
 
 /**
- * Schedule Rush: one 90-second run against a fixed, authored queue of
- * scheduling tasks. Deterministic on purpose — ramped difficulty, and every
- * run is scriptable in tests. Keycaps derive from KEYMAP so a remap
- * propagates to the cards.
+ * Block Party: one run against a fixed, authored queue of scheduling tasks.
+ * The first run is untimed practice; replays can race the clock.
+ * Deterministic on purpose: ramped difficulty, and every run is scriptable
+ * in tests. Keycaps derive from KEYMAP so a remap propagates to the cards.
  */
 
-export const RUN_DURATION_MS = 90_000;
+/** The clock for a timed run. Expiry snapshots the score; it never ends the run. */
+export const RUN_DURATION_MS = 120_000;
 export const TASK_BASE_POINTS = 100;
 /** Clear a task this fast to earn the speed bonus and grow the streak. */
 export const SPEED_BONUS_MS = 8_000;
@@ -28,7 +29,11 @@ export type GameTaskType =
   | "nudge"
   | "resize"
   | "delete"
-  | "undo";
+  | "undo"
+  | "legend"
+  | "eventJump"
+  | "pageJump"
+  | "palette";
 
 type GameTaskBase = {
   id: string;
@@ -65,7 +70,11 @@ export type GameTask =
       targetEventId: string;
       /** Where the restored block lands, so the ghost can show it. */
       target: GameSlot;
-    });
+    })
+  // Discovery beats: open a simulated overlay (legend / page-jump numbers /
+  // command palette) or jump to a block by its letter chip. No board change.
+  | (GameTaskBase & { type: "legend" | "pageJump" | "palette" })
+  | (GameTaskBase & { type: "eventJump"; targetEventId: string });
 
 const t = (hour: number, minute = 0) => hour * 60 + minute;
 
@@ -131,7 +140,7 @@ export const RUN_TASKS: readonly GameTask[] = [
     id: "nudge-standup",
     type: "nudge",
     title: "Standup moved",
-    instruction: "Push it down to 10:00 — hold Shift, tap the arrow.",
+    instruction: "Push it down to 10:00. Hold Shift and tap the arrow.",
     keycaps: ["Shift", "ArrowDown"],
     targetEventId: "piece-standup",
     target: { dayIndex: 0, startMin: t(10), endMin: t(10, 30) },
@@ -140,8 +149,9 @@ export const RUN_TASKS: readonly GameTask[] = [
     id: "resize-one-on-one",
     type: "resize",
     title: "1:1 running long",
-    instruction: "Tab to its end edge, then stretch it to 11:00.",
-    keycaps: [KEYMAP.edgeFocus.hotkey, ...KEYMAP.moveEvent.timedEdgeKeycaps],
+    instruction:
+      "Press Tab until the bottom edge lights up, then hold Shift and tap Down to reach 11:00.",
+    keycaps: [KEYMAP.edgeFocus.hotkey, "Shift", "ArrowDown"],
     targetEventId: "game-one-on-one",
     target: { dayIndex: 1, startMin: t(10), endMin: t(11) },
   },
@@ -149,7 +159,7 @@ export const RUN_TASKS: readonly GameTask[] = [
     id: "quicktime-focus",
     type: "quickTime",
     title: "Focus block",
-    instruction: "Guard Tuesday at 4 — type the time.",
+    instruction: "Guard Tuesday at 4. Just type the time.",
     keycaps: ["1", "6", "0", "0", "Enter"],
     piece: { id: "piece-focus", title: "Deep work", color: "slate" },
     target: { dayIndex: 1, startMin: t(16), endMin: t(17) },
@@ -165,11 +175,42 @@ export const RUN_TASKS: readonly GameTask[] = [
   {
     id: "undo-gym",
     type: "undo",
-    title: "Wait — it's back on",
+    title: "Wait, it's back on",
     instruction: "Undo brings it right back.",
     keycaps: KEYMAP.undo.keycaps,
     targetEventId: "game-gym",
     target: { dayIndex: 2, startMin: t(12), endMin: t(13) },
+  },
+  {
+    id: "legend-peek",
+    type: "legend",
+    title: "Blanking on a move?",
+    instruction: "The legend lists every shortcut. Open it, then close it.",
+    keycaps: ["?"],
+  },
+  {
+    id: "jump-to-kickoff",
+    type: "eventJump",
+    title: "Fly across the board",
+    instruction:
+      "Press H to reveal jump letters, then type the one on Team kickoff.",
+    keycaps: KEYMAP.eventJump.keycaps,
+    targetEventId: "game-kickoff",
+  },
+  {
+    id: "page-jump-peek",
+    type: "pageJump",
+    title: "Numbers jump anywhere",
+    instruction:
+      "Hold Cmd or Ctrl until the jump numbers appear, then press 1.",
+    keycaps: ["Mod", "1"],
+  },
+  {
+    id: "palette-peek",
+    type: "palette",
+    title: "One palette, every command",
+    instruction: "Open the command palette, then close it with Esc.",
+    keycaps: KEYMAP.commandPalette.keycaps,
   },
   {
     id: "nudge-review",
@@ -194,13 +235,14 @@ export const RUN_TASKS: readonly GameTask[] = [
 
 /** Dashed outline shown on the grid for the current task, if it has one. */
 export const getTaskGhost = (task: GameTask): GameSlot | null =>
-  task.type === "delete" ? null : task.target;
+  "target" in task ? task.target : null;
 
 /** The block a completed task touched, so the lock-in flash can find it. */
 export const getTaskBlockId = (taskId: string): string | null => {
   const task = RUN_TASKS.find((candidate) => candidate.id === taskId);
   if (!task || task.type === "delete") return null;
-  return "piece" in task ? task.piece.id : task.targetEventId;
+  if ("piece" in task) return task.piece.id;
+  return "targetEventId" in task ? task.targetEventId : null;
 };
 
 export type LearnedMove = { label: string; keys: readonly string[] };
@@ -225,6 +267,10 @@ const MOVE_LABELS: Record<GameTaskType, LearnedMove> = {
   },
   delete: { label: "Delete", keys: ["Delete"] },
   undo: { label: "Undo", keys: KEYMAP.undo.keycaps },
+  legend: { label: "Shortcut legend", keys: ["?"] },
+  eventJump: { label: "Jump to an event", keys: KEYMAP.eventJump.keycaps },
+  pageJump: { label: "Jump anywhere", keys: KEYMAP.jumpPageTarget.keycaps },
+  palette: { label: "Command palette", keys: KEYMAP.commandPalette.keycaps },
 };
 
 /** The distinct moves the player actually used, in the order they met them. */

--- a/packages/web/src/components/ShortcutShowcase/play-link.tsx
+++ b/packages/web/src/components/ShortcutShowcase/play-link.tsx
@@ -1,0 +1,39 @@
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { type FC, useEffect } from "react";
+import { shortcutShowcaseActions } from "@web/components/ShortcutShowcase/showcase.store";
+import { markWelcomeSeen } from "@web/components/WelcomeModal/welcome.modal.util";
+
+/**
+ * Synchronous read of the ?play= deep link, for the two spots that decide
+ * before the router-driven consumer below can run: the welcome modal's
+ * open-on-mount initializer and the showcase's resume-in-progress effect.
+ */
+export const hasPlayDeepLink = (): boolean =>
+  new URLSearchParams(window.location.search).has("play");
+
+/**
+ * Consumes a shared ?play=1 link: an explicit request to play Block Party,
+ * so it skips the welcome modal (the end screen still carries the signup
+ * CTA) and starts even for players who finished the game before. Consume
+ * and strip, so a reload does not restart the run. Lives apart from
+ * ShortcutShowcase because it needs the router, which the takeover's tests
+ * render without; sessions where RootShell gates the mount (mobile,
+ * billing) simply ignore the param.
+ */
+export const ShowcasePlayLink: FC = () => {
+  const { play } = useSearch({ from: "__root__" });
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!play) return;
+    markWelcomeSeen();
+    shortcutShowcaseActions.startFromLink();
+    navigate({
+      to: ".",
+      replace: true,
+      search: (prev) => ({ ...prev, play: undefined }),
+    });
+  }, [play, navigate]);
+
+  return null;
+};

--- a/packages/web/src/components/ShortcutShowcase/showcase.storage.ts
+++ b/packages/web/src/components/ShortcutShowcase/showcase.storage.ts
@@ -26,9 +26,9 @@ export function markShortcutShowcaseSeen(): void {
 }
 
 /**
- * A 90-second game has no mid-run resume point: any stored value under the
- * old step key — the sentinel below, or a lesson step id written before the
- * game shipped — just means "an unfinished attempt exists", and a reload
+ * A single-sitting game has no mid-run resume point: any stored value under the
+ * old step key (the sentinel below, or a lesson step id written before the
+ * game shipped) just means "an unfinished attempt exists", and a reload
  * re-offers the game from its how-to card.
  */
 export function hasShowcaseInProgress(): boolean {

--- a/packages/web/src/components/ShortcutShowcase/showcase.store.test.ts
+++ b/packages/web/src/components/ShortcutShowcase/showcase.store.test.ts
@@ -39,6 +39,17 @@ describe("shortcutShowcaseActions", () => {
     ).not.toBe("true");
   });
 
+  it("activates from a shared link even after the showcase was seen", () => {
+    shortcutShowcaseActions.startFromWelcome();
+    shortcutShowcaseActions.finish();
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
+
+    shortcutShowcaseActions.startFromLink();
+    const state = useShortcutShowcaseStore.getState();
+    expect(state.isActive).toBe(true);
+    expect(state.entry).toBe("link");
+  });
+
   it("finish leaves, marks seen, and clears the in-progress marker", () => {
     shortcutShowcaseActions.startFromWelcome();
     shortcutShowcaseActions.finish();

--- a/packages/web/src/components/ShortcutShowcase/showcase.store.ts
+++ b/packages/web/src/components/ShortcutShowcase/showcase.store.ts
@@ -11,7 +11,7 @@ import {
 } from "@web/components/ShortcutShowcase/showcase.storage";
 
 /** How the practice arena was opened, so the activation funnel can tell them apart. */
-export type ShowcaseEntry = "welcome" | "post_signup" | "palette";
+export type ShowcaseEntry = "welcome" | "post_signup" | "palette" | "link";
 
 /** Where a user who left early went next, so the funnel can tell them apart. */
 export type ShowcaseExit = "calendar" | "signup";
@@ -23,7 +23,7 @@ export type ShortcutShowcaseState = {
   isActive: boolean;
   /**
    * True once markSeen ran this session, so components re-render when the
-   * flag flips — a localStorage write notifies nobody. Storage stays the
+   * flag flips (a localStorage write notifies nobody). Storage stays the
    * durable source; readers check this OR the stored flag.
    */
   hasSeenShowcase: boolean;
@@ -79,6 +79,10 @@ export const shortcutShowcaseActions = {
   /** Palette re-entry: always allowed. The how-to card is one Enter long. */
   replay: () => {
     activate("palette");
+  },
+  /** A shared ?play=1 link: an explicit request, so no seen-flag gating. */
+  startFromLink: () => {
+    activate("link");
   },
   /**
    * Re-offer an unfinished attempt after reload, from the how-to card. Does

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -9,6 +9,7 @@ import { useDismissTransition } from "@web/common/hooks/useDismissTransition";
 import { GoogleButton } from "@web/components/AuthModal/components/GoogleButton";
 import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
+import { hasPlayDeepLink } from "@web/components/ShortcutShowcase/play-link";
 import { shortcutShowcaseActions } from "@web/components/ShortcutShowcase/showcase.store";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 import { keyboardKey } from "@web/shortcuts/is-bare-letter-key";
@@ -28,8 +29,11 @@ export function WelcomeModal() {
   const isGoogleAvailable = useIsGoogleAvailable();
   const { loading: isGoogleAuthLoading, startGoogleAuthorization } =
     useStartGoogleAuthorization({ intent: "signIn" });
+  // A ?play= deep link goes straight to the practice game. This initializer
+  // runs before ShowcasePlayLink's consume effect can mark welcome seen, so
+  // the param itself has to keep this modal closed.
   const [isOpen, setIsOpen] = useState(
-    () => !authenticated && !hasSeenWelcome(),
+    () => !authenticated && !hasSeenWelcome() && !hasPlayDeepLink(),
   );
   const { closing, beginDismiss, cancelDismiss } =
     useDismissTransition(MODAL_DISMISS_MS);

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -157,6 +157,7 @@
   --animate-showcase-enter-stage: showcaseEnterStage 550ms
     cubic-bezier(0.16, 1, 0.3, 1) forwards;
   --animate-keycap-flash: keycapFlash 700ms ease-out both;
+  --animate-keycap-next: keycapNext 1.1s ease-in-out infinite;
   --animate-game-score-pop: gameScorePop 900ms ease-out forwards;
   --animate-game-lock-flash: gameLockFlash 450ms ease-out both;
   --animate-game-focus-pulse: gameFocusPulse 1.4s ease-in-out infinite;
@@ -238,6 +239,18 @@
     35% {
       transform: scale(1.2);
       box-shadow: 0 0 0 2px var(--color-text);
+    }
+  }
+
+  /* The exact next key to press pulses until it is pressed. */
+  @keyframes keycapNext {
+    0%,
+    100% {
+      box-shadow: 0 0 0 1px var(--color-accent);
+    }
+    50% {
+      box-shadow: 0 0 0 3px
+        color-mix(in srgb, var(--color-accent) 45%, transparent);
     }
   }
 
@@ -591,6 +604,18 @@
 @utility c-keycap-flash {
   animation: var(--animate-keycap-flash);
   @apply motion-reduce:animate-none;
+}
+
+/* The task card's "press this next" chip: accent border, gentle pulse. */
+@utility c-keycap-next {
+  border-color: var(--color-accent);
+  color: var(--color-text);
+  animation: var(--animate-keycap-next);
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+    box-shadow: 0 0 0 1px var(--color-accent);
+  }
 }
 
 @utility c-shortcut-flash {


### PR DESCRIPTION
Reworks the onboarding practice game per founder feedback, renamed to **Block Party**.

## What changed

- **Untimed first run**: the first run is pure practice with no clock (HUD shows "Practice" + score/streak). The how-to card and end screen offer a timed "Race the clock" rematch (`T` / `P`).
- **The buzzer never ends a run**: when a timed run's clock hits zero, the score freezes into a buzzer snapshot and play continues; the end screen shows both the final and at-the-buzzer scores (`overtime` outcome replaces `time_up`).
- **Esc skips one task**, never the game. Leaving mid-run is the two-click "Leave practice" button; Esc still leaves from the how-to and end screens. Time bonus now requires a timed, unskipped, pre-buzzer full clear so Esc-spam can't farm points.
- **Reactive keycap hints**: the task card dims pressed keycaps and pulses the exact next key (new `c-keycap-next` utility, chord-aware, reduced-motion fallback).
- **Clear edge focus** on the "1:1 running long" task: the whole-block ring dims and a thick accent bar marks the focused edge; rewritten instruction + trimmed keycaps.
- **Four new discovery tasks** (queue is now 14): `?` legend, `H` event-jump letters (chips rendered on the practice blocks), Mod-hold page-jump numbers, and `Mod+K` palette, all simulated inside the arena so real overlays can never bury a run. The end screen's `?`/`h` text teaser is gone.
- **Removed the "Enable reminders" CTA** from the end screen.
- **Shareable deep link**: `?play=1` on any URL starts the game directly (consume-and-strip via a router-aware `ShowcasePlayLink`; welcome modal bypassed; works for fresh and returning visitors). The router JSON-parses search values, so the validator accepts string/number/boolean.
- Rename is user-facing strings only; analytics event names and storage keys are untouched (new additive properties: `timed`, `tasks_skipped`, `buzzer_score`, entry `"link"`, event `shortcut_game_task_skipped`). Timed run length 90s -> 120s for the longer queue. All em dashes removed from game copy and comments.

## Testing

- `game.state.test.ts` 22 tests (buzzer, skip, discovery completions, keycap progress)
- `ShortcutShowcase.test.tsx` 20 tests (Esc semantics, overlay-close-before-skip, leave button, timed/untimed HUD, CTA changes)
- e2e `shortcut-showcase.spec.ts`: 9 tests including the full 14-task run (with real Mod-hold) and the `?play=1` fresh-visitor flow
- `bun run lint` + `bun run type-check` clean; full web suite green
- Visually verified via screenshots: keycap progression, edge focus, sim overlays, jump letters, overtime HUD, end screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)