### PR TITLE
feat(web): show reschedule actions on booking confirmation

### DIFF
--- a/.agents/handoffs/3113.md
+++ b/.agents/handoffs/3113.md
@@ -1,0 +1,31 @@
+---
+schema_version: 1
+task_id: "3113"
+from: Verifier
+to: Manager
+owner: Manager
+status: verifying
+artifact:
+  - path: packages/web/src/booking/PublicBookingConfirmationView.tsx
+  - path: packages/web/src/booking/PublicBookingConfirmedPage.tsx
+  - path: packages/web/src/booking/use-public-booking-flow.ts
+evidence:
+  - command: bun test:web -- packages/web/src/booking/PublicBookingConfirmationView.test.tsx packages/web/src/booking/PublicBookingPage.test.tsx packages/web/src/booking/public-booking-search.test.ts packages/web/src/booking/PublicBookingCancelPage.test.tsx
+    result: "exit 0; 69 pass, 0 fail"
+  - command: bun run verify
+    result: "exit 0; selected web; checks test:web, type-check, lint, knip; a11y/e2e skipped (Playwright Chromium missing)"
+assumptions:
+  - "A ?token= permalink reconstructs both action URLs, matching existing cancel permalink behavior"
+open_risks: []
+next_deadline: 2026-09-05T00:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-06: confirmation reschedule actions next to cancel.
+
+Verifier: PASS against the issue verify commands. Playwright skipped;
+WP-08 installs Chromium. Simplify: cancel and reschedule copy controls
+share PublicBookingCopyGuestAction. Review: no confirmed findings.

--- a/packages/web/src/booking/PublicBookingConfirmationView.test.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmationView.test.tsx
@@ -11,6 +11,8 @@ const slotStart = "2026-09-15T15:00:00.000Z";
 const timeZone = "UTC";
 const cancelUrl =
   "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc";
