### PR TITLE
feat(web): Escape aborts the pending booking cancel confirm

### DIFF
--- a/.agents/handoffs/3134.md
+++ b/.agents/handoffs/3134.md
@@ -1,25 +1,37 @@
 ---
 schema_version: 1
 task_id: "3134"
-from: Implementer
-to: Verifier
-owner: Verifier
-status: verifying
+from: Reviewer
+to: Manager
+owner: Manager
+status: done
 artifact:
   - path: packages/web/src/booking/PublicBookingCancelPage.tsx
   - path: packages/web/src/booking/PublicBookingCancelPage.test.tsx
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3195
 evidence:
   - command: bun test:web packages/web/src/booking/PublicBookingCancelPage.test.tsx
     result: "10 pass, 0 fail"
     log: null
+  - command: bun run verify
+    result: "PASS. Selected packages: web. Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e. Checks skipped: (none). test:web 1613 pass. test:a11y 24 passed. test:e2e 109 passed."
+    log: null
 assumptions:
-  - "#3120 (retry after failed cancel) is still open, so Escape on the failed-cancel status view stays a no-op."
+  - "#3120 is still open, so Escape on the failed-cancel status view stays a no-op."
 open_risks: []
-next_deadline: 2026-09-04T00:00:00Z
+next_deadline: null
 retry: 0
 approval: none
 waiting_on: null
 escalation: null
 ---
 
-WP-06: Escape on `/book/cancel/:id` confirm view returns to `/book/confirmed/:id`.
+WP-06: Escape on cancel confirm returns to the confirmation page.
+
+Simplify: no further change. `enabled: isConfirmView && !busy` plus `inFlightRef` covers the click-to-re-render gap.
+
+Review: no confirmed findings.
+
+VERDICT: no confirmed findings
+FINDINGS:
+(none)

--- a/.agents/handoffs/3134.md
+++ b/.agents/handoffs/3134.md
@@ -1,0 +1,25 @@
+---
+schema_version: 1
+task_id: "3134"
+from: Implementer
+to: Verifier
+owner: Verifier
+status: verifying
+artifact:
+  - path: packages/web/src/booking/PublicBookingCancelPage.tsx
+  - path: packages/web/src/booking/PublicBookingCancelPage.test.tsx
+evidence:
+  - command: bun test:web packages/web/src/booking/PublicBookingCancelPage.test.tsx
+    result: "10 pass, 0 fail"
+    log: null
+assumptions:
+  - "#3120 (retry after failed cancel) is still open, so Escape on the failed-cancel status view stays a no-op."
+open_risks: []
+next_deadline: 2026-09-04T00:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-06: Escape on `/book/cancel/:id` confirm view returns to `/book/confirmed/:id`.

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,7 +13,7 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 3132 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3193 | bun run verify PASS (web 1580, a11y 24, e2e 109); review: no confirmed findings | null | 0 | none |
+| 3134 | high | Verifier | verifying | packages/web/src/booking/PublicBookingCancelPage.tsx | bun test:web PublicBookingCancelPage 10 pass | 2026-09-04T00:00:00Z | 0 | none |
 | 3158 | high | Implementer | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3168 | bun test:web 1569 pass; type-check pass; lint exit 0; knip pass | 2026-09-04T00:00:00Z | 0 | none |
 | 3129 | high | Verifier | verifying | packages/web/src/booking/BookingSettingsSection.tsx | bun test:web 30 pass; host-settings e2e 5 pass; test:a11y 24 pass; bun run verify PASS | 2026-09-03T20:00:00Z | 0 | none |
 | simplify-recent-3098 | medium | Manager | verifying | .agents/handoffs/simplify-recent-3098.md | bun run verify PASS (core, web, backend, type-check, lint, knip); focused web 161 pass; review: no confirmed findings | 2026-09-03T06:00:00Z | 1 | none |

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,7 +13,7 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 3134 | high | Verifier | verifying | packages/web/src/booking/PublicBookingCancelPage.tsx | bun test:web PublicBookingCancelPage 10 pass | 2026-09-04T00:00:00Z | 0 | none |
+| 3134 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3195 | bun run verify PASS (web 1613, a11y 24, e2e 109); review: no confirmed findings | null | 0 | none |
 | 3158 | high | Implementer | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3168 | bun test:web 1569 pass; type-check pass; lint exit 0; knip pass | 2026-09-04T00:00:00Z | 0 | none |
 | 3129 | high | Verifier | verifying | packages/web/src/booking/BookingSettingsSection.tsx | bun test:web 30 pass; host-settings e2e 5 pass; test:a11y 24 pass; bun run verify PASS | 2026-09-03T20:00:00Z | 0 | none |
 | simplify-recent-3098 | medium | Manager | verifying | .agents/handoffs/simplify-recent-3098.md | bun run verify PASS (core, web, backend, type-check, lint, knip); focused web 161 pass; review: no confirmed findings | 2026-09-03T06:00:00Z | 1 | none |

