### PR TITLE
feat(web): update card inside Settings billing (WP-07)

### DIFF
--- a/.agents/handoffs/3161.md
+++ b/.agents/handoffs/3161.md
@@ -1,0 +1,28 @@
+---
+schema_version: 1
+task_id: "3161"
+from: Implementer
+to: Verifier
+owner: Implementer
+status: running
+artifact:
+  - path: packages/web/src/billing/PlanSection.tsx
+  - path: packages/web/src/billing/CardUpdatePanel.tsx
+  - path: packages/web/src/billing/card-update.store.ts
+  - path: packages/web/src/billing/BillingPastDueBanner.tsx
+evidence:
+  - command: bun test --preload packages/web/src/__tests__/web.preload.ts packages/web/src/billing/PlanSection.test.tsx packages/web/src/billing/BillingBanner.test.tsx
+    result: pending
+assumptions:
+  - "WP-06 (#3160) lands on main before this PR merges"
+  - "Live Stripe 3DS card 4000 0025 0000 3155 waits for founder staging QA (WP-08); unit tests cover the fake renderer"
+open_risks: []
+next_deadline: 2026-09-04T00:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-07: Update card inside Settings > Billing via setup-mode embedded
+Checkout. Past-due banner CTA opens Settings with the form already mounted.

--- a/packages/web/src/__tests__/utils/state/reset-stores.ts
+++ b/packages/web/src/__tests__/utils/state/reset-stores.ts
@@ -14,6 +14,10 @@ import {
   useBillingPreviewStore,
 } from "@web/billing/billing-preview.store";
 import {
+  initialCardUpdateState,
+  useCardUpdateStore,
+} from "@web/billing/card-update.store";
+import {
   initialCheckoutPanelState,
   useCheckoutPanelStore,
 } from "@web/billing/checkout-panel.store";
@@ -114,6 +118,7 @@ const storeResets: StoreReset[] = [
   () => usePageJumpHintStore.setState(initialPageJumpHintState, true),
   () => useBillingPreviewStore.setState(initialBillingPreviewState, true),
   () => useCheckoutPanelStore.setState(initialCheckoutPanelState, true),
+  () => useCardUpdateStore.setState(initialCardUpdateState, true),
   resetShortcutHintProgressStoreForTests,
   resetShortcutTelemetryForTests,
 ];

--- a/packages/web/src/api/billing.api.ts
+++ b/packages/web/src/api/billing.api.ts
@@ -49,6 +49,13 @@ const BillingApi = {
     );
     return BillingStatusResponseSchema.parse(response.data);
   },
+
+  async createPaymentMethodSession(): Promise<BillingCheckoutResponse> {
+    const response = await BaseApi.post<BillingCheckoutResponse>(
+      `/billing/payment-method/session`,
+    );
+    return BillingCheckoutResponseSchema.parse(response.data);
+  },
 };
 
 export { BillingApi };

--- a/packages/web/src/auth/posthog/track.ts
+++ b/packages/web/src/auth/posthog/track.ts
@@ -33,6 +33,7 @@ export type ProductEvent =
   | "billing_gate_cta_clicked"
   | "billing_cancel_scheduled"
   | "billing_resumed"
+  | "billing_card_update_completed"
   | "shortcut_upgrade_prompted"
   | "notifications_enabled"
   | "notifications_disabled"

--- a/packages/web/src/billing/BillingBanner.test.tsx
+++ b/packages/web/src/billing/BillingBanner.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
 import { BillingBanner } from "@web/billing/BillingBanner";