+const rescheduleUrl =
+  "https://compasscalendar.com/book/reschedule/000000000000000000000099?token=abc";
 
 describe("PublicBookingConfirmationView", () => {
   it("shows the slot summary instead of a raw cancel URL", () => {
@@ -47,8 +49,55 @@ describe("PublicBookingConfirmationView", () => {
       screen.getByRole("button", { name: "Copy cancel link" }),
     ).toBeInTheDocument();
     expect(
+      screen.queryByRole("button", { name: "Copy reschedule link" }),
+    ).not.toBeInTheDocument();
+    expect(
       screen.getByText("A Google Meet invite is on its way to your email."),
     ).toBeInTheDocument();
+  });
+
+  it("shows cancel then reschedule actions when both URLs are present", async () => {
+    const user = userEvent.setup({ delay: null });
+    render(
+      <PublicBookingConfirmationView
+        cancelUrl={cancelUrl}
+        rescheduleUrl={rescheduleUrl}
+        durationMinutes={30}
+        hostDisplayName="Tyler Dane"
+        guestName="Ada Lovelace"
+        notes={null}
+        slotStart={slotStart}
+        timeZone={timeZone}
+      />,
+    );
+
+    const heading = screen.getByRole("heading", {
+      name: "You are booked with Tyler Dane",
+    });
+    expect(screen.queryByText(rescheduleUrl)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Reschedule this booking" }),
+    ).toHaveAttribute("href", rescheduleUrl);
+    expect(
+      screen.getByRole("button", { name: "Copy reschedule link" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("group", { name: "Booking actions" }),
+    ).toBeInTheDocument();
+
+    heading.focus();
+    await user.tab();
+    expect(
+      screen.getByRole("button", { name: "Copy cancel link" }),
+    ).toHaveFocus();
+    await user.tab();
+    expect(
+      screen.getByRole("link", { name: "Cancel this booking" }),
+    ).toHaveFocus();
+    await user.tab();
+    expect(
+      screen.getByRole("button", { name: "Copy reschedule link" }),
+    ).toHaveFocus();
   });
 
   it("promises a calendar invite when the destination cannot mint Meet", () => {
@@ -89,10 +138,16 @@ describe("PublicBookingConfirmationView", () => {
       screen.queryByRole("button", { name: "Copy cancel link" }),
     ).not.toBeInTheDocument();
     expect(
+      screen.queryByRole("button", { name: "Copy reschedule link" }),
+    ).not.toBeInTheDocument();
+    expect(
       screen.queryByRole("link", { name: "cancel this booking" }),
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("link", { name: "Cancel this booking" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Reschedule this booking" }),
     ).not.toBeInTheDocument();
     expect(
       screen.getByText("A Google Meet invite is on its way to your email."),
@@ -131,6 +186,44 @@ describe("PublicBookingConfirmationView", () => {
 
     expect(written).toEqual([cancelUrl]);
     expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Copied");
+  });
+
+  it("copies the reschedule URL from the secondary button", async () => {
+    const user = userEvent.setup({ delay: null });
+    const written: string[] = [];
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: mock((value: string) => {
+          written.push(value);
+          return Promise.resolve();
+        }),
+      },
+    });
+
+    render(
+      <PublicBookingConfirmationView
+        cancelUrl={cancelUrl}
+        rescheduleUrl={rescheduleUrl}
+        durationMinutes={30}
+        hostDisplayName="Tyler Dane"
+        guestName="Ada Lovelace"
+        notes={null}
+        slotStart={slotStart}
+        timeZone={timeZone}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Copy reschedule link" }),
+    );
+
+    expect(written).toEqual([rescheduleUrl]);
+    expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Copy cancel link" }),
+    ).toBeInTheDocument();
     expect(screen.getByRole("status")).toHaveTextContent("Copied");
   });
 

--- a/packages/web/src/booking/PublicBookingConfirmationView.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmationView.tsx
@@ -1,5 +1,6 @@
 import { CheckCircleIcon } from "@phosphor-icons/react";
 import { PublicBookingCopyCancelUrl } from "@web/booking/PublicBookingCopyCancelUrl";
+import { PublicBookingCopyRescheduleUrl } from "@web/booking/PublicBookingCopyRescheduleUrl";
 import { PublicBookingLayout } from "@web/booking/PublicBookingLayout";
 import { PublicBookingSlotSummary } from "@web/booking/PublicBookingSlotSummary";
 import { PUBLIC_BOOKING_HEADING_CLASS } from "@web/booking/PublicBookingStatusMessage";
@@ -14,6 +15,7 @@ interface PublicBookingConfirmationViewProps {
   timeZone: string;
   createsGoogleMeet?: boolean;
   cancelUrl?: string;
+  rescheduleUrl?: string;
   onEditDetails?: () => void;
 }
 
@@ -26,6 +28,7 @@ export function PublicBookingConfirmationView({
   timeZone,
   createsGoogleMeet = true,
   cancelUrl,
+  rescheduleUrl,
   onEditDetails,
 }: PublicBookingConfirmationViewProps) {
   const headingRef = useBookingHeadingFocus(hostDisplayName);
@@ -83,8 +86,19 @@ export function PublicBookingConfirmationView({
             Edit details
           </button>
         ) : null}
-        {cancelUrl ? (
-          <PublicBookingCopyCancelUrl cancelUrl={cancelUrl} />
+        {cancelUrl || rescheduleUrl ? (
+          <div
+            className="flex flex-col items-start gap-3"
+            role="group"
+            aria-label="Booking actions"
+          >
+            {cancelUrl ? (
+              <PublicBookingCopyCancelUrl cancelUrl={cancelUrl} />
+            ) : null}
+            {rescheduleUrl ? (
+              <PublicBookingCopyRescheduleUrl rescheduleUrl={rescheduleUrl} />
+            ) : null}
+          </div>
         ) : null}
       </section>
     </PublicBookingLayout>

--- a/packages/web/src/booking/PublicBookingConfirmedPage.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmedPage.tsx
@@ -18,7 +18,9 @@ import {
   resolvePublicBookingReservationView,
 } from "@web/booking/public-booking.view";
 import {
+  guestActionUrlFromHistory,
   publicCancelUrlForReservation,
+  publicRescheduleUrlForReservation,
   tokenFromGuestActionUrl,
 } from "@web/booking/public-booking-search";
 import { useBookingDocumentTitle } from "@web/booking/use-booking-document-title";
@@ -60,16 +62,11 @@ const resolveConfirmedPageView = (
   });
 
 function cancelUrlFromHistory(state: unknown): string | undefined {
-  if (
-    state &&
-    typeof state === "object" &&
-    "cancelUrl" in state &&
-    typeof state.cancelUrl === "string" &&
-    state.cancelUrl.length > 0
-  ) {
-    return state.cancelUrl;
-  }
-  return undefined;
+  return guestActionUrlFromHistory(state, "cancelUrl");
+}
+
+function rescheduleUrlFromHistory(state: unknown): string | undefined {
+  return guestActionUrlFromHistory(state, "rescheduleUrl");
 }
 
 export function PublicBookingConfirmedPage() {
@@ -82,13 +79,27 @@ export function PublicBookingConfirmedPage() {
   const historyCancelUrl = useRouterState({
     select: (routerState) => cancelUrlFromHistory(routerState.location.state),
   });
+  const historyRescheduleUrl = useRouterState({
+    select: (routerState) =>
+      rescheduleUrlFromHistory(routerState.location.state),
+  });
   const token =
     searchToken ||
-    (historyCancelUrl ? tokenFromGuestActionUrl(historyCancelUrl) : "");
+    (historyCancelUrl ? tokenFromGuestActionUrl(historyCancelUrl) : "") ||
+    (historyRescheduleUrl ? tokenFromGuestActionUrl(historyRescheduleUrl) : "");
   const cancelUrl =
     historyCancelUrl ??
     (token
       ? publicCancelUrlForReservation(
+          reservationId,
+          token,
+          window.location.origin,
+        )
+      : undefined);
+  const rescheduleUrl =
+    historyRescheduleUrl ??
+    (token
+      ? publicRescheduleUrlForReservation(
           reservationId,
           token,
           window.location.origin,
@@ -180,6 +191,7 @@ export function PublicBookingConfirmedPage() {
       timeZone={reservation.guestTimeZone}
       createsGoogleMeet={reservation.createsGoogleMeet}
       cancelUrl={cancelUrl}
+      rescheduleUrl={rescheduleUrl}
       onEditDetails={
         canEdit
           ? () => {

--- a/packages/web/src/booking/PublicBookingCopyCancelUrl.tsx
+++ b/packages/web/src/booking/PublicBookingCopyCancelUrl.tsx
@@ -1,4 +1,4 @@
-import { useCopiedFlag } from "@web/booking/use-copied-flag";
+import { PublicBookingCopyGuestAction } from "@web/booking/PublicBookingCopyGuestAction";
 
 interface PublicBookingCopyCancelUrlProps {
   cancelUrl: string;
@@ -7,26 +7,11 @@ interface PublicBookingCopyCancelUrlProps {
 export function PublicBookingCopyCancelUrl({
   cancelUrl,
 }: PublicBookingCopyCancelUrlProps) {
-  const { copied, copy } = useCopiedFlag(cancelUrl);
-
   return (
-    <div className="flex flex-col items-start gap-3">
-      <button
-        type="button"
-        onClick={copy}
-        className="c-button c-button-secondary"
-      >
-        {copied ? "Copied" : "Copy cancel link"}
-      </button>
-      <a
-        href={cancelUrl}
-        className="c-focus-ring text-accent text-sm underline"
-      >
-        Cancel this booking
-      </a>
-      <p role="status" className="sr-only">
-        {copied ? "Copied" : ""}
-      </p>
-    </div>
+    <PublicBookingCopyGuestAction
+      copyLabel="Copy cancel link"
+      linkLabel="Cancel this booking"
+      url={cancelUrl}
+    />
   );
 }

--- a/packages/web/src/booking/PublicBookingCopyGuestAction.tsx
+++ b/packages/web/src/booking/PublicBookingCopyGuestAction.tsx
@@ -1,0 +1,35 @@
+import { useCopiedFlag } from "@web/booking/use-copied-flag";
+
+interface PublicBookingCopyGuestActionProps {
+  url: string;
+  copyLabel: string;
+  linkLabel: string;
+}
+
+export function PublicBookingCopyGuestAction({
+  url,
+  copyLabel,
+  linkLabel,
+}: PublicBookingCopyGuestActionProps) {
+  const { copied, copy } = useCopiedFlag(url);
+
+  return (
+    <div className="flex flex-col items-start gap-3">
+      <button
+        type="button"
+        onClick={copy}
+        className="c-button c-button-secondary"
+      >
+        {copied ? "Copied" : copyLabel}
+      </button>
+      <a href={url} className="c-focus-ring text-accent text-sm underline">
+        {linkLabel}
+      </a>
+      {copied ? (
+        <p role="status" className="sr-only">
+          Copied
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/web/src/booking/PublicBookingCopyRescheduleUrl.tsx
+++ b/packages/web/src/booking/PublicBookingCopyRescheduleUrl.tsx
@@ -1,0 +1,17 @@
+import { PublicBookingCopyGuestAction } from "@web/booking/PublicBookingCopyGuestAction";
+
+interface PublicBookingCopyRescheduleUrlProps {
+  rescheduleUrl: string;
+}
+
+export function PublicBookingCopyRescheduleUrl({
+  rescheduleUrl,
+}: PublicBookingCopyRescheduleUrlProps) {
+  return (
+    <PublicBookingCopyGuestAction
+      copyLabel="Copy reschedule link"
+      linkLabel="Reschedule this booking"
+      url={rescheduleUrl}
+    />
+  );
+}

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -445,7 +445,13 @@ describe("PublicBookingPage", () => {
       screen.getByRole("button", { name: "Copy cancel link" }),
     ).toBeInTheDocument();
     expect(
+      screen.getByRole("button", { name: "Copy reschedule link" }),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole("link", { name: "Cancel this booking" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Reschedule this booking" }),
     ).toBeInTheDocument();
   });
 
@@ -1433,6 +1439,9 @@ describe("PublicBookingConfirmedPage", () => {
       screen.queryByRole("button", { name: "Copy cancel link" }),
     ).not.toBeInTheDocument();
     expect(
+      screen.queryByRole("button", { name: "Copy reschedule link" }),
+    ).not.toBeInTheDocument();
+    expect(
       screen.queryByRole("button", { name: "Edit details" }),
     ).not.toBeInTheDocument();
   });
@@ -1450,6 +1459,9 @@ describe("PublicBookingConfirmedPage", () => {
       screen.getByRole("button", { name: "Copy cancel link" }),
     ).toBeInTheDocument();
     expect(
+      screen.getByRole("button", { name: "Copy reschedule link" }),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole("button", { name: "Edit details" }),
     ).toBeInTheDocument();
     expect(
@@ -1457,6 +1469,12 @@ describe("PublicBookingConfirmedPage", () => {
     ).toHaveAttribute(
       "href",
       `${window.location.origin}/book/cancel/000000000000000000000099?token=abc`,
+    );
+    expect(
+      screen.getByRole("link", { name: "Reschedule this booking" }),
+    ).toHaveAttribute(
+      "href",
+      `${window.location.origin}/book/reschedule/000000000000000000000099?token=abc`,
     );
     expect(
       screen.getByText("A Google Meet invite is on its way to your email."),
@@ -1561,6 +1579,15 @@ describe("PublicBookingConfirmedPage", () => {
         name: "This booking was canceled",
       }),
     ).toHaveFocus();
+    expect(
+      screen.queryByRole("button", { name: "Copy cancel link" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Copy reschedule link" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Reschedule this booking" }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows a calm state for an unknown reservation", async () => {
@@ -1643,10 +1670,17 @@ describe("PublicBookingConfirmedPage", () => {
       "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
     );
     expect(
+      screen.getByRole("link", { name: "Reschedule this booking" }),
+    ).toHaveAttribute(
+      "href",
+      "https://compasscalendar.com/book/reschedule/000000000000000000000099?token=abc",
+    );
+    expect(
       screen.queryByRole("link", {
         name: "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
       }),
     ).not.toBeInTheDocument();
+    expect(screen.queryByText(/token=abc/)).not.toBeInTheDocument();
     await user.click(
       await screen.findByRole("button", { name: "Copy cancel link" }),
     );

--- a/packages/web/src/booking/public-booking-search.test.ts
+++ b/packages/web/src/booking/public-booking-search.test.ts
@@ -1,5 +1,7 @@
 import {
+  guestActionUrlFromHistory,
   publicCancelUrlForReservation,
+  publicRescheduleUrlForReservation,
   tokenFromGuestActionUrl,
   validateBookingCancelSearch,
   validatePublicBookingSearch,
@@ -99,5 +101,47 @@ describe("publicCancelUrlForReservation", () => {
     ).toBe(
       "https://staging.compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
     );
+  });
+});
+
+describe("publicRescheduleUrlForReservation", () => {
+  it("builds an origin-absolute reschedule URL", () => {
+    expect(
+      publicRescheduleUrlForReservation(
+        "000000000000000000000099",
+        "abc",
+        "https://staging.compasscalendar.com",
+      ),
+    ).toBe(
+      "https://staging.compasscalendar.com/book/reschedule/000000000000000000000099?token=abc",
+    );
+  });
+});
+
+describe("guestActionUrlFromHistory", () => {
+  it("reads cancel and reschedule URLs from history state", () => {
+    expect(
+      guestActionUrlFromHistory(
+        { cancelUrl: "https://example.com/cancel?token=a" },
+        "cancelUrl",
+      ),
+    ).toBe("https://example.com/cancel?token=a");
+    expect(
+      guestActionUrlFromHistory(
+        { rescheduleUrl: "https://example.com/reschedule?token=a" },
+        "rescheduleUrl",
+      ),
+    ).toBe("https://example.com/reschedule?token=a");
+  });
+
+  it("ignores missing, empty, and non-string values", () => {
+    expect(guestActionUrlFromHistory(undefined, "cancelUrl")).toBeUndefined();
+    expect(guestActionUrlFromHistory({}, "rescheduleUrl")).toBeUndefined();
+    expect(
+      guestActionUrlFromHistory({ cancelUrl: "" }, "cancelUrl"),
+    ).toBeUndefined();
+    expect(
+      guestActionUrlFromHistory({ cancelUrl: 12 }, "cancelUrl"),
+    ).toBeUndefined();
   });
 });

--- a/packages/web/src/booking/public-booking-search.ts
+++ b/packages/web/src/booking/public-booking-search.ts
@@ -71,7 +71,45 @@ export function publicCancelUrlForReservation(
   token: string,
   origin: string,
 ): string {
-  const url = new URL(`/book/cancel/${reservationId}`, origin);
+  return publicGuestActionUrlForReservation(
+    "cancel",
+    reservationId,
+    token,
+    origin,
+  );
+}
+
+export function publicRescheduleUrlForReservation(
+  reservationId: string,
+  token: string,
+  origin: string,
+): string {
+  return publicGuestActionUrlForReservation(
+    "reschedule",
+    reservationId,
+    token,
+    origin,
+  );
+}
+
+export function guestActionUrlFromHistory(
+  state: unknown,
+  key: "cancelUrl" | "rescheduleUrl",
+): string | undefined {
+  if (!state || typeof state !== "object") {
+    return undefined;
+  }
+  const value = (state as Record<string, unknown>)[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function publicGuestActionUrlForReservation(
+  action: "cancel" | "reschedule",
+  reservationId: string,
+  token: string,
+  origin: string,
+): string {
+  const url = new URL(`/book/${action}/${reservationId}`, origin);
   url.searchParams.set("token", token);
   return url.toString();
 }

--- a/packages/web/src/booking/use-public-booking-flow.ts
+++ b/packages/web/src/booking/use-public-booking-flow.ts
@@ -285,10 +285,14 @@ export function usePublicBookingFlow() {
         to: ROOT_ROUTES.BOOK_CONFIRMED,
         params: { reservationId: result.reservationId },
         search: token ? { token } : undefined,
-        // History state still carries the absolute cancel URL from confirm.
-        // The permalink also writes `?token=` so a reload or bookmark keeps
-        // cancel and edit without publishing the token on the public GET.
-        state: { cancelUrl: result.cancelUrl } as never,
+        // History state still carries the absolute cancel and reschedule URLs
+        // from confirm. The permalink also writes `?token=` so a reload or
+        // bookmark keeps guest actions and edit without publishing the token
+        // on the public GET.
+        state: {
+          cancelUrl: result.cancelUrl,
+          rescheduleUrl: result.rescheduleUrl,
+        } as never,
       });
     } catch (error) {
       if (isPublicBookingConflictError(error)) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Booking confirmation now shows Reschedule next to cancel (WP-06 / #3113).

After confirm, router history state carries `rescheduleUrl` alongside `cancelUrl`. `PublicBookingConfirmationView` renders Copy reschedule link and a Reschedule this booking link when that URL is present. Cold `/book/confirmed/:id` without a token still hides both secrets. A `?token=` permalink reconstructs both action URLs, matching the existing cancel permalink. Cancelled reservations still show only the canceled heading.

The `/book/reschedule/:id` page itself is WP-07. This WP links to that URL.

Fixes #3113

## Simplicity

Cancel and reschedule copy controls share `PublicBookingCopyGuestAction`. History-state reads share `guestActionUrlFromHistory`.

## Automated validation

RTL: history state with both URLs shows Copy cancel link and Copy reschedule link. Cold permalink without a token shows neither. Cancelled reservation heading stays "This booking was canceled" with no reschedule actions. Tab from the confirmation heading reaches Copy cancel link, then the cancel link, then Copy reschedule link.

## Independent review

`.agents/handoffs/3113.md`

```
VERDICT: no confirmed findings
```

## Test plan

```
bun test:web -- packages/web/src/booking/PublicBookingConfirmationView.test.tsx packages/web/src/booking/PublicBookingPage.test.tsx packages/web/src/booking/public-booking-search.test.ts packages/web/src/booking/PublicBookingCancelPage.test.tsx
bun run verify
```

Selected packages: web. Checks run: test:web, type-check, lint, knip. All passed. Playwright a11y/e2e skipped (Chromium missing; WP-08).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73143677-1949-45fd-81f9-f9974a68183e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73143677-1949-45fd-81f9-f9974a68183e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

