### PR TITLE
docs(billing): rewrite for embedded checkout (WP-08)

### DIFF
--- a/.agents/handoffs/3162.md
+++ b/.agents/handoffs/3162.md
@@ -1,0 +1,47 @@
+---
+schema_version: 1
+task_id: "3162"
+from: Implementer
+to: Founder
+owner: Founder
+status: waiting
+artifact:
+  - path: docs/features/billing.md
+  - path: docs/backend/README.md
+  - path: docs/Config/README.md
+  - path: docs/development/feature-file-map.md
+  - path: docs/frontend/shortcut-commandments.md
+evidence:
+  - command: bun lint
+    result: "exit 0; 25 pre-existing biome warnings, none in this diff"
+  - command: bun run verify
+    result: "PASS; type-check, lint, knip; no packages detected"
+  - command: grep -rn "portal\\|Opening Stripe\\|checkout.stripe.com\\|settings=billing" docs packages compass.example.yaml self-host
+    result: "billing hits: CSP allowlist checkout.stripe.com in docs/features/billing.md; packages/backend/src/billing/billing.routes.config.test.ts asserts /api/billing/portal/session is unmounted. Remaining portal hits are React/floating-ui."
+assumptions:
+  - "Milestone instruction overrides the issue body: do not run the staging QA checklist; record each item as waiting"
+  - "Remaining grep hits for portal are React/floating-ui portals and the test that asserts the Customer Portal route is gone"
+  - "checkout.stripe.com appears only in the CSP allowlist in docs/features/billing.md"
+open_risks: []
+next_deadline: 2026-09-10T00:00:00Z
+retry: 0
+approval: human
+waiting_on: founder staging QA
+escalation: null
+---
+
+WP-08: docs describe embedded Checkout and the Compass Settings > Billing
+view. CSP list and founder staging QA checklist live in
+`docs/features/billing.md`. This agent does not run the checklist.
+
+Founder staging QA (record pass/fail on `staging-cloud` after deploy):
+
+| Item | Result |
+| --- | --- |
+| `4242 4242 4242 4242` success into a trial | waiting |
+| `4000 0025 0000 3155` 3DS inside the iframe | waiting |
+| `4000 0000 0000 9995` decline | waiting |
+| Update card | waiting |
+| Cancel then Resume | waiting |
+| Receipt link | waiting |
+| setup-mode `checkout.session.completed` webhook 200 | waiting |

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,6 +13,7 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 3162 | high | Founder | waiting | docs/features/billing.md | bun run verify PASS (type-check, lint, knip); founder staging QA waiting | 2026-09-10T00:00:00Z | 0 | human |
 | 3134 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3195 | bun run verify PASS (web 1613, a11y 24, e2e 109); review: no confirmed findings | null | 0 | none |
 | 3158 | high | Implementer | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3168 | bun test:web 1569 pass; type-check pass; lint exit 0; knip pass | 2026-09-04T00:00:00Z | 0 | none |
 | 3129 | high | Verifier | verifying | packages/web/src/booking/BookingSettingsSection.tsx | bun test:web 30 pass; host-settings e2e 5 pass; test:a11y 24 pass; bun run verify PASS | 2026-09-03T20:00:00Z | 0 | none |

--- a/docs/Config/README.md
+++ b/docs/Config/README.md
@@ -98,7 +98,7 @@ database and must not share the backend's database user/data.
 |---|---|---|
 | `posthog.key` | No | PostHog project key injected into the web bundle. |
 | `posthog.host` | No | PostHog host injected into the web bundle. |
-| `stripe.secretKey` | No | Stripe secret (`sk_test_...` is fine on staging). All four Stripe keys are required together; omit the whole `stripe:` block on self-host. |
+| `stripe.secretKey` | No | Stripe secret (`sk_test_...` is fine on staging). All four Stripe keys are required together; omit the whole `stripe:` block on self-host. Hosted deploys set `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRICE_ID`, and `STRIPE_PUBLISHABLE_KEY` on the GitHub Environment; missing any one omits the block. |
 | `stripe.webhookSecret` | No | Stripe webhook signing secret. |
 | `stripe.priceId` | No | Stripe Price id for the hosted subscription. The amount lives on that Price in Stripe. |
