### PR TITLE
feat(web): add shortcuts for start-trial and reconnect banners

### DIFF
--- a/packages/web/src/billing/BillingBanner.test.tsx
+++ b/packages/web/src/billing/BillingBanner.test.tsx
@@ -1,0 +1,91 @@
+import { HotkeyManager, HotkeysProvider } from "@tanstack/react-hotkeys";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
+import { BillingBanner } from "@web/billing/BillingBanner";
+import {
+  POINTER_ACTION_ATTRIBUTE,
+  POINTER_ACTIONS,
+  POINTER_SHORTCUT_ATTRIBUTE,
+} from "@web/shortcuts/keyboard-only/pointer-action";
+import { START_TRIAL_SHORTCUT_KEY } from "@web/shortcuts/notice-focus/useNoticeActionShortcut";
+import { eventJumpActions } from "@web/shortcuts/shift-hint/event-jump.store";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import "@testing-library/jest-dom";
+
+afterEach(() => {
+  cleanup();
+  eventJumpActions.reset();
+});
+
+const renderBanner = (onCta = mock(), disabled = false) =>
+  render(
+    <HotkeysProvider>
+      <BillingBanner
+        ctaLabel="Start your free 7-day trial to save changes"
+        disabled={disabled}
+        message="You're looking around in read-only mode."
+        onCta={onCta}
+        pointerAction={POINTER_ACTIONS.startTrial}
+        shortcutKey={START_TRIAL_SHORTCUT_KEY}
+      />
+    </HotkeysProvider>,
+  );
+
+describe("BillingBanner", () => {
+  beforeEach(() => {
+    HotkeyManager.resetInstance();
+    document.body.removeAttribute("data-app-locked");
+    eventJumpActions.reset();
+  });
+
+  it("shows an S keycap and starts the trial when S is pressed", () => {
+    const onCta = mock();
+    renderBanner(onCta);
+
+    const button = screen.getByRole("button", {
+      name: "Start your free 7-day trial to save changes",
+    });
+    expect(within(button).getByText("S")).toBeTruthy();
+    expect(button).toHaveAttribute(
+      POINTER_SHORTCUT_ATTRIBUTE,
+      START_TRIAL_SHORTCUT_KEY,
+    );
+    expect(button).toHaveAttribute(
+      POINTER_ACTION_ATTRIBUTE,
+      POINTER_ACTIONS.startTrial,
+    );
+
+    pressKey("S");
+
+    expect(onCta).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start the trial with S while disabled", () => {
+    const onCta = mock();
+    renderBanner(onCta, true);
+    pressKey("S");
+    expect(onCta).not.toHaveBeenCalled();
+  });
+
+  it("does not start the trial with S while event jump is active", () => {
+    const onCta = mock();
+    eventJumpActions.setActive(true);
+    renderBanner(onCta);
+    pressKey("S");
+    expect(onCta).not.toHaveBeenCalled();
+  });
+
+  it("still runs the CTA from a click in tests", async () => {
+    const onCta = mock();
+    const user = userEvent.setup();
+    renderBanner(onCta);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Start your free 7-day trial to save changes",
+      }),
+    );
+    expect(onCta).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/src/billing/BillingBanner.tsx
+++ b/packages/web/src/billing/BillingBanner.tsx
@@ -1,22 +1,37 @@
 import { type FC } from "react";
+import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
+import {
+  POINTER_ACTION_ATTRIBUTE,
+  type PointerActionId,
+  pointerShortcutAttributes,
+} from "@web/shortcuts/keyboard-only/pointer-action";
+import { useNoticeActionShortcut } from "@web/shortcuts/notice-focus/useNoticeActionShortcut";
 
 type BillingBannerProps = {
   message: string;
   ctaLabel: string;
   disabled?: boolean;
   onCta: () => void;
+  shortcutKey?: string;
+  pointerAction?: PointerActionId;
 };
 
 /**
  * The non-blocking billing notice. `data-notice` is what the notice-focus
  * shortcut scans for, so it belongs here rather than in each caller.
+ * A `shortcutKey` binds the CTA while the banner is mounted: clicks are
+ * blocked in keyboard-only mode, so the keycap is the path to the action.
  */
 export const BillingBanner: FC<BillingBannerProps> = ({
   message,
   ctaLabel,
   disabled = false,
   onCta,
+  shortcutKey,
+  pointerAction,
 }) => {
+  useNoticeActionShortcut(shortcutKey, onCta, { enabled: !disabled });
+
   return (
     <div
       className="flex items-center justify-center gap-3 border-warning/40 border-b bg-warning/10 px-4 py-2 text-sm text-text"
@@ -25,12 +40,17 @@ export const BillingBanner: FC<BillingBannerProps> = ({
     >
       <p>{message}</p>
       <button
-        className="c-focus-ring font-medium text-warning underline-offset-4 hover:underline"
+        className="c-focus-ring inline-flex items-center gap-2 font-medium text-warning underline-offset-4 hover:underline"
         disabled={disabled}
         onClick={onCta}
         type="button"
+        {...(shortcutKey ? pointerShortcutAttributes(shortcutKey) : {})}
+        {...(pointerAction
+          ? { [POINTER_ACTION_ATTRIBUTE]: pointerAction }
+          : {})}
       >
         {ctaLabel}
+        {shortcutKey ? <ShortcutKeys keys={shortcutKey} /> : null}
       </button>
     </div>
   );

--- a/packages/web/src/billing/BillingBanner.tsx
+++ b/packages/web/src/billing/BillingBanner.tsx
@@ -5,14 +5,17 @@ import {
   type PointerActionId,
   pointerShortcutAttributes,
 } from "@web/shortcuts/keyboard-only/pointer-action";
-import { useNoticeActionShortcut } from "@web/shortcuts/notice-focus/useNoticeActionShortcut";
+import {
+  type NoticeActionKey,
+  useNoticeActionShortcut,
+} from "@web/shortcuts/notice-focus/useNoticeActionShortcut";
 
 type BillingBannerProps = {
   message: string;
   ctaLabel: string;
   disabled?: boolean;
   onCta: () => void;
-  shortcutKey?: string;
+  shortcutKey?: NoticeActionKey;
   pointerAction?: PointerActionId;
 };
 

--- a/packages/web/src/billing/BillingReadOnlyBanner.tsx
+++ b/packages/web/src/billing/BillingReadOnlyBanner.tsx
@@ -1,10 +1,14 @@
 import { type FC } from "react";
 import { BillingBanner } from "@web/billing/BillingBanner";
 import { useBillingRedirect } from "@web/billing/useBillingRedirect";
+import { POINTER_ACTIONS } from "@web/shortcuts/keyboard-only/pointer-action";
+import { START_TRIAL_SHORTCUT_KEY } from "@web/shortcuts/notice-focus/useNoticeActionShortcut";
 
 /**
  * Shown while a gated user is looking around the real calendar. Writes still
  * fail server-side; this is the standing reminder of why, plus the way out.
+ * `S` matches the billing-gate Start trial binding so look-around keeps the
+ * same key after the overlay unmounts.
  */
 export const BillingReadOnlyBanner: FC = () => {
   const { isRedirecting, redirectTo } = useBillingRedirect();
@@ -15,6 +19,8 @@ export const BillingReadOnlyBanner: FC = () => {
       disabled={isRedirecting}
       message="You're looking around in read-only mode."
       onCta={() => void redirectTo("checkout", "banner_checkout")}
+      pointerAction={POINTER_ACTIONS.startTrial}
+      shortcutKey={START_TRIAL_SHORTCUT_KEY}
     />
   );
 };

--- a/packages/web/src/common/utils/toast/ToastActionButton.tsx
+++ b/packages/web/src/common/utils/toast/ToastActionButton.tsx
@@ -1,19 +1,11 @@
 import { type ReactNode } from "react";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
-import { isEventJumpActive } from "@web/shortcuts/shift-hint/event-jump.store";
-import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
-import { isEditSequenceArmed } from "@web/shortcuts/useEditSequenceShortcut";
+import {
+  NOTICE_PRIMARY_ACTION_KEY,
+  useNoticeActionShortcut,
+} from "@web/shortcuts/notice-focus/useNoticeActionShortcut";
 
-export const TOAST_PRIMARY_ACTION_KEY = "1";
-
-const canHandleShortcut = (event: KeyboardEvent) =>
-  !event.isComposing &&
-  !event.metaKey &&
-  !event.ctrlKey &&
-  !event.altKey &&
-  !event.shiftKey &&
-  !isEventJumpActive() &&
-  !isEditSequenceArmed();
+export const TOAST_PRIMARY_ACTION_KEY = NOTICE_PRIMARY_ACTION_KEY;
 
 export function ToastActionButton({
   children,
@@ -22,20 +14,7 @@ export function ToastActionButton({
   children: ReactNode;
   onClick: () => void;
 }) {
-  // Digit 1 runs this toast CTA while mounted. Yields to typing (ignoreInputs),
-  // app-lock, event-jump, and an armed `e`… sequence.
-  useAppShortcut(
-    TOAST_PRIMARY_ACTION_KEY,
-    (event) => {
-      if (!canHandleShortcut(event)) return;
-      onClick();
-    },
-    {
-      ignoreInputs: true,
-      preventDefault: true,
-      stopPropagation: true,
-    },
-  );
+  useNoticeActionShortcut(TOAST_PRIMARY_ACTION_KEY, onClick);
 
   return (
     <button

--- a/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.test.tsx
+++ b/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.test.tsx
@@ -1,19 +1,45 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { HotkeyManager, HotkeysProvider } from "@tanstack/react-hotkeys";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import "@testing-library/jest-dom";
+import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
+import {
+  POINTER_ACTION_ATTRIBUTE,
+  POINTER_ACTIONS,
+  POINTER_SHORTCUT_ATTRIBUTE,
+} from "@web/shortcuts/keyboard-only/pointer-action";
+import { NOTICE_PRIMARY_ACTION_KEY } from "@web/shortcuts/notice-focus/useNoticeActionShortcut";
+import { eventJumpActions } from "@web/shortcuts/shift-hint/event-jump.store";
 import { CalendarConnectionBanner } from "./CalendarConnectionBanner";
 
 afterEach(() => {
   cleanup();
+  eventJumpActions.reset();
 });
 
+const renderBanner = (
+  kind: "reconnect" | "importFailed" | "delayed",
+  onAction = mock(),
+) =>
+  render(
+    <HotkeysProvider>
+      <CalendarConnectionBanner kind={kind} onAction={onAction} />
+    </HotkeysProvider>,
+  );
+
 describe("CalendarConnectionBanner", () => {
+  beforeEach(() => {
+    HotkeyManager.resetInstance();
+    document.body.removeAttribute("data-app-locked");
+    eventJumpActions.reset();
+  });
+
   it("shows a reconnect action for revoked access", async () => {
     const onAction = mock();
     const user = userEvent.setup();
 
-    render(<CalendarConnectionBanner kind="reconnect" onAction={onAction} />);
+    renderBanner("reconnect", onAction);
 
     expect(screen.getByRole("alert")).toHaveTextContent(
       "Google Calendar needs reconnecting.",
@@ -22,13 +48,41 @@ describe("CalendarConnectionBanner", () => {
     expect(onAction).toHaveBeenCalledTimes(1);
   });
 
+  it("shows a 1 keycap and reconnects when 1 is pressed", () => {
+    const onAction = mock();
+    renderBanner("reconnect", onAction);
+
+    const button = screen.getByRole("button", { name: "Reconnect" });
+    expect(within(button).getByText("1")).toBeTruthy();
+    expect(button).toHaveAttribute(
+      POINTER_SHORTCUT_ATTRIBUTE,
+      NOTICE_PRIMARY_ACTION_KEY,
+    );
+    expect(button).toHaveAttribute(
+      POINTER_ACTION_ATTRIBUTE,
+      POINTER_ACTIONS.reconnectGoogle,
+    );
+
+    pressKey("1");
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reconnect with 1 while event jump is active", () => {
+    const onAction = mock();
+    eventJumpActions.setActive(true);
+    renderBanner("reconnect", onAction);
+
+    pressKey("1");
+
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
   it("shows retry when the first import failed", async () => {
     const onAction = mock();
     const user = userEvent.setup();
 
-    render(
-      <CalendarConnectionBanner kind="importFailed" onAction={onAction} />,
-    );
+    renderBanner("importFailed", onAction);
 
     expect(screen.getByRole("alert")).toHaveTextContent(
       "Couldn't add your calendar.",
@@ -41,7 +95,7 @@ describe("CalendarConnectionBanner", () => {
     const onAction = mock();
     const user = userEvent.setup();
 
-    render(<CalendarConnectionBanner kind="delayed" onAction={onAction} />);
+    renderBanner("delayed", onAction);
 
     expect(screen.getByRole("status")).toHaveTextContent(
       "Calendar updates are delayed.",

--- a/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.tsx
+++ b/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.tsx
@@ -1,5 +1,15 @@
 import { type FC } from "react";
 import { type CalendarConnectionBannerKind } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
+import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
+import {
+  POINTER_ACTION_ATTRIBUTE,
+  POINTER_ACTIONS,
+  pointerShortcutAttributes,
+} from "@web/shortcuts/keyboard-only/pointer-action";
+import {
+  NOTICE_PRIMARY_ACTION_KEY,
+  useNoticeActionShortcut,
+} from "@web/shortcuts/notice-focus/useNoticeActionShortcut";
 
 const COPY: Record<
   CalendarConnectionBannerKind,
@@ -30,6 +40,10 @@ export const CalendarConnectionBanner: FC<CalendarConnectionBannerProps> = ({
 }) => {
   const { message, action } = COPY[kind];
   const isError = kind === "reconnect" || kind === "importFailed";
+  const pointerAction =
+    kind === "reconnect" ? POINTER_ACTIONS.reconnectGoogle : undefined;
+
+  useNoticeActionShortcut(NOTICE_PRIMARY_ACTION_KEY, onAction);
 
   return (
     <div
@@ -43,11 +57,16 @@ export const CalendarConnectionBanner: FC<CalendarConnectionBannerProps> = ({
     >
       <p>{message}</p>
       <button
-        className="c-focus-ring shrink-0 rounded-xs px-2 py-1 font-medium text-text hover:bg-surface-overlay"
+        className="c-focus-ring inline-flex shrink-0 items-center gap-2 rounded-xs px-2 py-1 font-medium text-text hover:bg-surface-overlay"
         onClick={onAction}
         type="button"
+        {...pointerShortcutAttributes(NOTICE_PRIMARY_ACTION_KEY)}
+        {...(pointerAction
+          ? { [POINTER_ACTION_ATTRIBUTE]: pointerAction }
+          : {})}
       >
         {action}
+        <ShortcutKeys keys={NOTICE_PRIMARY_ACTION_KEY} />
       </button>
     </div>
   );

--- a/packages/web/src/components/PointerHint/PointerHint.test.tsx
+++ b/packages/web/src/components/PointerHint/PointerHint.test.tsx
@@ -81,6 +81,49 @@ describe("PointerHint", () => {
     expect(screen.getByRole("status")).not.toHaveTextContent("Press");
   });
 
+  it("teaches the start-trial shortcut for the banner CTA", () => {
+    render(<PointerHint />);
+
+    act(() => {
+      pointerBlockActions.pulseBlockedClick({
+        actionId: POINTER_ACTIONS.startTrial,
+        shortcutKey: "S",
+      });
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Press S to start your trial.",
+    );
+  });
+
+  it("teaches the reconnect shortcut for the banner CTA", () => {
+    render(<PointerHint />);
+
+    act(() => {
+      pointerBlockActions.pulseBlockedClick({
+        actionId: POINTER_ACTIONS.reconnectGoogle,
+        shortcutKey: "1",
+      });
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Press 1 to reconnect Google Calendar.",
+    );
+  });
+
+  it("teaches a bound shortcut key outside the welcome modal", () => {
+    render(<PointerHint />);
+
+    act(() => {
+      pointerBlockActions.pulseBlockedClick({
+        actionId: "unknown",
+        shortcutKey: "S",
+      });
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent("Press S");
+  });
+
   it("teaches the matching welcome shortcut for the attempted control", () => {
     welcomeGuideActions.setFirstVisitOpen(true);
     render(<PointerHint />);

--- a/packages/web/src/components/PointerHint/PointerHint.tsx
+++ b/packages/web/src/components/PointerHint/PointerHint.tsx
@@ -52,6 +52,8 @@ const isContextualAttempt = (attempt: BlockedPointerAttempt | null) =>
   attempt?.actionId === POINTER_ACTIONS.sidebarOpen ||
   attempt?.actionId === POINTER_ACTIONS.goToToday ||
   attempt?.actionId === POINTER_ACTIONS.eventOpen ||
+  attempt?.actionId === POINTER_ACTIONS.startTrial ||
+  attempt?.actionId === POINTER_ACTIONS.reconnectGoogle ||
   attempt?.actionId === "grid.timed" ||
   attempt?.actionId === "grid.all-day" ||
   Boolean(attempt?.shortcutKey);
@@ -125,7 +127,23 @@ const pointerHintMessage = ({
     );
   }
 
-  if (welcomeOpen && attempt?.shortcutKey) {
+  if (attempt?.actionId === POINTER_ACTIONS.startTrial) {
+    return (
+      <>
+        Press <Key>S</Key> to start your trial.
+      </>
+    );
+  }
+
+  if (attempt?.actionId === POINTER_ACTIONS.reconnectGoogle) {
+    return (
+      <>
+        Press <Key>1</Key> to reconnect Google Calendar.
+      </>
+    );
+  }
+
+  if (attempt?.shortcutKey) {
     return (
       <>
         Press <Key>{attempt.shortcutKey}</Key>

--- a/packages/web/src/shortcuts/keyboard-only/pointer-action.test.ts
+++ b/packages/web/src/shortcuts/keyboard-only/pointer-action.test.ts
@@ -101,6 +101,31 @@ describe("teachingFromBlockedPointer", () => {
       attempt: { actionId: POINTER_ACTIONS.goToToday },
     });
   });
+
+  it("teaches start-trial and reconnect from annotated banner CTAs", () => {
+    const trial = document.createElement("button");
+    trial.setAttribute(POINTER_ACTION_ATTRIBUTE, POINTER_ACTIONS.startTrial);
+    trial.setAttribute(POINTER_SHORTCUT_ATTRIBUTE, "S");
+    expect(teachingFromBlockedPointer([trial, document], 0)).toEqual({
+      attempt: {
+        actionId: POINTER_ACTIONS.startTrial,
+        shortcutKey: "S",
+      },
+    });
+
+    const reconnect = document.createElement("button");
+    reconnect.setAttribute(
+      POINTER_ACTION_ATTRIBUTE,
+      POINTER_ACTIONS.reconnectGoogle,
+    );
+    reconnect.setAttribute(POINTER_SHORTCUT_ATTRIBUTE, "1");
+    expect(teachingFromBlockedPointer([reconnect, document], 0)).toEqual({
+      attempt: {
+        actionId: POINTER_ACTIONS.reconnectGoogle,
+        shortcutKey: "1",
+      },
+    });
+  });
 });
 
 describe("pointerGridIntentFromPointer", () => {

--- a/packages/web/src/shortcuts/keyboard-only/pointer-action.ts
+++ b/packages/web/src/shortcuts/keyboard-only/pointer-action.ts
@@ -23,6 +23,8 @@ export const POINTER_ACTIONS = {
   goToToday: "calendar.today",
   sidebarClose: "sidebar.close",
   sidebarOpen: "sidebar.open",
+  startTrial: "billing.start-trial",
+  reconnectGoogle: "google.reconnect",
 } as const;
 
 export type PointerActionId =

--- a/packages/web/src/shortcuts/notice-focus/useNoticeActionShortcut.test.tsx
+++ b/packages/web/src/shortcuts/notice-focus/useNoticeActionShortcut.test.tsx
@@ -1,0 +1,65 @@
+import { HotkeyManager, HotkeysProvider } from "@tanstack/react-hotkeys";
+import { renderHook } from "@testing-library/react";
+import { type ReactNode } from "react";
+import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
+import { clearAppLockReasons, setAppLockReason } from "@web/shortcuts/app-lock";
+import { useNoticeActionShortcut } from "@web/shortcuts/notice-focus/useNoticeActionShortcut";
+import { eventJumpActions } from "@web/shortcuts/shift-hint/event-jump.store";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <HotkeysProvider>{children}</HotkeysProvider>
+);
+
+describe("useNoticeActionShortcut", () => {
+  beforeEach(() => {
+    HotkeyManager.resetInstance();
+    clearAppLockReasons();
+    eventJumpActions.reset();
+    document.body.removeAttribute("data-app-locked");
+  });
+
+  afterEach(() => {
+    clearAppLockReasons();
+    eventJumpActions.reset();
+  });
+
+  it("runs the action on the bound key", () => {
+    const onClick = mock();
+    renderHook(() => useNoticeActionShortcut("S", onClick), { wrapper });
+
+    pressKey("S");
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when no key is bound or the binding is disabled", () => {
+    const onClick = mock();
+    renderHook(() => useNoticeActionShortcut(undefined, onClick), { wrapper });
+    pressKey("1");
+    expect(onClick).not.toHaveBeenCalled();
+
+    renderHook(
+      () => useNoticeActionShortcut("S", onClick, { enabled: false }),
+      {
+        wrapper,
+      },
+    );
+    pressKey("S");
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("yields while app-locked or event jump is active", () => {
+    const onClick = mock();
+    renderHook(() => useNoticeActionShortcut("1", onClick), { wrapper });
+
+    setAppLockReason("commandPalette", true);
+    pressKey("1");
+    expect(onClick).not.toHaveBeenCalled();
+    clearAppLockReasons();
+
+    eventJumpActions.setActive(true);
+    pressKey("1");
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/shortcuts/notice-focus/useNoticeActionShortcut.ts
+++ b/packages/web/src/shortcuts/notice-focus/useNoticeActionShortcut.ts
@@ -3,10 +3,14 @@ import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 import { isEditSequenceArmed } from "@web/shortcuts/useEditSequenceShortcut";
 
 /** Digit on standing notice CTAs and action toasts while they are mounted. */
-export const NOTICE_PRIMARY_ACTION_KEY = "1";
+export const NOTICE_PRIMARY_ACTION_KEY = "1" as const;
 
 /** Start-trial banner CTA. Same letter as the billing gate overlay. */
-export const START_TRIAL_SHORTCUT_KEY = "S";
+export const START_TRIAL_SHORTCUT_KEY = "S" as const;
+
+export type NoticeActionKey =
+  | typeof NOTICE_PRIMARY_ACTION_KEY
+  | typeof START_TRIAL_SHORTCUT_KEY;
 
 const canHandleNoticeAction = (event: KeyboardEvent) =>
   !event.isComposing &&
@@ -23,12 +27,12 @@ const canHandleNoticeAction = (event: KeyboardEvent) =>
  * stand-down as toast `1` and focus-notice `f`.
  */
 export function useNoticeActionShortcut(
-  key: string | undefined,
+  key: NoticeActionKey | undefined,
   onClick: () => void,
   options: { enabled?: boolean } = {},
 ) {
   useAppShortcut(
-    key || NOTICE_PRIMARY_ACTION_KEY,
+    key ?? NOTICE_PRIMARY_ACTION_KEY,
     (event) => {
       if (!canHandleNoticeAction(event)) return;
       onClick();

--- a/packages/web/src/shortcuts/notice-focus/useNoticeActionShortcut.ts
+++ b/packages/web/src/shortcuts/notice-focus/useNoticeActionShortcut.ts
@@ -1,0 +1,43 @@
+import { isEventJumpActive } from "@web/shortcuts/shift-hint/event-jump.store";
+import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
+import { isEditSequenceArmed } from "@web/shortcuts/useEditSequenceShortcut";
+
+/** Digit on standing notice CTAs and action toasts while they are mounted. */
+export const NOTICE_PRIMARY_ACTION_KEY = "1";
+
+/** Start-trial banner CTA. Same letter as the billing gate overlay. */
+export const START_TRIAL_SHORTCUT_KEY = "S";
+
+const canHandleNoticeAction = (event: KeyboardEvent) =>
+  !event.isComposing &&
+  !event.metaKey &&
+  !event.ctrlKey &&
+  !event.altKey &&
+  !event.shiftKey &&
+  !isEventJumpActive() &&
+  !isEditSequenceArmed();
+
+/**
+ * Runs a mounted notice CTA (banner or toast) from a bare key. Yields to
+ * typing, app-lock, event-jump, and an armed `e`… sequence — the same
+ * stand-down as toast `1` and focus-notice `f`.
+ */
+export function useNoticeActionShortcut(
+  key: string | undefined,
+  onClick: () => void,
+  options: { enabled?: boolean } = {},
+) {
+  useAppShortcut(
+    key || NOTICE_PRIMARY_ACTION_KEY,
+    (event) => {
+      if (!canHandleNoticeAction(event)) return;
+      onClick();
+    },
+    {
+      enabled: Boolean(key) && (options.enabled ?? true),
+      ignoreInputs: true,
+      preventDefault: true,
+      stopPropagation: true,
+    },
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clicks are blocked in keyboard-only mode, so the look-around trial banner and the Google reconnect banner had no one-key path to their CTAs (`f` only focuses the notice).

- Start trial banner binds `S` (same letter as the billing-gate overlay) with a visible keycap.
- Reconnect / Retry / Refresh banner binds `1` (same digit as the action toasts) with a visible keycap.
- Blocked clicks on those CTAs teach the matching key instead of the generic legend hint.

## Simplicity

Shared `useNoticeActionShortcut` owns the yield rules (typing, app-lock, event-jump, `e` sequences). Toast `1` now uses that hook instead of a copy of the same stand-down.

## Automated validation

Focused web tests: `S` starts trial, `1` reconnects, both yield while event jump is active or the CTA is disabled.

`bun run verify`:

```
Selected packages: web
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)
All checks passed
```

e2e: 101 passed. Could not exercise the banners in a signed-in browser here: they need Stripe look-around and a reconnect-required Google account.

## Independent review

```
VERDICT: no confirmed findings
FINDINGS:
(none)
```

Gate overlay and look-around banner are mutually exclusive, so `S` does not double-bind. Banner `1` matches the existing toast CTA; `connect()` already no-ops a second OAuth start.

## Test plan

- `bun test:web` on BillingBanner, CalendarConnectionBanner, useNoticeActionShortcut, PointerHint, pointer-action, google-reconnect toast
- `bun run verify` (test:web, type-check, lint, knip, test:a11y, test:e2e)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59e11e67-f614-4d09-b530-da8be2d8a4f1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59e11e67-f614-4d09-b530-da8be2d8a4f1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

