### PR TITLE
feat(billing): add stripe publishableKey config (WP-01)

### DIFF
--- a/.agents/handoffs/3155.md
+++ b/.agents/handoffs/3155.md
@@ -1,0 +1,44 @@
+---
+schema_version: 1
+task_id: "3155"
+from: Implementer
+to: Verifier
+owner: Implementer
+status: verifying
+artifact:
+  - path: packages/core/src/config/compass.config.ts
+  - path: packages/backend/src/common/constants/config.constants.ts
+  - path: packages/backend/src/common/constants/config.util.ts
+  - path: packages/core/src/types/config.types.ts
+  - path: packages/backend/src/config/controllers/config.controller.ts
+  - path: .github/workflows/_deploy-environment.yml
+  - path: packages/core/src/types/config.types.test.ts
+evidence:
+  - command: bun test:backend
+    result: "522 pass, 1 skip, 0 fail"
+  - command: bun test:core
+    result: "669 pass, 0 fail"
+  - command: bun test self-host/docker-compose.test.ts
+    result: "pass, including Stripe vars.STRIPE_PUBLISHABLE_KEY and publishableKey: assertions"
+  - command: bun run type-check
+    result: pass
+  - command: bun lint
+    result: "exit 0; 23 pre-existing biome warnings, none in this diff"
+  - command: bun knip
+    result: pass
+assumptions:
+  - "STRIPE_PUBLISHABLE_KEY is a GitHub Environment variable, not a secret"
+  - "Web consumers of AppConfigSchema stay compatible via publishableKey default null"
+open_risks: []
+next_deadline: 2026-09-03T23:59:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-01: stripe.publishableKey is the fourth all-four-or-none Stripe config
+value. GET /api/config emits billing.publishableKey when Stripe is
+configured, null otherwise. The hosted deploy workflow binds
+vars.STRIPE_PUBLISHABLE_KEY and only writes the stripe block when all
+four values are present.

--- a/.github/workflows/_deploy-environment.yml
+++ b/.github/workflows/_deploy-environment.yml
@@ -106,6 +106,7 @@ jobs:
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
           STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
           STRIPE_PRICE_ID: ${{ secrets.STRIPE_PRICE_ID }}
+          STRIPE_PUBLISHABLE_KEY: ${{ vars.STRIPE_PUBLISHABLE_KEY }}
         run: |
           echo "Deploying Compass ${RELEASE_TAG} (image version: ${IMAGE_VERSION}) to ${{ inputs.environment }}"
           # Only "production" ever runs the production runtime.nodeEnv; every
@@ -197,15 +198,16 @@ jobs:
             # if a repo-level STRIPE_* secret exists. Log to stderr — this
             # group is piped into compass.yaml.
             if { [ "${{ inputs.environment }}" = "production" ] || [ "${{ inputs.environment }}" = "staging-cloud" ]; } &&
-              [ -n "$STRIPE_SECRET_KEY" ] && [ -n "$STRIPE_WEBHOOK_SECRET" ] && [ -n "$STRIPE_PRICE_ID" ]; then
-              echo "Stripe config: writing stripe block (all three secrets present)" >&2
+              [ -n "$STRIPE_SECRET_KEY" ] && [ -n "$STRIPE_WEBHOOK_SECRET" ] && [ -n "$STRIPE_PRICE_ID" ] && [ -n "$STRIPE_PUBLISHABLE_KEY" ]; then
+              echo "Stripe config: writing stripe block (all four values present)" >&2
               printf '%s\n' \
                 'stripe:' \
                 "  secretKey: \"${STRIPE_SECRET_KEY}\"" \
                 "  webhookSecret: \"${STRIPE_WEBHOOK_SECRET}\"" \
-                "  priceId: \"${STRIPE_PRICE_ID}\""
+                "  priceId: \"${STRIPE_PRICE_ID}\"" \
+                "  publishableKey: \"${STRIPE_PUBLISHABLE_KEY}\""
             else
