### PR TITLE
feat(booking): let guests edit name and notes after confirm

### DIFF
--- a/.agents/handoffs/3136.md
+++ b/.agents/handoffs/3136.md
@@ -1,0 +1,43 @@
+---
+schema_version: 1
+task_id: "3136"
+from: Reviewer
+to: Manager
+owner: Manager
+status: verifying
+artifact:
+  - path: packages/backend/src/booking/services/public-booking.service.ts
+  - path: packages/web/src/booking/PublicBookingConfirmedPage.tsx
+  - path: packages/web/src/booking/PublicBookingEditDetailsForm.tsx
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3200
+evidence:
+  - command: bun test packages/core/src/types/booking.contracts.test.ts
+    result: "36 pass, 0 fail"
+    log: null
+  - command: bun test:backend -- packages/backend/src/booking/services/calendar-booking.service.test.ts packages/backend/src/booking/services/public-booking.service.db.test.ts packages/backend/src/booking/booking.rate-limit.db.test.ts
+    result: "45 pass (valid PATCH updates row and event title; wrong token unchanged; cancelled rejected with no command; PATCH 429 after 10)"
+    log: null
+  - command: bun test:web -- packages/web/src/booking/PublicBookingPage.test.tsx packages/web/src/booking/PublicBookingConfirmationView.test.tsx packages/web/src/booking/PublicBookingCancelPage.test.tsx
+    result: "52 pass (Edit details prefills; submit shows updated values; no email field; Escape returns to confirmation)"
+    log: null
+assumptions:
+  - "GET publishes guestName and notes without a token so a cold permalink can prefill. Edit details stays gated on cancelUrl in router history. Guest email is unpublished."
+  - "attendeesEdit preserve leaves the provider guest list untouched, so sending attendees with needsAction does not reset RSVP."
+open_risks: []
+next_deadline: 2026-09-04T06:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-08: guests edit name and notes after confirm.
+
+Simplify: `toPublicReservation` shared by GET and PATCH; confirmation
+actions stack on the existing flex column.
+
+Review: no confirmed findings.
+
+VERDICT: no confirmed findings
+FINDINGS:
+(none)

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,7 +13,8 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 3133 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3199 | bun run verify PASS (web/type-check/lint/knip); test:a11y 24; product e2e 86 including confirmation Escape; review: no confirmed findings | 2026-09-04T00:00:00Z | 0 | none |
+| 3136 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3200 | focused core 36, backend 45, web 52; review: no confirmed findings; bun run verify pending this revision | 2026-09-04T06:00:00Z | 0 | none |
+| 3133 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3199 | squash-merged 12bfcaa97; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3135 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3197 | bun run verify PASS (web shards 1617/1592, a11y 24, e2e 109); review: no confirmed findings after hours-draft fix | null | 0 | none |
 | 3162 | high | Founder | waiting | docs/features/billing.md | bun run verify PASS (type-check, lint, knip); founder staging QA waiting | 2026-09-10T00:00:00Z | 0 | human |
 | 3134 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3195 | bun run verify PASS (web 1613, a11y 24, e2e 109); review: no confirmed findings | null | 0 | none |

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -319,8 +319,12 @@ Unauthenticated:
   guestEmail, notes?, guestTimeZone}`. Re-checks busy, then creates.
 - `GET /api/booking/reservations/:id` — public confirmation payload
   (`slotStart`, `guestTimeZone`, `durationMinutes`, `hostDisplayName`,
-  `status`, `bookingSlug`). `404` when missing. No guest email, notes, or
-  cancel token.
+  `status`, `bookingSlug`, `guestName`, `notes`). `404` when missing. No
+  guest email or cancel token.
+- `PATCH /api/booking/reservations/:id` — `{token, name?, notes?}`. Verify
+  token. Updates the reservation and rewrites the calendar event title and
+  description. Guest email is not accepted. `404` when missing, cancelled, or
+  the token is invalid.
 - `POST /api/booking/reservations/:id/cancel` — `{token}`.
 - `GET /api/booking/reservations/:id/slots?token=&start=&end=&timeZone=`
   — bookable instants excluding this reservation from occupancy and
@@ -378,6 +382,9 @@ Guest reschedule is **in scope for v1.3**, not v1 / v1.1.
 
 ### Named warts
 
+- **Guest email is not editable after confirm.** The attendee identity and
+  Google invite are bound to the address collected at booking. Changing it
+  would send a new invitation, which v1.5 does not do.
 - **Slug is not editable in v1.** Allocation runs once on first enable; changing
   slugs needs a migration with redirects.
 - **Guest reschedule is v1.3, not v1.** In-place PATCH; same cancel token.

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -342,6 +342,11 @@ export async function preparePublicBookingPage(
           hostDisplayName: options.hostDisplayName ?? "Tyler Dane",
           status: options.reservationStatus ?? "confirmed",
           bookingSlug: slug,
+          guestName:
+            typeof lastPost?.guestName === "string"
+              ? lastPost.guestName
+              : "Guest User",
+          notes: typeof lastPost?.notes === "string" ? lastPost.notes : null,
         }),
       );
     }
@@ -388,6 +393,8 @@ export async function preparePublicBookingConfirmedPage(
           hostDisplayName: options.hostDisplayName ?? "Tyler Dane",
           status: options.reservationStatus ?? "confirmed",
           bookingSlug: options.slug ?? "tylerdane",
+          guestName: "Guest User",
+          notes: null,
         }),
       );
     }
@@ -455,6 +462,8 @@ export async function preparePublicBookingCancelPage(
           hostDisplayName: options.hostDisplayName ?? "Tyler Dane",
           status: options.reservationStatus ?? "confirmed",
           bookingSlug: "tylerdane",
+          guestName: "Guest User",
+          notes: null,
         }),
       );
     }

--- a/packages/backend/src/booking/booking-reservation.repository.ts
+++ b/packages/backend/src/booking/booking-reservation.repository.ts
@@ -79,6 +79,26 @@ class BookingReservationRepository {
     if (!result) return null;
     return BookingReservationRecordSchema.parse(result);
   }
+
+  async updateGuestDetails(
+    id: ObjectId,
+    details: { guestName: string; notes: string | null },
+  ): Promise<BookingReservationRecord | null> {
+    const now = new Date();
+    const result = await mongoService.bookingReservation.findOneAndUpdate(
+      { _id: id, status: "confirmed" },
+      {
+        $set: {
+          guestName: details.guestName,
+          notes: details.notes,
+          updatedAt: now,
+        },
+      },
+      { returnDocument: "after" },
+    );
+    if (!result) return null;
+    return BookingReservationRecordSchema.parse(result);
+  }
 }
 
 export const bookingReservationRepository = new BookingReservationRepository();

--- a/packages/backend/src/booking/booking.rate-limit.db.test.ts
+++ b/packages/backend/src/booking/booking.rate-limit.db.test.ts
@@ -58,6 +58,36 @@ describe("Public booking rate limits", () => {
     expect(throttled.status).toBe(429);
   });
 
+  it("throttles PATCH reservation after 10 requests in a minute", async () => {
+    const server = baseDriver.getServer();
+    const id = "0000000000000000000000bb";
+    for (let i = 0; i < 10; i += 1) {
+      await server
+        .patch(`/api/booking/reservations/${id}`)
+        .send({ token: "a".repeat(64), name: "Ada" })
+        .expect(Status.NOT_FOUND);
+    }
+    const throttled = await server
+      .patch(`/api/booking/reservations/${id}`)
+      .send({ token: "a".repeat(64), name: "Ada" });
+    expect(throttled.status).toBe(429);
+  });
+
+  it("does not throttle a different reservation id PATCH bucket", async () => {
+    const server = baseDriver.getServer();
+    const busyId = "0000000000000000000000cc";
+    const quietId = "0000000000000000000000dd";
+    for (let i = 0; i < 11; i += 1) {
+      await server
+        .patch(`/api/booking/reservations/${busyId}`)
+        .send({ token: "a".repeat(64), name: "Ada" });
+    }
+    await server
+      .patch(`/api/booking/reservations/${quietId}`)
+      .send({ token: "a".repeat(64), name: "Ada" })
+      .expect(Status.NOT_FOUND);
+  });
+
   it("does not throttle a different slug's bucket", async () => {
     const server = baseDriver.getServer();
     for (let i = 0; i < 61; i += 1) {

--- a/packages/backend/src/booking/booking.routes.config.ts
+++ b/packages/backend/src/booking/booking.routes.config.ts
@@ -52,6 +52,14 @@ const publicCancelLimiter = rateLimit({
   keyGenerator: bookingReservationKey,
 });
 
+const publicReservationPatchLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: bookingReservationKey,
+});
+
 /**
  * Host admin routes require a session. Public guest routes are unauthenticated.
  */
@@ -85,7 +93,11 @@ export class BookingRoutes extends CommonRoutesConfig {
 
     this.app
       .route(`/api/booking/reservations/:id`)
-      .get(publicReservationGetLimiter, bookingController.getPublicReservation);
+      .get(publicReservationGetLimiter, bookingController.getPublicReservation)
+      .patch(
+        publicReservationPatchLimiter,
+        bookingController.patchPublicReservation,
+      );
 
     this.app
       .route(`/api/booking/reservations/:id/cancel`)

--- a/packages/backend/src/booking/controllers/booking.controller.ts
+++ b/packages/backend/src/booking/controllers/booking.controller.ts
@@ -94,6 +94,27 @@ class BookingController {
     }
   };
 
+  patchPublicReservation = async (req: Request, res: Response) => {
+    try {
+      const parsedId = zObjectId.safeParse(req.params["id"]);
+      if (!parsedId.success) {
+        const { status, body } = toBookingErrorResponse(
+          bookingError("RESERVATION_NOT_FOUND", "Reservation not found"),
+        );
+        res.status(status).json(body);
+        return;
+      }
+      const response = await publicBookingService.patchPublicReservation(
+        parsedId.data,
+        req.body,
+      );
+      res.status(Status.OK).json(response);
+    } catch (error) {
+      const { status, body } = toBookingErrorResponse(error);
+      res.status(status).json(body);
+    }
+  };
+
   cancelReservation = async (req: Request, res: Response) => {
     try {
       const reservationId = zObjectId.parse(req.params["id"]);

--- a/packages/backend/src/booking/services/calendar-booking.port.ts
+++ b/packages/backend/src/booking/services/calendar-booking.port.ts
@@ -34,6 +34,16 @@ export interface CalendarBookingDeleteEventInput {
   eventId: EventId;
 }
 
+export interface CalendarBookingUpdateEventInput {
+  eventId: EventId;
+  title: string;
+  description: string;
+  start: DateTime;
+  end: DateTime;
+  timeZone: string;
+  guest: BookingEventGuest;
+}
+
 export interface CalendarBookingPort {
   getAvailability(
     userId: string,
@@ -44,6 +54,11 @@ export interface CalendarBookingPort {
     userId: string,
     input: CalendarBookingCreateEventInput,
   ): Promise<EventId>;
+
+  updateBookingEvent(
+    userId: string,
+    input: CalendarBookingUpdateEventInput,
+  ): Promise<void>;
 
   deleteBookingEvent(
     userId: string,

--- a/packages/backend/src/booking/services/calendar-booking.service.test.ts
+++ b/packages/backend/src/booking/services/calendar-booking.service.test.ts
@@ -176,6 +176,46 @@ describe("CalendarBookingService", () => {
     expect(submitCommand).not.toHaveBeenCalled();
   });
 
+  it("submits a booking update with the new title", async () => {
+    const eventId = faker.database.mongodbObjectId();
+    const submitCommand = mock(async () => ({
+      ok: true as const,
+      value: { commandId: faker.database.mongodbObjectId() },
+    }));
+    const service = new CalendarBookingService({
+      queryBusyAvailability: mock(async () => ({
+        ok: true as const,
+        value: busyResponse,
+      })),
+      submitCommand,
+    } as unknown as SyncServiceClient);
+
+    await service.updateBookingEvent(userId(), {
+      eventId,
+      title: "Grace and Tyler",
+      description: "bring tea",
+      start: "2026-09-01T15:00:00.000Z",
+      end: "2026-09-01T15:30:00.000Z",
+      timeZone: "America/Denver",
+      guest: { email: "ada@example.com", displayName: "Grace Hopper" },
+    });
+
+    expect(submitCommand).toHaveBeenCalledTimes(1);
+    expect(submitCommand.mock.calls[0]?.[1]).toMatchObject({
+      eventId,
+      expectedVersion: null,
+      input: {
+        kind: "update",
+        invitation: "all",
+        attendeesEdit: "preserve",
+        content: {
+          title: "Grace and Tyler",
+          description: "bring tea",
+        },
+      },
+    });
+  });
+
   it("submits delete with invitation all", async () => {
     const eventId = faker.database.mongodbObjectId();
     const submitCommand = mock(async () => ({

--- a/packages/backend/src/booking/services/calendar-booking.service.ts
+++ b/packages/backend/src/booking/services/calendar-booking.service.ts
@@ -13,6 +13,7 @@ import {
   type CalendarBookingDeleteEventInput,
   type CalendarBookingGetAvailabilityInput,
   type CalendarBookingPort,
+  type CalendarBookingUpdateEventInput,
 } from "@backend/booking/services/calendar-booking.port";
 import calendarService from "@backend/calendar/services/calendar.service";
 import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
@@ -22,6 +23,7 @@ import {
 } from "@backend/common/services/sync-service/sync-proxy-error";
 import { type SyncServiceClient } from "@backend/common/services/sync-service/sync-service.client";
 import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
+import { createHash } from "node:crypto";
 
 const mintEventId = (): EventId =>
   EventIdSchema.parse(new ObjectId().toHexString());
@@ -78,6 +80,56 @@ const toBookingCreateSubmitRequest = (
       recurrence: { kind: "single" },
     },
   });
+
+const toBookingUpdateSubmitRequest = (
+  input: CalendarBookingUpdateEventInput,
+) => {
+  const digest = createHash("sha256")
+    .update(
+      JSON.stringify({
+        title: input.title,
+        description: input.description,
+        displayName: input.guest.displayName,
+      }),
+    )
+    .digest("hex")
+    .slice(0, 40);
+  return CommandSubmitRequestSchema.parse({
+    idempotencyKey: IdempotencyKeySchema.parse(
+      `booking-update:${input.eventId}:${digest}`,
+    ),
+    eventId: input.eventId,
+    expectedVersion: null,
+    input: {
+      kind: "update",
+      invitation: "all",
+      attendeesEdit: "preserve",
+      content: {
+        title: input.title,
+        description: input.description,
+        location: null,
+        organizer: null,
+        attendees: [
+          {
+            email: input.guest.email,
+            displayName: input.guest.displayName,
+            responseStatus: "needsAction",
+          },
+        ],
+        conference: null,
+      },
+      schedule: {
+        kind: "timed",
+        start: input.start,
+        end: input.end,
+        timeZone: input.timeZone,
+      },
+      recurrence: { kind: "single" },
+      scope: "all",
+      recurrenceId: null,
+    },
+  });
+};
 
 export class CalendarBookingService implements CalendarBookingPort {
   constructor(
@@ -138,6 +190,27 @@ export class CalendarBookingService implements CalendarBookingPort {
       throwSyncCommandSubmitFailure(result.error.kind);
     }
     return eventId;
+  }
+
+  async updateBookingEvent(
+    userId: string,
+    input: CalendarBookingUpdateEventInput,
+  ): Promise<void> {
+    const guestEmail = input.guest.email.trim();
+    if (!guestEmail) {
+      throw bookingError("INVALID_INPUT", "Guest email is required");
+    }
+
+    const result = await this.client.submitCommand(
+      toSyncPrincipal(userId),
+      toBookingUpdateSubmitRequest({
+        ...input,
+        guest: { ...input.guest, email: guestEmail },
+      }),
+    );
+    if (!result.ok) {
+      throwSyncCommandSubmitFailure(result.error.kind);
+    }
   }
 
   async deleteBookingEvent(

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -109,6 +109,7 @@ describe("PublicBookingService", () => {
   let syncSpies: Array<{ mockRestore: () => void }> = [];
   let createBookingEvent: ReturnType<typeof mock>;
   let deleteBookingEvent: ReturnType<typeof mock>;
+  let updateBookingEvent: ReturnType<typeof mock>;
   let getAvailability: ReturnType<typeof mock>;
   let service: PublicBookingService;
 
@@ -124,11 +125,13 @@ describe("PublicBookingService", () => {
 
     createBookingEvent = mock(async () => new ObjectId().toString());
     deleteBookingEvent = mock(async () => undefined);
+    updateBookingEvent = mock(async () => undefined);
     getAvailability = mock(async () => busyResponse(true));
 
     const port: CalendarBookingPort = {
       getAvailability,
       createBookingEvent,
+      updateBookingEvent,
       deleteBookingEvent,
     };
     service = new PublicBookingService(port);
@@ -548,11 +551,12 @@ describe("PublicBookingService", () => {
       hostDisplayName: "Host User",
       status: "confirmed",
       bookingSlug: slug,
+      guestName: "Ada Lovelace",
+      notes: "secret notes",
     });
     expect(publicReservation).not.toHaveProperty("guestEmail");
     expect(publicReservation).not.toHaveProperty("cancelUrl");
     expect(publicReservation).not.toHaveProperty("rescheduleUrl");
-    expect(publicReservation).not.toHaveProperty("notes");
   });
 
   it("returns the booked slot duration after the host changes page duration", async () => {
@@ -745,6 +749,88 @@ describe("PublicBookingService", () => {
     expect(eventInput.description).toContain(`Cancel: ${created.cancelUrl}`);
   });
 
+  it("patches guest name and notes and submits an event update", async () => {
+    const { slug } = await enableBookingPage();
+    const created = await service.createReservation(slug, {
+      slotStart: "2026-09-07T10:00:00.000Z",
+      guestName: "Ada Lovelace",
+      guestEmail: "ada@example.com",
+      notes: "bring coffee",
+      guestTimeZone: "Europe/London",
+    });
+    const token = new URL(created.cancelUrl).searchParams.get("token");
+    const reservationId = new ObjectId(created.reservationId);
+
+    const patched = await service.patchPublicReservation(reservationId, {
+      token,
+      name: "Grace Hopper",
+      notes: "bring tea",
+    });
+
+    expect(patched.guestName).toBe("Grace Hopper");
+    expect(patched.notes).toBe("bring tea");
+    expect(updateBookingEvent).toHaveBeenCalledTimes(1);
+    expect(updateBookingEvent.mock.calls[0]?.[1]).toMatchObject({
+      title: "Grace Hopper and Host User",
+      description: "bring tea",
+    });
+    const stored = await bookingReservationRepository.findById(reservationId);
+    expect(stored?.guestName).toBe("Grace Hopper");
+    expect(stored?.notes).toBe("bring tea");
+    expect(stored?.guestEmail).toBe("ada@example.com");
+  });
+
+  it("rejects a wrong patch token without changing the row", async () => {
+    const { slug } = await enableBookingPage();
+    const created = await service.createReservation(slug, {
+      slotStart: "2026-09-07T10:00:00.000Z",
+      guestName: "Ada Lovelace",
+      guestEmail: "ada@example.com",
+      notes: "bring coffee",
+      guestTimeZone: "Europe/London",
+    });
+    const reservationId = new ObjectId(created.reservationId);
+
+    await expect(
+      service.patchPublicReservation(reservationId, {
+        token: "not-the-token",
+        name: "Grace Hopper",
+      }),
+    ).rejects.toMatchObject({ bookingCode: "RESERVATION_NOT_FOUND" });
+
+    expect(updateBookingEvent).not.toHaveBeenCalled();
+    const stored = await bookingReservationRepository.findById(reservationId);
+    expect(stored?.guestName).toBe("Ada Lovelace");
+    expect(stored?.notes).toBe("bring coffee");
+  });
+
+  it("rejects patching a cancelled reservation without a command", async () => {
+    const { slug } = await enableBookingPage();
+    const created = await service.createReservation(slug, {
+      slotStart: "2026-09-07T10:00:00.000Z",
+      guestName: "Ada Lovelace",
+      guestEmail: "ada@example.com",
+      notes: "bring coffee",
+      guestTimeZone: "Europe/London",
+    });
+    const token = new URL(created.cancelUrl).searchParams.get("token");
+    const reservationId = new ObjectId(created.reservationId);
+    await service.cancelReservation(reservationId, { token });
+    updateBookingEvent.mockClear();
+
+    await expect(
+      service.patchPublicReservation(reservationId, {
+        token,
+        name: "Grace Hopper",
+      }),
+    ).rejects.toMatchObject({ bookingCode: "RESERVATION_NOT_FOUND" });
+
+    expect(updateBookingEvent).not.toHaveBeenCalled();
+    const stored = await bookingReservationRepository.findById(reservationId);
+    expect(stored?.guestName).toBe("Ada Lovelace");
+    expect(stored?.status).toBe("cancelled");
+  });
+
   it("rejects invalid guest email", async () => {
     const { slug } = await enableBookingPage();
     await expect(
@@ -898,11 +984,12 @@ describe("Public booking routes", () => {
       hostDisplayName: "Permalink Host",
       status: "confirmed",
       bookingSlug: page.slug,
+      guestName: "Ada Lovelace",
+      notes: "secret notes",
     });
     expect(response.body).not.toHaveProperty("guestEmail");
     expect(response.body).not.toHaveProperty("cancelUrl");
     expect(response.body).not.toHaveProperty("rescheduleUrl");
-    expect(response.body).not.toHaveProperty("notes");
   });
 
   it("POST reservation returns 409 when bookable is false", async () => {

--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -13,6 +13,7 @@ import {
   CreateBookingReservationInputSchema,
   CreateBookingReservationResponseSchema,
   isGuestEmail,
+  PatchBookingReservationInputSchema,
   type PublicBookingPage,
   PublicBookingPageSchema,
   type PublicGetBookingReservationResponse,
@@ -33,6 +34,7 @@ import {
 } from "@backend/booking/booking-cancel-token";
 import { type BookingPageRecord } from "@backend/booking/booking-page.record";
 import { bookingPageRepository } from "@backend/booking/booking-page.repository";
+import { type BookingReservationRecord } from "@backend/booking/booking-reservation.record";
 import { bookingReservationRepository } from "@backend/booking/booking-reservation.repository";
 import { type CalendarBookingPort } from "@backend/booking/services/calendar-booking.port";
 import { CalendarBookingService } from "@backend/booking/services/calendar-booking.service";
@@ -95,6 +97,37 @@ const parseSlotsQuery = (rawQuery: unknown) => {
 
 const slotEndForStart = (slotStart: Date, durationMinutes: number): Date =>
   new Date(slotStart.getTime() + durationMinutes * 60_000);
+
+const bookingEventDescription = (
+  notes: string | null | undefined,
+  guestsCanInviteOthers: boolean,
+  cancelUrl: string,
+): string =>
+  [notes?.trim() || null, guestsCanInviteOthers ? null : `Cancel: ${cancelUrl}`]
+    .filter(Boolean)
+    .join("\n\n");
+
+const durationMinutesForReservation = (
+  reservation: BookingReservationRecord,
+  pageDurationMinutes: number,
+) => {
+  const fromSlot = Math.round(
+    (reservation.slotEnd.getTime() - reservation.slotStart.getTime()) / 60_000,
+  );
+  return BookingDurationMinutesSchema.safeParse(fromSlot).success
+    ? fromSlot
+    : pageDurationMinutes;
+};
+
+const nextGuestNotes = (
+  incoming: string | undefined,
+  current: string | null,
+): string | null => {
+  if (incoming === undefined) {
+    return current;
+  }
+  return incoming.length > 0 ? incoming : null;
+};
 
 /**
  * Every page-derived knob the slot engine reads, in one place.
@@ -276,12 +309,11 @@ export class PublicBookingService {
           // The cancel URL is a capability: anyone holding it can cancel. When
           // the guest may invite others, every invitee sees the description, so
           // keep the URL out of it — the guest gets it on the confirmation page.
-          description: [
-            input.notes?.trim(),
-            page.guestsCanInviteOthers ? null : `Cancel: ${cancelUrl}`,
-          ]
-            .filter(Boolean)
-            .join("\n\n"),
+          description: bookingEventDescription(
+            input.notes,
+            page.guestsCanInviteOthers,
+            cancelUrl,
+          ),
           start: input.slotStart,
           end: DateTimeSchema.parse(slotEnd.toISOString()),
           timeZone: page.timeZone,
@@ -371,14 +403,10 @@ export class PublicBookingService {
     }
 
     const hostDisplayName = await getHostDisplayName(page.userId);
-    const fromSlot = Math.round(
-      (reservation.slotEnd.getTime() - reservation.slotStart.getTime()) /
-        60_000,
+    const durationMinutes = durationMinutesForReservation(
+      reservation,
+      page.durationMinutes,
     );
-    const durationMinutes = BookingDurationMinutesSchema.safeParse(fromSlot)
-      .success
-      ? fromSlot
-      : page.durationMinutes;
     return PublicGetBookingReservationResponseSchema.parse({
       slotStart: reservation.slotStart.toISOString(),
       guestTimeZone: reservation.guestTimeZone,
@@ -386,7 +414,68 @@ export class PublicBookingService {
       hostDisplayName,
       status: reservation.status,
       bookingSlug: page.bookingSlug,
+      guestName: reservation.guestName,
+      notes: reservation.notes,
     });
+  }
+
+  async patchPublicReservation(reservationId: ObjectId, rawInput: unknown) {
+    const input = PatchBookingReservationInputSchema.parse(rawInput);
+    const reservation =
+      await bookingReservationRepository.findById(reservationId);
+    if (
+      !reservation ||
+      !verifyCancelToken(reservation.cancelTokenHash, input.token)
+    ) {
+      throw bookingError("RESERVATION_NOT_FOUND", "Reservation not found");
+    }
+
+    if (reservation.status === "cancelled") {
+      throw bookingError("RESERVATION_NOT_FOUND", "Reservation not found");
+    }
+
+    const page = await bookingPageRepository.findById(reservation.pageId);
+    if (!page?.bookingSlug) {
+      throw bookingError("RESERVATION_NOT_FOUND", "Reservation not found");
+    }
+
+    const guestName = input.name ?? reservation.guestName;
+    const notes = nextGuestNotes(input.notes, reservation.notes);
+    const hostDisplayName = await getHostDisplayName(page.userId);
+    const cancelUrl = buildGuestActionUrl(
+      "cancel",
+      reservationId.toString(),
+      input.token,
+    );
+
+    if (reservation.calendarEventId) {
+      await this.calendarBooking.updateBookingEvent(page.userId.toString(), {
+        eventId: reservation.calendarEventId as EventId,
+        title: `${guestName} and ${hostDisplayName}`,
+        description: bookingEventDescription(
+          notes,
+          page.guestsCanInviteOthers,
+          cancelUrl,
+        ),
+        start: DateTimeSchema.parse(reservation.slotStart.toISOString()),
+        end: DateTimeSchema.parse(reservation.slotEnd.toISOString()),
+        timeZone: page.timeZone,
+        guest: {
+          email: reservation.guestEmail,
+          displayName: guestName,
+        },
+      });
+    }
+
+    const updated = await bookingReservationRepository.updateGuestDetails(
+      reservationId,
+      { guestName, notes },
+    );
+    if (!updated) {
+      throw bookingError("RESERVATION_NOT_FOUND", "Reservation not found");
+    }
+
+    return this.getPublicReservation(reservationId);
   }
 
   async cancelReservation(

--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -119,6 +119,26 @@ const durationMinutesForReservation = (
     : pageDurationMinutes;
 };
 
+const toPublicReservation = (
+  reservation: BookingReservationRecord,
+  bookingSlug: string,
+  hostDisplayName: string,
+  pageDurationMinutes: number,
+): PublicGetBookingReservationResponse =>
+  PublicGetBookingReservationResponseSchema.parse({
+    slotStart: reservation.slotStart.toISOString(),
+    guestTimeZone: reservation.guestTimeZone,
+    durationMinutes: durationMinutesForReservation(
+      reservation,
+      pageDurationMinutes,
+    ),
+    hostDisplayName,
+    status: reservation.status,
+    bookingSlug,
+    guestName: reservation.guestName,
+    notes: reservation.notes,
+  });
+
 const nextGuestNotes = (
   incoming: string | undefined,
   current: string | null,
@@ -403,20 +423,12 @@ export class PublicBookingService {
     }
 
     const hostDisplayName = await getHostDisplayName(page.userId);
-    const durationMinutes = durationMinutesForReservation(
+    return toPublicReservation(
       reservation,
+      page.bookingSlug,
+      hostDisplayName,
       page.durationMinutes,
     );
-    return PublicGetBookingReservationResponseSchema.parse({
-      slotStart: reservation.slotStart.toISOString(),
-      guestTimeZone: reservation.guestTimeZone,
-      durationMinutes,
-      hostDisplayName,
-      status: reservation.status,
-      bookingSlug: page.bookingSlug,
-      guestName: reservation.guestName,
-      notes: reservation.notes,
-    });
   }
 
   async patchPublicReservation(reservationId: ObjectId, rawInput: unknown) {
@@ -475,7 +487,12 @@ export class PublicBookingService {
       throw bookingError("RESERVATION_NOT_FOUND", "Reservation not found");
     }
 
-    return this.getPublicReservation(reservationId);
+    return toPublicReservation(
+      updated,
+      page.bookingSlug,
+      hostDisplayName,
+      page.durationMinutes,
+    );
   }
 
   async cancelReservation(

--- a/packages/core/src/types/booking.contracts.test.ts
+++ b/packages/core/src/types/booking.contracts.test.ts
@@ -10,6 +10,7 @@ import {
   CreateBookingReservationInputSchema,
   CreateBookingReservationResponseSchema,
   isGuestEmail,
+  PatchBookingReservationInputSchema,
   PublicBookingPageSchema,
   PublicGetBookingPageResponseSchema,
   PublicGetBookingReservationResponseSchema,
@@ -324,7 +325,7 @@ describe("HTTP booking contracts", () => {
     ).toBe(true);
   });
 
-  it("parses a public reservation GET without guest contact fields", () => {
+  it("parses a public reservation GET with name and notes, not email", () => {
     const publicGet = {
       slotStart: "2026-09-01T15:00:00.000Z",
       guestTimeZone: "Europe/London",
@@ -332,6 +333,8 @@ describe("HTTP booking contracts", () => {
       hostDisplayName: "Tyler Dane",
       status: "confirmed",
       bookingSlug: "tylerdane",
+      guestName: "Ada Lovelace",
+      notes: "bring coffee",
     };
     expect(
       PublicGetBookingReservationResponseSchema.safeParse(publicGet).success,
@@ -343,11 +346,40 @@ describe("HTTP booking contracts", () => {
         durationMinutes: 30,
         hostDisplayName: "Tyler Dane",
         status: "confirmed",
+        bookingSlug: "tylerdane",
       }).success,
     ).toBe(false);
     expect(
       PublicGetBookingReservationResponseSchema.safeParse({
         ...publicGet,
+        guestEmail: "ada@example.com",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("parses a guest details PATCH and rejects email or empty edits", () => {
+    expect(
+      PatchBookingReservationInputSchema.safeParse({
+        token: "abc",
+        name: "Grace Hopper",
+        notes: "bring tea",
+      }).success,
+    ).toBe(true);
+    expect(
+      PatchBookingReservationInputSchema.safeParse({
+        token: "abc",
+        notes: "",
+      }).success,
+    ).toBe(true);
+    expect(
+      PatchBookingReservationInputSchema.safeParse({
+        token: "abc",
+      }).success,
+    ).toBe(false);
+    expect(
+      PatchBookingReservationInputSchema.safeParse({
+        token: "abc",
+        name: "Ada Lovelace",
         guestEmail: "ada@example.com",
       }).success,
     ).toBe(false);

--- a/packages/core/src/types/booking.contracts.ts
+++ b/packages/core/src/types/booking.contracts.ts
@@ -289,9 +289,24 @@ export const PublicGetBookingReservationResponseSchema = z.strictObject({
   hostDisplayName: z.string().trim().min(1).max(256),
   status: BookingReservationStatusSchema,
   bookingSlug: BookingSlugSchema,
+  guestName: z.string().trim().min(1).max(256),
+  notes: z.string().trim().max(4000).nullable(),
 });
 export type PublicGetBookingReservationResponse = z.infer<
   typeof PublicGetBookingReservationResponseSchema
+>;
+
+export const PatchBookingReservationInputSchema = z
+  .strictObject({
+    token: z.string().trim().min(1).max(256),
+    name: z.string().trim().min(1).max(256).optional(),
+    notes: z.string().trim().max(4000).optional(),
+  })
+  .refine((input) => input.name !== undefined || input.notes !== undefined, {
+    message: "Provide name or notes",
+  });
+export type PatchBookingReservationInput = z.infer<
+  typeof PatchBookingReservationInputSchema
 >;
 
 export const CancelBookingReservationInputSchema = z.strictObject({

--- a/packages/web/src/api/base/base.api.ts
+++ b/packages/web/src/api/base/base.api.ts
@@ -95,4 +95,7 @@ export const BaseApi = {
   put<T>(url: string, body?: unknown, config?: ApiMethodConfig) {
     return request<T>("PUT", url, body, config);
   },
+  patch<T>(url: string, body?: unknown, config?: ApiMethodConfig) {
+    return request<T>("PATCH", url, body, config);
+  },
 };

--- a/packages/web/src/api/public-booking.api.ts
+++ b/packages/web/src/api/public-booking.api.ts
@@ -9,6 +9,8 @@ import {
   CreateBookingReservationInputSchema,
   type CreateBookingReservationResponse,
   CreateBookingReservationResponseSchema,
+  type PatchBookingReservationInput,
+  PatchBookingReservationInputSchema,
   type PublicGetBookingPageResponse,
   PublicGetBookingPageResponseSchema,
   type PublicGetBookingReservationResponse,
@@ -77,6 +79,26 @@ const PublicBookingApi = {
     try {
       const response = await BaseApi.get<unknown>(
         `/booking/reservations/${encodeURIComponent(reservationId)}`,
+        { skipSessionRecovery: true },
+      );
+      return PublicGetBookingReservationResponseSchema.parse(response.data);
+    } catch (error) {
+      if (getErrorStatus(error) === 404) {
+        throw new PublicBookingNotFoundError();
+      }
+      throw error;
+    }
+  },
+
+  async patchReservation(
+    reservationId: string,
+    input: PatchBookingReservationInput,
+  ): Promise<PublicGetBookingReservationResponse> {
+    const parsed = PatchBookingReservationInputSchema.parse(input);
+    try {
+      const response = await BaseApi.patch<unknown>(
+        `/booking/reservations/${encodeURIComponent(reservationId)}`,
+        parsed,
         { skipSessionRecovery: true },
       );
       return PublicGetBookingReservationResponseSchema.parse(response.data);

--- a/packages/web/src/booking/PublicBookingCancelPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingCancelPage.test.tsx
@@ -31,6 +31,8 @@ function reservationGetHandler(overrides: Record<string, unknown> = {}) {
           hostDisplayName: "Tyler Dane",
           status: "confirmed",
           bookingSlug: "tylerdane",
+          guestName: "Guest User",
+          notes: null,
           ...overrides,
         }),
       ),

--- a/packages/web/src/booking/PublicBookingConfirmationView.test.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmationView.test.tsx
@@ -19,6 +19,8 @@ describe("PublicBookingConfirmationView", () => {
         cancelUrl={cancelUrl}
         durationMinutes={30}
         hostDisplayName="Tyler Dane"
+        guestName="Ada Lovelace"
+        notes={null}
         slotStart={slotStart}
         timeZone={timeZone}
       />,
@@ -27,6 +29,9 @@ describe("PublicBookingConfirmationView", () => {
     expect(
       screen.getByRole("heading", { name: "You are booked with Tyler Dane" }),
     ).toBeInTheDocument();
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+    expect(screen.queryByText("Notes")).not.toBeInTheDocument();
     expect(screen.getByText("When")).toBeInTheDocument();
     expect(
       screen.getByText(formatBookingSlotLabel(slotStart, timeZone)),
@@ -48,6 +53,8 @@ describe("PublicBookingConfirmationView", () => {
       <PublicBookingConfirmationView
         durationMinutes={30}
         hostDisplayName="Tyler Dane"
+        guestName="Ada Lovelace"
+        notes={null}
         slotStart={slotStart}
         timeZone={timeZone}
       />,
@@ -82,6 +89,8 @@ describe("PublicBookingConfirmationView", () => {
         cancelUrl={cancelUrl}
         durationMinutes={30}
         hostDisplayName="Tyler Dane"
+        guestName="Ada Lovelace"
+        notes={null}
         slotStart={slotStart}
         timeZone={timeZone}
       />,
@@ -92,5 +101,44 @@ describe("PublicBookingConfirmationView", () => {
     expect(written).toEqual([cancelUrl]);
     expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
     expect(screen.getByRole("status")).toHaveTextContent("Copied");
+  });
+
+  it("shows notes and Edit details when provided", async () => {
+    const user = userEvent.setup({ delay: null });
+    const onEditDetails = mock(() => undefined);
+    render(
+      <PublicBookingConfirmationView
+        cancelUrl={cancelUrl}
+        durationMinutes={30}
+        hostDisplayName="Tyler Dane"
+        guestName="Ada Lovelace"
+        notes="bring coffee"
+        onEditDetails={onEditDetails}
+        slotStart={slotStart}
+        timeZone={timeZone}
+      />,
+    );
+
+    expect(screen.getByText("Notes")).toBeInTheDocument();
+    expect(screen.getByText("bring coffee")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Edit details" }));
+    expect(onEditDetails).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides Edit details without an edit handler", () => {
+    render(
+      <PublicBookingConfirmationView
+        durationMinutes={30}
+        hostDisplayName="Tyler Dane"
+        guestName="Ada Lovelace"
+        notes={null}
+        slotStart={slotStart}
+        timeZone={timeZone}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Edit details" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/booking/PublicBookingConfirmationView.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmationView.tsx
@@ -7,18 +7,24 @@ import { useBookingHeadingFocus } from "@web/booking/use-booking-heading-focus";
 
 interface PublicBookingConfirmationViewProps {
   hostDisplayName: string;
+  guestName: string;
+  notes: string | null;
   durationMinutes: number;
   slotStart: string;
   timeZone: string;
   cancelUrl?: string;
+  onEditDetails?: () => void;
 }
 
 export function PublicBookingConfirmationView({
   hostDisplayName,
+  guestName,
+  notes,
   durationMinutes,
   slotStart,
   timeZone,
   cancelUrl,
+  onEditDetails,
 }: PublicBookingConfirmationViewProps) {
   const headingRef = useBookingHeadingFocus(hostDisplayName);
 
@@ -49,13 +55,38 @@ export function PublicBookingConfirmationView({
           slotStart={slotStart}
           timeZone={timeZone}
         />
+        <dl className="rounded-md border border-border bg-surface-panel px-3 py-2 text-sm text-text">
+          <div>
+            <dt className="text-text-muted">Name</dt>
+            <dd>{guestName}</dd>
+          </div>
+          {notes ? (
+            <div className="mt-2">
+              <dt className="text-text-muted">Notes</dt>
+              <dd>{notes}</dd>
+            </div>
+          ) : null}
+        </dl>
         <p className="text-sm text-text">
           {`A Google Meet invite is on its way to your email.${
             cancelUrl ? "" : " To cancel, use the link in that invite."
           }`}
         </p>
-        {cancelUrl ? (
-          <PublicBookingCopyCancelUrl cancelUrl={cancelUrl} />
+        {cancelUrl || onEditDetails ? (
+          <div className="flex flex-col items-start gap-3">
+            {onEditDetails ? (
+              <button
+                type="button"
+                onClick={onEditDetails}
+                className="c-button c-button-secondary"
+              >
+                Edit details
+              </button>
+            ) : null}
+            {cancelUrl ? (
+              <PublicBookingCopyCancelUrl cancelUrl={cancelUrl} />
+            ) : null}
+          </div>
         ) : null}
       </section>
     </PublicBookingLayout>

--- a/packages/web/src/booking/PublicBookingConfirmationView.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmationView.tsx
@@ -72,21 +72,17 @@ export function PublicBookingConfirmationView({
             cancelUrl ? "" : " To cancel, use the link in that invite."
           }`}
         </p>
