### PR TITLE
fix(web): bind reconnect banner to G instead of 1

### DIFF
--- a/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.test.tsx
+++ b/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.test.tsx
@@ -9,7 +9,7 @@ import {
   POINTER_ACTIONS,
   POINTER_SHORTCUT_ATTRIBUTE,
 } from "@web/shortcuts/keyboard-only/pointer-action";
-import { NOTICE_PRIMARY_ACTION_KEY } from "@web/shortcuts/notice-focus/useNoticeActionShortcut";
+import { CONNECTION_BANNER_SHORTCUT_KEY } from "@web/shortcuts/notice-focus/useNoticeActionShortcut";
 import { eventJumpActions } from "@web/shortcuts/shift-hint/event-jump.store";
 import { CalendarConnectionBanner } from "./CalendarConnectionBanner";
 
@@ -48,32 +48,41 @@ describe("CalendarConnectionBanner", () => {
     expect(onAction).toHaveBeenCalledTimes(1);
   });
 
-  it("shows a 1 keycap and reconnects when 1 is pressed", () => {
+  it("shows a G keycap and reconnects when G is pressed", () => {
     const onAction = mock();
     renderBanner("reconnect", onAction);
 
     const button = screen.getByRole("button", { name: "Reconnect" });
-    expect(within(button).getByText("1")).toBeTruthy();
+    expect(within(button).getByText("G")).toBeTruthy();
     expect(button).toHaveAttribute(
       POINTER_SHORTCUT_ATTRIBUTE,
-      NOTICE_PRIMARY_ACTION_KEY,
+      CONNECTION_BANNER_SHORTCUT_KEY,
     );
     expect(button).toHaveAttribute(
       POINTER_ACTION_ATTRIBUTE,
       POINTER_ACTIONS.reconnectGoogle,
     );
 
-    pressKey("1");
+    pressKey("G");
 
     expect(onAction).toHaveBeenCalledTimes(1);
   });
 
-  it("does not reconnect with 1 while event jump is active", () => {
+  it("leaves digit 1 for quick-time create", () => {
+    const onAction = mock();
+    renderBanner("reconnect", onAction);
+
+    pressKey("1");
+
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it("does not reconnect with G while event jump is active", () => {
     const onAction = mock();
     eventJumpActions.setActive(true);
     renderBanner("reconnect", onAction);
 
-    pressKey("1");
+    pressKey("G");
 
     expect(onAction).not.toHaveBeenCalled();
   });
@@ -101,6 +110,15 @@ describe("CalendarConnectionBanner", () => {
       "Calendar updates are delayed.",
     );
     await user.click(screen.getByRole("button", { name: "Refresh" }));
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs Refresh with G", () => {
+    const onAction = mock();
+    renderBanner("delayed", onAction);
+
+    pressKey("G");
+
     expect(onAction).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.tsx
+++ b/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.tsx
@@ -7,7 +7,7 @@ import {
   pointerShortcutAttributes,
 } from "@web/shortcuts/keyboard-only/pointer-action";
 import {
-  NOTICE_PRIMARY_ACTION_KEY,
+  CONNECTION_BANNER_SHORTCUT_KEY,
   useNoticeActionShortcut,
 } from "@web/shortcuts/notice-focus/useNoticeActionShortcut";
 
@@ -43,7 +43,7 @@ export const CalendarConnectionBanner: FC<CalendarConnectionBannerProps> = ({
   const pointerAction =
     kind === "reconnect" ? POINTER_ACTIONS.reconnectGoogle : undefined;
 
-  useNoticeActionShortcut(NOTICE_PRIMARY_ACTION_KEY, onAction);
+  useNoticeActionShortcut(CONNECTION_BANNER_SHORTCUT_KEY, onAction);
 
   return (
     <div
@@ -60,13 +60,13 @@ export const CalendarConnectionBanner: FC<CalendarConnectionBannerProps> = ({
         className="c-focus-ring inline-flex shrink-0 items-center gap-2 rounded-xs px-2 py-1 font-medium text-text hover:bg-surface-overlay"
         onClick={onAction}
         type="button"
-        {...pointerShortcutAttributes(NOTICE_PRIMARY_ACTION_KEY)}
+        {...pointerShortcutAttributes(CONNECTION_BANNER_SHORTCUT_KEY)}
         {...(pointerAction
           ? { [POINTER_ACTION_ATTRIBUTE]: pointerAction }
           : {})}
       >
         {action}
-        <ShortcutKeys keys={NOTICE_PRIMARY_ACTION_KEY} />
+        <ShortcutKeys keys={CONNECTION_BANNER_SHORTCUT_KEY} />
       </button>
     </div>
   );

--- a/packages/web/src/components/PointerHint/PointerHint.test.tsx
+++ b/packages/web/src/components/PointerHint/PointerHint.test.tsx
@@ -102,12 +102,12 @@ describe("PointerHint", () => {
     act(() => {
       pointerBlockActions.pulseBlockedClick({
         actionId: POINTER_ACTIONS.reconnectGoogle,
-        shortcutKey: "1",
+        shortcutKey: "G",
       });
     });
 
     expect(screen.getByRole("status")).toHaveTextContent(
-      "Press 1 to reconnect Google Calendar.",
+      "Press G to reconnect Google Calendar.",
     );
   });
 

--- a/packages/web/src/components/PointerHint/PointerHint.tsx
+++ b/packages/web/src/components/PointerHint/PointerHint.tsx
@@ -17,6 +17,7 @@ import {
   selectPointerBlockPulse,
   usePointerBlockStore,
 } from "@web/shortcuts/keyboard-only/pointer-block.store";
+import { CONNECTION_BANNER_SHORTCUT_KEY } from "@web/shortcuts/notice-focus/useNoticeActionShortcut";
 import {
   selectEventJumpPointerHintKey,
   useEventJumpStore,
@@ -138,7 +139,8 @@ const pointerHintMessage = ({
   if (attempt?.actionId === POINTER_ACTIONS.reconnectGoogle) {
     return (
       <>
-        Press <Key>1</Key> to reconnect Google Calendar.
+        Press <Key>{CONNECTION_BANNER_SHORTCUT_KEY}</Key> to reconnect Google
+        Calendar.
       </>
     );
   }

--- a/packages/web/src/shortcuts/keyboard-only/pointer-action.test.ts
+++ b/packages/web/src/shortcuts/keyboard-only/pointer-action.test.ts
@@ -118,11 +118,11 @@ describe("teachingFromBlockedPointer", () => {
       POINTER_ACTION_ATTRIBUTE,
       POINTER_ACTIONS.reconnectGoogle,
     );
-    reconnect.setAttribute(POINTER_SHORTCUT_ATTRIBUTE, "1");
+    reconnect.setAttribute(POINTER_SHORTCUT_ATTRIBUTE, "G");
     expect(teachingFromBlockedPointer([reconnect, document], 0)).toEqual({
       attempt: {
         actionId: POINTER_ACTIONS.reconnectGoogle,
-        shortcutKey: "1",
+        shortcutKey: "G",
       },
     });
   });

--- a/packages/web/src/shortcuts/notice-focus/useNoticeActionShortcut.test.tsx
+++ b/packages/web/src/shortcuts/notice-focus/useNoticeActionShortcut.test.tsx
@@ -51,15 +51,15 @@ describe("useNoticeActionShortcut", () => {
 
   it("yields while app-locked or event jump is active", () => {
     const onClick = mock();
-    renderHook(() => useNoticeActionShortcut("1", onClick), { wrapper });
+    renderHook(() => useNoticeActionShortcut("G", onClick), { wrapper });
 
     setAppLockReason("commandPalette", true);
-    pressKey("1");
+    pressKey("G");
     expect(onClick).not.toHaveBeenCalled();
     clearAppLockReasons();
 
     eventJumpActions.setActive(true);
-    pressKey("1");
+    pressKey("G");
     expect(onClick).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/shortcuts/notice-focus/useNoticeActionShortcut.ts
+++ b/packages/web/src/shortcuts/notice-focus/useNoticeActionShortcut.ts
@@ -2,15 +2,21 @@ import { isEventJumpActive } from "@web/shortcuts/shift-hint/event-jump.store";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 import { isEditSequenceArmed } from "@web/shortcuts/useEditSequenceShortcut";
 
-/** Digit on standing notice CTAs and action toasts while they are mounted. */
+/** Digit on action toasts while they are mounted. Standing banners must not
+ * use digits: they collide with quick-time create (`1` = 1:00). */
 export const NOTICE_PRIMARY_ACTION_KEY = "1" as const;
 
 /** Start-trial banner CTA. Same letter as the billing gate overlay. */
 export const START_TRIAL_SHORTCUT_KEY = "S" as const;
 
+/** Google connection banner CTA (Reconnect / Retry / Refresh). `G` matches
+ * Continue with Google on the welcome and auth overlays. */
+export const CONNECTION_BANNER_SHORTCUT_KEY = "G" as const;
+
 export type NoticeActionKey =
   | typeof NOTICE_PRIMARY_ACTION_KEY
-  | typeof START_TRIAL_SHORTCUT_KEY;
+  | typeof START_TRIAL_SHORTCUT_KEY
+  | typeof CONNECTION_BANNER_SHORTCUT_KEY;
 
 const canHandleNoticeAction = (event: KeyboardEvent) =>
   !event.isComposing &&


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Google connection banner used `1` for Reconnect / Retry / Refresh. Digit `1` is already the quick-time create shortcut (create event at 1:00), so the standing banner stole it.

Bind the standing connection banner to **G**, matching Continue with Google on the welcome and auth overlays. Toast CTAs keep `1` because they are transient overlays.

- Digit `1` no longer activates the banner
- `G` reconnects / retries / refreshes when the banner is visible
- Pointer teaching: "Press G to reconnect Google Calendar."

## Simplicity

One constant (`CONNECTION_BANNER_SHORTCUT_KEY`) is shared by the banner, keycap, pointer attribute, and hint copy. Toast `1` is left alone.

## Automated validation

Local `bun run verify` PASS (web, type-check, lint, knip, a11y, e2e). Banner tests: `G` runs Reconnect/Refresh; `1` does not.

## Independent review

Not run; change is a one-letter remapping plus regression coverage that `1` stays free for quick-time create.

## Test plan

- `bun run verify` (PASS: test:web, type-check, lint, knip, test:a11y, test:e2e)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59e11e67-f614-4d09-b530-da8be2d8a4f1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59e11e67-f614-4d09-b530-da8be2d8a4f1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

