### PR TITLE
fix(booking): rate-limit host admin GET and PUT page routes

### DIFF
--- a/.agents/handoffs/3143.md
+++ b/.agents/handoffs/3143.md
@@ -1,0 +1,37 @@
+---
+schema_version: 1
+task_id: "3143"
+from: Reviewer
+to: Manager
+owner: Manager
+status: verifying
+artifact:
+  - path: packages/backend/src/booking/booking.routes.config.ts
+  - path: packages/backend/src/booking/booking.rate-limit.db.test.ts
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3287
+evidence:
+  - command: bun test:backend -- packages/backend/src/booking/booking.rate-limit.db.test.ts packages/backend/src/booking/booking.routes.config.test.ts
+    result: "11 pass, 0 fail (GET 429 after 60, PUT 429 after 20, per-user isolation, production kill-switch still registers no routes)"
+    log: null
+  - command: bun run verify
+    result: "PASS. Selected packages: backend. Checks run: test:backend, type-check, lint, knip. Checks skipped: (none)."
+    log: null
+assumptions:
+  - "GET 60/min and PUT 20/min leave normal Settings use unaffected; they are not specified in the issue and can be tightened later."
+open_risks: []
+next_deadline: 2026-09-04T06:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-15: rate-limit host admin GET/PUT `/api/booking/page` per user.
+
+Simplify: optional-chain the session user id in the key generator.
+
+Review: no confirmed findings.
+
+VERDICT: no confirmed findings
+FINDINGS:
+(none)

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,7 +13,8 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 3142 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3286 | bun run verify PASS (backend, type-check, lint, knip); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
+| 3143 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3287 | bun run verify PASS (backend, type-check, lint, knip); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
+| 3142 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3286 | squash-merged 105ea7910; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3141 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3282 | squash-merged b69a4ed2b; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3140 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3281 | squash-merged f9cf87e8d; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3139 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3204 | squash-merged 964fd28ab; bun run verify PASS; review: no confirmed findings | null | 0 | none |

--- a/packages/backend/src/booking/booking.rate-limit.db.test.ts
+++ b/packages/backend/src/booking/booking.rate-limit.db.test.ts
@@ -1,5 +1,6 @@
 import { Status } from "@core/errors/status.codes";
 import { BaseDriver } from "@backend/__tests__/drivers/base.driver";
+import { UtilDriver } from "@backend/__tests__/drivers/util.driver";
 import {
   cleanupCollections,
   cleanupTestDb,
@@ -96,5 +97,77 @@ describe("Public booking rate limits", () => {
     await server
       .get("/api/booking/pages/quiet-neighbor-slug")
       .expect(Status.NOT_FOUND);
+  });
+});
+
+describe("Host admin booking rate limits", () => {
+  const baseDriver = new BaseDriver();
+
+  beforeAll(async () => {
+    await setupTestDb(import.meta.url);
+    await baseDriver.listen();
+  });
+
+  beforeEach(cleanupCollections);
+
+  afterAll(async () => {
+    await baseDriver.teardown();
+    await cleanupTestDb();
+  });
+
+  const sessionCookie = (userId: string) =>
+    `session=${JSON.stringify({ userId })}`;
+
+  const getAdminPage = (userId: string) =>
+    baseDriver
+      .getServer()
+      .get("/api/booking/page")
+      .set("Cookie", sessionCookie(userId));
+
+  const putAdminPage = (userId: string) =>
+    baseDriver
+      .getServer()
+      .put("/api/booking/page")
+      .set("Cookie", sessionCookie(userId))
+      .send({});
+
+  it("throttles GET /api/booking/page after 60 requests in a minute", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const userId = user._id.toString();
+    for (let i = 0; i < 60; i += 1) {
+      await getAdminPage(userId);
+    }
+    const throttled = await getAdminPage(userId);
+    expect(throttled.status).toBe(429);
+  });
+
+  it("throttles PUT /api/booking/page after 20 requests in a minute", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const userId = user._id.toString();
+    for (let i = 0; i < 20; i += 1) {
+      await putAdminPage(userId);
+    }
+    const throttled = await putAdminPage(userId);
+    expect(throttled.status).toBe(429);
+  });
+
+  it("does not throttle a different host's GET bucket", async () => {
+    const { user: busy } = await UtilDriver.setupTestUser();
+    const { user: quiet } = await UtilDriver.setupTestUser();
+    for (let i = 0; i < 61; i += 1) {
+      await getAdminPage(busy._id.toString());
+    }
+    const response = await getAdminPage(quiet._id.toString());
+    expect(response.status).not.toBe(429);
+  });
+
+  it("does not throttle a different host's PUT bucket", async () => {
+    const { user: busy } = await UtilDriver.setupTestUser();
+    const { user: quiet } = await UtilDriver.setupTestUser();
+    for (let i = 0; i < 21; i += 1) {
+      await putAdminPage(busy._id.toString());
+    }
+    const response = await putAdminPage(quiet._id.toString());
+    expect(response.status).not.toBe(429);
   });
 });

