### PR TITLE
fix(booking): mark cancel locally before deleting the event

### DIFF
--- a/.agents/handoffs/3147.md
+++ b/.agents/handoffs/3147.md
@@ -1,0 +1,38 @@
+---
+schema_version: 1
+task_id: "3147"
+from: Reviewer
+to: Manager
+owner: Manager
+status: verifying
+artifact:
+  - path: packages/backend/src/booking/services/public-booking.service.ts
+  - path: packages/backend/src/booking/booking-reservation.repository.ts
+  - path: docs/features/booking.md
+evidence:
+  - command: bun test:backend -- packages/backend/src/booking/services/public-booking.service.db.test.ts
+    result: "47 pass, 0 fail (failed delete leaves cancelled row; same slot bookable; retry still deletes; idempotent re-cancel still one delete)"
+    log: null
+  - command: bun run verify
+    result: "PASS. Selected packages: backend. Checks run: test:backend, type-check, lint, knip. Checks skipped: (none)."
+    log: null
+assumptions: []
+open_risks: []
+next_deadline: 2026-09-04T06:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-19: mark reservation cancelled before provider delete.
+
+Failed delete leaves a cancelled row (slot free). Retry still deletes while `calendarEventId` remains. Successful delete clears the id so a second cancel stays a no-op. `invitation: "all"` unchanged.
+
+Simplify: no further production change.
+
+Review: no confirmed findings.
+
+VERDICT: no confirmed findings
+FINDINGS:
+(none)

--- a/.agents/ledger.md
+++ b/.agents/ledger.md
@@ -13,7 +13,8 @@ Status: `queued` | `running` | `waiting` | `verifying` | `done` | `escalated`
 
 | task_id | priority | owner | status | artifact | evidence | next_deadline | retry | approval |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 3146 | high | Manager | verifying | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3290 | bun run verify PASS (backend, type-check, lint, knip); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
+| 3147 | high | Manager | verifying | packages/backend/src/booking/services/public-booking.service.ts | bun run verify PASS (backend, type-check, lint, knip); review: no confirmed findings | 2026-09-04T06:00:00Z | 0 | none |
+| 3146 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3290 | squash-merged 936e90b26; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3145 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3289 | squash-merged 41cb48cb6; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3144 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3288 | squash-merged 40e5a02f0; bun run verify PASS; review: no confirmed findings | null | 0 | none |
 | 3143 | high | Manager | done | https://github.com/KeepSoftwareSimple/compass-calendar/pull/3287 | squash-merged 58a4e58b9; bun run verify PASS; review: no confirmed findings | null | 0 | none |

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -242,8 +242,10 @@ decides whether a busy interval occupies a slot
 - Token is unguessable and stored hashed on the reservation as
   `cancelTokenHash`. It stays valid until `slotEnd` and then returns
   the same generic not-found as an unknown token.
-- Cancel deletes the calendar event (host as organizer) and marks the
-  reservation cancelled. Idempotent: a second cancel is a no-op success.
+- Cancel marks the reservation cancelled, then deletes the calendar
+  event (host as organizer, `invitation: "all"`). A failed delete
+  still frees the slot; retry deletes while `calendarEventId` remains.
+  Idempotent: a second cancel after a successful delete is a no-op.
 - Expired / unknown tokens return a generic not-found page, not a
   leak of whether the booking existed.
 

--- a/packages/backend/src/booking/booking-reservation.repository.ts
+++ b/packages/backend/src/booking/booking-reservation.repository.ts
@@ -144,6 +144,19 @@ class BookingReservationRepository {
     if (!result) return null;
     return BookingReservationRecordSchema.parse(result);
   }
+
+  async clearCalendarEventId(
+    id: ObjectId,
+  ): Promise<BookingReservationRecord | null> {
+    const now = new Date();
+    const result = await mongoService.bookingReservation.findOneAndUpdate(
+      { _id: id },
+      { $set: { calendarEventId: null, updatedAt: now } },
+      { returnDocument: "after" },
+    );
+    if (!result) return null;
+    return BookingReservationRecordSchema.parse(result);
+  }
 }
 
 export const bookingReservationRepository = new BookingReservationRepository();

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -648,6 +648,53 @@ describe("PublicBookingService", () => {
     expect(stored?.status).toBe("cancelled");
   });
 
