### PR TITLE
feat(web): hand-hold the Block Party onboarding game

### DIFF
--- a/e2e/onboarding/shortcut-showcase.spec.ts
+++ b/e2e/onboarding/shortcut-showcase.spec.ts
@@ -119,7 +119,7 @@ const clearTheQueue = async (page: Page) => {
 
   // place-party: down to 5pm, lock.
   await page.keyboard.press("c");
-  await pressTimes(page, "ArrowDown", 4);
+  await pressTimes(page, "ArrowDown", 2);
   await page.keyboard.press("Enter");
   await expect(showcase).toContainText("You cleared the week!");
 };
@@ -134,6 +134,24 @@ test("exploring without an account offers the game's how-to card", async ({
   await expect(showcase).toBeVisible();
   await expect(showcase).toContainText("Block Party");
   await expect(showcase).toContainText("keyboard-only");
+});
+
+test("stalling on a task surfaces its hint, and progress clears it", async ({
+  page,
+}) => {
+  await page.goto("/week", { waitUntil: "domcontentloaded" });
+  await leaveWelcome(page);
+  await startPracticing(page);
+
+  const showcase = page.getByRole("region", { name: "Shortcut practice" });
+  const hint = "Tap Left to reach Monday";
+  await expect(showcase).not.toContainText(hint);
+  // The hint lands after 7 idle seconds on the task.
+  await expect(showcase).toContainText(hint, { timeout: 9_000 });
+
+  // Real progress resets the stall and the hint goes away.
+  await page.keyboard.press("c");
+  await expect(showcase).not.toContainText(hint);
 });
 
 test("a full run clears the queue, shows the score, and graduates", async ({

--- a/packages/web/src/auth/posthog/track.ts
+++ b/packages/web/src/auth/posthog/track.ts
@@ -16,6 +16,7 @@ export type ProductEvent =
   | "shortcut_game_task_shown"
   | "shortcut_game_task_completed"
   | "shortcut_game_task_skipped"
+  | "shortcut_game_hint_shown"
   | "shortcut_game_replayed"
   | "first_event_prompt_shown"
   | "first_event_prompt_completed"

--- a/packages/web/src/components/ShortcutShowcase/GameHud.tsx
+++ b/packages/web/src/components/ShortcutShowcase/GameHud.tsx
@@ -3,6 +3,7 @@ import { type GameAward } from "@web/components/ShortcutShowcase/game.state";
 import {
   type GameTask,
   RUN_TASKS,
+  STUCK_SKIP_HINT,
   streakMultiplier,
 } from "@web/components/ShortcutShowcase/game.tasks";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
@@ -94,17 +95,21 @@ export const GameTaskQueue: FC<{
   taskIndex: number;
   keycaps: readonly string[];
   nextKeycapIndex: number;
-}> = ({ taskIndex, keycaps, nextKeycapIndex }) => {
+  /** 0 none, 1 the task's hint, 2 hint plus the Esc escape hatch. */
+  hintStage: 0 | 1 | 2;
+}> = ({ taskIndex, keycaps, nextKeycapIndex, hintStage }) => {
   const task: GameTask | undefined = RUN_TASKS[taskIndex];
   if (!task) return null;
   const upNext = RUN_TASKS.slice(taskIndex + 1, taskIndex + 3);
-  // Shift/Mod lead a chord, so their partner chip pulses too. The page-jump
-  // task is the exception: Mod is held alone first, the digit comes later.
+  // Mod leads a chord (undo, palette): its partner pulses with it. The
+  // page-jump task is the exception: Mod is held alone first.
   const nextKey = keycaps[nextKeycapIndex];
   const chordPartnerIndex =
-    task.type !== "pageJump" && (nextKey === "Shift" || nextKey === "Mod")
-      ? nextKeycapIndex + 1
-      : -1;
+    task.type !== "pageJump" && nextKey === "Mod" ? nextKeycapIndex + 1 : -1;
+  // Shift stays held through the arrow run: it pulses with the arrows behind
+  // it instead of dimming as done.
+  const shiftIndex = keycaps.indexOf("Shift");
+  const shiftHeld = shiftIndex !== -1 && nextKeycapIndex > shiftIndex;
 
   return (
     <div className="flex flex-col gap-3">
@@ -117,13 +122,28 @@ export const GameTaskQueue: FC<{
       >
         <h3 className="font-semibold text-lg text-text">{task.title}</h3>
         <p className="pt-1 text-sm text-text-muted">{task.instruction}</p>
+        {hintStage > 0 && (
+          <p className="c-game-hint-in pt-2 text-accent text-sm" role="status">
+            {task.hint}
+          </p>
+        )}
+        {hintStage > 1 && (
+          <p
+            className="c-game-hint-in pt-1 text-text-muted text-xs"
+            role="status"
+          >
+            {STUCK_SKIP_HINT}
+          </p>
+        )}
         <div className="flex items-center gap-1 pt-3">
           {keycaps.map((key, index) => (
             <ShortcutHint
               key={`${key}-${index}`}
               variant="keycap"
               className={
-                index === nextKeycapIndex || index === chordPartnerIndex
+                index === nextKeycapIndex ||
+                index === chordPartnerIndex ||
+                (shiftHeld && index === shiftIndex)
                   ? "c-keycap-next"
                   : index < nextKeycapIndex
                     ? "opacity-40"

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
@@ -100,7 +100,7 @@ const playWinningRun = async () => {
   pressKey("ArrowLeft", { shiftKey: true });
   // place-party
   pressKey("c");
-  for (let i = 0; i < 4; i += 1) pressKey("ArrowDown");
+  for (let i = 0; i < 2; i += 1) pressKey("ArrowDown");
   pressKey("Enter");
 };
 

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.tsx
@@ -45,7 +45,6 @@ import {
   TEXT_BUTTON_CLASS,
 } from "@web/components/ShortcutShowcase/showcase-buttons";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
-import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import { hasSeenWelcome } from "@web/components/WelcomeModal/welcome.modal.util";
 import { settingsActions } from "@web/settings/settings.store";
 import { useAppLockReason } from "@web/shortcuts/app-lock";
@@ -71,6 +70,11 @@ const HUD_TICK_MS = 250;
 
 /** How long a bare Mod hold takes to reveal the practice page-jump numbers. */
 const MOD_HOLD_REVEAL_MS = 600;
+
+/** Stall this long on a task and its card shows the more explicit hint. */
+const IDLE_HINT_MS = 7_000;
+/** Stall the same again and the card also offers the Esc escape hatch. */
+const IDLE_ESCALATE_MS = 7_000;
 
 /**
  * Block Party: the full-screen practice arena shown before a new user ever
@@ -241,6 +245,33 @@ const ShowcaseTakeover: FC = () => {
     }, HUD_TICK_MS);
     return () => window.clearInterval(id);
   }, [game.phase, game.timed, game.buzzer]);
+
+  // Stall detection for the task card's hint. Keyed on the game object
+  // itself: handleGameKey/tick return the SAME reference on no-op input, so
+  // only real progress (or a task change) resets the idle clock. Wrong-key
+  // mashing still counts as stuck.
+  const [hintStage, setHintStage] = useState<0 | 1 | 2>(0);
+  useEffect(() => {
+    setHintStage(0);
+    if (game.phase !== "running") return;
+    const t1 = window.setTimeout(() => setHintStage(1), IDLE_HINT_MS);
+    const t2 = window.setTimeout(
+      () => setHintStage(2),
+      IDLE_HINT_MS + IDLE_ESCALATE_MS,
+    );
+    return () => {
+      window.clearTimeout(t1);
+      window.clearTimeout(t2);
+    };
+  }, [game]);
+
+  useEffect(() => {
+    if (hintStage === 0) return;
+    track("shortcut_game_hint_shown", {
+      task_id: currentTask(gameRef.current)?.id ?? "none",
+      stage: hintStage,
+    });
+  }, [hintStage]);
 
   const seatFocus = () => {
     const root = regionRef.current;
@@ -639,7 +670,9 @@ const ShowcaseTakeover: FC = () => {
         <div
           className={`flex h-[80vh] max-h-160 w-full max-w-5xl gap-8 px-8 ${closing ? "c-showcase-enter-stage" : ""}`}
         >
-          <aside className="flex w-80 shrink-0 flex-col justify-center gap-4">
+          <aside
+            className={`flex w-80 shrink-0 flex-col justify-center gap-4 ${game.phase === "howto" ? "c-showcase-howto-in" : ""}`}
+          >
             {game.phase === "howto" ? (
               <>
                 <p className="font-medium text-accent text-xs uppercase tracking-wide">
@@ -649,35 +682,24 @@ const ShowcaseTakeover: FC = () => {
                   Compass is keyboard-only. Ready?
                 </h2>
                 <p className="text-sm text-text-muted">
-                  Your week needs scheduling. Work through the queue of tasks;
-                  each card teaches the move as it comes, and nothing here is
-                  saved. No clock on your first run.
+                  Schedule a practice week one task at a time. Each card shows
+                  the exact keys to press, and nothing is saved. No clock on
+                  your first run.
                 </p>
-                <div className="flex flex-col gap-1.5 text-sm text-text">
-                  <span className="flex items-center gap-2">
-                    <ShortcutKeys keys={[...KEYMAP.createEvent.keycaps]} />
-                    drops the next piece
-                  </span>
-                  <span className="flex items-center gap-2">
-                    <ShortcutKeys keys={["ArrowLeft", "ArrowDown"]} />
-                    move it into the outline
-                  </span>
-                  <span className="flex items-center gap-2">
-                    <ShortcutKeys keys={[...KEYMAP.saveDraft.keycaps]} />
-                    locks it in
-                  </span>
-                </div>
               </>
             ) : (
               <GameTaskQueue
                 taskIndex={game.taskIndex}
                 keycaps={task ? getDisplayKeycaps(task, game) : []}
                 nextKeycapIndex={task ? getNextKeycapIndex(task, game) : 0}
+                hintStage={hintStage}
               />
             )}
             {skipControls}
           </aside>
-          <div className="flex min-w-0 flex-1 flex-col">
+          <div
+            className={`flex min-w-0 flex-1 flex-col transition-opacity duration-500 motion-reduce:transition-none ${game.phase === "howto" ? "opacity-25" : "opacity-100"}`}
+          >
             {isRunning && (
               <GameHud
                 remainingSeconds={remainingSeconds}

--- a/packages/web/src/components/ShortcutShowcase/game.state.test.ts
+++ b/packages/web/src/components/ShortcutShowcase/game.state.test.ts
@@ -96,10 +96,8 @@ const WINNING_SCRIPT: GameKey[] = [
   key.closeOverlay,
   // nudge-review: Wed -> Tue
   key.arrow("left", true),
-  // place-party: spawn Wed 4pm, walk down to 5pm, lock
+  // place-party: spawn Wed 4:30pm, walk down to 5pm, lock
   key.create,
-  key.arrow("down"),
-  key.arrow("down"),
   key.arrow("down"),
   key.arrow("down"),
   key.enter,
@@ -397,7 +395,7 @@ describe("keycap progress", () => {
     expect(getNextKeycapIndex(task, state)).toBe(task.keycaps.length - 1);
   });
 
-  it("moves from Tab to Shift+Down once the resize edge is focused", () => {
+  it("walks both Tab chips, then the Shift+Down chips, on the resize card", () => {
     let state = playKeys(
       startRun(createInitialGameState(), T0),
       WINNING_SCRIPT.slice(0, 16),
@@ -409,8 +407,67 @@ describe("keycap progress", () => {
     expect(task.id).toBe("resize-one-on-one");
     expect(getNextKeycapIndex(task, state)).toBe(0);
 
-    state = playKeys(state, [key.tab, key.tab], T0);
+    state = handleGameKey(state, key.tab, T0);
+    // Start edge focused: the second Tab chip is next.
     expect(getNextKeycapIndex(task, state)).toBe(1);
+
+    state = handleGameKey(state, key.tab, T0);
+    // End edge focused: first Down chip, past the held Shift at index 2.
+    expect(getNextKeycapIndex(task, state)).toBe(3);
+
+    state = handleGameKey(state, key.arrow("down", true), T0);
+    expect(getNextKeycapIndex(task, state)).toBe(4);
+  });
+
+  it("walks the doubled arrow chips on place-review and self-corrects", () => {
+    let state = playKeys(
+      startRun(createInitialGameState(), T0),
+      WINNING_SCRIPT.slice(0, 8),
+      T0,
+    );
+    const task = currentTask(state) as NonNullable<
+      ReturnType<typeof currentTask>
+    >;
+    expect(task.id).toBe("place-review");
+    expect(getNextKeycapIndex(task, state)).toBe(0);
+
+    state = handleGameKey(state, key.create, T0);
+    expect(getNextKeycapIndex(task, state)).toBe(1);
+
+    state = handleGameKey(state, key.arrow("right"), T0);
+    expect(getNextKeycapIndex(task, state)).toBe(2);
+
+    // A wrong turn walks the pulse back: distance, not press count.
+    state = handleGameKey(state, key.arrow("left"), T0);
+    expect(getNextKeycapIndex(task, state)).toBe(1);
+
+    state = playKeys(state, [key.arrow("right"), key.arrow("right")], T0);
+    // On target: Enter is the last chip.
+    expect(getNextKeycapIndex(task, state)).toBe(task.keycaps.length - 1);
+  });
+
+  it("counts the nudge presses across the doubled Down chips", () => {
+    let state = playKeys(
+      startRun(createInitialGameState(), T0),
+      WINNING_SCRIPT.slice(0, 12),
+      T0,
+    );
+    const task = currentTask(state) as NonNullable<
+      ReturnType<typeof currentTask>
+    >;
+    expect(task.id).toBe("nudge-standup");
+    // Four presses to go: the first Down chip, past the held Shift.
+    expect(getNextKeycapIndex(task, state)).toBe(1);
+
+    state = handleGameKey(state, key.arrow("down", true), T0);
+    expect(getNextKeycapIndex(task, state)).toBe(2);
+
+    state = playKeys(
+      state,
+      [key.arrow("down", true), key.arrow("down", true)],
+      T0,
+    );
+    expect(getNextKeycapIndex(task, state)).toBe(4);
   });
 
   it("shows the jump target's live letter on the card and pulses it after H", () => {
@@ -498,6 +555,12 @@ describe("winning script sanity", () => {
         // Only already-satisfied tasks would be undo of something present.
         task.type === "undo",
       );
+    }
+  });
+
+  it("every task carries a stall hint", () => {
+    for (const task of RUN_TASKS) {
+      expect(task.hint.length).toBeGreaterThan(0);
     }
   });
 });

--- a/packages/web/src/components/ShortcutShowcase/game.state.ts
+++ b/packages/web/src/components/ShortcutShowcase/game.state.ts
@@ -1,5 +1,6 @@
 import {
   GAME_SEED_EVENTS,
+  type GameSlot,
   type GameTask,
   RUN_DURATION_MS,
   RUN_TASKS,
@@ -550,11 +551,20 @@ export const getDisplayKeycaps = (
   return task.keycaps;
 };
 
+/** Whole-block presses left to reach a slot: day taps plus 15-minute taps. */
+const pressesRemaining = (
+  block: { dayIndex: number; startMin: number },
+  target: GameSlot,
+): number =>
+  Math.abs(block.dayIndex - target.dayIndex) +
+  Math.abs(block.startMin - target.startMin) / PRACTICE_NUDGE_MIN;
+
 /**
  * Which display chip the player should press next, so the task card can dim
- * what's done and pulse what's expected. Derived entirely from the board,
- * so a wrong turn self-corrects. Indexes into `getDisplayKeycaps`: for the
- * H task, `task.keycaps.length` is the appended letter chip.
+ * what's done and pulse what's expected. Chips are authored one per press,
+ * and progress is derived entirely from the board, so a wrong turn
+ * self-corrects. Indexes into `getDisplayKeycaps`: for the H task,
+ * `task.keycaps.length` is the appended letter chip.
  */
 export const getNextKeycapIndex = (
   task: GameTask,
@@ -569,7 +579,10 @@ export const getNextKeycapIndex = (
         practice.placingId === task.piece.id &&
         !matchesSlot(block, task.target)
       ) {
-        return 1;
+        // Walk the arrow chips (indexes 1..arrowCount) as the piece closes in.
+        const arrowCount = task.keycaps.length - 2;
+        const remaining = pressesRemaining(block, task.target);
+        return Math.min(1 + Math.max(arrowCount - remaining, 0), arrowCount);
       }
       return task.keycaps.length - 1;
     }
@@ -578,11 +591,36 @@ export const getNextKeycapIndex = (
       if (blockById(practice, task.piece.id)) return enterIndex;
       return Math.min(state.digitBuffer.length, enterIndex - 1);
     }
-    case "resize":
-      return practice.focusedId === task.targetEventId &&
-        practice.edge === "end"
-        ? 1
-        : 0;
+    case "nudge": {
+      const block = blockById(practice, task.targetEventId);
+      if (!block) return 1;
+      // Index 0 is the held Shift; the arrow chips behind it count presses.
+      const remaining = pressesRemaining(block, task.target);
+      return Math.min(
+        Math.max(task.keycaps.length - remaining, 1),
+        task.keycaps.length - 1,
+      );
+    }
+    case "resize": {
+      const onEndEdge =
+        practice.focusedId === task.targetEventId && practice.edge === "end";
+      if (!onEndEdge) {
+        // Walk the Tab chips: second Tab once the start edge is focused.
+        return practice.focusedId === task.targetEventId &&
+          practice.edge === "start"
+          ? 1
+          : 0;
+      }
+      const block = blockById(practice, task.targetEventId);
+      const shiftIndex = task.keycaps.indexOf("Shift");
+      if (!block) return shiftIndex + 1;
+      const remaining =
+        Math.abs(block.endMin - task.target.endMin) / PRACTICE_NUDGE_MIN;
+      return Math.min(
+        Math.max(task.keycaps.length - remaining, shiftIndex + 1),
+        task.keycaps.length - 1,
+      );
+    }
     case "eventJump":
       return state.jumpChipsShown ? task.keycaps.length : 0;
     case "pageJump":

--- a/packages/web/src/components/ShortcutShowcase/game.tasks.ts
+++ b/packages/web/src/components/ShortcutShowcase/game.tasks.ts
@@ -45,9 +45,15 @@ type GameTaskBase = {
   title: string;
   /** One-line instruction under the headline. */
   instruction: string;
-  /** Keycap chips for the move this task teaches. */
+  /** Keycap chips for the move this task teaches, one chip per press. */
   keycaps: readonly string[];
+  /** Shown on the card when the player stalls; more explicit than `instruction`. */
+  hint: string;
 };
+
+/** Second idle beat: after the hint, offer the exit. */
+export const STUCK_SKIP_HINT =
+  "Still stuck? Esc skips this task and the run keeps going.";
 
 export type GameTask =
   | (GameTaskBase & {
@@ -116,6 +122,7 @@ export const RUN_TASKS: readonly GameTask[] = [
     type: "place",
     title: "Standup",
     instruction: "Get it into the outline on Monday, then lock it in.",
+    hint: "Press C and a Standup piece drops onto the board. Tap Left to reach Monday, then Enter locks it.",
     keycaps: [...KEYMAP.createEvent.keycaps, "ArrowLeft", "Enter"],
     piece: { id: "piece-standup", title: "Standup", color: "gold" },
     spawn: { dayIndex: 1, startMin: t(9), endMin: t(9, 30) },
@@ -126,6 +133,7 @@ export const RUN_TASKS: readonly GameTask[] = [
     type: "quickTime",
     title: "Lunch",
     instruction: "Just type the time, then lock it in.",
+    hint: "Type 1 2 3 0 and the piece appears at 12:30. Enter locks it.",
     keycaps: ["1", "2", "3", "0", "Enter"],
     piece: { id: "piece-lunch", title: "Lunch", color: "mint" },
     target: { dayIndex: 0, startMin: t(12, 30), endMin: t(13) },
@@ -135,7 +143,13 @@ export const RUN_TASKS: readonly GameTask[] = [
     type: "place",
     title: "Design review",
     instruction: "Wednesday afternoon. You know the drill.",
-    keycaps: [...KEYMAP.createEvent.keycaps, "ArrowRight", "Enter"],
+    hint: "Each Right tap moves the piece one day. Two taps reach Wednesday.",
+    keycaps: [
+      ...KEYMAP.createEvent.keycaps,
+      "ArrowRight",
+      "ArrowRight",
+      "Enter",
+    ],
     piece: { id: "piece-review", title: "Design review", color: "indigo" },
     spawn: { dayIndex: 0, startMin: t(14), endMin: t(15) },
     target: { dayIndex: 2, startMin: t(14), endMin: t(15) },
@@ -145,7 +159,8 @@ export const RUN_TASKS: readonly GameTask[] = [
     type: "nudge",
     title: "Standup moved",
     instruction: "Push it down to 10:00. Hold Shift and tap the arrow.",
-    keycaps: ["Shift", "ArrowDown"],
+    hint: "Keep tapping. Each Shift Down tap moves it 15 minutes; four taps reach 10:00.",
+    keycaps: ["Shift", "ArrowDown", "ArrowDown", "ArrowDown", "ArrowDown"],
     targetEventId: "piece-standup",
     target: { dayIndex: 0, startMin: t(10), endMin: t(10, 30) },
   },
@@ -155,7 +170,14 @@ export const RUN_TASKS: readonly GameTask[] = [
     title: "1:1 running long",
     instruction:
       "Press Tab until the bottom edge lights up, then hold Shift and tap Down to reach 11:00.",
-    keycaps: [KEYMAP.edgeFocus.hotkey, "Shift", "ArrowDown"],
+    hint: "Tab cycles what your arrows grab: whole block, top edge, bottom edge. Tab again until the bottom edge lights up, then Shift Down twice.",
+    keycaps: [
+      KEYMAP.edgeFocus.hotkey,
+      KEYMAP.edgeFocus.hotkey,
+      "Shift",
+      "ArrowDown",
+      "ArrowDown",
+    ],
     targetEventId: "game-one-on-one",
     target: { dayIndex: 1, startMin: t(10), endMin: t(11) },
   },
@@ -164,6 +186,7 @@ export const RUN_TASKS: readonly GameTask[] = [
     type: "quickTime",
     title: "Focus block",
     instruction: "Guard Tuesday at 4. Just type the time.",
+    hint: "Times here are 24-hour. Type 1 6 0 0 for 4:00 pm, then Enter.",
     keycaps: ["1", "6", "0", "0", "Enter"],
     piece: { id: "piece-focus", title: "Deep work", color: "slate" },
     target: { dayIndex: 1, startMin: t(16), endMin: t(17) },
@@ -173,6 +196,7 @@ export const RUN_TASKS: readonly GameTask[] = [
     type: "delete",
     title: "Gym got cancelled",
     instruction: "Clear it off the board.",
+    hint: "The Gym block is already selected. One press of Delete clears it.",
     keycaps: ["Delete"],
     targetEventId: "game-gym",
   },
@@ -181,6 +205,7 @@ export const RUN_TASKS: readonly GameTask[] = [
     type: "undo",
     title: "Wait, it's back on",
     instruction: "Undo brings it right back.",
+    hint: "Hold Cmd or Ctrl and press Z. The block comes right back.",
     keycaps: KEYMAP.undo.keycaps,
     targetEventId: "game-gym",
     target: { dayIndex: 2, startMin: t(12), endMin: t(13) },
@@ -190,6 +215,7 @@ export const RUN_TASKS: readonly GameTask[] = [
     type: "legend",
     title: "Blanking on a move?",
     instruction: "The legend lists every shortcut. Open it, then close it.",
+    hint: "The ? key is Shift and /. Open the legend, take a peek, then Esc closes it.",
     keycaps: ["?"],
   },
   {
@@ -198,6 +224,7 @@ export const RUN_TASKS: readonly GameTask[] = [
     title: "Fly across the board",
     instruction:
       "Press H to reveal jump letters, then type the one on Team kickoff.",
+    hint: "Press H and letters appear on every block. Type the letter sitting on Team kickoff.",
     keycaps: KEYMAP.eventJump.keycaps,
     targetEventId: "game-kickoff",
   },
@@ -207,6 +234,7 @@ export const RUN_TASKS: readonly GameTask[] = [
     title: "Numbers jump anywhere",
     instruction:
       "Hold Cmd or Ctrl until the jump numbers appear, then press 1.",
+    hint: "Hold Cmd or Ctrl alone and wait a beat. When the numbers appear, press 1 while still holding.",
     keycaps: ["Mod", "1"],
   },
   {
@@ -214,6 +242,7 @@ export const RUN_TASKS: readonly GameTask[] = [
     type: "palette",
     title: "One palette, every command",
     instruction: "Open the command palette, then close it with Esc.",
+    hint: "Hold Cmd or Ctrl and press K to open it, then Esc to close it.",
     keycaps: KEYMAP.commandPalette.keycaps,
   },
   {
@@ -221,6 +250,7 @@ export const RUN_TASKS: readonly GameTask[] = [
     type: "nudge",
     title: "Review slid to Tuesday",
     instruction: "Walk it one day left.",
+    hint: "Hold Shift and tap Left once. Sideways moves shift whole days.",
     keycaps: ["Shift", "ArrowLeft"],
     targetEventId: "piece-review",
     target: { dayIndex: 1, startMin: t(14), endMin: t(15) },
@@ -230,9 +260,10 @@ export const RUN_TASKS: readonly GameTask[] = [
     type: "place",
     title: "Ship-it party",
     instruction: "Wednesday at 5. Bring it home.",
-    keycaps: [...KEYMAP.createEvent.keycaps, "ArrowDown", "Enter"],
+    hint: "Press C to drop it, tap Down to reach 5:00, then Enter. Last one.",
+    keycaps: [...KEYMAP.createEvent.keycaps, "ArrowDown", "ArrowDown", "Enter"],
     piece: { id: "piece-party", title: "Ship-it party", color: "coral" },
-    spawn: { dayIndex: 2, startMin: t(16), endMin: t(17) },
+    spawn: { dayIndex: 2, startMin: t(16, 30), endMin: t(17, 30) },
     target: { dayIndex: 2, startMin: t(17), endMin: t(18) },
   },
 ];

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -158,6 +158,8 @@
     cubic-bezier(0.16, 1, 0.3, 1) forwards;
   --animate-keycap-flash: keycapFlash 700ms ease-out both;
   --animate-keycap-next: keycapNext 1.1s ease-in-out infinite;
+  --animate-game-howto-in: gameHowtoIn 500ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  --animate-game-hint-in: gameHintIn 300ms ease-out both;
   --animate-game-score-pop: gameScorePop 900ms ease-out forwards;
   --animate-game-lock-flash: gameLockFlash 450ms ease-out both;
   --animate-game-focus-pulse: gameFocusPulse 1.4s ease-in-out infinite;
@@ -247,10 +249,37 @@
     0%,
     100% {
       box-shadow: 0 0 0 1px var(--color-accent);
+      transform: scale(1);
     }
     50% {
-      box-shadow: 0 0 0 3px
-        color-mix(in srgb, var(--color-accent) 45%, transparent);
+      box-shadow:
+        0 0 0 3px color-mix(in srgb, var(--color-accent) 55%, transparent),
+        0 0 12px color-mix(in srgb, var(--color-accent) 45%, transparent);
+      transform: scale(1.12);
+    }
+  }
+
+  /* How-to card children rise in one after another. */
+  @keyframes gameHowtoIn {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  /* The stall hint eases onto the task card. */
+  @keyframes gameHintIn {
+    from {
+      opacity: 0;
+      transform: translateY(4px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
     }
   }
 
@@ -606,16 +635,44 @@
   @apply motion-reduce:animate-none;
 }
 
-/* The task card's "press this next" chip: accent border, gentle pulse. */
+/* The task card's "press this next" chip: accent glow, insistent pulse. */
 @utility c-keycap-next {
   border-color: var(--color-accent);
   color: var(--color-text);
+  background: color-mix(in srgb, var(--color-accent) 12%, transparent);
   animation: var(--animate-keycap-next);
 
   @media (prefers-reduced-motion: reduce) {
     animation: none;
     box-shadow: 0 0 0 1px var(--color-accent);
   }
+}
+
+/* The how-to card's beats stagger in: eyebrow, headline, copy, buttons. */
+@utility c-showcase-howto-in {
+  & > * {
+    animation: var(--animate-game-howto-in);
+  }
+  & > *:nth-child(2) {
+    animation-delay: 140ms;
+  }
+  & > *:nth-child(3) {
+    animation-delay: 280ms;
+  }
+  & > *:nth-child(4) {
+    animation-delay: 420ms;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    & > * {
+      animation: none;
+    }
+  }
+}
+
+@utility c-game-hint-in {
+  animation: var(--animate-game-hint-in);
+  @apply motion-reduce:animate-none;
 }
 
 @utility c-shortcut-flash {


### PR DESCRIPTION
## Problem

Users are tripping over the onboarding game: the intro is visually overwhelming, the next key to press is not apparent enough, there is no help when someone stalls, and tasks that need the same key pressed 2 to 4 times show that key's chip once, so players think one press is enough (worst case: the resize task's double Tab).

## Changes

**Per-press keycap chips.** Multi-press tasks now author one chip per press (resize is `Tab Tab Shift ↓ ↓`, the 15-minute nudge is `Shift ↓ ↓ ↓ ↓`) and `getNextKeycapIndex` derives chip progress from board distance, the same mechanism the typed-time digit chips already used. The pulse walks forward on every press, consumed chips dim, and a wrong turn walks the pulse back. A held `Shift` keeps pulsing alongside the arrows instead of dimming as done.

**Idle hints.** Every task carries a required `hint` string. After 7 seconds without game progress the card shows it (`role="status"` so it is announced politely); after 7 more it adds "Still stuck? Esc skips this task and the run keeps going." The timer is keyed on game-state identity, so wrong-key mashing still counts as stuck and the reducer stays pure. New `shortcut_game_hint_shown` event tracks which tasks stall people.

**Calmer, staged start.** The how-to card drops its three key-hint rows (task 1 re-teaches C, arrow, Enter one pulsing chip at a time), its beats stagger in, and the practice board sits at 25% opacity until the run starts, fading up on Enter.

**More apparent next key.** The `keycapNext` pulse gains a glow, slight scale, and accent background tint; the reduced-motion static ring is kept.

**Fewer arbitrary repeats.** The finale (`place-party`) spawns at 4:30 so it takes 2 Down presses instead of 4. `nudge-standup` keeps its 4 presses as the one deliberate repetition teacher, with the chips and hint making the count explicit.

## Testing

- `game.state.test.ts`: chip-walk cases for place-review, nudge, and resize (including wrong-turn self-correction), plus an every-task-has-a-hint sanity check. 28 pass.
- All 5 ShortcutShowcase unit files pass (76 tests), type-check and lint clean.
- e2e: all 10 onboarding shortcut-showcase tests pass, including a new stall-hint test (hint appears after 7 idle seconds, clears on progress).
- Browser-verified the staged intro, board dim, hint escalation, and pulse styling on the dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)