### PR TITLE
fix(web): land typed times on the focused week column

### DIFF
--- a/packages/web/src/shortcuts/quick-time/quick-time.util.test.ts
+++ b/packages/web/src/shortcuts/quick-time/quick-time.util.test.ts
@@ -138,11 +138,9 @@ describe("quickTimeTargetDay", () => {
 });
 
 describe("quickTimeFocusedColumnDay", () => {
-  const parse = (key: string) => dayjs(`${key}T00:00:00`);
-
   it("prefers a parked click over the jump-highlighted column", () => {
     expect(
-      quickTimeFocusedColumnDay("2026-08-04", ["2026-08-05"], parse)?.format(
+      quickTimeFocusedColumnDay("2026-08-04", ["2026-08-05"])?.format(
         "YYYY-MM-DD",
       ),
     ).toBe("2026-08-04");
@@ -150,16 +148,14 @@ describe("quickTimeFocusedColumnDay", () => {
 
   it("uses a single jump-highlighted column", () => {
     expect(
-      quickTimeFocusedColumnDay(null, ["2026-08-07"], parse)?.format(
-        "YYYY-MM-DD",
-      ),
+      quickTimeFocusedColumnDay(null, ["2026-08-07"])?.format("YYYY-MM-DD"),
     ).toBe("2026-08-07");
   });
 
   it("stays unset when jump has not chosen one day", () => {
-    expect(quickTimeFocusedColumnDay(null, [], parse)).toBeNull();
+    expect(quickTimeFocusedColumnDay(null, [])).toBeNull();
     expect(
-      quickTimeFocusedColumnDay(null, ["2026-08-02", "2026-08-08"], parse),
+      quickTimeFocusedColumnDay(null, ["2026-08-02", "2026-08-08"]),
     ).toBeNull();
   });
 });

--- a/packages/web/src/shortcuts/quick-time/quick-time.util.test.ts
+++ b/packages/web/src/shortcuts/quick-time/quick-time.util.test.ts
@@ -2,6 +2,7 @@ import dayjs from "@core/util/date/dayjs";
 import {
   buildQuickTimeSlots,
   canQuickTimeBufferGrow,
+  quickTimeFocusedColumnDay,
   quickTimeSequenceForHour,
   quickTimeTargetDay,
   resolveQuickTimeStart,
@@ -111,6 +112,55 @@ describe("quickTimeTargetDay", () => {
     expect(
       quickTimeTargetDay(startOfView, endOfView, now).format("YYYY-MM-DD"),
     ).toBe("2026-08-02");
+  });
+
+  it("uses a focused column in the view instead of today", () => {
+    const now = dayjs("2026-08-05T09:00:00");
+    const focused = dayjs("2026-08-04T00:00:00");
+
+    expect(
+      quickTimeTargetDay(startOfView, endOfView, now, focused).format(
+        "YYYY-MM-DD",
+      ),
+    ).toBe("2026-08-04");
+  });
+
+  it("ignores a focused day outside the view", () => {
+    const now = dayjs("2026-08-05T09:00:00");
+    const focused = dayjs("2026-09-01T00:00:00");
+
+    expect(
+      quickTimeTargetDay(startOfView, endOfView, now, focused).format(
+        "YYYY-MM-DD",
+      ),
+    ).toBe("2026-08-05");
+  });
+});
+
+describe("quickTimeFocusedColumnDay", () => {
+  const parse = (key: string) => dayjs(`${key}T00:00:00`);
+
+  it("prefers a parked click over the jump-highlighted column", () => {
+    expect(
+      quickTimeFocusedColumnDay("2026-08-04", ["2026-08-05"], parse)?.format(
+        "YYYY-MM-DD",
+      ),
+    ).toBe("2026-08-04");
+  });
+
+  it("uses a single jump-highlighted column", () => {
+    expect(
+      quickTimeFocusedColumnDay(null, ["2026-08-07"], parse)?.format(
+        "YYYY-MM-DD",
+      ),
+    ).toBe("2026-08-07");
+  });
+
+  it("stays unset when jump has not chosen one day", () => {
+    expect(quickTimeFocusedColumnDay(null, [], parse)).toBeNull();
+    expect(
+      quickTimeFocusedColumnDay(null, ["2026-08-02", "2026-08-08"], parse),
+    ).toBeNull();
   });
 });
 

--- a/packages/web/src/shortcuts/quick-time/quick-time.util.ts
+++ b/packages/web/src/shortcuts/quick-time/quick-time.util.ts
@@ -4,6 +4,7 @@ import {
   getTimeOptionByValue,
   parseUserTime,
 } from "@web/common/utils/datetime/web.date.util";
+import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 
 /** Longest sequence a typed time can be: HHMM. */
 export const QUICK_TIME_MAX_DIGITS = 4;
@@ -103,12 +104,19 @@ export const quickTimeTargetDay = (
 export const quickTimeFocusedColumnDay = (
   pointerDateKey: string | null,
   activeDayKeys: readonly string[],
-  parseDateKey: (dateKey: string) => Dayjs,
 ): Dayjs | null => {
-  if (pointerDateKey) return parseDateKey(pointerDateKey);
-  const dayKey = activeDayKeys.length === 1 ? activeDayKeys[0] : undefined;
-  return dayKey ? parseDateKey(dayKey) : null;
+  const dateKey =
+    pointerDateKey ??
+    (activeDayKeys.length === 1 ? activeDayKeys[0] : undefined);
+  return dateKey
+    ? dayjs(dateKey).tz(getEffectiveTimeZone(), true).startOf("day")
+    : null;
 };
+
+export const quickTimeDayFromEventStart = (
+  startDate: string | undefined,
+): Dayjs | null =>
+  startDate ? dayjs(startDate).tz(getEffectiveTimeZone()) : null;
 
 export type QuickTimeBusyInterval = {
   startMs: number;

--- a/packages/web/src/shortcuts/quick-time/quick-time.util.ts
+++ b/packages/web/src/shortcuts/quick-time/quick-time.util.ts
@@ -74,19 +74,41 @@ export function quickTimeSequenceForHour(
   return resolved?.hour() === hour ? sequence : null;
 }
 
+const dayIsInView = (day: Dayjs, startOfView: Dayjs, endOfView: Dayjs) =>
+  day.isBetween(startOfView, endOfView, "day", "[]");
+
 /**
- * The day a typed time lands on: today when the view contains it, else the
- * first day of the view. Mirrors createAlldayDraft's fallback so "create an
- * event" means the same day whichever gesture started it.
+ * The day a typed time lands on. A focused column (jump-selected day, parked
+ * empty-grid click, or the day of the focused event) wins when it is still in
+ * view. Otherwise today when the view contains it, else the first visible
+ * day, the same fallback createAlldayDraft uses so "create an event" means
+ * the same day whichever gesture started it.
  */
 export const quickTimeTargetDay = (
   startOfView: Dayjs,
   endOfView: Dayjs,
   now: Dayjs,
-): Dayjs =>
-  now.isBetween(startOfView, endOfView, "day", "[]")
+  focusedDay?: Dayjs | null,
+): Dayjs => {
+  if (focusedDay && dayIsInView(focusedDay, startOfView, endOfView)) {
+    return focusedDay.startOf("day");
+  }
+
+  return dayIsInView(now, startOfView, endOfView)
     ? now.startOf("day")
     : startOfView.startOf("day");
+};
+
+/** A parked click, then a single jump-highlighted column. */
+export const quickTimeFocusedColumnDay = (
+  pointerDateKey: string | null,
+  activeDayKeys: readonly string[],
+  parseDateKey: (dateKey: string) => Dayjs,
+): Dayjs | null => {
+  if (pointerDateKey) return parseDateKey(pointerDateKey);
+  const dayKey = activeDayKeys.length === 1 ? activeDayKeys[0] : undefined;
+  return dayKey ? parseDateKey(dayKey) : null;
+};
 
 export type QuickTimeBusyInterval = {
   startMs: number;

--- a/packages/web/src/shortcuts/shift-hint/event-jump.store.ts
+++ b/packages/web/src/shortcuts/shift-hint/event-jump.store.ts
@@ -132,6 +132,9 @@ export const isEventJumpActive = () => useEventJumpStore.getState().isActive;
 export const selectEventJumpActiveDayKeys = (state: EventJumpState) =>
   state.activeDayKeys;
 
+export const selectPointerDraftDateKey = (state: EventJumpState) =>
+  state.pointerDraftDateKey;
+
 export const selectEventJumpAnnouncement = (state: EventJumpState) =>
   state.announcement;
 

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.quick-time.test.tsx
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.quick-time.test.tsx
@@ -269,7 +269,7 @@ describe("typed-time deferred commit", () => {
         endDate: COLUMN_DAY.hour(10).format(),
         title: "Column event",
         isAllDay: false,
-      } as GridEvent;
+      } as unknown as GridEvent;
       const el = document.createElement("button");
       el.textContent = COLUMN_EVENT_ID;
       document.body.appendChild(el);

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.quick-time.test.tsx
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.quick-time.test.tsx
@@ -311,5 +311,22 @@ describe("typed-time deferred commit", () => {
         `${COLUMN_DAY.format("YYYY-MM-DD")} 12:30`,
       );
     });
+
+    it("still toggles jump off with h after a half-typed column time", () => {
+      const { createAt, type } = mountColumn();
+
+      act(() => {
+        dispatch(
+          keydown(columnLetter.toUpperCase(), {
+            shiftKey: true,
+          }),
+        );
+        type(["9"]);
+        dispatch(keydown("h"));
+      });
+
+      expect(createAt).not.toHaveBeenCalled();
+      expect(useEventJumpStore.getState().isActive).toBe(false);
+    });
   });
 });

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.quick-time.test.tsx
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.quick-time.test.tsx
@@ -1,11 +1,17 @@
 import { act, cleanup, renderHook } from "@testing-library/react";
+import { EventIdSchema } from "@core/types/domain-primitives";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+import { type GridEvent } from "@web/common/types/web.event.types";
 import { clearAppLockReasons, setAppLockReason } from "@web/shortcuts/app-lock";
 import {
   clearFloatingLayerReasons,
   setFloatingLayerReason,
 } from "@web/shortcuts/floating-layer";
-import { DIGIT_AMBIGUOUS_COMMIT_MS } from "@web/shortcuts/shift-hint/assign-shift-hint-keys";
+import {
+  DAY_JUMP_PREFIX_BY_WEEKDAY,
+  type DayJumpWeekday,
+  DIGIT_AMBIGUOUS_COMMIT_MS,
+} from "@web/shortcuts/shift-hint/assign-shift-hint-keys";
 import {
   eventJumpActions,
   useEventJumpStore,
@@ -244,6 +250,65 @@ describe("typed-time deferred commit", () => {
       const start = createAt.mock.calls[0]?.[0] as Dayjs;
       expect(start.format("YYYY-MM-DD HH:mm")).toBe(
         `${CLICKED_DAY.format("YYYY-MM-DD")} 17:00`,
+      );
+    });
+  });
+
+  describe("with a jump-selected column", () => {
+    const COLUMN_EVENT_ID = EventIdSchema.parse("aaaaaaaaaaaaaaaaaaaaaaaa");
+    const COLUMN_DAY =
+      TARGET_DAY.day() === 3 ? TARGET_DAY.add(1, "day") : TARGET_DAY.day(3);
+    const columnLetter =
+      DAY_JUMP_PREFIX_BY_WEEKDAY[COLUMN_DAY.day() as DayJumpWeekday];
+
+    const mountColumn = () => {
+      const createAt = mock((_start: Dayjs) => {});
+      const event = {
+        _id: COLUMN_EVENT_ID,
+        startDate: COLUMN_DAY.hour(9).format(),
+        endDate: COLUMN_DAY.hour(10).format(),
+        title: "Column event",
+        isAllDay: false,
+      } as GridEvent;
+      const el = document.createElement("button");
+      el.textContent = COLUMN_EVENT_ID;
+      document.body.appendChild(el);
+
+      renderHook(() =>
+        useShiftHoldEventHints({
+          createAtTime: (start) => createAt(start),
+          focus: () => {},
+          getQuickTimeDay: () => TARGET_DAY,
+          listVisible: () => [
+            { eventId: COLUMN_EVENT_ID, eventType: "timed", element: el },
+          ],
+          timedEvents: [event],
+        }),
+      );
+
+      const type = (keys: string[]) => {
+        for (const key of keys) dispatch(digit(key));
+      };
+
+      return { createAt, type };
+    };
+
+    it("creates 1230 on the focused day, not today", () => {
+      const { createAt, type } = mountColumn();
+
+      act(() => {
+        dispatch(
+          keydown(columnLetter.toUpperCase(), {
+            shiftKey: true,
+          }),
+        );
+        type(["1", "2", "3", "0"]);
+      });
+
+      const start = createAt.mock.calls[0]?.[0] as Dayjs;
+      expect(createAt).toHaveBeenCalledTimes(1);
+      expect(start.format("YYYY-MM-DD HH:mm")).toBe(
+        `${COLUMN_DAY.format("YYYY-MM-DD")} 12:30`,
       );
     });
   });

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
@@ -25,6 +25,7 @@ import {
 import { KEYMAP } from "@web/shortcuts/keymap";
 import {
   canQuickTimeBufferGrow,
+  quickTimeFocusedColumnDay,
   resolveQuickTimeStart,
 } from "@web/shortcuts/quick-time/quick-time.util";
 import {
@@ -74,13 +75,15 @@ const pointerDraftStart = (digits: string): Dayjs | null => {
   return dayjs(start).tz(getEffectiveTimeZone());
 };
 
-/** A click on another day retargets the typed time to that day. */
-const pointerDraftDay = (): Dayjs | null => {
-  const { pointerDraftDateKey } = useEventJumpStore.getState();
+/** Parked click, then a single jump-highlighted column. */
+const focusedColumnDay = (): Dayjs | null => {
+  const { pointerDraftDateKey, activeDayKeys } = useEventJumpStore.getState();
 
-  return pointerDraftDateKey
-    ? dayjs(pointerDraftDateKey).tz(getEffectiveTimeZone(), true)
-    : null;
+  return quickTimeFocusedColumnDay(
+    pointerDraftDateKey,
+    activeDayKeys,
+    (dateKey) => dayjs(dateKey).tz(getEffectiveTimeZone(), true),
+  );
 };
 
 /**
@@ -204,6 +207,7 @@ export function useShiftHoldEventHints({
   const quickTimeCommitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
+  const columnTimeBurstRef = useRef<{ digit: string; at: number }[]>([]);
   const createAtTimeRef = useRef(createAtTime);
   const focusRef = useRef(focus);
   const getQuickTimeDayRef = useRef(getQuickTimeDay);
@@ -241,9 +245,23 @@ export function useShiftHoldEventHints({
       eventJumpActions.setQuickTimeDigits("");
     };
 
+    const resetColumnTimeBurst = () => {
+      columnTimeBurstRef.current = [];
+    };
+
+    const recentColumnTimeDigits = () => {
+      const at = performance.now();
+      columnTimeBurstRef.current = columnTimeBurstRef.current.filter(
+        (entry) => at - entry.at < DIGIT_AMBIGUOUS_COMMIT_MS * 2,
+      );
+      return columnTimeBurstRef.current.map((entry) => entry.digit).join("");
+    };
+
     const commitQuickTime = () => {
       const digits = useEventJumpStore.getState().quickTimeDigits;
       resetQuickTime();
+      resetColumnTimeBurst();
+      clearAmbiguousCommitTimer();
       if (!digits) return;
 
       const now = dayjs().tz(getEffectiveTimeZone());
@@ -252,7 +270,7 @@ export function useShiftHoldEventHints({
         resolveQuickTimeStart(
           digits,
           now,
-          pointerDraftDay() ?? getQuickTimeDayRef.current(),
+          focusedColumnDay() ?? getQuickTimeDayRef.current(),
         );
       if (!start) return;
 
@@ -362,6 +380,7 @@ export function useShiftHoldEventHints({
       const assignments = rebuildAssignments();
       isActiveRef.current = true;
       bufferRef.current = "";
+      resetColumnTimeBurst();
       eventJumpActions.setActive(true);
       eventJumpActions.setActiveDayKeys([]);
       setHints(toActiveHints(assignments, visibleByIdRef.current));
@@ -370,6 +389,7 @@ export function useShiftHoldEventHints({
     const deactivate = () => {
       isActiveRef.current = false;
       bufferRef.current = "";
+      resetColumnTimeBurst();
       clearHints();
       eventJumpActions.setPointerDraftIntent(null);
       eventJumpActions.setActive(false);
@@ -441,6 +461,7 @@ export function useShiftHoldEventHints({
 
       if (match.kind === "selectDay") {
         clearAmbiguousCommitTimer();
+        resetColumnTimeBurst();
         bufferRef.current = match.buffer;
         shortcutHintProgressActions.demonstrate("week-day-focus");
         const dayName = dayNameForPrefix(match.dayPrefix);
@@ -538,10 +559,23 @@ export function useShiftHoldEventHints({
         return;
       }
 
-      // Only on an empty buffer: once a day letter is typed ("w"), the digits
-      // that follow are that day's event index. Esc or a second `h` clears the
-      // buffer and puts quick-time back within reach.
+      // Empty buffer: digits are times. Once a day letter is typed ("w"),
+      // 1-2 digits still index that day's events. A four-digit HHMM still
+      // creates on the selected column so focusing Tuesday then 1230 lands
+      // there instead of today.
       if (bufferRef.current === "" && tryQuickTimeKey(event)) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+
+      if (
+        event.key === "Enter" &&
+        recentColumnTimeDigits() &&
+        bufferRef.current !== ""
+      ) {
+        eventJumpActions.setQuickTimeDigits(recentColumnTimeDigits());
+        commitQuickTime();
         event.preventDefault();
         event.stopPropagation();
         return;
@@ -558,6 +592,7 @@ export function useShiftHoldEventHints({
       // Arrows keep mode on so letter-then-arrows can move focus.
       if (keyboardKey(event).startsWith("Arrow")) {
         clearAmbiguousCommitTimer();
+        resetColumnTimeBurst();
         stripDigitBuffer();
         return;
       }
@@ -569,6 +604,29 @@ export function useShiftHoldEventHints({
       const key = normalizedKeyboardKey(event);
       if (key.length !== 1) return;
 
+      const pickIndex = digitPickIndex(event);
+      const daySelected =
+        useEventJumpStore.getState().activeDayKeys.length === 1;
+      if (daySelected && pickIndex !== null && pickIndex < DIGIT_PICK_COUNT) {
+        const at = performance.now();
+        columnTimeBurstRef.current = [
+          ...columnTimeBurstRef.current.filter(
+            (entry) => at - entry.at < DIGIT_AMBIGUOUS_COMMIT_MS * 2,
+          ),
+          { digit: PICK_KEY_LABELS[pickIndex], at },
+        ];
+        const burst = columnTimeBurstRef.current
+          .map((entry) => entry.digit)
+          .join("");
+        if (!canQuickTimeBufferGrow(burst)) {
+          eventJumpActions.setQuickTimeDigits(burst);
+          commitQuickTime();
+          event.preventDefault();
+          event.stopPropagation();
+          return;
+        }
+      }
+
       // Swallow j/k and other unmatched printable shortcuts while jump is on.
       const match = matchDayJumpKeystroke({
         assignments: assignmentsRef.current,
@@ -577,6 +635,13 @@ export function useShiftHoldEventHints({
       });
 
       if (!match) {
+        if (recentColumnTimeDigits()) {
+          clearAmbiguousCommitTimer();
+          event.preventDefault();
+          event.stopPropagation();
+          keyupSwallow.add(key);
+          return;
+        }
         clearAmbiguousCommitTimer();
         stripDigitBuffer();
         // `e` is not a day prefix. Leave it unclaimed so a later-registered

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
@@ -79,11 +79,7 @@ const pointerDraftStart = (digits: string): Dayjs | null => {
 const focusedColumnDay = (): Dayjs | null => {
   const { pointerDraftDateKey, activeDayKeys } = useEventJumpStore.getState();
 
-  return quickTimeFocusedColumnDay(
-    pointerDraftDateKey,
-    activeDayKeys,
-    (dateKey) => dayjs(dateKey).tz(getEffectiveTimeZone(), true),
-  );
+  return quickTimeFocusedColumnDay(pointerDraftDateKey, activeDayKeys);
 };
 
 /**

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
@@ -631,7 +631,7 @@ export function useShiftHoldEventHints({
       });
 
       if (!match) {
-        if (recentColumnTimeDigits()) {
+        if (pickIndex !== null && recentColumnTimeDigits()) {
           clearAmbiguousCommitTimer();
           event.preventDefault();
           event.stopPropagation();

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGridQuickTimeSlots.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGridQuickTimeSlots.tsx
@@ -6,12 +6,20 @@ import { type GridVisibleDate } from "@web/grid/types/grid.types";
 import { QuickTimeSlots } from "@web/shortcuts/quick-time/QuickTimeSlots";
 import {
   buildQuickTimeSlots,
+  quickTimeFocusedColumnDay,
   quickTimeTargetDay,
   timedEventsToBusyIntervals,
 } from "@web/shortcuts/quick-time/quick-time.util";
+import {
+  selectEventJumpActive,
+  selectEventJumpActiveDayKeys,
+  selectPointerDraftDateKey,
+  useEventJumpStore,
+} from "@web/shortcuts/shift-hint/event-jump.store";
 import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 import { type Measurements_Grid } from "@web/views/Week/hooks/grid/useGridLayout";
 import { type WeekProps } from "@web/views/Week/hooks/useWeek";
+import { weekEventTargeting } from "@web/views/Week/interaction/registry/week-event.registry";
 
 interface Props {
   measurements: Measurements_Grid;
@@ -22,15 +30,20 @@ interface Props {
  * Week-grid host for the quick-time placeholders. Sources events from the same
  * cached week query MainGridEvents reads, the way MainGridBusyPeriods sources
  * its own availability query, so no new props thread through the grid.
+ * The chips follow the focused column (jump-selected day, parked click, or
+ * focused event) so they preview where a typed time would land.
  */
 export const MainGridQuickTimeSlots = ({ measurements, weekProps }: Props) => {
   const { component } = weekProps;
   // Same args as MainGridEvents so this shares that query's cache entry rather
   // than opening a second one.
-  const { timedEvents } = useWeekEventViewModel({
+  const { allDayEvents, timedEvents } = useWeekEventViewModel({
     startOfView: weekProps.query.startOfView,
     endOfView: weekProps.query.endOfView,
   });
+  const isJumpActive = useEventJumpStore(selectEventJumpActive);
+  const activeDayKeys = useEventJumpStore(selectEventJumpActiveDayKeys);
+  const pointerDraftDateKey = useEventJumpStore(selectPointerDraftDateKey);
   const visibleDates: GridVisibleDate[] = useMemo(
     () =>
       component.weekDays.map((date) => ({
@@ -42,17 +55,38 @@ export const MainGridQuickTimeSlots = ({ measurements, weekProps }: Props) => {
 
   const slots = useMemo(() => {
     const now = dayjs().tz(getEffectiveTimeZone());
+    const focusedColumn = quickTimeFocusedColumnDay(
+      pointerDraftDateKey,
+      activeDayKeys,
+      (dateKey) => dayjs(dateKey).tz(getEffectiveTimeZone(), true),
+    );
+    const focusedEvent = weekEventTargeting.getFocusedGridEventTarget();
+    const focusedStart = focusedEvent
+      ? [...allDayEvents, ...timedEvents].find(
+          (event) => event._id === focusedEvent.eventId,
+        )?.startDate
+      : undefined;
     const targetDay = quickTimeTargetDay(
       component.startOfView,
       component.endOfView,
       now,
+      focusedColumn ??
+        (focusedStart ? dayjs(focusedStart).tz(getEffectiveTimeZone()) : null),
     );
     return buildQuickTimeSlots({
       busy: timedEventsToBusyIntervals(timedEvents),
       now,
       targetDay,
     });
-  }, [component.endOfView, component.startOfView, timedEvents]);
+  }, [
+    activeDayKeys,
+    allDayEvents,
+    component.endOfView,
+    component.startOfView,
+    isJumpActive,
+    pointerDraftDateKey,
+    timedEvents,
+  ]);
 
   return (
     <QuickTimeSlots

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGridQuickTimeSlots.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGridQuickTimeSlots.tsx
@@ -60,7 +60,9 @@ export const MainGridQuickTimeSlots = ({ measurements, weekProps }: Props) => {
       pointerDraftDateKey,
       activeDayKeys,
     );
-    const focusedEvent = weekEventTargeting.getFocusedGridEventTarget();
+    const focusedEvent = isJumpActive
+      ? weekEventTargeting.getFocusedGridEventTarget()
+      : null;
     const targetDay = quickTimeTargetDay(
       component.startOfView,
       component.endOfView,

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGridQuickTimeSlots.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGridQuickTimeSlots.tsx
@@ -6,6 +6,7 @@ import { type GridVisibleDate } from "@web/grid/types/grid.types";
 import { QuickTimeSlots } from "@web/shortcuts/quick-time/QuickTimeSlots";
 import {
   buildQuickTimeSlots,
+  quickTimeDayFromEventStart,
   quickTimeFocusedColumnDay,
   quickTimeTargetDay,
   timedEventsToBusyIntervals,
@@ -58,20 +59,20 @@ export const MainGridQuickTimeSlots = ({ measurements, weekProps }: Props) => {
     const focusedColumn = quickTimeFocusedColumnDay(
       pointerDraftDateKey,
       activeDayKeys,
-      (dateKey) => dayjs(dateKey).tz(getEffectiveTimeZone(), true),
     );
     const focusedEvent = weekEventTargeting.getFocusedGridEventTarget();
-    const focusedStart = focusedEvent
-      ? [...allDayEvents, ...timedEvents].find(
-          (event) => event._id === focusedEvent.eventId,
-        )?.startDate
-      : undefined;
     const targetDay = quickTimeTargetDay(
       component.startOfView,
       component.endOfView,
       now,
       focusedColumn ??
-        (focusedStart ? dayjs(focusedStart).tz(getEffectiveTimeZone()) : null),
+        quickTimeDayFromEventStart(
+          focusedEvent
+            ? [...allDayEvents, ...timedEvents].find(
+                (event) => event._id === focusedEvent.eventId,
+              )?.startDate
+            : undefined,
+        ),
     );
     return buildQuickTimeSlots({
       busy: timedEventsToBusyIntervals(timedEvents),

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
@@ -37,6 +37,7 @@ import {
   initialEdgeFocusState,
   useEdgeFocusStore,
 } from "@web/grid/shortcuts/edge-focus.store";
+import { eventJumpActions } from "@web/shortcuts/shift-hint/event-jump.store";
 import {
   getWeekInteractionTargetAttributes,
   weekEventRegistry,
@@ -188,6 +189,7 @@ afterEach(() => {
   useViewStore.setState(initialViewState);
   useEdgeFocusStore.setState(initialEdgeFocusState, true);
   useEventClipboardStore.setState(initialEventClipboardState, true);
+  eventJumpActions.reset();
   draftActions.discard();
   setSystemTime();
   // Drain leftover swallowNextKeyup capture listeners from Mod+C / Mod+V.
@@ -1165,6 +1167,26 @@ describe("useWeekShortcutOwner shift+arrow event moves", () => {
     pressKey("ArrowRight", shiftKey);
 
     expect(getEditMutation(queryClient)).toBeUndefined();
+  });
+
+  it("creates a typed time on the focused event's day instead of today", async () => {
+    setSystemTime(new Date("2026-05-18T15:00:00.000Z"));
+    renderShortcuts();
+    addCalendarTarget().focus();
+
+    pressKey("1", { keyDownInit: { code: "Digit1" } });
+    pressKey("2", { keyDownInit: { code: "Digit2" } });
+    pressKey("3", { keyDownInit: { code: "Digit3" } });
+    pressKey("0", { keyDownInit: { code: "Digit0" } });
+
+    await waitFor(() => {
+      const draft = useDraftStore.getState().gridDraft;
+      expect(useDraftStore.getState().status?.activity).toBe("keyboardPlace");
+      expect(dayjs(draft?.values.schedule.start).format("YYYY-MM-DD")).toBe(
+        "2026-05-20",
+      );
+      expect(dayjs(draft?.values.schedule.start).format("HH:mm")).toBe("12:30");
+    });
   });
 
   it("places a keyboardPlace timed draft when Shift+Arrow is pressed with no focus", async () => {

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
@@ -21,7 +21,10 @@ import {
 import { useCalendarViewShortcuts } from "@web/grid/shortcuts/useCalendarViewShortcuts";
 import { useGridEventEditShortcuts } from "@web/grid/shortcuts/useGridEventEditShortcuts";
 import { useGridEventFormFieldSequences } from "@web/grid/shortcuts/useGridEventFormFieldSequences";
-import { quickTimeTargetDay } from "@web/shortcuts/quick-time/quick-time.util";
+import {
+  quickTimeFocusedColumnDay,
+  quickTimeTargetDay,
+} from "@web/shortcuts/quick-time/quick-time.util";
 import {
   eventJumpActions,
   useEventJumpStore,
@@ -266,15 +269,33 @@ export const useWeekShortcutOwner = ({
 
   // Typed-time create. Same guards and same form-closed/card-focused landing
   // as Shift+Arrow place-create, so the two gestures produce the same draft.
-  const getQuickTimeDay = useCallback(
-    () =>
-      quickTimeTargetDay(
-        startOfView,
-        endOfView,
-        dayjs().tz(getEffectiveTimeZone()),
-      ),
-    [endOfView, startOfView],
-  );
+  // A focused column (parked click, jump-selected day, or focused event)
+  // wins over today so 1230 lands where the user is looking.
+  const getQuickTimeDay = useCallback(() => {
+    const now = dayjs().tz(getEffectiveTimeZone());
+    const { pointerDraftDateKey, activeDayKeys } = useEventJumpStore.getState();
+    const focusedColumn = quickTimeFocusedColumnDay(
+      pointerDraftDateKey,
+      activeDayKeys,
+      (dateKey) => dayjs(dateKey).tz(getEffectiveTimeZone(), true),
+    );
+    const focusedEvent =
+      weekEventTargeting.getFocusedNavigableGridEventTarget() ??
+      weekEventTargeting.getFocusedGridEventTarget();
+    const focusedStart = focusedEvent
+      ? [...allDayEvents, ...timedEvents].find(
+          (event) => event._id === focusedEvent.eventId,
+        )?.startDate
+      : undefined;
+
+    return quickTimeTargetDay(
+      startOfView,
+      endOfView,
+      now,
+      focusedColumn ??
+        (focusedStart ? dayjs(focusedStart).tz(getEffectiveTimeZone()) : null),
+    );
+  }, [allDayEvents, endOfView, startOfView, timedEvents]);
 
   const createDraftAtTime = useCallback(
     (start: Dayjs) => {

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.ts
@@ -22,6 +22,7 @@ import { useCalendarViewShortcuts } from "@web/grid/shortcuts/useCalendarViewSho
 import { useGridEventEditShortcuts } from "@web/grid/shortcuts/useGridEventEditShortcuts";
 import { useGridEventFormFieldSequences } from "@web/grid/shortcuts/useGridEventFormFieldSequences";
 import {
+  quickTimeDayFromEventStart,
   quickTimeFocusedColumnDay,
   quickTimeTargetDay,
 } from "@web/shortcuts/quick-time/quick-time.util";
@@ -277,23 +278,22 @@ export const useWeekShortcutOwner = ({
     const focusedColumn = quickTimeFocusedColumnDay(
       pointerDraftDateKey,
       activeDayKeys,
-      (dateKey) => dayjs(dateKey).tz(getEffectiveTimeZone(), true),
     );
     const focusedEvent =
       weekEventTargeting.getFocusedNavigableGridEventTarget() ??
       weekEventTargeting.getFocusedGridEventTarget();
-    const focusedStart = focusedEvent
-      ? [...allDayEvents, ...timedEvents].find(
-          (event) => event._id === focusedEvent.eventId,
-        )?.startDate
-      : undefined;
-
     return quickTimeTargetDay(
       startOfView,
       endOfView,
       now,
       focusedColumn ??
-        (focusedStart ? dayjs(focusedStart).tz(getEffectiveTimeZone()) : null),
+        quickTimeDayFromEventStart(
+          focusedEvent
+            ? [...allDayEvents, ...timedEvents].find(
+                (event) => event._id === focusedEvent.eventId,
+              )?.startDate
+            : undefined,
+        ),
     );
   }, [allDayEvents, endOfView, startOfView, timedEvents]);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Typed time shortcuts such as `1230` were always created on today when today was in view. If a future or past column is focused, the draft and the `h` placeholder chips now land on that day instead.

Focus is, in order: a parked empty-grid click, a single jump-selected column (`Shift+T`, `h` then `t`), or the focused event's day. A four-digit HHMM typed after selecting a column still creates there, while 1-2 digits remain that day's event index.

## Simplicity

The target-day helper gained an optional focused day and a small column-key resolver. Week owner and slot host share that helper rather than each inventing a today-vs-column rule.

## Automated validation

```
Selected packages: web
Checks run: test:web, type-check, lint, knip
Checks skipped: test:a11y, test:e2e (Playwright Chromium missing at that run)
✓ selected checks passed; CI parity incomplete: Playwright Chromium missing
```

GitHub checks on this PR: lint, type-check, knip, unit (web/core/backend/sync/scripts), e2e, lighthouse, and CodeQL all passed.

Browser: week view, `Shift+R` on Thursday Sep 3, type `1230`. Draft is 12:30–1:30 PM on Thursday, not today (Wed Sep 2).

![HHMM chips on Thursday Sep 3](https://cursor.com/artifacts/c/art-6077f180-7981-4af3-999f-b67481097319)
![12:30 draft on Thursday Sep 3](https://cursor.com/artifacts/c/art-4cd2a72a-ce1e-4aa8-ab82-b7cf02f0636b)
<a href="https://cursor.com/agents/bc-91b9457e-3eb1-4127-8ee2-ad03c6ca4f8d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fthursday_shift_r_then_1230_draft.mp4"><img src="https://cursor.com/artifacts/c/art-ba89f879-6cc0-4fb0-9af1-777d78e365a1" alt="thursday_shift_r_then_1230_draft.mp4" /></a>

## Independent review

`.agents/handoffs/3078.md`: no confirmed findings.

## Test plan

- `bun test` focused: `quick-time.util.test.ts`, `useShiftHoldEventHints.quick-time.test.tsx`, `useWeekShortcutOwner.test.tsx`
- `bun run verify` (PASS: test:web, type-check, lint, knip)
- Browser: `Shift+R` then `1230` lands on Thursday
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91b9457e-3eb1-4127-8ee2-ad03c6ca4f8d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91b9457e-3eb1-4127-8ee2-ad03c6ca4f8d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

