### PR TITLE
feat(web): Settings > Billing management view (WP-06)

### DIFF
--- a/.agents/handoffs/3160.md
+++ b/.agents/handoffs/3160.md
@@ -3,19 +3,24 @@ schema_version: 1
 task_id: "3160"
 from: Implementer
 to: Verifier
-owner: Implementer
-status: running
+owner: Verifier
+status: verifying
 artifact:
   - path: packages/web/src/billing/PlanSection.tsx
   - path: packages/web/src/billing/CancelSubscriptionDialog.tsx
   - path: packages/web/src/api/billing.api.ts
   - path: packages/web/src/billing/billing.query.ts
+  - path: packages/web/src/billing/PlanSection.test.tsx
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3194
 evidence:
-  - command: bun test packages/web/src/billing/PlanSection.test.tsx
-    result: pending
+  - command: bun test --preload packages/web/src/__tests__/web.preload.ts packages/web/src/billing/PlanSection.test.tsx
+    result: "7 pass, 0 fail"
+  - command: bun run verify
+    result: "selected checks passed; test:web 1600+1592 pass, 0 fail; type-check pass; lint pass; knip pass; e2e/a11y skipped locally (Playwright missing)"
 assumptions:
   - "PlanSection is only mounted on the Settings Billing page, so subscription query enabled is page === billing && access.kind === server"
   - "Card update stays in WP-07; this WP has no Update card button"
+  - "Anonymous IndexedDB mode cannot open Settings > Billing because hasBilling is false; management UI is covered by PlanSection and SettingsModal tests"
 open_risks: []
 next_deadline: 2026-09-04T00:00:00Z
 retry: 0
@@ -26,4 +31,4 @@ escalation: null
 
 WP-06: Settings > Billing management view. Plan, price, renewal or end
 date, card on file, cancel or resume at period end, and receipts. Replaces
-the Manage billing portal button removed in WP-05.
+the Manage billing portal button removed in WP-05. PR #3194.

--- a/.agents/handoffs/3160.md
+++ b/.agents/handoffs/3160.md
@@ -1,0 +1,29 @@
+---
+schema_version: 1
+task_id: "3160"
+from: Implementer
+to: Verifier
+owner: Implementer
+status: running
+artifact:
+  - path: packages/web/src/billing/PlanSection.tsx
+  - path: packages/web/src/billing/CancelSubscriptionDialog.tsx
+  - path: packages/web/src/api/billing.api.ts
+  - path: packages/web/src/billing/billing.query.ts
+evidence:
+  - command: bun test packages/web/src/billing/PlanSection.test.tsx
+    result: pending
+assumptions:
+  - "PlanSection is only mounted on the Settings Billing page, so subscription query enabled is page === billing && access.kind === server"
+  - "Card update stays in WP-07; this WP has no Update card button"
+open_risks: []
+next_deadline: 2026-09-04T00:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-06: Settings > Billing management view. Plan, price, renewal or end
+date, card on file, cancel or resume at period end, and receipts. Replaces
+the Manage billing portal button removed in WP-05.

--- a/packages/web/src/__tests__/__mocks__/server/mock.handlers.ts
+++ b/packages/web/src/__tests__/__mocks__/server/mock.handlers.ts
@@ -78,6 +78,34 @@ export const globalHandlers = [
       }),
     );
   }),
