### PR TITLE
fix(web): smooth re-entry for returning users

### DIFF
--- a/packages/web/src/auth/compass/user/hooks/useLoadProfile.test.ts
+++ b/packages/web/src/auth/compass/user/hooks/useLoadProfile.test.ts
@@ -5,6 +5,7 @@ import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
 import * as realAuthStateUtil from "@web/auth/compass/state/auth.state.util";
 import { type UseLoadProfileResult } from "@web/auth/compass/user/hooks/useLoadProfile";
 import * as errorToast from "@web/common/utils/toast/error-toast.util";
+import * as sessionExpiredToast from "@web/common/utils/toast/session-expired.toast";
 import {
   afterAll,
   afterEach,
@@ -166,6 +167,10 @@ describe("useLoadProfile", () => {
       errorToast,
       "showSessionExpiredToast",
     ).mockReturnValue("toast-id");
+    const openAuthModal = spyOn(
+      sessionExpiredToast,
+      "openAuthModalFromOutsideRouter",
+    ).mockResolvedValue(undefined);
     const { useLoadProfile } = await importHook();
 
     renderHook(() => useLoadProfile(true));
@@ -174,10 +179,12 @@ describe("useLoadProfile", () => {
       expect(getProfile).toHaveBeenCalledTimes(1);
     });
     expect(showSessionExpiredToast).not.toHaveBeenCalled();
+    expect(openAuthModal).not.toHaveBeenCalled();
     showSessionExpiredToast.mockRestore();
+    openAuthModal.mockRestore();
   });
 
