### PR TITLE
fix(web): recover staging billing lifecycle

### DIFF
--- a/packages/web/src/billing/CheckoutCelebrationModal.tsx
+++ b/packages/web/src/billing/CheckoutCelebrationModal.tsx
@@ -6,8 +6,6 @@ import {
   useCheckoutCelebrationStore,
 } from "@web/billing/checkout-celebration.store";
 import { type AppAccess, useAppAccess } from "@web/billing/useAppAccess";
-import { MODAL_DISMISS_MS } from "@web/common/constants/motion.constants";
-import { useDismissTransition } from "@web/common/hooks/useDismissTransition";
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 import { PixelPirate } from "@web/components/WelcomeModal/PixelPirate";
@@ -41,7 +39,6 @@ const getBody = (access: AppAccess): string => {
 export const CheckoutCelebrationModal: FC = () => {
   const isCelebrating = useCheckoutCelebrationStore(selectIsCelebrating);
   const access = useAppAccess();
-  const { closing, beginDismiss } = useDismissTransition(MODAL_DISMISS_MS);
   const primaryButtonRef = useRef<HTMLButtonElement>(null);
   const shownRef = useRef(false);
 
@@ -55,15 +52,15 @@ export const CheckoutCelebrationModal: FC = () => {
 
   if (!isCelebrating) return null;
 
-  const dismiss = () => {
-    beginDismiss(checkoutCelebrationActions.dismiss);
-  };
+  // This is a blocking acknowledgement, not a dialog-to-dialog handoff. Keep
+  // its one exit path synchronous so a timer cannot strand a user after
+  // Checkout returns.
+  const dismiss = checkoutCelebrationActions.dismiss;
 
   return (
     <OverlayPanel
       align="center"
       ariaLabel={TITLE}
-      closing={closing}
       initialFocusRef={primaryButtonRef}
       onDismiss={dismiss}
       panelClassName={PANEL_CLASSNAME}

--- a/packages/web/src/billing/useBillingRedirect.ts
+++ b/packages/web/src/billing/useBillingRedirect.ts
@@ -56,6 +56,16 @@ const navigateToBillingUrl = (
   popup.location.replace(url);
 };
 
+const openPortalPopup = (): Window | null => {
+  try {
+    return window.open("about:blank", "_blank");
+  } catch {
+    // A restrictive browser or extension can throw before any network request
+    // starts. Treat it like a blocked popup so the portal still has a route.
+    return null;
+  }
+};
+
 /**
  * The one way out of Compass and into Stripe. Owns the in-flight latch (a
  * double click would otherwise open two Checkout sessions) and the failure
@@ -72,8 +82,7 @@ export function useBillingRedirect() {
     if (isRedirecting) return;
     setIsRedirecting(true);
     track("billing_gate_cta_clicked", { cta });
-    const popup =
-      kind === "portal" ? window.open("about:blank", "_blank") : null;
+    const popup = kind === "portal" ? openPortalPopup() : null;
     try {
       const { url } =
         kind === "checkout"

--- a/packages/web/src/components/RootShell/RootShell.test.tsx
+++ b/packages/web/src/components/RootShell/RootShell.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
 import userEvent from "@testing-library/user-event";
 import { act, type ReactElement } from "react";
-import { render, screen } from "@web/__tests__/__mocks__/mock.render";
+import { render, screen, waitFor } from "@web/__tests__/__mocks__/mock.render";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { createTestRouter } from "@web/__tests__/utils/providers/createTestRouter";
 import { BillingApi } from "@web/api/billing.api";
@@ -12,6 +12,10 @@ import {
   initialBillingPreviewState,
   useBillingPreviewStore,
 } from "@web/billing/billing-preview.store";
+import {
+  initialCheckoutCelebrationState,
+  useCheckoutCelebrationStore,
+} from "@web/billing/checkout-celebration.store";
 import { type AppAccess } from "@web/billing/useAppAccess";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
@@ -86,6 +90,7 @@ describe("RootShell billing gates", () => {
   afterEach(() => {
     access = { kind: "open" };
     useBillingPreviewStore.setState(initialBillingPreviewState);
+    useCheckoutCelebrationStore.setState(initialCheckoutCelebrationState);
     useSettingsStore.setState({
       isSettingsOpen: false,
       settingsPage: "accounts",
@@ -239,6 +244,48 @@ describe("RootShell billing gates", () => {
     expect(
       (router.state.location.search as { checkout?: string }).checkout,
     ).toBeUndefined();
+  });
+
+  it("dismisses the checkout celebration with Start planning", async () => {
+    access = {
+      kind: "server",
+      status: "trialing",
+      isReadOnly: false,
+      trialEndsAt: "2026-09-08T00:00:00.000Z",
+    };
+    await renderShell("/week?checkout=success");
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Start planning" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "You're aboard!" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("dismisses the checkout celebration with Enter", async () => {
+    access = {
+      kind: "server",
+      status: "trialing",
+      isReadOnly: false,
+      trialEndsAt: "2026-09-08T00:00:00.000Z",
+    };
+    await renderShell("/week?checkout=success");
+    const user = userEvent.setup();
+
+    expect(
+      screen.getByRole("button", { name: "Start planning" }),
+    ).toHaveFocus();
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "You're aboard!" }),
+      ).not.toBeInTheDocument();
+    });
   });
 });
 

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -820,6 +820,74 @@ describe("SettingsModal", () => {
     assign.mockRestore();
   });
 
+  it("falls back to the same tab when opening the portal popup throws", async () => {
+    const createPortalSession = spyOn(
+      BillingApi,
+      "createPortalSession",
+    ).mockResolvedValue({ url: "https://billing.stripe.com/p/ok" });
+    const open = spyOn(window, "open").mockImplementation(() => {
+      throw new Error("Popup unavailable");
+    });
+    const assign = spyOn(window.location, "assign").mockImplementation(
+      () => {},
+    );
+    access = {
+      kind: "server",
+      status: "trialing",
+      isReadOnly: false,
+      trialEndsAt: dayjs().add(3, "day").toISOString(),
+    };
+    const user = userEvent.setup();
+    renderSettings({ authenticated: true, page: "billing" });
+
+    await user.click(screen.getByRole("button", { name: "Manage billing" }));
+
+    await waitFor(() => {
+      expect(createPortalSession).toHaveBeenCalled();
+      expect(assign).toHaveBeenCalledWith("https://billing.stripe.com/p/ok");
+    });
+    createPortalSession.mockRestore();
+    open.mockRestore();
+    assign.mockRestore();
+  });
+
+  it("restores Manage billing and reports a portal-session failure", async () => {
+    const createPortalSession = spyOn(
+      BillingApi,
+      "createPortalSession",
+    ).mockRejectedValue(new Error("Stripe unavailable"));
+    const close = mock(() => {});
+    const popup = { close, closed: false, location: { replace: mock() } };
+    const open = spyOn(window, "open").mockReturnValue(
+      popup as unknown as Window,
+    );
+    const { port, mocks } = createTestToastPort();
+    registerToastPort(port);
+    access = {
+      kind: "server",
+      status: "trialing",
+      isReadOnly: false,
+      trialEndsAt: dayjs().add(3, "day").toISOString(),
+    };
+    const user = userEvent.setup();
+    renderSettings({ authenticated: true, page: "billing" });
+
+    await user.click(screen.getByRole("button", { name: "Manage billing" }));
+
+    await waitFor(() => {
+      expect(close).toHaveBeenCalled();
+      expect(
+        screen.getByRole("button", { name: "Manage billing" }),
+      ).toBeEnabled();
+      expect(mocks.error).toHaveBeenCalledWith(
+        "Couldn't open billing. Please try again.",
+        expect.any(Object),
+      );
+    });
+    createPortalSession.mockRestore();
+    open.mockRestore();
+  });
+
   it("jumps to Billing with 2 and back to Accounts with 1", async () => {
     access = {
       kind: "server",


### PR DESCRIPTION
## Summary
- dismiss Checkout success acknowledgement synchronously
- continue to Stripe through same-tab fallback when popup creation throws
- cover checkout-return click/Enter and portal failure behavior

## Validation
- bun test:web -- --runInBand packages/web/src/components/RootShell/RootShell.test.tsx packages/web/src/components/Settings/SettingsModal.test.tsx packages/web/src/billing/CheckoutCelebrationModal.test.tsx
- bun lint
- bun type-check
- bun run verify