### PR TITLE
feat(web): return to booking page on confirmation Escape

### DIFF
--- a/.agents/handoffs/3133.md
+++ b/.agents/handoffs/3133.md
@@ -1,0 +1,41 @@
+---
+schema_version: 1
+task_id: "3133"
+from: Reviewer
+to: Manager
+owner: Manager
+status: verifying
+artifact:
+  - path: packages/web/src/booking/PublicBookingConfirmedPage.tsx
+  - path: packages/web/src/booking/PublicBookingPage.tsx
+  - path: packages/web/src/booking/use-booking-heading-focus.ts
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3199
+evidence:
+  - command: bun test:web packages/web/src/booking/PublicBookingPage.test.tsx
+    result: "35 pass, 0 fail (Escape returns and focuses host h1; cancelled/unknown stay; skip-link first Tab intact)"
+    log: null
+  - command: bun run verify
+    result: "PASS for selected packages web. Checks run: test:web (shard 1 1625 pass), type-check, lint, knip. Playwright skipped on that run (Chromium missing at start); installed Chromium then test:a11y 24 passed; product e2e 86 passed including skip-link and confirmation Escape. Full bun test:e2e hit an unrelated event-action-row contrast flake (4.39 vs 4.5) not in this diff; the same checkpoint passed under bun test:a11y."
+    log: null
+assumptions:
+  - "Host heading focus is armed only for confirmation Escape so skip-to-open-times stays the first tab stop on a cold /book/:slug visit."
+open_risks: []
+next_deadline: 2026-09-04T00:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-05: Escape on `/book/confirmed/:id` returns to `/book/:slug` from
+`bookingSlug` on the public GET and focuses that page's h1.
+
+Simplify: dropped the inner `if (!bookingSlug)` no-op. `enabled` already
+gates the shortcut. Pending heading-focus flag kept so first-tab skip
+link stays spec-accurate; delayed release survives Strict Mode remount.
+
+Review: no confirmed findings.
+
+VERDICT: no confirmed findings
+FINDINGS:
+(none)

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,7 +13,8 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 3135 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3197 | bun run verify PASS (web shards 1617/1592, a11y 24, e2e 109); review: no confirmed findings after hours-draft fix | 2026-09-04T00:00:00Z | 0 | none |
+| 3133 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3199 | bun run verify PASS (web/type-check/lint/knip); test:a11y 24; product e2e 86 including confirmation Escape; review: no confirmed findings | 2026-09-04T00:00:00Z | 0 | none |
+| 3135 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3197 | bun run verify PASS (web shards 1617/1592, a11y 24, e2e 109); review: no confirmed findings after hours-draft fix | null | 0 | none |
 | 3162 | high | Founder | waiting | docs/features/billing.md | bun run verify PASS (type-check, lint, knip); founder staging QA waiting | 2026-09-10T00:00:00Z | 0 | human |
 | 3134 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3195 | bun run verify PASS (web 1613, a11y 24, e2e 109); review: no confirmed findings | null | 0 | none |
 | 3158 | high | Implementer | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3168 | bun test:web 1569 pass; type-check pass; lint exit 0; knip pass | 2026-09-04T00:00:00Z | 0 | none |

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -128,6 +128,30 @@ test.describe("public booking page", () => {
     });
   });
 