+  rest.get(`${ENV_WEB.API_BASEURL}/billing/subscription`, (_req, res, ctx) => {
+    return res(
+      ctx.status(Status.OK),
+      ctx.json({
+        subscriptionStatus: "active",
+        currentPeriodEnd: "2099-06-15T12:00:00.000Z",
+        cancelAtPeriodEnd: false,
+        trialEndsAt: null,
+        price: { amount: 1200, currency: "usd", interval: "month" },
+        paymentMethod: {
+          brand: "visa",
+          last4: "4242",
+          expMonth: 12,
+          expYear: 2099,
+        },
+        invoices: [
+          {
+            id: "in_test_1",
+            createdAt: "2099-05-15T12:00:00.000Z",
+            amountPaid: 1200,
+            currency: "usd",
+            status: "paid",
+            hostedInvoiceUrl: "https://invoice.stripe.com/test",
+          },
+        ],
+      }),
+    );
+  }),
   rest.get(`${ENV_WEB.API_BASEURL}/booking/page`, (_req, res, ctx) => {
     return res(
       ctx.status(Status.OK),

--- a/packages/web/src/api/billing.api.ts
+++ b/packages/web/src/api/billing.api.ts
@@ -3,6 +3,8 @@ import {
   BillingCheckoutResponseSchema,
   type BillingStatusResponse,
   BillingStatusResponseSchema,
+  type BillingSubscriptionResponse,
+  BillingSubscriptionResponseSchema,
 } from "@core/types/billing.types";
 import { BaseApi } from "@web/api/base/base.api";
 
@@ -11,6 +13,13 @@ const BillingApi = {
     const response =
       await BaseApi.get<BillingStatusResponse>(`/billing/status`);
     return BillingStatusResponseSchema.parse(response.data);
+  },
+
+  async getSubscription(): Promise<BillingSubscriptionResponse> {
+    const response = await BaseApi.get<BillingSubscriptionResponse>(
+      `/billing/subscription`,
+    );
+    return BillingSubscriptionResponseSchema.parse(response.data);
   },
 
   async createCheckoutSession(): Promise<BillingCheckoutResponse> {
@@ -24,6 +33,20 @@ const BillingApi = {
   async endTrial(): Promise<BillingStatusResponse> {
     const response =
       await BaseApi.post<BillingStatusResponse>(`/billing/trial/end`);
+    return BillingStatusResponseSchema.parse(response.data);
+  },
+
+  async cancelSubscription(): Promise<BillingStatusResponse> {
+    const response = await BaseApi.post<BillingStatusResponse>(
+      `/billing/subscription/cancel`,
+    );
+    return BillingStatusResponseSchema.parse(response.data);
+  },
+
+  async resumeSubscription(): Promise<BillingStatusResponse> {
+    const response = await BaseApi.post<BillingStatusResponse>(
+      `/billing/subscription/resume`,
+    );
     return BillingStatusResponseSchema.parse(response.data);
   },
 };

--- a/packages/web/src/auth/posthog/track.ts
+++ b/packages/web/src/auth/posthog/track.ts
@@ -31,6 +31,8 @@ export type ProductEvent =
   | "trial_celebration_shown"
   | "billing_gate_shown"
   | "billing_gate_cta_clicked"
+  | "billing_cancel_scheduled"
+  | "billing_resumed"
   | "shortcut_upgrade_prompted"
   | "notifications_enabled"
   | "notifications_disabled"

--- a/packages/web/src/billing/CancelSubscriptionDialog.tsx
+++ b/packages/web/src/billing/CancelSubscriptionDialog.tsx
@@ -1,0 +1,66 @@
+import {
+  OverlayPanel,
+  OverlayPanelActionButton,
+  OverlayPanelActions,
+} from "@web/components/OverlayPanel/OverlayPanel";
+
+interface CancelSubscriptionDialogProps {
+  isOpen: boolean;
+  isSubmitting: boolean;
+  isTrialing: boolean;
+  periodEndLabel: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+/**
+ * Confirms scheduling cancel-at-period-end. Access continues until the
+ * named date; resume is available until then.
+ */
+export function CancelSubscriptionDialog({
+  isOpen,
+  isSubmitting,
+  isTrialing,
+  periodEndLabel,
+  onCancel,
+  onConfirm,
+}: CancelSubscriptionDialogProps) {
+  if (!isOpen) return null;
+
+  const message = isTrialing
+    ? `You keep access until the trial ends on ${periodEndLabel}. You can resume any time before then.`
+    : `Your plan stays active until ${periodEndLabel}. You can resume any time before then.`;
+
+  const dismiss = () => {
+    if (isSubmitting) return;
+    onCancel();
+  };
+
+  return (
+    <OverlayPanel
+      title="Cancel your plan?"
+      message={message}
+      onDismiss={dismiss}
+      align="start"
+      variant="modal"
+    >
+      <OverlayPanelActions align="start">
+        <OverlayPanelActionButton
+          variant="destructive"
+          shortcut="Enter"
+          disabled={isSubmitting}
+          onClick={onConfirm}
+        >
+          {isSubmitting ? "Canceling…" : "Cancel subscription"}
+        </OverlayPanelActionButton>
+        <OverlayPanelActionButton
+          shortcut="Esc"
+          disabled={isSubmitting}
+          onClick={dismiss}
+        >
+          Keep plan
+        </OverlayPanelActionButton>
+      </OverlayPanelActions>
+    </OverlayPanel>
+  );
+}

--- a/packages/web/src/billing/PlanSection.test.tsx
+++ b/packages/web/src/billing/PlanSection.test.tsx
@@ -95,7 +95,7 @@ function PlanHarness() {
   return <PlanSection showShortcuts />;
 }
 
-const renderPlan = () => {
+const renderPlan = async () => {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
@@ -106,6 +106,9 @@ const renderPlan = () => {
       </HotkeysProvider>
     </QueryClientProvider>,
   );
+  await waitFor(() => {
+    expect(screen.queryByText("Loading your plan")).not.toBeInTheDocument();
+  });
   return { ...view, queryClient };
 };
 
@@ -140,7 +143,7 @@ describe("PlanSection", () => {
   });
 
   it("renders price, renewal, card, and receipts from the summary", async () => {
-    renderPlan();
+    await renderPlan();
 
     expect(screen.getByText("Premium")).toBeInTheDocument();
     await waitFor(() => {
@@ -169,7 +172,7 @@ describe("PlanSection", () => {
       cancelAtPeriodEnd: true,
     });
     const track = spyOn(Track, "track");
-    const { queryClient } = renderPlan();
+    const { queryClient } = await renderPlan();
     const invalidate = spyOn(
       queryClient,
       "invalidateQueries",
@@ -232,7 +235,7 @@ describe("PlanSection", () => {
     });
     const track = spyOn(Track, "track");
 
-    renderPlan();
+    await renderPlan();
 
     await waitFor(() => {
       expect(
@@ -261,7 +264,7 @@ describe("PlanSection", () => {
 
   it("keeps the badge and shows the fallback toast when the summary fails", async () => {
     getSubscription.mockRejectedValue(new Error("network"));
-    renderPlan();
+    await renderPlan();
 
     expect(screen.getByText("Premium")).toBeInTheDocument();
     await waitFor(() => {
@@ -275,7 +278,7 @@ describe("PlanSection", () => {
 
   it("says no card on file when Stripe has no payment method", async () => {
     getSubscription.mockResolvedValue(activeSummary({ paymentMethod: null }));
-    renderPlan();
+    await renderPlan();
 
     await waitFor(() => {
       expect(screen.getByText("No card on file")).toBeInTheDocument();
@@ -284,7 +287,7 @@ describe("PlanSection", () => {
 
   it("hides the receipts heading when the list is empty", async () => {
     getSubscription.mockResolvedValue(activeSummary({ invoices: [] }));
-    renderPlan();
+    await renderPlan();
 
     await waitFor(() => {
       expect(screen.getByText("$12.00 per month")).toBeInTheDocument();
@@ -307,7 +310,7 @@ describe("PlanSection", () => {
       }),
     );
     const user = userEvent.setup({ delay: null });
-    renderPlan();
+    await renderPlan();
 
     await waitFor(() => {
       expect(

--- a/packages/web/src/billing/PlanSection.test.tsx
+++ b/packages/web/src/billing/PlanSection.test.tsx
@@ -1,0 +1,325 @@
+import "@testing-library/jest-dom";
+import { HotkeysProvider } from "@tanstack/react-hotkeys";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { type BillingSubscriptionResponse } from "@core/types/billing.types";
+import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
+import { BillingApi } from "@web/api/billing.api";
+import * as Track from "@web/auth/posthog/track";
+import { type AppAccess } from "@web/billing/useAppAccess";
+import {
+  BILLING_PLAN_ENDS_TOAST_ID,
+  BILLING_PLAN_RENEWS_TOAST_ID,
+} from "@web/common/constants/toast.constants";
+import {
+  registerToastPort,
+  resetToastPort,
+} from "@web/common/utils/toast/toast.port";
+import {
+  initialSettingsState,
+  settingsActions,
+  useSettingsStore,
+} from "@web/settings/settings.store";
+import { useSettingsShortcuts } from "@web/settings/useSettingsShortcuts";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
+
+const actualUseAppAccess = (await import("@web/billing/useAppAccess"))
+  .useAppAccess;
+let isAppAccessMocked = true;
+let access: AppAccess = { kind: "open" };
+
+mock.module("@web/billing/useAppAccess", () => ({
+  useAppAccess: (...args: Parameters<typeof actualUseAppAccess>) =>
+    isAppAccessMocked ? access : actualUseAppAccess(...args),
+}));
+
+const { PlanSection } = await import("./PlanSection");
+const { billingQueryKeys } = await import("./billing.query");
+const { formatBillingDate } = await import("./billing-display");
+
+const PERIOD_END = "2099-06-15T12:00:00.000Z";
+const PERIOD_END_LABEL = formatBillingDate(PERIOD_END);
+
+const activeSummary = (
+  overrides: Partial<BillingSubscriptionResponse> = {},
+): BillingSubscriptionResponse => ({
+  subscriptionStatus: "active",
+  currentPeriodEnd: PERIOD_END,
+  cancelAtPeriodEnd: false,
+  trialEndsAt: null,
+  price: { amount: 1200, currency: "usd", interval: "month" },
+  paymentMethod: {
+    brand: "visa",
+    last4: "4242",
+    expMonth: 12,
+    expYear: 2099,
+  },
+  invoices: [
+    {
+      id: "in_paid",
+      createdAt: "2099-05-15T12:00:00.000Z",
+      amountPaid: 1200,
+      currency: "usd",
+      status: "paid",
+      hostedInvoiceUrl: "https://invoice.stripe.com/paid",
+    },
+    {
+      id: "in_trial",
+      createdAt: "2099-04-15T12:00:00.000Z",
+      amountPaid: 0,
+      currency: "usd",
+      status: "paid",
+      hostedInvoiceUrl: "https://invoice.stripe.com/trial",
+    },
+  ],
+  ...overrides,
+});
+
+function PlanHarness() {
+  useSettingsShortcuts({
+    enabled: true,
+    hasBilling: true,
+    hasBooking: false,
+    page: "billing",
+  });
+  return <PlanSection showShortcuts />;
+}
+
+const renderPlan = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const view = render(
+    <QueryClientProvider client={queryClient}>
+      <HotkeysProvider>
+        <PlanHarness />
+      </HotkeysProvider>
+    </QueryClientProvider>,
+  );
+  return { ...view, queryClient };
+};
+
+describe("PlanSection", () => {
+  let toastMocks: ReturnType<typeof createTestToastPort>["mocks"];
+  let getSubscription: ReturnType<typeof spyOn>;
+
+  afterAll(() => {
+    isAppAccessMocked = false;
+  });
+
+  beforeEach(() => {
+    access = {
+      kind: "server",
+      status: "active",
+      isReadOnly: false,
+      trialEndsAt: null,
+    };
+    settingsActions.openSettings("billing");
+    const { port, mocks } = createTestToastPort();
+    toastMocks = mocks;
+    registerToastPort(port);
+    getSubscription = spyOn(BillingApi, "getSubscription").mockResolvedValue(
+      activeSummary(),
+    );
+  });
+
+  afterEach(() => {
+    resetToastPort();
+    getSubscription.mockRestore();
+    useSettingsStore.setState(initialSettingsState, true);
+  });
+
+  it("renders price, renewal, card, and receipts from the summary", async () => {
+    renderPlan();
+
+    expect(screen.getByText("Premium")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("$12.00 per month")).toBeInTheDocument();
+    });
+    expect(screen.getByText(`Renews ${PERIOD_END_LABEL}`)).toBeInTheDocument();
+    expect(
+      screen.getByText("Visa ending in 4242, expires 12/99"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Receipts")).toBeInTheDocument();
+    expect(screen.getByText("$0.00")).toBeInTheDocument();
+    expect(screen.getAllByText("Paid")).toHaveLength(2);
+
+    const receipt = screen.getAllByRole("link", { name: "Receipt" })[0];
+    expect(receipt).toHaveAttribute("href", "https://invoice.stripe.com/paid");
+    expect(receipt).toHaveAttribute("target", "_blank");
+    expect(receipt).toHaveAttribute("rel", "noreferrer");
+  });
+
+  it("opens confirm with C and cancels at period end", async () => {
+    const user = userEvent.setup({ delay: null });
+    const cancel = spyOn(BillingApi, "cancelSubscription").mockResolvedValue({
+      subscriptionStatus: "active",
+      trialEndsAt: null,
+      isReadOnly: false,
+      cancelAtPeriodEnd: true,
+    });
+    const track = spyOn(Track, "track");
+    const { queryClient } = renderPlan();
+    const invalidate = spyOn(
+      queryClient,
+      "invalidateQueries",
+    ).mockResolvedValue(undefined);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Cancel subscription" }),
+      ).toBeInTheDocument();
+    });
+
+    await user.keyboard("c");
+
+    const dialog = screen.getByRole("dialog", { name: "Cancel your plan?" });
+    expect(dialog).toHaveTextContent(
+      `Your plan stays active until ${PERIOD_END_LABEL}. You can resume any time before then.`,
+    );
+
+    await user.click(
+      within(dialog).getByRole("button", { name: "Cancel subscription" }),
+    );
+
+    await waitFor(() => {
+      expect(cancel).toHaveBeenCalledTimes(1);
+    });
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: billingQueryKeys.status,
+    });
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: billingQueryKeys.subscription,
+    });
+    expect(track).toHaveBeenCalledWith("billing_cancel_scheduled");
+    expect(toastMocks.toast).toHaveBeenCalledWith(
+      `Your plan ends on ${PERIOD_END_LABEL}`,
+      expect.objectContaining({ toastId: BILLING_PLAN_ENDS_TOAST_ID }),
+    );
+
+    cancel.mockRestore();
+    track.mockRestore();
+    invalidate.mockRestore();
+  });
+
+  it("resumes when cancel-at-period-end is already scheduled", async () => {
+    getSubscription.mockResolvedValue(
+      activeSummary({ cancelAtPeriodEnd: true }),
+    );
+    access = {
+      kind: "server",
+      status: "active",
+      isReadOnly: false,
+      trialEndsAt: null,
+      cancelAtPeriodEnd: true,
+    };
+    const user = userEvent.setup({ delay: null });
+    const resume = spyOn(BillingApi, "resumeSubscription").mockResolvedValue({
+      subscriptionStatus: "active",
+      trialEndsAt: null,
+      isReadOnly: false,
+      cancelAtPeriodEnd: false,
+    });
+    const track = spyOn(Track, "track");
+
+    renderPlan();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Resume subscription" }),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("button", { name: "Cancel subscription" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(`Ends ${PERIOD_END_LABEL}`)).toBeInTheDocument();
+
+    await user.keyboard("r");
+
+    await waitFor(() => {
+      expect(resume).toHaveBeenCalledTimes(1);
+    });
+    expect(track).toHaveBeenCalledWith("billing_resumed");
+    expect(toastMocks.toast).toHaveBeenCalledWith(
+      "Your plan will renew",
+      expect.objectContaining({ toastId: BILLING_PLAN_RENEWS_TOAST_ID }),
+    );
+
+    resume.mockRestore();
+    track.mockRestore();
+  });
+
+  it("keeps the badge and shows the fallback toast when the summary fails", async () => {
+    getSubscription.mockRejectedValue(new Error("network"));
+    renderPlan();
+
+    expect(screen.getByText("Premium")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(toastMocks.error).toHaveBeenCalledWith(
+        "Couldn't load billing details.",
+        expect.anything(),
+      );
+    });
+    expect(screen.getByText("Premium")).toBeInTheDocument();
+  });
+
+  it("says no card on file when Stripe has no payment method", async () => {
+    getSubscription.mockResolvedValue(activeSummary({ paymentMethod: null }));
+    renderPlan();
+
+    await waitFor(() => {
+      expect(screen.getByText("No card on file")).toBeInTheDocument();
+    });
+  });
+
+  it("hides the receipts heading when the list is empty", async () => {
+    getSubscription.mockResolvedValue(activeSummary({ invoices: [] }));
+    renderPlan();
+
+    await waitFor(() => {
+      expect(screen.getByText("$12.00 per month")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Receipts")).not.toBeInTheDocument();
+  });
+
+  it("tells a trialing subscriber they keep access until the trial ends", async () => {
+    const trialEndsAt = PERIOD_END;
+    access = {
+      kind: "server",
+      status: "trialing",
+      isReadOnly: false,
+      trialEndsAt,
+    };
+    getSubscription.mockResolvedValue(
+      activeSummary({
+        subscriptionStatus: "trialing",
+        trialEndsAt,
+      }),
+    );
+    const user = userEvent.setup({ delay: null });
+    renderPlan();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Cancel subscription" }),
+      ).toBeInTheDocument();
+    });
+    await user.keyboard("c");
+
+    expect(
+      screen.getByRole("dialog", { name: "Cancel your plan?" }),
+    ).toHaveTextContent(
+      `You keep access until the trial ends on ${PERIOD_END_LABEL}. You can resume any time before then.`,
+    );
+  });
+});

--- a/packages/web/src/billing/PlanSection.tsx
+++ b/packages/web/src/billing/PlanSection.tsx
@@ -148,7 +148,7 @@ export const PlanSection: FC<PlanSectionProps> = ({
               {badge.label}
             </span>
             {summary?.price ? (
-              <p className="mt-1 text-text text-sm">
+              <p className="mt-1 text-sm text-text">
                 {formatBillingMoney(
                   summary.price.amount,
                   summary.price.currency,

--- a/packages/web/src/billing/PlanSection.tsx
+++ b/packages/web/src/billing/PlanSection.tsx
@@ -1,24 +1,72 @@
-import { type FC } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { type FC, useEffect, useState } from "react";
 import dayjs from "@core/util/date/dayjs";
+import { BillingApi } from "@web/api/billing.api";
+import { track } from "@web/auth/posthog/track";
+import {
+  billingQueryKeys,
+  useBillingSubscriptionQuery,
+} from "@web/billing/billing.query";
+import {
+  formatBillingDate,
+  formatBillingMoney,
+  formatCardOnFile,
+  formatInvoiceStatus,
+} from "@web/billing/billing-display";
+import { showBillingRequestError } from "@web/billing/billing-request-error";
+import { CancelSubscriptionDialog } from "@web/billing/CancelSubscriptionDialog";
 import {
   getPlanBadge,
   PLAN_BADGE_TONE_CLASSNAME,
 } from "@web/billing/planBadge";
 import { useAppAccess } from "@web/billing/useAppAccess";
+import {
+  BILLING_PLAN_ENDS_TOAST_ID,
+  BILLING_PLAN_RENEWS_TOAST_ID,
+} from "@web/common/constants/toast.constants";
+import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
+import {
+  OverlayPanelActionButton,
+  OverlayPanelActions,
+} from "@web/components/OverlayPanel/OverlayPanel";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
+import {
+  selectSettingsPage,
+  useSettingsStore,
+} from "@web/settings/settings.store";
+import { settingsShortcutAttrs } from "@web/settings/useSettingsShortcuts";
+
+const MANAGEABLE_STATUSES = new Set(["trialing", "active", "past_due"]);
+
+interface PlanSectionProps {
+  showShortcuts?: boolean;
+}
 
 /**
- * The account view's answer to "what am I paying for?". Until this existed,
- * every billing surface in the app was a gate or a warning, so a happy
- * subscriber had no way to confirm their own standing.
- *
- * Renders nothing when there is no plan to report (self-hosted, enforcement
- * paused, anonymous), rather than inventing billing chrome for installs that
- * have no billing. WP-06 rebuilds the management actions.
+ * Settings > Billing: plan, card on file, cancel or resume at period end,
+ * and receipts. Renders nothing when there is no plan to report (self-hosted,
+ * enforcement paused, anonymous).
  */
-export const PlanSection: FC = () => {
+export const PlanSection: FC<PlanSectionProps> = ({
+  showShortcuts = false,
+}) => {
   const access = useAppAccess();
+  const page = useSettingsStore(selectSettingsPage);
+  const queryClient = useQueryClient();
   const badge = getPlanBadge(access);
+  const subscriptionQuery = useBillingSubscriptionQuery(
+    page === "billing" && access.kind === "server",
+  );
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!subscriptionQuery.isError) return;
+    showBillingRequestError(
+      subscriptionQuery.error,
+      "Couldn't load billing details.",
+    );
+  }, [subscriptionQuery.error, subscriptionQuery.isError]);
 
   if (!badge) return null;
 
@@ -28,26 +76,184 @@ export const PlanSection: FC = () => {
       : null;
   const cancelScheduled =
     access.kind === "server" && access.cancelAtPeriodEnd === true;
+  const summary = subscriptionQuery.data;
+  const periodEnd = summary?.currentPeriodEnd ?? trialEndsAt;
+  const periodEndLabel = periodEnd ? formatBillingDate(periodEnd) : null;
+  const canManageCancellation =
+    summary != null && MANAGEABLE_STATUSES.has(summary.subscriptionStatus);
+  const receipts = summary?.invoices.slice(0, 12) ?? [];
+
+  const closeConfirm = () => {
+    if (isSubmitting) return;
+    setConfirmOpen(false);
+  };
+
+  const handleCancelConfirm = () => {
+    if (isSubmitting || !periodEndLabel) return;
+    setIsSubmitting(true);
+    void (async () => {
+      try {
+        await BillingApi.cancelSubscription();
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: billingQueryKeys.status }),
+          queryClient.invalidateQueries({
+            queryKey: billingQueryKeys.subscription,
+          }),
+        ]);
+        track("billing_cancel_scheduled");
+        showStatusToast(
+          BILLING_PLAN_ENDS_TOAST_ID,
+          `Your plan ends on ${periodEndLabel}`,
+        );
+        setConfirmOpen(false);
+      } catch (error) {
+        showBillingRequestError(error, "Couldn't cancel your plan.");
+      } finally {
+        setIsSubmitting(false);
+      }
+    })();
+  };
+
+  const handleResume = () => {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
+    void (async () => {
+      try {
+        await BillingApi.resumeSubscription();
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: billingQueryKeys.status }),
+          queryClient.invalidateQueries({
+            queryKey: billingQueryKeys.subscription,
+          }),
+        ]);
+        track("billing_resumed");
+        showStatusToast(BILLING_PLAN_RENEWS_TOAST_ID, "Your plan will renew");
+      } catch (error) {
+        showBillingRequestError(error, "Couldn't resume your plan.");
+      } finally {
+        setIsSubmitting(false);
+      }
+    })();
+  };
 
   return (
-    <div>
-      <p className="mb-1 block text-sm text-text">Plan</p>
-      <div className="flex items-center justify-between gap-2">
-        <div className="min-w-0">
-          <span
-            className={`shrink-0 rounded border border-border px-1.5 text-xs ${PLAN_BADGE_TONE_CLASSNAME[badge.tone]}`}
-          >
-            {badge.label}
-          </span>
-          {trialEndsAt ? (
-            <p className="mt-1 text-text-muted text-xs">
-              Your trial ends {dayjs(trialEndsAt).format("MMM D, YYYY")}
-              {cancelScheduled ? " and will not renew" : ""}. Press{" "}
-              <ShortcutKeys keys="B" /> to subscribe now.
-            </p>
-          ) : null}
+    <div className="flex flex-col gap-4">
+      <div>
+        <p className="mb-1 block text-sm text-text">Plan</p>
+        <div className="flex items-center justify-between gap-2">
+          <div className="min-w-0">
+            <span
+              className={`shrink-0 rounded border border-border px-1.5 text-xs ${PLAN_BADGE_TONE_CLASSNAME[badge.tone]}`}
+            >
+              {badge.label}
+            </span>
+            {summary?.price ? (
+              <p className="mt-1 text-text text-sm">
+                {formatBillingMoney(
+                  summary.price.amount,
+                  summary.price.currency,
+                )}{" "}
+                per {summary.price.interval}
+              </p>
+            ) : null}
+            {summary?.currentPeriodEnd ? (
+              <p className="mt-1 text-text-muted text-xs">
+                {summary.cancelAtPeriodEnd ? "Ends" : "Renews"}{" "}
+                {formatBillingDate(summary.currentPeriodEnd)}
+              </p>
+            ) : null}
+            {trialEndsAt ? (
+              <p className="mt-1 text-text-muted text-xs">
+                Your trial ends {dayjs(trialEndsAt).format("MMM D, YYYY")}
+                {cancelScheduled ? " and will not renew" : ""}. Press{" "}
+                <ShortcutKeys keys="B" /> to subscribe now.
+              </p>
+            ) : null}
+            {subscriptionQuery.isPending ? (
+              <p className="mt-1 text-text-muted text-xs">Loading your plan</p>
+            ) : null}
+          </div>
         </div>
       </div>
+
+      {summary ? (
+        <>
+          <p className="text-sm text-text">
+            {summary.paymentMethod
+              ? formatCardOnFile(summary.paymentMethod)
+              : "No card on file"}
+          </p>
+
+          {canManageCancellation ? (
+            <OverlayPanelActions align="start">
+              {summary.cancelAtPeriodEnd ? (
+                <OverlayPanelActionButton
+                  disabled={isSubmitting}
+                  onClick={handleResume}
+                  shortcut="R"
+                  showShortcut={showShortcuts}
+                  variant="secondary"
+                  {...settingsShortcutAttrs("resume-subscription")}
+                >
+                  Resume subscription
+                </OverlayPanelActionButton>
+              ) : (
+                <OverlayPanelActionButton
+                  disabled={isSubmitting || confirmOpen}
+                  onClick={() => setConfirmOpen(true)}
+                  shortcut="C"
+                  showShortcut={showShortcuts}
+                  variant="secondary"
+                  {...settingsShortcutAttrs("cancel-subscription")}
+                >
+                  Cancel subscription
+                </OverlayPanelActionButton>
+              )}
+            </OverlayPanelActions>
+          ) : null}
+
+          {receipts.length > 0 ? (
+            <div>
+              <p className="mb-1 block text-sm text-text">Receipts</p>
+              <ul className="flex flex-col gap-1">
+                {receipts.map((invoice) => (
+                  <li
+                    className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1 text-sm text-text"
+                    key={invoice.id}
+                  >
+                    <span>{formatBillingDate(invoice.createdAt)}</span>
+                    <span>
+                      {formatBillingMoney(invoice.amountPaid, invoice.currency)}
+                    </span>
+                    <span>{formatInvoiceStatus(invoice.status)}</span>
+                    {invoice.hostedInvoiceUrl ? (
+                      <a
+                        className="text-text underline-offset-4 hover:underline"
+                        href={invoice.hostedInvoiceUrl}
+                        rel="noreferrer"
+                        target="_blank"
+                      >
+                        Receipt
+                      </a>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </>
+      ) : null}
+
+      {periodEndLabel ? (
+        <CancelSubscriptionDialog
+          isOpen={confirmOpen}
+          isSubmitting={isSubmitting}
+          isTrialing={access.kind === "server" && access.status === "trialing"}
+          periodEndLabel={periodEndLabel}
+          onCancel={closeConfirm}
+          onConfirm={handleCancelConfirm}
+        />
+      ) : null}
     </div>
   );
 };

--- a/packages/web/src/billing/billing-display.ts
+++ b/packages/web/src/billing/billing-display.ts
@@ -1,0 +1,42 @@
+import dayjs from "@core/util/date/dayjs";
+
+const INVOICE_STATUS_LABEL: Record<string, string> = {
+  paid: "Paid",
+  open: "Open",
+  void: "Void",
+  uncollectible: "Uncollectible",
+};
+
+/** Stripe amounts are minor units. */
+export function formatBillingMoney(
+  amountMinor: number,
+  currency: string,
+): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: currency.toUpperCase(),
+  }).format(amountMinor / 100);
+}
+
+export function formatBillingDate(iso: string): string {
+  return dayjs(iso).format("MMM D, YYYY");
+}
+
+export function formatCardOnFile(card: {
+  brand: string;
+  last4: string;
+  expMonth: number;
+  expYear: number;
+}): string {
+  const brand = card.brand.charAt(0).toUpperCase() + card.brand.slice(1);
+  const month = String(card.expMonth).padStart(2, "0");
+  const year = String(card.expYear).slice(-2);
+  return `${brand} ending in ${card.last4}, expires ${month}/${year}`;
+}
+
+export function formatInvoiceStatus(status: string): string {
+  const mapped = INVOICE_STATUS_LABEL[status];
+  if (mapped) return mapped;
+  if (!status) return status;
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}

--- a/packages/web/src/billing/billing.query.ts
+++ b/packages/web/src/billing/billing.query.ts
@@ -3,12 +3,16 @@ import {
   queryOptions,
   useQuery,
 } from "@tanstack/react-query";
-import { type BillingStatusResponse } from "@core/types/billing.types";
+import {
+  type BillingStatusResponse,
+  type BillingSubscriptionResponse,
+} from "@core/types/billing.types";
 import { AppConfigApi } from "@web/api/app-config.api";
 import { BillingApi } from "@web/api/billing.api";
 
 export const billingQueryKeys = {
   status: ["billing", "status"] as const,
+  subscription: ["billing", "subscription"] as const,
   config: ["app-config"] as const,
 };
 
@@ -34,6 +38,23 @@ export function useBillingStatusQuery(enabled: boolean) {
     enabled,
     // Embedded Checkout completes in-page; still refetch on focus so a
     // webhook that lands while the tab is backgrounded shows up immediately.
+    refetchOnWindowFocus: "always",
+  });
+}
+
+export function billingSubscriptionQueryOptions() {
+  return queryOptions({
+    queryKey: billingQueryKeys.subscription,
+    queryFn: (): Promise<BillingSubscriptionResponse> =>
+      BillingApi.getSubscription(),
+    staleTime: 30_000,
+  });
+}
+
+export function useBillingSubscriptionQuery(enabled: boolean) {
+  return useQuery({
+    ...billingSubscriptionQueryOptions(),
+    enabled,
     refetchOnWindowFocus: "always",
   });
 }

--- a/packages/web/src/common/constants/toast.constants.ts
+++ b/packages/web/src/common/constants/toast.constants.ts
@@ -19,6 +19,8 @@ export const LOGGED_OUT_TOAST_ID: Id = "logged-out";
 export const EVENT_SAVE_UNAVAILABLE_TOAST_ID: Id = "event-save-unavailable";
 export const NOTIFICATIONS_STATUS_TOAST_ID: Id = "notifications-status";
 export const BILLING_SUBSCRIBED_TOAST_ID: Id = "billing-subscribed";
+export const BILLING_PLAN_ENDS_TOAST_ID: Id = "billing-plan-ends";
+export const BILLING_PLAN_RENEWS_TOAST_ID: Id = "billing-plan-renews";
 
 /**
  * Toast chrome follows `[data-theme]` instead of a JS hex snapshot, so body

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -760,6 +760,30 @@ describe("SettingsModal", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("renders plan, card, and receipts when opening Billing", async () => {
+    access = {
+      kind: "server",
+      status: "active",
+      isReadOnly: false,
+      trialEndsAt: null,
+    };
+    renderSettings({ authenticated: true, page: "billing" });
+
+    expect(screen.getByText("Premium")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("$12.00 per month")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText("Visa ending in 4242, expires 12/99"),
+    ).toBeInTheDocument();
+    const receipt = screen.getByRole("link", { name: "Receipt" });
+    expect(receipt).toHaveAttribute("target", "_blank");
+    expect(receipt).toHaveAttribute("rel", "noreferrer");
+    expect(
+      screen.getByRole("button", { name: "Cancel subscription" }),
+    ).toBeInTheDocument();
+  });
+
   it("counts down the trial and points at the early-upgrade shortcut", () => {
     access = {
       kind: "server",

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -241,7 +241,7 @@ export const SettingsModal: FC = () => {
         </nav>
         <div className="flex min-w-0 flex-1 flex-col gap-4">
           {page === "billing" ? (
-            <PlanSection />
+            <PlanSection showShortcuts={areHintsVisible} />
           ) : page === "booking" && IS_BOOKING_ENABLED ? (
             <Suspense fallback={null}>
               <BookingSettingsSection showShortcuts={areHintsVisible} />

--- a/packages/web/src/settings/useSettingsShortcuts.ts
+++ b/packages/web/src/settings/useSettingsShortcuts.ts
@@ -57,6 +57,11 @@ const shortcutIdForEvent = (
 
   const key = normalizedKeyboardKey(event);
   if (page === "booking" && isModEnter(event)) return "save-booking";
+  if (page === "billing") {
+    if (key === "c") return "cancel-subscription";
+    if (key === "r") return "resume-subscription";
+    return null;
+  }
   if (page !== "accounts") return null;
   if (key === "a") return "add-account";
   if (key === "e") return "export";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Settings > Billing is now the in-app place a subscriber manages their plan, replacing the Manage billing portal button WP-05 removed. Updating the card is still WP-07.

Closes #3160.

- `BillingApi` adds `getSubscription`, `cancelSubscription`, and `resumeSubscription`.
- `useBillingSubscriptionQuery` loads the summary while the Billing page is open.
- Plan row: badge, `Intl.NumberFormat` price, renews or ends date, existing trial copy and `B` hint.
- Card row: `{Brand} ending in {last4}, expires MM/YY`, or `No card on file`.
- Cancel (`C`) confirms via OverlayPanel, then toasts and tracks `billing_cancel_scheduled`. Resume (`R`) when `cancelAtPeriodEnd`.
- Receipts: up to 12 rows with `rel="noreferrer"` links. Trial $0 invoices show as `$0.00`.

## Simplicity

Grew the existing `PlanSection` instead of adding a new Settings page. Cancel confirmation is one OverlayPanel modeled on the upgrade dialog. No portal, no extra store.

## Automated validation

`bun run verify` PASS: `test:web` 1600 + 1592 pass, `type-check` pass, `lint` pass, `knip` pass. Playwright a11y/e2e skipped locally (Chromium missing; CI runs them).

Handoff: `.agents/handoffs/3160.md`

## Independent review

`.agents/handoffs/3160.md`

## Test plan

```
bun run verify
```

Selected: test:web, type-check, lint, knip.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0ba2f6a-bdca-4f94-a04f-f2a4d77d7dbb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0ba2f6a-bdca-4f94-a04f-f2a4d77d7dbb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

