### PR TITLE
fix(booking): default host timezone from calendar not UTC

### DIFF
--- a/.agents/handoffs/3149.md
+++ b/.agents/handoffs/3149.md
@@ -1,0 +1,47 @@
+---
+schema_version: 1
+task_id: "3149"
+from: Reviewer
+to: Manager
+owner: Manager
+status: verifying
+artifact:
+  - path: packages/backend/src/booking/services/booking-page.service.ts
+  - path: packages/backend/src/booking/booking-page.mapper.ts
+  - path: packages/web/src/booking/BookingSettingsSection.tsx
+evidence:
+  - command: bun test:backend
+    result: "580 pass, 1 skip, 0 fail"
+    log: null
+  - command: bun test:web
+    result: "733 pass, 0 fail"
+    log: null
+  - command: bun test:backend -- packages/backend/src/booking/services/booking-page.service.db.test.ts
+    result: "17 pass, 0 fail (GET uses host calendar TZ; stored UTC kept; unset enable rejected; explicit UTC enables)"
+    log: null
+  - command: bun test:web -- packages/web/src/booking/BookingSettingsSection.test.tsx
+    result: "34 pass, 0 fail (fresh page shows host calendar-view zone; stored UTC kept)"
+    log: null
+  - command: bun run type-check
+    result: pass
+    log: null
+assumptions:
+  - "Host timezone on an unconfigured GET comes from the primary calendar record, then any other calendar with a zone, then UTC only if none exist."
+  - "Settings still seeds unconfigured pages from getEffectiveTimeZone so the default matches the calendar view."
+open_risks: []
+next_deadline: 2026-09-04T20:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-21: booking timezone must not default to UTC.
+
+Simplify: no further production change.
+
+Review: no confirmed findings.
+
+VERDICT: no confirmed findings
+FINDINGS:
+(none)

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -177,7 +177,7 @@ One booking-page record per user.
 | Duration | `15` / `30` / `45` / `60` minutes. Default `30`. Custom minutes later. |
 | Destination calendar | Writable Google calendar (`canWrite`). Receives the created event. |
 | Blocking calendars | Calendars whose busy intervals occupy slots. Any calendar the host can read availability for, including `freeBusyReader`. Default: every imported calendar on the destination account. |
-| General availability | Weekly intervals in the **host booking timezone**. Empty weekday = unavailable. Default timezone: the timezone currently in the host's calendar view when they first enable booking. |
+| General availability | Weekly intervals in the **host booking timezone**. Empty weekday = unavailable. Default timezone: the timezone currently in the host's calendar view when they first enable booking, not UTC. An unconfigured admin GET uses the host's primary calendar timezone. |
 | Welcome text | Optional host-authored line (max 500 characters) shown under the public name. |
 | Scheduling window | Minimum notice default **4 hours**, capped at **1440 hours** (the 60-day horizon in hours). Maximum horizon default **60 days**. Buffer default off, capped at **1440 minutes** (one working day). The 60-day cap matches Sync's busy-query bound (`BUSY_QUERY_MAX_WINDOW_MS` in `packages/core/src/types/sync/availability.contracts.ts`). |
 | Buffer | Off by default. When on, **30 minutes between appointments**, applied to both sides of a booked slot so two meetings cannot sit adjacent. |

--- a/packages/backend/src/booking/booking-page.mapper.ts
+++ b/packages/backend/src/booking/booking-page.mapper.ts
@@ -6,10 +6,7 @@ import {
   BookingPageSchema,
   pickAdminPutBookingPageInput,
 } from "@core/types/booking.contracts";
-import {
-  CalendarIdSchema,
-  TimeZoneSchema,
-} from "@core/types/domain-primitives";
+import { CalendarIdSchema, type TimeZone } from "@core/types/domain-primitives";
 import { type BookingPageRecord } from "@backend/booking/booking-page.record";
 import { CONFIG } from "@backend/common/constants/config.constants";
 
