### PR TITLE
feat(web): Escape backs out one step on the public booking picker

### DIFF
--- a/.agents/handoffs/3132.md
+++ b/.agents/handoffs/3132.md
@@ -1,10 +1,10 @@
 ---
 schema_version: 1
 task_id: "3132"
-from: Implementer
-to: Verifier
-owner: Verifier
-status: verifying
+from: Reviewer
+to: Manager
+owner: Manager
+status: done
 artifact:
   - path: packages/web/src/booking/use-public-booking-flow.ts
   - path: packages/web/src/booking/PublicBookingSlotPicker.tsx
@@ -13,13 +13,15 @@ artifact:
   - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3193
 evidence:
   - command: bun test:web packages/web/src/booking/PublicBookingPage.test.tsx packages/web/src/booking/PublicBookingSlotPicker.test.tsx packages/web/src/booking/PublicBookingPicker.test.tsx
-    result: "41 pass, 0 fail"
+    result: "41 pass, 0 fail (after simplify enabled: showDetailsStep)"
+    log: null
+  - command: bun run verify
+    result: "PASS. Selected packages: web. Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e. Checks skipped: (none). test:web 1580 pass. test:a11y 24 passed. test:e2e 109 passed."
     log: null
 assumptions:
   - "Timezone OverlayPanel already holds the app lock, so the details Escape shortcut stands down without ignoreAppLock."
-  - "Slot-list Escape is a local keydown on the slot button, not the page shortcut."
 open_risks: []
-next_deadline: 2026-09-04T00:00:00Z
+next_deadline: null
 retry: 0
 approval: none
 waiting_on: null
@@ -27,3 +29,11 @@ escalation: null
 ---
 
 WP-04: Escape backs out one step on `/book/:slug`.
+
+Simplify: `enabled: showDetailsStep` instead of a runtime no-op.
+
+Review: no confirmed findings.
+
+VERDICT: no confirmed findings
+FINDINGS:
+(none)

--- a/.agents/handoffs/3132.md
+++ b/.agents/handoffs/3132.md
@@ -1,0 +1,29 @@
+---
+schema_version: 1
+task_id: "3132"
+from: Implementer
+to: Verifier
+owner: Verifier
+status: verifying
+artifact:
+  - path: packages/web/src/booking/use-public-booking-flow.ts
+  - path: packages/web/src/booking/PublicBookingSlotPicker.tsx
+  - path: packages/web/src/booking/PublicBookingPicker.tsx
+  - path: packages/web/src/booking/PublicBookingPage.test.tsx
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3193
+evidence:
+  - command: bun test:web packages/web/src/booking/PublicBookingPage.test.tsx packages/web/src/booking/PublicBookingSlotPicker.test.tsx packages/web/src/booking/PublicBookingPicker.test.tsx
+    result: "41 pass, 0 fail"
+    log: null
+assumptions:
+  - "Timezone OverlayPanel already holds the app lock, so the details Escape shortcut stands down without ignoreAppLock."
+  - "Slot-list Escape is a local keydown on the slot button, not the page shortcut."
+open_risks: []
+next_deadline: 2026-09-04T00:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-04: Escape backs out one step on `/book/:slug`.

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,7 +13,7 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 3132 | high | Verifier | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3193 | bun test:web focused booking 41 pass | 2026-09-04T00:00:00Z | 0 | none |
+| 3132 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3193 | bun run verify PASS (web 1580, a11y 24, e2e 109); review: no confirmed findings | null | 0 | none |
 | 3158 | high | Implementer | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3168 | bun test:web 1569 pass; type-check pass; lint exit 0; knip pass | 2026-09-04T00:00:00Z | 0 | none |
 | 3129 | high | Verifier | verifying | packages/web/src/booking/BookingSettingsSection.tsx | bun test:web 30 pass; host-settings e2e 5 pass; test:a11y 24 pass; bun run verify PASS | 2026-09-03T20:00:00Z | 0 | none |
 | simplify-recent-3098 | medium | Manager | verifying | .agents/handoffs/simplify-recent-3098.md | bun run verify PASS (core, web, backend, type-check, lint, knip); focused web 161 pass; review: no confirmed findings | 2026-09-03T06:00:00Z | 1 | none |

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,6 +13,7 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 3132 | high | Verifier | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3193 | bun test:web focused booking 41 pass | 2026-09-04T00:00:00Z | 0 | none |
 | 3158 | high | Implementer | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3168 | bun test:web 1569 pass; type-check pass; lint exit 0; knip pass | 2026-09-04T00:00:00Z | 0 | none |
 | 3129 | high | Verifier | verifying | packages/web/src/booking/BookingSettingsSection.tsx | bun test:web 30 pass; host-settings e2e 5 pass; test:a11y 24 pass; bun run verify PASS | 2026-09-03T20:00:00Z | 0 | none |
 | simplify-recent-3098 | medium | Manager | verifying | .agents/handoffs/simplify-recent-3098.md | bun run verify PASS (core, web, backend, type-check, lint, knip); focused web 161 pass; review: no confirmed findings | 2026-09-03T06:00:00Z | 1 | none |

