### PR TITLE
fix(booking): expire guest cancel and edit tokens at slotEnd

### DIFF
--- a/.agents/handoffs/3145.md
+++ b/.agents/handoffs/3145.md
@@ -1,0 +1,40 @@
+---
+schema_version: 1
+task_id: "3145"
+from: Reviewer
+to: Manager
+owner: Manager
+status: verifying
+artifact:
+  - path: packages/backend/src/booking/booking-cancel-token.ts
+  - path: packages/backend/src/booking/services/public-booking.service.ts
+  - path: docs/features/booking.md
+evidence:
+  - command: bun test:backend -- packages/backend/src/booking/booking-cancel-token.test.ts packages/backend/src/booking/services/public-booking.service.db.test.ts
+    result: "45 pass, 0 fail (expired cancel does not delete event; expired patch does not change guest name)"
+    log: null
+  - command: bun run verify
+    result: "PASS. Selected packages: backend. Checks run: test:backend, type-check, lint, knip. Checks skipped: (none)."
+    log: null
+assumptions:
+  - "Accepted query-string ?token= transport because moving to fragment or POST would break the WP-11 confirmation permalink."
+  - "Guest edit PATCH shares cancelTokenHash, so expiry applies to cancel and edit."
+open_risks: []
+next_deadline: 2026-09-04T06:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-17: expire guest cancel and edit tokens at `slotEnd`; keep query-string transport.
+
+Chose accept-and-document for `?token=` plus expiry. Expired tokens return `RESERVATION_NOT_FOUND` like a bad token.
+
+Simplify: no further production change.
+
+Review: no confirmed findings.
+
+VERDICT: no confirmed findings
+FINDINGS:
+(none)

--- a/.agents/handoffs/3145.md
+++ b/.agents/handoffs/3145.md
@@ -9,6 +9,7 @@ artifact:
   - path: packages/backend/src/booking/booking-cancel-token.ts
   - path: packages/backend/src/booking/services/public-booking.service.ts
   - path: docs/features/booking.md
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3289
 evidence:
   - command: bun test:backend -- packages/backend/src/booking/booking-cancel-token.test.ts packages/backend/src/booking/services/public-booking.service.db.test.ts
     result: "45 pass, 0 fail (expired cancel does not delete event; expired patch does not change guest name)"

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,7 +13,7 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 3145 | high | Manager | verifying | packages/backend/src/booking/booking-cancel-token.ts | bun run verify PASS (backend, type-check, lint, knip); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
+| 3145 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3289 | bun run verify PASS (backend, type-check, lint, knip); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
 | 3144 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3288 | squash-merged 40e5a02f0; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3143 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3287 | squash-merged 58a4e58b9; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3142 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3286 | squash-merged 105ea7910; bun run verify PASS; review: no confirmed findings | null | 0 | none |

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,7 +13,8 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 3144 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3288 | bun run verify PASS (backend, type-check, lint, knip); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
+| 3145 | high | Manager | verifying | packages/backend/src/booking/booking-cancel-token.ts | bun run verify PASS (backend, type-check, lint, knip); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
+| 3144 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3288 | squash-merged 40e5a02f0; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3143 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3287 | squash-merged 58a4e58b9; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3142 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3286 | squash-merged 105ea7910; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3141 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3282 | squash-merged b69a4ed2b; bun run verify PASS; review: no confirmed findings | null | 0 | none |

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -240,7 +240,8 @@ decides whether a busy interval occupies a slot
   description carries it too only when guests cannot invite others (see
   above). A permalink without the token does not invent a cancel path.
 - Token is unguessable and stored hashed on the reservation as
-  `cancelTokenHash`.
+  `cancelTokenHash`. It stays valid until `slotEnd` and then returns
+  the same generic not-found as an unknown token.
 - Cancel deletes the calendar event (host as organizer) and marks the
   reservation cancelled. Idempotent: a second cancel is a no-op success.
 - Expired / unknown tokens return a generic not-found page, not a
@@ -399,6 +400,11 @@ Guest reschedule is **in scope for v1.3**, not v1 / v1.1.
   per instance: N replicas yield about N times that, and a client that
   reconnects to a different replica resets its bucket. Accepted for v1
   while `isBookingEnabled` stays false in production.
+- **Cancel and edit tokens travel in the query string.** The bearer
+  lives in `?token=` on `/book/confirmed/:id` and `/book/cancel/:id`,
+  so it can appear in browser history, Referer headers, and access
+  logs. Accepted for v1: a fragment or POST landing page would break
+  the confirmation permalink. Tokens stop working at `slotEnd`.
 - **Guest email is not editable after confirm.** The attendee identity and
   Google invite are bound to the address collected at booking. Changing it
   would send a new invitation, which v1.5 does not do.

