### PR TITLE
fix(web): configure web vitals explicitly and reject zeroed timings

### DIFF
--- a/packages/backend/src/__tests__/backend.preload.ts
+++ b/packages/backend/src/__tests__/backend.preload.ts
@@ -15,6 +15,7 @@ import {
   startMemoryMongo,
   stopMemoryMongo,
 } from "@backend/__tests__/helpers/mongo-memory-server";
+import mongoService from "@backend/common/services/mongo.service";
 import { afterAll } from "bun:test";
 
 const uri = await startMemoryMongo();
@@ -26,5 +27,21 @@ await import("@backend/__tests__/backend.test.init");
 await import("@backend/__tests__/backend.test.start");
 
 afterAll(async () => {
+  // Close this worker's own connection before anything else.
+  //
+  // Under `test-mongo-env.ts` every worker shares one mongod supplied through
+  // COMPASS_TEST_MONGO_URI, which makes stopMemoryMongo() below a no-op - so
+  // without this line the worker finishes its last test still holding an open
+  // socket, and whether the process then exits is left to Bun's handle
+  // teardown. When it loses that race the worker never exits, the runner's
+  // `await proc.exited` blocks forever, and the CI step dies on its timeout
+  // with every test having passed. That is exactly what happened to
+  // `unit (scripts)` on #3101: all tests green at 17:15:51, silence until the
+  // 5-minute timeout at 17:21:00, and cleanup reaping an orphaned mongod
+  // alongside five live bun processes.
+  //
+  // mongoService.stop() is a no-op when the worker never connected, so this is
+  // safe for the suites that hold no database at all.
+  await mongoService.stop();
   await stopMemoryMongo();
 });

--- a/packages/backend/src/__tests__/backend.preload.ts
+++ b/packages/backend/src/__tests__/backend.preload.ts
@@ -15,7 +15,6 @@ import {
   startMemoryMongo,
   stopMemoryMongo,
 } from "@backend/__tests__/helpers/mongo-memory-server";
-import mongoService from "@backend/common/services/mongo.service";
 import { afterAll } from "bun:test";
 
 const uri = await startMemoryMongo();
@@ -27,21 +26,5 @@ await import("@backend/__tests__/backend.test.init");
 await import("@backend/__tests__/backend.test.start");
 
 afterAll(async () => {
-  // Close this worker's own connection before anything else.
-  //
-  // Under `test-mongo-env.ts` every worker shares one mongod supplied through
-  // COMPASS_TEST_MONGO_URI, which makes stopMemoryMongo() below a no-op - so
-  // without this line the worker finishes its last test still holding an open
-  // socket, and whether the process then exits is left to Bun's handle
-  // teardown. When it loses that race the worker never exits, the runner's
-  // `await proc.exited` blocks forever, and the CI step dies on its timeout
-  // with every test having passed. That is exactly what happened to
-  // `unit (scripts)` on #3101: all tests green at 17:15:51, silence until the
-  // 5-minute timeout at 17:21:00, and cleanup reaping an orphaned mongod
-  // alongside five live bun processes.
-  //
-  // mongoService.stop() is a no-op when the worker never connected, so this is
-  // safe for the suites that hold no database at all.
-  await mongoService.stop();
   await stopMemoryMongo();
 });

