### PR TITLE
feat(billing): surface a trial's scheduled cancel

### DIFF
--- a/packages/backend/src/billing/controllers/billing.controller.test.ts
+++ b/packages/backend/src/billing/controllers/billing.controller.test.ts
@@ -30,6 +30,7 @@ describe("BillingController", () => {
       subscriptionStatus: "trialing",
       trialEndsAt: "2026-08-20T00:00:00.000Z",
       isReadOnly: false,
+      cancelAtPeriodEnd: false,
     };
     spyOn(billingService, "getStatus").mockResolvedValue(status);
 

--- a/packages/backend/src/billing/services/billing.service.db.test.ts
+++ b/packages/backend/src/billing/services/billing.service.db.test.ts
@@ -57,6 +57,7 @@ describe("BillingService (db)", () => {
       subscriptionStatus: "active",
       trialEndsAt: null,
       isReadOnly: false,
+      cancelAtPeriodEnd: false,
     });
 
     const stored = await mongoService.user.findOne({ _id: userId });

--- a/packages/backend/src/billing/services/billing.service.test.ts
+++ b/packages/backend/src/billing/services/billing.service.test.ts
@@ -12,6 +12,7 @@ describe("deriveBillingStatus", () => {
       subscriptionStatus: "awaiting_checkout",
       trialEndsAt: null,
       isReadOnly: true,
+      cancelAtPeriodEnd: false,
     });
   });
 
@@ -20,6 +21,7 @@ describe("deriveBillingStatus", () => {
       subscriptionStatus: "awaiting_checkout",
       trialEndsAt: null,
       isReadOnly: true,
+      cancelAtPeriodEnd: false,
     });
   });
 
@@ -32,6 +34,7 @@ describe("deriveBillingStatus", () => {
       subscriptionStatus: "awaiting_checkout",
       trialEndsAt: null,
       isReadOnly: true,
+      cancelAtPeriodEnd: false,
     });
   });
 
@@ -47,6 +50,7 @@ describe("deriveBillingStatus", () => {
       subscriptionStatus: "awaiting_checkout",
       trialEndsAt: trialEndsAt.toISOString(),
       isReadOnly: true,
+      cancelAtPeriodEnd: false,
     });
   });
 
@@ -62,7 +66,20 @@ describe("deriveBillingStatus", () => {
       subscriptionStatus: "awaiting_checkout",
       trialEndsAt: trialEndsAt.toISOString(),
       isReadOnly: true,
+      cancelAtPeriodEnd: false,
     });
+  });
+
+  it("surfaces a scheduled cancel on a Stripe-backed trial", () => {
+    const status = deriveBillingStatus({
+      subscriptionStatus: "trialing",
+      trialEndsAt: new Date("2026-09-08T00:00:00.000Z"),
+      stripeSubscriptionId: "sub_123",
+      cancelAtPeriodEnd: true,
+    });
+
+    expect(status.subscriptionStatus).toBe("trialing");
+    expect(status.cancelAtPeriodEnd).toBe(true);
   });
 
   it("does not self-expire a Stripe-backed trialing record past trialEndsAt", () => {

--- a/packages/backend/src/billing/services/billing.service.ts
+++ b/packages/backend/src/billing/services/billing.service.ts
@@ -31,6 +31,7 @@ export const deriveBillingStatus = (
       subscriptionStatus: "awaiting_checkout",
       trialEndsAt: billing?.trialEndsAt?.toISOString() ?? null,
       isReadOnly: true,
+      cancelAtPeriodEnd: false,
     };
   }
 
@@ -42,6 +43,7 @@ export const deriveBillingStatus = (
       subscriptionStatus: "awaiting_checkout",
       trialEndsAt: billing.trialEndsAt?.toISOString() ?? null,
       isReadOnly: true,
+      cancelAtPeriodEnd: false,
     };
   }
 
@@ -49,6 +51,7 @@ export const deriveBillingStatus = (
     subscriptionStatus: billing.subscriptionStatus,
     trialEndsAt: billing.trialEndsAt?.toISOString() ?? null,
     isReadOnly: !WRITE_ACCESS_BY_STATUS[billing.subscriptionStatus],
+    cancelAtPeriodEnd: billing.cancelAtPeriodEnd === true,
   };
 };
 
@@ -77,6 +80,7 @@ class BillingService {
         subscriptionStatus: "active",
         trialEndsAt: null,
         isReadOnly: false,
+        cancelAtPeriodEnd: false,
       };
     }
 

