### PR TITLE
fix(web): teach advertised shortcuts on blocked clicks

### DIFF
--- a/packages/web/src/billing/BillingGateModal.test.tsx
+++ b/packages/web/src/billing/BillingGateModal.test.tsx
@@ -125,6 +125,13 @@ describe("BillingGateModal", () => {
     expect(
       screen.queryByRole("button", { name: "Export my data" }),
     ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Start trial" })).toHaveAttribute(
+      "data-pointer-shortcut",
+      "S",
+    );
+    expect(
+      screen.getByRole("button", { name: "Look around first" }),
+    ).toHaveAttribute("data-pointer-shortcut", "L");
   });
 
   it("does not mention a price on the start-trial or subscribe copy", () => {

--- a/packages/web/src/billing/BillingGateModal.tsx
+++ b/packages/web/src/billing/BillingGateModal.tsx
@@ -10,6 +10,11 @@ import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 import { PixelPirateScouting } from "@web/components/WelcomeModal/PixelPirateScouting";
 import { useAppLockReason } from "@web/shortcuts/app-lock";
+import {
+  POINTER_ACTION_ATTRIBUTE,
+  POINTER_ACTIONS,
+  pointerShortcutAttributes,
+} from "@web/shortcuts/keyboard-only/pointer-action";
 import { swallowNextKeyup } from "@web/shortcuts/swallow-next-keyup";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 
@@ -129,6 +134,10 @@ export const BillingGateModal: FC<BillingGateModalProps> = ({ status }) => {
             onClick={() => void redirectTo("checkout")}
             onPointerEnter={focusOnPointerEnter}
             type="button"
+            {...pointerShortcutAttributes("S")}
+            {...(isAwaitingCheckout
+              ? { [POINTER_ACTION_ATTRIBUTE]: POINTER_ACTIONS.startTrial }
+              : {})}
           >
             {isRedirecting
               ? "Opening Stripe…"
@@ -144,6 +153,7 @@ export const BillingGateModal: FC<BillingGateModalProps> = ({ status }) => {
             onClick={secondary.onClick}
             onPointerEnter={focusOnPointerEnter}
             type="button"
+            {...pointerShortcutAttributes(secondary.key)}
           >
             {isRedirecting && secondary.key === "M"
               ? "Opening Stripe…"

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -43,6 +43,7 @@ import {
   useSettingsStore,
 } from "@web/settings/settings.store";
 import { useAppLockReason } from "@web/shortcuts/app-lock";
+import { pointerShortcutAttributes } from "@web/shortcuts/keyboard-only/pointer-action";
 import { type ViewName } from "@web/shortcuts/shortcuts.constants";
 import { useTimezoneCmdItems } from "@web/timezone/useTimezoneCmdItems";
 import { filterSections, getLabelMatchRanges } from "./command-palette.search";
@@ -258,6 +259,7 @@ const CommandPaletteContent = ({
                         aria-selected={isActive}
                         disabled={item.disabled}
                         className={rowClassName}
+                        {...pointerShortcutAttributes("Enter")}
                       >
                         {content}
                       </button>

--- a/packages/web/src/components/CommandPalette/command-palette.search.test.ts
+++ b/packages/web/src/components/CommandPalette/command-palette.search.test.ts
@@ -47,6 +47,29 @@ describe("filterSections", () => {
     expect(result[0].items[0].label).toBe("Create Event");
   });
 
+  it("strips trailing sentence punctuation so play. still matches Play", () => {
+    const withPlay = [
+      {
+        id: "nav",
+        heading: "Navigation",
+        items: [
+          {
+            id: "practice-shortcuts",
+            label: "Play Block Party (practice shortcuts)",
+            icon: PlusIcon,
+            keywords: ["play", "game"],
+          },
+          { id: "create", label: "Create event", icon: PlusIcon },
+        ],
+      },
+    ];
+
+    const result = filterSections(withPlay, "play.");
+    expect(result).toHaveLength(1);
+    expect(result[0].items).toHaveLength(1);
+    expect(result[0].items[0].id).toBe("practice-shortcuts");
+  });
+
   it("matches a synonym via keywords, not just the label", () => {
     const withKeywords = [
       {

--- a/packages/web/src/components/CommandPalette/command-palette.search.ts
+++ b/packages/web/src/components/CommandPalette/command-palette.search.ts
@@ -2,6 +2,20 @@ import { type CommandItem, type CommandSection } from "./command-palette.types";
 
 const MIN_SUBSEQUENCE_TOKEN_LENGTH = 3;
 
+/** Strip wrapping quotes and trailing sentence punctuation so "play." still matches Play. */
+function normalizeSearchToken(token: string): string {
+  return token.replace(/^['"]+|['"]+$/g, "").replace(/[.!?]+$/g, "");
+}
+
+function tokenizeQuery(query: string): string[] {
+  return query
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .map(normalizeSearchToken)
+    .filter(Boolean);
+}
+
 /** Every word of the haystack starts with the token, e.g. "day" in "Go to Day". */
 function hasWordStartingWith(haystack: string, token: string): boolean {
   return haystack.split(/[\s-]+/).some((word) => word.startsWith(token));
@@ -70,7 +84,7 @@ export function scoreCommandItem(
   item: Pick<CommandItem, "label" | "keywords">,
   query: string,
 ): number {
-  const tokens = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  const tokens = tokenizeQuery(query);
   if (tokens.length === 0) return 0;
   return scoreAgainstTokens(item, tokens);
 }
@@ -88,7 +102,7 @@ export function getLabelMatchRanges(
   label: string,
   query: string,
 ): Array<[number, number]> {
-  const tokens = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  const tokens = tokenizeQuery(query);
   if (tokens.length === 0) return [];
 
   const lowerLabel = label.toLowerCase();
@@ -124,7 +138,7 @@ export function filterSections(
   sections: CommandSection[],
   search: string,
 ): CommandSection[] {
-  const tokens = search.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  const tokens = tokenizeQuery(search);
   if (tokens.length === 0) return sections;
 
   return sections

--- a/packages/web/src/components/CommandPalette/hooks/useShowAccountsCmdItems.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useShowAccountsCmdItems.ts
@@ -31,6 +31,8 @@ export const useShowAccountsCmdItems = (): CommandItem[] => {
         "options",
         "add account",
         "connect google",
+        "multiple google",
+        "google accounts",
         "disconnect account",
         "remove account",
         "export data",

--- a/packages/web/src/components/CommandPalette/more.cmd.constants.test.ts
+++ b/packages/web/src/components/CommandPalette/more.cmd.constants.test.ts
@@ -39,6 +39,8 @@ describe("getMoreCommandPaletteSections", () => {
     expect(getCommandPalettePlaceholder("week", false)).not.toContain(
       "feedback",
     );
+    expect(getCommandPalettePlaceholder("week", false)).toContain("play");
+    expect(getCommandPalettePlaceholder("day", false)).toContain("play");
   });
 
   it("opens the feedback request from the cloud command", () => {
@@ -56,6 +58,7 @@ describe("getMoreCommandPaletteSections", () => {
       view: "day",
     });
     expect(getCommandPalettePlaceholder("day", true)).toContain("feedback");
+    expect(getCommandPalettePlaceholder("day", true)).toContain("play");
     expect(getCommandPalettePlaceholder("day", true)).not.toContain("bug");
   });
 

--- a/packages/web/src/components/CommandPalette/more.cmd.constants.ts
+++ b/packages/web/src/components/CommandPalette/more.cmd.constants.ts
@@ -21,11 +21,13 @@ export function getCommandPalettePlaceholder(
 
   if (currentView === "day") {
     return feedbackEnabled
-      ? "Try: 'week', 'today', or 'feedback'"
-      : "Try: 'week' or 'today'";
+      ? "Try: 'play', 'week', or 'feedback'"
+      : "Try: 'play' or 'week'";
   }
 
-  return feedbackEnabled ? "Try: 'create' or 'feedback'" : "Try: 'create'";
+  return feedbackEnabled
+    ? "Try: 'play', 'create', or 'feedback'"
+    : "Try: 'play' or 'create'";
 }
 
 export function getMoreCommandPaletteSections(

--- a/packages/web/src/components/CommandPalette/navigation.cmd.constants.test.ts
+++ b/packages/web/src/components/CommandPalette/navigation.cmd.constants.test.ts
@@ -33,9 +33,9 @@ describe("getNavigationCommandItems", () => {
 
     expect(labels).toContain("Play Block Party (practice shortcuts)");
     expect(labels).toContain("Show welcome guide");
-    expect(labels.indexOf("Practice shortcuts")).toBeLessThan(
-      labels.indexOf("Show welcome guide"),
-    );
+    expect(
+      labels.indexOf("Play Block Party (practice shortcuts)"),
+    ).toBeLessThan(labels.indexOf("Show welcome guide"));
   });
 
   it("can list only view navigation for non-calendar surfaces", () => {

--- a/packages/web/src/components/CommandPalette/navigation.cmd.constants.ts
+++ b/packages/web/src/components/CommandPalette/navigation.cmd.constants.ts
@@ -134,6 +134,7 @@ export const getNavigationCommandItems = ({
         "practice",
         "shortcuts",
         "game",
+        "play",
         "block party",
       ],
       onClick: onPracticeShortcuts,

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
@@ -348,6 +348,10 @@ describe("OverlayPanel", () => {
     expect(
       within(screen.getByRole("button", { name: "Cancel" })).getByText("Esc"),
     ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Cancel" })).toHaveAttribute(
+      "data-pointer-shortcut",
+      "Esc",
+    );
   });
 
   it("hides a shortcut chip when showShortcut is false", () => {

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
@@ -14,6 +14,7 @@ import { getFocusableElements } from "@web/common/utils/focusable-elements";
 import { useOverlayEscape } from "@web/components/OverlayPanel/overlay-escape";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import { useAppLockReason } from "@web/shortcuts/app-lock";
+import { pointerShortcutAttributes } from "@web/shortcuts/keyboard-only/pointer-action";
 
 interface Props {
   /** Icon or element displayed at the top of the panel */
@@ -301,6 +302,7 @@ export const OverlayPanelActionButton = forwardRef<
         onPointerEnter?.(event);
       }}
       {...buttonProps}
+      {...(shortcut ? pointerShortcutAttributes(shortcut) : {})}
     >
       {children}
       {shortcut && showShortcut ? (

--- a/packages/web/src/components/PointerHint/PointerHint.test.tsx
+++ b/packages/web/src/components/PointerHint/PointerHint.test.tsx
@@ -124,6 +124,21 @@ describe("PointerHint", () => {
     expect(screen.getByRole("status")).toHaveTextContent("Press S");
   });
 
+  it("teaches a chord shortcut as separate keycaps", () => {
+    render(<PointerHint />);
+
+    act(() => {
+      pointerBlockActions.pulseBlockedClick({
+        actionId: "unknown",
+        shortcutKey: ["Mod", "K"],
+      });
+    });
+
+    const hint = screen.getByRole("status");
+    expect(hint).toHaveTextContent("Press");
+    expect(hint).toHaveTextContent("K");
+  });
+
   it("teaches the matching welcome shortcut for the attempted control", () => {
     welcomeGuideActions.setFirstVisitOpen(true);
     render(<PointerHint />);

--- a/packages/web/src/components/PointerHint/PointerHint.test.tsx
+++ b/packages/web/src/components/PointerHint/PointerHint.test.tsx
@@ -209,6 +209,20 @@ describe("PointerHint", () => {
     );
   });
 
+  it("teaches view shortcuts for the date heading", () => {
+    render(<PointerHint />);
+
+    act(() => {
+      pointerBlockActions.pulseBlockedClick({
+        actionId: POINTER_ACTIONS.switchView,
+      });
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Press W, D, or L to switch views.",
+    );
+  });
+
   it("teaches the assigned sequence for the attempted event", () => {
     render(<PointerHint />);
 
@@ -264,6 +278,21 @@ describe("PointerHint", () => {
 
     expect(screen.getByRole("status")).toHaveTextContent(
       "Press T to go to today.",
+    );
+  });
+
+  it("keeps the view-switch sentence after the session reminder threshold", () => {
+    sessionStorage.setItem(HINT_COUNT_KEY, "3");
+    render(<PointerHint />);
+
+    act(() => {
+      pointerBlockActions.pulseBlockedClick({
+        actionId: POINTER_ACTIONS.switchView,
+      });
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Press W, D, or L to switch views.",
     );
   });
 

--- a/packages/web/src/components/PointerHint/PointerHint.tsx
+++ b/packages/web/src/components/PointerHint/PointerHint.tsx
@@ -4,6 +4,7 @@ import {
   selectShowcaseActive,
   useShortcutShowcaseStore,
 } from "@web/components/ShortcutShowcase/showcase.store";
+import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import {
   selectWelcomeSurfaceOpen,
   useWelcomeGuideStore,
@@ -148,7 +149,7 @@ const pointerHintMessage = ({
   if (attempt?.shortcutKey) {
     return (
       <>
-        Press <Key>{attempt.shortcutKey}</Key>
+        Press <ShortcutKeys keys={attempt.shortcutKey} />
       </>
     );
   }

--- a/packages/web/src/components/PointerHint/PointerHint.tsx
+++ b/packages/web/src/components/PointerHint/PointerHint.tsx
@@ -53,6 +53,7 @@ const isContextualAttempt = (attempt: BlockedPointerAttempt | null) =>
   attempt?.actionId === POINTER_ACTIONS.sidebarClose ||
   attempt?.actionId === POINTER_ACTIONS.sidebarOpen ||
   attempt?.actionId === POINTER_ACTIONS.goToToday ||
+  attempt?.actionId === POINTER_ACTIONS.switchView ||
   attempt?.actionId === POINTER_ACTIONS.eventOpen ||
   attempt?.actionId === POINTER_ACTIONS.startTrial ||
   attempt?.actionId === POINTER_ACTIONS.reconnectGoogle ||
@@ -92,6 +93,14 @@ const pointerHintMessage = ({
     return (
       <>
         Press <Key>T</Key> to go to today.
+      </>
+    );
+  }
+
+  if (attempt?.actionId === POINTER_ACTIONS.switchView) {
+    return (
+      <>
+        Press <Key>W</Key>, <Key>D</Key>, or <Key>L</Key> to switch views.
       </>
     );
   }

--- a/packages/web/src/components/SelectView/SelectView.test.tsx
+++ b/packages/web/src/components/SelectView/SelectView.test.tsx
@@ -98,6 +98,7 @@ describe("SelectView", () => {
       expect(button).toBeInTheDocument();
       expect(button.textContent).toBe("July 2026");
       expect(button).toHaveAttribute("aria-expanded", "false");
+      expect(button).toHaveAttribute("data-pointer-action", "calendar.view");
     });
 
     it("renders the label as the page heading", async () => {
@@ -128,6 +129,9 @@ describe("SelectView", () => {
       expect(shortcutHints[1]).toHaveTextContent("D");
       expect(shortcutHints[2]).toHaveTextContent("W");
       expect(shortcutHints[3]).toHaveTextContent("L");
+      expect(
+        withinDropdown.getByRole("option", { name: /^week/i }),
+      ).toHaveAttribute("data-pointer-shortcut", "w");
     });
   });
 

--- a/packages/web/src/components/SelectView/SelectView.tsx
+++ b/packages/web/src/components/SelectView/SelectView.tsx
@@ -14,6 +14,10 @@ import { ROOT_ROUTES } from "@web/common/constants/routes";
 import { Z_INDEX_FLOATING_MENU } from "@web/common/constants/web.constants";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import { useFloatingLayer } from "@web/shortcuts/floating-layer";
+import {
+  POINTER_ACTIONS,
+  pointerShortcutAttributes,
+} from "@web/shortcuts/keyboard-only/pointer-action";
 import { pageJumpAttrs } from "@web/shortcuts/page-jump/page-jump.targets";
 import {
   LIFE_SHORTCUT,
@@ -152,6 +156,7 @@ export const SelectView = ({ label, onToday }: SelectViewProps) => {
           aria-expanded={isOpen}
           aria-haspopup="listbox"
           aria-controls={isOpen ? dropdownId : undefined}
+          data-pointer-action={POINTER_ACTIONS.switchView}
         >
           <span>{label}</span>
           <CaretDownIcon size={14} aria-hidden="true" />
@@ -199,6 +204,7 @@ export const SelectView = ({ label, onToday }: SelectViewProps) => {
                 role="option"
                 aria-selected={isSelected}
                 tabIndex={isActive ? 0 : -1}
+                {...pointerShortcutAttributes(option.key)}
                 className={classNames(
                   "c-focus-ring flex w-full cursor-pointer items-center gap-2 whitespace-nowrap px-3 py-2 text-left text-sm transition-colors",
                   isSelected ? "text-accent" : "text-text-muted",

--- a/packages/web/src/components/Sidebar/SidebarActions/SidebarActions.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarActions/SidebarActions.test.tsx
@@ -67,7 +67,7 @@ describe("SidebarActions", () => {
     ).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Open command palette" }),
-    ).toBeInTheDocument();
+    ).toHaveAttribute("data-pointer-shortcut", '["Mod","K"]');
   });
 
   it("labels the shortcuts button as a close action when shortcuts are open", () => {

--- a/packages/web/src/components/Sidebar/SidebarActions/SidebarActions.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarActions/SidebarActions.test.tsx
@@ -68,6 +68,9 @@ describe("SidebarActions", () => {
     expect(
       screen.getByRole("button", { name: "Open command palette" }),
     ).toHaveAttribute("data-pointer-shortcut", '["Mod","K"]');
+    expect(
+      screen.getByRole("button", { name: "Open settings" }),
+    ).toHaveAttribute("data-pointer-shortcut", '["Mod",","]');
   });
 
   it("labels the shortcuts button as a close action when shortcuts are open", () => {

--- a/packages/web/src/components/Sidebar/SidebarActions/SidebarActions.tsx
+++ b/packages/web/src/components/Sidebar/SidebarActions/SidebarActions.tsx
@@ -1,4 +1,4 @@
-import { CommandIcon, KeyboardIcon } from "@phosphor-icons/react";
+import { CommandIcon, GearIcon, KeyboardIcon } from "@phosphor-icons/react";
 import { useGoogleUiState } from "@web/auth/google/hooks/useConnectGoogle/useGoogleUiState";
 import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
 import {
@@ -8,6 +8,7 @@ import {
 } from "@web/events/stores/view.store";
 import {
   selectIsCmdPaletteOpen,
+  selectIsSettingsOpen,
   settingsActions,
   useSettingsStore,
 } from "@web/settings/settings.store";
@@ -15,6 +16,7 @@ import {
 export const SidebarActions = () => {
   const isShortcutsOpen = useViewStore(selectIsShortcutsOpen);
   const isCmdPaletteOpen = useSettingsStore(selectIsCmdPaletteOpen);
+  const isSettingsOpen = useSettingsStore(selectIsSettingsOpen);
   const googleState = useGoogleUiState();
   const isCalendarSyncing = googleState === "IMPORTING";
 
@@ -53,6 +55,23 @@ export const SidebarActions = () => {
       </div>
 
       <div className="flex items-center gap-2">
+        <TooltipWrapper
+          description="Open settings"
+          shortcut={["Mod", ","]}
+          onClick={() => settingsActions.openSettings()}
+        >
+          <button
+            aria-label="Open settings"
+            className="flex size-9 items-center justify-center rounded-default text-text-muted transition hover:bg-surface-panel hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            type="button"
+          >
+            <GearIcon
+              aria-hidden="true"
+              size={16}
+              weight={isSettingsOpen ? "fill" : "regular"}
+            />
+          </button>
+        </TooltipWrapper>
         <TooltipWrapper
           description="Open command palette"
           shortcut={["Mod", "K"]}

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
@@ -283,11 +283,14 @@ describe("SidebarStatusBar", () => {
     const { wrapper } = createStoreWrapper();
 
     render(<SidebarStatusBar />, { wrapper });
-    await user.click(
-      screen.getByRole("button", {
-        name: "Calendar updates are delayed. Open account settings",
-      }),
+    const settingsButton = screen.getByRole("button", {
+      name: "Calendar updates are delayed. Open account settings",
+    });
+    expect(settingsButton).toHaveAttribute(
+      "data-pointer-shortcut",
+      '["Mod",","]',
     );
+    await user.click(settingsButton);
 
     expect(openSettings).toHaveBeenCalledTimes(1);
     openSettings.mockRestore();

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
@@ -20,6 +20,7 @@ import {
 } from "@web/grid/shortcuts/edge-focus.store";
 import { KeyboardPlaceIndicator } from "@web/grid/shortcuts/KeyboardPlaceIndicator";
 import { settingsActions } from "@web/settings/settings.store";
+import { pointerShortcutAttributes } from "@web/shortcuts/keyboard-only/pointer-action";
 import { QuickTimeIndicator } from "@web/shortcuts/quick-time/QuickTimeIndicator";
 import { EventJumpIndicator } from "@web/shortcuts/shift-hint/EventJumpIndicator";
 import {
@@ -119,6 +120,7 @@ export const SidebarStatusBar: FC = () => {
           onClick={() => settingsActions.openSettings()}
           title={text || undefined}
           type="button"
+          {...pointerShortcutAttributes(["Mod", ","])}
         >
           <span
             aria-live="polite"

--- a/packages/web/src/components/Tooltip/TooltipWrapper.test.tsx
+++ b/packages/web/src/components/Tooltip/TooltipWrapper.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, mock } from "bun:test";
 import "@testing-library/jest-dom";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { type ButtonHTMLAttributes } from "react";
 import { TooltipWrapper } from "./TooltipWrapper";
 
 describe("TooltipWrapper", () => {
@@ -124,6 +125,32 @@ describe("TooltipWrapper", () => {
     expect(screen.getByRole("button", { name: /palette/i })).toHaveAttribute(
       "data-pointer-shortcut",
       '["Mod","K"]',
+    );
+  });
+
+  it("still opens on hover when the child is a function component without forwardRef", async () => {
+    const user = userEvent.setup();
+    const BareButton = ({
+      children,
+      ...props
+    }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+      <button type="button" {...props}>
+        {children}
+      </button>
+    );
+
+    render(
+      <TooltipWrapper description="Duplicate" shortcut={["Mod", "D"]}>
+        <BareButton aria-label="Duplicate">Dup</BareButton>
+      </TooltipWrapper>,
+    );
+
+    await user.hover(screen.getByRole("button", { name: "Duplicate" }));
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip.textContent).toBe("DuplicateD");
+    expect(screen.getByRole("button", { name: "Duplicate" })).toHaveAttribute(
+      "data-pointer-shortcut",
+      '["Mod","D"]',
     );
   });
 

--- a/packages/web/src/components/Tooltip/TooltipWrapper.test.tsx
+++ b/packages/web/src/components/Tooltip/TooltipWrapper.test.tsx
@@ -101,6 +101,32 @@ describe("TooltipWrapper", () => {
     expect(onClick).not.toHaveBeenCalled();
   });
 
+  it("annotates a single-key shortcut for blocked-click teaching", () => {
+    render(
+      <TooltipWrapper shortcut="?">
+        <button type="button">Shortcuts</button>
+      </TooltipWrapper>,
+    );
+
+    expect(screen.getByRole("button", { name: /shortcuts/i })).toHaveAttribute(
+      "data-pointer-shortcut",
+      "?",
+    );
+  });
+
+  it("annotates a chord shortcut as JSON for blocked-click teaching", () => {
+    render(
+      <TooltipWrapper shortcut={["Mod", "K"]}>
+        <button type="button">Palette</button>
+      </TooltipWrapper>,
+    );
+
+    expect(screen.getByRole("button", { name: /palette/i })).toHaveAttribute(
+      "data-pointer-shortcut",
+      '["Mod","K"]',
+    );
+  });
+
   it("does not render tooltip content until opened", async () => {
     const user = userEvent.setup();
     render(

--- a/packages/web/src/components/Tooltip/TooltipWrapper.tsx
+++ b/packages/web/src/components/Tooltip/TooltipWrapper.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { type ReactNode } from "react";
+import { isValidElement, type ReactNode } from "react";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import {
   Tooltip,
@@ -7,6 +7,7 @@ import {
   TooltipTrigger,
 } from "@web/components/Tooltip";
 import { type TooltipOptions } from "@web/components/Tooltip/tooltip.types";
+import { pointerShortcutAttributes } from "@web/shortcuts/keyboard-only/pointer-action";
 import { ShortcutHint } from "../Shortcuts/ShortcutHint";
 import { TooltipDescription } from "./Description/TooltipDescription";
 
@@ -28,11 +29,19 @@ export const TooltipWrapper: React.FC<Props> = ({
   placement,
   shortcut,
 }) => {
+  const pointerAttrs =
+    typeof shortcut === "string" || Array.isArray(shortcut)
+      ? pointerShortcutAttributes(shortcut)
+      : {};
+  const annotateChild = isValidElement(children);
+
   return (
     <Tooltip placement={placement}>
       <TooltipTrigger
+        asChild={annotateChild}
         aria-disabled={disabled || undefined}
         onClick={disabled ? undefined : onClick}
+        {...pointerAttrs}
       >
         {children}
       </TooltipTrigger>

--- a/packages/web/src/components/Tooltip/TooltipWrapper.tsx
+++ b/packages/web/src/components/Tooltip/TooltipWrapper.tsx
@@ -1,5 +1,10 @@
 import type React from "react";
-import { isValidElement, type ReactNode } from "react";
+import {
+  cloneElement,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+} from "react";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import {
   Tooltip,
@@ -32,18 +37,22 @@ export const TooltipWrapper: React.FC<Props> = ({
   const pointerAttrs =
     typeof shortcut === "string" || Array.isArray(shortcut)
       ? pointerShortcutAttributes(shortcut)
-      : {};
-  const annotateChild = isValidElement(children);
+      : undefined;
+  // Stamp the child, not the trigger. `asChild` would merge a ref onto
+  // function-component children (IconButton) that do not forward refs, and
+  // hover would never open. The wrapper trigger still owns hover/focus.
+  const triggerChild =
+    pointerAttrs && isValidElement(children)
+      ? cloneElement(children as ReactElement, pointerAttrs)
+      : children;
 
   return (
     <Tooltip placement={placement}>
       <TooltipTrigger
-        asChild={annotateChild}
         aria-disabled={disabled || undefined}
         onClick={disabled ? undefined : onClick}
-        {...pointerAttrs}
       >
-        {children}
+        {triggerChild}
       </TooltipTrigger>
 
       <TooltipContent>

--- a/packages/web/src/components/WelcomeModal/useFlashedWelcomeShortcut.ts
+++ b/packages/web/src/components/WelcomeModal/useFlashedWelcomeShortcut.ts
@@ -19,11 +19,16 @@ export function useFlashedWelcomeShortcut(): string | null {
   useEffect(() => {
     if (pulse === lastPulseRef.current) return;
     lastPulseRef.current = pulse;
-    if (!attempt?.shortcutKey) {
+    const shortcut = attempt?.shortcutKey;
+    const flashKey =
+      typeof shortcut === "string"
+        ? shortcut
+        : (shortcut?.[shortcut.length - 1] ?? null);
+    if (!flashKey) {
       setFlashedKey(null);
       return;
     }
-    setFlashedKey(attempt.shortcutKey);
+    setFlashedKey(flashKey);
     const timer = window.setTimeout(() => setFlashedKey(null), KEYCAP_FLASH_MS);
     return () => window.clearTimeout(timer);
   }, [pulse, attempt?.shortcutKey]);

--- a/packages/web/src/shortcuts/keyboard-only/pointer-action.test.ts
+++ b/packages/web/src/shortcuts/keyboard-only/pointer-action.test.ts
@@ -11,7 +11,9 @@ import {
   POINTER_ACTIONS,
   POINTER_EVENT_ID_ATTRIBUTE,
   POINTER_SHORTCUT_ATTRIBUTE,
+  parsePointerShortcut,
   pointerGridIntentFromPointer,
+  pointerShortcutAttributes,
   resolveBlockedPointerAttempt,
   teachingFromBlockedPointer,
 } from "@web/shortcuts/keyboard-only/pointer-action";
@@ -48,6 +50,21 @@ describe("resolveBlockedPointerAttempt", () => {
       actionId: "unknown",
       shortcutKey: "1",
     });
+  });
+
+  it("decodes a chord shortcut encoded as JSON", () => {
+    const target = document.createElement("button");
+    target.setAttribute(
+      POINTER_SHORTCUT_ATTRIBUTE,
+      pointerShortcutAttributes(["Mod", "K"])[POINTER_SHORTCUT_ATTRIBUTE],
+    );
+
+    expect(resolveBlockedPointerAttempt([target, document])).toEqual({
+      actionId: "unknown",
+      shortcutKey: ["Mod", "K"],
+    });
+    expect(parsePointerShortcut('["Mod",","]')).toEqual(["Mod", ","]);
+    expect(parsePointerShortcut("z")).toBe("z");
   });
 
   it("keeps an action and a shortcut from different ancestors", () => {

--- a/packages/web/src/shortcuts/keyboard-only/pointer-action.test.ts
+++ b/packages/web/src/shortcuts/keyboard-only/pointer-action.test.ts
@@ -119,6 +119,14 @@ describe("teachingFromBlockedPointer", () => {
     });
   });
 
+  it("teaches view switching from the annotated date heading", () => {
+    const target = document.createElement("button");
+    target.setAttribute(POINTER_ACTION_ATTRIBUTE, POINTER_ACTIONS.switchView);
+    expect(teachingFromBlockedPointer([target, document], 0)).toEqual({
+      attempt: { actionId: POINTER_ACTIONS.switchView },
+    });
+  });
+
   it("teaches start-trial and reconnect from annotated banner CTAs", () => {
     const trial = document.createElement("button");
     trial.setAttribute(POINTER_ACTION_ATTRIBUTE, POINTER_ACTIONS.startTrial);

--- a/packages/web/src/shortcuts/keyboard-only/pointer-action.ts
+++ b/packages/web/src/shortcuts/keyboard-only/pointer-action.ts
@@ -23,6 +23,7 @@ export const POINTER_GRID_CREATE_REQUEST = "compass:pointer-grid-create";
 export const POINTER_ACTIONS = {
   eventOpen: "event.open",
   goToToday: "calendar.today",
+  switchView: "calendar.view",
   sidebarClose: "sidebar.close",
   sidebarOpen: "sidebar.open",
   startTrial: "billing.start-trial",

--- a/packages/web/src/shortcuts/keyboard-only/pointer-action.ts
+++ b/packages/web/src/shortcuts/keyboard-only/pointer-action.ts
@@ -32,10 +32,12 @@ export const POINTER_ACTIONS = {
 export type PointerActionId =
   (typeof POINTER_ACTIONS)[keyof typeof POINTER_ACTIONS];
 
+export type PointerShortcutKey = string | string[];
+
 export type BlockedPointerAttempt = {
   actionId: PointerActionId | "grid.timed" | "grid.all-day" | "unknown";
   eventId?: string;
-  shortcutKey?: string;
+  shortcutKey?: PointerShortcutKey;
   gridDate?: string;
   gridTimeKey?: string;
   gridTimeLabel?: string;
@@ -51,7 +53,7 @@ export const resolveBlockedPointerAttempt = (
 ): BlockedPointerAttempt => {
   let actionId: PointerActionId | "unknown" = "unknown";
   let eventId: string | undefined;
-  let shortcutKey: string | undefined;
+  let shortcutKey: PointerShortcutKey | undefined;
 
   for (const target of path) {
     if (!(target instanceof HTMLElement)) continue;
@@ -64,7 +66,7 @@ export const resolveBlockedPointerAttempt = (
     }
     if (shortcutKey === undefined) {
       const shortcut = target.getAttribute(POINTER_SHORTCUT_ATTRIBUTE);
-      if (shortcut) shortcutKey = shortcut;
+      if (shortcut) shortcutKey = parsePointerShortcut(shortcut);
     }
     if (actionId !== "unknown" && shortcutKey !== undefined) break;
   }
@@ -76,9 +78,35 @@ export const resolveBlockedPointerAttempt = (
   };
 };
 
-export const pointerShortcutAttributes = (key: string) => ({
-  [POINTER_SHORTCUT_ATTRIBUTE]: key,
+/** Encode a one-key or chord shortcut onto `data-pointer-shortcut`. */
+export const pointerShortcutAttributes = (
+  key: string | readonly string[],
+): { readonly [POINTER_SHORTCUT_ATTRIBUTE]: string } => ({
+  [POINTER_SHORTCUT_ATTRIBUTE]:
+    typeof key === "string" ? key : JSON.stringify(key),
 });
+
+/**
+ * Reverse `pointerShortcutAttributes`. A JSON array is a chord (`Mod+K`);
+ * anything else is a single key, including a literal that happens to start
+ * with `[`.
+ */
+export const parsePointerShortcut = (raw: string): PointerShortcutKey => {
+  if (!raw.startsWith("[")) return raw;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      Array.isArray(parsed) &&
+      parsed.length > 0 &&
+      parsed.every((item) => typeof item === "string")
+    ) {
+      return parsed;
+    }
+  } catch {
+    // A single-key annotation that starts with `[`.
+  }
+  return raw;
+};
 
 export const pointerPassAttributes = {
   [POINTER_PASS_ATTRIBUTE]: "",

--- a/packages/web/src/timezone/GridTimezoneLabel.test.tsx
+++ b/packages/web/src/timezone/GridTimezoneLabel.test.tsx
@@ -41,6 +41,7 @@ describe("GridTimezoneLabel", () => {
       name: `Calendar timezone: ${abbreviation}`,
     });
     expect(label).toHaveTextContent(abbreviation);
+    expect(label).toHaveAttribute("data-pointer-shortcut", "z");
 
     await user.tab();
     expect(screen.getByRole("button", { name: "Before" })).toHaveFocus();

--- a/packages/web/src/timezone/GridTimezoneLabel.tsx
+++ b/packages/web/src/timezone/GridTimezoneLabel.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useMinuteTick } from "@web/common/hooks/useMinuteTick";
 import { GRID_TIME_COLUMN_WIDTH } from "@web/grid/grid.constants";
+import { pointerShortcutAttributes } from "@web/shortcuts/keyboard-only/pointer-action";
 import {
   refreshEffectiveTimeZoneFromBrowser,
   useEffectiveTimeZone,
@@ -16,7 +17,7 @@ const travelingLabelClassName =
 
 /**
  * Week/Day grid-corner control showing the effective timezone abbreviation.
- * Click opens time travel (the same picker, committing a secondary zone).
+ * A blocked click teaches `z`; Enter/Space still opens time travel.
  */
 export const GridTimezoneLabel = () => {
   const timeZone = useEffectiveTimeZone();
@@ -58,6 +59,7 @@ export const GridTimezoneLabel = () => {
           onClick={openTimeTravel}
           style={{ width: GRID_TIME_COLUMN_WIDTH }}
           type="button"
+          {...pointerShortcutAttributes("z")}
         >
           {travelAbbreviation}
         </button>
@@ -72,6 +74,7 @@ export const GridTimezoneLabel = () => {
         onClick={openTimeTravel}
         style={isTraveling ? { width: GRID_TIME_COLUMN_WIDTH } : undefined}
         type="button"
+        {...pointerShortcutAttributes("z")}
       >
         {abbreviation}
       </button>

--- a/packages/web/src/timezone/TimezoneOptionButton.tsx
+++ b/packages/web/src/timezone/TimezoneOptionButton.tsx
@@ -1,3 +1,5 @@
+import { pointerShortcutAttributes } from "@web/shortcuts/keyboard-only/pointer-action";
+
 export function TimezoneOptionButton({
   active,
   description,
@@ -24,6 +26,7 @@ export function TimezoneOptionButton({
       role="option"
       tabIndex={-1}
       type="button"
+      {...pointerShortcutAttributes("Enter")}
     >
       <span className="text-text">{label}</span>
       <span className="text-text-muted text-xs">{description}</span>

--- a/packages/web/src/timezone/TimezonePickerDialog.test.tsx
+++ b/packages/web/src/timezone/TimezonePickerDialog.test.tsx
@@ -33,7 +33,7 @@ describe("TimezonePickerDialog", () => {
 
     expect(
       screen.getByRole("option", { name: /Use browser timezone \(Auto\)/ }),
-    ).toBeInTheDocument();
+    ).toHaveAttribute("data-pointer-shortcut", "Enter");
 
     await user.type(
       screen.getByRole("combobox", { name: "Search timezones" }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The monthly email promises that clicking a control reveals its shortcut, that command-palette `play` starts Block Party, and that `z` / `Mod+,` / the 7-day trial are ready for returning users.

Several of those advertised click targets still fell through to a generic "keyboard only" hint. This change annotates them so a blocked click teaches the real binding, and it makes `play` (including `play.`) find Block Party.

- Tooltip-wrapped controls (command palette, `?` legend, `J`/`K` nav) now carry `data-pointer-shortcut`, including chords like `Mod+K`.
- Timezone label teaches `z`. Settings status bar and a new always-visible settings button teach `Mod+,`. Trial gate teaches `S` / `L`. Overlay action buttons teach their keycaps.
- Date heading teaches `W`, `D`, or `L`. Timezone picker rows teach `Enter`.
- Palette search strips wrapping quotes and trailing `.!?` so email copy `play.` still matches. Week/Day placeholders now suggest `play`.
- Hover tooltips stay on a wrapper trigger. Stamping the shortcut via `asChild` broke `FormActionsRow` hover because `IconButton` does not forward refs. The child is cloned with the attribute instead.

## Simplicity

Pointer teaching is centralized: `TooltipWrapper` and `OverlayPanelActionButton` stamp the same attribute the capture-phase hint already reads. Chord encoding is JSON on that one attribute, decoded in `parsePointerShortcut`. View switching uses a dedicated pointer action so the hint can name `W`/`D`/`L` together.

## Automated validation

- Focused pointer-teaching suite: 115 pass, including settings gear, view heading, timezone rows, `play.`, timezone `z`, and trial `S`/`L`.
- `FormActionsRow` + `TooltipWrapper` hover tests pass after dropping `asChild`.
- `bun run verify` on the hover-fix commit: `test:web`, `type-check`, `lint`, `knip` passed.

## Independent review

Not run. Request `/review` if a specialist pass is needed before merge.

## Test plan

- `bun test:web` on tooltip, pointer-hint, pointer-action, timezone, command palette, billing gate, overlay, sidebar, SelectView, FormActionsRow
- `bun type-check`
- `bun lint`
- `bun run verify`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-caf68105-6ebf-4e12-bba5-025e31e79178?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-caf68105-6ebf-4e12-bba5-025e31e79178&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

