### PR TITLE
fix(ci): diagnose wedged unit test runs instead of raising the timeout

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -219,8 +219,9 @@ jobs:
       # because a worker leaked an open Mongo handle and never exited. The same
       # commit re-ran in 5s. Raising the number would only have made that hang
       # cost ten minutes instead of five, while blinding the step to a real
-      # regression. The leak is fixed in backend.preload.ts, and
-      # test-mongo-env.ts now kills a wedged run at 4 minutes with a diagnosis.
+      # regression. The leak itself is not fixed here - see test-mongo-env.ts,
+      # which now kills a wedged run at 4 minutes and names the likely cause
+      # instead of letting this timeout fire with no output.
       - name: Run ${{ matrix.project }} tests
         if: needs.changes.outputs.code == 'true' && (matrix.project != 'web')
         timeout-minutes: 5

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -211,6 +211,16 @@ jobs:
         run: |
           bun run test:web
 
+      # 5 minutes is deliberate, and deliberately not raised. These suites run in
+      # seconds on ubuntu-latest - scripts ~5s, backend ~13s, core ~2s, sync
+      # ~105s at its slowest - so the budget is already an order of magnitude
+      # clear of the slowest of them. When `scripts` tripped this on #3101 it was
+      # not slow: every test passed, then the runner sat silent for five minutes
+      # because a worker leaked an open Mongo handle and never exited. The same
+      # commit re-ran in 5s. Raising the number would only have made that hang
+      # cost ten minutes instead of five, while blinding the step to a real
+      # regression. The leak is fixed in backend.preload.ts, and
+      # test-mongo-env.ts now kills a wedged run at 4 minutes with a diagnosis.
       - name: Run ${{ matrix.project }} tests
         if: needs.changes.outputs.code == 'true' && (matrix.project != 'web')
         timeout-minutes: 5

--- a/packages/backend/src/__tests__/backend.preload.ts
+++ b/packages/backend/src/__tests__/backend.preload.ts
@@ -15,6 +15,7 @@ import {
   startMemoryMongo,
   stopMemoryMongo,
 } from "@backend/__tests__/helpers/mongo-memory-server";
+import mongoService from "@backend/common/services/mongo.service";
 import { afterAll } from "bun:test";
 
 const uri = await startMemoryMongo();
@@ -26,5 +27,21 @@ await import("@backend/__tests__/backend.test.init");
 await import("@backend/__tests__/backend.test.start");
 
 afterAll(async () => {
+  // Close this worker's own connection before anything else.
+  //
+  // Under `test-mongo-env.ts` every worker shares one mongod supplied through
+  // COMPASS_TEST_MONGO_URI, which makes stopMemoryMongo() below a no-op - so
+  // without this line the worker finishes its last test still holding an open
+  // socket, and whether the process then exits is left to Bun's handle
+  // teardown. When it loses that race the worker never exits, the runner's
+  // `await proc.exited` blocks forever, and the CI step dies on its timeout
+  // with every test having passed. That is exactly what happened to
+  // `unit (scripts)` on #3101: all tests green at 17:15:51, silence until the
+  // 5-minute timeout at 17:21:00, and cleanup reaping an orphaned mongod
+  // alongside five live bun processes.
+  //
+  // mongoService.stop() is a no-op when the worker never connected, so this is
+  // safe for the suites that hold no database at all.
+  await mongoService.stop();
   await stopMemoryMongo();
 });

--- a/packages/backend/src/__tests__/backend.preload.ts
+++ b/packages/backend/src/__tests__/backend.preload.ts
@@ -15,7 +15,6 @@ import {
   startMemoryMongo,
   stopMemoryMongo,
 } from "@backend/__tests__/helpers/mongo-memory-server";
-import mongoService from "@backend/common/services/mongo.service";
 import { afterAll } from "bun:test";
 
 const uri = await startMemoryMongo();
@@ -27,21 +26,5 @@ await import("@backend/__tests__/backend.test.init");
 await import("@backend/__tests__/backend.test.start");
 
 afterAll(async () => {
-  // Close this worker's own connection before anything else.
-  //
-  // Under `test-mongo-env.ts` every worker shares one mongod supplied through
-  // COMPASS_TEST_MONGO_URI, which makes stopMemoryMongo() below a no-op - so
-  // without this line the worker finishes its last test still holding an open
-  // socket, and whether the process then exits is left to Bun's handle
-  // teardown. When it loses that race the worker never exits, the runner's
-  // `await proc.exited` blocks forever, and the CI step dies on its timeout
-  // with every test having passed. That is exactly what happened to
-  // `unit (scripts)` on #3101: all tests green at 17:15:51, silence until the
-  // 5-minute timeout at 17:21:00, and cleanup reaping an orphaned mongod
-  // alongside five live bun processes.
-  //
-  // mongoService.stop() is a no-op when the worker never connected, so this is
-  // safe for the suites that hold no database at all.
-  await mongoService.stop();
   await stopMemoryMongo();
 });

