### PR TITLE
fix(web): focus email when login and signup open

### DIFF
--- a/packages/web/src/components/AuthModal/AuthModal.test.tsx
+++ b/packages/web/src/components/AuthModal/AuthModal.test.tsx
@@ -1109,6 +1109,7 @@ describe("Shortcut hints", () => {
       ),
     ).toBeTruthy();
 
+    screen.getByRole("dialog").focus();
     await user.keyboard("u");
 
     await waitFor(() => {
@@ -1125,7 +1126,7 @@ describe("Shortcut hints", () => {
     await waitForAuthModal();
 
     const email = screen.getByLabelText(/email/i);
-    await user.click(email);
+    expect(email).toHaveFocus();
     await user.keyboard("user@example.com");
 
     expect(email).toHaveValue("user@example.com");
@@ -1143,6 +1144,7 @@ describe("Shortcut hints", () => {
       within(screen.getByRole("button", { name: /^log in$/i })).getByText("i"),
     ).toBeTruthy();
 
+    screen.getByRole("dialog").focus();
     await user.keyboard("i");
 
     await waitFor(() => {
@@ -1158,9 +1160,56 @@ describe("Shortcut hints", () => {
     await user.click(screen.getByRole("button", { name: /open modal/i }));
     await waitForAuthModal();
 
+    screen.getByRole("dialog").focus();
     await user.keyboard("g");
 
     expect(mockGoogleLogin).toHaveBeenCalled();
+  });
+});
+
+describe("Initial focus", () => {
+  beforeEach(() => {
+    installAuthModalTestSeams();
+  });
+
+  it("focuses email on login so typing can start immediately", async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(<div />, "/?auth=login");
+    await waitForAuthModal();
+
+    const email = screen.getByLabelText(/email/i);
+    expect(email).toHaveFocus();
+    await user.keyboard("returning@example.com");
+    expect(email).toHaveValue("returning@example.com");
+    expect(
+      screen.getByRole("heading", { name: /hey, welcome back/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("focuses email on signup so typing can start immediately", async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(<div />, "/?auth=signup");
+    await waitForAuthModal(/nice to meet you/i);
+
+    const email = screen.getByLabelText(/email/i);
+    expect(email).toHaveFocus();
+    await user.keyboard("new@example.com");
+    expect(email).toHaveValue("new@example.com");
+    expect(screen.getByLabelText(/name/i)).toHaveValue("");
+  });
+
+  it("reseats email when switching from login to signup", async () => {
+    const user = userEvent.setup();
+    await renderWithProviders(<div />, "/?auth=login");
+    await waitForAuthModal();
+
+    await user.click(screen.getByRole("button", { name: /^sign up$/i }));
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /nice to meet you/i }),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText(/email/i)).toHaveFocus();
   });
 });
 

--- a/packages/web/src/components/AuthModal/AuthModal.tsx
+++ b/packages/web/src/components/AuthModal/AuthModal.tsx
@@ -1,6 +1,13 @@
 import { DotIcon } from "@phosphor-icons/react";
 import { useSearch } from "@tanstack/react-router";
-import { type FC, useCallback, useEffect, useRef, useState } from "react";
+import {
+  type FC,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { consumeGoogleAuthNeedsConsentRetry } from "@web/auth/google/authorization/google-authorization.storage";
 import { useStartGoogleAuthorization } from "@web/auth/google/authorization/useStartGoogleAuthorization";
 import { useIsGoogleAvailable } from "@web/auth/google/hooks/useIsGoogleAvailable/useIsGoogleAvailable";
@@ -82,6 +89,8 @@ export const AuthModal: FC = () => {
 
   const [signUpName, setSignUpName] = useState("");
   const prevViewRef = useRef(currentView);
+  // OverlayPanel would otherwise seat the view-switch chip (first focusable).
+  const emailInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (prevViewRef.current !== "signUp" && currentView === "signUp") {
@@ -89,6 +98,18 @@ export const AuthModal: FC = () => {
     }
     prevViewRef.current = currentView;
   }, [currentView]);
+
+  useLayoutEffect(() => {
+    if (!isOpen) return;
+    if (
+      currentView !== "login" &&
+      currentView !== "loginAfterReset" &&
+      currentView !== "signUp"
+    ) {
+      return;
+    }
+    emailInputRef.current?.focus();
+  }, [currentView, isOpen]);
 
   const handleSwitchAuth = useCallback(
     () => setView(currentView === "signUp" ? "login" : "signUp"),
@@ -185,6 +206,7 @@ export const AuthModal: FC = () => {
           </button>
         ) : null
       }
+      initialFocusRef={emailInputRef}
       onDismiss={closeModal}
       variant="modal"
       widthClassName="w-120"
@@ -196,6 +218,7 @@ export const AuthModal: FC = () => {
             onSubmit={handleSignUp}
             onNameChange={setSignUpName}
             isSubmitting={isSubmitting}
+            emailInputRef={emailInputRef}
           />
         )}
         {isLoginView && (
@@ -203,6 +226,7 @@ export const AuthModal: FC = () => {
             onSubmit={handleLogin}
             onForgotPassword={navigateToForgotPassword}
             isSubmitting={isSubmitting}
+            emailInputRef={emailInputRef}
             statusMessage={
               currentView === "loginAfterReset"
                 ? "Password reset successful. Log in with your new password."

--- a/packages/web/src/components/AuthModal/forms/LogInForm.tsx
+++ b/packages/web/src/components/AuthModal/forms/LogInForm.tsx
@@ -1,4 +1,4 @@
-import { type FC } from "react";
+import { type FC, type RefObject } from "react";
 import {
   type LogInFormData,
   LogInSchema,
@@ -17,6 +17,8 @@ interface SignInFormProps {
   isSubmitting?: boolean;
   /** Optional status message shown above the form */
   statusMessage?: string | null;
+  /** Seats dialog focus on email so typing can start immediately. */
+  emailInputRef?: RefObject<HTMLInputElement | null>;
 }
 
 /**
@@ -29,6 +31,7 @@ export const LogInForm: FC<SignInFormProps> = ({
   onForgotPassword,
   isSubmitting,
   statusMessage,
+  emailInputRef,
 }) => {
   const form = useZodForm({
     schema: LogInSchema,
@@ -45,6 +48,7 @@ export const LogInForm: FC<SignInFormProps> = ({
       ) : null}
 
       <AuthInput
+        ref={emailInputRef}
         type="email"
         placeholder="Email"
         ariaLabel="Email"

--- a/packages/web/src/components/AuthModal/forms/LogInForm.tsx
+++ b/packages/web/src/components/AuthModal/forms/LogInForm.tsx
@@ -1,4 +1,4 @@
-import { type FC, type RefObject } from "react";
+import { type FC, type Ref } from "react";
 import {
   type LogInFormData,
   LogInSchema,
@@ -18,7 +18,7 @@ interface SignInFormProps {
   /** Optional status message shown above the form */
   statusMessage?: string | null;
   /** Seats dialog focus on email so typing can start immediately. */
-  emailInputRef?: RefObject<HTMLInputElement | null>;
+  emailInputRef?: Ref<HTMLInputElement>;
 }
 
 /**

--- a/packages/web/src/components/AuthModal/forms/SignUpForm.tsx
+++ b/packages/web/src/components/AuthModal/forms/SignUpForm.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, type FC, type RefObject, useCallback } from "react";
+import { type ChangeEvent, type FC, type Ref, useCallback } from "react";
 import {
   type SignUpFormData,
   SignUpSchema,
@@ -16,7 +16,7 @@ interface SignUpFormProps {
   /** Whether form submission is in progress */
   isSubmitting?: boolean;
   /** Seats dialog focus on email so typing can start immediately. */
-  emailInputRef?: RefObject<HTMLInputElement | null>;
+  emailInputRef?: Ref<HTMLInputElement>;
 }
 
 /**

--- a/packages/web/src/components/AuthModal/forms/SignUpForm.tsx
+++ b/packages/web/src/components/AuthModal/forms/SignUpForm.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, type FC, useCallback } from "react";
+import { type ChangeEvent, type FC, type RefObject, useCallback } from "react";
 import {
   type SignUpFormData,
   SignUpSchema,
@@ -15,6 +15,8 @@ interface SignUpFormProps {
   onNameChange?: (name: string) => void;
   /** Whether form submission is in progress */
   isSubmitting?: boolean;
+  /** Seats dialog focus on email so typing can start immediately. */
+  emailInputRef?: RefObject<HTMLInputElement | null>;
 }
 
 /**
@@ -26,6 +28,7 @@ export const SignUpForm: FC<SignUpFormProps> = ({
   onSubmit,
   onNameChange,
   isSubmitting,
+  emailInputRef,
 }) => {
   const form = useZodForm({
     schema: SignUpSchema,
@@ -56,6 +59,7 @@ export const SignUpForm: FC<SignUpFormProps> = ({
       />
 
       <AuthInput
+        ref={emailInputRef}
         type="email"
         placeholder="Email"
         ariaLabel="Email"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Opening login or signup from the welcome modal (`i` / `U`) left focus on the header view-switch chip, so the next keystrokes never reached a field.

The auth dialog now seats focus on the email input for login and signup, including after switching views, so typing can start immediately.

## Simplicity

Reuses OverlayPanel's existing `initialFocusRef` and a view-change `useLayoutEffect`. No new focus helper or dialog remount.

## Automated validation

- Welcome modal `i` then typing `returning@example.com` lands in login Email with no click.
- Welcome modal `U` then typing `new@example.com` lands in signup Email; Name stays empty.
- `bun run test:web -- packages/web/src/components/AuthModal/AuthModal.test.tsx`: 49 pass
- `bun run verify`: test:web, type-check, lint, knip, test:a11y, test:e2e all passed

## Independent review

No confirmed findings on the focus handoff. OverlayPanel still needs `initialFocusRef` so its mount effect does not steal focus back to the switch chip after the layout effect.

## Test plan

- `bun run test:web -- packages/web/src/components/AuthModal/AuthModal.test.tsx`
- `bun run type-check`
- `bun run verify`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-881f0fdd-305c-480e-bf25-93e7f8874436?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-881f0fdd-305c-480e-bf25-93e7f8874436&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

