### PR TITLE
feat(web): allow pointer clicks on the life page

### DIFF
--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -335,6 +335,8 @@ On Day view, holding Mod reveals numbered chips left to right: `1` on the view d
 
 Compass is the keyboard calendar: pointer clicks, right-clicks, and double-clicks do not perform the clicked action (scroll and hover still work). A blocked click on a known action shows a transient, contextual hint with the keyboard path for that action. Clicking an event also activates its jump assignments and selects that event, so the displayed token plus Enter works immediately without first pressing `H`. Keyboard activation is unaffected: Enter/Space on a native button still works, Shift+F10 still opens the focused event's context menu, and `M` opens it directly.
 
+`/life` is the exception: it is a public lead magnet, so pointer clicks work there like a normal page. The calendar views stay keyboard-only.
+
 ### Steps
 
 1. Navigate to `/week` with at least one event visible.
@@ -470,7 +472,7 @@ If time is limited, run these checks before shipping shortcut-related changes:
 13. Cmd+D / Ctrl+D duplicates a focused event in Day and Week view.
 14. With a focused event, `E` then `T` opens the form with the title focused; `E` then `A` / `C` jump to guests / color; bare `E` alone does nothing.
 15. Pressing `H` shows event jump chips; a day letter + digit focuses that event; `Shift` + the day letter enters a column without a prior `H`; Shift+Tab does not show chips.
-16. Mouse clicks, right-clicks, and double-clicks are inert everywhere; a blocked click shows the keyboard-only hint. `M` opens the focused event's menu; `F` focuses the newest notice.
+16. Mouse clicks, right-clicks, and double-clicks are inert on calendar views; a blocked click shows the keyboard-only hint. `/life` allows normal clicks. `M` opens the focused event's menu; `F` focuses the newest notice.
 17. PageUp / PageDown scroll the timed grid by one viewport in Day and Week view even when an event is focused; they do not fire in a text input.
 18. Alt+ArrowUp / Alt+ArrowDown pan the timed grid by one hour in Day and Week view even when an event is focused; they do not fire in a text input.
 19. `Z` opens time travel in Day and Week view; Cmd+Z / Ctrl+Z still undoes and does not open the picker.

--- a/docs/frontend/contextual-pointer-guidance.md
+++ b/docs/frontend/contextual-pointer-guidance.md
@@ -23,6 +23,9 @@ of a generic legend. Acceptance coverage lives in
 
 Unannotated controls keep the generic keyboard-only fallback.
 
+`/life` does not suppress pointer events. Visitors who land on that page as a
+lead magnet can click controls normally; `PointerHint` is not mounted there.
+
 ## Adding a target
 
 - Add a `POINTER_ACTIONS` id.

--- a/docs/frontend/frontend-runtime-flow.md
+++ b/docs/frontend/frontend-runtime-flow.md
@@ -65,7 +65,9 @@ Files:
 prompt, global navigation / calendar-shell shortcuts, and pointer suppression.
 Those calendar-onboarding overlays are skipped on `/life` and on mobile OSes
 (the overlays would paint over `MobileGate`, so a phone user sees the gate
-first instead of a walkthrough they cannot use).
+first instead of a walkthrough they cannot use). Pointer suppression is also
+skipped on `/life` so first-time visitors can click the page like a normal
+site; the calendar views stay keyboard-only.
 
 Welcome → signup → first-event contract:
 

