### PR TITLE
feat(sync): exclude event ids from busy availability

### DIFF
--- a/.agents/handoffs/3110.md
+++ b/.agents/handoffs/3110.md
@@ -1,18 +1,21 @@
 ---
 schema_version: 1
 task_id: "3110"
-from: Implementer
-to: Verifier
-owner: Implementer
-status: running
+from: Verifier
+to: Manager
+owner: Manager
+status: verifying
 artifact:
   - path: packages/core/src/types/sync/availability.contracts.ts
   - path: packages/sync/src/domain/busy-query.service.ts
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3316
 evidence:
-  - command: bun test:core
-    result: not yet run
-  - command: bun test:sync
-    result: not yet run
+  - command: bun run verify
+    result: "exit 0; selected core, sync; checks test:core, test:sync, type-check, lint, knip; all passed"
+  - command: bun test:core -- packages/core/src/types/sync/availability.contracts.test.ts
+    result: "exit 0; 5 pass, 0 fail"
+  - command: bun test:sync -- packages/sync/src/domain/busy-query.service.db.test.ts packages/sync/src/domain/busy-availability.service.db.test.ts
+    result: "exit 0; 21 pass, 0 fail"
 assumptions:
   - "excludeEventIds is Compass EventId, dropped before merge; unknown ids are no-ops"
 open_risks: []
@@ -23,5 +26,6 @@ waiting_on: null
 escalation: null
 ---
 
-WP-03: optional excludeEventIds on busy availability so a reservation can
-self-exclude while picking a new slot. No public HTTP reschedule in this WP.
+WP-03 excludeEventIds on busy availability.
+
+Verifier: PASS. Simplify: no further reduction. Review: no confirmed findings.

--- a/.agents/handoffs/3110.md
+++ b/.agents/handoffs/3110.md
@@ -1,0 +1,27 @@
+---
+schema_version: 1
+task_id: "3110"
+from: Implementer
+to: Verifier
+owner: Implementer
+status: running
+artifact:
+  - path: packages/core/src/types/sync/availability.contracts.ts
+  - path: packages/sync/src/domain/busy-query.service.ts
+evidence:
+  - command: bun test:core
+    result: not yet run
+  - command: bun test:sync
+    result: not yet run
+assumptions:
+  - "excludeEventIds is Compass EventId, dropped before merge; unknown ids are no-ops"
+open_risks: []
+next_deadline: 2026-09-05T00:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-03: optional excludeEventIds on busy availability so a reservation can
+self-exclude while picking a new slot. No public HTTP reschedule in this WP.

--- a/packages/core/src/types/sync/availability.contracts.test.ts
+++ b/packages/core/src/types/sync/availability.contracts.test.ts
@@ -1,0 +1,49 @@
+import { faker } from "@faker-js/faker";
+import { BusyAvailabilityRequestSchema } from "@core/types/sync/availability.contracts";
+import { describe, expect, it } from "bun:test";
+
+const objectId = () => faker.database.mongodbObjectId();
+
+const baseRequest = () => ({
+  calendarIds: [objectId()],
+  start: "2026-07-14T00:00:00.000Z",
+  end: "2026-07-15T00:00:00.000Z",
+  maxAgeMs: 300_000,
+  purpose: "booking_confirmation" as const,
+});
+
+describe("BusyAvailabilityRequestSchema", () => {
+  it("accepts a request without excludeEventIds", () => {
+    expect(BusyAvailabilityRequestSchema.safeParse(baseRequest()).success).toBe(
+      true,
+    );
+  });
+
+  it("accepts an optional array of event ids", () => {
+    const request = { ...baseRequest(), excludeEventIds: [objectId()] };
+    expect(BusyAvailabilityRequestSchema.safeParse(request).success).toBe(true);
+  });
+
+  it("accepts an empty excludeEventIds array", () => {
+    const request = { ...baseRequest(), excludeEventIds: [] };
+    expect(BusyAvailabilityRequestSchema.safeParse(request).success).toBe(true);
+  });
+
+  it("rejects extra keys", () => {
+    const request = { ...baseRequest(), eventTitles: ["secret"] };
+    expect(BusyAvailabilityRequestSchema.safeParse(request).success).toBe(
+      false,
+    );
+  });
+
+  it("rejects extra keys alongside excludeEventIds", () => {
+    const request = {
+      ...baseRequest(),
+      excludeEventIds: [objectId()],
+      calendarEventId: objectId(),
+    };
+    expect(BusyAvailabilityRequestSchema.safeParse(request).success).toBe(
+      false,
+    );
+  });
+});

