### PR TITLE
fix(web): save booking settings with Mod+Enter

### DIFF
--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -182,8 +182,8 @@ timezone `<select>` plus a checkbox and two time inputs per weekday.
 - **Jump:** `e` then a letter focuses a field (`e` enable, `d` duration,
   `c` destination, `b` blocking, `z` timezone, `h` hours including date
   overrides, `w` welcome, `n` notice, `x` horizon, `o` buffer and limits,
-  `l` link). Settings owns `s` (save) and digits `1/2/3` (nav) on this
-  page, which is why the leader is `e` rather than `Mod+digit`. Focus
+  `l` link). Settings owns Mod+Enter (save) and digits `1/2/3` (nav) on
+  this page, which is why the leader is `e` rather than `Mod+digit`. Focus
   uses `data-booking-field` and does not click, so jumping onto a
   checkbox does not toggle it.
 - **Save:** a successful save that returns a booking URL copies it. A

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
 import { HotkeysProvider, resolveModifier } from "@tanstack/react-hotkeys";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { rest } from "msw";
 import { CalendarIdSchema } from "@core/types/domain-primitives";
@@ -23,6 +23,7 @@ import {
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { ENV_WEB } from "@web/common/constants/env.constants";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
+import { useSettingsShortcuts } from "@web/settings/useSettingsShortcuts";
 import {
   clearAppLockReasons,
   isAppLocked,
@@ -86,6 +87,35 @@ const healthyGoogleMetadata = {
     connections: [createMockConnection("host@example.com")],
   },
 };
+
+function BookingSettingsWithShortcuts({
+  showShortcuts = false,
+}: {
+  showShortcuts?: boolean;
+}) {
+  useSettingsShortcuts({
+    enabled: true,
+    hasBilling: false,
+    hasBooking: true,
+    page: "booking",
+  });
+  return <BookingSettingsSection showShortcuts={showShortcuts} />;
+}
+
+function dispatchModKey(target: HTMLElement, key: string) {
+  const modifierKey = resolveModifier("Mod");
+  const isControl = modifierKey === "Control";
+  target.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      ctrlKey: isControl,
+      key,
+      metaKey: !isControl,
+    }),
+  );
+}
 
 describe("BookingSettingsSection", () => {
   it("shows connect Google prompt when Google is not healthy", () => {
@@ -597,6 +627,75 @@ describe("BookingSettingsSection", () => {
     });
   });
 
+  it("saves with Mod+Enter while welcome text is focused, and ignores bare s", async () => {
+    const user = userEvent.setup({ delay: null });
+    userMetadataActions.set(healthyGoogleMetadata);
+    let putCount = 0;
+    let savedBody: unknown;
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+      rest.put(bookingPageUrl, async (req, res, ctx) => {
+        putCount += 1;
+        savedBody = await req.json();
+        return res(ctx.json(savedBody as object));
+      }),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+
+    render(
+      <HotkeysProvider>
+        <BookingSettingsWithShortcuts />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    const welcome = await screen.findByLabelText("Welcome text");
+    await user.type(welcome, "s");
+    expect(putCount).toBe(0);
+    expect(welcome).toHaveValue("s");
+
+    dispatchModKey(welcome, "Enter");
+
+    await waitFor(() => {
+      expect(savedBody).toMatchObject({ welcomeText: "s" });
+    });
+    expect(putCount).toBe(1);
+  });
+
+  it("advertises Mod+Enter on the save button when shortcut chips are shown", async () => {
+    userMetadataActions.set(healthyGoogleMetadata);
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    const save = await screen.findByRole("button", {
+      name: /Save booking settings/,
+    });
+    expect(save).toHaveAttribute(
+      "aria-keyshortcuts",
+      "Meta+Enter Control+Enter",
+    );
+    expect(within(save).getByText("Enter")).toBeInTheDocument();
+  });
+
   it("blocks the save while extra hours on a date override cannot be read", async () => {
     const user = userEvent.setup({ delay: null });
     userMetadataActions.set(healthyGoogleMetadata);
@@ -883,7 +982,8 @@ describe("BOOKING_SEQUENCE_FIELDS", () => {
   });
 
   it("leaves Settings' own booking-page keys alone", () => {
-    // Settings owns bare `s` for Save on this page. Digits are nav.
+    // Save is Mod+Enter; `s` stays free so it can type in hours and welcome.
+    // Digits are Settings nav.
     const keys = BOOKING_SEQUENCE_FIELDS.map((entry) => entry.key);
     expect(keys).not.toContain("s");
     for (const key of keys) expect(key).not.toMatch(/^\d$/);

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -662,9 +662,10 @@ export function BookingSettingsSection({
         <OverlayPanelActions align="start">
           <OverlayPanelActionButton
             aria-busy={saveMutation.isPending || undefined}
+            aria-keyshortcuts="Meta+Enter Control+Enter"
             disabled={saveMutation.isPending}
             onClick={handleSave}
-            shortcut="S"
+            shortcut={["Mod", "Enter"]}
             showShortcut={showShortcuts}
             variant="primary"
             {...settingsShortcutAttrs("save-booking")}
@@ -674,8 +675,9 @@ export function BookingSettingsSection({
         </OverlayPanelActions>
       </div>
 
-      <p className="text-text-muted text-xs">
-        Press <kbd>e</kbd> then a letter to jump to a field. <kbd>S</kbd> saves.
+      <p className="flex flex-wrap items-center gap-x-1 text-text-muted text-xs">
+        Press <kbd>e</kbd> then a letter to jump to a field.
+        <ShortcutKeys keys={["Mod", "Enter"]} /> saves.
       </p>
 
       <EditSequenceMenu

--- a/packages/web/src/booking/booking-sequence.fields.ts
+++ b/packages/web/src/booking/booking-sequence.fields.ts
@@ -6,9 +6,10 @@
  *
  * Data-only on purpose, mirroring edit-sequence.fields.ts.
  *
- * `s` is deliberately absent: Settings owns bare `s` for Save on this page.
- * Digits are unavailable too - Settings nav owns Mod+1/2/3 - which is why this
- * surface reuses the letter leader rather than the event form's Mod+digit jump.
+ * `s` is deliberately absent so it can type in hours and welcome fields.
+ * Save is Mod+Enter, owned by Settings. Digits are unavailable too - Settings
+ * nav owns 1/2/3 - which is why this surface reuses the letter leader rather
+ * than the event form's Mod+digit jump.
  */
 export const BOOKING_SEQUENCE_FIELDS = [
   { key: "e", field: "enabled", label: "Enable booking" },

--- a/packages/web/src/settings/useSettingsShortcuts.ts
+++ b/packages/web/src/settings/useSettingsShortcuts.ts
@@ -2,7 +2,10 @@ import { useEffect } from "react";
 import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
 import { type SettingsPage } from "@web/settings/settings.store";
 import { physicalDigitIndex } from "@web/shortcuts/digit-pick.util";
-import { normalizedKeyboardKey } from "@web/shortcuts/is-bare-letter-key";
+import {
+  keyboardKey,
+  normalizedKeyboardKey,
+} from "@web/shortcuts/is-bare-letter-key";
 import { useModHoldHintShortcut } from "@web/shortcuts/mod-hold/useModHoldHintShortcut";
 
 export const SETTINGS_SHORTCUT_ATTR = "data-settings-shortcut";
@@ -23,10 +26,21 @@ const clickSettingsShortcut = (id: string): boolean => {
   return true;
 };
 
+const isModEnter = (event: KeyboardEvent) =>
+  keyboardKey(event) === "Enter" &&
+  (event.metaKey || event.ctrlKey) &&
+  !event.altKey &&
+  !event.shiftKey;
+
 /**
  * Maps a key to a Settings control. Nav digits 1/2 always win over in-page
  * actions so a user looking at Accounts can still jump to Billing. Disconnect
  * rows therefore have no digit shortcut (hover + Enter activates them).
+ *
+ * Booking save is Mod+Enter, matching the event form, so it still fires while
+ * focus is in an input. OverlayPanel's onModEnter is not wired on Settings,
+ * and should stay unwired: this capture-phase chord is the save path, and
+ * both together would double-fire.
  */
 const shortcutIdForEvent = (
   event: KeyboardEvent,
@@ -43,7 +57,7 @@ const shortcutIdForEvent = (
 
   const key = normalizedKeyboardKey(event);
   if (page === "billing" && key === "m") return "manage-billing";
-  if (page === "booking" && key === "s") return "save-booking";
+  if (page === "booking" && isModEnter(event)) return "save-booking";
   if (page !== "accounts") return null;
   if (key === "a") return "add-account";
   if (key === "e") return "export";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Booking Settings used a bare `s` shortcut to save. That listener skips editable targets, so typing `s` in welcome text or weekly hours never saved (and looked like a no-op).

Save now uses **Mod+Enter**, the same chord as the event form. Settings already handles Mod chords in capture without skipping inputs, so it works while a field is focused.

## Simplicity

Reused the existing Settings Mod-chord path (`useSettingsShortcuts` → `onModChord`) instead of wiring OverlayPanel `onModEnter` (that would double-fire) or adding a second listener.

## Automated validation

- Focused: `bun test:web packages/web/src/booking/BookingSettingsSection.test.tsx` — 27 pass, including “saves with Mod+Enter while welcome text is focused, and ignores bare s”
- `bun run verify`:

```
merge-base: c18eb68a87e773b15532de5c1ff43be3e3410c44 (origin/main)
Detected changes in: web
Running: test:web → type-check → lint → knip → test:a11y → test:e2e
Checks skipped: (none)
✓ All checks passed
```

Host Settings live save on staging still needs a signed-in Compass session. After this ships, re-save weekly hours / Saturday extra hours with Mod+Enter so public slots appear on `/book/compassstaging`.

## Independent review

Self-review of the full diff: no confirmed findings. OverlayPanel `onModEnter` left unwired on Settings so the capture-phase chord is the only save path.

## Test plan

- `bun test:web packages/web/src/booking/BookingSettingsSection.test.tsx`
- `bun run verify`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cc2f22a-81fc-4a6b-b898-af14a69681db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cc2f22a-81fc-4a6b-b898-af14a69681db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