@@ -49,7 +46,7 @@ export const mapBookingPageRecordToAdminResponse = (
 /**
  * A record that was saved but never enabled has no slug and no public URL.
  * isConfigured: true tells the client the host's stored timezone is a real
- * choice that must not be re-seeded from the browser.
+ * choice that must not be re-seeded from the calendar view.
  */
 export const mapBookingPageRecordToSetupResponse = (
   record: Pick<
@@ -83,12 +80,14 @@ const PLACEHOLDER_CALENDAR_ID = CalendarIdSchema.parse(
   "000000000000000000000001",
 );
 
-export const buildDefaultAdminPutInput = (): AdminPutBookingPageInput => ({
+export const buildDefaultAdminPutInput = (
+  timeZone: TimeZone,
+): AdminPutBookingPageInput => ({
   enabled: false,
   durationMinutes: 30,
   destinationCalendarId: PLACEHOLDER_CALENDAR_ID,
   blockingCalendarIds: [PLACEHOLDER_CALENDAR_ID],
-  timeZone: TimeZoneSchema.parse("UTC"),
+  timeZone,
   weeklyAvailability: [],
   welcomeText: null,
   minNoticeHours: 4,

--- a/packages/backend/src/booking/booking.error.ts
+++ b/packages/backend/src/booking/booking.error.ts
@@ -8,6 +8,7 @@ const logger = Logger("app:booking.error");
 export const BookingErrorCodeSchema = z.enum([
   "GOOGLE_NOT_CONNECTED",
   "DESTINATION_NOT_WRITABLE",
+  "TIMEZONE_REQUIRED",
   "BLOCKING_CALENDAR_INVALID",
   "INVALID_INPUT",
   "BILLING_REQUIRED",
@@ -21,6 +22,7 @@ export type BookingErrorCode = z.infer<typeof BookingErrorCodeSchema>;
 const STATUS_BY_CODE: Record<BookingErrorCode, Status> = {
   GOOGLE_NOT_CONNECTED: Status.FORBIDDEN,
   DESTINATION_NOT_WRITABLE: Status.FORBIDDEN,
+  TIMEZONE_REQUIRED: Status.BAD_REQUEST,
   BLOCKING_CALENDAR_INVALID: Status.BAD_REQUEST,
   INVALID_INPUT: Status.BAD_REQUEST,
   BILLING_REQUIRED: Status.FORBIDDEN,

--- a/packages/backend/src/booking/services/booking-page.service.db.test.ts
+++ b/packages/backend/src/booking/services/booking-page.service.db.test.ts
@@ -9,6 +9,7 @@ import {
 import { BaseDriver } from "@backend/__tests__/drivers/base.driver";
 import { UserDriver } from "@backend/__tests__/drivers/user.driver";
 import { UtilDriver } from "@backend/__tests__/drivers/util.driver";
+import { seedGoogleCalendar } from "@backend/__tests__/helpers/event-propagation.test-helpers";
 import {
   cleanupCollections,
   cleanupTestDb,
@@ -146,11 +147,43 @@ describe("BookingPageService", () => {
         enabled: false,
         durationMinutes: 30,
         weeklyAvailability: [],
-        // Nothing saved, so the timeZone is a placeholder the client replaces.
         isConfigured: false,
       }),
     );
     expect(await bookingPageRepository.findByUserId(user._id)).toBeNull();
+  });
+
+  it("returns the host calendar timezone on GET before any PUT, not UTC", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    await seedGoogleCalendar(user._id, { timeZone: "America/Chicago" });
+
+    const page = await bookingPageService.getAdminPage(user._id);
+
+    expect(page).toEqual(
+      expect.objectContaining({
+        timeZone: "America/Chicago",
+        isConfigured: false,
+      }),
+    );
+    expect(page.timeZone).not.toBe("UTC");
+  });
+
+  it("returns a stored UTC timezone unchanged", async () => {
+    const userId = await createNamedUser("Utc Host");
+
+    await bookingPageService.putAdminPage(
+      userId,
+      samplePutInput({ enabled: false, timeZone: "UTC" }),
+    );
+
+    const page = await bookingPageService.getAdminPage(userId);
+
+    expect(page).toEqual(
+      expect.objectContaining({
+        isConfigured: true,
+        timeZone: "UTC",
+      }),
+    );
   });
 
   it("reports a saved-but-never-enabled page as configured", async () => {
@@ -391,6 +424,42 @@ describe("BookingPageService", () => {
     ).rejects.toMatchObject({
       bookingCode: "BLOCKING_CALENDAR_INVALID",
     });
+  });
+
+  it("rejects enable when timezone is unset", async () => {
+    const userId = await createNamedUser("No Zone");
+    const calendar = writableCalendar();
+    mockHealthySync([calendar]);
+    const { timeZone: _unused, ...withoutTimeZone } = samplePutInput({
+      destinationCalendarId: calendar.id,
+      blockingCalendarIds: [calendar.id],
+    });
+
+    await expect(
+      bookingPageService.putAdminPage(userId, withoutTimeZone),
+    ).rejects.toMatchObject({
+      bookingCode: "TIMEZONE_REQUIRED",
+    });
+  });
+
+  it("enables when timezone is explicit, including UTC", async () => {
+    const userId = await createNamedUser("Explicit Zone");
+    const calendar = writableCalendar();
+    mockHealthySync([calendar]);
+    const input = samplePutInput({
+      destinationCalendarId: calendar.id,
+      blockingCalendarIds: [calendar.id],
+      timeZone: "UTC",
+    });
+
+    const page = await bookingPageService.putAdminPage(userId, input);
+
+    expect(page).toEqual(
+      expect.objectContaining({
+        enabled: true,
+        timeZone: "UTC",
+      }),
+    );
   });
 });
 

--- a/packages/backend/src/booking/services/booking-page.service.ts
+++ b/packages/backend/src/booking/services/booking-page.service.ts
@@ -5,6 +5,7 @@ import {
   AdminPutBookingPageInputSchema,
   allocateBookingSlug,
 } from "@core/types/booking.contracts";
+import { type TimeZone, TimeZoneSchema } from "@core/types/domain-primitives";
 import { type ProviderCalendar } from "@core/types/sync/connection.contracts";
 import { assertBillingAllowsWrites } from "@backend/billing/billing.guard";
 import { bookingError } from "@backend/booking/booking.error";
@@ -23,8 +24,39 @@ import { throwSyncProxyFailure } from "@backend/common/services/sync-service/syn
 import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
 
 const SLUG_ALLOCATION_MAX_ATTEMPTS = 8;
+const FALLBACK_HOST_TIME_ZONE = TimeZoneSchema.parse("UTC");
 
 const emailLocalPart = (email: string): string => email.split("@")[0] ?? email;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const resolveHostTimeZone = async (userId: ObjectId): Promise<TimeZone> => {
+  const calendars = await calendarService.list(userId);
+  const ranked = [
+    ...calendars.filter((calendar) => calendar.isPrimary),
+    ...calendars.filter((calendar) => !calendar.isPrimary),
+  ];
+  for (const calendar of ranked) {
+    if (calendar.timeZone) {
+      return TimeZoneSchema.parse(calendar.timeZone);
+    }
+  }
+  return FALLBACK_HOST_TIME_ZONE;
+};
+
+const assertTimeZoneForEnable = (rawInput: unknown): void => {
+  if (!isRecord(rawInput) || rawInput["enabled"] !== true) {
+    return;
+  }
+  const timeZone = rawInput["timeZone"];
+  if (typeof timeZone !== "string" || timeZone.trim() === "") {
+    throw bookingError(
+      "TIMEZONE_REQUIRED",
+      "Choose a booking timezone before enabling",
+    );
+  }
+};
 
 const assertHealthyGoogleForEnable = async (userId: string): Promise<void> => {
   const client = getSyncServiceClient();
@@ -119,9 +151,8 @@ class BookingPageService {
   async getAdminPage(userId: ObjectId): Promise<AdminGetBookingPageResult> {
     const record = await bookingPageRepository.findByUserId(userId);
     if (!record) {
-      // Nothing saved yet, so the timeZone below is only a placeholder - the
-      // client seeds the real one off isConfigured: false.
-      return { ...buildDefaultAdminPutInput(), isConfigured: false };
+      const timeZone = await resolveHostTimeZone(userId);
+      return { ...buildDefaultAdminPutInput(timeZone), isConfigured: false };
     }
 
     if (!record.bookingSlug) {
@@ -138,6 +169,7 @@ class BookingPageService {
     userId: ObjectId,
     rawInput: unknown,
   ): Promise<AdminGetBookingPageResult> {
+    assertTimeZoneForEnable(rawInput);
     const input = AdminPutBookingPageInputSchema.parse(rawInput);
 
     if (input.enabled) {

--- a/packages/core/src/types/booking.contracts.ts
+++ b/packages/core/src/types/booking.contracts.ts
@@ -446,8 +446,9 @@ export function pickAdminPutBookingPageInput(source: {
  * saved but never enabled (so no slug was allocated). `isConfigured` tells
  * those two apart, which the wire otherwise could not - both came back as a
  * bare input object. The client needs the distinction to know whether it may
- * seed the timezone from the browser: the server has no user timezone and can
- * only fill in a placeholder.
+ * seed the timezone from the calendar view: an unconfigured GET already
+ * returns the host calendar timezone, and the client must not overwrite a
+ * stored choice (including UTC) once isConfigured is true.
  */
 export const AdminGetBookingPageSetupResponseSchema =
   AdminPutBookingPageInputSchema.extend({ isConfigured: z.boolean() });

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -438,7 +438,8 @@ describe("BookingSettingsSection", () => {
             durationMinutes: 30,
             destinationCalendarId: writableCalendar.id,
             blockingCalendarIds: [writableCalendar.id],
-            // The server placeholder: it has no user timezone to offer.
+            // Fallback when the host has no calendar timezone yet. Settings
+            // still seeds the calendar-view zone for an unconfigured page.
             timeZone: "UTC",
             weeklyAvailability: [],
             minNoticeHours: 4,

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -170,9 +170,9 @@ const buildInitialForm = (
           availabilityCalendars,
         );
 
-  // The server has no user timezone, so an unconfigured page carries a "UTC"
-  // placeholder. Seed the browser's zone there, but leave a configured page's
-  // stored zone alone - a host who deliberately picked UTC must keep it.
+  // Unconfigured pages seed from the calendar-view zone (the same
+  // default-timezone the rest of the app uses). A configured page's stored
+  // zone stays, including UTC.
   const timeZone =
     page && !isUnconfiguredBookingPage(page)
       ? base.timeZone

--- a/packages/web/src/booking/booking.query.ts
+++ b/packages/web/src/booking/booking.query.ts
@@ -40,6 +40,7 @@ const BOOKING_SAVE_ERROR_COPY: Record<string, string> = {
     "One of your blocking calendars can't be checked for busy times. Uncheck it and save again.",
   DESTINATION_NOT_WRITABLE:
     "The destination calendar can't accept new events. Choose a different calendar and save again.",
+  TIMEZONE_REQUIRED: "Choose a booking timezone before enabling booking.",
   INVALID_INPUT:
     "Some settings couldn't be saved. Check the highlighted fields and try again.",
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3149

## Summary

Stop defaulting an unconfigured booking page to UTC.

- Admin GET with no saved page returns the host's primary calendar timezone
- Enabling without a timezone is rejected (`TIMEZONE_REQUIRED`)
- Enabling with an explicit timezone, including UTC, succeeds
- A page already stored as UTC is returned as UTC
- Settings still seeds a fresh page from the calendar-view zone (`getEffectiveTimeZone`)

## Simplicity

Reuse the calendar record timezone the rest of the app already stores. Do not add a third timezone source.

## Automated validation

- Backend GET for a host with a Chicago primary calendar returns `America/Chicago`, not UTC
- Backend enable without `timeZone` is `TIMEZONE_REQUIRED`
- Backend enable with explicit UTC succeeds; stored UTC GET stays UTC
- Settings RTL: a fresh page shows the host calendar-view zone; a configured UTC page stays UTC

## Independent review

`.agents/handoffs/3149.md`

VERDICT: no confirmed findings
FINDINGS:
(none)

## Test plan

- `bun test:backend -- packages/backend/src/booking/services/booking-page.service.db.test.ts` — 17 pass, 0 fail
- `bun test:web -- packages/web/src/booking/BookingSettingsSection.test.tsx` — 34 pass, 0 fail
- `bun test:backend` — 580 pass, 1 skip, 0 fail
- `bun test:web` — 733 pass, 0 fail
- `bun run type-check` — pass
- `bun lint` — no new errors (pre-existing warnings only)
- `bun knip` — pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec67721b-395d-454e-bd11-696669d367b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec67721b-395d-454e-bd11-696669d367b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

