### PR TITLE
fix(booking): let the Compass calendar block availability

### DIFF
--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -3,6 +3,9 @@ import { expect, type Page } from "@playwright/test";
 /** ObjectId-shaped id for stubbed Google calendar in host settings e2e. */
 export const BOOKING_CALENDAR_ID = "64b7f0a1c2d3e4f5a6b7c8d9";
 
+/** ObjectId-shaped id for the stubbed Compass-local calendar. */
+export const COMPASS_CALENDAR_ID = "64b7f0a1c2d3e4f5a6b7c8e0";
+
 export const HOST_ACCOUNT_EMAIL = "host@example.com";
 
 function jsonResponse(body: unknown, status = 200) {
@@ -33,6 +36,27 @@ const googleCalendar = {
   isVisible: true,
   isActive: true,
   accountEmail: HOST_ACCOUNT_EMAIL,
+};
+
+const compassCalendar = {
+  id: COMPASS_CALENDAR_ID,
+  name: "Compass",
+  description: "",
+  timeZone: "America/Chicago",
+  foregroundColor: "#000000",
+  backgroundColor: "#ffffff",
+  provider: "local",
+  access: "owner",
+  capabilities: {
+    canReadAvailability: true,
+    canReadDetails: true,
+    canWrite: true,
+    canManage: true,
+    canWatchEvents: true,
+  },
+  isPrimary: false,
+  isVisible: true,
+  isActive: true,
 };
 
 function monthKeyInZone(date: Date, timeZone: string): string {
@@ -514,7 +538,9 @@ export async function prepareSignedInBookingSettingsPage(
     const path = url.pathname;
 
     if (path.endsWith("/api/calendars")) {
-      return route.fulfill(jsonResponse({ calendars: [googleCalendar] }));
+      return route.fulfill(
+        jsonResponse({ calendars: [googleCalendar, compassCalendar] }),
+      );
     }
 
     if (path.endsWith("/api/event") && request.method() === "GET") {

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -106,7 +106,13 @@ test("saves with Compass checked as a blocking calendar", async ({ page }) => {
   const settingsDialog = page.getByRole("dialog", { name: "Settings" });
   const compass = settingsDialog.getByRole("checkbox", { name: "Compass" });
   await expect(compass).toBeVisible();
-  await compass.check();
+  // Placeholder defaults check Compass first; the saved-page seed then
+  // unchecks it. Wait for that before checking it for the PUT.
+  await expect.poll(async () => compass.isChecked()).toBe(false);
+  await compass.evaluate((el) => {
+    (el as HTMLInputElement).click();
+  });
+  await expect(compass).toBeChecked();
 
   await dispatchClick(
     settingsDialog.getByRole("button", { name: "Save booking settings" }),

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "@playwright/test";
 import {
+  BOOKING_CALENDAR_ID,
+  COMPASS_CALENDAR_ID,
   dispatchClick,
   dispatchFill,
   prepareSignedInBookingSettingsPage,
@@ -96,4 +98,22 @@ test("saves welcome text", async ({ page }) => {
   await expect(
     settingsDialog.getByRole("link", { name: "Open booking page" }),
   ).toHaveAttribute("href", bookingUrl);
+});
+
+test("saves with Compass checked as a blocking calendar", async ({ page }) => {
+  const captured = await prepareSignedInBookingSettingsPage(page);
+
+  const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+  const compass = settingsDialog.getByRole("checkbox", { name: "Compass" });
+  await expect(compass).toBeVisible();
+  await compass.check();
+
+  await dispatchClick(
+    settingsDialog.getByRole("button", { name: "Save booking settings" }),
+  );
+
+  await expect.poll(() => captured.putBodies.length).toBe(1);
+  expect(captured.putBodies[0]?.blockingCalendarIds).toEqual(
+    expect.arrayContaining([BOOKING_CALENDAR_ID, COMPASS_CALENDAR_ID]),
+  );
 });

--- a/packages/backend/src/booking/services/booking-page.service.db.test.ts
+++ b/packages/backend/src/booking/services/booking-page.service.db.test.ts
@@ -315,6 +315,7 @@ describe("BookingPageService", () => {
     const userId = await createNamedUser("Local Blocker");
     const calendar = writableCalendar();
     mockHealthySync([calendar]);
+    await calendarService.ensureLocalCalendar(userId);
     const localCalendar = await calendarService.getLocalCalendar(userId);
     if (!localCalendar) {
       throw new Error("expected Compass-local calendar after user create");

--- a/packages/backend/src/booking/services/booking-page.service.db.test.ts
+++ b/packages/backend/src/booking/services/booking-page.service.db.test.ts
@@ -13,6 +13,7 @@ import * as billingGuard from "@backend/billing/billing.guard";
 import { ensureBookingIndexes } from "@backend/booking/booking-indexes";
 import { bookingPageRepository } from "@backend/booking/booking-page.repository";
 import bookingPageService from "@backend/booking/services/booking-page.service";
+import calendarService from "@backend/calendar/services/calendar.service";
 import * as syncServiceFactory from "@backend/common/services/sync-service/sync-service.factory";
 import { eventMutationError } from "@backend/event/event.error";
 import userService from "@backend/user/services/user.service";
@@ -307,6 +308,49 @@ describe("BookingPageService", () => {
       ),
     ).rejects.toMatchObject({
       bookingCode: "DESTINATION_NOT_WRITABLE",
+    });
+  });
+
+  it("accepts the Compass-local calendar as a blocking calendar", async () => {
+    const userId = await createNamedUser("Local Blocker");
+    const calendar = writableCalendar();
+    mockHealthySync([calendar]);
+    const localCalendar = await calendarService.getLocalCalendar(userId);
+    if (!localCalendar) {
+      throw new Error("expected Compass-local calendar after user create");
+    }
+    const localId = localCalendar._id.toHexString();
+
+    const saved = await bookingPageService.putAdminPage(
+      userId,
+      samplePutInput({
+        destinationCalendarId: calendar.id,
+        blockingCalendarIds: [calendar.id, localId],
+      }),
+    );
+
+    expect(saved).toEqual(
+      expect.objectContaining({
+        blockingCalendarIds: expect.arrayContaining([calendar.id, localId]),
+      }),
+    );
+  });
+
+  it("rejects enable when a blocking calendar is unknown", async () => {
+    const userId = await createNamedUser("Bad Blocker");
+    const calendar = writableCalendar();
+    mockHealthySync([calendar]);
+
+    await expect(
+      bookingPageService.putAdminPage(
+        userId,
+        samplePutInput({
+          destinationCalendarId: calendar.id,
+          blockingCalendarIds: [calendar.id, new ObjectId().toString()],
+        }),
+      ),
+    ).rejects.toMatchObject({
+      bookingCode: "BLOCKING_CALENDAR_INVALID",
     });
   });
 });

--- a/packages/backend/src/booking/services/booking-page.service.ts
+++ b/packages/backend/src/booking/services/booking-page.service.ts
@@ -15,6 +15,7 @@ import {
   mapPutInputToRecordFields,
 } from "@backend/booking/booking-page.mapper";
 import { bookingPageRepository } from "@backend/booking/booking-page.repository";
+import calendarService from "@backend/calendar/services/calendar.service";
 import mongoService from "@backend/common/services/mongo.service";
 import { resolveGoogleConnectionFromSync } from "@backend/common/services/sync-service/google-connection-status";
 import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
@@ -78,6 +79,10 @@ const assertCalendarsForEnable = async (
       .filter((calendar) => calendar.capabilities.canReadBusy)
       .map((calendar) => calendar.id as string),
   );
+  const localCalendar = await calendarService.getLocalCalendar(userId);
+  if (localCalendar) {
+    availabilityIds.add(localCalendar._id.toHexString());
+  }
   const invalidBlocking = input.blockingCalendarIds.find(
     (calendarId) => !availabilityIds.has(calendarId as string),
   );

--- a/packages/backend/src/booking/services/calendar-booking.service.test.ts
+++ b/packages/backend/src/booking/services/calendar-booking.service.test.ts
@@ -1,8 +1,17 @@
 import { faker } from "@faker-js/faker";
 import { BOOKING_CONFIRMATION_MAX_AGE_MS } from "@backend/booking/services/calendar-booking.port";
 import { CalendarBookingService } from "@backend/booking/services/calendar-booking.service";
+import calendarService from "@backend/calendar/services/calendar.service";
 import { type SyncServiceClient } from "@backend/common/services/sync-service/sync-service.client";
-import { describe, expect, it, mock } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
 
 const userId = () => faker.database.mongodbObjectId();
 const calendarId = () => faker.database.mongodbObjectId();
@@ -17,6 +26,13 @@ const busyResponse = {
 };
 
 describe("CalendarBookingService", () => {
+  beforeEach(() => {
+    spyOn(calendarService, "getLocalCalendar").mockResolvedValue(null);
+  });
+  afterEach(() => {
+    mock.restore();
+  });
+
   it("queries busy availability with booking_confirmation purpose and short maxAge", async () => {
     const queryBusyAvailability = mock(async () => ({
       ok: true as const,
@@ -39,6 +55,35 @@ describe("CalendarBookingService", () => {
       expect.objectContaining({
         purpose: "booking_confirmation",
         maxAgeMs: BOOKING_CONFIRMATION_MAX_AGE_MS,
+      }),
+    );
+  });
+
+  it("allowlists the Compass-local calendar as unbacked busy", async () => {
+    mock.restore();
+    const localId = calendarId();
+    spyOn(calendarService, "getLocalCalendar").mockResolvedValue({
+      _id: { toHexString: () => localId },
+    } as never);
+    const queryBusyAvailability = mock(async () => ({
+      ok: true as const,
+      value: busyResponse,
+    }));
+    const service = new CalendarBookingService({
+      queryBusyAvailability,
+      submitCommand: mock(async () => ({ ok: true as const, value: {} })),
+    } as unknown as SyncServiceClient);
+
+    await service.getAvailability(userId(), {
+      calendarIds: [localId, calendarId()],
+      start: "2026-09-01T12:00:00.000Z",
+      end: "2026-09-02T12:00:00.000Z",
+    });
+
+    expect(queryBusyAvailability).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        unbackedCalendarIds: [localId],
       }),
     );
   });

--- a/packages/backend/src/booking/services/calendar-booking.service.ts
+++ b/packages/backend/src/booking/services/calendar-booking.service.ts
@@ -14,6 +14,7 @@ import {
   type CalendarBookingGetAvailabilityInput,
   type CalendarBookingPort,
 } from "@backend/booking/services/calendar-booking.port";
+import calendarService from "@backend/calendar/services/calendar.service";
 import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
 import {
   throwSyncCommandSubmitFailure,
@@ -87,6 +88,13 @@ export class CalendarBookingService implements CalendarBookingPort {
     userId: string,
     input: CalendarBookingGetAvailabilityInput,
   ) {
+    const localCalendar = await calendarService.getLocalCalendar(userId);
+    const localId = localCalendar?._id.toHexString();
+    const unbackedCalendarIds =
+      localId !== undefined &&
+      input.calendarIds.some((calendarId) => calendarId === localId)
+        ? [SyncEventCalendarIdSchema.parse(localId)]
+        : undefined;
     const result = await this.client.queryBusyAvailability(
       toSyncPrincipal(userId),
       {
@@ -95,6 +103,7 @@ export class CalendarBookingService implements CalendarBookingPort {
         end: input.end,
         maxAgeMs: input.maxAgeMs ?? BOOKING_CONFIRMATION_MAX_AGE_MS,
         purpose: "booking_confirmation",
+        ...(unbackedCalendarIds ? { unbackedCalendarIds } : {}),
       },
     );
     if (!result.ok) {

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -14,6 +14,7 @@ import { bookingReservationRepository } from "@backend/booking/booking-reservati
 import bookingPageService from "@backend/booking/services/booking-page.service";
 import { type CalendarBookingPort } from "@backend/booking/services/calendar-booking.port";
 import { PublicBookingService } from "@backend/booking/services/public-booking.service";
+import calendarService from "@backend/calendar/services/calendar.service";
 import * as syncServiceFactory from "@backend/common/services/sync-service/sync-service.factory";
 import userService from "@backend/user/services/user.service";
 import {
@@ -356,6 +357,74 @@ describe("PublicBookingService", () => {
           Date.parse(slot.slotStart) === Date.parse("2026-09-07T10:00:00.000Z"),
       ),
     ).toBe(false);
+  });
+
+  it("occupies a Compass-local busy interval and fail-closes confirmation", async () => {
+    const userId = await createNamedUser("Compass Host");
+    const calendar = writableCalendar();
+    mockHealthySync([calendar]);
+    spyOn(billingGuard, "assertBillingAllowsWrites").mockResolvedValue(
+      undefined,
+    );
+    const localCalendar = await calendarService.getLocalCalendar(userId);
+    if (!localCalendar) {
+      throw new Error("expected Compass-local calendar after user create");
+    }
+    const localId = localCalendar._id.toHexString();
+    const page = await bookingPageService.putAdminPage(
+      userId,
+      samplePutInput({
+        destinationCalendarId: calendar.id,
+        blockingCalendarIds: [calendar.id, localId],
+      }),
+    );
+    const slug = "slug" in page ? page.slug : "";
+
+    getAvailability.mockImplementation(async (_userId, query) => {
+      expect(query.calendarIds).toEqual(
+        expect.arrayContaining([calendar.id, localId]),
+      );
+      return {
+        ...busyResponse(true),
+        intervals: [
+          {
+            start: "2026-09-07T10:00:00.000Z",
+            end: "2026-09-07T11:00:00.000Z",
+            hostIsOrganizer: true,
+            hostResponseStatus: null,
+          },
+        ],
+      };
+    });
+
+    const slots = await service.getSlots(slug, {
+      start: "2026-09-07T00:00:00.000Z",
+      end: "2026-09-08T00:00:00.000Z",
+      timeZone: "UTC",
+    });
+    expect(
+      slots.slots.some(
+        (slot) =>
+          Date.parse(slot.slotStart) === Date.parse("2026-09-07T10:00:00.000Z"),
+      ),
+    ).toBe(false);
+
+    getAvailability.mockImplementation(async (_userId, query) => {
+      expect(query.calendarIds).toEqual(
+        expect.arrayContaining([calendar.id, localId]),
+      );
+      return busyResponse(false);
+    });
+
+    await expect(
+      service.createReservation(slug, {
+        slotStart: "2026-09-07T12:00:00.000Z",
+        guestName: "Ada Lovelace",
+        guestEmail: "ada@example.com",
+        guestTimeZone: "Europe/London",
+      }),
+    ).rejects.toMatchObject({ bookingCode: "SLOT_UNAVAILABLE" });
+    expect(createBookingEvent).not.toHaveBeenCalled();
   });
 
   it("returns welcome text on the public page without date overrides", async () => {

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -366,6 +366,7 @@ describe("PublicBookingService", () => {
     spyOn(billingGuard, "assertBillingAllowsWrites").mockResolvedValue(
       undefined,
     );
+    await calendarService.ensureLocalCalendar(userId);
     const localCalendar = await calendarService.getLocalCalendar(userId);
     if (!localCalendar) {
       throw new Error("expected Compass-local calendar after user create");

--- a/packages/core/src/types/sync/availability.contracts.ts
+++ b/packages/core/src/types/sync/availability.contracts.ts
@@ -28,6 +28,9 @@ export const BusyAvailabilityRequestSchema = z
     // The oldest a calendar's last successful sync may be and still count fresh.
     maxAgeMs: z.number().int().positive(),
     purpose: BusyQueryPurposeSchema,
+    // Compass-local calendar ids: cloud-only events at generation 0, no
+    // provider resource. Any other missing resource stays notImported.
+    unbackedCalendarIds: z.array(SyncEventCalendarIdSchema).max(100).optional(),
   })
   .refine((r) => Date.parse(r.end) > Date.parse(r.start), {
     message: "end must be after start",

--- a/packages/sync/src/domain/busy-availability.service.db.test.ts
+++ b/packages/sync/src/domain/busy-availability.service.db.test.ts
@@ -10,6 +10,7 @@ import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { computeBusyAvailability } from "@sync/domain/busy-query.service";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
+import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 
@@ -24,6 +25,7 @@ describe("computeBusyAvailability", () => {
   let connections: ProviderConnectionRepository;
   let resources: SyncResourceRepository;
   let occurrences: EventOccurrenceRepository;
+  let calendars: ProviderCalendarRepository;
   let tenantId: TenantId;
   let principalId: PrincipalId;
   let accountSeq: number;
@@ -32,6 +34,7 @@ describe("computeBusyAvailability", () => {
     connections = new ProviderConnectionRepository(storage.db());
     resources = new SyncResourceRepository(storage.db());
     occurrences = new EventOccurrenceRepository(storage.db(), storage.client());
+    calendars = new ProviderCalendarRepository(storage.db());
     tenantId = objectId() as TenantId;
     principalId = objectId() as PrincipalId;
     accountSeq = 0;
@@ -121,7 +124,7 @@ describe("computeBusyAvailability", () => {
 
   const run = (calendarIds: SyncEventCalendarId[]) =>
     computeBusyAvailability(
-      { occurrences, resources, connections },
+      { occurrences, resources, connections, calendars },
       {
         tenantId,
         principalId,
@@ -168,15 +171,72 @@ describe("computeBusyAvailability", () => {
       connectionId: conn,
       lastSuccessAt: fresh,
     });
-    const ghost = objectId() as SyncEventCalendarId; // no resource
+    const ghost = await calendars.upsertByProviderCalendar({
+      tenantId,
+      principalId,
+      connectionId: conn,
+      providerCalendarId: "ghost@google.com",
+      displayName: "Ghost",
+      color: null,
+      active: true,
+      primary: false,
+      accessRole: "owner",
+      capabilities: {
+        canReadEvents: true,
+        canWriteEvents: true,
+        canReadBusy: true,
+        canInviteAttendees: true,
+      },
+    });
 
-    const result = await run([calA, ghost]);
+    const result = await run([calA, ghost._id as SyncEventCalendarId]);
 
     expect(result.complete).toBe(false);
     expect(result.bookable).toBe(false);
     expect(result.issues).toEqual([
-      { calendarId: ghost, reason: "notImported" },
+      { calendarId: ghost._id, reason: "notImported" },
     ]);
+  });
+
+  it("includes Compass-local busy at generation 0 without a sync resource", async () => {
+    const localCalendarId = objectId() as SyncEventCalendarId;
+    await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.eventOccurrences)
+      .insertOne({
+        _id: objectId(),
+        tenantId,
+        principalId,
+        eventId: objectId(),
+        occurrenceKey: `${localCalendarId}:local`,
+        calendarId: localCalendarId,
+        generation: 0,
+        startAt: new Date("2026-07-14T10:00:00.000Z"),
+        endAt: new Date("2026-07-14T10:30:00.000Z"),
+        busy: true,
+        cancelled: false,
+      });
+
+    const result = await run([localCalendarId]);
+
+    expect(result.complete).toBe(true);
+    expect(result.bookable).toBe(true);
+    expect(result.issues).toEqual([]);
+    expect(result.connections).toEqual([]);
+    expect(
+      result.intervals.map((i) => [i.start.toISOString(), i.end.toISOString()]),
+    ).toEqual([["2026-07-14T10:00:00.000Z", "2026-07-14T10:30:00.000Z"]]);
+  });
+
+  it("treats a Compass-local calendar with no occurrences as empty busy", async () => {
+    const localCalendarId = objectId() as SyncEventCalendarId;
+
+    const result = await run([localCalendarId]);
+
+    expect(result.complete).toBe(true);
+    expect(result.bookable).toBe(true);
+    expect(result.issues).toEqual([]);
+    expect(result.intervals).toEqual([]);
   });
 
   it("flags a never-synced calendar", async () => {

--- a/packages/sync/src/domain/busy-availability.service.db.test.ts
+++ b/packages/sync/src/domain/busy-availability.service.db.test.ts
@@ -122,13 +122,17 @@ describe("computeBusyAvailability", () => {
     return calendarId;
   };
 
-  const run = (calendarIds: SyncEventCalendarId[]) =>
+  const run = (
+    calendarIds: SyncEventCalendarId[],
+    unbackedCalendarIds?: SyncEventCalendarId[],
+  ) =>
     computeBusyAvailability(
       { occurrences, resources, connections, calendars },
       {
         tenantId,
         principalId,
         calendarIds,
+        unbackedCalendarIds,
         start: WINDOW_START,
         end: WINDOW_END,
         maxAgeMs: MAX_AGE_MS,
@@ -217,7 +221,7 @@ describe("computeBusyAvailability", () => {
         cancelled: false,
       });
 
-    const result = await run([localCalendarId]);
+    const result = await run([localCalendarId], [localCalendarId]);
 
     expect(result.complete).toBe(true);
     expect(result.bookable).toBe(true);
@@ -231,12 +235,24 @@ describe("computeBusyAvailability", () => {
   it("treats a Compass-local calendar with no occurrences as empty busy", async () => {
     const localCalendarId = objectId() as SyncEventCalendarId;
 
-    const result = await run([localCalendarId]);
+    const result = await run([localCalendarId], [localCalendarId]);
 
     expect(result.complete).toBe(true);
     expect(result.bookable).toBe(true);
     expect(result.issues).toEqual([]);
     expect(result.intervals).toEqual([]);
+  });
+
+  it("fails closed for a missing resource that is not allowlisted as unbacked", async () => {
+    const unknown = objectId() as SyncEventCalendarId;
+
+    const result = await run([unknown]);
+
+    expect(result.complete).toBe(false);
+    expect(result.bookable).toBe(false);
+    expect(result.issues).toEqual([
+      { calendarId: unknown, reason: "notImported" },
+    ]);
   });
 
   it("flags a never-synced calendar", async () => {

--- a/packages/sync/src/domain/busy-query.service.ts
+++ b/packages/sync/src/domain/busy-query.service.ts
@@ -181,6 +181,10 @@ export interface BusyAvailabilityInput {
   principalId: PrincipalId;
   // The blocking calendars whose busy data is requested.
   calendarIds: readonly SyncEventCalendarId[];
+  // Compass-local ids the caller has already identified. Missing resources
+  // outside this set stay notImported so a purged Google calendar cannot
+  // fail open as empty Compass busy.
+  unbackedCalendarIds?: readonly SyncEventCalendarId[];
   // Half-open query window [start, end).
   start: Date;
   end: Date;
@@ -215,6 +219,7 @@ export async function computeBusyAvailability(
   const providerCalendarIds = new Set(
     providerCalendars.map((calendar) => calendar._id as string),
   );
+  const unbackedCalendarIds = new Set(input.unbackedCalendarIds ?? []);
 
   const present: CalendarGeneration[] = [];
   const issues: CalendarIssue[] = [];
@@ -223,18 +228,21 @@ export async function computeBusyAvailability(
   for (const calendarId of input.calendarIds) {
     const resource = freshness.get(calendarId);
     if (!resource) {
-      if (providerCalendarIds.has(calendarId)) {
-        issues.push({ calendarId, reason: "notImported" });
+      if (
+        unbackedCalendarIds.has(calendarId) &&
+        !providerCalendarIds.has(calendarId)
+      ) {
+        // Compass-local calendar: events live in Sync with no provider resource.
+        // Generation 0 is the only generation those writes ever use. Missing
+        // occurrences are empty busy, not a freshness miss — fail closed only
+        // when this query itself throws.
+        present.push({
+          calendarId,
+          generation: UNBACKED_CALENDAR_GENERATION,
+        });
         continue;
       }
-      // Compass-local calendar: events live in Sync with no provider resource.
-      // Generation 0 is the only generation those writes ever use. Missing
-      // occurrences are empty busy, not a freshness miss — fail closed only
-      // when this query itself throws.
-      present.push({
-        calendarId,
-        generation: UNBACKED_CALENDAR_GENERATION,
-      });
+      issues.push({ calendarId, reason: "notImported" });
       continue;
     }
     backingConnectionIds.add(resource.connectionId);

--- a/packages/sync/src/domain/busy-query.service.ts
+++ b/packages/sync/src/domain/busy-query.service.ts
@@ -14,8 +14,13 @@ import {
   type CalendarGeneration,
   type EventOccurrenceRepository,
 } from "@sync/storage/repositories/event-occurrence.repository";
+import { type ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { type ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
+
+// Cloud-only Compass events (`connectionId: null`) always persist at
+// generation 0. See `buildCloudEventRecord` in cloud-command.service.ts.
+const UNBACKED_CALENDAR_GENERATION = 0;
 
 // A normalized, half-open [start, end) busy interval on the UTC instant axis.
 export interface BusyInterval {
@@ -168,6 +173,7 @@ export interface BusyAvailabilityDeps {
   events?: EventRepository;
   resources: SyncResourceRepository;
   connections: ProviderConnectionRepository;
+  calendars: ProviderCalendarRepository;
 }
 
 export interface BusyAvailabilityInput {
@@ -202,6 +208,13 @@ export async function computeBusyAvailability(
     input.principalId,
     input.calendarIds,
   );
+  const providerCalendars = await deps.calendars.listByPrincipal(
+    input.tenantId,
+    input.principalId,
+  );
+  const providerCalendarIds = new Set(
+    providerCalendars.map((calendar) => calendar._id as string),
+  );
 
   const present: CalendarGeneration[] = [];
   const issues: CalendarIssue[] = [];
@@ -210,7 +223,18 @@ export async function computeBusyAvailability(
   for (const calendarId of input.calendarIds) {
     const resource = freshness.get(calendarId);
     if (!resource) {
-      issues.push({ calendarId, reason: "notImported" });
+      if (providerCalendarIds.has(calendarId)) {
+        issues.push({ calendarId, reason: "notImported" });
+        continue;
+      }
+      // Compass-local calendar: events live in Sync with no provider resource.
+      // Generation 0 is the only generation those writes ever use. Missing
+      // occurrences are empty busy, not a freshness miss — fail closed only
+      // when this query itself throws.
+      present.push({
+        calendarId,
+        generation: UNBACKED_CALENDAR_GENERATION,
+      });
       continue;
     }
     backingConnectionIds.add(resource.connectionId);

--- a/packages/sync/src/safety/isolation-matrix.db.test.ts
+++ b/packages/sync/src/safety/isolation-matrix.db.test.ts
@@ -229,13 +229,13 @@ describe("R-SEC-03 isolation matrix", () => {
         connections: unknown[];
         bookable: boolean;
       };
-      // A calendar id this principal does not own is indistinguishable from
-      // Compass-local (no provider_calendars row). Return empty busy for
-      // *this* principal, never the owner's intervals.
+      // A calendar id this principal does not own has no events resource here.
+      // Treat that as notImported and fail closed; do not return the owner's
+      // intervals under an empty Compass-unbacked result.
       expect(body.intervals).toEqual([]);
       expect(body.connections).toEqual([]);
-      expect(body.issues).toEqual([]);
-      expect(body.bookable).toBe(true);
+      expect(body.bookable).toBe(false);
+      expect(body.issues).toEqual([{ calendarId, reason: "notImported" }]);
       expect(JSON.stringify(body)).not.toContain("owner-secret-meeting");
     });
 

--- a/packages/sync/src/safety/isolation-matrix.db.test.ts
+++ b/packages/sync/src/safety/isolation-matrix.db.test.ts
@@ -229,10 +229,13 @@ describe("R-SEC-03 isolation matrix", () => {
         connections: unknown[];
         bookable: boolean;
       };
+      // A calendar id this principal does not own is indistinguishable from
+      // Compass-local (no provider_calendars row). Return empty busy for
+      // *this* principal, never the owner's intervals.
       expect(body.intervals).toEqual([]);
       expect(body.connections).toEqual([]);
-      expect(body.bookable).toBe(false);
-      expect(body.issues).toEqual([{ calendarId, reason: "notImported" }]);
+      expect(body.issues).toEqual([]);
+      expect(body.bookable).toBe(true);
       expect(JSON.stringify(body)).not.toContain("owner-secret-meeting");
     });
 

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -420,6 +420,7 @@ export function registerConnectionRoutes(
             events: repos.events,
             resources: repos.syncResources,
             connections: repos.connections,
+            calendars: repos.calendars,
           },
           {
             tenantId: auth.tenantId,

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -426,6 +426,7 @@ export function registerConnectionRoutes(
             tenantId: auth.tenantId,
             principalId: auth.principalId,
             calendarIds: query.calendarIds,
+            unbackedCalendarIds: query.unbackedCalendarIds,
             start,
             end,
             maxAgeMs: query.maxAgeMs,

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -827,6 +827,45 @@ describe("BookingSettingsSection", () => {
     ).toBeInTheDocument();
   });
 
+  it("checks the Compass calendar by default on an unconfigured page", async () => {
+    const compass = createMockCalendar({
+      name: "Compass",
+      provider: "local",
+    });
+
+    userMetadataActions.set(healthyGoogleMetadata);
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(
+          ctx.json({
+            ...unconfiguredPage(),
+            destinationCalendarId: "000000000000000000000001",
+            blockingCalendarIds: ["000000000000000000000001"],
+          }),
+        ),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [
+      writableCalendar,
+      compass,
+    ]);
+
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    expect(
+      await screen.findByRole("checkbox", { name: "Compass" }),
+    ).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Work" })).toBeChecked();
+  });
+
   it("blocks enable without a destination calendar", async () => {
     const user = userEvent.setup({ delay: null });
 

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -96,6 +96,7 @@ const buildInitialForm = (
   page: AdminGetBookingPageResult | undefined,
   effectiveTimeZone: string,
   writableCalendars: Calendar[],
+  availabilityCalendars: Calendar[],
 ): AdminPutBookingPageInput => {
   const base = page ?? {
     enabled: false,
@@ -126,7 +127,7 @@ const buildInitialForm = (
       ? base.blockingCalendarIds
       : defaultBlockingCalendarIdsForDestination(
           destinationCalendarId,
-          writableCalendars,
+          availabilityCalendars,
         );
 
   // The server has no user timezone, so an unconfigured page carries a "UTC"
@@ -181,7 +182,12 @@ export function BookingSettingsSection({
   const { data: serverPage, isPending } = useBookingPageQuery(isGoogleHealthy);
   const saveMutation = useSaveBookingPageMutation();
   const [form, setForm] = useState<AdminPutBookingPageInput>(() =>
-    buildInitialForm(undefined, effectiveTimeZone, writableCalendars),
+    buildInitialForm(
+      undefined,
+      effectiveTimeZone,
+      writableCalendars,
+      availabilityCalendars,
+    ),
   );
   const [enableError, setEnableError] = useState<string | null>(null);
   const [areHoursValid, setAreHoursValid] = useState(true);
@@ -233,11 +239,12 @@ export function BookingSettingsSection({
       serverPage,
       effectiveTimeZone,
       writableCalendars,
+      availabilityCalendars,
     );
     setForm(seeded);
     setMinNoticeText(String(seeded.minNoticeHours));
     setHorizonText(String(seeded.maxHorizonDays));
-  }, [effectiveTimeZone, serverPage, writableCalendars]);
+  }, [availabilityCalendars, effectiveTimeZone, serverPage, writableCalendars]);
 
   if (!isGoogleHealthy) {
     return <BookingConnectGooglePrompt />;

--- a/packages/web/src/booking/booking.util.test.ts
+++ b/packages/web/src/booking/booking.util.test.ts
@@ -1,0 +1,72 @@
+import { CalendarIdSchema } from "@core/types/domain-primitives";
+import { createMockCalendar } from "@web/__tests__/utils/factories/calendar.factory";
+import { defaultBlockingCalendarIdsForDestination } from "@web/booking/booking.util";
+import { createObjectIdString } from "@web/common/utils/id/object-id.util";
+import { describe, expect, it } from "bun:test";
+
+const calendarId = () => CalendarIdSchema.parse(createObjectIdString());
+
+describe("defaultBlockingCalendarIdsForDestination", () => {
+  it("includes Compass alongside the destination account's calendars", () => {
+    const workId = calendarId();
+    const personalId = calendarId();
+    const compassId = calendarId();
+    const work = createMockCalendar({
+      id: workId,
+      name: "Work",
+      accountEmail: "host@example.com",
+    });
+    const personal = createMockCalendar({
+      id: personalId,
+      name: "Personal",
+      accountEmail: "other@example.com",
+    });
+    const compass = createMockCalendar({
+      id: compassId,
+      name: "Compass",
+      provider: "local",
+    });
+
+    expect(
+      defaultBlockingCalendarIdsForDestination(workId, [
+        work,
+        personal,
+        compass,
+      ]),
+    ).toEqual([workId, compassId]);
+  });
+
+  it("still includes Compass when the destination has no account email", () => {
+    const destinationId = calendarId();
+    const compassId = calendarId();
+    const destination = createMockCalendar({
+      id: destinationId,
+      name: "Work",
+    });
+    const compass = createMockCalendar({
+      id: compassId,
+      name: "Compass",
+      provider: "local",
+    });
+
+    expect(
+      defaultBlockingCalendarIdsForDestination(destinationId, [
+        destination,
+        compass,
+      ]),
+    ).toEqual([destinationId, compassId]);
+  });
+
+  it("does not duplicate Compass when it is already in the blocking set", () => {
+    const compassId = calendarId();
+    const compass = createMockCalendar({
+      id: compassId,
+      name: "Compass",
+      provider: "local",
+    });
+
+    expect(
+      defaultBlockingCalendarIdsForDestination(compassId, [compass]),
+    ).toEqual([compassId]);
+  });
+});

--- a/packages/web/src/booking/booking.util.ts
+++ b/packages/web/src/booking/booking.util.ts
@@ -5,7 +5,10 @@ import {
 } from "@core/types/booking.contracts";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
-import { getWritableCalendars } from "@web/calendars/calendar.util";
+import {
+  getLocalCalendar,
+  getWritableCalendars,
+} from "@web/calendars/calendar.util";
 
 export const BOOKING_PLACEHOLDER_CALENDAR_ID =
   "000000000000000000000001" as CalendarId;
@@ -23,19 +26,27 @@ export function defaultBlockingCalendarIdsForDestination(
   destinationCalendarId: CalendarId,
   calendars: Calendar[],
 ): CalendarId[] {
+  const readable = getAvailabilityReadableCalendars(calendars);
   const destination = calendars.find(
     (calendar) => calendar.id === destinationCalendarId,
   );
-  if (!destination?.accountEmail) {
-    return [destinationCalendarId];
+  const accountEmail = destination?.accountEmail;
+  const ids: CalendarId[] =
+    accountEmail === undefined
+      ? [destinationCalendarId]
+      : readable
+          .filter(
+            (calendar) =>
+              calendar.accountEmail?.toLowerCase() ===
+              accountEmail.toLowerCase(),
+          )
+          .map((calendar) => calendar.id);
+  const blockingIds = ids.length > 0 ? ids : [destinationCalendarId];
+  const local = getLocalCalendar(readable);
+  if (local && !blockingIds.includes(local.id)) {
+    blockingIds.push(local.id);
   }
-  const accountEmail = destination.accountEmail.toLowerCase();
-  const onAccount = getAvailabilityReadableCalendars(calendars).filter(
-    (calendar) => calendar.accountEmail?.toLowerCase() === accountEmail,
-  );
-  return onAccount.length > 0
-    ? onAccount.map((calendar) => calendar.id)
-    : [destinationCalendarId];
+  return blockingIds;
 }
 
 export function isPlaceholderDestinationCalendar(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #3083.

The Compass-local calendar could be shown under Blocking calendars, but enabling with it checked returned `BLOCKING_CALENDAR_INVALID`, and even a passing PUT would not have contributed busy because the sync busy query required a provider resource.

**Design:** local Compass events already live in the sync event store as cloud-only records (`connectionId: null`, generation 0) keyed by the backend `CalendarRecord` ObjectId. They have no sync resource.

Do not teach Google-imported calendars without a resource to fail open. Split:

- Provider calendar in `provider_calendars` but no events resource: still `notImported` (fail-closed).
- Calendar id in the request's `unbackedCalendarIds` allowlist and not in `provider_calendars`: Compass-unbacked. Include at generation 0, always fresh, no connection. Empty busy is fine. Query throw still fail-closes.
- Any other missing resource: `notImported`. A purged Google calendar cannot fail open as empty Compass busy.

`CalendarBookingService.getAvailability` looks up the Compass-local calendar and passes only that id as `unbackedCalendarIds`.

Backend `assertCalendarsForEnable` now allows the local calendar id for blocking. Destination stays Google-writable-only. Web defaults include Compass next to the destination account, and form seed / destination-change both use `availabilityCalendars`.

## Simplicity

One busy-query branch plus an explicit allowlist from the backend, instead of a second merge path over local events. The calendar controller already exposes Compass; validation and defaults now match that list.

## Automated validation

- `bun test:sync` busy-availability + isolation-matrix: pass (Compass gen-0 busy, empty Compass, unknown id fail-closed, foreign calendar id notImported)
- `bun test:backend` booking-page, public-booking, calendar-booking: pass (local calendar accepted; unknown blocking id rejected; Compass busy occupies a slot and confirmation fail-closes; unbacked allowlist forwarded)
- `bun test:web` booking.util + BookingSettingsSection: pass (Compass in default set and checked on an unconfigured page)
- `bunx playwright test e2e/booking/host-settings.spec.ts`: 4 passed (save with Compass checked)

## Independent review

VERDICT: no confirmed findings

Earlier finding: treating any unknown calendar id as Compass-unbacked fail-opened booking after Google retention purge. Addressed by the `unbackedCalendarIds` allowlist. Re-review of the current diff: no confirmed findings.

## Test plan

- `bun test:sync packages/sync/src/domain/busy-availability.service.db.test.ts packages/sync/src/safety/isolation-matrix.db.test.ts`
- `bun test:backend packages/backend/src/booking/services/booking-page.service.db.test.ts packages/backend/src/booking/services/public-booking.service.db.test.ts packages/backend/src/booking/services/calendar-booking.service.test.ts`
- `bun test:web packages/web/src/booking/booking.util.test.ts packages/web/src/booking/BookingSettingsSection.test.tsx`
- `bunx playwright test e2e/booking/host-settings.spec.ts`
- `bun run verify`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6e2dba1-cfc3-4458-b158-14d650287a70?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6e2dba1-cfc3-4458-b158-14d650287a70&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

