### PR TITLE
fix(web): keep event form title visible beside copy button

### DIFF
--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -313,6 +313,33 @@ describe("EventForm", () => {
     ).toBeInTheDocument();
   });
 
+  it("stacks the title input above its underline so the copy button does not squeeze the field", () => {
+    renderWithStore(
+      <EventForm
+        draft={createEditDraft({ title: "Standup" })}
+        isDraft={false}
+        isExistingEvent={true}
+        onClose={mock()}
+        onDelete={mock()}
+        onDuplicate={mock()}
+        onSubmit={mock()}
+        setDraft={mock()}
+      />,
+    );
+
+    const title = screen.getByPlaceholderText("Title");
+    const copyTitle = screen.getByRole("button", { name: "copy event title" });
+
+    // Focusable renders the input and a decorative underline as a fragment.
+    // They must share a wrapping box; if they land as flex siblings of the
+    // copy button, the 100%-wide underline collapses the input to a bar.
+    expect(title.parentElement).not.toBe(copyTitle.parentElement);
+    expect(title.parentElement?.contains(copyTitle)).toBe(false);
+    expect(copyTitle.parentElement?.contains(title)).toBe(true);
+    expect(title.nextElementSibling).not.toBe(copyTitle);
+    expect(title).toHaveValue("Standup");
+  });
+
   it("renders as a transparent sidebar column with the save footer after the fields", () => {
     renderWithStore(
       <EventForm

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -895,28 +895,34 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
             </div>
 
             <div className="flex items-start gap-1">
-              <Focusable
-                id={EVENT_FORM_TITLE_ID}
-                Component="input"
-                className={classNames(
-                  INPUT_RESET_CLASSNAME,
-                  // w-full: an input's intrinsic size-attribute width would
-                  // overflow the sidebar-width form and force horizontal scroll
-                  "min-w-0 flex-1 bg-transparent font-semibold text-xl",
-                )}
-                autoFocus
-                disabled={isReadOnly}
-                onChange={onChangeTitle}
-                onKeyDown={handleTitleKeyDown}
-                placeholder="Title"
-                aria-label="Title"
-                name="Event Title"
-                aria-invalid={titleError ? true : undefined}
-                aria-describedby={titleErrorDescribedBy}
-                underlineColor={eventColor}
-                value={displayTitle}
-                withUnderline
-              />
+              {/* Focusable with withUnderline is a fragment (input +
+                divider). Wrap it so those stack in a box; otherwise they
+                become flex siblings of the copy button and the 100%-wide
+                underline squeezes the input into a bar. */}
+              <div className="min-w-0 flex-1">
+                <Focusable
+                  id={EVENT_FORM_TITLE_ID}
+                  Component="input"
+                  className={classNames(
+                    INPUT_RESET_CLASSNAME,
+                    // w-full: an input's intrinsic size-attribute width would
+                    // overflow the sidebar-width form and force horizontal scroll
+                    "w-full bg-transparent font-semibold text-xl",
+                  )}
+                  autoFocus
+                  disabled={isReadOnly}
+                  onChange={onChangeTitle}
+                  onKeyDown={handleTitleKeyDown}
+                  placeholder="Title"
+                  aria-label="Title"
+                  name="Event Title"
+                  aria-invalid={titleError ? true : undefined}
+                  aria-describedby={titleErrorDescribedBy}
+                  underlineColor={eventColor}
+                  value={displayTitle}
+                  withUnderline
+                />
+              </div>
               <CopyButton label="copy event title" text={displayTitle} />
             </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pressing `c` to create a draft, then typing a title, updated the calendar card but not the sidebar title field. The field rendered as a black bar.

Cause: the title `Focusable` renders an input plus underline as a fragment. After copy buttons were added, those children sat in a flex row with the copy button. The focused underline is `width: 100%`, so it squeezed the input to zero width.

Fix: wrap the title `Focusable` in `min-w-0 flex-1` (same pattern as the description field) so the input and underline stack, and the copy button sits beside that box.

## Simplicity

Call-site wrap only, matching the description field. No Focusable API change (DatePicker uses it as `customInput`).

## Automated validation

- `bun test:web packages/web/src/views/Forms/EventForm/EventForm.test.tsx` — 46 pass, including a regression that the title and underline share a wrapping box that is a sibling of the copy button.
- `bun run verify` — PASS. Selected packages: web. Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e. Checks skipped: (none).

Browser: press `c`, type `Title visible in form`. Title is visible in the form as large underlined text (not a collapsed black bar) and on the draft card.

![Title visible in the event form after pressing C](https://cursor.com/artifacts/c/art-c731fad4-52ce-4ac9-9089-bce997f45554)
<a href="https://cursor.com/agents/bc-0726b4d7-1b85-4749-87db-2f141b16b3d4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevent_form_title_visible_after_c.mp4"><img src="https://cursor.com/artifacts/c/art-4a170238-cfb0-404b-9288-30cbdc3b9da3" alt="event_form_title_visible_after_c.mp4" /></a>

## Independent review

Layout-only wrap. No confirmed findings: title remains a labelled textbox (`aria-label="Title"`), autoFocus and Enter-to-save are unchanged, copy button stays a sibling of the stacked input/underline box.

## Test plan

- `bun test:web packages/web/src/views/Forms/EventForm/EventForm.test.tsx`
- `bun run verify` (test:web, type-check, lint, knip, test:a11y, test:e2e)
- Browser: `c` then type a title; confirm it is visible in the form and on the grid.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0726b4d7-1b85-4749-87db-2f141b16b3d4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0726b4d7-1b85-4749-87db-2f141b16b3d4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

