### PR TITLE
feat(billing): add subscription summary, cancel, and resume (WP-02)

### DIFF
--- a/.agents/handoffs/3156.md
+++ b/.agents/handoffs/3156.md
@@ -1,0 +1,37 @@
+---
+schema_version: 1
+task_id: "3156"
+from: Implementer
+to: Verifier
+owner: Implementer
+status: verifying
+artifact:
+  - path: packages/core/src/types/billing.types.ts
+  - path: packages/backend/src/billing/services/stripe.service.ts
+  - path: packages/backend/src/billing/billing.routes.config.ts
+  - path: packages/backend/src/billing/controllers/billing.controller.ts
+  - path: packages/backend/src/billing/billing.routes.config.test.ts
+evidence:
+  - command: bun test:backend
+    result: "531 pass, 1 skip, 0 fail"
+  - command: bun test:core
+    result: "668 pass, 0 fail"
+  - command: bun run type-check
+    result: pass
+  - command: bun lint
+    result: "exit 0; pre-existing biome warnings only"
+  - command: bun knip
+    result: pass
+assumptions:
+  - "GET /billing/subscription returns stored Mongo fields, not deriveBillingStatus"
+  - "Cancel and resume return BillingStatusResponse, matching endTrialNow"
+open_risks: []
+next_deadline: 2026-09-03T23:59:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-02: GET /api/billing/subscription plus cancel and resume endpoints.
+GET is behind billingReadLimiter; POSTs reuse sessionWriteLimiter.

--- a/docs/backend/README.md
+++ b/docs/backend/README.md
@@ -25,7 +25,7 @@ Backend routes are registered from
 | Config | `packages/backend/src/config/config.routes.config.ts` | Public runtime config used by the web app. |
 | Auth | `packages/backend/src/auth/auth.routes.config.ts` | Compass-owned auth helpers and authenticated Google connect. SuperTokens also mounts recipe routes under `/api`. |
 | User | `packages/backend/src/user/user.routes.config.ts` | Profile and metadata for the active session. |
-| Billing | `packages/backend/src/billing/billing.routes.config.ts` | Session status, Checkout, Billing Portal, and unauthenticated Stripe webhook. Self-host omits Stripe keys and stays fully writable. |
+| Billing | `packages/backend/src/billing/billing.routes.config.ts` | Session status, Checkout, Billing Portal, `GET /api/billing/subscription`, cancel and resume, and unauthenticated Stripe webhook. Self-host omits Stripe keys and stays fully writable. |
 | Events | `packages/backend/src/event/event.routes.config.ts` | Event CRUD and reorder/delete helpers. |
 | Event stream | `packages/backend/src/events/events.routes.config.ts` | Authenticated SSE stream at `GET /api/events/stream`. |
 | Calendars | `packages/backend/src/calendar/calendar.routes.config.ts` | Calendar list and selection routes. |

--- a/packages/backend/src/billing/billing.routes.config.test.ts
+++ b/packages/backend/src/billing/billing.routes.config.test.ts
@@ -1,0 +1,44 @@
+import express from "express";
+import {
+  BillingRoutes,
+  billingReadLimiter,
+  sessionWriteLimiter,
+} from "@backend/billing/billing.routes.config";
+import billingController from "@backend/billing/controllers/billing.controller";
+import { describe, expect, it } from "bun:test";
+
+type RouteLayer = {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: Array<{ handle: (...args: never[]) => unknown }>;
+  };
+};
+
+const routeHandles = (path: string, method: string): unknown[] => {
+  const app = express();
+  new BillingRoutes(app);
+  const stack = (app as unknown as { _router?: { stack?: RouteLayer[] } })
+    ._router?.stack;
+  const layer = stack?.find(
+    (entry) => entry.route?.path === path && entry.route.methods[method],
+  );
+  return (layer?.route?.stack ?? []).map((item) => item.handle);
+};
+
+describe("BillingRoutes limiters", () => {
+  it("puts GET /api/billing/subscription behind billingReadLimiter", () => {
+    const handles = routeHandles("/api/billing/subscription", "get");
+    expect(handles).toContain(billingReadLimiter);
+    expect(handles).toContain(billingController.getSubscription);
+  });
+
+  it("puts cancel and resume behind sessionWriteLimiter", () => {
+    const cancel = routeHandles("/api/billing/subscription/cancel", "post");
+    const resume = routeHandles("/api/billing/subscription/resume", "post");
+    expect(cancel).toContain(sessionWriteLimiter);
+    expect(cancel).toContain(billingController.cancelSubscription);
+    expect(resume).toContain(sessionWriteLimiter);
+    expect(resume).toContain(billingController.resumeSubscription);
+  });
+});

