### PR TITLE
refactor(web): extract shared booking number-field row

### DIFF
--- a/packages/web/src/booking/BookingNumberField.tsx
+++ b/packages/web/src/booking/BookingNumberField.tsx
@@ -1,0 +1,68 @@
+import { BookingFieldLabel } from "@web/booking/BookingFieldLabel";
+import {
+  type BookingSequenceField,
+  bookingFieldAttrs,
+} from "@web/booking/booking-sequence.fields";
+
+interface BookingNumberFieldProps {
+  field: BookingSequenceField;
+  id: string;
+  label: string;
+  value: string;
+  onChange: (raw: string) => void;
+  invalid: boolean;
+  invalidMessage: string;
+  min: number;
+  max?: number;
+  showShortcuts: boolean;
+}
+
+/**
+ * The number-input row the booking form uses for the minimum-notice and
+ * horizon fields: a labelled `<input type="number">` with an inline error
+ * message wired up through `aria-invalid`/`aria-describedby`. Both fields
+ * hold the raw text in the parent so an empty field can surface as an
+ * inline error instead of a silent Save block.
+ */
+export function BookingNumberField({
+  field,
+  id,
+  label,
+  value,
+  onChange,
+  invalid,
+  invalidMessage,
+  min,
+  max,
+  showShortcuts,
+}: BookingNumberFieldProps) {
+  const errorId = `${id}-error`;
+  return (
+    <div>
+      <BookingFieldLabel
+        field={field}
+        htmlFor={id}
+        showShortcuts={showShortcuts}
+      >
+        {label}
+      </BookingFieldLabel>
+      <input
+        {...bookingFieldAttrs(field)}
+        aria-describedby={invalid ? errorId : undefined}
+        aria-invalid={invalid || undefined}
+        className="c-focus-ring w-full rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text aria-invalid:border-error"
+        id={id}
+        max={max}
+        min={min}
+        onChange={(event) => onChange(event.target.value)}
+        type="number"
+        value={value}
+      />
+      {invalid ? (
+        <p className="text-error text-xs" id={errorId} role="alert">
+          {invalidMessage}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -17,6 +17,7 @@ import { BookingCheckboxRow } from "@web/booking/BookingCheckboxRow";
 import { BookingConnectGooglePrompt } from "@web/booking/BookingConnectGooglePrompt";
 import { BookingCopyLink } from "@web/booking/BookingCopyLink";
 import { BookingFieldLabel } from "@web/booking/BookingFieldLabel";
+import { BookingNumberField } from "@web/booking/BookingNumberField";
 import { BookingTimezoneField } from "@web/booking/BookingTimezoneField";
 import { BookingWeeklyHoursEditor } from "@web/booking/BookingWeeklyHoursEditor";
 import {
@@ -541,87 +542,41 @@ export function BookingSettingsSection({
       </div>
 
       <div className="grid grid-cols-2 gap-3">
-        <div>
-          <BookingFieldLabel
-            field="notice"
-            htmlFor="booking-min-notice"
-            showShortcuts={showShortcuts}
-          >
-            Minimum notice (hours)
-          </BookingFieldLabel>
-          <input
-            {...bookingFieldAttrs("notice")}
-            aria-describedby={
-              minNoticeInvalid ? "booking-min-notice-error" : undefined
+        <BookingNumberField
+          field="notice"
+          id="booking-min-notice"
+          invalid={minNoticeInvalid}
+          invalidMessage="Enter 0 or more hours."
+          label="Minimum notice (hours)"
+          min={0}
+          onChange={(raw) => {
+            setMinNoticeText(raw);
+            const parsed = parseBookingCount(raw, MIN_NOTICE_BOUNDS);
+            if (parsed !== null) {
+              updateForm({ minNoticeHours: parsed });
             }
-            aria-invalid={minNoticeInvalid || undefined}
-            className="c-focus-ring w-full rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text aria-invalid:border-error"
-            id="booking-min-notice"
-            min={0}
-            onChange={(event) => {
-              setMinNoticeText(event.target.value);
-              const parsed = parseBookingCount(
-                event.target.value,
-                MIN_NOTICE_BOUNDS,
-              );
-              if (parsed !== null) {
-                updateForm({ minNoticeHours: parsed });
-              }
-            }}
-            type="number"
-            value={minNoticeText}
-          />
-          {minNoticeInvalid ? (
-            <p
-              className="text-error text-xs"
-              id="booking-min-notice-error"
-              role="alert"
-            >
-              Enter 0 or more hours.
-            </p>
-          ) : null}
-        </div>
-        <div>
-          <BookingFieldLabel
-            field="horizon"
-            htmlFor="booking-max-horizon"
-            showShortcuts={showShortcuts}
-          >
-            Maximum horizon (days)
-          </BookingFieldLabel>
-          <input
-            {...bookingFieldAttrs("horizon")}
-            aria-describedby={
-              horizonInvalid ? "booking-max-horizon-error" : undefined
+          }}
+          showShortcuts={showShortcuts}
+          value={minNoticeText}
+        />
+        <BookingNumberField
+          field="horizon"
+          id="booking-max-horizon"
+          invalid={horizonInvalid}
+          invalidMessage="Enter 1 to 60 days."
+          label="Maximum horizon (days)"
+          max={60}
+          min={1}
+          onChange={(raw) => {
+            setHorizonText(raw);
+            const parsed = parseBookingCount(raw, HORIZON_BOUNDS);
+            if (parsed !== null) {
+              updateForm({ maxHorizonDays: parsed });
             }
-            aria-invalid={horizonInvalid || undefined}
-            className="c-focus-ring w-full rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text aria-invalid:border-error"
-            id="booking-max-horizon"
-            max={60}
-            min={1}
-            onChange={(event) => {
-              setHorizonText(event.target.value);
-              const parsed = parseBookingCount(
-                event.target.value,
-                HORIZON_BOUNDS,
-              );
-              if (parsed !== null) {
-                updateForm({ maxHorizonDays: parsed });
-              }
-            }}
-            type="number"
-            value={horizonText}
-          />
-          {horizonInvalid ? (
-            <p
-              className="text-error text-xs"
-              id="booking-max-horizon-error"
-              role="alert"
-            >
-              Enter 1 to 60 days.
-            </p>
-          ) : null}
-        </div>
+          }}
+          showShortcuts={showShortcuts}
+          value={horizonText}
+        />
       </div>
 
       <fieldset


### PR DESCRIPTION
## Summary

The minimum-notice and maximum-horizon inputs in `BookingSettingsSection` were 35-line clones of the same labelled `<input type="number">` with an `aria-invalid` + `aria-describedby` inline error, differing only in the field name, bounds, and text. A class or aria tweak on one row had to be mirrored on the other by hand, or the two silently drifted.

Extract the row into a `BookingNumberField` component; the parent still owns the raw text and parsed number so an empty field surfaces as an inline error instead of a dead Save button (the whole point of `parseBookingCount`).

## Simplicity

Fewer identical branches. `BookingSettingsSection.tsx` shrinks by ~45 lines net (`-79 / +34`), and the new component is a plain thin wrapper (68 lines, no state).

## Automated validation

- `bun test:web -- packages/web/src/booking/BookingSettingsSection.test.tsx` — 29/29 pass
- `bun run type-check` — pass
- `bun run lint` — pass (23 pre-existing warnings unchanged)
- `bunx biome check --write` on both files — clean

## Independent review

None (self-authored; small, mechanical extraction with test coverage on both fields).

## Test plan

- `bun test:web -- packages/web/src/booking/BookingSettingsSection.test.tsx`
- `bun run type-check`
- `bun run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSE38oY6sGDAZHSbBPXucb

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSE38oY6sGDAZHSbBPXucb)_