### PR TITLE
fix(onboarding): reactive discovery chips and end-screen-only timed start

### DIFF
--- a/e2e/onboarding/shortcut-showcase.spec.ts
+++ b/e2e/onboarding/shortcut-showcase.spec.ts
@@ -172,17 +172,27 @@ test("a full run clears the queue, shows the score, and graduates", async ({
   ).toBeVisible();
 });
 
-test("T races the clock and the buzzer never ends the run", async ({
+test("the end screen's rematch races the clock with a full timer", async ({
   page,
 }) => {
   await page.goto("/week", { waitUntil: "domcontentloaded" });
   await leaveWelcome(page);
 
+  // The how-to card only starts practice: no timed option up front.
   const showcase = page.getByRole("region", { name: "Shortcut practice" });
   await expect(
-    showcase.getByRole("button", { name: "Race the clock" }),
+    showcase.getByRole("button", { name: "Start practicing" }),
   ).toBeVisible();
-  await page.keyboard.press("t");
+  await expect(
+    showcase.getByRole("button", { name: /Race the clock/ }),
+  ).toHaveCount(0);
+  await startPracticing(page);
+
+  // Esc-skip the whole queue: the fastest road to the end screen.
+  await pressTimes(page, "Escape", 14);
+  await expect(showcase).toContainText("You cleared the week!");
+
+  await page.keyboard.press("p");
   await expect(showcase).toContainText("Task 1/14");
   await expect(showcase.getByRole("timer")).toBeVisible();
   await expect(showcase.getByRole("timer")).toContainText("2:00");

--- a/packages/web/src/components/ShortcutShowcase/GameHud.tsx
+++ b/packages/web/src/components/ShortcutShowcase/GameHud.tsx
@@ -87,20 +87,22 @@ export const GameHud: FC<{
 
 /**
  * The piece queue: the current task as a big card with its keycaps, and the
- * next two peeking underneath (the "next piece" preview). Chips ahead of
- * `nextKeycapIndex` are still to come, the chip at it pulses as the exact
- * next key, and chips behind it dim as done.
+ * next two peeking underneath (the "next piece" preview). `keycaps` comes in
+ * as a prop (getDisplayKeycaps) because a card's chips can change mid-task.
+ * Chips ahead of `nextKeycapIndex` are still to come, the chip at it pulses
+ * as the exact next key, and chips behind it dim as done.
  */
 export const GameTaskQueue: FC<{
   taskIndex: number;
+  keycaps: readonly string[];
   nextKeycapIndex: number;
-}> = ({ taskIndex, nextKeycapIndex }) => {
+}> = ({ taskIndex, keycaps, nextKeycapIndex }) => {
   const task: GameTask | undefined = RUN_TASKS[taskIndex];
   if (!task) return null;
   const upNext = RUN_TASKS.slice(taskIndex + 1, taskIndex + 3);
   // Shift/Mod lead a chord, so their partner chip pulses too. The page-jump
   // task is the exception: Mod is held alone first, the digit comes later.
-  const nextKey = task.keycaps[nextKeycapIndex];
+  const nextKey = keycaps[nextKeycapIndex];
   const chordPartnerIndex =
     task.type !== "pageJump" && (nextKey === "Shift" || nextKey === "Mod")
       ? nextKeycapIndex + 1
@@ -118,7 +120,7 @@ export const GameTaskQueue: FC<{
         <h3 className="font-semibold text-lg text-text">{task.title}</h3>
         <p className="pt-1 text-sm text-text-muted">{task.instruction}</p>
         <div className="flex items-center gap-1 pt-3">
-          {task.keycaps.map((key, index) => (
+          {keycaps.map((key, index) => (
             <ShortcutHint
               key={`${key}-${index}`}
               variant="keycap"

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
@@ -192,14 +192,39 @@ describe("ShortcutShowcase", () => {
     expect(screen.getByText("Practice")).toBeTruthy();
   });
 
-  it("T races the clock from the how-to card", () => {
+  it("offers no timed start from the how-to card", () => {
     render(<ShortcutShowcase />);
     act(() => shortcutShowcaseActions.startFromWelcome());
 
+    // The clock is only offered on the end screen, after a practice run.
+    expect(screen.queryByRole("button", { name: /Race the clock/ })).toBeNull();
     pressKey("t");
-    expect(screen.getByText(`Task 1/${RUN_TASKS.length}`)).toBeTruthy();
-    expect(screen.getByRole("timer")).toBeTruthy();
-    expect(screen.getByRole("timer").textContent).toBe("2:00");
+    expect(screen.queryByText(/^Task 1\//)).toBeNull();
+  });
+
+  it("swaps the task card's chips as the move unfolds", () => {
+    render(<ShortcutShowcase />);
+    act(() => shortcutShowcaseActions.startFromWelcome());
+    pressKey("Enter");
+
+    // Esc-skip to the jump task. With every board task skipped, letters run
+    // over the three seed events alone, so kickoff's chip is A here.
+    for (let i = 0; i < 9; i += 1) pressKey("Escape");
+    expect(screen.getByText("Fly across the board")).toBeTruthy();
+    expect(screen.getByText("A")).toBeTruthy();
+    pressKey("h");
+    // The chips on the blocks join the one already on the card.
+    expect(screen.getAllByText("A").length).toBe(2);
+
+    // Skip past the jump and page-jump tasks to reach the palette task:
+    // its Mod+K hint becomes Esc once the palette opens.
+    pressKey("Escape");
+    pressKey("Escape");
+    expect(screen.getByText("One palette, every command")).toBeTruthy();
+    expect(screen.getByText("K")).toBeTruthy();
+    pressKey("k", modInit());
+    expect(screen.queryByText("K")).toBeNull();
+    expect(screen.getAllByText("Esc").length).toBe(2);
   });
 
   it("clears the queue with the taught keys and reaches the end screen", async () => {

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
@@ -16,6 +16,7 @@ import {
   createInitialGameState,
   currentTask,
   type GameKey,
+  getDisplayKeycaps,
   getJumpLetters,
   getNextKeycapIndex,
   handleGameKey,
@@ -108,9 +109,11 @@ const ShowcaseTakeover: FC = () => {
     setGame((state) => handleGameKey(state, key, Date.now()));
   };
 
-  const begin = (timed: boolean) => {
+  // The how-to card only starts practice runs; the timed challenge waits on
+  // the end screen, once the player has actually met the moves.
+  const begin = () => {
     setRemainingSeconds(RUN_DURATION_MS / 1000);
-    setGame((state) => startRun({ ...state, timed }, Date.now()));
+    setGame((state) => startRun(state, Date.now()));
   };
 
   const replay = (timed: boolean) => {
@@ -399,12 +402,7 @@ const ShowcaseTakeover: FC = () => {
     if (phase === "howto") {
       if (event.key === "Enter" && !event.repeat && !focusedButton) {
         claim(event);
-        begin(false);
-        return;
-      }
-      if (isBareLetterKey(event, "t") && !event.repeat) {
-        claim(event);
-        begin(true);
+        begin();
         return;
       }
       if (isBareLetterKey(event, "u") && !authenticated) {
@@ -563,26 +561,16 @@ const ShowcaseTakeover: FC = () => {
   const skipControls = (
     <div className="flex flex-wrap items-center gap-2 pt-2">
       {game.phase === "howto" && (
-        <>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              className={PRIMARY_BUTTON_CLASS}
-              onClick={() => begin(false)}
-            >
-              Start practicing
-            </button>
-            <ShortcutHint className="shrink-0">Enter</ShortcutHint>
-          </div>
+        <div className="flex items-center gap-2">
           <button
             type="button"
-            className={SECONDARY_BUTTON_CLASS}
-            onClick={() => begin(true)}
+            className={PRIMARY_BUTTON_CLASS}
+            onClick={begin}
           >
-            Race the clock
-            <ShortcutHint className="shrink-0">T</ShortcutHint>
+            Start practicing
           </button>
-        </>
+          <ShortcutHint className="shrink-0">Enter</ShortcutHint>
+        </div>
       )}
       {!authenticated && (
         <button
@@ -689,6 +677,7 @@ const ShowcaseTakeover: FC = () => {
             ) : (
               <GameTaskQueue
                 taskIndex={game.taskIndex}
+                keycaps={task ? getDisplayKeycaps(task, game) : []}
                 nextKeycapIndex={task ? getNextKeycapIndex(task, game) : 0}
               />
             )}

--- a/packages/web/src/components/ShortcutShowcase/game.state.test.ts
+++ b/packages/web/src/components/ShortcutShowcase/game.state.test.ts
@@ -3,6 +3,7 @@ import {
   currentTask,
   type GameKey,
   type GameState,
+  getDisplayKeycaps,
   getJumpLetters,
   getNextKeycapIndex,
   handleGameKey,
@@ -401,6 +402,41 @@ describe("keycap progress", () => {
 
     state = playKeys(state, [key.tab, key.tab], T0);
     expect(getNextKeycapIndex(task, state)).toBe(1);
+  });
+
+  it("shows the jump target's live letter on the card and pulses it after H", () => {
+    let state = playKeys(
+      startRun(createInitialGameState(), T0),
+      WINNING_SCRIPT.slice(0, 29),
+      T0,
+    );
+    const task = currentTask(state) as NonNullable<
+      ReturnType<typeof currentTask>
+    >;
+    expect(task.id).toBe("jump-to-kickoff");
+    // The full sequence is on the card up front: H, then kickoff's letter.
+    expect(getDisplayKeycaps(task, state)).toEqual(["H", "S"]);
+    expect(getNextKeycapIndex(task, state)).toBe(0);
+
+    state = handleGameKey(state, key.jump, T0);
+    expect(getNextKeycapIndex(task, state)).toBe(1);
+  });
+
+  it("swaps the palette card's hint to Esc while the sim palette is open", () => {
+    let state = playKeys(
+      startRun(createInitialGameState(), T0),
+      WINNING_SCRIPT.slice(0, 33),
+      T0,
+    );
+    const task = currentTask(state) as NonNullable<
+      ReturnType<typeof currentTask>
+    >;
+    expect(task.id).toBe("palette-peek");
+    expect(getDisplayKeycaps(task, state)).toEqual(task.keycaps);
+
+    state = handleGameKey(state, key.palette, T0);
+    expect(getDisplayKeycaps(task, state)).toEqual(["Esc"]);
+    expect(getNextKeycapIndex(task, state)).toBe(0);
   });
 });
 

--- a/packages/web/src/components/ShortcutShowcase/game.state.ts
+++ b/packages/web/src/components/ShortcutShowcase/game.state.ts
@@ -521,11 +521,30 @@ export const handleGameKey = (
 };
 
 /**
- * Which chip in `task.keycaps` the player should press next, so the task
- * card can dim what's done and pulse what's expected. Derived entirely from
- * the board, so a wrong turn self-corrects. `keycaps.length` means every
- * chip is behind the player (e.g. the H task, where the next key is the
- * letter on a block, not a card chip).
+ * The chips the task card shows. Usually the task's static keycaps, but a
+ * card can change chips as the move unfolds: the jump card carries the
+ * target's live letter (assigned by board order, so it shifts with skips),
+ * and the palette card's hint becomes the Esc that closes it.
+ */
+export const getDisplayKeycaps = (
+  task: GameTask,
+  state: GameState,
+): readonly string[] => {
+  if (task.type === "eventJump") {
+    const letter = getJumpLetters(state.practice)[task.targetEventId];
+    return letter ? [...task.keycaps, letter.toUpperCase()] : task.keycaps;
+  }
+  if (task.type === "palette" && state.simOverlay === "palette") {
+    return ["Esc"];
+  }
+  return task.keycaps;
+};
+
+/**
+ * Which display chip the player should press next, so the task card can dim
+ * what's done and pulse what's expected. Derived entirely from the board,
+ * so a wrong turn self-corrects. Indexes into `getDisplayKeycaps`: for the
+ * H task, `task.keycaps.length` is the appended letter chip.
  */
 export const getNextKeycapIndex = (
   task: GameTask,


### PR DESCRIPTION
Follow-ups to #3047 from first-run feedback:

- **How-to card starts practice only.** The "Race the clock" button and its T hotkey are gone from the first screen; the timed challenge is offered solely on the end-screen rematch, after the player has met the moves.
- **The jump task's card shows the keys as they go.** A new derived helper (`getDisplayKeycaps`) appends the target block's live jump letter to the card (letters are assigned by board order, so the chip always matches what's on the block), and it pulses as the next key once H reveals the chips.
- **The palette task's hint follows the move.** While the simulated palette is open, the card's Mod+K chips become the Esc that actually completes the task.

Verified: lint, type-check, 45 game unit tests (2 new reducer tests + 2 new component tests), full web suite (2 unrelated useAppAccess flakes pass in isolation), 9/9 onboarding e2e, and screenshots of each new card state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)