--- a/packages/backend/src/booking/booking-cancel-token.test.ts
+++ b/packages/backend/src/booking/booking-cancel-token.test.ts
@@ -1,0 +1,56 @@
+import {
+  guestActionTokenAuthorizes,
+  guestActionTokenIsLive,
+  hashCancelToken,
+  verifyCancelToken,
+} from "@backend/booking/booking-cancel-token";
+import { describe, expect, it } from "bun:test";
+import { randomBytes } from "node:crypto";
+
+describe("guestActionTokenIsLive", () => {
+  const slotEnd = new Date("2026-09-07T10:30:00.000Z");
+
+  it("is live before slotEnd and expired at and after slotEnd", () => {
+    expect(
+      guestActionTokenIsLive(slotEnd, new Date("2026-09-07T10:29:59.999Z")),
+    ).toBe(true);
+    expect(guestActionTokenIsLive(slotEnd, slotEnd)).toBe(false);
+    expect(
+      guestActionTokenIsLive(slotEnd, new Date("2026-09-07T10:30:00.001Z")),
+    ).toBe(false);
+  });
+});
+
+describe("guestActionTokenAuthorizes", () => {
+  const token = randomBytes(32).toString("base64url");
+  const hash = hashCancelToken(token);
+  const slotEnd = new Date("2026-09-07T10:30:00.000Z");
+
+  it("authorizes a matching live token and rejects expired or wrong tokens", () => {
+    expect(
+      guestActionTokenAuthorizes(
+        hash,
+        token,
+        slotEnd,
+        new Date("2026-09-07T10:00:00.000Z"),
+      ),
+    ).toBe(true);
+    expect(
+      guestActionTokenAuthorizes(
+        hash,
+        token,
+        slotEnd,
+        new Date("2026-09-07T10:30:00.000Z"),
+      ),
+    ).toBe(false);
+    expect(
+      guestActionTokenAuthorizes(
+        hash,
+        `${token}x`,
+        slotEnd,
+        new Date("2026-09-07T10:00:00.000Z"),
+      ),
+    ).toBe(false);
+    expect(verifyCancelToken(hash, token)).toBe(true);
+  });
+});

--- a/packages/backend/src/booking/booking-cancel-token.ts
+++ b/packages/backend/src/booking/booking-cancel-token.ts
@@ -18,3 +18,20 @@ export const verifyCancelToken = (
   }
   return timingSafeEqual(stored, candidate);
 };
+
+/** Valid while `now` is strictly before `slotEnd` (half-open, like the slot). */
+export const guestActionTokenIsLive = (
+  slotEnd: Date,
+  now: Date = new Date(),
+): boolean => now.getTime() < slotEnd.getTime();
+
+export const guestActionTokenAuthorizes = (
+  storedHash: string,
+  rawToken: string,
+  slotEnd: Date,
+  now: Date = new Date(),
+): boolean => {
+  const hashOk = verifyCancelToken(storedHash, rawToken);
+  const live = guestActionTokenIsLive(slotEnd, now);
+  return hashOk && live;
+};

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -10,6 +10,10 @@ import {
   setupTestDb,
 } from "@backend/__tests__/helpers/mock.db.setup";
 import * as billingGuard from "@backend/billing/billing.guard";
+import {
+  generateCancelToken,
+  hashCancelToken,
+} from "@backend/booking/booking-cancel-token";
 import { ensureBookingIndexes } from "@backend/booking/booking-indexes";
 import { bookingReservationRepository } from "@backend/booking/booking-reservation.repository";
 import bookingPageService from "@backend/booking/services/booking-page.service";
@@ -574,6 +578,32 @@ describe("PublicBookingService", () => {
     expect(stored?.status).toBe("cancelled");
   });
 