-        {cancelUrl || onEditDetails ? (
-          <div className="flex flex-col items-start gap-3">
-            {onEditDetails ? (
-              <button
-                type="button"
-                onClick={onEditDetails}
-                className="c-button c-button-secondary"
-              >
-                Edit details
-              </button>
-            ) : null}
-            {cancelUrl ? (
-              <PublicBookingCopyCancelUrl cancelUrl={cancelUrl} />
-            ) : null}
-          </div>
+        {onEditDetails ? (
+          <button
+            type="button"
+            onClick={onEditDetails}
+            className="c-button c-button-secondary"
+          >
+            Edit details
+          </button>
+        ) : null}
+        {cancelUrl ? (
+          <PublicBookingCopyCancelUrl cancelUrl={cancelUrl} />
         ) : null}
       </section>
     </PublicBookingLayout>

--- a/packages/web/src/booking/PublicBookingConfirmedPage.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmedPage.tsx
@@ -1,8 +1,14 @@
 import { useNavigate, useParams, useRouterState } from "@tanstack/react-router";
+import { useState } from "react";
 import { PublicBookingNotFoundError } from "@web/api/public-booking.api";
+import { getErrorStatus } from "@web/api/util/api.util";
 import { PublicBookingConfirmationView } from "@web/booking/PublicBookingConfirmationView";
+import { PublicBookingEditDetailsForm } from "@web/booking/PublicBookingEditDetailsForm";
 import { PublicBookingStatusMessage } from "@web/booking/PublicBookingStatusMessage";
-import { usePublicBookingReservationQuery } from "@web/booking/public-booking.query";
+import {
+  usePatchPublicBookingReservationMutation,
+  usePublicBookingReservationQuery,
+} from "@web/booking/public-booking.query";
 import { useBookingDocumentTitle } from "@web/booking/use-booking-document-title";
 import { requestPublicBookingPageHeadingFocus } from "@web/booking/use-booking-heading-focus";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
@@ -73,6 +79,18 @@ function cancelUrlFromHistory(state: unknown): string | undefined {
   return undefined;
 }
 
+function tokenFromCancelUrl(cancelUrl: string): string {
+  try {
+    return (
+      new URL(cancelUrl, "https://compasscalendar.com").searchParams.get(
+        "token",
+      ) ?? ""
+    );
+  } catch {
+    return "";
+  }
+}
+
 export function PublicBookingConfirmedPage() {
   const { reservationId } = useParams({
     from: "/book/confirmed/$reservationId",
@@ -80,16 +98,23 @@ export function PublicBookingConfirmedPage() {
   const cancelUrl = useRouterState({
     select: (routerState) => cancelUrlFromHistory(routerState.location.state),
   });
+  const token = cancelUrl ? tokenFromCancelUrl(cancelUrl) : "";
   const reservationQuery = usePublicBookingReservationQuery(reservationId);
+  const patchReservation =
+    usePatchPublicBookingReservationMutation(reservationId);
+  const [isEditing, setIsEditing] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
   useBookingDocumentTitle("Booking confirmed");
   const navigate = useNavigate();
 
   const view = resolveConfirmedPageView(reservationQuery);
   const bookingSlug =
     view.kind === "confirmation" ? view.reservation.bookingSlug : "";
+  const canEdit = view.kind === "confirmation" && token.length > 0;
 
   // Escape returns to the host's public page. OverlayPanel peels first.
-  // Unknown and cancelled views have no slug path, so they stay put.
+  // An open edit form backs out one step. Unknown and cancelled views have
+  // no slug path, so they stay put.
   useAppShortcut(
     "Escape",
     (event) => {
@@ -97,6 +122,11 @@ export function PublicBookingConfirmedPage() {
         return;
       }
       event.preventDefault();
+      if (isEditing) {
+        setIsEditing(false);
+        setSaveError(null);
+        return;
+      }
       requestPublicBookingPageHeadingFocus();
       void navigate({
         to: ROOT_ROUTES.BOOK,
@@ -111,13 +141,57 @@ export function PublicBookingConfirmedPage() {
   }
 
   const { reservation } = view;
+
+  if (isEditing && canEdit) {
+    return (
+      <PublicBookingEditDetailsForm
+        guestName={reservation.guestName}
+        notes={reservation.notes ?? ""}
+        disabled={patchReservation.isPending}
+        error={saveError}
+        onCancel={() => {
+          setIsEditing(false);
+          setSaveError(null);
+        }}
+        onSubmit={(values) => {
+          setSaveError(null);
+          patchReservation.mutate(
+            { token, name: values.name, notes: values.notes },
+            {
+              onSuccess: () => {
+                setIsEditing(false);
+              },
+              onError: (error) => {
+                setSaveError(
+                  getErrorStatus(error) === 404
+                    ? "This booking could not be updated. Use the link in your invite."
+                    : "Could not save your details. Please try again.",
+                );
+              },
+            },
+          );
+        }}
+      />
+    );
+  }
+
   return (
     <PublicBookingConfirmationView
       hostDisplayName={reservation.hostDisplayName}
+      guestName={reservation.guestName}
+      notes={reservation.notes}
       durationMinutes={reservation.durationMinutes}
       slotStart={reservation.slotStart}
       timeZone={reservation.guestTimeZone}
       cancelUrl={cancelUrl}
+      onEditDetails={
+        canEdit
+          ? () => {
+              setSaveError(null);
+              setIsEditing(true);
+            }
+          : undefined
+      }
     />
   );
 }

--- a/packages/web/src/booking/PublicBookingEditDetailsForm.tsx
+++ b/packages/web/src/booking/PublicBookingEditDetailsForm.tsx
@@ -1,0 +1,124 @@
+import { type FormEvent, useRef, useState } from "react";
+import { PublicBookingLayout } from "@web/booking/PublicBookingLayout";
+import { PUBLIC_BOOKING_HEADING_CLASS } from "@web/booking/PublicBookingStatusMessage";
+import { useBookingHeadingFocus } from "@web/booking/use-booking-heading-focus";
+
+interface PublicBookingEditDetailsFormProps {
+  guestName: string;
+  notes: string;
+  disabled: boolean;
+  error: string | null;
+  onCancel: () => void;
+  onSubmit: (values: { name: string; notes: string }) => void;
+}
+
+const INVALID_FIELD_CLASS_NAME = "c-field border-error";
+
+export function PublicBookingEditDetailsForm({
+  guestName,
+  notes,
+  disabled,
+  error,
+  onCancel,
+  onSubmit,
+}: PublicBookingEditDetailsFormProps) {
+  const headingRef = useBookingHeadingFocus("edit-details");
+  const nameRef = useRef<HTMLInputElement>(null);
+  const [name, setName] = useState(guestName);
+  const [noteValue, setNoteValue] = useState(notes);
+  const [nameError, setNameError] = useState<string | undefined>();
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (disabled) {
+      return;
+    }
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setNameError("Enter your name.");
+      nameRef.current?.focus();
+      return;
+    }
+    onSubmit({ name: trimmedName, notes: noteValue.trim() });
+  };
+
+  return (
+    <PublicBookingLayout>
+      <form
+        aria-labelledby="booking-edit-details-heading"
+        className="flex flex-col gap-4"
+        noValidate
+        onSubmit={handleSubmit}
+      >
+        <h1
+          ref={headingRef}
+          id="booking-edit-details-heading"
+          tabIndex={-1}
+          className={PUBLIC_BOOKING_HEADING_CLASS}
+        >
+          Edit details
+        </h1>
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="text-text-muted">Name</span>
+          <input
+            ref={nameRef}
+            required
+            type="text"
+            autoComplete="name"
+            maxLength={256}
+            value={name}
+            disabled={disabled}
+            aria-invalid={nameError ? true : undefined}
+            aria-describedby={nameError ? "booking-edit-name-error" : undefined}
+            onChange={(event) => {
+              setName(event.target.value);
+              setNameError(undefined);
+            }}
+            className={nameError ? INVALID_FIELD_CLASS_NAME : "c-field"}
+          />
+          {nameError ? (
+            <span
+              id="booking-edit-name-error"
+              role="alert"
+              className="text-error text-xs"
+            >
+              {nameError}
+            </span>
+          ) : null}
+        </label>
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="text-text-muted">Notes (optional)</span>
+          <textarea
+            rows={3}
+            maxLength={4000}
+            value={noteValue}
+            disabled={disabled}
+            onChange={(event) => setNoteValue(event.target.value)}
+            className="c-field"
+          />
+        </label>
+        {error ? (
+          <p role="alert" className="text-error text-sm">
+            {error}
+          </p>
+        ) : null}
+        <button
+          type="submit"
+          disabled={disabled}
+          aria-busy={disabled || undefined}
+          className="c-button c-button-primary"
+        >
+          {disabled ? "Saving..." : "Save details"}
+        </button>
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={onCancel}
+          className="c-button c-button-secondary"
+        >
+          Back
+        </button>
+      </form>
+    </PublicBookingLayout>
+  );
+}

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -251,6 +251,8 @@ function reservationGetHandler(
           hostDisplayName: "Tyler Dane",
           status: "confirmed",
           bookingSlug: "tylerdane",
+          guestName: "Guest User",
+          notes: null,
           ...overrides,
         }),
       ),
@@ -1423,8 +1425,12 @@ describe("PublicBookingConfirmedPage", () => {
     expect(
       screen.getByText(/A Google Meet invite is on its way to your email/),
     ).toBeInTheDocument();
+    expect(screen.getByText("Guest User")).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Copy cancel link" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Edit details" }),
     ).not.toBeInTheDocument();
   });
 
@@ -1598,5 +1604,156 @@ describe("PublicBookingConfirmedPage", () => {
     ]);
     expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
     expect(screen.getByRole("status")).toHaveTextContent("Copied");
+  });
+
+  it("opens Edit details from confirmation, prefills, and shows saved values", async () => {
+    const user = userEvent.setup({ delay: null });
+    const patches: Array<Record<string, unknown>> = [];
+
+    server.use(
+      pageHandler(),
+      slotsInWindow([currentSlot]),
+      reservationGetHandler({
+        guestName: "Ada Lovelace",
+        notes: "bring coffee",
+      }),
+      rest.post(
+        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/reservations`,
+        async (_req, res, ctx) =>
+          res(
+            ctx.status(Status.OK),
+            ctx.json({
+              reservationId: "000000000000000000000099",
+              slotStart: currentSlot.slotStart,
+              slotEnd: currentSlot.slotEnd,
+              guestTimeZone: "UTC",
+              cancelUrl:
+                "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+              rescheduleUrl:
+                "https://compasscalendar.com/book/reschedule/000000000000000000000099?token=abc",
+            }),
+          ),
+      ),
+      rest.patch(
+        `${ENV_WEB.API_BASEURL}/booking/reservations/000000000000000000000099`,
+        async (req, res, ctx) => {
+          const body = (await req.json()) as Record<string, unknown>;
+          patches.push(body);
+          return res(
+            ctx.status(Status.OK),
+            ctx.json({
+              slotStart: currentSlot.slotStart,
+              guestTimeZone: "UTC",
+              durationMinutes: 30,
+              hostDisplayName: "Tyler Dane",
+              status: "confirmed",
+              bookingSlug: "tylerdane",
+              guestName: body.name,
+              notes: body.notes,
+            }),
+          );
+        },
+      ),
+    );
+
+    renderBookingRoute("/book/tylerdane");
+    await user.click(
+      await screen.findByRole("button", {
+        name: slotButtonName(currentSlot.slotStart),
+      }),
+    );
+    await user.type(screen.getByLabelText("Name"), "Ada Lovelace");
+    await user.type(screen.getByLabelText("Email"), "ada@example.com");
+    await user.type(screen.getByLabelText("Notes (optional)"), "bring coffee");
+    await user.click(screen.getByRole("button", { name: "Confirm booking" }));
+
+    expect(
+      await screen.findByRole("button", { name: "Edit details" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+    expect(screen.getByText("bring coffee")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Edit details" }));
+
+    const editHeading = await screen.findByRole("heading", {
+      name: "Edit details",
+    });
+    expect(editHeading).toHaveFocus();
+    expect(screen.getByLabelText("Name")).toHaveValue("Ada Lovelace");
+    expect(screen.getByLabelText("Notes (optional)")).toHaveValue(
+      "bring coffee",
+    );
+    expect(screen.queryByLabelText("Email")).not.toBeInTheDocument();
+
+    await user.clear(screen.getByLabelText("Name"));
+    await user.type(screen.getByLabelText("Name"), "Grace Hopper");
+    await user.clear(screen.getByLabelText("Notes (optional)"));
+    await user.type(screen.getByLabelText("Notes (optional)"), "bring tea");
+    await user.click(screen.getByRole("button", { name: "Save details" }));
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "You are booked with Tyler Dane",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Grace Hopper")).toBeInTheDocument();
+    expect(screen.getByText("bring tea")).toBeInTheDocument();
+    expect(screen.queryByText("Ada Lovelace")).not.toBeInTheDocument();
+    expect(patches).toEqual([
+      { token: "abc", name: "Grace Hopper", notes: "bring tea" },
+    ]);
+  });
+
+  it("returns from Edit details to confirmation on Escape", async () => {
+    const user = userEvent.setup({ delay: null });
+    server.use(
+      pageHandler(),
+      slotsInWindow([currentSlot]),
+      reservationGetHandler({
+        guestName: "Ada Lovelace",
+        notes: "bring coffee",
+      }),
+      rest.post(
+        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane/reservations`,
+        async (_req, res, ctx) =>
+          res(
+            ctx.status(Status.OK),
+            ctx.json({
+              reservationId: "000000000000000000000099",
+              slotStart: currentSlot.slotStart,
+              slotEnd: currentSlot.slotEnd,
+              guestTimeZone: "UTC",
+              cancelUrl:
+                "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+              rescheduleUrl:
+                "https://compasscalendar.com/book/reschedule/000000000000000000000099?token=abc",
+            }),
+          ),
+      ),
+    );
+
+    const { router } = renderBookingRoute("/book/tylerdane");
+    await user.click(
+      await screen.findByRole("button", {
+        name: slotButtonName(currentSlot.slotStart),
+      }),
+    );
+    await user.type(screen.getByLabelText("Name"), "Ada Lovelace");
+    await user.type(screen.getByLabelText("Email"), "ada@example.com");
+    await user.click(screen.getByRole("button", { name: "Confirm booking" }));
+    await user.click(
+      await screen.findByRole("button", { name: "Edit details" }),
+    );
+    await screen.findByRole("heading", { name: "Edit details" });
+    await user.keyboard("{Escape}");
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "You are booked with Tyler Dane",
+      }),
+    ).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe(
+      "/book/confirmed/000000000000000000000099",
+    );
   });
 });

