### PR TITLE
fix(web): let series-scope toast own digits 1 and 2

### DIFF
--- a/packages/web/src/events/recurrence/RecurrenceScopeOpportunityHost.test.tsx
+++ b/packages/web/src/events/recurrence/RecurrenceScopeOpportunityHost.test.tsx
@@ -1,19 +1,46 @@
-import { HotkeyManager } from "@tanstack/react-hotkeys";
 import { type EventId } from "@core/types/domain-primitives";
+import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import {
   cleanup,
   fireEvent,
   render,
+  renderHook,
   waitFor,
 } from "@web/__tests__/__mocks__/mock.render";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { recurrenceScopeOpportunityActions } from "@web/events/recurrence/recurrence-scope-opportunity.store";
+import { useShiftHoldEventHints } from "@web/shortcuts/shift-hint/useShiftHoldEventHints";
 import { RecurrenceScopeOpportunityHost } from "./RecurrenceScopeOpportunityHost";
-import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
+
+const occurrence = () =>
+  createMockEvent({
+    recurrence: {
+      kind: "occurrence",
+      seriesId: "0123456789abcdef11111111" as EventId,
+    },
+  });
+
+const beginReadyAsk = () =>
+  recurrenceScopeOpportunityActions.begin({
+    kind: "delete",
+    original: occurrence(),
+    source: "local",
+  });
+
+const pressDigit = (value: "1" | "2") =>
+  fireEvent.keyDown(document, { key: value, code: `Digit${value}` });
 
 describe("RecurrenceScopeOpportunityHost", () => {
   beforeEach(() => {
-    HotkeyManager.resetInstance();
     document.body.removeAttribute("data-app-locked");
     recurrenceScopeOpportunityActions.reset();
   });
@@ -23,28 +50,76 @@ describe("RecurrenceScopeOpportunityHost", () => {
     recurrenceScopeOpportunityActions.reset();
   });
 
-  it("promotes the live opportunity with 2", async () => {
-    const id = recurrenceScopeOpportunityActions.begin({
-      kind: "delete",
-      original: createMockEvent({
-        recurrence: {
-          kind: "occurrence",
-          seriesId: "0123456789abcdef11111111" as EventId,
-        },
-      }),
-      source: "local",
-    });
+  it("promotes following with 1", async () => {
+    const id = beginReadyAsk();
     const requestPromotion = spyOn(
       recurrenceScopeOpportunityActions,
       "requestPromotion",
     );
 
     render(<RecurrenceScopeOpportunityHost />);
-    fireEvent.keyDown(document, { key: "2" });
+    pressDigit("1");
+
+    await waitFor(() => {
+      expect(requestPromotion).toHaveBeenCalledWith(id, "thisAndFollowing");
+    });
+    requestPromotion.mockRestore();
+  });
+
+  it("promotes the live opportunity with 2", async () => {
+    const id = beginReadyAsk();
+    const requestPromotion = spyOn(
+      recurrenceScopeOpportunityActions,
+      "requestPromotion",
+    );
+
+    render(<RecurrenceScopeOpportunityHost />);
+    pressDigit("2");
 
     await waitFor(() => {
       expect(requestPromotion).toHaveBeenCalledWith(id, "all");
     });
+    requestPromotion.mockRestore();
+  });
+
+  it("does not steal 1 when no series-scope toast is live", () => {
+    const requestPromotion = spyOn(
+      recurrenceScopeOpportunityActions,
+      "requestPromotion",
+    );
+
+    render(<RecurrenceScopeOpportunityHost />);
+    pressDigit("1");
+
+    expect(requestPromotion).not.toHaveBeenCalled();
+    requestPromotion.mockRestore();
+  });
+
+  it("takes 1 from quick-time create while the toast is live", async () => {
+    const id = beginReadyAsk();
+    const requestPromotion = spyOn(
+      recurrenceScopeOpportunityActions,
+      "requestPromotion",
+    );
+    const createAt = mock((_start: Dayjs) => {});
+
+    render(<RecurrenceScopeOpportunityHost />);
+    renderHook(() =>
+      useShiftHoldEventHints({
+        createAtTime: createAt,
+        focus: () => {},
+        getQuickTimeDay: () => dayjs().startOf("day"),
+        listVisible: () => [],
+        timedEvents: [],
+      }),
+    );
+
+    pressDigit("1");
+
+    await waitFor(() => {
+      expect(requestPromotion).toHaveBeenCalledWith(id, "thisAndFollowing");
+    });
+    expect(createAt).not.toHaveBeenCalled();
     requestPromotion.mockRestore();
   });
 });

--- a/packages/web/src/events/recurrence/RecurrenceScopeOpportunityHost.tsx
+++ b/packages/web/src/events/recurrence/RecurrenceScopeOpportunityHost.tsx
@@ -1,59 +1,62 @@
 import { useEffect } from "react";
+import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
 import {
   showRecurrenceScopePromotionToast,
   showRecurrenceScopeToast,
 } from "@web/common/utils/toast/recurrence-scope.toast";
 import { useEventMutations } from "@web/events/mutations/useEventMutations";
 import {
+  isRecurrenceScopeAskReady,
   recurrenceScopeOpportunityActions,
   selectRecurrenceScopeOpportunity,
   useRecurrenceScopeOpportunityStore,
 } from "@web/events/recurrence/recurrence-scope-opportunity.store";
-import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
+import { isAppLocked } from "@web/shortcuts/app-lock";
+import { digitPickIndex } from "@web/shortcuts/digit-pick.util";
+import { isEditSequenceArmed } from "@web/shortcuts/useEditSequenceShortcut";
 
-const canHandleShortcut = (event: KeyboardEvent) =>
-  !event.isComposing &&
-  !event.metaKey &&
-  !event.ctrlKey &&
-  !event.altKey &&
-  !event.shiftKey;
+const scopeForToastDigit = (
+  event: KeyboardEvent,
+): "thisAndFollowing" | "all" | null => {
+  if (
+    event.isComposing ||
+    isAppLocked() ||
+    isEditableKeyboardTarget(event) ||
+    isEditSequenceArmed()
+  ) {
+    return null;
+  }
+
+  const pickIndex = digitPickIndex(event);
+  if (pickIndex === 0) return "thisAndFollowing";
+  if (pickIndex === 1) return "all";
+  return null;
+};
 
 export function RecurrenceScopeOpportunityHost() {
   const opportunity = useRecurrenceScopeOpportunityStore(
     selectRecurrenceScopeOpportunity,
   );
   const { promoteRecurring } = useEventMutations();
-  const isReady = opportunity?.status === "ready";
 
-  useAppShortcut(
-    "1",
-    (event) => {
-      if (!opportunity || !canHandleShortcut(event)) return;
-      recurrenceScopeOpportunityActions.requestPromotion(
-        opportunity.id,
-        "thisAndFollowing",
-      );
-    },
-    {
-      enabled: isReady,
-      ignoreInputs: true,
-      preventDefault: true,
-      stopPropagation: true,
-    },
-  );
-  useAppShortcut(
-    "2",
-    (event) => {
-      if (!opportunity || !canHandleShortcut(event)) return;
-      recurrenceScopeOpportunityActions.requestPromotion(opportunity.id, "all");
-    },
-    {
-      enabled: isReady,
-      ignoreInputs: true,
-      preventDefault: true,
-      stopPropagation: true,
-    },
-  );
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      if (!isRecurrenceScopeAskReady()) return;
+      const scope = scopeForToastDigit(event);
+      if (!scope) return;
+
+      const current = useRecurrenceScopeOpportunityStore.getState().opportunity;
+      if (!current || current.status !== "ready") return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      recurrenceScopeOpportunityActions.requestPromotion(current.id, scope);
+    };
+
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => document.removeEventListener("keydown", onKeyDown, true);
+  }, []);
 
   useEffect(() => {
     if (opportunity?.status !== "ready") return;

--- a/packages/web/src/events/recurrence/RecurrenceScopeOpportunityHost.tsx
+++ b/packages/web/src/events/recurrence/RecurrenceScopeOpportunityHost.tsx
@@ -11,27 +11,9 @@ import {
   selectRecurrenceScopeOpportunity,
   useRecurrenceScopeOpportunityStore,
 } from "@web/events/recurrence/recurrence-scope-opportunity.store";
+import { recurrenceScopeForToastDigit } from "@web/events/recurrence/recurrence-scope-toast-digit";
 import { isAppLocked } from "@web/shortcuts/app-lock";
-import { digitPickIndex } from "@web/shortcuts/digit-pick.util";
 import { isEditSequenceArmed } from "@web/shortcuts/useEditSequenceShortcut";
-
-const scopeForToastDigit = (
-  event: KeyboardEvent,
-): "thisAndFollowing" | "all" | null => {
-  if (
-    event.isComposing ||
-    isAppLocked() ||
-    isEditableKeyboardTarget(event) ||
-    isEditSequenceArmed()
-  ) {
-    return null;
-  }
-
-  const pickIndex = digitPickIndex(event);
-  if (pickIndex === 0) return "thisAndFollowing";
-  if (pickIndex === 1) return "all";
-  return null;
-};
 
 export function RecurrenceScopeOpportunityHost() {
   const opportunity = useRecurrenceScopeOpportunityStore(
@@ -43,7 +25,16 @@ export function RecurrenceScopeOpportunityHost() {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.defaultPrevented) return;
       if (!isRecurrenceScopeAskReady()) return;
-      const scope = scopeForToastDigit(event);
+      if (
+        event.isComposing ||
+        isAppLocked() ||
+        isEditableKeyboardTarget(event) ||
+        isEditSequenceArmed()
+      ) {
+        return;
+      }
+
+      const scope = recurrenceScopeForToastDigit(event);
       if (!scope) return;
 
       const current = useRecurrenceScopeOpportunityStore.getState().opportunity;

--- a/packages/web/src/events/recurrence/recurrence-scope-opportunity.store.test.ts
+++ b/packages/web/src/events/recurrence/recurrence-scope-opportunity.store.test.ts
@@ -1,6 +1,7 @@
 import { type EventId } from "@core/types/domain-primitives";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import {
+  isRecurrenceScopeAskReady,
   isRecurrenceScopeEditAskDeclined,
   recurrenceScopeOpportunityActions,
   useRecurrenceScopeOpportunityStore,
@@ -15,6 +16,21 @@ const original = createMockEvent({
 });
 
 describe("recurrenceScopeOpportunityActions", () => {
+  it("is ready only while the series-scope toast can still promote", () => {
+    recurrenceScopeOpportunityActions.reset();
+    expect(isRecurrenceScopeAskReady()).toBe(false);
+
+    const id = recurrenceScopeOpportunityActions.begin({
+      kind: "delete",
+      original,
+      source: "local",
+    });
+    expect(isRecurrenceScopeAskReady()).toBe(true);
+
+    recurrenceScopeOpportunityActions.requestPromotion(id, "all");
+    expect(isRecurrenceScopeAskReady()).toBe(false);
+  });
+
   it("only promotes the currently-live opportunity once", () => {
     recurrenceScopeOpportunityActions.reset();
     const id = recurrenceScopeOpportunityActions.begin({

--- a/packages/web/src/events/recurrence/recurrence-scope-opportunity.store.ts
+++ b/packages/web/src/events/recurrence/recurrence-scope-opportunity.store.ts
@@ -139,3 +139,7 @@ export const isRecurrenceScopeEditAskDeclined = (instanceId: string): boolean =>
   useRecurrenceScopeOpportunityStore
     .getState()
     .declinedEditInstanceIds.has(instanceId);
+
+/** True while the "Apply to series?" toast is live and 1/2 should promote. */
+export const isRecurrenceScopeAskReady = (): boolean =>
+  useRecurrenceScopeOpportunityStore.getState().opportunity?.status === "ready";

--- a/packages/web/src/events/recurrence/recurrence-scope-toast-digit.test.ts
+++ b/packages/web/src/events/recurrence/recurrence-scope-toast-digit.test.ts
@@ -1,0 +1,19 @@
+import { recurrenceScopeForToastDigit } from "./recurrence-scope-toast-digit";
+import { describe, expect, it } from "bun:test";
+
+const digit = (value: string) =>
+  ({
+    key: value,
+    code: `Digit${value}`,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+  }) as Pick<KeyboardEvent, "code" | "key" | "ctrlKey" | "metaKey" | "altKey">;
+
+describe("recurrenceScopeForToastDigit", () => {
+  it("maps 1 to following, 2 to all, and leaves other digits alone", () => {
+    expect(recurrenceScopeForToastDigit(digit("1"))).toBe("thisAndFollowing");
+    expect(recurrenceScopeForToastDigit(digit("2"))).toBe("all");
+    expect(recurrenceScopeForToastDigit(digit("3"))).toBeNull();
+  });
+});

--- a/packages/web/src/events/recurrence/recurrence-scope-toast-digit.ts
+++ b/packages/web/src/events/recurrence/recurrence-scope-toast-digit.ts
@@ -1,0 +1,11 @@
+import { digitPickIndex } from "@web/shortcuts/digit-pick.util";
+
+/** Maps the series-scope toast's advertised keys: 1 = following, 2 = all. */
+export const recurrenceScopeForToastDigit = (
+  event: Pick<KeyboardEvent, "code" | "key" | "ctrlKey" | "metaKey" | "altKey">,
+): "thisAndFollowing" | "all" | null => {
+  const pickIndex = digitPickIndex(event);
+  if (pickIndex === 0) return "thisAndFollowing";
+  if (pickIndex === 1) return "all";
+  return null;
+};

--- a/packages/web/src/shortcuts/notice-focus/useNoticeActionShortcut.ts
+++ b/packages/web/src/shortcuts/notice-focus/useNoticeActionShortcut.ts
@@ -3,7 +3,8 @@ import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 import { isEditSequenceArmed } from "@web/shortcuts/useEditSequenceShortcut";
 
 /** Action-toast CTA (Sign up / Sign in). Letter keys only: digits belong to
- * quick-time create (`1` = 1:00). Same letter as the start-trial banner. */
+ * quick-time create (`1` = 1:00), except the series-scope toast which owns
+ * 1/2 while it is visible. Same letter as the start-trial banner. */
 export const TOAST_PRIMARY_ACTION_KEY = "S" as const;
 
 /** Start-trial banner CTA. Same letter as the billing gate overlay. */

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.quick-time.test.tsx
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.quick-time.test.tsx
@@ -1,7 +1,9 @@
 import { act, cleanup, renderHook } from "@testing-library/react";
-import { EventIdSchema } from "@core/types/domain-primitives";
+import { type EventId, EventIdSchema } from "@core/types/domain-primitives";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { type GridEvent } from "@web/common/types/web.event.types";
+import { recurrenceScopeOpportunityActions } from "@web/events/recurrence/recurrence-scope-opportunity.store";
 import { clearAppLockReasons, setAppLockReason } from "@web/shortcuts/app-lock";
 import {
   clearFloatingLayerReasons,
@@ -20,6 +22,18 @@ import { useShiftHoldEventHints } from "@web/shortcuts/shift-hint/useShiftHoldEv
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const TARGET_DAY = dayjs().startOf("day");
+
+const beginSeriesAsk = () =>
+  recurrenceScopeOpportunityActions.begin({
+    kind: "delete",
+    original: createMockEvent({
+      recurrence: {
+        kind: "occurrence",
+        seriesId: "0123456789abcdef11111111" as EventId,
+      },
+    }),
+    source: "local",
+  });
 
 const keydown = (key: string, init: KeyboardEventInit = {}) =>
   new KeyboardEvent("keydown", {
@@ -66,6 +80,7 @@ describe("typed-time ownership", () => {
     clearAppLockReasons();
     clearFloatingLayerReasons();
     eventJumpActions.reset();
+    recurrenceScopeOpportunityActions.reset();
   });
 
   afterEach(() => {
@@ -73,6 +88,7 @@ describe("typed-time ownership", () => {
     clearAppLockReasons();
     clearFloatingLayerReasons();
     eventJumpActions.reset();
+    recurrenceScopeOpportunityActions.reset();
   });
 
   it("creates on the fourth digit, which cannot grow further", () => {
@@ -183,6 +199,42 @@ describe("typed-time ownership", () => {
 
     expect(event.defaultPrevented).toBe(false);
     expect(useEventJumpStore.getState().quickTimeDigits).toBe("");
+  });
+
+  it("leaves 1 and 2 unclaimed while the series-scope toast is live", () => {
+    beginSeriesAsk();
+    const { createAt } = mountOwner();
+
+    const one = dispatch(digit("1"));
+    expect(one.defaultPrevented).toBe(false);
+    expect(useEventJumpStore.getState().quickTimeDigits).toBe("");
+    expect(createAt).not.toHaveBeenCalled();
+
+    const two = dispatch(digit("2"));
+    expect(two.defaultPrevented).toBe(false);
+    expect(useEventJumpStore.getState().quickTimeDigits).toBe("");
+    expect(createAt).not.toHaveBeenCalled();
+  });
+
+  it("still claims other digits while the series-scope toast is live", () => {
+    beginSeriesAsk();
+    mountOwner();
+
+    const event = dispatch(digit("3"));
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(useEventJumpStore.getState().quickTimeDigits).toBe("3");
+  });
+
+  it("claims 1 again after the series-scope toast is dismissed", () => {
+    const id = beginSeriesAsk();
+    mountOwner();
+    recurrenceScopeOpportunityActions.dismiss(id);
+
+    const event = dispatch(digit("1"));
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(useEventJumpStore.getState().quickTimeDigits).toBe("1");
   });
 
   it("keeps digit precedence while event jump is active with no day prefix", () => {

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
@@ -4,6 +4,7 @@ import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
 import { isRecurrenceScopeAskReady } from "@web/events/recurrence/recurrence-scope-opportunity.store";
+import { recurrenceScopeForToastDigit } from "@web/events/recurrence/recurrence-scope-toast-digit";
 import { isEventFormOpen } from "@web/events/stores/draft.store";
 import { isAppLocked } from "@web/shortcuts/app-lock";
 import {
@@ -496,10 +497,8 @@ export function useShiftHoldEventHints({
       // The series-scope toast owns 1 (following) and 2 (all). Leave those
       // keys unclaimed so RecurrenceScopeOpportunityHost can promote, including
       // while jump-mode column digits would otherwise seed a 1:00/2:00 draft.
-      if (isRecurrenceScopeAskReady()) {
-        const pickIndex = digitPickIndex(event);
-        const digit = pickIndex === null ? null : PICK_KEY_LABELS[pickIndex];
-        if (digit === "1" || digit === "2") return;
+      if (isRecurrenceScopeAskReady() && recurrenceScopeForToastDigit(event)) {
+        return;
       }
 
       if (!isActiveRef.current) {

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
@@ -3,6 +3,7 @@ import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
+import { isRecurrenceScopeAskReady } from "@web/events/recurrence/recurrence-scope-opportunity.store";
 import { isEventFormOpen } from "@web/events/stores/draft.store";
 import { isAppLocked } from "@web/shortcuts/app-lock";
 import {
@@ -491,6 +492,15 @@ export function useShiftHoldEventHints({
       // in both on and off states: jump stays on after focusing a card, and
       // the two capture listeners can register in either order.
       if (isEditSequenceArmed()) return;
+
+      // The series-scope toast owns 1 (following) and 2 (all). Leave those
+      // keys unclaimed so RecurrenceScopeOpportunityHost can promote, including
+      // while jump-mode column digits would otherwise seed a 1:00/2:00 draft.
+      if (isRecurrenceScopeAskReady()) {
+        const pickIndex = digitPickIndex(event);
+        const digit = pickIndex === null ? null : PICK_KEY_LABELS[pickIndex];
+        if (digit === "1" || digit === "2") return;
+      }
 
       if (!isActiveRef.current) {
         if (isAppLocked() || isEditableKeyboardTarget(event)) return;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Typing `1` or `2` while the recurring-event "Apply to series?" toast is visible was creating a draft at 1:00 or 2:00 instead of choosing Following or All. Quick-time create listens in the capture phase and claimed those digits before the toast could.

This change:

- Yields `1` and `2` from quick-time while that toast is live, including in event-jump column-digit mode.
- Handles those keys on a capture-phase listener in `RecurrenceScopeOpportunityHost`, matching the physical digit keys shown on the toast.
- Leaves other digits (and `1`/`2` once the toast is gone) as quick-time create.

## Simplicity

One store predicate (`isRecurrenceScopeAskReady`) and a shared `recurrenceScopeForToastDigit` helper so the toast host and quick-time yield cannot drift. The toast host already owned 1/2 via TanStack hotkeys; those lost the race to capture-phase quick-time, so the host now listens the same way.

## Automated validation

`bun run verify` PASS: `test:web`, `type-check`, `lint`, `knip`.

Focused web tests covering:

- Toast `1` promotes following, `2` promotes all
- Toast does not steal `1` when it is not live
- With both listeners mounted, `1` promotes and does not seed a draft
- Quick-time leaves `1`/`2` unclaimed while the toast is live, still claims `3`, and claims `1` again after dismiss

## Independent review

`.agents/handoffs/3105.md`. Verdict: no confirmed findings.

## Test plan

- `bun test:web` on `RecurrenceScopeOpportunityHost.test.tsx`, `recurrence-scope-opportunity.store.test.ts`, `recurrence-scope-toast-digit.test.ts`, and `useShiftHoldEventHints.quick-time.test.tsx`
- `bun run verify` (test:web, type-check, lint, knip)
- GitHub required checks green (unit web, e2e, lint, type-check, knip)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ad45f15-1156-4c04-a7ac-43b3599a29eb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ad45f15-1156-4c04-a7ac-43b3599a29eb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

