### PR TITLE
feat(booking): do not promise a Meet invite that cannot be minted

### DIFF
--- a/.agents/handoffs/3138.md
+++ b/.agents/handoffs/3138.md
@@ -1,0 +1,42 @@
+---
+schema_version: 1
+task_id: "3138"
+from: Reviewer
+to: Manager
+owner: Manager
+status: verifying
+artifact:
+  - path: packages/web/src/booking/PublicBookingConfirmationView.tsx
+  - path: packages/web/src/booking/BookingSettingsSection.tsx
+  - path: packages/backend/src/booking/services/public-booking.service.ts
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3202
+evidence:
+  - command: bun test:web -- packages/web/src/booking/PublicBookingConfirmationView.test.tsx packages/web/src/booking/BookingSettingsSection.test.tsx packages/web/src/booking/PublicBookingPage.test.tsx
+    result: "77 pass (Meet sentence exact; calendar-invite sentence exact and no Meet; Settings warning present/absent)"
+    log: null
+  - command: bun test:backend -- packages/backend/src/booking/services/public-booking.service.db.test.ts
+    result: "createsGoogleMeet true/false pinned on public page and reservation GET"
+    log: null
+  - command: bun run verify
+    result: "PASS. Selected packages: core, sync, web, backend. Checks run: test:core, test:sync, test:web, test:backend, type-check, lint, knip, test:a11y, test:e2e. Checks skipped: (none)."
+    log: null
+assumptions:
+  - "Public GET publishes createsGoogleMeet without a token so the confirmation permalink can branch copy. Local and unknown destinations are false. Google calendars missing conferenceProperties stay true."
+  - "The cancel-fallback clause is untouched for WP-11."
+open_risks: []
+next_deadline: 2026-09-04T06:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-10: do not promise a Meet invite that cannot be minted.
+
+Simplify: no further production change. One boolean through discovery to copy.
+
+Review: no confirmed findings.
+
+VERDICT: no confirmed findings
+FINDINGS:
+(none)

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,7 +13,8 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 3137 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3201 | bun run verify PASS (sync, backend, type-check, lint, knip); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
+| 3138 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3202 | bun run verify PASS (core, sync, web, backend, type-check, lint, knip, a11y, e2e); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
+| 3137 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3201 | squash-merged 2ac4e9a5c; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3136 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3200 | squash-merged db747490e; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3133 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3199 | squash-merged 12bfcaa97; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3135 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3197 | bun run verify PASS (web shards 1617/1592, a11y 24, e2e 109); review: no confirmed findings after hours-draft fix | null | 0 | none |

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -110,7 +110,7 @@ test.describe("public booking page", () => {
     await expect(page.getByText("Duration")).toBeVisible();
     await expect(page.getByText("Timezone")).toBeVisible();
     await expect(
-      page.getByText(/A Google Meet invite is on its way to your email/),
+      page.getByText("A Google Meet invite is on its way to your email."),
     ).toBeVisible();
     await expect(
       page.getByRole("link", { name: "cancel this booking" }),

--- a/packages/backend/src/booking/services/booking-page.service.db.test.ts
+++ b/packages/backend/src/booking/services/booking-page.service.db.test.ts
@@ -47,6 +47,7 @@ const writableCalendar = (id = calendarId()) => ({
     canReadBusy: true,
     canInviteAttendees: true,
   },
+  createsGoogleMeet: true,
   createdAt: "2026-07-01T00:00:00.000Z",
   updatedAt: "2026-07-20T12:00:00.000Z",
 });

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -50,6 +50,7 @@ const writableCalendar = (id = calendarId()) => ({
     canReadBusy: true,
     canInviteAttendees: true,
   },
+  createsGoogleMeet: true,
   createdAt: "2026-07-01T00:00:00.000Z",
   updatedAt: "2026-07-20T12:00:00.000Z",
 });
@@ -448,6 +449,43 @@ describe("PublicBookingService", () => {
     expect(page).not.toHaveProperty("dateOverrides");
   });
 
+  it("carries createsGoogleMeet true when the destination can mint Meet", async () => {
+    const { slug } = await enableBookingPage();
+    const page = await service.getPublicPage(slug);
+    expect(page.createsGoogleMeet).toBe(true);
+  });
+
+  it("carries createsGoogleMeet false when the destination cannot mint Meet", async () => {
+    const userId = await createNamedUser("No Meet Host");
+    const calendar = { ...writableCalendar(), createsGoogleMeet: false };
+    mockHealthySync([calendar]);
+    spyOn(billingGuard, "assertBillingAllowsWrites").mockResolvedValue(
+      undefined,
+    );
+    const page = await bookingPageService.putAdminPage(
+      userId,
+      samplePutInput({
+        destinationCalendarId: calendar.id,
+        blockingCalendarIds: [calendar.id],
+      }),
+    );
+    const slug = "slug" in page ? page.slug : "";
+
+    const publicPage = await service.getPublicPage(slug);
+    expect(publicPage.createsGoogleMeet).toBe(false);
+
+    const created = await service.createReservation(slug, {
+      slotStart: "2026-09-07T10:00:00.000Z",
+      guestName: "Ada Lovelace",
+      guestEmail: "ada@example.com",
+      guestTimeZone: "Europe/London",
+    });
+    const publicReservation = await service.getPublicReservation(
+      new ObjectId(created.reservationId),
+    );
+    expect(publicReservation.createsGoogleMeet).toBe(false);
+  });
+
   it("clamps a requested window that extends past the host horizon", async () => {
     const userId = await createNamedUser("Short Horizon Host");
     const calendar = writableCalendar();
@@ -555,6 +593,7 @@ describe("PublicBookingService", () => {
       bookingSlug: slug,
       guestName: "Ada Lovelace",
       notes: "secret notes",
+      createsGoogleMeet: true,
     });
     expect(publicReservation).not.toHaveProperty("guestEmail");
     expect(publicReservation).not.toHaveProperty("cancelUrl");
@@ -954,6 +993,7 @@ describe("Public booking routes", () => {
         durationMinutes: 30,
         enabled: true,
         maxHorizonDays: 60,
+        createsGoogleMeet: true,
       }),
     );
   });
