### PR TITLE
fix(web): keep cancel actions on the confirmation permalink

### DIFF
--- a/.agents/handoffs/3139.md
+++ b/.agents/handoffs/3139.md
@@ -1,0 +1,43 @@
+---
+schema_version: 1
+task_id: "3139"
+from: Reviewer
+to: Manager
+owner: Manager
+status: verifying
+artifact:
+  - path: packages/web/src/booking/PublicBookingConfirmedPage.tsx
+  - path: packages/web/src/booking/PublicBookingConfirmationView.tsx
+  - path: docs/features/booking.md
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3204
+evidence:
+  - command: bun test:web -- packages/web/src/booking/public-booking-search.test.ts packages/web/src/booking/PublicBookingConfirmationView.test.tsx packages/web/src/booking/PublicBookingPage.test.tsx packages/web/src/booking/PublicBookingCancelPage.test.tsx packages/web/src/routers/index.test.tsx
+    result: "68 pass, 0 fail (cold permalink with token shows cancel and edit; without token no invite-cancel sentence)"
+    log: null
+  - command: bunx playwright test e2e/booking/public-booking.spec.ts
+    result: "26 pass (refresh keeps cancel/edit; cold permalink has no false invite cancel copy)"
+    log: null
+  - command: bun run verify
+    result: "PASS. Selected packages: web. Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e. Checks skipped: (none)."
+    log: null
+assumptions:
+  - "The cancel capability stays the unguessable token. Confirmation writes it into ?token= rather than publishing cancelUrl on the public GET."
+  - "History state still carries the confirm-response cancelUrl so copy/href keep the API-issued absolute URL after submit."
+open_risks: []
+next_deadline: 2026-09-04T06:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-11: confirmation permalink is not a dead end.
+
+Simplify: no further production change. Token search validator reused
+on the confirmed route.
+
+Review: no confirmed findings.
+
+VERDICT: no confirmed findings
+FINDINGS:
+(none)

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,7 +13,8 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 3138 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3202 | bun run verify PASS (core, sync, web, backend, type-check, lint, knip, a11y, e2e); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
+| 3139 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3204 | bun run verify PASS (web, type-check, lint, knip, a11y 24, e2e 110); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
+| 3138 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3202 | squash-merged 144c0690f; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3137 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3201 | squash-merged 2ac4e9a5c; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3136 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3200 | squash-merged db747490e; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3133 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3199 | squash-merged 12bfcaa97; bun run verify PASS; review: no confirmed findings | null | 0 | none |

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -35,9 +35,16 @@ The guest's selection lives in `/book/:slug` search params
 picker, refresh keeps the selection, and the link is shareable. Invalid
 params drop to defaults; they never error.
 
-Confirmation permalink: `/book/confirmed/:reservationId` (survives
-refresh; cancel and reschedule copy is only present when the guest just
-confirmed or just rescheduled, via history state).
+Confirmation permalink: `/book/confirmed/:reservationId?token=…`.
+The cancel (and post-confirm edit) capability is that unguessable token,
+not the reservation id. Just-confirmed navigation writes `?token=` into
+the permalink so a reload, bookmark, or self-sent link keeps cancel and
+edit. The public reservation GET does not return `cancelUrl` or the
+token. A permalink without `token` still shows the booking from GET,
+with no cancel or edit actions, and does not tell the guest to look for
+a cancel link in the invite: that URL is omitted from the event
+description when guests can invite others, which is the default.
+Reschedule copy stays history-only (v1.3).
 
 Cancel: `/book/cancel/:reservationId?token=…`.
 
@@ -149,8 +156,9 @@ times (and, on details, before the form).
 On confirm, Compass creates a timed Google Calendar event on the
 host's destination calendar, invites the guest, auto-adds a Google
 Meet link, and Google emails the invite. Compass shows a confirmation
-screen with the booked time (guest timezone) and cancel plus
-reschedule links (history state only).
+screen with the booked time (guest timezone). Cancel and edit-details
+are present when the permalink carries `?token=`. Reschedule links stay
+history state only (v1.3).
 
 **Event title:** `{Guest name} and {Host name}`.
 
@@ -227,8 +235,10 @@ decides whether a busy interval occupies a slot
 
 ## Guest cancel
 
