### PR TITLE
feat(web): default to light theme

### DIFF
--- a/docs/development/testing-playbook.md
+++ b/docs/development/testing-playbook.md
@@ -515,7 +515,7 @@ must inspect.
 region and keeps its own targeted per-date contrast regression (below).
 
 `e2e/accessibility/booking-a11y.spec.ts` covers public booking: picker and
-details (light and dark `prefers-color-scheme`), slots error, 409 conflict,
+details (light default and stored dark theme), slots error, 409 conflict,
 confirmation (confirmed, cancelled, not-found, load error), and cancel
 (confirm, in-flight, success, not-found, error). CI `bun run test:e2e`
 runs the whole `e2e/` tree, including this file.

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -99,9 +99,8 @@ flowchart TD
   permalink -->|tokenized cancel URL| cancel
 ```
 
-Public booking follows `prefers-color-scheme` when `compass.theme` is
-unset: a light OS uses `light-beach`, a dark OS keeps the app dark
-default. A stored theme wins over the OS.
+Public booking uses `light-beach` when `compass.theme` is unset. A
+stored theme wins.
 
 ### Guest keyboard path
 

--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -11,36 +11,39 @@ import {
 import { expectNoAxeViolations } from "../utils/axe-assertion";
 
 test.describe("public booking page color scheme", () => {
-  (["light", "dark"] as const).forEach((colorScheme) => {
-    test.describe(`${colorScheme} OS`, () => {
-      test.use({ colorScheme });
-
+  (
+    [
+      { name: "light", theme: "light-beach", stored: null },
+      { name: "dark", theme: "dark-abyss", stored: "dark-abyss" },
+    ] as const
+  ).forEach(({ name, theme, stored }) => {
+    test.describe(`${name} theme`, () => {
       test("the picker has no automatically detectable accessibility violations", async ({
         page,
       }) => {
+        if (stored) {
+          await page.addInitScript((value) => {
+            localStorage.setItem("compass.theme", value);
+          }, stored);
+        }
         await preparePublicBookingPage(page);
         await expect(
           page.getByRole("heading", { name: "Pick a time" }),
         ).toBeVisible();
-        if (colorScheme === "light") {
-          await expect(page.locator("html")).toHaveAttribute(
-            "data-theme",
-            "light-beach",
-          );
-        } else {
-          await expect(page.locator("html")).not.toHaveAttribute(
-            "data-theme",
-            "light-beach",
-          );
-        }
+        await expect(page.locator("html")).toHaveAttribute("data-theme", theme);
         await expectNoAxeViolations(page, {
-          checkpoint: `public booking page ${colorScheme}`,
+          checkpoint: `public booking page ${name}`,
         });
       });
 
       test("the details step has no automatically detectable accessibility violations", async ({
         page,
       }) => {
+        if (stored) {
+          await page.addInitScript((value) => {
+            localStorage.setItem("compass.theme", value);
+          }, stored);
+        }
         const { slotStart } = buildBookableSlot();
         await preparePublicBookingPage(page);
         await page
@@ -50,7 +53,7 @@ test.describe("public booking page color scheme", () => {
           page.getByRole("heading", { name: "Your details" }),
         ).toBeVisible();
         await expectNoAxeViolations(page, {
-          checkpoint: `public booking details ${colorScheme}`,
+          checkpoint: `public booking details ${name}`,
         });
       });
     });

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -700,23 +700,12 @@ test.describe("public booking page", () => {
 });
 
 test.describe("public booking theme", () => {
-  test("uses the light theme when OS is light and nothing is stored", async ({
-    page,
-  }) => {
-    await page.emulateMedia({ colorScheme: "light" });
-    await preparePublicBookingPage(page);
-    await expect(page.locator("html")).toHaveAttribute(
-      "data-theme",
-      "light-beach",
-    );
-  });
-
-  test("keeps the dark default when OS is dark and nothing is stored", async ({
+  test("uses the light default when nothing is stored, even if OS is dark", async ({
     page,
   }) => {
     await page.emulateMedia({ colorScheme: "dark" });
     await preparePublicBookingPage(page);
-    await expect(page.locator("html")).not.toHaveAttribute(
+    await expect(page.locator("html")).toHaveAttribute(
       "data-theme",
       "light-beach",
     );
@@ -728,9 +717,9 @@ test.describe("public booking theme", () => {
     });
     await page.emulateMedia({ colorScheme: "light" });
     await preparePublicBookingPage(page);
-    await expect(page.locator("html")).not.toHaveAttribute(
+    await expect(page.locator("html")).toHaveAttribute(
       "data-theme",
-      "light-beach",
+      "dark-abyss",
     );
   });
 });

--- a/e2e/calendars/calendar-experience.spec.ts
+++ b/e2e/calendars/calendar-experience.spec.ts
@@ -389,8 +389,16 @@ test("day view separates visible calendars into distinct columns", async ({
 
   await expect(primaryHeader).toBeVisible();
   await expect(readerHeader).toBeVisible();
-  await expect(primaryHeader).toHaveCSS("color", "rgb(198, 208, 217)");
-  await expect(readerHeader).toHaveCSS("color", "rgb(198, 208, 217)");
+  const themeTextColor = await page.evaluate(() => {
+    const probe = document.createElement("span");
+    probe.style.color = "var(--text)";
+    document.documentElement.appendChild(probe);
+    const color = getComputedStyle(probe).color;
+    probe.remove();
+    return color;
+  });
+  await expect(primaryHeader).toHaveCSS("color", themeTextColor);
+  await expect(readerHeader).toHaveCSS("color", themeTextColor);
   await expect(primaryEvent).toBeVisible();
   await expect(readerEvent).toBeVisible();
 

--- a/packages/web/src/common/styles/theme-css.test.ts
+++ b/packages/web/src/common/styles/theme-css.test.ts
@@ -98,6 +98,10 @@ describe("Tailwind theme CSS", () => {
     }
   });
 
+  it("declares Light Beach as the :root default", () => {
+    expect(indexCss).toMatch(/:root,\s*\[data-theme="light-beach"\]/);
+  });
+
   it("declares the Light Beach theme scope", () => {
     expect(indexCss).toContain('[data-theme="light-beach"]');
     expect(indexCss).toContain("color-scheme: light");
@@ -122,10 +126,14 @@ describe("Tailwind theme CSS", () => {
     }
   });
 
-  it("keeps colors.ts hex values in sync with index.css role values", () => {
+  it("keeps colors.ts hex values in sync with the dark-abyss block", () => {
+    const block = indexCss.match(/\[data-theme="dark-abyss"\]\s*\{([^}]*)\}/);
+    expect(block).not.toBeNull();
+    const body = block?.[1] ?? "";
+
     for (const [jsKey, cssToken] of Object.entries(jsColorKeyToCssToken)) {
       const hex = colors[jsKey as keyof typeof colors];
-      const match = indexCss.match(
+      const match = body.match(
         new RegExp(`--${cssToken}:\\s*(#[0-9a-fA-F]{6});`),
       );
       expect(match).not.toBeNull();