--- a/packages/web/src/booking/PublicBookingMonthGrid.tsx
+++ b/packages/web/src/booking/PublicBookingMonthGrid.tsx
@@ -241,6 +241,6 @@ function weekRowKey(
   return `${monthKey}-empty`;
 }
 
-function bookingDayButtonId(monthKey: string, dateKey: string): string {
+export function bookingDayButtonId(monthKey: string, dateKey: string): string {
   return `booking-day-${monthKey}-${dateKey}`;
 }

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -1,3 +1,4 @@
+import { HotkeysProvider } from "@tanstack/react-hotkeys";
 import {
   createMemoryHistory,
   createRouter,
@@ -29,7 +30,12 @@ function renderBookingRoute(path: string) {
     defaultPendingMs: 0,
   });
   const { wrapper } = createStoreWrapper();
-  const result = render(<RouterProvider router={router} />, { wrapper });
+  const result = render(
+    <HotkeysProvider>
+      <RouterProvider router={router} />
+    </HotkeysProvider>,
+    { wrapper },
+  );
   return { ...result, router };
 }
 
@@ -1281,6 +1287,107 @@ describe("PublicBookingPage", () => {
     releaseNextMonthSlots();
     expect(
       await screen.findByRole("heading", { name: "Pick a time" }),
+    ).toBeInTheDocument();
+  });
+
+  it("returns to the picker on Escape from Your details", async () => {
+    const user = userEvent.setup({ delay: null });
+    server.use(pageHandler(), slotsInWindow([currentSlot]));
+    renderBookingRoute("/book/tylerdane");
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: slotButtonName(currentSlot.slotStart),
+      }),
+    );
+    await screen.findByRole("heading", { name: "Your details" });
+    await user.type(screen.getByLabelText("Name"), "Guest User");
+    await user.keyboard("{Escape}");
+
+    const pickerHeading = await screen.findByRole("heading", {
+      name: "Pick a time",
+    });
+    await waitFor(() => {
+      expect(pickerHeading).toHaveFocus();
+    });
+    expect(
+      screen.queryByRole("heading", { name: "Your details" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("moves focus from a slot to the selected day on Escape", async () => {
+    const user = userEvent.setup({ delay: null });
+    server.use(pageHandler(), slotsInWindow([currentSlot]));
+    renderBookingRoute("/book/tylerdane");
+
+    await screen.findByRole("heading", { name: "Pick a time" });
+    const dateKey = formatBookingDateKey(currentSlot.slotStart, guestTimeZone);
+    const day = await screen.findByRole("button", {
+      name: formatBookingMonthDayLabel(dateKey, guestTimeZone),
+    });
+    const slot = await screen.findByRole("button", {
+      name: slotButtonName(currentSlot.slotStart),
+    });
+    slot.focus();
+    await user.keyboard("{Escape}");
+    expect(day).toHaveFocus();
+    expect(
+      screen.getByRole("heading", { name: "Pick a time" }),
+    ).toBeInTheDocument();
+  });
+
+  it("closes the timezone panel on Escape without leaving Your details", async () => {
+    const user = userEvent.setup({ delay: null });
+    server.use(pageHandler(), slotsInWindow([currentSlot]));
+    renderBookingRoute("/book/tylerdane");
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: slotButtonName(currentSlot.slotStart),
+      }),
+    );
+    await screen.findByRole("heading", { name: "Your details" });
+    await user.click(screen.getByRole("button", { name: /^Timezone:/ }));
+    expect(
+      await screen.findByRole("heading", { name: "Timezone" }),
+    ).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("heading", { name: "Timezone" }),
+      ).not.toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("heading", { name: "Your details" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Pick a time" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not navigate away when Escape is pressed on the month grid", async () => {
+    const user = userEvent.setup({ delay: null });
+    server.use(pageHandler(), slotsInWindow([currentSlot]));
+    const { router } = renderBookingRoute("/book/tylerdane");
+
+    await screen.findByRole("heading", { name: "Pick a time" });
+    const dateKey = formatBookingDateKey(currentSlot.slotStart, guestTimeZone);
+    const day = await screen.findByRole("button", {
+      name: formatBookingMonthDayLabel(dateKey, guestTimeZone),
+    });
+    day.focus();
+    const href = router.state.location.href;
+    await user.keyboard("{Escape}");
+
+    expect(day).toHaveFocus();
+    expect(router.state.location.href).toBe(href);
+    expect(
+      screen.getByRole("heading", { name: "Book with Tyler Dane" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Pick a time" }),
     ).toBeInTheDocument();
   });
 });

--- a/packages/web/src/booking/PublicBookingPicker.test.tsx
+++ b/packages/web/src/booking/PublicBookingPicker.test.tsx
@@ -78,4 +78,20 @@ describe("PublicBookingPicker", () => {
     await user.click(day);
     expect(day).toHaveFocus();
   });
+
+  it("returns focus to the selected day on Escape from a slot", async () => {
+    const user = userEvent.setup({ delay: null });
+    renderPicker();
+
+    const day = screen.getByRole("button", {
+      name: formatBookingMonthDayLabel(selectedDateKey, timeZone),
+    });
+    const firstSlotButton = screen.getByRole("button", {
+      name: formatBookingSlotTime(firstSlot, timeZone),
+    });
+
+    firstSlotButton.focus();
+    await user.keyboard("{Escape}");
+    expect(day).toHaveFocus();
+  });
 });

