### PR TITLE
refactor(scripts): drain constraint allowlists to documented globs

### DIFF
--- a/.agents/handoffs/3220.md
+++ b/.agents/handoffs/3220.md
@@ -1,0 +1,32 @@
+---
+schema_version: 1
+task_id: "3220"
+from: Implementer
+to: Verifier
+owner: Verifier
+status: verifying
+artifact:
+  - path: packages/scripts/src/testing/check-agent-constraints.ts
+  - path: packages/scripts/src/testing/check-agent-constraints.test.ts
+evidence:
+  - command: bun test packages/scripts/src/testing/check-agent-constraints.test.ts
+    result: "19 pass, 0 fail"
+    log: null
+  - command: bun packages/scripts/src/testing/check-agent-constraints.ts
+    result: pass
+    log: null
+assumptions:
+  - "Db tests that seed via mongoService cannot drop that import without a new collection accessor; those stay a glob"
+  - "Web locator tests that query data-* overlay roots, react-datepicker, and aria-hidden keycaps are structural"
+  - "scanBunDockerfilePins stays; WP-09 only drains path allowlists, it does not drop bun pin scanning"
+open_risks: []
+next_deadline: 2026-09-04T23:59:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+Rebuilt on current main without `.agents/ledger.md`. Remaining barrels
+deleted; checker allowlists are empty or glob+reason. Docker bun-pin
+scanning from main is kept.

