### PR TITLE
fix(web): unwrap posthog's rejection prefix before dropping known noise

### DIFF
--- a/packages/web/src/auth/posthog/posthog-exception-filter.util.test.ts
+++ b/packages/web/src/auth/posthog/posthog-exception-filter.util.test.ts
@@ -62,6 +62,24 @@ describe("filterPosthogBeforeSend", () => {
     ).toBeNull();
   });
 
+  // The shape production actually sends: posthog-js wraps a non-Error
+  // rejection value in its own prefix before before_send sees it. Asserting
+  // the bare string alone let an anchored pattern pass here and never match
+  // a real payload.
+  it("drops the CefSharp scanner signature as posthog-js wraps it", () => {
+    expect(
+      filterPosthogBeforeSend(
+        exceptionEvent([
+          {
+            type: "UnhandledRejection",
+            value:
+              "Non-Error promise rejection captured with value: Object Not Found Matching Id:4, MethodName:update, ParamCount:4",
+          },
+        ]),
+      ),
+    ).toBeNull();
+  });
+
   it("drops the CefSharp scanner signature regardless of the scan id", () => {
     expect(
       filterPosthogBeforeSend(
@@ -74,6 +92,31 @@ describe("filterPosthogBeforeSend", () => {
         ]),
       ),
     ).toBeNull();
+  });
+
+  it("drops a primitive-wrapped ResizeObserver warning", () => {
+    expect(
+      filterPosthogBeforeSend(
+        exceptionEvent([
+          {
+            type: "UnhandledRejection",
+            value:
+              "Primitive value captured as exception: ResizeObserver loop limit exceeded",
+          },
+        ]),
+      ),
+    ).toBeNull();
+  });
+
+  it("keeps a wrapped rejection that carries app stack frames", () => {
+    const event = exceptionEvent([
+      {
+        type: "UnhandledRejection",
+        value: "Non-Error promise rejection captured with value: Script error.",
+        stacktrace: { frames: [{ filename: "/index.js", function: "boot" }] },
+      },
+    ]);
+    expect(filterPosthogBeforeSend(event)).toBe(event);
   });
 
   it("drops opaque browser Script error. with no stack frames", () => {

--- a/packages/web/src/auth/posthog/posthog-exception-filter.util.ts
+++ b/packages/web/src/auth/posthog/posthog-exception-filter.util.ts
@@ -2,9 +2,29 @@ import { type CaptureResult } from "posthog-js";
 import { isTransientBrowserNetworkMessage } from "@web/api/util/backend-unavailable-error.util";
 
 /**
+ * posthog-js does not hand `before_send` the raw rejection value: when a
+ * promise rejects with a non-Error (or a primitive), the SDK stringifies it
+ * behind one of these prefixes. Every message comparison below has to run on
+ * the unwrapped value, or an anchored pattern silently never matches in
+ * production while passing against a hand-written bare string in a test.
+ */
+const SDK_WRAPPER_PREFIXES = [
+  "Non-Error promise rejection captured with value: ",
+  "Primitive value captured as exception: ",
+];
+
+const unwrapSdkMessage = (value: string): string => {
+  const prefix = SDK_WRAPPER_PREFIXES.find((candidate) =>
+    value.startsWith(candidate),
+  );
+  return prefix ? value.slice(prefix.length) : value;
+};
+
+/**
  * Unhandledrejection signature emitted by CefSharp / embedded WebView
  * automation scanners. No app frames, not actionable. The numeric id varies
  * per scan (seen Id:1, Id:2, ...), so match the shape rather than one value.
+ * Anchored against the unwrapped message - see `unwrapSdkMessage`.
  */
 const CEFSHARP_SCANNER_MESSAGE_PATTERN =
   /^Object Not Found Matching Id:\d+, MethodName:update, ParamCount:4$/;
@@ -71,13 +91,15 @@ const hasStackFrames = (entry: ExceptionEntry): boolean => {
 const isDroppableException = (entry: ExceptionEntry): boolean => {
   if (typeof entry.value !== "string") return false;
 
-  if (CEFSHARP_SCANNER_MESSAGE_PATTERN.test(entry.value)) return true;
+  const message = unwrapSdkMessage(entry.value);
 
-  if (RESIZE_OBSERVER_LOOP_MESSAGES.has(entry.value)) return true;
+  if (CEFSHARP_SCANNER_MESSAGE_PATTERN.test(message)) return true;
+
+  if (RESIZE_OBSERVER_LOOP_MESSAGES.has(message)) return true;
 
   // Opaque cross-origin errors. Keep the rare case where frames somehow
   // survived sanitization so a real stack is never discarded.
-  if (entry.value === SCRIPT_ERROR_MESSAGE && !hasStackFrames(entry)) {
+  if (message === SCRIPT_ERROR_MESSAGE && !hasStackFrames(entry)) {
     return true;
   }
 
@@ -86,7 +108,7 @@ const isDroppableException = (entry: ExceptionEntry): boolean => {
   // only creates noise. SuperTokens' session fetch often rejects outside our
   // `doesSessionExist` try/catch, so client-side catch alone can't cover it.
   return (
-    entry.type === "TypeError" && isTransientBrowserNetworkMessage(entry.value)
+    entry.type === "TypeError" && isTransientBrowserNetworkMessage(message)
   );
 };
 


### PR DESCRIPTION
## Why

Nine `\$exception` events fired from prod on 2026-09-01 after six quiet days, which looked like a regression from that day's ~20 web PRs. It isn't one.

All 9 were **one anonymous visitor, one session, 97 milliseconds**, with `synthetic: true` and **zero stack frames** even with `onlyAppFrames: false` — the CefSharp/embedded-WebView signature this repo already filters. The same signature fired 8 times on **2026-08-21** (`Id:1`), eleven days before any Sept 1 commit. Browser exceptions arrive in isolated bursts (Aug 2, 13, 14, 18, 21, Sep 1) with multi-day zero gaps throughout, so the quiet window was a gap, not a baseline.

The actual defect: **the filter for exactly this signature has never worked.**

`posthog-exception-filter.util.ts` matched the value with an anchored pattern:

```
/^Object Not Found Matching Id:\d+, MethodName:update, ParamCount:4$/
```

But posthog-js does not hand `before_send` the raw rejection value — a non-Error rejection is stringified behind `Non-Error promise rejection captured with value: `. The `^` anchor therefore could not match a real payload. The `Set.has()` / `===` checks for the ResizeObserver warnings and `Script error.` have the identical hole.

The tests hid it: they fed the **bare, unprefixed** string with `type: "Error"` — the wrong shape — so they passed while production kept filing issues. #2839 correctly fixed "the id varies per scan" and inherited the anchor flaw.

## What changed

- Unwrap the SDK's wrapper prefix **once** at the top of `isDroppableException`, so every comparison below runs on the real message. Placing it at the boundary closes the ResizeObserver and `Script error.` holes at the same time.
- Kept the regex anchored — `^...$` was never the bug, it was being applied to the wrong string. Loosening it to a substring match would have hidden the defect and widened what gets silently dropped.
- Corrected the fixtures to the payload production actually sends (`type: "UnhandledRejection"`, prefixed value), kept a bare-string case, and added a case asserting a wrapped rejection **with app stack frames** is not dropped, so the normalization can't over-match.

## Verification

- Fixtures were corrected **first**: they failed against the unfixed filter (2 fail / 14 pass), proving the tests were the blind spot. After the fix 16/16, and 33/33 across `src/auth/posthog/`.
- `bun run lint` and `bun run type-check` both exit 0.
- No browser-preview check: the payload comes from an injected third-party script, so the preview cannot produce it — unit tests are the only real proof. Prod confirmation waits on the manual deploy dispatch, then re-checking PostHog issue `01a02693-a9c0-72b0-b7f5-2ee68a0db95a`.

## Not in scope

That session logged **607 console errors in 13 active seconds**, the highest rate in the Aug 25–Sep 2 window. `capture_console_errors: false` is deliberate, so none reached error tracking. Likely the same injected script, but unverified — worth a separate look rather than expanding this change.

Also confirmed, since it was asked: the affected visitor had **no degraded experience** — 0 clicks, 0 keypresses, no rage clicks, no dead clicks (rage-click capture is healthy project-wide, so the absence is real).

🤖 Generated with [Claude Code](https://claude.com/claude-code)