### PR TITLE
fix(web): move booking settings hint out of the sticky save bar

### DIFF
--- a/.agents/handoffs/3129.md
+++ b/.agents/handoffs/3129.md
@@ -1,0 +1,26 @@
+---
+schema_version: 1
+task_id: "3129"
+from: Implementer
+to: Verifier
+owner: Verifier
+status: verifying
+artifact:
+  - path: packages/web/src/booking/BookingSettingsSection.tsx
+  - path: packages/web/src/booking/BookingSettingsSection.test.tsx
+evidence:
+  - command: bun test:web packages/web/src/booking/BookingSettingsSection.test.tsx
+    result: "30 pass, 0 fail"
+    log: null
+assumptions:
+  - "Issue citations on origin/main were current: sticky bar at BookingSettingsSection.tsx:625-644, OverlayPanel p-8 at OverlayPanel.tsx:126, public sticky idiom at PublicBookingPage.tsx:13-14."
+  - "Settings scrollport padding is OverlayPanel p-8. The remaining button-only bar uses -mb-8 + pb-8 so the painted bar covers that 32px strip. Horizontal -mx is omitted because the section sits beside the Settings nav, not full-bleed like the public page."
+open_risks: []
+next_deadline: 2026-09-03T20:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-01: keyboard hint is the first node in Booking settings, above Public booking link. Sticky save bar holds Save only.

--- a/.agents/handoffs/3129.md
+++ b/.agents/handoffs/3129.md
@@ -1,14 +1,15 @@
 ---
 schema_version: 1
 task_id: "3129"
-from: Implementer
-to: Verifier
-owner: Verifier
+from: Reviewer
+to: Manager
+owner: Manager
 status: verifying
 artifact:
   - path: packages/web/src/booking/BookingSettingsSection.tsx
   - path: packages/web/src/booking/BookingSettingsSection.test.tsx
   - path: e2e/booking/host-settings.spec.ts
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3152
 evidence:
   - command: bun test:web packages/web/src/booking/BookingSettingsSection.test.tsx
     result: "30 pass, 0 fail"
@@ -20,7 +21,7 @@ evidence:
     result: "24 passed, including settings booking section"
     log: null
   - command: bun run verify
-    result: "selected checks passed (test:web, type-check, lint, knip); a11y re-run after Chromium install"
+    result: "Selected packages: web. Checks run: test:web, type-check, lint, knip. selected checks passed."
     log: null
 assumptions:
   - "Issue citations on origin/main were current: sticky bar at BookingSettingsSection.tsx:625-644, OverlayPanel p-8 at OverlayPanel.tsx:126, public sticky idiom at PublicBookingPage.tsx:13-14."
@@ -33,4 +34,4 @@ waiting_on: null
 escalation: null
 ---
 
-WP-01: keyboard hint is the first node in Booking settings, above Public booking link. Sticky save bar holds Save only.
+WP-01 ready to merge. `/simplify` made no file changes. Independent `/review`: no confirmed findings.

--- a/.agents/handoffs/3129.md
+++ b/.agents/handoffs/3129.md
@@ -8,13 +8,23 @@ status: verifying
 artifact:
   - path: packages/web/src/booking/BookingSettingsSection.tsx
   - path: packages/web/src/booking/BookingSettingsSection.test.tsx
+  - path: e2e/booking/host-settings.spec.ts
 evidence:
   - command: bun test:web packages/web/src/booking/BookingSettingsSection.test.tsx
     result: "30 pass, 0 fail"
     log: null
+  - command: bunx playwright test e2e/booking/host-settings.spec.ts
+    result: "5 passed"
+    log: null
+  - command: bun run test:a11y
+    result: "24 passed, including settings booking section"
+    log: null
+  - command: bun run verify
+    result: "selected checks passed (test:web, type-check, lint, knip); a11y re-run after Chromium install"
+    log: null
 assumptions:
   - "Issue citations on origin/main were current: sticky bar at BookingSettingsSection.tsx:625-644, OverlayPanel p-8 at OverlayPanel.tsx:126, public sticky idiom at PublicBookingPage.tsx:13-14."
