### PR TITLE
fix(web): allow pointer billing actions

### DIFF
--- a/packages/web/src/billing/CheckoutCelebrationModal.tsx
+++ b/packages/web/src/billing/CheckoutCelebrationModal.tsx
@@ -9,6 +9,7 @@ import { type AppAccess, useAppAccess } from "@web/billing/useAppAccess";
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 import { PixelPirate } from "@web/components/WelcomeModal/PixelPirate";
+import { pointerPassAttributes } from "@web/shortcuts/keyboard-only/pointer-action";
 
 const PANEL_CLASSNAME =
   "max-w-full gap-4 border border-border bg-surface text-center text-text shadow-xl";
@@ -75,6 +76,7 @@ export const CheckoutCelebrationModal: FC = () => {
           onClick={dismiss}
           ref={primaryButtonRef}
           type="button"
+          {...pointerPassAttributes}
         >
           Start planning
           <ShortcutHint className="ml-2">Enter</ShortcutHint>

--- a/packages/web/src/billing/PlanSection.tsx
+++ b/packages/web/src/billing/PlanSection.tsx
@@ -9,6 +9,7 @@ import { useBillingRedirect } from "@web/billing/useBillingRedirect";
 import { focusOnPointerEnter } from "@web/common/utils/focus-on-pointer-enter";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import { settingsShortcutAttrs } from "@web/settings/useSettingsShortcuts";
+import { pointerPassAttributes } from "@web/shortcuts/keyboard-only/pointer-action";
 
 const OUTLINE_BUTTON_CLASSNAME =
   "c-focus-ring inline-flex shrink-0 items-center rounded border border-border bg-surface-overlay px-2 py-1 text-xs text-text transition-colors hover:bg-surface-panel disabled:pointer-events-none disabled:opacity-60";
@@ -59,6 +60,7 @@ export const PlanSection: FC<{
           onClick={() => void redirectTo("portal", "settings_portal")}
           onPointerEnter={focusOnPointerEnter}
           type="button"
+          {...pointerPassAttributes}
           {...settingsShortcutAttrs("manage-billing")}
         >
           {isRedirecting ? "Opening Stripe…" : "Manage billing"}

--- a/packages/web/src/components/RootShell/RootShell.test.tsx
+++ b/packages/web/src/components/RootShell/RootShell.test.tsx
@@ -255,9 +255,11 @@ describe("RootShell billing gates", () => {
     };
     await renderShell("/week?checkout=success");
 
-    await userEvent.click(
-      screen.getByRole("button", { name: "Start planning" }),
-    );
+    const startPlanning = screen.getByRole("button", {
+      name: "Start planning",
+    });
+    expect(startPlanning).toHaveAttribute("data-pointer-pass", "");
+    await userEvent.click(startPlanning);
 
     await waitFor(() => {
       expect(

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -782,7 +782,11 @@ describe("SettingsModal", () => {
     const user = userEvent.setup();
     renderSettings({ authenticated: true, page: "billing" });
 
-    await user.click(screen.getByRole("button", { name: "Manage billing" }));
+    const manageBilling = screen.getByRole("button", {
+      name: "Manage billing",
+    });
+    expect(manageBilling).toHaveAttribute("data-pointer-pass", "");
+    await user.click(manageBilling);
 
     await waitFor(() => {
       expect(open).toHaveBeenCalledWith("about:blank", "_blank");


### PR DESCRIPTION
Allows the checkout-return acknowledgement and Settings billing portal control through the keyboard-first pointer guard. Adds integration-path regression assertions.