### PR TITLE
fix(ci): run the unit matrix once per PR push

### DIFF
--- a/.agents/handoffs/3214.md
+++ b/.agents/handoffs/3214.md
@@ -1,0 +1,29 @@
+---
+schema_version: 1
+task_id: "3214"
+from: Implementer
+to: Verifier
+owner: Verifier
+status: verifying
+artifact:
+  - path: .github/workflows/test-unit.yml
+  - path: .github/workflows/test-e2e.yml
+  - path: docs/CI-CD/workflows.md
+evidence:
+  - command: bun packages/scripts/src/testing/detect-code-changes.test.ts
+    result: pending
+    log: null
+assumptions:
+  - "The changes job and per-step if: gating are untouched."
+  - "Nothing uses workflow_run on the old Test name."
+open_risks:
+  - "Approval boundary is human because the diff touches .github/workflows/."
+next_deadline: 2026-09-04T14:00:00Z
+retry: 0
+approval: human
+waiting_on: null
+escalation: null
+---
+
+Providers L WP-03: Unit workflow runs once per PR push. E2E and Unit are
+distinct workflow names for `gh run list`.

--- a/.agents/handoffs/3214.md
+++ b/.agents/handoffs/3214.md
@@ -1,23 +1,27 @@
 ---
 schema_version: 1
 task_id: "3214"
-from: Implementer
-to: Verifier
-owner: Verifier
+from: Reviewer
+to: Manager
+owner: Manager
 status: verifying
 artifact:
   - path: .github/workflows/test-unit.yml
   - path: .github/workflows/test-e2e.yml
   - path: docs/CI-CD/workflows.md
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3284
 evidence:
-  - command: bun packages/scripts/src/testing/detect-code-changes.test.ts
-    result: pending
+  - command: bun test packages/scripts/src/testing/detect-code-changes.test.ts
+    result: "6 pass, 0 fail (Unit/E2E names, push branches, unit concurrency group)"
+    log: null
+  - command: bun run verify
+    result: "PASS. Selected packages: scripts. Checks run: test:scripts, type-check, lint, knip. Checks skipped: (none)."
     log: null
 assumptions:
   - "The changes job and per-step if: gating are untouched."
-  - "Nothing uses workflow_run on the old Test name."
+  - "Required GitHub checks are job names, not the workflow display name Test."
 open_risks:
-  - "Approval boundary is human because the diff touches .github/workflows/."
+  - "Approval boundary is human because the diff touches .github/workflows/. Confirm ruleset required checks still match after the Unit/E2E rename."
 next_deadline: 2026-09-04T14:00:00Z
 retry: 0
 approval: human
@@ -25,5 +29,12 @@ waiting_on: null
 escalation: null
 ---
 
-Providers L WP-03: Unit workflow runs once per PR push. E2E and Unit are
-distinct workflow names for `gh run list`.
+Providers L WP-03: Unit workflow runs once per PR push.
+
+Simplify: no further production change (copied the E2E concurrency/push pattern).
+
+Review: no confirmed findings.
+
+VERDICT: no confirmed findings
+FINDINGS:
+(none)

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,7 +13,7 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 3214 | high | Verifier | verifying | .github/workflows/test-unit.yml | pending bun run verify | 2026-09-04T14:00:00Z | 0 | human |
+| 3214 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3284 | bun run verify PASS (scripts, type-check, lint, knip); review: no confirmed findings | 2026-09-04T14:00:00Z | 0 | human |
 | 3140 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3281 | bun run verify PASS (web, type-check, lint, knip, a11y, e2e 110); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
 | 3139 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3204 | squash-merged 964fd28ab; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3138 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3202 | squash-merged 144c0690f; bun run verify PASS; review: no confirmed findings | null | 0 | none |

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,6 +13,7 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 3214 | high | Verifier | verifying | .github/workflows/test-unit.yml | pending bun run verify | 2026-09-04T14:00:00Z | 0 | human |
 | 3140 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3281 | bun run verify PASS (web, type-check, lint, knip, a11y, e2e 110); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
 | 3139 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3204 | squash-merged 964fd28ab; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3138 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3202 | squash-merged 144c0690f; bun run verify PASS; review: no confirmed findings | null | 0 | none |

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,4 +1,4 @@
-name: Test
+name: E2E
 
 on:
   pull_request:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -1,10 +1,12 @@
-name: Test
+name: Unit
 
 on:
   pull_request:
     branches:
       - main
   push:
+    branches:
+      - main
     paths-ignore:
       - ".gitignore"
       - "**/*.md"
@@ -13,6 +15,10 @@ on:
 permissions:
   contents: read
   pull-requests: read
+
+concurrency:
+  group: unit-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # Required status checks cannot come from a workflow that path filtering

