### PR TITLE
fix(booking): pin slots availability to host timezone

### DIFF
--- a/.agents/handoffs/3150.md
+++ b/.agents/handoffs/3150.md
@@ -1,0 +1,40 @@
+---
+schema_version: 1
+task_id: "3150"
+from: Reviewer
+to: Manager
+owner: Manager
+status: verifying
+artifact:
+  - path: packages/backend/src/booking/services/public-booking.service.ts
+  - path: packages/backend/src/booking/services/public-booking.service.db.test.ts
+  - path: docs/features/booking.md
+evidence:
+  - command: bun test:backend -- packages/backend/src/booking/services/public-booking.service.db.test.ts
+    result: "48 pass, 0 fail (UTC vs Asia/Tokyo slot sets equal)"
+    log: null
+  - command: bun test:backend
+    result: "581 pass, 0 fail"
+    log: null
+  - command: bun run type-check
+    result: pass
+    log: null
+assumptions:
+  - "Kept the required timeZone query param. Availability stays on page.timeZone."
+open_risks: []
+next_deadline: 2026-09-04T20:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-22: keep slots `timeZone` and pin that it does not change availability.
+
+Simplify: no further production change.
+
+Review: no confirmed findings.
+
+VERDICT: no confirmed findings
+FINDINGS:
+(none)

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -328,10 +328,11 @@ Unauthenticated:
   `This page is not accepting bookings.` (no billing, plan, or payment
   wording).
 - `GET /api/booking/pages/:slug/slots?start=&end=&timeZone=` — bookable
-  instants in the guest timezone for that window. The guest UI requests
-  **one month at a time** (plus prefetch of adjacent months). Window
-  must be within the 60-day horizon. A host who cannot write is
-  `{ slots: [], bookable: false }`.
+  instants for that window, computed in the **host** timezone. `timeZone`
+  is required (guest rendering and logs) and does not change the slot
+  set. The guest UI requests **one month at a time** (plus prefetch of
+  adjacent months). Window must be within the 60-day horizon. A host who
+  cannot write is `{ slots: [], bookable: false }`.
 - `POST /api/booking/pages/:slug/reservations` — `{slotStart, guestName,
   guestEmail, notes?, guestTimeZone}`. Re-checks billing and busy, then
   creates. A host who cannot write is the same `409` as GET page and

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -826,6 +826,27 @@ describe("PublicBookingService", () => {
     expect(response.slots.map((slot) => slot.slotStart)).not.toContain(booked);
   });
 
+  it("returns the same slot set for two different guest timeZone values", async () => {
+    const { slug } = await enableBookingPage();
+    const window = {
+      start: "2026-09-07T00:00:00.000Z",
+      end: "2026-09-08T00:00:00.000Z",
+    };
+
+    const utc = await service.getSlots(slug, {
+      ...window,
+      timeZone: "UTC",
+    });
+    const tokyo = await service.getSlots(slug, {
+      ...window,
+      timeZone: "Asia/Tokyo",
+    });
+
+    expect(utc.bookable).toBe(true);
+    expect(utc.slots.length).toBeGreaterThan(0);
+    expect(tokyo).toEqual(utc);
+  });
+
   it("does not fetch a confirmed reservation far outside the requested window", async () => {
     const { slug, pageId } = await enableBookingPage();
     await seedConfirmedReservation(

--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -355,6 +355,8 @@ export class PublicBookingService {
       });
     }
     const query = parseSlotsQuery(rawQuery);
+    // Guest `timeZone` is required on the wire for rendering and logs.
+    // Availability is always computed in `page.timeZone`.
     const now = new Date();
     const windowStart = new Date(query.start);
     const requestedEnd = new Date(query.end);

--- a/packages/core/src/types/booking.contracts.ts
+++ b/packages/core/src/types/booking.contracts.ts
@@ -254,6 +254,7 @@ export type PublicGetBookingPageResponse = z.infer<
   typeof PublicGetBookingPageResponseSchema
 >;
 
+/** Guest IANA zone is required for rendering and logs. Availability uses the host page timezone. */
 export const BookingSlotsQuerySchema = z.strictObject({
   start: DateTimeSchema,
   end: DateTimeSchema,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3150

## Summary

Keep the required `timeZone` query param on `GET /api/booking/pages/:slug/slots`. Availability stays in the host page timezone. The guest param is for rendering and logs only.

A test requests the same window with `UTC` and `Asia/Tokyo` and asserts identical slot sets. The HTTP sketch now says the param does not change the slot set.

## Simplicity

Keep the existing query field. Do not drop it from the web client.

## Automated validation

- `getSlots` with `timeZone=UTC` and `timeZone=Asia/Tokyo` returns the same `{ slots, bookable }`
- Existing public booking service tests still pass

## Independent review

`.agents/handoffs/3150.md`

VERDICT: no confirmed findings
FINDINGS:
(none)

## Test plan

- `bun test:backend -- packages/backend/src/booking/services/public-booking.service.db.test.ts` — 48 pass, 0 fail
- `bun test:backend` — 581 pass, 0 fail
- `bun run type-check` — pass
- `bun lint` — no new errors (pre-existing warnings only)
- `bun knip` — pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec67721b-395d-454e-bd11-696669d367b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec67721b-395d-454e-bd11-696669d367b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