--- a/packages/scripts/src/testing/test-mongo-env.ts
+++ b/packages/scripts/src/testing/test-mongo-env.ts
@@ -112,9 +112,11 @@ try {
         console.error(
           `\n${pkg}: tests stopped reporting but 'bun test' has not exited after ` +
             `${formatDuration(started)}s. This is an open-handle leak in a test ` +
-            `worker, not a slow suite - a worker is still holding something ` +
-            `(usually a Mongo connection; see the afterAll in backend.preload.ts). ` +
-            `Killing it so the failure is visible rather than silent.`,
+            `worker, not a slow suite - a worker has finished its tests but is ` +
+            `still holding something open (a Mongo connection is the usual ` +
+            `culprit: cleanupTestDb deliberately never disconnects, and the ` +
+            `shared-mongod path makes stopMemoryMongo a no-op). Killing it so ` +
+            `the failure is visible rather than a silent step timeout.`,
         );
         proc.kill();
         resolve(1);

--- a/packages/scripts/src/testing/test-mongo-env.ts
+++ b/packages/scripts/src/testing/test-mongo-env.ts
@@ -84,13 +84,45 @@ const testTargets = [
 
 console.log(`Running ${label} (${pkg})...`);
 
+/**
+ * How long to wait for `bun test` to exit before declaring it wedged.
+ *
+ * A worker that ends still holding an open handle never exits, and
+ * `await proc.exited` then blocks forever - the run dies on the CI step's own
+ * `timeout-minutes` with no output after the last passing test, which reads as
+ * a mystery rather than a diagnosis. The slowest of these suites (sync) runs in
+ * about 105s on ubuntu-latest, so four minutes is well clear of a legitimately
+ * slow run while still landing inside the step timeout, where this can say what
+ * actually happened and name the processes still alive.
+ */
+const EXIT_TIMEOUT_MS = 4 * 60 * 1000;
+
 try {
   const proc = Bun.spawn(testTargets, {
     env,
     stdout: "inherit",
     stderr: "inherit",
   });
-  const code = await proc.exited;
+
+  let wedged: ReturnType<typeof setTimeout> | undefined;
+  const code = await Promise.race([
+    proc.exited,
+    new Promise<number>((resolve) => {
+      wedged = setTimeout(() => {
+        console.error(
+          `\n${pkg}: tests stopped reporting but 'bun test' has not exited after ` +
+            `${formatDuration(started)}s. This is an open-handle leak in a test ` +
+            `worker, not a slow suite - a worker is still holding something ` +
+            `(usually a Mongo connection; see the afterAll in backend.preload.ts). ` +
+            `Killing it so the failure is visible rather than silent.`,
+        );
+        proc.kill();
+        resolve(1);
+      }, EXIT_TIMEOUT_MS);
+    }),
+  ]);
+  clearTimeout(wedged);
+
   console.log(`\n${pkg}: finished in ${formatDuration(started)}s`);
 
   if (code !== 0) {


### PR DESCRIPTION
## Summary

Follow-up 3 of 3 from the Sept 2 LCP investigation (#3101).

**The task was to raise the `unit (scripts)` timeout. I'm proposing we don't, because the timeout wasn't the problem — it did its job.**

The brief's premise was that `scripts` and `backend` boot an in-memory MongoDB and are "structurally slower". The measured durations say otherwise:

| project | "Run tests" step | boots mongo |
|---|---|---|
| core | ~2s | no |
| **scripts** | **~4–5s** | yes |
| backend | ~12–13s | yes |
| sync | ~32–105s | yes |
| web | ~92–103s | no |

`scripts` is the *second fastest* job. It is not near five minutes; it is roughly 1.5% of it.

### What actually happened on #3101

Run [33659924797](https://github.com/KeepSoftwareSimple/compass-calendar/actions/runs/33659924797), same commit `682fd43`, two attempts:

- **Attempt 1** — `Run scripts tests` 17:15:48 → 17:21:00 = **5m12s**, timed out.
- **Attempt 2** — same step, same commit: 17:22:22 → 17:22:27 = **5 seconds**.

Every test passed, the last finishing at `17:15:51.94`. Then **5m08s of no output**, then the timeout, then:

```
Cleaning up orphan processes
Terminate orphan process: pid (2416) (bun)
Terminate orphan process: pid (2432) (mongod-x64-ubuntu-6.0.14)
Terminate orphan process: pid (2510) (bun)
```

That's a hang, not a slow suite. A bigger number buys a ten-minute hang instead of a five-minute one — precisely the "bigger number that hides a genuine regression" the brief warned against. It reproduced on #3102 (a web-only diff) within the hour, so it's a recurring tax on unrelated PRs, not a one-off.

### Diagnosis

Under `test-mongo-env.ts` every worker shares one mongod via `COMPASS_TEST_MONGO_URI`. Two things line up:

1. `stopMemoryMongo()` returns immediately when that variable is set, so the preload's `afterAll` does nothing on the CI path.
2. `cleanupTestDb()` deliberately never disconnects — `mongoService.start()` reconnecting on a new db name is what gives cross-file isolation.

A worker can finish its last test still holding an open socket, and whether it exits is left to Bun's handle teardown. Lose that race and the worker never exits → `await proc.exited` blocks forever → `server.stop()` in its `finally` never runs, which is why mongod outlived the job.

### What this PR does — and what it deliberately no longer does

**It does not fix the leak.** An earlier revision of this PR closed the connection in the preload's `afterAll`. CI disproved it and I've reverted it (`0cef66a`).

That change passed here but broke #3102, where it turned the rare hang into a reliable failure — 3 failed tests and 6 unhandled errors, led by:

```
afterAll(leaveTestFileUrl)
error: Cannot call afterAll() after the test run has completed
```

then `process.stderr` coming back undefined and an `EEXIST` from `epoll_ctl`. Closing the client from a preload `afterAll` tears the worker down while later files in that worker are still registering hooks: a preload's `afterAll` does not mean "once, after every file", which is what the change assumed. The pre-existing `afterAll(stopMemoryMongo)` never exposed that because it's a no-op on this path. And because it passed here while failing there, the breakage is ordering-dependent — trading a rare hang for a flaky failure, which is worse.

**What remains stands on its own:**

- **`test-mongo-env.ts`** — bound the wait on `proc.exited` at 4 minutes. A wedged run now dies with a message naming the likely cause rather than silently consuming the step timeout with no output after the last passing test. Four minutes clears sync's ~105s worst case while landing *inside* the 5-minute step timeout, so the diagnosis actually gets printed.
- **`test-unit.yml`** — timeout unchanged at 5 minutes, with the reasoning recorded so the next person to meet this doesn't just bump it.

So: the hang is now **fast and legible instead of slow and mysterious**, and the underlying leak is documented in code where the next person will find it. That's a smaller claim than the earlier revision made, and it's the one I can support.

### Fixing the leak properly

Worth doing, but not blind. It needs an environment where the mongo-backed suites actually run, so a candidate teardown can be tested against real worker-ordering before it reaches CI — exactly what the reverted attempt lacked. Happy to open that separately.

## Simplicity

One `Promise.race` in the runner plus comments. No new dependency, no new abstraction, no test skipped or quarantined, and no change to the per-file isolation contract `cleanupTestDb` deliberately maintains.

## Automated validation

```
bun run lint         # exit 0; custom checkers (semantic-colors, agent-constraints) both ran and passed
bun run type-check   # clean
```

Lint reports 23 warnings, identical to the base commit's baseline; 0 fall in the files touched here.

**What I could not verify:** the mongo-backed suites don't run in this sandbox — `mongodb-memory-server` cannot bind a port (`listenInCluster` EPERM), so `bun run test:scripts` fails during setup on an unmodified checkout too. That limitation is why the reverted attempt reached CI unproven; the remaining change carries no such risk, since the watchdog only fires on a run that was already going to fail.

## Independent review

No `/review` handoff. Every claim is traceable: run 33659924797 attempts 1 and 2 for the timings and orphan-process list, [job 100358068711](https://github.com/KeepSoftwareSimple/compass-calendar/actions/runs/33663056318/job/100358068711) for the failure that disproved the preload fix, and `mongo-memory-server.ts` / `mock.db.setup.ts` for the two conditions behind the leak.

## Test plan

```
bun run lint
bun run type-check
```

Plus the full `unit` matrix on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EatK3AHJUb1nX5ngEtTpE3