--- a/packages/backend/src/billing/billing.routes.config.ts
+++ b/packages/backend/src/billing/billing.routes.config.ts
@@ -6,9 +6,16 @@ import billingController from "@backend/billing/controllers/billing.controller";
 import billingWebhookController from "@backend/billing/controllers/billing.webhook.controller";
 import { CommonRoutesConfig } from "@backend/common/common.routes.config";
 
-const sessionWriteLimiter = rateLimit({
+export const sessionWriteLimiter = rateLimit({
   windowMs: 60 * 1000,
   limit: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+export const billingReadLimiter = rateLimit({
+  windowMs: 60_000,
+  limit: 60,
   standardHeaders: true,
   legacyHeaders: false,
 });
@@ -37,8 +44,8 @@ export function mountStripeWebhook(app: express.Application): void {
 
 /**
  * Billing routes: trial status, Stripe Checkout, ending a trial early,
- * and Billing Portal. The Stripe webhook is mounted separately, ahead of
- * body parsers; see `mountStripeWebhook`.
+ * Billing Portal, and in-app subscription management. The Stripe webhook
+ * is mounted separately, ahead of body parsers; see `mountStripeWebhook`.
  */
 export class BillingRoutes extends CommonRoutesConfig {
   constructor(app: express.Application) {
@@ -65,6 +72,21 @@ export class BillingRoutes extends CommonRoutesConfig {
       .route(`/api/billing/portal/session`)
       .all(verifySession())
       .post(sessionWriteLimiter, billingController.createPortalSession);
+
+    this.app
+      .route(`/api/billing/subscription`)
+      .all(verifySession())
+      .get(billingReadLimiter, billingController.getSubscription);
+
+    this.app
+      .route(`/api/billing/subscription/cancel`)
+      .all(verifySession())
+      .post(sessionWriteLimiter, billingController.cancelSubscription);
+
+    this.app
+      .route(`/api/billing/subscription/resume`)
+      .all(verifySession())
+      .post(sessionWriteLimiter, billingController.resumeSubscription);
 
     return this.app;
   }

--- a/packages/backend/src/billing/controllers/billing.controller.ts
+++ b/packages/backend/src/billing/controllers/billing.controller.ts
@@ -5,6 +5,8 @@ import {
   type BillingCheckoutResponse,
   type BillingPortalResponse,
   type BillingStatusResponse,
+  type BillingSubscriptionResponse,
+  BillingSubscriptionResponseSchema,
 } from "@core/types/billing.types";
 import { zObjectId } from "@core/types/type.utils";
 import { BillingHttpError } from "@backend/billing/billing.errors";
@@ -78,6 +80,55 @@ class BillingController {
       const userId = zObjectId.parse(req.session?.getUserId());
       const result = await stripeService.createPortalSession(userId.toString());
       res.status(Status.OK).json(result);
+    } catch (e) {
+      sendBillingError(res, e);
+    }
+  };
+
+  getSubscription = async (
+    req: Request<never, BillingSubscriptionResponse, never, never>,
+    res: Response<BillingSubscriptionResponse | { error: string }>,
+  ) => {
+    try {
+      const userId = zObjectId.parse(req.session?.getUserId());
+      const summary = await stripeService.getSubscriptionSummary(
+        userId.toString(),
+      );
+      res
+        .status(Status.OK)
+        .json(BillingSubscriptionResponseSchema.parse(summary));
+    } catch (e) {
+      sendBillingError(res, e);
+    }
+  };
+
+  cancelSubscription = async (
+    req: Request<never, BillingStatusResponse, never, never>,
+    res: Response<BillingStatusResponse | { error: string }>,
+  ) => {
+    try {
+      const userId = zObjectId.parse(req.session?.getUserId());
+      const status = await stripeService.setCancelAtPeriodEnd(
+        userId.toString(),
+        true,
+      );
+      res.status(Status.OK).json(status);
+    } catch (e) {
+      sendBillingError(res, e);
+    }
+  };
+
+  resumeSubscription = async (
+    req: Request<never, BillingStatusResponse, never, never>,
+    res: Response<BillingStatusResponse | { error: string }>,
+  ) => {
+    try {
+      const userId = zObjectId.parse(req.session?.getUserId());
+      const status = await stripeService.setCancelAtPeriodEnd(
+        userId.toString(),
+        false,
+      );
+      res.status(Status.OK).json(status);
     } catch (e) {
       sendBillingError(res, e);
     }

--- a/packages/backend/src/billing/services/stripe.service.db.test.ts
+++ b/packages/backend/src/billing/services/stripe.service.db.test.ts
@@ -520,4 +520,314 @@ describe("StripeService", () => {
       ).rejects.toMatchObject({ name: "BillingHttpError", status: 400 });
     });
   });
+
+  describe("getSubscriptionSummary", () => {
+    const periodEnd = new Date("2026-10-01T00:00:00.000Z");
+    const trialEnd = new Date("2026-09-10T00:00:00.000Z");
+
+    const seedUser = async (billing: Record<string, unknown>) => {
+      const userId = mongoService.objectId();
+      await mongoService.user.insertOne({
+        _id: userId,
+        email: "sub@example.com",
+        name: "Sub User",
+        firstName: "Sub",
+        lastName: "User",
+        locale: "en",
+        billing,
+      });
+      return userId;
+    };
+
+    const cardPaymentMethod = {
+      id: "pm_card",
+      card: {
+        brand: "visa",
+        last4: "4242",
+        exp_month: 12,
+        exp_year: 2030,
+      },
+    };
+
+    const liveSubscription = (
+      paymentMethod: unknown,
+      overrides: Record<string, unknown> = {},
+    ) => ({
+      id: "sub_live",
+      status: "active",
+      customer: "cus_live",
+      cancel_at_period_end: false,
+      default_payment_method: paymentMethod,
+      items: {
+        data: [
+          {
+            price: {
+              id: "price_test",
+              unit_amount: 1200,
+              currency: "usd",
+              recurring: { interval: "month" },
+            },
+            current_period_end: 1_758_800_000,
+          },
+        ],
+      },
+      ...overrides,
+    });
+
+    it("maps price, card, and invoices from Stripe", async () => {
+      using _env = mockEnv(stripeConfigured);
+      const userId = await seedUser({
+        subscriptionStatus: "active",
+        stripeCustomerId: "cus_live",
+        stripeSubscriptionId: "sub_live",
+        currentPeriodEnd: periodEnd,
+        cancelAtPeriodEnd: false,
+        trialEndsAt: trialEnd,
+      });
+
+      const retrieve = mock(() =>
+        Promise.resolve(liveSubscription(cardPaymentMethod)),
+      );
+      const customersRetrieve = mock();
+      const invoicesList = mock(() =>
+        Promise.resolve({
+          data: [
+            {
+              id: "in_1",
+              created: 1_756_000_000,
+              amount_paid: 1200,
+              currency: "usd",
+              status: "paid",
+              hosted_invoice_url: "https://invoice.stripe.com/i/1",
+            },
+          ],
+        }),
+      );
+      setStripeClientForTests({
+        subscriptions: { retrieve },
+        customers: { retrieve: customersRetrieve },
+        invoices: { list: invoicesList },
+      } as unknown as Stripe);
+
+      const result = await stripeService.getSubscriptionSummary(
+        userId.toString(),
+      );
+
+      expect(retrieve.mock.calls[0]?.[0]).toBe("sub_live");
+      expect(retrieve.mock.calls[0]?.[1]).toEqual({
+        expand: ["default_payment_method"],
+      });
+      expect(customersRetrieve).not.toHaveBeenCalled();
+      expect(invoicesList.mock.calls[0]?.[0]).toEqual({
+        customer: "cus_live",
+        limit: 12,
+      });
+      expect(result).toEqual({
+        subscriptionStatus: "active",
+        currentPeriodEnd: periodEnd.toISOString(),
+        cancelAtPeriodEnd: false,
+        trialEndsAt: trialEnd.toISOString(),
+        price: { amount: 1200, currency: "usd", interval: "month" },
+        paymentMethod: {
+          brand: "visa",
+          last4: "4242",
+          expMonth: 12,
+          expYear: 2030,
+        },
+        invoices: [
+          {
+            id: "in_1",
+            createdAt: new Date(1_756_000_000 * 1000).toISOString(),
+            amountPaid: 1200,
+            currency: "usd",
+            status: "paid",
+            hostedInvoiceUrl: "https://invoice.stripe.com/i/1",
+          },
+        ],
+      });
+    });
+
+    it("falls back to the customer default payment method", async () => {
+      using _env = mockEnv(stripeConfigured);
+      const userId = await seedUser({
+        subscriptionStatus: "active",
+        stripeCustomerId: "cus_live",
+        stripeSubscriptionId: "sub_live",
+      });
+
+      const retrieve = mock(() => Promise.resolve(liveSubscription(null)));
+      const customersRetrieve = mock(() =>
+        Promise.resolve({
+          id: "cus_live",
+          invoice_settings: { default_payment_method: cardPaymentMethod },
+        }),
+      );
+      setStripeClientForTests({
+        subscriptions: { retrieve },
+        customers: { retrieve: customersRetrieve },
+        invoices: { list: mock(() => Promise.resolve({ data: [] })) },
+      } as unknown as Stripe);
+
+      const result = await stripeService.getSubscriptionSummary(
+        userId.toString(),
+      );
+
+      expect(customersRetrieve.mock.calls[0]?.[0]).toBe("cus_live");
+      expect(customersRetrieve.mock.calls[0]?.[1]).toEqual({
+        expand: ["invoice_settings.default_payment_method"],
+      });
+      expect(result.paymentMethod).toEqual({
+        brand: "visa",
+        last4: "4242",
+        expMonth: 12,
+        expYear: 2030,
+      });
+    });
+
+    it("returns nulls and skips Stripe when there is no subscription id", async () => {
+      using _env = mockEnv(stripeConfigured);
+      const userId = await seedUser({
+        subscriptionStatus: "awaiting_checkout",
+        stripeCustomerId: "cus_pending",
+      });
+
+      const retrieve = mock(() => Promise.reject(new Error("no stripe")));
+      const invoicesList = mock(() => Promise.reject(new Error("no stripe")));
+      setStripeClientForTests({
+        subscriptions: { retrieve },
+        invoices: { list: invoicesList },
+      } as unknown as Stripe);
+
+      const result = await stripeService.getSubscriptionSummary(
+        userId.toString(),
+      );
+
+      expect(retrieve).not.toHaveBeenCalled();
+      expect(invoicesList).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        subscriptionStatus: "awaiting_checkout",
+        currentPeriodEnd: null,
+        cancelAtPeriodEnd: false,
+        trialEndsAt: null,
+        price: null,
+        paymentMethod: null,
+        invoices: [],
+      });
+    });
+  });
+
+  describe("setCancelAtPeriodEnd", () => {
+    const seedSubscriber = async (billing: Record<string, unknown> = {}) => {
+      const userId = mongoService.objectId();
+      await mongoService.user.insertOne({
+        _id: userId,
+        email: "cancel@example.com",
+        name: "Cancel User",
+        firstName: "Cancel",
+        lastName: "User",
+        locale: "en",
+        billing: {
+          subscriptionStatus: "active",
+          stripeCustomerId: "cus_live",
+          stripeSubscriptionId: "sub_live",
+          ...billing,
+        },
+      });
+      return userId;
+    };
+
+    const updatedSubscription = (cancelAtPeriodEnd: boolean) =>
+      ({
+        id: "sub_live",
+        status: "active",
+        customer: "cus_live",
+        cancel_at_period_end: cancelAtPeriodEnd,
+        items: {
+          data: [
+            {
+              price: { id: "price_test" },
+              current_period_end: 1_758_800_000,
+            },
+          ],
+        },
+      }) as unknown as Stripe.Subscription;
+
+    it("cancels at period end and returns the fresh status", async () => {
+      using _env = mockEnv(stripeConfigured);
+      const userId = await seedSubscriber();
+      const update = mock(() => Promise.resolve(updatedSubscription(true)));
+      setStripeClientForTests({
+        subscriptions: { update },
+      } as unknown as Stripe);
+
+      const result = await stripeService.setCancelAtPeriodEnd(
+        userId.toString(),
+        true,
+      );
+
+      expect(update.mock.calls[0]?.[0]).toBe("sub_live");
+      expect(update.mock.calls[0]?.[1]).toEqual({ cancel_at_period_end: true });
+      expect(result.cancelAtPeriodEnd).toBe(true);
+      expect(result.subscriptionStatus).toBe("active");
+      const stored = await mongoService.user.findOne({ _id: userId });
+      expect(stored?.billing?.cancelAtPeriodEnd).toBe(true);
+    });
+
+    it("resumes a subscription scheduled to cancel", async () => {
+      using _env = mockEnv(stripeConfigured);
+      const userId = await seedSubscriber({ cancelAtPeriodEnd: true });
+      const update = mock(() => Promise.resolve(updatedSubscription(false)));
+      setStripeClientForTests({
+        subscriptions: { update },
+      } as unknown as Stripe);
+
+      const result = await stripeService.setCancelAtPeriodEnd(
+        userId.toString(),
+        false,
+      );
+
+      expect(update.mock.calls[0]?.[1]).toEqual({
+        cancel_at_period_end: false,
+      });
+      expect(result.cancelAtPeriodEnd).toBe(false);
+      const stored = await mongoService.user.findOne({ _id: userId });
+      expect(stored?.billing?.cancelAtPeriodEnd).toBe(false);
+    });
+
+    it.each([
+      "awaiting_checkout",
+      "expired",
+      "canceled",
+    ] as const)("rejects with 409 when status is %s", async (status) => {
+      using _env = mockEnv(stripeConfigured);
+      const userId = await seedSubscriber({ subscriptionStatus: status });
+      const update = mock(() => Promise.resolve(updatedSubscription(true)));
+      setStripeClientForTests({
+        subscriptions: { update },
+      } as unknown as Stripe);
+
+      await expect(
+        stripeService.setCancelAtPeriodEnd(userId.toString(), true),
+      ).rejects.toMatchObject({
+        name: "BillingHttpError",
+        status: 409,
+        clientMessage: "No active subscription to update.",
+      });
+      expect(update).not.toHaveBeenCalled();
+    });
+
+    it("rejects with 409 when there is no subscription id", async () => {
+      using _env = mockEnv(stripeConfigured);
+      const userId = await seedSubscriber({
+        stripeSubscriptionId: undefined,
+      });
+
+      await expect(
+        stripeService.setCancelAtPeriodEnd(userId.toString(), true),
+      ).rejects.toMatchObject({
+        status: 409,
+        clientMessage: "No active subscription to update.",
+      });
+    });
+  });
 });

