### PR TITLE
feat(billing): add stripe.js embedded checkout port (WP-04)

### DIFF
--- a/.agents/handoffs/3158.md
+++ b/.agents/handoffs/3158.md
@@ -4,20 +4,23 @@ task_id: "3158"
 from: Implementer
 to: Verifier
 owner: Implementer
-status: running
+status: verifying
 artifact:
   - path: packages/web/src/billing/embedded-checkout/embedded-checkout.port.tsx
   - path: packages/web/src/billing/billing-request-error.ts
   - path: packages/web/src/billing/billing.query.ts
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3168
 evidence:
   - command: bun test:web
-    result: pending
+    result: "1569 pass, 0 fail, including embedded-checkout.port.test.tsx"
   - command: bun run type-check
-    result: pending
+    result: pass
   - command: bun lint
-    result: pending
+    result: "exit 0; 23 pre-existing biome warnings, none in this diff"
   - command: bun knip
-    result: pending
+    result: pass
+  - command: grep -rn loadStripe packages/web/src
+    result: "only embedded-checkout.port.tsx"
 assumptions:
   - "@stripe/react-stripe-js@6.9.0 exports EmbeddedCheckoutProvider and EmbeddedCheckout from the package root"
   - "Docker web already uses oven/bun:1.3.14, so no Bun bump"

--- a/.agents/handoffs/3158.md
+++ b/.agents/handoffs/3158.md
@@ -1,0 +1,34 @@
+---
+schema_version: 1
+task_id: "3158"
+from: Implementer
+to: Verifier
+owner: Implementer
+status: running
+artifact:
+  - path: packages/web/src/billing/embedded-checkout/embedded-checkout.port.tsx
+  - path: packages/web/src/billing/billing-request-error.ts
+  - path: packages/web/src/billing/billing.query.ts
+evidence:
+  - command: bun test:web
+    result: pending
+  - command: bun run type-check
+    result: pending
+  - command: bun lint
+    result: pending
+  - command: bun knip
+    result: pending
+assumptions:
+  - "@stripe/react-stripe-js@6.9.0 exports EmbeddedCheckoutProvider and EmbeddedCheckout from the package root"
+  - "Docker web already uses oven/bun:1.3.14, so no Bun bump"
+open_risks: []
+next_deadline: 2026-09-04T00:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-04: web Stripe.js foundation. Lazy `loadStripe` behind `getStripePromise`,
+embedded Checkout default renderer, and `setEmbeddedCheckoutForTests` seam.
+No user-visible change. Consumers are #3159 and #3161.

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,6 +13,7 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 3158 | high | Implementer | running | packages/web/src/billing/embedded-checkout/embedded-checkout.port.tsx | pending local verify | 2026-09-04T00:00:00Z | 0 | none |
 | 3129 | high | Verifier | verifying | packages/web/src/booking/BookingSettingsSection.tsx | bun test:web 30 pass; host-settings e2e 5 pass; test:a11y 24 pass; bun run verify PASS | 2026-09-03T20:00:00Z | 0 | none |
 | simplify-recent-3098 | medium | Manager | verifying | .agents/handoffs/simplify-recent-3098.md | bun run verify PASS (core, web, backend, type-check, lint, knip); focused web 161 pass; review: no confirmed findings | 2026-09-03T06:00:00Z | 1 | none |
 | simplify-recent-3047 | medium | Manager | verifying | .agents/handoffs/simplify-recent-3047.md | focused web 79 pass; core/sync 49 pass; verify package checks pass; a11y retry pass; review: no confirmed findings | 2026-09-02T06:00:00Z | 1 | none |

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,7 +13,7 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 3158 | high | Implementer | running | packages/web/src/billing/embedded-checkout/embedded-checkout.port.tsx | pending local verify | 2026-09-04T00:00:00Z | 0 | none |
+| 3158 | high | Implementer | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3168 | bun test:web 1569 pass; type-check pass; lint exit 0; knip pass | 2026-09-04T00:00:00Z | 0 | none |
 | 3129 | high | Verifier | verifying | packages/web/src/booking/BookingSettingsSection.tsx | bun test:web 30 pass; host-settings e2e 5 pass; test:a11y 24 pass; bun run verify PASS | 2026-09-03T20:00:00Z | 0 | none |
 | simplify-recent-3098 | medium | Manager | verifying | .agents/handoffs/simplify-recent-3098.md | bun run verify PASS (core, web, backend, type-check, lint, knip); focused web 161 pass; review: no confirmed findings | 2026-09-03T06:00:00Z | 1 | none |
 | simplify-recent-3047 | medium | Manager | verifying | .agents/handoffs/simplify-recent-3047.md | focused web 79 pass; core/sync 49 pass; verify package checks pass; a11y retry pass; review: no confirmed findings | 2026-09-02T06:00:00Z | 1 | none |

