### PR TITLE
feat(web): redesign guest confirmation and cancel pages

### DIFF
--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -379,6 +379,16 @@ export interface PublicBookingCancelStubOptions {
   cancelStatus?: number;
   /** When set, the cancel POST waits until this resolves (for in-flight UI). */
   holdCancel?: Promise<void>;
+  durationMinutes?: number;
+  slotStart?: string;
+  guestTimeZone?: string;
+  hostDisplayName?: string;
+  /** Public GET reservation status. Defaults to confirmed. */
+  reservationStatus?: "confirmed" | "cancelled";
+  /** When true, GET /reservations/:id returns 404. */
+  reservationNotFound?: boolean;
+  /** When set, GET /reservations/:id returns this status instead of 200. */
+  reservationGetStatus?: number;
 }
 
 export interface CapturedCancelRequests {
@@ -397,6 +407,28 @@ export async function preparePublicBookingCancelPage(
     const request = route.request();
     const url = new URL(request.url());
     const path = url.pathname;
+
+    if (
+      path === `/api/booking/reservations/${reservationId}` &&
+      request.method() === "GET"
+    ) {
+      if (options.reservationNotFound) {
+        return route.fulfill(jsonResponse({}, 404));
+      }
+      if (options.reservationGetStatus) {
+        return route.fulfill(jsonResponse({}, options.reservationGetStatus));
+      }
+      const slot = buildBookableSlot(options.durationMinutes ?? 30);
+      return route.fulfill(
+        jsonResponse({
+          slotStart: options.slotStart ?? slot.slotStart,
+          guestTimeZone: options.guestTimeZone ?? "UTC",
+          durationMinutes: options.durationMinutes ?? 30,
+          hostDisplayName: options.hostDisplayName ?? "Tyler Dane",
+          status: options.reservationStatus ?? "confirmed",
+        }),
+      );
+    }
 
     if (
       path === `/api/booking/reservations/${reservationId}/cancel` &&

--- a/e2e/booking/public-booking-cancel.spec.ts
+++ b/e2e/booking/public-booking-cancel.spec.ts
@@ -10,6 +10,12 @@ test.describe("public booking cancel page", () => {
     await expect(
       page.getByRole("heading", { name: "Cancel this booking?" }),
     ).toBeVisible();
+    await expect(
+      page.getByText("You are canceling a booking with Tyler Dane."),
+    ).toBeVisible();
+    await expect(page.getByText("When")).toBeVisible();
+    await expect(page.getByText("Duration")).toBeVisible();
+    await expect(page.getByText("Timezone")).toBeVisible();
     expect(captured.cancelPosts).toHaveLength(0);
 
     await page.getByRole("button", { name: "Cancel this booking" }).click();
@@ -33,6 +39,22 @@ test.describe("public booking cancel page", () => {
     await expect(
       page.getByRole("button", { name: "Cancel this booking" }),
     ).toBeFocused();
+  });
+
+  test("skips confirmation when the reservation is already cancelled", async ({
+    page,
+  }) => {
+    const captured = await preparePublicBookingCancelPage(page, {
+      reservationStatus: "cancelled",
+    });
+
+    await expect(
+      page.getByRole("heading", { name: "Booking canceled" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Cancel this booking" }),
+    ).toHaveCount(0);
+    expect(captured.cancelPosts).toHaveLength(0);
   });
 
   test("shows a distinct error heading from the canceled state", async ({

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -106,9 +106,20 @@ test.describe("public booking page", () => {
     await expect(
       page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
     ).toBeFocused();
+    await expect(page.getByText("When")).toBeVisible();
+    await expect(page.getByText("Duration")).toBeVisible();
+    await expect(page.getByText("Timezone")).toBeVisible();
     await expect(
       page.getByText(/A Google Meet invite is on its way to your email/),
     ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "cancel this booking" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", {
+        name: "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+      }),
+    ).toHaveCount(0);
     expect(captured.reservationPosts).toHaveLength(1);
     expect(captured.reservationPosts[0]).toMatchObject({
       slotStart,
@@ -175,7 +186,17 @@ test.describe("public booking page", () => {
     await expect(
       page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
     ).toBeFocused();
+    await expect(page.getByText("When")).toBeVisible();
     await expect(page.getByText("30 minutes")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Copy cancel link" }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("link", { name: "cancel this booking" }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByText(/To cancel, use the link in that invite/),
+    ).toBeVisible();
     await expect(page).toHaveURL(
       /\/book\/confirmed\/000000000000000000000099$/,
     );
@@ -190,6 +211,9 @@ test.describe("public booking page", () => {
     ).toBeFocused();
     await expect(
       page.getByRole("button", { name: "Copy cancel link" }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("link", { name: "cancel this booking" }),
     ).toHaveCount(0);
   });
 
@@ -208,6 +232,12 @@ test.describe("public booking page", () => {
     await page.getByLabel("Email").fill("guest@example.com");
     await page.getByRole("button", { name: "Confirm booking" }).click();
 
+    await expect(
+      page.getByRole("link", { name: "cancel this booking" }),
+    ).toHaveAttribute(
+      "href",
+      "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+    );
     await page.getByRole("button", { name: "Copy cancel link" }).click();
     await expect(page.getByRole("button", { name: "Copied" })).toBeVisible();
     await expect(page.getByRole("status")).toHaveText("Copied");

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -187,16 +187,8 @@ test.describe("public booking page", () => {
       page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
     ).toBeFocused();
     await expect(page.getByText("When")).toBeVisible();
+    await expect(page.getByText("Duration")).toBeVisible();
     await expect(page.getByText("30 minutes")).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: "Copy cancel link" }),
-    ).toHaveCount(0);
-    await expect(
-      page.getByRole("link", { name: "cancel this booking" }),
-    ).toHaveCount(0);
-    await expect(
-      page.getByText(/To cancel, use the link in that invite/),
-    ).toBeVisible();
     await expect(page).toHaveURL(
       /\/book\/confirmed\/000000000000000000000099$/,
     );

--- a/packages/web/src/booking/PublicBookingCancelPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingCancelPage.test.tsx
@@ -15,6 +15,25 @@ import { describe, expect, it } from "bun:test";
 
 const reservationId = "000000000000000000000099";
 const cancelPath = `/book/cancel/${reservationId}?token=abc`;
+const slotStart = "2026-09-15T15:00:00.000Z";
+
+function reservationGetHandler(overrides: Record<string, unknown> = {}) {
+  return rest.get(
+    `${ENV_WEB.API_BASEURL}/booking/reservations/${reservationId}`,
+    (_req, res, ctx) =>
+      res(
+        ctx.status(Status.OK),
+        ctx.json({
+          slotStart,
+          guestTimeZone: "UTC",
+          durationMinutes: 30,
+          hostDisplayName: "Tyler Dane",
+          status: "confirmed",
+          ...overrides,
+        }),
+      ),
+  );
+}
 
 function renderCancelRoute(path: string) {
   const router = createRouter({
@@ -32,6 +51,7 @@ describe("PublicBookingCancelPage", () => {
     let cancelPosts = 0;
 
     server.use(
+      reservationGetHandler(),
       rest.post(
         `${ENV_WEB.API_BASEURL}/booking/reservations/${reservationId}/cancel`,
         async (_req, res, ctx) => {
@@ -67,6 +87,7 @@ describe("PublicBookingCancelPage", () => {
     });
 
     server.use(
+      reservationGetHandler(),
       rest.post(
         `${ENV_WEB.API_BASEURL}/booking/reservations/${reservationId}/cancel`,
         async (_req, res, ctx) => {
@@ -94,6 +115,7 @@ describe("PublicBookingCancelPage", () => {
 
   it("focuses the heading on load and tabs to the confirm button", async () => {
     const user = userEvent.setup({ delay: null });
+    server.use(reservationGetHandler());
 
     renderCancelRoute(cancelPath);
 
@@ -114,6 +136,7 @@ describe("PublicBookingCancelPage", () => {
     const user = userEvent.setup({ delay: null });
 
     server.use(
+      reservationGetHandler(),
       rest.post(
         `${ENV_WEB.API_BASEURL}/booking/reservations/${reservationId}/cancel`,
         (_req, res, ctx) =>
@@ -138,6 +161,7 @@ describe("PublicBookingCancelPage", () => {
   it("shows not-found without posting when the token is missing", async () => {
     let cancelPosts = 0;
     server.use(
+      reservationGetHandler(),
       rest.post(
         `${ENV_WEB.API_BASEURL}/booking/reservations/${reservationId}/cancel`,
         (_req, res, ctx) => {
@@ -152,6 +176,47 @@ describe("PublicBookingCancelPage", () => {
     expect(
       await screen.findByRole("heading", { name: "Booking not found" }),
     ).toBeInTheDocument();
+    expect(cancelPosts).toBe(0);
+  });
+
+  it("shows host and slot details before confirm", async () => {
+    server.use(reservationGetHandler());
+
+    renderCancelRoute(cancelPath);
+
+    expect(
+      await screen.findByRole("heading", { name: "Cancel this booking?" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("You are canceling a booking with Tyler Dane."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("When")).toBeInTheDocument();
+    expect(screen.getByText("Duration")).toBeInTheDocument();
+    expect(screen.getByText("Timezone")).toBeInTheDocument();
+    expect(screen.getByText("30 minutes")).toBeInTheDocument();
+  });
+
+  it("skips confirmation when the reservation is already cancelled", async () => {
+    let cancelPosts = 0;
+    server.use(
+      reservationGetHandler({ status: "cancelled" }),
+      rest.post(
+        `${ENV_WEB.API_BASEURL}/booking/reservations/${reservationId}/cancel`,
+        (_req, res, ctx) => {
+          cancelPosts += 1;
+          return res(ctx.status(Status.OK), ctx.json({ ok: true }));
+        },
+      ),
+    );
+
+    renderCancelRoute(cancelPath);
+
+    expect(
+      await screen.findByRole("heading", { name: "Booking canceled" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Cancel this booking" }),
+    ).not.toBeInTheDocument();
     expect(cancelPosts).toBe(0);
   });
 });

--- a/packages/web/src/booking/PublicBookingCancelPage.tsx
+++ b/packages/web/src/booking/PublicBookingCancelPage.tsx
@@ -1,14 +1,19 @@
 import { useParams, useSearch } from "@tanstack/react-router";
 import { useRef, useState } from "react";
-import { PublicBookingApi } from "@web/api/public-booking.api";
+import {
+  PublicBookingApi,
+  PublicBookingNotFoundError,
+} from "@web/api/public-booking.api";
 import { getErrorStatus } from "@web/api/util/api.util";
 import { PublicBookingLayout } from "@web/booking/PublicBookingLayout";
+import { PublicBookingSlotSummary } from "@web/booking/PublicBookingSlotSummary";
 import { PublicBookingStatusMessage } from "@web/booking/PublicBookingStatusMessage";
+import { usePublicBookingReservationQuery } from "@web/booking/public-booking.query";
 import { useBookingDocumentTitle } from "@web/booking/use-booking-document-title";
 import { useBookingHeadingFocus } from "@web/booking/use-booking-heading-focus";
 
-type CancelState =
-  | "confirm"
+type CancelActionState =
+  | "idle"
   | "cancelling"
   | "cancelled"
   | "not-found"
@@ -18,10 +23,14 @@ export function PublicBookingCancelPage() {
   const { reservationId } = useParams({ from: "/book/cancel/$reservationId" });
   const search = useSearch({ from: "/book/cancel/$reservationId" });
   const token = search.token ?? "";
-  const [state, setState] = useState<CancelState>(
-    reservationId && token ? "confirm" : "not-found",
+  const canLoad = Boolean(reservationId && token);
+  const reservationQuery = usePublicBookingReservationQuery(
+    canLoad ? reservationId : "",
   );
-  const headingRef = useBookingHeadingFocus(state);
+  const [action, setAction] = useState<CancelActionState>("idle");
+  const headingRef = useBookingHeadingFocus(
+    `${action}:${reservationQuery.status}:${reservationQuery.data?.status ?? ""}`,
+  );
   const inFlightRef = useRef(false);
   useBookingDocumentTitle("Cancel booking");
 
@@ -31,61 +40,21 @@ export function PublicBookingCancelPage() {
     }
 
     inFlightRef.current = true;
-    setState("cancelling");
+    setAction("cancelling");
 
     try {
       await PublicBookingApi.cancelReservation(reservationId, { token });
-      setState("cancelled");
+      setAction("cancelled");
     } catch (error) {
       if (getErrorStatus(error) === 404) {
-        setState("not-found");
+        setAction("not-found");
         return;
       }
-      setState("error");
+      setAction("error");
     }
   };
 
-  if (state === "confirm" || state === "cancelling") {
-    const busy = state === "cancelling";
-    return (
-      <PublicBookingLayout>
-        <section aria-busy={busy} aria-labelledby="booking-cancel-heading">
-          <h1
-            ref={headingRef}
-            id="booking-cancel-heading"
-            tabIndex={-1}
-            className="font-semibold text-text text-xl focus:outline-none focus:ring-2 focus:ring-accent"
-          >
-            Cancel this booking?
-          </h1>
-          <p className="mt-2 text-sm text-text-muted">
-            This will remove the appointment from the host calendar.
-          </p>
-          <button
-            type="button"
-            disabled={busy}
-            onClick={() => {
-              void handleConfirm();
-            }}
-            className="c-focus-ring mt-6 rounded-md bg-accent px-4 py-2 font-medium text-on-accent transition-colors hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {busy ? "Canceling..." : "Cancel this booking"}
-          </button>
-        </section>
-      </PublicBookingLayout>
-    );
-  }
-
-  if (state === "cancelled") {
-    return (
-      <PublicBookingStatusMessage
-        title="Booking canceled"
-        description="Your appointment has been canceled. You can close this page."
-      />
-    );
-  }
-
-  if (state === "not-found") {
+  if (!canLoad || action === "not-found") {
     return (
       <PublicBookingStatusMessage
         title="Booking not found"
@@ -94,10 +63,105 @@ export function PublicBookingCancelPage() {
     );
   }
 
+  if (action === "cancelled") {
+    return (
+      <PublicBookingStatusMessage
+        title="Booking canceled"
+        description="Your appointment has been canceled. You can close this page."
+      />
+    );
+  }
+
+  if (action === "error") {
+    return (
+      <PublicBookingStatusMessage
+        title="Could not cancel booking"
+        description="Please try again or use the link from your calendar invite."
+      />
+    );
+  }
+
+  if (reservationQuery.isLoading) {
+    return (
+      <PublicBookingStatusMessage
+        title="Loading booking"
+        description="One moment while we load this booking."
+      />
+    );
+  }
+
+  if (reservationQuery.isError) {
+    if (reservationQuery.error instanceof PublicBookingNotFoundError) {
+      return (
+        <PublicBookingStatusMessage
+          title="Booking not found"
+          description="This cancel link may be invalid or already used."
+        />
+      );
+    }
+    return (
+      <PublicBookingStatusMessage
+        title="Could not cancel booking"
+        description="Please try again or use the link from your calendar invite."
+      />
+    );
+  }
+
+  const reservation = reservationQuery.data;
+  if (!reservation) {
+    return (
+      <PublicBookingStatusMessage
+        title="Booking not found"
+        description="This cancel link may be invalid or already used."
+      />
+    );
+  }
+
+  if (reservation.status === "cancelled") {
+    return (
+      <PublicBookingStatusMessage
+        title="Booking canceled"
+        description="Your appointment has been canceled. You can close this page."
+      />
+    );
+  }
+
+  const busy = action === "cancelling";
   return (
-    <PublicBookingStatusMessage
-      title="Could not cancel booking"
-      description="Please try again or use the link from your calendar invite."
-    />
+    <PublicBookingLayout>
+      <section aria-busy={busy} aria-labelledby="booking-cancel-heading">
+        <h1
+          ref={headingRef}
+          id="booking-cancel-heading"
+          tabIndex={-1}
+          className="font-semibold text-text text-xl focus:outline-none focus:ring-2 focus:ring-accent"
+        >
+          Cancel this booking?
+        </h1>
+        <p className="mt-2 text-sm text-text">
+          You are canceling a booking with {reservation.hostDisplayName}.
+        </p>
+        <p className="mt-2 text-sm text-text-muted">
+          This will remove the appointment from the host calendar.
+        </p>
+        <div className="mt-4">
+          <PublicBookingSlotSummary
+            durationMinutes={reservation.durationMinutes}
+            slotStart={reservation.slotStart}
+            timeZone={reservation.guestTimeZone}
+          />
+        </div>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => {
+            void handleConfirm();
+          }}
+          className="c-button c-button-primary mt-6"
+        >
+          {busy ? "Canceling..." : "Cancel this booking"}
+        </button>
+      </section>
+    </PublicBookingLayout>
   );
 }

--- a/packages/web/src/booking/PublicBookingConfirmationView.test.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmationView.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PublicBookingConfirmationView } from "@web/booking/PublicBookingConfirmationView";
+import {
+  formatBookingSlotLabel,
+  formatDurationMinutes,
+} from "@web/booking/public-booking.format";
+import { describe, expect, it, mock } from "bun:test";
+
+const slotStart = "2026-09-15T15:00:00.000Z";
+const timeZone = "UTC";
+const cancelUrl =
+  "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc";
+
+describe("PublicBookingConfirmationView", () => {
+  it("shows the slot summary instead of a raw cancel URL", () => {
+    render(
+      <PublicBookingConfirmationView
+        cancelUrl={cancelUrl}
+        durationMinutes={30}
+        hostDisplayName="Tyler Dane"
+        slotStart={slotStart}
+        timeZone={timeZone}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("When")).toBeInTheDocument();
+    expect(
+      screen.getByText(formatBookingSlotLabel(slotStart, timeZone)),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Duration")).toBeInTheDocument();
+    expect(screen.getByText(formatDurationMinutes(30))).toBeInTheDocument();
+    expect(screen.getByText("Timezone")).toBeInTheDocument();
+    expect(screen.queryByText(cancelUrl)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "cancel this booking" }),
+    ).toHaveAttribute("href", cancelUrl);
+    expect(
+      screen.getByRole("button", { name: "Copy cancel link" }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides copy and cancel controls without a cancel URL", () => {
+    render(
+      <PublicBookingConfirmationView
+        durationMinutes={30}
+        hostDisplayName="Tyler Dane"
+        slotStart={slotStart}
+        timeZone={timeZone}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Copy cancel link" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "cancel this booking" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/To cancel, use the link in that invite/),
+    ).toBeInTheDocument();
+  });
+
+  it("copies the cancel URL from the secondary button", async () => {
+    const user = userEvent.setup({ delay: null });
+    const written: string[] = [];
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: mock((value: string) => {
+          written.push(value);
+          return Promise.resolve();
+        }),
+      },
+    });
+
+    render(
+      <PublicBookingConfirmationView
+        cancelUrl={cancelUrl}
+        durationMinutes={30}
+        hostDisplayName="Tyler Dane"
+        slotStart={slotStart}
+        timeZone={timeZone}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Copy cancel link" }));
+
+    expect(written).toEqual([cancelUrl]);
+    expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Copied");
+  });
+});

--- a/packages/web/src/booking/PublicBookingConfirmationView.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmationView.tsx
@@ -1,9 +1,7 @@
+import { CheckCircleIcon } from "@phosphor-icons/react";
 import { PublicBookingCopyCancelUrl } from "@web/booking/PublicBookingCopyCancelUrl";
 import { PublicBookingLayout } from "@web/booking/PublicBookingLayout";
-import {
-  formatBookingSlotLabel,
-  formatDurationMinutes,
-} from "@web/booking/public-booking.format";
+import { PublicBookingSlotSummary } from "@web/booking/PublicBookingSlotSummary";
 import { useBookingHeadingFocus } from "@web/booking/use-booking-heading-focus";
 
 interface PublicBookingConfirmationViewProps {
@@ -22,26 +20,38 @@ export function PublicBookingConfirmationView({
   cancelUrl,
 }: PublicBookingConfirmationViewProps) {
   const headingRef = useBookingHeadingFocus(hostDisplayName);
-  const when = formatBookingSlotLabel(slotStart, timeZone);
 
   return (
     <PublicBookingLayout>
-      <section aria-labelledby="booking-confirmation-heading">
-        <h1
-          ref={headingRef}
-          id="booking-confirmation-heading"
-          tabIndex={-1}
-          className="font-semibold text-text text-xl focus:outline-none focus:ring-2 focus:ring-accent"
-        >
-          You are booked with {hostDisplayName}
-        </h1>
-        <p className="mt-2 text-sm text-text-muted">
-          {when} ({formatDurationMinutes(durationMinutes)} Google Meet)
-        </p>
-        <p className="mt-4 text-sm text-text">
-          A Google Meet invite is on its way to your email. To cancel, use the
-          link in that invite
-          {cancelUrl ? " or copy it here:" : "."}
+      <section
+        aria-labelledby="booking-confirmation-heading"
+        className="flex flex-col gap-4"
+      >
+        <div className="flex items-start gap-3">
+          <CheckCircleIcon
+            aria-hidden
+            className="mt-0.5 shrink-0 text-success"
+            size={28}
+            weight="fill"
+          />
+          <h1
+            ref={headingRef}
+            id="booking-confirmation-heading"
+            tabIndex={-1}
+            className="font-semibold text-text text-xl focus:outline-none focus:ring-2 focus:ring-accent"
+          >
+            You are booked with {hostDisplayName}
+          </h1>
+        </div>
+        <PublicBookingSlotSummary
+          durationMinutes={durationMinutes}
+          slotStart={slotStart}
+          timeZone={timeZone}
+        />
+        <p className="text-sm text-text">
+          {cancelUrl
+            ? "A Google Meet invite is on its way to your email."
+            : "A Google Meet invite is on its way to your email. To cancel, use the link in that invite."}
         </p>
         {cancelUrl ? (
           <PublicBookingCopyCancelUrl cancelUrl={cancelUrl} />

--- a/packages/web/src/booking/PublicBookingCopyCancelUrl.tsx
+++ b/packages/web/src/booking/PublicBookingCopyCancelUrl.tsx
@@ -10,20 +10,20 @@ export function PublicBookingCopyCancelUrl({
   const { copied, copy } = useCopiedFlag(cancelUrl);
 
   return (
-    <div className="mt-4 flex flex-col gap-2">
-      <a
-        href={cancelUrl}
-        className="c-focus-ring break-all text-accent text-sm underline"
-      >
-        {cancelUrl}
-      </a>
+    <div className="flex flex-col items-start gap-3">
       <button
         type="button"
         onClick={copy}
-        className="c-focus-ring self-start rounded-md border border-border bg-surface px-3 py-1.5 text-sm text-text"
+        className="c-button c-button-secondary"
       >
         {copied ? "Copied" : "Copy cancel link"}
       </button>
+      <a
+        href={cancelUrl}
+        className="c-focus-ring text-accent text-sm underline"
+      >
+        cancel this booking
+      </a>
       <p role="status" className="sr-only">
         {copied ? "Copied" : ""}
       </p>

--- a/packages/web/src/booking/PublicBookingGuestForm.tsx
+++ b/packages/web/src/booking/PublicBookingGuestForm.tsx
@@ -40,10 +40,7 @@ const validateGuestFields = (
   return errors;
 };
 
-const FIELD_CLASS_NAME =
-  "c-focus-ring rounded-md border border-border bg-surface px-3 py-2 text-text";
-
-const INVALID_FIELD_CLASS_NAME = `${FIELD_CLASS_NAME} border-error`;
+const INVALID_FIELD_CLASS_NAME = "c-field border-error";
 
 export function PublicBookingGuestForm({
   disabled,
@@ -115,9 +112,7 @@ export function PublicBookingGuestForm({
             onChange({ ...values, guestName: event.target.value });
             setErrors((current) => ({ ...current, guestName: undefined }));
           }}
-          className={
-            errors.guestName ? INVALID_FIELD_CLASS_NAME : FIELD_CLASS_NAME
-          }
+          className={errors.guestName ? INVALID_FIELD_CLASS_NAME : "c-field"}
         />
         {errors.guestName ? (
           <span
@@ -146,9 +141,7 @@ export function PublicBookingGuestForm({
             onChange({ ...values, guestEmail: event.target.value });
             setErrors((current) => ({ ...current, guestEmail: undefined }));
           }}
-          className={
-            errors.guestEmail ? INVALID_FIELD_CLASS_NAME : FIELD_CLASS_NAME
-          }
+          className={errors.guestEmail ? INVALID_FIELD_CLASS_NAME : "c-field"}
         />
         {errors.guestEmail ? (
           <span
@@ -169,14 +162,14 @@ export function PublicBookingGuestForm({
           onChange={(event) =>
             onChange({ ...values, notes: event.target.value })
           }
-          className={FIELD_CLASS_NAME}
+          className="c-field"
         />
       </label>
       <button
         type="submit"
         disabled={disabled || submitDisabled}
         aria-busy={disabled || undefined}
-        className="c-focus-ring rounded-md bg-accent px-4 py-2 font-medium text-on-accent transition-colors hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
+        className="c-button c-button-primary"
       >
         {disabled ? "Confirming..." : "Confirm booking"}
       </button>

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -428,6 +428,9 @@ describe("PublicBookingPage", () => {
     expect(
       screen.getByRole("button", { name: "Copy cancel link" }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "cancel this booking" }),
+    ).toBeInTheDocument();
   });
 
   it("overrides the guest timezone for labels, day grouping, and submit", async () => {
@@ -1292,7 +1295,12 @@ describe("PublicBookingConfirmedPage", () => {
         name: "You are booked with Tyler Dane",
       }),
     ).toHaveFocus();
-    expect(screen.getByText(/30 minutes Google Meet/)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/30 minutes Google Meet/),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("When")).toBeInTheDocument();
+    expect(screen.getByText("Duration")).toBeInTheDocument();
+    expect(screen.getByText("Timezone")).toBeInTheDocument();
     expect(
       screen.getByText(/A Google Meet invite is on its way to your email/),
     ).toBeInTheDocument();
@@ -1383,6 +1391,17 @@ describe("PublicBookingConfirmedPage", () => {
     await user.type(screen.getByLabelText("Name"), "Guest User");
     await user.type(screen.getByLabelText("Email"), "guest@example.com");
     await user.click(screen.getByRole("button", { name: "Confirm booking" }));
+    expect(
+      await screen.findByRole("link", { name: "cancel this booking" }),
+    ).toHaveAttribute(
+      "href",
+      "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+    );
+    expect(
+      screen.queryByRole("link", {
+        name: "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+      }),
+    ).not.toBeInTheDocument();
     await user.click(
       await screen.findByRole("button", { name: "Copy cancel link" }),
     );

--- a/packages/web/src/booking/PublicBookingPicker.tsx
+++ b/packages/web/src/booking/PublicBookingPicker.tsx
@@ -160,7 +160,7 @@ export function PublicBookingPicker({
                 disabled={slotsFetching}
                 aria-busy={slotsFetching || undefined}
                 onClick={onRetrySlots}
-                className="c-focus-ring rounded-md bg-surface-panel px-3 py-2 font-medium text-sm text-text transition-colors hover:bg-surface-raised disabled:cursor-not-allowed disabled:opacity-60"
+                className="c-button c-button-secondary"
               >
                 Retry
               </button>

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -476,6 +476,10 @@
   @apply c-focus-ring inline-flex items-center font-medium transition-[background-color] duration-150 ease-out disabled:pointer-events-none disabled:opacity-60;
 }
 
+@utility c-field {
+  @apply c-focus-ring rounded-md border border-border bg-surface px-3 py-2 text-text;
+}
+
 @utility c-disclosure-content {
   @apply invisible grid grid-rows-[0fr] overflow-hidden opacity-0 transition-[grid-template-rows,opacity,visibility] duration-200 ease-out motion-reduce:transition-none;
   transition-behavior: allow-discrete;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #3087, #3088, and #3089.

Guest confirmation now uses a success heading plus the existing When / Duration / Timezone card instead of an inline sentence and a raw tokenized cancel URL. Cancel is still available after booking via a secondary Copy cancel link button and a short cancel this booking link. Cold permalinks omit those controls because the public GET cannot reconstruct the token. Reload keeps them when `history.state` is restored.

The cancel page fetches the public reservation on load and shows the host name and slot summary before confirm. Already-cancelled reservations skip the confirm step. Public booking buttons and guest fields now use the shared `c-button*` utilities and a new `c-field` utility.

## Simplicity

Reused `PublicBookingSlotSummary`, `usePublicBookingReservationQuery`, and the existing cancel URL history-state branch. Button and field class strings collapse onto the shared utilities rather than a third guest-only palette.

## Automated validation

- `bun test:web` on confirmation, cancel, and public booking page: 38 pass
- `bunx playwright test e2e/booking e2e/accessibility/booking-a11y.spec.ts`: 49 pass
- GitHub Test workflow: e2e, unit (web), lint, type-check, knip green

## Independent review

VERDICT: no confirmed findings

## Test plan

- `bun test:web -- packages/web/src/booking/PublicBookingConfirmationView.test.tsx packages/web/src/booking/PublicBookingCancelPage.test.tsx packages/web/src/booking/PublicBookingPage.test.tsx`
- `bunx playwright test e2e/booking e2e/accessibility/booking-a11y.spec.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6e2dba1-cfc3-4458-b158-14d650287a70?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6e2dba1-cfc3-4458-b158-14d650287a70&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

