### PR TITLE
fix(web): pin booking keyboard hints to the sticky save bar

### DIFF
--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -195,7 +195,9 @@ describe("BookingSettingsSection", () => {
     const save = await screen.findByRole("button", {
       name: "Save booking settings",
     });
-    expect(save.parentElement?.parentElement?.className).toContain("sticky");
+    const stickyBar = save.parentElement?.parentElement;
+    expect(stickyBar?.className).toContain("sticky");
+    expect(stickyBar).toHaveTextContent("then a letter to jump to a field");
 
     await user.selectOptions(screen.getByLabelText("Duration"), "30");
     await user.click(

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -687,12 +687,11 @@ export function BookingSettingsSection({
             {saveMutation.isPending ? "Saving…" : "Save booking settings"}
           </OverlayPanelActionButton>
         </OverlayPanelActions>
+        <p className="mt-2 flex flex-wrap items-center gap-x-1 text-text-muted text-xs">
+          Press <kbd>e</kbd> then a letter to jump to a field.
+          <ShortcutKeys keys={["Mod", "Enter"]} /> saves.
+        </p>
       </div>
-
-      <p className="flex flex-wrap items-center gap-x-1 text-text-muted text-xs">
-        Press <kbd>e</kbd> then a letter to jump to a field.
-        <ShortcutKeys keys={["Mod", "Enter"]} /> saves.
-      </p>
 
       <EditSequenceMenu
         getAnchor={() => sectionRef.current}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The booking settings keyboard hint ("Press e then a letter to jump to a field. Mod+Enter saves.") rendered after the sticky save bar, so it was off-screen on a long form.

The hint now lives inside the sticky save bar, pinned with the Save button. Per-field hints, hold-Mod chips, and the e which-key overlay are unchanged.

Fixes #3085

## Simplicity

Moved the existing paragraph into the sticky container. No new layout primitive.

## Automated validation

`bun run verify` first pass failed on a flake in `e2e/accessibility/app-a11y.spec.ts` ("the event action row is accessible", contrast on an unrelated Open/N shortcut chip). Retry of `bun test:a11y` passed 24/24. `bun test:e2e` passed. Other verify checks (test:web, type-check, lint, knip) passed on the first run.

## Independent review

VERDICT: no confirmed findings

Hint copy, per-field aria-describedby, and save shortcut wiring are unchanged. The sticky container still uses `bg-surface-panel` so scrolling content does not show through.

## Test plan

- `bun test:web packages/web/src/booking/BookingSettingsSection.test.tsx`
- `bun test:a11y` (retry after flake)
- `bun test:e2e`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6e2dba1-cfc3-4458-b158-14d650287a70?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6e2dba1-cfc3-4458-b158-14d650287a70&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

