### PR TITLE
perf(web): take the booking stack off the boot path and gate mobile LCP

### DIFF
--- a/.github/perf/assert-budget.ts
+++ b/.github/perf/assert-budget.ts
@@ -1,18 +1,38 @@
 /**
  * Performance budget gate, invoked by .github/workflows/perf-budget.yml.
  *
- * Runs Lighthouse (desktop preset) against the compressed local server a few
- * times and asserts the median against the budgets below. Medians are used
- * because single Lighthouse runs vary run-to-run, especially on CI runners.
+ * Runs Lighthouse against the compressed local server a few times per profile
+ * and asserts the median against the budgets below. Medians are used because
+ * single Lighthouse runs vary run-to-run, especially on CI runners.
  *
  * Lighthouse is pinned because @lhci/cli's bundled Lighthouse 12 reports
  * NO_LCP against current Chrome; 13.x traces LCP correctly.
  *
- * Baseline (2026-08-24, desktop preset over gzip): LCP ~1.9s, FCP ~0.8s,
- * script transfer ~916 KB after the event-form lazy split. The 1,000 KB
- * script budget leaves ~84 KB of headroom, deliberately less than the
- * ~170 KB gz editor stack (TipTap/react-datepicker/react-select) so a
- * static re-import of the event form fails the gate.
+ * Two profiles, because desktop alone was hiding the problem that matters.
+ * Desktop is the blocking gate. Mobile (Lighthouse's default preset: mobile
+ * emulation over throttled 4G) is warn-only and exists because production's
+ * slowest real users are mobile and far from the origin - the cohort desktop
+ * numbers say nothing about. Both run against localhost, so neither sees real
+ * RTT; treat mobile as a throttling proxy, not a field measurement.
+ *
+ * CALIBRATE THESE FROM A CI RUN, NEVER FROM A LAPTOP. The same build measures
+ * ~150 KB smaller locally than on an ubuntu-latest runner, so local numbers
+ * will set a budget that fails the moment it lands. Read the actuals off a
+ * recent green run of this workflow on main.
+ *
+ * Baseline (2026-09-02, ubuntu-latest, over gzip), measured after the booking
+ * stack left the boot path:
+ *   desktop  LCP ~2.01s, FCP ~1.41s, script transfer 976,450 bytes
+ *   mobile   LCP ~8.27s, FCP ~6.28s
+ * The immediately preceding main was ~984,700 bytes, so that change is worth
+ * ~8 KB of real transfer.
+ *
+ * The 990 KB script budget leaves ~13 KB of headroom - deliberately less than
+ * the ~170 KB gz editor stack (TipTap/react-datepicker/react-select), so a
+ * static re-import of the event form still fails the gate, and in line with
+ * the ~15 KB this gate has actually run with since it was introduced. Script
+ * transfer is near-deterministic (runs vary by tens of bytes), so it can sit
+ * this tight; the paint metrics vary by runner and get much wider headroom.
  */
 import { mkdirSync } from "node:fs";
 
@@ -21,29 +41,58 @@ const URL_UNDER_TEST = process.env.PERF_URL || "http://localhost:9161/";
 const RUNS = 3;
 const REPORT_DIR = "perf-reports";
 
