### PR TITLE
test(booking): close out v1.5 e2e, a11y, and spec

### DIFF
--- a/.agents/handoffs/3151.md
+++ b/.agents/handoffs/3151.md
@@ -1,0 +1,28 @@
+---
+schema_version: 1
+task_id: "3151"
+from: Implementer
+to: Verifier
+owner: Verifier
+status: running
+artifact:
+  - path: e2e/booking/public-booking-v15.spec.ts
+  - path: e2e/booking/booking-harness.ts
+  - path: e2e/accessibility/booking-a11y.spec.ts
+  - path: docs/features/booking.md
+evidence:
+  - command: bunx playwright test e2e/booking/public-booking-v15.spec.ts e2e/accessibility/booking-a11y.spec.ts
+    result: not yet run
+    log: null
+assumptions:
+  - "WP-05 Escape-from-confirmation is already covered in e2e/booking/public-booking.spec.ts; this closeout adds WP-04, WP-06, WP-07, WP-08, and WP-11."
+  - "#3128 Deferred items remain valid: buffer at window edges, BookingSettingsSection size, guest reschedule v1.3, v1.4 items, guest email editing, slug editing."
+open_risks: []
+next_deadline: 2026-09-04T23:59:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-23: e2e, a11y, and spec closeout for Booking v1.5.

--- a/.agents/handoffs/3151.md
+++ b/.agents/handoffs/3151.md
@@ -1,21 +1,25 @@
 ---
 schema_version: 1
 task_id: "3151"
-from: Implementer
-to: Verifier
-owner: Verifier
-status: running
+from: Reviewer
+to: Manager
+owner: Manager
+status: verifying
 artifact:
   - path: e2e/booking/public-booking-v15.spec.ts
   - path: e2e/booking/booking-harness.ts
   - path: e2e/accessibility/booking-a11y.spec.ts
   - path: docs/features/booking.md
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3306
 evidence:
-  - command: bunx playwright test e2e/booking/public-booking-v15.spec.ts e2e/accessibility/booking-a11y.spec.ts
-    result: not yet run
+  - command: bunx playwright test e2e/booking e2e/accessibility/booking-a11y.spec.ts
+    result: "63 passed (booking e2e + booking a11y, including 8 new v1.5 specs and 3 new a11y states)"
+    log: null
+  - command: bun run verify
+    result: "Selected packages: web. Checks run: test:web, type-check, lint, knip, test:e2e. test:a11y failed once on unrelated datepicker hover contrast flake, then bun run test:a11y passed 27/27."
     log: null
 assumptions:
-  - "WP-05 Escape-from-confirmation is already covered in e2e/booking/public-booking.spec.ts; this closeout adds WP-04, WP-06, WP-07, WP-08, and WP-11."
+  - "WP-05 Escape-from-confirmation remains covered in e2e/booking/public-booking.spec.ts."
   - "#3128 Deferred items remain valid: buffer at window edges, BookingSettingsSection size, guest reschedule v1.3, v1.4 items, guest email editing, slug editing."
 open_risks: []
 next_deadline: 2026-09-04T23:59:00Z
@@ -26,3 +30,11 @@ escalation: null
 ---
 
 WP-23: e2e, a11y, and spec closeout for Booking v1.5.
+
+Simplify: no production change.
+
+Review: no confirmed findings.
+
+VERDICT: no confirmed findings
+FINDINGS:
+(none)

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -1,21 +1,24 @@
-# Compass Calendar Booking (v1 / v1.1 / v1.3)
+# Compass Calendar Booking (v1 / v1.1 / v1.5)
 
 Locked product spec for public scheduling on Compass Cloud
 (`https://compasscalendar.com`). Approved 2026-08-30. v1.1 shipped
 RSVP-strict occupancy and public page identity (date-specific
-availability exceptions were removed in v1.2). v1.3 adds guest
-reschedule. v1.3 is the current staging milestone.
+availability exceptions were removed in v1.2). v1.5 shipped keyboard
+Escape paths, guest edit-details after confirm, confirmation permalink
+tokens, and the audit fixes on milestone Booking v1.5. v1.3 (guest
+reschedule) remains specified here and is not shipped.
 
 Compass never sends email itself. Google emails the guest when Compass
 creates the calendar event with `invitation: "all"`.
 
 ## Status
 
