### PR TITLE
feat(backend): align updateBookingEvent and forward excludeEventIds

### DIFF
--- a/.agents/handoffs/3111.md
+++ b/.agents/handoffs/3111.md
@@ -1,16 +1,21 @@
 ---
 schema_version: 1
 task_id: "3111"
-from: Implementer
-to: Verifier
-owner: Implementer
-status: running
+from: Verifier
+to: Manager
+owner: Manager
+status: verifying
 artifact:
   - path: packages/backend/src/booking/services/calendar-booking.port.ts
   - path: packages/backend/src/booking/services/calendar-booking.service.ts
+  - path: packages/backend/src/booking/services/calendar-booking.service.test.ts
 evidence:
   - command: bun test:backend -- packages/backend/src/booking/services/calendar-booking.service.test.ts
-    result: not yet run
+    result: "exit 0; 8 pass, 0 fail"
+  - command: bun test:backend
+    result: "exit 0; all backend tests passed"
+  - command: bun run verify
+    result: "exit 0; selected core, sync, backend; checks test:core, test:sync, test:backend:fast, type-check, lint, knip"
 assumptions:
   - "updateBookingEvent already existed for v1.4 guest details; this WP aligns the patch (preserve attendees/Meet) and forwards excludeEventIds"
   - "Idempotency key is update:${eventId}:${start}:${digest} so a same-start title/description edit still writes"
@@ -23,3 +28,9 @@ escalation: null
 ---
 
 WP-04: updateBookingEvent port plus excludeEventIds on getAvailability.
+
+Verifier: PASS. Simplify: no further reduction. Review: no confirmed findings.
+`createConference` is absent on update. Attendees and Meet stay off the
+patch (empty attendees / null conference; Sync mergeUpdateContent keeps
+provider membership and conference). Create still replace+conference;
+delete still kind delete.

--- a/.agents/handoffs/3111.md
+++ b/.agents/handoffs/3111.md
@@ -1,0 +1,25 @@
+---
+schema_version: 1
+task_id: "3111"
+from: Implementer
+to: Verifier
+owner: Implementer
+status: running
+artifact:
+  - path: packages/backend/src/booking/services/calendar-booking.port.ts
+  - path: packages/backend/src/booking/services/calendar-booking.service.ts
+evidence:
+  - command: bun test:backend -- packages/backend/src/booking/services/calendar-booking.service.test.ts
+    result: not yet run
+assumptions:
+  - "updateBookingEvent already existed for v1.4 guest details; this WP aligns the patch (preserve attendees/Meet) and forwards excludeEventIds"
+  - "Idempotency key is update:${eventId}:${start}:${digest} so a same-start title/description edit still writes"
+open_risks: []
+next_deadline: 2026-09-05T00:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-04: updateBookingEvent port plus excludeEventIds on getAvailability.

--- a/packages/backend/src/booking/services/calendar-booking.port.ts
+++ b/packages/backend/src/booking/services/calendar-booking.port.ts
@@ -17,6 +17,7 @@ export interface CalendarBookingGetAvailabilityInput {
   start: DateTime;
   end: DateTime;
   maxAgeMs?: number;
+  excludeEventIds?: readonly EventId[];
 }
 
 export interface CalendarBookingCreateEventInput {

--- a/packages/backend/src/booking/services/calendar-booking.service.test.ts
+++ b/packages/backend/src/booking/services/calendar-booking.service.test.ts
@@ -86,6 +86,36 @@ describe("CalendarBookingService", () => {
         unbackedCalendarIds: [localId],
       }),
     );