-              echo "Stripe config: omitting stripe block (environment=${{ inputs.environment }}; secretKey=$([ -n "$STRIPE_SECRET_KEY" ] && echo present || echo empty); webhookSecret=$([ -n "$STRIPE_WEBHOOK_SECRET" ] && echo present || echo empty); priceId=$([ -n "$STRIPE_PRICE_ID" ] && echo present || echo empty))" >&2
+              echo "Stripe config: omitting stripe block (environment=${{ inputs.environment }}; secretKey=$([ -n "$STRIPE_SECRET_KEY" ] && echo present || echo empty); webhookSecret=$([ -n "$STRIPE_WEBHOOK_SECRET" ] && echo present || echo empty); priceId=$([ -n "$STRIPE_PRICE_ID" ] && echo present || echo empty); publishableKey=$([ -n "$STRIPE_PUBLISHABLE_KEY" ] && echo present || echo empty))" >&2
             fi
             # Billing operator knobs (both optional; omit → schema defaults of
             # enforcement false + empty bypass list). The block header is

--- a/compass.example.yaml
+++ b/compass.example.yaml
@@ -45,7 +45,8 @@ supertokens:
 #   secretKey: REPLACE_WITH_STRIPE_SECRET_KEY # sk_test_... is fine for staging
 #   webhookSecret: REPLACE_WITH_STRIPE_WEBHOOK_SECRET
 #   priceId: REPLACE_WITH_STRIPE_PRICE_ID
-# Omit the whole block for self-host. All three values are required together.
+#   publishableKey: REPLACE_WITH_STRIPE_PUBLISHABLE_KEY # pk_test_... is fine for staging
+# Omit the whole block for self-host. All four values are required together.
 
 # billing:
 #   enforcement: false # operator pause switch — keep the app free for everyone

--- a/docs/Config/README.md
+++ b/docs/Config/README.md
@@ -98,6 +98,7 @@ database and must not share the backend's database user/data.
 |---|---|---|
 | `posthog.key` | No | PostHog project key injected into the web bundle. |
 | `posthog.host` | No | PostHog host injected into the web bundle. |
-| `stripe.secretKey` | No | Stripe secret (`sk_test_...` is fine on staging). All three Stripe keys are required together; omit the whole `stripe:` block on self-host. |
+| `stripe.secretKey` | No | Stripe secret (`sk_test_...` is fine on staging). All four Stripe keys are required together; omit the whole `stripe:` block on self-host. |
 | `stripe.webhookSecret` | No | Stripe webhook signing secret. |
 | `stripe.priceId` | No | Stripe Price id for the hosted subscription. The amount lives on that Price in Stripe. |
+| `stripe.publishableKey` | No | Stripe publishable key (`pk_test_...` is fine on staging). Served to the web as `billing.publishableKey` so Stripe.js can load without a rebuild. |

--- a/packages/backend/src/billing/billing.guard.db.test.ts
+++ b/packages/backend/src/billing/billing.guard.db.test.ts
@@ -21,6 +21,7 @@ const stripeConfigured = {
   STRIPE_SECRET_KEY: "rk_test_123",
   STRIPE_WEBHOOK_SECRET: "whsec_test",
   STRIPE_PRICE_ID: "price_test",
+  STRIPE_PUBLISHABLE_KEY: "pk_test_123",
   BILLING_ENFORCEMENT: true,
 };
 