-| `stripe.publishableKey` | No | Stripe publishable key (`pk_test_...` is fine on staging). Served to the web as `billing.publishableKey` so Stripe.js can load without a rebuild. |
+| `stripe.publishableKey` | No | Stripe publishable key (`pk_test_...` is fine on staging). Served to the web as `billing.publishableKey` on `/api/config` so Stripe.js can load on the first checkout surface without a rebuild. |

--- a/docs/backend/README.md
+++ b/docs/backend/README.md
@@ -25,7 +25,7 @@ Backend routes are registered from
 | Config | `packages/backend/src/config/config.routes.config.ts` | Public runtime config used by the web app. |
 | Auth | `packages/backend/src/auth/auth.routes.config.ts` | Compass-owned auth helpers and authenticated Google connect. SuperTokens also mounts recipe routes under `/api`. |
 | User | `packages/backend/src/user/user.routes.config.ts` | Profile and metadata for the active session. |
-| Billing | `packages/backend/src/billing/billing.routes.config.ts` | Session status, Checkout, Billing Portal, `GET /api/billing/subscription`, cancel and resume, and unauthenticated Stripe webhook. Self-host omits Stripe keys and stays fully writable. |
+| Billing | `packages/backend/src/billing/billing.routes.config.ts` | Session status, embedded Checkout, setup-mode payment-method session, `GET /api/billing/subscription`, cancel and resume, and unauthenticated Stripe webhook. Self-host omits Stripe keys and stays fully writable. |
 | Events | `packages/backend/src/event/event.routes.config.ts` | Event CRUD and reorder/delete helpers. |
 | Event stream | `packages/backend/src/events/events.routes.config.ts` | Authenticated SSE stream at `GET /api/events/stream`. |
 | Calendars | `packages/backend/src/calendar/calendar.routes.config.ts` | Calendar list and selection routes. |

--- a/docs/development/feature-file-map.md
+++ b/docs/development/feature-file-map.md
@@ -183,6 +183,10 @@ the full picture.
 - Shared plan/price copy: `packages/core/src/constants/billing.constants.ts`
 - Read-only look-around: `packages/web/src/billing/billing-preview.store.ts`, `packages/web/src/billing/BillingReadOnlyBanner.tsx`
 - Server access + paid gate: `packages/web/src/billing/useAppAccess.ts`, `packages/web/src/billing/BillingGateModal.tsx`
+- Embedded Checkout port (only `loadStripe` call) and lazy seam: `packages/web/src/billing/embedded-checkout/embedded-checkout.port.tsx`, `embedded-checkout.seam.ts`
+- Gate checkout store: `packages/web/src/billing/checkout-panel.store.ts`
+- Update-card store: `packages/web/src/billing/card-update.store.ts`
+- Settings > Billing management: `packages/web/src/billing/PlanSection.tsx`
 - Trial countdown + early upgrade: `packages/web/src/billing/TrialBadge.tsx`, `packages/web/src/billing/trialDaysLeft.ts`, `packages/web/src/billing/UpgradeConfirmation/`
 - Backend billing: `packages/backend/src/billing`
 - Overview: [Billing And Trial](../features/billing.md)

--- a/docs/features/billing.md
+++ b/docs/features/billing.md
@@ -1,9 +1,13 @@
 # Billing And Trial
 
-Hosted Compass uses Stripe Checkout (subscription mode, 7-day trial)
-and the Stripe Billing Portal. The subscription amount lives on the Stripe
-Price behind `stripe.priceId`, so operators can change it in Stripe without
-a web deploy. There is no Stripe.js and no publishable key in the web bundle.
+Hosted Compass uses Stripe **embedded** Checkout (subscription mode, 7-day
+trial) rendered inside the app, and a Compass-built Settings > Billing view
+for the card on file, cancel or resume, and receipts. The subscription
+amount lives on the Stripe Price behind `stripe.priceId`, so operators can
+change it in Stripe without a web deploy. Stripe.js loads lazily from
+`js.stripe.com` on the first checkout surface (the gate or Update card);
+the publishable key is served by `/api/config` as `billing.publishableKey`
+and is never baked into the web bundle.
 
 Self-host installs omit the `stripe:` config block. `/api/config` then reports
 `billing.isConfigured: false`, the web never shows a paid gate, and event
@@ -82,11 +86,14 @@ production.
   browser-local trial: a trial is only ever asked for at the moment of
   commitment (sign up, sign in, connect an account).
 - **Signed up, no card yet:** `awaiting_checkout`, read-only,