+  it("rejects an expired cancel token at slotEnd with RESERVATION_NOT_FOUND", async () => {
+    const { pageId } = await enableBookingPage();
+    const token = generateCancelToken();
+    const reservationId = new ObjectId();
+    await bookingReservationRepository.insert({
+      _id: reservationId,
+      pageId,
+      slotStart: new Date("2025-09-07T10:00:00.000Z"),
+      slotEnd: new Date("2025-09-07T10:30:00.000Z"),
+      guestName: "Ada Lovelace",
+      guestEmail: "ada@example.com",
+      notes: null,
+      guestTimeZone: "UTC",
+      status: "confirmed",
+      calendarEventId: "past-evt",
+      cancelTokenHash: hashCancelToken(token),
+    });
+
+    await expect(
+      service.cancelReservation(reservationId, { token }),
+    ).rejects.toMatchObject({ bookingCode: "RESERVATION_NOT_FOUND" });
+    expect(deleteBookingEvent).not.toHaveBeenCalled();
+    const stored = await bookingReservationRepository.findById(reservationId);
+    expect(stored?.status).toBe("confirmed");
+  });
+
   it("returns minimal public reservation details", async () => {
     const { slug } = await enableBookingPage();
     const created = await service.createReservation(slug, {
@@ -1054,6 +1084,35 @@ describe("PublicBookingService", () => {
     const stored = await bookingReservationRepository.findById(reservationId);
     expect(stored?.guestName).toBe("Ada Lovelace");
     expect(stored?.status).toBe("cancelled");
+  });
+
+  it("rejects an expired patch token at slotEnd with RESERVATION_NOT_FOUND", async () => {
+    const { pageId } = await enableBookingPage();
+    const token = generateCancelToken();
+    const reservationId = new ObjectId();
+    await bookingReservationRepository.insert({
+      _id: reservationId,
+      pageId,
+      slotStart: new Date("2025-09-07T10:00:00.000Z"),
+      slotEnd: new Date("2025-09-07T10:30:00.000Z"),
+      guestName: "Ada Lovelace",
+      guestEmail: "ada@example.com",
+      notes: "bring coffee",
+      guestTimeZone: "UTC",
+      status: "confirmed",
+      calendarEventId: "past-evt",
+      cancelTokenHash: hashCancelToken(token),
+    });
+
+    await expect(
+      service.patchPublicReservation(reservationId, {
+        token,
+        name: "Grace Hopper",
+      }),
+    ).rejects.toMatchObject({ bookingCode: "RESERVATION_NOT_FOUND" });
+    expect(updateBookingEvent).not.toHaveBeenCalled();
+    const stored = await bookingReservationRepository.findById(reservationId);
+    expect(stored?.guestName).toBe("Ada Lovelace");
   });
 
   it("rejects invalid guest email", async () => {

--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -31,8 +31,8 @@ import dayjs from "@core/util/date/dayjs";
 import { bookingError } from "@backend/booking/booking.error";
 import {
   generateCancelToken,
+  guestActionTokenAuthorizes,
   hashCancelToken,
-  verifyCancelToken,
 } from "@backend/booking/booking-cancel-token";
 import { type BookingPageRecord } from "@backend/booking/booking-page.record";
 import { bookingPageRepository } from "@backend/booking/booking-page.repository";
@@ -523,7 +523,11 @@ export class PublicBookingService {
       await bookingReservationRepository.findById(reservationId);
     if (
       !reservation ||
-      !verifyCancelToken(reservation.cancelTokenHash, input.token)
+      !guestActionTokenAuthorizes(
+        reservation.cancelTokenHash,
+        input.token,
+        reservation.slotEnd,
+      )
     ) {
       throw bookingError("RESERVATION_NOT_FOUND", "Reservation not found");
     }
@@ -595,7 +599,11 @@ export class PublicBookingService {
       await bookingReservationRepository.findById(reservationId);
     if (
       !reservation ||
-      !verifyCancelToken(reservation.cancelTokenHash, token)
+      !guestActionTokenAuthorizes(
+        reservation.cancelTokenHash,
+        token,
+        reservation.slotEnd,
+      )
     ) {
       throw bookingError("RESERVATION_NOT_FOUND", "Reservation not found");
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #3145 (Booking v1.5 WP-17).

Decide-then-document: keep query-string `?token=` on confirm/cancel permalinks (moving to fragment or POST would break the WP-11 permalink). Tokens now expire at `slotEnd` for both guest cancel and guest edit (`PATCH`), which share `cancelTokenHash`. Expired tokens return the same generic `RESERVATION_NOT_FOUND` as a bad token, and do not delete the calendar event or mutate guest details.

## Simplicity

Two small helpers on the existing cancel-token module (`guestActionTokenIsLive`, `guestActionTokenAuthorizes`). Hash and expiry both always run. No transport change.

## Automated validation

- Expired cancel at `slotEnd` rejects with `RESERVATION_NOT_FOUND`; `deleteBookingEvent` is not called; row stays `confirmed`.
- Expired patch at `slotEnd` rejects with `RESERVATION_NOT_FOUND`; guest name is unchanged.
- Matching live tokens still authorize; wrong tokens still fail.

## Independent review

`.agents/handoffs/3145.md`

```
VERDICT: no confirmed findings
FINDINGS:
(none)
```

## Test plan

- `bun test:backend -- packages/backend/src/booking/booking-cancel-token.test.ts packages/backend/src/booking/services/public-booking.service.db.test.ts` (45 pass, 0 fail)
- `bun run verify` PASS. Selected packages: backend. Checks run: test:backend, type-check, lint, knip.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec67721b-395d-454e-bd11-696669d367b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec67721b-395d-454e-bd11-696669d367b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

