### PR TITLE
fix(web): peel settings on escape and defer reconnect during trial gate

### DIFF
--- a/docs/acceptance/google-sync.md
+++ b/docs/acceptance/google-sync.md
@@ -42,6 +42,14 @@ Do not wait for a failed create/edit/delete (for example HTTP `410` with
 `GOOGLE_REVOKED`) to reveal the problem. Prefer steering the user toward
 reconnect before they invest time writing an event that will not save.
 
+The one exception is the billing gate. While `BillingGateModal` owns the
+screen (signed-in, read-only, not looking around, not celebrating checkout),
+do not show the reconnect or delayed-sync toast: Start trial is the only
+primary action. After "Look around first", or on a refused write, show the
+toast as usual. Sidebar and Settings status may still say reconnect is
+required during the gate; only the toast waits so it cannot compete with
+the conversion surface.
+
 ### One story across the UI
 
 Toast, sidebar status, Settings / Accounts status, and any other sync or auth

--- a/docs/features/billing.md
+++ b/docs/features/billing.md
@@ -90,6 +90,8 @@ production.
   `BILLING_REQUIRED` branch in `useEventMutations` exits the preview, so the
   first refused save brings the gate straight back. That refusal does not
   show the catch-all "something went wrong" toast — the gate is the feedback.
