### PR TITLE
test(e2e): date-override slots and settings save

### DIFF
--- a/.agents/handoffs/3065.md
+++ b/.agents/handoffs/3065.md
@@ -1,0 +1,29 @@
+---
+schema_version: 1
+task_id: "3065"
+from: Implementer
+to: Verifier
+owner: Verifier
+status: verifying
+artifact:
+  - path: e2e/booking/public-booking.spec.ts
+  - path: e2e/booking/host-settings.spec.ts
+  - path: e2e/booking/booking-harness.ts
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/issues/3065
+evidence:
+  - command: bunx playwright test e2e/booking
+    result: pending first run after implementer commit
+    log: null
+assumptions:
+  - Stubbed Saturday slots stand in for extra-hours date overrides. The slot engine remains covered by packages/core unit tests.
+  - Staging host Settings still cannot be smoked without a signed-in compasscaltest3@gmail.com session.
+open_risks:
+  - Playwright date input fill can be picky; fallback is the same dispatchFill path host-settings already uses.
+next_deadline: 2026-09-01T20:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-08 leftover from Booking v1.1 closeout: Playwright for Saturday-only guest slots and Settings date-override plus welcome text.

--- a/.agents/handoffs/3065.md
+++ b/.agents/handoffs/3065.md
@@ -1,29 +1,31 @@
 ---
 schema_version: 1
 task_id: "3065"
-from: Implementer
-to: Verifier
-owner: Verifier
+from: Reviewer
+to: Manager
+owner: Manager
 status: verifying
 artifact:
   - path: e2e/booking/public-booking.spec.ts
   - path: e2e/booking/host-settings.spec.ts
   - path: e2e/booking/booking-harness.ts
-  - url: https://github.com/KeepSoftwareSimple/compass-calendar/issues/3065
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3066
 evidence:
-  - command: bunx playwright test e2e/booking
-    result: pending first run after implementer commit
+  - command: bunx playwright test e2e/booking e2e/accessibility/booking-a11y.spec.ts
+    result: 49 passed
+    log: null
+  - command: bun run verify
+    result: PASS. Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e. First verify failed on unrelated flaky e2e/accessibility/app-a11y.spec.ts event action row contrast; retry passed 105 e2e.
     log: null
 assumptions:
   - Stubbed Saturday slots stand in for extra-hours date overrides. The slot engine remains covered by packages/core unit tests.
   - Staging host Settings still cannot be smoked without a signed-in compasscaltest3@gmail.com session.
-open_risks:
-  - Playwright date input fill can be picky; fallback is the same dispatchFill path host-settings already uses.
-next_deadline: 2026-09-01T20:00:00Z
-retry: 0
+open_risks: []
+next_deadline: 2026-09-01T20:30:00Z
+retry: 1
 approval: none
 waiting_on: null
 escalation: null
 ---
 
-WP-08 leftover from Booking v1.1 closeout: Playwright for Saturday-only guest slots and Settings date-override plus welcome text.
+Independent review: no confirmed findings. Simplify: no behavior-preserving edits. Ready to squash-merge after required GitHub checks.

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,6 +13,7 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 3065 | high | Verifier | verifying | e2e/booking/public-booking.spec.ts | bunx playwright test e2e/booking (pending) | 2026-09-01T20:00:00Z | 0 | none |
 | simplify-recent-3040 | medium | Manager | verifying | .agents/handoffs/simplify-recent-3040.md | focused web 46 pass; core/backend error+contracts pass; verify package checks pass; review: no confirmed findings | 2026-09-01T06:00:00Z | 1 | none |
 | 2980 | high | Manager | waiting | https://github.com/KeepSoftwareSimple/compass-calendar/pull/2980 | verify PASS (web, type-check, lint, knip, a11y, e2e); review: no confirmed findings | 2026-08-31T00:00:00Z | 1 | none |
 | 2878 | medium | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/2878 | bun run verify: web, type-check, lint, knip passed; bun test:a11y 7 passed | 2026-08-26T03:00:00Z | 0 | none |

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,7 +13,7 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 3065 | high | Verifier | verifying | e2e/booking/public-booking.spec.ts | bunx playwright test e2e/booking (pending) | 2026-09-01T20:00:00Z | 0 | none |
+| 3065 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3066 | bun run verify PASS (web, type-check, lint, knip, a11y, e2e); review: no confirmed findings | 2026-09-01T20:30:00Z | 1 | none |
 | simplify-recent-3040 | medium | Manager | verifying | .agents/handoffs/simplify-recent-3040.md | focused web 46 pass; core/backend error+contracts pass; verify package checks pass; review: no confirmed findings | 2026-09-01T06:00:00Z | 1 | none |
 | 2980 | high | Manager | waiting | https://github.com/KeepSoftwareSimple/compass-calendar/pull/2980 | verify PASS (web, type-check, lint, knip, a11y, e2e); review: no confirmed findings | 2026-08-31T00:00:00Z | 1 | none |
 | 2878 | medium | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/2878 | bun run verify: web, type-check, lint, knip passed; bun test:a11y 7 passed | 2026-08-26T03:00:00Z | 0 | none |

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -134,6 +134,44 @@ export function buildSameDaySiblingSlot(
   };
 }
 