-v1 and v1.1 are implemented in the Compass monorepo (public
-`/book/:username`, host Settings, backend APIs). v1.3 (guest reschedule)
-is specified here and implemented on the Booking v1.3 milestone. Booking
-is enabled in development and staging (`runtime.nodeEnv` other than
-`production`) and disabled in production. Do not flip `isBookingEnabled`.
+v1, v1.1, and v1.5 are implemented in the Compass monorepo (public
+`/book/:username`, host Settings, backend APIs, guest cancel and
+edit-details). v1.3 (guest reschedule) is specified here and is not
+implemented. Booking is enabled in development and staging
+(`runtime.nodeEnv` other than `production`) and disabled in production.
+Do not flip `isBookingEnabled`.
 A standalone Compass Booking product (separate brand, domain, or
 deployable) is **explicitly deferred**. The seams below are the
 extraction path; they are not a second service in v1.
@@ -145,11 +148,32 @@ focus uses the accent ring. Intended Tab order on the picker:
    with {host}** on load and after each state change. Tab then reaches
    the picker (same month grid and slot list as the public page), then
    **Confirm**. A 409 conflict focuses the alert. Missing or invalid
-   token focuses the not-found heading.
+   token focuses the not-found heading. This path is v1.3 and is not
+   shipped.
 
 The month grid stays in the DOM ahead of the slot list. The skip link
 exists so keyboard users are not forced through every day cell before
 times (and, on details, before the form).
+
+### Escape
+
+Escape peels one layer. OverlayPanel (timezone picker, discard confirm)
+holds the app lock first.
+
+- **Your details:** Escape is **Change time**. Focus returns to **Pick a
+  time**.
+- **Timezone overlay:** Escape closes the overlay and leaves the current
+  step (picker or details) in place.
+- **Slot list:** Escape moves focus to the selected day. It does not
+  change the URL.
+- **Month grid:** Escape is a no-op. It does not leave `/book/:slug`.
+- **Confirmation** (`/book/confirmed/:id`): Escape returns to
+  `/book/:bookingSlug` and focuses **Book with {host}**. Unknown,
+  cancelled, and load-error states have no slug path and stay put.
+- **Edit details:** Escape returns to confirmation without PATCHing.
+- **Cancel confirm** (`/book/cancel/:id`): Escape returns to
+  `/book/confirmed/:id` with the same `?token=` and does not POST.
+  In-flight cancel does not navigate or abort.
 
 ### Outcome
 
@@ -212,6 +236,10 @@ timezone `<select>` plus a checkbox and two time inputs per weekday.
   stays.
 - **Open booking page** sits next to Copy and opens the public URL in a
   new tab. There is no authenticated preview iframe.
+- **Discard:** Escape on a dirty Booking form opens **Discard unsaved
+  changes?** instead of closing Settings. Cancel (Escape) keeps the
+  edits. **Discard** (Shift+Escape or Mod+Enter) closes Settings without
+  saving.
 
 ## Busy occupancy
 
@@ -233,12 +261,16 @@ decides whether a busy interval occupies a slot
 - The public busy wire never includes titles, attendees, or emails.
   Optional facts are `hostIsOrganizer` and `hostResponseStatus` only.
 
-## Guest cancel
+## Guest cancel and edit details
 
 - Confirmation page includes a tokenized cancel URL when `?token=` is on
   the permalink (just-confirmed navigation writes it there). The event
   description carries it too only when guests cannot invite others (see
   above). A permalink without the token does not invent a cancel path.
+- **Edit details** uses the same token. Name and notes only; email is not
+  on the form and is not accepted on PATCH. **Save details** PATCHes
+  `{token, name?, notes?}` and rewrites the Google event title and
+  description. **Back** or Escape returns to confirmation without saving.
 - Token is unguessable and stored hashed on the reservation as
   `cancelTokenHash`. It stays valid until `slotEnd` and then returns
   the same generic not-found as an unknown token.
@@ -258,7 +290,7 @@ There is no host reservation inbox.
 - Confirmation shows **Reschedule** (link + **Copy reschedule link**) next
   to cancel when history state has `rescheduleUrl`. Cold permalink has
   neither reschedule secret. Cancel and edit use `?token=` on the