--- a/packages/core/src/types/sync/availability.contracts.ts
+++ b/packages/core/src/types/sync/availability.contracts.ts
@@ -1,5 +1,5 @@
 import { z } from "zod/v4";
-import { DateTimeSchema } from "@core/types/domain-primitives";
+import { DateTimeSchema, EventIdSchema } from "@core/types/domain-primitives";
 import { AttendeeResponseStatusSchema } from "@core/types/event-attendance.contracts";
 import { ConnectionStateSchema } from "@core/types/sync/connection.contracts";
 import { SyncEventCalendarIdSchema } from "@core/types/sync/event.contracts";
@@ -31,6 +31,10 @@ export const BusyAvailabilityRequestSchema = z
     // Compass-local calendar ids: cloud-only events at generation 0, no
     // provider resource. Any other missing resource stays notImported.
     unbackedCalendarIds: z.array(SyncEventCalendarIdSchema).max(100).optional(),
+    // Drop these Compass event ids before merge. Unknown ids are ignored.
+    // Omit or pass [] for today's merge behavior. Event ids never appear on
+    // the busy response wire.
+    excludeEventIds: z.array(EventIdSchema).max(100).optional(),
   })
   .refine((r) => Date.parse(r.end) > Date.parse(r.start), {
     message: "end must be after start",

--- a/packages/sync/src/domain/busy-availability.service.db.test.ts
+++ b/packages/sync/src/domain/busy-availability.service.db.test.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import { type EventId } from "@core/types/domain-primitives";
 import { type ConnectionState } from "@core/types/sync/connection.contracts";
 import { type SyncEventCalendarId } from "@core/types/sync/event.contracts";
 import {
@@ -125,6 +126,7 @@ describe("computeBusyAvailability", () => {
   const run = (
     calendarIds: SyncEventCalendarId[],
     unbackedCalendarIds?: SyncEventCalendarId[],
+    excludeEventIds?: EventId[],
   ) =>
     computeBusyAvailability(
       { occurrences, resources, connections, calendars },
@@ -133,6 +135,7 @@ describe("computeBusyAvailability", () => {
         principalId,
         calendarIds,
         unbackedCalendarIds,
+        excludeEventIds,
         start: WINDOW_START,
         end: WINDOW_END,
         maxAgeMs: MAX_AGE_MS,
@@ -317,5 +320,23 @@ describe("computeBusyAvailability", () => {
     expect(result.complete).toBe(true); // the data itself is fresh
     expect(result.bookable).toBe(false); // but the connection cannot be verified
     expect(result.connections).toEqual([]); // no record to report freshness for
+  });
+
+  it("still fail-closes on incomplete freshness when excludeEventIds is set", async () => {
+    const conn = await seedConnection("healthy", old);
+    const cal = await seedCalendar({
+      connectionId: conn,
+      lastSuccessAt: old,
+      intervals: [["2026-07-14T13:00Z", "2026-07-14T14:00Z"]],
+    });
+
+    const result = await run([cal], undefined, [objectId() as EventId]);
+
+    expect(result.issues).toEqual([{ calendarId: cal, reason: "stale" }]);
+    expect(result.complete).toBe(false);
+    expect(result.bookable).toBe(false);
+    expect(
+      result.intervals.map((i) => [i.start.toISOString(), i.end.toISOString()]),
+    ).toEqual([["2026-07-14T13:00:00.000Z", "2026-07-14T14:00:00.000Z"]]);
   });
 });

--- a/packages/sync/src/domain/busy-query.service.db.test.ts
+++ b/packages/sync/src/domain/busy-query.service.db.test.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import { type EventId } from "@core/types/domain-primitives";
 import { type SyncEventCalendarId } from "@core/types/sync/event.contracts";
 import {
   type PrincipalId,
@@ -37,10 +38,11 @@ describe("queryBusyIntervals", () => {
     generation?: number;
     busy?: boolean;
     cancelled?: boolean;
+    eventId?: string;
   }) => {
     // Unique eventId + occurrenceKey per doc: the collection has a unique index
     // on (eventId, generation, occurrenceKey), so distinct seeds must not collide.
-    const eventId = objectId();
+    const eventId = input.eventId ?? objectId();
     return storage
       .db()
       .collection(SYNC_COLLECTIONS.eventOccurrences)
@@ -56,11 +58,13 @@ describe("queryBusyIntervals", () => {
         ...(input.end ? { endAt: new Date(input.end) } : {}),
         busy: input.busy ?? true,
         cancelled: input.cancelled ?? false,
-      });
+      })
+      .then(() => eventId);
   };
 
   const query = (
     calendars: Array<{ calendarId: SyncEventCalendarId; generation: number }>,
+    excludeEventIds?: readonly EventId[],
   ) =>
     queryBusyIntervals(
       { occurrences },
@@ -70,6 +74,7 @@ describe("queryBusyIntervals", () => {
         calendars,
         start: WINDOW_START,
         end: WINDOW_END,
+        excludeEventIds,
       },
     );
 
@@ -200,5 +205,67 @@ describe("queryBusyIntervals", () => {
     });
 
     expect(await query([{ calendarId: calendarA, generation: 0 }])).toEqual([]);
+  });
+
+  it("drops an excluded event before merge and keeps overlapping host busy", async () => {
+    const bookingId = objectId();
+    await seed({
+      calendarId: calendarA,
+      start: "2026-07-14T10:00Z",
+      end: "2026-07-14T11:00Z",
+    });
+    await seed({
+      calendarId: calendarA,
+      start: "2026-07-14T10:00Z",
+      end: "2026-07-14T10:30Z",
+      eventId: bookingId,
+    });
+
+    const result = await query(
+      [{ calendarId: calendarA, generation: 0 }],
+      [bookingId as EventId],
+    );
+
+    expect(iso(result)).toEqual([
+      ["2026-07-14T10:00:00.000Z", "2026-07-14T11:00:00.000Z"],
+    ]);
+  });
+
+  it("ignores unknown excludeEventIds", async () => {
+    await seed({
+      calendarId: calendarA,
+      start: "2026-07-14T10:00Z",
+      end: "2026-07-14T11:00Z",
+    });
+
+    const result = await query(
+      [{ calendarId: calendarA, generation: 0 }],
+      [objectId() as EventId],
+    );
+
+    expect(iso(result)).toEqual([
+      ["2026-07-14T10:00:00.000Z", "2026-07-14T11:00:00.000Z"],
+    ]);
+  });
+
+  it("matches today's merge when excludeEventIds is empty or omitted", async () => {
+    await seed({
+      calendarId: calendarA,
+      start: "2026-07-14T09:00Z",
+      end: "2026-07-14T10:00Z",
+    });
+    await seed({
+      calendarId: calendarA,
+      start: "2026-07-14T10:00Z",
+      end: "2026-07-14T11:00Z",
+    });
+
+    const omitted = await query([{ calendarId: calendarA, generation: 0 }]);
+    const empty = await query([{ calendarId: calendarA, generation: 0 }], []);
+
+    expect(iso(omitted)).toEqual([
+      ["2026-07-14T09:00:00.000Z", "2026-07-14T11:00:00.000Z"],
+    ]);
+    expect(iso(empty)).toEqual(iso(omitted));
   });
 });

--- a/packages/sync/src/domain/busy-query.service.ts
+++ b/packages/sync/src/domain/busy-query.service.ts
@@ -80,6 +80,8 @@ export interface BusyQueryInput {
   // Half-open query window [start, end).
   start: Date;
   end: Date;
+  // Drop these events before merge. Unknown ids are ignored.
+  excludeEventIds?: readonly EventId[];
 }
 
 // The merged busy intervals within [start, end) for the given calendars. Each
@@ -107,6 +109,7 @@ export async function queryBusyOccurrences(
 
   const windowStart = input.start.getTime();
   const windowEnd = input.end.getTime();
+  const excluded = new Set(input.excludeEventIds ?? []);
   return occurrences
     .map((occurrence) => ({
       start:
@@ -117,7 +120,11 @@ export async function queryBusyOccurrences(
         occurrence.endAt.getTime() < windowEnd ? occurrence.endAt : input.end,
       eventId: occurrence.eventId,
     }))
-    .filter((interval) => interval.end.getTime() > interval.start.getTime());
+    .filter(
+      (interval) =>
+        interval.end.getTime() > interval.start.getTime() &&
+        !excluded.has(interval.eventId),
+    );
 }
 
 export async function queryBusyIntervals(
@@ -191,6 +198,8 @@ export interface BusyAvailabilityInput {
   // The oldest a calendar's last successful sync may be and still count as fresh.
   maxAgeMs: number;
   now: Date;
+  // Drop these events before merge. Unknown ids are ignored.
+  excludeEventIds?: readonly EventId[];
 }
 
 // The busy intervals for a set of calendars plus the freshness/completeness
@@ -270,6 +279,7 @@ export async function computeBusyAvailability(
           calendars: present,
           start: input.start,
           end: input.end,
+          excludeEventIds: input.excludeEventIds,
         },
       )
     : [];

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -427,6 +427,7 @@ export function registerConnectionRoutes(
             principalId: auth.principalId,
             calendarIds: query.calendarIds,
             unbackedCalendarIds: query.unbackedCalendarIds,
+            excludeEventIds: query.excludeEventIds,
             start,
             end,
             maxAgeMs: query.maxAgeMs,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Booking v1.3 WP-03 (#3110). Lets a busy-availability query drop named Compass events before intervals merge, so a guest can pick a new slot without the current reservation occupying it.

- Optional `excludeEventIds` on `BusyAvailabilityRequestSchema` (max 100). Unknown ids are ignored. Omit or `[]` keeps today's merge.
- `queryBusyOccurrences` / `computeBusyAvailability` drop those events before merge.
- Occupancy facts and the busy response wire are unchanged: no event ids on intervals.
- HTTP busy route forwards the field. No public reschedule HTTP in this WP.

Fixes #3110

## Simplicity

One optional array on the existing request schema. Filtering is a Set lookup in `queryBusyOccurrences`, so both interval merge and availability evidence share the same drop. No further reduction after the simplify pass.

## Automated validation

`bun run verify`:

```
Selected packages: core, sync
Checks run: test:core, test:sync, type-check, lint, knip
Checks skipped: (none)
All checks passed
```

Focused:

- `bun test:core -- packages/core/src/types/sync/availability.contracts.test.ts`: 5 pass
- `bun test:sync --` busy-query and busy-availability db tests: 21 pass

Overlapping host 10:00-11:00 plus booking 10:00-10:30: excluding the booking id still occupies 10:00-11:00. Unknown ids are ignored. Empty or omitted `excludeEventIds` still merges touching intervals. A request with `excludeEventIds` still fail-closes on stale freshness.

## Independent review

`.agents/handoffs/3110.md`

```
VERDICT: no confirmed findings
FINDINGS:
(none)
```

Event ids stay off the busy response. Public booking slot JSON is unchanged.

## Test plan

- `bun test:core`
- `bun test:sync`
- `bun run type-check`
- `bun lint`
- `bun knip`
- `bun run verify`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73143677-1949-45fd-81f9-f9974a68183e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73143677-1949-45fd-81f9-f9974a68183e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