@@ -58,6 +59,7 @@ describe("assertBillingAllowsWrites", () => {
       STRIPE_SECRET_KEY: "rk_test_123",
       STRIPE_WEBHOOK_SECRET: "whsec_test",
       STRIPE_PRICE_ID: "price_test",
+      STRIPE_PUBLISHABLE_KEY: "pk_test_123",
       BILLING_ENFORCEMENT: false,
     });
     const userId = await insertUser({

--- a/packages/backend/src/billing/services/billing.service.db.test.ts
+++ b/packages/backend/src/billing/services/billing.service.db.test.ts
@@ -19,6 +19,7 @@ const stripeEnforcing = {
   STRIPE_SECRET_KEY: "rk_test_123",
   STRIPE_WEBHOOK_SECRET: "whsec_test",
   STRIPE_PRICE_ID: "price_test",
+  STRIPE_PUBLISHABLE_KEY: "pk_test_123",
   BILLING_ENFORCEMENT: true,
 };
 

--- a/packages/backend/src/billing/services/billing.webhook.service.db.test.ts
+++ b/packages/backend/src/billing/services/billing.webhook.service.db.test.ts
@@ -31,6 +31,7 @@ const stripeConfigured = {
   STRIPE_SECRET_KEY: "rk_test_123",
   STRIPE_WEBHOOK_SECRET: "whsec_test",
   STRIPE_PRICE_ID: "price_test",
+  STRIPE_PUBLISHABLE_KEY: "pk_test_123",
 };
 
 const jsonRes = () => {

--- a/packages/backend/src/billing/services/stripe.service.db.test.ts
+++ b/packages/backend/src/billing/services/stripe.service.db.test.ts
@@ -23,6 +23,7 @@ const stripeConfigured = {
   STRIPE_SECRET_KEY: "rk_test_123",
   STRIPE_WEBHOOK_SECRET: "whsec_test",
   STRIPE_PRICE_ID: "price_test",
+  STRIPE_PUBLISHABLE_KEY: "pk_test_123",
   FRONTEND_URL: "http://localhost:9080",
 } as const;
 

--- a/packages/backend/src/common/constants/config.constants.test.ts
+++ b/packages/backend/src/common/constants/config.constants.test.ts
@@ -58,29 +58,42 @@ describe("config.constants", () => {
     const env = parseConfigFromEnv(validEnv);
 
     expect(env.STRIPE_SECRET_KEY).toBeUndefined();
+    expect(env.STRIPE_PUBLISHABLE_KEY).toBeUndefined();
     expect(isStripeConfigured(env)).toBe(false);
   });
 
-  it("rejects a partial Stripe configuration", () => {
-    expect(() =>
-      parseConfigFromEnv({
-        ...validEnv,
-        STRIPE_SECRET_KEY: "rk_test_123",
-      }),
-    ).toThrow(
-      "Stripe configuration requires secretKey, webhookSecret, and priceId together",
-    );
+  const stripeFour = {
+    STRIPE_SECRET_KEY: "rk_test_123",
+    STRIPE_WEBHOOK_SECRET: "whsec_test",
+    STRIPE_PRICE_ID: "price_test",
+    STRIPE_PUBLISHABLE_KEY: "pk_test_123",
+  };
+
+  it("rejects any three of the four Stripe values", () => {
+    const missingOne: Array<keyof typeof stripeFour> = [
+      "STRIPE_SECRET_KEY",
+      "STRIPE_WEBHOOK_SECRET",
+      "STRIPE_PRICE_ID",
+      "STRIPE_PUBLISHABLE_KEY",
+    ];
+
+    for (const omitted of missingOne) {
+      const partial: Partial<typeof stripeFour> = { ...stripeFour };
+      delete partial[omitted];
+      expect(() => parseConfigFromEnv({ ...validEnv, ...partial })).toThrow(
+        "Stripe configuration requires secretKey, webhookSecret, priceId, and publishableKey together",
+      );
+    }
   });
 
-  it("reports Stripe as configured only when all three values are present", () => {
+  it("reports Stripe as configured only when all four values are present", () => {
     const env = parseConfigFromEnv({
       ...validEnv,
-      STRIPE_SECRET_KEY: "rk_test_123",
-      STRIPE_WEBHOOK_SECRET: "whsec_test",
-      STRIPE_PRICE_ID: "price_test",
+      ...stripeFour,
     });
 
     expect(isStripeConfigured(env)).toBe(true);
+    expect(env.STRIPE_PUBLISHABLE_KEY).toBe("pk_test_123");
   });
 
   it("trims Stripe values from env and compass.yaml", () => {
@@ -89,9 +102,11 @@ describe("config.constants", () => {
       STRIPE_SECRET_KEY: " rk_test_123\n",
       STRIPE_WEBHOOK_SECRET: " whsec_test ",
       STRIPE_PRICE_ID: "price_test\n",
+      STRIPE_PUBLISHABLE_KEY: " pk_test_123\n",
     });
     expect(fromEnv.STRIPE_PRICE_ID).toBe("price_test");
     expect(fromEnv.STRIPE_SECRET_KEY).toBe("rk_test_123");
+    expect(fromEnv.STRIPE_PUBLISHABLE_KEY).toBe("pk_test_123");
 
     const fromFile = parseRawConfig({
       ...baseRawConfig,
@@ -99,10 +114,12 @@ describe("config.constants", () => {
         secretKey: " sk_test_abc ",
         webhookSecret: "whsec_file",
         priceId: " price_file\n",
+        publishableKey: " pk_file\n",
       },
     });
     expect(fromFile.STRIPE_PRICE_ID).toBe("price_file");
     expect(fromFile.STRIPE_SECRET_KEY).toBe("sk_test_abc");
+    expect(fromFile.STRIPE_PUBLISHABLE_KEY).toBe("pk_file");
   });
 
   it("rejects partially configured Google credentials", () => {

--- a/packages/backend/src/common/constants/config.constants.ts
+++ b/packages/backend/src/common/constants/config.constants.ts
@@ -56,6 +56,7 @@ const ConfigSchema = z
     STRIPE_SECRET_KEY: z.string().nonempty().optional(),
     STRIPE_WEBHOOK_SECRET: z.string().nonempty().optional(),
     STRIPE_PRICE_ID: z.string().nonempty().optional(),
+    STRIPE_PUBLISHABLE_KEY: z.string().nonempty().optional(),
     // Operator pause switch: when false, trial/billing gates stay off for
     // everyone regardless of Stripe configuration.
     BILLING_ENFORCEMENT: BooleanFromInput.default(false),
@@ -85,14 +86,15 @@ const ConfigSchema = z
       env.STRIPE_SECRET_KEY,
       env.STRIPE_WEBHOOK_SECRET,
       env.STRIPE_PRICE_ID,
+      env.STRIPE_PUBLISHABLE_KEY,
     ];
     const present = stripeKeys.filter(Boolean).length;
-    if (present > 0 && present < 3) {
+    if (present > 0 && present < 4) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
         fatal: true,
         message:
-          "Stripe configuration requires secretKey, webhookSecret, and priceId together",
+          "Stripe configuration requires secretKey, webhookSecret, priceId, and publishableKey together",
         path: ["STRIPE_SECRET_KEY"],
       });
     }
@@ -143,6 +145,7 @@ export function parseRawConfig(config: CompassConfig): Config {
     STRIPE_SECRET_KEY: nonEmpty(config.stripe?.secretKey),
     STRIPE_WEBHOOK_SECRET: nonEmpty(config.stripe?.webhookSecret),
     STRIPE_PRICE_ID: nonEmpty(config.stripe?.priceId),
+    STRIPE_PUBLISHABLE_KEY: nonEmpty(config.stripe?.publishableKey),
     BILLING_ENFORCEMENT: config.billing?.enforcement,
     BILLING_BYPASS_EMAILS: toEmailList(config.billing?.bypassEmails),
   });
@@ -180,6 +183,7 @@ export function parseConfigFromEnv(
     STRIPE_SECRET_KEY: nonEmpty(rawEnv["STRIPE_SECRET_KEY"]),
     STRIPE_WEBHOOK_SECRET: nonEmpty(rawEnv["STRIPE_WEBHOOK_SECRET"]),
     STRIPE_PRICE_ID: nonEmpty(rawEnv["STRIPE_PRICE_ID"]),
+    STRIPE_PUBLISHABLE_KEY: nonEmpty(rawEnv["STRIPE_PUBLISHABLE_KEY"]),
     BILLING_ENFORCEMENT: nonEmpty(rawEnv["BILLING_ENFORCEMENT"]),
     BILLING_BYPASS_EMAILS: toEmailList(
       rawEnv["BILLING_BYPASS_EMAILS"]?.split(","),

--- a/packages/backend/src/common/constants/config.util.ts
+++ b/packages/backend/src/common/constants/config.util.ts
@@ -18,12 +18,16 @@ const isStripeValueValid = (value?: string): boolean =>
 export const isStripeConfigured = (
   env: Pick<
     Config,
-    "STRIPE_SECRET_KEY" | "STRIPE_WEBHOOK_SECRET" | "STRIPE_PRICE_ID"
+    | "STRIPE_SECRET_KEY"
+    | "STRIPE_WEBHOOK_SECRET"
+    | "STRIPE_PRICE_ID"
+    | "STRIPE_PUBLISHABLE_KEY"
   >,
 ): boolean =>
   isStripeValueValid(env.STRIPE_SECRET_KEY) &&
   isStripeValueValid(env.STRIPE_WEBHOOK_SECRET) &&
-  isStripeValueValid(env.STRIPE_PRICE_ID);
+  isStripeValueValid(env.STRIPE_PRICE_ID) &&
+  isStripeValueValid(env.STRIPE_PUBLISHABLE_KEY);
 
 export const isBillingEnforced = (
   env: Pick<Config, "BILLING_ENFORCEMENT">,

--- a/packages/backend/src/config/config.route.test.ts
+++ b/packages/backend/src/config/config.route.test.ts
@@ -30,6 +30,7 @@ describe("GET /api/config", () => {
           isConfigured: false,
           enforcement: false,
           trialLengthDays: 7,
+          publishableKey: null,
         },
       });
     } finally {
@@ -62,6 +63,7 @@ describe("GET /api/config", () => {
           isConfigured: false,
           enforcement: false,
           trialLengthDays: 7,
+          publishableKey: null,
         },
       });
     } finally {

--- a/packages/backend/src/config/controllers/config.controller.test.ts
+++ b/packages/backend/src/config/controllers/config.controller.test.ts
@@ -46,6 +46,7 @@ describe("ConfigController.get sync cutover posture", () => {
       isConfigured: false,
       enforcement: false,
       trialLengthDays: 7,
+      publishableKey: null,
     });
   });
 });
@@ -65,5 +66,41 @@ describe("ConfigController.get billing enforcement", () => {
   it("reports true once the operator enables it", () => {
     CONFIG.BILLING_ENFORCEMENT = true;
     expect(invokeGet().billing.enforcement).toBe(true);
+  });
+});
+
+describe("ConfigController.get billing publishableKey", () => {
+  const originals = {
+    secretKey: CONFIG.STRIPE_SECRET_KEY,
+    webhookSecret: CONFIG.STRIPE_WEBHOOK_SECRET,
+    priceId: CONFIG.STRIPE_PRICE_ID,
+    publishableKey: CONFIG.STRIPE_PUBLISHABLE_KEY,
+  };
+
+  afterEach(() => {
+    CONFIG.STRIPE_SECRET_KEY = originals.secretKey;
+    CONFIG.STRIPE_WEBHOOK_SECRET = originals.webhookSecret;
+    CONFIG.STRIPE_PRICE_ID = originals.priceId;
+    CONFIG.STRIPE_PUBLISHABLE_KEY = originals.publishableKey;
+  });
+
+  it("returns null when Stripe is not configured", () => {
+    CONFIG.STRIPE_SECRET_KEY = undefined;
+    CONFIG.STRIPE_WEBHOOK_SECRET = undefined;
+    CONFIG.STRIPE_PRICE_ID = undefined;
+    CONFIG.STRIPE_PUBLISHABLE_KEY = undefined;
+
+    expect(invokeGet().billing.publishableKey).toBeNull();
+    expect(invokeGet().billing.isConfigured).toBe(false);
+  });
+
+  it("returns the configured key when Stripe is fully configured", () => {
+    CONFIG.STRIPE_SECRET_KEY = "rk_test_123";
+    CONFIG.STRIPE_WEBHOOK_SECRET = "whsec_test";
+    CONFIG.STRIPE_PRICE_ID = "price_test";
+    CONFIG.STRIPE_PUBLISHABLE_KEY = "pk_test_123";
+
+    expect(invokeGet().billing.publishableKey).toBe("pk_test_123");
+    expect(invokeGet().billing.isConfigured).toBe(true);
   });
 });

--- a/packages/backend/src/config/controllers/config.controller.ts
+++ b/packages/backend/src/config/controllers/config.controller.ts
@@ -24,6 +24,9 @@ class ConfigController {
           isConfigured: isStripeConfigured(CONFIG),
           enforcement: isBillingEnforced(CONFIG),
           trialLengthDays: BILLING_PLAN.TRIAL_LENGTH_DAYS,
+          publishableKey: isStripeConfigured(CONFIG)
+            ? (CONFIG.STRIPE_PUBLISHABLE_KEY ?? null)
+            : null,
         },
       }),
     );

