### PR TITLE
feat(sync): reflect the Meet URL Google mints on booking create

### DIFF
--- a/.agents/handoffs/3137.md
+++ b/.agents/handoffs/3137.md
@@ -1,0 +1,41 @@
+---
+schema_version: 1
+task_id: "3137"
+from: Reviewer
+to: Manager
+owner: Manager
+status: verifying
+artifact:
+  - path: packages/sync/src/providers/google/google-event-writer.adapter.ts
+  - path: packages/sync/src/domain/provider-command.service.ts
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3201
+evidence:
+  - command: bun test packages/sync/src/providers/google/google-event-writer.adapter.test.ts packages/sync/src/providers/google/google-event.normalizer.test.ts
+    result: "71 pass (hangoutLink and entryPoints return conference; malformed URL does not throw; patch omits conferenceData)"
+    log: null
+  - command: bun test:sync -- packages/sync/src/domain/provider-command.service.db.test.ts
+    result: "83 pass (stored create record carries minted Meet URL, not command null)"
+    log: null
+  - command: bun run verify
+    result: "PASS. Selected packages: sync, backend. Checks run: test:sync, test:backend, type-check, lint, knip. Checks skipped: (none)."
+    log: null
+assumptions:
+  - "Conference is read-reflected from the create response only. Patch still omits conferenceData."
+  - "The Compass event form Join meeting link reads stored event conference.url."
+open_risks: []
+next_deadline: 2026-09-04T06:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-09: capture the Meet URL Google mints on booking create.
+
+Simplify: no further production change. `mapConference` is the one parser.
+
+Review: no confirmed findings.
+
+VERDICT: no confirmed findings
+FINDINGS:
+(none)

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,7 +13,8 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 3136 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3200 | focused core 36, backend 45, web 52; review: no confirmed findings; bun run verify pending this revision | 2026-09-04T06:00:00Z | 0 | none |
+| 3137 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3201 | bun run verify PASS (sync, backend, type-check, lint, knip); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
+| 3136 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3200 | squash-merged db747490e; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3133 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3199 | squash-merged 12bfcaa97; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3135 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3197 | bun run verify PASS (web shards 1617/1592, a11y 24, e2e 109); review: no confirmed findings after hours-draft fix | null | 0 | none |
 | 3162 | high | Founder | waiting | docs/features/billing.md | bun run verify PASS (type-check, lint, knip); founder staging QA waiting | 2026-09-10T00:00:00Z | 0 | human |

--- a/packages/backend/src/booking/services/calendar-booking.service.test.ts
+++ b/packages/backend/src/booking/services/calendar-booking.service.test.ts
@@ -146,6 +146,7 @@ describe("CalendarBookingService", () => {
         responseStatus: "needsAction",
       },
     ]);