--- a/packages/backend/src/billing/services/stripe.service.db.test.ts
+++ b/packages/backend/src/billing/services/stripe.service.db.test.ts
@@ -419,14 +419,16 @@ describe("StripeService", () => {
         subscriptionStatus: "active",
         trialEndsAt: new Date(1_756_200_000 * 1000).toISOString(),
         isReadOnly: false,
+        cancelAtPeriodEnd: false,
       });
       expect(update.mock.calls[0]?.[0]).toBe("sub_trial");
       expect(update.mock.calls[0]?.[1]).toEqual({
         trial_end: "now",
         proration_behavior: "none",
+        cancel_at_period_end: false,
       });
       expect(update.mock.calls[0]?.[2]).toEqual({
-        idempotencyKey: "compass-end-trial-sub_trial",
+        idempotencyKey: "compass-end-trial-v2-sub_trial",
       });
 
       const stored = await mongoService.user.findOne({ _id: userId });
@@ -450,25 +452,24 @@ describe("StripeService", () => {
       expect(result.isReadOnly).toBe(false);
     });
 
-    it("still charges a trial that is set to cancel at period end", async () => {
+    it("clears a scheduled cancel while charging the trial", async () => {
       using _env = mockEnv(stripeConfigured);
       const userId = await seedTrialingUser({ cancelAtPeriodEnd: true });
 
+      const update = mock(() => Promise.resolve(stripeSubscription("active")));
       setStripeClientForTests({
-        subscriptions: {
-          update: mock(() =>
-            Promise.resolve(
-              stripeSubscription("active", { cancel_at_period_end: true }),
-            ),
-          ),
-        },
+        subscriptions: { update },
       } as unknown as Stripe);
 
       const result = await stripeService.endTrialNow(userId.toString());
 
       expect(result.subscriptionStatus).toBe("active");
+      expect(result.cancelAtPeriodEnd).toBe(false);
+      expect(update.mock.calls[0]?.[1]).toMatchObject({
+        cancel_at_period_end: false,
+      });
       const stored = await mongoService.user.findOne({ _id: userId });
-      expect(stored?.billing?.cancelAtPeriodEnd).toBe(true);
+      expect(stored?.billing?.cancelAtPeriodEnd).toBe(false);
     });
 
     it("rejects with 409 when the account is not trialing", async () => {

--- a/packages/backend/src/billing/services/stripe.service.ts
+++ b/packages/backend/src/billing/services/stripe.service.ts
@@ -182,6 +182,10 @@ class StripeService {
    * If the charge fails Stripe moves the subscription to `past_due`, which
    * stays writable and raises the dunning banner. The caller is told the
    * resulting status rather than a blanket success.
+   *
+   * A cancel scheduled from the Billing Portal is cleared here: subscribing
+   * now and cancelling at period end are contradictory instructions, and the
+   * one the user just gave wins.
    */
   endTrialNow = async (userId: string): Promise<BillingStatusResponse> => {
     if (!isStripeConfigured(CONFIG)) {
@@ -203,8 +207,14 @@ class StripeService {
     const subscription = await stripe.subscriptions
       .update(
         subscriptionId,
-        { trial_end: "now", proration_behavior: "none" },
-        { idempotencyKey: `compass-end-trial-${subscriptionId}` },
+        {
+          trial_end: "now",
+          proration_behavior: "none",
+          cancel_at_period_end: false,
+        },
+        // v2 when cancel_at_period_end was added, same reason as the
+        // checkout prefix: a param change must not replay as the old call.
+        { idempotencyKey: `compass-end-trial-v2-${subscriptionId}` },
       )
       .catch(wrapStripeFailure);
 

--- a/packages/core/src/types/billing.types.ts
+++ b/packages/core/src/types/billing.types.ts
@@ -17,6 +17,11 @@ export const BillingStatusResponseSchema = z.object({
   trialEndsAt: z.string().nullable(),
   /** True when the account must not mutate events. */
   isReadOnly: z.boolean(),
+  /**
+   * True when the subscription is set to cancel at period end instead of
+   * renewing. Defaulted so a response from an older server still parses.
+   */
+  cancelAtPeriodEnd: z.boolean().default(false),
 });
 export type BillingStatusResponse = z.infer<typeof BillingStatusResponseSchema>;
 

--- a/packages/web/src/billing/PlanSection.tsx
+++ b/packages/web/src/billing/PlanSection.tsx
@@ -36,6 +36,8 @@ export const PlanSection: FC<{
     access.kind === "server" && access.status === "trialing"
       ? access.trialEndsAt
       : null;
+  const cancelScheduled =
+    access.kind === "server" && access.cancelAtPeriodEnd === true;
 
   return (
     <div>
@@ -49,7 +51,8 @@ export const PlanSection: FC<{
           </span>
           {trialEndsAt ? (
             <p className="mt-1 text-text-muted text-xs">
-              Your trial ends {dayjs(trialEndsAt).format("MMM D, YYYY")}. Press{" "}
+              Your trial ends {dayjs(trialEndsAt).format("MMM D, YYYY")}
+              {cancelScheduled ? " and will not renew" : ""}. Press{" "}
               <ShortcutKeys keys="B" /> to subscribe now.
             </p>
           ) : null}

--- a/packages/web/src/billing/TrialBadge.test.tsx
+++ b/packages/web/src/billing/TrialBadge.test.tsx
@@ -91,6 +91,22 @@ describe("TrialBadge", () => {
     ).toHaveTextContent("Last day");
   });
 
+  it("says the trial will not renew when a cancel is scheduled", () => {
+    access = {
+      kind: "server",
+      status: "trialing",
+      isReadOnly: false,
+      trialEndsAt: trialEndingIn(5),
+      cancelAtPeriodEnd: true,
+    };
+    render(<TrialBadge />);
+
+    const badge = screen.getByRole("button", {
+      name: "5 days left in your trial. It will not renew. Subscribe now.",
+    });
+    expect(badge).toHaveTextContent("5d");
+  });
+
   it("carries no tabindex, so Mod+2 still lands on the day grid", () => {
     access = {
       kind: "server",

--- a/packages/web/src/billing/TrialBadge.tsx
+++ b/packages/web/src/billing/TrialBadge.tsx
@@ -29,7 +29,9 @@ export function TrialBadge() {
   }
 
   const daysLeft = getTrialDaysLeft(access.trialEndsAt);
-  const description = formatTrialBadgeDescription(daysLeft);
+  const description = access.cancelAtPeriodEnd
+    ? `${formatTrialBadgeDescription(daysLeft)}. It will not renew`
+    : formatTrialBadgeDescription(daysLeft);
 
   return (
     <TooltipWrapper description={description} shortcut="B">

--- a/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationProvider.test.tsx
+++ b/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationProvider.test.tsx
@@ -84,6 +84,7 @@ describe("UpgradeConfirmationProvider", () => {
       subscriptionStatus: "active",
       trialEndsAt: null,
       isReadOnly: false,
+      cancelAtPeriodEnd: false,
     });
     await openDialog();
 
@@ -112,6 +113,7 @@ describe("UpgradeConfirmationProvider", () => {
       subscriptionStatus: "past_due",
       trialEndsAt: null,
       isReadOnly: false,
+      cancelAtPeriodEnd: false,
     });
     await openDialog();
 

--- a/packages/web/src/billing/useAppAccess.test.tsx
+++ b/packages/web/src/billing/useAppAccess.test.tsx
@@ -45,6 +45,7 @@ const stubBilling = (body: {
   subscriptionStatus: string;
   trialEndsAt: string | null;
   isReadOnly: boolean;
+  cancelAtPeriodEnd?: boolean;
 }) => {
   server.use(
     rest.get(`${ENV_WEB.API_BASEURL}/billing/status`, (_req, res, ctx) =>
@@ -86,6 +87,30 @@ describe("useAppAccess", () => {
         status: "trialing",
         isReadOnly: false,
         trialEndsAt: "2026-09-03T00:00:00.000Z",
+        // The schema defaults an absent cancelAtPeriodEnd to false, so an
+        // older server response still parses.
+        cancelAtPeriodEnd: false,
+      });
+    });
+  });
+
+  it("passes through a scheduled cancel on a trialing account", async () => {
+    stubConfig(true);
+    stubBilling({
+      subscriptionStatus: "trialing",
+      trialEndsAt: "2026-09-03T00:00:00.000Z",
+      isReadOnly: false,
+      cancelAtPeriodEnd: true,
+    });
+
+    const { result } = renderHook(() => useAppAccess(), {
+      wrapper: createWrapper(true),
+    });
+    await waitFor(() => {
+      expect(result.current).toMatchObject({
+        kind: "server",
+        status: "trialing",
+        cancelAtPeriodEnd: true,
       });
     });
   });
@@ -155,6 +180,7 @@ describe("useAppAccess", () => {
         status: "active",
         isReadOnly: false,
         trialEndsAt: null,
+        cancelAtPeriodEnd: false,
       });
     });
   });

--- a/packages/web/src/billing/useAppAccess.ts
+++ b/packages/web/src/billing/useAppAccess.ts
@@ -13,6 +13,12 @@ export type AppAccess =
       status: BillingSubscriptionStatus;
       isReadOnly: boolean;
       trialEndsAt: string | null;
+      /**
+       * True when the subscription is set to cancel at period end instead of
+       * renewing. Optional so the many test fixtures that predate it stay
+       * valid; absent reads as false.
+       */
+      cancelAtPeriodEnd?: boolean;
     }
   | { kind: "open" };
 
@@ -62,5 +68,6 @@ export function useAppAccess(): AppAccess {
     status: billingQuery.data.subscriptionStatus,
     isReadOnly: billingQuery.data.isReadOnly,
     trialEndsAt: billingQuery.data.trialEndsAt,
+    cancelAtPeriodEnd: billingQuery.data.cancelAtPeriodEnd,
   };
 }

--- a/packages/web/src/components/RootShell/RootShell.test.tsx
+++ b/packages/web/src/components/RootShell/RootShell.test.tsx
@@ -217,6 +217,7 @@ describe("RootShell billing gates", () => {
       subscriptionStatus: "active",
       trialEndsAt: null,
       isReadOnly: false,
+      cancelAtPeriodEnd: false,
     });
     await renderShell("/week?settings=billing");
 

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -763,6 +763,23 @@ describe("SettingsModal", () => {
     ).toBeTruthy();
   });
 
+  it("says a cancel-scheduled trial will not renew", () => {
+    access = {
+      kind: "server",
+      status: "trialing",
+      isReadOnly: false,
+      trialEndsAt: dayjs().add(3, "day").toISOString(),
+      cancelAtPeriodEnd: true,
+    };
+    renderSettings({ authenticated: true, page: "billing" });
+
+    expect(
+      screen.getByText(/to subscribe now/).closest("p") as HTMLElement,
+    ).toHaveTextContent(
+      `Your trial ends ${dayjs().add(3, "day").format("MMM D, YYYY")} and will not renew. Press B to subscribe now.`,
+    );
+  });
+
   it("opens the billing portal from Manage billing in a new tab", async () => {
     const createPortalSession = spyOn(
       BillingApi,


### PR DESCRIPTION
## Problem

Canceling a trialing subscription from the Stripe billing portal uses cancel-at-period-end, so Stripe stays `trialing` and Compass showed zero change: Settings still read "Your trial ends Sep 8, 2026. Press B to subscribe now." and the trial badge kept counting down. The webhook already persisted `billing.cancelAtPeriodEnd`, but nothing ever read it.

## Changes

- **Wire**: `BillingStatusResponse` gains `cancelAtPeriodEnd`, defaulted to `false` on parse so a response from an older server still passes the web schema during a rolling deploy. `deriveBillingStatus` reflects the stored flag on live subscriptions and forces `false` on the awaiting_checkout and bypass branches.
- **Settings Billing**: cancel-scheduled trials read "Your trial ends Sep 8, 2026 and will not renew. Press B to subscribe now." The B path doubles as the resubscribe path, and Manage billing is unchanged.
- **Trial badge**: tooltip and aria-label gain "It will not renew" while the compact label stays.
- **endTrialNow (the B shortcut)**: now passes `cancel_at_period_end: false` alongside `trial_end: "now"`. Previously a cancel-scheduled user who pressed B paid for a period that would still cancel; subscribing now and cancelling at period end are contradictory, and the instruction the user just gave wins. Idempotency key bumped to `-v2-` for the param change.

## Tests

- deriveBillingStatus surfaces the flag on a Stripe-backed trial and defaults it elsewhere
- endTrialNow clears a scheduled cancel while charging (rewrote the test that pinned the old carry-through behavior)
- useAppAccess passes the flag through; the schema default is pinned
- TrialBadge and SettingsModal assert the cancel-aware copy (full-sentence assertions)

Backend billing suite 55/55, web billing + settings suites green, type-check and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)