+    expect(queryBusyAvailability.mock.calls[0]?.[1]).not.toHaveProperty(
+      "excludeEventIds",
+    );
+  });
+
+  it("forwards excludeEventIds on the busy query when provided", async () => {
+    const queryBusyAvailability = mock(async () => ({
+      ok: true as const,
+      value: busyResponse,
+    }));
+    const service = new CalendarBookingService({
+      queryBusyAvailability,
+      submitCommand: mock(async () => ({ ok: true as const, value: {} })),
+    } as unknown as SyncServiceClient);
+    const excluded = [faker.database.mongodbObjectId()];
+
+    await service.getAvailability(userId(), {
+      calendarIds: [calendarId()],
+      start: "2026-09-01T12:00:00.000Z",
+      end: "2026-09-02T12:00:00.000Z",
+      excludeEventIds: excluded,
+    });
+
+    expect(queryBusyAvailability).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        excludeEventIds: excluded,
+        purpose: "booking_confirmation",
+      }),
+    );
   });
 
   it("returns bookable false without throwing", async () => {
@@ -202,19 +232,34 @@ describe("CalendarBookingService", () => {
     });
 
     expect(submitCommand).toHaveBeenCalledTimes(1);
-    expect(submitCommand.mock.calls[0]?.[1]).toMatchObject({
+    const request = submitCommand.mock.calls[0]?.[1];
+    expect(request).toMatchObject({
       eventId,
       expectedVersion: null,
       input: {
         kind: "update",
         invitation: "all",
         attendeesEdit: "preserve",
+        scope: "all",
+        recurrenceId: null,
         content: {
           title: "Grace and Tyler",
           description: "bring tea",
+          location: null,
+        },
+        schedule: {
+          kind: "timed",
+          start: "2026-09-01T15:00:00.000Z",
+          end: "2026-09-01T15:30:00.000Z",
+          timeZone: "America/Denver",
         },
       },
     });
+    expect(request.idempotencyKey.startsWith(`update:${eventId}:`)).toBe(true);
+    expect(request.idempotencyKey).toContain("2026-09-01T15:00:00.000Z");
+    expect(request.input).not.toHaveProperty("createConference");
+    expect(request.input.content.attendees).toEqual([]);
+    expect(request.input.content.conference).toBeNull();
   });
 
   it("submits delete with invitation all", async () => {

--- a/packages/backend/src/booking/services/calendar-booking.service.ts
+++ b/packages/backend/src/booking/services/calendar-booking.service.ts
@@ -96,7 +96,7 @@ const toBookingUpdateSubmitRequest = (
     .slice(0, 40);
   return CommandSubmitRequestSchema.parse({
     idempotencyKey: IdempotencyKeySchema.parse(
-      `booking-update:${input.eventId}:${digest}`,
+      `update:${input.eventId}:${input.start}:${digest}`,
     ),
     eventId: input.eventId,
     expectedVersion: null,
@@ -109,13 +109,7 @@ const toBookingUpdateSubmitRequest = (
         description: input.description,
         location: null,
         organizer: null,
-        attendees: [
-          {
-            email: input.guest.email,
-            displayName: input.guest.displayName,
-            responseStatus: "needsAction",
-          },
-        ],
+        attendees: [],
         conference: null,
       },
       schedule: {
@@ -156,6 +150,9 @@ export class CalendarBookingService implements CalendarBookingPort {
         maxAgeMs: input.maxAgeMs ?? BOOKING_CONFIRMATION_MAX_AGE_MS,
         purpose: "booking_confirmation",
         ...(unbackedCalendarIds ? { unbackedCalendarIds } : {}),
+        ...(input.excludeEventIds
+          ? { excludeEventIds: [...input.excludeEventIds] }
+          : {}),
       },
     );
     if (!result.ok) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Booking v1.3 WP-04 (#3111). Aligns `updateBookingEvent` with the in-place PATCH contract and forwards WP-03 `excludeEventIds` on `getAvailability`.

- Update submit: `kind: update`, `invitation: all`, `attendeesEdit: preserve`, `scope: all`, `recurrenceId: null`, `expectedVersion: null`.
- No `createConference`. Content is title, description, `location: null`, empty attendees, `conference: null` so Sync `mergeUpdateContent` keeps Meet and guests.
- Idempotency key `update:${eventId}:${start}:${digest}` so a same-start title/description edit still writes (v1.4 guest details).
- `getAvailability` forwards `excludeEventIds` when provided.
- Create still uses `attendeesEdit: replace` and `createConference: true`. Delete still uses `kind: delete`.

Stacked on #3316 (WP-03) so `BusyAvailabilityRequest` already has `excludeEventIds`. Retarget to `main` after that merges.

Fixes #3111

## Simplicity

Existing `updateBookingEvent` (v1.4 guest details) is reused. The patch body stops sending guest attendees. One optional field on the availability input.

## Automated validation

`bun run verify`:

```
Selected packages: core, sync, backend
Checks run: test:core, test:sync, test:backend:fast, type-check, lint, knip
Checks skipped: (none)
All checks passed
```

Also `bun test:backend`: 582 pass, 1 skip, 0 fail.

Update payload assertions: kind update, invitation all, attendeesEdit preserve, no createConference, schedule matches input, attendees `[]`, conference null. `getAvailability` forwards `excludeEventIds`.

## Independent review

`.agents/handoffs/3111.md`

```
VERDICT: no confirmed findings
FINDINGS:
(none)
```

## Test plan

- `bun test:backend`
- `bun run type-check`
- `bun lint`
- `bun knip`
- `bun run verify`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73143677-1949-45fd-81f9-f9974a68183e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73143677-1949-45fd-81f9-f9974a68183e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