--- a/packages/web/src/booking/public-booking.query.ts
+++ b/packages/web/src/booking/public-booking.query.ts
@@ -8,6 +8,7 @@ import { useEffect, useMemo } from "react";
 import {
   type BookingSlotsResponse,
   type CreateBookingReservationInput,
+  type PatchBookingReservationInput,
 } from "@core/types/booking.contracts";
 import {
   PublicBookingApi,
@@ -241,6 +242,23 @@ export function useCreatePublicBookingReservationMutation(slug: string) {
       void queryClient.invalidateQueries({
         queryKey: publicBookingQueryKeys.slotsAll(slug),
       });
+    },
+  });
+}
+
+export function usePatchPublicBookingReservationMutation(
+  reservationId: string,
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input: PatchBookingReservationInput) =>
+      PublicBookingApi.patchReservation(reservationId, input),
+    onSuccess: (data) => {
+      queryClient.setQueryData(
+        publicBookingQueryKeys.reservation(reservationId),
+        data,
+      );
     },
   });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Guests can edit name and notes after confirming a booking, from the confirmation page.

- `PATCH /api/booking/reservations/:id` takes `{ token, name?, notes? }` and verifies the cancel token the same way cancel does (invalid token is `RESERVATION_NOT_FOUND`, no id-enumeration oracle).
- Valid PATCH updates the reservation row and submits a sync `update` command: title `{Guest name} and {Host name}`, description follows the existing create rules (cancel URL only when `guestsCanInviteOthers` is off). `attendeesEdit: "preserve"`, `conference: null`.
- Public GET now includes `guestName` and `notes` so the confirmation form can prefill. Guest email is still unpublished and not accepted on PATCH.
- Confirmation page shows **Edit details** next to cancel affordances when the post-confirm `cancelUrl` (and token) is present. Opening the form focuses its heading. Escape backs out to confirmation. Guest email is not on the form.