-  confirmation URL (see Guest cancel).
+  confirmation URL (see Guest cancel and edit details).
 - `/book/reschedule/:id?token=` reuses the public month/slot picker. Do
   not re-collect name, email, or notes. Duration comes from current page
   settings (same in-flight duration wart as confirm).
@@ -347,12 +379,11 @@ Unauthenticated:
   the token is invalid.
 - `POST /api/booking/reservations/:id/cancel` — `{token}`.
 - `GET /api/booking/reservations/:id/slots?token=&start=&end=&timeZone=`
-  — bookable instants excluding this reservation from occupancy and
-  max-per-day. Verify token. `404` when missing or invalid.
-- `POST /api/booking/reservations/:id/reschedule` — `{token, slotStart,
-  guestTimeZone}`. Re-checks busy excluding self, PATCHes the event,
-  updates reservation times. Create response also includes
-  `rescheduleUrl`.
+  — v1.3, not shipped. Would return bookable instants excluding this
+  reservation from occupancy and max-per-day.
+- `POST /api/booking/reservations/:id/reschedule` — v1.3, not shipped.
+  `{token, slotStart, guestTimeZone}`. Create response still includes
+  `rescheduleUrl` for that specified flow.
 
 Authenticated (host session + writable billing, same as event writes):
 
@@ -396,7 +427,7 @@ Guest reschedule is **in scope for v1.3**, not v1 / v1.1.
 | Calendar application port | `packages/backend/src/booking/services/calendar-booking.port.ts`, `services/calendar-booking.service.ts` |
 | Sync busy occupancy | `packages/sync/src/domain/occurrence-projection.ts`, `busy-query.service.ts`, `booking-occupancy-facts.ts` |
 | Host Settings UI | `packages/web/src/booking/BookingSettingsSection.tsx`, `packages/web/src/components/Settings/SettingsModal.tsx` |
-| Public guest UI | `packages/web/src/booking/PublicBookingPage.tsx`, `PublicBookingConfirmedPage.tsx`, `PublicBookingCancelPage.tsx` |
+| Public guest UI | `packages/web/src/booking/PublicBookingPage.tsx`, `PublicBookingConfirmedPage.tsx`, `PublicBookingCancelPage.tsx`, `PublicBookingEditDetailsForm.tsx` |
 | Public web API client | `packages/web/src/api/public-booking.api.ts` |
 | E2e | `e2e/booking/`, `e2e/accessibility/booking-a11y.spec.ts` |
 
@@ -416,6 +447,11 @@ Guest reschedule is **in scope for v1.3**, not v1 / v1.1.
 - **Guest email is not editable after confirm.** The attendee identity and
   Google invite are bound to the address collected at booking. Changing it
   would send a new invitation, which v1.5 does not do.
+- **Keyboard-targeted event is not in the event-jump store.** f4 targeting
+  lives as a local ref plus DOM focus in the hint hook
+  (`packages/web/src/shortcuts/shift-hint/event-jump.store.ts`). Enter has
+  nothing in that store to check. Recorded in WP-12; do not fold targeting
+  into the store in a drive-by.
 - **Slug is not editable in v1.** Allocation runs once on first enable; changing
   slugs needs a migration with redirects.
 - **Guest reschedule is v1.3, not v1.** In-place PATCH; same cancel token.

--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -102,6 +102,39 @@ test.describe("public booking confirmation page", () => {
     });
   });
 
