### PR TITLE
fix(booking): bound confirmed reservation scans to the requested window

### DIFF
--- a/.agents/handoffs/3142.md
+++ b/.agents/handoffs/3142.md
@@ -1,0 +1,38 @@
+---
+schema_version: 1
+task_id: "3142"
+from: Reviewer
+to: Manager
+owner: Manager
+status: verifying
+artifact:
+  - path: packages/backend/src/booking/booking-reservation.repository.ts
+  - path: packages/backend/src/booking/services/public-booking.service.ts
+  - path: packages/backend/src/booking/booking-indexes.ts
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3286
+evidence:
+  - command: bun test:backend -- packages/backend/src/booking/booking-reservation.repository.test.ts packages/backend/src/booking/booking-indexes.db.test.ts packages/backend/src/booking/services/public-booking.service.db.test.ts
+    result: "45 pass, 0 fail (far-outside row not fetched; adjacent and midnight buffers still block; same-day max-per-day still applies; explain uses a page+slotStart index)"
+    log: null
+  - command: bun run verify
+    result: "PASS. Selected packages: backend. Checks run: test:backend, type-check, lint, knip. Checks skipped: (none)."
+    log: null
+assumptions:
+  - "Local-day widening is required so maxBookingsPerDay stays identical; buffer widening alone would miss earlier same-day starts."
+open_risks: []
+next_deadline: 2026-09-04T06:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-14: bound confirmed reservation scans to the requested window.
+
+Simplify: no further production change. The explain helper exists only because new backend tests cannot import mongoService.
+
+Review: no confirmed findings.
+
+VERDICT: no confirmed findings
+FINDINGS:
+(none)

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,7 +13,8 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 3141 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3282 | bun run verify PASS (backend, type-check, lint, knip); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
+| 3142 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3286 | bun run verify PASS (backend, type-check, lint, knip); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
+| 3141 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3282 | squash-merged b69a4ed2b; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3140 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3281 | squash-merged f9cf87e8d; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3139 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3204 | squash-merged 964fd28ab; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3138 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3202 | squash-merged 144c0690f; bun run verify PASS; review: no confirmed findings | null | 0 | none |

--- a/packages/backend/src/__tests__/helpers/booking-reservation.explain.ts
+++ b/packages/backend/src/__tests__/helpers/booking-reservation.explain.ts
@@ -1,0 +1,15 @@
+import { type ObjectId } from "mongodb";
+import mongoService from "@backend/common/services/mongo.service";
+
+/** Planner for the windowed confirmed scan WP-14 uses. */
+export const explainWindowedConfirmedReservationScan = (
+  pageId: ObjectId,
+  range: { from: Date; to: Date },
+) =>
+  mongoService.bookingReservation
+    .find({
+      pageId,
+      status: "confirmed",
+      slotStart: { $gte: range.from, $lt: range.to },
+    })
+    .explain("queryPlanner");

