### PR TITLE
fix(booking): re-check billing before guest confirm

### DIFF
--- a/.agents/handoffs/3146.md
+++ b/.agents/handoffs/3146.md
@@ -1,0 +1,39 @@
+---
+schema_version: 1
+task_id: "3146"
+from: Reviewer
+to: Manager
+owner: Manager
+status: verifying
+artifact:
+  - path: packages/backend/src/booking/services/public-booking.service.ts
+  - path: packages/backend/src/booking/services/public-booking.service.db.test.ts
+  - path: docs/features/booking.md
+evidence:
+  - command: bun test:backend -- packages/backend/src/booking/services/public-booking.service.db.test.ts packages/backend/src/booking/services/booking-page.service.db.test.ts
+    result: "58 pass, 0 fail (lapsed host confirm submits no create; page GET uses guest-safe copy; enable billing guards unchanged)"
+    log: null
+  - command: bun run verify
+    result: "PASS. Selected packages: backend. Checks run: test:backend, type-check, lint, knip. Checks skipped: (none)."
+    log: null
+assumptions:
+  - "Did not change billing.guard or stripe files; public paths remap BILLING_REQUIRED to existing SLOT_UNAVAILABLE so merge-guard path patterns stay clear."
+open_risks: []
+next_deadline: 2026-09-04T06:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-18: re-check billing on guest confirm, page GET, and slots.
+
+Guest copy is `This page is not accepting bookings.` Confirm submits no create command. Slots return `{ slots: [], bookable: false }`.
+
+Simplify: no further production change.
+
+Review: no confirmed findings.
+
+VERDICT: no confirmed findings
+FINDINGS:
+(none)

--- a/.agents/handoffs/3146.md
+++ b/.agents/handoffs/3146.md
@@ -9,6 +9,7 @@ artifact:
   - path: packages/backend/src/booking/services/public-booking.service.ts
   - path: packages/backend/src/booking/services/public-booking.service.db.test.ts
   - path: docs/features/booking.md
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3290
 evidence:
   - command: bun test:backend -- packages/backend/src/booking/services/public-booking.service.db.test.ts packages/backend/src/booking/services/booking-page.service.db.test.ts
     result: "58 pass, 0 fail (lapsed host confirm submits no create; page GET uses guest-safe copy; enable billing guards unchanged)"

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,7 +13,8 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 3145 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3289 | bun run verify PASS (backend, type-check, lint, knip); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
+| 3146 | high | Manager | verifying | packages/backend/src/booking/services/public-booking.service.ts | bun run verify PASS (backend, type-check, lint, knip); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
+| 3145 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3289 | squash-merged 41cb48cb6; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3144 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3288 | squash-merged 40e5a02f0; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3143 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3287 | squash-merged 58a4e58b9; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3142 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3286 | squash-merged 105ea7910; bun run verify PASS; review: no confirmed findings | null | 0 | none |

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,7 +13,7 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 3146 | high | Manager | verifying | packages/backend/src/booking/services/public-booking.service.ts | bun run verify PASS (backend, type-check, lint, knip); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
+| 3146 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3290 | bun run verify PASS (backend, type-check, lint, knip); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
 | 3145 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3289 | squash-merged 41cb48cb6; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3144 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3288 | squash-merged 40e5a02f0; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3143 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3287 | squash-merged 58a4e58b9; bun run verify PASS; review: no confirmed findings | null | 0 | none |

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -322,13 +322,18 @@ Unauthenticated:
 
 - `GET /api/booking/pages/:slug` — public page (host display name,
   duration, timezone, enabled, optional welcome text). `404` when
-  missing or disabled.
+  missing or disabled. A host who cannot write is `409` with
+  `This page is not accepting bookings.` (no billing, plan, or payment
+  wording).
 - `GET /api/booking/pages/:slug/slots?start=&end=&timeZone=` — bookable
   instants in the guest timezone for that window. The guest UI requests
   **one month at a time** (plus prefetch of adjacent months). Window
