### PR TITLE
fix(web): f4 then Enter opens the targeted event, not a 4am draft

### DIFF
--- a/.agents/handoffs/3140.md
+++ b/.agents/handoffs/3140.md
@@ -1,0 +1,39 @@
+---
+schema_version: 1
+task_id: "3140"
+from: Reviewer
+to: Manager
+owner: Manager
+status: verifying
+artifact:
+  - path: packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
+  - path: packages/web/src/shortcuts/shift-hint/event-jump.store.ts
+  - path: packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.quick-time.test.tsx
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3281
+evidence:
+  - command: bun test:web -- packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.quick-time.test.tsx packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx
+    result: "57 pass, 0 fail (f then 4 then Enter opens fourth Friday event, no draft; same after 800ms; W then 1230 then Enter still creates 12:30)"
+    log: null
+  - command: bun run verify
+    result: "PASS. Selected packages: web. Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e. Checks skipped: (none)."
+    log: null
+assumptions:
+  - "commitFocus does not resetColumnTimeBurst because unique ordinals are also HHMM prefixes; W then 1230 on a one-event column unique-matches on the leading 1."
+  - "Targeted event stays a local ref plus DOM focus; not added to event-jump.store."
+open_risks: []
+next_deadline: 2026-09-04T06:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-12: f then 4 then Enter opens the targeted event, not a 4am draft.
+
+Simplify: no further production change. Enter gate plus local focused-event ref.
+
+Review: no confirmed findings.
+
+VERDICT: no confirmed findings
+FINDINGS:
+(none)

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,7 +13,8 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 3139 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3204 | bun run verify PASS (web, type-check, lint, knip, a11y 24, e2e 110); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
+| 3140 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3281 | bun run verify PASS (web, type-check, lint, knip, a11y, e2e 110); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
+| 3139 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3204 | squash-merged 964fd28ab; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3138 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3202 | squash-merged 144c0690f; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3137 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3201 | squash-merged 2ac4e9a5c; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3136 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3200 | squash-merged db747490e; bun run verify PASS; review: no confirmed findings | null | 0 | none |

--- a/packages/web/src/shortcuts/shift-hint/event-jump.store.ts
+++ b/packages/web/src/shortcuts/shift-hint/event-jump.store.ts
@@ -15,6 +15,10 @@ export type EventJumpState = {
   pointerHintKey: string | null;
   /** Event that owns `pointerHintKey`, so rebuilds can refresh the token. */
   pointerHintEventId: string | null;
+  // Keyboard-targeted event is not stored here. It lives in the hint hook as
+  // a local ref plus DOM focus, which is why Enter has nothing in this store
+  // to check. Recorded as a wart (WP-12); do not fold targeting into this
+  // store in a drive-by.
   /** Date selected by the latest blocked empty-grid click. */
   pointerDraftDateKey: string | null;
   pointerDraftStart: string | null;

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.quick-time.test.tsx
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.quick-time.test.tsx
@@ -355,6 +355,7 @@ describe("typed-time deferred commit", () => {
           }),
         );
         type(["1", "2", "3", "0"]);
+        dispatch(keydown("Enter"));
       });
 
       const start = createAt.mock.calls[0]?.[0] as Dayjs;