--- a/packages/core/src/config/compass.config.ts
+++ b/packages/core/src/config/compass.config.ts
@@ -56,7 +56,7 @@ const CompassConfigSchema = z
         host: optionalString,
       })
       .nullish(),
-    // Hosted Stripe billing. All-three-or-none is enforced when this is
+    // Hosted Stripe billing. All-four-or-none is enforced when this is
     // mapped into backend CONFIG (see config.constants superRefine). Omit
     // the whole block for self-host — billing enforcement then stays off.
     stripe: z
@@ -64,6 +64,7 @@ const CompassConfigSchema = z
         secretKey: optionalString,
         webhookSecret: optionalString,
         priceId: optionalString,
+        publishableKey: optionalString,
       })
       .nullish(),
     // Operator pause switch for trial/billing gates, independent of whether

--- a/packages/core/src/types/config.types.test.ts
+++ b/packages/core/src/types/config.types.test.ts
@@ -1,0 +1,17 @@
+import { AppConfigSchema } from "@core/types/config.types";
+import { describe, expect, it } from "bun:test";
+
+describe("AppConfigSchema", () => {
+  it("defaults billing.publishableKey to null when the field is omitted", () => {
+    const parsed = AppConfigSchema.parse({
+      google: { isConfigured: false },
+      billing: {
+        isConfigured: false,
+        enforcement: false,
+        trialLengthDays: 7,
+      },
+    });
+
+    expect(parsed.billing.publishableKey).toBeNull();
+  });
+});