--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -264,7 +264,7 @@ describe("CommandPalette", () => {
     fireEvent.keyDown(input, { key: "ArrowDown" }); // Create all-day event
     expect(activeRowText(container)).toBe("Create all-day event");
     fireEvent.keyDown(input, { key: "ArrowDown" }); // skips Undo last change
-    expect(activeRowText(container)).toBe("Switch to light theme");
+    expect(activeRowText(container)).toBe("Switch to dark theme");
   });
 
   it("runs the active item's onClick and closes on Enter", async () => {
@@ -324,7 +324,7 @@ describe("CommandPalette", () => {
 
     fireEvent.change(input, { target: { value: "ligh" } });
     expect(input).toHaveValue("ligh");
-    expect(rowLabel("Switch to light theme")).toBeInTheDocument();
+    expect(rowLabel("Switch to dark theme")).toBeInTheDocument();
     expect(screen.queryByText("Go to Today")).not.toBeInTheDocument();
 
     fireEvent.keyDown(input, { key: "Escape" });

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -7,8 +7,54 @@
  * common/styles/colors.ts (guarded by theme-css.test.ts).
  */
 
-/* Theme 01 — Dark Abyss (default) */
+/* Theme 01 — Light Beach (default) */
 :root,
+[data-theme="light-beach"] {
+  color-scheme: light;
+
+  /* Surfaces — warm sand, layered down */
+  --background: #f3eee2;
+  --surface: #ece6d7;
+  --surface-panel: #e7e0cf;
+  --surface-raised: #e1d9c6;
+  --surface-overlay: hsl(40 25% 25% / 6%);
+
+  /* Borders */
+  --border: hsl(40 20% 30% / 15%);
+  --border-strong: #a89c81;
+
+  /* Text — warm ink, darkest on the lightest surface */
+  --text: #403a2f;
+  --text-muted: #5e5847;
+  --text-subtle: #948b74;
+
+  /* Accents — near-black ink; hover/strong go darker (inverse of dark theme) */
+  --accent: #2b2a27;
+  --accent-hover: #403d37;
+  --accent-strong: #141412; /* pressed / elevated underside */
+  --accent-secondary: #6d6b65;
+  --accent-secondary-hover: #6b6862;
+  --on-accent: #f6f3ea; /* text on accent fills */
+
+  /* Status */
+  --success: #57876a;
+  --warning: #9c7d45;
+  --error: #ad6553;
+  --info: #8a8475;
+
+  /* Overlays */
+  --overlay-backdrop: hsl(40 25% 15% / 40%);
+  --shadow-default: hsl(40 25% 25% / 18%);
+
+  --transition-default: 0.3s;
+}
+
+/*
+ * Theme 02 — Dark Abyss. Redefines the same 22 roles as the light block above.
+ * Scoped to the attribute only (no :root), so it sits later in source order and
+ * wins over the light block's :root defaults at equal specificity — placement,
+ * not specificity, is what makes it override. See theme-css.test.ts for parity.
+ */
 [data-theme="dark-abyss"] {
   color-scheme: dark;
 
@@ -48,52 +94,6 @@
   /* Overlays */
   --overlay-backdrop: hsl(0 0 0 / 80%);
   --shadow-default: hsl(0 0 0 / 25%);
-
-  --transition-default: 0.3s;
-}
-
-/*
- * Theme 02 — Light Beach. Redefines the same 22 roles as the dark block above.
- * Scoped to the attribute only (no :root), so it sits later in source order and
- * wins over the dark block's :root defaults at equal specificity — placement,
- * not specificity, is what makes it override. See theme-css.test.ts for parity.
- */
-[data-theme="light-beach"] {
-  color-scheme: light;
-
-  /* Surfaces — warm sand, layered down */
-  --background: #f3eee2;
-  --surface: #ece6d7;
-  --surface-panel: #e7e0cf;
-  --surface-raised: #e1d9c6;
-  --surface-overlay: hsl(40 25% 25% / 6%);
-
-  /* Borders */
-  --border: hsl(40 20% 30% / 15%);
-  --border-strong: #a89c81;
-
-  /* Text — warm ink, darkest on the lightest surface */
-  --text: #403a2f;
-  --text-muted: #5e5847;
-  --text-subtle: #948b74;
-
-  /* Accents — near-black ink; hover/strong go darker (inverse of dark theme) */
-  --accent: #2b2a27;
-  --accent-hover: #403d37;
-  --accent-strong: #141412; /* pressed / elevated underside */
-  --accent-secondary: #6d6b65;
-  --accent-secondary-hover: #6b6862;
-  --on-accent: #f6f3ea; /* text on accent fills */
-
-  /* Status */
-  --success: #57876a;
-  --warning: #9c7d45;
-  --error: #ad6553;
-  --info: #8a8475;
-
-  /* Overlays */
-  --overlay-backdrop: hsl(40 25% 15% / 40%);
-  --shadow-default: hsl(40 25% 25% / 18%);
 
   --transition-default: 0.3s;
 }
@@ -1005,12 +1005,12 @@
 }
 
 :root .c-all-day-checkbox:checked,
-[data-theme="dark-abyss"] .c-all-day-checkbox:checked {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M3.5 8.5L6.5 11.5L12.5 4.5' stroke='%2305121a' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
-}
-
 [data-theme="light-beach"] .c-all-day-checkbox:checked {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M3.5 8.5L6.5 11.5L12.5 4.5' stroke='%23f6f3ea' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+}
+
+[data-theme="dark-abyss"] .c-all-day-checkbox:checked {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M3.5 8.5L6.5 11.5L12.5 4.5' stroke='%2305121a' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
 }
 
 /*

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -1,33 +1,27 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="light-beach">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#06090f" />
+    <meta name="theme-color" content="#f3eee2" />
 
     <!--
-      Apply the theme before first paint so light visitors don't flash the
-      default dark palette while the app boots (index.tsx awaits IndexedDB
-      first). Runs pre-module, so the key + colors are hard-coded here; keep
-      them in sync with settings/theme/theme.constants.ts and
-      settings/theme/theme.util.ts. Dark is the CSS default, so only light
-      needs touching. An explicit stored choice wins; otherwise follow
-      prefers-color-scheme.
+      Apply a stored dark theme before first paint so those visitors don't
+      flash the default light palette while the app boots (index.tsx awaits
+      IndexedDB first). Runs pre-module, so the key + colors are hard-coded
+      here; keep them in sync with settings/theme/theme.constants.ts and
+      settings/theme/theme.util.ts. Light is the CSS default, so only dark
+      needs touching. An explicit stored choice wins.
     -->
     <script>
       try {
         const stored = localStorage.getItem("compass.theme");
-        const useLight =
-          stored === "light-beach" ||
-          (stored === null &&
-            window.matchMedia &&
-            window.matchMedia("(prefers-color-scheme: light)").matches);
-        if (useLight) {
-          document.documentElement.setAttribute("data-theme", "light-beach");
+        if (stored === "dark-abyss") {
+          document.documentElement.setAttribute("data-theme", "dark-abyss");
           document
             .querySelector('meta[name="theme-color"]')
-            .setAttribute("content", "#f3eee2");
+            .setAttribute("content", "#06090f");
         }
       } catch {}
     </script>

--- a/packages/web/src/settings/theme/theme.constants.ts
+++ b/packages/web/src/settings/theme/theme.constants.ts
@@ -13,11 +13,11 @@ export const THEMES = {
 export type ThemeName = keyof typeof THEMES;
 
 /**
- * Dark is the CSS :root fallback and the value used when
- * `prefers-color-scheme` is dark or unavailable. Light is applied only when
- * the visitor stored `light-beach` or the OS is light and nothing is stored.
+ * Light is the CSS :root fallback and the value used when nothing is stored
+ * or the stored value is unknown. Dark is applied only when the visitor
+ * stored `dark-abyss`.
  */
-export const DEFAULT_THEME: ThemeName = "dark-abyss";
+export const DEFAULT_THEME: ThemeName = "light-beach";
 
 /**
  * localStorage key for the persisted choice, registered in the app-wide

--- a/packages/web/src/settings/theme/theme.store.test.ts
+++ b/packages/web/src/settings/theme/theme.store.test.ts
@@ -37,20 +37,20 @@ describe("theme store + util", () => {
     restoreMatchMedia = undefined;
   });
 
-  it("falls back to the default theme when nothing is stored and OS is dark", () => {
+  it("uses the light default when nothing is stored, even if OS is dark", () => {
     restoreMatchMedia = stubColorScheme(false);
-    expect(readStoredTheme()).toBe("dark-abyss");
+    expect(readStoredTheme()).toBe("light-beach");
   });
 
-  it("follows prefers-color-scheme light when nothing is stored", () => {
+  it("uses the light default when nothing is stored and OS is light", () => {
     restoreMatchMedia = stubColorScheme(true);
     expect(readStoredTheme()).toBe("light-beach");
   });
 
-  it("falls back to the default theme for an unknown stored value", () => {
-    restoreMatchMedia = stubColorScheme(true);
+  it("falls back to the light default for an unknown stored value", () => {
+    restoreMatchMedia = stubColorScheme(false);
     persistentBrowserStore.set(THEME_STORAGE_KEY, "neon-swamp");
-    expect(readStoredTheme()).toBe("dark-abyss");
+    expect(readStoredTheme()).toBe("light-beach");
   });
 
   it("reads back a valid stored theme", () => {

--- a/packages/web/src/settings/theme/theme.util.ts
+++ b/packages/web/src/settings/theme/theme.util.ts
@@ -10,28 +10,11 @@ export const isThemeName = (value: string | null): value is ThemeName =>
   value !== null && value in THEMES;
 
 /**
- * OS light/dark when the visitor has never stored a theme. Guests on public
- * pages hit this path; signed-in users who picked a theme do not.
- */
-export const readPreferredColorSchemeTheme = (): ThemeName => {
-  if (typeof window.matchMedia !== "function") {
-    return DEFAULT_THEME;
-  }
-  return window.matchMedia("(prefers-color-scheme: light)").matches
-    ? "light-beach"
-    : DEFAULT_THEME;
-};
-
-/**
  * The persisted theme. An explicit stored choice always wins. When the key is
- * missing, follow `prefers-color-scheme`. Unknown stored values keep the
- * dark default so a corrupt key does not flip the palette on every visit.
+ * missing or unknown, use the light default.
  */
 export const readStoredTheme = (): ThemeName => {
   const stored = persistentBrowserStore.get(THEME_STORAGE_KEY);
-  if (stored === null) {
-    return readPreferredColorSchemeTheme();
-  }
   return isThemeName(stored) ? stored : DEFAULT_THEME;
 };
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,9 +18,9 @@ export default defineConfig({
   },
   use: {
     baseURL: `http://localhost:${TEST_PORT}`,
-    // Historic app tests assume Dark Abyss tokens. Guest booking specs that
-    // cover prefers-color-scheme override this per test.
-    colorScheme: "dark",
+    // Product default is Light Beach. Specs that need Dark Abyss set
+    // compass.theme in localStorage.
+    colorScheme: "light",
     trace: "on-first-retry",
   },
   projects: [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First-time visitors now land on Light Beach instead of Dark Abyss. The CSS `:root` fallback, the unstored JS default, the no-flash boot script, and the `theme-color` meta all use the light palette. An explicit stored `dark-abyss` choice still wins. `prefers-color-scheme` no longer selects the unstored theme.

![Week view on the light default](https://cursor.com/artifacts/c/art-302c0027-e30f-4e0d-9eaf-174c509a191a)

<a href="https://cursor.com/agents/bc-eec2c396-8f85-4501-812a-fb434b5cba1e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdefault_light_theme_and_toggle_to_dark.mp4"><img src="https://cursor.com/artifacts/c/art-458179e7-5a79-48f6-a44e-19bb1f02cc9d" alt="default_light_theme_and_toggle_to_dark.mp4" /></a>

## Simplicity

The unstored path now returns `DEFAULT_THEME` (`light-beach`) instead of branching on OS color scheme. The no-flash script only applies dark when `compass.theme` is `dark-abyss`. Light is the HTML and CSS default, so that is the only override.

## Automated validation

Local `bun run verify` PASS. Checks run: `test:web`, `type-check`, `lint`, `knip`, `test:a11y`, `test:e2e`. None skipped.

Browser: anonymous week view at `http://localhost:9080` loads with `data-theme="light-beach"` after clearing `compass.theme`. Command palette offers "Switch to dark theme" and applying it paints Dark Abyss.

## Independent review

VERDICT: no confirmed findings

Reviewed the full `origin/main...HEAD` diff for theme fallback, no-flash boot, CSS `:root` order, checkbox stroke pairing, and test/docs alignment. Stored `dark-abyss` still wins. Unstored visitors no longer follow OS dark.

## Test plan

- `bun test:web` (theme store, CSS parity, command palette labels)
- `bunx playwright test` booking theme + calendar column spec
- `bun run verify` (test:web, type-check, lint, knip, test:a11y, test:e2e)
- Browser: first load light default, command-palette toggle to dark

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eec2c396-8f85-4501-812a-fb434b5cba1e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eec2c396-8f85-4501-812a-fb434b5cba1e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

