### PR TITLE
feat(booking): availability exceptions and page identity

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -203,6 +203,19 @@ jobs:
           path: ~/.cache/mongodb-binaries
           key: ${{ runner.os }}-mongodb-memory-server
 
+      # jsdom + MSW in one long-lived process can push a 7 GB hosted runner
+      # into the OOM killer (exit 137 / "runner has received a shutdown
+      # signal"). Extra swap keeps the suite from taking the runner down.
+      - name: Add swap space
+        if: needs.changes.outputs.code == 'true' && (matrix.project == 'web')
+        run: |
+          sudo fallocate -l 4G /swapfile || sudo dd if=/dev/zero of=/swapfile bs=1M count=4096
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          sudo swapon --show
+          free -h
+
       - name: Run web tests
         if: needs.changes.outputs.code == 'true' && (matrix.project == 'web')
         timeout-minutes: 5

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -203,19 +203,6 @@ jobs:
           path: ~/.cache/mongodb-binaries
           key: ${{ runner.os }}-mongodb-memory-server
 
-      # jsdom + MSW in one long-lived process can push a 7 GB hosted runner
-      # into the OOM killer (exit 137 / "runner has received a shutdown
-      # signal"). Extra swap keeps the suite from taking the runner down.
-      - name: Add swap space
-        if: needs.changes.outputs.code == 'true' && (matrix.project == 'web')
-        run: |
-          sudo fallocate -l 4G /swapfile || sudo dd if=/dev/zero of=/swapfile bs=1M count=4096
-          sudo chmod 600 /swapfile
-          sudo mkswap /swapfile
-          sudo swapon /swapfile
-          sudo swapon --show
-          free -h
-
       - name: Run web tests
         if: needs.changes.outputs.code == 'true' && (matrix.project == 'web')
         timeout-minutes: 5

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -1,19 +1,22 @@
-# Compass Calendar Booking (v1)
+# Compass Calendar Booking (v1 / v1.1)
 
 Locked product spec for public scheduling on Compass Cloud
-(`https://compasscalendar.com`). Approved 2026-08-30.
+(`https://compasscalendar.com`). Approved 2026-08-30. v1.1 (availability
+exceptions, RSVP-strict occupancy, and public page identity) is the
+current staging milestone.
 
 Compass never sends email itself. Google emails the guest when Compass
 creates the calendar event with `invitation: "all"`.
 
 ## Status
 
-v1 is implemented in the Compass monorepo (public `/book/:username`, host
-Settings, backend APIs). It is enabled in development and staging
-(`runtime.nodeEnv` other than `production`) and disabled in production.
-A standalone Compass Booking product (separate
-brand, domain, or deployable) is **explicitly deferred**. The seams below
-are the extraction path; they are not a second service in v1.
+v1 and v1.1 are implemented in the Compass monorepo (public
+`/book/:username`, host Settings, backend APIs). Booking is enabled in
+development and staging (`runtime.nodeEnv` other than `production`) and
+disabled in production. Do not flip `isBookingEnabled`. A standalone
+Compass Booking product (separate brand, domain, or deployable) is
+**explicitly deferred**. The seams below are the extraction path; they
+are not a second service in v1.
 
 ## Public URL
 
@@ -155,6 +158,8 @@ One booking-page record per user.
 | Destination calendar | Writable Google calendar (`canWrite`). Receives the created event. |
 | Blocking calendars | Calendars whose busy intervals occupy slots. Any calendar the host can read availability for, including `freeBusyReader`. Default: every imported calendar on the destination account. |
 | General availability | Weekly intervals in the **host booking timezone**. Empty weekday = unavailable. Default timezone: the timezone currently in the host's calendar view when they first enable booking. |
+| Date overrides | Per host-timezone date, capped at 60. **Blocked** offers no slots that day. **Extra hours** replace that day's weekly template (they do not add to it). |
+| Welcome text | Optional host-authored line (max 500 characters) shown under the public name. |
 | Scheduling window | Minimum notice default **4 hours**. Maximum horizon default **60 days**. The 60-day cap matches Sync's busy-query bound (`BUSY_QUERY_MAX_WINDOW_MS` in `packages/core/src/types/sync/availability.contracts.ts`). |
 | Buffer | Off by default. When on, **30 minutes between appointments**, applied to both sides of a booked slot so two meetings cannot sit adjacent. |
 | Max bookings per day | Off by default. When on, default **4**. Counts confirmed booking reservations that day in the host timezone, not every calendar event. |
@@ -175,39 +180,39 @@ timezone `<select>` plus a checkbox and two time inputs per weekday.
   for a break). A blank day is unavailable. The parser reuses
   `parseUserTime` with an explicit PM-correction rule.
 - **Jump:** `e` then a letter focuses a field (`e` enable, `d` duration,
-  `c` destination, `b` blocking, `z` timezone, `h` hours, `n` notice,
-  `x` horizon, `o` buffer and limits, `l` link). Settings owns `s` (save)
-  and digits `1/2/3` (nav) on this page, which is why the leader is `e`
-  rather than `Mod+digit`. Focus uses `data-booking-field` and does not
-  click, so jumping onto a checkbox does not toggle it.
+  `c` destination, `b` blocking, `z` timezone, `h` hours including date
+  overrides, `w` welcome, `n` notice, `x` horizon, `o` buffer and limits,
+  `l` link). Settings owns `s` (save) and digits `1/2/3` (nav) on this
+  page, which is why the leader is `e` rather than `Mod+digit`. Focus
+  uses `data-booking-field` and does not click, so jumping onto a
+  checkbox does not toggle it.
 - **Save:** a successful save that returns a booking URL copies it. A
   page that has never been enabled has no slug yet, so the toast says to
   enable booking instead. Safari can drop a copy that follows the save
   round trip; the toast then names `e` then `l`, and the Copy button
   stays.
+- **Open booking page** sits next to Copy and opens the public URL in a
+  new tab. There is no authenticated preview iframe.
 
 ## Busy occupancy
 
-v1 uses **Sync busy intervals**, not a new RSVP filter.
+v1.1 occupancy is RSVP-strict. Sync still returns facts only; Booking
+decides whether a busy interval occupies a slot
+(`packages/core/src/booking/occupies-booking-slot.ts`).
 
-- Occupied = an occurrence with `busy: true` and `cancelled: false`
-  (`listBusyOverlapping` in
-  `packages/sync/src/storage/repositories/event-occurrence.repository.ts`).
-- Transparent / free events do not block. Google typically marks
-  declined events transparent.
+- Occupied = an occurrence with `busy: true` and `cancelled: false`,
+  **and** the host is the organizer **or** has accepted.
+- `needsAction`, declined, and tentative invites do not occupy.
+- Transparent / free events do not block. Cancelled occurrences stay
+  excluded.
+- Legacy busy intervals with no occupancy facts still occupy (fail
+  closed to the pre-v1.1 busy-only behavior).
 - Confirm **fail-closed**: if Sync returns `bookable: false` (stale,
   unhealthy, or incomplete), the slot is not offered and confirm is
-  rejected (`409`). Policy stays in Booking; Sync stays facts-only.
-  See [Product Suite Boundaries](../architecture/product-suite-boundaries.md).
-
-Known gap (since resolved): occurrence projection previously forced
-`busy: true` (`packages/sync/src/domain/occurrence-projection.ts`). Google
-already normalizes transparency; `provider-page-applier.ts` stores
-`providerMetadata.transparency = "transparent"` for free events.
-Occurrences now honor that flag. Cancelled occurrences stay excluded.
-
-RSVP-strict "only organized or accepted invites block" is **v1.1**,
-not v1.
+  rejected (`409`). See
+  [Product Suite Boundaries](../architecture/product-suite-boundaries.md).
+- The public busy wire never includes titles, attendees, or emails.
+  Optional facts are `hostIsOrganizer` and `hostResponseStatus` only.
 
 ## Guest cancel
 
@@ -266,7 +271,8 @@ session.
 Unauthenticated:
 
 - `GET /api/booking/pages/:slug` — public page (host display name,
-  duration, timezone, enabled). `404` when missing or disabled.
+  duration, timezone, enabled, optional welcome text). `404` when
+  missing or disabled. Date overrides stay host-only.
 - `GET /api/booking/pages/:slug/slots?start=&end=&timeZone=` — bookable
   instants in the guest timezone for that window. The guest UI requests
   **one month at a time** (plus prefetch of adjacent months). Window
@@ -285,7 +291,7 @@ Authenticated (host session + writable billing, same as event writes):
   enable.
 - Enabling without a healthy Google connection is a typed `403`.
 
-## Out of v1
+## Out of v1 / v1.1
 
 - Multiple event types / appointment types
 - Custom intake questions
@@ -294,12 +300,15 @@ Authenticated (host session + writable billing, same as event writes):
 - Guest reschedule
 - Compass-sent email or SMS
 - `guestsCanModify`
-- RSVP-strict occupancy
 - Editable slug
 - Standalone booking brand, domain, or deployable
 - Production billing packaging specific to booking (uses the existing
   calendar write gate)
 - Non-Google destination calendars
+- Flipping the production gate
+- Host reservation inbox
+- Meet URL on the confirmation screen (Google creates conference
+  asynchronously; the invite email already has it)
 
 ## Implementation
 
@@ -309,12 +318,13 @@ Authenticated (host session + writable billing, same as event writes):
 | --- | --- |
 | Shared contracts | `packages/core/src/types/booking.contracts.ts` |
 | Slot engine | `packages/core/src/booking/compute-booking-slots.ts` |
+| Occupancy policy | `packages/core/src/booking/occupies-booking-slot.ts` |
 | Backend admin API | `packages/backend/src/booking/controllers/booking.controller.ts`, `services/booking-page.service.ts` |
 | Backend public API | `packages/backend/src/booking/services/public-booking.service.ts` |
 | Reservations + cancel tokens | `packages/backend/src/booking/booking-reservation.repository.ts`, `booking-cancel-token.ts` |
 | Calendar application port | `packages/backend/src/booking/services/calendar-booking.port.ts`, `services/calendar-booking.service.ts` |
-| Sync busy occupancy | `packages/sync/src/domain/occurrence-projection.ts`, `busy-query.service.ts` |
-| Host Settings UI | `packages/web/src/booking/BookingSettingsSection.tsx`, `packages/web/src/components/Settings/SettingsModal.tsx` |
+| Sync busy occupancy | `packages/sync/src/domain/occurrence-projection.ts`, `busy-query.service.ts`, `booking-occupancy-facts.ts` |
+| Host Settings UI | `packages/web/src/booking/BookingSettingsSection.tsx`, `BookingDateOverridesEditor.tsx`, `packages/web/src/components/Settings/SettingsModal.tsx` |
 | Public guest UI | `packages/web/src/booking/PublicBookingPage.tsx`, `PublicBookingConfirmedPage.tsx`, `PublicBookingCancelPage.tsx` |
 | Public web API client | `packages/web/src/api/public-booking.api.ts` |
 | E2e | `e2e/booking/`, `e2e/accessibility/booking-a11y.spec.ts` |
@@ -326,7 +336,6 @@ Authenticated (host session + writable billing, same as event writes):
 - **No guest reschedule.** Cancel and rebook, or the host deletes the event.
 - **Confirm is fail-closed.** When Sync reports `bookable: false`, slots
   disappear and confirm returns `409`.