--- a/packages/web/src/auth/posthog/posthog-web-vitals-filter.util.test.ts
+++ b/packages/web/src/auth/posthog/posthog-web-vitals-filter.util.test.ts
@@ -1,0 +1,76 @@
+import { type CaptureResult } from "posthog-js";
+import { filterPosthogWebVitals } from "./posthog-web-vitals-filter.util";
+import { describe, expect, it } from "bun:test";
+
+const vitalsEvent = (properties: Record<string, unknown>): CaptureResult =>
+  ({
+    uuid: "test-uuid",
+    event: "$web_vitals",
+    properties,
+  }) as CaptureResult;
+
+describe("filterPosthogWebVitals", () => {
+  it("passes through a null event", () => {
+    expect(filterPosthogWebVitals(null)).toBeNull();
+  });
+
+  it("passes through non-web-vitals events", () => {
+    const event = {
+      uuid: "1",
+      event: "$pageview",
+      properties: { $web_vitals_LCP_value: 0 },
+    } as CaptureResult;
+    expect(filterPosthogWebVitals(event)).toBe(event);
+  });
+
+  it("leaves a genuine measurement untouched", () => {
+    const event = vitalsEvent({
+      $web_vitals_LCP_value: 2400,
+      $web_vitals_FCP_value: 900,
+    });
+    expect(filterPosthogWebVitals(event)).toBe(event);
+    expect(event.properties?.["$web_vitals_LCP_value"]).toBe(2400);
+  });
+
+  it("keeps a legitimate CLS of zero", () => {
+    const event = vitalsEvent({ $web_vitals_CLS_value: 0 });
+    expect(filterPosthogWebVitals(event)).toBe(event);
+    expect(event.properties?.["$web_vitals_CLS_value"]).toBe(0);
+  });
+
+  it("strips a zeroed LCP but keeps the rest of the batch", () => {
+    const event = vitalsEvent({
+      $web_vitals_LCP_value: 0,
+      $web_vitals_LCP_event: { name: "LCP", value: 0 },
+      $web_vitals_FCP_value: 900,
+    });
+
+    const filtered = filterPosthogWebVitals(event);
+
+    expect(filtered).toBe(event);
+    expect(filtered?.properties).not.toHaveProperty("$web_vitals_LCP_value");
+    expect(filtered?.properties).not.toHaveProperty("$web_vitals_LCP_event");
+    expect(filtered?.properties?.["$web_vitals_FCP_value"]).toBe(900);
+  });
+
+  it("strips every zeroed timing metric", () => {
+    const event = vitalsEvent({
+      $web_vitals_LCP_value: 0,
+      $web_vitals_FCP_value: 0,
+      $web_vitals_INP_value: 0,
+      $web_vitals_CLS_value: 0.05,
+    });
+
+    const filtered = filterPosthogWebVitals(event);
+
+    expect(filtered?.properties).toEqual({ $web_vitals_CLS_value: 0.05 });
+  });
+
+  it("drops the event when nothing measurable is left", () => {
+    const event = vitalsEvent({
+      $web_vitals_LCP_value: 0,
+      $web_vitals_LCP_event: { name: "LCP", value: 0 },
+    });
+    expect(filterPosthogWebVitals(event)).toBeNull();
+  });
+});

--- a/packages/web/src/auth/posthog/posthog-web-vitals-filter.util.ts
+++ b/packages/web/src/auth/posthog/posthog-web-vitals-filter.util.ts
@@ -1,0 +1,50 @@
+import { type CaptureResult } from "posthog-js";
+
+/**
+ * Metrics whose zero value is impossible rather than merely excellent.
+ *
+ * LCP, FCP and INP all measure "how long until X happened". Zero means X was
+ * never timed, not that it happened instantly - a paint cannot land in the same
+ * millisecond the navigation started, and an interaction cannot take no time at
+ * all. CLS is deliberately absent: a page that never shifts really does score 0,
+ * and that is the score we want to keep.
+ */
+const NON_ZERO_METRICS = ["LCP", "FCP", "INP"] as const;
+
+/**
+ * posthog-js only rejects a metric whose value is null or undefined
+ * (`isNullish(metric?.value)` in its web-vitals extension), so a zero sails
+ * through into `$web_vitals_<name>_value`. One such LCP = 0 landed on
+ * 2026-08-26. A zero is not a fast page, it is the absence of a measurement,
+ * and left in place it drags every average toward zero exactly when the sample
+ * count is too small to absorb it.
+ *
+ * A single `$web_vitals` event carries whichever metrics happened to be in
+ * posthog's flush buffer, so this strips only the bogus metric's own properties
+ * and keeps the rest of the event. The event is dropped entirely only when
+ * nothing measurable is left.
+ */
+export function filterPosthogWebVitals(
+  event: CaptureResult | null,
+): CaptureResult | null {
+  if (!event || event.event !== "$web_vitals") return event;
+
+  const properties = event.properties;
+  if (!properties) return event;
+
+  let droppedAny = false;
+  for (const metric of NON_ZERO_METRICS) {
+    if (properties[`$web_vitals_${metric}_value`] === 0) {
+      delete properties[`$web_vitals_${metric}_value`];
+      delete properties[`$web_vitals_${metric}_event`];
+      droppedAny = true;
+    }
+  }
+  if (!droppedAny) return event;
+
+  // Every metric in the batch was bogus; there is nothing left to report.
+  const hasRemainingMetric = Object.keys(properties).some(
+    (key) => key.startsWith("$web_vitals_") && key.endsWith("_value"),
+  );
+  return hasRemainingMetric ? event : null;
+}