@@ -1018,6 +1058,7 @@ describe("Public booking routes", () => {
       bookingSlug: page.slug,
       guestName: "Ada Lovelace",
       notes: "secret notes",
+      createsGoogleMeet: true,
     });
     expect(response.body).not.toHaveProperty("guestEmail");
     expect(response.body).not.toHaveProperty("cancelUrl");

--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -38,8 +38,11 @@ import { type BookingReservationRecord } from "@backend/booking/booking-reservat
 import { bookingReservationRepository } from "@backend/booking/booking-reservation.repository";
 import { type CalendarBookingPort } from "@backend/booking/services/calendar-booking.port";
 import { CalendarBookingService } from "@backend/booking/services/calendar-booking.service";
+import calendarService from "@backend/calendar/services/calendar.service";
 import { CONFIG } from "@backend/common/constants/config.constants";
 import mongoService from "@backend/common/services/mongo.service";
+import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
+import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
 
 const isDuplicateSlotError = (error: unknown): boolean =>
   error instanceof MongoServerError && error.code === 11000;
@@ -124,6 +127,7 @@ const toPublicReservation = (
   bookingSlug: string,
   hostDisplayName: string,
   pageDurationMinutes: number,
+  createsGoogleMeet: boolean,
 ): PublicGetBookingReservationResponse =>
   PublicGetBookingReservationResponseSchema.parse({
     slotStart: reservation.slotStart.toISOString(),
@@ -137,6 +141,7 @@ const toPublicReservation = (
     bookingSlug,
     guestName: reservation.guestName,
     notes: reservation.notes,
+    createsGoogleMeet,
   });
 
 const nextGuestNotes = (
@@ -147,6 +152,29 @@ const nextGuestNotes = (
     return current;
   }
   return incoming.length > 0 ? incoming : null;
+};
+
+const destinationCreatesGoogleMeet = async (
+  userId: ObjectId,
+  destinationCalendarId: string,
+): Promise<boolean> => {
+  const local = await calendarService.getLocalCalendar(userId);
+  if (local && local._id.toHexString() === destinationCalendarId) {
+    return false;
+  }
+
+  const client = getSyncServiceClient();
+  const result = await client.listCalendars(toSyncPrincipal(userId.toString()));
+  if (!result.ok) {
+    return true;
+  }
+  const destination = result.value.calendars.find(
+    (calendar) => (calendar.id as string) === destinationCalendarId,
+  );
+  if (!destination) {
+    return false;
+  }
+  return destination.createsGoogleMeet !== false;
 };
 
 /**
@@ -192,8 +220,12 @@ export class PublicBookingService {
   async getPublicPage(slug: string): Promise<PublicBookingPage> {
     const page = await resolveEnabledPage(slug);
     const hostDisplayName = await getHostDisplayName(page.userId);
+    const createsGoogleMeet = await destinationCreatesGoogleMeet(
+      page.userId,
+      page.destinationCalendarId,
+    );
     return PublicBookingPageSchema.parse(
-      toPublicBookingPage(page, hostDisplayName),
+      toPublicBookingPage(page, hostDisplayName, createsGoogleMeet),
     );
   }
 
@@ -423,11 +455,16 @@ export class PublicBookingService {
     }
 
     const hostDisplayName = await getHostDisplayName(page.userId);
+    const createsGoogleMeet = await destinationCreatesGoogleMeet(
+      page.userId,
+      page.destinationCalendarId,
+    );
     return toPublicReservation(
       reservation,
       page.bookingSlug,
       hostDisplayName,
       page.durationMinutes,
+      createsGoogleMeet,
     );
   }
 
@@ -487,11 +524,16 @@ export class PublicBookingService {
       throw bookingError("RESERVATION_NOT_FOUND", "Reservation not found");
     }
 
+    const createsGoogleMeet = await destinationCreatesGoogleMeet(
+      page.userId,
+      page.destinationCalendarId,
+    );
     return toPublicReservation(
       updated,
       page.bookingSlug,
       hostDisplayName,
       page.durationMinutes,
+      createsGoogleMeet,
     );
   }
 

--- a/packages/backend/src/calendar/calendar.record.mapper.test.ts
+++ b/packages/backend/src/calendar/calendar.record.mapper.test.ts
@@ -54,4 +54,16 @@ describe("mapCalendarRecord", () => {
     expect(calendar).not.toHaveProperty("source");
     expect(calendar).not.toHaveProperty("etag");
   });
+
+  it("marks a local calendar as unable to mint Meet", () => {
+    const calendar = mapCalendarRecord(
+      buildRecord({ source: { provider: "local" } }),
+    );
+    expect(calendar.createsGoogleMeet).toBe(false);
+  });
+
+  it("marks a google-sourced calendar as Meet-capable by default", () => {
+    const calendar = mapCalendarRecord(buildRecord());
+    expect(calendar.createsGoogleMeet).toBe(true);
+  });
 });

--- a/packages/backend/src/calendar/calendar.record.mapper.ts
+++ b/packages/backend/src/calendar/calendar.record.mapper.ts
@@ -18,4 +18,5 @@ export const mapCalendarRecord = (record: CalendarRecord): Calendar => ({
   isPrimary: record.isPrimary,
   isVisible: record.isVisible,
   isActive: record.isActive,
+  createsGoogleMeet: record.source.provider === "google",
 });

--- a/packages/backend/src/common/services/sync-service/calendar-list.translation.test.ts
+++ b/packages/backend/src/common/services/sync-service/calendar-list.translation.test.ts
@@ -130,4 +130,14 @@ describe("syncCalendarToBrowser", () => {
     // Capabilities are derived from the access role, matching the legacy mapper.
     expect(result.capabilities).toEqual(getCalendarCapabilities(browserAccess));
   });
+
+  it("maps createsGoogleMeet through", () => {
+    expect(
+      syncCalendarToBrowser(providerCalendar({ createsGoogleMeet: false }))
+        .createsGoogleMeet,
+    ).toBe(false);
+    expect(syncCalendarToBrowser(providerCalendar()).createsGoogleMeet).toBe(
+      true,
+    );
+  });
 });

--- a/packages/backend/src/common/services/sync-service/calendar-list.translation.ts
+++ b/packages/backend/src/common/services/sync-service/calendar-list.translation.ts
@@ -74,6 +74,7 @@ const syncCalendarToBrowser = (
     isPrimary: calendar.primary,
     isVisible: true,
     isActive: calendar.active,
+    createsGoogleMeet: calendar.createsGoogleMeet !== false,
     ...(accountEmail ? { accountEmail } : {}),
   });
 };

--- a/packages/core/src/types/booking.contracts.test.ts
+++ b/packages/core/src/types/booking.contracts.test.ts
@@ -126,12 +126,13 @@ describe("PublicBookingPageSchema", () => {
       "enabled",
       "maxHorizonDays",
       "welcomeText",
+      "createsGoogleMeet",
     ]);
   });
 
   it("projects an admin page without calendar ids or date overrides", () => {
     const admin = BookingPageSchema.parse(fullAdminPage());
-    const pub = toPublicBookingPage(admin, "Tyler Dane");
+    const pub = toPublicBookingPage(admin, "Tyler Dane", true);
 
     expect(PublicBookingPageSchema.safeParse(pub).success).toBe(true);
     expect(pub).toEqual({
@@ -141,6 +142,7 @@ describe("PublicBookingPageSchema", () => {
       enabled: true,
       maxHorizonDays: 60,
       welcomeText: null,
+      createsGoogleMeet: true,
     });
     expect(Object.keys(pub)).not.toContain("destinationCalendarId");
     expect(Object.keys(pub)).not.toContain("blockingCalendarIds");
@@ -338,6 +340,10 @@ describe("HTTP booking contracts", () => {
     };
     expect(
       PublicGetBookingReservationResponseSchema.safeParse(publicGet).success,
+    ).toBe(true);
+    expect(
+      PublicGetBookingReservationResponseSchema.parse(publicGet)
+        .createsGoogleMeet,
     ).toBe(true);
     expect(
       PublicGetBookingReservationResponseSchema.safeParse({

--- a/packages/core/src/types/booking.contracts.ts
+++ b/packages/core/src/types/booking.contracts.ts
@@ -198,6 +198,7 @@ export const PublicBookingPageSchema = z.strictObject({
   enabled: z.boolean(),
   maxHorizonDays: z.number().int().positive().max(60),
   welcomeText: BookingWelcomeTextSchema.nullable().default(null),
+  createsGoogleMeet: z.boolean().default(true),
 });
 export type PublicBookingPage = z.infer<typeof PublicBookingPageSchema>;
 
@@ -211,6 +212,7 @@ export const toPublicBookingPage = (
     | "welcomeText"
   >,
   hostDisplayName: string,
+  createsGoogleMeet: boolean,
 ): PublicBookingPage =>
   PublicBookingPageSchema.parse({
     hostDisplayName,
@@ -219,6 +221,7 @@ export const toPublicBookingPage = (
     enabled: page.enabled,
     maxHorizonDays: page.maxHorizonDays,
     welcomeText: page.welcomeText ?? null,
+    createsGoogleMeet,
   });
 
 export const BookingReservationStatusSchema = z.enum([
@@ -291,6 +294,7 @@ export const PublicGetBookingReservationResponseSchema = z.strictObject({
   bookingSlug: BookingSlugSchema,
   guestName: z.string().trim().min(1).max(256),
   notes: z.string().trim().max(4000).nullable(),
+  createsGoogleMeet: z.boolean().default(true),
 });
 export type PublicGetBookingReservationResponse = z.infer<
   typeof PublicGetBookingReservationResponseSchema

--- a/packages/core/src/types/calendar.contracts.test.ts
+++ b/packages/core/src/types/calendar.contracts.test.ts
@@ -44,6 +44,16 @@ describe("Calendar Contracts", () => {
 
       expect(result.success).toBe(true);
     });
+
+    it("accepts createsGoogleMeet and omits it when absent", () => {
+      expect(CalendarSchema.parse(validCalendar).createsGoogleMeet).toBe(
+        undefined,
+      );
+      expect(
+        CalendarSchema.parse({ ...validCalendar, createsGoogleMeet: false })
+          .createsGoogleMeet,
+      ).toBe(false);
+    });
   });
 
   describe("getCalendarCapabilities", () => {

--- a/packages/core/src/types/calendar.contracts.ts
+++ b/packages/core/src/types/calendar.contracts.ts
@@ -38,6 +38,9 @@ export const CalendarSchema = z.strictObject({
   isPrimary: z.boolean(),
   isVisible: z.boolean(),
   isActive: z.boolean(),
+  // Whether this calendar can mint a Google Meet URL. Local calendars are
+  // false. Omitted or true keeps the current Meet promise.
+  createsGoogleMeet: z.boolean().optional(),
   // Email of the connected provider account this calendar belongs to. This is
   // the calendar's only account identity on the wire: emails are unique per
   // user (one Google account = one connection), so grouping and labelling key

--- a/packages/core/src/types/sync/connection.contracts.test.ts
+++ b/packages/core/src/types/sync/connection.contracts.test.ts
@@ -315,6 +315,17 @@ describe("Sync connection contracts", () => {
       expect(ProviderCalendarSchema.safeParse(calendar).success).toBe(true);
     });
 
+    it("defaults createsGoogleMeet to true when omitted", () => {
+      const parsed = ProviderCalendarSchema.parse(validCalendar());
+      expect(parsed.createsGoogleMeet).toBe(true);
+      expect(
+        ProviderCalendarSchema.parse({
+          ...validCalendar(),
+          createsGoogleMeet: false,
+        }).createsGoogleMeet,
+      ).toBe(false);
+    });
+
     it("rejects product preference fields", () => {
       const calendar = { ...validCalendar(), visible: true };
       expect(ProviderCalendarSchema.safeParse(calendar).success).toBe(false);

--- a/packages/core/src/types/sync/connection.contracts.ts
+++ b/packages/core/src/types/sync/connection.contracts.ts
@@ -173,6 +173,7 @@ export const ProviderCalendarSchema = z.strictObject({
   primary: z.boolean(),
   accessRole: CalendarAccessRoleSchema,
   capabilities: SyncCalendarCapabilitiesSchema,
+  createsGoogleMeet: z.boolean().default(true),
   createdAt: DateTimeSchema,
   updatedAt: DateTimeSchema,
 });

--- a/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
@@ -32,6 +32,7 @@ const discovered = (
     canReadBusy: true,
     canInviteAttendees: true,
   },
+  createsGoogleMeet: true,
 });
 
 // Replays scripted discovery passes and records the cursor each call received.
@@ -179,6 +180,23 @@ describe("syncCalendarList", () => {
     // The discovery cursor is stored on the calendarList resource for next pass.
     expect((await calendarListResource(conn))?.syncCursor).toBe("cur-1");
     expect(discovery.cursors).toEqual([undefined]); // first pass is a full list
+  });
+
+  it("persists createsGoogleMeet from discovery", async () => {
+    const conn = connection();
+    const noMeet = { ...discovered("resource"), createsGoogleMeet: false };
+    const discovery = new FakeDiscovery([
+      { calendars: [discovered("primary"), noMeet], cursor: "c" },
+    ]);
+
+    await syncCalendarList(deps(discovery), conn, now);
+
+    const docs = await calendarDocs(conn);
+    const byId = Object.fromEntries(
+      docs.map((doc) => [doc.providerCalendarId, doc.createsGoogleMeet]),
+    );
+    expect(byId["primary"]).toBe(true);
+    expect(byId["resource"]).toBe(false);
   });
 
   it("ensures an events resource for each active calendar so its import can run", async () => {

--- a/packages/sync/src/domain/calendar-list-sync.service.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.ts
@@ -154,6 +154,7 @@ export async function syncCalendarList(
       primary: calendar.primary,
       accessRole: calendar.accessRole,
       capabilities: calendar.capabilities,
+      createsGoogleMeet: calendar.createsGoogleMeet,
     });
     upserted.push(record);
   }

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -79,6 +79,7 @@ const discovery = {
           canReadBusy: true,
           canInviteAttendees: true,
         },
+        createsGoogleMeet: true,
       },
     ],
     cursor: "cursor-1",

--- a/packages/sync/src/providers/google/google-calendar.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-calendar.adapter.test.ts
@@ -113,6 +113,7 @@ describe("GoogleCalendarAdapter", () => {
           canReadBusy: true,
           canInviteAttendees: true,
         },
+        createsGoogleMeet: true,
       },
     ]);
   });
@@ -370,6 +371,65 @@ describe("GoogleCalendarAdapter", () => {
     expect(calendars).toHaveLength(1);
     expect(calendars[0].providerCalendarId).toBe("no-color");
     expect(calendars[0].color).toBeNull();
+  });
+
+  it("treats missing conference types as Meet-capable", async () => {
+    const api = new FakeCalendarListApi([
+      page({ items: [entry({ id: "primary" })], nextSyncToken: "s" }),
+    ]);
+    const { adapter } = adapterWith(api);
+
+    const { calendars } = await adapter.discoverCalendars({
+      accessToken: "at",
+    });
+
+    expect(calendars[0].createsGoogleMeet).toBe(true);
+  });
+
+  it("maps hangoutsMeet as Meet-capable", async () => {
+    const api = new FakeCalendarListApi([
+      page({
+        items: [
+          entry({
+            id: "meet",
+            conferenceProperties: {
+              allowedConferenceSolutionTypes: ["hangoutsMeet"],
+            },
+          }),
+        ],
+        nextSyncToken: "s",
+      }),
+    ]);
+    const { adapter } = adapterWith(api);
+
+    const { calendars } = await adapter.discoverCalendars({
+      accessToken: "at",
+    });
+
+    expect(calendars[0].createsGoogleMeet).toBe(true);
+  });
+
+  it("maps a calendar without hangoutsMeet as not Meet-capable", async () => {
+    const api = new FakeCalendarListApi([
+      page({
+        items: [
+          entry({
+            id: "resource",
+            conferenceProperties: {
+              allowedConferenceSolutionTypes: ["eventHangout"],
+            },
+          }),
+        ],
+        nextSyncToken: "s",
+      }),
+    ]);
+    const { adapter } = adapterWith(api);
+
+    const { calendars } = await adapter.discoverCalendars({
+      accessToken: "at",
+    });
+
+    expect(calendars[0].createsGoogleMeet).toBe(false);
   });
 
   it("returns a null cursor when the provider sends no sync token", async () => {

--- a/packages/sync/src/providers/google/google-calendar.adapter.ts
+++ b/packages/sync/src/providers/google/google-calendar.adapter.ts
@@ -230,7 +230,19 @@ async function mapCalendar(
     active: item.deleted !== true && item.hidden !== true,
     accessRole,
     capabilities: CAPABILITIES_BY_ROLE[accessRole],
+    createsGoogleMeet: calendarCreatesGoogleMeet(
+      item.conferenceProperties?.allowedConferenceSolutionTypes,
+    ),
   };
+}
+
+// Missing types keep the current Meet promise. An advertised list that does
+// not include hangoutsMeet cannot mint a Meet URL.
+function calendarCreatesGoogleMeet(
+  allowedTypes: readonly string[] | null | undefined,
+): boolean {
+  if (allowedTypes == null) return true;
+  return allowedTypes.includes("hangoutsMeet");
 }
 
 function mapAccessRole(

--- a/packages/sync/src/providers/provider-calendar.port.ts
+++ b/packages/sync/src/providers/provider-calendar.port.ts
@@ -27,6 +27,10 @@ export interface DiscoveredCalendar {
   readonly active: boolean;
   readonly accessRole: CalendarAccessRole;
   readonly capabilities: SyncCalendarCapabilities;
+  // Whether this calendar can mint a Google Meet URL. Missing conference
+  // types from Google keep the current Meet promise (true). An advertised
+  // list that omits hangoutsMeet is false.
+  readonly createsGoogleMeet: boolean;
 }
 
 // The result of one discovery pass: the full set of calendars the provider

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -1022,6 +1022,7 @@ export function toProviderCalendar(
     primary: record.primary,
     accessRole: record.accessRole,
     capabilities: record.capabilities,
+    createsGoogleMeet: record.createsGoogleMeet,
     createdAt: record.createdAt.toISOString(),
     updatedAt: record.updatedAt.toISOString(),
   });

--- a/packages/sync/src/storage/contracts/provider-calendar.contracts.ts
+++ b/packages/sync/src/storage/contracts/provider-calendar.contracts.ts
@@ -37,6 +37,9 @@ export const ProviderCalendarRecordSchema = z.strictObject({
   primary: z.boolean(),
   accessRole: CalendarAccessRoleSchema,
   capabilities: SyncCalendarCapabilitiesSchema,
+  // Default true so documents discovered before this field existed still
+  // promise Meet, matching Google's omitted conferenceProperties.
+  createsGoogleMeet: z.boolean().default(true),
   createdAt: z.date(),
   updatedAt: z.date(),
 });

--- a/packages/sync/src/storage/repositories/provider-calendar.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/provider-calendar.repository.db.test.ts
@@ -107,6 +107,17 @@ describe("ProviderCalendarRepository", () => {
     expect(updated.capabilities.canWriteEvents).toBe(false);
   });
 
+  it("updates createsGoogleMeet on re-discovery", async () => {
+    const connectionId = objectId();
+    await repo.upsertByProviderCalendar(
+      baseUpsert({ connectionId, createsGoogleMeet: true }),
+    );
+    const updated = await repo.upsertByProviderCalendar(
+      baseUpsert({ connectionId, createsGoogleMeet: false }),
+    );
+    expect(updated.createsGoogleMeet).toBe(false);
+  });
+
   it("does not leak calendars across principals", async () => {
     const tenantId = objectId();
     const connectionId = objectId();

--- a/packages/sync/src/storage/repositories/provider-calendar.repository.ts
+++ b/packages/sync/src/storage/repositories/provider-calendar.repository.ts
@@ -48,6 +48,7 @@ export class ProviderCalendarRepository {
           primary: fields.primary,
           accessRole: fields.accessRole,
           capabilities: fields.capabilities,
+          createsGoogleMeet: fields.createsGoogleMeet,
           updatedAt: now,
         },
         $setOnInsert: {

--- a/packages/web/src/__tests__/utils/factories/calendar.factory.ts
+++ b/packages/web/src/__tests__/utils/factories/calendar.factory.ts
@@ -14,7 +14,7 @@ import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 export function createMockCalendar(
   overrides: Partial<Calendar> = {},
 ): Calendar {
-  return {
+  const calendar: Calendar = {
     id: CalendarIdSchema.parse(createObjectIdString()),
     name: "Work",
     description: "",
@@ -27,8 +27,16 @@ export function createMockCalendar(
     isPrimary: false,
     isVisible: true,
     isActive: true,
+    createsGoogleMeet: true,
     ...overrides,
   };
+  if (
+    calendar.provider === "local" &&
+    overrides.createsGoogleMeet === undefined
+  ) {
+    calendar.createsGoogleMeet = false;
+  }
+  return calendar;
 }
 
 /** A healthy connected-account summary; override state fields to break it. */

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -948,6 +948,77 @@ describe("BookingSettingsSection", () => {
     ).toBeInTheDocument();
   });
 