-  `BillingGateModal` with Start trial (Stripe Checkout). The gate also offers
-  "Look around first", which unmounts it and drops the user onto the real
-  calendar behind `BillingReadOnlyBanner`. That preview lives in
-  `billing-preview.store.ts` and is deliberately in-memory, so a reload puts
-  the trial ask back. Writes still fail server-side, and the
+  `BillingGateModal` with Start trial. Checkout happens inside the gate:
+  Start trial (`S`) mounts Stripe embedded Checkout in the same overlay.
+  Completion raises the celebration through `onComplete`; the webhook remains
+  the source of truth and a short poll of `GET /api/billing/status` waits for
+  it. The gate also offers "Look around first" (`L`), which unmounts it and
+  drops the user onto the real calendar behind `BillingReadOnlyBanner`. That
+  preview lives in `billing-preview.store.ts` and is deliberately in-memory, so
+  a reload puts the trial ask back. Writes still fail server-side, and the
   `BILLING_REQUIRED` branch in `useEventMutations` exits the preview, so the
   first refused save brings the gate straight back. That refusal does not
   show the catch-all "something went wrong" toast — the gate is the feedback.
@@ -99,27 +106,48 @@ production.
   that jump. Press `B` (keycap-styled in the badge tooltip and on Settings →
   Billing) to subscribe early. That shortcut is registered by
   `UpgradeConfirmationProvider` and keeps working while Settings is open.
-- **Active / past_due:** writable. `past_due` also shows a banner. Settings
-  splits Accounts and Billing; Billing is hidden on installs with no plan.
-- **Active / past_due:** writable. `past_due` also shows a banner.
+- **Active / past_due:** writable. `past_due` also shows a banner whose CTA
+  opens Settings on Billing with Update card already mounted.
 - **Expired / canceled:** read-only until they subscribe again. A later
   Checkout does not grant another trial.
 
 There is no `POST /api/billing/trial/start`. A trial only begins through
-Stripe Checkout (`trial_period_days` on the first subscription).
+Stripe Checkout (`trial_period_days` on the first subscription). Sessions
+use `ui_mode: "embedded"` and `redirect_on_completion: "never"`, so
+Checkout stays inside Compass. Redirect-based payment methods are therefore
+unavailable by design.
 
 A trial can be *ended* early through `POST /api/billing/trial/end`, which calls
 `subscriptions.update(trial_end: "now")` and writes the returned Subscription
 through the webhook's own `applySubscription`, so status is fresh in the same
-response and the Stripe field mapping stays in one place. The Billing Portal
-cannot shorten a trial, which is why this endpoint exists. Three ways in, all
+response and the Stripe field mapping stays in one place. Three ways in, all
 gated on a running trial: the badge, a "Subscribe now" palette command, and
-bare `B`. "Manage billing" is a different action: it opens the Stripe Customer
-Portal in a new tab (popup-blocked fallback: same-tab, returning to
-`?settings=billing`). Portal return reopens Settings on Billing and refetches
-status on window focus so a trial that became Premium is visible immediately.
-A declined card lands on `past_due` (still writable), so the confirm dialog
-reports the resulting status instead of a blanket success.
+bare `B`. "Manage billing" on that confirm dialog opens Settings on Billing;
+it does not charge today and does not end the trial. A declined card lands
+on `past_due` (still writable), so the confirm dialog reports the resulting
+status instead of a blanket success.
+
+**Settings > Billing** (`PlanSection.tsx`) is the management view. It shows
+the plan badge, price from the Stripe Price (minor units formatted in the
+browser), renews or ends date, and the card on file (`{Brand} ending in
+{last4}, expires MM/YY`, or "No card on file"). From there:
+
+- **Update card** (`U`) mounts a setup-mode embedded Checkout session
+  (`POST /api/billing/payment-method/session`). The webhook
+  `checkout.session.completed` for `mode: "setup"` sets the default payment
+  method on the Customer and Subscription. After `onComplete`, Compass toasts
+  "Card updated" and polls until Settings shows the new last4.
+- **Cancel subscription** (`C`) schedules cancel at period end. Trialing
+  copy: access continues until the trial ends. Toast: "Your plan ends on
+  {date}". **Resume subscription** (`R`) appears while `cancelAtPeriodEnd`
+  is set.
+- **Receipts:** up to 12 invoices, linking to Stripe-hosted PDFs
+  (`target="_blank"`). The heading is hidden when the list is empty. A $0.00
+  trial invoice still appears.
+
+Deliberate exclusions: no address or tax ID editing in Compass, and no
+redirect-based payment methods (`redirect_on_completion: "never"`). Sales
+tax is still collected at Checkout (see Staging).
 
 ## Account deletion
 