--- a/docs/CI-CD/workflows.md
+++ b/docs/CI-CD/workflows.md
@@ -4,9 +4,9 @@ Compass uses GitHub Actions for continuous integration, Docker Hub for image dis
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| Test | Push / PR to `main` | Runs lint, knip, type-check, and unit tests |
+| Unit (`test-unit.yml`) | Push / PR to `main` | Runs lint, knip, type-check, and unit tests |
 | PR body | Pull request | Fails empty template sections (including docs-only PRs) |
-| Test (e2e) | Push / PR to `main` | Playwright e2e (docs-only diffs skipped) |
+| E2E (`test-e2e.yml`) | Push / PR to `main` | Playwright e2e (docs-only diffs skipped) |
 | CodeQL | Push / PR to `main` | Static security analysis |
 | Performance budget | Push / PR touching web/core | Lighthouse budget (not a required merge check) |
 | Error autofix (`error-autofix.yml`) | `posthog[bot]` issue / `workflow_dispatch` | Governed Routine: triage or fix PostHog error issues |
@@ -29,7 +29,7 @@ switch (`BOOKING_LOOP_ENABLED`) stays a repo variable (default off).
 
 ---
 
-## Test Workflow
+## Unit workflow
 
 Source: [`.github/workflows/test-unit.yml`](../../.github/workflows/test-unit.yml)
 

--- a/docs/development/testing-playbook.md
+++ b/docs/development/testing-playbook.md
@@ -23,19 +23,20 @@ Avoid defaulting to `bun run test` unless you really need the full suite.
 then `type-check`, `lint`, and `knip`. Web or `e2e/` changes also select
 `test:a11y` and `test:e2e`. Read the printed skip list before treating a green
 run as CI-complete — missing Playwright Chromium skips those jobs and reports
-incomplete parity instead of claiming they passed. GitHub still runs the full
-unit matrix and e2e on every non-docs PR; this helper does not.
+incomplete parity instead of claiming they passed. GitHub still runs the Unit workflow matrix and the E2E workflow on every
+non-docs PR; this helper does not.
 
 ## CI Unit Test Workflow
 
 Source of truth:
 
-- `.github/workflows/test-unit.yml`
-- `.github/workflows/test-e2e.yml`
+- `.github/workflows/test-unit.yml` (workflow name: `Unit`)
+- `.github/workflows/test-e2e.yml` (workflow name: `E2E`)
 
 Unit workflow (`test-unit.yml`):
 
-- triggers on `push`
+- triggers on `pull_request` to `main` and `push` to `main`
+- uses `concurrency` so a new PR push cancels the previous PR run
 - runs a matrix across `core`, `sync`, `web`, `backend`, and `scripts`
 - uses `fail-fast: false`, so one failing lane does not cancel the others
 - runs `bun run test:<project>` in each lane after dependency install

--- a/packages/scripts/src/testing/detect-code-changes.test.ts
+++ b/packages/scripts/src/testing/detect-code-changes.test.ts
@@ -74,6 +74,21 @@ describe("detect-code-changes", () => {
     }
   });
 
+  it("runs Unit once per PR push and names Unit vs E2E", () => {
+    const unit = readFileSync(".github/workflows/test-unit.yml", "utf8");
+    const e2e = readFileSync(".github/workflows/test-e2e.yml", "utf8");
+
+    expect(unit).toMatch(/^name: Unit$/m);
+    expect(e2e).toMatch(/^name: E2E$/m);
+    expect(unit).toContain("branches:");
+    expect(unit).toContain(
+      "group: unit-${{ github.event.pull_request.number || github.ref }}",
+    );
+    expect(unit).toContain(
+      "cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
+    );
+  });
+
   it("runs checks for non-pull-request events without calling GitHub", () => {
     const result = runDetector("push");
 


### PR DESCRIPTION
Fixes #3214

## Summary

The Unit workflow (`test-unit.yml`) triggered on every `push` with no branch filter, so each PR push ran lint/knip/type-check and the unit matrix twice (PR event plus branch push). Push is now limited to `main`, matching E2E. PR runs use a concurrency group that cancels in-progress work. Workflow names are `Unit` and `E2E` so `gh run list --workflow=Unit` and `--workflow=E2E` resolve.

Approval boundary is **human**: this touches `.github/workflows/`.

## Simplicity

Copied the existing E2E `push.branches` and `concurrency` pattern onto Unit. Did not change the `changes` job or per-step `if:` gating.

## Automated validation

`bun run verify` PASS. Selected packages: scripts. Checks run: test:scripts, type-check, lint, knip. Checks skipped: (none).

`bun test packages/scripts/src/testing/detect-code-changes.test.ts`: 6 pass.

## Independent review

`.agents/handoffs/3214.md`. VERDICT: no confirmed findings.

## Test plan

```
bun test packages/scripts/src/testing/detect-code-changes.test.ts
bun run type-check
bun lint
bun knip
bun run verify
```