### PR TITLE
feat(web): capture shortcut_key, context, and view on shortcut_unavailable_attempt

### DIFF
--- a/packages/web/src/auth/posthog/track.test.ts
+++ b/packages/web/src/auth/posthog/track.test.ts
@@ -29,6 +29,9 @@ const {
   recordShortcutUnavailableAttempt,
   resetShortcutTelemetryForTests,
 } = await import("@web/shortcuts/tips/shortcut-telemetry");
+const { clearAppLockReasons, setAppLockReason } = await import(
+  "@web/shortcuts/app-lock"
+);
 const { getShortcutHint } = await import(
   "@web/shortcuts/tips/shortcut-tips.data"
 );
@@ -123,15 +126,63 @@ describe("shortcut telemetry", () => {
     ).toMatchObject({ invocations: 1, lastInvokedAt: 200_000 });
   });
 
-  it("captures a detectable unavailable attempt without key or content data", () => {
-    recordShortcutUnavailableAttempt("create-event", "app_locked");
+  it("captures which registered shortcut was blocked, by which lock, where", () => {
+    window.history.pushState({}, "", "/week/2026-09-06");
+    setAppLockReason("settingsModal", true);
+    setAppLockReason("billingGate", true);
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    recordShortcutUnavailableAttempt("edge-focus", "app_locked", {
+      hotkey: "Tab",
+      event: {
+        altKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        shiftKey: false,
+        repeat: true,
+      },
+    });
 
     expect(capture).toHaveBeenCalledWith("shortcut_unavailable_attempt", {
-      action_id: "calendar.create_timed_event",
-      feature_area: "event_creation",
+      action_id: "event.edge_focus",
+      active_element: "input",
+      context: "billingGate+settingsModal",
+      feature_area: "event_editing",
+      is_repeat: true,
       outcome: "unavailable",
       reason_code: "app_locked",
+      shortcut_key: "Tab",
       source: "keyboard",
+      view: "week_view",
+      was_modifier_held: false,
     });
+    input.remove();
+    clearAppLockReasons();
+  });
+
+  it("names the lock context unknown when no reason is registered", () => {
+    window.history.pushState({}, "", "/day");
+    recordShortcutUnavailableAttempt("nudge", "app_locked", {
+      hotkey: { key: "ArrowLeft", shift: true },
+      event: {
+        altKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        shiftKey: true,
+        repeat: false,
+      },
+    });
+
+    expect(capture).toHaveBeenCalledWith(
+      "shortcut_unavailable_attempt",
+      expect.objectContaining({
+        context: "unknown",
+        shortcut_key: "Shift+ArrowLeft",
+        view: "day_view",
+        was_modifier_held: true,
+      }),
+    );
   });
 });

--- a/packages/web/src/shortcuts/app-lock.test.ts
+++ b/packages/web/src/shortcuts/app-lock.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
 import {
   clearAppLockReasons,
+  getAppLockReasons,
   hasAppLockReason,
   setAppLockReason,
   useAppLockReason,
@@ -53,5 +54,14 @@ describe("app-lock", () => {
 
     setAppLockReason("billingGate", false);
     expect(hasAppLockReason("billingGate")).toBe(false);
+  });
+
+  it("lists active reasons sorted for stable telemetry keys", () => {
+    setAppLockReason("settingsModal", true);
+    setAppLockReason("billingGate", true);
+    expect(getAppLockReasons()).toEqual(["billingGate", "settingsModal"]);
+
+    clearAppLockReasons();
+    expect(getAppLockReasons()).toEqual([]);
   });
 });

--- a/packages/web/src/shortcuts/app-lock.ts
+++ b/packages/web/src/shortcuts/app-lock.ts
@@ -18,6 +18,9 @@ export const setAppLockReason = registry.set;
 
 export const hasAppLockReason = registry.has;
 
+/** Sorted names of every reason currently holding the lock. */
+export const getAppLockReasons = registry.active;
+
 export const subscribeAppLock = registry.subscribe;
 
 /** Clears every reason — used by tests between cases. */

--- a/packages/web/src/shortcuts/reason-registry.ts
+++ b/packages/web/src/shortcuts/reason-registry.ts
@@ -39,6 +39,8 @@ export function createReasonRegistry(onChange?: (anyActive: boolean) => void) {
     },
     isAnyActive: () => reasons.size > 0,
     has: (reason: string) => reasons.has(reason),