-  - "Settings scrollport padding is OverlayPanel p-8. The remaining button-only bar uses -mb-8 + pb-8 so the painted bar covers that 32px strip. Horizontal -mx is omitted because the section sits beside the Settings nav, not full-bleed like the public page."
+  - "Settings scrollport padding is OverlayPanel p-8. The remaining button-only bar uses -bottom-8 + pb-8 so the painted bar covers that 32px strip without -mb-8 shrinking the scroll range. Horizontal -mx is omitted because the section sits beside the Settings nav, not full-bleed like the public page."
 open_risks: []
 next_deadline: 2026-09-03T20:00:00Z
 retry: 0

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,7 +13,7 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 3129 | high | Verifier | verifying | packages/web/src/booking/BookingSettingsSection.tsx | bun test:web BookingSettingsSection.test.tsx: 30 pass | 2026-09-03T20:00:00Z | 0 | none |
+| 3129 | high | Verifier | verifying | packages/web/src/booking/BookingSettingsSection.tsx | bun test:web 30 pass; host-settings e2e 5 pass; test:a11y 24 pass; bun run verify PASS | 2026-09-03T20:00:00Z | 0 | none |
 | simplify-recent-3098 | medium | Manager | verifying | .agents/handoffs/simplify-recent-3098.md | bun run verify PASS (core, web, backend, type-check, lint, knip); focused web 161 pass; review: no confirmed findings | 2026-09-03T06:00:00Z | 1 | none |
 | simplify-recent-3047 | medium | Manager | verifying | .agents/handoffs/simplify-recent-3047.md | focused web 79 pass; core/sync 49 pass; verify package checks pass; a11y retry pass; review: no confirmed findings | 2026-09-02T06:00:00Z | 1 | none |
 | 2980 | high | Manager | waiting | https://github.com/KeepSoftwareSimple/compass-calendar/pull/2980 | verify PASS (web, type-check, lint, knip, a11y, e2e); review: no confirmed findings | 2026-08-31T00:00:00Z | 1 | none |

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,6 +13,7 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 3129 | high | Verifier | verifying | packages/web/src/booking/BookingSettingsSection.tsx | bun test:web BookingSettingsSection.test.tsx: 30 pass | 2026-09-03T20:00:00Z | 0 | none |
 | simplify-recent-3098 | medium | Manager | verifying | .agents/handoffs/simplify-recent-3098.md | bun run verify PASS (core, web, backend, type-check, lint, knip); focused web 161 pass; review: no confirmed findings | 2026-09-03T06:00:00Z | 1 | none |
 | simplify-recent-3047 | medium | Manager | verifying | .agents/handoffs/simplify-recent-3047.md | focused web 79 pass; core/sync 49 pass; verify package checks pass; a11y retry pass; review: no confirmed findings | 2026-09-02T06:00:00Z | 1 | none |
 | 2980 | high | Manager | waiting | https://github.com/KeepSoftwareSimple/compass-calendar/pull/2980 | verify PASS (web, type-check, lint, knip, a11y, e2e); review: no confirmed findings | 2026-08-31T00:00:00Z | 1 | none |

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -100,6 +100,45 @@ test("saves welcome text", async ({ page }) => {
   ).toHaveAttribute("href", bookingUrl);
 });
 