--- a/packages/web/src/booking/PublicBookingCancelPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingCancelPage.test.tsx
@@ -1,3 +1,4 @@
+import { HotkeysProvider } from "@tanstack/react-hotkeys";
 import {
   createMemoryHistory,
   createRouter,
@@ -42,7 +43,13 @@ function renderCancelRoute(path: string) {
     defaultPendingMs: 0,
   });
   const { wrapper } = createStoreWrapper();
-  return render(<RouterProvider router={router} />, { wrapper });
+  const result = render(
+    <HotkeysProvider>
+      <RouterProvider router={router} />
+    </HotkeysProvider>,
+    { wrapper },
+  );
+  return { ...result, router };
 }
 
 describe("PublicBookingCancelPage", () => {
@@ -218,5 +225,102 @@ describe("PublicBookingCancelPage", () => {
       screen.queryByRole("button", { name: "Cancel this booking" }),
     ).not.toBeInTheDocument();
     expect(cancelPosts).toBe(0);
+  });
+
+  it("returns to the confirmation page on Escape without posting", async () => {
+    const user = userEvent.setup({ delay: null });
+    let cancelPosts = 0;
+    server.use(
+      reservationGetHandler(),
+      rest.post(
+        `${ENV_WEB.API_BASEURL}/booking/reservations/${reservationId}/cancel`,
+        (_req, res, ctx) => {
+          cancelPosts += 1;
+          return res(ctx.status(Status.OK), ctx.json({ ok: true }));
+        },
+      ),
+    );
+
+    const { router } = renderCancelRoute(cancelPath);
+
+    expect(
+      await screen.findByRole("heading", { name: "Cancel this booking?" }),
+    ).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "You are booked with Tyler Dane",
+      }),
+    ).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe(
+      `/book/confirmed/${reservationId}`,
+    );
+    expect(cancelPosts).toBe(0);
+  });
+
+  it("does not navigate or abort when Escape is pressed during cancel POST", async () => {
+    const user = userEvent.setup({ delay: null });
+    let cancelPosts = 0;
+    let release!: () => void;
+    const hold = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    server.use(
+      reservationGetHandler(),
+      rest.post(
+        `${ENV_WEB.API_BASEURL}/booking/reservations/${reservationId}/cancel`,
+        async (_req, res, ctx) => {
+          cancelPosts += 1;
+          await hold;
+          return res(ctx.status(Status.OK), ctx.json({ ok: true }));
+        },
+      ),
+    );
+
+    const { router } = renderCancelRoute(cancelPath);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Cancel this booking" }),
+    );
+    expect(
+      await screen.findByRole("button", { name: "Canceling..." }),
+    ).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+
+    expect(
+      screen.getByRole("heading", { name: "Cancel this booking?" }),
+    ).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe(
+      `/book/cancel/${reservationId}`,
+    );
+    expect(cancelPosts).toBe(1);
+
+    release();
+    expect(
+      await screen.findByRole("heading", { name: "Booking canceled" }),
+    ).toBeInTheDocument();
+    expect(cancelPosts).toBe(1);
+  });
+
+  it("does not navigate on Escape from the not-found heading", async () => {
+    const user = userEvent.setup({ delay: null });
+    const { router } = renderCancelRoute(`/book/cancel/${reservationId}`);
+
+    const heading = await screen.findByRole("heading", {
+      name: "Booking not found",
+    });
+    await waitFor(() => {
+      expect(heading).toHaveFocus();
+    });
+    await user.keyboard("{Escape}");
+
+    expect(
+      screen.getByRole("heading", { name: "Booking not found" }),
+    ).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe(
+      `/book/cancel/${reservationId}`,
+    );
   });
 });