@@ -159,16 +187,24 @@ Stripe Checkout.
 
 ## Staging
 
-Set `STRIPE_SECRET_KEY` (`sk_test_...` is fine), `STRIPE_WEBHOOK_SECRET`,
-and `STRIPE_PRICE_ID` on the `staging-cloud` GitHub Environment, then
+Set all four Stripe GitHub Environment variables on `staging-cloud`, then
 **re-run Deploy staging** so `~/compass/compass.yaml` is rewritten. A restart
 on old yaml will not pick up new secrets. Confirm `/api/config` shows
-`billing.isConfigured: true`.
+`billing.isConfigured: true` and a non-null `billing.publishableKey`.
+
+- `STRIPE_SECRET_KEY` (`sk_test_...` is fine)
+- `STRIPE_WEBHOOK_SECRET`
+- `STRIPE_PRICE_ID`
+- `STRIPE_PUBLISHABLE_KEY` (`pk_test_...` is fine)
+
+All four are required together. If any is missing, the deploy omits the
+`stripe:` block and hosted billing stays off.
 
 The webhook endpoint (`https://staging.compasscalendar.com/api/billing/webhook/stripe`)
 must subscribe to Checkout and Subscriptions snapshot events, not Accounts v2:
 
-- `checkout.session.completed`
+- `checkout.session.completed` (subscription Checkout and setup-mode card
+  updates both arrive on this event; setup-mode has `mode: "setup"`)
 - `customer.subscription.created`
 - `customer.subscription.updated`
 - `customer.subscription.deleted`
@@ -184,12 +220,57 @@ register each jurisdiction under Tax > Registrations and set a product tax
 code, in test and live mode separately. Without a registration Stripe
 calculates zero tax rather than erroring, so a missing one is silent.
 
+### Manual QA checklist (founder, on staging-cloud)
+
+Do this after every prior embedded-billing package is deployed. Use a real
+signed-in hosted account that is not on the bypass list.
+
+1. **Happy path:** Start trial with `4242 4242 4242 4242` (any future expiry,
+   any CVC). Checkout stays inside the gate. Celebration appears. Status
+   becomes `trialing`.
+2. **3DS:** Start trial with `4000 0025 0000 3155`. Complete 3DS inside the
+   Stripe iframe (do not leave Compass). Celebration still fires through
+   `onComplete`.
+3. **Decline:** `4000 0000 0000 9995` is rejected inside the iframe. The gate
+   stays up; no celebration; status stays `awaiting_checkout`.
+4. **Update card:** Settings > Billing, Update card (`U`). Complete a
+   setup-mode session. Toast "Card updated". The card row shows the new last4.
+5. **Cancel then Resume:** Cancel (`C`) schedules end at period end. Resume
+   (`R`) restores renewal. Toasts match the dates shown on the plan row.
+6. **Receipt:** open a Receipt link. It loads a Stripe-hosted PDF in a new tab.
+7. **Setup-mode webhook:** Stripe Dashboard (or Compass `app:billing.webhook`
+   logs) shows a successful `checkout.session.completed` delivery for the
+   setup-mode session (`mode: "setup"`), HTTP 200, and no
+   `No Compass user for setup checkout session` / `No Stripe customer for
+   setup checkout session` warning.
+
+## Content Security Policy
+
+The repo ships no CSP. The hosted Caddyfile lives on the host, not in this
+tree. Operators who front the web with a Content-Security-Policy header need
+these Stripe origins so embedded Checkout and Update card can load:
+
+| Directive | Origins |
+| --- | --- |
+| `script-src` | `https://js.stripe.com` `https://*.js.stripe.com` |
+| `frame-src` | `https://js.stripe.com` `https://*.js.stripe.com` `https://hooks.stripe.com` `https://checkout.stripe.com` |
+| `connect-src` | `https://api.stripe.com` `https://checkout.stripe.com` |
+| `img-src` | `https://*.stripe.com` |
+
+If Link is enabled, also add `https://link.com` and `https://*.link.com` to
+`frame-src` and `connect-src`.
+
 ## Key files
 
 - Trial length: `packages/core/src/constants/billing.constants.ts`
 - Status derivation: `packages/backend/src/billing/services/billing.service.ts`
