### PR TITLE
refactor(web): share the guest reservation view resolver

### DIFF
--- a/packages/web/src/booking/PublicBookingCancelPage.tsx
+++ b/packages/web/src/booking/PublicBookingCancelPage.tsx
@@ -1,9 +1,6 @@
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { useRef, useState } from "react";
-import {
-  PublicBookingApi,
-  PublicBookingNotFoundError,
-} from "@web/api/public-booking.api";
+import { PublicBookingApi } from "@web/api/public-booking.api";
 import { getErrorStatus } from "@web/api/util/api.util";
 import { PublicBookingLayout } from "@web/booking/PublicBookingLayout";
 import { PublicBookingSlotSummary } from "@web/booking/PublicBookingSlotSummary";
@@ -12,6 +9,10 @@ import {
   PublicBookingStatusMessage,
 } from "@web/booking/PublicBookingStatusMessage";
 import { usePublicBookingReservationQuery } from "@web/booking/public-booking.query";
+import {
+  type PublicBookingReservationView,
+  resolvePublicBookingReservationView,
+} from "@web/booking/public-booking.view";
 import { useBookingDocumentTitle } from "@web/booking/use-booking-document-title";
 import { useBookingHeadingFocus } from "@web/booking/use-booking-heading-focus";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
@@ -45,40 +46,22 @@ const BOOKING_LOADING = {
   description: "One moment while we load this booking.",
 } as const;
 
