### PR TITLE
fix(web): collapse per-instance lock ids in shortcut_unavailable_attempt context

### DIFF
--- a/packages/web/src/auth/posthog/track.test.ts
+++ b/packages/web/src/auth/posthog/track.test.ts
@@ -126,10 +126,12 @@ describe("shortcut telemetry", () => {
     ).toMatchObject({ invocations: 1, lastInvokedAt: 200_000 });
   });
 
-  it("captures which registered shortcut was blocked, by which lock, where", () => {
+  it("captures which shortcut was blocked, by which lock owners, where", () => {
     window.history.pushState({}, "", "/week/2026-09-06");
     setAppLockReason("settingsModal", true);
     setAppLockReason("billingGate", true);
+    setAppLockReason("overlayPanel::r3:", true);
+    setAppLockReason("overlayPanel::r79:", true);
     const input = document.createElement("input");
     document.body.appendChild(input);
     input.focus();
@@ -148,7 +150,7 @@ describe("shortcut telemetry", () => {
     expect(capture).toHaveBeenCalledWith("shortcut_unavailable_attempt", {
       action_id: "event.edge_focus",
       active_element: "input",
-      context: "billingGate+settingsModal",
+      context: "billingGate+overlayPanel+settingsModal",
       feature_area: "event_editing",
       is_repeat: true,
       outcome: "unavailable",

--- a/packages/web/src/shortcuts/tips/shortcut-telemetry.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-telemetry.ts
@@ -140,6 +140,16 @@ function viewFromPathname(pathname: string): string {
   return match?.[1] ?? "other";
 }
 
+/** Lock owners as a stable, low-cardinality key. OverlayPanel registers
+ * `overlayPanel:<useId>` per instance so nested panels unlock independently;
+ * the instance suffix is dropped here so PostHog can group on the name. */
+function lockContext(): string {
+  const names = new Set(
+    getAppLockReasons().map((reason) => reason.split(":")[0]),
+  );
+  return [...names].sort().join("+") || "unknown";
+}
+
 /** Static registration string for a hotkey (e.g. "Shift+ArrowLeft"). */
 function registeredHotkeyLabel(hotkey: RegisterableHotkey): string {
   if (typeof hotkey === "string") return hotkey;
@@ -173,7 +183,7 @@ export function recordShortcutUnavailableAttempt(
   track("shortcut_unavailable_attempt", {
     action_id: hint.actionId,
     active_element: document.activeElement?.tagName.toLowerCase() ?? "none",
-    context: getAppLockReasons().join("+") || "unknown",
+    context: lockContext(),
     feature_area: hint.featureArea,
     is_repeat: event.repeat,
     outcome: "unavailable",


### PR DESCRIPTION
## Summary

Follow-up to #3307. The first real staging event carried

```
context = overlayPanel::r3:+overlayPanel::r79:+settingsModal
```

because `OverlayPanel` registers an app-lock reason per React `useId` so nested panels can unlock independently. Those ids fragment any GROUP BY on `context`. The telemetry now keeps only the name before the colon and dedupes, giving `overlayPanel+settingsModal`.

## Test plan

- [x] track / app-lock / useAppShortcut suites (24 pass), type-check
- [ ] After staging deploy: open Settings, press `C`, confirm `context=overlayPanel+settingsModal` in PostHog

🤖 Generated with [Claude Code](https://claude.com/claude-code)