-- **Occupancy is busy-interval based**, not RSVP-strict (v1.1).
 - **Google-only destination** calendars; password-only hosts see a connect-Google
   prompt in Settings.
 - **A duration change re-prices in-flight confirms.** A guest who picked a

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -138,6 +138,7 @@ export interface PublicBookingStubOptions {
   slug?: string;
   hostDisplayName?: string;
   durationMinutes?: number;
+  welcomeText?: string | null;
   slots?: Array<{ slotStart: string; slotEnd: string }>;
   bookable?: boolean;
   /** When set, POST /reservations returns this status instead of 200. */
@@ -194,6 +195,7 @@ export async function preparePublicBookingPage(
           timeZone: "America/Chicago",
           enabled: true,
           maxHorizonDays: 60,
+          welcomeText: options.welcomeText ?? null,
         }),
       );
     }
@@ -420,6 +422,8 @@ export async function prepareSignedInBookingSettingsPage(
     blockingCalendarIds: [BOOKING_CALENDAR_ID],
     timeZone: "America/New_York",
     weeklyAvailability: [],
+    dateOverrides: [],
+    welcomeText: null,
     minNoticeHours: 4,
     maxHorizonDays: 60,
     bufferMinutes: null,

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -25,6 +25,9 @@ test("settings booking page shows a copyable public link after save", async ({
   await expect(settingsDialog.getByLabel("Public booking link")).toHaveValue(
     bookingUrl,
   );
+  await expect(
+    settingsDialog.getByRole("link", { name: "Open booking page" }),
+  ).toHaveAttribute("href", bookingUrl);
   expect(captured.putBodies[0]).toMatchObject({ durationMinutes: 30 });
 
   // A second save has to reach the network too. Seeding the form from the

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -74,7 +74,9 @@ test.describe("public booking page", () => {
     await expect(
       page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
     ).toBeFocused();
-    await expect(page.getByText(/Google Meet/)).toBeVisible();
+    await expect(
+      page.getByText(/A Google Meet invite is on its way to your email/),
+    ).toBeVisible();
     expect(captured.reservationPosts).toHaveLength(1);
     expect(captured.reservationPosts[0]).toMatchObject({
       slotStart,

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -9,8 +9,17 @@ import {
 
 test.describe("public booking page", () => {
   test("loads without login and shows the host heading", async ({ page }) => {
-    await preparePublicBookingPage(page);
+    await preparePublicBookingPage(page, {
+      welcomeText: "30 minutes to talk through Compass Calendar.",
+    });
 
+    await expect(
+      page.getByRole("heading", { name: "Book with Tyler Dane" }),
+    ).toBeVisible();
+    await expect(page.getByText("30 minutes Google Meet")).toBeVisible();
+    await expect(
+      page.getByText("30 minutes to talk through Compass Calendar."),
+    ).toBeVisible();
     await expect(page.getByText(/Times shown in your timezone/)).toBeVisible();
     await expect(
       page.getByRole("heading", { name: "Pick a time" }),
@@ -65,6 +74,7 @@ test.describe("public booking page", () => {
     await expect(
       page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
     ).toBeFocused();
+    await expect(page.getByText(/Google Meet/)).toBeVisible();
     expect(captured.reservationPosts).toHaveLength(1);
     expect(captured.reservationPosts[0]).toMatchObject({
       slotStart,

--- a/packages/backend/src/booking/booking-page.mapper.ts
+++ b/packages/backend/src/booking/booking-page.mapper.ts
@@ -29,6 +29,8 @@ export const mapBookingPageRecordToWire = (
     blockingCalendarIds: record.blockingCalendarIds,
     timeZone: record.timeZone,
     weeklyAvailability: record.weeklyAvailability,
+    dateOverrides: record.dateOverrides ?? [],
+    welcomeText: record.welcomeText ?? null,
     minNoticeHours: record.minNoticeHours,
     maxHorizonDays: record.maxHorizonDays,
     bufferMinutes: record.bufferMinutes,
@@ -59,6 +61,8 @@ export const mapBookingPageRecordToSetupResponse = (
     | "blockingCalendarIds"
     | "timeZone"
     | "weeklyAvailability"
+    | "dateOverrides"
+    | "welcomeText"
     | "minNoticeHours"
     | "maxHorizonDays"
     | "bufferMinutes"
@@ -73,6 +77,8 @@ export const mapBookingPageRecordToSetupResponse = (
     blockingCalendarIds: record.blockingCalendarIds,
     timeZone: record.timeZone,
     weeklyAvailability: record.weeklyAvailability,
+    dateOverrides: record.dateOverrides ?? [],
+    welcomeText: record.welcomeText ?? null,
     minNoticeHours: record.minNoticeHours,
     maxHorizonDays: record.maxHorizonDays,
     bufferMinutes: record.bufferMinutes,
@@ -94,6 +100,8 @@ export const mapPutInputToRecordFields = (
   blockingCalendarIds: input.blockingCalendarIds,
   timeZone: input.timeZone,
   weeklyAvailability: input.weeklyAvailability,
+  dateOverrides: input.dateOverrides ?? [],
+  welcomeText: input.welcomeText ?? null,
   minNoticeHours: input.minNoticeHours,
   maxHorizonDays: input.maxHorizonDays,
   bufferMinutes: input.bufferMinutes,
@@ -112,6 +120,8 @@ export const buildDefaultAdminPutInput = (): AdminPutBookingPageInput => ({
   blockingCalendarIds: [PLACEHOLDER_CALENDAR_ID],
   timeZone: TimeZoneSchema.parse("UTC"),
   weeklyAvailability: [],
+  dateOverrides: [],
+  welcomeText: null,
   minNoticeHours: 4,
   maxHorizonDays: 60,
   bufferMinutes: null,

--- a/packages/backend/src/booking/booking-page.record.ts
+++ b/packages/backend/src/booking/booking-page.record.ts
@@ -1,9 +1,11 @@
 import { z } from "zod/v4";
 import {
   BookingBufferMinutesSchema,
+  BookingDateOverridesSchema,
   BookingDurationMinutesSchema,
   BookingMaxBookingsPerDaySchema,
   BookingSlugSchema,
+  BookingWelcomeTextSchema,
   WeeklyAvailabilitySchema,
 } from "@core/types/booking.contracts";
 import {
@@ -24,6 +26,8 @@ export const BookingPageRecordSchema = z.strictObject({
   blockingCalendarIds: z.array(CalendarIdSchema).min(1).readonly(),
   timeZone: TimeZoneSchema,
   weeklyAvailability: WeeklyAvailabilitySchema,
+  dateOverrides: BookingDateOverridesSchema.default([]),
+  welcomeText: BookingWelcomeTextSchema.nullable().default(null),
   minNoticeHours: z.number().int().nonnegative(),
   maxHorizonDays: z.number().int().positive().max(60),
   bufferMinutes: BookingBufferMinutesSchema,

--- a/packages/backend/src/booking/services/booking-page.service.db.test.ts
+++ b/packages/backend/src/booking/services/booking-page.service.db.test.ts
@@ -203,6 +203,42 @@ describe("BookingPageService", () => {
     expect("durationMinutes" in updated && updated.durationMinutes).toBe(45);
   });
 
+  it("persists date overrides and welcome text", async () => {
+    const userId = await createNamedUser("Override Host");
+    const calendar = writableCalendar();
+    mockHealthySync([calendar]);
+    const input = samplePutInput({
+      destinationCalendarId: calendar.id,
+      blockingCalendarIds: [calendar.id],
+      dateOverrides: [
+        { kind: "blocked", date: "2026-09-07" },
+        {
+          kind: "hours",
+          date: "2026-09-12",
+          intervals: [{ start: "09:00", end: "12:00" }],
+        },
+      ],
+      welcomeText: "30 minutes to talk through Compass Calendar.",
+    });
+
+    await bookingPageService.putAdminPage(userId, input);
+    const page = await bookingPageService.getAdminPage(userId);
+
+    expect(page).toEqual(
+      expect.objectContaining({
+        dateOverrides: [
+          { kind: "blocked", date: "2026-09-07" },
+          {
+            kind: "hours",
+            date: "2026-09-12",
+            intervals: [{ start: "09:00", end: "12:00" }],
+          },
+        ],
+        welcomeText: "30 minutes to talk through Compass Calendar.",
+      }),
+    );
+  });
+
   it("suffixes reserved slug collisions", async () => {
     const firstUserId = await createNamedUser("Week");
     const secondUserId = await createNamedUser("Week");

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -302,6 +302,100 @@ describe("PublicBookingService", () => {
     expect(JSON.stringify(response)).not.toContain("intervals");
   });
 
+  it("offers Saturday starts from a persisted hours override", async () => {
+    const { slug } = await enableBookingPage("Saturday Host", {
+      weeklyAvailability: [],
+      dateOverrides: [
+        {
+          kind: "hours",
+          date: "2026-09-12",
+          intervals: [{ start: "09:00", end: "10:00" }],
+        },
+      ],
+    });
+
+    const response = await service.getSlots(slug, {
+      start: "2026-09-12T00:00:00.000Z",
+      end: "2026-09-13T00:00:00.000Z",
+      timeZone: "UTC",
+    });
+
+    expect(response.bookable).toBe(true);
+    expect(response.slots.map((slot) => slot.slotStart)).toEqual([
+      "2026-09-12T09:00:00.000Z",
+      "2026-09-12T09:15:00.000Z",
+      "2026-09-12T09:30:00.000Z",
+    ]);
+  });
+
+  it("does not occupy a slot for a needsAction invite", async () => {
+    const { slug } = await enableBookingPage();
+    getAvailability.mockImplementation(async () => ({
+      ...busyResponse(true),
+      intervals: [
+        {
+          start: "2026-09-07T10:00:00.000Z",
+          end: "2026-09-07T11:00:00.000Z",
+          hostIsOrganizer: false,
+          hostResponseStatus: "needsAction",
+        },
+      ],
+    }));
+
+    const response = await service.getSlots(slug, {
+      start: "2026-09-07T00:00:00.000Z",
+      end: "2026-09-08T00:00:00.000Z",
+      timeZone: "UTC",
+    });
+
+    expect(
+      response.slots.some(
+        (slot) => slot.slotStart === "2026-09-07T10:00:00.000Z",
+      ),
+    ).toBe(true);
+  });
+
+  it("occupies a slot when the host organized the busy interval", async () => {
+    const { slug } = await enableBookingPage();
+    getAvailability.mockImplementation(async () => ({
+      ...busyResponse(true),
+      intervals: [
+        {
+          start: "2026-09-07T10:00:00.000Z",
+          end: "2026-09-07T11:00:00.000Z",
+          hostIsOrganizer: true,
+          hostResponseStatus: null,
+        },
+      ],
+    }));
+
+    const response = await service.getSlots(slug, {
+      start: "2026-09-07T00:00:00.000Z",
+      end: "2026-09-08T00:00:00.000Z",
+      timeZone: "UTC",
+    });
+
+    expect(
+      response.slots.some(
+        (slot) => slot.slotStart === "2026-09-07T10:00:00.000Z",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns welcome text on the public page without date overrides", async () => {
+    const { slug } = await enableBookingPage("Welcome Host", {
+      welcomeText: "30 minutes to talk through Compass Calendar.",
+      dateOverrides: [{ kind: "blocked", date: "2026-09-07" }],
+    });
+
+    const page = await service.getPublicPage(slug);
+
+    expect(page.welcomeText).toBe(
+      "30 minutes to talk through Compass Calendar.",
+    );
+    expect(page).not.toHaveProperty("dateOverrides");
+  });
+
   it("clamps a requested window that extends past the host horizon", async () => {
     const userId = await createNamedUser("Short Horizon Host");
     const calendar = writableCalendar();

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -322,9 +322,9 @@ describe("PublicBookingService", () => {
 
     expect(response.bookable).toBe(true);
     expect(response.slots.map((slot) => slot.slotStart)).toEqual([
-      "2026-09-12T09:00:00.000Z",
-      "2026-09-12T09:15:00.000Z",
-      "2026-09-12T09:30:00.000Z",
+      "2026-09-12T09:00:00Z",
+      "2026-09-12T09:15:00Z",
+      "2026-09-12T09:30:00Z",
     ]);
   });
 
@@ -350,7 +350,8 @@ describe("PublicBookingService", () => {
 
     expect(
       response.slots.some(
-        (slot) => slot.slotStart === "2026-09-07T10:00:00.000Z",
+        (slot) =>
+          Date.parse(slot.slotStart) === Date.parse("2026-09-07T10:00:00.000Z"),
       ),
     ).toBe(true);
   });
@@ -377,7 +378,8 @@ describe("PublicBookingService", () => {
 
     expect(
       response.slots.some(
-        (slot) => slot.slotStart === "2026-09-07T10:00:00.000Z",
+        (slot) =>
+          Date.parse(slot.slotStart) === Date.parse("2026-09-07T10:00:00.000Z"),
       ),
     ).toBe(false);
   });

--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -3,6 +3,7 @@ import {
   type ComputeBookingSlotsInput,
   computeBookingSlots,
 } from "@core/booking/compute-booking-slots";
+import { occupiesBookingSlot } from "@core/booking/occupies-booking-slot";
 import {
   BookingDurationMinutesSchema,
   BookingSlotsQuerySchema,
@@ -108,14 +109,17 @@ const slotEngineInputForPage = (
   timeZone: page.timeZone,
   durationMinutes: page.durationMinutes,
   weeklyAvailability: page.weeklyAvailability,
+  dateOverrides: page.dateOverrides ?? [],
   minNoticeHours: page.minNoticeHours,
   maxHorizonDays: page.maxHorizonDays,
   bufferMinutes: page.bufferMinutes,
   maxBookingsPerDay: page.maxBookingsPerDay,
-  busyIntervals: availability.intervals.map((interval) => ({
-    start: new Date(interval.start),
-    end: new Date(interval.end),
-  })),
+  busyIntervals: availability.intervals
+    .filter((interval) => occupiesBookingSlot(interval))
+    .map((interval) => ({
+      start: new Date(interval.start),
+      end: new Date(interval.end),
+    })),
   confirmedReservationStarts,
   now: window.now,
   windowStart: window.windowStart,

--- a/packages/core/src/booking/compute-booking-slots.test.ts
+++ b/packages/core/src/booking/compute-booking-slots.test.ts
@@ -165,6 +165,98 @@ describe("computeBookingSlots", () => {
     expect(new Set(slots).size).toBe(slots.length);
   });
 
+  it("removes every start on a blocked weekday that would otherwise be open", () => {
+    const slots = computeBookingSlots(
+      baseInput({
+        dateOverrides: [{ kind: "blocked", date: "2026-09-07" }],
+      }),
+    );
+
+    expect(slots.filter((slot) => slot.startsWith("2026-09-07"))).toEqual([]);
+    expect(slots.some((slot) => slot.startsWith("2026-09-09"))).toBe(true);
+  });
+
+  it("offers Saturday starts from a hours override when Saturday has no weekly hours", () => {
+    const slots = computeBookingSlots(
+      baseInput({
+        dateOverrides: [
+          {
+            kind: "hours",
+            date: "2026-09-12",
+            intervals: [{ start: "09:00", end: "10:00" }],
+          },
+        ],
+      }),
+    );
+
+    expect(slots.filter((slot) => slot.startsWith("2026-09-12"))).toEqual([
+      "2026-09-12T15:00:00Z",
+      "2026-09-12T15:15:00Z",
+      "2026-09-12T15:30:00Z",
+    ]);
+  });
+
+  it("replaces Monday weekly hours with a hours override", () => {
+    const slots = computeBookingSlots(
+      baseInput({
+        dateOverrides: [
+          {
+            kind: "hours",
+            date: "2026-09-07",
+            intervals: [{ start: "13:00", end: "17:00" }],
+          },
+        ],
+        windowStart: new Date("2026-09-07T06:00:00.000Z"),
+        windowEnd: new Date("2026-09-08T06:00:00.000Z"),
+      }),
+    );
+
+    expect(slots[0]).toBe("2026-09-07T19:00:00Z");
+    expect(slots.some((slot) => slot.startsWith("2026-09-07T15:"))).toBe(false);
+  });
+
+  it("offers override hours when weekly availability is otherwise empty", () => {
+    const slots = computeBookingSlots(
+      baseInput({
+        weeklyAvailability: [],
+        dateOverrides: [
+          {
+            kind: "hours",
+            date: "2026-09-12",
+            intervals: [{ start: "09:00", end: "10:00" }],
+          },
+        ],
+      }),
+    );
+
+    expect(slots).toEqual([
+      "2026-09-12T15:00:00Z",
+      "2026-09-12T15:15:00Z",
+      "2026-09-12T15:30:00Z",
+    ]);
+  });
+
+  it("skips invalid local times on a DST spring-forward override date", () => {
+    const slots = computeBookingSlots(
+      baseInput({
+        now: new Date("2026-03-01T00:00:00.000Z"),
+        windowStart: new Date("2026-03-08T07:00:00.000Z"),
+        windowEnd: new Date("2026-03-09T07:00:00.000Z"),
+        weeklyAvailability: [],
+        dateOverrides: [
+          {
+            kind: "hours",
+            date: "2026-03-08",
+            intervals: [{ start: "02:00", end: "04:00" }],
+          },
+        ],
+        durationMinutes: 15,
+      }),
+    );
+
+    expect(slots.every((slot) => !slot.includes("T08:30:00"))).toBe(true);
+  });
+
   it("skips invalid local times on DST spring-forward", () => {
     const slots = computeBookingSlots(
       baseInput({

--- a/packages/core/src/booking/compute-booking-slots.ts
+++ b/packages/core/src/booking/compute-booking-slots.ts
@@ -1,4 +1,5 @@
 import {
+  type BookingDateOverrides,
   type BookingDurationMinutes,
   localTimeToMinutes,
   type WeeklyAvailability,
@@ -17,6 +18,7 @@ export interface ComputeBookingSlotsInput {
   timeZone: string;
   durationMinutes: BookingDurationMinutes;
   weeklyAvailability: WeeklyAvailability;
+  dateOverrides?: BookingDateOverrides;
   minNoticeHours: number;
   maxHorizonDays: number;
   bufferMinutes: number | null;
@@ -121,9 +123,26 @@ const availabilityForWeekday = (
   weekday: number,
 ) => weeklyAvailability.filter((interval) => interval.weekday === weekday);
 
+const availabilityForLocalDate = (
+  weeklyAvailability: WeeklyAvailability,
+  dateOverrides: BookingDateOverrides,
+  localDate: string,
+  weekday: number,
+): readonly { start: string; end: string }[] | null => {
+  const override = dateOverrides.find((entry) => entry.date === localDate);
+  if (override?.kind === "blocked") {
+    return null;
+  }
+  if (override?.kind === "hours") {
+    return override.intervals;
+  }
+  return availabilityForWeekday(weeklyAvailability, weekday);
+};
+
 /**
- * Pure slot engine: weekly hours, busy/reservation buffers, min notice,
- * horizon, and max-per-day caps. Returns UTC instants valid as slot starts.
+ * Pure slot engine: weekly hours, date overrides, busy/reservation buffers,
+ * min notice, horizon, and max-per-day caps. Returns UTC instants valid as
+ * slot starts.
  */
 export const computeBookingSlots = (
   input: ComputeBookingSlotsInput,
@@ -132,6 +151,7 @@ export const computeBookingSlots = (
     timeZone,
     durationMinutes,
     weeklyAvailability,
+    dateOverrides = [],
     minNoticeHours,
     maxHorizonDays,
     bufferMinutes,
@@ -143,7 +163,7 @@ export const computeBookingSlots = (
     windowEnd,
   } = input;
 
-  if (weeklyAvailability.length === 0) {
+  if (weeklyAvailability.length === 0 && dateOverrides.length === 0) {
     return [];
   }
 
@@ -176,8 +196,17 @@ export const computeBookingSlots = (
 
   while (dayCursor.isSameOrBefore(lastDay, "day")) {
     const weekday = toIsoWeekday(dayCursor);
-    const dayAvailability = availabilityForWeekday(weeklyAvailability, weekday);
     const localDate = dayCursor.format("YYYY-MM-DD");
+    const dayAvailability = availabilityForLocalDate(
+      weeklyAvailability,
+      dateOverrides,
+      localDate,
+      weekday,
+    );
+    if (dayAvailability === null) {
+      dayCursor = dayCursor.add(1, "day");
+      continue;
+    }
 
     if (
       maxBookingsPerDay !== null &&

--- a/packages/core/src/booking/occupies-booking-slot.test.ts
+++ b/packages/core/src/booking/occupies-booking-slot.test.ts
@@ -1,0 +1,39 @@
+import { occupiesBookingSlot } from "@core/booking/occupies-booking-slot";
+import { describe, expect, it } from "bun:test";
+
+describe("occupiesBookingSlot", () => {
+  it("treats a host-organized interval as occupying", () => {
+    expect(
+      occupiesBookingSlot({
+        hostIsOrganizer: true,
+        hostResponseStatus: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("treats an accepted invite as occupying", () => {
+    expect(
+      occupiesBookingSlot({
+        hostIsOrganizer: false,
+        hostResponseStatus: "accepted",
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    "needsAction",
+    "declined",
+    "tentative",
+  ] as const)("does not occupy a %s invite", (hostResponseStatus) => {
+    expect(
+      occupiesBookingSlot({
+        hostIsOrganizer: false,
+        hostResponseStatus,
+      }),
+    ).toBe(false);
+  });
+
+  it("occupies a legacy interval that has no RSVP facts", () => {
+    expect(occupiesBookingSlot({})).toBe(true);
+  });
+});

--- a/packages/core/src/booking/occupies-booking-slot.ts
+++ b/packages/core/src/booking/occupies-booking-slot.ts
@@ -1,0 +1,23 @@
+import { type AttendeeResponseStatus } from "@core/types/event-attendance.contracts";
+
+export interface BookingOccupancyFacts {
+  hostIsOrganizer?: boolean;
+  hostResponseStatus?: AttendeeResponseStatus | null;
+}
+
+/**
+ * Booking policy: a busy interval occupies a slot only when the host
+ * organized it or accepted it. Missing facts (legacy busy intervals) occupy,
+ * matching the pre-v1.1 busy-only behavior.
+ */
+export const occupiesBookingSlot = (facts: BookingOccupancyFacts): boolean => {
+  if (
+    facts.hostIsOrganizer === undefined &&
+    facts.hostResponseStatus === undefined
+  ) {
+    return true;
+  }
+  return (
+    facts.hostIsOrganizer === true || facts.hostResponseStatus === "accepted"
+  );
+};

--- a/packages/core/src/types/booking.contracts.test.ts
+++ b/packages/core/src/types/booking.contracts.test.ts
@@ -118,10 +118,11 @@ describe("PublicBookingPageSchema", () => {
       "timeZone",
       "enabled",
       "maxHorizonDays",
+      "welcomeText",
     ]);
   });
 
-  it("projects an admin page without calendar ids", () => {
+  it("projects an admin page without calendar ids or date overrides", () => {
     const admin = BookingPageSchema.parse(fullAdminPage());
     const pub = toPublicBookingPage(admin, "Tyler Dane");
 
@@ -132,9 +133,150 @@ describe("PublicBookingPageSchema", () => {
       timeZone: "America/Denver",
       enabled: true,
       maxHorizonDays: 60,
+      welcomeText: null,
     });
     expect(Object.keys(pub)).not.toContain("destinationCalendarId");
     expect(Object.keys(pub)).not.toContain("blockingCalendarIds");
+    expect(Object.keys(pub)).not.toContain("dateOverrides");
+  });
+});
+
+describe("date overrides and welcome text", () => {
+  it("defaults missing dateOverrides and welcomeText", () => {
+    const page = BookingPageSchema.parse(fullAdminPage());
+    expect(page.dateOverrides).toEqual([]);
+    expect(page.welcomeText).toBeNull();
+  });
+
+  it("parses a blocked date and a Saturday hours override", () => {
+    const parsed = AdminPutBookingPageInputSchema.safeParse({
+      enabled: true,
+      durationMinutes: 30,
+      destinationCalendarId: calendarId(),
+      blockingCalendarIds: [calendarId()],
+      timeZone: "America/Denver",
+      weeklyAvailability: [{ weekday: 1, start: "09:00", end: "12:00" }],
+      dateOverrides: [
+        { kind: "blocked", date: "2026-09-07" },
+        {
+          kind: "hours",
+          date: "2026-09-12",
+          intervals: [{ start: "09:00", end: "12:00" }],
+        },
+      ],
+      welcomeText: "30 minutes to talk through Compass Calendar.",
+      minNoticeHours: 4,
+      maxHorizonDays: 60,
+      bufferMinutes: null,
+      maxBookingsPerDay: null,
+      guestsCanInviteOthers: true,
+    });
+
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.welcomeText).toBe(
+        "30 minutes to talk through Compass Calendar.",
+      );
+    }
+  });
+
+  it("rejects duplicate override dates", () => {
+    expect(
+      AdminPutBookingPageInputSchema.safeParse({
+        enabled: false,
+        durationMinutes: 30,
+        destinationCalendarId: calendarId(),
+        blockingCalendarIds: [calendarId()],
+        timeZone: "UTC",
+        weeklyAvailability: [],
+        dateOverrides: [
+          { kind: "blocked", date: "2026-09-07" },
+          {
+            kind: "hours",
+            date: "2026-09-07",
+            intervals: [{ start: "09:00", end: "10:00" }],
+          },
+        ],
+        minNoticeHours: 4,
+        maxHorizonDays: 60,
+        bufferMinutes: null,
+        maxBookingsPerDay: null,
+        guestsCanInviteOthers: true,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects overlapping hours on one date, empty hours, and 61 overrides", () => {
+    const base = {
+      enabled: false,
+      durationMinutes: 30 as const,
+      destinationCalendarId: calendarId(),
+      blockingCalendarIds: [calendarId()],
+      timeZone: "UTC",
+      weeklyAvailability: [],
+      minNoticeHours: 4,
+      maxHorizonDays: 60,
+      bufferMinutes: null,
+      maxBookingsPerDay: null,
+      guestsCanInviteOthers: true,
+    };
+
+    expect(
+      AdminPutBookingPageInputSchema.safeParse({
+        ...base,
+        dateOverrides: [
+          {
+            kind: "hours",
+            date: "2026-09-12",
+            intervals: [
+              { start: "09:00", end: "12:00" },
+              { start: "11:00", end: "13:00" },
+            ],
+          },
+        ],
+      }).success,
+    ).toBe(false);
+
+    expect(
+      AdminPutBookingPageInputSchema.safeParse({
+        ...base,
+        dateOverrides: [{ kind: "hours", date: "2026-09-12", intervals: [] }],
+      }).success,
+    ).toBe(false);
+
+    expect(
+      AdminPutBookingPageInputSchema.safeParse({
+        ...base,
+        dateOverrides: Array.from({ length: 61 }, (_, index) => {
+          const date = new Date(Date.UTC(2026, 0, 1 + index));
+          const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+          const day = String(date.getUTCDate()).padStart(2, "0");
+          return {
+            kind: "blocked" as const,
+            date: `${date.getUTCFullYear()}-${month}-${day}`,
+          };
+        }),
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects welcome text longer than 500 characters", () => {
+    expect(
+      AdminPutBookingPageInputSchema.safeParse({
+        enabled: false,
+        durationMinutes: 30,
+        destinationCalendarId: calendarId(),
+        blockingCalendarIds: [calendarId()],
+        timeZone: "UTC",
+        weeklyAvailability: [],
+        welcomeText: "w".repeat(501),
+        minNoticeHours: 4,
+        maxHorizonDays: 60,
+        bufferMinutes: null,
+        maxBookingsPerDay: null,
+        guestsCanInviteOthers: true,
+      }).success,
+    ).toBe(false);
   });
 });
 
@@ -204,6 +346,7 @@ describe("HTTP booking contracts", () => {
         timeZone: admin.timeZone,
         enabled: admin.enabled,
         maxHorizonDays: admin.maxHorizonDays,
+        welcomeText: null,
       }).success,
     ).toBe(true);
 

--- a/packages/core/src/types/booking.contracts.ts
+++ b/packages/core/src/types/booking.contracts.ts
@@ -143,6 +143,124 @@ export const WeeklyAvailabilitySchema = z
   });
 export type WeeklyAvailability = z.infer<typeof WeeklyAvailabilitySchema>;
 
+const LOCAL_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+const isRealLocalDate = (value: string): boolean => {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) {
+    return false;
+  }
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
+};
+
+/** Host-timezone calendar date `YYYY-MM-DD`. */
+export const BookingLocalDateSchema = z
+  .string()
+  .trim()
+  .regex(LOCAL_DATE_PATTERN, { message: "Date must be YYYY-MM-DD" })
+  .refine(isRealLocalDate, { message: "Date must be a real calendar date" });
+export type BookingLocalDate = z.infer<typeof BookingLocalDateSchema>;
+
+export const DateHoursIntervalSchema = z
+  .strictObject({
+    start: LocalTimeOfDaySchema,
+    end: LocalTimeOfDaySchema,
+  })
+  .refine(
+    ({ start, end }) => localTimeToMinutes(end) > localTimeToMinutes(start),
+    { message: "Availability end must be after start", path: ["end"] },
+  );
+export type DateHoursInterval = z.infer<typeof DateHoursIntervalSchema>;
+
+const dateHoursOverlap = (
+  left: DateHoursInterval,
+  right: DateHoursInterval,
+): boolean => {
+  const leftStart = localTimeToMinutes(left.start);
+  const leftEnd = localTimeToMinutes(left.end);
+  const rightStart = localTimeToMinutes(right.start);
+  const rightEnd = localTimeToMinutes(right.end);
+  return leftStart < rightEnd && rightStart < leftEnd;
+};
+
+export const BookingBlockedDateOverrideSchema = z.strictObject({
+  kind: z.literal("blocked"),
+  date: BookingLocalDateSchema,
+});
+
+export const BookingHoursDateOverrideSchema = z
+  .strictObject({
+    kind: z.literal("hours"),
+    date: BookingLocalDateSchema,
+    intervals: z.array(DateHoursIntervalSchema).min(1).readonly(),
+  })
+  .superRefine((override, ctx) => {
+    for (let i = 0; i < override.intervals.length; i += 1) {
+      const left = override.intervals[i];
+      if (!left) {
+        continue;
+      }
+      for (let j = i + 1; j < override.intervals.length; j += 1) {
+        const right = override.intervals[j];
+        if (!right) {
+          continue;
+        }
+        if (dateHoursOverlap(left, right)) {
+          ctx.addIssue({
+            code: "custom",
+            message: "Date override hours must not overlap",
+            path: ["intervals", j],
+          });
+        }
+      }
+    }
+  });
+
+export const BookingDateOverrideSchema = z.discriminatedUnion("kind", [
+  BookingBlockedDateOverrideSchema,
+  BookingHoursDateOverrideSchema,
+]);
+export type BookingDateOverride = z.infer<typeof BookingDateOverrideSchema>;
+
+export const BookingDateOverridesSchema = z
+  .array(BookingDateOverrideSchema)
+  .max(60)
+  .readonly()
+  .superRefine((overrides, ctx) => {
+    const seen = new Set<string>();
+    for (let i = 0; i < overrides.length; i += 1) {
+      const override = overrides[i];
+      if (!override) {
+        continue;
+      }
+      if (seen.has(override.date)) {
+        ctx.addIssue({
+          code: "custom",
+          message: "Date overrides must be unique",
+          path: [i, "date"],
+        });
+      }
+      seen.add(override.date);
+    }
+  });
+export type BookingDateOverrides = z.infer<typeof BookingDateOverridesSchema>;
+
+export const BookingWelcomeTextSchema = z
+  .string()
+  .trim()
+  .max(500)
+  .nullable()
+  .transform((value) => (value === "" ? null : value));
+export type BookingWelcomeText = z.infer<typeof BookingWelcomeTextSchema>;
+
 export const BookingBufferMinutesSchema = z
   .int()
   .positive()
@@ -169,6 +287,8 @@ export const BookingPageSchema = z.strictObject({
   blockingCalendarIds: z.array(CalendarIdSchema).min(1).readonly(),
   timeZone: TimeZoneSchema,
   weeklyAvailability: WeeklyAvailabilitySchema,
+  dateOverrides: BookingDateOverridesSchema.default([]),
+  welcomeText: BookingWelcomeTextSchema.nullable().default(null),
   minNoticeHours: z.number().int().nonnegative().default(4),
   maxHorizonDays: z.number().int().positive().max(60).default(60),
   bufferMinutes: BookingBufferMinutesSchema,
@@ -185,13 +305,18 @@ export const PublicBookingPageSchema = z.strictObject({
   timeZone: TimeZoneSchema,
   enabled: z.boolean(),
   maxHorizonDays: z.number().int().positive().max(60),
+  welcomeText: BookingWelcomeTextSchema.nullable().default(null),
 });
 export type PublicBookingPage = z.infer<typeof PublicBookingPageSchema>;
 
 export const toPublicBookingPage = (
   page: Pick<
     BookingPage,
-    "durationMinutes" | "timeZone" | "enabled" | "maxHorizonDays"
+    | "durationMinutes"
+    | "timeZone"
+    | "enabled"
+    | "maxHorizonDays"
+    | "welcomeText"
   >,
   hostDisplayName: string,
 ): PublicBookingPage =>
@@ -201,6 +326,7 @@ export const toPublicBookingPage = (
     timeZone: page.timeZone,
     enabled: page.enabled,
     maxHorizonDays: page.maxHorizonDays,
+    welcomeText: page.welcomeText ?? null,
   });
 
 export const BookingReservationStatusSchema = z.enum([
@@ -295,6 +421,8 @@ export const AdminPutBookingPageInputSchema = z.strictObject({
   blockingCalendarIds: z.array(CalendarIdSchema).min(1).readonly(),
   timeZone: TimeZoneSchema,
   weeklyAvailability: WeeklyAvailabilitySchema,
+  dateOverrides: BookingDateOverridesSchema.default([]),
+  welcomeText: BookingWelcomeTextSchema.nullable().default(null),
   minNoticeHours: z.number().int().nonnegative().default(4),
   maxHorizonDays: z.number().int().positive().max(60).default(60),
   bufferMinutes: BookingBufferMinutesSchema,

--- a/packages/core/src/types/sync/availability.contracts.ts
+++ b/packages/core/src/types/sync/availability.contracts.ts
@@ -1,5 +1,6 @@
 import { z } from "zod/v4";
 import { DateTimeSchema } from "@core/types/domain-primitives";
+import { AttendeeResponseStatusSchema } from "@core/types/event-attendance.contracts";
 import { ConnectionStateSchema } from "@core/types/sync/connection.contracts";
 import { SyncEventCalendarIdSchema } from "@core/types/sync/event.contracts";
 import { ConnectionIdSchema } from "@core/types/sync/identity.contracts";
@@ -41,9 +42,13 @@ export type BusyAvailabilityRequest = z.infer<
 >;
 
 // A normalized half-open busy interval on the wire (ISO instants).
+// Occupancy facts are optional so display callers can keep {start,end} only.
+// Booking uses hostIsOrganizer / hostResponseStatus; emails never appear.
 export const BusyIntervalSchema = z.strictObject({
   start: DateTimeSchema,
   end: DateTimeSchema,
+  hostIsOrganizer: z.boolean().optional(),
+  hostResponseStatus: AttendeeResponseStatusSchema.nullable().optional(),
 });
 
 // Why a requested calendar's busy data could not be freshly included.

--- a/packages/scripts/src/testing/test-parallel.test.ts
+++ b/packages/scripts/src/testing/test-parallel.test.ts
@@ -1,4 +1,9 @@
-import { parallelArgsFor, testArgvFor } from "./test-parallel";
+import {
+  parallelArgsFor,
+  shardTargets,
+  testArgvFor,
+  webSuiteShardCount,
+} from "./test-parallel";
 import { describe, expect, it } from "bun:test";
 
 const argvOpts = {
@@ -31,5 +36,38 @@ describe("testArgvFor", () => {
         targets: ["./packages/core/src"],
       }),
     ).toContain("--parallel");
+  });
+});
+
+describe("shardTargets", () => {
+  it("keeps a single shard when count is 1", () => {
+    expect(shardTargets(["a", "b", "c"], 1)).toEqual([["a", "b", "c"]]);
+  });
+
+  it("splits files into contiguous shards", () => {
+    expect(shardTargets(["a", "b", "c", "d"], 2)).toEqual([
+      ["a", "b"],
+      ["c", "d"],
+    ]);
+  });
+
+  it("does not emit empty shards when the count exceeds the file count", () => {
+    expect(shardTargets(["a", "b"], 4)).toEqual([["a"], ["b"]]);
+  });
+});
+
+describe("webSuiteShardCount", () => {
+  it("stays on one process for an explicit path focus", () => {
+    expect(webSuiteShardCount({ explicitPathCount: 1 })).toBe(1);
+  });
+
+  it("defaults the full suite to two processes", () => {
+    expect(webSuiteShardCount({ explicitPathCount: 0 })).toBe(2);
+  });
+
+  it("honors WEB_TEST_SHARDS when focusing the full suite", () => {
+    expect(webSuiteShardCount({ explicitPathCount: 0, envShards: "3" })).toBe(
+      3,
+    );
   });
 });

--- a/packages/scripts/src/testing/test-parallel.ts
+++ b/packages/scripts/src/testing/test-parallel.ts
@@ -9,6 +9,7 @@
 import { backendTestSpawnEnv } from "./backend-test-env";
 import {
   formatDuration,
+  parseExtraArgs,
   resolveTestTargets,
   warnIfBunVersionMismatch,
 } from "./runner-utils";
@@ -57,9 +58,46 @@ const PROFILES: Record<
 
 // Web uses jsdom + MSW XHR patching + module singletons that Bun's parallel
 // `--isolate` clears between files (MSW's oldXMLHttpRequest becomes undefined).
-// One process, sequential files is still far faster than the old per-file launcher.
+// Sequential files in one process is still far faster than the old per-file
+// launcher. The full web suite then runs as a few sequential processes so
+// jsdom/MSW RSS is released between shards — a single 3k-test process has
+// been SIGKILL'd (exit 137) on 7 GB GitHub runners.
 export function parallelArgsFor(profile: ProfileName): string[] {
   return profile === "web" ? [] : ["--parallel"];
+}
+
+export function shardTargets(
+  targets: string[],
+  shardCount: number,
+): string[][] {
+  if (targets.length === 0 || shardCount <= 1) {
+    return [targets];
+  }
+  const count = Math.min(Math.floor(shardCount), targets.length);
+  const size = Math.ceil(targets.length / count);
+  const shards: string[][] = [];
+  for (let i = 0; i < targets.length; i += size) {
+    shards.push(targets.slice(i, i + size));
+  }
+  return shards;
+}
+
+export function webSuiteShardCount(opts: {
+  explicitPathCount: number;
+  envShards?: string;
+}): number {
+  if (opts.explicitPathCount > 0) {
+    return 1;
+  }
+  const raw = opts.envShards;
+  if (raw === undefined || raw === "") {
+    return 2;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return 2;
+  }
+  return Math.floor(parsed);
 }
 
 export function testArgvFor(
@@ -109,32 +147,51 @@ async function runCli(): Promise<void> {
   const { targets, bunFlags } = resolveTestTargets(scan, extraArgs, {
     expandDirectory: true,
   });
+  const { explicitPaths } = parseExtraArgs(extraArgs);
+  const shards =
+    profile === "web"
+      ? shardTargets(
+          targets,
+          webSuiteShardCount({
+            explicitPathCount: explicitPaths.length,
+            envShards: process.env.WEB_TEST_SHARDS,
+          }),
+        )
+      : [targets];
 
   const started = Date.now();
-  const testTargets = testArgvFor(profile, {
-    preloadPath,
-    bunFlags,
-    targets,
-  });
-
-  console.log(`Running ${label}...`);
-
   const spawnEnv =
     profile === "backend-fast" || profile === "scripts-fast"
       ? backendTestSpawnEnv(FAST_MONGO_URI)
       : { ...process.env, TZ: "Etc/UTC", NODE_ENV: "test" };
 
-  const proc = Bun.spawn(testTargets, {
-    env: spawnEnv,
-    stdout: "inherit",
-    stderr: "inherit",
-  });
-  const code = await proc.exited;
-  console.log(`\n${label}: finished in ${formatDuration(started)}s`);
+  for (const [index, shard] of shards.entries()) {
+    const shardLabel =
+      shards.length > 1
+        ? `${label} shard ${index + 1}/${shards.length} (${shard.length} files)`
+        : label;
+    console.log(`Running ${shardLabel}...`);
 
-  if (code !== 0) {
-    process.exit(code ?? 1);
+    const proc = Bun.spawn(
+      testArgvFor(profile, {
+        preloadPath,
+        bunFlags,
+        targets: shard,
+      }),
+      {
+        env: spawnEnv,
+        stdout: "inherit",
+        stderr: "inherit",
+      },
+    );
+    const code = await proc.exited;
+    if (code !== 0) {
+      console.log(`\n${shardLabel}: finished in ${formatDuration(started)}s`);
+      process.exit(code ?? 1);
+    }
   }
+
+  console.log(`\n${label}: finished in ${formatDuration(started)}s`);
 }
 
 if (import.meta.main) {

--- a/packages/scripts/src/testing/test-parallel.ts
+++ b/packages/scripts/src/testing/test-parallel.ts
@@ -154,7 +154,7 @@ async function runCli(): Promise<void> {
           targets,
           webSuiteShardCount({
             explicitPathCount: explicitPaths.length,
-            envShards: process.env.WEB_TEST_SHARDS,
+            envShards: process.env["WEB_TEST_SHARDS"],
           }),
         )
       : [targets];

--- a/packages/sync/src/domain/booking-occupancy-facts.test.ts
+++ b/packages/sync/src/domain/booking-occupancy-facts.test.ts
@@ -1,0 +1,85 @@
+import { occupancyFactsForEvent } from "@sync/domain/booking-occupancy-facts";
+import { type EventRecord } from "@sync/storage/contracts/event.contracts";
+import { describe, expect, it } from "bun:test";
+
+const event = (overrides: Partial<EventRecord["content"]> = {}): EventRecord =>
+  ({
+    content: {
+      title: "Busy",
+      description: "",
+      location: null,
+      organizer: null,
+      attendees: [],
+      conference: null,
+      ...overrides,
+    },
+  }) as EventRecord;
+
+describe("occupancyFactsForEvent", () => {
+  it("treats a missing event as host-organized", () => {
+    expect(occupancyFactsForEvent(undefined, "host@example.com")).toEqual({
+      hostIsOrganizer: true,
+      hostResponseStatus: null,
+    });
+  });
+
+  it("treats a Compass-created event with no organizer as host-organized", () => {
+    expect(occupancyFactsForEvent(event(), "host@example.com")).toEqual({
+      hostIsOrganizer: true,
+      hostResponseStatus: null,
+    });
+  });
+
+  it("matches the organizer email case-insensitively", () => {
+    expect(
+      occupancyFactsForEvent(
+        event({
+          organizer: { email: "Host@Example.com", displayName: "Host" },
+        }),
+        "host@example.com",
+      ),
+    ).toEqual({ hostIsOrganizer: true, hostResponseStatus: null });
+  });
+
+  it("reads the host attendee response when the host is not the organizer", () => {
+    expect(
+      occupancyFactsForEvent(
+        event({
+          organizer: { email: "other@example.com", displayName: "Other" },
+          attendees: [
+            {
+              email: "HOST@example.com",
+              displayName: "Host",
+              responseStatus: "needsAction",
+            },
+          ],
+        }),
+        "host@example.com",
+      ),
+    ).toEqual({
+      hostIsOrganizer: false,
+      hostResponseStatus: "needsAction",
+    });
+  });
+
+  it("reads an accepted invite when the host is not the organizer", () => {
+    expect(
+      occupancyFactsForEvent(
+        event({
+          organizer: { email: "other@example.com", displayName: "Other" },
+          attendees: [
+            {
+              email: "host@example.com",
+              displayName: "Host",
+              responseStatus: "accepted",
+            },
+          ],
+        }),
+        "host@example.com",
+      ),
+    ).toEqual({
+      hostIsOrganizer: false,
+      hostResponseStatus: "accepted",
+    });
+  });
+});

--- a/packages/sync/src/domain/booking-occupancy-facts.ts
+++ b/packages/sync/src/domain/booking-occupancy-facts.ts
@@ -1,0 +1,36 @@
+import { type AttendeeResponseStatus } from "@core/types/event-attendance.contracts";
+import { type EventRecord } from "@sync/storage/contracts/event.contracts";
+
+export interface OccupancyFacts {
+  hostIsOrganizer: boolean;
+  hostResponseStatus: AttendeeResponseStatus | null;
+}
+
+/**
+ * Facts only: whether this event's host identity matches the organizer or
+ * an attendee, and that attendee's response. Booking decides occupancy.
+ * A missing event (occurrence-only fixture) is treated as host-organized.
+ */
+export const occupancyFactsForEvent = (
+  event: EventRecord | undefined,
+  accountEmail: string | null,
+): OccupancyFacts => {
+  if (!event) {
+    return { hostIsOrganizer: true, hostResponseStatus: null };
+  }
+
+  const self = accountEmail?.trim().toLowerCase() ?? null;
+  const organizerEmail = event.content.organizer?.email.trim().toLowerCase();
+  const hostIsOrganizer =
+    organizerEmail === undefined || organizerEmail === self;
+  const selfAttendee = self
+    ? event.content.attendees.find(
+        (attendee) => attendee.email.trim().toLowerCase() === self,
+      )
+    : undefined;
+
+  return {
+    hostIsOrganizer,
+    hostResponseStatus: selfAttendee?.responseStatus ?? null,
+  };
+};

--- a/packages/sync/src/domain/busy-query.service.test.ts
+++ b/packages/sync/src/domain/busy-query.service.test.ts
@@ -78,6 +78,27 @@ describe("mergeBusyIntervals", () => {
     ]);
   });
 
+  it("does not merge touching intervals with different occupancy facts", () => {
+    const out = mergeBusyIntervals([
+      {
+        start: new Date("2026-07-14T09:00Z"),
+        end: new Date("2026-07-14T10:00Z"),
+        hostIsOrganizer: true,
+        hostResponseStatus: null,
+      },
+      {
+        start: new Date("2026-07-14T10:00Z"),
+        end: new Date("2026-07-14T11:00Z"),
+        hostIsOrganizer: false,
+        hostResponseStatus: "needsAction",
+      },
+    ]);
+
+    expect(out).toHaveLength(2);
+    expect(out[0]?.hostIsOrganizer).toBe(true);
+    expect(out[1]?.hostResponseStatus).toBe("needsAction");
+  });
+
   it("drops empty (zero-length) intervals", () => {
     const out = mergeBusyIntervals([
       iv("2026-07-14T09:00Z", "2026-07-14T09:00Z"),

--- a/packages/sync/src/domain/busy-query.service.ts
+++ b/packages/sync/src/domain/busy-query.service.ts
@@ -1,3 +1,5 @@
+import { type EventId } from "@core/types/domain-primitives";
+import { type AttendeeResponseStatus } from "@core/types/event-attendance.contracts";
 import { type ConnectionState } from "@core/types/sync/connection.contracts";
 import { type SyncEventCalendarId } from "@core/types/sync/event.contracts";
 import {
@@ -5,6 +7,9 @@ import {
   type PrincipalId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
+import { occupancyFactsForEvent } from "@sync/domain/booking-occupancy-facts";
+import { type EventRecord } from "@sync/storage/contracts/event.contracts";
+import { type EventRepository } from "@sync/storage/repositories/event.repository";
 import {
   type CalendarGeneration,
   type EventOccurrenceRepository,
@@ -16,6 +21,8 @@ import { type SyncResourceRepository } from "@sync/storage/repositories/sync-res
 export interface BusyInterval {
   start: Date;
   end: Date;
+  hostIsOrganizer?: boolean;
+  hostResponseStatus?: AttendeeResponseStatus | null;
 }
 
 // Merge half-open [start, end) intervals into the minimal set of
@@ -24,6 +31,9 @@ export interface BusyInterval {
 // so availability must treat them as one busy block [9,11). Empty intervals
 // (start >= end) contribute no busy time and are dropped. Pure and input-order
 // independent.
+const occupancyKey = (interval: BusyInterval): string =>
+  `${interval.hostIsOrganizer ?? ""}:${interval.hostResponseStatus ?? ""}`;
+
 export function mergeBusyIntervals(
   intervals: readonly BusyInterval[],
 ): BusyInterval[] {
@@ -38,12 +48,16 @@ export function mergeBusyIntervals(
   const merged: BusyInterval[] = [];
   for (const current of sorted) {
     const last = merged[merged.length - 1];
-    if (last && current.start.getTime() <= last.end.getTime()) {
+    if (
+      last &&
+      occupancyKey(last) === occupancyKey(current) &&
+      current.start.getTime() <= last.end.getTime()
+    ) {
       // Overlapping or touching: extend the open block if this one reaches
       // further (a fully-nested interval leaves the end unchanged).
       if (current.end.getTime() > last.end.getTime()) last.end = current.end;
     } else {
-      merged.push({ start: current.start, end: current.end });
+      merged.push({ ...current });
     }
   }
   return merged;
@@ -68,10 +82,16 @@ export interface BusyQueryInput {
 // spills past either edge contributes only its in-window busy time. This returns
 // intervals only; freshness/completeness/bookability evidence is layered on by a
 // later slice.
-export async function queryBusyIntervals(
+export interface BusyOccurrenceInterval {
+  start: Date;
+  end: Date;
+  eventId: EventId;
+}
+
+export async function queryBusyOccurrences(
   deps: BusyQueryDeps,
   input: BusyQueryInput,
-): Promise<BusyInterval[]> {
+): Promise<BusyOccurrenceInterval[]> {
   const occurrences = await deps.occurrences.listBusyOverlapping({
     tenantId: input.tenantId,
     principalId: input.principalId,
@@ -82,12 +102,24 @@ export async function queryBusyIntervals(
 
   const windowStart = input.start.getTime();
   const windowEnd = input.end.getTime();
-  const clamped = occurrences.map((o) => ({
-    start: o.startAt.getTime() > windowStart ? o.startAt : input.start,
-    end: o.endAt.getTime() < windowEnd ? o.endAt : input.end,
-  }));
+  return occurrences
+    .map((occurrence) => ({
+      start:
+        occurrence.startAt.getTime() > windowStart
+          ? occurrence.startAt
+          : input.start,
+      end:
+        occurrence.endAt.getTime() < windowEnd ? occurrence.endAt : input.end,
+      eventId: occurrence.eventId,
+    }))
+    .filter((interval) => interval.end.getTime() > interval.start.getTime());
+}
 
-  return mergeBusyIntervals(clamped);
+export async function queryBusyIntervals(
+  deps: BusyQueryDeps,
+  input: BusyQueryInput,
+): Promise<BusyInterval[]> {
+  return mergeBusyIntervals(await queryBusyOccurrences(deps, input));
 }
 
 // Why a requested calendar's busy data could not be freshly included.
@@ -133,6 +165,7 @@ export interface BusyAvailability {
 
 export interface BusyAvailabilityDeps {
   occurrences: EventOccurrenceRepository;
+  events?: EventRepository;
   resources: SyncResourceRepository;
   connections: ProviderConnectionRepository;
 }
@@ -196,8 +229,8 @@ export async function computeBusyAvailability(
     }
   }
 
-  const intervals = present.length
-    ? await queryBusyIntervals(
+  const rawIntervals = present.length
+    ? await queryBusyOccurrences(
         { occurrences: deps.occurrences },
         {
           tenantId: input.tenantId,
@@ -208,6 +241,21 @@ export async function computeBusyAvailability(
         },
       )
     : [];
+
+  const eventsById = new Map<string, EventRecord>();
+  if (deps.events && rawIntervals.length > 0) {
+    const eventIds = [
+      ...new Set(rawIntervals.map((interval) => interval.eventId)),
+    ];
+    const events = await deps.events.findByIds(
+      input.tenantId,
+      input.principalId,
+      eventIds,
+    );
+    for (const event of events) {
+      eventsById.set(event._id, event);
+    }
+  }
 
   // Freshness for exactly the connections backing the requested calendars.
   const allConnections = await deps.connections.listByPrincipal(
@@ -230,6 +278,31 @@ export async function computeBusyAvailability(
     connections.length === backingConnectionIds.size &&
     connections.every((c) => c.state === "healthy");
   const bookable = complete && allBackingHealthy;
+
+  const emailByConnectionId = new Map(
+    allConnections
+      .filter((connection) => backingConnectionIds.has(connection._id))
+      .map((connection) => [connection._id, connection.account.email]),
+  );
+  const fallbackEmail =
+    [...emailByConnectionId.values()].find((email) => email !== null) ?? null;
+
+  const intervals = mergeBusyIntervals(
+    rawIntervals.map((interval) => {
+      const event = eventsById.get(interval.eventId);
+      const accountEmail =
+        (event?.connectionId
+          ? emailByConnectionId.get(event.connectionId)
+          : undefined) ?? fallbackEmail;
+      const facts = occupancyFactsForEvent(event, accountEmail);
+      return {
+        start: interval.start,
+        end: interval.end,
+        hostIsOrganizer: facts.hostIsOrganizer,
+        hostResponseStatus: facts.hostResponseStatus,
+      };
+    }),
+  );
 
   return {
     intervals,

--- a/packages/sync/src/domain/provider-page-applier.db.test.ts
+++ b/packages/sync/src/domain/provider-page-applier.db.test.ts
@@ -138,6 +138,7 @@ describe("ProviderPageApplier", () => {
       {
         startAt: new Date("2026-07-14T15:00:00.000Z"),
         endAt: new Date("2026-07-14T16:00:00.000Z"),
+        eventId: expect.any(String),
       },
     ]);
   });
@@ -165,6 +166,7 @@ describe("ProviderPageApplier", () => {
       {
         startAt: new Date("2026-07-14T15:00:00.000Z"),
         endAt: new Date("2026-07-14T16:00:00.000Z"),
+        eventId: expect.any(String),
       },
     ]);
   });

--- a/packages/sync/src/server/availability.routes.db.test.ts
+++ b/packages/sync/src/server/availability.routes.db.test.ts
@@ -204,6 +204,8 @@ describe("POST /internal/availability/busy", () => {
       {
         start: "2026-07-14T09:00:00.000Z",
         end: "2026-07-14T11:00:00.000Z",
+        hostIsOrganizer: true,
+        hostResponseStatus: null,
       },
     ]);
     expect(body.complete).toBe(true);

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -417,6 +417,7 @@ export function registerConnectionRoutes(
         const availability = await computeBusyAvailability(
           {
             occurrences: repos.eventOccurrences,
+            events: repos.events,
             resources: repos.syncResources,
             connections: repos.connections,
           },
@@ -960,6 +961,8 @@ function toBusyAvailabilityResponse(
     intervals: availability.intervals.map((i) => ({
       start: i.start.toISOString(),
       end: i.end.toISOString(),
+      hostIsOrganizer: i.hostIsOrganizer,
+      hostResponseStatus: i.hostResponseStatus,
     })),
     computedAt: availability.computedAt.toISOString(),
     connections: availability.connections.map((c) => ({

--- a/packages/sync/src/storage/repositories/event-occurrence.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/event-occurrence.repository.db.test.ts
@@ -543,7 +543,9 @@ describe("EventOccurrenceRepository", () => {
         start: windowStart,
         end: windowEnd,
       });
-      expect(busy).toEqual([{ startAt: inLookbackStart, endAt: windowEnd }]);
+      expect(busy).toEqual([
+        { startAt: inLookbackStart, endAt: windowEnd, eventId: eventIn },
+      ]);
     });
   });
 });

--- a/packages/sync/src/storage/repositories/event-occurrence.repository.ts
+++ b/packages/sync/src/storage/repositories/event-occurrence.repository.ts
@@ -59,6 +59,7 @@ export interface BusyOverlapQuery {
 export interface OccurrenceInterval {
   startAt: Date;
   endAt: Date;
+  eventId: EventId;
 }
 
 // Repository for `event_occurrences`. Rebuilding a series' window
@@ -273,7 +274,12 @@ export class EventOccurrenceRepository {
     };
     return this.collection
       .find(filter)
-      .project<OccurrenceInterval>({ startAt: 1, endAt: 1, _id: 0 })
+      .project<OccurrenceInterval>({
+        startAt: 1,
+        endAt: 1,
+        eventId: 1,
+        _id: 0,
+      })
       .sort({ startAt: 1 })
       .toArray();
   }

--- a/packages/web/src/__tests__/__mocks__/server/mock.handlers.ts
+++ b/packages/web/src/__tests__/__mocks__/server/mock.handlers.ts
@@ -88,6 +88,8 @@ export const globalHandlers = [
         blockingCalendarIds: ["000000000000000000000001"],
         timeZone: "UTC",
         weeklyAvailability: [],
+        dateOverrides: [],
+        welcomeText: null,
         minNoticeHours: 4,
         maxHorizonDays: 60,
         bufferMinutes: null,

--- a/packages/web/src/booking/BookingCopyLink.test.tsx
+++ b/packages/web/src/booking/BookingCopyLink.test.tsx
@@ -25,6 +25,16 @@ describe("BookingCopyLink", () => {
       expect(mockWriteText).toHaveBeenCalledWith(bookingUrl);
     });
   });
+
+  it("opens the public booking page in a new tab", () => {
+    const bookingUrl = "https://compasscalendar.com/book/hostuser";
+    render(<BookingCopyLink bookingUrl={bookingUrl} />);
+
+    const openLink = screen.getByRole("link", { name: "Open booking page" });
+    expect(openLink).toHaveAttribute("href", bookingUrl);
+    expect(openLink).toHaveAttribute("target", "_blank");
+    expect(openLink).toHaveAttribute("rel", "noreferrer");
+  });
 });
 
 const originalClipboard = navigator.clipboard;

--- a/packages/web/src/booking/BookingCopyLink.tsx
+++ b/packages/web/src/booking/BookingCopyLink.tsx
@@ -33,6 +33,14 @@ export function BookingCopyLink({ bookingUrl }: BookingCopyLinkProps) {
         >
           {copied ? "Copied" : "Copy"}
         </button>
+        <a
+          className="c-focus-ring shrink-0 rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text transition-colors hover:bg-surface-panel"
+          href={bookingUrl}
+          rel="noreferrer"
+          target="_blank"
+        >
+          Open booking page
+        </a>
       </div>
     </div>
   );

--- a/packages/web/src/booking/BookingDateOverridesEditor.tsx
+++ b/packages/web/src/booking/BookingDateOverridesEditor.tsx
@@ -1,0 +1,214 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  type BookingDateOverride,
+  type BookingDateOverrides,
+} from "@core/types/booking.contracts";
+import {
+  formatHoursRanges,
+  parseHoursRanges,
+} from "@web/booking/weekly-hours.parse";
+
+interface BookingDateOverridesEditorProps {
+  value: BookingDateOverrides;
+  onChange: (value: BookingDateOverrides) => void;
+  onValidityChange?: (isValid: boolean) => void;
+  disabled?: boolean;
+}
+
+interface DraftRow {
+  key: string;
+  date: string;
+  kind: "blocked" | "hours";
+  hoursText: string;
+}
+
+const toDrafts = (value: BookingDateOverrides): DraftRow[] =>
+  value.map((override, index) => ({
+    key: `${override.date}-${override.kind}-${index}`,
+    date: override.date,
+    kind: override.kind,
+    hoursText:
+      override.kind === "hours" ? formatHoursRanges(override.intervals) : "",
+  }));
+
+const parseDrafts = (
+  drafts: DraftRow[],
+): { ok: true; overrides: BookingDateOverride[] } | { ok: false } => {
+  const overrides: BookingDateOverride[] = [];
+  const seen = new Set<string>();
+
+  for (const draft of drafts) {
+    if (draft.date.trim() === "") {
+      continue;
+    }
+    if (seen.has(draft.date)) {
+      return { ok: false };
+    }
+    seen.add(draft.date);
+
+    if (draft.kind === "blocked") {
+      overrides.push({ kind: "blocked", date: draft.date });
+      continue;
+    }
+
+    const parsed = parseHoursRanges(draft.hoursText);
+    if (!parsed.ok || parsed.ranges.length === 0) {
+      return { ok: false };
+    }
+    overrides.push({
+      kind: "hours",
+      date: draft.date,
+      intervals: parsed.ranges,
+    });
+  }
+
+  return { ok: true, overrides };
+};
+
+export function BookingDateOverridesEditor({
+  value,
+  onChange,
+  onValidityChange,
+  disabled = false,
+}: BookingDateOverridesEditorProps) {
+  const [drafts, setDrafts] = useState<DraftRow[]>(() => toDrafts(value));
+  const parsed = parseDrafts(drafts);
+  const emittedRef = useRef<BookingDateOverrides>(value);
+
+  useEffect(() => {
+    if (value === emittedRef.current) return;
+    emittedRef.current = value;
+    setDrafts(toDrafts(value));
+    onValidityChange?.(true);
+  }, [onValidityChange, value]);
+
+  const commit = (next: DraftRow[]) => {
+    setDrafts(next);
+    const result = parseDrafts(next);
+    onValidityChange?.(result.ok);
+    if (result.ok) {
+      emittedRef.current = result.overrides;
+      onChange(result.overrides);
+    }
+  };
+
+  const updateDraft = (key: string, patch: Partial<DraftRow>) => {
+    commit(
+      drafts.map((draft) =>
+        draft.key === key ? { ...draft, ...patch } : draft,
+      ),
+    );
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-sm text-text">Date overrides</p>
+      <p className="text-text-muted text-xs">
+        Block a day or replace that day's weekly hours. Extra hours replace the
+        weekday template.
+      </p>
+      {drafts.map((draft) => (
+        <div
+          className="flex flex-col gap-1 sm:flex-row sm:items-center"
+          key={draft.key}
+        >
+          <label
+            className="sr-only"
+            htmlFor={`booking-override-date-${draft.key}`}
+          >
+            Override date
+          </label>
+          <input
+            className="c-focus-ring rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text"
+            disabled={disabled}
+            id={`booking-override-date-${draft.key}`}
+            onChange={(event) =>
+              updateDraft(draft.key, { date: event.target.value })
+            }
+            type="date"
+            value={draft.date}
+          />
+          <label
+            className="sr-only"
+            htmlFor={`booking-override-kind-${draft.key}`}
+          >
+            Override kind
+          </label>
+          <select
+            className="c-focus-ring rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text"
+            disabled={disabled}
+            id={`booking-override-kind-${draft.key}`}
+            onChange={(event) =>
+              updateDraft(draft.key, {
+                kind: event.target.value as DraftRow["kind"],
+              })
+            }
+            value={draft.kind}
+          >
+            <option value="blocked">Blocked</option>
+            <option value="hours">Extra hours</option>
+          </select>
+          {draft.kind === "hours" ? (
+            <>
+              <label
+                className="sr-only"
+                htmlFor={`booking-override-hours-${draft.key}`}
+              >
+                Extra hours
+              </label>
+              <input
+                aria-invalid={
+                  draft.hoursText.trim() !== "" &&
+                  !parseHoursRanges(draft.hoursText).ok
+                    ? true
+                    : undefined
+                }
+                className="c-focus-ring min-w-0 flex-1 rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text aria-invalid:border-error"
+                disabled={disabled}
+                id={`booking-override-hours-${draft.key}`}
+                onChange={(event) =>
+                  updateDraft(draft.key, { hoursText: event.target.value })
+                }
+                placeholder="9-12"
+                value={draft.hoursText}
+              />
+            </>
+          ) : null}
+          <button
+            className="c-focus-ring shrink-0 rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text hover:bg-surface-panel"
+            disabled={disabled}
+            onClick={() =>
+              commit(drafts.filter((row) => row.key !== draft.key))
+            }
+            type="button"
+          >
+            Remove
+          </button>
+        </div>
+      ))}
+      {parsed.ok ? null : (
+        <p className="text-error text-xs" role="alert">
+          Check override dates and hours. Extra hours cannot be blank.
+        </p>
+      )}
+      <button
+        className="c-focus-ring self-start rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text hover:bg-surface-panel"
+        disabled={disabled}
+        onClick={() =>
+          commit([
+            ...drafts,
+            {
+              key: `new-${drafts.length}-${Date.now()}`,
+              date: "",
+              kind: "blocked",
+              hoursText: "",
+            },
+          ])
+        }
+        type="button"
+      >
+        Add date override
+      </button>
+    </div>
+  );
+}

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -563,7 +563,7 @@ describe("BookingSettingsSection", () => {
       ),
       rest.put(bookingPageUrl, async (req, res, ctx) => {
         savedBody = await req.json();
-        return res(ctx.json(savedBody));
+        return res(ctx.json(savedBody as object));
       }),
     );
 

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -179,6 +179,9 @@ describe("BookingSettingsSection", () => {
     expect(await screen.findByLabelText("Public booking link")).toHaveValue(
       bookingUrl,
     );
+    const openLink = screen.getByRole("link", { name: "Open booking page" });
+    expect(openLink).toHaveAttribute("href", bookingUrl);
+    expect(openLink).toHaveAttribute("target", "_blank");
   });
 
   it("saves again after the first save, sending only PUT input keys", async () => {
@@ -253,6 +256,7 @@ describe("BookingSettingsSection", () => {
     expect(Object.keys(savedBodies[1] ?? {}).sort()).toEqual([
       "blockingCalendarIds",
       "bufferMinutes",
+      "dateOverrides",
       "destinationCalendarId",
       "durationMinutes",
       "enabled",
@@ -262,6 +266,7 @@ describe("BookingSettingsSection", () => {
       "minNoticeHours",
       "timeZone",
       "weeklyAvailability",
+      "welcomeText",
     ]);
   });
 
@@ -380,6 +385,33 @@ describe("BookingSettingsSection", () => {
     await user.keyboard("h");
 
     expect(document.activeElement).toBe(screen.getByLabelText("Monday"));
+  });
+
+  it("jumps to welcome text with e then w", async () => {
+    const user = userEvent.setup({ delay: null });
+    userMetadataActions.set(healthyGoogleMetadata);
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+    await screen.findByRole("button", { name: "Save booking settings" });
+
+    await user.keyboard("e");
+    await user.keyboard("w");
+
+    expect(document.activeElement).toBe(screen.getByLabelText("Welcome text"));
   });
 
   it("jumps to the timezone trigger with e then z", async () => {
@@ -517,6 +549,96 @@ describe("BookingSettingsSection", () => {
     expect(putCount).toBe(0);
     expect(
       screen.getByText("Fix the weekly hours that could not be read."),
+    ).toBeInTheDocument();
+  });
+
+  it("saves welcome text and a blocked date override", async () => {
+    const user = userEvent.setup({ delay: null });
+    userMetadataActions.set(healthyGoogleMetadata);
+    let savedBody: unknown;
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+      rest.put(bookingPageUrl, async (req, res, ctx) => {
+        savedBody = await req.json();
+        return res(ctx.json(savedBody));
+      }),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+    await screen.findByRole("button", { name: "Save booking settings" });
+
+    await user.type(
+      screen.getByLabelText("Welcome text"),
+      "30 minutes to talk through Compass.",
+    );
+    await user.click(screen.getByRole("button", { name: "Add date override" }));
+    await user.type(screen.getByLabelText("Override date"), "2026-09-07");
+
+    await user.click(
+      screen.getByRole("button", { name: "Save booking settings" }),
+    );
+
+    await waitFor(() => {
+      expect(savedBody).toMatchObject({
+        welcomeText: "30 minutes to talk through Compass.",
+        dateOverrides: [{ kind: "blocked", date: "2026-09-07" }],
+      });
+    });
+  });
+
+  it("blocks the save while extra hours on a date override cannot be read", async () => {
+    const user = userEvent.setup({ delay: null });
+    userMetadataActions.set(healthyGoogleMetadata);
+    let putCount = 0;
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+      rest.put(bookingPageUrl, async (req, res, ctx) => {
+        putCount += 1;
+        return res(ctx.json(await req.json()));
+      }),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+    await screen.findByRole("button", { name: "Save booking settings" });
+
+    await user.click(screen.getByRole("button", { name: "Add date override" }));
+    await user.type(screen.getByLabelText("Override date"), "2026-09-12");
+    await user.selectOptions(screen.getByLabelText("Override kind"), "hours");
+
+    await user.click(
+      screen.getByRole("button", { name: "Save booking settings" }),
+    );
+
+    expect(putCount).toBe(0);
+    expect(
+      screen.getByText("Fix the date overrides that could not be read."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Check override dates and hours. Extra hours cannot be blank.",
+      ),
     ).toBeInTheDocument();
   });
 

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -105,6 +105,8 @@ const buildInitialForm = (
     blockingCalendarIds: [BOOKING_PLACEHOLDER_CALENDAR_ID],
     timeZone: TimeZoneSchema.parse(effectiveTimeZone),
     weeklyAvailability: [],
+    dateOverrides: [],
+    welcomeText: null,
     minNoticeHours: 4,
     maxHorizonDays: 60,
     bufferMinutes: null,

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -16,6 +16,7 @@ import { useAppAccess } from "@web/billing/useAppAccess";
 import { BookingCheckboxRow } from "@web/booking/BookingCheckboxRow";
 import { BookingConnectGooglePrompt } from "@web/booking/BookingConnectGooglePrompt";
 import { BookingCopyLink } from "@web/booking/BookingCopyLink";
+import { BookingDateOverridesEditor } from "@web/booking/BookingDateOverridesEditor";
 import { BookingFieldLabel } from "@web/booking/BookingFieldLabel";
 import { BookingTimezoneField } from "@web/booking/BookingTimezoneField";
 import { BookingWeeklyHoursEditor } from "@web/booking/BookingWeeklyHoursEditor";
@@ -184,6 +185,7 @@ export function BookingSettingsSection({
   );
   const [enableError, setEnableError] = useState<string | null>(null);
   const [areHoursValid, setAreHoursValid] = useState(true);
+  const [areOverridesValid, setAreOverridesValid] = useState(true);
   const [minNoticeText, setMinNoticeText] = useState(() =>
     String(form.minNoticeHours),
   );
@@ -303,6 +305,14 @@ export function BookingSettingsSection({
   const handleSave = () => {
     if (!areHoursValid) {
       setEnableError("Fix the weekly hours that could not be read.");
+      return;
+    }
+    if (!areOverridesValid) {
+      setEnableError("Fix the date overrides that could not be read.");
+      return;
+    }
+    if ((form.welcomeText?.length ?? 0) > 500) {
+      setEnableError("Welcome text must be 500 characters or fewer.");
       return;
     }
     if (minNoticeInvalid || horizonInvalid) {
@@ -474,13 +484,49 @@ export function BookingSettingsSection({
         />
       </div>
 
-      <div {...bookingFieldAttrs("hours")}>
+      <div className="flex flex-col gap-4" {...bookingFieldAttrs("hours")}>
         <BookingWeeklyHoursEditor
           onChange={(weeklyAvailability) => updateForm({ weeklyAvailability })}
           onValidityChange={setAreHoursValid}
           shortcutKeys={showShortcuts ? bookingJumpKeys("hours") : undefined}
           value={form.weeklyAvailability}
         />
+        <BookingDateOverridesEditor
+          onChange={(dateOverrides) => updateForm({ dateOverrides })}
+          onValidityChange={setAreOverridesValid}
+          value={form.dateOverrides ?? []}
+        />
+      </div>
+
+      <div>
+        <BookingFieldLabel
+          field="welcome"
+          htmlFor="booking-welcome"
+          showShortcuts={showShortcuts}
+        >
+          Welcome text
+        </BookingFieldLabel>
+        <textarea
+          {...bookingFieldAttrs("welcome")}
+          aria-invalid={
+            (form.welcomeText?.length ?? 0) > 500 ? true : undefined
+          }
+          className="c-focus-ring min-h-20 w-full rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text aria-invalid:border-error"
+          id="booking-welcome"
+          maxLength={500}
+          onChange={(event) =>
+            updateForm({
+              welcomeText:
+                event.target.value.trim() === "" ? null : event.target.value,
+            })
+          }
+          value={form.welcomeText ?? ""}
+        />
+        {(form.welcomeText?.length ?? 0) > 500 ? (
+          <p className="text-error text-xs" role="alert">
+            Welcome text must be 500 characters or fewer.
+          </p>
+        ) : null}
       </div>
 
       <div className="grid grid-cols-2 gap-3">

--- a/packages/web/src/booking/PublicBookingConfirmationView.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmationView.tsx
@@ -36,11 +36,11 @@ export function PublicBookingConfirmationView({
           You are booked with {hostDisplayName}
         </h1>
         <p className="mt-2 text-sm text-text-muted">
-          {when} ({formatDurationMinutes(durationMinutes)})
+          {when} ({formatDurationMinutes(durationMinutes)} Google Meet)
         </p>
         <p className="mt-4 text-sm text-text">
-          A calendar invite is on its way to your email. To cancel, use the link
-          in that invite
+          A Google Meet invite is on its way to your email. To cancel, use the
+          link in that invite
           {cancelUrl ? " or copy it here:" : "."}
         </p>
         {cancelUrl ? (

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -191,6 +191,7 @@ const publicPagePayload = (overrides: Record<string, unknown> = {}) => ({
   timeZone: "America/Chicago",
   enabled: true,
   maxHorizonDays: 60,
+  welcomeText: null,
   ...overrides,
 });
 
@@ -311,6 +312,34 @@ describe("PublicBookingPage", () => {
     expect(screen.getByRole("heading", { name: "Your details" })).toHaveFocus();
   });
 
+  it("shows host-authored welcome text under the Google Meet line", async () => {
+    server.use(
+      rest.get(
+        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane`,
+        (_req, res, ctx) =>
+          res(
+            ctx.status(Status.OK),
+            ctx.json(
+              publicPagePayload({
+                welcomeText: "30 minutes to talk through Compass Calendar.",
+              }),
+            ),
+          ),
+      ),
+      slotsInWindow([currentSlot]),
+    );
+
+    renderBookingRoute("/book/tylerdane");
+
+    expect(
+      await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("30 minutes Google Meet")).toBeInTheDocument();
+    expect(
+      screen.getByText("30 minutes to talk through Compass Calendar."),
+    ).toBeInTheDocument();
+  });
+
   it("labels times in the guest timezone and confirms a booking", async () => {
     const user = userEvent.setup({ delay: null });
     let postedBody: unknown;
@@ -343,6 +372,7 @@ describe("PublicBookingPage", () => {
     expect(
       await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
     ).toBeInTheDocument();
+    expect(screen.getByText("30 minutes Google Meet")).toBeInTheDocument();
     expect(screen.getByRole("main").parentElement).toHaveAttribute(
       "data-document-scroll",
     );
@@ -1228,7 +1258,10 @@ describe("PublicBookingConfirmedPage", () => {
         name: "You are booked with Tyler Dane",
       }),
     ).toHaveFocus();
-    expect(screen.getByText(/30 minutes/)).toBeInTheDocument();
+    expect(screen.getByText(/30 minutes Google Meet/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/A Google Meet invite is on its way to your email/),
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Copy cancel link" }),
     ).not.toBeInTheDocument();

--- a/packages/web/src/booking/PublicBookingPage.tsx
+++ b/packages/web/src/booking/PublicBookingPage.tsx
@@ -81,8 +81,11 @@ export function PublicBookingPage() {
           Book with {page.hostDisplayName}
         </h1>
         <p className="text-sm text-text-muted">
-          {formatDurationMinutes(page.durationMinutes)} meeting
+          {formatDurationMinutes(page.durationMinutes)} Google Meet
         </p>
+        {page.welcomeText ? (
+          <p className="text-sm text-text">{page.welcomeText}</p>
+        ) : null}
         <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-sm text-text-muted">
           <p>Times shown in your timezone</p>
           <PublicBookingTimezoneControl

--- a/packages/web/src/booking/booking-sequence.fields.ts
+++ b/packages/web/src/booking/booking-sequence.fields.ts
@@ -17,6 +17,7 @@ export const BOOKING_SEQUENCE_FIELDS = [
   { key: "b", field: "blocking", label: "Blocking calendars" },
   { key: "z", field: "timezone", label: "Booking timezone" },
   { key: "h", field: "hours", label: "Weekly hours" },
+  { key: "w", field: "welcome", label: "Welcome text" },
   { key: "n", field: "notice", label: "Minimum notice" },
   { key: "x", field: "horizon", label: "Maximum horizon" },
   { key: "o", field: "options", label: "Buffer and limits" },

--- a/packages/web/src/booking/booking.util.ts
+++ b/packages/web/src/booking/booking.util.ts
@@ -99,6 +99,8 @@ export function toBookingPageInput(
     blockingCalendarIds: page.blockingCalendarIds,
     timeZone: page.timeZone,
     weeklyAvailability: page.weeklyAvailability,
+    dateOverrides: page.dateOverrides ?? [],
+    welcomeText: page.welcomeText ?? null,
     minNoticeHours: page.minNoticeHours,
     maxHorizonDays: page.maxHorizonDays,
     bufferMinutes: page.bufferMinutes,

--- a/packages/web/src/booking/booking.util.ts
+++ b/packages/web/src/booking/booking.util.ts
@@ -90,7 +90,10 @@ export const ISO_WEEKDAYS = [1, 2, 3, 4, 5, 6, 7] as const;
  * Pick the fields explicitly so a response-only key can never ride along.
  */
 export function toBookingPageInput(
-  page: AdminPutBookingPageInput,
+  page: Omit<AdminPutBookingPageInput, "dateOverrides" | "welcomeText"> & {
+    dateOverrides?: AdminPutBookingPageInput["dateOverrides"];
+    welcomeText?: AdminPutBookingPageInput["welcomeText"];
+  },
 ): AdminPutBookingPageInput {
   return {
     enabled: page.enabled,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Booking v1.1 on staging: date-specific availability overrides, RSVP-strict occupancy, and a shareable public page identity.

- Host-timezone date overrides: **blocked** days and **extra hours** that replace that day's weekly template, capped at 60.
- Slot engine applies overrides (blocked weekday, Saturday extra hours, DST).
- Settings date-override editor next to weekly hours, plus welcome text (`e` then `w`). Overrides fold into `e` then `h`.
- Occupancy occupies a slot only when the host is the organizer or has accepted. `needsAction`, declined, and tentative invites do not occupy. Sync still returns facts only (`hostIsOrganizer`, `hostResponseStatus`); titles and attendee PII stay off the busy wire.
- Public page shows optional welcome text and Google Meet copy. Settings adds **Open booking page**.
- Production gate stays off (`isBookingEnabled` is still false when `nodeEnv === production`).

CI: required `unit (web)` is green on `822f08b65` (push 1m52s, PR Test 1m57s). The jsdom suite runs as two sequential processes so RSS is released between halves.

Fixes #3053 #3054 #3055 #3056 #3057 #3058 #3059
Closes #3060

## Simplicity

Reuse the existing hours parser and weekly-hours seed/resync pattern. Occupancy policy lives in Booking (`occupiesBookingSlot`); Sync only attaches organizer/response facts. No new event types, intake, reschedule, or production enablement.

## Automated validation

- GitHub: all 27 checks green on `822f08b65`, including both `unit (web)` jobs.
- `bun test:web` after sharding: 2 x 181 files, 3028 pass, 82.7s
- `bun test packages/scripts/src/testing/test-parallel.test.ts`: 10 pass
- `bun run type-check`: pass
- Prior verify on the booking change: test:core, test:sync, test:backend, lint, knip, Playwright booking e2e + a11y (47)

## Independent review

Required checks are green. Ready to squash-merge.

## Test plan

- `bun test:core` (674 pass)
- `bun test:web` (3028 pass, two sequential shards)
- `bun test:backend` (516 pass)
- `bun test:sync` (1109 pass)
- `bun type-check`
- `bun lint`
- `bunx playwright test e2e/booking e2e/accessibility/booking-a11y.spec.ts` (47 pass)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e3a5814-cc35-4f75-8b75-0a7b89dfaef4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e3a5814-cc35-4f75-8b75-0a7b89dfaef4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