--- a/bun.lock
+++ b/bun.lock
@@ -135,6 +135,8 @@
         "@floating-ui/react": "^0.27.3",
         "@phosphor-icons/react": "^2.1.7",
         "@react-oauth/google": "^0.7.0",
+        "@stripe/react-stripe-js": "6.9.0",
+        "@stripe/stripe-js": "9.15.0",
         "@tanstack/react-hotkeys": "^0.3.1",
         "@tanstack/react-query": "^5",
         "@tanstack/react-router": "^1.170.17",
@@ -469,6 +471,10 @@
     "@sinonjs/fake-timers": ["@sinonjs/fake-timers@10.3.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.0" } }, "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA=="],
 
     "@so-ric/colorspace": ["@so-ric/colorspace@1.1.6", "", { "dependencies": { "color": "^5.0.2", "text-hex": "1.0.x" } }, "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw=="],
+
+    "@stripe/react-stripe-js": ["@stripe/react-stripe-js@6.9.0", "", { "dependencies": { "prop-types": "^15.7.2" }, "peerDependencies": { "@stripe/stripe-js": ">=9.10.0 <10.0.0", "react": ">=16.8.0 <20.0.0", "react-dom": ">=16.8.0 <20.0.0" } }, "sha512-wyFt2sT2EdXfyo8YNSTeEm9gb2yFJf03Da8acQOeDxzjWGwD5xDF7ecSPI64upvJ2IjvypqEF9IIVUnxtPY+zA=="],
+
+    "@stripe/stripe-js": ["@stripe/stripe-js@9.15.0", "", {}, "sha512-0ySfsYH9XzfEspNS6MXMU2cjGsxNXWDQT9JxS43nOAatj6jDEP0fLBm2BanfblzU/GL/kDjFFcKmGInHmrASeg=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.2.2", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.2" } }, "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA=="],
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -10,6 +10,8 @@
     "@floating-ui/react": "^0.27.3",
     "@phosphor-icons/react": "^2.1.7",
     "@react-oauth/google": "^0.7.0",
+    "@stripe/react-stripe-js": "6.9.0",
+    "@stripe/stripe-js": "9.15.0",
     "@tanstack/react-hotkeys": "^0.3.1",
     "@tanstack/react-query": "^5",
     "@tanstack/react-router": "^1.170.17",

--- a/packages/web/src/__tests__/helpers/web-test-seams.ts
+++ b/packages/web/src/__tests__/helpers/web-test-seams.ts
@@ -14,6 +14,7 @@ import {
   resetGoogleAvailabilityForTests,
   setGoogleAvailabilityForTests,
 } from "@web/auth/google/hooks/useIsGoogleAvailable/useIsGoogleAvailable";
+import { resetEmbeddedCheckoutForTests } from "@web/billing/embedded-checkout/embedded-checkout.port";
 import {
   registerToastPort,
   resetToastPort,
@@ -184,4 +185,5 @@ export function resetWebTestSeams(): void {
   // AuthModal owns emailpassword reset — production SuperTokens patches XHR vs MSW.
   resetUseCompleteAuthenticationForTests();
   resetGoogleAvailabilityForTests();
+  resetEmbeddedCheckoutForTests();
 }

--- a/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationProvider.tsx
+++ b/packages/web/src/billing/UpgradeConfirmation/UpgradeConfirmationProvider.tsx
@@ -3,15 +3,13 @@ import { type PropsWithChildren, useCallback, useState } from "react";
 import { BillingApi } from "@web/api/billing.api";
 import { track } from "@web/auth/posthog/track";
 import { billingQueryKeys } from "@web/billing/billing.query";
+import { showBillingRequestError } from "@web/billing/billing-request-error";
 import {
   UpgradeConfirmationContext,
   useUpgradeConfirmationState,
 } from "@web/billing/UpgradeConfirmation/hooks/useUpgradeConfirmation";
 import { UpgradeConfirmationDialog } from "@web/billing/UpgradeConfirmation/UpgradeConfirmationDialog";
-import {
-  showBillingRequestError,
-  useBillingRedirect,
-} from "@web/billing/useBillingRedirect";
+import { useBillingRedirect } from "@web/billing/useBillingRedirect";
 import { useIsTrialing } from "@web/billing/useIsTrialing";
 import { BILLING_SUBSCRIBED_TOAST_ID } from "@web/common/constants/toast.constants";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";

--- a/packages/web/src/billing/billing-request-error.ts
+++ b/packages/web/src/billing/billing-request-error.ts
@@ -1,0 +1,17 @@
+import {
+  getApiErrorMessage,
+  isSessionLevelError,
+} from "@web/api/util/api.util";
+import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
+
+/** Stripe 500s are not useful to the user; keep the surface-specific fallback. */
+export const showBillingRequestError = (
+  error: unknown,
+  fallback: string,
+): void => {
+  if (isSessionLevelError(error)) return;
+  const fromApi = getApiErrorMessage(error);
+  showErrorToast(
+    fromApi && fromApi !== "Internal server error" ? fromApi : fallback,
+  );
+};

--- a/packages/web/src/billing/billing.query.ts
+++ b/packages/web/src/billing/billing.query.ts
@@ -54,6 +54,10 @@ export function useAppConfigQuery() {
   return useQuery(appConfigQueryOptions());
 }
 
+export function useStripePublishableKey(): string | null {
+  return useAppConfigQuery().data?.billing.publishableKey ?? null;
+}
+
 /**
  * The operator pause switch. False (paused) whenever config is pending or
  * errored, not just when the server says so, so a slow network never flashes

--- a/packages/web/src/billing/embedded-checkout/embedded-checkout.port.test.tsx
+++ b/packages/web/src/billing/embedded-checkout/embedded-checkout.port.test.tsx
@@ -1,0 +1,132 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, renderHook, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { rest } from "msw";
+import { type PropsWithChildren } from "react";
+import { server } from "@web/__tests__/__mocks__/server/mock.server";
+import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
+import { useStripePublishableKey } from "@web/billing/billing.query";
+import { ENV_WEB } from "@web/common/constants/env.constants";
+import {
+  registerToastPort,
+  resetToastPort,
+} from "@web/common/utils/toast/toast.port";
+import {
+  type EmbeddedCheckoutProps,
+  fetchEmbeddedCheckoutClientSecret,
+  getEmbeddedCheckoutComponent,
+  getStripePromise,
+  resetEmbeddedCheckoutForTests,
+  StripeEmbeddedCheckout,
+  setEmbeddedCheckoutForTests,
+} from "./embedded-checkout.port";
+import { afterEach, describe, expect, it } from "bun:test";
+
+afterEach(() => {
+  resetEmbeddedCheckoutForTests();
+  resetToastPort();
+});
+
+function FakeCheckout({ onComplete }: EmbeddedCheckoutProps) {
+  return (
+    <button type="button" onClick={onComplete}>
+      Complete checkout
+    </button>
+  );
+}
+
+describe("getStripePromise", () => {
+  it("returns the same promise for the same key and a different one for a different key", () => {
+    const first = getStripePromise("pk_test_a");
+    const sameKey = getStripePromise("pk_test_a");
+    const otherKey = getStripePromise("pk_test_b");
+
+    expect(first).toBe(sameKey);
+    expect(first).not.toBe(otherKey);
+  });
+});
+
+describe("embedded checkout test seam", () => {
+  it("returns a registered fake and restores the default when set to null", () => {
+    expect(getEmbeddedCheckoutComponent()).toBe(StripeEmbeddedCheckout);
+
+    setEmbeddedCheckoutForTests(FakeCheckout);
+    expect(getEmbeddedCheckoutComponent()).toBe(FakeCheckout);
+
+    setEmbeddedCheckoutForTests(null);
+    expect(getEmbeddedCheckoutComponent()).toBe(StripeEmbeddedCheckout);
+  });
+
+  it("lets a fake complete checkout without loading Stripe.js", async () => {
+    setEmbeddedCheckoutForTests(FakeCheckout);
+    const Checkout = getEmbeddedCheckoutComponent();
+    let completed = false;
+    render(
+      <Checkout
+        publishableKey="pk_test_a"
+        fetchClientSecret={() => Promise.resolve("cs_test")}
+        onComplete={() => {
+          completed = true;
+        }}
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Complete checkout" }),
+    );
+    expect(completed).toBe(true);
+  });
+});
+
+describe("fetchEmbeddedCheckoutClientSecret", () => {
+  it("shows the billing error toast when fetchClientSecret rejects", async () => {
+    const { port, mocks } = createTestToastPort();
+    registerToastPort(port);
+
+    await expect(
+      fetchEmbeddedCheckoutClientSecret(() =>
+        Promise.reject(new Error("network")),
+      ),
+    ).rejects.toThrow("network");
+
+    expect(mocks.error).toHaveBeenCalledWith(
+      "Couldn't start checkout. Please try again.",
+      expect.any(Object),
+    );
+  });
+});
+
+describe("useStripePublishableKey", () => {
+  it("reads billing.publishableKey from app config", async () => {
+    server.use(
+      rest.get(`${ENV_WEB.API_BASEURL}/config`, (_req, res, ctx) =>
+        res(
+          ctx.json({
+            google: { isConfigured: false },
+            billing: {
+              isConfigured: true,
+              enforcement: true,
+              trialLengthDays: 7,
+              publishableKey: "pk_test_live",
+            },
+          }),
+        ),
+      ),
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useStripePublishableKey(), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe("pk_test_live");
+    });
+  });
+});

--- a/packages/web/src/billing/embedded-checkout/embedded-checkout.port.tsx
+++ b/packages/web/src/billing/embedded-checkout/embedded-checkout.port.tsx
@@ -1,0 +1,77 @@
+import {
+  EmbeddedCheckout,
+  EmbeddedCheckoutProvider,
+} from "@stripe/react-stripe-js";
+import { loadStripe } from "@stripe/stripe-js";
+import { type ComponentType, useMemo } from "react";
+import { showBillingRequestError } from "@web/billing/billing-request-error";
+
+export type EmbeddedCheckoutProps = {
+  publishableKey: string;
+  fetchClientSecret: () => Promise<string>;
+  onComplete: () => void;
+  className?: string;
+};
+
+const CHECKOUT_REQUEST_FALLBACK = "Couldn't start checkout. Please try again.";
+
+const stripePromises = new Map<string, ReturnType<typeof loadStripe>>();
+
+/** Memoised per key. Call on first mount of a checkout surface, never at boot. */
+export function getStripePromise(publishableKey: string) {
+  const existing = stripePromises.get(publishableKey);
+  if (existing) return existing;
+  const promise = loadStripe(publishableKey);
+  stripePromises.set(publishableKey, promise);
+  return promise;
+}
+
+export function fetchEmbeddedCheckoutClientSecret(
+  fetchClientSecret: () => Promise<string>,
+): Promise<string> {
+  return fetchClientSecret().catch((error: unknown) => {
+    showBillingRequestError(error, CHECKOUT_REQUEST_FALLBACK);
+    throw error;
+  });
+}
+
+export function StripeEmbeddedCheckout({
+  publishableKey,
+  fetchClientSecret,
+  onComplete,
+  className,
+}: EmbeddedCheckoutProps) {
+  const stripe = getStripePromise(publishableKey);
+  const options = useMemo(
+    () => ({
+      fetchClientSecret: () =>
+        fetchEmbeddedCheckoutClientSecret(fetchClientSecret),
+      onComplete,
+    }),
+    [fetchClientSecret, onComplete],
+  );
+
+  return (
+    <EmbeddedCheckoutProvider stripe={stripe} options={options}>
+      <EmbeddedCheckout className={className} />
+    </EmbeddedCheckoutProvider>
+  );
+}
+
+let embeddedCheckoutOverride: ComponentType<EmbeddedCheckoutProps> | null =
+  null;
+
+export function getEmbeddedCheckoutComponent(): ComponentType<EmbeddedCheckoutProps> {
+  return embeddedCheckoutOverride ?? StripeEmbeddedCheckout;
+}
+
+export function setEmbeddedCheckoutForTests(
+  component: ComponentType<EmbeddedCheckoutProps> | null,
+): void {
+  embeddedCheckoutOverride = component;
+}
+
+export function resetEmbeddedCheckoutForTests(): void {
+  embeddedCheckoutOverride = null;
+  stripePromises.clear();
+}

--- a/packages/web/src/billing/useBillingRedirect.ts
+++ b/packages/web/src/billing/useBillingRedirect.ts
@@ -1,23 +1,7 @@
 import { useState } from "react";
 import { BillingApi } from "@web/api/billing.api";
-import {
-  getApiErrorMessage,
-  isSessionLevelError,
-} from "@web/api/util/api.util";
 import { track } from "@web/auth/posthog/track";
-import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
-
-/** Stripe 500s are not useful to the user; keep the surface-specific fallback. */
-export const showBillingRequestError = (
-  error: unknown,
-  fallback: string,
-): void => {
-  if (isSessionLevelError(error)) return;
-  const fromApi = getApiErrorMessage(error);
-  showErrorToast(
-    fromApi && fromApi !== "Internal server error" ? fromApi : fallback,
-  );
-};
+import { showBillingRequestError } from "@web/billing/billing-request-error";
 
 type BillingRedirectKind = "checkout" | "portal";
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3158

## Summary

Adds the web Stripe.js foundation for embedded Checkout: lazy per-key `loadStripe`, a default `EmbeddedCheckout` renderer, and `setEmbeddedCheckoutForTests` so later packages can swap a fake without `mock.module`. Moves `showBillingRequestError` out of `useBillingRedirect` so WP-05 can delete that hook. Pins `@stripe/stripe-js@9.15.0` and `@stripe/react-stripe-js@6.9.0` after confirming `EmbeddedCheckoutProvider` and `EmbeddedCheckout` export from the package root. Nothing user-visible.

## Simplicity

The port is one module. `loadStripe` is memoised per publishable key. Tests inject a fake via the same seam pattern as the toast port, rather than mocking Stripe modules.

## Automated validation

- `bun test:web`: 1569 pass, 0 fail (includes `embedded-checkout.port.test.tsx`: promise identity, seam set/null, fake Complete checkout button, fetchClientSecret rejection toast via toast port, `useStripePublishableKey`)
- `bun run type-check`: pass
- `bun lint`: exit 0 (23 pre-existing biome warnings, none in this diff)
- `bun knip`: pass
- `grep -rn loadStripe packages/web/src`: only `embedded-checkout.port.tsx`

Confirmed before pin: `@stripe/react-stripe-js@6.9.0` exports `EmbeddedCheckoutProvider` and `EmbeddedCheckout` from the package root. Docker web already uses `oven/bun:1.3.14`.

## Independent review

`.agents/handoffs/3158.md`

## Test plan

```
bun test:web
bun run type-check
bun lint
bun knip
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0ba2f6a-bdca-4f94-a04f-f2a4d77d7dbb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0ba2f6a-bdca-4f94-a04f-f2a4d77d7dbb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