+  test("tokenized permalink confirmation has no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await preparePublicBookingConfirmedPage(page, { token: "abc" });
+    await expect(
+      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Edit details" }),
+    ).toBeVisible();
+    await expectNoAxeViolations(page, {
+      checkpoint: "booking confirmation permalink with token",
+    });
+  });
+
+  test("edit-details form has no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await preparePublicBookingConfirmedPage(page, {
+      token: "abc",
+      guestName: "Ada Lovelace",
+      notes: "bring coffee",
+    });
+    await page.getByRole("button", { name: "Edit details" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Edit details" }),
+    ).toBeVisible();
+    await expect(page.getByLabel("Email")).toHaveCount(0);
+    await expectNoAxeViolations(page, {
+      checkpoint: "booking edit details",
+    });
+  });
+
   test("cancelled state has no automatically detectable accessibility violations", async ({
     page,
   }) => {
@@ -234,6 +267,22 @@ test.describe("settings booking section", () => {
     await expect(settingsDialog.getByText("Enter 1 to 60 days.")).toBeVisible();
     await expectNoAxeViolations(page, {
       checkpoint: "settings booking error",
+      include: "[role='dialog']",
+    });
+  });
+
+  test("discard confirmation has no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await prepareSignedInBookingSettingsPage(page);
+    const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+    await settingsDialog.getByLabel("Duration").selectOption("30");
+    await page.keyboard.press("Escape");
+    await expect(
+      page.getByRole("dialog", { name: "Discard unsaved changes?" }),
+    ).toBeVisible();
+    await expectNoAxeViolations(page, {
+      checkpoint: "settings booking discard confirmation",
       include: "[role='dialog']",
     });
   });

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -216,18 +216,58 @@ export interface PublicBookingStubOptions {
   reservationNotFound?: boolean;
   /** When set, GET /reservations/:id returns this status instead of 200. */
   reservationGetStatus?: number;
+  /** Confirmation permalink `?token=`. Omit for a cold load with no secret. */
+  token?: string;
+  guestName?: string;
+  notes?: string | null;
 }
 
 export interface CapturedBookingRequests {
   reservationPosts: Array<Record<string, unknown>>;
+  reservationPatches: Array<Record<string, unknown>>;
   slotGets: number;
   slotQueries: Array<{ start: string | null; end: string | null }>;
+}
+
+function reservationPayload(input: {
+  slotStart: string;
+  guestTimeZone: string;
+  durationMinutes: number;
+  hostDisplayName: string;
+  status: "confirmed" | "cancelled";
+  bookingSlug: string;
+  guestName: string;
+  notes: string | null;
+}) {
+  return {
+    slotStart: input.slotStart,
+    guestTimeZone: input.guestTimeZone,
+    durationMinutes: input.durationMinutes,
+    hostDisplayName: input.hostDisplayName,
+    status: input.status,
+    bookingSlug: input.bookingSlug,
+    guestName: input.guestName,
+    notes: input.notes,
+  };
+}
+
+function applyReservationPatch(
+  body: Record<string, unknown>,
+  current: { guestName: string; notes: string | null },
+): { guestName: string; notes: string | null } {
+  const guestName =
+    typeof body.name === "string" && body.name.trim().length > 0
+      ? body.name.trim()
+      : current.guestName;
+  const notes = typeof body.notes === "string" ? body.notes : current.notes;
+  return { guestName, notes };
 }
 
 /**
  * Stub public booking APIs for the shipped two-pane picker: month-window
  * slot GETs (filtered by `start`/`end`), day-scoped slot buttons, the
- * details step, confirmation permalink GET, and cancel POST-on-confirm.
+ * details step, confirmation permalink GET, guest details PATCH, and
+ * cancel POST-on-confirm.
  */
 export async function preparePublicBookingPage(
   page: Page,
@@ -236,12 +276,19 @@ export async function preparePublicBookingPage(
   const slug = options.slug ?? "tylerdane";
   const captured: CapturedBookingRequests = {
     reservationPosts: [],
+    reservationPatches: [],
     slotGets: 0,
     slotQueries: [],
   };
   const slot =
     options.slots?.[0] ?? buildBookableSlot(options.durationMinutes ?? 30);
   const slots = options.slots ?? [slot];
+  const hostDisplayName = options.hostDisplayName ?? "Tyler Dane";
+  const durationMinutes = options.durationMinutes ?? 30;
+  let guestName = options.guestName ?? "Guest User";
+  let notes = options.notes ?? null;
+  let postedSlotStart = slot.slotStart;
+  let postedTimeZone = "UTC";
 
   await page.route("**/api/**", async (route) => {
     const request = route.request();
@@ -251,8 +298,8 @@ export async function preparePublicBookingPage(
     if (path === `/api/booking/pages/${slug}` && request.method() === "GET") {
       return route.fulfill(
         jsonResponse({
-          hostDisplayName: options.hostDisplayName ?? "Tyler Dane",
-          durationMinutes: options.durationMinutes ?? 30,
+          hostDisplayName,
+          durationMinutes,
           timeZone: "America/Chicago",
           enabled: true,
           maxHorizonDays: 60,
@@ -304,6 +351,16 @@ export async function preparePublicBookingPage(
       if (options.confirmStatus === 409) {
         return route.fulfill(jsonResponse({}, 409));
       }
+      if (typeof body.guestName === "string") {
+        guestName = body.guestName;
+      }
+      notes = typeof body.notes === "string" ? body.notes : null;
+      if (typeof body.slotStart === "string") {
+        postedSlotStart = body.slotStart;
+      }
+      if (typeof body.guestTimeZone === "string") {
+        postedTimeZone = body.guestTimeZone;
+      }
       return route.fulfill(
         jsonResponse({
           reservationId: "000000000000000000000099",
@@ -320,34 +377,49 @@ export async function preparePublicBookingPage(
 
     if (
       /^\/api\/booking\/reservations\/[^/]+$/.test(path) &&
+      request.method() === "PATCH"
+    ) {
+      const body = (request.postDataJSON() ?? {}) as Record<string, unknown>;
+      captured.reservationPatches.push(body);
+      const next = applyReservationPatch(body, { guestName, notes });
+      guestName = next.guestName;
+      notes = next.notes;
+      return route.fulfill(
+        jsonResponse(
+          reservationPayload({
+            slotStart: postedSlotStart,
+            guestTimeZone: postedTimeZone,
+            durationMinutes,
+            hostDisplayName,
+            status: options.reservationStatus ?? "confirmed",
+            bookingSlug: slug,
+            guestName,
+            notes,
+          }),
+        ),
+      );
+    }
+
+    if (
+      /^\/api\/booking\/reservations\/[^/]+$/.test(path) &&
       request.method() === "GET"
     ) {
       if (options.reservationNotFound) {
         return route.fulfill(jsonResponse({}, 404));
       }
-      const lastPost = captured.reservationPosts.at(-1);
-      const postedSlotStart =
-        typeof lastPost?.slotStart === "string"
-          ? lastPost.slotStart
-          : slot.slotStart;
-      const postedTimeZone =
-        typeof lastPost?.guestTimeZone === "string"
-          ? lastPost.guestTimeZone
-          : "UTC";
       return route.fulfill(
-        jsonResponse({
-          slotStart: postedSlotStart,
-          guestTimeZone: postedTimeZone,
-          durationMinutes: options.durationMinutes ?? 30,
-          hostDisplayName: options.hostDisplayName ?? "Tyler Dane",
-          status: options.reservationStatus ?? "confirmed",
-          bookingSlug: slug,
-          guestName:
-            typeof lastPost?.guestName === "string"
-              ? lastPost.guestName
-              : "Guest User",
-          notes: typeof lastPost?.notes === "string" ? lastPost.notes : null,
-        }),
+        jsonResponse(
+          reservationPayload({
+            slotStart: postedSlotStart,
+            guestTimeZone: postedTimeZone,
+            durationMinutes,
+            hostDisplayName,
+            status: options.reservationStatus ?? "confirmed",
+            bookingSlug: slug,
+            guestName,
+            notes,
+          }),
+        ),
       );
     }
 
@@ -365,15 +437,51 @@ export async function preparePublicBookingPage(
 export async function preparePublicBookingConfirmedPage(
   page: Page,
   options: PublicBookingStubOptions & { reservationId?: string } = {},
-): Promise<void> {
+): Promise<CapturedBookingRequests> {
   const reservationId = options.reservationId ?? "000000000000000000000099";
   const slot =
     options.slots?.[0] ?? buildBookableSlot(options.durationMinutes ?? 30);
+  const hostDisplayName = options.hostDisplayName ?? "Tyler Dane";
+  const durationMinutes = options.durationMinutes ?? 30;
+  const slug = options.slug ?? "tylerdane";
+  let guestName = options.guestName ?? "Guest User";
+  let notes = options.notes ?? null;
+  const captured: CapturedBookingRequests = {
+    reservationPosts: [],
+    reservationPatches: [],
+    slotGets: 0,
+    slotQueries: [],
+  };
 
   await page.route("**/api/**", async (route) => {
     const request = route.request();
     const url = new URL(request.url());
     const path = url.pathname;
+
+    if (
+      /^\/api\/booking\/reservations\/[^/]+$/.test(path) &&
+      request.method() === "PATCH"
+    ) {
+      const body = (request.postDataJSON() ?? {}) as Record<string, unknown>;
+      captured.reservationPatches.push(body);
+      const next = applyReservationPatch(body, { guestName, notes });
+      guestName = next.guestName;
+      notes = next.notes;
+      return route.fulfill(
+        jsonResponse(
+          reservationPayload({
+            slotStart: slot.slotStart,
+            guestTimeZone: "UTC",
+            durationMinutes,
+            hostDisplayName,
+            status: options.reservationStatus ?? "confirmed",
+            bookingSlug: slug,
+            guestName,
+            notes,
+          }),
+        ),
+      );
+    }
 
     if (
       /^\/api\/booking\/reservations\/[^/]+$/.test(path) &&
@@ -386,25 +494,32 @@ export async function preparePublicBookingConfirmedPage(
         return route.fulfill(jsonResponse({}, options.reservationGetStatus));
       }
       return route.fulfill(
-        jsonResponse({
-          slotStart: slot.slotStart,
-          guestTimeZone: "UTC",
-          durationMinutes: options.durationMinutes ?? 30,
-          hostDisplayName: options.hostDisplayName ?? "Tyler Dane",
-          status: options.reservationStatus ?? "confirmed",
-          bookingSlug: options.slug ?? "tylerdane",
-          guestName: "Guest User",
-          notes: null,
-        }),
+        jsonResponse(
+          reservationPayload({
+            slotStart: slot.slotStart,
+            guestTimeZone: "UTC",
+            durationMinutes,
+            hostDisplayName,
+            status: options.reservationStatus ?? "confirmed",
+            bookingSlug: slug,
+            guestName,
+            notes,
+          }),
+        ),
       );
     }
 
     return route.fulfill(jsonResponse({}));
   });
 
-  await page.goto(`/book/confirmed/${reservationId}`, {
+  const search = options.token
+    ? `?token=${encodeURIComponent(options.token)}`
+    : "";
+  await page.goto(`/book/confirmed/${reservationId}${search}`, {
     waitUntil: "domcontentloaded",
   });
+
+  return captured;
 }
 
 export interface PublicBookingCancelStubOptions {
@@ -730,4 +845,17 @@ export function formatSlotButtonLabel(
   }).format(new Date(slotStart));
   const escaped = time.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   return new RegExp(escaped, "i");
+}
+
+export function formatMonthDayButtonLabel(
+  slotStart: string,
+  timeZone = "UTC",
+): string {
+  return new Intl.DateTimeFormat(undefined, {
+    timeZone,
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(slotStart));
 }

--- a/e2e/booking/public-booking-v15.spec.ts
+++ b/e2e/booking/public-booking-v15.spec.ts
@@ -1,0 +1,250 @@
+import { expect, type Page, test } from "@playwright/test";
+import {
+  buildBookableSlot,
+  dispatchFill,
+  formatMonthDayButtonLabel,
+  formatSlotButtonLabel,
+  preparePublicBookingCancelPage,
+  preparePublicBookingConfirmedPage,
+  preparePublicBookingPage,
+  prepareSignedInBookingSettingsPage,
+} from "./booking-harness";
+
+async function guestTimeZone(page: Page): Promise<string> {
+  return page.evaluate(() => Intl.DateTimeFormat().resolvedOptions().timeZone);
+}
+
+test.describe("booking v1.5 escape and self-service", () => {
+  test("returns to the picker on Escape from Your details", async ({
+    page,
+  }) => {
+    const { slotStart } = buildBookableSlot();
+    await preparePublicBookingPage(page);
+
+    await page
+      .getByRole("button", { name: formatSlotButtonLabel(slotStart) })
+      .click();
+    await expect(
+      page.getByRole("heading", { name: "Your details" }),
+    ).toBeFocused();
+    await page.getByLabel("Name").fill("Guest User");
+
+    await page.keyboard.press("Escape");
+
+    await expect(
+      page.getByRole("heading", { name: "Pick a time" }),
+    ).toBeFocused();
+    await expect(
+      page.getByRole("heading", { name: "Your details" }),
+    ).toHaveCount(0);
+    await expect(page).toHaveURL(/\/book\/tylerdane/);
+  });
+
+  test("closes the timezone overlay on Escape without leaving Your details", async ({
+    page,
+  }) => {
+    const { slotStart } = buildBookableSlot();
+    await preparePublicBookingPage(page);
+
+    await page
+      .getByRole("button", { name: formatSlotButtonLabel(slotStart) })
+      .click();
+    await expect(
+      page.getByRole("heading", { name: "Your details" }),
+    ).toBeVisible();
+    await page.getByRole("button", { name: /^Timezone:/ }).click();
+    await expect(page.getByRole("heading", { name: "Timezone" })).toBeVisible();
+
+    await page.keyboard.press("Escape");
+
+    await expect(page.getByRole("heading", { name: "Timezone" })).toHaveCount(
+      0,
+    );
+    await expect(
+      page.getByRole("heading", { name: "Your details" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Pick a time" }),
+    ).toHaveCount(0);
+  });
+
+  test("moves focus from a slot to the selected day on Escape", async ({
+    page,
+  }) => {
+    const { slotStart } = buildBookableSlot();
+    await preparePublicBookingPage(page);
+    const timeZone = await guestTimeZone(page);
+    const day = page.getByRole("button", {
+      name: formatMonthDayButtonLabel(slotStart, timeZone),
+    });
+    const slot = page.getByRole("button", {
+      name: formatSlotButtonLabel(slotStart, timeZone),
+    });
+
+    await expect(
+      page.getByRole("heading", { name: "Pick a time" }),
+    ).toBeVisible();
+    await slot.focus();
+    await expect(slot).toBeFocused();
+
+    await page.keyboard.press("Escape");
+
+    await expect(day).toBeFocused();
+    await expect(
+      page.getByRole("heading", { name: "Pick a time" }),
+    ).toBeVisible();
+    await expect(page).toHaveURL(/\/book\/tylerdane/);
+  });
+
+  test("does not leave the month grid on Escape", async ({ page }) => {
+    const { slotStart } = buildBookableSlot();
+    await preparePublicBookingPage(page);
+    const timeZone = await guestTimeZone(page);
+    const day = page.getByRole("button", {
+      name: formatMonthDayButtonLabel(slotStart, timeZone),
+    });
+
+    await expect(
+      page.getByRole("heading", { name: "Pick a time" }),
+    ).toBeVisible();
+    await day.focus();
+    const href = page.url();
+
+    await page.keyboard.press("Escape");
+
+    await expect(day).toBeFocused();
+    expect(page.url()).toBe(href);
+    await expect(
+      page.getByRole("heading", { name: "Pick a time" }),
+    ).toBeVisible();
+  });
+
+  test("returns to confirmation on Escape from cancel without posting", async ({
+    page,
+  }) => {
+    const captured = await preparePublicBookingCancelPage(page);
+
+    await expect(
+      page.getByRole("heading", { name: "Cancel this booking?" }),
+    ).toBeFocused();
+
+    await page.keyboard.press("Escape");
+
+    await expect(
+      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+    ).toBeVisible();
+    await expect(page).toHaveURL(
+      /\/book\/confirmed\/000000000000000000000099\?token=abc$/,
+    );
+    await expect(
+      page.getByRole("button", { name: "Edit details" }),
+    ).toBeVisible();
+    expect(captured.cancelPosts).toHaveLength(0);
+  });
+
+  test("edits name and notes from a cold tokenized confirmation permalink", async ({
+    page,
+  }) => {
+    const captured = await preparePublicBookingConfirmedPage(page, {
+      token: "abc",
+      guestName: "Ada Lovelace",
+      notes: "bring coffee",
+    });
+
+    await expect(
+      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+    ).toBeFocused();
+    await expect(page).toHaveURL(
+      /\/book\/confirmed\/000000000000000000000099\?token=abc$/,
+    );
+    await expect(page.getByText("Ada Lovelace")).toBeVisible();
+    await expect(page.getByText("bring coffee")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Copy cancel link" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "Cancel this booking" }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Edit details" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Edit details" }),
+    ).toBeFocused();
+    await expect(page.getByLabel("Name")).toHaveValue("Ada Lovelace");
+    await expect(page.getByLabel("Notes (optional)")).toHaveValue(
+      "bring coffee",
+    );
+    await expect(page.getByLabel("Email")).toHaveCount(0);
+
+    await page.getByLabel("Name").fill("Grace Hopper");
+    await page.getByLabel("Notes (optional)").fill("bring tea");
+    await page.getByRole("button", { name: "Save details" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+    ).toBeVisible();
+    await expect(page.getByText("Grace Hopper")).toBeVisible();
+    await expect(page.getByText("bring tea")).toBeVisible();
+    await expect(page.getByText("Ada Lovelace")).toHaveCount(0);
+    expect(captured.reservationPatches).toEqual([
+      { token: "abc", name: "Grace Hopper", notes: "bring tea" },
+    ]);
+  });
+
+  test("returns from Edit details to confirmation on Escape without saving", async ({
+    page,
+  }) => {
+    await preparePublicBookingConfirmedPage(page, {
+      token: "abc",
+      guestName: "Ada Lovelace",
+      notes: "bring coffee",
+    });
+
+    await page.getByRole("button", { name: "Edit details" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Edit details" }),
+    ).toBeFocused();
+    await page.getByLabel("Name").fill("Grace Hopper");
+
+    await page.keyboard.press("Escape");
+
+    await expect(
+      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+    ).toBeVisible();
+    await expect(page.getByText("Ada Lovelace")).toBeVisible();
+    await expect(page.getByText("Grace Hopper")).toHaveCount(0);
+    await expect(page).toHaveURL(
+      /\/book\/confirmed\/000000000000000000000099\?token=abc$/,
+    );
+  });
+});
+
+test.describe("booking v1.5 settings discard", () => {
+  test.use({ viewport: { width: 1600, height: 900 } });
+
+  test("Escape on dirty booking settings asks before discarding", async ({
+    page,
+  }) => {
+    await prepareSignedInBookingSettingsPage(page);
+    const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+    await expect(settingsDialog.getByLabel("Duration")).toBeVisible();
+    await settingsDialog.getByLabel("Duration").selectOption("30");
+    await dispatchFill(
+      settingsDialog.getByLabel("Welcome text"),
+      "Scratch this welcome.",
+    );
+
+    await page.keyboard.press("Escape");
+
+    const discard = page.getByRole("dialog", {
+      name: "Discard unsaved changes?",
+    });
+    await expect(discard).toBeVisible();
+    await expect(settingsDialog).toBeVisible();
+    await expect(settingsDialog.getByLabel("Duration")).toHaveValue("30");
+    await expect(settingsDialog.getByLabel("Welcome text")).toHaveValue(
+      "Scratch this welcome.",
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #3151 (Booking v1.5 WP-23 closeout).

Adds Playwright coverage for the Escape paths, guest edit-details, a cold tokenized confirmation permalink, and Settings discard confirmation. Extends booking a11y scans to the edit-details form, tokenized permalink, and discard dialog. Updates `docs/features/booking.md` so header/status, Escape, cancel/edit-details, HTTP sketch, and named warts match what shipped (v1.3 reschedule routes marked not shipped).

#3128 Deferred items were re-checked and remain valid: buffer at weekly-availability window edges, `BookingSettingsSection` decomposition, guest reschedule (v1.3), v1.4 items, guest email editing, and slug editing.

## Simplicity

Harness PATCH/token stubs reuse one reservation payload helper. New e2e lives in `public-booking-v15.spec.ts` so the existing public-booking spec stays unchanged. WP-05 Escape-from-confirmation was already covered there. No production code in this WP.

## Automated validation

- `bunx playwright test e2e/booking e2e/accessibility/booking-a11y.spec.ts`: 63 passed, including 8 new v1.5 specs and 3 new a11y states.
- `bun run verify`: selected web; `test:web`, `type-check`, `lint`, `knip`, `test:e2e` passed. `test:a11y` failed once on an unrelated datepicker hover-contrast flake, then `bun run test:a11y` passed 27/27.

## Independent review

`.agents/handoffs/3151.md`

VERDICT: no confirmed findings
FINDINGS:
(none)

## Test plan

- `bunx playwright test e2e/booking e2e/accessibility/booking-a11y.spec.ts` (63 passed)
- `bun run verify` (web: test:web, type-check, lint, knip, test:e2e)
- `bun run test:a11y` (27 passed on retry)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec67721b-395d-454e-bd11-696669d367b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec67721b-395d-454e-bd11-696669d367b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

