### PR TITLE
fix(ci): stop passing issue JSON through the environment in the picker

### DIFF
--- a/.github/scripts/agent-loop-lib.sh
+++ b/.github/scripts/agent-loop-lib.sh
@@ -74,12 +74,27 @@ milestone_slug() {
     | sed -E 's/[^a-z0-9.]+/-/g; s/^-+//; s/-+$//'
 }
 
+# Concatenate two JSON arrays. Payloads go through a pipe, not argv/env,
+# because issue bodies across a milestone can exceed ARG_MAX.
 json_concat() {
   local a=${1:-[]}
   local b=${2:-[]}
   if [ -z "$a" ]; then a='[]'; fi
   if [ -z "$b" ]; then b='[]'; fi
-  A="$a" B="$b" python3 -c 'import json,os; print(json.dumps(json.loads(os.environ["A"])+json.loads(os.environ["B"])))'
+  {
+    printf '%s' "$a"
+    printf '\0'
+    printf '%s' "$b"
+  } | python3 -c 'import json,sys
+raw = sys.stdin.buffer.read()
+a, b = raw.split(b"\0", 1)
+print(json.dumps(json.loads(a or b"[]") + json.loads(b or b"[]")))'
+}
+
+issue_numbers_from_json() {
+  python3 -c 'import json,sys
+for issue in json.loads(sys.stdin.read() or "[]"):
+    print(issue["number"])'
 }
 
 prompt_path_for_milestone() {

--- a/.github/scripts/agent-loop-next.sh
+++ b/.github/scripts/agent-loop-next.sh
@@ -171,7 +171,11 @@ prs_json=$(
     --json number,title,body
 )
 
-all_open='[]'
+picker_tmp=$(mktemp -d)
+trap 'rm -rf "$picker_tmp"' EXIT
+printf '%s' "$prs_json" >"${picker_tmp}/prs.json"
+
+open_numbers=()
 declare -A MILESTONE_ISSUES=()
 for milestone in "${MILESTONES[@]}"; do
   issues_json=$(
@@ -182,7 +186,9 @@ for milestone in "${MILESTONES[@]}"; do
     issues_json='[]'
   fi
   MILESTONE_ISSUES["$milestone"]=$issues_json
-  all_open=$(json_concat "$all_open" "$issues_json")
+  while IFS= read -r n; do
+    [ -n "$n" ] && open_numbers+=("$n")
+  done < <(printf '%s' "$issues_json" | issue_numbers_from_json)
 done
 
 selected=""
@@ -191,18 +197,19 @@ for milestone in "${MILESTONES[@]}"; do
   if [ -z "$issues_json" ] || [ "$issues_json" = "[]" ]; then
     continue
   fi
+  printf '%s' "$issues_json" >"${picker_tmp}/issues.json"
   selected=$(
-    ISSUES_JSON="$issues_json" PRS_JSON="$prs_json" ALL_OPEN_JSON="$all_open" \
+    OPEN_NUMBERS="${open_numbers[*]}" \
     SKIP_LABEL="$NEEDS_HUMAN_LABEL" LEGACY_SKIP_LABEL="$LEGACY_NEEDS_HUMAN_LABEL" \
     RUNNING_LABEL="$RUNNING_LABEL" LEGACY_RUNNING_LABEL="$LEGACY_RUNNING_LABEL" \
     QUOTA_WAITING_LABEL="$QUOTA_WAITING_LABEL" LEGACY_QUOTA_WAITING_LABEL="$LEGACY_QUOTA_WAITING_LABEL" \
     READY_LABEL="$READY_LABEL" \
-    python3 - <<'PY'
-import json, os, re
+    python3 - "${picker_tmp}/issues.json" "${picker_tmp}/prs.json" <<'PY'
+import json, os, re, sys
 
-issues = json.loads(os.environ["ISSUES_JSON"])
-prs = json.loads(os.environ["PRS_JSON"])
-all_open = json.loads(os.environ["ALL_OPEN_JSON"] or "[]")
+issues = json.load(open(sys.argv[1], encoding="utf-8"))
+prs = json.load(open(sys.argv[2], encoding="utf-8"))
+open_numbers = {int(n) for n in os.environ.get("OPEN_NUMBERS", "").split() if n}
 ready_label = os.environ["READY_LABEL"]
 skip_labels = {
     os.environ["SKIP_LABEL"],
@@ -212,7 +219,6 @@ skip_labels = {
     os.environ["QUOTA_WAITING_LABEL"],
     os.environ["LEGACY_QUOTA_WAITING_LABEL"],
 }
-open_numbers = {issue["number"] for issue in all_open}
 
 issues.sort(key=lambda i: i["number"])
 

--- a/.github/scripts/agent-loop-next.test.sh
+++ b/.github/scripts/agent-loop-next.test.sh
@@ -178,6 +178,28 @@ assert_contains "$out" "ISSUE_NUMBER=3222" "skips WP whose Depends on issue is s
 out=$(STUB_L_OPEN="$L_HUMAN" STUB_P0_OPEN="$P0_DEP" run_next)
 assert_contains "$out" "ISSUE_NUMBER=3236" "human leftovers on L do not block P0"
 
+if grep -q 'os.environ\["A"\]' "${ROOT}/.github/scripts/agent-loop-lib.sh"; then
+  echo "FAIL json_concat still passes JSON through the environment" >&2
+  FAIL=$((FAIL + 1))
+else
+  echo "ok json_concat does not use env vars for JSON payloads"
+  PASS=$((PASS + 1))
+fi
+if grep -q 'ISSUES_JSON=\|ALL_OPEN_JSON=' "${ROOT}/.github/scripts/agent-loop-next.sh"; then
+  echo "FAIL picker still passes issue JSON through the environment" >&2
+  FAIL=$((FAIL + 1))
+else
+  echo "ok picker reads issue JSON from files, not env"
+  PASS=$((PASS + 1))
+fi
+
+# shellcheck disable=SC1091
+source "${ROOT}/.github/scripts/agent-loop-lib.sh"
+big=$(python3 -c 'print("[" + ",".join(["{\"n\":%d}" % i for i in range(8000)]) + "]")')
+concat_out=$(json_concat "$big" "$big")
+concat_len=$(printf '%s' "$concat_out" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')
+assert_eq "$concat_len" "16000" "json_concat concatenates large arrays via a pipe"
+
 echo
 echo "passed=${PASS} failed=${FAIL}"
 if [ "$FAIL" -ne 0 ]; then


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #3311. A live dry-run of `agent-loop-next.sh` failed with `/usr/bin/python3: Argument list too long` because `json_concat` and the picker Python stuffed full issue bodies into the environment.

JSON now moves through a pipe (concat) and temp files (picker). Open-issue numbers for `Depends on:` checks are collected as integers, not concatenated issue payloads.

Human merge required (touches `.github/`). Do not label `agent-automerge`.

## Simplicity

Same picker, smaller transport. No second loop or ledger.

## Automated validation

- `bash .github/scripts/agent-loop-next.test.sh` (15 pass, including a 16k-item concat and a grep that env transport is gone)
- `bash .github/scripts/agent-loop-merge-guard.test.sh` (8 pass)

## Independent review

Needed so the providers kick can pick an issue. Same approval boundary as WP-01.

## Test plan

- `bash .github/scripts/agent-loop-next.test.sh`
- `bash .github/scripts/agent-loop-merge-guard.test.sh`
- live dry-run of `agent-loop-next.sh` after merge

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef6e39c4-a4b6-4e0b-9d22-cc18bd946439?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef6e39c4-a4b6-4e0b-9d22-cc18bd946439&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