--- a/e2e/life/pointer-clicks.spec.ts
+++ b/e2e/life/pointer-clicks.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+
+// `/life` is a public lead magnet: first-time visitors can click like a
+// normal page. Calendar views stay keyboard-only (see mouse-inert.spec.ts).
+test("life page allows pointer clicks without the keyboard-only hint", async ({
+  page,
+}) => {
+  await page.goto("/life", { waitUntil: "domcontentloaded" });
+  await expect(page.getByRole("heading", { name: "Life" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Next life variation" }).click();
+  await expect(page.getByText("Long", { exact: true })).toBeVisible();
+  await expect(page.locator("[data-pointer-hint]")).toHaveCount(0);
+
+  await page.getByRole("textbox", { name: "Date of birth" }).click();
+  await expect(
+    page.getByRole("button", { name: "Previous month" }),
+  ).toBeVisible();
+  await expect(page.locator("[data-pointer-hint]")).toHaveCount(0);
+});

--- a/e2e/life/pointer-clicks.spec.ts
+++ b/e2e/life/pointer-clicks.spec.ts
@@ -8,7 +8,9 @@ test("life page allows pointer clicks without the keyboard-only hint", async ({
   await page.goto("/life", { waitUntil: "domcontentloaded" });
   await expect(page.getByRole("heading", { name: "Life" })).toBeVisible();
 
-  await page.getByRole("button", { name: "Next life variation" }).click();
+  await page
+    .getByRole("button", { name: "Next life variation", exact: true })
+    .click();
   await expect(page.getByText("Long", { exact: true })).toBeVisible();
   await expect(page.locator("[data-pointer-hint]")).toHaveCount(0);
 

--- a/packages/web/src/components/RootShell/RootShell.test.tsx
+++ b/packages/web/src/components/RootShell/RootShell.test.tsx
@@ -24,6 +24,7 @@ import {
   selectSettingsPage,
   useSettingsStore,
 } from "@web/settings/settings.store";
+import { pointerBlockActions } from "@web/shortcuts/keyboard-only/pointer-block.store";
 import {
   afterAll,
   afterEach,
@@ -266,28 +267,16 @@ describe("RootShell calendar onboarding on /life", () => {
     );
   });
 
-  it("lets pointer clicks change the life variation without a keyboard-only hint", async () => {
-    const user = userEvent.setup();
+  it("does not mount the keyboard-only pointer hint on /life", async () => {
     await renderShell("/life", { anonymous: true });
 
-    await user.click(
-      screen.getByRole("button", { name: "Next life variation" }),
-    );
-
-    expect(screen.getByText("Long")).toBeInTheDocument();
-    expect(document.querySelector("[data-pointer-hint]")).toBeNull();
-  });
-
-  it("opens the birth date picker from a pointer click", async () => {
-    const user = userEvent.setup();
-    await renderShell("/life", { anonymous: true });
-
-    await user.click(screen.getByRole("textbox", { name: "Date of birth" }));
+    act(() => {
+      pointerBlockActions.pulseBlockedClick();
+    });
 
     expect(
-      screen.getByRole("button", { name: "Previous month" }),
-    ).toBeInTheDocument();
-    expect(document.querySelector("[data-pointer-hint]")).toBeNull();
+      screen.queryByText(/Compass is keyboard only/i),
+    ).not.toBeInTheDocument();
   });
 
   it("still shows welcome on /week for a first-time anonymous visitor", async () => {

--- a/packages/web/src/components/RootShell/RootShell.test.tsx
+++ b/packages/web/src/components/RootShell/RootShell.test.tsx
@@ -266,6 +266,30 @@ describe("RootShell calendar onboarding on /life", () => {
     );
   });
 
+  it("lets pointer clicks change the life variation without a keyboard-only hint", async () => {
+    const user = userEvent.setup();
+    await renderShell("/life", { anonymous: true });
+
+    await user.click(
+      screen.getByRole("button", { name: "Next life variation" }),
+    );
+
+    expect(screen.getByText("Long")).toBeInTheDocument();
+    expect(document.querySelector("[data-pointer-hint]")).toBeNull();
+  });
+
+  it("opens the birth date picker from a pointer click", async () => {
+    const user = userEvent.setup();
+    await renderShell("/life", { anonymous: true });
+
+    await user.click(screen.getByRole("textbox", { name: "Date of birth" }));
+
+    expect(
+      screen.getByRole("button", { name: "Previous month" }),
+    ).toBeInTheDocument();
+    expect(document.querySelector("[data-pointer-hint]")).toBeNull();
+  });
+
   it("still shows welcome on /week for a first-time anonymous visitor", async () => {
     await renderShell("/week", { anonymous: true });
 

--- a/packages/web/src/components/RootShell/RootShell.tsx
+++ b/packages/web/src/components/RootShell/RootShell.tsx
@@ -46,7 +46,8 @@ import { isLifePathname } from "./isLifePathname";
  */
 export function RootShell() {
   const { pathname } = useLocation();
-  const deferCalendarOnboarding = isLifePathname(pathname);
+  const isLifeView = isLifePathname(pathname);
+  const deferCalendarOnboarding = isLifeView;
   // The keyboard onboarding overlays paint over MobileGate (they're fixed
   // full-screen), so a phone user would finish the whole walkthrough only to
   // land on "open this on a computer". Gate them up front instead.
@@ -59,7 +60,7 @@ export function RootShell() {
   usePlanChangeToasts();
   useNavigationShortcuts();
   useCalendarShellShortcuts();
-  usePointerSuppression();
+  usePointerSuppression(!isLifeView);
   useFocusNoticeShortcut();
   useEventContextMenuShortcut();
 
@@ -100,7 +101,7 @@ export function RootShell() {
       {showCalendarOnboarding && <ShortcutShowcase />}
       {showCalendarOnboarding && <FirstEventPrompt />}
       {gateStatus === null && isWelcomeGuideOpen && <WelcomeGuideModal />}
-      <PointerHint />
+      {!isLifeView && <PointerHint />}
     </AuthModalProvider>
   );
 }

--- a/packages/web/src/shortcuts/keyboard-only/pointer-block.test.ts
+++ b/packages/web/src/shortcuts/keyboard-only/pointer-block.test.ts
@@ -202,4 +202,40 @@ describe("createPointerBlockListener", () => {
     onPointerEvent(keyboardMenu.event);
     expect(keyboardMenu.preventDefault).not.toHaveBeenCalled();
   });
+
+  it("passes trusted pointer gestures when isEnabled returns false", () => {
+    const onBlockedGesture = mock(() => {});
+    const { onPointerEvent } = createPointerBlockListener({
+      isEnabled: () => false,
+      onBlockedGesture,
+    });
+
+    const down = fakeEvent({ type: "pointerdown" });
+    const click = fakeEvent({ type: "click", detail: 1 });
+    onPointerEvent(down.event);
+    onPointerEvent(click.event);
+
+    expect(down.preventDefault).not.toHaveBeenCalled();
+    expect(click.preventDefault).not.toHaveBeenCalled();
+    expect(onBlockedGesture).not.toHaveBeenCalled();
+  });
+
+  it("starts blocking again as soon as isEnabled returns true", () => {
+    let enabled = false;
+    const onBlockedGesture = mock(() => {});
+    const { onPointerEvent } = createPointerBlockListener({
+      isEnabled: () => enabled,
+      onBlockedGesture,
+    });
+
+    const allowed = fakeEvent({ type: "pointerdown" });
+    onPointerEvent(allowed.event);
+    expect(allowed.preventDefault).not.toHaveBeenCalled();
+
+    enabled = true;
+    const blocked = fakeEvent({ type: "pointerdown" });
+    onPointerEvent(blocked.event);
+    expect(blocked.preventDefault).toHaveBeenCalledTimes(1);
+    expect(onBlockedGesture).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/web/src/shortcuts/keyboard-only/pointer-block.ts
+++ b/packages/web/src/shortcuts/keyboard-only/pointer-block.ts
@@ -8,6 +8,9 @@
  * keyboard activation of every native button - the one thing a keyboard-only
  * app depends on. Synthetic .click() calls (react-datepicker's open path, the
  * Life view's derived clicks) are untrusted and must also pass.
+ *
+ * `/life` is a public lead magnet, so the listener can also no-op while
+ * `isEnabled` is false and let pointer gestures reach the page normally.
  */
 
 export const POINTER_BLOCK_EVENT_TYPES = [
@@ -72,10 +75,14 @@ export interface PointerBlockEvent {
  */
 export const createPointerBlockListener = (options: {
   onBlockedGesture: (event: PointerBlockEvent) => void;
+  /** When this returns false, pointer gestures pass through unblocked. */
+  isEnabled?: () => boolean;
 }) => {
   let lastBlockedPointerDownAt: number | null = null;
 
   const onPointerEvent = (event: PointerBlockEvent): void => {
+    if (options.isEnabled?.() === false) return;
+
     const msSinceBlockedPointerDown =
       lastBlockedPointerDownAt === null
         ? undefined

--- a/packages/web/src/shortcuts/keyboard-only/usePointerSuppression.ts
+++ b/packages/web/src/shortcuts/keyboard-only/usePointerSuppression.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import {
   type BlockedPointerAttempt,
   pointerGridIntentFromPointer,
@@ -14,16 +14,22 @@ import { pointerBlockActions } from "@web/shortcuts/keyboard-only/pointer-block.
 import { eventJumpActions } from "@web/shortcuts/shift-hint/event-jump.store";
 
 /**
- * Compass is the keyboard calendar: the mouse does nothing, permanently.
+ * Compass is the keyboard calendar: the mouse does nothing, permanently,
+ * except on `/life`. That page is a lead magnet for visitors who may not have
+ * an account and do not know Compass is keyboard-only, so clicks work there.
  * Window capture listeners run before React's delegated root listeners, so
  * pointer gestures never reach any handler. Scroll and hover stay live, and
  * shouldBlockPointerEvent passes keyboard-activation clicks (Enter/Space on a
  * native button), keyboard contextmenu (Shift+F10), and synthetic .click()
  * calls through. Blocked gestures pulse the store so PointerHint can teach.
  */
-export function usePointerSuppression() {
+export function usePointerSuppression(enabled = true) {
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
+
   useEffect(() => {
     const { onPointerEvent, onKeyDown } = createPointerBlockListener({
+      isEnabled: () => enabledRef.current,
       onBlockedGesture: (event) => {
         const path = event.composedPath?.() ?? [];
         const { attempt: baseAttempt, jumpEventId } =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`/life` is a lead magnet for people who may not have an account and do not know Compass is keyboard-only. Pointer suppression now no-ops on that route so clicks work like a normal page (header arrows, birth date picker, sidebar controls). Calendar views stay keyboard-only, and the keyboard-only hint is not mounted on `/life`.

![Life page after a click changes the variation to Long](https://cursor.com/artifacts/c/art-33f1075f-8fdb-4a97-acdb-b1b4bac5ddb6)
![Birth date picker opened by a mouse click on /life](https://cursor.com/artifacts/c/art-20cbc778-e2c6-4a41-b520-ae9465abd2a1)

<a href="https://cursor.com/agents/bc-ab6355b2-8344-4dbf-b936-7bdc24d9583b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flife_page_clicks_work.mp4"><img src="https://cursor.com/artifacts/c/art-3ffa8015-f14d-4a82-8e9c-bc0b26ba9251" alt="life_page_clicks_work.mp4" /></a>

## Simplicity

Reuses the existing `isLifePathname` gate in `RootShell` and a listener `isEnabled` callback. No new click handlers or per-control exceptions.

## Automated validation

- `bun test:web` on `pointer-block.test.ts` and `RootShell.test.tsx`: 31 pass
- Playwright `e2e/life/pointer-clicks.spec.ts`: 1 passed
- `bun run verify`: Selected packages: web. Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e. Checks skipped: (none). All checks passed.
- GitHub required checks: green
- Browser: clicked next variation to Long, opened the birth date picker, selected Jan 15. No keyboard-only hint.

## Independent review

VERDICT: no confirmed findings

The `/life` skip is pathname-gated in `RootShell`, the listener `isEnabled` ref updates immediately on navigation, and calendar mouse-inert e2e still passed.

## Test plan

- `bun test:web packages/web/src/shortcuts/keyboard-only/pointer-block.test.ts packages/web/src/components/RootShell/RootShell.test.tsx`
- `bunx playwright test e2e/life/pointer-clicks.spec.ts`
- `bun run verify`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab6355b2-8344-4dbf-b936-7bdc24d9583b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab6355b2-8344-4dbf-b936-7bdc24d9583b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

