### PR TITLE
fix(booking): cap host notice hours and buffer minutes

### DIFF
--- a/.agents/handoffs/3148.md
+++ b/.agents/handoffs/3148.md
@@ -1,0 +1,40 @@
+---
+schema_version: 1
+task_id: "3148"
+from: Reviewer
+to: Manager
+owner: Manager
+status: verifying
+artifact:
+  - path: packages/core/src/types/booking.contracts.ts
+  - path: packages/web/src/booking/BookingSettingsSection.tsx
+  - path: packages/backend/src/booking/booking-page.record.ts
+evidence:
+  - command: bun test:core -- packages/core/src/types/booking.contracts.test.ts
+    result: "37 pass, 0 fail (caps accepted; values above rejected)"
+    log: null
+  - command: bun test:backend -- packages/backend/src/booking/services/booking-page.service.db.test.ts
+    result: "13 pass, 0 fail (out-of-range PUT does not persist)"
+    log: null
+  - command: bun test:web -- packages/web/src/booking/BookingSettingsSection.test.tsx
+    result: "34 pass, 0 fail (1441 hours shows Enter 0 to 1440 hours and blocks save)"
+    log: null
+assumptions:
+  - "Buffer stays a 30-minute checkbox in Settings; the API still rejects bufferMinutes above 1440."
+open_risks: []
+next_deadline: 2026-09-04T20:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-20: cap `minNoticeHours` at 1440 (60-day horizon in hours) and `bufferMinutes` at 1440 (one working day). Settings shows the notice limit inline.
+
+Simplify: no further production change.
+
+Review: no confirmed findings.
+
+VERDICT: no confirmed findings
+FINDINGS:
+(none)

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -179,7 +179,7 @@ One booking-page record per user.
 | Blocking calendars | Calendars whose busy intervals occupy slots. Any calendar the host can read availability for, including `freeBusyReader`. Default: every imported calendar on the destination account. |
 | General availability | Weekly intervals in the **host booking timezone**. Empty weekday = unavailable. Default timezone: the timezone currently in the host's calendar view when they first enable booking. |
 | Welcome text | Optional host-authored line (max 500 characters) shown under the public name. |
-| Scheduling window | Minimum notice default **4 hours**. Maximum horizon default **60 days**. The 60-day cap matches Sync's busy-query bound (`BUSY_QUERY_MAX_WINDOW_MS` in `packages/core/src/types/sync/availability.contracts.ts`). |
+| Scheduling window | Minimum notice default **4 hours**, capped at **1440 hours** (the 60-day horizon in hours). Maximum horizon default **60 days**. Buffer default off, capped at **1440 minutes** (one working day). The 60-day cap matches Sync's busy-query bound (`BUSY_QUERY_MAX_WINDOW_MS` in `packages/core/src/types/sync/availability.contracts.ts`). |
 | Buffer | Off by default. When on, **30 minutes between appointments**, applied to both sides of a booked slot so two meetings cannot sit adjacent. |
 | Max bookings per day | Off by default. When on, default **4**. Counts confirmed booking reservations that day in the host timezone, not every calendar event. |
 | Guest permissions | Maps to Google `guestsCanInviteOthers`. Default **on**. This is not Compass UI. `guestsCanModify` stays off. |