+test("keyboard hint sits above the public link and the last control stays above Save", async ({
+  page,
+}) => {
+  await prepareSignedInBookingSettingsPage(page, {
+    bookingUrl: "https://compasscalendar.com/book/hostuser",
+  });
+
+  const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+  const hint = settingsDialog.getByText("then a letter to jump to a field");
+  const publicLink = settingsDialog.getByLabel("Public booking link");
+  const lastControl = settingsDialog.getByRole("checkbox", {
+    name: "Guest can invite others",
+  });
+  const save = settingsDialog.getByRole("button", {
+    name: "Save booking settings",
+  });
+
+  await expect(hint).toBeVisible();
+  const hintBox = await hint.boundingBox();
+  const linkBox = await publicLink.boundingBox();
+  expect(hintBox).not.toBeNull();
+  expect(linkBox).not.toBeNull();
+  expect(hintBox!.y + hintBox!.height).toBeLessThan(linkBox!.y);
+
+  await lastControl.scrollIntoViewIfNeeded();
+  await settingsDialog.evaluate((el) => {
+    el.scrollTop = el.scrollHeight;
+  });
+
+  const lastBox = await lastControl.boundingBox();
+  const saveBarTop = await save.evaluate((el) => {
+    const bar = el.closest(".sticky");
+    return bar?.getBoundingClientRect().y ?? null;
+  });
+  expect(lastBox).not.toBeNull();
+  expect(saveBarTop).not.toBeNull();
+  expect(lastBox!.y + lastBox!.height).toBeLessThanOrEqual(saveBarTop!);
+});
+
 test("saves with Compass checked as a blocking calendar", async ({ page }) => {
   const captured = await prepareSignedInBookingSettingsPage(page);
 

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -108,6 +108,18 @@ function BookingSettingsWithShortcuts({
   return <BookingSettingsSection showShortcuts={showShortcuts} />;
 }
 
+function findStickyAncestor(element: HTMLElement): HTMLElement | null {
+  let current: HTMLElement | null = element;
+  while (current) {
+    const className = current.getAttribute("class") ?? "";
+    if (className.split(/\s+/).includes("sticky")) {
+      return current;
+    }
+    current = current.parentElement;
+  }
+  return null;
+}
+
 function dispatchModKey(target: HTMLElement, key: string) {
   const modifierKey = resolveModifier("Mod");
   const isControl = modifierKey === "Control";
@@ -201,9 +213,12 @@ describe("BookingSettingsSection", () => {
     const save = await screen.findByRole("button", {
       name: "Save booking settings",
     });
-    const stickyBar = save.parentElement?.parentElement;
-    expect(stickyBar?.className).toContain("sticky");
-    expect(stickyBar).toHaveTextContent("then a letter to jump to a field");
+    const stickyBar = findStickyAncestor(save);
+    expect(stickyBar).not.toBeNull();
+    expect(
+      screen.getByText(/then a letter to jump to a field/),
+    ).toBeInTheDocument();
+    expect(stickyBar).not.toHaveTextContent("then a letter to jump to a field");
 
     await user.selectOptions(screen.getByLabelText("Duration"), "30");
     await user.click(
@@ -220,6 +235,70 @@ describe("BookingSettingsSection", () => {
     const openLink = screen.getByRole("link", { name: "Open booking page" });
     expect(openLink).toHaveAttribute("href", bookingUrl);
     expect(openLink).toHaveAttribute("target", "_blank");
+  });
+
+  it("renders the keyboard hint above the public link, outside the sticky save bar", async () => {
+    userMetadataActions.set(healthyGoogleMetadata);
+    const bookingUrl = "https://compasscalendar.com/book/hostuser";
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(
+          ctx.json({
+            id: createObjectIdString(),
+            slug: "hostuser",
+            hostUserId: createObjectIdString(),
+            enabled: true,
+            durationMinutes: 30,
+            destinationCalendarId: writableCalendar.id,
+            blockingCalendarIds: [writableCalendar.id],
+            timeZone: "America/New_York",
+            weeklyAvailability: [],
+            minNoticeHours: 4,
+            maxHorizonDays: 60,
+            bufferMinutes: null,
+            maxBookingsPerDay: null,
+            guestsCanInviteOthers: true,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            bookingUrl,
+          }),
+        ),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    const hint = await screen.findByText(/then a letter to jump to a field/);
+    const publicLink = screen.getByLabelText("Public booking link");
+    const save = screen.getByRole("button", { name: /Save booking settings/ });
+    const lastControl = screen.getByRole("checkbox", {
+      name: "Guest can invite others",
+    });
+
+    expect(
+      hint.compareDocumentPosition(publicLink) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).not.toBe(0);
+
+    const stickyBar = findStickyAncestor(save);
+    expect(stickyBar).not.toBeNull();
+    expect(stickyBar!.contains(save)).toBe(true);
+    expect(stickyBar!.contains(hint)).toBe(false);
+    expect(stickyBar!.contains(lastControl)).toBe(false);
+    expect(within(save).getByText("Enter")).toBeInTheDocument();
+    expect(
+      lastControl.compareDocumentPosition(save) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).not.toBe(0);
   });
 
   it("saves again after the first save, sending only PUT input keys", async () => {

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -61,11 +61,11 @@ import { useEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 
 const DURATION_OPTIONS: BookingDurationMinutes[] = [15, 30, 45, 60];
 
-// OverlayPanel is the scrollport and uses p-8. sticky bottom-0 pins to that
-// padding box, so -mb-8 + pb-8 extend the painted bar into the 32px strip
-// below it. Hint copy lives at the top of the section, not in this bar.
+// OverlayPanel is the scrollport and uses p-8. sticky bottom-0 would pin to
+// that padding box and leave a 32px unpainted strip; -bottom-8 + pb-8 drop
+// the painted bar into the padding without shrinking the scroll range.
 const BOOKING_SETTINGS_SAVE_BAR_CLASS_NAME =
-  "sticky bottom-0 z-10 -mb-8 border-border border-t bg-surface-panel pt-3 pb-8";
+  "sticky -bottom-8 z-10 border-border border-t bg-surface-panel pt-3 pb-8";
 
 // Named so the value the checkbox writes and the value its label promises can
 // only ever be the same number.

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -61,6 +61,12 @@ import { useEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 
 const DURATION_OPTIONS: BookingDurationMinutes[] = [15, 30, 45, 60];
 
+// OverlayPanel is the scrollport and uses p-8. sticky bottom-0 pins to that
+// padding box, so -mb-8 + pb-8 extend the painted bar into the 32px strip
+// below it. Hint copy lives at the top of the section, not in this bar.
+const BOOKING_SETTINGS_SAVE_BAR_CLASS_NAME =
+  "sticky bottom-0 z-10 -mb-8 border-border border-t bg-surface-panel pt-3 pb-8";
+
 // Named so the value the checkbox writes and the value its label promises can
 // only ever be the same number.
 const DEFAULT_BUFFER_MINUTES = 30;
@@ -364,6 +370,11 @@ export function BookingSettingsSection({
       disabled={isReadOnly || saveMutation.isPending}
       ref={sectionRef}
     >
+      <p className="flex flex-wrap items-center gap-x-1 text-text-muted text-xs">
+        Press <kbd>e</kbd> then a letter to jump to a field.
+        <ShortcutKeys keys={["Mod", "Enter"]} /> saves.
+      </p>
+
       {savedPage ? (
         <div {...bookingFieldAttrs("link")}>
           <BookingCopyLink bookingUrl={savedPage.bookingUrl} />
@@ -622,7 +633,7 @@ export function BookingSettingsSection({
         </BookingCheckboxRow>
       </fieldset>
 
-      <div className="sticky bottom-0 z-10 bg-surface-panel pt-3">
+      <div className={BOOKING_SETTINGS_SAVE_BAR_CLASS_NAME}>
         <OverlayPanelActions align="start">
           <OverlayPanelActionButton
             aria-busy={saveMutation.isPending || undefined}
@@ -637,10 +648,6 @@ export function BookingSettingsSection({
             {saveMutation.isPending ? "Saving…" : "Save booking settings"}
           </OverlayPanelActionButton>
         </OverlayPanelActions>
-        <p className="mt-2 flex flex-wrap items-center gap-x-1 text-text-muted text-xs">
-          Press <kbd>e</kbd> then a letter to jump to a field.
-          <ShortcutKeys keys={["Mod", "Enter"]} /> saves.
-        </p>
       </div>
 
       <EditSequenceMenu


### PR DESCRIPTION
Fixes #3129

## Summary

Move the Booking settings keyboard hint to the top of the section, above **Public booking link**. The sticky bar now holds only **Save booking settings**. The remaining bar paints into OverlayPanel's `p-8` bottom padding (`-bottom-8` + `pb-8`) so form fields no longer scroll through an unpainted 32px strip, without shrinking the scroll range.

Hint wording is unchanged (WP-03). `isBookingEnabled` is unchanged.

## Simplicity

One paragraph moved; one class name extracted for the button-only sticky bar. `/simplify` made no further file changes. Horizontal `-mx` from the public booking idiom is omitted because this section sits beside the Settings nav, not full-bleed.

## Automated validation

- `bun test:web packages/web/src/booking/BookingSettingsSection.test.tsx`: 30 pass, 0 fail
- `bunx playwright test e2e/booking/host-settings.spec.ts`: 5 passed, including hint placement and last-control-above-Save at max scroll
- `bun run test:a11y`: 24 passed (includes settings booking section)
- `bun run verify`: Selected packages: web. Checks run: test:web, type-check, lint, knip. Selected checks passed.

## Independent review

`.agents/handoffs/3129.md`: `/review` VERDICT: no confirmed findings.

## Test plan

- `bun test:web packages/web/src/booking/BookingSettingsSection.test.tsx`
- `bunx playwright test e2e/booking/host-settings.spec.ts`
- `bun run test:a11y`
- `bun run verify`