+import { BillingPastDueBanner } from "@web/billing/BillingPastDueBanner";
 import { BillingReadOnlyBanner } from "@web/billing/BillingReadOnlyBanner";
 import {
   billingPreviewActions,
@@ -10,9 +11,19 @@ import {
   useBillingPreviewStore,
 } from "@web/billing/billing-preview.store";
 import {
+  initialCardUpdateState,
+  useCardUpdateStore,
+} from "@web/billing/card-update.store";
+import {
   initialCheckoutPanelState,
   useCheckoutPanelStore,
 } from "@web/billing/checkout-panel.store";
+import {
+  initialSettingsState,
+  selectIsSettingsOpen,
+  selectSettingsPage,
+  useSettingsStore,
+} from "@web/settings/settings.store";
 import {
   POINTER_ACTION_ATTRIBUTE,
   POINTER_ACTIONS,
@@ -28,6 +39,8 @@ afterEach(() => {
   eventJumpActions.reset();
   useBillingPreviewStore.setState(initialBillingPreviewState, true);
   useCheckoutPanelStore.setState(initialCheckoutPanelState, true);
+  useCardUpdateStore.setState(initialCardUpdateState, true);
+  useSettingsStore.setState(initialSettingsState, true);
 });
 
 const renderBanner = (onCta = mock(), disabled = false) =>
@@ -113,5 +126,20 @@ describe("BillingBanner", () => {
 
     expect(useBillingPreviewStore.getState().isPreviewing).toBe(false);
     expect(useCheckoutPanelStore.getState().isOpen).toBe(true);
+  });
+
+  it("opens Settings on Billing with the card form already open", async () => {
+    const user = userEvent.setup({ delay: null });
+    render(
+      <HotkeysProvider>
+        <BillingPastDueBanner />
+      </HotkeysProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Update card" }));
+
+    expect(selectIsSettingsOpen(useSettingsStore.getState())).toBe(true);
+    expect(selectSettingsPage(useSettingsStore.getState())).toBe("billing");
+    expect(useCardUpdateStore.getState().isOpen).toBe(true);
   });
 });

--- a/packages/web/src/billing/BillingPastDueBanner.tsx
+++ b/packages/web/src/billing/BillingPastDueBanner.tsx
@@ -1,6 +1,7 @@
 import { type FC } from "react";
 import { track } from "@web/auth/posthog/track";
 import { BillingBanner } from "@web/billing/BillingBanner";
+import { cardUpdateActions } from "@web/billing/card-update.store";
 import { settingsActions } from "@web/settings/settings.store";
 
 /**
@@ -14,6 +15,7 @@ export const BillingPastDueBanner: FC = () => {
       message="Payment failed. Update your card to keep Compass after this period."
       onCta={() => {
         track("billing_gate_cta_clicked", { cta: "past_due_update_card" });
+        cardUpdateActions.open();
         settingsActions.openSettings("billing");
       }}
     />

--- a/packages/web/src/billing/CardUpdatePanel.tsx
+++ b/packages/web/src/billing/CardUpdatePanel.tsx
@@ -1,0 +1,49 @@
+import { type FC, Suspense } from "react";
+import { BillingApi } from "@web/api/billing.api";
+import { getEmbeddedCheckoutComponent } from "@web/billing/embedded-checkout/embedded-checkout.seam";
+import { focusOnPointerEnter } from "@web/common/utils/focus-on-pointer-enter";
+import { OverlayPanelActionButton } from "@web/components/OverlayPanel/OverlayPanel";
+
+interface CardUpdatePanelProps {
+  publishableKey: string;
+  onCancel: () => void;
+  onComplete: () => void;
+}
+
+/**
+ * Setup-mode embedded Checkout for replacing the card on file. Lives under
+ * the Settings card row, not in the billing gate.
+ */
+export const CardUpdatePanel: FC<CardUpdatePanelProps> = ({
+  publishableKey,
+  onCancel,
+  onComplete,
+}) => {
+  const EmbeddedCheckout = getEmbeddedCheckoutComponent();
+
+  return (
+    <div className="flex w-full flex-col gap-3">
+      <Suspense
+        fallback={
+          <p className="text-sm text-text-muted">Loading checkout...</p>
+        }
+      >
+        <EmbeddedCheckout
+          className="w-full"
+          fetchClientSecret={() =>
+            BillingApi.createPaymentMethodSession().then((r) => r.clientSecret)
+          }
+          onComplete={onComplete}
+          publishableKey={publishableKey}
+        />
+      </Suspense>
+      <OverlayPanelActionButton
+        onClick={onCancel}
+        onPointerEnter={focusOnPointerEnter}
+        variant="secondary"
+      >
+        Cancel
+      </OverlayPanelActionButton>
+    </div>
+  );
+};

--- a/packages/web/src/billing/PlanSection.test.tsx
+++ b/packages/web/src/billing/PlanSection.test.tsx
@@ -1,14 +1,29 @@
 import "@testing-library/jest-dom";
 import { HotkeysProvider } from "@tanstack/react-hotkeys";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { type BillingSubscriptionResponse } from "@core/types/billing.types";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { BillingApi } from "@web/api/billing.api";
 import * as Track from "@web/auth/posthog/track";
+import {
+  initialCardUpdateState,
+  useCardUpdateStore,
+} from "@web/billing/card-update.store";
+import {
+  type EmbeddedCheckoutProps,
+  setEmbeddedCheckoutForTests,
+} from "@web/billing/embedded-checkout/embedded-checkout.seam";
 import { type AppAccess } from "@web/billing/useAppAccess";
 import {
+  BILLING_CARD_UPDATED_TOAST_ID,
   BILLING_PLAN_ENDS_TOAST_ID,
   BILLING_PLAN_RENEWS_TOAST_ID,
 } from "@web/common/constants/toast.constants";
@@ -99,6 +114,15 @@ const renderPlan = async () => {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
+  queryClient.setQueryData(billingQueryKeys.config, {
+    google: { isConfigured: false },
+    billing: {
+      isConfigured: true,
+      enforcement: true,
+      trialLengthDays: 7,
+      publishableKey: "pk_test_card",
+    },
+  });
   const view = render(
     <QueryClientProvider client={queryClient}>
       <HotkeysProvider>
@@ -137,9 +161,12 @@ describe("PlanSection", () => {
   });
 
   afterEach(() => {
+    cleanup();
     resetToastPort();
     getSubscription.mockRestore();
     useSettingsStore.setState(initialSettingsState, true);
+    useCardUpdateStore.setState(initialCardUpdateState, true);
+    setEmbeddedCheckoutForTests(null);
   });
 
   it("renders price, renewal, card, and receipts from the summary", async () => {
@@ -324,5 +351,68 @@ describe("PlanSection", () => {
     ).toHaveTextContent(
       `You keep access until the trial ends on ${PERIOD_END_LABEL}. You can resume any time before then.`,
     );
+  });
+
+  it("mounts the card form with U and unmounts it with Cancel", async () => {
+    function FakeCheckout() {
+      return <div>Fake card checkout</div>;
+    }
+    setEmbeddedCheckoutForTests(FakeCheckout);
+    const user = userEvent.setup({ delay: null });
+    await renderPlan();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Update card" }),
+      ).toBeInTheDocument();
+    });
+
+    await user.keyboard("u");
+    expect(screen.getByText("Fake card checkout")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Update card" }),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByText("Fake card checkout")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Update card" })).toHaveFocus();
+  });
+
+  it("completes a card update, toasts, tracks, and polls the subscription", async () => {
+    function FakeCheckout({ onComplete }: EmbeddedCheckoutProps) {
+      return (
+        <button type="button" onClick={onComplete}>
+          Complete card update
+        </button>
+      );
+    }
+    setEmbeddedCheckoutForTests(FakeCheckout);
+    const user = userEvent.setup({ delay: null });
+    const track = spyOn(Track, "track");
+    const { queryClient } = await renderPlan();
+    const invalidate = spyOn(queryClient, "invalidateQueries");
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Update card" }),
+      ).toBeInTheDocument();
+    });
+    await user.keyboard("u");
+    await user.click(
+      screen.getByRole("button", { name: "Complete card update" }),
+    );
+
+    expect(track).toHaveBeenCalledWith("billing_card_update_completed");
+    expect(toastMocks.toast).toHaveBeenCalledWith(
+      "Card updated",
+      expect.objectContaining({ toastId: BILLING_CARD_UPDATED_TOAST_ID }),
+    );
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: billingQueryKeys.subscription,
+    });
+    expect(screen.getByRole("button", { name: "Update card" })).toHaveFocus();
+
+    track.mockRestore();
+    invalidate.mockRestore();
   });
 });