-- Confirmation page includes a tokenized cancel URL; the event description
-  carries it too only when guests cannot invite others (see above).
+- Confirmation page includes a tokenized cancel URL when `?token=` is on
+  the permalink (just-confirmed navigation writes it there). The event
+  description carries it too only when guests cannot invite others (see
+  above). A permalink without the token does not invent a cancel path.
 - Token is unguessable and stored hashed on the reservation as
   `cancelTokenHash`.
 - Cancel deletes the calendar event (host as organizer) and marks the
@@ -244,7 +254,8 @@ There is no host reservation inbox.
 - Reuses `cancelTokenHash` / `?token=`. No second secret.
 - Confirmation shows **Reschedule** (link + **Copy reschedule link**) next
   to cancel when history state has `rescheduleUrl`. Cold permalink has
-  neither secret.
+  neither reschedule secret. Cancel and edit use `?token=` on the
+  confirmation URL (see Guest cancel).
 - `/book/reschedule/:id?token=` reuses the public month/slot picker. Do
   not re-collect name, email, or notes. Duration comes from current page
   settings (same in-flight duration wart as confirm).

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -364,10 +364,7 @@ export async function preparePublicBookingPage(
 
 export async function preparePublicBookingConfirmedPage(
   page: Page,
-  options: PublicBookingStubOptions & {
-    reservationId?: string;
-    token?: string;
-  } = {},
+  options: PublicBookingStubOptions & { reservationId?: string } = {},
 ): Promise<void> {
   const reservationId = options.reservationId ?? "000000000000000000000099";
   const slot =
@@ -405,10 +402,7 @@ export async function preparePublicBookingConfirmedPage(
     return route.fulfill(jsonResponse({}));
   });
 
-  const tokenQuery = options.token
-    ? `?token=${encodeURIComponent(options.token)}`
-    : "";
-  await page.goto(`/book/confirmed/${reservationId}${tokenQuery}`, {
+  await page.goto(`/book/confirmed/${reservationId}`, {
     waitUntil: "domcontentloaded",
   });
 }

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -364,7 +364,10 @@ export async function preparePublicBookingPage(
 
 export async function preparePublicBookingConfirmedPage(
   page: Page,
-  options: PublicBookingStubOptions & { reservationId?: string } = {},
+  options: PublicBookingStubOptions & {
+    reservationId?: string;
+    token?: string;
+  } = {},
 ): Promise<void> {
   const reservationId = options.reservationId ?? "000000000000000000000099";
   const slot =
@@ -402,7 +405,10 @@ export async function preparePublicBookingConfirmedPage(
     return route.fulfill(jsonResponse({}));
   });
 
-  await page.goto(`/book/confirmed/${reservationId}`, {
+  const tokenQuery = options.token
+    ? `?token=${encodeURIComponent(options.token)}`
+    : "";
+  await page.goto(`/book/confirmed/${reservationId}${tokenQuery}`, {
     waitUntil: "domcontentloaded",
   });
 }

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -113,7 +113,7 @@ test.describe("public booking page", () => {
       page.getByText("A Google Meet invite is on its way to your email."),
     ).toBeVisible();
     await expect(
-      page.getByRole("link", { name: "cancel this booking" }),
+      page.getByRole("link", { name: "Cancel this booking" }),
     ).toBeVisible();
     await expect(
       page.getByRole("link", {
@@ -199,7 +199,7 @@ test.describe("public booking page", () => {
       page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
     ).toBeFocused();
     await expect(page).toHaveURL(
-      /\/book\/confirmed\/000000000000000000000099$/,
+      /\/book\/confirmed\/000000000000000000000099\?token=abc$/,
     );
     await expect(
       page.getByRole("button", { name: "Copy cancel link" }),
@@ -214,11 +214,20 @@ test.describe("public booking page", () => {
     await expect(page.getByText("Duration")).toBeVisible();
     await expect(page.getByText("30 minutes")).toBeVisible();
     await expect(page).toHaveURL(
-      /\/book\/confirmed\/000000000000000000000099$/,
+      /\/book\/confirmed\/000000000000000000000099\?token=abc$/,
     );
+    await expect(
+      page.getByRole("button", { name: "Copy cancel link" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "Cancel this booking" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Edit details" }),
+    ).toBeVisible();
   });
 
-  test("does not show a cancel copy button on a cold confirmation permalink", async ({
+  test("does not promise an invite cancel link on a cold confirmation permalink", async ({
     page,
   }) => {
     await preparePublicBookingConfirmedPage(page);
@@ -229,8 +238,35 @@ test.describe("public booking page", () => {
       page.getByRole("button", { name: "Copy cancel link" }),
     ).toHaveCount(0);
     await expect(
-      page.getByRole("link", { name: "cancel this booking" }),
+      page.getByRole("link", { name: "Cancel this booking" }),
     ).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: "Edit details" }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByText("A Google Meet invite is on its way to your email."),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/To cancel, use the link in that invite/),
+    ).toHaveCount(0);
+  });
+
+  test("offers cancel and edit on a confirmation permalink with a token", async ({
+    page,
+  }) => {
+    await preparePublicBookingConfirmedPage(page, { token: "abc" });
+    await expect(
+      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+    ).toBeFocused();
+    await expect(
+      page.getByRole("button", { name: "Copy cancel link" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Edit details" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "Cancel this booking" }),
+    ).toBeVisible();
   });
 
   test("copies the cancel link from the confirmation page", async ({
@@ -249,7 +285,7 @@ test.describe("public booking page", () => {
     await page.getByRole("button", { name: "Confirm booking" }).click();
 
     await expect(
-      page.getByRole("link", { name: "cancel this booking" }),
+      page.getByRole("link", { name: "Cancel this booking" }),
     ).toHaveAttribute(
       "href",
       "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -251,24 +251,6 @@ test.describe("public booking page", () => {
     ).toHaveCount(0);
   });
 
-  test("offers cancel and edit on a confirmation permalink with a token", async ({
-    page,
-  }) => {
-    await preparePublicBookingConfirmedPage(page, { token: "abc" });
-    await expect(
-      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
-    ).toBeFocused();
-    await expect(
-      page.getByRole("button", { name: "Copy cancel link" }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: "Edit details" }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("link", { name: "Cancel this booking" }),
-    ).toBeVisible();
-  });
-
   test("copies the cancel link from the confirmation page", async ({
     page,
     context,

--- a/packages/web/src/booking/PublicBookingCancelPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingCancelPage.test.tsx
@@ -259,6 +259,13 @@ describe("PublicBookingCancelPage", () => {
     expect(router.state.location.pathname).toBe(
       `/book/confirmed/${reservationId}`,
     );
+    expect(router.state.location.search).toEqual({ token: "abc" });
+    expect(
+      screen.getByRole("button", { name: "Copy cancel link" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Edit details" }),
+    ).toBeInTheDocument();
     expect(cancelPosts).toBe(0);
   });
 

--- a/packages/web/src/booking/PublicBookingCancelPage.tsx
+++ b/packages/web/src/booking/PublicBookingCancelPage.tsx
@@ -136,6 +136,7 @@ export function PublicBookingCancelPage() {
       void navigate({
         to: ROOT_ROUTES.BOOK_CONFIRMED,
         params: { reservationId },
+        search: token ? { token } : undefined,
       });
     },
     { enabled: isConfirmView && !busy, ignoreInputs: false },

--- a/packages/web/src/booking/PublicBookingConfirmationView.test.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmationView.test.tsx
@@ -41,7 +41,7 @@ describe("PublicBookingConfirmationView", () => {
     expect(screen.getByText("Timezone")).toBeInTheDocument();
     expect(screen.queryByText(cancelUrl)).not.toBeInTheDocument();
     expect(
-      screen.getByRole("link", { name: "cancel this booking" }),
+      screen.getByRole("link", { name: "Cancel this booking" }),
     ).toHaveAttribute("href", cancelUrl);
     expect(
       screen.getByRole("button", { name: "Copy cancel link" }),
@@ -92,10 +92,14 @@ describe("PublicBookingConfirmationView", () => {
       screen.queryByRole("link", { name: "cancel this booking" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByText(
-        "A Google Meet invite is on its way to your email. To cancel, use the link in that invite.",
-      ),
+      screen.queryByRole("link", { name: "Cancel this booking" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText("A Google Meet invite is on its way to your email."),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/To cancel, use the link in that invite/),
+    ).not.toBeInTheDocument();
   });
 
   it("copies the cancel URL from the secondary button", async () => {

--- a/packages/web/src/booking/PublicBookingConfirmationView.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmationView.tsx
@@ -70,11 +70,9 @@ export function PublicBookingConfirmationView({
           ) : null}
         </dl>
         <p className="text-sm text-text">
-          {`${
-            createsGoogleMeet
-              ? "A Google Meet invite is on its way to your email."
-              : "A calendar invite is on its way to your email."
-          }${cancelUrl ? "" : " To cancel, use the link in that invite."}`}
+          {createsGoogleMeet
+            ? "A Google Meet invite is on its way to your email."
+            : "A calendar invite is on its way to your email."}
         </p>
         {onEditDetails ? (
           <button

--- a/packages/web/src/booking/PublicBookingConfirmedPage.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmedPage.tsx
@@ -1,4 +1,9 @@
-import { useNavigate, useParams, useRouterState } from "@tanstack/react-router";
+import {
+  useNavigate,
+  useParams,
+  useRouterState,
+  useSearch,
+} from "@tanstack/react-router";
 import { useState } from "react";
 import { PublicBookingNotFoundError } from "@web/api/public-booking.api";
 import { getErrorStatus } from "@web/api/util/api.util";
@@ -9,6 +14,10 @@ import {
   usePatchPublicBookingReservationMutation,
   usePublicBookingReservationQuery,
 } from "@web/booking/public-booking.query";
+import {
+  publicCancelUrlForReservation,
+  tokenFromGuestActionUrl,
+} from "@web/booking/public-booking-search";
 import { useBookingDocumentTitle } from "@web/booking/use-booking-document-title";
 import { requestPublicBookingPageHeadingFocus } from "@web/booking/use-booking-heading-focus";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
@@ -79,26 +88,28 @@ function cancelUrlFromHistory(state: unknown): string | undefined {
   return undefined;
 }
 
-function tokenFromCancelUrl(cancelUrl: string): string {
-  try {
-    return (
-      new URL(cancelUrl, "https://compasscalendar.com").searchParams.get(
-        "token",
-      ) ?? ""
-    );
-  } catch {
-    return "";
-  }
-}
-
 export function PublicBookingConfirmedPage() {
   const { reservationId } = useParams({
     from: "/book/confirmed/$reservationId",
   });
-  const cancelUrl = useRouterState({
+  const { token: searchToken } = useSearch({
+    from: "/book/confirmed/$reservationId",
+  });
+  const historyCancelUrl = useRouterState({
     select: (routerState) => cancelUrlFromHistory(routerState.location.state),
   });
-  const token = cancelUrl ? tokenFromCancelUrl(cancelUrl) : "";
+  const token =
+    searchToken ||
+    (historyCancelUrl ? tokenFromGuestActionUrl(historyCancelUrl) : "");
+  const cancelUrl =
+    historyCancelUrl ??
+    (token
+      ? publicCancelUrlForReservation(
+          reservationId,
+          token,
+          window.location.origin,
+        )
+      : undefined);
   const reservationQuery = usePublicBookingReservationQuery(reservationId);
   const patchReservation =
     usePatchPublicBookingReservationMutation(reservationId);

--- a/packages/web/src/booking/PublicBookingCopyCancelUrl.tsx
+++ b/packages/web/src/booking/PublicBookingCopyCancelUrl.tsx
@@ -22,7 +22,7 @@ export function PublicBookingCopyCancelUrl({
         href={cancelUrl}
         className="c-focus-ring text-accent text-sm underline"
       >
-        cancel this booking
+        Cancel this booking
       </a>
       <p role="status" className="sr-only">
         {copied ? "Copied" : ""}

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -445,7 +445,7 @@ describe("PublicBookingPage", () => {
       screen.getByRole("button", { name: "Copy cancel link" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("link", { name: "cancel this booking" }),
+      screen.getByRole("link", { name: "Cancel this booking" }),
     ).toBeInTheDocument();
   });
 
@@ -1423,16 +1423,46 @@ describe("PublicBookingConfirmedPage", () => {
     expect(screen.getByText("Duration")).toBeInTheDocument();
     expect(screen.getByText("Timezone")).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "A Google Meet invite is on its way to your email. To cancel, use the link in that invite.",
-      ),
+      screen.getByText("A Google Meet invite is on its way to your email."),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/To cancel, use the link in that invite/),
+    ).not.toBeInTheDocument();
     expect(screen.getByText("Guest User")).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Copy cancel link" }),
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Edit details" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("offers cancel and edit on a cold permalink with a token", async () => {
+    server.use(reservationGetHandler());
+    renderBookingRoute("/book/confirmed/000000000000000000000099?token=abc");
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "You are booked with Tyler Dane",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Copy cancel link" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Edit details" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Cancel this booking" }),
+    ).toHaveAttribute(
+      "href",
+      `${window.location.origin}/book/cancel/000000000000000000000099?token=abc`,
+    );
+    expect(
+      screen.getByText("A Google Meet invite is on its way to your email."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/To cancel, use the link in that invite/),
     ).not.toBeInTheDocument();
   });
 
@@ -1446,10 +1476,11 @@ describe("PublicBookingConfirmedPage", () => {
       }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "A calendar invite is on its way to your email. To cancel, use the link in that invite.",
-      ),
+      screen.getByText("A calendar invite is on its way to your email."),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/To cancel, use the link in that invite/),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByText(/A Google Meet invite is on its way to your email/),
     ).not.toBeInTheDocument();
@@ -1606,7 +1637,7 @@ describe("PublicBookingConfirmedPage", () => {
     await user.type(screen.getByLabelText("Email"), "guest@example.com");
     await user.click(screen.getByRole("button", { name: "Confirm booking" }));
     expect(
-      await screen.findByRole("link", { name: "cancel this booking" }),
+      await screen.findByRole("link", { name: "Cancel this booking" }),
     ).toHaveAttribute(
       "href",
       "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",

--- a/packages/web/src/booking/public-booking-search.test.ts
+++ b/packages/web/src/booking/public-booking-search.test.ts
@@ -1,4 +1,6 @@
 import {
+  publicCancelUrlForReservation,
+  tokenFromGuestActionUrl,
   validateBookingCancelSearch,
   validatePublicBookingSearch,
 } from "@web/booking/public-booking-search";
@@ -62,5 +64,40 @@ describe("validateBookingCancelSearch", () => {
       token: undefined,
     });
     expect(validateBookingCancelSearch({})).toEqual({ token: undefined });
+  });
+});
+
+describe("tokenFromGuestActionUrl", () => {
+  it("reads token from an absolute cancel URL", () => {
+    expect(
+      tokenFromGuestActionUrl(
+        "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+      ),
+    ).toBe("abc");
+  });
+
+  it("reads token from a relative URL", () => {
+    expect(tokenFromGuestActionUrl("/book/cancel/99?token=secret")).toBe(
+      "secret",
+    );
+  });
+
+  it("returns empty when token is missing or the URL is unusable", () => {
+    expect(tokenFromGuestActionUrl("/book/cancel/99")).toBe("");
+    expect(tokenFromGuestActionUrl("://bad")).toBe("");
+  });
+});
+
+describe("publicCancelUrlForReservation", () => {
+  it("builds an origin-absolute cancel URL", () => {
+    expect(
+      publicCancelUrlForReservation(
+        "000000000000000000000099",
+        "abc",
+        "https://staging.compasscalendar.com",
+      ),
+    ).toBe(
+      "https://staging.compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+    );
   });
 });

--- a/packages/web/src/booking/public-booking-search.ts
+++ b/packages/web/src/booking/public-booking-search.ts
@@ -40,9 +40,9 @@ export function validatePublicBookingSearch(
 }
 
 /**
- * The cancel link's `?token=` must survive on its own route: previously it
- * lived only because the root route's auth-modal whitelist happened to share
- * the param name.
+ * Guest-action `?token=` on cancel and confirmation permalinks. Previously
+ * it lived only because the root route's auth-modal whitelist happened to
+ * share the param name.
  */
 export function validateBookingCancelSearch(search: Record<string, unknown>): {
   token?: string;
@@ -53,4 +53,25 @@ export function validateBookingCancelSearch(search: Record<string, unknown>): {
         ? search["token"]
         : undefined,
   };
+}
+
+export function tokenFromGuestActionUrl(url: string): string {
+  try {
+    return (
+      new URL(url, "https://compasscalendar.com").searchParams.get("token") ??
+      ""
+    );
+  } catch {
+    return "";
+  }
+}
+
+export function publicCancelUrlForReservation(
+  reservationId: string,
+  token: string,
+  origin: string,
+): string {
+  const url = new URL(`/book/cancel/${reservationId}`, origin);
+  url.searchParams.set("token", token);
+  return url.toString();
 }

--- a/packages/web/src/booking/use-public-booking-flow.ts
+++ b/packages/web/src/booking/use-public-booking-flow.ts
@@ -22,7 +22,10 @@ import {
   usePublicBookingPageQuery,
   usePublicBookingSlotsQuery,
 } from "@web/booking/public-booking.query";
-import { type PublicBookingSearch } from "@web/booking/public-booking-search";
+import {
+  type PublicBookingSearch,
+  tokenFromGuestActionUrl,
+} from "@web/booking/public-booking-search";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
 import { isHigherEscapeOwner } from "@web/shortcuts/escape-ownership";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
@@ -277,10 +280,14 @@ export function usePublicBookingFlow() {
           guestTimeZone: values.guestTimeZone,
         }),
       );
+      const token = tokenFromGuestActionUrl(result.cancelUrl);
       await navigate({
         to: ROOT_ROUTES.BOOK_CONFIRMED,
         params: { reservationId: result.reservationId },
-        // Post-submit only: the public GET cannot reconstruct the cancel token.
+        search: token ? { token } : undefined,
+        // History state still carries the absolute cancel URL from confirm.
+        // The permalink also writes `?token=` so a reload or bookmark keeps
+        // cancel and edit without publishing the token on the public GET.
         state: { cancelUrl: result.cancelUrl } as never,
       });
     } catch (error) {

--- a/packages/web/src/routers/router.routes.tsx
+++ b/packages/web/src/routers/router.routes.tsx
@@ -65,6 +65,7 @@ export const publicBookCancelRoute = createRoute({
 export const publicBookConfirmedRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: ROOT_ROUTES.BOOK_CONFIRMED,
+  validateSearch: validateBookingCancelSearch,
   component: lazyRouteComponent(
     () => import("@web/booking/PublicBookingConfirmedPage"),
     "PublicBookingConfirmedPage",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3139

## Summary

A confirmation permalink is no longer a dead end. Just-confirmed navigation writes the guest `?token=` onto `/book/confirmed/:id`, so a reload, bookmark, or self-sent link keeps cancel and edit. The public reservation GET still does not return `cancelUrl`.

A permalink without a token still shows the booking from GET, with no cancel or edit controls, and does not tell the guest to use a cancel link in the invite (that URL is omitted when guests can invite others, the default). The cancel link visible text is now `Cancel this booking`.

Decision recorded in `docs/features/booking.md`. Meet/calendar-invite first sentence is unchanged (WP-10). Reschedule is not implemented.

## Simplicity

Reused the existing cancel-route token search validator on the confirmation route. Reconstruct the cancel URL from `reservationId` + token only when history state has no `cancelUrl`. No further production change after simplify.

## Automated validation

- Focused web: 68 pass (cold permalink with token shows cancel and edit; without token the invite sentence has no cancel fallback)
- Booking e2e: 26 pass (refresh keeps cancel/edit; cold permalink has no false invite cancel copy)
- Booking a11y: 17 pass
- `bun run verify` PASS. Selected packages: web. Checks run: test:web, type-check, lint, knip, test:a11y (24), test:e2e (110). Checks skipped: none.

## Independent review

`.agents/handoffs/3139.md`

VERDICT: no confirmed findings
FINDINGS:
(none)

## Test plan

- `bun test:web -- packages/web/src/booking/public-booking-search.test.ts packages/web/src/booking/PublicBookingConfirmationView.test.tsx packages/web/src/booking/PublicBookingPage.test.tsx packages/web/src/booking/PublicBookingCancelPage.test.tsx packages/web/src/routers/index.test.tsx` (68 pass)
- `bunx playwright test e2e/booking/public-booking.spec.ts` (26 pass)
- `bunx playwright test e2e/accessibility/booking-a11y.spec.ts` (17 pass)
- `bun run verify` (PASS)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec67721b-395d-454e-bd11-696669d367b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec67721b-395d-454e-bd11-696669d367b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