--- a/packages/backend/src/booking/booking.routes.config.ts
+++ b/packages/backend/src/booking/booking.routes.config.ts
@@ -61,14 +61,8 @@ const publicReservationPatchLimiter = rateLimit({
   keyGenerator: bookingReservationKey,
 });
 
-const bookingAdminKey = (req: express.Request): string => {
-  const session = (req as SessionRequest).session;
-  const userId =
-    session && typeof session.getUserId === "function"
-      ? session.getUserId()
-      : "unknown";
-  return `booking-admin:${userId}`;
-};
+const bookingAdminKey = (req: express.Request): string =>
+  `booking-admin:${(req as SessionRequest).session?.getUserId?.() ?? "unknown"}`;
 
 // GET is Settings load/poll; 60/min matches the public page read budget.
 const adminPageGetLimiter = rateLimit({

--- a/packages/backend/src/booking/booking.routes.config.ts
+++ b/packages/backend/src/booking/booking.routes.config.ts
@@ -1,5 +1,6 @@
 import type express from "express";
 import rateLimit from "express-rate-limit";
+import { type SessionRequest } from "supertokens-node/framework/express";
 import { isBookingEnabled } from "@core/util/env.util";
 import { verifySession } from "@backend/auth/session/session.middleware";
 import bookingController from "@backend/booking/controllers/booking.controller";
@@ -60,6 +61,33 @@ const publicReservationPatchLimiter = rateLimit({
   keyGenerator: bookingReservationKey,
 });
 
+const bookingAdminKey = (req: express.Request): string => {
+  const session = (req as SessionRequest).session;
+  const userId =
+    session && typeof session.getUserId === "function"
+      ? session.getUserId()
+      : "unknown";
+  return `booking-admin:${userId}`;
+};
+
+// GET is Settings load/poll; 60/min matches the public page read budget.
+const adminPageGetLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: bookingAdminKey,
+});
+
+// PUT is a save. A host retries a handful of times, not sixty.
+const adminPagePutLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 20,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: bookingAdminKey,
+});
+
 /**
  * Host admin routes require a session. Public guest routes are unauthenticated.
  */
@@ -76,8 +104,8 @@ export class BookingRoutes extends CommonRoutesConfig {
     this.app
       .route(`/api/booking/page`)
       .all(verifySession())
-      .get(bookingController.getPage)
-      .put(bookingController.putPage);
+      .get(adminPageGetLimiter, bookingController.getPage)
+      .put(adminPagePutLimiter, bookingController.putPage);
 
     this.app
       .route(`/api/booking/pages/:slug`)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3143

## Summary

Host admin `GET` and `PUT /api/booking/page` sat behind `verifySession()` with no rate limiter, while every public booking route already had one. Authentication is not a rate limit.

Both routes now carry per-user limiters (not per slug/IP):

- `GET`: 60/min, Settings load/poll
- `PUT`: 20/min, a handful of saves, not sixty

Buckets are isolated per user so one host cannot exhaust another.

## Simplicity

Follows the existing `express-rate-limit` pattern in `booking.routes.config.ts`. The key generator optional-chains the session user id.

## Automated validation

`bun run verify` PASS. Selected packages: backend. Checks run: test:backend, type-check, lint, knip. Checks skipped: (none).

Focused backend tests: 11 pass (GET 429 after 60, PUT 429 after 20, per-user isolation, production kill-switch still registers no routes).

## Independent review

`.agents/handoffs/3143.md`

```
VERDICT: no confirmed findings
FINDINGS:
(none)
```

## Test plan

- `bun test:backend -- packages/backend/src/booking/booking.rate-limit.db.test.ts packages/backend/src/booking/booking.routes.config.test.ts` (11 pass)
- `bun run verify` (PASS: backend, type-check, lint, knip)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec67721b-395d-454e-bd11-696669d367b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec67721b-395d-454e-bd11-696669d367b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