--- a/packages/backend/src/booking/booking-page.record.ts
+++ b/packages/backend/src/booking/booking-page.record.ts
@@ -1,5 +1,7 @@
 import { z } from "zod/v4";
 import {
+  BOOKING_MAX_HORIZON_DAYS,
+  BOOKING_MAX_MIN_NOTICE_HOURS,
   BookingBufferMinutesSchema,
   BookingDurationMinutesSchema,
   BookingMaxBookingsPerDaySchema,
@@ -29,8 +31,12 @@ export const BookingPageRecordSchema = z.object({
   timeZone: TimeZoneSchema,
   weeklyAvailability: WeeklyAvailabilitySchema,
   welcomeText: BookingWelcomeTextSchema.nullable().default(null),
-  minNoticeHours: z.number().int().nonnegative(),
-  maxHorizonDays: z.number().int().positive().max(60),
+  minNoticeHours: z
+    .number()
+    .int()
+    .nonnegative()
+    .max(BOOKING_MAX_MIN_NOTICE_HOURS),
+  maxHorizonDays: z.number().int().positive().max(BOOKING_MAX_HORIZON_DAYS),
   bufferMinutes: BookingBufferMinutesSchema,
   maxBookingsPerDay: BookingMaxBookingsPerDaySchema,
   guestsCanInviteOthers: z.boolean(),

--- a/packages/backend/src/booking/services/booking-page.service.db.test.ts
+++ b/packages/backend/src/booking/services/booking-page.service.db.test.ts
@@ -1,6 +1,11 @@
 import { ObjectId } from "mongodb";
+import { ZodError } from "zod/v4";
 import { Status } from "@core/errors/status.codes";
-import { AdminPutBookingPageInputSchema } from "@core/types/booking.contracts";
+import {
+  AdminPutBookingPageInputSchema,
+  BOOKING_MAX_BUFFER_MINUTES,
+  BOOKING_MAX_MIN_NOTICE_HOURS,
+} from "@core/types/booking.contracts";
 import { BaseDriver } from "@backend/__tests__/drivers/base.driver";
 import { UserDriver } from "@backend/__tests__/drivers/user.driver";
 import { UtilDriver } from "@backend/__tests__/drivers/util.driver";
@@ -221,6 +226,38 @@ describe("BookingPageService", () => {
     expect(page).toEqual(
       expect.objectContaining({
         welcomeText: "30 minutes to talk through Compass Calendar.",
+      }),
+    );
+  });
+
+  it("rejects a PUT with out-of-range notice or buffer and does not persist", async () => {
+    const userId = await createNamedUser("Bound Host");
+    const calendar = writableCalendar();
+    mockHealthySync([calendar]);
+    const input = samplePutInput({
+      destinationCalendarId: calendar.id,
+      blockingCalendarIds: [calendar.id],
+    });
+    await bookingPageService.putAdminPage(userId, input);
+
+    await expect(
+      bookingPageService.putAdminPage(userId, {
+        ...input,
+        minNoticeHours: BOOKING_MAX_MIN_NOTICE_HOURS + 1,
+      }),
+    ).rejects.toBeInstanceOf(ZodError);
+    await expect(
+      bookingPageService.putAdminPage(userId, {
+        ...input,
+        bufferMinutes: BOOKING_MAX_BUFFER_MINUTES + 1,
+      }),
+    ).rejects.toBeInstanceOf(ZodError);
+
+    const page = await bookingPageService.getAdminPage(userId);
+    expect(page).toEqual(
+      expect.objectContaining({
+        minNoticeHours: 4,
+        bufferMinutes: null,
       }),
     );
   });

--- a/packages/core/src/types/booking.contracts.test.ts
+++ b/packages/core/src/types/booking.contracts.test.ts
@@ -3,6 +3,8 @@ import {
   AdminGetBookingPageResponseSchema,
   AdminPutBookingPageInputSchema,
   allocateBookingSlug,
+  BOOKING_MAX_BUFFER_MINUTES,
+  BOOKING_MAX_MIN_NOTICE_HOURS,
   BookingPageSchema,
   BookingReservationSlotsQuerySchema,
   BookingSlugSchema,
@@ -94,6 +96,47 @@ describe("BookingPageSchema", () => {
       BookingPageSchema.safeParse({
         ...fullAdminPage(),
         maxHorizonDays: 61,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("accepts minNoticeHours and bufferMinutes at their caps and rejects above", () => {
+    const base = {
+      enabled: true,
+      durationMinutes: 30,
+      destinationCalendarId: calendarId(),
+      blockingCalendarIds: [calendarId()],
+      timeZone: "UTC",
+      weeklyAvailability: [{ weekday: 1, start: "09:00", end: "17:00" }],
+      minNoticeHours: 4,
+      maxHorizonDays: 60,
+      bufferMinutes: null as number | null,
+      maxBookingsPerDay: null,
+      guestsCanInviteOthers: true,
+    };
+
+    expect(
+      AdminPutBookingPageInputSchema.safeParse({
+        ...base,
+        minNoticeHours: BOOKING_MAX_MIN_NOTICE_HOURS,
+      }).success,
+    ).toBe(true);
+    expect(
+      AdminPutBookingPageInputSchema.safeParse({
+        ...base,
+        minNoticeHours: BOOKING_MAX_MIN_NOTICE_HOURS + 1,
+      }).success,
+    ).toBe(false);
+    expect(
+      AdminPutBookingPageInputSchema.safeParse({
+        ...base,
+        bufferMinutes: BOOKING_MAX_BUFFER_MINUTES,
+      }).success,
+    ).toBe(true);
+    expect(
+      AdminPutBookingPageInputSchema.safeParse({
+        ...base,
+        bufferMinutes: BOOKING_MAX_BUFFER_MINUTES + 1,
       }).success,
     ).toBe(false);
   });

--- a/packages/core/src/types/booking.contracts.ts
+++ b/packages/core/src/types/booking.contracts.ts
@@ -29,6 +29,12 @@ export const BOOKING_RESERVED_SLUGS = [
 
 export type BookingReservedSlug = (typeof BOOKING_RESERVED_SLUGS)[number];
 
+export const BOOKING_MAX_HORIZON_DAYS = 60;
+/** Hours in the longest bookable horizon; notice beyond this can never yield a slot. */
+export const BOOKING_MAX_MIN_NOTICE_HOURS = BOOKING_MAX_HORIZON_DAYS * 24;
+/** A buffer longer than a working day is not a buffer. */
+export const BOOKING_MAX_BUFFER_MINUTES = 24 * 60;
+
 export const BookingPageIdSchema =
   ObjectIdStringSchema.brand<"BookingPageId">();
 export type BookingPageId = z.infer<typeof BookingPageIdSchema>;
@@ -157,6 +163,7 @@ export type BookingWelcomeText = z.infer<typeof BookingWelcomeTextSchema>;
 export const BookingBufferMinutesSchema = z
   .int()
   .positive()
+  .max(BOOKING_MAX_BUFFER_MINUTES)
   .nullable()
   .default(null);
 export type BookingBufferMinutes = z.infer<typeof BookingBufferMinutesSchema>;
@@ -181,8 +188,18 @@ export const BookingPageSchema = z.strictObject({
   timeZone: TimeZoneSchema,
   weeklyAvailability: WeeklyAvailabilitySchema,
   welcomeText: BookingWelcomeTextSchema.nullable().default(null),
-  minNoticeHours: z.number().int().nonnegative().default(4),
-  maxHorizonDays: z.number().int().positive().max(60).default(60),
+  minNoticeHours: z
+    .number()
+    .int()
+    .nonnegative()
+    .max(BOOKING_MAX_MIN_NOTICE_HOURS)
+    .default(4),
+  maxHorizonDays: z
+    .number()
+    .int()
+    .positive()
+    .max(BOOKING_MAX_HORIZON_DAYS)
+    .default(BOOKING_MAX_HORIZON_DAYS),
   bufferMinutes: BookingBufferMinutesSchema,
   maxBookingsPerDay: BookingMaxBookingsPerDaySchema,
   guestsCanInviteOthers: z.boolean().default(true),
@@ -196,7 +213,7 @@ export const PublicBookingPageSchema = z.strictObject({
   durationMinutes: BookingDurationMinutesSchema,
   timeZone: TimeZoneSchema,
   enabled: z.boolean(),
-  maxHorizonDays: z.number().int().positive().max(60),
+  maxHorizonDays: z.number().int().positive().max(BOOKING_MAX_HORIZON_DAYS),
   welcomeText: BookingWelcomeTextSchema.nullable().default(null),
   createsGoogleMeet: z.boolean().default(true),
 });
@@ -368,8 +385,18 @@ export const AdminPutBookingPageInputSchema = z.strictObject({
   timeZone: TimeZoneSchema,
   weeklyAvailability: WeeklyAvailabilitySchema,
   welcomeText: BookingWelcomeTextSchema.nullable().default(null),
-  minNoticeHours: z.number().int().nonnegative().default(4),
-  maxHorizonDays: z.number().int().positive().max(60).default(60),
+  minNoticeHours: z
+    .number()
+    .int()
+    .nonnegative()
+    .max(BOOKING_MAX_MIN_NOTICE_HOURS)
+    .default(4),
+  maxHorizonDays: z
+    .number()
+    .int()
+    .positive()
+    .max(BOOKING_MAX_HORIZON_DAYS)
+    .default(BOOKING_MAX_HORIZON_DAYS),
   bufferMinutes: BookingBufferMinutesSchema,
   maxBookingsPerDay: BookingMaxBookingsPerDaySchema,
   guestsCanInviteOthers: z.boolean().default(true),

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -1277,6 +1277,60 @@ describe("BookingSettingsSection", () => {
       expect(savedBody).toMatchObject({ maxHorizonDays: 30 });
     });
   });
+
+  it("shows an inline error for out-of-range notice and blocks save", async () => {
+    const user = userEvent.setup({ delay: null });
+    let savedBody: unknown;
+
+    userMetadataActions.set(healthyGoogleMetadata);
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+      rest.put(bookingPageUrl, async (req, res, ctx) => {
+        savedBody = await req.json();
+        return res(ctx.json({ ...(savedBody as object), isConfigured: true }));
+      }),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    const notice = await screen.findByLabelText("Minimum notice (hours)");
+    await user.clear(notice);
+    await user.type(notice, "1441");
+
+    expect(screen.getByText("Enter 0 to 1440 hours.")).toBeInTheDocument();
+    expect(notice).toHaveAttribute("aria-invalid", "true");
+
+    await user.click(
+      screen.getByRole("button", { name: "Save booking settings" }),
+    );
+    expect(
+      screen.getByText("Fix the highlighted number fields before saving."),
+    ).toBeInTheDocument();
+    expect(savedBody).toBeUndefined();
+
+    await user.clear(notice);
+    await user.type(notice, "4");
+    expect(
+      screen.queryByText("Enter 0 to 1440 hours."),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Save booking settings" }),
+    );
+    await waitFor(() => {
+      expect(savedBody).toMatchObject({ minNoticeHours: 4 });
+    });
+  });
 });
 
 describe("BOOKING_SEQUENCE_FIELDS", () => {

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -9,6 +9,8 @@ import {
   type AdminGetBookingPageResponse,
   type AdminGetBookingPageResult,
   type AdminPutBookingPageInput,
+  BOOKING_MAX_HORIZON_DAYS,
+  BOOKING_MAX_MIN_NOTICE_HOURS,
   type BookingDurationMinutes,
 } from "@core/types/booking.contracts";
 import { type Calendar } from "@core/types/calendar.contracts";
@@ -126,10 +128,9 @@ const parseBookingCount = (
   return value;
 };
 
-// Bounds mirror AdminPutBookingPageInputSchema (nonnegative notice; 1-60 day
-// horizon). Notice has no schema max, so any nonnegative integer parses.
-const MIN_NOTICE_BOUNDS = { min: 0, max: Number.MAX_SAFE_INTEGER };
-const HORIZON_BOUNDS = { min: 1, max: 60 };
+// Bounds mirror AdminPutBookingPageInputSchema.
+const MIN_NOTICE_BOUNDS = { min: 0, max: BOOKING_MAX_MIN_NOTICE_HOURS };
+const HORIZON_BOUNDS = { min: 1, max: BOOKING_MAX_HORIZON_DAYS };
 
 const buildInitialForm = (
   page: AdminGetBookingPageResult | undefined,
@@ -653,8 +654,9 @@ export function BookingSettingsSection({
             field="notice"
             id="booking-min-notice"
             invalid={minNoticeInvalid}
-            invalidMessage="Enter 0 or more hours."
+            invalidMessage={`Enter 0 to ${BOOKING_MAX_MIN_NOTICE_HOURS} hours.`}
             label="Minimum notice (hours)"
+            max={BOOKING_MAX_MIN_NOTICE_HOURS}
             min={0}
             onChange={(raw) => {
               setMinNoticeText(raw);
@@ -670,9 +672,9 @@ export function BookingSettingsSection({
             field="horizon"
             id="booking-max-horizon"
             invalid={horizonInvalid}
-            invalidMessage="Enter 1 to 60 days."
+            invalidMessage={`Enter 1 to ${BOOKING_MAX_HORIZON_DAYS} days.`}
             label="Maximum horizon (days)"
-            max={60}
+            max={BOOKING_MAX_HORIZON_DAYS}
             min={1}
             onChange={(raw) => {
               setHorizonText(raw);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3148

## Summary

Caps host booking notice and buffer so Settings cannot store unbounded numbers.

- `minNoticeHours` max is 1440 (60-day horizon in hours)
- `bufferMinutes` max is 1440 (one working day)
- Settings notice field uses those bounds and shows `Enter 0 to 1440 hours.`
- Buffer stays a 30-minute checkbox; the API still rejects `bufferMinutes` above 1440
- Defaults stay `minNoticeHours: 4` and `bufferMinutes: null`

## Simplicity

Reuse the existing schema fields and the notice input already in Settings. Do not add a numeric buffer editor.

## Automated validation

- Core schema: values at the caps parse; 1441 hours and 1441 minutes fail
- Backend PUT: out-of-range notice/buffer does not persist
- Settings: 1441 hours shows the inline bound copy and blocks save

## Independent review

`.agents/handoffs/3148.md`

VERDICT: no confirmed findings
FINDINGS:
(none)

## Test plan

- `bun test:core -- packages/core/src/types/booking.contracts.test.ts` — 37 pass, 0 fail
- `bun test:backend -- packages/backend/src/booking/services/booking-page.service.db.test.ts` — 13 pass, 0 fail
- `bun test:web -- packages/web/src/booking/BookingSettingsSection.test.tsx` — 34 pass, 0 fail
- `bun run type-check` — pass
- `bun lint` — no new errors (pre-existing warnings only)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec67721b-395d-454e-bd11-696669d367b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec67721b-395d-454e-bd11-696669d367b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