+  Google reconnect and delayed-sync toasts also wait until Look around (or a
+  write): they must not sit on top of Start trial.
 - **Trialing:** writable, with a days-left badge in the sidebar month picker
   header (`TrialBadge.tsx`, via `DatePicker`'s `headerEndContent` slot). The
   badge carries no `tabindex`: `getPageJumpFocusElement` seats Mod+2 on the

--- a/docs/frontend/shortcut-commandments.md
+++ b/docs/frontend/shortcut-commandments.md
@@ -86,6 +86,12 @@ Escape closes the open listbox, then the form, then event-jump, then the
 palette. A shortcut that swallows Escape while a floating layer is open
 is a bug. Floating layers register with `useFloatingLayer`.
 
+Dismissible `OverlayPanel`s (Settings, confirmations, About) listen for
+Escape on `document`, last-in-wins, so the key still peels the top overlay
+when focus has fallen to `document.body`. Panels that omit `onDismiss`
+(the billing gate) stay undismissible. Toasts advertise Esc only when no
+higher owner holds the key.
+
 ---
 
 ## Adding a jump target

--- a/packages/web/src/billing/BillingGateModal.test.tsx
+++ b/packages/web/src/billing/BillingGateModal.test.tsx
@@ -13,6 +13,7 @@ import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { type ApiError } from "@web/api/api.types";
 import { BillingApi } from "@web/api/billing.api";
 import { SessionContext } from "@web/auth/compass/session/session.context";
+import { resetBillingGateAttentionForTests } from "@web/billing/billing-gate-attention";
 import {
   initialBillingPreviewState,
   useBillingPreviewStore,
@@ -66,6 +67,7 @@ describe("BillingGateModal", () => {
   afterEach(() => {
     assign.mockClear();
     useBillingPreviewStore.setState(initialBillingPreviewState);
+    resetBillingGateAttentionForTests();
   });
 
   it("redirects to Stripe Checkout from Start trial", async () => {

--- a/packages/web/src/billing/BillingGateModal.tsx
+++ b/packages/web/src/billing/BillingGateModal.tsx
@@ -1,8 +1,11 @@
 import { type FC, useEffect, useRef } from "react";
 import { track } from "@web/auth/posthog/track";
+import { setBillingGateOwnsScreen } from "@web/billing/billing-gate-attention";
 import { billingPreviewActions } from "@web/billing/billing-preview.store";
 import { useBillingRedirect } from "@web/billing/useBillingRedirect";
 import { focusOnPointerEnter } from "@web/common/utils/focus-on-pointer-enter";
+import { deferGoogleDelayedToastIfVisible } from "@web/common/utils/toast/google-delayed.toast";
+import { deferGoogleReconnectToastIfVisible } from "@web/common/utils/toast/google-reconnect.toast";
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 import { PixelPirateScouting } from "@web/components/WelcomeModal/PixelPirateScouting";
@@ -52,6 +55,13 @@ export const BillingGateModal: FC<BillingGateModalProps> = ({ status }) => {
       track("billing_gate_shown", { status });
     }
   }, [status]);
+
+  useEffect(() => {
+    setBillingGateOwnsScreen(true);
+    deferGoogleReconnectToastIfVisible();
+    deferGoogleDelayedToastIfVisible();
+    return () => setBillingGateOwnsScreen(false);
+  }, []);
 
   const lookAround = () => {
     track("billing_gate_cta_clicked", { cta: "preview" });

--- a/packages/web/src/billing/billing-gate-attention.ts
+++ b/packages/web/src/billing/billing-gate-attention.ts
@@ -1,0 +1,58 @@
+import { useCheckoutCelebrationStore } from "@web/billing/checkout-celebration.store";
+
+/**
+ * The billing gate is the only thing on screen until the user starts a trial
+ * or looks around. Reconnect / delayed-sync toasts wait so they cannot compete
+ * with Start trial.
+ */
+
+let ownsScreen = false;
+let pendingReconnect: {
+  connectionId?: string | null;
+  accountEmail?: string | null;
+} | null = null;
+let pendingDelayed = false;
+
+export function setBillingGateOwnsScreen(owns: boolean): void {
+  ownsScreen = owns;
+}
+
+export function isBillingGateOwningScreen(): boolean {
+  return ownsScreen;
+}
+
+export function shouldDeferAttentionToasts(): boolean {
+  return ownsScreen || useCheckoutCelebrationStore.getState().isCelebrating;
+}
+
+export function rememberPendingReconnect(target: {
+  connectionId?: string | null;
+  accountEmail?: string | null;
+}): void {
+  pendingReconnect = target;
+}
+
+export function takePendingReconnect(): {
+  connectionId?: string | null;
+  accountEmail?: string | null;
+} | null {
+  const next = pendingReconnect;
+  pendingReconnect = null;
+  return next;
+}
+
+export function rememberPendingDelayed(): void {
+  pendingDelayed = true;
+}
+
+export function takePendingDelayed(): boolean {
+  const next = pendingDelayed;
+  pendingDelayed = false;
+  return next;
+}
+
+export function resetBillingGateAttentionForTests(): void {
+  ownsScreen = false;
+  pendingReconnect = null;
+  pendingDelayed = false;
+}

--- a/packages/web/src/billing/billing-preview.store.ts
+++ b/packages/web/src/billing/billing-preview.store.ts
@@ -1,4 +1,7 @@
 import { create } from "zustand";
+import { setBillingGateOwnsScreen } from "@web/billing/billing-gate-attention";
+import { flushDeferredGoogleDelayedToast } from "@web/common/utils/toast/google-delayed.toast";
+import { flushDeferredGoogleReconnectToast } from "@web/common/utils/toast/google-reconnect.toast";
 
 export type BillingPreviewState = {
   /**
@@ -23,6 +26,12 @@ export const useBillingPreviewStore = create<BillingPreviewState>()(() => ({
 export const billingPreviewActions = {
   enter: () => {
     useBillingPreviewStore.setState({ isPreviewing: true });
+    // Release the gate's exclusive hold before flush so the pending reconnect
+    // toast is actually allowed to appear. The modal unmounts on the next
+    // render; this must not wait for that effect.
+    setBillingGateOwnsScreen(false);
+    flushDeferredGoogleReconnectToast();
+    flushDeferredGoogleDelayedToast();
   },
   /**
    * Bring the gate back. Called when a write is refused with

--- a/packages/web/src/common/utils/toast/ToastDismissHint.test.tsx
+++ b/packages/web/src/common/utils/toast/ToastDismissHint.test.tsx
@@ -1,13 +1,26 @@
 import { render, screen } from "@testing-library/react";
 import { ToastDismissHint } from "@web/common/utils/toast/ToastDismissHint";
-import { describe, expect, it } from "bun:test";
+import { clearAppLockReasons, setAppLockReason } from "@web/shortcuts/app-lock";
+import { afterEach, describe, expect, it } from "bun:test";
 
 describe("ToastDismissHint", () => {
+  afterEach(() => {
+    clearAppLockReasons();
+  });
+
   it("shows an Esc keycap and how to dismiss", () => {
     render(<ToastDismissHint />);
 
     expect(screen.getByRole("note")).toBeTruthy();
     expect(screen.getByText("Press Esc to dismiss")).toBeTruthy();
     expect(screen.getByText("Esc")).toBeTruthy();
+  });
+
+  it("hides the Esc tip while an overlay owns Escape", () => {
+    setAppLockReason("settingsModal", true);
+    render(<ToastDismissHint />);
+
+    expect(screen.queryByRole("note")).toBeNull();
+    expect(screen.queryByText("Press Esc to dismiss")).toBeNull();
   });
 });

--- a/packages/web/src/common/utils/toast/ToastDismissHint.tsx
+++ b/packages/web/src/common/utils/toast/ToastDismissHint.tsx
@@ -1,9 +1,29 @@
+import { useSyncExternalStore } from "react";
+import { subscribeAppLock } from "@web/shortcuts/app-lock";
+import { isHigherEscapeOwner } from "@web/shortcuts/escape-ownership";
+import { subscribeFloatingLayer } from "@web/shortcuts/floating-layer";
 import { ShortcutTipParts } from "@web/shortcuts/tips/ShortcutTipParts";
 
 const DISMISS_TIP_PARTS = ["Press ", { key: "Esc" }, " to dismiss"] as const;
 
+const subscribeEscapeOwners = (onStoreChange: () => void) => {
+  const unsubLock = subscribeAppLock(onStoreChange);
+  const unsubFloat = subscribeFloatingLayer(onStoreChange);
+  return () => {
+    unsubLock();
+    unsubFloat();
+  };
+};
+
 /** Footer tip so Escape-to-dismiss is visible without a close control. */
 export function ToastDismissHint() {
+  const hide = useSyncExternalStore(
+    subscribeEscapeOwners,
+    isHigherEscapeOwner,
+    () => false,
+  );
+  if (hide) return null;
+
   return (
     <p className="text-text-muted text-xs" role="note">
       <ShortcutTipParts parts={DISMISS_TIP_PARTS} />

--- a/packages/web/src/common/utils/toast/google-delayed.toast.test.tsx
+++ b/packages/web/src/common/utils/toast/google-delayed.toast.test.tsx
@@ -4,9 +4,21 @@ import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
 import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
 import * as realConnectGoogle from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
-import { GoogleDelayedToast } from "@web/common/utils/toast/google-delayed.toast";
+import {
+  resetBillingGateAttentionForTests,
+  setBillingGateOwnsScreen,
+} from "@web/billing/billing-gate-attention";
+import {
+  billingPreviewActions,
+  initialBillingPreviewState,
+  useBillingPreviewStore,
+} from "@web/billing/billing-preview.store";
+import {
+  GoogleDelayedToast,
+  showGoogleDelayedToast,
+} from "@web/common/utils/toast/google-delayed.toast";
 import { registerToastPort } from "@web/common/utils/toast/toast.port";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockRefresh = mock();
 
@@ -46,5 +58,38 @@ describe("GoogleDelayedToast", () => {
 
     expect(mocks.dismiss).toHaveBeenCalledWith("google-delayed");
     expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("showGoogleDelayedToast", () => {
+  const { port, mocks } = createTestToastPort();
+
+  beforeEach(() => {
+    mocks.error.mockClear();
+    mocks.isActive.mockReturnValue(false);
+    registerToastPort(port);
+    resetBillingGateAttentionForTests();
+    useBillingPreviewStore.setState(initialBillingPreviewState);
+  });
+
+  afterEach(() => {
+    resetBillingGateAttentionForTests();
+    useBillingPreviewStore.setState(initialBillingPreviewState);
+  });
+
+  it("does not show while the billing gate owns the screen", () => {
+    setBillingGateOwnsScreen(true);
+    showGoogleDelayedToast();
+    expect(mocks.error).not.toHaveBeenCalled();
+  });
+
+  it("shows the deferred toast after Look around first", () => {
+    setBillingGateOwnsScreen(true);
+    showGoogleDelayedToast();
+    expect(mocks.error).not.toHaveBeenCalled();
+
+    billingPreviewActions.enter();
+
+    expect(mocks.error).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/web/src/common/utils/toast/google-delayed.toast.tsx
+++ b/packages/web/src/common/utils/toast/google-delayed.toast.tsx
@@ -1,6 +1,11 @@
 import { createElement } from "react";
 import { type Id } from "react-toastify";
 import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
+import {
+  rememberPendingDelayed,
+  shouldDeferAttentionToasts,
+  takePendingDelayed,
+} from "@web/billing/billing-gate-attention";
 import { GOOGLE_DELAYED_TOAST_ID } from "@web/common/constants/toast.constants";
 import {
   ErrorToastSeverity,
@@ -42,6 +47,11 @@ export const GoogleDelayedToast = ({ toastId }: GoogleDelayedToastProps) => {
 };
 
 export function showGoogleDelayedToast(): Id {
+  if (shouldDeferAttentionToasts()) {
+    rememberPendingDelayed();
+    return GOOGLE_DELAYED_TOAST_ID;
+  }
+
   return showErrorToast(
     createElement(GoogleDelayedToast, { toastId: GOOGLE_DELAYED_TOAST_ID }),
     {
@@ -49,6 +59,19 @@ export function showGoogleDelayedToast(): Id {
       severity: ErrorToastSeverity.CRITICAL,
     },
   );
+}
+
+export function deferGoogleDelayedToastIfVisible(): void {
+  const toast = getToast();
+  if (toast.isActive?.(GOOGLE_DELAYED_TOAST_ID) !== true) return;
+
+  rememberPendingDelayed();
+  dismissGoogleDelayedToast();
+}
+
+export function flushDeferredGoogleDelayedToast(): void {
+  if (!takePendingDelayed()) return;
+  showGoogleDelayedToast();
 }
 
 // The toast is CRITICAL severity (autoClose: false, closeOnClick: false) so

--- a/packages/web/src/common/utils/toast/google-reconnect.toast.test.tsx
+++ b/packages/web/src/common/utils/toast/google-reconnect.toast.test.tsx
@@ -5,12 +5,28 @@ import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
 import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
 import * as realConnectGoogle from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import {
+  isBillingGateOwningScreen,
+  resetBillingGateAttentionForTests,
+  setBillingGateOwnsScreen,
+} from "@web/billing/billing-gate-attention";
+import {
+  billingPreviewActions,
+  initialBillingPreviewState,
+  useBillingPreviewStore,
+} from "@web/billing/billing-preview.store";
+import {
+  checkoutCelebrationActions,
+  initialCheckoutCelebrationState,
+  useCheckoutCelebrationStore,
+} from "@web/billing/checkout-celebration.store";
+import {
   GoogleReconnectToast,
+  resetGoogleReconnectToastStateForTests,
   showGoogleReconnectToast,
 } from "@web/common/utils/toast/google-reconnect.toast";
 import { registerToastPort } from "@web/common/utils/toast/toast.port";
 import { eventJumpActions } from "@web/shortcuts/shift-hint/event-jump.store";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockConnect = mock();
 const mockUseConnectGoogle = mock(() => ({ connect: mockConnect }));
@@ -122,8 +138,20 @@ describe("showGoogleReconnectToast", () => {
 
   beforeEach(() => {
     mocks.error.mockClear();
+    mocks.dismiss.mockClear();
     mocks.isActive.mockReturnValue(false);
     registerToastPort(port);
+    resetGoogleReconnectToastStateForTests();
+    resetBillingGateAttentionForTests();
+    useBillingPreviewStore.setState(initialBillingPreviewState);
+    useCheckoutCelebrationStore.setState(initialCheckoutCelebrationState);
+  });
+
+  afterEach(() => {
+    resetGoogleReconnectToastStateForTests();
+    resetBillingGateAttentionForTests();
+    useBillingPreviewStore.setState(initialBillingPreviewState);
+    useCheckoutCelebrationStore.setState(initialCheckoutCelebrationState);
   });
 
   it("does not stack a second toast while one is already visible", () => {
@@ -141,5 +169,35 @@ describe("showGoogleReconnectToast", () => {
     });
 
     expect(mocks.error).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not show while the billing gate owns the screen", () => {
+    setBillingGateOwnsScreen(true);
+
+    showGoogleReconnectToast({ accountEmail: "lance@example.com" });
+
+    expect(mocks.error).not.toHaveBeenCalled();
+  });
+
+  it("shows the deferred toast after Look around first", () => {
+    setBillingGateOwnsScreen(true);
+    showGoogleReconnectToast({
+      accountEmail: "lance@example.com",
+      connectionId: "conn-1",
+    });
+    expect(mocks.error).not.toHaveBeenCalled();
+
+    billingPreviewActions.enter();
+
+    expect(mocks.error).toHaveBeenCalledTimes(1);
+    expect(isBillingGateOwningScreen()).toBe(false);
+  });
+
+  it("does not show during checkout celebration", () => {
+    checkoutCelebrationActions.celebrate();
+
+    showGoogleReconnectToast({ accountEmail: "lance@example.com" });
+
+    expect(mocks.error).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/common/utils/toast/google-reconnect.toast.tsx
+++ b/packages/web/src/common/utils/toast/google-reconnect.toast.tsx
@@ -7,6 +7,11 @@ import {
   selectGoogleSyncConnections,
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
+import {
+  rememberPendingReconnect,
+  shouldDeferAttentionToasts,
+  takePendingReconnect,
+} from "@web/billing/billing-gate-attention";
 import { GOOGLE_REVOKED_TOAST_ID } from "@web/common/constants/toast.constants";
 import {
   ErrorToastSeverity,
@@ -17,6 +22,7 @@ import { ToastNotice } from "@web/common/utils/toast/ToastNotice";
 import { getToast } from "@web/common/utils/toast/toast.port";
 
 let hasShownReconnectToastThisLoad = false;
+let lastReconnectTarget: GoogleReconnectTarget = {};
 
 /** True after any path has already raised the reconnect toast this page load. */
 export const hasShownGoogleReconnectToastThisLoad = (): boolean =>
@@ -25,6 +31,11 @@ export const hasShownGoogleReconnectToastThisLoad = (): boolean =>
 export const clearGoogleReconnectToastGate = (): void => {
   hasShownReconnectToastThisLoad = false;
 };
+
+export function resetGoogleReconnectToastStateForTests(): void {
+  hasShownReconnectToastThisLoad = false;
+  lastReconnectTarget = {};
+}
 
 interface GoogleReconnectToastProps {
   toastId: Id;
@@ -102,6 +113,12 @@ export const GoogleReconnectToast = ({
 export function showGoogleReconnectToast(
   target: GoogleReconnectTarget = {},
 ): Id {
+  lastReconnectTarget = target;
+  if (shouldDeferAttentionToasts()) {
+    rememberPendingReconnect(target);
+    return GOOGLE_REVOKED_TOAST_ID;
+  }
+
   hasShownReconnectToastThisLoad = true;
   return showErrorToast(
     createElement(GoogleReconnectToast, {
@@ -114,6 +131,22 @@ export function showGoogleReconnectToast(
       severity: ErrorToastSeverity.CRITICAL,
     },
   );
+}
+
+export function deferGoogleReconnectToastIfVisible(): void {
+  const toast = getToast();
+  const visible = toast.isActive?.(GOOGLE_REVOKED_TOAST_ID) === true;
+  if (!visible && !hasShownReconnectToastThisLoad) return;
+
+  rememberPendingReconnect(lastReconnectTarget);
+  hasShownReconnectToastThisLoad = false;
+  dismissGoogleReconnectToast();
+}
+
+export function flushDeferredGoogleReconnectToast(): void {
+  const pending = takePendingReconnect();
+  if (!pending) return;
+  showGoogleReconnectToast(pending);
 }
 
 export function dismissGoogleReconnectToast(): void {

--- a/packages/web/src/components/FirstEventPrompt/FirstEventPrompt.test.tsx
+++ b/packages/web/src/components/FirstEventPrompt/FirstEventPrompt.test.tsx
@@ -13,6 +13,11 @@ import {
   initialShortcutShowcaseState,
   useShortcutShowcaseStore,
 } from "@web/components/ShortcutShowcase/showcase.store";
+import {
+  initialSettingsState,
+  settingsActions,
+  useSettingsStore,
+} from "@web/settings/settings.store";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
 const markShowcaseSeen = () => {
@@ -23,6 +28,7 @@ describe("FirstEventPrompt", () => {
   beforeEach(() => {
     useFirstEventPromptStore.setState({ ...initialFirstEventPromptState });
     useShortcutShowcaseStore.setState(initialShortcutShowcaseState);
+    useSettingsStore.setState(initialSettingsState);
     persistentBrowserStore.set(STORAGE_KEYS.FIRST_EVENT_DONE, "");
     persistentBrowserStore.set(STORAGE_KEYS.HAS_SEEN_SHORTCUT_SHOWCASE, "");
     localStorage.setItem("compass.onboarding.checklist-done", "");
@@ -31,6 +37,7 @@ describe("FirstEventPrompt", () => {
   afterEach(() => {
     useFirstEventPromptStore.setState({ ...initialFirstEventPromptState });
     useShortcutShowcaseStore.setState(initialShortcutShowcaseState);
+    useSettingsStore.setState(initialSettingsState);
   });
 
   it("stays hidden before the showcase has ever been seen", () => {
@@ -63,6 +70,15 @@ describe("FirstEventPrompt", () => {
   it("stays hidden while the showcase takeover is active", () => {
     markShowcaseSeen();
     useShortcutShowcaseStore.setState({ isActive: true });
+    render(<FirstEventPrompt />);
+    expect(
+      screen.queryByRole("complementary", { name: "Create your first event" }),
+    ).toBeNull();
+  });
+
+  it("stays hidden while Settings is open", () => {
+    markShowcaseSeen();
+    settingsActions.openSettings();
     render(<FirstEventPrompt />);
     expect(
       screen.queryByRole("complementary", { name: "Create your first event" }),

--- a/packages/web/src/components/FirstEventPrompt/FirstEventPrompt.tsx
+++ b/packages/web/src/components/FirstEventPrompt/FirstEventPrompt.tsx
@@ -17,6 +17,11 @@ import {
   useShortcutShowcaseStore,
 } from "@web/components/ShortcutShowcase/showcase.store";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
+import {
+  selectIsAboutOpen,
+  selectIsSettingsOpen,
+  useSettingsStore,
+} from "@web/settings/settings.store";
 import { KEYMAP } from "@web/shortcuts/keymap";
 
 /** How long the celebration copy holds before it fades out for good. */
@@ -97,12 +102,17 @@ export const FirstEventPrompt: FC = () => {
   // the storage read covers earlier sessions and the legacy tour key.
   const seenThisSession = useShortcutShowcaseStore(selectHasSeenShowcase);
   const isDone = useFirstEventPromptStore(selectFirstEventDone);
+  const isSettingsOpen = useSettingsStore(selectIsSettingsOpen);
+  const isAboutOpen = useSettingsStore(selectIsAboutOpen);
   // Without storage (private mode), completion and dismissal can never
   // persist, so the card would haunt every reload; better to not show it.
   // Sit above the auth modal in z-index, so stay hidden while login/signup
-  // is open even if the showcase flag is already set.
+  // is open even if the showcase flag is already set. Settings and About
+  // paint below this tooltip layer, so hide rather than compete.
   const isLive =
     !isAuthModalOpen &&
+    !isSettingsOpen &&
+    !isAboutOpen &&
     !isDone &&
     persistentBrowserStore.isAvailable() &&
     isShowcaseHandoffEligible(isShowcaseActive, seenThisSession);

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
@@ -5,9 +5,14 @@ import {
   OverlayPanel,
   OverlayPanelActionButton,
 } from "@web/components/OverlayPanel/OverlayPanel";
-import { describe, expect, it, mock } from "bun:test";
+import { clearOverlayEscapeStack } from "@web/components/OverlayPanel/overlay-escape";
+import { afterEach, describe, expect, it, mock } from "bun:test";
 
 describe("OverlayPanel", () => {
+  afterEach(() => {
+    clearOverlayEscapeStack();
+  });
+
   it("locks app shortcuts while mounted and clears on unmount", () => {
     const { unmount } = render(
       <OverlayPanel title="Confirm" onDismiss={() => {}} />,
@@ -251,6 +256,60 @@ describe("OverlayPanel", () => {
     await user.keyboard("{Shift>}{Escape}{/Shift}");
     expect(shifted).toBe(1);
     expect(dismissed).toBe(1);
+  });
+
+  it("dismisses on Escape when focus is on document.body", async () => {
+    const user = userEvent.setup();
+    let dismissed = 0;
+
+    render(
+      <OverlayPanel
+        title="Confirm"
+        onDismiss={() => {
+          dismissed += 1;
+        }}
+      >
+        <button type="button">Inside</button>
+      </OverlayPanel>,
+    );
+
+    (document.activeElement as HTMLElement | null)?.blur();
+
+    await user.keyboard("{Escape}");
+    expect(dismissed).toBe(1);
+  });
+
+  it("peels only the topmost dismissible panel on Escape", async () => {
+    const user = userEvent.setup();
+    let firstDismissed = 0;
+    let secondDismissed = 0;
+
+    render(
+      <>
+        <OverlayPanel
+          title="First"
+          onDismiss={() => {
+            firstDismissed += 1;
+          }}
+        >
+          <button type="button">First stay</button>
+        </OverlayPanel>
+        <OverlayPanel
+          title="Second"
+          onDismiss={() => {
+            secondDismissed += 1;
+          }}
+        >
+          <button type="button">Second stay</button>
+        </OverlayPanel>
+      </>,
+    );
+
+    (document.activeElement as HTMLElement | null)?.blur();
+    await user.keyboard("{Escape}");
+
+    expect(secondDismissed).toBe(1);
+    expect(firstDismissed).toBe(0);
   });
 
   it("does not dismiss on Escape when onDismiss is omitted", async () => {

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
@@ -147,6 +147,20 @@ export const OverlayPanel = ({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      if (e.shiftKey && onShiftEscape) {
+        e.preventDefault();
+        e.stopPropagation();
+        onShiftEscape();
+        return;
+      }
+      if (onDismiss) {
+        e.preventDefault();
+        e.stopPropagation();
+        onDismiss();
+        return;
+      }
+    }
     if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && onModEnter) {
       // Prevent the focused button (often Cancel) from activating on Enter.
       e.preventDefault();
@@ -169,7 +183,7 @@ export const OverlayPanel = ({
   };
 
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: The backdrop catches outside clicks and Tab/Mod+Enter. Escape is a document listener (useOverlayEscape) so it still works when focus is on body.
+    // biome-ignore lint/a11y/noStaticElementInteractions: The backdrop catches outside clicks, Tab/Mod+Enter, and in-tree Escape. Document Escape (useOverlayEscape) covers the case where focus is on body.
     <div
       className={backdropClasses}
       data-closing={closing || undefined}

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
@@ -11,6 +11,7 @@ import {
 import { Z_INDEX_MODAL } from "@web/common/constants/web.constants";
 import { focusOnPointerEnter } from "@web/common/utils/focus-on-pointer-enter";
 import { getFocusableElements } from "@web/common/utils/focusable-elements";
+import { useOverlayEscape } from "@web/components/OverlayPanel/overlay-escape";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import { useAppLockReason } from "@web/shortcuts/app-lock";
 
@@ -88,6 +89,7 @@ export const OverlayPanel = ({
   const messageId = `${baseId}-message`;
   // Unique per instance: app-lock reasons are a Set, not refcounted.
   useAppLockReason(`overlayPanel:${baseId}`, true);
+  useOverlayEscape({ onDismiss, onShiftEscape });
 
   useEffect(() => {
     if (role !== "dialog") return;
@@ -145,20 +147,6 @@ export const OverlayPanel = ({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Escape") {
-      if (e.shiftKey && onShiftEscape) {
-        e.preventDefault();
-        e.stopPropagation();
-        onShiftEscape();
-        return;
-      }
-      if (onDismiss) {
-        e.preventDefault();
-        e.stopPropagation();
-        onDismiss();
-        return;
-      }
-    }
     if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && onModEnter) {
       // Prevent the focused button (often Cancel) from activating on Enter.
       e.preventDefault();
@@ -181,7 +169,7 @@ export const OverlayPanel = ({
   };
 
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: The backdrop catches outside clicks and Escape to dismiss the panel.
+    // biome-ignore lint/a11y/noStaticElementInteractions: The backdrop catches outside clicks and Tab/Mod+Enter. Escape is a document listener (useOverlayEscape) so it still works when focus is on body.
     <div
       className={backdropClasses}
       data-closing={closing || undefined}

--- a/packages/web/src/components/OverlayPanel/overlay-escape.ts
+++ b/packages/web/src/components/OverlayPanel/overlay-escape.ts
@@ -1,0 +1,90 @@
+import { useEffect, useRef } from "react";
+import { isFloatingLayerOpen } from "@web/shortcuts/floating-layer";
+
+type OverlayEscapeHandlers = {
+  onDismiss?: () => void;
+  onShiftEscape?: () => void;
+};
+
+const stack: OverlayEscapeHandlers[] = [];
+let listening = false;
+
+const onDocumentKeyDown = (event: KeyboardEvent) => {
+  if (event.key !== "Escape" || event.defaultPrevented) return;
+  // Listboxes and menus peel first. A document listener that closed the
+  // overlay underneath them would skip a layer.
+  if (isFloatingLayerOpen()) return;
+
+  const top = stack[stack.length - 1];
+  if (!top) return;
+
+  if (event.shiftKey && top.onShiftEscape) {
+    event.preventDefault();
+    event.stopPropagation();
+    top.onShiftEscape();
+    return;
+  }
+
+  if (top.onDismiss) {
+    event.preventDefault();
+    event.stopPropagation();
+    top.onDismiss();
+  }
+};
+
+const ensureListener = () => {
+  if (listening) return;
+  listening = true;
+  document.addEventListener("keydown", onDocumentKeyDown);
+};
+
+const releaseListener = () => {
+  if (stack.length > 0 || !listening) return;
+  listening = false;
+  document.removeEventListener("keydown", onDocumentKeyDown);
+};
+
+/**
+ * Document-level Escape for OverlayPanel. Last-in-wins so stacked panels peel
+ * one at a time, and the listener does not depend on focus sitting inside the
+ * overlay (React onKeyDown on the backdrop misses Escape when focus is on
+ * document.body).
+ *
+ * Panels that omit `onDismiss` (the billing gate) never join the stack.
+ */
+export function useOverlayEscape({
+  onDismiss,
+  onShiftEscape,
+}: OverlayEscapeHandlers) {
+  const handlersRef = useRef({ onDismiss, onShiftEscape });
+  handlersRef.current = { onDismiss, onShiftEscape };
+
+  const enabled = Boolean(onDismiss || onShiftEscape);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const entry: OverlayEscapeHandlers = {
+      get onDismiss() {
+        return handlersRef.current.onDismiss;
+      },
+      get onShiftEscape() {
+        return handlersRef.current.onShiftEscape;
+      },
+    };
+    stack.push(entry);
+    ensureListener();
+
+    return () => {
+      const index = stack.lastIndexOf(entry);
+      if (index >= 0) stack.splice(index, 1);
+      releaseListener();
+    };
+  }, [enabled]);
+}
+
+/** Test-only: drop every registered overlay so cases cannot leak a listener. */
+export function clearOverlayEscapeStack() {
+  stack.length = 0;
+  releaseListener();
+}

--- a/packages/web/src/components/OverlayPanel/overlay-escape.ts
+++ b/packages/web/src/components/OverlayPanel/overlay-escape.ts
@@ -48,7 +48,8 @@ const releaseListener = () => {
  * Document-level Escape for OverlayPanel. Last-in-wins so stacked panels peel
  * one at a time, and the listener does not depend on focus sitting inside the
  * overlay (React onKeyDown on the backdrop misses Escape when focus is on
- * document.body).
+ * document.body). In-tree keydowns still go through OverlayPanel's React
+ * handler, which preventDefaults so this listener does not double-fire.
  *
  * Panels that omit `onDismiss` (the billing gate) never join the stack.
  */

--- a/packages/web/src/components/RootShell/RootShell.test.tsx
+++ b/packages/web/src/components/RootShell/RootShell.test.tsx
@@ -6,6 +6,7 @@ import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { createTestRouter } from "@web/__tests__/utils/providers/createTestRouter";
 import { BillingApi } from "@web/api/billing.api";
 import { SessionContext } from "@web/auth/compass/session/session.context";
+import { resetBillingGateAttentionForTests } from "@web/billing/billing-gate-attention";
 import {
   billingPreviewActions,
   initialBillingPreviewState,
@@ -89,6 +90,7 @@ describe("RootShell billing gates", () => {
       isSettingsOpen: false,
       settingsPage: "accounts",
     });
+    resetBillingGateAttentionForTests();
     resetToastPort();
   });
 

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -432,6 +432,27 @@ describe("SettingsModal", () => {
     expect(screen.queryByText("Settings")).not.toBeInTheDocument();
   });
 
+  it("closes on Escape even when focus is on document.body", async () => {
+    const user = userEvent.setup({ delay: null });
+    renderSettings();
+
+    (document.activeElement as HTMLElement | null)?.blur();
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByText("Settings")).not.toBeInTheDocument();
+  });
+
+  it("shows a Close control with an Esc chip", async () => {
+    const user = userEvent.setup({ delay: null });
+    renderSettings();
+
+    const close = screen.getByRole("button", { name: /Close/ });
+    expect(within(close).getByText("Esc")).toBeTruthy();
+
+    await user.click(close);
+    expect(screen.queryByText("Settings")).not.toBeInTheDocument();
+  });
+
   it("shows the derived default calendar in the picker when nothing is stored", () => {
     const primary = createMockCalendar({ name: "Personal", isPrimary: true });
     const side = createMockCalendar({ name: "Side project" });

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -179,6 +179,16 @@ export const SettingsModal: FC = () => {
       initialFocusRef={initialFocusRef}
       onDismiss={handleDismiss}
       title="Settings"
+      titleAction={
+        <OverlayPanelActionButton
+          className="shrink-0"
+          onClick={handleDismiss}
+          shortcut="Esc"
+          variant="ghost"
+        >
+          Close
+        </OverlayPanelActionButton>
+      }
       variant="modal"
       widthClassName="w-[640px]"
     >

--- a/packages/web/src/shortcuts/app-lock.ts
+++ b/packages/web/src/shortcuts/app-lock.ts
@@ -16,6 +16,8 @@ const registry = createReasonRegistry((locked) => {
 
 export const setAppLockReason = registry.set;
 
+export const subscribeAppLock = registry.subscribe;
+
 /** Clears every reason — used by tests between cases. */
 export const clearAppLockReasons = registry.clear;
 

--- a/packages/web/src/shortcuts/floating-layer.ts
+++ b/packages/web/src/shortcuts/floating-layer.ts
@@ -9,6 +9,8 @@ const registry = createReasonRegistry();
 
 export const setFloatingLayerReason = registry.set;
 
+export const subscribeFloatingLayer = registry.subscribe;
+
 /** Clears every reason — used by tests between cases. */
 export const clearFloatingLayerReasons = registry.clear;
 

--- a/packages/web/src/shortcuts/reason-registry.ts
+++ b/packages/web/src/shortcuts/reason-registry.ts
@@ -7,7 +7,11 @@ import { useEffect } from "react";
  */
 export function createReasonRegistry(onChange?: (anyActive: boolean) => void) {
   const reasons = new Set<string>();
-  const sync = () => onChange?.(reasons.size > 0);
+  const listeners = new Set<() => void>();
+  const sync = () => {
+    onChange?.(reasons.size > 0);
+    for (const listener of listeners) listener();
+  };
 
   const set = (reason: string, active: boolean) => {
     if (active) {
@@ -34,6 +38,12 @@ export function createReasonRegistry(onChange?: (anyActive: boolean) => void) {
       sync();
     },
     isAnyActive: () => reasons.size > 0,
+    subscribe: (listener: () => void) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
     useReason,
   };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Settings opened via `Mod+,` could trap keyboard users: Escape only fired when focus sat inside the overlay, there was no Close control, and the first-event prompt painted above the modal. Signed-in users hitting the trial gate also saw a Google reconnect toast on top of Start trial, with a false "Press Esc to dismiss" hint because the gate holds app-lock.

This change:

- Makes OverlayPanel Escape a document-level, last-in-wins listener so Settings (and other dismissible overlays) always peel, even when focus is on `document.body`. In-tree Escape still preventDefaults so one keypress peels one layer. The billing gate still omits `onDismiss` and stays undismissible.
- Adds an always-visible Settings Close control with an Esc chip.
- Defers Google reconnect and delayed-sync toasts while the billing gate owns the screen; Look around flushes them. Write-time reconnect is unchanged.
- Hides the first-event prompt while Settings or About is open, and hides the toast Esc hint while a higher Escape owner is active.

## Simplicity

One OverlayPanel Escape stack instead of per-modal shortcuts. Toast deferral is a small billing-gate flag plus pending flush on Look around, not a new attention coordinator.

## Automated validation

Focused web tests cover OverlayPanel Escape with body focus and stacked panels, Settings Close/Esc, reconnect and delayed toast deferral until Look around, FirstEventPrompt hidden while Settings is open, and ToastDismissHint hidden under app-lock.

Browser (anonymous IndexedDB, http://localhost:9080): welcome Explore without an account, leave shortcut practice, first-event prompt visible, `Ctrl+,` opens Settings with Close + Esc chip and no overlapping first-event prompt, Escape closes Settings and the prompt returns, focusing Close and pressing Enter also closes Settings.

Signed-in awaiting_checkout + reconnect toast was not exercised in the browser (no SuperTokens/Google in this environment). Coverage is the focused toast/gate tests.

## Independent review

Read-only pass of `origin/main...HEAD` (24 files). No confirmed findings: billing gate still omits `onDismiss`, Look around clears owns-screen before flushing toasts, document Escape stands down when `defaultPrevented` or a floating layer is open.

## Test plan

- `bun packages/scripts/src/testing/test-parallel.ts web --` on OverlayPanel, SettingsModal, google-reconnect/delayed toasts, ToastDismissHint, FirstEventPrompt, BillingGateModal, RootShell
- `bun run verify`

```
Selected packages: web
Checks run: test:web, type-check, lint, knip
Checks skipped: test:a11y (Playwright Chromium missing); test:e2e (Playwright Chromium missing)
selected checks passed
```

CI: pull_request Test was green (including unit (scripts) in 31s and e2e). A concurrent push-event unit (scripts) job timed out after 5 minutes with no failing assertion; retriggered.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c629139d-79b0-4f0f-8674-d29c4d713c86?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c629139d-79b0-4f0f-8674-d29c4d713c86&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