-- Checkout / portal: `packages/backend/src/billing/services/stripe.service.ts`
+- Checkout and payment-method sessions: `packages/backend/src/billing/services/stripe.service.ts`
 - Webhook: `packages/backend/src/billing/services/billing.webhook.service.ts`
 - Write guard: `packages/backend/src/billing/billing.guard.ts`
 - Web access: `packages/web/src/billing/useAppAccess.ts`
 - Read-only look-around: `packages/web/src/billing/billing-preview.store.ts`
+- Embedded Checkout port (the only `loadStripe` call): `packages/web/src/billing/embedded-checkout/embedded-checkout.port.tsx`
+- Lazy seam: `packages/web/src/billing/embedded-checkout/embedded-checkout.seam.ts`
+- Gate checkout store: `packages/web/src/billing/checkout-panel.store.ts`
+- Update-card store: `packages/web/src/billing/card-update.store.ts`
+- Settings > Billing management: `packages/web/src/billing/PlanSection.tsx`

--- a/docs/frontend/shortcut-commandments.md
+++ b/docs/frontend/shortcut-commandments.md
@@ -73,6 +73,16 @@ a draft on a focused column.
 
 Do not run both maps at once. Do not invent a second hold key.
 
+Settings is an OverlayPanel with its own letter map while it holds app-lock
+(`packages/web/src/settings/useSettingsShortcuts.ts`). Those letters are not
+page-jump digits; they activate controls already on the Settings overlay.
+Billing: `U` Update card,
+`C` Cancel subscription, `R` Resume subscription. Accounts: `A` Add account,
+`E` Export, `D` Delete account, `O` Log out. `B` (trial badge / Start
+Premium) is registered by `UpgradeConfirmationProvider` and keeps working
+while Settings is open. The `?` overlay remains the catalog; hold-Mod still
+reveals the chips.
+
 ## 7. Leaders wait, then teach
 
 `e` then a letter within ~600ms is silent muscle memory. Hold the leader


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #3162 (WP-08 of Embedded billing v1 / #3154).

`docs/features/billing.md` now describes Stripe **embedded** Checkout inside the app and the Compass-built Settings > Billing view. Stale hosted-Checkout / Billing Portal wording is gone.

- Intro: Stripe.js loads lazily from `js.stripe.com`; `billing.publishableKey` comes from `/api/config`.
- What users see: checkout stays in the gate; `onComplete` raises celebration; webhook is source of truth. Management view covers card on file, Update card (setup-mode), cancel/resume, receipts. No address/tax-ID editing; `redirect_on_completion: "never"`.
- Staging: all four GitHub Environment vars (`STRIPE_PUBLISHABLE_KEY` included) or the deploy omits the block. Manual QA checklist for the founder.
- New CSP section for operators who front the web with a policy.
- Key files: port, seam, both stores, `PlanSection.tsx`.

Also reconciled `docs/backend/README.md`, `docs/Config/README.md`, `docs/development/feature-file-map.md`, and Settings overlay letters in `docs/frontend/shortcut-commandments.md`.

Founder staging QA is **waiting** (`.agents/handoffs/3162.md`). This PR does not run the checklist and does not deploy.

## Simplicity

Docs-only. No product or route changes.

## Automated validation

- `bun run verify`: PASS (type-check, lint, knip; no packages detected)
- `docs/features/billing.md` contains no "Billing Portal" and no `success_url`; it describes `publishableKey`, `onComplete`, the CSP list, and the QA checklist
- Grep `portal|Opening Stripe|checkout.stripe.com|settings=billing` over `docs packages compass.example.yaml self-host`: remaining billing hits are the CSP allowlist (`checkout.stripe.com`) and the test that asserts `/api/billing/portal/session` is unmounted. Other `portal` hits are React/floating-ui.

## Independent review

Docs-only rewrite against #3162 acceptance. No confirmed findings.

## Test plan

```
bun run verify
bun lint
bun run type-check
grep -rn "portal\|Opening Stripe\|checkout.stripe.com\|settings=billing" docs packages compass.example.yaml self-host
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0ba2f6a-bdca-4f94-a04f-f2a4d77d7dbb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0ba2f6a-bdca-4f94-a04f-f2a4d77d7dbb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

