### PR TITLE
fix(booking): log failed race compensation instead of swallowing it

### DIFF
--- a/.agents/handoffs/3141.md
+++ b/.agents/handoffs/3141.md
@@ -1,0 +1,37 @@
+---
+schema_version: 1
+task_id: "3141"
+from: Reviewer
+to: Manager
+owner: Manager
+status: verifying
+artifact:
+  - path: packages/backend/src/booking/services/public-booking.service.ts
+  - path: packages/backend/src/booking/services/public-booking.service.db.test.ts
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3282
+evidence:
+  - command: bun test:backend -- packages/backend/src/booking/services/public-booking.service.db.test.ts
+    result: "37 pass, 0 fail (failed compensation logs event id and still returns SLOT_UNAVAILABLE; adjacent-grid and E11000 races still pass)"
+    log: null
+  - command: bun run verify
+    result: "PASS. Selected packages: backend. Checks run: test:backend, type-check, lint, knip. Checks skipped: (none)."
+    log: null
+assumptions:
+  - "The symmetric both-abort false-negative remains accepted and is unchanged."
+open_risks: []
+next_deadline: 2026-09-04T06:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-13: a failed race compensation must not silently orphan a Google event.
+
+Simplify: no further production change.
+
+Review: no confirmed findings.
+
+VERDICT: no confirmed findings
+FINDINGS:
+(none)

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,7 +13,8 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 3140 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3281 | bun run verify PASS (web, type-check, lint, knip, a11y, e2e 110); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
+| 3141 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3282 | bun run verify PASS (backend, type-check, lint, knip); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
+| 3140 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3281 | squash-merged f9cf87e8d; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3139 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3204 | squash-merged 964fd28ab; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3138 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3202 | squash-merged 144c0690f; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3137 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3201 | squash-merged 2ac4e9a5c; bun run verify PASS; review: no confirmed findings | null | 0 | none |

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -1,4 +1,5 @@
 import { ObjectId } from "mongodb";
+import { BaseError } from "@core/errors/errors.base";
 import { Status } from "@core/errors/status.codes";
 import { AdminPutBookingPageInputSchema } from "@core/types/booking.contracts";
 import { BaseDriver } from "@backend/__tests__/drivers/base.driver";
@@ -14,7 +15,10 @@ import { bookingReservationRepository } from "@backend/booking/booking-reservati
 import bookingPageService from "@backend/booking/services/booking-page.service";
 import { type CalendarBookingPort } from "@backend/booking/services/calendar-booking.port";
 import { CalendarBookingService } from "@backend/booking/services/calendar-booking.service";
-import { PublicBookingService } from "@backend/booking/services/public-booking.service";
+import {
+  PublicBookingService,
+  publicBookingCompensationLog,
+} from "@backend/booking/services/public-booking.service";
 import calendarService from "@backend/calendar/services/calendar.service";
 import { type SyncServiceClient } from "@backend/common/services/sync-service/sync-service.client";
 import * as syncServiceFactory from "@backend/common/services/sync-service/sync-service.factory";