--- a/packages/backend/src/billing/services/stripe.service.ts
+++ b/packages/backend/src/billing/services/stripe.service.ts
@@ -1,7 +1,9 @@
+import type Stripe from "stripe";
 import { Status } from "@core/errors/status.codes";
 import {
   type BillingCheckoutResponse,
   type BillingStatusResponse,
+  type BillingSubscriptionResponse,
 } from "@core/types/billing.types";
 import {
   BILLING_PLAN,
@@ -223,6 +225,110 @@ class StripeService {
     return billingService.getStatus(userId);
   };
 
+  getSubscriptionSummary = async (
+    userId: string,
+  ): Promise<BillingSubscriptionResponse> => {
+    const _id = mongoService.objectId(userId);
+    const user = await mongoService.user.findOne({ _id });
+    if (!user) {
+      throw new Error("User not found");
+    }
+
+    const billing = user.billing;
+    const mongo = {
+      subscriptionStatus: billing?.subscriptionStatus ?? "none",
+      currentPeriodEnd: billing?.currentPeriodEnd?.toISOString() ?? null,
+      cancelAtPeriodEnd: billing?.cancelAtPeriodEnd === true,
+      trialEndsAt: billing?.trialEndsAt?.toISOString() ?? null,
+    };
+
+    const subscriptionId = billing?.stripeSubscriptionId;
+    if (!subscriptionId) {
+      return { ...mongo, price: null, paymentMethod: null, invoices: [] };
+    }
+
+    if (!isStripeConfigured(CONFIG)) {
+      throw new Error("Stripe is not configured");
+    }
+
+    const stripe = getStripeClient();
+    const subscription = await stripe.subscriptions
+      .retrieve(subscriptionId, { expand: ["default_payment_method"] })
+      .catch(wrapStripeFailure);
+
+    let paymentMethod = cardFromPaymentMethod(
+      subscription.default_payment_method,
+    );
+    const customerId =
+      customerIdOf(subscription.customer) ?? billing?.stripeCustomerId;
+    if (!paymentMethod && customerId) {
+      const customer = await stripe.customers
+        .retrieve(customerId, {
+          expand: ["invoice_settings.default_payment_method"],
+        })
+        .catch(wrapStripeFailure);
+      if (!("deleted" in customer && customer.deleted)) {
+        paymentMethod = cardFromPaymentMethod(
+          customer.invoice_settings.default_payment_method,
+        );
+      }
+    }
+
+    const invoices = customerId
+      ? (
+          await stripe.invoices
+            .list({ customer: customerId, limit: 12 })
+            .catch(wrapStripeFailure)
+        ).data.flatMap((invoice) => {
+          const mapped = mapInvoice(invoice);
+          return mapped ? [mapped] : [];
+        })
+      : [];
+
+    return {
+      ...mongo,
+      price: mapPrice(subscription),
+      paymentMethod,
+      invoices,
+    };
+  };
+
+  setCancelAtPeriodEnd = async (
+    userId: string,
+    cancel: boolean,
+  ): Promise<BillingStatusResponse> => {
+    if (!isStripeConfigured(CONFIG)) {
+      throw new Error("Stripe is not configured");
+    }
+
+    const _id = mongoService.objectId(userId);
+    const user = await mongoService.user.findOne({ _id });
+    if (!user) {
+      throw new Error("User not found");
+    }
+
+    const status = user.billing?.subscriptionStatus;
+    const subscriptionId = user.billing?.stripeSubscriptionId;
+    const canUpdate =
+      Boolean(subscriptionId) &&
+      (status === "trialing" || status === "active" || status === "past_due");
+    if (!subscriptionId || !canUpdate) {
+      throw new BillingHttpError(
+        Status.CONFLICT,
+        "No active subscription to update.",
+      );
+    }
+
+    const stripe = getStripeClient();
+    const subscription = await stripe.subscriptions
+      .update(subscriptionId, { cancel_at_period_end: cancel })
+      .catch(wrapStripeFailure);
+
+    await applySubscription(userId, subscription, new Date());
+
+    return billingService.getStatus(userId);
+  };
+
   createPortalSession = async (
     userId: string,
   ): Promise<BillingCheckoutResponse> => {
@@ -267,5 +373,57 @@ function isMissingStripeCustomer(error: unknown): boolean {
       candidate.message.startsWith("No such customer"))
   );
 }