-  it("shows a signed-out toast when a returning visitor's profile request is unauthorized", async () => {
+  it("shows a signed-out toast and opens the login modal when a returning visitor's profile request is unauthorized", async () => {
     hasUserEverAuthenticated.mockReturnValue(true);
     const error = Object.assign(new Error("Request failed with status 401"), {
       response: { status: Status.UNAUTHORIZED },
@@ -187,6 +194,10 @@ describe("useLoadProfile", () => {
       errorToast,
       "showSessionExpiredToast",
     ).mockReturnValue("toast-id");
+    const openAuthModal = spyOn(
+      sessionExpiredToast,
+      "openAuthModalFromOutsideRouter",
+    ).mockResolvedValue(undefined);
     const { useLoadProfile } = await importHook();
 
     renderHook(() => useLoadProfile(true));
@@ -194,6 +205,8 @@ describe("useLoadProfile", () => {
     await waitFor(() => {
       expect(showSessionExpiredToast).toHaveBeenCalledTimes(1);
     });
+    expect(openAuthModal).toHaveBeenCalledWith("login");
     showSessionExpiredToast.mockRestore();
+    openAuthModal.mockRestore();
   });
 });

--- a/packages/web/src/auth/compass/user/hooks/useLoadProfile.ts
+++ b/packages/web/src/auth/compass/user/hooks/useLoadProfile.ts
@@ -9,6 +9,7 @@ import {
   markUserAsAuthenticated,
 } from "@web/auth/compass/state/auth.state.util";
 import { showSessionExpiredToast } from "@web/common/utils/toast/error-toast.util";
+import { openAuthModalFromOutsideRouter } from "@web/common/utils/toast/session-expired.toast";
 
 export type UseLoadProfileResult = {
   email: string | null;
@@ -58,6 +59,10 @@ export function useLoadProfile(
         if (isUnauthorized) {
           if (hasUserEverAuthenticated()) {
             showSessionExpiredToast();
+            // The calendar behind the toast shows local demo events, which a
+            // returning user reads as lost data — and a dismissed toast would
+            // strand them there. Seat the login form front and center instead.
+            void openAuthModalFromOutsideRouter("login");
           }
           return;
         }

--- a/packages/web/src/common/utils/toast/session-expired.toast.tsx
+++ b/packages/web/src/common/utils/toast/session-expired.toast.tsx
@@ -18,7 +18,7 @@ interface SessionExpiredToastProps {
 // dynamically to avoid a module cycle: this file sits on the API error path
 // (api.util -> error-toast.util -> here), and the router's root route
 // renders AuthModal, which pulls that same API/error-toast chain back in.
-async function openAuthModalFromOutsideRouter(
+export async function openAuthModalFromOutsideRouter(
   view: AuthView = "login",
 ): Promise<void> {
   const { router } = await import("@web/routers");

--- a/packages/web/src/components/FirstEventPrompt/first-event.storage.test.ts
+++ b/packages/web/src/components/FirstEventPrompt/first-event.storage.test.ts
@@ -7,11 +7,13 @@ import {
 import { beforeEach, describe, expect, it } from "bun:test";
 
 const LEGACY_CHECKLIST_DONE_KEY = "compass.onboarding.checklist-done";
+const LEGACY_TOUR_SEEN_KEY = "compass.onboarding.has-seen-onboarding-tour";
 
 describe("first-event storage", () => {
   beforeEach(() => {
     persistentBrowserStore.set(STORAGE_KEYS.FIRST_EVENT_DONE, "");
     localStorage.setItem(LEGACY_CHECKLIST_DONE_KEY, "");
+    localStorage.setItem(LEGACY_TOUR_SEEN_KEY, "");
   });
 
   it("is unset until marked", () => {
@@ -38,5 +40,16 @@ describe("first-event storage", () => {
     localStorage.setItem(LEGACY_CHECKLIST_DONE_KEY, "dismissed");
     markFirstEventDone("completed");
     expect(getFirstEventDone()).toBe("completed");
+  });
+
+  it("treats retired-tour viewers as done so established users never see the prompt", () => {
+    localStorage.setItem(LEGACY_TOUR_SEEN_KEY, "true");
+    expect(getFirstEventDone()).toBe("completed");
+  });
+
+  it("lets an explicit dismissal win over the retired-tour key", () => {
+    localStorage.setItem(LEGACY_TOUR_SEEN_KEY, "true");
+    markFirstEventDone("dismissed");
+    expect(getFirstEventDone()).toBe("dismissed");
   });
 });

--- a/packages/web/src/components/FirstEventPrompt/first-event.storage.ts
+++ b/packages/web/src/components/FirstEventPrompt/first-event.storage.ts
@@ -12,12 +12,22 @@ export type FirstEventDoneReason = "completed" | "dismissed";
 const LEGACY_CHECKLIST_DONE_KEY =
   "compass.onboarding.checklist-done" as (typeof STORAGE_KEYS)["FIRST_EVENT_DONE"];
 
+/**
+ * The retired guided tour's seen key marks established pre-showcase users.
+ * showcase.storage.ts honors it as "has seen the showcase", which alone would
+ * qualify that cohort for this prompt — on a calendar already full of events.
+ * Anyone holding the key predates the prompt, so treat them as done too.
+ */
+const LEGACY_TOUR_SEEN_KEY = "compass.onboarding.has-seen-onboarding-tour";
+
 export function getFirstEventDone(): FirstEventDoneReason | null {
   if (!persistentBrowserStore.isAvailable()) return null;
   const value = persistentBrowserStore.get(STORAGE_KEYS.FIRST_EVENT_DONE);
   if (value === "completed" || value === "dismissed") return value;
   const legacy = persistentBrowserStore.get(LEGACY_CHECKLIST_DONE_KEY);
-  return legacy === "completed" || legacy === "dismissed" ? legacy : null;
+  if (legacy === "completed" || legacy === "dismissed") return legacy;
+  const sawTour = persistentBrowserStore.get(LEGACY_TOUR_SEEN_KEY) === "true";
+  return sawTour ? "completed" : null;
 }
 
 export function markFirstEventDone(reason: FirstEventDoneReason): void {


### PR DESCRIPTION
## What

Two small fixes for existing users revisiting the app (ahead of the monthly email), both verified live in the browser.

### 1. Expired session: open the login modal, not just a toast

A previously-authenticated user whose session has expired landed on a calendar of local demo events with only a dismissible "You've been signed out" toast. The demo events read as lost data, and dismissing the toast stranded them with no visible sign-in affordance.

Now the load-time 401 also opens the login modal directly, reusing the toast's existing `openAuthModalFromOutsideRouter` helper (now exported). The toast stays as context behind it. The mid-session 401 path in `api.util.ts` is deliberately untouched.

### 2. Retired-tour cohort no longer sees "Add your first event"

Users who saw the short-lived guided tour (Aug 8-12) hold `has-seen-onboarding-tour`, which `showcase.storage.ts` honors as "has seen the showcase" — the sole remaining condition for the first-event card. So established users with full calendars qualified for "Add your first event". `getFirstEventDone()` now honors the tour key the same way it already honors the retired checklist's done key.

## Testing

- New unit tests for both paths (tour-key retirement + precedence; modal open on returning-visitor 401, not for first-time visitors)
- `bun run type-check` and `bun run lint` clean
- Verified in the dev browser: legacy tour key alone no longer renders the card (control case with the showcase key still does); seeding `compass.auth` with `hasAuthenticated: true` and no session reloads into the login modal at `?auth=login` with the toast behind it

🤖 Generated with [Claude Code](https://claude.com/claude-code)