@@ -729,6 +733,59 @@ describe("PublicBookingService", () => {
         new Date("2026-09-07T12:00:00.000Z"),
       );
     expect(survivors).toHaveLength(1);
+  });
+
+  it("logs a failed race compensation without changing SLOT_UNAVAILABLE", async () => {
+    const { slug, pageId, userId, calendarId } = await enableBookingPage();
+    createBookingEvent.mockImplementation(async () => {
+      await seedConfirmedReservation(
+        pageId,
+        "2026-09-07T10:15:00.000Z",
+        "2026-09-07T10:45:00.000Z",
+      );
+      return "our-evt";
+    });
+    deleteBookingEvent.mockImplementation(async () => {
+      throw new BaseError(
+        "SYNC_UNAVAILABLE",
+        "could not delete the orphaned event",
+        Status.SERVICE_UNAVAILABLE,
+        true,
+      );
+    });
+    const logSpy = spyOn(publicBookingCompensationLog, "failed");
+
+    try {
+      await expect(
+        service.createReservation(slug, {
+          slotStart: "2026-09-07T10:00:00.000Z",
+          guestName: "Ada Lovelace",
+          guestEmail: "ada@example.com",
+          guestTimeZone: "Europe/London",
+        }),
+      ).rejects.toMatchObject({ bookingCode: "SLOT_UNAVAILABLE" });
+
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(logSpy.mock.calls[0]?.[0]).toMatchObject({
+        result: "SYNC_UNAVAILABLE",
+      });
+      expect(logSpy.mock.calls[0]?.[1]).toMatchObject({
+        tenantId: userId.toString(),
+        principalId: userId.toString(),
+        calendarId,
+        eventId: "our-evt",
+        slotStart: "2026-09-07T10:00:00.000Z",
+      });
+      const survivors =
+        await bookingReservationRepository.listConfirmedOverlapping(
+          pageId,
+          new Date("2026-09-07T09:00:00.000Z"),
+          new Date("2026-09-07T12:00:00.000Z"),
+        );
+      expect(survivors).toHaveLength(1);
+    } finally {
+      logSpy.mockRestore();
+    }
   });
 
   it("translates a same-start duplicate insert into SLOT_UNAVAILABLE", async () => {

--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -4,6 +4,8 @@ import {
   computeBookingSlots,
 } from "@core/booking/compute-booking-slots";
 import { occupiesBookingSlot } from "@core/booking/occupies-booking-slot";
+import { BaseError } from "@core/errors/errors.base";
+import { Logger } from "@core/logger/winston.logger";
 import {
   BookingDurationMinutesSchema,
   BookingSlotsQuerySchema,
@@ -44,8 +46,34 @@ import mongoService from "@backend/common/services/mongo.service";
 import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
 import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
 
+const logger = Logger("app:booking.public");
+
 const isDuplicateSlotError = (error: unknown): boolean =>
   error instanceof MongoServerError && error.code === 11000;
+
+const compensationFailureCause = (error: unknown): string => {
+  if (error instanceof BaseError) return error.result;
+  if (error instanceof Error) return error.message;
+  return String(error);
+};
+
+export const publicBookingCompensationLog = {
+  failed(
+    error: unknown,
+    context: {
+      tenantId: string;
+      principalId: string;
+      calendarId: string;
+      eventId: string;
+      slotStart: string;
+    },
+  ): void {
+    logger.error(
+      `Failed to compensate booking calendar event ${context.eventId}: ${compensationFailureCause(error)}`,
+      context,
+    );
+  },
+};
 
 const buildGuestActionUrl = (
   action: "cancel" | "reschedule",
@@ -424,11 +452,21 @@ export class PublicBookingService {
       });
     } catch (error) {
       if (calendarEventId) {
+        const eventId = calendarEventId;
+        const principal = toSyncPrincipal(page.userId.toString());
         await this.calendarBooking
           .deleteBookingEvent(page.userId.toString(), {
-            eventId: calendarEventId,
+            eventId,
           })
-          .catch(() => undefined);
+          .catch((compensationError: unknown) => {
+            publicBookingCompensationLog.failed(compensationError, {
+              tenantId: principal.tenantId,
+              principalId: principal.principalId,
+              calendarId: page.destinationCalendarId,
+              eventId,
+              slotStart: slotStart.toISOString(),
+            });
+          });
       }
       if (isDuplicateSlotError(error)) {
         throw bookingError(

--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -459,6 +459,8 @@ export class PublicBookingService {
             eventId,
           })
           .catch((compensationError: unknown) => {
+            // The guest still gets SLOT_UNAVAILABLE. Log enough to find and
+            // remove the orphaned Google event by hand.
             publicBookingCompensationLog.failed(compensationError, {
               tenantId: principal.tenantId,
               principalId: principal.principalId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3141

## Summary

Overlap race compensation deleted the Google event in a `.catch(() => undefined)`, so a failed delete left an orphaned calendar event with no reservation row and no log. Compensation still returns `SLOT_UNAVAILABLE` to the guest and still removes the losing row, but a failed delete is now logged with tenant, principal, calendar id, event id, and slot start. `BaseError` is logged via `.result`.

## Simplicity

One compensation log helper on the existing catch path. No change to the accepted symmetric both-abort case.

## Automated validation

`bun run verify` PASS. Selected packages: backend. Checks run: test:backend, type-check, lint, knip. Checks skipped: (none).

Focused `public-booking.service.db.test.ts`: 37 pass, including failed compensation logging plus the existing adjacent-grid overlap and same-start `E11000` tests.

## Independent review

`.agents/handoffs/3141.md`

VERDICT: no confirmed findings
FINDINGS:
(none)

## Test plan

```
bun test:backend -- packages/backend/src/booking/services/public-booking.service.db.test.ts
bun run verify
```

Focused: 37 pass. Verify: all selected checks passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec67721b-395d-454e-bd11-696669d367b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec67721b-395d-454e-bd11-696669d367b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