--- a/packages/backend/src/booking/booking-indexes.db.test.ts
+++ b/packages/backend/src/booking/booking-indexes.db.test.ts
@@ -1,0 +1,67 @@
+import { ObjectId } from "mongodb";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import { ensureBookingIndexes } from "@backend/booking/booking-indexes";
+import mongoService from "@backend/common/services/mongo.service";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
+
+const indexNamesFromPlan = (stage: unknown, names: string[] = []): string[] => {
+  if (!stage || typeof stage !== "object") return names;
+  const record = stage as Record<string, unknown>;
+  if (typeof record.indexName === "string") names.push(record.indexName);
+  if (record.inputStage) indexNamesFromPlan(record.inputStage, names);
+  if (Array.isArray(record.inputStages)) {
+    for (const child of record.inputStages) {
+      indexNamesFromPlan(child, names);
+    }
+  }
+  return names;
+};
+
+describe("booking indexes", () => {
+  beforeAll(async () => {
+    await setupTestDb(import.meta.url);
+    await ensureBookingIndexes();
+  });
+
+  beforeEach(cleanupCollections);
+
+  afterAll(cleanupTestDb);
+
+  it("uses a page+slotStart index for a windowed confirmed scan, not a collection scan", async () => {
+    const pageId = new ObjectId();
+    const query = {
+      pageId,
+      status: "confirmed" as const,
+      slotStart: {
+        $gte: new Date("2026-09-07T00:00:00.000Z"),
+        $lt: new Date("2026-09-08T00:00:00.000Z"),
+      },
+    };
+
+    const explained = await mongoService.bookingReservation
+      .find(query)
+      .explain("queryPlanner");
+    const plan = (explained as { queryPlanner?: { winningPlan?: unknown } })
+      .queryPlanner?.winningPlan;
+    const used = indexNamesFromPlan(plan);
+    expect(used.length).toBeGreaterThan(0);
+    expect(
+      used.some(
+        (name) =>
+          name === "booking_reservation_page_slot_confirmed_unique" ||
+          name === "booking_reservation_page_status_slot",
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/backend/src/booking/booking-indexes.db.test.ts
+++ b/packages/backend/src/booking/booking-indexes.db.test.ts
@@ -1,11 +1,11 @@
 import { ObjectId } from "mongodb";
+import { explainWindowedConfirmedReservationScan } from "@backend/__tests__/helpers/booking-reservation.explain";
 import {
   cleanupCollections,
   cleanupTestDb,
   setupTestDb,
 } from "@backend/__tests__/helpers/mock.db.setup";
 import { ensureBookingIndexes } from "@backend/booking/booking-indexes";
-import mongoService from "@backend/common/services/mongo.service";
 import {
   afterAll,
   beforeAll,
@@ -40,18 +40,10 @@ describe("booking indexes", () => {
 
   it("uses a page+slotStart index for a windowed confirmed scan, not a collection scan", async () => {
     const pageId = new ObjectId();
-    const query = {
-      pageId,
-      status: "confirmed" as const,
-      slotStart: {
-        $gte: new Date("2026-09-07T00:00:00.000Z"),
-        $lt: new Date("2026-09-08T00:00:00.000Z"),
-      },
-    };
-
-    const explained = await mongoService.bookingReservation
-      .find(query)
-      .explain("queryPlanner");
+    const explained = await explainWindowedConfirmedReservationScan(pageId, {
+      from: new Date("2026-09-07T00:00:00.000Z"),
+      to: new Date("2026-09-08T00:00:00.000Z"),
+    });
     const plan = (explained as { queryPlanner?: { winningPlan?: unknown } })
       .queryPlanner?.winningPlan;
     const used = indexNamesFromPlan(plan);

--- a/packages/backend/src/booking/booking-indexes.ts
+++ b/packages/backend/src/booking/booking-indexes.ts
@@ -22,6 +22,10 @@ export async function ensureBookingIndexes(): Promise<void> {
       partialFilterExpression: { status: "confirmed" },
     },
   );
+  // Windowed confirmed scans (`status` + `slotStart` range) can use this
+  // compound or the unique sibling above. The unique index is partial on
+  // `status: "confirmed"`: Atlas will not consider it unless the query
+  // states that predicate. Always include `status: "confirmed"`.
   await mongoService.bookingReservation.createIndex(
     { pageId: 1, status: 1, slotStart: 1 },
     { name: "booking_reservation_page_status_slot" },

--- a/packages/backend/src/booking/booking-reservation.repository.test.ts
+++ b/packages/backend/src/booking/booking-reservation.repository.test.ts
@@ -1,0 +1,36 @@
+import { confirmedReservationScanRange } from "@backend/booking/booking-reservation.repository";
+import { describe, expect, it } from "bun:test";
+
+describe("confirmedReservationScanRange", () => {
+  it("covers the local days of an intra-day window", () => {
+    const range = confirmedReservationScanRange(
+      { bufferMinutes: 15, durationMinutes: 30, timeZone: "UTC" },
+      new Date("2026-09-07T09:30:00.000Z"),
+      new Date("2026-09-07T11:00:00.000Z"),
+    );
+
+    expect(range.from.toISOString()).toBe("2026-09-07T00:00:00.000Z");
+    expect(range.to.toISOString()).toBe("2026-09-08T00:00:00.000Z");
+  });
+
+  it("extends past local midnight when duration plus buffer outruns the day bound", () => {
+    const range = confirmedReservationScanRange(
+      { bufferMinutes: 30, durationMinutes: 30, timeZone: "UTC" },
+      new Date("2026-09-07T23:00:00.000Z"),
+      new Date("2026-09-07T23:30:00.000Z"),
+    );
+
+    expect(range.from.toISOString()).toBe("2026-09-07T00:00:00.000Z");
+    expect(range.to.toISOString()).toBe("2026-09-08T00:30:00.000Z");
+  });
+
+  it("treats a null buffer as zero extra width", () => {
+    const range = confirmedReservationScanRange(
+      { bufferMinutes: null, durationMinutes: 30, timeZone: "UTC" },
+      new Date("2026-09-07T23:00:00.000Z"),
+      new Date("2026-09-07T23:30:00.000Z"),
+    );
+
+    expect(range.to.toISOString()).toBe("2026-09-08T00:00:00.000Z");
+  });
+});

--- a/packages/backend/src/booking/booking-reservation.repository.ts
+++ b/packages/backend/src/booking/booking-reservation.repository.ts
@@ -1,6 +1,7 @@
 import { type ObjectId } from "mongodb";
 import { z } from "zod/v4";
 import { zObjectId } from "@core/types/type.utils";
+import dayjs from "@core/util/date/dayjs";
 import {
   type BookingReservationRecord,
   BookingReservationRecordSchema,
@@ -14,6 +15,43 @@ const ConfirmedSlotRowSchema = z.object({
   slotStart: z.date(),
 });
 
+/**
+ * Half-open [from, to) of `slotStart` values the slot engine can still see.
+ *
+ * Buffer collision uses the reservation interval expanded by `bufferMinutes`
+ * on each side, so a start `duration+buffer` before the window (or after it)
+ * can still block a candidate. `maxBookingsPerDay` counts every confirmed
+ * start on each local day that has a candidate, so the range also covers
+ * those local days in full.
+ */
+export const confirmedReservationScanRange = (
+  page: {
+    bufferMinutes: number | null;
+    durationMinutes: number;
+    timeZone: string;
+  },
+  windowStart: Date,
+  windowEnd: Date,
+): { from: Date; to: Date } => {
+  const bufferMs = (page.bufferMinutes ?? 0) * 60_000;
+  const durationMs = page.durationMinutes * 60_000;
+  const fromByBuffer = new Date(windowStart.getTime() - durationMs - bufferMs);
+  const toByBuffer = new Date(windowEnd.getTime() + durationMs + bufferMs);
+  const fromByDay = dayjs(windowStart)
+    .tz(page.timeZone)
+    .startOf("day")
+    .toDate();
+  const toByDay = dayjs(windowEnd)
+    .tz(page.timeZone)
+    .add(1, "day")
+    .startOf("day")
+    .toDate();
+  return {
+    from: new Date(Math.min(fromByBuffer.getTime(), fromByDay.getTime())),
+    to: new Date(Math.max(toByBuffer.getTime(), toByDay.getTime())),
+  };
+};
+
 export type InsertBookingReservationInput = Omit<
   BookingReservationRecord,
   "createdAt" | "updatedAt"
@@ -26,9 +64,16 @@ class BookingReservationRepository {
     return BookingReservationRecordSchema.parse(record);
   }
 
-  async listConfirmedStartsByPageId(pageId: ObjectId): Promise<Date[]> {
+  async listConfirmedStartsByPageId(
+    pageId: ObjectId,
+    range: { from: Date; to: Date },
+  ): Promise<Date[]> {
     const rows = await mongoService.bookingReservation
-      .find({ pageId, status: "confirmed" })
+      .find({
+        pageId,
+        status: "confirmed",
+        slotStart: { $gte: range.from, $lt: range.to },
+      })
       .project({ slotStart: 1 })
       .toArray();
     return rows.map((row) => ConfirmedSlotRowSchema.parse(row).slotStart);

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -679,6 +679,103 @@ describe("PublicBookingService", () => {
     expect(response.slots.map((slot) => slot.slotStart)).not.toContain(booked);
   });
 
+  it("does not fetch a confirmed reservation far outside the requested window", async () => {
+    const { slug, pageId } = await enableBookingPage();
+    await seedConfirmedReservation(
+      pageId,
+      "2025-09-08T10:00:00.000Z",
+      "2025-09-08T10:30:00.000Z",
+    );
+    const listSpy = spyOn(
+      bookingReservationRepository,
+      "listConfirmedStartsByPageId",
+    );
+
+    try {
+      const response = await service.getSlots(slug, {
+        start: "2026-09-07T00:00:00.000Z",
+        end: "2026-09-08T00:00:00.000Z",
+        timeZone: "UTC",
+      });
+
+      const fetched = (await listSpy.mock.results[0]?.value) as Date[];
+      expect(fetched.map((start) => start.toISOString())).not.toContain(
+        "2025-09-08T10:00:00.000Z",
+      );
+      expect(response.bookable).toBe(true);
+      expect(response.slots.map((slot) => slot.slotStart)).toContain(
+        "2026-09-07T10:00:00Z",
+      );
+    } finally {
+      listSpy.mockRestore();
+    }
+  });
+
+  it("still blocks the adjacent slot when a reservation sits just outside the window inside the buffer", async () => {
+    const { slug, pageId } = await enableBookingPage("Buffer Host", {
+      bufferMinutes: 15,
+    });
+    await seedConfirmedReservation(
+      pageId,
+      "2026-09-07T09:00:00.000Z",
+      "2026-09-07T09:30:00.000Z",
+    );
+
+    const response = await service.getSlots(slug, {
+      start: "2026-09-07T09:30:00.000Z",
+      end: "2026-09-07T11:00:00.000Z",
+      timeZone: "UTC",
+    });
+
+    expect(response.slots.map((slot) => slot.slotStart)).not.toContain(
+      "2026-09-07T09:30:00Z",
+    );
+    expect(response.slots.map((slot) => slot.slotStart)).toContain(
+      "2026-09-07T09:45:00Z",
+    );
+  });
+
+  it("still blocks the last slot when a buffered reservation starts after local midnight", async () => {
+    const { slug, pageId } = await enableBookingPage("Late Buffer Host", {
+      bufferMinutes: 30,
+      weeklyAvailability: [{ weekday: 1, start: "21:00", end: "23:59" }],
+    });
+    await seedConfirmedReservation(
+      pageId,
+      "2026-09-08T00:10:00.000Z",
+      "2026-09-08T00:40:00.000Z",
+    );
+
+    const response = await service.getSlots(slug, {
+      start: "2026-09-07T21:00:00.000Z",
+      end: "2026-09-07T23:30:00.000Z",
+      timeZone: "UTC",
+    });
+
+    const starts = response.slots.map((slot) => slot.slotStart);
+    expect(starts).toContain("2026-09-07T21:00:00Z");
+    expect(starts).not.toContain("2026-09-07T23:15:00Z");
+  });
+
+  it("still applies max bookings per day when the only reservation is earlier the same local day", async () => {
+    const { slug, pageId } = await enableBookingPage("Cap Host", {
+      maxBookingsPerDay: 1,
+    });
+    await seedConfirmedReservation(
+      pageId,
+      "2026-09-07T10:00:00.000Z",
+      "2026-09-07T10:30:00.000Z",
+    );
+
+    const response = await service.getSlots(slug, {
+      start: "2026-09-07T14:00:00.000Z",
+      end: "2026-09-07T17:00:00.000Z",
+      timeZone: "UTC",
+    });
+
+    expect(response.slots).toEqual([]);
+  });
+
   it("accepts a second non-overlapping booking on the same page", async () => {
     const { slug } = await enableBookingPage();
     await service.createReservation(slug, {

--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -37,7 +37,10 @@ import {
 import { type BookingPageRecord } from "@backend/booking/booking-page.record";
 import { bookingPageRepository } from "@backend/booking/booking-page.repository";
 import { type BookingReservationRecord } from "@backend/booking/booking-reservation.record";
-import { bookingReservationRepository } from "@backend/booking/booking-reservation.repository";
+import {
+  bookingReservationRepository,
+  confirmedReservationScanRange,
+} from "@backend/booking/booking-reservation.repository";
 import { type CalendarBookingPort } from "@backend/booking/services/calendar-booking.port";
 import { CalendarBookingService } from "@backend/booking/services/calendar-booking.service";
 import calendarService from "@backend/calendar/services/calendar.service";
@@ -294,7 +297,10 @@ export class PublicBookingService {
     }
 
     const confirmedStarts =
-      await bookingReservationRepository.listConfirmedStartsByPageId(page._id);
+      await bookingReservationRepository.listConfirmedStartsByPageId(
+        page._id,
+        confirmedReservationScanRange(page, windowStart, windowEnd),
+      );
     const slotStarts = computeBookingSlots(
       slotEngineInputForPage(page, availability, confirmedStarts, {
         now,
@@ -347,7 +353,10 @@ export class PublicBookingService {
     }
 
     const confirmedStarts =
-      await bookingReservationRepository.listConfirmedStartsByPageId(page._id);
+      await bookingReservationRepository.listConfirmedStartsByPageId(
+        page._id,
+        confirmedReservationScanRange(page, slotStart, slotEnd),
+      );
     const allowedStarts = new Set(
       computeBookingSlots(
         slotEngineInputForPage(page, availability, confirmedStarts, {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3142

## Summary

`listConfirmedStartsByPageId` loaded every confirmed reservation for a booking page on every slots and confirm request. A year-old page paid a year of history for a window that only needs nearby starts.

The query is now a half-open `slotStart` range covering:

- the requested window, widened by duration and `bufferMinutes` so buffer collisions stay identical (including across local midnight)
- the local days of that window, so `maxBookingsPerDay` still counts morning reservations when the guest asks for afternoon slots

The query states `status: "confirmed"` explicitly so Atlas can use the existing partial unique index (or the compound `pageId/status/slotStart` sibling). Availability behavior is unchanged.

## Simplicity

No new index. The range helper is the one extra function; both `getSlots` and `createReservation` pass it the same way. The explain helper exists only because new backend tests cannot import `mongoService`.

## Automated validation

`bun run verify` PASS. Selected packages: backend. Checks run: test:backend, type-check, lint, knip. Checks skipped: (none).

Focused backend tests: 45 pass, including far-outside rows not fetched, adjacent-buffer blocking, midnight-crossing buffer, same-day max-per-day, and an explain plan that uses a page+slotStart index rather than a collection scan.

## Independent review

`.agents/handoffs/3142.md`

```
VERDICT: no confirmed findings
FINDINGS:
(none)
```

## Test plan

- `bun test:backend -- packages/backend/src/booking/booking-reservation.repository.test.ts packages/backend/src/booking/booking-indexes.db.test.ts packages/backend/src/booking/services/public-booking.service.db.test.ts` (45 pass)
- `bun run verify` (PASS: backend, type-check, lint, knip)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec67721b-395d-454e-bd11-696669d367b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec67721b-395d-454e-bd11-696669d367b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

