### PR TITLE
refactor(web): resolve confirmed-page view like cancel page

### DIFF
--- a/packages/web/src/booking/PublicBookingConfirmedPage.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmedPage.tsx
@@ -5,6 +5,57 @@ import { PublicBookingStatusMessage } from "@web/booking/PublicBookingStatusMess
 import { usePublicBookingReservationQuery } from "@web/booking/public-booking.query";
 import { useBookingDocumentTitle } from "@web/booking/use-booking-document-title";
 
+const BOOKING_LOADING = {
+  title: "Loading booking",
+  description: "One moment while we load this confirmation.",
+} as const;
+
+const BOOKING_NOT_FOUND = {
+  title: "Booking not found",
+  description:
+    "This confirmation link may be incorrect or no longer available.",
+} as const;
+
+const BOOKING_LOAD_FAILED = {
+  title: "Could not load booking",
+  description: "Please refresh and try again.",
+} as const;
+
+const BOOKING_CANCELED = {
+  title: "This booking was canceled",
+  description:
+    "The appointment is no longer on the host calendar. You can close this page.",
+} as const;
+
+type ConfirmedPageView =
+  | { kind: "status"; title: string; description: string }
+  | {
+      kind: "confirmation";
+      reservation: NonNullable<
+        ReturnType<typeof usePublicBookingReservationQuery>["data"]
+      >;
+    };
+
+const resolveConfirmedPageView = (
+  reservationQuery: ReturnType<typeof usePublicBookingReservationQuery>,
+): ConfirmedPageView => {
+  if (reservationQuery.isLoading) return { kind: "status", ...BOOKING_LOADING };
+  if (reservationQuery.isError) {
+    return {
+      kind: "status",
+      ...(reservationQuery.error instanceof PublicBookingNotFoundError
+        ? BOOKING_NOT_FOUND
+        : BOOKING_LOAD_FAILED),
+    };
+  }
+  const reservation = reservationQuery.data;
+  if (!reservation) return { kind: "status", ...BOOKING_NOT_FOUND };
+  if (reservation.status === "cancelled") {
+    return { kind: "status", ...BOOKING_CANCELED };
+  }
+  return { kind: "confirmation", reservation };
+};
+
 function cancelUrlFromHistory(state: unknown): string | undefined {
   if (
     state &&
@@ -28,51 +79,12 @@ export function PublicBookingConfirmedPage() {
   const reservationQuery = usePublicBookingReservationQuery(reservationId);
   useBookingDocumentTitle("Booking confirmed");
 
-  if (reservationQuery.isLoading) {
-    return (
-      <PublicBookingStatusMessage
-        title="Loading booking"
-        description="One moment while we load this confirmation."
-      />
-    );
+  const view = resolveConfirmedPageView(reservationQuery);
+  if (view.kind === "status") {
+    return <PublicBookingStatusMessage {...view} />;
   }
 
-  if (reservationQuery.isError) {
-    if (reservationQuery.error instanceof PublicBookingNotFoundError) {
-      return (
-        <PublicBookingStatusMessage
-          title="Booking not found"
-          description="This confirmation link may be incorrect or no longer available."
-        />
-      );
-    }
-    return (
-      <PublicBookingStatusMessage
-        title="Could not load booking"
-        description="Please refresh and try again."
-      />
-    );
-  }
-
-  if (!reservationQuery.data) {
-    return (
-      <PublicBookingStatusMessage
-        title="Booking not found"
-        description="This confirmation link may be incorrect or no longer available."
-      />
-    );
-  }
-
-  const reservation = reservationQuery.data;
-  if (reservation.status === "cancelled") {
-    return (
-      <PublicBookingStatusMessage
-        title="This booking was canceled"
-        description="The appointment is no longer on the host calendar. You can close this page."
-      />
-    );
-  }
-
+  const { reservation } = view;
   return (
     <PublicBookingConfirmationView
       hostDisplayName={reservation.hostDisplayName}


### PR DESCRIPTION
## Summary

`PublicBookingConfirmedPage` had four early-return `PublicBookingStatusMessage` branches (loading, load failed, not found, cancelled) sitting in imperative if/else at the top of the render, with the not-found title and description duplicated between the error path and the empty-`data` path.

#3125 just gave the sibling cancel page a `resolveCancelPageView` helper that returns a discriminated view. Do the same here so the two pages read the same way and each status copy pair lives in one `const`.

Behavior is unchanged: same status branches in the same order (loading > not-found error > load-failed error > null data > cancelled reservation > confirmation view), same document title, same cancel-URL history read.

## Simplicity

One file, `+55 / -43`. The imperative early-return ladder collapses into a `switch`-free discriminated view, and the "Booking not found" copy is defined once instead of twice.

## Automated validation

- `bun test:web -- packages/web/src/booking/PublicBookingPage.test.tsx packages/web/src/booking/PublicBookingConfirmationView.test.tsx packages/web/src/booking/PublicBookingCancelPage.test.tsx` — 38/38 pass (covers every status branch: shows details, cancelled, unknown, retryable, copies cancel URL)
- `bun run type-check` — pass
- `bunx biome check --write` — clean

## Independent review

None (self-authored; mirrors an accepted pattern from the sibling cancel page landed in #3125, with full test coverage of every branch).

## Test plan

- `bun test:web -- packages/web/src/booking/PublicBookingPage.test.tsx packages/web/src/booking/PublicBookingConfirmationView.test.tsx packages/web/src/booking/PublicBookingCancelPage.test.tsx`
- `bun run type-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSE38oY6sGDAZHSbBPXucb

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSE38oY6sGDAZHSbBPXucb)_