### PR TITLE
docs(web): name the posthog exception wire properties next to capture_exceptions

### DIFF
--- a/packages/web/src/auth/posthog/posthog.bootstrap.ts
+++ b/packages/web/src/auth/posthog/posthog.bootstrap.ts
@@ -26,6 +26,12 @@ export function initPosthog(): PostHog | undefined {
     api_host: ENV_WEB.POSTHOG_HOST!,
     // Assumes the US cloud; self-hosters on another instance would differ.
     ui_host: "https://us.posthog.com",
+    // Captured errors land on the event as `$exception_list[]` (type, value,
+    // stacktrace.frames) plus the flattened `$exception_types` /
+    // `$exception_values` arrays. The legacy `$exception_type` /
+    // `$exception_message` scalars are never sent by this SDK line, so a
+    // query on them reads null for every event and looks like a broken
+    // integration when nothing is wrong.
     capture_exceptions: {
       capture_unhandled_errors: true,
       capture_unhandled_rejections: true,


### PR DESCRIPTION
## Summary
- Comment-only. An observability audit reported `$exception_type` / `$exception_message` as null on every `$exception` event over 7 days. Neither property exists in the project taxonomy: posthog-js 1.413 and posthog-node 5.48 send `$exception_list[]` (type, value, stacktrace.frames) plus the flattened `$exception_types` / `$exception_values` arrays, and every one of the 123 events had them populated.
- Nothing in `posthog.bootstrap.ts` was misconfigured (unhandled errors and rejections on, `console.error` capture deliberately off, every manual `captureException` passes an `Error`). Verified live on staging: an injected `window.onerror` TypeError and an `unhandledrejection` RangeError both landed in PostHog within seconds with stack frames and issue ids.
- This names the real property shape where the next reader will look before concluding the integration is broken.

## Test plan
- [x] `biome check` on the touched file
- [x] `posthog-exception-filter.util.test.ts` (16 pass)
- [x] Live staging error injection produced `$exception` events with type, message, and stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)