-type CancelPageView =
-  | { kind: "status"; title: string; description: string }
-  | {
-      kind: "confirm";
-      reservation: NonNullable<
-        ReturnType<typeof usePublicBookingReservationQuery>["data"]
-      >;
-    };
-
 const resolveCancelPageView = (
   canLoad: boolean,
   action: CancelActionState,
   reservationQuery: ReturnType<typeof usePublicBookingReservationQuery>,
-): CancelPageView => {
+): PublicBookingReservationView => {
   if (!canLoad || action === "not-found") {
     return { kind: "status", ...BOOKING_NOT_FOUND };
   }
   if (action === "cancelled") return { kind: "status", ...BOOKING_CANCELED };
   if (action === "error") return { kind: "status", ...BOOKING_CANCEL_FAILED };
-  if (reservationQuery.isLoading) return { kind: "status", ...BOOKING_LOADING };
-  if (reservationQuery.isError) {
-    return {
-      kind: "status",
-      ...(reservationQuery.error instanceof PublicBookingNotFoundError
-        ? BOOKING_NOT_FOUND
-        : BOOKING_CANCEL_FAILED),
-    };
-  }
-  const reservation = reservationQuery.data;
-  if (!reservation) return { kind: "status", ...BOOKING_NOT_FOUND };
-  if (reservation.status === "cancelled") {
-    return { kind: "status", ...BOOKING_CANCELED };
-  }
-  return { kind: "confirm", reservation };
+  return resolvePublicBookingReservationView(reservationQuery, {
+    loading: BOOKING_LOADING,
+    notFound: BOOKING_NOT_FOUND,
+    loadFailed: BOOKING_CANCEL_FAILED,
+    cancelled: BOOKING_CANCELED,
+  });
 };
 
 export function PublicBookingCancelPage() {
@@ -119,7 +102,7 @@ export function PublicBookingCancelPage() {
 
   const view = resolveCancelPageView(canLoad, action, reservationQuery);
   const busy = action === "cancelling";
-  const isConfirmView = view.kind === "confirm";
+  const isConfirmView = view.kind === "reservation";
 
   // Escape on the confirm view returns to the confirmation page. OverlayPanel
   // (if any) peels first. In-flight cancel must not navigate or abort.

--- a/packages/web/src/booking/PublicBookingConfirmedPage.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmedPage.tsx
@@ -5,7 +5,6 @@ import {
   useSearch,
 } from "@tanstack/react-router";
 import { useState } from "react";
-import { PublicBookingNotFoundError } from "@web/api/public-booking.api";
 import { getErrorStatus } from "@web/api/util/api.util";
 import { PublicBookingConfirmationView } from "@web/booking/PublicBookingConfirmationView";
 import { PublicBookingEditDetailsForm } from "@web/booking/PublicBookingEditDetailsForm";
@@ -14,6 +13,10 @@ import {
   usePatchPublicBookingReservationMutation,
   usePublicBookingReservationQuery,
 } from "@web/booking/public-booking.query";
+import {
+  type PublicBookingReservationView,
+  resolvePublicBookingReservationView,
+} from "@web/booking/public-booking.view";
 import {
   publicCancelUrlForReservation,
   tokenFromGuestActionUrl,
@@ -46,34 +49,15 @@ const BOOKING_CANCELED = {
     "The appointment is no longer on the host calendar. You can close this page.",
 } as const;
 
-type ConfirmedPageView =
-  | { kind: "status"; title: string; description: string }
-  | {
-      kind: "confirmation";
-      reservation: NonNullable<
-        ReturnType<typeof usePublicBookingReservationQuery>["data"]
-      >;
-    };
-
 const resolveConfirmedPageView = (
   reservationQuery: ReturnType<typeof usePublicBookingReservationQuery>,
-): ConfirmedPageView => {
-  if (reservationQuery.isLoading) return { kind: "status", ...BOOKING_LOADING };
-  if (reservationQuery.isError) {
-    return {
-      kind: "status",
-      ...(reservationQuery.error instanceof PublicBookingNotFoundError
-        ? BOOKING_NOT_FOUND
-        : BOOKING_LOAD_FAILED),
-    };
-  }
-  const reservation = reservationQuery.data;
-  if (!reservation) return { kind: "status", ...BOOKING_NOT_FOUND };
-  if (reservation.status === "cancelled") {
-    return { kind: "status", ...BOOKING_CANCELED };
-  }
-  return { kind: "confirmation", reservation };
-};
+): PublicBookingReservationView =>
+  resolvePublicBookingReservationView(reservationQuery, {
+    loading: BOOKING_LOADING,
+    notFound: BOOKING_NOT_FOUND,
+    loadFailed: BOOKING_LOAD_FAILED,
+    cancelled: BOOKING_CANCELED,
+  });
 
 function cancelUrlFromHistory(state: unknown): string | undefined {
   if (
@@ -120,8 +104,8 @@ export function PublicBookingConfirmedPage() {
 
   const view = resolveConfirmedPageView(reservationQuery);
   const bookingSlug =
-    view.kind === "confirmation" ? view.reservation.bookingSlug : "";
-  const canEdit = view.kind === "confirmation" && token.length > 0;
+    view.kind === "reservation" ? view.reservation.bookingSlug : "";
+  const canEdit = view.kind === "reservation" && token.length > 0;
 
   // Escape returns to the host's public page. OverlayPanel peels first.
   // An open edit form backs out one step. Unknown and cancelled views have

--- a/packages/web/src/booking/public-booking.view.ts
+++ b/packages/web/src/booking/public-booking.view.ts
@@ -1,0 +1,57 @@
+import { type UseQueryResult } from "@tanstack/react-query";
+import { type PublicGetBookingReservationResponse } from "@core/types/booking.contracts";
+import { PublicBookingNotFoundError } from "@web/api/public-booking.api";
+
+/** Title and description handed straight to `PublicBookingStatusMessage`. */
+export interface PublicBookingStatusCopy {
+  title: string;
+  description: string;
+}
+
+/**
+ * What a guest page should render once the reservation query has settled:
+ * either a terminal status message, or the reservation itself.
+ */
+export type PublicBookingReservationView =
+  | ({ kind: "status" } & PublicBookingStatusCopy)
+  | { kind: "reservation"; reservation: PublicGetBookingReservationResponse };
+
+/** The four terminal states every guest page has to spell out for itself. */
+export interface PublicBookingReservationCopy {
+  loading: PublicBookingStatusCopy;
+  notFound: PublicBookingStatusCopy;
+  loadFailed: PublicBookingStatusCopy;
+  cancelled: PublicBookingStatusCopy;
+}
+
+/**
+ * Map a reservation query onto a view. The confirmed and cancel pages differ
+ * only in the copy they show and in the checks they run *before* the query
+ * matters, so the query-to-view mapping itself lives here once: a missing
+ * reservation and a cancelled one must stay indistinguishable from a
+ * not-found link across both pages.
+ */
+export const resolvePublicBookingReservationView = (
+  reservationQuery: UseQueryResult<PublicGetBookingReservationResponse>,
+  copy: PublicBookingReservationCopy,
+): PublicBookingReservationView => {
+  if (reservationQuery.isLoading) {
+    return { kind: "status", ...copy.loading };
+  }
+  if (reservationQuery.isError) {
+    return {
+      kind: "status",
+      ...(reservationQuery.error instanceof PublicBookingNotFoundError
+        ? copy.notFound
+        : copy.loadFailed),
+    };
+  }
+  const reservation = reservationQuery.data;
+  if (!reservation) {
+    return { kind: "status", ...copy.notFound };
+  }
+  if (reservation.status === "cancelled") {
+    return { kind: "status", ...copy.cancelled };
+  }
+  return { kind: "reservation", reservation };
+};


### PR DESCRIPTION
## Summary

`PublicBookingConfirmedPage` and `PublicBookingCancelPage` each carried their own copy of the same query-to-view mapping: loading, not-found vs. load-failed on error, missing data, and `status === "cancelled"` all collapse to a status message, otherwise render the reservation. #3127 aligned the two pages by duplicating that logic, so a change to how a cancelled or missing reservation reads has to be made twice or the two pages drift.

This extracts the mapping into `resolvePublicBookingReservationView` in a new `public-booking.view.ts`. Each page still owns its own copy strings and passes them in; each page keeps its own pre-query checks (the cancel page's `canLoad` guard and its in-page cancel action states) and delegates only the settled-query part.

It also drops the duplicated view types, which reached for the reservation shape via `NonNullable<ReturnType<typeof usePublicBookingReservationQuery>["data"]>` in both files, in favour of the `PublicGetBookingReservationResponse` contract that query actually returns.

Behavior is unchanged: branch order and every user-facing string are identical. The discriminant is now `"reservation"` on both pages instead of `"confirmation"` / `"confirm"`.

## Simplicity

Net removal: ~40 lines of duplicated branching and two hand-rolled view unions replaced by one shared resolver plus two copy tables. The shared piece takes copy as data rather than growing page-specific flags, so neither page gained a parameter it has to reason about.

## Automated validation

- `bun type-check` — pass
- `bun lint` — pass (no new diagnostics on the changed files)
- `bun test:web packages/web/src/booking/` — 176 pass, 0 fail across 16 files

## Independent review

Not run. Refactor is behavior-preserving and covered by the existing booking suite, which exercises both pages' loading, not-found, load-failed, and cancelled branches.

## Test plan

```
bun type-check
bun lint
bun test:web packages/web/src/booking/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgSdvfFCP6fjcnNJFsrmXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgSdvfFCP6fjcnNJFsrmXS)_