### PR TITLE
feat(scripts): single incremental type-check with project references

### DIFF
--- a/.agents/handoffs/3222.md
+++ b/.agents/handoffs/3222.md
@@ -1,0 +1,50 @@
+---
+schema_version: 1
+task_id: "3222"
+from: Verifier
+to: MergeGuard
+owner: MergeGuard
+status: verifying
+artifact:
+  - path: tsconfig.typecheck.json
+  - path: package.json
+  - path: .github/workflows/test-unit.yml
+evidence:
+  - command: bunx typescript@7.0.2 -b tsconfig.typecheck.json --dry
+    result: "typescript@7.0.2 supports --build with project references; emits .tsbuildinfo at build/node/tsconfig.tsbuildinfo, packages/web/tsconfig.app.tsbuildinfo, packages/web/tsconfig.test.tsbuildinfo"
+    log: null
+  - command: bun run type-check
+    result: "pass; one bunx/tsc -b process (not three serial bunx invocations); warm run ~2.7s vs cold ~3.4s locally"
+    log: null
+  - command: deliberately broken packages/core/src/constants/core.constants.ts
+    result: "old three-invocation and new single-build both report TS2322 and TS6133 on core.constants.ts:37"
+    log: null
+  - command: bun run verify scripts
+    result: "PASS. Selected packages: scripts. Checks run: test:scripts, type-check, lint, knip. Checks skipped: (none)."
+    log: null
+  - command: bun test:scripts
+    result: "105 pass, 0 fail (via verify scripts run)"
+    log: null
+assumptions:
+  - "CI type-check job cache key includes bun.lock and tsconfig hashes; warm CI under 20s is validated post-merge"
+  - "Web tsconfigs stay non-composite so @core path imports keep working without a core project reference graph"
+open_risks:
+  - "Diff touches .github/workflows/test-unit.yml; merge guard may downgrade agent-automerge despite Approval boundary allow"
+next_deadline: null
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+Providers L WP-12. Simplify: no further change.
+
+Review:
+
+VERDICT: no confirmed findings
+FINDINGS:
+(none)
+
+Single `tsc -b tsconfig.typecheck.json --noEmit` replaces three serial
+`bunx typescript@7.0.2` runs. Solution references root, web app, and web
+tests. CI caches `**/*.tsbuildinfo`.

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -152,6 +152,15 @@ jobs:
         run: |
           bun install --frozen-lockfile
 
+      - name: Cache TypeScript incremental build info
+        uses: actions/cache@v5
+        with:
+          path: |
+            **/*.tsbuildinfo
+          key: ${{ runner.os }}-tsc-${{ hashFiles('bun.lock', 'tsconfig.json', 'tsconfig.typecheck.json', 'packages/**/tsconfig*.json') }}
+          restore-keys: |
+            ${{ runner.os }}-tsc-${{ hashFiles('bun.lock') }}-
+
       - name: Run type-check
         run: |
           bun run type-check

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test:scripts": "bun packages/scripts/src/testing/test-mongo-env.ts scripts --",
     "test:scripts:fast": "bun packages/scripts/src/testing/test-parallel.ts scripts-fast -- --path-ignore-patterns '**/*.db.test.ts'",
     "test:scripts:db": "bun packages/scripts/src/testing/test-mongo-env.ts scripts -- './packages/scripts/src/**/*.db.test.ts'",
-    "type-check": "bunx typescript@7.0.2 --noEmit && bunx typescript@7.0.2 -p packages/web/tsconfig.app.json --noEmit && bun run type-check:web-tests",
+    "type-check": "bunx typescript@7.0.2 -b tsconfig.typecheck.json --noEmit",
     "type-check:web-tests": "bunx typescript@7.0.2 -p packages/web/tsconfig.test.json --noEmit",
     "verify": "bun packages/scripts/src/testing/verify.ts",
     "build:backend": "bun packages/scripts/src/commands/build.backend.ts",

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,0 +1,8 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.json" },
+    { "path": "./packages/web/tsconfig.app.json" },
+    { "path": "./packages/web/tsconfig.test.json" }
+  ]
+}


### PR DESCRIPTION
Fixes #3222

## Summary

Root `type-check` ran three serial `bunx typescript@7.0.2` invocations, each re-resolving the pinned compiler. This WP adds a solution `tsconfig.typecheck.json` with project references so one `tsc -b --noEmit` covers the root monorepo graph, web app, and web tests. CI caches `**/*.tsbuildinfo` keyed on `bun.lock` and tsconfig hashes.

Confirmed: `typescript@7.0.2` (native compiler) supports `--build` with project references and emits `.tsbuildinfo` files.

## Simplicity

No new runtime code. One solution config, one script line change, one CI cache step. Web tsconfigs stay non-composite so existing `@core/*` path imports continue to work without restructuring the core project graph.

## Automated validation

- `bun run type-check`: one `tsc -b` process (not three serial invocations); warm ~2.7s vs cold ~3.4s locally
- Deliberately broken file: old three-invocation and new single-build report the same TS2322/TS6133 on `core.constants.ts`
- `.tsbuildinfo` emitted at `build/node/tsconfig.tsbuildinfo`, `packages/web/tsconfig.app.tsbuildinfo`, `packages/web/tsconfig.test.tsbuildinfo`

## Independent review

`.agents/handoffs/3222.md`

VERDICT: no confirmed findings

## Test plan

- `bun test:scripts` (105 pass, 0 fail via verify)
- `bun run type-check`
- `bun lint` (27 pre-existing warnings, none in diff)
- `bun knip`
- `bun run verify scripts` — PASS