+    /** Sorted snapshot of the active reasons (stable for telemetry keys). */
+    active: () => [...reasons].sort(),
     subscribe: (listener: () => void) => {
       listeners.add(listener);
       return () => {

--- a/packages/web/src/shortcuts/tips/shortcut-telemetry.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-telemetry.ts
@@ -1,4 +1,11 @@
+import {
+  formatHotkey,
+  type RegisterableHotkey,
+  rawHotkeyToParsedHotkey,
+} from "@tanstack/react-hotkeys";
 import { track } from "@web/auth/posthog/track";
+import { ROOT_ROUTES } from "@web/common/constants/routes";
+import { getAppLockReasons } from "@web/shortcuts/app-lock";
 import {
   readShortcutUsageProfile,
   type ShortcutActionUsage,
@@ -119,19 +126,63 @@ export function recordShortcutInvocation(
   }
 }
 
+const VIEW_BY_ROUTE = [
+  [ROOT_ROUTES.WEEK, "week_view"],
+  [ROOT_ROUTES.DAY, "day_view"],
+  [ROOT_ROUTES.LIFE, "life_view"],
+] as const;
+
+/** The calendar surface a shortcut was attempted on, from the URL alone. */
+function viewFromPathname(pathname: string): string {
+  const match = VIEW_BY_ROUTE.find(
+    ([route]) => pathname === route || pathname.startsWith(`${route}/`),
+  );
+  return match?.[1] ?? "other";
+}
+
+/** Static registration string for a hotkey (e.g. "Shift+ArrowLeft"). */
+function registeredHotkeyLabel(hotkey: RegisterableHotkey): string {
+  if (typeof hotkey === "string") return hotkey;
+  return formatHotkey(rawHotkeyToParsedHotkey(hotkey));
+}
+
+export type ShortcutUnavailableAttempt = {
+  /** The hotkey as registered, never the raw key the user typed. */
+  hotkey: RegisterableHotkey;
+  /** The keydown/keyup that matched the registration. */
+  event: Pick<
+    KeyboardEvent,
+    "altKey" | "ctrlKey" | "metaKey" | "shiftKey" | "repeat"
+  >;
+};
+
 /** A registered shortcut reached the app handler but an app-level lock owned
- * the keyboard. No typed value, DOM content, or key value is captured. */
+ * the keyboard. `context` names the lock owner(s) (settingsModal,
+ * commandPalette, billingGate...) so we can tell "pressed Tab inside a modal
+ * form" apart from "wanted to create an event behind the billing gate".
+ * Only the static registration string, lock names, view name, modifier
+ * flags, and the focused element's tag are captured. No typed value, DOM
+ * content, or raw key value is captured. */
 export function recordShortcutUnavailableAttempt(
   hintId: ShortcutHintId,
   reasonCode: "app_locked",
+  attempt: ShortcutUnavailableAttempt,
 ): void {
   const hint = getShortcutHint(hintId);
+  const { event } = attempt;
   track("shortcut_unavailable_attempt", {
     action_id: hint.actionId,
+    active_element: document.activeElement?.tagName.toLowerCase() ?? "none",
+    context: getAppLockReasons().join("+") || "unknown",
     feature_area: hint.featureArea,
+    is_repeat: event.repeat,
     outcome: "unavailable",
     reason_code: reasonCode,
+    shortcut_key: registeredHotkeyLabel(attempt.hotkey),
     source: "keyboard",
+    view: viewFromPathname(window.location.pathname),
+    was_modifier_held:
+      event.altKey || event.ctrlKey || event.metaKey || event.shiftKey,
   });
 }
 

--- a/packages/web/src/shortcuts/useAppShortcut.ts
+++ b/packages/web/src/shortcuts/useAppShortcut.ts
@@ -89,7 +89,10 @@ export function useAppShortcut(
     (event) => {
       if (!ignoreAppLock && isAppLocked()) {
         if (telemetryHintId) {
-          recordShortcutUnavailableAttempt(telemetryHintId, "app_locked");
+          recordShortcutUnavailableAttempt(telemetryHintId, "app_locked", {
+            hotkey,
+            event,
+          });
         }
         if (
           requiresWrite &&


### PR DESCRIPTION
## Summary

PostHog showed 362 `shortcut_unavailable_attempt` events in 7 days carrying only `action_id` / `feature_area`. The event fires when a *registered* shortcut is pressed while an app lock (settings modal, command palette, billing gate, showcase) owns the keyboard. Without the lock name we could not tell "pressed Tab inside a modal form" apart from "wanted to create an event behind the billing gate".

The event now also carries:

| property | value |
| --- | --- |
| `shortcut_key` | the static registration string, e.g. `Tab`, `C`, `Shift+ArrowLeft` |
| `context` | sorted active app-lock reason names joined with `+`, e.g. `settingsModal`, `billingGate+commandPalette`; `unknown` if none |
| `view` | `week_view` / `day_view` / `life_view` / `other`, from the pathname |
| `was_modifier_held` | any of alt/ctrl/meta/shift down |
| `is_repeat` | key auto-repeat (explains the Tab bursts) |
| `active_element` | tag name of the focused element, e.g. `input`, `body` |

Privacy stays the same: no typed value, DOM content, or raw key value is captured. `shortcut_key` is the registration string, not `event.key`.

## Changes

- `reason-registry.ts` gains `active()`; `app-lock.ts` exports it as `getAppLockReasons()`.
- `recordShortcutUnavailableAttempt` takes the registered hotkey and the matched keyboard event.
- `useAppShortcut` passes both through at the single call site.

## Test plan

- [x] `bun test` on track, app-lock, and useAppShortcut suites (24 pass)
- [x] `bun run type-check`, `bun run lint`
- [ ] After staging deploy: open Settings, press `C`, confirm the PostHog event shows `shortcut_key=C`, `context=settingsModal`, `view=week_view`

🤖 Generated with [Claude Code](https://claude.com/claude-code)