--- a/packages/core/src/types/config.types.ts
+++ b/packages/core/src/types/config.types.ts
@@ -31,11 +31,15 @@ export const AppConfigSchema = z.object({
       isConfigured: z.boolean(),
       enforcement: z.boolean().default(false),
       trialLengthDays: z.number(),
+      // Public Stripe.js key. Default null so old /api/config payloads still
+      // parse until every backend is on the four-value stripe block.
+      publishableKey: z.string().nullable().default(null),
     })
     .default({
       isConfigured: false,
       enforcement: false,
       trialLengthDays: BILLING_PLAN.TRIAL_LENGTH_DAYS,
+      publishableKey: null,
     }),
 });
 

--- a/self-host/compass.example.yaml
+++ b/self-host/compass.example.yaml
@@ -46,6 +46,7 @@ supertokens:
 #   secretKey: REPLACE_WITH_STRIPE_SECRET_KEY
 #   webhookSecret: REPLACE_WITH_STRIPE_WEBHOOK_SECRET
 #   priceId: REPLACE_WITH_STRIPE_PRICE_ID
+#   publishableKey: REPLACE_WITH_STRIPE_PUBLISHABLE_KEY
 # Omit this block on self-host. Compass stays fully writable without Stripe.
 
 # Compass Sync service — self-host runs the same architecture as Compass

