### PR TITLE
refactor(booking): fold the repeated guest reservation lookups into helpers

### DIFF
--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -76,6 +76,15 @@ const assertHostAllowsGuestWrites = async (userId: ObjectId): Promise<void> => {
   }
 };
 
+/**
+ * Every guest-facing lookup failure - unknown id, wrong or expired token,
+ * cancelled reservation, missing page - answers with the same 404. Minting it
+ * in one place keeps the code and the message from drifting apart and
+ * accidentally telling a guest which of those it was.
+ */
+const reservationNotFound = () =>
+  bookingError("RESERVATION_NOT_FOUND", "Reservation not found");
+
 const isDuplicateSlotError = (error: unknown): boolean =>
   error instanceof MongoServerError && error.code === 11000;
 
@@ -178,26 +187,74 @@ const durationMinutesForReservation = (
     : pageDurationMinutes;
 };
 
-const toPublicReservation = (
+/**
+ * Load a reservation the guest's token actually authorizes, or 404.
+ *
+ * The cancel and patch entrypoints both stand on exactly this check, so it
+ * lives here once: a token that no longer authorizes must never reach the
+ * calendar calls below it.
+ */
+const loadGuestAuthorizedReservation = async (
+  reservationId: ObjectId,
+  token: string,
+): Promise<BookingReservationRecord> => {
+  const reservation =
+    await bookingReservationRepository.findById(reservationId);
+  if (
+    !reservation ||
+    !guestActionTokenAuthorizes(
+      reservation.cancelTokenHash,
+      token,
+      reservation.slotEnd,
+    )
+  ) {
+    throw reservationNotFound();
+  }
+  return reservation;
+};
+
+const resolveReservationPage = async (
   reservation: BookingReservationRecord,
-  bookingSlug: string,
+): Promise<BookingPageRecord> => {
+  const page = await bookingPageRepository.findById(reservation.pageId);
+  if (!page) {
+    throw reservationNotFound();
+  }
+  return page;
+};
+
+/** As above, but for the reads that have to hand the guest back a slug. */
+const resolveReservationPublicPage = async (
+  reservation: BookingReservationRecord,
+): Promise<BookingPageRecord & { bookingSlug: string }> => {
+  const page = await resolveReservationPage(reservation);
+  if (!page.bookingSlug) {
+    throw reservationNotFound();
+  }
+  return { ...page, bookingSlug: page.bookingSlug };
+};
+
+const presentReservation = async (
+  reservation: BookingReservationRecord,
+  page: BookingPageRecord & { bookingSlug: string },
   hostDisplayName: string,
-  pageDurationMinutes: number,
-  createsGoogleMeet: boolean,
-): PublicGetBookingReservationResponse =>
+): Promise<PublicGetBookingReservationResponse> =>
   PublicGetBookingReservationResponseSchema.parse({
     slotStart: reservation.slotStart.toISOString(),
     guestTimeZone: reservation.guestTimeZone,
     durationMinutes: durationMinutesForReservation(
       reservation,
-      pageDurationMinutes,
+      page.durationMinutes,
     ),
     hostDisplayName,
     status: reservation.status,
-    bookingSlug,
+    bookingSlug: page.bookingSlug,
     guestName: reservation.guestName,
     notes: reservation.notes,
-    createsGoogleMeet,
+    createsGoogleMeet: await destinationCreatesGoogleMeet(
+      page.userId,
+      page.destinationCalendarId,
+    ),
   });
 
 const nextGuestNotes = (
@@ -528,51 +585,29 @@ export class PublicBookingService {
     const reservation =
       await bookingReservationRepository.findById(reservationId);
     if (!reservation) {
-      throw bookingError("RESERVATION_NOT_FOUND", "Reservation not found");
+      throw reservationNotFound();
     }
 
-    const page = await bookingPageRepository.findById(reservation.pageId);
-    if (!page?.bookingSlug) {
-      throw bookingError("RESERVATION_NOT_FOUND", "Reservation not found");
-    }
-
-    const hostDisplayName = await getHostDisplayName(page.userId);
-    const createsGoogleMeet = await destinationCreatesGoogleMeet(
-      page.userId,
-      page.destinationCalendarId,
-    );
-    return toPublicReservation(
+    const page = await resolveReservationPublicPage(reservation);
+    return presentReservation(
       reservation,
-      page.bookingSlug,
-      hostDisplayName,
-      page.durationMinutes,
-      createsGoogleMeet,
+      page,
+      await getHostDisplayName(page.userId),
     );
   }
 
   async patchPublicReservation(reservationId: ObjectId, rawInput: unknown) {
     const input = PatchBookingReservationInputSchema.parse(rawInput);
-    const reservation =
-      await bookingReservationRepository.findById(reservationId);
-    if (
-      !reservation ||
-      !guestActionTokenAuthorizes(
-        reservation.cancelTokenHash,
-        input.token,
-        reservation.slotEnd,
-      )
-    ) {
-      throw bookingError("RESERVATION_NOT_FOUND", "Reservation not found");
-    }
+    const reservation = await loadGuestAuthorizedReservation(
+      reservationId,
+      input.token,
+    );
 
     if (reservation.status === "cancelled") {
-      throw bookingError("RESERVATION_NOT_FOUND", "Reservation not found");
+      throw reservationNotFound();
     }
 
-    const page = await bookingPageRepository.findById(reservation.pageId);
-    if (!page?.bookingSlug) {
-      throw bookingError("RESERVATION_NOT_FOUND", "Reservation not found");
-    }
+    const page = await resolveReservationPublicPage(reservation);
 
     const guestName = input.name ?? reservation.guestName;
     const notes = nextGuestNotes(input.notes, reservation.notes);
@@ -607,20 +642,10 @@ export class PublicBookingService {
       { guestName, notes },
     );
     if (!updated) {
-      throw bookingError("RESERVATION_NOT_FOUND", "Reservation not found");
+      throw reservationNotFound();
     }
 
-    const createsGoogleMeet = await destinationCreatesGoogleMeet(
-      page.userId,
-      page.destinationCalendarId,
-    );
-    return toPublicReservation(
-      updated,
-      page.bookingSlug,
-      hostDisplayName,
-      page.durationMinutes,
-      createsGoogleMeet,
-    );
+    return presentReservation(updated, page, hostDisplayName);
   }
 
   async cancelReservation(
@@ -628,25 +653,11 @@ export class PublicBookingService {
     rawInput: unknown,
   ): Promise<void> {
     const { token } = CancelBookingReservationInputSchema.parse(rawInput);
-    const reservation =
-      await bookingReservationRepository.findById(reservationId);
-    if (
-      !reservation ||
-      !guestActionTokenAuthorizes(
-        reservation.cancelTokenHash,
-        token,
-        reservation.slotEnd,
-      )
-    ) {
-      throw bookingError("RESERVATION_NOT_FOUND", "Reservation not found");
-    }
-
-    const pageRecord = await mongoService.bookingPage.findOne({
-      _id: reservation.pageId,
-    });
-    if (!pageRecord) {
-      throw bookingError("RESERVATION_NOT_FOUND", "Reservation not found");
-    }
+    const reservation = await loadGuestAuthorizedReservation(
+      reservationId,
+      token,
+    );
+    const page = await resolveReservationPage(reservation);
 
     // Cancel local state first so a crash after the provider delete cannot
     // leave a confirmed row occupying the slot. Retry still deletes while
@@ -659,10 +670,9 @@ export class PublicBookingService {
       return;
     }
 
-    await this.calendarBooking.deleteBookingEvent(
-      pageRecord.userId.toString(),
-      { eventId: reservation.calendarEventId as EventId },
-    );
+    await this.calendarBooking.deleteBookingEvent(page.userId.toString(), {
+      eventId: reservation.calendarEventId as EventId,
+    });
     await bookingReservationRepository.clearCalendarEventId(reservationId);
   }
 }


### PR DESCRIPTION
## Summary

`public-booking.service.ts` has picked up four guest entrypoints over the last week (#3282, #3286, #3289, #3290, #3291), and each grew its own copy of the same preamble:

- `bookingError("RESERVATION_NOT_FOUND", "Reservation not found")` was spelled out **seven** times. The vagueness of that message is deliberate (a guest must not learn *which* of unknown-id / wrong-token / expired-token / cancelled / missing-page they hit), and seven copies is seven chances for one of them to drift into being more specific.
- The find-reservation-then-verify-token block was duplicated verbatim between `patchPublicReservation` and `cancelReservation`. That is the one check that must never be skipped, kept in two places.
- `getPublicReservation` and `patchPublicReservation` both ended with the same host-name + `destinationCreatesGoogleMeet` + five-positional-argument `toPublicReservation` sequence.

This PR extracts:

| helper | replaces |
| --- | --- |
| `reservationNotFound()` | 7 inline `bookingError(...)` pairs |
| `loadGuestAuthorizedReservation()` | the duplicated find-and-authorize block in patch and cancel |
| `resolveReservationPage()` / `resolveReservationPublicPage()` | 3 page-load-or-404 blocks (the latter for reads that owe the guest a slug) |
| `presentReservation()` | `toPublicReservation` plus the `destinationCreatesGoogleMeet` call both its callers made |

`presentReservation` also removes a real footgun: `toPublicReservation(reservation, bookingSlug, hostDisplayName, pageDurationMinutes, createsGoogleMeet)` took `bookingSlug` and `hostDisplayName` as adjacent bare strings, so transposing them type-checked cleanly and would have leaked the host's name into the slug field.

### One intentional behavior change

`cancelReservation` reached past the repository into `mongoService.bookingPage.findOne` directly — the only guest path that did. It now uses `bookingPageRepository.findById` like the other three, which parses the document against `BookingPageRecordSchema`. A page document that fails that parse already breaks every other guest route, so this makes cancel consistent rather than uniquely lenient. Cancel keeps its weaker requirement of *not* needing a `bookingSlug`, which is why there are two page resolvers rather than one.

## Simplicity

Behavior-preserving apart from the note above. Branch order, guard conditions, and every message string are unchanged. The service methods lose ~50 lines of preamble; the helpers add ~65 including doc comments, which is the honest trade: the duplication moves into named, documented single definitions instead of being spread across four methods.

## Automated validation

- `bun type-check` — pass
- `bun lint` — pass (0 diagnostics on the changed file)
- `bun test:backend packages/backend/src/booking/` — **could not run in this environment**: `mongodb-memory-server` fails at `server.listen` on `::` before any test body loads (`error: Failed to listen at ::`). That is the sandbox, not this change; it reproduces on tests that touch none of this code. CI runs the suite.

## Independent review

Not run. Every extracted block is a verbatim move; the single semantic change is called out above rather than buried.

## Test plan

```
bun type-check
bun lint
bun test:backend packages/backend/src/booking/   # CI - blocked locally, see above
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgSdvfFCP6fjcnNJFsrmXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgSdvfFCP6fjcnNJFsrmXS)_