--- a/packages/web/src/billing/PlanSection.tsx
+++ b/packages/web/src/billing/PlanSection.tsx
@@ -1,11 +1,13 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { type FC, useEffect, useState } from "react";
+import { type FC, useEffect, useRef, useState } from "react";
 import dayjs from "@core/util/date/dayjs";
 import { BillingApi } from "@web/api/billing.api";
 import { track } from "@web/auth/posthog/track";
 import {
   billingQueryKeys,
+  startBillingStatusPoll,
   useBillingSubscriptionQuery,
+  useStripePublishableKey,
 } from "@web/billing/billing.query";
 import {
   formatBillingDate,
@@ -15,12 +17,19 @@ import {
 } from "@web/billing/billing-display";
 import { showBillingRequestError } from "@web/billing/billing-request-error";
 import { CancelSubscriptionDialog } from "@web/billing/CancelSubscriptionDialog";
+import { CardUpdatePanel } from "@web/billing/CardUpdatePanel";
+import {
+  cardUpdateActions,
+  selectCardUpdateOpen,
+  useCardUpdateStore,
+} from "@web/billing/card-update.store";
 import {
   getPlanBadge,
   PLAN_BADGE_TONE_CLASSNAME,
 } from "@web/billing/planBadge";
 import { useAppAccess } from "@web/billing/useAppAccess";
 import {
+  BILLING_CARD_UPDATED_TOAST_ID,
   BILLING_PLAN_ENDS_TOAST_ID,
   BILLING_PLAN_RENEWS_TOAST_ID,
 } from "@web/common/constants/toast.constants";
@@ -54,6 +63,11 @@ export const PlanSection: FC<PlanSectionProps> = ({
   const page = useSettingsStore(selectSettingsPage);
   const queryClient = useQueryClient();
   const badge = getPlanBadge(access);
+  const publishableKey = useStripePublishableKey();
+  const isCardUpdateOpen = useCardUpdateStore(selectCardUpdateOpen);
+  const updateCardButtonRef = useRef<HTMLButtonElement>(null);
+  const stopCardPollRef = useRef<(() => void) | null>(null);
+  const wasCardUpdateOpen = useRef(false);
   const subscriptionQuery = useBillingSubscriptionQuery(
     page === "billing" && access.kind === "server",
   );
@@ -67,6 +81,20 @@ export const PlanSection: FC<PlanSectionProps> = ({
       "Couldn't load billing details.",
     );
   }, [subscriptionQuery.error, subscriptionQuery.isError]);
+
+  useEffect(() => {
+    if (wasCardUpdateOpen.current && !isCardUpdateOpen) {
+      updateCardButtonRef.current?.focus({ preventScroll: true });
+    }
+    wasCardUpdateOpen.current = isCardUpdateOpen;
+  }, [isCardUpdateOpen]);
+
+  useEffect(
+    () => () => {
+      stopCardPollRef.current?.();
+    },
+    [],
+  );
 
   if (!badge) return null;
 
@@ -136,6 +164,20 @@ export const PlanSection: FC<PlanSectionProps> = ({
     })();
   };
 
+  const handleCardUpdateComplete = () => {
+    cardUpdateActions.close();
+    track("billing_card_update_completed");
+    showStatusToast(BILLING_CARD_UPDATED_TOAST_ID, "Card updated");
+    stopCardPollRef.current?.();
+    stopCardPollRef.current = startBillingStatusPoll(
+      queryClient,
+      () => {
+        stopCardPollRef.current = null;
+      },
+      billingQueryKeys.subscription,
+    );
+  };
+
   return (
     <div className="flex flex-col gap-4">
       <div>
@@ -183,6 +225,32 @@ export const PlanSection: FC<PlanSectionProps> = ({
               ? formatCardOnFile(summary.paymentMethod)
               : "No card on file"}
           </p>
+
+          {isCardUpdateOpen ? (
+            publishableKey ? (
+              <CardUpdatePanel
+                publishableKey={publishableKey}
+                onCancel={cardUpdateActions.close}
+                onComplete={handleCardUpdateComplete}
+              />
+            ) : (
+              <p className="text-sm text-text-muted">Loading checkout...</p>
+            )
+          ) : (
+            <OverlayPanelActions align="start">
+              <OverlayPanelActionButton
+                ref={updateCardButtonRef}
+                disabled={isSubmitting}
+                onClick={cardUpdateActions.open}
+                shortcut="U"
+                showShortcut={showShortcuts}
+                variant="secondary"
+                {...settingsShortcutAttrs("update-card")}
+              >
+                Update card
+              </OverlayPanelActionButton>
+            </OverlayPanelActions>
+          )}
 
           {canManageCancellation ? (
             <OverlayPanelActions align="start">

--- a/packages/web/src/billing/billing.query.ts
+++ b/packages/web/src/billing/billing.query.ts
@@ -84,9 +84,10 @@ const STATUS_POLL_WINDOW_MS = 15_000;
 export function startBillingStatusPoll(
   queryClient: QueryClient,
   onWindowEnd: () => void,
+  queryKey: readonly unknown[] = billingQueryKeys.status,
 ): () => void {
   const invalidate = () => {
-    void queryClient.invalidateQueries({ queryKey: billingQueryKeys.status });
+    void queryClient.invalidateQueries({ queryKey });
   };
   invalidate();
   const interval = window.setInterval(invalidate, STATUS_POLL_MS);

--- a/packages/web/src/billing/card-update.store.ts
+++ b/packages/web/src/billing/card-update.store.ts
@@ -1,0 +1,28 @@
+import { create } from "zustand";
+
+export type CardUpdateState = {
+  isOpen: boolean;
+};
+
+export const initialCardUpdateState: CardUpdateState = {
+  isOpen: false,
+};
+
+/**
+ * In-memory: the gate's checkout panel and Settings card-update form must
+ * not open each other. A reload leaves the form closed.
+ */
+export const useCardUpdateStore = create<CardUpdateState>()(() => ({
+  ...initialCardUpdateState,
+}));
+
+export const cardUpdateActions = {
+  open: () => {
+    useCardUpdateStore.setState({ isOpen: true });
+  },
+  close: () => {
+    useCardUpdateStore.setState({ isOpen: false });
+  },
+};
+
+export const selectCardUpdateOpen = (state: CardUpdateState) => state.isOpen;

--- a/packages/web/src/common/constants/toast.constants.ts
+++ b/packages/web/src/common/constants/toast.constants.ts
@@ -21,6 +21,7 @@ export const NOTIFICATIONS_STATUS_TOAST_ID: Id = "notifications-status";
 export const BILLING_SUBSCRIBED_TOAST_ID: Id = "billing-subscribed";
 export const BILLING_PLAN_ENDS_TOAST_ID: Id = "billing-plan-ends";
 export const BILLING_PLAN_RENEWS_TOAST_ID: Id = "billing-plan-renews";
+export const BILLING_CARD_UPDATED_TOAST_ID: Id = "billing-card-updated";
 
 /**
  * Toast chrome follows `[data-theme]` instead of a JS hex snapshot, so body

--- a/packages/web/src/components/CommandPalette/hooks/useShowBillingCmdItems.test.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useShowBillingCmdItems.test.ts
@@ -2,6 +2,10 @@ import { renderHook } from "@testing-library/react";
 import { act } from "react";
 import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
 import * as realUsesession from "@web/auth/compass/session/useSession";
+import {
+  initialCardUpdateState,
+  useCardUpdateStore,
+} from "@web/billing/card-update.store";
 import * as realUseappaccess from "@web/billing/useAppAccess";
 import { type AppAccess } from "@web/billing/useAppAccess";
 import {
@@ -78,5 +82,26 @@ describe("useShowBillingCmdItems", () => {
     expect(selectOverlayOpenedFromPalette(useSettingsStore.getState())).toBe(
       true,
     );
+  });
+
+  it("opens Settings on Billing with the card form from Update card", () => {
+    access = {
+      kind: "server",
+      status: "active",
+      isReadOnly: false,
+      trialEndsAt: null,
+    };
+    useCardUpdateStore.setState(initialCardUpdateState, true);
+
+    const { result } = renderHook(() => useShowBillingCmdItems());
+    const updateCard = result.current.find((item) => item.id === "update-card");
+    expect(updateCard?.label).toBe("Update card");
+
+    act(() => {
+      updateCard?.onClick?.();
+    });
+
+    expect(selectSettingsPage(useSettingsStore.getState())).toBe("billing");
+    expect(useCardUpdateStore.getState().isOpen).toBe(true);
   });
 });

--- a/packages/web/src/components/CommandPalette/hooks/useShowBillingCmdItems.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useShowBillingCmdItems.ts
@@ -1,5 +1,6 @@
 import { CreditCardIcon } from "@phosphor-icons/react";
 import { useSession } from "@web/auth/compass/session/useSession";
+import { cardUpdateActions } from "@web/billing/card-update.store";
 import { getPlanBadge } from "@web/billing/planBadge";
 import { useAppAccess } from "@web/billing/useAppAccess";
 import { type CommandItem } from "@web/components/CommandPalette/command-palette.types";
@@ -33,6 +34,16 @@ export const useShowBillingCmdItems = (): CommandItem[] => {
       badge: badge.label,
       onClick: () =>
         settingsActions.openSettings("billing", { fromPalette: true }),
+    },
+    {
+      id: "update-card",
+      label: "Update card",
+      icon: CreditCardIcon,
+      keywords: ["card", "payment", "billing", "update"],
+      onClick: () => {
+        cardUpdateActions.open();
+        settingsActions.openSettings("billing", { fromPalette: true });
+      },
     },
   ];
 };

--- a/packages/web/src/settings/useSettingsShortcuts.ts
+++ b/packages/web/src/settings/useSettingsShortcuts.ts
@@ -60,6 +60,7 @@ const shortcutIdForEvent = (
   if (page === "billing") {
     if (key === "c") return "cancel-subscription";
     if (key === "r") return "resume-subscription";
+    if (key === "u") return "update-card";
     return null;
   }
   if (page !== "accounts") return null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

A subscriber can replace their card inside Settings > Billing through setup-mode embedded Checkout. The past-due banner takes them straight to that form.

Closes #3161.

- `BillingApi.createPaymentMethodSession()` parses `{ clientSecret }`.
- New `card-update.store` (separate from the gate checkout panel).
- Plan card row: Update card (`U`) mounts the lazy embedded Checkout inline; Cancel unmounts and returns focus.
- On complete: toast "Card updated", track `billing_card_update_completed`, poll `["billing","subscription"]` for 15s.
- Past-due "Update card" CTA opens Settings on Billing with the form already mounted.
- Optional palette item "Update card".

Live Stripe 3DS (`4000 0025 0000 3155`) stays on founder staging QA (WP-08).

## Simplicity

Reused the WP-05 embedded Checkout seam and generalized `startBillingStatusPoll` to take a query key instead of adding a second poller.

## Automated validation

Focused tests: PlanSection, BillingBanner, useShowBillingCmdItems (19 pass). `type-check` and `knip` pass.

## Independent review

`.agents/handoffs/3161.md`

## Test plan

```
bun test:web
bun run type-check
bun lint
bun knip
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0ba2f6a-bdca-4f94-a04f-f2a4d77d7dbb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0ba2f6a-bdca-4f94-a04f-f2a4d77d7dbb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