--- a/packages/web/src/booking/PublicBookingCancelPage.tsx
+++ b/packages/web/src/booking/PublicBookingCancelPage.tsx
@@ -1,4 +1,4 @@
-import { useParams, useSearch } from "@tanstack/react-router";
+import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { useRef, useState } from "react";
 import {
   PublicBookingApi,
@@ -14,6 +14,9 @@ import {
 import { usePublicBookingReservationQuery } from "@web/booking/public-booking.query";
 import { useBookingDocumentTitle } from "@web/booking/use-booking-document-title";
 import { useBookingHeadingFocus } from "@web/booking/use-booking-heading-focus";
+import { ROOT_ROUTES } from "@web/common/constants/routes";
+import { isHigherEscapeOwner } from "@web/shortcuts/escape-ownership";
+import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 
 type CancelActionState =
   | "idle"
@@ -81,6 +84,7 @@ const resolveCancelPageView = (
 export function PublicBookingCancelPage() {
   const { reservationId } = useParams({ from: "/book/cancel/$reservationId" });
   const search = useSearch({ from: "/book/cancel/$reservationId" });
+  const navigate = useNavigate();
   const token = search.token ?? "";
   const canLoad = Boolean(reservationId && token);
   const reservationQuery = usePublicBookingReservationQuery(
@@ -114,12 +118,34 @@ export function PublicBookingCancelPage() {
   };
 
   const view = resolveCancelPageView(canLoad, action, reservationQuery);
+  const busy = action === "cancelling";
+  const isConfirmView = view.kind === "confirm";
+
+  // Escape on the confirm view returns to the confirmation page. OverlayPanel
+  // (if any) peels first. In-flight cancel must not navigate or abort.
+  useAppShortcut(
+    "Escape",
+    (event) => {
+      if (isHigherEscapeOwner()) {
+        return;
+      }
+      if (!isConfirmView || inFlightRef.current || !reservationId) {
+        return;
+      }
+      event.preventDefault();
+      void navigate({
+        to: ROOT_ROUTES.BOOK_CONFIRMED,
+        params: { reservationId },
+      });
+    },
+    { enabled: isConfirmView && !busy, ignoreInputs: false },
+  );
+
   if (view.kind === "status") {
     return <PublicBookingStatusMessage {...view} />;
   }
 
   const { reservation } = view;
-  const busy = action === "cancelling";
   return (
     <PublicBookingLayout>
       <section aria-busy={busy} aria-labelledby="booking-cancel-heading">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3134

## Summary

On `/book/cancel/:id`, Escape on the confirm view returns to `/book/confirmed/:id` without posting. Escape is a no-op while the cancel request is in flight, and on the not-found or already-cancelled states.

#3120 (retry after failed cancel) is still open, so the failed-cancel status view is left alone.

## Simplicity

Reuses `useAppShortcut` + `isHigherEscapeOwner` like WP-04. The shortcut is enabled only on the confirm view and disabled while `cancelling`. `inFlightRef` still stands the handler down across the click-to-re-render gap.

## Automated validation

`bun run verify` PASS. Selected packages: web. Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e. Checks skipped: (none). test:web 1613 pass. test:a11y 24 passed. test:e2e 109 passed. Focused cancel RTL: 10 pass.

## Independent review

`.agents/handoffs/3134.md`

VERDICT: no confirmed findings
FINDINGS:
(none)

## Test plan

- `bun test:web packages/web/src/booking/PublicBookingCancelPage.test.tsx` (10 pass)
- `bun run verify` (PASS: test:web, type-check, lint, knip, test:a11y, test:e2e)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec67721b-395d-454e-bd11-696669d367b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec67721b-395d-454e-bd11-696669d367b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