Fixes #3136

## Simplicity

One PATCH on the existing reservation resource, one `updateBookingEvent` port method mirroring create/delete, and a dedicated edit form component. Token comes from the existing cancel URL. No email rewrite and no reschedule.

Follow-up simplify: shared `toPublicReservation` mapper for GET and PATCH, and dropped the extra wrapper around confirmation actions.

## Automated validation

`bun run verify` PASS.

```
Selected packages: core, web, backend
Checks run: test:core, test:web, test:backend, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)
All checks passed
```

- `test:core`: 676 pass
- `test:web`: shard 1 1629 pass, shard 2 1592 pass
- `test:backend`: 548 pass, 1 skip
- `test:a11y`: 24 passed
- `test:e2e`: 110 passed
- Focused: core contracts 36; backend calendar-booking + public-booking.service.db + rate-limit.db 45 (valid PATCH updates row and event title; wrong token unchanged; cancelled rejected with no command; PATCH 429 after 10); web PublicBookingPage + ConfirmationView + CancelPage 52 (Edit details prefills; submit shows updated values; no email field; Escape returns to confirmation)

## Independent review

`.agents/handoffs/3136.md`

```
VERDICT: no confirmed findings
FINDINGS:
(none)
```

## Test plan

Commands actually run:

- `bun run verify` (core, web, backend, type-check, lint, knip, test:a11y, test:e2e)
- `bun test packages/core/src/types/booking.contracts.test.ts`
- `bun test:backend -- packages/backend/src/booking/services/calendar-booking.service.test.ts packages/backend/src/booking/services/public-booking.service.db.test.ts packages/backend/src/booking/booking.rate-limit.db.test.ts`
- `bun test:web -- packages/web/src/booking/PublicBookingPage.test.tsx packages/web/src/booking/PublicBookingConfirmationView.test.tsx packages/web/src/booking/PublicBookingCancelPage.test.tsx`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec67721b-395d-454e-bd11-696669d367b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec67721b-395d-454e-bd11-696669d367b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

