### PR TITLE
feat(web): name OverlayPanel lock reasons by title for shortcut telemetry

### DIFF
--- a/packages/web/src/auth/posthog/track.test.ts
+++ b/packages/web/src/auth/posthog/track.test.ts
@@ -130,8 +130,8 @@ describe("shortcut telemetry", () => {
     window.history.pushState({}, "", "/week/2026-09-06");
     setAppLockReason("settingsModal", true);
     setAppLockReason("billingGate", true);
-    setAppLockReason("overlayPanel::r3:", true);
-    setAppLockReason("overlayPanel::r79:", true);
+    setAppLockReason("overlayPanel:settings::r3:", true);
+    setAppLockReason("overlayPanel:settings::r79:", true);
     const input = document.createElement("input");
     document.body.appendChild(input);
     input.focus();
@@ -150,7 +150,7 @@ describe("shortcut telemetry", () => {
     expect(capture).toHaveBeenCalledWith("shortcut_unavailable_attempt", {
       action_id: "event.edge_focus",
       active_element: "input",
-      context: "billingGate+overlayPanel+settingsModal",
+      context: "billingGate+overlayPanel:settings+settingsModal",
       feature_area: "event_editing",
       is_repeat: true,
       outcome: "unavailable",

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
@@ -16,6 +16,16 @@ import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import { useAppLockReason } from "@web/shortcuts/app-lock";
 import { pointerShortcutAttributes } from "@web/shortcuts/keyboard-only/pointer-action";
 
+/** Stable, low-cardinality label for a panel's app-lock reason. */
+function lockLabel(name: string | undefined): string {
+  const slug = (name ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_|_$/g, "")
+    .slice(0, 32);
+  return slug || "panel";
+}
+
 interface Props {
   /** Icon or element displayed at the top of the panel */
   icon?: ReactNode;
@@ -88,8 +98,12 @@ export const OverlayPanel = ({
   const baseId = useId();
   const titleId = `${baseId}-title`;
   const messageId = `${baseId}-message`;
-  // Unique per instance: app-lock reasons are a Set, not refcounted.
-  useAppLockReason(`overlayPanel:${baseId}`, true);
+  // Unique per instance: app-lock reasons are a Set, not refcounted. The
+  // title slug in the middle is what shortcut telemetry groups on.
+  useAppLockReason(
+    `overlayPanel:${lockLabel(title ?? ariaLabel)}:${baseId}`,
+    true,
+  );
   useOverlayEscape({ onDismiss, onShiftEscape });
 
   useEffect(() => {

--- a/packages/web/src/shortcuts/tips/shortcut-telemetry.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-telemetry.ts
@@ -141,11 +141,14 @@ function viewFromPathname(pathname: string): string {
 }
 
 /** Lock owners as a stable, low-cardinality key. OverlayPanel registers
- * `overlayPanel:<useId>` per instance so nested panels unlock independently;
- * the instance suffix is dropped here so PostHog can group on the name. */
+ * `overlayPanel:<title slug>:<useId>` per instance so nested panels unlock
+ * independently; the instance suffix is dropped here so PostHog can group on
+ * `overlayPanel:<title slug>`. */
 function lockContext(): string {
   const names = new Set(
-    getAppLockReasons().map((reason) => reason.split(":")[0]),
+    getAppLockReasons().map((reason) =>
+      reason.split(":").slice(0, 2).join(":"),
+    ),
   );
   return [...names].sort().join("+") || "unknown";
 }


### PR DESCRIPTION
## Summary

Follow-up to #3307 and #3315. Staging validation showed the welcome modal reporting `context = overlayPanel`, and 27 dialogs share that component, so the value could not say *which* panel blocked the shortcut.

- `OverlayPanel` now registers `overlayPanel:<title slug>:<useId>` (slug from `title`, else `ariaLabel`, else `panel`). The `useId` suffix is kept so nested panels still unlock independently.
- Telemetry collapses each reason to its first two segments, so PostHog groups on `overlayPanel:settings`, `overlayPanel:welcome_to_compass_calendar`, and so on. Named reasons like `settingsModal` are unchanged.

## Test plan

- [x] track, OverlayPanel, app-lock, useAppShortcut, Settings suites (94 pass); type-check; lint
- [ ] After staging deploy: press `C` behind the welcome modal and confirm `context=overlayPanel:welcome_to_compass_calendar`

🤖 Generated with [Claude Code](https://claude.com/claude-code)