### PR TITLE
fix(web): map 1200 shortcut to noon

### DIFF
--- a/packages/web/src/shortcuts/quick-time/quick-time.util.test.ts
+++ b/packages/web/src/shortcuts/quick-time/quick-time.util.test.ts
@@ -28,6 +28,18 @@ describe("resolveQuickTimeStart", () => {
     expect(resolve("1700", "21:00")).toBe("17:00");
   });
 
+  it("reads 1200 as noon, not midnight, whatever the time of day", () => {
+    expect(resolve("1200", "09:00")).toBe("12:00");
+    expect(resolve("1200", "21:00")).toBe("12:00");
+    expect(resolve("12", "09:00")).toBe("12:00");
+    expect(resolve("1230", "09:00")).toBe("12:30");
+  });
+
+  it("still takes an explicit midnight sequence literally", () => {
+    expect(resolve("0000", "09:00")).toBe("00:00");
+    expect(resolve("0", "00:30")).toBe("00:00");
+  });
+
   it("expands one and two digits to the top of the hour", () => {
     expect(resolve("9", "08:00")).toBe("09:00");
     expect(resolve("11", "08:00")).toBe("11:00");
@@ -69,6 +81,16 @@ describe("quickTimeSequenceForHour", () => {
     // morning hour has no sequence of its own.
     expect(quickTimeSequenceForHour(9, at("21:00"), DAY)).toBeNull();
   });
+
+  it("skips midnight, which has no useful shortcut", () => {
+    expect(quickTimeSequenceForHour(0, at("09:00"), DAY)).toBeNull();
+    expect(quickTimeSequenceForHour(0, at("21:00"), DAY)).toBeNull();
+  });
+
+  it("advertises noon as 1200 even in the morning", () => {
+    expect(quickTimeSequenceForHour(12, at("09:00"), DAY)).toBe("1200");
+    expect(quickTimeSequenceForHour(12, at("21:00"), DAY)).toBe("1200");
+  });
 });
 
 describe("quickTimeTargetDay", () => {
@@ -99,16 +121,15 @@ describe("buildQuickTimeSlots", () => {
     const slots = buildQuickTimeSlots({ busy: [], now, targetDay: DAY });
     const sequences = slots.map((slot) => slot.sequence);
 
-    expect(sequences[0]).toBe("0000");
+    expect(sequences[0]).toBe("0100");
     expect(sequences.at(-1)).toBe("2300");
     expect(sequences).toContain("0900");
+    expect(sequences).toContain("1200");
     expect(sequences).toContain("1700");
+    expect(sequences).not.toContain("0000");
   });
 
-  it("skips noon in the morning, which no sequence reaches", () => {
-    // parseUserTime reads "1200" as 12 AM while the current time is AM (the
-    // event form's time field behaves the same way), so noon has no sequence
-    // of its own before midday and gets no chip rather than a lying one.
+  it("advertises noon as 1200 and omits the midnight slot", () => {
     const morning = buildQuickTimeSlots({ busy: [], now, targetDay: DAY });
     const afternoon = buildQuickTimeSlots({
       busy: [],
@@ -116,8 +137,10 @@ describe("buildQuickTimeSlots", () => {
       targetDay: DAY,
     });
 
-    expect(morning.map((slot) => slot.sequence)).not.toContain("1200");
+    expect(morning.map((slot) => slot.sequence)).toContain("1200");
     expect(afternoon.map((slot) => slot.sequence)).toContain("1200");
+    expect(morning.map((slot) => slot.sequence)).not.toContain("0000");
+    expect(afternoon.map((slot) => slot.sequence)).not.toContain("0000");
   });
 
   it("drops the hours an event already covers", () => {

--- a/packages/web/src/shortcuts/quick-time/quick-time.util.ts
+++ b/packages/web/src/shortcuts/quick-time/quick-time.util.ts
@@ -14,16 +14,24 @@ const DIGITS_ONLY = /^\d{1,4}$/;
 export const canQuickTimeBufferGrow = (digits: string) =>
   digits.length < QUICK_TIME_MAX_DIGITS;
 
+/** True when the typed digits name 12 o'clock, not 00 (midnight). */
+const isTwelveOClockDigits = (digits: string) => {
+  const hour =
+    digits.length <= 2
+      ? Number.parseInt(digits, 10)
+      : Number.parseInt(digits.slice(0, -2), 10);
+  return hour === 12;
+};
+
 /**
  * Resolve a typed digit sequence to a start time on `targetDay`.
  *
  * The 12-hour ambiguity ("1130" at 9am vs 9pm) is settled by `parseUserTime`'s
  * meridiem inheritance: passing `now` as its current value shifts an hour in
- * 1-12 into PM when now is PM, and leaves 13-23 ("1700") alone. Reusing it
- * keeps a typed time on the grid identical to the same digits typed into the
- * event form's time field, warts included - notably that "1200" typed in the
- * morning resolves to 12 AM, not noon (see quickTimeSequenceForHour, which
- * declines to advertise a sequence that would not land where its chip says).
+ * 1-11 into PM when now is PM, and leaves 13-23 ("1700") alone. "12" / "1200"
+ * is the exception: parseUserTime would pull those to midnight while the
+ * current time is AM, but the shortcut always lands them at noon. Midnight
+ * has no advertised sequence.
  */
 export function resolveQuickTimeStart(
   digits: string,
@@ -38,7 +46,10 @@ export function resolveQuickTimeStart(
   const time = getDayjsByTimeValue(parsed.value);
   if (!time.isValid()) return null;
 
-  return targetDay.startOf("day").hour(time.hour()).minute(time.minute());
+  const hour =
+    time.hour() === 0 && isTwelveOClockDigits(digits) ? 12 : time.hour();
+
+  return targetDay.startOf("day").hour(hour).minute(time.minute());
 }
 
 /**
@@ -55,6 +66,8 @@ export function quickTimeSequenceForHour(
   now: Dayjs,
   targetDay: Dayjs,
 ): string | null {
+  if (hour === 0) return null;
+
   const sequence = `${String(hour).padStart(2, "0")}00`;
   const resolved = resolveQuickTimeStart(sequence, now, targetDay);
 
@@ -104,9 +117,10 @@ export type QuickTimeSlot = {
 };
 
 /**
- * One placeholder per open hour of `targetDay`: hours already covered by an
- * event are dropped so chips never pile onto a card, and hours with no
- * reachable sequence are dropped by quickTimeSequenceForHour.
+ * One placeholder per open hour of `targetDay` except midnight, which has no
+ * useful shortcut: hours already covered by an event are dropped so chips
+ * never pile onto a card, and hours with no reachable sequence are dropped
+ * by quickTimeSequenceForHour.
  */
 export function buildQuickTimeSlots({
   busy,
@@ -120,7 +134,7 @@ export function buildQuickTimeSlots({
   const day = targetDay.startOf("day");
   const slots: QuickTimeSlot[] = [];
 
-  for (let hour = 0; hour < 24; hour += 1) {
+  for (let hour = 1; hour < 24; hour += 1) {
     const sequence = quickTimeSequenceForHour(hour, now, day);
     if (!sequence) continue;
 

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.quick-time.test.tsx
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.quick-time.test.tsx
@@ -79,6 +79,15 @@ describe("typed-time ownership", () => {
     expect(useEventJumpStore.getState().quickTimeDigits).toBe("");
   });
 
+  it("creates at noon when 1200 is typed", () => {
+    const { createAt, type } = mountOwner();
+
+    type(["1", "2", "0", "0"]);
+
+    expect(createAt).toHaveBeenCalledTimes(1);
+    expect(startedAt(createAt)).toBe("12:00");
+  });
+
   it("consumes each digit so it reaches no other handler", () => {
     mountOwner();
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Typed `1200` (and `12` / `1230`) now creates at noon instead of midnight. The midnight hour is no longer advertised as a quick-time slot chip.

`parseUserTime` still inherits AM for `12` in the event form. The grid shortcut is the exception: those digits always mean noon, matching the pointer hint ("Type 1200 to create an event at 12:00 PM").

## Simplicity

The noon remap is a one-line hour correction after the existing parser, plus skipping hour 0 when building slot chips. Explicit `0000` still resolves to midnight if typed.

## Automated validation

- Focused web tests: `bun test:web` on `quick-time.util.test.ts` and `useShiftHoldEventHints.quick-time.test.tsx` — 35 pass, including `creates at noon when 1200 is typed`.
- `bun run verify`: selected `test:web`, `type-check`, `lint`, `knip` — passed. Playwright Chromium was not installed locally (`test:a11y` / `test:e2e` skipped); GitHub CI covers those.

Browser check on `/week` (anonymous IndexedDB): press `h` shows `1200` on the 12 PM row and starts chips at `0100` with no midnight `0000`. Typing `1200` opens a draft at 12 PM–1 PM.

![1200 chip on the noon row](https://cursor.com/artifacts/c/art-4e43c7a0-6956-4595-9490-9acade4c1c7b)
![Event form at 12 PM after typing 1200](https://cursor.com/artifacts/c/art-762ee6ba-3c4b-403e-99b7-7f7f31f10244)
<a href="https://cursor.com/agents/bc-3a336ece-6d5c-4071-89eb-9bf018604916/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftype_1200_creates_noon_event.mp4"><img src="https://cursor.com/artifacts/c/art-6c9ae158-d57b-41b7-b007-dab43ad328f2" alt="type_1200_creates_noon_event.mp4" /></a>

## Independent review

Read the util + test diff against the request (1200 → noon, skip 12 AM chip). No confirmed findings: remap is gated on parsed hour 0 plus 12-o'clock digits, so explicit `0000` still means midnight; chips and `quickTimeSequenceForHour(0)` both omit hour 0.

## Test plan

```
bun test:web packages/web/src/shortcuts/quick-time/quick-time.util.test.ts packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.quick-time.test.tsx
bun run verify
```

Browser: `bun run dev:web` → `/week` → `h` → type `1200`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a336ece-6d5c-4071-89eb-9bf018604916?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a336ece-6d5c-4071-89eb-9bf018604916&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

