### PR TITLE
fix(web): add diagnostic properties to sse connection degraded events

### DIFF
--- a/packages/web/src/sse/client/sse.client.test.ts
+++ b/packages/web/src/sse/client/sse.client.test.ts
@@ -1,3 +1,4 @@
+import * as posthogBootstrap from "@web/auth/posthog/posthog.bootstrap";
 import {
   closeStream,
   isSseDegraded,
@@ -12,7 +13,18 @@ import {
   expect,
   it,
   mock,
+  spyOn,
 } from "bun:test";
+
+const capture = mock();
+const getPosthogClient = spyOn(
+  posthogBootstrap,
+  "getPosthogClient",
+).mockReturnValue({ capture } as never);
+
+afterAll(() => {
+  getPosthogClient.mockRestore();
+});
 
 // Minimal EventSource fake: no network, just enough surface for sse.client's
 // addEventListener/removeEventListener/close and readyState check.
@@ -51,16 +63,21 @@ class FakeEventSource {
 describe("sse.client degraded state", () => {
   const originalEventSource = globalThis.EventSource;
   const originalSetTimeout = globalThis.setTimeout;
+  const originalDateNow = Date.now;
   let fakeEs: FakeEventSource;
   let timerCallbacks: Array<{ callback: () => void; delayMs: number }>;
   let setTimeoutSpy: ReturnType<typeof mock>;
+  let nowMs: number;
 
   afterAll(() => {
     globalThis.EventSource = originalEventSource;
     globalThis.setTimeout = originalSetTimeout;
+    Date.now = originalDateNow;
   });
 
   beforeEach(() => {
+    capture.mockClear();
+    getPosthogClient.mockReturnValue({ capture } as never);
     fakeEs = new FakeEventSource();
     // @ts-expect-error test double, not a full EventSource
     globalThis.EventSource = Object.assign(
@@ -79,15 +96,37 @@ describe("sse.client degraded state", () => {
     });
     // @ts-expect-error partial override, only setTimeout is invoked by name here
     globalThis.setTimeout = setTimeoutSpy;
+
+    nowMs = 1_000_000;
+    Date.now = () => nowMs;
+    window.history.replaceState(null, "", "/");
+    Object.defineProperty(navigator, "onLine", {
+      configurable: true,
+      value: true,
+    });
   });
 
   afterEach(() => {
     closeStream();
+    Date.now = originalDateNow;
+    Object.defineProperty(navigator, "onLine", {
+      configurable: true,
+      value: true,
+    });
+    window.history.replaceState(null, "", "/");
   });
 
   const runDegradedTimer = () => {
     const due = timerCallbacks.find((t) => t.delayMs === 15_000);
     due?.callback();
+  };
+
+  const openThenError = (readyState = FakeEventSource.CONNECTING) => {
+    openStream();
+    fakeEs.readyState = FakeEventSource.OPEN;
+    fakeEs.dispatch("open");
+    fakeEs.readyState = readyState;
+    fakeEs.dispatch("error");
   };
 
   it("starts not degraded", () => {
@@ -114,6 +153,7 @@ describe("sse.client degraded state", () => {
     runDegradedTimer();
 
     expect(isSseDegraded()).toBe(false);
+    expect(capture).not.toHaveBeenCalled();
   });
 
   it("notifies subscribers when degraded flips", () => {
@@ -149,5 +189,104 @@ describe("sse.client degraded state", () => {
     closeStream();
 
     expect(isSseDegraded()).toBe(false);
+  });
+
+  it("captures diagnostic properties on the first degraded report", () => {
+    window.history.replaceState(null, "", "/week");
+    openStream();
+    fakeEs.readyState = FakeEventSource.OPEN;
+    fakeEs.dispatch("open");
+    fakeEs.dispatch("message", {
+      data: JSON.stringify({
+        type: "eventsChanged",
+        calendarId: "507f1f77bcf86cd799439011",
+        eventIds: ["507f1f77bcf86cd799439012"],
+        reason: "updated",
+      }),
+    });
+    fakeEs.dispatch("message", {
+      data: JSON.stringify({
+        type: "calendarsChanged",
+        calendarIds: ["507f1f77bcf86cd799439011"],
+      }),
+    });
+    nowMs += 4_000;
+    fakeEs.readyState = FakeEventSource.CONNECTING;
+    fakeEs.dispatch("error");
+    runDegradedTimer();
+
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(capture).toHaveBeenCalledWith("sse_connection_degraded", {
+      reconnect_count: 1,
+      error_type: "timeout",
+      connection_duration_ms: 4_000,
+      retry_attempt: 0,
+      user_event_count: 2,
+      page_path: "/week",
+    });
+  });
+
+  it("records connection_duration_ms from last open to the first error", () => {
+    openStream();
+    fakeEs.readyState = FakeEventSource.OPEN;
+    fakeEs.dispatch("open");
+    nowMs += 12_500;
+    fakeEs.readyState = FakeEventSource.CONNECTING;
+    fakeEs.dispatch("error");
+    runDegradedTimer();
+
+    expect(capture).toHaveBeenCalledWith(
+      "sse_connection_degraded",
+      expect.objectContaining({ connection_duration_ms: 12_500 }),
+    );
+  });
+
+  it("counts retry_attempt from zero for the first failure in an episode", () => {
+    openThenError();
+    fakeEs.dispatch("error");
+    fakeEs.dispatch("error");
+    runDegradedTimer();
+
+    expect(capture).toHaveBeenCalledWith(
+      "sse_connection_degraded",
+      expect.objectContaining({
+        retry_attempt: 2,
+        reconnect_count: 3,
+      }),
+    );
+  });
+
+  it("classifies a closed EventSource as server_closed", () => {
+    openThenError(FakeEventSource.CLOSED);
+    runDegradedTimer();
+
+    expect(capture).toHaveBeenCalledWith(
+      "sse_connection_degraded",
+      expect.objectContaining({ error_type: "server_closed" }),
+    );
+  });
+
+  it("classifies an offline browser as network_error", () => {
+    Object.defineProperty(navigator, "onLine", {
+      configurable: true,
+      value: false,
+    });
+    openThenError();
+    runDegradedTimer();
+
+    expect(capture).toHaveBeenCalledWith(
+      "sse_connection_degraded",
+      expect.objectContaining({ error_type: "network_error" }),
+    );
+  });
+
+  it("does not let a PostHog failure interrupt degraded-state reporting", () => {
+    capture.mockImplementationOnce(() => {
+      throw new Error("capture unavailable");
+    });
+    openThenError();
+
+    expect(() => runDegradedTimer()).not.toThrow();
+    expect(isSseDegraded()).toBe(true);
   });
 });

--- a/packages/web/src/sse/client/sse.client.ts
+++ b/packages/web/src/sse/client/sse.client.ts
@@ -29,15 +29,49 @@ function getListeners(
 
 const reopenListeners = new Set<() => void>();
 
+// Native EventSource does not expose WebSocket-style close codes. Classify
+// from the signals the browser does give us so PostHog can split the
+// sse_connection_degraded series instead of a single unlabelled count.
+type SseDegradedErrorType = "network_error" | "timeout" | "server_closed";
+
 let es: EventSource | null = null;
 let forwardingHandler: ((e: MessageEvent) => void) | null = null;
 let openHandler: (() => void) | null = null;
 let errorHandler: (() => void) | null = null;
 let degradedTimer: ReturnType<typeof setTimeout> | null = null;
 let reconnectCount = 0;
+let episodeErrorCount = 0;
 let hasReportedDegraded = false;
+let connectionOpenedAtMs: number | null = null;
+let connectionDurationMs = 0;
+let userEventCount = 0;
+let lastErrorType: SseDegradedErrorType = "timeout";
 
 const DEGRADED_AFTER_MS = 15_000;
+
+function classifySseError(source: EventSource | null): SseDegradedErrorType {
+  if (typeof navigator !== "undefined" && navigator.onLine === false) {
+    return "network_error";
+  }
+  if (source?.readyState === EventSource.CLOSED) {
+    return "server_closed";
+  }
+  return "timeout";
+}
+
+function currentPagePath(): string {
+  if (typeof window === "undefined") return "";
+  return window.location.pathname;
+}
+
+function resetConnectionDiagnostics() {
+  reconnectCount = 0;
+  episodeErrorCount = 0;
+  connectionOpenedAtMs = null;
+  connectionDurationMs = 0;
+  userEventCount = 0;
+  lastErrorType = "timeout";
+}
 
 // Whether the live stream has been down long enough that displayed data can
 // no longer be trusted as fresh. Previously this was analytics-only
@@ -65,9 +99,18 @@ function reportSseDegraded() {
   sseDegradedStore.set(true);
   if (hasReportedDegraded) return;
   hasReportedDegraded = true;
-  getPosthogClient()?.capture("sse_connection_degraded", {
-    reconnect_count: reconnectCount,
-  });
+  try {
+    getPosthogClient()?.capture("sse_connection_degraded", {
+      reconnect_count: reconnectCount,
+      error_type: lastErrorType,
+      connection_duration_ms: connectionDurationMs,
+      retry_attempt: Math.max(0, episodeErrorCount - 1),
+      user_event_count: userEventCount,
+      page_path: currentPagePath(),
+    });
+  } catch {
+    // Analytics must never interrupt the stream lifecycle it observes.
+  }
 }
 
 function armDegradedTimer() {
@@ -85,6 +128,7 @@ export const openStream = (): EventSource => {
     withCredentials: true,
   });
   forwardingHandler = (e: MessageEvent) => {
+    userEventCount += 1;
     let raw: unknown;
     try {
       raw = JSON.parse(e.data as string);
@@ -110,6 +154,10 @@ export const openStream = (): EventSource => {
   openHandler = () => {
     clearDegradedTimer();
     hasReportedDegraded = false;
+    episodeErrorCount = 0;
+    connectionOpenedAtMs = Date.now();
+    userEventCount = 0;
+    lastErrorType = "timeout";
     sseDegradedStore.set(false);
     for (const listener of reopenListeners) {
       listener();
@@ -117,6 +165,14 @@ export const openStream = (): EventSource => {
   };
   errorHandler = () => {
     reconnectCount += 1;
+    episodeErrorCount += 1;
+    lastErrorType = classifySseError(es);
+    if (episodeErrorCount === 1) {
+      connectionDurationMs =
+        connectionOpenedAtMs === null
+          ? 0
+          : Math.max(0, Date.now() - connectionOpenedAtMs);
+    }
     armDegradedTimer();
   };
   es.addEventListener(SSE_MESSAGE_EVENT, forwardingHandler);
@@ -142,6 +198,7 @@ export const closeStream = (): void => {
   forwardingHandler = null;
   openHandler = null;
   errorHandler = null;
+  resetConnectionDiagnostics();
 };
 
 export const getStream = (): EventSource | null => es;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`sse_connection_degraded` previously captured only `reconnect_count`. That property is a lifetime error counter (max 208 in the spike window), so it cannot tell a first blip from a tab that has been flapping for hours.

The event now also sends:

- `error_type`: `network_error` (browser offline), `server_closed` (EventSource `readyState === CLOSED`), or `timeout` (native auto-reconnect still `CONNECTING` after 15s). EventSource has no WebSocket close codes; this is the classifier the browser actually allows.
- `connection_duration_ms`: time from last successful `open` to the first error in this down episode (`0` if the stream never opened).
- `retry_attempt`: 0-based count of EventSource `error` events in this episode (`0` on the first failure).
- `user_event_count`: SSE `message` frames received since the last `open`.
- `page_path`: `window.location.pathname`.

`reconnect_count` is kept for continuity. Capture is wrapped so a PostHog failure cannot interrupt the stream lifecycle.

## PostHog findings (existing data, 15 Aug to 3 Sep UTC)

Governed catalog consulted: no match. Counts below are from `events` (`filterTestAccounts: false`).

- 143 events, 6 distinct users. Staging 94, production 49. Internal/test filtering hides almost all of them.
- Daily volume matches the reported climb, peaking at 22 events / 4 users on 1 Sep.
- Paths are almost all `/week` (and dated week URLs). A few fire on `/book/...` in the same minute as `/week`, which is multi-tab: `SessionProvider` opens the stream for any authenticated page, not only the calendar shell.
- `reconnect_count` median 4, mean ~13, max 208: the old counter accumulated across the tab lifetime, including blips that recovered inside 15s.

## Server-side investigation plan (not in this PR)

No server timeout or leak fix ships here. Next pass, after this instrumentation is in production:

1. **Cluster `connection_duration_ms`.** Bands at ~60s / ~120s / ~300s point at Caddy or Node idle/request timeouts. Very short durations with `user_event_count` 0 point at connect/replay failure, not idle cut-off. The SSE handler never calls `req.setTimeout(0)` / `socket.setTimeout(0)`; heartbeats are 25s comments (`: keepalive`).
2. **Confirm `#2925` (27 Aug).** Closing the stream when `fetchUserMetadata` fails is correct, but a flapping metadata fetch would produce connect-fail loops (`connection_duration_ms` near 0, `user_event_count` 0, rising `retry_attempt`). That deploy sits in the middle of the spike.
3. **Caddy `/sync/*` outage (Aug 2026).** Documented in `docs/self-hosting/server-guide.md`. Missing push would not close SSE by itself, but a Caddyfile edit against a stale backup could also have changed proxy timeouts. Check the live Caddyfile for `flush_interval` / transport timeouts on `/api/*`.
4. **Multi-tab / booking.** Same-minute `/week` + `/book/...` events are two EventSource connections per user. Correlate with `page_path` after deploy; consider not opening the stream on public booking routes.
5. **Memory / FD leaks.** `SSEServer` stores `Set<Response>` per user, removes on write failure and `req "close"`. `#2925` already closes the leak on replay failure. After deploy, compare `subscriberCount` vs process FD count under a long-lived staging tab, including laptop sleep.
6. **Staging vs production.** Staging produced ~2x the events. Separate `environment` (already a super property) when reading the new properties so deploy/restart noise is not mixed with production.

## Simplicity

One capture site, one classifier, no new modules. Diagnostics reset on `open` and `closeStream` so episode fields do not leak across connections.

## Automated validation

`bun packages/scripts/src/testing/test-parallel.ts web -- packages/web/src/sse/client/sse.client.test.ts`: 12 pass, 0 fail (covers property payload, duration, retry indexing, `network_error` / `server_closed` / `timeout`, and capture throwing).

## Independent review

Not run yet. Request `/review` on this diff.

## Test plan

- `bun packages/scripts/src/testing/test-parallel.ts web -- packages/web/src/sse/client/sse.client.test.ts` (12 pass)
- `bun run verify` after PR open

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6bfb325e-b469-4340-a796-7b5f689f3489?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6bfb325e-b469-4340-a796-7b5f689f3489&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