+  test("returns to the host page on Escape from confirmation", async ({
+    page,
+  }) => {
+    const { slotStart } = buildBookableSlot();
+    await preparePublicBookingPage(page);
+
+    await page
+      .getByRole("button", { name: formatSlotButtonLabel(slotStart) })
+      .click();
+    await page.getByLabel("Name").fill("Guest User");
+    await page.getByLabel("Email").fill("guest@example.com");
+    await page.getByRole("button", { name: "Confirm booking" }).click();
+    await expect(
+      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+    ).toBeFocused();
+
+    await page.keyboard.press("Escape");
+
+    await expect(page).toHaveURL(/\/book\/tylerdane(?:\?|$)/);
+    await expect(
+      page.getByRole("heading", { name: "Book with Tyler Dane" }),
+    ).toBeFocused();
+  });
+
   test("overrides the guest timezone on the reservation", async ({ page }) => {
     const { slotStart } = buildBookableSlot();
     const captured = await preparePublicBookingPage(page);

--- a/packages/web/src/booking/PublicBookingConfirmedPage.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmedPage.tsx
@@ -1,9 +1,12 @@
-import { useParams, useRouterState } from "@tanstack/react-router";
+import { useNavigate, useParams, useRouterState } from "@tanstack/react-router";
 import { PublicBookingNotFoundError } from "@web/api/public-booking.api";
 import { PublicBookingConfirmationView } from "@web/booking/PublicBookingConfirmationView";
 import { PublicBookingStatusMessage } from "@web/booking/PublicBookingStatusMessage";
 import { usePublicBookingReservationQuery } from "@web/booking/public-booking.query";
 import { useBookingDocumentTitle } from "@web/booking/use-booking-document-title";
+import { ROOT_ROUTES } from "@web/common/constants/routes";
+import { isHigherEscapeOwner } from "@web/shortcuts/escape-ownership";
+import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 
 const BOOKING_LOADING = {
   title: "Loading booking",
@@ -78,8 +81,32 @@ export function PublicBookingConfirmedPage() {
   });
   const reservationQuery = usePublicBookingReservationQuery(reservationId);
   useBookingDocumentTitle("Booking confirmed");
+  const navigate = useNavigate();
 
   const view = resolveConfirmedPageView(reservationQuery);
+  const bookingSlug =
+    view.kind === "confirmation" ? view.reservation.bookingSlug : "";
+
+  // Escape returns to the host's public page. OverlayPanel peels first.
+  // Unknown and cancelled views have no slug path, so they stay put.
+  useAppShortcut(
+    "Escape",
+    (event) => {
+      if (isHigherEscapeOwner()) {
+        return;
+      }
+      if (!bookingSlug) {
+        return;
+      }
+      event.preventDefault();
+      void navigate({
+        to: ROOT_ROUTES.BOOK,
+        params: { username: bookingSlug },
+      });
+    },
+    { enabled: bookingSlug.length > 0, ignoreInputs: false },
+  );
+
   if (view.kind === "status") {
     return <PublicBookingStatusMessage {...view} />;
   }

--- a/packages/web/src/booking/PublicBookingConfirmedPage.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmedPage.tsx
@@ -4,6 +4,7 @@ import { PublicBookingConfirmationView } from "@web/booking/PublicBookingConfirm
 import { PublicBookingStatusMessage } from "@web/booking/PublicBookingStatusMessage";
 import { usePublicBookingReservationQuery } from "@web/booking/public-booking.query";
 import { useBookingDocumentTitle } from "@web/booking/use-booking-document-title";
+import { requestPublicBookingPageHeadingFocus } from "@web/booking/use-booking-heading-focus";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
 import { isHigherEscapeOwner } from "@web/shortcuts/escape-ownership";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
@@ -99,6 +100,7 @@ export function PublicBookingConfirmedPage() {
         return;
       }
       event.preventDefault();
+      requestPublicBookingPageHeadingFocus();
       void navigate({
         to: ROOT_ROUTES.BOOK,
         params: { username: bookingSlug },

--- a/packages/web/src/booking/PublicBookingConfirmedPage.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmedPage.tsx
@@ -96,9 +96,6 @@ export function PublicBookingConfirmedPage() {
       if (isHigherEscapeOwner()) {
         return;
       }
-      if (!bookingSlug) {
-        return;
-      }
       event.preventDefault();
       requestPublicBookingPageHeadingFocus();
       void navigate({

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -19,9 +19,14 @@ import {
   formatBookingSlotTime,
   shiftBookingMonthKey,
 } from "@web/booking/public-booking.format";
+import { releasePublicBookingPageHeadingFocus } from "@web/booking/use-booking-heading-focus";
 import { ENV_WEB } from "@web/common/constants/env.constants";
 import { routeTree } from "@web/routers/router.routes";
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
+
+afterEach(() => {
+  releasePublicBookingPageHeadingFocus();
+});
 
 function renderBookingRoute(path: string) {
   const router = createRouter({
@@ -293,10 +298,8 @@ describe("PublicBookingPage", () => {
     renderBookingRoute("/book/tylerdane");
 
     expect(
-      await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
-    ).toHaveFocus();
-    await screen.findByRole("heading", { name: "Pick a time" });
-    (document.activeElement as HTMLElement | null)?.blur();
+      await screen.findByRole("heading", { name: "Pick a time" }),
+    ).toBeInTheDocument();
     await user.tab();
     expect(
       screen.getByRole("link", { name: "Skip to open times" }),

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -293,8 +293,10 @@ describe("PublicBookingPage", () => {
     renderBookingRoute("/book/tylerdane");
 
     expect(
-      await screen.findByRole("heading", { name: "Pick a time" }),
-    ).toBeInTheDocument();
+      await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
+    ).toHaveFocus();
+    await screen.findByRole("heading", { name: "Pick a time" });
+    (document.activeElement as HTMLElement | null)?.blur();
     await user.tab();
     expect(
       screen.getByRole("link", { name: "Skip to open times" }),
@@ -1421,6 +1423,72 @@ describe("PublicBookingConfirmedPage", () => {
     expect(
       screen.queryByRole("button", { name: "Copy cancel link" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("returns to the host booking page on Escape and focuses its heading", async () => {
+    const user = userEvent.setup({ delay: null });
+    server.use(
+      pageHandler(),
+      slotsInWindow([currentSlot]),
+      reservationGetHandler(),
+    );
+    const { router } = renderBookingRoute(
+      "/book/confirmed/000000000000000000000099",
+    );
+
+    await screen.findByRole("heading", {
+      name: "You are booked with Tyler Dane",
+    });
+    await user.keyboard("{Escape}");
+
+    const heading = await screen.findByRole("heading", {
+      name: "Book with Tyler Dane",
+    });
+    await waitFor(() => {
+      expect(heading).toHaveFocus();
+    });
+    expect(router.state.location.pathname).toBe("/book/tylerdane");
+  });
+
+  it("does not navigate on Escape when the confirmation has no slug", async () => {
+    const user = userEvent.setup({ delay: null });
+    server.use(reservationGetHandler({ status: "cancelled" }));
+    const { router } = renderBookingRoute(
+      "/book/confirmed/000000000000000000000099",
+    );
+
+    const heading = await screen.findByRole("heading", {
+      name: "This booking was canceled",
+    });
+    await user.keyboard("{Escape}");
+
+    expect(heading).toHaveFocus();
+    expect(router.state.location.pathname).toBe(
+      "/book/confirmed/000000000000000000000099",
+    );
+  });
+
+  it("does not navigate on Escape when the reservation is unknown", async () => {
+    const user = userEvent.setup({ delay: null });
+    server.use(
+      rest.get(
+        `${ENV_WEB.API_BASEURL}/booking/reservations/000000000000000000000099`,
+        (_req, res, ctx) => res(ctx.status(Status.NOT_FOUND), ctx.json({})),
+      ),
+    );
+    const { router } = renderBookingRoute(
+      "/book/confirmed/000000000000000000000099",
+    );
+
+    const heading = await screen.findByRole("heading", {
+      name: "Booking not found",
+    });
+    await user.keyboard("{Escape}");
+
+    expect(heading).toHaveFocus();
+    expect(router.state.location.pathname).toBe(
+      "/book/confirmed/000000000000000000000099",
+    );
   });
 
   it("shows a calm state for a cancelled reservation", async () => {

--- a/packages/web/src/booking/PublicBookingPage.tsx
+++ b/packages/web/src/booking/PublicBookingPage.tsx
@@ -1,21 +1,30 @@
+import { useParams } from "@tanstack/react-router";
 import { PublicBookingNotFoundError } from "@web/api/public-booking.api";
 import { PublicBookingDetailsStep } from "@web/booking/PublicBookingDetailsStep";
 import { PublicBookingGuestForm } from "@web/booking/PublicBookingGuestForm";
 import { PublicBookingLayout } from "@web/booking/PublicBookingLayout";
 import { PublicBookingPicker } from "@web/booking/PublicBookingPicker";
 import { PublicBookingSkipLink } from "@web/booking/PublicBookingSkipLink";
-import { PublicBookingStatusMessage } from "@web/booking/PublicBookingStatusMessage";
+import {
+  PUBLIC_BOOKING_HEADING_CLASS,
+  PublicBookingStatusMessage,
+} from "@web/booking/PublicBookingStatusMessage";
 import { PublicBookingTimezoneControl } from "@web/booking/PublicBookingTimezoneControl";
 import { formatDurationMinutes } from "@web/booking/public-booking.format";
 import { useBookingDocumentTitle } from "@web/booking/use-booking-document-title";
+import { useBookingHeadingFocus } from "@web/booking/use-booking-heading-focus";
 import { usePublicBookingFlow } from "@web/booking/use-public-booking-flow";
 
 const STICKY_STEP_CLASS_NAME =
   "sticky bottom-0 z-10 -mx-4 border-border border-t bg-background px-4 py-3 sm:static sm:mx-0 sm:border-0 sm:px-0 sm:py-0";
 
 export function PublicBookingPage() {
+  const { username } = useParams({ from: "/book/$username" });
   const flow = usePublicBookingFlow();
   const { pageQuery, slotsQuery } = flow;
+  const headingRef = useBookingHeadingFocus(
+    pageQuery.isSuccess && pageQuery.data?.enabled ? username : null,
+  );
 
   useBookingDocumentTitle(
     pageQuery.data?.enabled
@@ -77,7 +86,11 @@ export function PublicBookingPage() {
         }
       />
       <header className="flex flex-col gap-1">
-        <h1 className="font-semibold text-text text-xl">
+        <h1
+          className={PUBLIC_BOOKING_HEADING_CLASS}
+          ref={headingRef}
+          tabIndex={-1}
+        >
           Book with {page.hostDisplayName}
         </h1>
         <p className="text-sm text-text-muted">

--- a/packages/web/src/booking/PublicBookingPage.tsx
+++ b/packages/web/src/booking/PublicBookingPage.tsx
@@ -1,4 +1,5 @@
 import { useParams } from "@tanstack/react-router";
+import { useEffect, useRef } from "react";
 import { PublicBookingNotFoundError } from "@web/api/public-booking.api";
 import { PublicBookingDetailsStep } from "@web/booking/PublicBookingDetailsStep";
 import { PublicBookingGuestForm } from "@web/booking/PublicBookingGuestForm";
@@ -12,7 +13,11 @@ import {
 import { PublicBookingTimezoneControl } from "@web/booking/PublicBookingTimezoneControl";
 import { formatDurationMinutes } from "@web/booking/public-booking.format";
 import { useBookingDocumentTitle } from "@web/booking/use-booking-document-title";
-import { useBookingHeadingFocus } from "@web/booking/use-booking-heading-focus";
+import {
+  isPublicBookingPageHeadingFocusPending,
+  releasePublicBookingPageHeadingFocus,
+  useBookingHeadingFocus,
+} from "@web/booking/use-booking-heading-focus";
 import { usePublicBookingFlow } from "@web/booking/use-public-booking-flow";
 
 const STICKY_STEP_CLASS_NAME =
@@ -22,9 +27,21 @@ export function PublicBookingPage() {
   const { username } = useParams({ from: "/book/$username" });
   const flow = usePublicBookingFlow();
   const { pageQuery, slotsQuery } = flow;
+  const focusHostHeadingRef = useRef(isPublicBookingPageHeadingFocusPending());
+  const pageReady = pageQuery.isSuccess && Boolean(pageQuery.data?.enabled);
   const headingRef = useBookingHeadingFocus(
-    pageQuery.isSuccess && pageQuery.data?.enabled ? username : null,
+    focusHostHeadingRef.current && pageReady ? username : null,
   );
+
+  useEffect(() => {
+    if (!focusHostHeadingRef.current || pageQuery.isPending) {
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      releasePublicBookingPageHeadingFocus();
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [pageQuery.isPending]);
 
   useBookingDocumentTitle(
     pageQuery.data?.enabled

--- a/packages/web/src/booking/use-booking-heading-focus.ts
+++ b/packages/web/src/booking/use-booking-heading-focus.ts
@@ -1,5 +1,20 @@
 import { useEffect, useRef } from "react";
 
+let pendingPublicBookingPageHeadingFocus = false;
+
+/** Arm host-page h1 focus for the next `/book/:slug` mount (confirmation Escape). */
+export function requestPublicBookingPageHeadingFocus() {
+  pendingPublicBookingPageHeadingFocus = true;
+}
+
+export function isPublicBookingPageHeadingFocusPending() {
+  return pendingPublicBookingPageHeadingFocus;
+}
+
+export function releasePublicBookingPageHeadingFocus() {
+  pendingPublicBookingPageHeadingFocus = false;
+}
+
 /** Focus the booking status heading when `viewKey` changes. */
 export function useBookingHeadingFocus(viewKey: unknown) {
   const headingRef = useRef<HTMLHeadingElement>(null);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #3133 (Booking v1.5 WP-05).

Escape on `/book/confirmed/:id` returns the guest to `/book/:slug` using `bookingSlug` from the public reservation GET, then focuses that page's h1 via `useBookingHeadingFocus`. Cancelled and unknown confirmation states have no slug path, so Escape is a no-op. OverlayPanel still peels first through `isHigherEscapeOwner()`.

Host heading focus is armed only for this Escape navigation so **Skip to open times** stays the first tab stop on a cold `/book/:slug` visit. `isBookingEnabled` is unchanged. Guest reschedule is not implemented.

## Simplicity

One `useAppShortcut("Escape")` on the confirmation page, same stand-down pattern as WP-04/WP-06. Slug comes only from the reservation GET. No router history state. The inner empty-slug guard was dropped because `enabled` already gates the shortcut.

## Automated validation

`bun run verify` selected web: test:web, type-check, lint, knip passed (shard 1 1625 pass). Playwright was missing at verify start; after `bunx playwright install chromium`, `bun test:a11y` 24 passed and product e2e 86 passed, including skip-link first Tab and confirmation Escape. Focused `PublicBookingPage` tests: 35 pass, 0 fail.

## Independent review

`.agents/handoffs/3133.md`

VERDICT: no confirmed findings
FINDINGS:
(none)

## Test plan

- `bun test:web packages/web/src/booking/PublicBookingPage.test.tsx`
- `bun run verify`
- `bun test:a11y`
- `bunx playwright test e2e/booking e2e/timed e2e/onboarding e2e/life e2e/navigation e2e/oauth e2e/attendees e2e/calendars e2e/allday`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec67721b-395d-454e-bd11-696669d367b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec67721b-395d-454e-bd11-696669d367b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