--- a/packages/web/src/booking/PublicBookingPicker.tsx
+++ b/packages/web/src/booking/PublicBookingPicker.tsx
@@ -1,5 +1,8 @@
 import { type Ref, useEffect, useRef, useState } from "react";
-import { PublicBookingMonthGrid } from "@web/booking/PublicBookingMonthGrid";
+import {
+  bookingDayButtonId,
+  PublicBookingMonthGrid,
+} from "@web/booking/PublicBookingMonthGrid";
 import { PublicBookingMonthGridSkeleton } from "@web/booking/PublicBookingMonthGridSkeleton";
 import { PublicBookingSlotPaneSkeleton } from "@web/booking/PublicBookingSlotPaneSkeleton";
 import { PublicBookingSlotPicker } from "@web/booking/PublicBookingSlotPicker";
@@ -173,6 +176,14 @@ export function PublicBookingPicker({
               selectedSlotStart={selectedSlotStart}
               headingRef={slotsHeadingRef}
               onSelectSlot={onSelectSlot}
+              onEscapeToSelectedDay={() => {
+                if (!selectedDateKey) {
+                  return;
+                }
+                document
+                  .getElementById(bookingDayButtonId(monthKey, selectedDateKey))
+                  ?.focus();
+              }}
               onJumpToNextAvailable={onJumpToNextAvailable}
             />
           )}

--- a/packages/web/src/booking/PublicBookingSlotPicker.test.tsx
+++ b/packages/web/src/booking/PublicBookingSlotPicker.test.tsx
@@ -137,4 +137,29 @@ describe("PublicBookingSlotPicker", () => {
     await user.keyboard("{End}");
     expect(last).toHaveFocus();
   });
+
+  it("calls onEscapeToSelectedDay from a focused slot", async () => {
+    const user = userEvent.setup({ delay: null });
+    const escaped: number[] = [];
+    render(
+      <PublicBookingSlotPicker
+        slots={slots}
+        selectedDateKey="2026-08-17"
+        guestTimeZone={timeZone}
+        selectedSlotStart={null}
+        onSelectSlot={() => {}}
+        onEscapeToSelectedDay={() => {
+          escaped.push(1);
+        }}
+      />,
+    );
+
+    screen
+      .getByRole("button", {
+        name: formatBookingSlotTime(dayA, timeZone),
+      })
+      .focus();
+    await user.keyboard("{Escape}");
+    expect(escaped).toHaveLength(1);
+  });
 });

