### PR TITLE
fix(web): stop repeating email on destination calendar select

### DIFF
--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -827,6 +827,47 @@ describe("BookingSettingsSection", () => {
     expect(writeText).not.toHaveBeenCalled();
   });
 
+  it("labels a Google primary destination calendar with the calendar name only", async () => {
+    const primary = createMockCalendar({
+      name: "host@example.com",
+      accountEmail: "host@example.com",
+      isPrimary: true,
+    });
+
+    userMetadataActions.set(healthyGoogleMetadata);
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(
+          ctx.json({
+            ...unconfiguredPage(),
+            destinationCalendarId: primary.id,
+            blockingCalendarIds: [primary.id],
+          }),
+        ),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [primary]);
+
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    const combobox = await screen.findByRole("combobox", {
+      name: "Destination calendar",
+    });
+    const option = within(combobox).getByRole("option");
+    expect(option.textContent).toBe("host@example.com");
+    expect(
+      within(combobox).getByRole("group", { name: "host@example.com" }),
+    ).toBeInTheDocument();
+  });
+
   it("blocks enable without a destination calendar", async () => {
     const user = userEvent.setup({ delay: null });
 

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -257,6 +257,8 @@ export function BookingSettingsSection({
     availabilityCalendars,
     connections,
   );
+  const { groups: writableGroups, ungrouped: writableUngrouped } =
+    groupCalendarsByAccount(writableCalendars, connections);
   const updateForm = (patch: Partial<AdminPutBookingPageInput>) => {
     setForm((current) => ({ ...current, ...patch }));
     setEnableError(null);
@@ -439,12 +441,24 @@ export function BookingSettingsSection({
               No writable calendars
             </option>
           ) : (
-            writableCalendars.map((calendar) => (
-              <option key={calendar.id} value={calendar.id}>
-                {calendar.name}
-                {calendar.accountEmail ? ` (${calendar.accountEmail})` : ""}
-              </option>
-            ))
+            <>
+              {writableGroups
+                .filter((group) => group.calendars.length > 0)
+                .map((group) => (
+                  <optgroup key={group.accountEmail} label={group.accountEmail}>
+                    {group.calendars.map((calendar) => (
+                      <option key={calendar.id} value={calendar.id}>
+                        {calendar.name}
+                      </option>
+                    ))}
+                  </optgroup>
+                ))}
+              {writableUngrouped.map((calendar) => (
+                <option key={calendar.id} value={calendar.id}>
+                  {calendar.name}
+                </option>
+              ))}
+            </>
           )}
         </select>
       </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Google primary calendars report their display name as the account email. Booking settings then appended ` (accountEmail)` to every destination option, so primaries rendered as `me@gmail.com (me@gmail.com)`.

The destination select now groups writable calendars by account the same way Settings' Default Calendar picker does: `optgroup` labeled with the account email, option text is the calendar name only.

Fixes #3082

## Simplicity

Reuses `groupCalendarsByAccount`, already used for blocking calendars in this section. No new label helper and no third inline format. Simplify pass: no extra commit.

## Automated validation

`bun run verify` PASS.

Selected packages: web
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)

Focused: `bun test:web packages/web/src/booking/BookingSettingsSection.test.tsx` (28 pass), including a whole-string assertion that a Google primary option is `host@example.com`.

## Independent review

VERDICT: no confirmed findings

Native select, option values, and the empty-writable placeholder are unchanged. Account grouping matches the Default Calendar picker, including empty-group filtering. Keyboard and screen-reader names stay on the existing `Destination calendar` combobox.

## Test plan

- `bun test:web packages/web/src/booking/BookingSettingsSection.test.tsx`
- `bun run verify`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6e2dba1-cfc3-4458-b158-14d650287a70?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6e2dba1-cfc3-4458-b158-14d650287a70&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