+
+const customerIdOf = (value: unknown): string | undefined => {
+  if (typeof value === "string" && value.length > 0) return value;
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "id" in value &&
+    typeof (value as { id: unknown }).id === "string"
+  ) {
+    return (value as { id: string }).id;
+  }
+  return undefined;
+};
+
+const cardFromPaymentMethod = (
+  value: unknown,
+): BillingSubscriptionResponse["paymentMethod"] => {
+  if (typeof value !== "object" || value === null) return null;
+  const card = (value as Stripe.PaymentMethod).card;
+  if (!card?.brand || !card.last4) return null;
+  return {
+    brand: card.brand,
+    last4: card.last4,
+    expMonth: card.exp_month,
+    expYear: card.exp_year,
+  };
+};
+
+const mapPrice = (
+  subscription: Stripe.Subscription,
+): BillingSubscriptionResponse["price"] => {
+  const price = subscription.items.data[0]?.price;
+  if (!price || typeof price === "string") return null;
+  const amount = price.unit_amount;
+  const interval = price.recurring?.interval;
+  if (amount == null || !price.currency || !interval) return null;
+  return { amount, currency: price.currency, interval };
+};
+
+const mapInvoice = (
+  invoice: Stripe.Invoice,
+): BillingSubscriptionResponse["invoices"][number] | null => {
+  if (!invoice.id) return null; // basil types leave Invoice.id optional
+  return {
+    id: invoice.id,
+    createdAt: new Date(invoice.created * 1000).toISOString(),
+    amountPaid: invoice.amount_paid,
+    currency: invoice.currency,
+    status: invoice.status ?? "unknown",
+    hostedInvoiceUrl: invoice.hosted_invoice_url ?? null,
+  };
+};
 
 export default new StripeService();

