### PR TITLE
feat(billing): add setup-mode payment-method session (WP-03)

### DIFF
--- a/.agents/handoffs/3157.md
+++ b/.agents/handoffs/3157.md
@@ -1,0 +1,34 @@
+---
+schema_version: 1
+task_id: "3157"
+from: Implementer
+to: Verifier
+owner: Implementer
+status: verifying
+artifact:
+  - path: packages/backend/src/billing/services/stripe.service.ts
+  - path: packages/backend/src/billing/services/billing.webhook.service.ts
+  - path: packages/backend/src/billing/billing.routes.config.ts
+  - path: packages/core/src/types/billing.types.ts
+evidence:
+  - command: bun test:backend
+    result: "528 pass, 1 skip, 0 fail"
+  - command: bun run type-check
+    result: pass
+  - command: bun lint
+    result: pass
+  - command: bun knip
+    result: pass
+assumptions:
+  - "No Dashboard change: checkout.session.completed already covers setup-mode sessions"
+  - "BillingClientSecretResponseSchema is temporary until WP-05 collapses it into checkout"
+open_risks: []
+next_deadline: 2026-09-03T23:59:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-03: setup-mode embedded Checkout for updating the card on file.
+Webhook sets the new card as the customer and subscription default.

--- a/packages/backend/src/billing/billing.payment-method.routes.test.ts
+++ b/packages/backend/src/billing/billing.payment-method.routes.test.ts
@@ -1,0 +1,32 @@
+import express from "express";
+import {
+  BillingRoutes,
+  sessionWriteLimiter,
+} from "@backend/billing/billing.routes.config";
+import billingController from "@backend/billing/controllers/billing.controller";
+import { describe, expect, it } from "bun:test";
+
+type RouteLayer = {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: Array<{ handle: (...args: never[]) => unknown }>;
+  };
+};
+
+describe("POST /api/billing/payment-method/session limiter", () => {
+  it("sits behind sessionWriteLimiter", () => {
+    const app = express();
+    new BillingRoutes(app);
+    const stack = (app as unknown as { _router?: { stack?: RouteLayer[] } })
+      ._router?.stack;
+    const layer = stack?.find(
+      (entry) =>
+        entry.route?.path === "/api/billing/payment-method/session" &&
+        entry.route.methods.post,
+    );
+    const handles = (layer?.route?.stack ?? []).map((item) => item.handle);
+    expect(handles).toContain(sessionWriteLimiter);
+    expect(handles).toContain(billingController.createPaymentMethodSession);
+  });
+});

--- a/packages/backend/src/billing/billing.routes.config.ts
+++ b/packages/backend/src/billing/billing.routes.config.ts
@@ -69,6 +69,11 @@ export class BillingRoutes extends CommonRoutesConfig {
       .post(sessionWriteLimiter, billingController.endTrial);
 
     this.app
+      .route(`/api/billing/payment-method/session`)
+      .all(verifySession())
+      .post(sessionWriteLimiter, billingController.createPaymentMethodSession);
+
+    this.app
       .route(`/api/billing/portal/session`)
       .all(verifySession())
       .post(sessionWriteLimiter, billingController.createPortalSession);

--- a/packages/backend/src/billing/controllers/billing.controller.ts
+++ b/packages/backend/src/billing/controllers/billing.controller.ts
@@ -3,6 +3,8 @@ import { Status } from "@core/errors/status.codes";
 import { Logger } from "@core/logger/winston.logger";
 import {
   type BillingCheckoutResponse,
+  type BillingClientSecretResponse,
+  BillingClientSecretResponseSchema,
   type BillingPortalResponse,
   type BillingStatusResponse,
   type BillingSubscriptionResponse,
@@ -67,6 +69,23 @@ class BillingController {
       const userId = zObjectId.parse(req.session?.getUserId());
       const status = await stripeService.endTrialNow(userId.toString());
       res.status(Status.OK).json(status);
+    } catch (e) {
+      sendBillingError(res, e);
+    }
+  };
+
+  createPaymentMethodSession = async (
+    req: Request<never, BillingClientSecretResponse, never, never>,
+    res: Response<BillingClientSecretResponse | { error: string }>,
+  ) => {
+    try {
+      const userId = zObjectId.parse(req.session?.getUserId());
+      const result = await stripeService.createPaymentMethodSession(
+        userId.toString(),
+      );
+      res
+        .status(Status.OK)
+        .json(BillingClientSecretResponseSchema.parse(result));
     } catch (e) {
       sendBillingError(res, e);
     }

--- a/packages/backend/src/billing/services/billing.webhook.service.db.test.ts
+++ b/packages/backend/src/billing/services/billing.webhook.service.db.test.ts
@@ -532,4 +532,245 @@ describe("Stripe webhook", () => {
       }),
     ).toBe(1);
   });