-  must be within the 60-day horizon.
+  must be within the 60-day horizon. A host who cannot write is
+  `{ slots: [], bookable: false }`.
 - `POST /api/booking/pages/:slug/reservations` — `{slotStart, guestName,
-  guestEmail, notes?, guestTimeZone}`. Re-checks busy, then creates.
+  guestEmail, notes?, guestTimeZone}`. Re-checks billing and busy, then
+  creates. A host who cannot write is the same `409` as GET page and
+  submits no create command.
 - `GET /api/booking/reservations/:id` — public confirmation payload
   (`slotStart`, `guestTimeZone`, `durationMinutes`, `hostDisplayName`,
   `status`, `bookingSlug`, `guestName`, `notes`). `404` when missing. No

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -26,6 +26,7 @@ import {
 import calendarService from "@backend/calendar/services/calendar.service";
 import { type SyncServiceClient } from "@backend/common/services/sync-service/sync-service.client";
 import * as syncServiceFactory from "@backend/common/services/sync-service/sync-service.factory";
+import { eventMutationError } from "@backend/event/event.error";
 import userService from "@backend/user/services/user.service";
 import {
   afterAll,
@@ -271,6 +272,75 @@ describe("PublicBookingService", () => {
     ).rejects.toMatchObject({ bookingCode: "SLOT_UNAVAILABLE" });
 
     expect(createBookingEvent).not.toHaveBeenCalled();
+  });
+
+  it("rejects confirm when the host cannot write and submits no create command", async () => {
+    const { slug } = await enableBookingPage();
+    spyOn(billingGuard, "assertBillingAllowsWrites").mockRejectedValue(
+      eventMutationError(
+        "BILLING_REQUIRED",
+        "A paid subscription is required to make changes",
+      ),
+    );
+
+    const error = await service
+      .createReservation(slug, {
+        slotStart: "2026-09-07T10:00:00.000Z",
+        guestName: "Ada Lovelace",
+        guestEmail: "ada@example.com",
+        guestTimeZone: "Europe/London",
+      })
+      .catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({
+      bookingCode: "SLOT_UNAVAILABLE",
+      message: "This page is not accepting bookings.",
+    });
+    expect(JSON.stringify(error)).not.toMatch(
+      /billing|plan|payment|paid|subscription/i,
+    );
+    expect(createBookingEvent).not.toHaveBeenCalled();
+  });
+
+  it("returns unbookable slots when the host cannot write", async () => {
+    const { slug } = await enableBookingPage();
+    spyOn(billingGuard, "assertBillingAllowsWrites").mockRejectedValue(
+      eventMutationError(
+        "BILLING_REQUIRED",
+        "A paid subscription is required to make changes",
+      ),
+    );
+
+    const response = await service.getSlots(slug, {
+      start: "2026-09-07T00:00:00.000Z",
+      end: "2026-09-08T00:00:00.000Z",
+      timeZone: "UTC",
+    });
+
+    expect(response).toEqual({ slots: [], bookable: false });
+    expect(getAvailability).not.toHaveBeenCalled();
+  });
+
+  it("rejects public page GET when the host cannot write without billing wording", async () => {
+    const { slug } = await enableBookingPage();
+    spyOn(billingGuard, "assertBillingAllowsWrites").mockRejectedValue(
+      eventMutationError(
+        "BILLING_REQUIRED",
+        "A paid subscription is required to make changes",
+      ),
+    );
+
+    const error = await service
+      .getPublicPage(slug)
+      .catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({
+      bookingCode: "SLOT_UNAVAILABLE",
+      message: "This page is not accepting bookings.",
+    });
+    expect(JSON.stringify(error)).not.toMatch(
+      /billing|plan|payment|paid|subscription/i,
+    );
   });
 
   it("rejects slot not in engine output", async () => {

--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -28,6 +28,7 @@ import {
   type BusyAvailabilityResponse,
 } from "@core/types/sync/availability.contracts";
 import dayjs from "@core/util/date/dayjs";
+import { assertBillingAllowsWrites } from "@backend/billing/billing.guard";
 import { bookingError } from "@backend/booking/booking.error";
 import {
   generateCancelToken,
@@ -50,6 +51,30 @@ import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-prin
 import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
 
 const logger = Logger("app:booking.public");
+
+const GUEST_PAGE_NOT_ACCEPTING_BOOKINGS =
+  "This page is not accepting bookings.";
+
+const isBillingRequiredError = (error: unknown): boolean =>
+  error instanceof BaseError && error.code === "BILLING_REQUIRED";
+
+const hostAllowsGuestWrites = async (userId: ObjectId): Promise<boolean> => {
+  try {
+    await assertBillingAllowsWrites(userId.toString());
+    return true;
+  } catch (error) {
+    if (isBillingRequiredError(error)) {
+      return false;
+    }
+    throw error;
+  }
+};
+
+const assertHostAllowsGuestWrites = async (userId: ObjectId): Promise<void> => {
+  if (!(await hostAllowsGuestWrites(userId))) {
+    throw bookingError("SLOT_UNAVAILABLE", GUEST_PAGE_NOT_ACCEPTING_BOOKINGS);
+  }
+};
 
 const isDuplicateSlotError = (error: unknown): boolean =>
   error instanceof MongoServerError && error.code === 11000;
@@ -250,6 +275,7 @@ export class PublicBookingService {
 
   async getPublicPage(slug: string): Promise<PublicBookingPage> {
     const page = await resolveEnabledPage(slug);
+    await assertHostAllowsGuestWrites(page.userId);
     const hostDisplayName = await getHostDisplayName(page.userId);
     const createsGoogleMeet = await destinationCreatesGoogleMeet(
       page.userId,
@@ -265,6 +291,12 @@ export class PublicBookingService {
     rawQuery: unknown,
   ): Promise<BookingSlotsResponse> {
     const page = await resolveEnabledPage(slug);
+    if (!(await hostAllowsGuestWrites(page.userId))) {
+      return BookingSlotsResponseSchema.parse({
+        slots: [],
+        bookable: false,
+      });
+    }
     const query = parseSlotsQuery(rawQuery);
     const now = new Date();
     const windowStart = new Date(query.start);
@@ -323,6 +355,7 @@ export class PublicBookingService {
 
   async createReservation(slug: string, rawInput: unknown) {
     const page = await resolveEnabledPage(slug);
+    await assertHostAllowsGuestWrites(page.userId);
     const input = CreateBookingReservationInputSchema.parse(rawInput);
     assertGuestEmail(input.guestEmail);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #3146 (Booking v1.5 WP-18).

Public confirm, page GET, and slots re-check the existing write gate (`assertBillingAllowsWrites`) so a host who enabled while paid and then lapsed does not keep creating events. `BILLING_REQUIRED` is remapped before it leaves the public API. Guests see `This page is not accepting bookings.` (`SLOT_UNAVAILABLE`) on confirm and GET, and `{ slots: [], bookable: false }` on slots. No billing, plan, or payment wording. Host enable guards are unchanged. Did not edit `billing` or `stripe` files.

## Simplicity

One remap helper in `public-booking.service.ts`. Reuses `SLOT_UNAVAILABLE` and the existing `bookable: false` slots shape. No new error code.

## Automated validation

- Confirm against a write-blocked host returns `SLOT_UNAVAILABLE` with the exact guest string and does not call `createBookingEvent`.
- Slots for that host return `{ slots: [], bookable: false }` without fetching availability.
- Page GET returns the same guest-safe error; serialized error has no billing/plan/payment wording.
- Existing enable billing guard and happy-path confirm tests still pass.

## Independent review

`.agents/handoffs/3146.md`

```
VERDICT: no confirmed findings
FINDINGS:
(none)
```

## Test plan

- `bun test:backend -- packages/backend/src/booking/services/public-booking.service.db.test.ts packages/backend/src/booking/services/booking-page.service.db.test.ts` (58 pass, 0 fail)
- `bun run verify` PASS. Selected packages: backend. Checks run: test:backend, type-check, lint, knip.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec67721b-395d-454e-bd11-696669d367b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec67721b-395d-454e-bd11-696669d367b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

