### PR TITLE
fix(web): map booking save failures to actionable toasts

### DIFF
--- a/packages/web/src/api/util/api.util.test.ts
+++ b/packages/web/src/api/util/api.util.test.ts
@@ -159,6 +159,23 @@ describe("getApiErrorMessage", () => {
     ).toBeUndefined();
     expect(getApiErrorMessage(new Error("nope"))).toBeUndefined();
   });
+
+  it("returns the message string from a { code, message } envelope", () => {
+    const error = createApiError({
+      data: {
+        code: "BLOCKING_CALENDAR_INVALID",
+        message: "Calendar is not readable",
+      },
+    });
+    expect(getApiErrorMessage(error)).toBe("Calendar is not readable");
+  });
+
+  it("prefers data.error over data.message when both exist", () => {
+    const error = createApiError({
+      data: { error: "Billing copy", message: "Ignored envelope" },
+    });
+    expect(getApiErrorMessage(error)).toBe("Billing copy");
+  });
 });
 
 describe("getApiErrorCode", () => {

--- a/packages/web/src/api/util/api.util.ts
+++ b/packages/web/src/api/util/api.util.ts
@@ -93,13 +93,16 @@ export const getApiErrorCode = (error: ApiError): string | undefined => {
   return typeof code === "string" ? code : undefined;
 };
 
-/** Safe `error` string from a JSON `{ error: string }` API body, if present. */
+/** Safe user-facing string from a JSON API body, if present. */
 export const getApiErrorMessage = (error: unknown): string | undefined => {
   if (!isApiError(error)) return undefined;
   const data = getApiErrorData(error);
-  if (!data || typeof data !== "object" || !("error" in data)) return undefined;
-  const message = (data as { error?: unknown }).error;
-  return typeof message === "string" && message.trim() ? message : undefined;
+  if (!data || typeof data !== "object") return undefined;
+  const record = data as { error?: unknown; message?: unknown };
+  for (const value of [record.error, record.message]) {
+    if (typeof value === "string" && value.trim()) return value;
+  }
+  return undefined;
 };
 
 export const parseApiError = <T>(

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -5,6 +5,7 @@ import userEvent from "@testing-library/user-event";
 import { rest } from "msw";
 import { CalendarIdSchema } from "@core/types/domain-primitives";
 import { server } from "@web/__tests__/__mocks__/server/mock.server";
+import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
 import {
   createMockCalendar,
@@ -23,6 +24,10 @@ import {
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { ENV_WEB } from "@web/common/constants/env.constants";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
+import {
+  registerToastPort,
+  resetToastPort,
+} from "@web/common/utils/toast/toast.port";
 import { useSettingsShortcuts } from "@web/settings/useSettingsShortcuts";
 import {
   clearAppLockReasons,
@@ -45,6 +50,7 @@ afterEach(() => {
   setPinnedTimeZone(null);
   clearAppLockReasons();
   setClipboard(originalClipboard);
+  resetToastPort();
 });
 
 const writableCalendar = createMockCalendar({
@@ -915,6 +921,8 @@ describe("BookingSettingsSection", () => {
 
   it("shows an error on PUT 403 without crashing Settings", async () => {
     const user = userEvent.setup({ delay: null });
+    const { port, mocks } = createTestToastPort();
+    registerToastPort(port);
 
     userMetadataActions.set(healthyGoogleMetadata);
 
@@ -965,6 +973,77 @@ describe("BookingSettingsSection", () => {
     expect(
       screen.getByRole("button", { name: "Save booking settings" }),
     ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mocks.error).toHaveBeenCalledWith(
+        "Could not save booking settings. Please try again.",
+        expect.any(Object),
+      );
+    });
+    expect(String(mocks.error.mock.calls[0]?.[0])).not.toMatch(
+      /Request failed for/,
+    );
+  });
+
+  it("explains a blocking-calendar save failure without transport text", async () => {
+    const user = userEvent.setup({ delay: null });
+    const { port, mocks } = createTestToastPort();
+    registerToastPort(port);
+
+    userMetadataActions.set(healthyGoogleMetadata);
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(
+          ctx.json({
+            enabled: false,
+            durationMinutes: 30,
+            destinationCalendarId: writableCalendar.id,
+            blockingCalendarIds: [writableCalendar.id],
+            timeZone: "UTC",
+            weeklyAvailability: [],
+            minNoticeHours: 4,
+            maxHorizonDays: 60,
+            bufferMinutes: null,
+            maxBookingsPerDay: null,
+            guestsCanInviteOthers: true,
+          }),
+        ),
+      ),
+      rest.put(bookingPageUrl, (_req, res, ctx) =>
+        res(
+          ctx.status(400),
+          ctx.json({
+            code: "BLOCKING_CALENDAR_INVALID",
+            message: "Calendar is not readable",
+          }),
+        ),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    await screen.findByRole("button", { name: "Save booking settings" });
+    await user.click(
+      screen.getByRole("button", { name: "Save booking settings" }),
+    );
+
+    await waitFor(() => {
+      expect(mocks.error).toHaveBeenCalledWith(
+        "One of your blocking calendars can't be checked for busy times. Uncheck it and save again.",
+        expect.any(Object),
+      );
+    });
+    expect(String(mocks.error.mock.calls[0]?.[0])).not.toMatch(
+      /Request failed for/,
+    );
   });
 
   it("shows an inline error for a cleared horizon field and blocks save", async () => {

--- a/packages/web/src/booking/booking.query.ts
+++ b/packages/web/src/booking/booking.query.ts
@@ -35,6 +35,15 @@ export function useBookingPageQuery(enabled: boolean) {
   });
 }
 
+const BOOKING_SAVE_ERROR_COPY: Record<string, string> = {
+  BLOCKING_CALENDAR_INVALID:
+    "One of your blocking calendars can't be checked for busy times. Uncheck it and save again.",
+  DESTINATION_NOT_WRITABLE:
+    "The destination calendar can't accept new events. Choose a different calendar and save again.",
+  INVALID_INPUT:
+    "Some settings couldn't be saved. Check the highlighted fields and try again.",
+};
+
 function handleBookingSaveError(
   error: unknown,
   queryClient: QueryClient,
@@ -54,8 +63,9 @@ function handleBookingSaveError(
       });
       return;
     }
-    if (error.message) {
-      showErrorToast(error.message);
+    const copy = code ? BOOKING_SAVE_ERROR_COPY[code] : undefined;
+    if (copy) {
+      showErrorToast(copy);
       return;
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Saving booking settings showed transport text like "Request failed for PUT /booking/page with status 400" because `handleBookingSaveError` echoed `error.message` and `getApiErrorMessage` only read `{ error }`, not the booking `{ code, message }` envelope.

`getApiErrorMessage` now reads `message` as well (preferring `error` when both exist). Booking save maps known codes to actionable copy and never surfaces "Request failed for..." on that path.

Fixes #3086

## Simplicity

A small code-to-copy map in the existing save-error handler. No new toast stack.

## Automated validation

`bun run verify` PASS.

Selected packages: web
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)

Focused: BookingSettingsSection toast-port assertions for `BLOCKING_CALENDAR_INVALID` and PUT 403; `api.util.test` envelope coverage.

## Independent review

VERDICT: no confirmed findings

BILLING_REQUIRED still opens billing instead of toasting. Unknown codes and network failures use the existing fallback. No em-dashes in the new copy. `getApiErrorMessage` still prefers `{ error }` so billing strings stay unchanged.

## Test plan

- `bun test:web packages/web/src/booking/BookingSettingsSection.test.tsx packages/web/src/api/util/api.util.test.ts`
- `bun run verify`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6e2dba1-cfc3-4458-b158-14d650287a70?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6e2dba1-cfc3-4458-b158-14d650287a70&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