+  it("warns next to Destination calendar when it cannot mint Meet", async () => {
+    const noMeet = createMockCalendar({
+      name: "Resource room",
+      accountEmail: "host@example.com",
+      createsGoogleMeet: false,
+    });
+
+    userMetadataActions.set(healthyGoogleMetadata);
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(
+          ctx.json({
+            ...unconfiguredPage(),
+            destinationCalendarId: noMeet.id,
+            blockingCalendarIds: [noMeet.id],
+          }),
+        ),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [noMeet]);
+
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    const warning =
+      "This calendar cannot create a Google Meet link. Guests will get a calendar invite without a Meet URL.";
+    await screen.findByRole("combobox", { name: "Destination calendar" });
+    expect(screen.getByText(warning)).toBeInTheDocument();
+    expect(
+      screen.getByRole("combobox", { name: "Destination calendar" }),
+    ).toHaveAccessibleDescription(warning);
+  });
+
+  it("does not warn when the destination can mint Meet", async () => {
+    userMetadataActions.set(healthyGoogleMetadata);
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(
+          ctx.json({
+            ...unconfiguredPage(),
+            destinationCalendarId: writableCalendar.id,
+            blockingCalendarIds: [writableCalendar.id],
+          }),
+        ),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    await screen.findByRole("combobox", { name: "Destination calendar" });
+    expect(
+      screen.queryByText(/cannot create a Google Meet link/),
+    ).not.toBeInTheDocument();
+  });
+
   it("checks the Compass calendar by default on an unconfigured page", async () => {
     const compass = createMockCalendar({
       name: "Compass",

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -325,6 +325,12 @@ export function BookingSettingsSection({
   );
   const { groups: writableGroups, ungrouped: writableUngrouped } =
     groupCalendarsByAccount(writableCalendars, connections);
+  const destinationCalendar = writableCalendars.find(
+    (calendar) => calendar.id === form.destinationCalendarId,
+  );
+  const destinationCannotMintMeet =
+    destinationCalendar?.createsGoogleMeet === false;
+  const destinationMeetWarningId = "booking-destination-meet-warning";
   const updateForm = (patch: Partial<AdminPutBookingPageInput>) => {
     setForm((current) => ({ ...current, ...patch }));
     setEnableError(null);
@@ -496,6 +502,9 @@ export function BookingSettingsSection({
           </BookingFieldLabel>
           <select
             {...bookingFieldAttrs("destination")}
+            aria-describedby={
+              destinationCannotMintMeet ? destinationMeetWarningId : undefined
+            }
             className="c-focus-ring w-full rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text hover:bg-surface-panel"
             id="booking-destination-calendar"
             onChange={(event) =>
@@ -531,6 +540,16 @@ export function BookingSettingsSection({
               </>
             )}
           </select>
+          {destinationCannotMintMeet ? (
+            <p
+              className="mt-1 text-sm text-warning"
+              id={destinationMeetWarningId}
+              role="status"
+            >
+              This calendar cannot create a Google Meet link. Guests will get a
+              calendar invite without a Meet URL.
+            </p>
+          ) : null}
         </div>
 
         <fieldset

--- a/packages/web/src/booking/PublicBookingConfirmationView.test.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmationView.test.tsx
@@ -46,6 +46,31 @@ describe("PublicBookingConfirmationView", () => {
     expect(
       screen.getByRole("button", { name: "Copy cancel link" }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText("A Google Meet invite is on its way to your email."),
+    ).toBeInTheDocument();
+  });
+
+  it("promises a calendar invite when the destination cannot mint Meet", () => {
+    render(
+      <PublicBookingConfirmationView
+        cancelUrl={cancelUrl}
+        createsGoogleMeet={false}
+        durationMinutes={30}
+        hostDisplayName="Tyler Dane"
+        guestName="Ada Lovelace"
+        notes={null}
+        slotStart={slotStart}
+        timeZone={timeZone}
+      />,
+    );
+
+    expect(
+      screen.getByText("A calendar invite is on its way to your email."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("A Google Meet invite is on its way to your email."),
+    ).not.toBeInTheDocument();
   });
 
   it("hides copy and cancel controls without a cancel URL", () => {
@@ -67,7 +92,9 @@ describe("PublicBookingConfirmationView", () => {
       screen.queryByRole("link", { name: "cancel this booking" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByText(/To cancel, use the link in that invite/),
+      screen.getByText(
+        "A Google Meet invite is on its way to your email. To cancel, use the link in that invite.",
+      ),
     ).toBeInTheDocument();
   });
 

--- a/packages/web/src/booking/PublicBookingConfirmationView.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmationView.tsx
@@ -12,6 +12,7 @@ interface PublicBookingConfirmationViewProps {
   durationMinutes: number;
   slotStart: string;
   timeZone: string;
+  createsGoogleMeet?: boolean;
   cancelUrl?: string;
   onEditDetails?: () => void;
 }
@@ -23,6 +24,7 @@ export function PublicBookingConfirmationView({
   durationMinutes,
   slotStart,
   timeZone,
+  createsGoogleMeet = true,
   cancelUrl,
   onEditDetails,
 }: PublicBookingConfirmationViewProps) {
@@ -68,9 +70,11 @@ export function PublicBookingConfirmationView({
           ) : null}
         </dl>
         <p className="text-sm text-text">
-          {`A Google Meet invite is on its way to your email.${
-            cancelUrl ? "" : " To cancel, use the link in that invite."
-          }`}
+          {`${
+            createsGoogleMeet
+              ? "A Google Meet invite is on its way to your email."
+              : "A calendar invite is on its way to your email."
+          }${cancelUrl ? "" : " To cancel, use the link in that invite."}`}
         </p>
         {onEditDetails ? (
           <button

--- a/packages/web/src/booking/PublicBookingConfirmedPage.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmedPage.tsx
@@ -183,6 +183,7 @@ export function PublicBookingConfirmedPage() {
       durationMinutes={reservation.durationMinutes}
       slotStart={reservation.slotStart}
       timeZone={reservation.guestTimeZone}
+      createsGoogleMeet={reservation.createsGoogleMeet}
       cancelUrl={cancelUrl}
       onEditDetails={
         canEdit

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -1423,7 +1423,9 @@ describe("PublicBookingConfirmedPage", () => {
     expect(screen.getByText("Duration")).toBeInTheDocument();
     expect(screen.getByText("Timezone")).toBeInTheDocument();
     expect(
-      screen.getByText(/A Google Meet invite is on its way to your email/),
+      screen.getByText(
+        "A Google Meet invite is on its way to your email. To cancel, use the link in that invite.",
+      ),
     ).toBeInTheDocument();
     expect(screen.getByText("Guest User")).toBeInTheDocument();
     expect(
@@ -1431,6 +1433,25 @@ describe("PublicBookingConfirmedPage", () => {
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Edit details" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("promises a calendar invite when the reservation cannot mint Meet", async () => {
+    server.use(reservationGetHandler({ createsGoogleMeet: false }));
+    renderBookingRoute("/book/confirmed/000000000000000000000099");
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "You are booked with Tyler Dane",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "A calendar invite is on its way to your email. To cancel, use the link in that invite.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/A Google Meet invite is on its way to your email/),
     ).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3138

## Summary

Confirmation copy now depends on whether the destination calendar can mint Google Meet. Google calendar-list discovery records `createsGoogleMeet` from `conferenceProperties.allowedConferenceSolutionTypes` (missing types keep the current Meet promise; an advertised list without `hangoutsMeet` is false). Public GET page and reservation carry that boolean. Guests see a calendar-invite sentence when Meet cannot be minted. Booking Settings warns next to Destination calendar at selection time.

The confirmation cancel-fallback clause is unchanged (WP-11). `isBookingEnabled` is unchanged. No em-dashes.

## Simplicity

One boolean on the calendar, not the full Google conference-types array. Public schemas default true so old payloads still promise Meet. The cancel-fallback sentence is still concatenated in `PublicBookingConfirmationView`. No further production change after implement.

## Automated validation

- Confirmation RTL: Meet-capable destination shows the full Meet sentence; a non-Meet destination shows the full calendar-invite sentence and does not mention Meet.
- Settings RTL: destination warning for a non-Meet calendar, absent for a Meet-capable one.
- Backend: public page and reservation GET pin `createsGoogleMeet` true/false from the destination calendar.

## Independent review

`.agents/handoffs/3138.md`

VERDICT: no confirmed findings
FINDINGS:
(none)

## Test plan

- `bun test:web -- packages/web/src/booking/PublicBookingConfirmationView.test.tsx packages/web/src/booking/BookingSettingsSection.test.tsx packages/web/src/booking/PublicBookingPage.test.tsx` (77 pass)
- `bun test:backend -- packages/backend/src/booking/services/public-booking.service.db.test.ts` (createsGoogleMeet true/false pinned)
- `bun test:sync -- packages/sync/src/providers/google/google-calendar.adapter.test.ts packages/sync/src/domain/calendar-list-sync.service.db.test.ts packages/sync/src/storage/repositories/provider-calendar.repository.db.test.ts`
- `bun run type-check` (pass)
- `bun run lint` (exit 0)
- `bun run verify` PASS (core, sync, web, backend, type-check, lint, knip, test:a11y, test:e2e)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec67721b-395d-454e-bd11-696669d367b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec67721b-395d-454e-bd11-696669d367b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

