### PR TITLE
feat(web): confirm discard before Escape closes dirty booking settings

### DIFF
--- a/.agents/handoffs/3135.md
+++ b/.agents/handoffs/3135.md
@@ -1,0 +1,38 @@
+---
+schema_version: 1
+task_id: "3135"
+from: Reviewer
+to: Manager
+owner: Manager
+status: verifying
+artifact:
+  - path: packages/web/src/booking/BookingSettingsSection.tsx
+  - path: packages/web/src/components/Settings/SettingsModal.tsx
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3197
+evidence:
+  - command: bun test:web packages/web/src/booking/booking.util.test.ts packages/web/src/components/Settings/SettingsModal.test.tsx packages/web/src/booking/BookingSettingsSection.test.tsx
+    result: "86 pass, 0 fail (plus later SettingsModal 50 pass including uncommitted-hours Escape)"
+    log: null
+  - command: bun run verify
+    result: "PASS. Selected packages: web. Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e. Checks skipped: (none). test:web shards 1617 and 1592 pass. test:a11y 24 passed. test:e2e 109 passed."
+    log: null
+assumptions:
+  - "Uncommitted weekly-hours text is treated as dirty, matching in-progress notice/horizon text."
+open_risks: []
+next_deadline: 2026-09-04T00:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-07: Escape in Settings > Booking confirms discard of unsaved edits.
+
+Simplify: no further change. The fragment around the fieldset keeps the
+discard dialog outside `disabled`, which a nested fieldset would block.
+
+Review: no remaining confirmed findings after the hours-draft dirty fix.
+
+VERDICT: no confirmed findings
+FINDINGS:
+(none)

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,6 +13,7 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 3135 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3197 | bun run verify PASS (web shards 1617/1592, a11y 24, e2e 109); review: no confirmed findings after hours-draft fix | 2026-09-04T00:00:00Z | 0 | none |
 | 3134 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3195 | bun run verify PASS (web 1613, a11y 24, e2e 109); review: no confirmed findings | null | 0 | none |
 | 3158 | high | Implementer | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3168 | bun test:web 1569 pass; type-check pass; lint exit 0; knip pass | 2026-09-04T00:00:00Z | 0 | none |
 | 3129 | high | Verifier | verifying | packages/web/src/booking/BookingSettingsSection.tsx | bun test:web 30 pass; host-settings e2e 5 pass; test:a11y 24 pass; bun run verify PASS | 2026-09-03T20:00:00Z | 0 | none |

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -232,6 +232,7 @@ export function BookingSettingsSection({
     String(form.maxHorizonDays),
   );
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const [hoursDraftDirty, setHoursDraftDirty] = useState(false);
   const sectionRef = useRef<HTMLFieldSetElement>(null);
   const baselineFormRef = useRef<AdminPutBookingPageInput | null>(null);
 
@@ -284,13 +285,14 @@ export function BookingSettingsSection({
   }, [availabilityCalendars, effectiveTimeZone, serverPage, writableCalendars]);
 
   const isDirty =
-    baselineFormRef.current !== null &&
-    isBookingSettingsFormDirty({
-      baseline: baselineFormRef.current,
-      form,
-      horizonText,
-      minNoticeText,
-    });
+    (baselineFormRef.current !== null &&
+      isBookingSettingsFormDirty({
+        baseline: baselineFormRef.current,
+        form,
+        horizonText,
+        minNoticeText,
+      })) ||
+    hoursDraftDirty;
 
   if (dismissGuardRef) {
     dismissGuardRef.current = () => {
@@ -575,6 +577,7 @@ export function BookingSettingsSection({
             onChange={(weeklyAvailability) =>
               updateForm({ weeklyAvailability })
             }
+            onDraftDirtyChange={setHoursDraftDirty}
             onValidityChange={setAreHoursValid}
             shortcutKeys={showShortcuts ? bookingJumpKeys("hours") : undefined}
             value={form.weeklyAvailability}

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  type MutableRefObject,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   type AdminGetBookingPageResponse,
   type AdminGetBookingPageResult,
@@ -29,6 +35,7 @@ import {
   canEnableBookingPage,
   defaultBlockingCalendarIdsForDestination,
   getAvailabilityReadableCalendars,
+  isBookingSettingsFormDirty,
   isPlaceholderDestinationCalendar,
   isUnconfiguredBookingPage,
   resolveWritableCalendars,
@@ -60,6 +67,7 @@ import { ShortcutTipParts } from "@web/shortcuts/tips/ShortcutTipParts";
 import { type ShortcutTipPart } from "@web/shortcuts/tips/shortcut-tips.data";
 import { useEditSequenceShortcut } from "@web/shortcuts/useEditSequenceShortcut";
 import { useEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
+import { DiscardUnsavedChangesDialog } from "@web/views/Forms/EventForm/DiscardUnsavedChangesDialog";
 
 const DURATION_OPTIONS: BookingDurationMinutes[] = [15, 30, 45, 60];
 
@@ -167,10 +175,19 @@ const buildInitialForm = (
 
 interface BookingSettingsSectionProps {
   showShortcuts: boolean;
+  /**
+   * Settings OverlayPanel owns Escape. When this returns true, Settings must
+   * not dismiss: the booking form is dirty and the discard dialog is open.
+   */
+  dismissGuardRef?: MutableRefObject<(() => boolean) | null>;
+  /** Close Settings after the host confirms discarding unsaved booking edits. */
+  onDiscardUnsaved?: () => void;
 }
 
 export function BookingSettingsSection({
   showShortcuts,
+  dismissGuardRef,
+  onDiscardUnsaved,
 }: BookingSettingsSectionProps) {
   const googleConnectionState = useUserMetadataStore(
     selectGoogleConnectionState,
@@ -214,7 +231,9 @@ export function BookingSettingsSection({
   const [horizonText, setHorizonText] = useState(() =>
     String(form.maxHorizonDays),
   );
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
   const sectionRef = useRef<HTMLFieldSetElement>(null);
+  const baselineFormRef = useRef<AdminPutBookingPageInput | null>(null);
 
   const minNoticeInvalid =
     parseBookingCount(minNoticeText, MIN_NOTICE_BOUNDS) === null;
@@ -261,7 +280,31 @@ export function BookingSettingsSection({
     setForm(seeded);
     setMinNoticeText(String(seeded.minNoticeHours));
     setHorizonText(String(seeded.maxHorizonDays));
+    baselineFormRef.current = seeded;
   }, [availabilityCalendars, effectiveTimeZone, serverPage, writableCalendars]);
+
+  const isDirty =
+    baselineFormRef.current !== null &&
+    isBookingSettingsFormDirty({
+      baseline: baselineFormRef.current,
+      form,
+      horizonText,
+      minNoticeText,
+    });
+
+  if (dismissGuardRef) {
+    dismissGuardRef.current = () => {
+      if (!isDirty) return false;
+      setIsConfirmOpen(true);
+      return true;
+    };
+  }
+
+  useEffect(() => {
+    return () => {
+      if (dismissGuardRef) dismissGuardRef.current = null;
+    };
+  }, [dismissGuardRef]);
 
   if (!isGoogleHealthy) {
     return <BookingConnectGooglePrompt />;
@@ -375,298 +418,317 @@ export function BookingSettingsSection({
   };
 
   return (
-    <fieldset
-      className="flex flex-col gap-4"
-      disabled={isReadOnly || saveMutation.isPending}
-      ref={sectionRef}
-    >
-      <p className="text-text-muted text-xs">
-        <ShortcutTipParts parts={BOOKING_SETTINGS_HINT_PARTS} />
-      </p>
-
-      {savedPage ? (
-        <div {...bookingFieldAttrs("link")}>
-          <BookingCopyLink bookingUrl={savedPage.bookingUrl} />
-        </div>
-      ) : null}
-
-      <label
-        className="flex items-center gap-2 text-sm text-text"
-        {...bookingFieldAttrs("enabled")}
-      >
-        <input
-          checked={form.enabled}
-          className="c-all-day-checkbox"
-          onChange={(event) => handleEnableChange(event.target.checked)}
-          type="checkbox"
-        />
-        Enable booking page
-        {showShortcuts ? (
-          <ShortcutKeys keys={bookingJumpKeys("enabled")} />
-        ) : null}
-      </label>
-      {enableError ? (
-        <p className="text-error text-sm" role="alert">
-          {enableError}
-        </p>
-      ) : null}
-
-      <div>
-        <BookingFieldLabel
-          field="duration"
-          htmlFor="booking-duration"
-          showShortcuts={showShortcuts}
-        >
-          Duration
-        </BookingFieldLabel>
-        <select
-          {...bookingFieldAttrs("duration")}
-          className="c-focus-ring w-full rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text hover:bg-surface-panel"
-          id="booking-duration"
-          onChange={(event) =>
-            updateForm({
-              durationMinutes: Number(
-                event.target.value,
-              ) as BookingDurationMinutes,
-            })
-          }
-          value={form.durationMinutes}
-        >
-          {DURATION_OPTIONS.map((minutes) => (
-            <option key={minutes} value={minutes}>
-              {minutes} minutes
-            </option>
-          ))}
-        </select>
-      </div>
-
-      <div>
-        <BookingFieldLabel
-          field="destination"
-          htmlFor="booking-destination-calendar"
-          showShortcuts={showShortcuts}
-        >
-          Destination calendar
-        </BookingFieldLabel>
-        <select
-          {...bookingFieldAttrs("destination")}
-          className="c-focus-ring w-full rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text hover:bg-surface-panel"
-          id="booking-destination-calendar"
-          onChange={(event) =>
-            handleDestinationChange(event.target.value as CalendarId)
-          }
-          value={form.destinationCalendarId}
-        >
-          {writableCalendars.length === 0 ? (
-            <option value={BOOKING_PLACEHOLDER_CALENDAR_ID}>
-              No writable calendars
-            </option>
-          ) : (
-            <>
-              {writableGroups
-                .filter((group) => group.calendars.length > 0)
-                .map((group) => (
-                  <optgroup key={group.accountEmail} label={group.accountEmail}>
-                    {group.calendars.map((calendar) => (
-                      <option key={calendar.id} value={calendar.id}>
-                        {calendar.name}
-                      </option>
-                    ))}
-                  </optgroup>
-                ))}
-              {writableUngrouped.map((calendar) => (
-                <option key={calendar.id} value={calendar.id}>
-                  {calendar.name}
-                </option>
-              ))}
-            </>
-          )}
-        </select>
-      </div>
-
+    <>
       <fieldset
-        className="flex flex-col gap-2"
-        {...bookingFieldAttrs("blocking")}
+        className="flex flex-col gap-4"
+        disabled={isReadOnly || saveMutation.isPending}
+        ref={sectionRef}
       >
-        <legend className="mb-1 flex items-center gap-1 text-sm text-text">
-          Blocking calendars
-          {showShortcuts ? (
-            <ShortcutKeys keys={bookingJumpKeys("blocking")} />
-          ) : null}
-        </legend>
-        {availabilityCalendars.length === 0 ? (
-          <p className="text-sm text-text-muted">No calendars available.</p>
-        ) : (
-          <>
-            {groups
-              .filter((group) => group.calendars.length > 0)
-              .map((group) => (
-                <div className="flex flex-col gap-1" key={group.accountEmail}>
-                  <p className="text-text-muted text-xs">
-                    {group.accountEmail}
-                  </p>
-                  {group.calendars.map(renderBlockingCalendar)}
-                </div>
-              ))}
-            {ungrouped.map(renderBlockingCalendar)}
-          </>
-        )}
-      </fieldset>
+        <p className="text-text-muted text-xs">
+          <ShortcutTipParts parts={BOOKING_SETTINGS_HINT_PARTS} />
+        </p>
 
-      <div {...bookingFieldAttrs("timezone")}>
-        <BookingTimezoneField
-          onChange={(timeZone) => updateForm({ timeZone })}
-          shortcutKeys={showShortcuts ? bookingJumpKeys("timezone") : undefined}
-          timeZone={form.timeZone}
-        />
-      </div>
+        {savedPage ? (
+          <div {...bookingFieldAttrs("link")}>
+            <BookingCopyLink bookingUrl={savedPage.bookingUrl} />
+          </div>
+        ) : null}
 
-      <div className="flex flex-col gap-4" {...bookingFieldAttrs("hours")}>
-        <BookingWeeklyHoursEditor
-          onChange={(weeklyAvailability) => updateForm({ weeklyAvailability })}
-          onValidityChange={setAreHoursValid}
-          shortcutKeys={showShortcuts ? bookingJumpKeys("hours") : undefined}
-          value={form.weeklyAvailability}
-        />
-      </div>
-
-      <div>
-        <BookingFieldLabel
-          field="welcome"
-          htmlFor="booking-welcome"
-          showShortcuts={showShortcuts}
+        <label
+          className="flex items-center gap-2 text-sm text-text"
+          {...bookingFieldAttrs("enabled")}
         >
-          Welcome text
-        </BookingFieldLabel>
-        <textarea
-          {...bookingFieldAttrs("welcome")}
-          aria-invalid={
-            (form.welcomeText?.length ?? 0) > 500 ? true : undefined
-          }
-          className="c-focus-ring min-h-20 w-full rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text aria-invalid:border-error"
-          id="booking-welcome"
-          maxLength={500}
-          onChange={(event) =>
-            updateForm({
-              welcomeText:
-                event.target.value.trim() === "" ? null : event.target.value,
-            })
-          }
-          value={form.welcomeText ?? ""}
-        />
-        {(form.welcomeText?.length ?? 0) > 500 ? (
-          <p className="text-error text-xs" role="alert">
-            Welcome text must be 500 characters or fewer.
+          <input
+            checked={form.enabled}
+            className="c-all-day-checkbox"
+            onChange={(event) => handleEnableChange(event.target.checked)}
+            type="checkbox"
+          />
+          Enable booking page
+          {showShortcuts ? (
+            <ShortcutKeys keys={bookingJumpKeys("enabled")} />
+          ) : null}
+        </label>
+        {enableError ? (
+          <p className="text-error text-sm" role="alert">
+            {enableError}
           </p>
         ) : null}
-      </div>
 
-      <div className="grid grid-cols-2 gap-3">
-        <BookingNumberField
-          field="notice"
-          id="booking-min-notice"
-          invalid={minNoticeInvalid}
-          invalidMessage="Enter 0 or more hours."
-          label="Minimum notice (hours)"
-          min={0}
-          onChange={(raw) => {
-            setMinNoticeText(raw);
-            const parsed = parseBookingCount(raw, MIN_NOTICE_BOUNDS);
-            if (parsed !== null) {
-              updateForm({ minNoticeHours: parsed });
-            }
-          }}
-          showShortcuts={showShortcuts}
-          value={minNoticeText}
-        />
-        <BookingNumberField
-          field="horizon"
-          id="booking-max-horizon"
-          invalid={horizonInvalid}
-          invalidMessage="Enter 1 to 60 days."
-          label="Maximum horizon (days)"
-          max={60}
-          min={1}
-          onChange={(raw) => {
-            setHorizonText(raw);
-            const parsed = parseBookingCount(raw, HORIZON_BOUNDS);
-            if (parsed !== null) {
-              updateForm({ maxHorizonDays: parsed });
-            }
-          }}
-          showShortcuts={showShortcuts}
-          value={horizonText}
-        />
-      </div>
-
-      <fieldset
-        className="flex flex-col gap-2"
-        {...bookingFieldAttrs("options")}
-      >
-        <legend className="mb-1 flex items-center gap-1 text-sm text-text">
-          Buffer and limits
-          {showShortcuts ? (
-            <ShortcutKeys keys={bookingJumpKeys("options")} />
-          ) : null}
-        </legend>
-
-        <BookingCheckboxRow
-          checked={form.bufferMinutes !== null}
-          onChange={(checked) =>
-            updateForm({
-              bufferMinutes: checked ? DEFAULT_BUFFER_MINUTES : null,
-            })
-          }
-        >
-          Buffer between appointments ({DEFAULT_BUFFER_MINUTES} minutes)
-        </BookingCheckboxRow>
-
-        <BookingCheckboxRow
-          checked={form.maxBookingsPerDay !== null}
-          onChange={(checked) =>
-            updateForm({
-              maxBookingsPerDay: checked ? DEFAULT_MAX_BOOKINGS_PER_DAY : null,
-            })
-          }
-        >
-          Max bookings per day ({DEFAULT_MAX_BOOKINGS_PER_DAY})
-        </BookingCheckboxRow>
-
-        <BookingCheckboxRow
-          checked={form.guestsCanInviteOthers}
-          onChange={(guestsCanInviteOthers) =>
-            updateForm({ guestsCanInviteOthers })
-          }
-        >
-          Guest can invite others
-        </BookingCheckboxRow>
-      </fieldset>
-
-      <div className={BOOKING_SETTINGS_SAVE_BAR_CLASS_NAME}>
-        {/* Default align=end keeps the always-on chip Save off the hours column. */}
-        <OverlayPanelActions>
-          <OverlayPanelActionButton
-            aria-busy={saveMutation.isPending || undefined}
-            aria-keyshortcuts="Meta+Enter Control+Enter"
-            className="whitespace-nowrap"
-            disabled={saveMutation.isPending}
-            onClick={handleSave}
-            shortcut={["Mod", "Enter"]}
-            showShortcut
-            variant="primary"
-            {...settingsShortcutAttrs("save-booking")}
+        <div>
+          <BookingFieldLabel
+            field="duration"
+            htmlFor="booking-duration"
+            showShortcuts={showShortcuts}
           >
-            {saveMutation.isPending ? "Saving…" : "Save booking settings"}
-          </OverlayPanelActionButton>
-        </OverlayPanelActions>
-      </div>
+            Duration
+          </BookingFieldLabel>
+          <select
+            {...bookingFieldAttrs("duration")}
+            className="c-focus-ring w-full rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text hover:bg-surface-panel"
+            id="booking-duration"
+            onChange={(event) =>
+              updateForm({
+                durationMinutes: Number(
+                  event.target.value,
+                ) as BookingDurationMinutes,
+              })
+            }
+            value={form.durationMinutes}
+          >
+            {DURATION_OPTIONS.map((minutes) => (
+              <option key={minutes} value={minutes}>
+                {minutes} minutes
+              </option>
+            ))}
+          </select>
+        </div>
 
-      <EditSequenceMenu
-        getAnchor={() => sectionRef.current}
-        options={BOOKING_SEQUENCE_FIELDS}
-        prompt="Jump to which field?"
-        scope="booking"
+        <div>
+          <BookingFieldLabel
+            field="destination"
+            htmlFor="booking-destination-calendar"
+            showShortcuts={showShortcuts}
+          >
+            Destination calendar
+          </BookingFieldLabel>
+          <select
+            {...bookingFieldAttrs("destination")}
+            className="c-focus-ring w-full rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text hover:bg-surface-panel"
+            id="booking-destination-calendar"
+            onChange={(event) =>
+              handleDestinationChange(event.target.value as CalendarId)
+            }
+            value={form.destinationCalendarId}
+          >
+            {writableCalendars.length === 0 ? (
+              <option value={BOOKING_PLACEHOLDER_CALENDAR_ID}>
+                No writable calendars
+              </option>
+            ) : (
+              <>
+                {writableGroups
+                  .filter((group) => group.calendars.length > 0)
+                  .map((group) => (
+                    <optgroup
+                      key={group.accountEmail}
+                      label={group.accountEmail}
+                    >
+                      {group.calendars.map((calendar) => (
+                        <option key={calendar.id} value={calendar.id}>
+                          {calendar.name}
+                        </option>
+                      ))}
+                    </optgroup>
+                  ))}
+                {writableUngrouped.map((calendar) => (
+                  <option key={calendar.id} value={calendar.id}>
+                    {calendar.name}
+                  </option>
+                ))}
+              </>
+            )}
+          </select>
+        </div>
+
+        <fieldset
+          className="flex flex-col gap-2"
+          {...bookingFieldAttrs("blocking")}
+        >
+          <legend className="mb-1 flex items-center gap-1 text-sm text-text">
+            Blocking calendars
+            {showShortcuts ? (
+              <ShortcutKeys keys={bookingJumpKeys("blocking")} />
+            ) : null}
+          </legend>
+          {availabilityCalendars.length === 0 ? (
+            <p className="text-sm text-text-muted">No calendars available.</p>
+          ) : (
+            <>
+              {groups
+                .filter((group) => group.calendars.length > 0)
+                .map((group) => (
+                  <div className="flex flex-col gap-1" key={group.accountEmail}>
+                    <p className="text-text-muted text-xs">
+                      {group.accountEmail}
+                    </p>
+                    {group.calendars.map(renderBlockingCalendar)}
+                  </div>
+                ))}
+              {ungrouped.map(renderBlockingCalendar)}
+            </>
+          )}
+        </fieldset>
+
+        <div {...bookingFieldAttrs("timezone")}>
+          <BookingTimezoneField
+            onChange={(timeZone) => updateForm({ timeZone })}
+            shortcutKeys={
+              showShortcuts ? bookingJumpKeys("timezone") : undefined
+            }
+            timeZone={form.timeZone}
+          />
+        </div>
+
+        <div className="flex flex-col gap-4" {...bookingFieldAttrs("hours")}>
+          <BookingWeeklyHoursEditor
+            onChange={(weeklyAvailability) =>
+              updateForm({ weeklyAvailability })
+            }
+            onValidityChange={setAreHoursValid}
+            shortcutKeys={showShortcuts ? bookingJumpKeys("hours") : undefined}
+            value={form.weeklyAvailability}
+          />
+        </div>
+
+        <div>
+          <BookingFieldLabel
+            field="welcome"
+            htmlFor="booking-welcome"
+            showShortcuts={showShortcuts}
+          >
+            Welcome text
+          </BookingFieldLabel>
+          <textarea
+            {...bookingFieldAttrs("welcome")}
+            aria-invalid={
+              (form.welcomeText?.length ?? 0) > 500 ? true : undefined
+            }
+            className="c-focus-ring min-h-20 w-full rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text aria-invalid:border-error"
+            id="booking-welcome"
+            maxLength={500}
+            onChange={(event) =>
+              updateForm({
+                welcomeText:
+                  event.target.value.trim() === "" ? null : event.target.value,
+              })
+            }
+            value={form.welcomeText ?? ""}
+          />
+          {(form.welcomeText?.length ?? 0) > 500 ? (
+            <p className="text-error text-xs" role="alert">
+              Welcome text must be 500 characters or fewer.
+            </p>
+          ) : null}
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <BookingNumberField
+            field="notice"
+            id="booking-min-notice"
+            invalid={minNoticeInvalid}
+            invalidMessage="Enter 0 or more hours."
+            label="Minimum notice (hours)"
+            min={0}
+            onChange={(raw) => {
+              setMinNoticeText(raw);
+              const parsed = parseBookingCount(raw, MIN_NOTICE_BOUNDS);
+              if (parsed !== null) {
+                updateForm({ minNoticeHours: parsed });
+              }
+            }}
+            showShortcuts={showShortcuts}
+            value={minNoticeText}
+          />
+          <BookingNumberField
+            field="horizon"
+            id="booking-max-horizon"
+            invalid={horizonInvalid}
+            invalidMessage="Enter 1 to 60 days."
+            label="Maximum horizon (days)"
+            max={60}
+            min={1}
+            onChange={(raw) => {
+              setHorizonText(raw);
+              const parsed = parseBookingCount(raw, HORIZON_BOUNDS);
+              if (parsed !== null) {
+                updateForm({ maxHorizonDays: parsed });
+              }
+            }}
+            showShortcuts={showShortcuts}
+            value={horizonText}
+          />
+        </div>
+
+        <fieldset
+          className="flex flex-col gap-2"
+          {...bookingFieldAttrs("options")}
+        >
+          <legend className="mb-1 flex items-center gap-1 text-sm text-text">
+            Buffer and limits
+            {showShortcuts ? (
+              <ShortcutKeys keys={bookingJumpKeys("options")} />
+            ) : null}
+          </legend>
+
+          <BookingCheckboxRow
+            checked={form.bufferMinutes !== null}
+            onChange={(checked) =>
+              updateForm({
+                bufferMinutes: checked ? DEFAULT_BUFFER_MINUTES : null,
+              })
+            }
+          >
+            Buffer between appointments ({DEFAULT_BUFFER_MINUTES} minutes)
+          </BookingCheckboxRow>
+
+          <BookingCheckboxRow
+            checked={form.maxBookingsPerDay !== null}
+            onChange={(checked) =>
+              updateForm({
+                maxBookingsPerDay: checked
+                  ? DEFAULT_MAX_BOOKINGS_PER_DAY
+                  : null,
+              })
+            }
+          >
+            Max bookings per day ({DEFAULT_MAX_BOOKINGS_PER_DAY})
+          </BookingCheckboxRow>
+
+          <BookingCheckboxRow
+            checked={form.guestsCanInviteOthers}
+            onChange={(guestsCanInviteOthers) =>
+              updateForm({ guestsCanInviteOthers })
+            }
+          >
+            Guest can invite others
+          </BookingCheckboxRow>
+        </fieldset>
+
+        <div className={BOOKING_SETTINGS_SAVE_BAR_CLASS_NAME}>
+          {/* Default align=end keeps the always-on chip Save off the hours column. */}
+          <OverlayPanelActions>
+            <OverlayPanelActionButton
+              aria-busy={saveMutation.isPending || undefined}
+              aria-keyshortcuts="Meta+Enter Control+Enter"
+              className="whitespace-nowrap"
+              disabled={saveMutation.isPending}
+              onClick={handleSave}
+              shortcut={["Mod", "Enter"]}
+              showShortcut
+              variant="primary"
+              {...settingsShortcutAttrs("save-booking")}
+            >
+              {saveMutation.isPending ? "Saving…" : "Save booking settings"}
+            </OverlayPanelActionButton>
+          </OverlayPanelActions>
+        </div>
+
+        <EditSequenceMenu
+          getAnchor={() => sectionRef.current}
+          options={BOOKING_SEQUENCE_FIELDS}
+          prompt="Jump to which field?"
+          scope="booking"
+        />
+      </fieldset>
+      <DiscardUnsavedChangesDialog
+        isOpen={isConfirmOpen}
+        onCancel={() => setIsConfirmOpen(false)}
+        onDiscard={() => {
+          setIsConfirmOpen(false);
+          onDiscardUnsaved?.();
+        }}
       />
-    </fieldset>
+    </>
   );
 }

--- a/packages/web/src/booking/BookingWeeklyHoursEditor.tsx
+++ b/packages/web/src/booking/BookingWeeklyHoursEditor.tsx
@@ -20,6 +20,8 @@ interface BookingWeeklyHoursEditorProps {
   disabled?: boolean;
   /** Raised when a row cannot be read, so the form can block saving. */
   onValidityChange?: (isValid: boolean) => void;
+  /** True while a row's typed text has not been committed into `value`. */
+  onDraftDirtyChange?: (isDirty: boolean) => void;
   /** Jump keys to reveal beside the legend while hold-Mod hints are up. */
   shortcutKeys?: readonly string[];
 }
@@ -47,6 +49,7 @@ export function BookingWeeklyHoursEditor({
   onChange,
   disabled = false,
   onValidityChange,
+  onDraftDirtyChange,
   shortcutKeys,
 }: BookingWeeklyHoursEditorProps) {
   // Raw text per row so a half-typed value is never yanked out from under the
@@ -60,6 +63,7 @@ export function BookingWeeklyHoursEditor({
   // outside - the server response seeding the form - so the rows resync,
   // without yanking a half-typed value out from under the user.
   const emittedRef = useRef<WeeklyAvailability>(value);
+  const draftDirtyRef = useRef(false);
 
   useEffect(() => {
     if (value === emittedRef.current) return;
@@ -71,6 +75,16 @@ export function BookingWeeklyHoursEditor({
   useEffect(() => {
     onValidityChange?.(Object.keys(errors).length === 0);
   }, [errors, onValidityChange]);
+
+  useEffect(() => {
+    if (!onDraftDirtyChange) return;
+    const dirty = ISO_WEEKDAYS.some(
+      (weekday) => (texts[weekday] ?? "") !== textForWeekday(value, weekday),
+    );
+    if (draftDirtyRef.current === dirty) return;
+    draftDirtyRef.current = dirty;
+    onDraftDirtyChange(dirty);
+  }, [onDraftDirtyChange, texts, value]);
 
   const commit = (nextTexts: Record<Weekday, string>) => {
     const nextErrors: Partial<Record<Weekday, string>> = {};

--- a/packages/web/src/booking/booking.util.test.ts
+++ b/packages/web/src/booking/booking.util.test.ts
@@ -1,6 +1,13 @@
-import { CalendarIdSchema } from "@core/types/domain-primitives";
+import { type AdminPutBookingPageInput } from "@core/types/booking.contracts";
+import {
+  CalendarIdSchema,
+  TimeZoneSchema,
+} from "@core/types/domain-primitives";
 import { createMockCalendar } from "@web/__tests__/utils/factories/calendar.factory";
-import { defaultBlockingCalendarIdsForDestination } from "@web/booking/booking.util";
+import {
+  defaultBlockingCalendarIdsForDestination,
+  isBookingSettingsFormDirty,
+} from "@web/booking/booking.util";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import { describe, expect, it } from "bun:test";
 
@@ -68,5 +75,64 @@ describe("defaultBlockingCalendarIdsForDestination", () => {
     expect(
       defaultBlockingCalendarIdsForDestination(compassId, [compass]),
     ).toEqual([compassId]);
+  });
+});
+
+const bookingForm = (
+  overrides: Partial<AdminPutBookingPageInput> = {},
+): AdminPutBookingPageInput => {
+  const destinationCalendarId = CalendarIdSchema.parse(createObjectIdString());
+  return {
+    enabled: false,
+    durationMinutes: 30,
+    destinationCalendarId,
+    blockingCalendarIds: [destinationCalendarId],
+    timeZone: TimeZoneSchema.parse("UTC"),
+    weeklyAvailability: [],
+    welcomeText: null,
+    minNoticeHours: 4,
+    maxHorizonDays: 60,
+    bufferMinutes: null,
+    maxBookingsPerDay: null,
+    guestsCanInviteOthers: true,
+    ...overrides,
+  };
+};
+
+describe("isBookingSettingsFormDirty", () => {
+  it("is clean when the form matches the seeded page", () => {
+    const baseline = bookingForm();
+    expect(
+      isBookingSettingsFormDirty({
+        baseline,
+        form: { ...baseline },
+        horizonText: "60",
+        minNoticeText: "4",
+      }),
+    ).toBe(false);
+  });
+
+  it("is dirty when a PUT field changes", () => {
+    const baseline = bookingForm();
+    expect(
+      isBookingSettingsFormDirty({
+        baseline,
+        form: { ...baseline, durationMinutes: 45 },
+        horizonText: "60",
+        minNoticeText: "4",
+      }),
+    ).toBe(true);
+  });
+
+  it("is dirty when a number field is cleared even if the parsed value is unchanged", () => {
+    const baseline = bookingForm();
+    expect(
+      isBookingSettingsFormDirty({
+        baseline,
+        form: baseline,
+        horizonText: "",
+        minNoticeText: "4",
+      }),
+    ).toBe(true);
   });
 });

--- a/packages/web/src/booking/booking.util.ts
+++ b/packages/web/src/booking/booking.util.ts
@@ -110,6 +110,35 @@ export function toBookingPageInput(
 }
 
 /**
+ * Compare the live Settings form against the last seeded page. Number fields
+ * keep raw text until parse succeeds, so an in-progress (or cleared) value
+ * counts as dirty even when `form.minNoticeHours` / `form.maxHorizonDays`
+ * still hold the previous integer.
+ */
+export function isBookingSettingsFormDirty({
+  form,
+  baseline,
+  minNoticeText,
+  horizonText,
+}: {
+  form: AdminPutBookingPageInput;
+  baseline: AdminPutBookingPageInput;
+  minNoticeText: string;
+  horizonText: string;
+}): boolean {
+  if (
+    JSON.stringify(toBookingPageInput(form)) !==
+    JSON.stringify(toBookingPageInput(baseline))
+  ) {
+    return true;
+  }
+  return (
+    minNoticeText !== String(baseline.minNoticeHours) ||
+    horizonText !== String(baseline.maxHorizonDays)
+  );
+}
+
+/**
  * A page the host has never saved. `GET /booking/page` answers with the same
  * bare input shape whether the host never saved or saved without ever
  * enabling, so the explicit flag is the only way to tell them apart - and the

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -922,6 +922,28 @@ describe("SettingsModal", () => {
     ).toBeInTheDocument();
   });
 
+  it("asks before discarding uncommitted weekly hours on Escape", async () => {
+    const user = userEvent.setup({ delay: null });
+    const calendar = createMockCalendar({ name: "Work" });
+    renderSettings({
+      authenticated: true,
+      calendars: [calendar],
+      page: "booking",
+    });
+
+    await screen.findByRole("button", { name: "Save booking settings" });
+    await user.type(screen.getByLabelText("Monday"), "9");
+    await user.keyboard("{Escape}");
+
+    expect(
+      screen.getByRole("dialog", { name: "Discard unsaved changes?" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("dialog", { name: "Settings" }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Monday")).toHaveValue("9");
+  });
+
   it("asks before discarding unsaved booking edits on Escape", async () => {
     const user = userEvent.setup({ delay: null });
     const calendar = createMockCalendar({ name: "Work" });

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -921,4 +921,112 @@ describe("SettingsModal", () => {
       await screen.findByText("Loading booking settings\u2026"),
     ).toBeInTheDocument();
   });
+
+  it("asks before discarding unsaved booking edits on Escape", async () => {
+    const user = userEvent.setup({ delay: null });
+    const calendar = createMockCalendar({ name: "Work" });
+    renderSettings({
+      authenticated: true,
+      calendars: [calendar],
+      page: "booking",
+    });
+
+    await screen.findByRole("button", { name: "Save booking settings" });
+    await user.selectOptions(screen.getByLabelText("Duration"), "45");
+    await user.keyboard("{Escape}");
+
+    expect(
+      screen.getByRole("dialog", { name: "Discard unsaved changes?" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("dialog", { name: "Settings" }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Duration")).toHaveValue("45");
+  });
+
+  it("closes Settings after confirming discard of booking edits", async () => {
+    const user = userEvent.setup({ delay: null });
+    const calendar = createMockCalendar({ name: "Work" });
+    renderSettings({
+      authenticated: true,
+      calendars: [calendar],
+      page: "booking",
+    });
+
+    await screen.findByRole("button", { name: "Save booking settings" });
+    await user.selectOptions(screen.getByLabelText("Duration"), "45");
+    await user.keyboard("{Escape}");
+    await user.click(screen.getByRole("button", { name: "Discard" }));
+
+    expect(
+      screen.queryByRole("dialog", { name: "Settings" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps booking edits when the discard confirmation is dismissed", async () => {
+    const user = userEvent.setup({ delay: null });
+    const calendar = createMockCalendar({ name: "Work" });
+    renderSettings({
+      authenticated: true,
+      calendars: [calendar],
+      page: "booking",
+    });
+
+    await screen.findByRole("button", { name: "Save booking settings" });
+    await user.selectOptions(screen.getByLabelText("Duration"), "45");
+    await user.keyboard("{Escape}");
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(
+      screen.queryByRole("dialog", { name: "Discard unsaved changes?" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("dialog", { name: "Settings" }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Duration")).toHaveValue("45");
+  });
+
+  it("closes Settings on Escape when booking settings are unchanged", async () => {
+    const user = userEvent.setup({ delay: null });
+    const calendar = createMockCalendar({ name: "Work" });
+    renderSettings({
+      authenticated: true,
+      calendars: [calendar],
+      page: "booking",
+    });
+
+    await screen.findByRole("button", { name: "Save booking settings" });
+    await user.keyboard("{Escape}");
+
+    expect(
+      screen.queryByRole("dialog", { name: "Discard unsaved changes?" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("dialog", { name: "Settings" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("disarms the e leader on Escape without closing Booking Settings", async () => {
+    const user = userEvent.setup({ delay: null });
+    const calendar = createMockCalendar({ name: "Work" });
+    renderSettings({
+      authenticated: true,
+      calendars: [calendar],
+      page: "booking",
+    });
+
+    await screen.findByRole("button", { name: "Save booking settings" });
+    await user.keyboard("e");
+    await user.keyboard("{Escape}");
+
+    expect(
+      screen.queryByRole("dialog", { name: "Discard unsaved changes?" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("dialog", { name: "Settings" }),
+    ).toBeInTheDocument();
+
+    await user.keyboard("h");
+    expect(document.activeElement).not.toBe(screen.getByLabelText("Monday"));
+  });
 });

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -77,7 +77,8 @@ const navButtonClassName = (current: boolean) =>
  * The app's Settings menu (Mod+,): Accounts (timezone, calendars, Google
  * connections, export / delete / log out) and Billing (plan) as sibling
  * pages. ESC steps back a level - out of an open disconnect
- * confirmation first, then out of the modal - via `handleDismiss`, since
+ * confirmation first, then out of a dirty Booking form's discard
+ * prompt, then out of the modal - via `handleDismiss`, since
  * OverlayPanel already routes both ESC and a backdrop click through
  * `onDismiss`.
  */
@@ -87,6 +88,7 @@ export const SettingsModal: FC = () => {
   const initialFocusRef = useRef<HTMLButtonElement>(null);
   const reseatFocusOnAccountsRef = useRef(false);
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  const bookingDismissGuardRef = useRef<(() => boolean) | null>(null);
   const { skipFocusRestoreRef, handleDismiss: dismissToPalette } =
     usePaletteAwareOverlayDismiss(isOpen, settingsActions.closeSettings);
   useAppLockReason("settingsModal", isOpen);
@@ -149,6 +151,9 @@ export const SettingsModal: FC = () => {
       setConfirmingId(null);
       return;
     }
+    // Booking form is dirty: ask before dropping the modal. The e-leader
+    // capture-phase Escape never reaches here.
+    if (bookingDismissGuardRef.current?.()) return;
     dismissToPalette();
   };
 
@@ -244,7 +249,11 @@ export const SettingsModal: FC = () => {
             <PlanSection showShortcuts={areHintsVisible} />
           ) : page === "booking" && IS_BOOKING_ENABLED ? (
             <Suspense fallback={null}>
-              <BookingSettingsSection showShortcuts={areHintsVisible} />
+              <BookingSettingsSection
+                dismissGuardRef={bookingDismissGuardRef}
+                onDiscardUnsaved={dismissToPalette}
+                showShortcuts={areHintsVisible}
+              />
             </Suspense>
           ) : (
             <>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #3135 (Booking v1.5 WP-07).

Escape in Settings > Booking no longer drops unsaved edits. When the booking form differs from the last seeded page (or weekly-hours text is still uncommitted), Settings stays open and the existing `Discard unsaved changes?` dialog asks first. Confirming discard closes Settings. Dismissing the dialog leaves the edits in place. A clean form still closes immediately. Escape while the `e` leader is armed still only disarms the sequence.

Dirty state compares `toBookingPageInput(form)` plus in-progress notice/horizon text against the seeded baseline, and treats uncommitted weekly-hours draft text as dirty. `isBookingEnabled` is unchanged.

## Simplicity

Reuses `DiscardUnsavedChangesDialog` and intercepts Settings `handleDismiss` via a booking-owned guard. No second overlay-escape stack for the form itself. The stacked discard dialog is the same event-form pattern. The fieldset fragment keeps that dialog outside `disabled`.

## Automated validation

`bun run verify` PASS. Selected packages: web. Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e. Checks skipped: (none). test:web shards 1617 and 1592 pass, 0 fail. test:a11y 24 passed. test:e2e 109 passed.

Focused Settings/booking tests cover dirty confirm, discard, keep edits, clean close, e-leader disarm, and uncommitted Monday hours.

## Independent review

`.agents/handoffs/3135.md`

VERDICT: no confirmed findings
FINDINGS:
(none)

## Test plan

- `bun test:web packages/web/src/booking/booking.util.test.ts packages/web/src/components/Settings/SettingsModal.test.tsx packages/web/src/booking/BookingSettingsSection.test.tsx`
- `bun run verify`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec67721b-395d-454e-bd11-696669d367b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec67721b-395d-454e-bd11-696669d367b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