+/**
+ * Next Saturday at 15:00 UTC. Stands in for extra-hours date overrides on a
+ * weekday with no weekly template. 15:00 UTC stays Saturday in US and
+ * European Playwright timezones.
+ */
+export function buildUpcomingSaturdaySlot(durationMinutes = 30): {
+  slotStart: string;
+  slotEnd: string;
+} {
+  const now = new Date();
+  const start = new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate(),
+      15,
+      0,
+      0,
+      0,
+    ),
+  );
+  const daysUntilSaturday = (6 - start.getUTCDay() + 7) % 7;
+  if (daysUntilSaturday === 0 && start.getTime() <= now.getTime()) {
+    start.setUTCDate(start.getUTCDate() + 7);
+  } else {
+    start.setUTCDate(start.getUTCDate() + daysUntilSaturday);
+  }
+  if (start.getTime() <= now.getTime()) {
+    start.setUTCDate(start.getUTCDate() + 7);
+  }
+  return {
+    slotStart: start.toISOString(),
+    slotEnd: new Date(
+      start.getTime() + durationMinutes * 60 * 1000,
+    ).toISOString(),
+  };
+}
+
 export interface PublicBookingStubOptions {
   slug?: string;
   hostDisplayName?: string;

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -639,13 +639,13 @@ export const dispatchFill = async (
 ) => {
   await locator.waitFor({ state: "attached", timeout: 10000 });
   await locator.evaluate((el, nextValue) => {
-    const input = el as HTMLInputElement;
-    const setter = Object.getOwnPropertyDescriptor(
-      HTMLInputElement.prototype,
-      "value",
-    )?.set;
-    setter?.call(input, nextValue);
-    input.dispatchEvent(new Event("input", { bubbles: true }));
+    const proto =
+      el instanceof HTMLTextAreaElement
+        ? HTMLTextAreaElement.prototype
+        : HTMLInputElement.prototype;
+    const setter = Object.getOwnPropertyDescriptor(proto, "value")?.set;
+    setter?.call(el, nextValue);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
   }, value);
 };
 

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -73,3 +73,40 @@ test("clearing the horizon field shows an inline error and blocks save", async (
   await expect.poll(() => captured.putBodies.length).toBe(1);
   expect(captured.putBodies[0]).toMatchObject({ maxHorizonDays: 30 });
 });
+
+test("saves a date override and welcome text", async ({ page }) => {
+  const bookingUrl = "https://compasscalendar.com/book/hostuser";
+  const captured = await prepareSignedInBookingSettingsPage(page, {
+    bookingUrl,
+  });
+
+  const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+  await dispatchClick(
+    settingsDialog.getByRole("button", { name: "Add date override" }),
+  );
+  await dispatchFill(settingsDialog.getByLabel("Override date"), "2026-09-12");
+  await settingsDialog.getByLabel("Override kind").selectOption("hours");
+  await dispatchFill(settingsDialog.getByLabel("Extra hours"), "9-12");
+  await dispatchFill(
+    settingsDialog.getByLabel("Welcome text"),
+    "30 minutes to talk through Compass.",
+  );
+  await dispatchClick(
+    settingsDialog.getByRole("button", { name: "Save booking settings" }),
+  );
+
+  await expect.poll(() => captured.putBodies.length).toBe(1);
+  expect(captured.putBodies[0]).toMatchObject({
+    welcomeText: "30 minutes to talk through Compass.",
+    dateOverrides: [
+      {
+        kind: "hours",
+        date: "2026-09-12",
+        intervals: [{ start: "09:00", end: "12:00" }],
+      },
+    ],
+  });
+  await expect(
+    settingsDialog.getByRole("link", { name: "Open booking page" }),
+  ).toHaveAttribute("href", bookingUrl);
+});

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 import {
   buildBookableSlot,
   buildSameDaySiblingSlot,
+  buildUpcomingSaturdaySlot,
   formatSlotButtonLabel,
   preparePublicBookingConfirmedPage,
   preparePublicBookingPage,
@@ -24,6 +25,37 @@ test.describe("public booking page", () => {
     await expect(
       page.getByRole("heading", { name: "Pick a time" }),
     ).toBeVisible();
+  });
+
+  test("shows Saturday times when that day is only available via a date override", async ({
+    page,
+  }) => {
+    const saturday = buildUpcomingSaturdaySlot();
+    await preparePublicBookingPage(page, { slots: [saturday] });
+
+    const slotButton = page.getByRole("button", {
+      name: formatSlotButtonLabel(saturday.slotStart),
+    });
+    if (await page.getByText("No open times this month.").isVisible()) {
+      await page
+        .getByRole("button", { name: "Jump to next available day" })
+        .click();
+    }
+
+    await expect(slotButton).toBeVisible();
+    const saturdayName = await page.evaluate((iso) => {
+      const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      return new Intl.DateTimeFormat(undefined, {
+        weekday: "long",
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+        timeZone,
+      }).format(new Date(iso));
+    }, saturday.slotStart);
+    await expect(
+      page.getByRole("button", { name: saturdayName }),
+    ).toHaveAttribute("aria-pressed", "true");
   });
 
   test("walks the picker with the keyboard via the skip link", async ({


### PR DESCRIPTION
## Summary

Leftover Booking v1.1 Playwright coverage that WP-07 (#3059) asked for and staging could not smoke without a signed-in host.

- Guest picker: Saturday-only stubbed slots (the extra-hours date-override case) still show times.
- Settings Booking: save extra hours plus welcome text; Open booking page stays present.
- `dispatchFill` now sets textarea values so Welcome text can be filled.

Fixes #3065

## Simplicity

Reuse the existing public-slot and host-settings harnesses. Slot-engine policy stays in `packages/core` unit tests. No extra helpers beyond `buildUpcomingSaturdaySlot`.

## Automated validation

- `bunx playwright test e2e/booking e2e/accessibility/booking-a11y.spec.ts`: 49 passed
- `bun run verify`: PASS. Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
- First verify hit a flake in unrelated `e2e/accessibility/app-a11y.spec.ts` (event action row contrast). Retry: 105 e2e passed.

## Independent review

No confirmed findings. Diff is e2e plus agent handoff only.

## Test plan

- `bunx playwright test e2e/booking e2e/accessibility/booking-a11y.spec.ts`
- `bun run verify`