### PR TITLE
docs(booking): record that public rate limits are per-process

### DIFF
--- a/.agents/handoffs/3144.md
+++ b/.agents/handoffs/3144.md
@@ -1,0 +1,39 @@
+---
+schema_version: 1
+task_id: "3144"
+from: Reviewer
+to: Manager
+owner: Manager
+status: verifying
+artifact:
+  - path: docs/features/booking.md
+  - path: packages/backend/src/booking/booking.routes.config.ts
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3288
+evidence:
+  - command: bun test:backend -- packages/backend/src/booking/booking.rate-limit.db.test.ts packages/backend/src/booking/booking.routes.config.test.ts
+    result: "11 pass, 0 fail (existing public and admin rate-limit tests unchanged)"
+    log: null
+  - command: bun run verify
+    result: "PASS. Selected packages: backend. Checks run: test:backend, type-check, lint, knip. Checks skipped: (none)."
+    log: null
+assumptions:
+  - "Accepted per-process buckets rather than a shared store because booking is off in production and a Redis-backed limiter is out of v1 scope."
+open_risks: []
+next_deadline: 2026-09-04T06:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-16: document that public booking rate limits are per-process.
+
+Chose accept-and-document over a shared store.
+
+Simplify: no further production change.
+
+Review: no confirmed findings.
+
+VERDICT: no confirmed findings
+FINDINGS:
+(none)

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,7 +13,8 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 3143 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3287 | bun run verify PASS (backend, type-check, lint, knip); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
+| 3144 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3288 | bun run verify PASS (backend, type-check, lint, knip); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
+| 3143 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3287 | squash-merged 58a4e58b9; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3142 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3286 | squash-merged 105ea7910; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3141 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3282 | squash-merged b69a4ed2b; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3140 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3281 | squash-merged f9cf87e8d; bun run verify PASS; review: no confirmed findings | null | 0 | none |

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -393,6 +393,12 @@ Guest reschedule is **in scope for v1.3**, not v1 / v1.1.
 
 ### Named warts
 
+- **Public booking rate limits are per process.** `express-rate-limit`
+  buckets live in memory on each app replica. The numbers in
+  `booking.routes.config.ts` (for example 10 confirms per minute) are
+  per instance: N replicas yield about N times that, and a client that
+  reconnects to a different replica resets its bucket. Accepted for v1
+  while `isBookingEnabled` stays false in production.
 - **Guest email is not editable after confirm.** The attendee identity and
   Google invite are bound to the address collected at booking. Changing it
   would send a new invitation, which v1.5 does not do.

--- a/packages/backend/src/booking/booking.routes.config.ts
+++ b/packages/backend/src/booking/booking.routes.config.ts
@@ -10,6 +10,10 @@ import { CONFIG } from "@backend/common/constants/config.constants";
 const bookingSlugKey = (req: express.Request): string =>
   `${req.ip ?? "unknown"}:${req.params["slug"] ?? "unknown"}`;
 
+// All booking limiters in this file are in-memory per-process buckets.
+// With N replicas the advertised limit is really Nx the number here, and
+// a client that lands on another replica starts a fresh bucket. Accepted
+// for v1: booking is off in production.
 const publicPageLimiter = rateLimit({
   windowMs: 60 * 1000,
   limit: 60,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3144

## Summary

Chose **accept the per-process behavior**, not a shared store.

Public (and admin) booking limiters use `express-rate-limit`'s default memory store. With N replicas the advertised 10 confirms/min is about 10xN, and a client that lands on another replica starts a fresh bucket. Booking is off in production (`isBookingEnabled` is false there), so a Redis-backed limiter is not the v1 job. Leaving that implied would read as a guarantee the numbers do not provide.

This PR records the wart in `docs/features/booking.md` and comments the limiter block in `booking.routes.config.ts`.

## Simplicity

Documentation and one comment. No new store, replica coordination, or test-only production hook.

## Automated validation

`bun run verify` PASS. Selected packages: backend. Checks run: test:backend, type-check, lint, knip. Checks skipped: (none).

Existing rate-limit tests: 11 pass, unchanged.

## Independent review

`.agents/handoffs/3144.md`

```
VERDICT: no confirmed findings
FINDINGS:
(none)
```

## Test plan

- `bun test:backend -- packages/backend/src/booking/booking.rate-limit.db.test.ts packages/backend/src/booking/booking.routes.config.test.ts` (11 pass)
- `bun run verify` (PASS: backend, type-check, lint, knip)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec67721b-395d-454e-bd11-696669d367b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec67721b-395d-454e-bd11-696669d367b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

