### PR TITLE
fix(web): keep guest form off empty-horizon jump

### DIFF
--- a/.agents/handoffs/3076.md
+++ b/.agents/handoffs/3076.md
@@ -8,9 +8,13 @@ status: verifying
 artifact:
   - path: packages/web/src/booking/use-public-booking-flow.ts
   - path: packages/web/src/booking/PublicBookingPage.test.tsx
+  - path: e2e/booking/public-booking.spec.ts
 evidence:
   - command: bun test:web packages/web/src/booking/PublicBookingPage.test.tsx
-    result: pending
+    result: 28 pass
+    log: null
+  - command: bunx playwright test e2e/booking/public-booking.spec.ts
+    result: 26 pass
     log: null
 assumptions:
   - Empty-horizon jump on staging opened Your details because showConflictForm treated any alert as a 409.

--- a/.agents/handoffs/3076.md
+++ b/.agents/handoffs/3076.md
@@ -1,0 +1,26 @@
+---
+schema_version: 1
+task_id: "3076"
+from: Implementer
+to: Verifier
+owner: Verifier
+status: verifying
+artifact:
+  - path: packages/web/src/booking/use-public-booking-flow.ts
+  - path: packages/web/src/booking/PublicBookingPage.test.tsx
+evidence:
+  - command: bun test:web packages/web/src/booking/PublicBookingPage.test.tsx
+    result: pending
+    log: null
+assumptions:
+  - Empty-horizon jump on staging opened Your details because showConflictForm treated any alert as a 409.
+  - 409 still keeps typed guest fields via the same SLOT_CONFLICT_ALERT string.
+open_risks: []
+next_deadline: 2026-09-02T03:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+Guest details form on the picker is only for the 409 conflict alert. Horizon-empty jump keeps Pick a time.

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -410,9 +410,19 @@ test.describe("public booking page", () => {
       page.getByRole("button", { name: "Previous month" }),
     ).toBeEnabled();
     await expect(page.getByText("Loading open times")).toHaveCount(0);
-    // Horizon can omit the month after next (60 days from 1 Sep does not
-    // cover November), so do not require a third fetch. Revisiting the
-    // prefetched month must not issue another request.
+    // Adjacent prefetch of the month after next may still be in flight when
+    // the 60-day horizon reaches that month (from 2 Sep, 1 Nov is in range).
+    // Do not require a third fetch; snapshot only after the count is stable
+    // so revisiting the prefetched month is not blamed for that request.
+    let previousGets = -1;
+    await expect
+      .poll(() => {
+        const n = captured.slotGets;
+        const stable = n >= 2 && n === previousGets;
+        previousGets = n;
+        return stable;
+      })
+      .toBe(true);
     const afterArrive = captured.slotGets;
 
     await page.getByRole("button", { name: "Previous month" }).click();

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -974,6 +974,40 @@ describe("PublicBookingPage", () => {
     ).toHaveAttribute("aria-pressed", "true");
   });
 
+  it("does not open Your details when jump finds no times in the horizon", async () => {
+    const user = userEvent.setup({ delay: null });
+    server.use(pageHandler(), slotsInWindow([]));
+
+    renderBookingRoute("/book/tylerdane");
+
+    await screen.findByRole("heading", { name: "Book with Tyler Dane" });
+    expect(
+      await screen.findByText("No open times this month."),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Jump to next available day" }),
+    );
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(
+      "No open times in the next 60 days. Check back later.",
+    );
+    await waitFor(() => {
+      expect(alert).toHaveFocus();
+    });
+    expect(
+      screen.getByRole("heading", { name: "Pick a time" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Your details" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Confirm booking" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Select a time to continue.")).toBeInTheDocument();
+  });
+
   it("returns to the picker with the day and typed fields intact", async () => {
     const user = userEvent.setup({ delay: null });
     server.use(pageHandler(), slotsInWindow([currentSlot, laterCurrentSlot]));

--- a/packages/web/src/booking/use-public-booking-flow.ts
+++ b/packages/web/src/booking/use-public-booking-flow.ts
@@ -32,6 +32,9 @@ const EMPTY_GUEST_DETAILS: PublicBookingGuestDetails = {
   notes: "",
 };
 
+const SLOT_CONFLICT_ALERT =
+  "This time is no longer available. Pick another slot.";
+
 /**
  * All state and behavior of the guest booking flow. The URL is the source of
  * truth for the selection (month, day, slot, timezone): Back returns from the
@@ -128,7 +131,10 @@ export function usePublicBookingFlow() {
     availableDateKeys[0] ??
     null;
 
-  const showConflictForm = !showDetailsStep && alertMessage !== null;
+  // 409 only: keep typed details while they pick another slot. Other alerts
+  // (empty horizon, confirm failure) must not open the guest form.
+  const showConflictForm =
+    !showDetailsStep && alertMessage === SLOT_CONFLICT_ALERT;
   const slotsHasData = Boolean(slotsQuery.data);
   const slotsFetching =
     !slotsHasData && (slotsQuery.isPending || slotsQuery.isFetching);
@@ -262,7 +268,7 @@ export function usePublicBookingFlow() {
       });
     } catch (error) {
       if (isPublicBookingConflictError(error)) {
-        setAlertMessage("This time is no longer available. Pick another slot.");
+        setAlertMessage(SLOT_CONFLICT_ALERT);
         setChangingTime(false);
         updateSearch({ slot: undefined });
         await slotsQuery.refetch();


### PR DESCRIPTION
Fixes #3076

## Summary

On the public booking page, **Jump to next available day** with no times in the host horizon set an alert. Any alert opened the 409 guest-details form, so staging guests saw **Your details** and a disabled Confirm with no selected time.

The picker guest form now opens only for the slot-conflict alert. Horizon-empty jump stays on **Pick a time**.

Also: the public-booking e2e that asserts a prefetched month is not refetched now waits for adjacent prefetch to settle (from 2 Sep the 60-day horizon includes 1 Nov). Rebased/merged with #3075.

## Simplicity

One constant for the 409 copy, used by both the setter and `showConflictForm`. No extra React state.

## Automated validation

- `bun test:web packages/web/src/booking/PublicBookingPage.test.tsx` — 28 pass, including empty-horizon jump and the 409 keep-details test.
- `bunx playwright test e2e/booking/public-booking.spec.ts` — 26 pass; prefetch test re-passed after merging #3075.
- `bun run verify`: PASS. Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e. First verify failed on the date-sensitive prefetch e2e; settle wait then 105 e2e passed.

## Independent review

`.agents/handoffs/3076.md`: no confirmed findings. Simplify: no behavior-preserving edits.

## Test plan

- `bun test:web packages/web/src/booking/PublicBookingPage.test.tsx`
- `bunx playwright test e2e/booking/public-booking.spec.ts`
- `bun run verify`