+
+  describe("setup-mode checkout.session.completed", () => {
+    const seedCustomer = async (billing: Record<string, unknown> = {}) => {
+      const userId = mongoService.objectId();
+      await mongoService.user.insertOne({
+        _id: userId,
+        email: "setup@example.com",
+        name: "Setup User",
+        firstName: "Setup",
+        lastName: "User",
+        locale: "en",
+        billing: {
+          subscriptionStatus: "active",
+          stripeCustomerId: "cus_setup",
+          ...billing,
+        },
+      });
+      return userId;
+    };
+
+    const setupEvent = (userId: string, eventId = "evt_setup_1") =>
+      ({
+        id: eventId,
+        type: "checkout.session.completed",
+        created: 1_775_000_100,
+        data: {
+          object: {
+            id: "cs_setup_1",
+            mode: "setup",
+            client_reference_id: userId,
+            customer: "cus_setup",
+          },
+        },
+      }) as unknown as Stripe.Event;
+
+    const retrievedSetupSession = (userId: string) => ({
+      id: "cs_setup_1",
+      mode: "setup",
+      client_reference_id: userId,
+      customer: "cus_setup",
+      setup_intent: {
+        id: "seti_1",
+        payment_method: "pm_new",
+      },
+    });
+
+    it("sets the customer and subscription default payment method", async () => {
+      using _env = mockEnv(stripeConfigured);
+      const userId = await seedCustomer({
+        stripeSubscriptionId: "sub_setup",
+      });
+      const customersUpdate = mock(() => Promise.resolve({ id: "cus_setup" }));
+      const subscriptionsUpdate = mock(() =>
+        Promise.resolve(
+          subscription({
+            id: "sub_setup",
+            status: "active",
+            customer: "cus_setup",
+            default_payment_method: "pm_new",
+          }),
+        ),
+      );
+      const sessionsRetrieve = mock(() =>
+        Promise.resolve(retrievedSetupSession(userId.toString())),
+      );
+      setStripeClientForTests({
+        checkout: { sessions: { retrieve: sessionsRetrieve } },
+        customers: { update: customersUpdate },
+        subscriptions: { update: subscriptionsUpdate },
+      } as unknown as Stripe);
+
+      await processStripeEvent(setupEvent(userId.toString()));
+
+      expect(sessionsRetrieve.mock.calls[0]?.[0]).toBe("cs_setup_1");
+      expect(sessionsRetrieve.mock.calls[0]?.[1]).toEqual({
+        expand: ["setup_intent"],
+      });
+      expect(customersUpdate.mock.calls[0]).toEqual([
+        "cus_setup",
+        { invoice_settings: { default_payment_method: "pm_new" } },
+      ]);
+      expect(subscriptionsUpdate.mock.calls[0]).toEqual([
+        "sub_setup",
+        { default_payment_method: "pm_new" },
+      ]);
+      const stored = await mongoService.user.findOne({ _id: userId });
+      expect(stored?.billing?.subscriptionStatus).toBe("active");
+      expect(stored?.billing?.stripeSubscriptionId).toBe("sub_setup");
+    });
+
+    it("updates only the customer when there is no subscription id", async () => {
+      using _env = mockEnv(stripeConfigured);
+      const userId = await seedCustomer();
+      const customersUpdate = mock(() => Promise.resolve({ id: "cus_setup" }));
+      const subscriptionsUpdate = mock();
+      setStripeClientForTests({
+        checkout: {
+          sessions: {
+            retrieve: mock(() =>
+              Promise.resolve(retrievedSetupSession(userId.toString())),
+            ),
+          },
+        },
+        customers: { update: customersUpdate },
+        subscriptions: { update: subscriptionsUpdate },
+      } as unknown as Stripe);
+
+      await processStripeEvent(setupEvent(userId.toString(), "evt_setup_2"));
+
+      expect(customersUpdate).toHaveBeenCalled();
+      expect(subscriptionsUpdate).not.toHaveBeenCalled();
+    });
+
+    it("still applies a subscription-mode checkout along the existing path", async () => {
+      using _env = mockEnv(stripeConfigured);
+      const userId = mongoService.objectId();
+      await mongoService.user.insertOne({
+        _id: userId,
+        email: "submode@example.com",
+        name: "Sub",
+        firstName: "Sub",
+        lastName: "User",
+        locale: "en",
+        billing: { subscriptionStatus: "awaiting_checkout" },
+      });
+      const sessionsRetrieve = mock();
+      const retrieve = mock(() =>
+        Promise.resolve(
+          subscription({ metadata: { compassUserId: userId.toString() } }),
+        ),
+      );
+      setStripeClientForTests({
+        checkout: { sessions: { retrieve: sessionsRetrieve } },
+        subscriptions: { retrieve },
+      } as unknown as Stripe);
+
+      await processStripeEvent({
+        id: "evt_sub_mode_1",
+        type: "checkout.session.completed",
+        created: 1_775_000_100,
+        data: {
+          object: {
+            id: "cs_sub_1",
+            mode: "subscription",
+            client_reference_id: userId.toString(),
+            customer: "cus_1",
+            subscription: "sub_1",
+          },
+        },
+      } as unknown as Stripe.Event);
+
+      expect(sessionsRetrieve).not.toHaveBeenCalled();
+      expect(retrieve).toHaveBeenCalled();
+      const stored = await mongoService.user.findOne({ _id: userId });
+      expect(stored?.billing?.subscriptionStatus).toBe("trialing");
+    });
+
+    it("leaves no billingEvent row when Stripe fails, so the retry reprocesses", async () => {
+      using _env = mockEnv(stripeConfigured);
+      const userId = await seedCustomer({ stripeSubscriptionId: "sub_setup" });
+      setStripeClientForTests({
+        checkout: {
+          sessions: {
+            retrieve: mock(() =>
+              Promise.reject(new Error("stripe unavailable")),
+            ),
+          },
+        },
+      } as unknown as Stripe);
+
+      const event = setupEvent(userId.toString(), "evt_setup_fail");
+      await expect(processStripeEvent(event)).rejects.toThrow(
+        "stripe unavailable",
+      );
+      expect(
+        await mongoService.billingEvent.countDocuments({ _id: event.id }),
+      ).toBe(0);
+    });
+
+    it("accepts a signed setup-mode event", async () => {
+      using _env = mockEnv(stripeConfigured);
+      const userId = await seedCustomer({ stripeSubscriptionId: "sub_setup" });
+      const stripe = realStripe();
+      const customersUpdate = mock(() => Promise.resolve({ id: "cus_setup" }));
+      const subscriptionsUpdate = mock(() =>
+        Promise.resolve(
+          subscription({
+            id: "sub_setup",
+            status: "active",
+            customer: "cus_setup",
+          }),
+        ),
+      );
+      setStripeClientForTests({
+        webhooks: stripe.webhooks,
+        checkout: {
+          sessions: {
+            retrieve: mock(() =>
+              Promise.resolve(retrievedSetupSession(userId.toString())),
+            ),
+          },
+        },
+        customers: { update: customersUpdate },
+        subscriptions: { update: subscriptionsUpdate },
+      } as unknown as Stripe);
+
+      const payload = JSON.stringify({
+        id: "evt_setup_signed",
+        type: "checkout.session.completed",
+        created: 1_775_000_100,
+        data: {
+          object: {
+            id: "cs_setup_1",
+            mode: "setup",
+            client_reference_id: userId.toString(),
+            customer: "cus_setup",
+          },
+        },
+      });
+      const signature = await stripe.webhooks.generateTestHeaderStringAsync({
+        payload,
+        secret: stripeConfigured.STRIPE_WEBHOOK_SECRET,
+      });
+
+      const { res, json } = jsonRes();
+      await billingWebhookController.handleStripe(
+        {
+          body: Buffer.from(payload),
+          headers: { "stripe-signature": signature },
+        } as unknown as Request,
+        res,
+      );
+
+      expect((res.status as ReturnType<typeof mock>).mock.calls[0]?.[0]).toBe(
+        Status.OK,
+      );
+      expect(json).toHaveBeenCalledWith({ received: true });
+      expect(customersUpdate).toHaveBeenCalled();
+      expect(subscriptionsUpdate).toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/backend/src/billing/services/billing.webhook.service.ts
+++ b/packages/backend/src/billing/services/billing.webhook.service.ts
@@ -51,6 +51,9 @@ const customerIdOf = (value: unknown): string | undefined => {
   return undefined;
 };
 
+const paymentMethodIdOf = (value: unknown): string | undefined =>
+  customerIdOf(value);
+
 /**
  * The single place Stripe subscription fields are mapped onto `billing.*`.
  * Exported because ending a trial early applies the Subscription that
@@ -132,6 +135,63 @@ async function findUserIdForSubscription(
   return null;
 }
 
+async function handleSetupCheckoutSession(
+  stripe: Stripe,
+  session: Stripe.Checkout.Session,
+  eventCreatedAt: Date,
+): Promise<void> {
+  const retrieved = await stripe.checkout.sessions.retrieve(session.id, {
+    expand: ["setup_intent"],
+  });
+  const setupIntent = retrieved.setup_intent;
+  const paymentMethodId = paymentMethodIdOf(
+    typeof setupIntent === "object" && setupIntent !== null
+      ? setupIntent.payment_method
+      : undefined,
+  );
+  if (!paymentMethodId) {
+    throw new Error(
+      `setup checkout ${session.id} had no SetupIntent payment method`,
+    );
+  }
+
+  const customerId =
+    customerIdOf(retrieved.customer) ?? customerIdOf(session.customer);
+  let userId: string | null =
+    retrieved.client_reference_id ?? session.client_reference_id ?? null;
+  if (!userId && customerId) {
+    const byCustomer = await mongoService.user.findOne({
+      "billing.stripeCustomerId": customerId,
+    });
+    userId = byCustomer?._id.toString() ?? null;
+  }
+  if (!userId) {
+    logger.warn(`No Compass user for setup checkout session ${session.id}`);
+    return;
+  }
+
+  const user = await mongoService.user.findOne({
+    _id: mongoService.objectId(userId),
+  });
+  const resolvedCustomerId = customerId ?? user?.billing?.stripeCustomerId;
+  if (!resolvedCustomerId) {
+    logger.warn(`No Stripe customer for setup checkout session ${session.id}`);
+    return;
+  }
+
+  await stripe.customers.update(resolvedCustomerId, {
+    invoice_settings: { default_payment_method: paymentMethodId },
+  });
+
+  const subscriptionId = user?.billing?.stripeSubscriptionId;
+  if (!subscriptionId) return;
+
+  const subscription = await stripe.subscriptions.update(subscriptionId, {
+    default_payment_method: paymentMethodId,
+  });
+  await applySubscription(userId, subscription, eventCreatedAt);
+}
+
 async function handleEvent(event: Stripe.Event): Promise<void> {
   if (!HANDLED_TYPES.has(event.type)) return;
 
@@ -140,6 +200,10 @@ async function handleEvent(event: Stripe.Event): Promise<void> {
 
   if (event.type === "checkout.session.completed") {
     const session = event.data.object as Stripe.Checkout.Session;
+    if (session.mode === "setup") {
+      await handleSetupCheckoutSession(stripe, session, eventCreatedAt);
+      return;
+    }
     const subscriptionId = subscriptionIdOf(session.subscription);
     if (!subscriptionId) {
       logger.warn("checkout.session.completed had no subscription id");

--- a/packages/backend/src/billing/services/stripe.service.db.test.ts
+++ b/packages/backend/src/billing/services/stripe.service.db.test.ts
@@ -831,4 +831,77 @@ describe("StripeService", () => {
       });
     });
   });
+
+  describe("createPaymentMethodSession", () => {
+    it("creates a setup-mode embedded Checkout session", async () => {
+      using _env = mockEnv(stripeConfigured);
+      const userId = mongoService.objectId();
+      await mongoService.user.insertOne({
+        _id: userId,
+        email: "card@example.com",
+        name: "Card User",
+        firstName: "Card",
+        lastName: "User",
+        locale: "en",
+        billing: {
+          subscriptionStatus: "active",
+          stripeCustomerId: "cus_card",
+          stripeSubscriptionId: "sub_card",
+        },
+      });
+
+      const sessionsCreate = mock(() =>
+        Promise.resolve({ client_secret: "seti_secret_1" }),
+      );
+      setStripeClientForTests({
+        checkout: { sessions: { create: sessionsCreate } },
+      } as unknown as Stripe);
+
+      const result = await stripeService.createPaymentMethodSession(
+        userId.toString(),
+      );
+
+      expect(result).toEqual({ clientSecret: "seti_secret_1" });
+      expect(sessionsCreate.mock.calls[0]?.[0]).toEqual({
+        mode: "setup",
+        customer: "cus_card",
+        payment_method_types: ["card"],
+        ui_mode: "embedded",
+        redirect_on_completion: "never",
+        client_reference_id: userId.toString(),
+        setup_intent_data: { metadata: { compassUserId: userId.toString() } },
+      });
+      expect(sessionsCreate.mock.calls[0]?.[1]).toBeUndefined();
+    });
+
+    it("rejects with 409 and skips Stripe when the user has no customer id", async () => {
+      using _env = mockEnv(stripeConfigured);
+      const userId = mongoService.objectId();
+      await mongoService.user.insertOne({
+        _id: userId,
+        email: "none@example.com",
+        name: "None User",
+        firstName: "None",
+        lastName: "User",
+        locale: "en",
+        billing: { subscriptionStatus: "awaiting_checkout" },
+      });
+
+      const sessionsCreate = mock(() =>
+        Promise.resolve({ client_secret: "seti_secret_1" }),
+      );
+      setStripeClientForTests({
+        checkout: { sessions: { create: sessionsCreate } },
+      } as unknown as Stripe);
+
+      await expect(
+        stripeService.createPaymentMethodSession(userId.toString()),
+      ).rejects.toMatchObject({
+        name: "BillingHttpError",
+        status: 409,
+        clientMessage: "No billing account yet.",
+      });
+      expect(sessionsCreate).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/backend/src/billing/services/stripe.service.ts
+++ b/packages/backend/src/billing/services/stripe.service.ts
@@ -2,6 +2,7 @@ import type Stripe from "stripe";
 import { Status } from "@core/errors/status.codes";
 import {
   type BillingCheckoutResponse,
+  type BillingClientSecretResponse,
   type BillingStatusResponse,
   type BillingSubscriptionResponse,
 } from "@core/types/billing.types";
@@ -356,6 +357,44 @@ class StripeService {
       .catch(wrapStripeFailure);
 
     return { url: session.url };
+  };
+
+  createPaymentMethodSession = async (
+    userId: string,
+  ): Promise<BillingClientSecretResponse> => {
+    if (!isStripeConfigured(CONFIG)) {
+      throw new Error("Stripe is not configured");
+    }
+
+    const _id = mongoService.objectId(userId);
+    const user = await mongoService.user.findOne({ _id });
+    if (!user) {
+      throw new Error("User not found");
+    }
+
+    const customerId = user.billing?.stripeCustomerId;
+    if (!customerId) {
+      throw new BillingHttpError(Status.CONFLICT, "No billing account yet.");
+    }
+
+    const stripe = getStripeClient();
+    const session = await stripe.checkout.sessions
+      .create({
+        mode: "setup",
+        customer: customerId,
+        payment_method_types: ["card"],
+        ui_mode: "embedded",
+        redirect_on_completion: "never",
+        client_reference_id: userId,
+        setup_intent_data: { metadata: { compassUserId: userId } },
+      })
+      .catch(wrapStripeFailure);
+
+    if (!session.client_secret) {
+      throw new Error("Stripe Checkout did not return a client secret");
+    }
+
+    return { clientSecret: session.client_secret };
   };
 }
 

--- a/packages/core/src/types/billing.types.ts
+++ b/packages/core/src/types/billing.types.ts
@@ -32,6 +32,14 @@ export type BillingCheckoutResponse = z.infer<
   typeof BillingCheckoutResponseSchema
 >;
 
+/** Setup-mode embedded Checkout. WP-05 collapses this into checkout. */
+export const BillingClientSecretResponseSchema = z.object({
+  clientSecret: z.string(),
+});
+export type BillingClientSecretResponse = z.infer<
+  typeof BillingClientSecretResponseSchema
+>;
+
 export const BillingPortalResponseSchema = z.object({
   url: z.string().url(),
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3157

## Summary

Adds `POST /api/billing/payment-method/session` that creates a setup-mode embedded Checkout session and returns `{ clientSecret }`. On `checkout.session.completed` with `session.mode === "setup"`, expands the setup intent and sets the payment method as the customer (and subscription, if present) default. Stripe failures drop the `billingEvent` row so Stripe can retry.

Rebased onto main after WP-02 (#3165) landed. Kept WP-02 subscription tests and appended the setup-session tests.

## Simplicity

One new authenticated route behind the existing `sessionWriteLimiter`. Webhook setup handling runs first in `checkout.session.completed`, then the existing subscription-mode path.

## Automated validation

Focused after rebase:
- `bun test:backend` on stripe.service.db.test.ts, billing.payment-method.routes.test.ts, billing.routes.config.test.ts, billing.webhook.service.db.test.ts: 45 pass, 0 fail
- `bun run type-check`: pass
- `bun lint`: exit 0 (23 pre-existing biome warnings, none in this diff)

## Independent review

`.agents/handoffs/3157.md`

## Test plan

```
bun test:backend
bun run type-check
bun lint
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0ba2f6a-bdca-4f94-a04f-f2a4d77d7dbb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0ba2f6a-bdca-4f94-a04f-f2a4d77d7dbb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