@@ -379,6 +380,127 @@ describe("typed-time deferred commit", () => {
 
       expect(createAt).not.toHaveBeenCalled();
       expect(useEventJumpStore.getState().isActive).toBe(false);
+    });
+  });
+
+  describe("with a Friday column of four events", () => {
+    const FRIDAY = TARGET_DAY.day() === 5 ? TARGET_DAY : TARGET_DAY.day(5);
+    const fridayIds = [1, 2, 3, 4].map((n) =>
+      EventIdSchema.parse(`f${"a".repeat(23)}${n}`),
+    );
+    const fridayElements: HTMLButtonElement[] = [];
+
+    const mountFriday = () => {
+      const createAt = mock((_start: Dayjs) => {});
+      const openEvent = mock((_eventId: string) => {});
+      const events = fridayIds.map((id, index) => {
+        const hour = 9 + index * 2;
+        return {
+          _id: id,
+          startDate: FRIDAY.hour(hour).format(),
+          endDate: FRIDAY.hour(hour + 1).format(),
+          title: `Friday ${index + 1}`,
+          isAllDay: false,
+        } as unknown as GridEvent;
+      });
+
+      fridayElements.splice(0, fridayElements.length);
+      for (const id of fridayIds) {
+        const el = document.createElement("button");
+        el.type = "button";
+        el.textContent = id;
+        el.dataset.eventId = id;
+        el.addEventListener("keydown", (event) => {
+          if (event.key !== "Enter") return;
+          event.preventDefault();
+          openEvent(id);
+        });
+        document.body.appendChild(el);
+        fridayElements.push(el);
+      }
+
+      renderHook(() =>
+        useShiftHoldEventHints({
+          createAtTime: (start) => createAt(start),
+          focus: (target) => {
+            target.element.focus();
+          },
+          getQuickTimeDay: () => TARGET_DAY,
+          listVisible: () =>
+            fridayIds.map((eventId, index) => ({
+              eventId,
+              eventType: "timed" as const,
+              element: fridayElements[index]!,
+            })),
+          timedEvents: events,
+        }),
+      );
+
+      const pressFriday = () => {
+        dispatch(keydown("F", { shiftKey: true }));
+      };
+
+      return { createAt, openEvent, pressFriday };
+    };
+
+    afterEach(() => {
+      for (const el of fridayElements) {
+        el.remove();
+      }
+      fridayElements.splice(0, fridayElements.length);
+    });
+
+    it("opens the fourth Friday event on f then 4 then Enter, with no draft", () => {
+      const { createAt, openEvent, pressFriday } = mountFriday();
+      const fourthId = fridayIds[3]!;
+      const fourthEl = fridayElements[3]!;
+
+      pressFriday();
+      dispatch(digit("4"));
+      const enter = new KeyboardEvent("keydown", {
+        bubbles: true,
+        cancelable: true,
+        key: "Enter",
+      });
+      act(() => {
+        fourthEl.dispatchEvent(enter);
+      });
+
+      expect(document.activeElement).toBe(fourthEl);
+      expect(enter.defaultPrevented).toBe(true);
+      expect(openEvent).toHaveBeenCalledTimes(1);
+      expect(openEvent).toHaveBeenCalledWith(fourthId);
+      expect(createAt).not.toHaveBeenCalled();
+    });
+
+    it("opens the fourth Friday event on f then 4 after the burst window, with no draft", async () => {
+      const { createAt, openEvent, pressFriday } = mountFriday();
+      const fourthId = fridayIds[3]!;
+      const fourthEl = fridayElements[3]!;
+
+      pressFriday();
+      dispatch(digit("4"));
+
+      await act(
+        () =>
+          new Promise<void>((resolve) => {
+            setTimeout(resolve, DIGIT_AMBIGUOUS_COMMIT_MS * 2 + 50);
+          }),
+      );
+
+      const enter = new KeyboardEvent("keydown", {
+        bubbles: true,
+        cancelable: true,
+        key: "Enter",
+      });
+      act(() => {
+        fourthEl.dispatchEvent(enter);
+      });
+
+      expect(document.activeElement).toBe(fourthEl);
+      expect(openEvent).toHaveBeenCalledTimes(1);
+      expect(openEvent).toHaveBeenCalledWith(fourthId);
+      expect(createAt).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
+++ b/packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.ts
@@ -206,6 +206,8 @@ export function useShiftHoldEventHints({
     null,
   );
   const columnTimeBurstRef = useRef<{ digit: string; at: number }[]>([]);
+  /** Event last focused by jump. Not in the store (see event-jump.store wart). */
+  const focusedJumpEventIdRef = useRef<string | null>(null);
   const createAtTimeRef = useRef(createAtTime);
   const focusRef = useRef(focus);
   const getQuickTimeDayRef = useRef(getQuickTimeDay);
@@ -259,6 +261,7 @@ export function useShiftHoldEventHints({
       const digits = useEventJumpStore.getState().quickTimeDigits;
       resetQuickTime();
       resetColumnTimeBurst();
+      focusedJumpEventIdRef.current = null;
       clearAmbiguousCommitTimer();
       if (!digits) return;
 
@@ -379,6 +382,7 @@ export function useShiftHoldEventHints({
       isActiveRef.current = true;
       bufferRef.current = "";
       resetColumnTimeBurst();
+      focusedJumpEventIdRef.current = null;
       eventJumpActions.setActive(true);
       eventJumpActions.setActiveDayKeys([]);
       setHints(toActiveHints(assignments, visibleByIdRef.current));
@@ -388,12 +392,14 @@ export function useShiftHoldEventHints({
       isActiveRef.current = false;
       bufferRef.current = "";
       resetColumnTimeBurst();
+      focusedJumpEventIdRef.current = null;
       clearHints();
       eventJumpActions.setPointerDraftIntent(null);
       eventJumpActions.setActive(false);
     };
 
     const focusEvent = (eventId: string) => {
+      focusedJumpEventIdRef.current = eventId;
       const target = visibleByIdRef.current.get(eventId);
       if (!target) return;
       target.element.scrollIntoView({ block: "nearest" });
@@ -402,6 +408,12 @@ export function useShiftHoldEventHints({
 
     const commitFocus = (eventId: string, dayKey: string, buffer: string) => {
       clearAmbiguousCommitTimer();
+      // Do not resetColumnTimeBurst here. Unique ordinals (w1, f4) are also
+      // valid HHMM prefixes. W then 1230 on a column with one event
+      // unique-matches on the leading 1; clearing the burst would drop that
+      // digit and 230 would not auto-commit as 12:30 (#3078). Enter is gated
+      // on focusedJumpEventIdRef instead, so f4 then Enter opens the event
+      // rather than committing leftover "4" as 4am.
       eventJumpActions.setActiveDayKeys([dayKey]);
       focusEvent(eventId);
       // Keep the day prefix so the next digit indexes within the same day.
@@ -567,7 +579,8 @@ export function useShiftHoldEventHints({
       // Empty buffer: digits are times. Once a day letter is typed ("w"),
       // 1-2 digits still index that day's events. A four-digit HHMM still
       // creates on the selected column so focusing Tuesday then 1230 lands
-      // there instead of today.
+      // there instead of today. Enter after an ordinal focus opens that
+      // event; it does not commit the leftover hour digit as a draft.
       if (bufferRef.current === "" && tryQuickTimeKey(event)) {
         event.preventDefault();
         event.stopPropagation();
@@ -579,11 +592,15 @@ export function useShiftHoldEventHints({
         recentColumnTimeDigits() &&
         bufferRef.current !== ""
       ) {
-        eventJumpActions.setQuickTimeDigits(recentColumnTimeDigits());
-        commitQuickTime();
-        event.preventDefault();
-        event.stopPropagation();
-        return;
+        if (focusedJumpEventIdRef.current) {
+          resetColumnTimeBurst();
+        } else {
+          eventJumpActions.setQuickTimeDigits(recentColumnTimeDigits());
+          commitQuickTime();
+          event.preventDefault();
+          event.stopPropagation();
+          return;
+        }
       }
 
       if (event.key === "Escape") {
@@ -752,6 +769,7 @@ export function useShiftHoldEventHints({
       // External resets clear the store without going through deactivate();
       // drop local chips/buffer to match.
       bufferRef.current = "";
+      focusedJumpEventIdRef.current = null;
       assignmentsRef.current = [];
       visibleByIdRef.current = new Map();
       setHints([]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3140

## Summary

On week view, `f` then `4` focuses the fourth Friday event, but Enter within 800ms opened a 4am draft. The digit was stored as both an event ordinal and a pending hour; the column-time Enter path never checked whether an event was already targeted, so it stole Enter from the card.

Enter is now gated on the jump-focused event, so the card can open. The typed-time burst is left intact in `commitFocus` so `W` then `1230` still auto-creates 12:30 on the selected column. Targeted event stays a local ref plus DOM focus, not a store field (recorded wart).

## Simplicity

No store refactor. One local ref for the Enter gate, plus tests for the no-delay and post-800ms paths.

## Automated validation

`bun run verify` PASS. Selected packages: web. Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e. Checks skipped: (none).

Focused web tests: 57 pass, 0 fail, including `f` then `4` then Enter with no delay (opens event, no draft) and after the 800ms window, plus `W` then `1230` then Enter still creating 12:30.

## Independent review

`.agents/handoffs/3140.md`

VERDICT: no confirmed findings
FINDINGS:
(none)

## Test plan

```
bun test:web -- packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.quick-time.test.tsx packages/web/src/shortcuts/shift-hint/useShiftHoldEventHints.test.tsx
bun run verify
```

Focused: 57 pass. Verify: all selected checks passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec67721b-395d-454e-bd11-696669d367b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec67721b-395d-454e-bd11-696669d367b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