--- a/self-host/docker-compose.test.ts
+++ b/self-host/docker-compose.test.ts
@@ -521,8 +521,12 @@ describe("staging deploy workflow", () => {
     expect(workflow).toContain(
       "STRIPE_PRICE_ID: $".concat("{{ secrets.STRIPE_PRICE_ID }}"),
     );
+    expect(workflow).toContain(
+      "STRIPE_PUBLISHABLE_KEY: $".concat("{{ vars.STRIPE_PUBLISHABLE_KEY }}"),
+    );
     expect(workflow).not.toContain("&& secrets.STRIPE_SECRET_KEY ||");
     expect(workflow).toContain("'stripe:'");
+    expect(workflow).toContain("publishableKey:");
     expect(workflow).toContain("staging-selfhosted must omit this block");
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #3155.

`stripe.publishableKey` is the fourth Stripe config value (all-four-or-none). `GET /api/config` reports it as `billing.publishableKey` so the web can load Stripe.js from a runtime value instead of a rebuild. The hosted deploy workflow binds `STRIPE_PUBLISHABLE_KEY` from a GitHub Environment variable and only writes the `stripe:` block when all four values are present.

Old `/api/config` payloads without `publishableKey` still parse as `null`.

## Simplicity

Reused the existing all-or-none Stripe refine, `isStripeConfigured` helper, and `/api/config` payload. No new abstraction.

## Automated validation

```
bun test:backend
# 522 pass, 1 skip, 0 fail

bun test:core
# 669 pass, 0 fail

bun test self-host/docker-compose.test.ts
# pass (includes vars.STRIPE_PUBLISHABLE_KEY binding and publishableKey: yaml line)

bun run type-check
# pass

bun lint
# exit 0; 23 pre-existing biome warnings, none in this diff

bun knip
# pass
```

## Independent review

`.agents/handoffs/3155.md`

## Test plan

Commands above were actually run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0ba2f6a-bdca-4f94-a04f-f2a4d77d7dbb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0ba2f6a-bdca-4f94-a04f-f2a4d77d7dbb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