--- a/packages/scripts/src/testing/check-agent-constraints.test.ts
+++ b/packages/scripts/src/testing/check-agent-constraints.test.ts
@@ -1,11 +1,16 @@
 import {
+  BARREL_ALLOWLIST,
   duplicateEventSchemaHits,
   isBarrelSource,
   locatorHits,
+  MONGO_SERVICE_TEST_ALLOWLIST,
+  matchesConstraintAllow,
+  matchGlob,
   mongoServiceImportHits,
   ovenBunVersion,
   scanBunDockerfilePins,
   scanConstraints,
+  WEB_LOCATOR_ALLOWLIST,
 } from "./check-agent-constraints";
 import { describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
@@ -120,6 +125,102 @@ describe("scanConstraints", () => {
     expect(
       hits.some((hit) => hit.includes("packages/web/src/Widget.tsx")),
     ).toBe(false);
+  });
+
+  it("does not require checker edits for new provider test files", () => {
+    const root = mkdtempSync(join(tmpdir(), "provider-tests-"));
+    writeTree(root, {
+      "packages/web/src/index.tsx":
+        'import { init } from "@web/auth/posthog/posthog.bootstrap";\nvoid import("./app.bootstrap");\n',
+      "packages/sync/src/providers/microsoft/x.test.ts":
+        'describe("x", () => {\n  it("ok", () => {\n    expect(true).toBe(true);\n  });\n});\n',
+      "packages/web/src/auth/providers/y.test.tsx":
+        'it("renders a named control", () => {\n  expect("Save").toBe("Save");\n});\n',
+    });
+
+    const hits = scanConstraints(root);
+    expect(
+      hits.filter(
+        (hit) =>
+          hit.path.includes("providers/microsoft") ||
+          hit.path.includes("auth/providers"),
+      ),
+    ).toEqual([]);
+  });
+
+  it("still flags locators in new web tests outside documented globs", () => {
+    const root = mkdtempSync(join(tmpdir(), "locator-new-"));
+    writeTree(root, {
+      "packages/web/src/index.tsx":
+        'import { init } from "@web/auth/posthog/posthog.bootstrap";\nvoid import("./app.bootstrap");\n',
+      "packages/web/src/auth/providers/y.test.tsx":
+        'screen.getByTestId("provider-row");\n',
+    });
+
+    expect(
+      scanConstraints(root).map((hit) => `${hit.rule}:${hit.path}`),
+    ).toContain("web-locator:packages/web/src/auth/providers/y.test.tsx");
+  });
+});
+
+describe("constraint allowlist globs", () => {
+  it("matches nested shortcut tests and not auth provider tests", () => {
+    expect(
+      matchGlob(
+        "packages/web/src/shortcuts/edit-sequence/EditSequenceMenu.test.tsx",
+        "packages/web/src/shortcuts/**/*.test.tsx",
+      ),
+    ).toBe(true);
+    expect(
+      matchesConstraintAllow(
+        "packages/web/src/auth/providers/y.test.tsx",
+        WEB_LOCATOR_ALLOWLIST,
+      ),
+    ).toBe(false);
+    expect(
+      matchesConstraintAllow(
+        "packages/web/src/views/Forms/EventForm/EventForm.readOnly.test.tsx",
+        WEB_LOCATOR_ALLOWLIST,
+      ),
+    ).toBe(true);
+    expect(
+      matchesConstraintAllow(
+        "packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.test.tsx",
+        WEB_LOCATOR_ALLOWLIST,
+      ),
+    ).toBe(true);
+  });
+
+  it("covers backend db tests and the mongoService unit test", () => {
+    expect(
+      matchesConstraintAllow(
+        "packages/backend/src/billing/billing.guard.db.test.ts",
+        MONGO_SERVICE_TEST_ALLOWLIST,
+      ),
+    ).toBe(true);
+    expect(
+      matchesConstraintAllow(
+        "packages/backend/src/common/services/mongo.service.test.ts",
+        MONGO_SERVICE_TEST_ALLOWLIST,
+      ),
+    ).toBe(true);
+    expect(
+      matchesConstraintAllow(
+        "packages/backend/src/new.service.test.ts",
+        MONGO_SERVICE_TEST_ALLOWLIST,
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps allowlists empty or glob entries with a reason", () => {
+    expect(BARREL_ALLOWLIST).toEqual([]);
+    for (const entry of [
+      ...WEB_LOCATOR_ALLOWLIST,
+      ...MONGO_SERVICE_TEST_ALLOWLIST,
+    ]) {
+      expect(entry.glob.includes("*")).toBe(true);
+      expect(entry.reason.length).toBeGreaterThan(0);
+    }
   });
 });
 

--- a/packages/scripts/src/testing/check-agent-constraints.ts
+++ b/packages/scripts/src/testing/check-agent-constraints.ts
@@ -11,56 +11,87 @@ const DOCKERFILE_DIRS = ["self-host", ".github/docker"];
 
 const SOURCE_EXT = /\.(ts|tsx)$/;
 
-/** Existing component barrels. Do not add paths; delete these in a follow-up. */
-export const BARREL_ALLOWLIST = new Set([
-  "packages/web/src/components/AbsoluteOverflowLoader/index.ts",
-  "packages/web/src/components/Tooltip/index.ts",
-  "packages/web/src/views/Forms/EventForm/SaveSection/index.ts",
-  "packages/web/src/views/GoogleAuthCallback/index.ts",
-  "packages/web/src/views/NotFound/index.ts",
-]);
+export type ConstraintAllow = { glob: string; reason: string };
 
-/** Existing web tests that still use CSS/`data-*` locators. Do not add paths. */
-export const WEB_LOCATOR_ALLOWLIST = new Set([
-  "packages/web/src/components/AuthenticatedLayout/AuthenticatedLayout.test.tsx",
-  "packages/web/src/components/CommandPalette/CommandPalette.test.tsx",
-  "packages/web/src/components/ContextMenu/contextMenuLayering.test.tsx",
-  "packages/web/src/components/Focusable/Focusable.test.tsx",
-  "packages/web/src/components/SelectView/SelectView.test.tsx",
-  "packages/web/src/components/Shortcuts/ShortcutKeys.test.tsx",
-  "packages/web/src/components/Shortcuts/ShortcutList.test.tsx",
-  "packages/web/src/components/Sidebar/CalendarList/AnonymousCalendarRow.test.tsx",
-  "packages/web/src/components/Sidebar/MonthPicker/MonthPicker.test.tsx",
-  "packages/web/src/components/Tooltip/TooltipWrapper.test.tsx",
-  "packages/web/src/grid/components/EventCard.test.tsx",
-  "packages/web/src/grid/components/EventGrid.test.tsx",
-  "packages/web/src/grid/components/TimedGrid.test.tsx",
-  "packages/web/src/shortcuts/edit-sequence/EditSequenceMenu.test.tsx",
-  "packages/web/src/shortcuts/form-digit-jump/FormDigitHintOverlay.test.tsx",
-  "packages/web/src/shortcuts/page-jump/PageJumpHintOverlay.test.tsx",
-  "packages/web/src/shortcuts/shift-hint/ShiftHintOverlay.test.tsx",
-  "packages/web/src/views/Forms/EventForm/DateControlsSection/RecurrenceSection/RecurrenceSection.test.tsx",
-  "packages/web/src/views/Forms/EventForm/EventForm.readOnly.test.tsx",
-  "packages/web/src/views/Life/LifeView.test.tsx",
-]);
+/** Empty: remaining barrels were deleted; imports target the concrete files. */
+export const BARREL_ALLOWLIST: ConstraintAllow[] = [];
 
 /**
- * Backend tests that still import the mongoService singleton.
- * Follow-up: migrate to setupTestDb. Do not add paths.
- * scripts `*.db.test.ts` and sync's `sync-mongo.service` are out of scope.
+ * Structural locator exceptions. New tests outside these globs are still
+ * flagged, including `packages/web/src/auth/providers/**`.
  */
-export const MONGO_SERVICE_TEST_ALLOWLIST = new Set([
-  "packages/backend/src/auth/services/google/google.auth.service.db.test.ts",
-  "packages/backend/src/billing/billing.guard.db.test.ts",
-  "packages/backend/src/billing/services/billing.service.db.test.ts",
-  "packages/backend/src/billing/services/billing.webhook.service.db.test.ts",
-  "packages/backend/src/billing/services/stripe.service.db.test.ts",
-  "packages/backend/src/calendar/services/calendar.service.db.test.ts",
-  "packages/backend/src/common/services/mongo.service.test.ts",
-  "packages/backend/src/health/controllers/health.controller.db.test.ts",
-  "packages/backend/src/user/controllers/user.controller.db.test.ts",
-  "packages/backend/src/user/services/user.service.db.test.ts",
-]);
+export const WEB_LOCATOR_ALLOWLIST: ConstraintAllow[] = [
+  {
+    glob: "packages/web/src/shortcuts/**/*.test.tsx",
+    reason:
+      "hint overlays and the edit-sequence menu expose data-* roots, not roles",
+  },
+  {
+    glob: "packages/web/src/grid/components/*.test.tsx",
+    reason: "grid layers and edge-focus are data-* layout hooks",
+  },
+  {
+    glob: "packages/web/src/components/Sidebar/MonthPicker/*.test.tsx",
+    reason: "react-datepicker internals have no accessible names",
+  },
+  {
+    glob: "packages/web/src/components/CommandPalette/*.test.tsx",
+    reason: "command rows expose aria-hidden keycaps",
+  },
+  {
+    glob: "packages/web/src/components/ContextMenu/*.test.tsx",
+    reason: "the portal menu is class-based, not a named role",
+  },
+  {
+    glob: "packages/web/src/components/Focusable/*.test.tsx",
+    reason: "the focus ring is a CSS class with no role",
+  },
+  {
+    glob: "packages/web/src/components/SelectView/*.test.tsx",
+    reason: "the open listbox is still a testid surface",
+  },
+  {
+    glob: "packages/web/src/components/Shortcuts/*.test.tsx",
+    reason: "keycaps are aria-hidden",
+  },
+  {
+    glob: "packages/web/src/components/Sidebar/CalendarList/*.test.tsx",
+    reason: "the color swatch is aria-hidden",
+  },
+  {
+    glob: "packages/web/src/components/Tooltip/*.test.tsx",
+    reason: "shortcut-node is a test-only child without a name",
+  },
+  {
+    glob: "packages/web/src/components/AuthenticatedLayout/*.test.tsx",
+    reason: "route-outlet fixtures use testids",
+  },
+  {
+    glob: "packages/web/src/views/Forms/EventForm/**/*.test.tsx",
+    reason: "recurrence data-selected chips and read-only fieldsets",
+  },
+  {
+    glob: "packages/web/src/views/Life/*.test.tsx",
+    reason: "life-grid dots are data-total-dots and ring classes",
+  },
+];
+
+/**
+ * Db tests seed and assert through the mongoService singleton. Sync's
+ * `sync-mongo.service` is out of scope. New backend unit tests that are not
+ * `*.db.test.ts` still cannot import mongoService.
+ */
+export const MONGO_SERVICE_TEST_ALLOWLIST: ConstraintAllow[] = [
+  {
+    glob: "packages/backend/src/**/*.db.test.ts",
+    reason:
+      "db tests insert and assert via the mongoService singleton until a collection accessor replaces it",
+  },
+  {
+    glob: "packages/backend/src/**/mongo.service.test.ts",
+    reason: "this file is the mongoService unit test",
+  },
+];
 
 const REEXPORT_FROM =
   /export\s+(?:\*|type\s+\{[^}]*\}|\{[^}]*\})\s+from\s+["']/;
@@ -74,6 +105,23 @@ const DUPLICATE_EVENT_SCHEMA =
   /(?:const|let|var)\s+EventSchema\s*=\s*z\.object/;
 
 export type ConstraintHit = { path: string; rule: string; line: number };
+
+export function matchesConstraintAllow(
+  path: string,
+  allowlist: ConstraintAllow[],
+): boolean {
+  return allowlist.some((entry) => matchGlob(path, entry.glob));
+}
+
+export function matchGlob(path: string, glob: string): boolean {
+  const pattern = glob
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*\//g, "\0")
+    .replace(/\*\*/g, "\0")
+    .replace(/\*/g, "[^/]*")
+    .replace(/\0/g, "(?:.*/)?");
+  return new RegExp(`^${pattern}$`).test(path);
+}
 
 export function isBarrelSource(source: string): boolean {
   if (REEXPORT_FROM.test(source)) return true;
@@ -139,18 +187,21 @@ export function scanConstraints(root = repoRoot): ConstraintHit[] {
     const source = readFileSync(file, "utf8");
 
     if (isIndexModule(rel) && rel !== APP_ENTRY && isBarrelSource(source)) {
-      if (!BARREL_ALLOWLIST.has(rel)) {
+      if (!matchesConstraintAllow(rel, BARREL_ALLOWLIST)) {
         hits.push({ path: rel, rule: "barrel", line: 1 });
       }
     }
 
-    if (isWebTest(rel) && !WEB_LOCATOR_ALLOWLIST.has(rel)) {
+    if (isWebTest(rel) && !matchesConstraintAllow(rel, WEB_LOCATOR_ALLOWLIST)) {
       for (const line of locatorHits(source)) {
         hits.push({ path: rel, rule: "web-locator", line });
       }
     }
 
-    if (isBackendOrSyncTest(rel) && !MONGO_SERVICE_TEST_ALLOWLIST.has(rel)) {
+    if (
+      isBackendOrSyncTest(rel) &&
+      !matchesConstraintAllow(rel, MONGO_SERVICE_TEST_ALLOWLIST)
+    ) {
       for (const line of mongoServiceImportHits(source)) {
         hits.push({ path: rel, rule: "mongoService-import", line });
       }

--- a/packages/web/src/components/AbsoluteOverflowLoader/index.ts
+++ b/packages/web/src/components/AbsoluteOverflowLoader/index.ts
@@ -1,1 +1,0 @@
-export { AbsoluteOverflowLoader } from "./AbsoluteOverflowLoader";

--- a/packages/web/src/components/Shortcuts/ShortcutList.tsx
+++ b/packages/web/src/components/Shortcuts/ShortcutList.tsx
@@ -3,12 +3,12 @@ import {
   ShortcutProBadge,
 } from "@web/billing/ShortcutProBadge";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
+import { TooltipDescription } from "@web/components/Tooltip/Description/TooltipDescription";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-} from "@web/components/Tooltip";
-import { TooltipDescription } from "@web/components/Tooltip/Description/TooltipDescription";
+} from "@web/components/Tooltip/Tooltip";
 import { type Shortcut } from "@web/shortcuts/global.shortcut.types";
 
 const ROW_CLASSNAME =

--- a/packages/web/src/components/Sidebar/CalendarList/AnonymousCalendarRow.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AnonymousCalendarRow.tsx
@@ -11,7 +11,7 @@ import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-} from "@web/components/Tooltip";
+} from "@web/components/Tooltip/Tooltip";
 
 const ANONYMOUS_SAVE_MESSAGE = "Sign up to save your changes across browsers";
 

--- a/packages/web/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/web/src/components/Tooltip/Tooltip.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { Tooltip, TooltipContent, TooltipTrigger } from "./index";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./Tooltip";
 import { describe, expect, it, mock } from "bun:test";
 
 describe("Tooltip interactive option", () => {

--- a/packages/web/src/components/Tooltip/TooltipWrapper.tsx
+++ b/packages/web/src/components/Tooltip/TooltipWrapper.tsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-} from "@web/components/Tooltip";
+} from "@web/components/Tooltip/Tooltip";
 import { type TooltipOptions } from "@web/components/Tooltip/tooltip.types";
 import { pointerShortcutAttributes } from "@web/shortcuts/keyboard-only/pointer-action";
 import { ShortcutHint } from "../Shortcuts/ShortcutHint";

--- a/packages/web/src/components/Tooltip/index.ts
+++ b/packages/web/src/components/Tooltip/index.ts
@@ -1,3 +1,0 @@
-import { Tooltip, TooltipContent, TooltipTrigger } from "./Tooltip";
-
-export { Tooltip, TooltipContent, TooltipTrigger };

--- a/packages/web/src/routers/index.tsx
+++ b/packages/web/src/routers/index.tsx
@@ -3,7 +3,7 @@ import {
   createRouter,
   RouterProvider,
 } from "@tanstack/react-router";
-import { AbsoluteOverflowLoader } from "@web/components/AbsoluteOverflowLoader";
+import { AbsoluteOverflowLoader } from "@web/components/AbsoluteOverflowLoader/AbsoluteOverflowLoader";
 import { routeTree } from "@web/routers/router.routes";
 
 export const router = createRouter({

--- a/packages/web/src/routers/router.routes.tsx
+++ b/packages/web/src/routers/router.routes.tsx
@@ -22,7 +22,7 @@ import {
   validateWeekDateParam,
 } from "@web/routers/loaders";
 import { validateLifeSearch } from "@web/views/Life/life-search";
-import { NotFoundView } from "@web/views/NotFound";
+import { NotFoundView } from "@web/views/NotFound/NotFound";
 
 export const rootRoute = createRootRoute({
   component: lazyRouteComponent(
@@ -155,7 +155,7 @@ export const googleAuthCallbackRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: ROOT_ROUTES.GOOGLE_AUTH_CALLBACK,
   component: lazyRouteComponent(
-    () => import("@web/views/GoogleAuthCallback"),
+    () => import("@web/views/GoogleAuthCallback/GoogleAuthCallback"),
     "GoogleAuthCallbackView",
   ),
 });

--- a/packages/web/src/views/Cleanup/Cleanup.tsx
+++ b/packages/web/src/views/Cleanup/Cleanup.tsx
@@ -2,7 +2,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
 import { clearAllBrowserStorage } from "@web/common/utils/cleanup/browser.cleanup.util";
-import { AbsoluteOverflowLoader } from "@web/components/AbsoluteOverflowLoader";
+import { AbsoluteOverflowLoader } from "@web/components/AbsoluteOverflowLoader/AbsoluteOverflowLoader";
 
 const REDIRECT_DELAY_MS = 3000;
 

--- a/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.test.tsx
@@ -32,7 +32,7 @@ import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { useEditSequenceShortcut } from "@web/shortcuts/useEditSequenceShortcut";
 import { type Props as DateTimeSectionProps } from "@web/views/Forms/EventForm/DateControlsSection/DateTimeSection/DateTimeSection";
 import { getFormDates } from "@web/views/Forms/EventForm/DateControlsSection/DateTimeSection/form.datetime.util";
-import * as realSavesection from "@web/views/Forms/EventForm/SaveSection";
+import * as realSavesection from "@web/views/Forms/EventForm/SaveSection/SaveSection";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 /**
@@ -93,13 +93,17 @@ mock.module(
   }),
 );
 
-mockModuleForFile("@web/views/Forms/EventForm/SaveSection", realSavesection, {
-  SaveSection: ({ onSubmit }: { onSubmit: () => void }) => (
-    <button type="button" onClick={onSubmit}>
-      Save
-    </button>
-  ),
-});
+mockModuleForFile(
+  "@web/views/Forms/EventForm/SaveSection/SaveSection",
+  realSavesection,
+  {
+    SaveSection: ({ onSubmit }: { onSubmit: () => void }) => (
+      <button type="button" onClick={onSubmit}>
+        Save
+      </button>
+    ),
+  },
+);
 
 const { EventForm } = require("./EventForm") as typeof import("./EventForm");
 

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -74,7 +74,7 @@ import { EventColorPicker } from "@web/views/Forms/EventForm/EventColorPicker/Ev
 import { EventDetailsSection } from "@web/views/Forms/EventForm/EventDetailsSection";
 import { FormActionsRow } from "@web/views/Forms/EventForm/FormActionsRow";
 import { RsvpControl } from "@web/views/Forms/EventForm/RsvpControl";
-import { SaveSection } from "@web/views/Forms/EventForm/SaveSection";
+import { SaveSection } from "@web/views/Forms/EventForm/SaveSection/SaveSection";
 import {
   type GridEventFormProps,
   type SetEventFormSchedule,

--- a/packages/web/src/views/Forms/EventForm/SaveSection/index.ts
+++ b/packages/web/src/views/Forms/EventForm/SaveSection/index.ts
@@ -1,3 +1,0 @@
-import { SaveSection } from "./SaveSection";
-
-export { SaveSection };

--- a/packages/web/src/views/GoogleAuthCallback/index.ts
+++ b/packages/web/src/views/GoogleAuthCallback/index.ts
@@ -1,1 +1,0 @@
-export { GoogleAuthCallbackView } from "./GoogleAuthCallback";

--- a/packages/web/src/views/Life/LifeGrid.tsx
+++ b/packages/web/src/views/Life/LifeGrid.tsx
@@ -3,7 +3,7 @@ import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-} from "@web/components/Tooltip";
+} from "@web/components/Tooltip/Tooltip";
 import { getLifeDotLabel, WEEKS_PER_ROW } from "./life.utils";
 
 interface LifeGridProps {

--- a/packages/web/src/views/NotFound/index.ts
+++ b/packages/web/src/views/NotFound/index.ts
@@ -1,3 +1,0 @@
-import { NotFoundView } from "./NotFound";
-
-export { NotFoundView };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Providers L WP-09 rebuilt on current main. Supersedes the conflicting [#3294](https://github.com/KeepSoftwareSimple/compass-calendar/pull/3294).

- Delete the five remaining web barrel `index.ts` files and retarget imports to the concrete modules.
- Convert `WEB_LOCATOR_ALLOWLIST` and `MONGO_SERVICE_TEST_ALLOWLIST` from path sets to glob+reason entries so new provider tests do not require checker edits.
- Keep `scanBunDockerfilePins` (dropped on the stale branch).
- No `.agents/ledger.md`.

Fixes #3220

## Simplicity

One glob matcher, empty barrel allowlist, no per-file path additions.

## Automated validation

- `bun test packages/scripts/src/testing/check-agent-constraints.test.ts` (19 pass)
- `bun packages/scripts/src/testing/check-agent-constraints.ts` (no hits)

## Independent review

Handoff: `.agents/handoffs/3220.md`. Approval boundary is allow.

## Test plan

- `bun test packages/scripts/src/testing/check-agent-constraints.test.ts`
- `bun packages/scripts/src/testing/check-agent-constraints.ts`
- `bun run verify`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef6e39c4-a4b6-4e0b-9d22-cc18bd946439?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef6e39c4-a4b6-4e0b-9d22-cc18bd946439&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