--- a/packages/core/src/types/billing.types.ts
+++ b/packages/core/src/types/billing.types.ts
@@ -37,4 +37,40 @@ export const BillingPortalResponseSchema = z.object({
 });
 export type BillingPortalResponse = z.infer<typeof BillingPortalResponseSchema>;
 
+export const BillingPriceSchema = z.object({
+  amount: z.number(),
+  currency: z.string(),
+  interval: z.enum(["day", "week", "month", "year"]),
+});
+
+export const BillingPaymentMethodSchema = z.object({
+  brand: z.string(),
+  last4: z.string(),
+  expMonth: z.number(),
+  expYear: z.number(),
+});
+
+export const BillingInvoiceSchema = z.object({
+  id: z.string(),
+  createdAt: z.string(),
+  amountPaid: z.number(),
+  currency: z.string(),
+  status: z.string(),
+  hostedInvoiceUrl: z.string().nullable(),
+});
+
+/** Settings > Billing management payload. Dates are ISO strings. */
+export const BillingSubscriptionResponseSchema = z.object({
+  subscriptionStatus: BillingSubscriptionStatusSchema,
+  currentPeriodEnd: z.string().nullable(),
+  cancelAtPeriodEnd: z.boolean(),
+  trialEndsAt: z.string().nullable(),
+  price: BillingPriceSchema.nullable(),
+  paymentMethod: BillingPaymentMethodSchema.nullable(),
+  invoices: z.array(BillingInvoiceSchema),
+});
+export type BillingSubscriptionResponse = z.infer<
+  typeof BillingSubscriptionResponseSchema
+>;
+
 export type { BillingSubscriptionStatus };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #3156.

Adds three authenticated billing routes for the Settings > Billing management view:

- `GET /api/billing/subscription` returns Mongo plan fields plus live Stripe price, card on file, and up to 12 invoices.
- `POST /api/billing/subscription/cancel` and `POST /api/billing/subscription/resume` flip `cancel_at_period_end` and return the fresh `BillingStatusResponse`.

GET sits behind `billingReadLimiter` (60/min). Both POSTs reuse `sessionWriteLimiter`. Stripe calls go through `setStripeClientForTests` in tests. No hosted portal.

## Simplicity

`setCancelAtPeriodEnd` reuses `applySubscription` the same way `endTrialNow` does. Payment-method fallback is a short helper, not a new client layer.

## Automated validation

```
bun test:backend
# 531 pass, 1 skip, 0 fail

bun test:core
# 668 pass, 0 fail

bun run type-check
# pass

bun lint
# exit 0; pre-existing biome warnings only

bun knip
# pass
```

## Independent review

`.agents/handoffs/3156.md`

## Test plan

Commands above were actually run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0ba2f6a-bdca-4f94-a04f-f2a4d77d7dbb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0ba2f6a-bdca-4f94-a04f-f2a4d77d7dbb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