--- a/packages/web/src/auth/posthog/posthog.bootstrap.ts
+++ b/packages/web/src/auth/posthog/posthog.bootstrap.ts
@@ -2,6 +2,7 @@ import { type PostHog } from "posthog-js";
 import { isPosthogEnabled } from "@web/auth/posthog/posthog.util";
 import { filterPosthogDeadClick } from "@web/auth/posthog/posthog-dead-click-filter.util";
 import { filterPosthogBeforeSend } from "@web/auth/posthog/posthog-exception-filter.util";
+import { filterPosthogWebVitals } from "@web/auth/posthog/posthog-web-vitals-filter.util";
 import { ENV_WEB } from "@web/common/constants/env.constants";
 
 let client: PostHog | undefined;
@@ -39,8 +40,38 @@ export function initPosthog(): PostHog | undefined {
     // Drop known-unactionable exception signatures (SuperTokens/browser
     // network blips, CefSharp scanner noise, opaque "Script error.") before
     // they become issues, then the dead clicks posthog's own mutation clock
-    // mis-scores on our static onboarding overlays.
-    before_send: [filterPosthogBeforeSend, filterPosthogDeadClick],
+    // mis-scores on our static onboarding overlays, then the web vitals that
+    // report a zero where a timing should be.
+    before_send: [
+      filterPosthogBeforeSend,
+      filterPosthogDeadClick,
+      filterPosthogWebVitals,
+    ],
+    // Web vitals were running entirely on PostHog's server-side default
+    // (`$web_vitals_enabled_server_side` was true on every event, and
+    // `$web_vitals_allowed_metrics` was null, so the project was not
+    // restricting metrics). Stating it here instead means the setting is
+    // reviewable in the diff and cannot be changed out from under a deploy by
+    // a remote-config edit - client config wins over remote config in
+    // posthog-js's `allowedMetrics` resolution.
+    capture_performance: {
+      web_vitals: true,
+      web_vitals_allowed_metrics: ["LCP", "CLS", "FCP", "INP"],
+      // posthog-js buffers metrics and flushes on exactly three triggers: a URL
+      // change, the buffer reaching `web_vitals_allowed_metrics.length`, or
+      // this timer. There is deliberately no pagehide flush, so anything still
+      // buffered when the page unloads is simply lost. LCP and INP are only
+      // reported by the web-vitals library on first interaction or page hide,
+      // which is why they miss far more often than FCP.
+      //
+      // Shortening the window from posthog's 5000ms default does not rescue a
+      // metric that arrives during unload - nothing can, short of a pagehide
+      // flush upstream - but it does shrink the window in which an already
+      // complete measurement sits unsent, which is where short visits lose
+      // theirs. The cost is up to four `$web_vitals` events per pageview
+      // instead of two, which is noise at this traffic volume.
+      web_vitals_delayed_flush_ms: 1000,
+    },
     // Product events are queued and sent in batches by the SDK. Keyboard
     // handlers only enqueue meaningful outcomes and never wait on transport.
     request_batching: true,


### PR DESCRIPTION
## Summary

Follow-up 1 of 3 from the Sept 2 LCP investigation (#3101). Makes LCP measurable so the brotli work is verifiable.

`posthog.init()` passed no `capture_performance` at all, so web vitals ran entirely on PostHog's server-side default. This declares the config client-side, shortens the flush window, and drops zeroed timings.

**Two findings that correct the premise of the task, both worth reading before review:**

**1. The missing-LCP share is 58% of pageviews, not 76% of events.** The "715 of 945 events carry no LCP" figure counts events, but posthog emits ~2 `$web_vitals` events per pageview (metrics split across flush buckets — measured at exactly 2.0 events per `$window_id`). At the pageview level over the last 30 days: 572 windows, 240 with an LCP, **42% coverage**. Still bad, but a different number, and the event-level one overstates it.

**2. Raising `web_vitals_delayed_flush_ms` would have made this worse, so I lowered it instead.** Reading posthog-js 1.409's web-vitals extension (`_addToBuffer` / `_flushToCapture`), the buffer flushes on exactly three triggers: a URL change, the buffer filling to `web_vitals_allowed_metrics.length`, or the delayed-flush timer. **There is no pagehide flush** — anything still buffered at unload is simply lost. LCP and INP are only reported by the web-vitals library on first interaction or page hide, which is why they miss far more often than FCP (592 FCP vs 257 LCP across 1143 events). A *longer* timer means a wider window in which a complete measurement sits unsent. Shortened 5000ms → 1000ms.

To be explicit about expectations: a shorter window cannot rescue a metric that arrives *during* unload — nothing client-side can, short of a pagehide flush upstream. **I do not expect coverage to jump dramatically after deploy.** It should improve for short visits, where an already-complete buffer currently dies with the page. The coverage tile below is how we find out on real traffic; I am not claiming a fix from a local build.

**Hypotheses ruled out along the way**, so nobody re-runs them:

| Hypothesis | Verdict |
|---|---|
| Pages unload before the flush | **No.** No-LCP windows lasted *longer* (45.1s vs 40.9s median) |
| Server-side config restricts metrics | **No.** `$web_vitals_allowed_metrics` is null on all events; all four allowed |
| Browsers lacking the LCP API | **No.** Firefox 60%, Safari 60% — they'd be 0%. Brave is an outlier at 18% (shields), Chrome 52% is the bulk |
| SPA soft navigation | **Real but small.** Rank-2+ views 17% vs first views 41%, only 52 of 624 views |

The residual cause is the posthog-js buffering gap itself, which is a library limitation rather than a misconfiguration on our side.

Also drops `LCP`/`FCP`/`INP` readings of zero. posthog-js only rejects a metric whose value is *nullish* (`isNullish(metric?.value)`), so a zero passes straight through; one such LCP = 0 landed on 2026-08-26. A zero is the absence of a measurement, not a fast page. CLS is deliberately exempt — a page that never shifts really does score 0.

**Saved dashboard:** [Web vitals: LCP measurement health](https://us.posthog.com/project/165441/dashboard/2058733), pinned, three tiles:
- [LCP coverage](https://us.posthog.com/project/165441/insights/aUAavz6b) — share of pageviews reporting an LCP at all, with sample size. This is the post-deploy check.
- [LCP by path × device × new-vs-returning](https://us.posthog.com/project/165441/insights/KSMNTt3K) — `samples` is the first column on purpose.
- [LCP over time with daily sample size](https://us.posthog.com/project/165441/insights/etfbzczN) — sample count as bars behind the metric.

The segmentation already reproduces the original investigation's conclusion: `/week` desktop **new** visitors median 3436ms (n=158) vs **returning** 930ms (n=10). The trend was traffic mix, not a regression.

## Simplicity

Config is declarative in the existing `posthog.init()` call. The zero filter is one pure function added to the `before_send` array already there, mirroring `filterPosthogDeadClick`. It strips only the bogus metric's own properties rather than dropping the whole event, since one `$web_vitals` event carries whatever was in the buffer; the event is dropped only when nothing measurable remains. No new abstraction, no new dependency, no change to the boot path.

## Automated validation

PostHog queries against live `compasscalendar.com` traffic (30 days) established the baseline recorded above — 42% pageview coverage, the 2.0-events-per-window split, and each ruled-out hypothesis. Every dashboard query was run through `execute-sql` before being saved.

Post-deploy verification is deliberately **not** claimed here — it only proves out on real traffic, via the coverage tile.

## Independent review

No `/review` handoff. Findings above are from direct reading of the vendored posthog-js 1.409 web-vitals source and the live PostHog data, both cited inline so a reviewer can re-run them.

## Test plan

```
bun test packages/web/src/auth/posthog/posthog-web-vitals-filter.util.test.ts   # 7 pass, 0 fail
bun run lint         # exit 0; custom checkers (semantic-colors, agent-constraints) both ran and passed
bun run type-check   # clean
```

Lint reports 23 warnings, all pre-existing: an untouched build of the base commit (`ed10a6b`) reports the identical 23, and 0 diagnostics fall in the files this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EatK3AHJUb1nX5ngEtTpE3

---
_Generated by [Claude Code](https://claude.ai/code/session_01EatK3AHJUb1nX5ngEtTpE3)_