+  it("marks cancelled before delete so a failed provider delete does not keep the slot", async () => {
+    const { slug } = await enableBookingPage();
+    const slotStart = "2026-09-07T10:00:00.000Z";
+    const created = await service.createReservation(slug, {
+      slotStart,
+      guestName: "Ada Lovelace",
+      guestEmail: "ada@example.com",
+      guestTimeZone: "Europe/London",
+    });
+    const token = new URL(created.cancelUrl).searchParams.get("token");
+    expect(token).toBeTruthy();
+    const reservationId = new ObjectId(created.reservationId);
+
+    deleteBookingEvent.mockImplementation(async () => {
+      throw new BaseError(
+        "SYNC_UNAVAILABLE",
+        "could not delete the booking event",
+        Status.SERVICE_UNAVAILABLE,
+        true,
+      );
+    });
+
+    await expect(
+      service.cancelReservation(reservationId, { token }),
+    ).rejects.toMatchObject({ result: "SYNC_UNAVAILABLE" });
+    expect(deleteBookingEvent).toHaveBeenCalledTimes(1);
+    const stored = await bookingReservationRepository.findById(reservationId);
+    expect(stored?.status).toBe("cancelled");
+    expect(stored?.calendarEventId).toBeTruthy();
+
+    const retry = await service.createReservation(slug, {
+      slotStart,
+      guestName: "Grace Hopper",
+      guestEmail: "grace@example.com",
+      guestTimeZone: "America/New_York",
+    });
+    expect(retry.reservationId).toBeTruthy();
+
+    deleteBookingEvent.mockImplementation(async () => undefined);
+    await service.cancelReservation(reservationId, { token });
+    expect(deleteBookingEvent).toHaveBeenCalledTimes(2);
+    const afterRetry =
+      await bookingReservationRepository.findById(reservationId);
+    expect(afterRetry?.status).toBe("cancelled");
+    expect(afterRetry?.calendarEventId).toBeNull();
+  });
+
   it("rejects an expired cancel token at slotEnd with RESERVATION_NOT_FOUND", async () => {
     const { pageId } = await enableBookingPage();
     const token = generateCancelToken();

--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -641,10 +641,6 @@ export class PublicBookingService {
       throw bookingError("RESERVATION_NOT_FOUND", "Reservation not found");
     }
 
-    if (reservation.status === "cancelled") {
-      return;
-    }
-
     const pageRecord = await mongoService.bookingPage.findOne({
       _id: reservation.pageId,
     });
@@ -652,14 +648,22 @@ export class PublicBookingService {
       throw bookingError("RESERVATION_NOT_FOUND", "Reservation not found");
     }
 
-    if (reservation.calendarEventId) {
-      await this.calendarBooking.deleteBookingEvent(
-        pageRecord.userId.toString(),
-        { eventId: reservation.calendarEventId as EventId },
-      );
+    // Cancel local state first so a crash after the provider delete cannot
+    // leave a confirmed row occupying the slot. Retry still deletes while
+    // `calendarEventId` remains.
+    if (reservation.status === "confirmed") {
+      await bookingReservationRepository.markCancelled(reservationId);
     }
 
-    await bookingReservationRepository.markCancelled(reservationId);
+    if (!reservation.calendarEventId) {
+      return;
+    }
+
+    await this.calendarBooking.deleteBookingEvent(
+      pageRecord.userId.toString(),
+      { eventId: reservation.calendarEventId as EventId },
+    );
+    await bookingReservationRepository.clearCalendarEventId(reservationId);
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #3147 (Booking v1.5 WP-19).

Cancel used to delete the provider event before marking the row cancelled. A crash between those steps left a confirmed reservation occupying the slot with no event. Cancel now marks the row cancelled first, then deletes. A failed delete still frees the slot; retry still deletes while `calendarEventId` remains. A successful delete clears that id so a second cancel stays a no-op. `invitation: "all"` is unchanged so Google still emails the guest.

## Simplicity

Reorder plus `clearCalendarEventId` after a successful delete. No new status, no new error code.

## Automated validation

- Provider delete failure leaves `status: cancelled`; the same slot is bookable again.
- Repeat cancel after that failure still issues the delete, then clears `calendarEventId`.
- Existing idempotent re-cancel still calls delete once.

## Independent review

`.agents/handoffs/3147.md`

```
VERDICT: no confirmed findings
FINDINGS:
(none)
```

## Test plan

- `bun test:backend -- packages/backend/src/booking/services/public-booking.service.db.test.ts` (47 pass, 0 fail)
- `bun run verify` PASS. Selected packages: backend. Checks run: test:backend, type-check, lint, knip.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec67721b-395d-454e-bd11-696669d367b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec67721b-395d-454e-bd11-696669d367b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