-/** [label, budget, unit, level] — level "error" fails the job, "warn" logs. */
-const BUDGETS = [
+/** [label, budget, unit, level] - level "error" fails the job, "warn" logs. */
+const DESKTOP_BUDGETS = [
   {
     metric: "lcp",
     label: "Largest Contentful Paint",
-    max: 3000,
+    max: 2500,
     unit: "ms",
     level: "error",
   },
   {
     metric: "fcp",
     label: "First Contentful Paint",
-    max: 1500,
+    max: 1600,
     unit: "ms",
     level: "warn",
   },
   {
     metric: "scriptBytes",
     label: "Script transfer size",
-    max: 1_000_000,
+    max: 990_000,
     unit: "bytes",
     level: "error",
   },
+] as const;
+
+// Warn-only for now: this profile has no track record on CI runners, and its
+// job is to make the mobile number visible on every PR rather than to block.
+// Tighten and promote to "error" once a few runs establish its variance.
+const MOBILE_BUDGETS = [
+  {
+    metric: "lcp",
+    label: "Largest Contentful Paint",
+    max: 9000,
+    unit: "ms",
+    level: "warn",
+  },
+  {
+    metric: "fcp",
+    label: "First Contentful Paint",
+    max: 6800,
+    unit: "ms",
+    level: "warn",
+  },
+] as const;
+
+/**
+ * `preset` is passed to Lighthouse verbatim; omitting it selects Lighthouse's
+ * own default, which is the throttled mobile profile.
+ */
+const PROFILES = [
+  { name: "desktop", preset: "desktop", budgets: DESKTOP_BUDGETS },
+  { name: "mobile", preset: undefined, budgets: MOBILE_BUDGETS },
 ] as const;
 
 interface RunMetrics {
@@ -70,15 +119,19 @@ function median(values: number[]): number {
   return sorted[Math.floor(sorted.length / 2)];
 }
 
-async function runLighthouse(runIndex: number): Promise<RunMetrics> {
-  const reportPath = `${REPORT_DIR}/run-${runIndex}.json`;
+async function runLighthouse(
+  profileName: string,
+  preset: string | undefined,
+  runIndex: number,
+): Promise<RunMetrics> {
+  const reportPath = `${REPORT_DIR}/${profileName}-run-${runIndex}.json`;
   const proc = Bun.spawn(
     [
       "npx",
       "--yes",
       `lighthouse@${LIGHTHOUSE_VERSION}`,
       URL_UNDER_TEST,
-      "--preset=desktop",
+      ...(preset ? [`--preset=${preset}`] : []),
       "--only-categories=performance",
       "--output=json",
       `--output-path=${reportPath}`,
@@ -89,7 +142,9 @@ async function runLighthouse(runIndex: number): Promise<RunMetrics> {
   );
 
   if ((await proc.exited) !== 0) {
-    throw new Error(`Lighthouse run ${runIndex} exited non-zero`);
+    throw new Error(
+      `Lighthouse ${profileName} run ${runIndex} exited non-zero`,
+    );
   }
 
   const report = (await Bun.file(reportPath).json()) as LighthouseReport;
@@ -98,11 +153,11 @@ async function runLighthouse(runIndex: number): Promise<RunMetrics> {
 
   if (typeof lcpAudit?.numericValue !== "number") {
     throw new Error(
-      `Run ${runIndex} produced no LCP value (${lcpAudit?.errorMessage ?? "unknown error"})`,
+      `${profileName} run ${runIndex} produced no LCP value (${lcpAudit?.errorMessage ?? "unknown error"})`,
     );
   }
   if (typeof fcpAudit?.numericValue !== "number") {
-    throw new Error(`Run ${runIndex} produced no FCP value`);
+    throw new Error(`${profileName} run ${runIndex} produced no FCP value`);
   }
 
   const scriptRow = report.audits["resource-summary"]?.details?.items?.find(
@@ -118,36 +173,41 @@ async function runLighthouse(runIndex: number): Promise<RunMetrics> {
 
 mkdirSync(REPORT_DIR, { recursive: true });
 
-const runs: RunMetrics[] = [];
-for (let i = 1; i <= RUNS; i++) {
-  console.log(`\nLighthouse run ${i}/${RUNS} against ${URL_UNDER_TEST}...`);
-  runs.push(await runLighthouse(i));
-}
-
-const medians: RunMetrics = {
-  lcp: median(runs.map((r) => r.lcp)),
-  fcp: median(runs.map((r) => r.fcp)),
-  scriptBytes: median(runs.map((r) => r.scriptBytes)),
-};
-
-console.log(`\nPerformance budget (median of ${RUNS} runs):`);
 let failed = false;
-for (const budget of BUDGETS) {
-  const value = medians[budget.metric];
-  const overBudget = value > budget.max;
-  const status = overBudget
-    ? budget.level === "error"
-      ? "FAIL"
-      : "WARN"
-    : "ok";
-  const all = runs.map((r) => Math.round(r[budget.metric])).join(", ");
 
-  console.log(
-    `  [${status}] ${budget.label}: ${Math.round(value)} ${budget.unit}` +
-      ` (budget ${budget.max} ${budget.unit}; runs: ${all})`,
-  );
-  if (overBudget && budget.level === "error") {
-    failed = true;
+for (const profile of PROFILES) {
+  const runs: RunMetrics[] = [];
+  for (let i = 1; i <= RUNS; i++) {
+    console.log(
+      `\nLighthouse ${profile.name} run ${i}/${RUNS} against ${URL_UNDER_TEST}...`,
+    );
+    runs.push(await runLighthouse(profile.name, profile.preset, i));
+  }
+
+  const medians: RunMetrics = {
+    lcp: median(runs.map((r) => r.lcp)),
+    fcp: median(runs.map((r) => r.fcp)),
+    scriptBytes: median(runs.map((r) => r.scriptBytes)),
+  };
+
+  console.log(`\n${profile.name} performance budget (median of ${RUNS} runs):`);
+  for (const budget of profile.budgets) {
+    const value = medians[budget.metric];
+    const overBudget = value > budget.max;
+    const status = overBudget
+      ? budget.level === "error"
+        ? "FAIL"
+        : "WARN"
+      : "ok";
+    const all = runs.map((r) => Math.round(r[budget.metric])).join(", ");
+
+    console.log(
+      `  [${status}] ${budget.label}: ${Math.round(value)} ${budget.unit}` +
+        ` (budget ${budget.max} ${budget.unit}; runs: ${all})`,
+    );
+    if (overBudget && budget.level === "error") {
+      failed = true;
+    }
   }
 }
 

--- a/.github/workflows/perf-budget.yml
+++ b/.github/workflows/perf-budget.yml
@@ -30,7 +30,9 @@ concurrency:
 jobs:
   lighthouse:
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    # Two Lighthouse profiles x 3 runs each; the mobile profile is the slower
+    # of the two. Sized with headroom for a cold npx download of Lighthouse.
+    timeout-minutes: 20
 
     steps:
       - name: Check out Git repository

--- a/packages/web/inject-module-preloads.ts
+++ b/packages/web/inject-module-preloads.ts
@@ -17,12 +17,17 @@ interface Metafile {
 // Dynamic imports made from deeper chunks are normally the lazy route views
 // and excluded from preloading, but some of them always execute on boot. Each
 // source file listed here gets its containing chunk (plus that chunk's static
-// closure) preloaded as well. RootShell is the root route's component - kept
-// a lazy import only so route-shape tests can mock its auth stack (see
-// router.routes.tsx) - and renders on every page load, 404s included.
+// closure) preloaded as well. AppRoot is the root route's component and
+// RootShell the pathless calendar-shell route beneath it - both kept lazy
+// imports only so route-shape tests can mock their auth stack (see
+// router.routes.tsx) - and both render on every page load, 404s included.
+// Missing one costs a whole round-trip, since they load in series.
 // Metafile input keys are relative to the build's cwd, so entries here are
 // matched by path suffix.
-export const ALWAYS_BOOT_SOURCES = ["src/components/RootShell/RootShell.tsx"];
+export const ALWAYS_BOOT_SOURCES = [
+  "src/components/RootShell/AppRoot.tsx",
+  "src/components/RootShell/RootShell.tsx",
+];
 
 /**
  * Injects `<link rel="modulepreload">` tags for every boot-critical chunk into

--- a/packages/web/src/booking/BookingSettingsSection.lazy.ts
+++ b/packages/web/src/booking/BookingSettingsSection.lazy.ts
@@ -1,0 +1,13 @@
+import { lazyRouteComponent } from "@tanstack/react-router";
+
+// Lazy: SettingsModal mounts unconditionally in CompassRequiredProviders, so
+// a static import here puts the whole booking admin stack (weekly-hours and
+// date-override editors, the timezone combobox, the booking Zod contracts) in
+// the boot chunk of every page load — ~21KB gz that production never runs,
+// since IS_BOOKING_ENABLED is false outside dev. This is the only static edge
+// into that graph. No preload helper: unlike the event form, the section is
+// already behind a settings page the user has to navigate to.
+export const LazyBookingSettingsSection = lazyRouteComponent(
+  () => import("@web/booking/BookingSettingsSection"),
+  "BookingSettingsSection",
+);

--- a/packages/web/src/booking/public-booking-search.ts
+++ b/packages/web/src/booking/public-booking-search.ts
@@ -1,7 +1,7 @@
 import {
   isBookingDateKey,
   isBookingMonthKey,
-} from "@web/booking/public-booking.format";
+} from "@web/booking/public-booking.keys";
 import { isValidTimeZone } from "@web/timezone/browser-timezone";
 
 export interface PublicBookingSearch {

--- a/packages/web/src/booking/public-booking.format.test.ts
+++ b/packages/web/src/booking/public-booking.format.test.ts
@@ -5,15 +5,17 @@ import {
   formatBookingMonthKey,
   formatDurationMinutes,
   getPublicBookingMonthWindow,
-  isBookingDateKey,
   isBookingMonthAvailable,
-  isBookingMonthKey,
   listBookingAvailableDateKeysInMonth,
   listBookingAvailableDayKeys,
   listBookingMonthGridWeeks,
   shiftBookingMonthKey,
   stepBookingAvailableDay,
 } from "@web/booking/public-booking.format";
+import {
+  isBookingDateKey,
+  isBookingMonthKey,
+} from "@web/booking/public-booking.keys";
 import { describe, expect, it } from "bun:test";
 
 const utc = TimeZoneSchema.parse("UTC");

--- a/packages/web/src/booking/public-booking.format.ts
+++ b/packages/web/src/booking/public-booking.format.ts
@@ -3,9 +3,7 @@ import {
   BookingSlotsQuerySchema,
 } from "@core/types/booking.contracts";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
-
-const MONTH_KEY_PATTERN = /^\d{4}-\d{2}$/;
-const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+import { isBookingMonthKey } from "@web/booking/public-booking.keys";
 
 /**
  * Constructing an `Intl.DateTimeFormat` is the expensive part, and the guest
@@ -63,12 +61,6 @@ const dateKeyFormatter = perTimeZoneFormatter(
   { year: "numeric", month: "2-digit", day: "2-digit" },
   "en-CA",
 );
-
-export const isBookingMonthKey = (value: string): boolean =>
-  MONTH_KEY_PATTERN.test(value);
-
-export const isBookingDateKey = (value: string): boolean =>
-  DATE_KEY_PATTERN.test(value);
 
 export function formatBookingMonthKey(
   instant: Date | string | Dayjs,

--- a/packages/web/src/booking/public-booking.keys.ts
+++ b/packages/web/src/booking/public-booking.keys.ts
@@ -1,0 +1,13 @@
+// The month/date key predicates live apart from public-booking.format so the
+// router's search validators can reach them without importing that module.
+// public-booking.format pulls BookingSlotsQuerySchema as a value, and one Zod
+// import drags the whole booking.contracts module - ~15KB of schemas that
+// evaluate at module load - onto the boot path of every page, for two regexes.
+const MONTH_KEY_PATTERN = /^\d{4}-\d{2}$/;
+const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export const isBookingMonthKey = (value: string): boolean =>
+  MONTH_KEY_PATTERN.test(value);
+
+export const isBookingDateKey = (value: string): boolean =>
+  DATE_KEY_PATTERN.test(value);

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -164,7 +164,7 @@ const renderSettings = ({
   connections?: GoogleSyncConnectionSummary[];
   calendars?: Calendar[];
   open?: boolean;
-  page?: "accounts" | "billing";
+  page?: "accounts" | "billing" | "booking";
 } = {}) => {
   authenticated = isAuthenticated;
   userMetadataActions.set({
@@ -1053,6 +1053,19 @@ describe("SettingsModal", () => {
     ).not.toBeInTheDocument();
     expect(
       screen.getByRole("dialog", { name: "Settings" }),
+    ).toBeInTheDocument();
+  });
+
+  // The booking section is lazily imported (BookingSettingsSection.lazy) to
+  // keep the booking admin stack off the boot chunk, behind a Suspense
+  // fallback of null. A chunk that never resolves would render an empty
+  // settings pane rather than throwing, so assert the section actually
+  // arrives instead of trusting the boundary.
+  it("resolves the lazily loaded booking section", async () => {
+    renderSettings({ authenticated: true, page: "booking" });
+
+    expect(
+      await screen.findByText("Loading booking settings\u2026"),
     ).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -1,4 +1,4 @@
-import { type FC, useEffect, useRef, useState } from "react";
+import { type FC, Suspense, useEffect, useRef, useState } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
@@ -20,7 +20,7 @@ import { PlanSection } from "@web/billing/PlanSection";
 import { getPlanBadge } from "@web/billing/planBadge";
 import { useUpgradeConfirmation } from "@web/billing/UpgradeConfirmation/hooks/useUpgradeConfirmation";
 import { useAppAccess } from "@web/billing/useAppAccess";
-import { BookingSettingsSection } from "@web/booking/BookingSettingsSection";
+import { LazyBookingSettingsSection as BookingSettingsSection } from "@web/booking/BookingSettingsSection.lazy";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import {
   compareCalendars,
@@ -239,7 +239,9 @@ export const SettingsModal: FC = () => {
           {page === "billing" ? (
             <PlanSection showShortcuts={areHintsVisible} />
           ) : page === "booking" && IS_BOOKING_ENABLED ? (
-            <BookingSettingsSection showShortcuts={areHintsVisible} />
+            <Suspense fallback={null}>
+              <BookingSettingsSection showShortcuts={areHintsVisible} />
+            </Suspense>
           ) : (
             <>
               <DefaultTimezonePicker />

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -89,16 +89,19 @@
     <link rel="icon" href="/favicon.ico" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <!--
+      One combined stylesheet, not three: each render-blocking cross-origin
+      <link> costs its own round-trip before first paint, which dominates for
+      the distant cold-cache visitors who see the worst LCP. css2 requires the
+      family params in alphabetical order.
+
+      Rubik is the body font (and so the LCP text); its axis is capped at 700
+      because nothing uses 800/900 (heaviest in use: font-bold). Italic stays
+      - LifeQuote renders one, and the description editor can mark any text
+      italic.
+    -->
     <link
-      href="https://fonts.googleapis.com/css2?family=Rubik:ital,wght@0,300..900;1,300..900&display=swap"
-      rel="stylesheet"
-    />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Caveat:wght@400..700&display=swap"
-      rel="stylesheet"
-    />
-    <link
-      href="https://fonts.googleapis.com/css2?family=VT323&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Caveat:wght@400..700&family=Rubik:ital,wght@0,300..700;1,300..700&family=VT323&display=swap"
       rel="stylesheet"
     />
 


### PR DESCRIPTION
## The reported regression isn't real

Investigated a reported LCP rise on compasscalendar.com (~1.2s Aug 26 → ~2.8s Sep 1). Pooled over enough samples, LCP **halved**:

| Window | Samples | Avg | p50 | p75 |
|---|---|---|---|---|
| Aug 11–28 | 197 | 4348ms | 3488ms | 5382ms |
| Aug 29–Sep 1 | 33 | 2213ms | 1672ms | 2880ms |

The trend was noise on ~5 LCP samples/day (Aug 26 was 4 measurements, one a bogus `LCP = 0`). Two facts close off the code hypothesis: prod deploys are manual, and most of the suspect commits didn't ship until **Sep 1 18:26 UTC** — after the days blamed; and Sep 1 was already at 2626ms *before* that deploy.

Session replays show the real change: a September email campaign plus a Product Hunt referral began sending cold-cache mobile users from IN/AE/AU/BE. Campaign hits went 0→13/day, mobile 0→11/day. The traffic mix shifted, not the app.

## What this changes

The app *is* slow for that audience, so this fixes what costs them.

- **Lazy-load `BookingSettingsSection`.** `SettingsModal` mounts unconditionally in `CompassRequiredProviders`, so its static import put the booking admin stack in the boot chunk of every page load — dead code in production, where `IS_BOOKING_ENABLED` is false.
- **Split out `public-booking.keys`.** The router's search validators pulled `public-booking.format`, whose `BookingSlotsQuerySchema` *value* import dragged all of `booking.contracts` onto the boot path for two regexes.
- **Add `AppRoot` to `ALWAYS_BOOT_SOURCES`.** The root route component changed to `AppRoot`, so it ran on every boot with no `modulepreload` and added a fourth serial lazy level in front of the week grid.
- **Three render-blocking font stylesheets → one**, Rubik capped at 700 (nothing uses 800/900). Italic stays — `LifeQuote` renders one and the description editor can mark text italic.

### On the size numbers

Two counts, both real, measuring different things:

| Measure | Before | After |
|---|---|---|
| Preloaded boot-chunk set (gz) | 560,365 B | 528,014 B |
| **Script transferred during a Lighthouse run (CI)** | **984,724 B** | **976,450 B** |

The second (~8.3KB) is the conservative one and the one to quote — the first counts chunks the browser may fetch either way. No booking code is left on the boot path.

## Perf gate

It was intact and never disabled — just too slack to catch creep (LCP 3000ms against a ~2.1s CI baseline). Re-baselined and added a **warn-only mobile profile**, because desktop-over-localhost was hiding the number that matters:

- desktop LCP ~2.0s (blocking gate, 2500ms)
- **mobile LCP ~8.3s** (warn, 9000ms)

Budgets are calibrated from CI runs, not a laptop — the same build measures **~150KB smaller locally** than on ubuntu-latest, which failed this gate once on the first push. The header comment now says so explicitly. Job timeout raised for the doubled run count.

## Verification

- `type-check` and `lint` clean (23 warnings — exactly the baseline's).
- Web suite **3098 pass / 4 fail** locally; the 4 are pre-existing `useAppAccess` full-suite timeouts, confirmed identical on an untouched build of the base commit. `unit (web)` passes on CI.
- Perf gate green on both profiles; fail path confirmed to still exit 1.
- The new lazy-boundary test is mutation-tested — breaking the import makes it fail.

## Notes

Lighthouse shows little LCP movement from the bundle work. That's expected, not a null result: lantern uses a fixed 40ms RTT and structurally can't see the round-trip savings these fixes work through. The transfer reduction is measured; the LCP win is inferred.

Two follow-ups deliberately out of scope: **brotli** (prod negotiates gzip only — ~90–115KB more, the biggest remaining lever, but it means editing the unmanaged prod Caddyfile), and **LCP sampling** (715 of 945 web-vitals events carry no LCP value, which is why a non-existent regression was investigable at all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)