--- a/packages/web/src/booking/PublicBookingSlotPicker.tsx
+++ b/packages/web/src/booking/PublicBookingSlotPicker.tsx
@@ -19,6 +19,7 @@ interface PublicBookingSlotPickerProps {
   selectedSlotStart: string | null;
   headingRef?: Ref<HTMLHeadingElement>;
   onSelectSlot: (slotStart: string) => void;
+  onEscapeToSelectedDay?: () => void;
   onJumpToNextAvailable?: () => void;
 }
 
@@ -62,6 +63,7 @@ export function PublicBookingSlotPicker({
   selectedSlotStart,
   headingRef,
   onSelectSlot,
+  onEscapeToSelectedDay,
   onJumpToNextAvailable,
 }: PublicBookingSlotPickerProps) {
   const daySlots = useMemo(
@@ -112,6 +114,11 @@ export function PublicBookingSlotPicker({
     event: KeyboardEvent<HTMLButtonElement>,
     index: number,
   ) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onEscapeToSelectedDay?.();
+      return;
+    }
     const nextIndex = stepSlotIndex(index, daySlots.length, event.key);
     if (nextIndex === null) {
       return;

--- a/packages/web/src/booking/use-public-booking-flow.ts
+++ b/packages/web/src/booking/use-public-booking-flow.ts
@@ -24,6 +24,8 @@ import {
 } from "@web/booking/public-booking.query";
 import { type PublicBookingSearch } from "@web/booking/public-booking-search";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
+import { isHigherEscapeOwner } from "@web/shortcuts/escape-ownership";
+import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 import { getBrowserTimeZone } from "@web/timezone/browser-timezone";
 
 const EMPTY_GUEST_DETAILS: PublicBookingGuestDetails = {
@@ -198,6 +200,24 @@ export function usePublicBookingFlow() {
     pendingPickerFocusRef.current = true;
     setChangingTime(true);
   };
+
+  // Escape on Your details is the keyboard equivalent of Change time.
+  // OverlayPanel (timezone) holds the app lock, so ignoreAppLock stays false.
+  // Slot-list Escape is owned by PublicBookingSlotPicker, not this shortcut.
+  useAppShortcut(
+    "Escape",
+    (event) => {
+      if (isHigherEscapeOwner()) {
+        return;
+      }
+      if (!showDetailsStep) {
+        return;
+      }
+      event.preventDefault();
+      handleChangeTime();
+    },
+    { ignoreInputs: false },
+  );
 
   const handlePrefetchMonth = (nextMonthKey: string) => {
     if (!pageQuery.data) {

--- a/packages/web/src/booking/use-public-booking-flow.ts
+++ b/packages/web/src/booking/use-public-booking-flow.ts
@@ -210,13 +210,10 @@ export function usePublicBookingFlow() {
       if (isHigherEscapeOwner()) {
         return;
       }
-      if (!showDetailsStep) {
-        return;
-      }
       event.preventDefault();
       handleChangeTime();
     },
-    { ignoreInputs: false },
+    { enabled: showDetailsStep, ignoreInputs: false },
   );
 
   const handlePrefetchMonth = (nextMonthKey: string) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3132

## Summary

On `/book/:slug`, Escape now backs out exactly one step:

- **Your details:** same destination as Change time (picker, focus on Pick a time).
- **Slot list:** focus moves to the selected month-grid day.
- **Timezone OverlayPanel:** still peels first; the booking step is unchanged.
- **Month grid:** Escape is a no-op and does not leave the page.

## Simplicity

Reuses `handleChangeTime`, existing focus refs, and `bookingDayButtonId`. The details shortcut is `enabled` only on that step. OverlayPanel already holds the app lock, so the shortcut stands down via `isHigherEscapeOwner` without `ignoreAppLock`.

## Automated validation

`bun run verify` PASS. Selected packages: web. Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e. Checks skipped: (none). test:web 1580 pass. test:a11y 24 passed. test:e2e 109 passed. Focused booking Escape RTL: 41 pass.

Issue noted the preview pane cannot deliver synthetic keys; acceptance is the jsdom RTL cases above.

## Independent review

`.agents/handoffs/3132.md`

VERDICT: no confirmed findings
FINDINGS:
(none)

## Test plan

- `bun test:web packages/web/src/booking/PublicBookingPage.test.tsx packages/web/src/booking/PublicBookingSlotPicker.test.tsx packages/web/src/booking/PublicBookingPicker.test.tsx` (41 pass)
- `bun run verify` (PASS: test:web, type-check, lint, knip, test:a11y, test:e2e)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec67721b-395d-454e-bd11-696669d367b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec67721b-395d-454e-bd11-696669d367b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

