### PR TITLE
feat(web): copy buttons, text selection, and confusion-gated keyboard hint

### DIFF
--- a/e2e/timed/mouse-inert.spec.ts
+++ b/e2e/timed/mouse-inert.spec.ts
@@ -7,8 +7,12 @@ import {
   prepareCalendarPage,
 } from "../utils/event-test-utils";
 
-test("event form copy buttons copy field text", async ({ page }) => {
+const getFormTitleInput = (page: import("@playwright/test").Page) =>
+  page.getByRole("form").getByRole("textbox", { name: "Title" });
+
+test("event form copy buttons copy field text", async ({ page, context }) => {
   await prepareCalendarPage(page);
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
 
   const title = createEventTitle("Copy Field Target");
   await openTimedEventFormWithKeyboard(page);
@@ -21,20 +25,20 @@ test("event form copy buttons copy field text", async ({ page }) => {
   await eventButton.focus();
   await page.keyboard.press("Enter");
 
-  await expect(page.getByLabel("Title")).toBeVisible();
+  await expect(getFormTitleInput(page)).toBeVisible();
 
   await page.getByRole("button", { name: "copy event title" }).click();
-  const clipboardTitle = await page.evaluate(() =>
-    navigator.clipboard.readText(),
-  );
-  expect(clipboardTitle).toBe(title);
+  await expect(page.getByRole("button", { name: "Copied" })).toBeVisible();
+  await expect
+    .poll(async () => page.evaluate(() => navigator.clipboard.readText()))
+    .toBe(title);
 });
 
 test("text can be selected in the event title field", async ({ page }) => {
   await prepareCalendarPage(page);
   await openTimedEventFormWithKeyboard(page);
 
-  const titleField = page.getByLabel("Title");
+  const titleField = getFormTitleInput(page);
   await titleField.fill("Selectable title");
   await titleField.selectText();
 

--- a/e2e/timed/mouse-inert.spec.ts
+++ b/e2e/timed/mouse-inert.spec.ts
@@ -3,34 +3,55 @@ import {
   createEventTitle,
   expectTimedEventVisible,
   fillTitleAndSaveEventForm,
-  getMainGridPoint,
   openTimedEventFormWithKeyboard,
   prepareCalendarPage,
 } from "../utils/event-test-utils";
 
-// Compass is the keyboard calendar: the mouse is permanently inert. These
-// tests are the behavioral contract for the always-on pointer suppression.
-
-test("empty timed-grid clicks teach the matching HHMM shortcut", async ({
-  page,
-}) => {
+test("event form copy buttons copy field text", async ({ page }) => {
   await prepareCalendarPage(page);
 
-  const { x, y } = await getMainGridPoint(page, { xRatio: 0.6, yRatio: 0.6 });
-  await page.mouse.click(x, y);
+  const title = createEventTitle("Copy Field Target");
+  await openTimedEventFormWithKeyboard(page);
+  await fillTitleAndSaveEventForm(page, title);
+  await expectTimedEventVisible(page, title);
 
-  await expect(page.getByLabel("Title")).toHaveCount(0);
-  await expect(page.locator("[data-pointer-hint]")).toContainText(
-    /Type \d{4} to create an event at/,
+  const eventButton = page
+    .locator("#mainGrid")
+    .getByRole("button", { name: title });
+  await eventButton.focus();
+  await page.keyboard.press("Enter");
+
+  await expect(page.getByLabel("Title")).toBeVisible();
+
+  await page.getByRole("button", { name: "copy event title" }).click();
+  const clipboardTitle = await page.evaluate(() =>
+    navigator.clipboard.readText(),
   );
+  expect(clipboardTitle).toBe(title);
 });
 
-test("mouse clicks are inert and show the keyboard-only hint", async ({
+test("text can be selected in the event title field", async ({ page }) => {
+  await prepareCalendarPage(page);
+  await openTimedEventFormWithKeyboard(page);
+
+  const titleField = page.getByLabel("Title");
+  await titleField.fill("Selectable title");
+  await titleField.selectText();
+
+  const selected = await titleField.evaluate(
+    (el) =>
+      (el as HTMLInputElement).selectionStart !==
+      (el as HTMLInputElement).selectionEnd,
+  );
+  expect(selected).toBe(true);
+});
+
+test("keyboard-only hint is not shown on the first mouse click", async ({
   page,
 }) => {
   await prepareCalendarPage(page);
 
-  const title = createEventTitle("Mouse Inert Target");
+  const title = createEventTitle("No Immediate Hint");
   await openTimedEventFormWithKeyboard(page);
   await fillTitleAndSaveEventForm(page, title);
   await expectTimedEventVisible(page, title);
@@ -40,28 +61,12 @@ test("mouse clicks are inert and show the keyboard-only hint", async ({
     .getByRole("button", { name: title });
 
   await eventButton.click({ force: true });
-  await expect(page.getByLabel("Title")).toHaveCount(0);
-  await expect(eventButton).toBeFocused();
-  await expect(page.locator("[data-pointer-hint]")).toBeVisible();
-
-  // Clicking empty grid does not open a draft either.
-  const { x, y } = await getMainGridPoint(page, { xRatio: 0.6, yRatio: 0.6 });
-  await page.mouse.click(x, y);
-  await expect(page.getByLabel("Title")).toHaveCount(0);
-
-  // A blocked click still selects the event so Enter opens it without
-  // an extra keyboard focus step.
-  await eventButton.click({ force: true });
-  await expect(page.getByLabel("Title")).toHaveCount(0);
-  await page.keyboard.press("Enter");
-  await expect(page.getByLabel("Title")).toBeVisible();
+  await expect(page.locator("[data-pointer-hint]")).toHaveCount(0);
 });
 
 test("keyboard activation of native buttons still works", async ({ page }) => {
   await prepareCalendarPage(page);
 
-  // Enter on a focused native button fires a trusted click with detail 0;
-  // the blocker must pass it or every button in the app dies.
   const timezoneButton = page.getByRole("button", {
     name: /Calendar timezone/,
   });
@@ -71,25 +76,4 @@ test("keyboard activation of native buttons still works", async ({ page }) => {
 
   await page.keyboard.press("Escape");
   await expect(page.getByRole("combobox")).toHaveCount(0);
-});
-
-test("right-click is blocked; m opens the menu instead", async ({ page }) => {
-  await prepareCalendarPage(page);
-  const title = createEventTitle("No Right Click");
-  await openTimedEventFormWithKeyboard(page);
-  await fillTitleAndSaveEventForm(page, title);
-  await expectTimedEventVisible(page, title);
-
-  const eventButton = page
-    .locator("#mainGrid")
-    .getByRole("button", { name: title });
-
-  await eventButton.click({ button: "right", force: true });
-  await expect(page.getByRole("menuitem")).toHaveCount(0);
-
-  await eventButton.focus();
-  await page.keyboard.press("m");
-  await expect(page.getByRole("menuitem").first()).toBeVisible();
-  await page.keyboard.press("Escape");
-  await expect(page.getByRole("menuitem")).toHaveCount(0);
 });

--- a/packages/web/src/__tests__/utils/state/reset-stores.ts
+++ b/packages/web/src/__tests__/utils/state/reset-stores.ts
@@ -56,6 +56,8 @@ import {
   initialPointerBlockState,
   usePointerBlockStore,
 } from "@web/shortcuts/keyboard-only/pointer-block.store";
+import { pointerConfusionActions } from "@web/shortcuts/keyboard-only/pointer-confusion.store";
+import { resetPointerHintPersistenceForTests } from "@web/shortcuts/keyboard-only/pointer-hint.storage";
 import {
   initialPageJumpHintState,
   usePageJumpHintStore,
@@ -99,6 +101,10 @@ const storeResets: StoreReset[] = [
     useWelcomeGuideStore.setState(useWelcomeGuideStore.getInitialState(), true),
   () => useThemeStore.setState(useThemeStore.getInitialState(), true),
   () => useEditSequenceStore.setState(initialEditSequenceState, true),
+  () => {
+    resetPointerHintPersistenceForTests();
+    pointerConfusionActions.resetForTests();
+  },
   () => usePointerBlockStore.setState(initialPointerBlockState, true),
   () => useEventJumpStore.setState(initialEventJumpState, true),
   () => usePageJumpHintStore.setState(initialPageJumpHintState, true),

--- a/packages/web/src/common/constants/storage.constants.ts
+++ b/packages/web/src/common/constants/storage.constants.ts
@@ -49,7 +49,11 @@ type StorageKey =
   // Device-local opt-in for upcoming-event browser notifications. Only ever
   // written "true" right after the browser grants permission, so a stale flag
   // can never outlive a revoked grant (the permission is re-read on load).
-  | "compass.notifications.enabled";
+  | "compass.notifications.enabled"
+  // Keyboard-only hint guardrails (lifetime cap, permanent dismiss, spacing).
+  | "compass.pointer-hint.lifetime-count"
+  | "compass.pointer-hint.dismissed-permanently"
+  | "compass.pointer-hint.last-shown-at";
 
 export const STORAGE_KEYS: Record<
   | "AUTH"
@@ -75,7 +79,10 @@ export const STORAGE_KEYS: Record<
   | "DEFAULT_TIMEZONE"
   | "TIME_TRAVEL_TIMEZONE"
   | "TIMEZONE_MISMATCH_SNOOZED_BROWSER"
-  | "NOTIFICATIONS_ENABLED",
+  | "NOTIFICATIONS_ENABLED"
+  | "POINTER_HINT_LIFETIME_COUNT"
+  | "POINTER_HINT_DISMISSED_PERMANENTLY"
+  | "POINTER_HINT_LAST_SHOWN_AT",
   StorageKey
 > = {
   AUTH: "compass.auth",
@@ -106,4 +113,8 @@ export const STORAGE_KEYS: Record<
   TIMEZONE_MISMATCH_SNOOZED_BROWSER:
     "compass.timezone.mismatch-snoozed-browser",
   NOTIFICATIONS_ENABLED: "compass.notifications.enabled",
+  POINTER_HINT_LIFETIME_COUNT: "compass.pointer-hint.lifetime-count",
+  POINTER_HINT_DISMISSED_PERMANENTLY:
+    "compass.pointer-hint.dismissed-permanently",
+  POINTER_HINT_LAST_SHOWN_AT: "compass.pointer-hint.last-shown-at",
 } as const;

--- a/packages/web/src/common/utils/html/html-to-plain-text.util.ts
+++ b/packages/web/src/common/utils/html/html-to-plain-text.util.ts
@@ -1,0 +1,11 @@
+/**
+ * Strip HTML to plain text for clipboard export. Uses the browser parser so
+ * block tags become natural word breaks without pulling in a sanitizer.
+ */
+export function htmlToPlainText(html: string): string {
+  const trimmed = html.trim();
+  if (!trimmed) return "";
+
+  const doc = new DOMParser().parseFromString(trimmed, "text/html");
+  return doc.body.textContent?.replace(/\u00a0/g, " ").trim() ?? "";
+}

--- a/packages/web/src/components/CopyButton/CopyButton.test.tsx
+++ b/packages/web/src/components/CopyButton/CopyButton.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CopyButton } from "@web/components/CopyButton/CopyButton";
+import { describe, expect, it, mock } from "bun:test";
+
+mock.module("@web/common/utils/clipboard/clipboard.util", () => ({
+  copyText: mock(async () => true),
+}));
+
+describe("CopyButton", () => {
+  it("copies text and shows a checkmark label", async () => {
+    const user = userEvent.setup();
+    render(<CopyButton label="copy event title" text="Standup" />);
+
+    const button = screen.getByRole("button", { name: "copy event title" });
+    expect(button).toHaveAttribute("data-pointer-pass", "");
+    await user.click(button);
+
+    expect(await screen.findByRole("button", { name: "Copied" })).toBeVisible();
+  });
+
+  it("is disabled when there is nothing to copy", () => {
+    render(<CopyButton label="copy event title" text="   " />);
+    expect(
+      screen.getByRole("button", { name: "copy event title" }),
+    ).toBeDisabled();
+  });
+});

--- a/packages/web/src/components/CopyButton/CopyButton.tsx
+++ b/packages/web/src/components/CopyButton/CopyButton.tsx
@@ -1,0 +1,81 @@
+import { Check, Copy } from "@phosphor-icons/react";
+import classNames from "classnames";
+import { useEffect, useRef, useState } from "react";
+import { copyText } from "@web/common/utils/clipboard/clipboard.util";
+import IconButton from "@web/components/IconButton/IconButton";
+import { pointerPassAttributes } from "@web/shortcuts/keyboard-only/pointer-action";
+import { pointerConfusionActions } from "@web/shortcuts/keyboard-only/pointer-confusion.store";
+
+const COPIED_RESET_MS = 1500;
+const ICON_SIZE = 16;
+
+export interface CopyButtonProps {
+  /** Text written to the clipboard on click. */
+  text: string;
+  /** Accessible name, e.g. "copy event title". */
+  label: string;
+  className?: string;
+  /** Called after a successful copy (for confusion-score telemetry). */
+  onCopied?: () => void;
+}
+
+/**
+ * Small copy icon beside a copyable value. Low opacity by default, full opacity
+ * on hover and keyboard focus. Swaps to a checkmark briefly after copying.
+ */
+export function CopyButton({
+  text,
+  label,
+  className,
+  onCopied,
+}: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current);
+      }
+    },
+    [],
+  );
+
+  const handleCopy = () => {
+    if (!text.trim()) return;
+
+    void copyText(text).then((didCopy) => {
+      if (!didCopy) return;
+      onCopied?.();
+      pointerConfusionActions.recordCopyButtonClick();
+      setCopied(true);
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current);
+      }
+      timeoutRef.current = window.setTimeout(
+        () => setCopied(false),
+        COPIED_RESET_MS,
+      );
+    });
+  };
+
+  const ariaLabel = copied ? "Copied" : label;
+
+  return (
+    <IconButton
+      {...pointerPassAttributes}
+      aria-label={ariaLabel}
+      className={classNames(
+        "shrink-0 opacity-25 transition-opacity hover:opacity-100 focus-visible:opacity-100",
+        className,
+      )}
+      disabled={!text.trim()}
+      onClick={handleCopy}
+      size="small"
+      tabIndex={0}
+      type="button"
+    >
+      {copied ? <Check size={ICON_SIZE} /> : <Copy size={ICON_SIZE} />}
+    </IconButton>
+  );
+}

--- a/packages/web/src/components/PointerHint/PointerHint.test.tsx
+++ b/packages/web/src/components/PointerHint/PointerHint.test.tsx
@@ -1,4 +1,5 @@
 import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { PointerHint } from "@web/components/PointerHint/PointerHint";
 import {
   initialShortcutShowcaseState,
@@ -8,10 +9,10 @@ import {
 import { welcomeGuideActions } from "@web/components/WelcomeModal/welcome.guide.store";
 import { POINTER_ACTIONS } from "@web/shortcuts/keyboard-only/pointer-action";
 import {
-  initialPointerBlockState,
-  pointerBlockActions,
-  usePointerBlockStore,
-} from "@web/shortcuts/keyboard-only/pointer-block.store";
+  pointerConfusionActions,
+  usePointerConfusionStore,
+} from "@web/shortcuts/keyboard-only/pointer-confusion.store";
+import { resetPointerHintPersistenceForTests } from "@web/shortcuts/keyboard-only/pointer-hint.storage";
 import { KEYMAP } from "@web/shortcuts/keymap";
 import {
   eventJumpActions,
@@ -20,33 +21,31 @@ import {
 } from "@web/shortcuts/shift-hint/event-jump.store";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
-const HINT_COUNT_KEY = "compass.pointer-hint-count";
-
 describe("PointerHint", () => {
   beforeEach(() => {
-    usePointerBlockStore.setState(initialPointerBlockState, true);
+    resetPointerHintPersistenceForTests();
+    pointerConfusionActions.resetForTests();
     useShortcutShowcaseStore.setState(initialShortcutShowcaseState, true);
     useEventJumpStore.setState(initialEventJumpState, true);
     welcomeGuideActions.setFirstVisitOpen(false);
     welcomeGuideActions.close();
-    sessionStorage.removeItem(HINT_COUNT_KEY);
   });
 
   afterEach(() => {
-    usePointerBlockStore.setState(initialPointerBlockState, true);
+    resetPointerHintPersistenceForTests();
+    pointerConfusionActions.resetForTests();
     useShortcutShowcaseStore.setState(initialShortcutShowcaseState, true);
     useEventJumpStore.setState(initialEventJumpState, true);
     welcomeGuideActions.setFirstVisitOpen(false);
     welcomeGuideActions.close();
-    sessionStorage.removeItem(HINT_COUNT_KEY);
   });
 
-  it("stays hidden until a click is blocked, then teaches", () => {
+  it("stays hidden until the confusion heuristic fires", () => {
     render(<PointerHint />);
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
 
     act(() => {
-      pointerBlockActions.pulseBlockedClick();
+      pointerConfusionActions.triggerHintForTests({ actionId: "unknown" });
     });
 
     expect(screen.getByRole("status")).toHaveTextContent(
@@ -59,7 +58,7 @@ describe("PointerHint", () => {
     render(<PointerHint />);
 
     act(() => {
-      pointerBlockActions.pulseBlockedClick();
+      pointerConfusionActions.triggerHintForTests({ actionId: "unknown" });
     });
 
     expect(screen.getByRole("status")).toHaveTextContent(
@@ -73,7 +72,7 @@ describe("PointerHint", () => {
     render(<PointerHint />);
 
     act(() => {
-      pointerBlockActions.pulseBlockedClick();
+      pointerConfusionActions.triggerHintForTests({ actionId: "unknown" });
     });
 
     expect(screen.getByRole("status")).toHaveTextContent(
@@ -86,7 +85,7 @@ describe("PointerHint", () => {
     render(<PointerHint />);
 
     act(() => {
-      pointerBlockActions.pulseBlockedClick({
+      pointerConfusionActions.triggerHintForTests({
         actionId: POINTER_ACTIONS.startTrial,
         shortcutKey: "S",
       });
@@ -101,7 +100,7 @@ describe("PointerHint", () => {
     render(<PointerHint />);
 
     act(() => {
-      pointerBlockActions.pulseBlockedClick({
+      pointerConfusionActions.triggerHintForTests({
         actionId: POINTER_ACTIONS.reconnectGoogle,
         shortcutKey: "G",
       });
@@ -112,11 +111,11 @@ describe("PointerHint", () => {
     );
   });
 
-  it("teaches Escape for the up-next banner dismiss control", () => {
+  it("teaches Esc for the up-next dismiss target", () => {
     render(<PointerHint />);
 
     act(() => {
-      pointerBlockActions.pulseBlockedClick({
+      pointerConfusionActions.triggerHintForTests({
         actionId: POINTER_ACTIONS.upNextDismiss,
         shortcutKey: "Esc",
       });
@@ -127,81 +126,11 @@ describe("PointerHint", () => {
     );
   });
 
-  it("teaches a bound shortcut key outside the welcome modal", () => {
+  it("teaches the sidebar close shortcut", () => {
     render(<PointerHint />);
 
     act(() => {
-      pointerBlockActions.pulseBlockedClick({
-        actionId: "unknown",
-        shortcutKey: "S",
-      });
-    });
-
-    expect(screen.getByRole("status")).toHaveTextContent("Press S");
-  });
-
-  it("teaches a chord shortcut as separate keycaps", () => {
-    render(<PointerHint />);
-
-    act(() => {
-      pointerBlockActions.pulseBlockedClick({
-        actionId: "unknown",
-        shortcutKey: ["Mod", "K"],
-      });
-    });
-
-    const hint = screen.getByRole("status");
-    expect(hint).toHaveTextContent("Press");
-    expect(hint).toHaveTextContent("K");
-  });
-
-  it("teaches the matching welcome shortcut for the attempted control", () => {
-    welcomeGuideActions.setFirstVisitOpen(true);
-    render(<PointerHint />);
-
-    act(() => {
-      pointerBlockActions.pulseBlockedClick({
-        actionId: "unknown",
-        shortcutKey: "1",
-      });
-    });
-
-    expect(screen.getByRole("status")).toHaveTextContent("Press 1");
-  });
-
-  it("keeps the welcome shortcut sentence after the session reminder threshold", () => {
-    sessionStorage.setItem(HINT_COUNT_KEY, "3");
-    welcomeGuideActions.setFirstVisitOpen(true);
-    render(<PointerHint />);
-
-    act(() => {
-      pointerBlockActions.pulseBlockedClick({
-        actionId: "unknown",
-        shortcutKey: "U",
-      });
-    });
-
-    expect(screen.getByRole("status")).toHaveTextContent("Press U");
-  });
-
-  it("points at the on-screen keys while the showcase is active", () => {
-    shortcutShowcaseActions.replay();
-    render(<PointerHint />);
-
-    act(() => {
-      pointerBlockActions.pulseBlockedClick();
-    });
-
-    expect(screen.getByRole("status")).toHaveTextContent(
-      "Keyboard only. Follow the keys on screen.",
-    );
-  });
-
-  it("teaches the sidebar shortcut for the attempted action", () => {
-    render(<PointerHint />);
-
-    act(() => {
-      pointerBlockActions.pulseBlockedClick({
+      pointerConfusionActions.triggerHintForTests({
         actionId: POINTER_ACTIONS.sidebarClose,
       });
     });
@@ -211,11 +140,25 @@ describe("PointerHint", () => {
     );
   });
 
-  it("teaches the today shortcut for the month picker today control", () => {
+  it("teaches the sidebar open shortcut", () => {
     render(<PointerHint />);
 
     act(() => {
-      pointerBlockActions.pulseBlockedClick({
+      pointerConfusionActions.triggerHintForTests({
+        actionId: POINTER_ACTIONS.sidebarOpen,
+      });
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Press ] to open the sidebar.",
+    );
+  });
+
+  it("teaches the today shortcut", () => {
+    render(<PointerHint />);
+
+    act(() => {
+      pointerConfusionActions.triggerHintForTests({
         actionId: POINTER_ACTIONS.goToToday,
       });
     });
@@ -225,11 +168,11 @@ describe("PointerHint", () => {
     );
   });
 
-  it("teaches view shortcuts for the date heading", () => {
+  it("teaches view switching", () => {
     render(<PointerHint />);
 
     act(() => {
-      pointerBlockActions.pulseBlockedClick({
+      pointerConfusionActions.triggerHintForTests({
         actionId: POINTER_ACTIONS.switchView,
       });
     });
@@ -239,12 +182,40 @@ describe("PointerHint", () => {
     );
   });
 
-  it("teaches the assigned sequence for the attempted event", () => {
+  it("teaches a bound shortcut when present", () => {
+    render(<PointerHint />);
+
+    act(() => {
+      pointerConfusionActions.triggerHintForTests({
+        actionId: "unknown",
+        shortcutKey: "Mod+K",
+      });
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent("Press");
+  });
+
+  it("uses showcase copy while practice mode is active", () => {
+    act(() => {
+      shortcutShowcaseActions.startFromWelcome();
+    });
+    render(<PointerHint />);
+
+    act(() => {
+      pointerConfusionActions.triggerHintForTests({ actionId: "unknown" });
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Keyboard only. Follow the keys on screen.",
+    );
+  });
+
+  it("teaches the assigned event-jump key when present", () => {
     render(<PointerHint />);
 
     act(() => {
       eventJumpActions.setPointerHint({ eventId: "event-1", key: "W2" });
-      pointerBlockActions.pulseBlockedClick({
+      pointerConfusionActions.triggerHintForTests({
         actionId: POINTER_ACTIONS.eventOpen,
         eventId: "event-1",
       });
@@ -259,7 +230,7 @@ describe("PointerHint", () => {
     render(<PointerHint />);
 
     act(() => {
-      pointerBlockActions.pulseBlockedClick({
+      pointerConfusionActions.triggerHintForTests({
         actionId: POINTER_ACTIONS.eventOpen,
         eventId: "event-1",
       });
@@ -270,84 +241,11 @@ describe("PointerHint", () => {
     );
   });
 
-  it("shortens to a brief pulse after a few reminders in the session", () => {
-    sessionStorage.setItem(HINT_COUNT_KEY, "3");
-    render(<PointerHint />);
-
-    act(() => {
-      pointerBlockActions.pulseBlockedClick();
-    });
-
-    expect(screen.getByRole("status")).toHaveTextContent("Keyboard only.");
-    expect(screen.getByRole("status")).not.toHaveTextContent("Press");
-  });
-
-  it("keeps the contextual sentence after the session reminder threshold", () => {
-    sessionStorage.setItem(HINT_COUNT_KEY, "3");
-    render(<PointerHint />);
-
-    act(() => {
-      pointerBlockActions.pulseBlockedClick({
-        actionId: POINTER_ACTIONS.sidebarClose,
-      });
-    });
-
-    expect(screen.getByRole("status")).toHaveTextContent(
-      "Press ] to close the sidebar.",
-    );
-  });
-
-  it("keeps the today shortcut sentence after the session reminder threshold", () => {
-    sessionStorage.setItem(HINT_COUNT_KEY, "3");
-    render(<PointerHint />);
-
-    act(() => {
-      pointerBlockActions.pulseBlockedClick({
-        actionId: POINTER_ACTIONS.goToToday,
-      });
-    });
-
-    expect(screen.getByRole("status")).toHaveTextContent(
-      "Press T to go to today.",
-    );
-  });
-
-  it("keeps the view-switch sentence after the session reminder threshold", () => {
-    sessionStorage.setItem(HINT_COUNT_KEY, "3");
-    render(<PointerHint />);
-
-    act(() => {
-      pointerBlockActions.pulseBlockedClick({
-        actionId: POINTER_ACTIONS.switchView,
-      });
-    });
-
-    expect(screen.getByRole("status")).toHaveTextContent(
-      "Press W, D, or L to switch views.",
-    );
-  });
-
-  it("keeps the up-next dismiss sentence after the session reminder threshold", () => {
-    sessionStorage.setItem(HINT_COUNT_KEY, "3");
-    render(<PointerHint />);
-
-    act(() => {
-      pointerBlockActions.pulseBlockedClick({
-        actionId: POINTER_ACTIONS.upNextDismiss,
-        shortcutKey: "Esc",
-      });
-    });
-
-    expect(screen.getByRole("status")).toHaveTextContent(
-      "Press Esc to dismiss.",
-    );
-  });
-
   it("names the quarter-hour an empty timed-grid click aimed at", () => {
     render(<PointerHint />);
 
     act(() => {
-      pointerBlockActions.pulseBlockedClick({
+      pointerConfusionActions.triggerHintForTests({
         actionId: "grid.timed",
         gridDate: "2026-08-29",
         gridTimeKey: "1130",
@@ -364,7 +262,7 @@ describe("PointerHint", () => {
     render(<PointerHint />);
 
     act(() => {
-      pointerBlockActions.pulseBlockedClick({
+      pointerConfusionActions.triggerHintForTests({
         actionId: "grid.timed",
         gridDate: "2026-08-29",
         gridTimeKey: "1830",
@@ -377,29 +275,11 @@ describe("PointerHint", () => {
     );
   });
 
-  it("keeps the timed-grid shortcut sentence after the session reminder threshold", () => {
-    sessionStorage.setItem(HINT_COUNT_KEY, "3");
-    render(<PointerHint />);
-
-    act(() => {
-      pointerBlockActions.pulseBlockedClick({
-        actionId: "grid.timed",
-        gridDate: "2026-08-29",
-        gridTimeKey: "1200",
-        gridTimeLabel: "12:00 PM",
-      });
-    });
-
-    expect(screen.getByRole("status")).toHaveTextContent(
-      "Type 1200 to create an event at 12:00 PM.",
-    );
-  });
-
   it("teaches Shift+C for a click on the all-day row", () => {
     render(<PointerHint />);
 
     act(() => {
-      pointerBlockActions.pulseBlockedClick({
+      pointerConfusionActions.triggerHintForTests({
         actionId: "grid.all-day",
         gridDate: "2026-08-29",
       });
@@ -408,5 +288,23 @@ describe("PointerHint", () => {
     expect(screen.getByRole("status")).toHaveTextContent(
       "Press Shift+C to create an all-day event here.",
     );
+  });
+
+  it("dismisses permanently from the hint control", async () => {
+    const user = userEvent.setup();
+    render(<PointerHint />);
+
+    act(() => {
+      pointerConfusionActions.triggerHintForTests({ actionId: "unknown" });
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Dismiss keyboard tips permanently",
+      }),
+    );
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(usePointerConfusionStore.getState().score).toBe(0);
   });
 });

--- a/packages/web/src/components/PointerHint/PointerHint.tsx
+++ b/packages/web/src/components/PointerHint/PointerHint.tsx
@@ -1,5 +1,7 @@
+import { X } from "@phosphor-icons/react";
 import { type FC, type ReactNode, useEffect, useState } from "react";
 import { Z_INDEX_TOOLTIP } from "@web/common/constants/web.constants";
+import IconButton from "@web/components/IconButton/IconButton";
 import {
   selectShowcaseActive,
   useShortcutShowcaseStore,
@@ -12,12 +14,14 @@ import {
 import {
   type BlockedPointerAttempt,
   POINTER_ACTIONS,
+  pointerPassAttributes,
 } from "@web/shortcuts/keyboard-only/pointer-action";
 import {
-  selectLatestPointerAttempt,
-  selectPointerBlockPulse,
-  usePointerBlockStore,
-} from "@web/shortcuts/keyboard-only/pointer-block.store";
+  pointerConfusionActions,
+  selectPointerConfusionAttempt,
+  selectPointerConfusionHintPulse,
+  usePointerConfusionStore,
+} from "@web/shortcuts/keyboard-only/pointer-confusion.store";
 import { KEYMAP } from "@web/shortcuts/keymap";
 import {
   CONNECTION_BANNER_SHORTCUT_KEY,
@@ -29,50 +33,19 @@ import {
 } from "@web/shortcuts/shift-hint/event-jump.store";
 
 const HINT_VISIBLE_MS = 2500;
-const HINT_BRIEF_MS = 400;
-const HINT_FULL_LIMIT = 3;
-const HINT_COUNT_KEY = "compass.pointer-hint-count";
-
-const readHintCount = () => {
-  try {
-    return Number(sessionStorage.getItem(HINT_COUNT_KEY) ?? "0");
-  } catch {
-    return 0;
-  }
-};
-
-const writeHintCount = (count: number) => {
-  try {
-    sessionStorage.setItem(HINT_COUNT_KEY, String(count));
-  } catch {
-    // sessionStorage can throw in privacy modes; the hint still shows.
-  }
-};
 
 const Key = ({ children }: { children: string }) => (
   <kbd className="c-keycap">{children}</kbd>
 );
 
-/**
- * A named action (or a bound shortcut) earns the full display time; only the
- * anonymous "keyboard only" pulse shortens. Derived from the attempt rather
- * than enumerated, so a new pointer action does not have to be registered
- * here as well as in `pointerHintMessage`.
- */
-const isContextualAttempt = (attempt: BlockedPointerAttempt | null) =>
-  attempt != null &&
-  (attempt.actionId !== "unknown" || Boolean(attempt.shortcutKey));
-
 const pointerHintMessage = ({
   attempt,
   eventJumpKey,
-  isBrief,
   showcaseActive,
   welcomeOpen,
 }: {
   attempt: BlockedPointerAttempt | null;
   eventJumpKey: string | null;
-  isBrief: boolean;
   showcaseActive: boolean;
   welcomeOpen: boolean;
 }): ReactNode => {
@@ -174,8 +147,6 @@ const pointerHintMessage = ({
     );
   }
 
-  if (isBrief) return "Keyboard only.";
-
   if (welcomeOpen) return "Use the keys on this screen.";
 
   return (
@@ -186,35 +157,21 @@ const pointerHintMessage = ({
 };
 
 /**
- * Teaches instead of silently ignoring: when a mouse click is blocked, a
- * transient pill explains the exact keyboard path for recognized targets and
- * falls back to the legend while coverage is expanded. Mounted in RootShell
- * so it shows with the sidebar closed too.
- * Top-center to stay clear of the Up Next banner's bottom-center spot.
+ * Teaches the keyboard model when confusion heuristics fire, not on every
+ * blocked click. Mounted in RootShell so it shows with the sidebar closed too.
  */
 export const PointerHint: FC = () => {
-  const pulse = usePointerBlockStore(selectPointerBlockPulse);
-  const attempt = usePointerBlockStore(selectLatestPointerAttempt);
+  const pulse = usePointerConfusionStore(selectPointerConfusionHintPulse);
+  const attempt = usePointerConfusionStore(selectPointerConfusionAttempt);
   const eventJumpKey = useEventJumpStore(selectEventJumpPointerHintKey);
   const showcaseActive = useShortcutShowcaseStore(selectShowcaseActive);
   const welcomeOpen = useWelcomeGuideStore(selectWelcomeSurfaceOpen);
   const [isVisible, setIsVisible] = useState(false);
-  const [isBrief, setIsBrief] = useState(false);
 
   useEffect(() => {
     if (pulse === 0) return;
-    const next = readHintCount() + 1;
-    writeHintCount(next);
-    const brief = next > HINT_FULL_LIMIT;
-    setIsBrief(brief);
     setIsVisible(true);
-    const contextual = isContextualAttempt(
-      usePointerBlockStore.getState().latestAttempt,
-    );
-    const timer = window.setTimeout(
-      () => setIsVisible(false),
-      brief && !contextual ? HINT_BRIEF_MS : HINT_VISIBLE_MS,
-    );
+    const timer = window.setTimeout(() => setIsVisible(false), HINT_VISIBLE_MS);
     return () => window.clearTimeout(timer);
   }, [pulse]);
 
@@ -223,18 +180,32 @@ export const PointerHint: FC = () => {
   return (
     <div
       aria-live="polite"
-      className="fixed top-4 left-1/2 -translate-x-1/2 starting:translate-y-1 rounded-lg border border-border bg-surface-panel/90 px-3 py-1.5 text-sm text-text starting:opacity-0 shadow-xl backdrop-blur-md transition-all duration-200 ease-out motion-reduce:transition-none"
+      className="fixed top-4 left-1/2 flex max-w-[min(100vw-2rem,36rem)] -translate-x-1/2 items-start gap-2 starting:translate-y-1 rounded-lg border border-border bg-surface-panel/90 px-3 py-1.5 text-sm text-text starting:opacity-0 shadow-xl backdrop-blur-md transition-all duration-200 ease-out motion-reduce:transition-none"
       data-pointer-hint=""
       role="status"
       style={{ zIndex: Z_INDEX_TOOLTIP }}
     >
-      {pointerHintMessage({
-        attempt,
-        eventJumpKey,
-        isBrief,
-        showcaseActive,
-        welcomeOpen,
-      })}
+      <span className="min-w-0 flex-1">
+        {pointerHintMessage({
+          attempt,
+          eventJumpKey,
+          showcaseActive,
+          welcomeOpen,
+        })}
+      </span>
+      <IconButton
+        {...pointerPassAttributes}
+        aria-label="Dismiss keyboard tips permanently"
+        className="shrink-0 opacity-70 hover:opacity-100"
+        onClick={() => {
+          pointerConfusionActions.dismissPermanently();
+          setIsVisible(false);
+        }}
+        size="small"
+        type="button"
+      >
+        <X size={16} />
+      </IconButton>
     </div>
   );
 };

--- a/packages/web/src/components/RootShell/RootShell.test.tsx
+++ b/packages/web/src/components/RootShell/RootShell.test.tsx
@@ -29,7 +29,7 @@ import {
   selectSettingsPage,
   useSettingsStore,
 } from "@web/settings/settings.store";
-import { pointerBlockActions } from "@web/shortcuts/keyboard-only/pointer-block.store";
+import { pointerConfusionActions } from "@web/shortcuts/keyboard-only/pointer-confusion.store";
 import {
   afterAll,
   afterEach,
@@ -323,7 +323,7 @@ describe("RootShell calendar onboarding on /life", () => {
     await renderShell("/life", { anonymous: true });
 
     act(() => {
-      pointerBlockActions.pulseBlockedClick();
+      pointerConfusionActions.triggerHintForTests({ actionId: "unknown" });
     });
 
     expect(

--- a/packages/web/src/components/RootShell/RootShell.tsx
+++ b/packages/web/src/components/RootShell/RootShell.tsx
@@ -30,7 +30,7 @@ import {
 } from "@web/components/WelcomeModal/welcome.guide.store";
 import { UpcomingEventNotifier } from "@web/notifications/UpcomingEventNotifier";
 import { useEventContextMenuShortcut } from "@web/shortcuts/context-menu/useEventContextMenuShortcut";
-import { usePointerSuppression } from "@web/shortcuts/keyboard-only/usePointerSuppression";
+import { usePointerConfusionTracker } from "@web/shortcuts/keyboard-only/usePointerConfusionTracker";
 import { useFocusNoticeShortcut } from "@web/shortcuts/notice-focus/useFocusNoticeShortcut";
 import {
   useCalendarShellShortcuts,
@@ -60,7 +60,7 @@ export function RootShell() {
   usePlanChangeToasts();
   useNavigationShortcuts();
   useCalendarShellShortcuts();
-  usePointerSuppression(!isLifeView);
+  usePointerConfusionTracker(!isLifeView);
   useFocusNoticeShortcut();
   useEventContextMenuShortcut();
 

--- a/packages/web/src/components/WelcomeModal/WelcomeGuideBody.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeGuideBody.test.tsx
@@ -1,10 +1,6 @@
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import {
-  initialPointerBlockState,
-  pointerBlockActions,
-  usePointerBlockStore,
-} from "@web/shortcuts/keyboard-only/pointer-block.store";
+import { pointerConfusionActions } from "@web/shortcuts/keyboard-only/pointer-confusion.store";
 import { useFlashedWelcomeShortcut } from "./useFlashedWelcomeShortcut";
 import { WelcomeGuideBody } from "./WelcomeGuideBody";
 import { afterEach, describe, expect, it, mock } from "bun:test";
@@ -34,7 +30,7 @@ const captureLinkClick = (name: string) => {
 
 describe("WelcomeGuideBody", () => {
   afterEach(() => {
-    usePointerBlockStore.setState(initialPointerBlockState, true);
+    pointerConfusionActions.resetForTests();
   });
 
   it("explains that numbered shortcuts open the FAQ", () => {
@@ -151,7 +147,7 @@ describe("WelcomeGuideBody", () => {
     expect(hintWrap?.className).not.toMatch(/c-keycap-flash/);
 
     act(() => {
-      pointerBlockActions.pulseBlockedClick({
+      pointerConfusionActions.recordDeadClick({
         actionId: "unknown",
         shortcutKey: "1",
       });
@@ -160,7 +156,7 @@ describe("WelcomeGuideBody", () => {
     expect(hintWrap?.className).toMatch(/c-keycap-flash/);
 
     act(() => {
-      pointerBlockActions.pulseBlockedClick({ actionId: "unknown" });
+      pointerConfusionActions.recordDeadClick({ actionId: "unknown" });
     });
 
     expect(hintWrap?.className).not.toMatch(/c-keycap-flash/);
@@ -170,7 +166,7 @@ describe("WelcomeGuideBody", () => {
     const first = renderWelcomeGuide();
 
     act(() => {
-      pointerBlockActions.pulseBlockedClick({
+      pointerConfusionActions.recordDeadClick({
         actionId: "unknown",
         shortcutKey: "1",
       });

--- a/packages/web/src/components/WelcomeModal/useFlashedWelcomeShortcut.ts
+++ b/packages/web/src/components/WelcomeModal/useFlashedWelcomeShortcut.ts
@@ -1,19 +1,17 @@
 import { useEffect, useRef, useState } from "react";
 import {
-  selectLatestPointerAttempt,
-  selectPointerBlockPulse,
-  usePointerBlockStore,
-} from "@web/shortcuts/keyboard-only/pointer-block.store";
+  selectPointerConfusionAttempt,
+  selectPointerConfusionDeadClickPulse,
+  usePointerConfusionStore,
+} from "@web/shortcuts/keyboard-only/pointer-confusion.store";
 
 export const KEYCAP_FLASH_MS = 700;
 
-/** The shortcut key currently flashing after a blocked click, or null. */
+/** The shortcut key currently flashing after a dead click, or null. */
 export function useFlashedWelcomeShortcut(): string | null {
-  const pulse = usePointerBlockStore(selectPointerBlockPulse);
-  const attempt = usePointerBlockStore(selectLatestPointerAttempt);
+  const pulse = usePointerConfusionStore(selectPointerConfusionDeadClickPulse);
+  const attempt = usePointerConfusionStore(selectPointerConfusionAttempt);
   const [flashedKey, setFlashedKey] = useState<string | null>(null);
-  // Ignore the pulse already in the store on mount so a remount does not
-  // replay a flash from an earlier blocked click.
   const lastPulseRef = useRef(pulse);
 
   useEffect(() => {

--- a/packages/web/src/grid/components/AllDayEventCard.tsx
+++ b/packages/web/src/grid/components/AllDayEventCard.tsx
@@ -130,7 +130,7 @@ const AllDayEventCardBase = (
       role="button"
       tabIndex={0}
       className={cn(
-        "absolute min-h-2.5 select-none overflow-hidden rounded-xs bg-(--event-bg) pr-0.75 pl-1.25 transition-[background-color,filter] duration-260 ease-[cubic-bezier(0.16,1,0.3,1)] hover:bg-(--event-hover-bg)",
+        "absolute min-h-2.5 overflow-hidden rounded-xs bg-(--event-bg) pr-0.75 pl-1.25 transition-[background-color,filter] duration-260 ease-[cubic-bezier(0.16,1,0.3,1)] hover:bg-(--event-hover-bg)",
         {
           "hover:cursor-pointer": !isPlaceholder,
           "outline outline-dashed outline-1 outline-text-muted/50":

--- a/packages/web/src/grid/components/TimedEventCard.tsx
+++ b/packages/web/src/grid/components/TimedEventCard.tsx
@@ -256,7 +256,7 @@ const TimedEventCardBase = (
       role="button"
       tabIndex={0}
       className={cn(
-        "absolute min-h-2.5 select-none overflow-hidden rounded-xs pr-0.75 pl-1.25 transition-[background-color,filter] duration-[260ms] ease-[cubic-bezier(0.16,1,0.3,1)]",
+        "absolute min-h-2.5 overflow-hidden rounded-xs pr-0.75 pl-1.25 transition-[background-color,filter] duration-[260ms] ease-[cubic-bezier(0.16,1,0.3,1)]",
         "bg-(--event-bg) hover:bg-(--event-hover-bg)",
         "hover:cursor-pointer",
         eventFocusOutlineClass(focusedEdge),

--- a/packages/web/src/shortcuts/keyboard-only/pointer-block.store.ts
+++ b/packages/web/src/shortcuts/keyboard-only/pointer-block.store.ts
@@ -35,9 +35,3 @@ export const pointerBlockActions = {
       { type: "pulseBlockedClick" },
     ),
 };
-
-export const selectPointerBlockPulse = (state: PointerBlockState) =>
-  state.blockedClickPulse;
-
-export const selectLatestPointerAttempt = (state: PointerBlockState) =>
-  state.latestAttempt;

--- a/packages/web/src/shortcuts/keyboard-only/pointer-confusion.store.test.ts
+++ b/packages/web/src/shortcuts/keyboard-only/pointer-confusion.store.test.ts
@@ -1,0 +1,58 @@
+import { act, renderHook } from "@testing-library/react";
+import {
+  POINTER_CONFUSION_THRESHOLD,
+  pointerConfusionActions,
+  selectPointerConfusionHintPulse,
+  selectPointerConfusionScore,
+  usePointerConfusionStore,
+} from "@web/shortcuts/keyboard-only/pointer-confusion.store";
+import { resetPointerHintPersistenceForTests } from "@web/shortcuts/keyboard-only/pointer-hint.storage";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+describe("pointerConfusionActions", () => {
+  beforeEach(() => {
+    resetPointerHintPersistenceForTests();
+    pointerConfusionActions.resetForTests();
+  });
+
+  it("shows the hint when the score reaches the threshold", () => {
+    for (let i = 0; i < POINTER_CONFUSION_THRESHOLD - 1; i += 1) {
+      pointerConfusionActions.recordDeadClick({ actionId: "unknown" });
+    }
+    expect(usePointerConfusionStore.getState().hintPulse).toBe(0);
+
+    pointerConfusionActions.recordDeadClick({ actionId: "unknown" });
+
+    expect(usePointerConfusionStore.getState().hintPulse).toBe(1);
+    expect(usePointerConfusionStore.getState().score).toBe(0);
+  });
+
+  it("subtracts for copy and keyboard signals", () => {
+    pointerConfusionActions.recordDeadClick({ actionId: "unknown" });
+    pointerConfusionActions.recordDeadClick({ actionId: "unknown" });
+    pointerConfusionActions.recordCopyButtonClick();
+    pointerConfusionActions.recordKeyboardSuccess();
+
+    expect(usePointerConfusionStore.getState().score).toBe(0);
+  });
+});
+
+describe("pointer confusion selectors", () => {
+  beforeEach(() => {
+    pointerConfusionActions.resetForTests();
+  });
+
+  it("exposes score and hint pulse", () => {
+    const { result, rerender } = renderHook(() => ({
+      score: usePointerConfusionStore(selectPointerConfusionScore),
+      pulse: usePointerConfusionStore(selectPointerConfusionHintPulse),
+    }));
+
+    expect(result.current.score).toBe(0);
+    act(() => {
+      pointerConfusionActions.recordDeadClick({ actionId: "unknown" });
+    });
+    rerender();
+    expect(result.current.score).toBe(1);
+  });
+});

--- a/packages/web/src/shortcuts/keyboard-only/pointer-confusion.store.ts
+++ b/packages/web/src/shortcuts/keyboard-only/pointer-confusion.store.ts
@@ -1,0 +1,143 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import { type BlockedPointerAttempt } from "@web/shortcuts/keyboard-only/pointer-action";
+import {
+  readPointerHintDismissedPermanently,
+  readPointerHintLastShownAt,
+  readPointerHintLifetimeCount,
+  writePointerHintDismissedPermanently,
+  writePointerHintLastShownAt,
+  writePointerHintLifetimeCount,
+} from "@web/shortcuts/keyboard-only/pointer-hint.storage";
+
+export const POINTER_CONFUSION_THRESHOLD = 4;
+export const POINTER_CONFUSION_LIFETIME_LIMIT = 3;
+export const POINTER_CONFUSION_MIN_GAP_MS = 10_000;
+export const POINTER_CONFUSION_DECAY_INTERVAL_MS = 20_000;
+export const POINTER_CONFUSION_REGION_RADIUS_PX = 48;
+export const POINTER_CONFUSION_REGION_WINDOW_MS = 3_000;
+
+type PointerConfusionState = {
+  score: number;
+  hintPulse: number;
+  deadClickPulse: number;
+  latestAttempt: BlockedPointerAttempt | null;
+};
+
+const initialState: PointerConfusionState = {
+  score: 0,
+  hintPulse: 0,
+  deadClickPulse: 0,
+  latestAttempt: null,
+};
+
+export const usePointerConfusionStore = create<PointerConfusionState>()(
+  devtools(() => ({ ...initialState }), { name: "pointer-confusion" }),
+);
+
+const canShowPointerHint = () => {
+  if (readPointerHintDismissedPermanently()) return false;
+  if (readPointerHintLifetimeCount() >= POINTER_CONFUSION_LIFETIME_LIMIT) {
+    return false;
+  }
+  const lastShownAt = readPointerHintLastShownAt();
+  if (
+    lastShownAt !== null &&
+    Date.now() - lastShownAt < POINTER_CONFUSION_MIN_GAP_MS
+  ) {
+    return false;
+  }
+  return true;
+};
+
+const markPointerHintShown = () => {
+  writePointerHintLifetimeCount(readPointerHintLifetimeCount() + 1);
+  writePointerHintLastShownAt(Date.now());
+};
+
+const adjustScore = (delta: number) => {
+  const nextScore = Math.max(
+    0,
+    usePointerConfusionStore.getState().score + delta,
+  );
+  usePointerConfusionStore.setState({ score: nextScore }, false, {
+    type: "adjustScore",
+    delta,
+  });
+
+  if (nextScore >= POINTER_CONFUSION_THRESHOLD && canShowPointerHint()) {
+    markPointerHintShown();
+    usePointerConfusionStore.setState(
+      (state) => ({
+        score: 0,
+        hintPulse: state.hintPulse + 1,
+      }),
+      false,
+      { type: "triggerHint" },
+    );
+  }
+};
+
+export const pointerConfusionActions = {
+  resetForTests: () => {
+    usePointerConfusionStore.setState(initialState, false, {
+      type: "resetForTests",
+    });
+  },
+  recordDeadClick: (attempt: BlockedPointerAttempt) => {
+    usePointerConfusionStore.setState(
+      (state) => ({
+        latestAttempt: attempt,
+        deadClickPulse: state.deadClickPulse + 1,
+      }),
+      false,
+      { type: "recordDeadClick" },
+    );
+    adjustScore(1);
+  },
+  recordRegionBurst: (attempt: BlockedPointerAttempt) => {
+    usePointerConfusionStore.setState(
+      (state) => ({
+        latestAttempt: attempt,
+        deadClickPulse: state.deadClickPulse + 1,
+      }),
+      false,
+      { type: "recordRegionBurst" },
+    );
+    adjustScore(2);
+  },
+  recordTextSelection: () => adjustScore(-1),
+  recordCopyButtonClick: () => adjustScore(-1),
+  recordKeyboardSuccess: () => adjustScore(-2),
+  decayScore: () => adjustScore(-1),
+  dismissPermanently: () => {
+    writePointerHintDismissedPermanently();
+    usePointerConfusionStore.setState({ score: 0 }, false, {
+      type: "dismissPermanently",
+    });
+  },
+  /** Test helper: show the hint with a specific attempt context. */
+  triggerHintForTests: (attempt: BlockedPointerAttempt) => {
+    usePointerConfusionStore.setState(
+      (state) => ({
+        latestAttempt: attempt,
+        hintPulse: state.hintPulse + 1,
+      }),
+      false,
+      { type: "triggerHintForTests" },
+    );
+  },
+};
+
+export const selectPointerConfusionHintPulse = (state: PointerConfusionState) =>
+  state.hintPulse;
+
+export const selectPointerConfusionAttempt = (state: PointerConfusionState) =>
+  state.latestAttempt;
+
+export const selectPointerConfusionDeadClickPulse = (
+  state: PointerConfusionState,
+) => state.deadClickPulse;
+
+export const selectPointerConfusionScore = (state: PointerConfusionState) =>
+  state.score;

--- a/packages/web/src/shortcuts/keyboard-only/pointer-hint.storage.ts
+++ b/packages/web/src/shortcuts/keyboard-only/pointer-hint.storage.ts
@@ -1,0 +1,39 @@
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+
+const store = persistentBrowserStore;
+
+export const readPointerHintLifetimeCount = (): number => {
+  const raw = store.get(STORAGE_KEYS.POINTER_HINT_LIFETIME_COUNT);
+  const parsed = Number(raw ?? "0");
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+export const writePointerHintLifetimeCount = (count: number) => {
+  store.set(STORAGE_KEYS.POINTER_HINT_LIFETIME_COUNT, String(count));
+};
+
+export const readPointerHintDismissedPermanently = (): boolean =>
+  store.get(STORAGE_KEYS.POINTER_HINT_DISMISSED_PERMANENTLY) === "true";
+
+export const writePointerHintDismissedPermanently = () => {
+  store.set(STORAGE_KEYS.POINTER_HINT_DISMISSED_PERMANENTLY, "true");
+};
+
+export const readPointerHintLastShownAt = (): number | null => {
+  const raw = store.get(STORAGE_KEYS.POINTER_HINT_LAST_SHOWN_AT);
+  if (!raw) return null;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+export const writePointerHintLastShownAt = (timestampMs: number) => {
+  store.set(STORAGE_KEYS.POINTER_HINT_LAST_SHOWN_AT, String(timestampMs));
+};
+
+/** Test-only reset for persisted hint guardrails. */
+export const resetPointerHintPersistenceForTests = () => {
+  store.remove(STORAGE_KEYS.POINTER_HINT_LIFETIME_COUNT);
+  store.remove(STORAGE_KEYS.POINTER_HINT_DISMISSED_PERMANENTLY);
+  store.remove(STORAGE_KEYS.POINTER_HINT_LAST_SHOWN_AT);
+};

--- a/packages/web/src/shortcuts/keyboard-only/usePointerConfusionTracker.ts
+++ b/packages/web/src/shortcuts/keyboard-only/usePointerConfusionTracker.ts
@@ -1,0 +1,160 @@
+import { useEffect, useRef } from "react";
+import {
+  type BlockedPointerAttempt,
+  POINTER_PASS_ATTRIBUTE,
+  resolveBlockedPointerAttempt,
+} from "@web/shortcuts/keyboard-only/pointer-action";
+import {
+  POINTER_CONFUSION_DECAY_INTERVAL_MS,
+  POINTER_CONFUSION_REGION_RADIUS_PX,
+  POINTER_CONFUSION_REGION_WINDOW_MS,
+  pointerConfusionActions,
+} from "@web/shortcuts/keyboard-only/pointer-confusion.store";
+
+const ACTIVITY_EVENTS = ["pointerdown", "keydown", "scroll"] as const;
+
+const isFormControl = (target: EventTarget | null): boolean => {
+  if (!(target instanceof Element)) return false;
+  return Boolean(
+    target.closest(
+      "input, textarea, select, [contenteditable='true'], [contenteditable='']",
+    ),
+  );
+};
+
+const isPointerPassTarget = (target: EventTarget | null): boolean => {
+  if (!(target instanceof Element)) return false;
+  return Boolean(target.closest(`[${POINTER_PASS_ATTRIBUTE}]`));
+};
+
+const isWorkingLink = (target: EventTarget | null): boolean => {
+  if (!(target instanceof Element)) return false;
+  const link = target.closest("a[href]");
+  if (!(link instanceof HTMLAnchorElement)) return false;
+  return link.href.length > 0 && link.href !== "#";
+};
+
+const isNativeButton = (target: EventTarget | null): boolean => {
+  if (!(target instanceof Element)) return false;
+  return Boolean(target.closest("button"));
+};
+
+/**
+ * Elements that look interactive but intentionally ignore mouse activation
+ * (grid event cards, annotated chrome, etc.).
+ */
+const isInertInteractiveTarget = (target: EventTarget | null): boolean => {
+  if (!(target instanceof Element)) return false;
+  if (isPointerPassTarget(target)) return false;
+  if (isFormControl(target)) return false;
+  if (isWorkingLink(target)) return false;
+  if (isNativeButton(target)) return false;
+
+  return Boolean(target.closest("[data-pointer-action], [role='button']"));
+};
+
+const hasMeaningfulSelection = () => {
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed) return false;
+  return selection.toString().trim().length > 0;
+};
+
+/**
+ * Tracks mouse confusion signals and adjusts the per-session score that gates
+ * the keyboard-only hint. Mounted once in RootShell for calendar views.
+ */
+export function usePointerConfusionTracker(enabled = true) {
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
+
+  const lastClickRef = useRef<{
+    x: number;
+    y: number;
+    at: number;
+    attempt: BlockedPointerAttempt;
+  } | null>(null);
+  const selectionHandledRef = useRef(false);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let decayTimer: number | null = null;
+
+    const scheduleDecay = () => {
+      if (decayTimer !== null) {
+        window.clearTimeout(decayTimer);
+      }
+      decayTimer = window.setTimeout(() => {
+        if (!enabledRef.current) return;
+        pointerConfusionActions.decayScore();
+        scheduleDecay();
+      }, POINTER_CONFUSION_DECAY_INTERVAL_MS);
+    };
+
+    const onActivity = () => {
+      if (!enabledRef.current) return;
+      scheduleDecay();
+    };
+
+    const onPointerDown = (event: PointerEvent) => {
+      if (!enabledRef.current) return;
+      onActivity();
+
+      const target = event.target;
+      if (!isInertInteractiveTarget(target)) {
+        lastClickRef.current = null;
+        return;
+      }
+
+      const path = event.composedPath() as EventTarget[];
+      const attempt = resolveBlockedPointerAttempt(path);
+      const now = performance.now();
+      const previous = lastClickRef.current;
+      const x = event.clientX;
+      const y = event.clientY;
+
+      if (
+        previous &&
+        now - previous.at <= POINTER_CONFUSION_REGION_WINDOW_MS &&
+        Math.hypot(previous.x - x, previous.y - y) <=
+          POINTER_CONFUSION_REGION_RADIUS_PX
+      ) {
+        pointerConfusionActions.recordRegionBurst(attempt);
+      } else {
+        pointerConfusionActions.recordDeadClick(attempt);
+      }
+
+      lastClickRef.current = { x, y, at: now, attempt };
+    };
+
+    const onSelectionChange = () => {
+      if (!enabledRef.current) return;
+      if (!hasMeaningfulSelection()) {
+        selectionHandledRef.current = false;
+        return;
+      }
+      if (selectionHandledRef.current) return;
+      selectionHandledRef.current = true;
+      pointerConfusionActions.recordTextSelection();
+      onActivity();
+    };
+
+    for (const type of ACTIVITY_EVENTS) {
+      window.addEventListener(type, onActivity, { passive: true });
+    }
+    window.addEventListener("pointerdown", onPointerDown, true);
+    document.addEventListener("selectionchange", onSelectionChange);
+    scheduleDecay();
+
+    return () => {
+      if (decayTimer !== null) {
+        window.clearTimeout(decayTimer);
+      }
+      for (const type of ACTIVITY_EVENTS) {
+        window.removeEventListener(type, onActivity);
+      }
+      window.removeEventListener("pointerdown", onPointerDown, true);
+      document.removeEventListener("selectionchange", onSelectionChange);
+    };
+  }, [enabled]);
+}

--- a/packages/web/src/shortcuts/useAppShortcut.ts
+++ b/packages/web/src/shortcuts/useAppShortcut.ts
@@ -4,6 +4,7 @@ import {
   useHotkey,
 } from "@tanstack/react-hotkeys";
 import { isAppLocked } from "@web/shortcuts/app-lock";
+import { pointerConfusionActions } from "@web/shortcuts/keyboard-only/pointer-confusion.store";
 import { recordShortcutUnavailableAttempt } from "@web/shortcuts/tips/shortcut-telemetry";
 import { type ShortcutHintId } from "@web/shortcuts/tips/shortcut-tips.data";
 
@@ -61,6 +62,7 @@ export function useAppShortcut(
       }
 
       handler(event);
+      pointerConfusionActions.recordKeyboardSuccess();
     },
     {
       enabled,

--- a/packages/web/src/views/Forms/EventForm/EventDetailsSection.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventDetailsSection.tsx
@@ -1,6 +1,7 @@
 import { UsersIcon, VideoCameraIcon } from "@phosphor-icons/react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { type EventContent } from "@core/types/event.contracts";
+import { CopyButton } from "@web/components/CopyButton/CopyButton";
 import { AttendeeRsvpStatus } from "@web/views/Forms/EventForm/AttendeeRsvpStatus";
 import {
   ATTENDEE_RSVP_LABEL,
@@ -45,6 +46,17 @@ export const EventDetailsSection = ({
     ? attendees
     : attendees.slice(0, MAX_VISIBLE_ATTENDEES);
   const hiddenAttendeeCount = attendees.length - visibleAttendees.length;
+  const attendeeListPlainText = useMemo(
+    () =>
+      attendees
+        .map((attendee) => {
+          const name = attendee.displayName ?? attendee.email;
+          const isOrganizer = organizer?.email === attendee.email;
+          return isOrganizer ? `${name} (organizer)` : name;
+        })
+        .join("\n"),
+    [attendees, organizer?.email],
+  );
 
   return (
     <div className="flex flex-col gap-2 rounded-md bg-surface-overlay p-3 text-text text-xs">
@@ -70,11 +82,15 @@ export const EventDetailsSection = ({
         >
           <div className="flex items-center gap-2 text-text-muted">
             <UsersIcon size={16} className="shrink-0" />
-            <span>
+            <span className="min-w-0 flex-1">
               {formatAttendeeRsvpTally(
                 attendees.map((attendee) => attendee.responseStatus),
               )}
             </span>
+            <CopyButton
+              label="copy attendee list"
+              text={attendeeListPlainText}
+            />
           </div>
           <ul className="flex flex-col gap-1 pl-6">
             {visibleAttendees.map((attendee) => {

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -37,7 +37,9 @@ import {
   isDeleteTextEditingTarget,
   shouldDeferEnterToTarget,
 } from "@web/common/utils/form/form.util";
+import { htmlToPlainText } from "@web/common/utils/html/html-to-plain-text.util";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
+import { CopyButton } from "@web/components/CopyButton/CopyButton";
 import { DescriptionEditor } from "@web/components/DescriptionEditor/DescriptionEditor";
 import {
   Focusable,
@@ -73,6 +75,10 @@ import { DiscardUnsavedChangesDialog } from "@web/views/Forms/EventForm/DiscardU
 import { EventColorPicker } from "@web/views/Forms/EventForm/EventColorPicker/EventColorPicker";
 import { EventDetailsSection } from "@web/views/Forms/EventForm/EventDetailsSection";
 import { FormActionsRow } from "@web/views/Forms/EventForm/FormActionsRow";
+import {
+  formatAttendeeListPlainText,
+  formatEventPlainText,
+} from "@web/views/Forms/EventForm/format-event-plain-text";
 import { RsvpControl } from "@web/views/Forms/EventForm/RsvpControl";
 import { SaveSection } from "@web/views/Forms/EventForm/SaveSection";
 import {
@@ -365,6 +371,40 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
               statusForEmail(attendeeRsvpByEmail, chip.email),
             ),
           );
+    const descriptionPlainText = useMemo(
+      () => htmlToPlainText(description),
+      [description],
+    );
+    const attendeeListPlainText = useMemo(
+      () => formatAttendeeListPlainText(attendeeChips),
+      [attendeeChips],
+    );
+    const eventPlainText = useMemo(() => {
+      const calendarName =
+        draft.kind === "edit"
+          ? originalCalendarName
+          : draft.values.calendarId
+            ? (calendarLookup.get(draft.values.calendarId)?.name ?? null)
+            : (defaultTargetCalendar?.name ?? null);
+
+      return formatEventPlainText({
+        title: displayTitle,
+        schedule: draft.values.schedule,
+        location,
+        description,
+        attendees: attendeeChips.length > 0 ? attendeeChips : undefined,
+        calendarName,
+      });
+    }, [
+      attendeeChips,
+      calendarLookup,
+      defaultTargetCalendar,
+      description,
+      displayTitle,
+      draft,
+      location,
+      originalCalendarName,
+    ]);
     const latestDraftRef = useRef(draft);
     const { startDate: eventStartDate, endDate: eventEndDate } =
       scheduleDateStrings(draft);
@@ -843,36 +883,42 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
         >
           {/* Scrollable body; the save footer below stays pinned. */}
           <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-4 pt-1 pb-4 [scrollbar-gutter:stable]">
-            <FormActionsRow
-              isExistingEvent={isExistingEvent}
-              isReadOnly={isReadOnly}
-              onClose={requestClose}
-              onDelete={onDeleteEvent}
-              onDuplicate={onDuplicateEvent}
-            />
+            <div className="flex items-start justify-between gap-2">
+              <FormActionsRow
+                isExistingEvent={isExistingEvent}
+                isReadOnly={isReadOnly}
+                onClose={requestClose}
+                onDelete={onDeleteEvent}
+                onDuplicate={onDuplicateEvent}
+              />
+              <CopyButton label="copy event" text={eventPlainText} />
+            </div>
 
-            <Focusable
-              id={EVENT_FORM_TITLE_ID}
-              Component="input"
-              className={classNames(
-                INPUT_RESET_CLASSNAME,
-                // w-full: an input's intrinsic size-attribute width would
-                // overflow the sidebar-width form and force horizontal scroll
-                "w-full bg-transparent font-semibold text-xl",
-              )}
-              autoFocus
-              disabled={isReadOnly}
-              onChange={onChangeTitle}
-              onKeyDown={handleTitleKeyDown}
-              placeholder="Title"
-              aria-label="Title"
-              name="Event Title"
-              aria-invalid={titleError ? true : undefined}
-              aria-describedby={titleErrorDescribedBy}
-              underlineColor={eventColor}
-              value={displayTitle}
-              withUnderline
-            />
+            <div className="flex items-start gap-1">
+              <Focusable
+                id={EVENT_FORM_TITLE_ID}
+                Component="input"
+                className={classNames(
+                  INPUT_RESET_CLASSNAME,
+                  // w-full: an input's intrinsic size-attribute width would
+                  // overflow the sidebar-width form and force horizontal scroll
+                  "min-w-0 flex-1 bg-transparent font-semibold text-xl",
+                )}
+                autoFocus
+                disabled={isReadOnly}
+                onChange={onChangeTitle}
+                onKeyDown={handleTitleKeyDown}
+                placeholder="Title"
+                aria-label="Title"
+                name="Event Title"
+                aria-invalid={titleError ? true : undefined}
+                aria-describedby={titleErrorDescribedBy}
+                underlineColor={eventColor}
+                value={displayTitle}
+                withUnderline
+              />
+              <CopyButton label="copy event title" text={displayTitle} />
+            </div>
 
             {/* Same fieldset mechanism as the title above, covering
               date/recurrence/calendar/description in one wrapper. Its
@@ -957,7 +1003,7 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
                     Component="input"
                     className={classNames(
                       INPUT_RESET_CLASSNAME,
-                      "w-full bg-transparent text-sm",
+                      "min-w-0 flex-1 bg-transparent text-sm",
                     )}
                     disabled={isReadOnly}
                     onChange={onChangeLocation}
@@ -967,6 +1013,7 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
                     name="Event Location"
                     value={location}
                   />
+                  <CopyButton label="copy event location" text={location} />
                 </div>
               </FormCard>
 
@@ -1003,20 +1050,36 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
                         }
                       />
                     </div>
+                    <CopyButton
+                      label="copy attendee list"
+                      text={attendeeListPlainText}
+                    />
                   </div>
                 </FormCard>
               )}
 
               <FormCard>
-                <DescriptionEditor
-                  id={EVENT_FORM_DESCRIPTION_ID}
-                  resetKey={draft.kind === "edit" ? draft.source.id : "create"}
-                  value={description}
-                  onChange={(html) => patchDraftFields({ description: html })}
-                  editable={!isReadOnly}
-                  underlineColor={eventColor}
-                  onKeyDown={handleIgnoredKeys}
-                />
+                <div className="flex items-start gap-1">
+                  <div className="min-w-0 flex-1">
+                    <DescriptionEditor
+                      id={EVENT_FORM_DESCRIPTION_ID}
+                      resetKey={
+                        draft.kind === "edit" ? draft.source.id : "create"
+                      }
+                      value={description}
+                      onChange={(html) =>
+                        patchDraftFields({ description: html })
+                      }
+                      editable={!isReadOnly}
+                      underlineColor={eventColor}
+                      onKeyDown={handleIgnoredKeys}
+                    />
+                  </div>
+                  <CopyButton
+                    label="copy event description"
+                    text={descriptionPlainText}
+                  />
+                </div>
               </FormCard>
             </fieldset>
 

--- a/packages/web/src/views/Forms/EventForm/format-event-plain-text.test.ts
+++ b/packages/web/src/views/Forms/EventForm/format-event-plain-text.test.ts
@@ -1,0 +1,36 @@
+import { htmlToPlainText } from "@web/common/utils/html/html-to-plain-text.util";
+import { timedGridSchedule } from "@web/events/grid-event-draft.adapter";
+import { formatEventPlainText } from "@web/views/Forms/EventForm/format-event-plain-text";
+import { describe, expect, it } from "bun:test";
+
+describe("formatEventPlainText", () => {
+  it("formats title, schedule, location, attendees, and description", () => {
+    const schedule = timedGridSchedule(
+      new Date("2026-03-10T15:00:00.000Z"),
+      new Date("2026-03-10T16:00:00.000Z"),
+    );
+
+    const text = formatEventPlainText({
+      title: "Design review",
+      schedule,
+      location: "Room 4",
+      description: "<p>Bring mocks</p>",
+      attendees: [{ email: "alex@example.com", displayName: "Alex" }],
+      calendarName: "Work",
+    });
+
+    expect(text).toContain("Design review");
+    expect(text).toContain("Location: Room 4");
+    expect(text).toContain("Calendar: Work");
+    expect(text).toContain("Alex <alex@example.com>");
+    expect(text).toContain("Bring mocks");
+  });
+});
+
+describe("htmlToPlainText", () => {
+  it("strips markup", () => {
+    expect(htmlToPlainText("<p>Hello <strong>world</strong></p>")).toBe(
+      "Hello world",
+    );
+  });
+});

--- a/packages/web/src/views/Forms/EventForm/format-event-plain-text.ts
+++ b/packages/web/src/views/Forms/EventForm/format-event-plain-text.ts
@@ -1,0 +1,84 @@
+import { type AttendeeInput } from "@core/types/event-attendance.contracts";
+import dayjs from "@core/util/date/dayjs";
+import { getTimesLabel } from "@web/common/utils/datetime/web.date.util";
+import { htmlToPlainText } from "@web/common/utils/html/html-to-plain-text.util";
+import { type GridScheduleDraft } from "@web/events/event-draft.types";
+
+const formatAttendeeLine = (attendee: AttendeeInput) =>
+  attendee.displayName
+    ? `${attendee.displayName} <${attendee.email}>`
+    : attendee.email;
+
+const formatScheduleLine = (schedule: GridScheduleDraft): string => {
+  const start = dayjs(schedule.start);
+  const end = dayjs(schedule.end);
+
+  if (schedule.kind === "allDay") {
+    const endInclusive = end.subtract(1, "day");
+    const sameDay = start.isSame(endInclusive, "day");
+    if (sameDay) {
+      return `All day, ${start.format("dddd, MMMM D, YYYY")}`;
+    }
+    return `All day, ${start.format("MMM D, YYYY")} - ${endInclusive.format("MMM D, YYYY")}`;
+  }
+
+  const sameDay = start.isSame(end, "day");
+  const dateLabel = start.format("dddd, MMMM D, YYYY");
+  const timeLabel = getTimesLabel(start.format(), end.format());
+  return sameDay ? `${dateLabel}, ${timeLabel}` : `${dateLabel}, ${timeLabel}`;
+};
+
+export interface FormatEventPlainTextInput {
+  title: string;
+  schedule: GridScheduleDraft;
+  location: string;
+  description: string;
+  attendees?: readonly AttendeeInput[];
+  calendarName?: string | null;
+}
+
+/**
+ * Formats the sidebar event form as plain text suitable for email or notes.
+ */
+export function formatEventPlainText({
+  title,
+  schedule,
+  location,
+  description,
+  attendees,
+  calendarName,
+}: FormatEventPlainTextInput): string {
+  const lines: string[] = [];
+  lines.push(title.trim() || "Untitled event");
+  lines.push(formatScheduleLine(schedule));
+
+  if (calendarName) {
+    lines.push(`Calendar: ${calendarName}`);
+  }
+
+  if (location.trim()) {
+    lines.push(`Location: ${location.trim()}`);
+  }
+
+  if (attendees && attendees.length > 0) {
+    lines.push("Attendees:");
+    for (const attendee of attendees) {
+      lines.push(`- ${formatAttendeeLine(attendee)}`);
+    }
+  }
+
+  const descriptionText = htmlToPlainText(description);
+  if (descriptionText) {
+    lines.push("");
+    lines.push(descriptionText);
+  }
+
+  return lines.join("\n");
+}
+
+export function formatAttendeeListPlainText(
+  attendees: readonly AttendeeInput[],
+): string {
+  if (attendees.length === 0) return "";
+  return attendees.map(formatAttendeeLine).join("\n");
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enables mouse copy and text selection in the event sidebar while keeping keyboard-first teaching, but only when users appear confused.

### Part 1: Copy buttons
- Adds reusable `CopyButton` (25% opacity default, full on hover/focus, checkmark for 1.5s after copy, `data-pointer-pass`, accessible labels)
- Places copy controls beside event title, location, description, attendee list, and whole-event plain-text export in the sidebar form
- Adds `formatEventPlainText` for formatted clipboard export

### Part 2: Remove suppression
- Removes global pointer suppression from `RootShell` so click-drag selection works in the form and grid cards
- Drops `select-none` from timed/all-day event cards

### Part 3: Confusion heuristic
- Tracks a per-session confusion score from dead clicks, rapid clicks in the same region, text selection, copy-button use, and successful keyboard commands
- Shows the keyboard-only `PointerHint` only when score reaches 4, with lifetime cap (3), 10s minimum gap, score decay every 20s of activity, and a permanent dismiss control

## Testing

- `bun run verify` (web): test:web, type-check, lint, knip — PASS
- New unit tests: CopyButton, formatEventPlainText, pointer-confusion store, updated PointerHint/WelcomeGuide tests
- Updated e2e contract in `mouse-inert.spec.ts` for selection/copy behavior
- Manual: dev web on :9080 — copy buttons visible on hover beside title/location

![Copy button beside event title on hover](https://cursor.com/artifacts/c/art-856c725f-45d6-43ce-9971-f195a28924c4)
![Copy button beside location on hover](https://cursor.com/artifacts/c/art-fa435c98-bf88-46c3-ac6f-469b77109e4d)

<a href="https://cursor.com/agents/bc-01a068a2-46ef-7620-b0e7-d7a1cff9e056/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcopy_buttons_and_selection_demo.mp4"><img src="https://cursor.com/artifacts/c/art-84187853-3685-403b-bd36-97e5dd722ada" alt="copy_buttons_and_selection_demo.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a068a2-46ef-7620-b0e7-d7a1cff9e056?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a068a2-46ef-7620-b0e7-d7a1cff9e056&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