+    expect(request.input.content.conference).toBeNull();
   });
 
   it("rejects empty guest email before submit", async () => {

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -13,8 +13,10 @@ import { ensureBookingIndexes } from "@backend/booking/booking-indexes";
 import { bookingReservationRepository } from "@backend/booking/booking-reservation.repository";
 import bookingPageService from "@backend/booking/services/booking-page.service";
 import { type CalendarBookingPort } from "@backend/booking/services/calendar-booking.port";
+import { CalendarBookingService } from "@backend/booking/services/calendar-booking.service";
 import { PublicBookingService } from "@backend/booking/services/public-booking.service";
 import calendarService from "@backend/calendar/services/calendar.service";
+import { type SyncServiceClient } from "@backend/common/services/sync-service/sync-service.client";
 import * as syncServiceFactory from "@backend/common/services/sync-service/sync-service.factory";
 import userService from "@backend/user/services/user.service";
 import {
@@ -747,6 +749,36 @@ describe("PublicBookingService", () => {
       description: string;
     };
     expect(eventInput.description).toContain(`Cancel: ${created.cancelUrl}`);
+  });
+
+  it("asks Sync to mint Meet on confirm and does not invent a conference URL", async () => {
+    const { slug } = await enableBookingPage();
+    const submitCommand = mock(async () => ({
+      ok: true as const,
+      value: { commandId: new ObjectId().toString() },
+    }));
+    spyOn(calendarService, "getLocalCalendar").mockResolvedValue(null);
+    const bookingService = new PublicBookingService(
+      new CalendarBookingService({
+        queryBusyAvailability: mock(async () => ({
+          ok: true as const,
+          value: busyResponse(true),
+        })),
+        submitCommand,
+      } as unknown as SyncServiceClient),
+    );
+
+    await bookingService.createReservation(slug, {
+      slotStart: "2026-09-07T10:00:00.000Z",
+      guestName: "Ada Lovelace",
+      guestEmail: "ada@example.com",
+      guestTimeZone: "Europe/London",
+    });
+
+    expect(submitCommand).toHaveBeenCalledTimes(1);
+    const [, request] = submitCommand.mock.calls[0] ?? [];
+    expect(request.input.createConference).toBe(true);
+    expect(request.input.content.conference).toBeNull();
   });
 
   it("patches guest name and notes and submits an event update", async () => {

--- a/packages/sync/src/domain/provider-command.service.db.test.ts
+++ b/packages/sync/src/domain/provider-command.service.db.test.ts
@@ -302,6 +302,46 @@ describe("executeProviderCreate", () => {
     expect(stored?.providerMetadata).toEqual({ iCalUID: "g-evt-1@google.com" });
   });
 
+  it("stores the Meet URL Google minted on create, not the command's null", async () => {
+    const { tenantId, principalId, calendar, command } = await seed();
+    const writer = new FakeWriter();
+    writer.result = {
+      providerEventId: "g-evt-1",
+      providerVersion: "etag-1",
+      conference: {
+        url: "https://meet.google.com/abc-defg-hij",
+        label: "Google Meet",
+      },
+    };
+
+    await executeProviderCreate(
+      {
+        commands,
+        events,
+        occurrences,
+        resources,
+        writer,
+        custody: tokenSource(),
+      },
+      command,
+      calendar,
+      now,
+    );
+
+    const stored = await events.findById(
+      tenantId,
+      principalId,
+      command.eventId,
+    );
+    expect(
+      command.input.kind === "create" && command.input.content.conference,
+    ).toBe(null);
+    expect(stored?.content.conference).toEqual({
+      url: "https://meet.google.com/abc-defg-hij",
+      label: "Google Meet",
+    });
+  });
+
   it("passes the caller's invitation intent through to the writer", async () => {
     const { calendar, command } = await seed("all");
     const writer = new FakeWriter();

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -315,9 +315,12 @@ function buildLinkedEventRecord(
     throw new Error("buildLinkedEventRecord requires a create command");
   }
   const { input } = command;
-  const content = intendedAttendees
+  const withAttendees = intendedAttendees
     ? { ...input.content, attendees: intendedAttendees }
     : input.content;
+  const content = result.conference
+    ? { ...withAttendees, conference: result.conference }
+    : withAttendees;
   return {
     _id: command.eventId,
     tenantId: command.tenantId,

--- a/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
@@ -400,7 +400,60 @@ describe("GoogleEventWriter", () => {
     expect(api.calls.insert[0].requestBody.guestsCanInviteOthers).toBe(true);
   });
 
-  it("conditions a patch on the expected version via If-Match", async () => {
+  it("returns the Meet URL Google mints on create", async () => {
+    const hangoutApi = new FakeEventsApi({
+      insert: {
+        ...scriptedEvent("abc12deadbeef00000000000"),
+        hangoutLink: "https://meet.google.com/abc-defg-hij",
+      },
+    });
+    const hangout = await writerWith(hangoutApi).writer.createEvent({
+      ...baseCreate,
+      createConference: true,
+    });
+    expect(hangout.conference).toEqual({
+      url: "https://meet.google.com/abc-defg-hij",
+      label: null,
+    });
+
+    const entryPointApi = new FakeEventsApi({
+      insert: {
+        ...scriptedEvent("abc12deadbeef00000000000"),
+        conferenceData: {
+          conferenceSolution: { name: "Google Meet" },
+          entryPoints: [
+            { entryPointType: "phone", uri: "tel:+1-555" },
+            { entryPointType: "video", uri: "https://meet.google.com/xyz" },
+          ],
+        },
+      },
+    });
+    const fromEntryPoints = await writerWith(entryPointApi).writer.createEvent({
+      ...baseCreate,
+      createConference: true,
+    });
+    expect(fromEntryPoints.conference).toEqual({
+      url: "https://meet.google.com/xyz",
+      label: "Google Meet",
+    });
+  });
+
+  it("drops a malformed Meet URL on create instead of throwing", async () => {
+    const api = new FakeEventsApi({
+      insert: {
+        ...scriptedEvent("abc12deadbeef00000000000"),
+        hangoutLink: "not-a-url",
+      },
+    });
+    const result = await writerWith(api).writer.createEvent({
+      ...baseCreate,
+      createConference: true,
+    });
+    expect(result.conference).toBeUndefined();
+    expect(result.providerEventId).toBe("abc12deadbeef00000000000");
+  });
+
+  it("does not write conferenceData on patch", async () => {
     const api = new FakeEventsApi();
     const { writer } = writerWith(api);
 
@@ -411,6 +464,8 @@ describe("GoogleEventWriter", () => {
 
     expect(api.calls.patch[0].ifMatch).toBe('"v1"');
     expect(result.providerVersion).toBe('"v2"');
+    expect(api.calls.patch[0].requestBody).not.toHaveProperty("conferenceData");
+    expect(api.calls.patch[0]).not.toHaveProperty("conferenceDataVersion");
   });
 
   it("patches unconditionally when no version is known", async () => {

--- a/packages/sync/src/providers/google/google-event-writer.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.ts
@@ -10,7 +10,10 @@ import {
 import { type SyncEventContent } from "@core/types/sync/event.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { googleColorIdFields } from "@sync/providers/google/google-color.map";
-import { normalizeGoogleEvent } from "@sync/providers/google/google-event.normalizer";
+import {
+  mapConference,
+  normalizeGoogleEvent,
+} from "@sync/providers/google/google-event.normalizer";
 import { GOOGLE_REQUEST_TIMEOUT_MS } from "@sync/providers/google/google-http.constants";
 import { googleInstanceEventId } from "@sync/providers/google/google-instance-id";
 import {
@@ -308,10 +311,12 @@ function toResult(event: gSchema$Event): ProviderWriteResult {
       "Google returned an event without an id or etag",
     );
   }
+  const conference = mapConference(event);
   return {
     providerEventId: event.id,
     providerVersion: event.etag,
     ...(event.iCalUID ? { icalUid: event.iCalUID } : {}),
+    ...(conference ? { conference } : {}),
   };
 }
 

--- a/packages/sync/src/providers/google/google-event.normalizer.ts
+++ b/packages/sync/src/providers/google/google-event.normalizer.ts
@@ -174,7 +174,8 @@ function mapAttendees(
     }));
 }
 
-function mapConference(item: gSchema$Event): Conference | null {
+/** Read-reflected Meet URL. Writers reuse this on create responses. */
+export function mapConference(item: gSchema$Event): Conference | null {
   const url =
     item.hangoutLink ??
     item.conferenceData?.entryPoints?.find(

--- a/packages/sync/src/providers/provider-event-writer.port.ts
+++ b/packages/sync/src/providers/provider-event-writer.port.ts
@@ -1,5 +1,8 @@
 import { type EventSchedule } from "@core/types/event.contracts";
-import { type Attendee } from "@core/types/event-attendance.contracts";
+import {
+  type Attendee,
+  type Conference,
+} from "@core/types/event-attendance.contracts";
 import { type SyncEventContent } from "@core/types/sync/event.contracts";
 import { ProviderError } from "@sync/providers/provider-error";
 import { type ProviderEventRead } from "@sync/providers/provider-event.port";
@@ -101,6 +104,10 @@ export interface ProviderWriteResult {
   // Google's cross-copy correlation key when the write response includes it.
   // Optional so non-Google writers and older fixtures stay valid.
   readonly icalUid?: string;
+  // Meet URL Google minted on create (or echoed on a later write). Omitted
+  // when the response has none. Create records overlay this onto command
+  // content, which sends `conference: null`.
+  readonly conference?: Conference;
 }
 
 // A provider-neutral event mutation port. Neutral inputs in, provider identity


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After a booking confirm, Compass now keeps the Google Meet URL Google mints so the event form can render **Join meeting**.

- `createEvent` reflects `hangoutLink` or a `conferenceData.entryPoints` video URI through the existing `mapConference` helper.
- `executeProviderCreate` overlays that conference onto the stored event instead of keeping the command's `conference: null`.
- Patch still omits `conferenceData`. Do not write conference on update.

Fixes #3137

## Simplicity

Reuse `mapConference` on the create response. One optional field on `ProviderWriteResult`. No new conference write path.

## Automated validation

`bun run verify` PASS.

```
Selected packages: sync, backend
Checks run: test:sync, test:backend, type-check, lint, knip
Checks skipped: (none)
All checks passed
```

Focused:

- adapter + normalizer: 71 pass (hangoutLink and entryPoints return conference; malformed URL does not throw; patch omits `conferenceData`)
- `provider-command.service.db.test.ts`: 83 pass (stored create record carries the minted Meet URL)
- `public-booking.service.db.test.ts` + calendar-booking: confirm still sets `createConference: true` and `conference: null` on the command

## Independent review

`.agents/handoffs/3137.md`

```
VERDICT: no confirmed findings
FINDINGS:
(none)
```

## Test plan

Commands actually run:

- `bun run verify` (sync, backend, type-check, lint, knip)
- `bun test packages/sync/src/providers/google/google-event-writer.adapter.test.ts packages/sync/src/providers/google/google-event.normalizer.test.ts`
- `bun test:sync -- packages/sync/src/domain/provider-command.service.db.test.ts`
- `bun test:backend -- packages/backend/src/booking/services/calendar-booking.service.test.ts packages/backend/src/booking/services/public-booking.service.db.test.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec67721b-395d-454e-bd11-696669d367b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec67721b-395d-454e-bd11-696669d367b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

