### PR TITLE
test(e2e): cover guest reschedule and close booking v1.3

### DIFF
--- a/.agents/handoffs/3113.md
+++ b/.agents/handoffs/3113.md
@@ -1,0 +1,31 @@
+---
+schema_version: 1
+task_id: "3113"
+from: Verifier
+to: Manager
+owner: Manager
+status: verifying
+artifact:
+  - path: packages/web/src/booking/PublicBookingConfirmationView.tsx
+  - path: packages/web/src/booking/PublicBookingConfirmedPage.tsx
+  - path: packages/web/src/booking/use-public-booking-flow.ts
+evidence:
+  - command: bun test:web -- packages/web/src/booking/PublicBookingConfirmationView.test.tsx packages/web/src/booking/PublicBookingPage.test.tsx packages/web/src/booking/public-booking-search.test.ts packages/web/src/booking/PublicBookingCancelPage.test.tsx
+    result: "exit 0; 69 pass, 0 fail"
+  - command: bun run verify
+    result: "exit 0; selected web; checks test:web, type-check, lint, knip; a11y/e2e skipped (Playwright Chromium missing)"
+assumptions:
+  - "A ?token= permalink reconstructs both action URLs, matching existing cancel permalink behavior"
+open_risks: []
+next_deadline: 2026-09-05T00:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-06: confirmation reschedule actions next to cancel.
+
+Verifier: PASS against the issue verify commands. Playwright skipped;
+WP-08 installs Chromium. Simplify: cancel and reschedule copy controls
+share PublicBookingCopyGuestAction. Review: no confirmed findings.

--- a/.agents/handoffs/3114.md
+++ b/.agents/handoffs/3114.md
@@ -1,0 +1,32 @@
+---
+schema_version: 1
+task_id: "3114"
+from: Verifier
+to: Manager
+owner: Manager
+status: verifying
+artifact:
+  - path: packages/web/src/booking/PublicBookingReschedulePage.tsx
+  - path: packages/web/src/booking/use-public-booking-reschedule-flow.ts
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3321
+evidence:
+  - command: bun test:web -- packages/web/src/booking/PublicBookingReschedulePage.test.tsx packages/web/src/booking/public-booking-search.test.ts packages/web/src/booking/PublicBookingPage.test.tsx packages/web/src/routers/index.test.tsx
+    result: "exit 0; 62 pass, 0 fail"
+  - command: bun run verify
+    result: "exit 0; selected web; checks test:web, type-check, lint, knip; 749 pass; a11y/e2e skipped (Playwright Chromium missing)"
+assumptions:
+  - "PR is stacked on WP-06 (#3320) so the diff stays WP-07-only; live slots/reschedule APIs come from WP-05 (#3319)"
+open_risks: []
+next_deadline: 2026-09-05T18:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-07: public reschedule page at `/book/reschedule/$reservationId`.
+
+Verifier: PASS against the issue verify commands. Playwright skipped;
+WP-08 installs Chromium. Review: no confirmed findings.
+Simplify: reservation slot helpers parallel the host-page slot helpers
+instead of a shared generic, because the key and token gate differ.

--- a/.agents/handoffs/3115.md
+++ b/.agents/handoffs/3115.md
@@ -1,0 +1,35 @@
+---
+schema_version: 1
+task_id: "3115"
+from: Verifier
+to: Manager
+owner: Manager
+status: verifying
+artifact:
+  - path: e2e/booking/public-booking-reschedule.spec.ts
+  - path: e2e/accessibility/booking-a11y.spec.ts
+  - path: docs/features/booking.md
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3323
+evidence:
+  - command: bunx playwright install chromium
+    result: "exit 0; Chromium 148.0.7778.96 installed"
+  - command: bun test:e2e
+    result: "exit 0; 128 passed, 0 fail"
+  - command: bun test:a11y
+    result: "exit 0; 31 passed, 0 fail"
+assumptions:
+  - "Confirm-to-reschedule follows the confirmation href path on the Playwright origin because create returns compasscalendar.com URLs"
+open_risks:
+  - "WP-04 PR #3318 closed unmerged after WP-03 squash; WP-05 #3319 is still stacked on that branch"
+next_deadline: 2026-09-05T18:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-08: e2e, a11y, and spec closeout for guest reschedule.
+
+Verifier: PASS against the issue verify commands. Review: no confirmed
+findings. Tracking #3107 closes when this PR merges. Production gate
+unchanged. `.github/` untouched.

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -1,4 +1,4 @@
-# Compass Calendar Booking (v1 / v1.1 / v1.5)
+# Compass Calendar Booking (v1 / v1.1 / v1.3 / v1.5)
 
 Locked product spec for public scheduling on Compass Cloud
 (`https://compasscalendar.com`). Approved 2026-08-30. v1.1 shipped
@@ -6,17 +6,17 @@ RSVP-strict occupancy and public page identity (date-specific
 availability exceptions were removed in v1.2). v1.5 shipped keyboard
 Escape paths, guest edit-details after confirm, confirmation permalink
 tokens, and the audit fixes on milestone Booking v1.5. v1.3 (guest
-reschedule) remains specified here and is not shipped.
+reschedule) is specified here and implemented; the production gate stays
+off.
 
 Compass never sends email itself. Google emails the guest when Compass
 creates the calendar event with `invitation: "all"`.
 
 ## Status
 
-v1, v1.1, and v1.5 are implemented in the Compass monorepo (public
-`/book/:username`, host Settings, backend APIs, guest cancel and
-edit-details). v1.3 (guest reschedule) is specified here and is not
-implemented. Booking is enabled in development and staging
+v1, v1.1, v1.3, and v1.5 are implemented in the Compass monorepo (public
+`/book/:username`, host Settings, backend APIs, guest cancel, guest
+reschedule, and edit-details). Booking is enabled in development and staging
 (`runtime.nodeEnv` other than `production`) and disabled in production.
 Do not flip `isBookingEnabled`.
 A standalone Compass Booking product (separate brand, domain, or
@@ -379,11 +379,11 @@ Unauthenticated:
   the token is invalid.
 - `POST /api/booking/reservations/:id/cancel` — `{token}`.
 - `GET /api/booking/reservations/:id/slots?token=&start=&end=&timeZone=`
-  — v1.3, not shipped. Would return bookable instants excluding this
-  reservation from occupancy and max-per-day.
-- `POST /api/booking/reservations/:id/reschedule` — v1.3, not shipped.
-  `{token, slotStart, guestTimeZone}`. Create response still includes
-  `rescheduleUrl` for that specified flow.
+  — bookable instants excluding this reservation from occupancy and
+  max-per-day. Same window rules as the public page slots endpoint.
+- `POST /api/booking/reservations/:id/reschedule` — `{token, slotStart,
+  guestTimeZone}`. In-place calendar PATCH. Same slot is an idempotent
+  success. Create response includes `rescheduleUrl`.
 
 Authenticated (host session + writable billing, same as event writes):
 
@@ -422,14 +422,14 @@ Guest reschedule is **in scope for v1.3**, not v1 / v1.1.
 | Slot engine | `packages/core/src/booking/compute-booking-slots.ts` |
 | Occupancy policy | `packages/core/src/booking/occupies-booking-slot.ts` |
 | Backend admin API | `packages/backend/src/booking/controllers/booking.controller.ts`, `services/booking-page.service.ts` |
-| Backend public API | `packages/backend/src/booking/services/public-booking.service.ts` |
+| Backend public API | `packages/backend/src/booking/booking.routes.config.ts`, `services/public-booking.service.ts` |
 | Reservations + cancel tokens | `packages/backend/src/booking/booking-reservation.repository.ts`, `booking-cancel-token.ts` |
-| Calendar application port | `packages/backend/src/booking/services/calendar-booking.port.ts`, `services/calendar-booking.service.ts` |
+| Calendar application port | `packages/backend/src/booking/services/calendar-booking.port.ts` (`updateBookingEvent`), `services/calendar-booking.service.ts` |
 | Sync busy occupancy | `packages/sync/src/domain/occurrence-projection.ts`, `busy-query.service.ts`, `booking-occupancy-facts.ts` |
 | Host Settings UI | `packages/web/src/booking/BookingSettingsSection.tsx`, `packages/web/src/components/Settings/SettingsModal.tsx` |
-| Public guest UI | `packages/web/src/booking/PublicBookingPage.tsx`, `PublicBookingConfirmedPage.tsx`, `PublicBookingCancelPage.tsx`, `PublicBookingEditDetailsForm.tsx` |
+| Public guest UI | `packages/web/src/booking/PublicBookingPage.tsx`, `PublicBookingConfirmedPage.tsx`, `PublicBookingCancelPage.tsx`, `PublicBookingReschedulePage.tsx`, `PublicBookingCopyRescheduleUrl.tsx`, `PublicBookingEditDetailsForm.tsx` |
 | Public web API client | `packages/web/src/api/public-booking.api.ts` |
-| E2e | `e2e/booking/`, `e2e/accessibility/booking-a11y.spec.ts` |
+| E2e | `e2e/booking/`, `e2e/booking/public-booking-reschedule.spec.ts`, `e2e/accessibility/booking-a11y.spec.ts` |
 
 ### Named warts
 
@@ -439,11 +439,12 @@ Guest reschedule is **in scope for v1.3**, not v1 / v1.1.
   per instance: N replicas yield about N times that, and a client that
   reconnects to a different replica resets its bucket. Accepted for v1
   while `isBookingEnabled` stays false in production.
-- **Cancel and edit tokens travel in the query string.** The bearer
-  lives in `?token=` on `/book/confirmed/:id` and `/book/cancel/:id`,
-  so it can appear in browser history, Referer headers, and access
-  logs. Accepted for v1: a fragment or POST landing page would break
-  the confirmation permalink. Tokens stop working at `slotEnd`.
+- **Cancel, edit, and reschedule tokens travel in the query string.** The
+  bearer lives in `?token=` on `/book/confirmed/:id`, `/book/cancel/:id`,
+  and `/book/reschedule/:id`, so it can appear in browser history, Referer
+  headers, and access logs. Accepted for v1: a fragment or POST landing
+  page would break the confirmation permalink. Tokens stop working at
+  `slotEnd`.
 - **Guest email is not editable after confirm.** The attendee identity and
   Google invite are bound to the address collected at booking. Changing it
   would send a new invitation, which v1.5 does not do.
@@ -454,9 +455,10 @@ Guest reschedule is **in scope for v1.3**, not v1 / v1.1.
   into the store in a drive-by.
 - **Slug is not editable in v1.** Allocation runs once on first enable; changing
   slugs needs a migration with redirects.
-- **Guest reschedule is v1.3, not v1.** In-place PATCH; same cancel token.
-  Host-edited events still use `expectedVersion: null` on the booking
-  update path.
+- **Host-edited etag overwrite uses `expectedVersion: null`.** Guest
+  reschedule PATCHes the same Google event in place. Host-edited events
+  still omit a stored etag on the booking update path, so a concurrent
+  host edit can be overwritten. Accepted for v1.3.
 - **Confirm is fail-closed.** When Sync reports `bookable: false`, slots
   disappear and confirm returns `409`.
 - **Google-only destination** calendars; password-only hosts see a connect-Google

--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -6,6 +6,7 @@ import {
   preparePublicBookingCancelPage,
   preparePublicBookingConfirmedPage,
   preparePublicBookingPage,
+  preparePublicBookingReschedulePage,
   prepareSignedInBookingSettingsPage,
 } from "../booking/booking-harness";
 import { expectNoAxeViolations } from "../utils/axe-assertion";
@@ -238,6 +239,66 @@ test.describe("public booking cancel page", () => {
       page.getByRole("heading", { name: "Could not cancel booking" }),
     ).toBeVisible();
     await expectNoAxeViolations(page, { checkpoint: "cancel error" });
+  });
+});
+
+test.describe("public booking reschedule page", () => {
+  test("picker has no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await preparePublicBookingReschedulePage(page);
+    await expect(
+      page.getByRole("heading", {
+        name: "Reschedule your booking with Tyler Dane",
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Pick a time" }),
+    ).toBeVisible();
+    await expectNoAxeViolations(page, {
+      checkpoint: "booking reschedule picker",
+    });
+  });
+
+  test("not-found state has no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await preparePublicBookingReschedulePage(page, { token: "" });
+    await expect(
+      page.getByRole("heading", { name: "Booking not found" }),
+    ).toBeVisible();
+    await expectNoAxeViolations(page, {
+      checkpoint: "booking reschedule not found",
+    });
+  });
+
+  test("canceled state has no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await preparePublicBookingReschedulePage(page, {
+      reservationStatus: "cancelled",
+    });
+    await expect(
+      page.getByRole("heading", { name: "This booking was canceled" }),
+    ).toBeVisible();
+    await expectNoAxeViolations(page, {
+      checkpoint: "booking reschedule canceled",
+    });
+  });
+
+  test("conflict alert has no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    const { slotStart } = buildBookableSlot();
+    await preparePublicBookingReschedulePage(page, { rescheduleStatus: 409 });
+    await page
+      .getByRole("button", { name: formatSlotButtonLabel(slotStart) })
+      .click();
+    await page.getByRole("button", { name: "Confirm" }).click();
+    await expect(page.getByRole("alert")).toBeVisible();
+    await expectNoAxeViolations(page, {
+      checkpoint: "booking reschedule conflict",
+    });
   });
 });
 

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -225,7 +225,9 @@ export interface PublicBookingStubOptions {
 export interface CapturedBookingRequests {
   reservationPosts: Array<Record<string, unknown>>;
   reservationPatches: Array<Record<string, unknown>>;
+  reschedulePosts: Array<Record<string, unknown>>;
   slotGets: number;
+  reservationSlotGets: number;
   slotQueries: Array<{ start: string | null; end: string | null }>;
 }
 
@@ -277,9 +279,12 @@ export async function preparePublicBookingPage(
   const captured: CapturedBookingRequests = {
     reservationPosts: [],
     reservationPatches: [],
+    reschedulePosts: [],
     slotGets: 0,
+    reservationSlotGets: 0,
     slotQueries: [],
   };
+  const reservationId = "000000000000000000000099";
   const slot =
     options.slots?.[0] ?? buildBookableSlot(options.durationMinutes ?? 30);
   const slots = options.slots ?? [slot];
@@ -288,6 +293,7 @@ export async function preparePublicBookingPage(
   let guestName = options.guestName ?? "Guest User";
   let notes = options.notes ?? null;
   let postedSlotStart = slot.slotStart;
+  let postedSlotEnd = slot.slotEnd;
   let postedTimeZone = "UTC";
 
   await page.route("**/api/**", async (route) => {
@@ -361,16 +367,74 @@ export async function preparePublicBookingPage(
       if (typeof body.guestTimeZone === "string") {
         postedTimeZone = body.guestTimeZone;
       }
+      const origin = new URL(request.url()).origin;
       return route.fulfill(
         jsonResponse({
-          reservationId: "000000000000000000000099",
+          reservationId,
           slotStart: body.slotStart,
-          slotEnd: slot.slotEnd,
+          slotEnd: postedSlotEnd,
           guestTimeZone: body.guestTimeZone,
-          cancelUrl:
-            "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
-          rescheduleUrl:
-            "https://compasscalendar.com/book/reschedule/000000000000000000000099?token=abc",
+          cancelUrl: `${origin}/book/cancel/${reservationId}?token=abc`,
+          rescheduleUrl: `${origin}/book/reschedule/${reservationId}?token=abc`,
+        }),
+      );
+    }
+
+    if (
+      path === `/api/booking/reservations/${reservationId}/slots` &&
+      request.method() === "GET"
+    ) {
+      captured.reservationSlotGets += 1;
+      const windowStart = url.searchParams.get("start");
+      const windowEnd = url.searchParams.get("end");
+      captured.slotQueries.push({
+        start: windowStart,
+        end: windowEnd,
+      });
+      const startMs = windowStart ? Date.parse(windowStart) : Number.NaN;
+      const endMs = windowEnd ? Date.parse(windowEnd) : Number.NaN;
+      const slotsInWindow = slots.filter((entry) => {
+        const slotMs = Date.parse(entry.slotStart);
+        return slotMs >= startMs && slotMs < endMs;
+      });
+      return route.fulfill(
+        jsonResponse({
+          bookable: options.bookable ?? true,
+          slots: slotsInWindow,
+        }),
+      );
+    }
+
+    if (
+      path === `/api/booking/reservations/${reservationId}/reschedule` &&
+      request.method() === "POST"
+    ) {
+      const body = (request.postDataJSON() ?? {}) as Record<string, unknown>;
+      captured.reschedulePosts.push(body);
+      if (typeof body.slotStart === "string") {
+        postedSlotStart = body.slotStart;
+        const matched = slots.find(
+          (entry) => entry.slotStart === body.slotStart,
+        );
+        postedSlotEnd =
+          matched?.slotEnd ??
+          new Date(
+            Date.parse(postedSlotStart) + durationMinutes * 60 * 1000,
+          ).toISOString();
+      }
+      if (typeof body.guestTimeZone === "string") {
+        postedTimeZone = body.guestTimeZone;
+      }
+      return route.fulfill(
+        jsonResponse({
+          reservationId,
+          slotStart: postedSlotStart,
+          slotEnd: postedSlotEnd,
+          guestTimeZone: postedTimeZone,
+          durationMinutes,
+          hostDisplayName,
+          status: "confirmed",
+          bookingSlug: slug,
         }),
       );
     }
@@ -449,7 +513,9 @@ export async function preparePublicBookingConfirmedPage(
   const captured: CapturedBookingRequests = {
     reservationPosts: [],
     reservationPatches: [],
+    reschedulePosts: [],
     slotGets: 0,
+    reservationSlotGets: 0,
     slotQueries: [],
   };
 
@@ -603,6 +669,166 @@ export async function preparePublicBookingCancelPage(
 
   const search = token ? `?token=${encodeURIComponent(token)}` : "";
   await page.goto(`/book/cancel/${reservationId}${search}`, {
+    waitUntil: "domcontentloaded",
+  });
+
+  return captured;
+}
+
+export interface PublicBookingRescheduleStubOptions {
+  reservationId?: string;
+  token?: string;
+  durationMinutes?: number;
+  slots?: Array<{ slotStart: string; slotEnd: string }>;
+  bookable?: boolean;
+  /** HTTP status for POST /reservations/:id/reschedule. Default 200. */
+  rescheduleStatus?: number;
+  /** When set, the reschedule POST waits until this resolves (for in-flight UI). */
+  holdReschedule?: Promise<void>;
+  guestTimeZone?: string;
+  hostDisplayName?: string;
+  slug?: string;
+  /** Public GET reservation status. Defaults to confirmed. */
+  reservationStatus?: "confirmed" | "cancelled";
+  /** When true, GET /reservations/:id returns 404. */
+  reservationNotFound?: boolean;
+  /** When set, GET /reservations/:id returns this status instead of 200. */
+  reservationGetStatus?: number;
+}
+
+export interface CapturedRescheduleRequests {
+  reschedulePosts: Array<Record<string, unknown>>;
+  reservationSlotGets: number;
+}
+
+export async function preparePublicBookingReschedulePage(
+  page: Page,
+  options: PublicBookingRescheduleStubOptions = {},
+): Promise<CapturedRescheduleRequests> {
+  const reservationId = options.reservationId ?? "000000000000000000000099";
+  const token = options.token ?? "abc";
+  const slug = options.slug ?? "tylerdane";
+  const durationMinutes = options.durationMinutes ?? 30;
+  const hostDisplayName = options.hostDisplayName ?? "Tyler Dane";
+  const first = options.slots?.[0] ?? buildBookableSlot(durationMinutes);
+  const slots = options.slots ?? [first];
+  let currentSlotStart = first.slotStart;
+  let currentSlotEnd = first.slotEnd;
+  let guestTimeZone = options.guestTimeZone ?? "UTC";
+  const captured: CapturedRescheduleRequests = {
+    reschedulePosts: [],
+    reservationSlotGets: 0,
+  };
+
+  await page.route("**/api/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname;
+
+    if (path === `/api/booking/pages/${slug}` && request.method() === "GET") {
+      return route.fulfill(
+        jsonResponse({
+          hostDisplayName,
+          durationMinutes,
+          timeZone: "America/Chicago",
+          enabled: true,
+          maxHorizonDays: 60,
+          welcomeText: null,
+        }),
+      );
+    }
+
+    if (
+      path === `/api/booking/reservations/${reservationId}` &&
+      request.method() === "GET"
+    ) {
+      if (options.reservationNotFound) {
+        return route.fulfill(jsonResponse({}, 404));
+      }
+      if (options.reservationGetStatus) {
+        return route.fulfill(jsonResponse({}, options.reservationGetStatus));
+      }
+      return route.fulfill(
+        jsonResponse({
+          slotStart: currentSlotStart,
+          guestTimeZone,
+          durationMinutes,
+          hostDisplayName,
+          status: options.reservationStatus ?? "confirmed",
+          bookingSlug: slug,
+          guestName: "Guest User",
+          notes: null,
+        }),
+      );
+    }
+
+    if (
+      path === `/api/booking/reservations/${reservationId}/slots` &&
+      request.method() === "GET"
+    ) {
+      captured.reservationSlotGets += 1;
+      const windowStart = url.searchParams.get("start");
+      const windowEnd = url.searchParams.get("end");
+      const startMs = windowStart ? Date.parse(windowStart) : Number.NaN;
+      const endMs = windowEnd ? Date.parse(windowEnd) : Number.NaN;
+      const slotsInWindow = slots.filter((entry) => {
+        const slotMs = Date.parse(entry.slotStart);
+        return slotMs >= startMs && slotMs < endMs;
+      });
+      return route.fulfill(
+        jsonResponse({
+          bookable: options.bookable ?? true,
+          slots: slotsInWindow,
+        }),
+      );
+    }
+
+    if (
+      path === `/api/booking/reservations/${reservationId}/reschedule` &&
+      request.method() === "POST"
+    ) {
+      const body = (request.postDataJSON() ?? {}) as Record<string, unknown>;
+      captured.reschedulePosts.push(body);
+      if (options.holdReschedule) {
+        await options.holdReschedule;
+      }
+      const status = options.rescheduleStatus ?? 200;
+      if (status !== 200) {
+        return route.fulfill(jsonResponse({}, status));
+      }
+      if (typeof body.slotStart === "string") {
+        currentSlotStart = body.slotStart;
+        const matched = slots.find(
+          (entry) => entry.slotStart === body.slotStart,
+        );
+        currentSlotEnd =
+          matched?.slotEnd ??
+          new Date(
+            Date.parse(currentSlotStart) + durationMinutes * 60 * 1000,
+          ).toISOString();
+      }
+      if (typeof body.guestTimeZone === "string") {
+        guestTimeZone = body.guestTimeZone;
+      }
+      return route.fulfill(
+        jsonResponse({
+          reservationId,
+          slotStart: currentSlotStart,
+          slotEnd: currentSlotEnd,
+          guestTimeZone,
+          durationMinutes,
+          hostDisplayName,
+          status: "confirmed",
+          bookingSlug: slug,
+        }),
+      );
+    }
+
+    return route.fulfill(jsonResponse({}));
+  });
+
+  const search = token ? `?token=${encodeURIComponent(token)}` : "";
+  await page.goto(`/book/reschedule/${reservationId}${search}`, {
     waitUntil: "domcontentloaded",
   });
 
@@ -845,6 +1071,20 @@ export function formatSlotButtonLabel(
   }).format(new Date(slotStart));
   const escaped = time.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   return new RegExp(escaped, "i");
+}
+
+export function formatSlotWhenLabel(
+  slotStart: string,
+  timeZone = "UTC",
+): string {
+  return new Intl.DateTimeFormat(undefined, {
+    timeZone,
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(slotStart));
 }
 
 export function formatMonthDayButtonLabel(

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -367,15 +367,14 @@ export async function preparePublicBookingPage(
       if (typeof body.guestTimeZone === "string") {
         postedTimeZone = body.guestTimeZone;
       }
-      const origin = new URL(page.url()).origin;
       return route.fulfill(
         jsonResponse({
           reservationId,
           slotStart: body.slotStart,
           slotEnd: postedSlotEnd,
           guestTimeZone: body.guestTimeZone,
-          cancelUrl: `${origin}/book/cancel/${reservationId}?token=abc`,
-          rescheduleUrl: `${origin}/book/reschedule/${reservationId}?token=abc`,
+          cancelUrl: `https://compasscalendar.com/book/cancel/${reservationId}?token=abc`,
+          rescheduleUrl: `https://compasscalendar.com/book/reschedule/${reservationId}?token=abc`,
         }),
       );
     }

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -367,7 +367,7 @@ export async function preparePublicBookingPage(
       if (typeof body.guestTimeZone === "string") {
         postedTimeZone = body.guestTimeZone;
       }
-      const origin = new URL(request.url()).origin;
+      const origin = new URL(page.url()).origin;
       return route.fulfill(
         jsonResponse({
           reservationId,

--- a/e2e/booking/public-booking-reschedule.spec.ts
+++ b/e2e/booking/public-booking-reschedule.spec.ts
@@ -1,0 +1,130 @@
+import { expect, type Page, test } from "@playwright/test";
+import {
+  buildBookableSlot,
+  buildSameDaySiblingSlot,
+  formatSlotButtonLabel,
+  formatSlotWhenLabel,
+  preparePublicBookingPage,
+  preparePublicBookingReschedulePage,
+} from "./booking-harness";
+
+async function guestTimeZone(page: Page): Promise<string> {
+  return page.evaluate(() => Intl.DateTimeFormat().resolvedOptions().timeZone);
+}
+
+test.describe("public booking reschedule", () => {
+  test("confirm then reschedule to a new slot shows the new time", async ({
+    page,
+  }) => {
+    const first = buildBookableSlot();
+    const second = buildSameDaySiblingSlot(first);
+    const captured = await preparePublicBookingPage(page, {
+      slots: [first, second],
+    });
+    const timeZone = await guestTimeZone(page);
+
+    await page
+      .getByRole("button", { name: formatSlotButtonLabel(first.slotStart) })
+      .click();
+    await page.getByLabel("Name").fill("Guest User");
+    await page.getByLabel("Email").fill("guest@example.com");
+    await page.getByRole("button", { name: "Confirm booking" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+    ).toBeFocused();
+    await expect(
+      page.getByText(formatSlotWhenLabel(first.slotStart, timeZone)),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "Reschedule this booking" }),
+    ).toBeVisible();
+
+    await page.getByRole("link", { name: "Reschedule this booking" }).click();
+
+    await expect(
+      page.getByRole("heading", {
+        name: "Reschedule your booking with Tyler Dane",
+      }),
+    ).toBeFocused();
+    await expect(page).toHaveURL(
+      /\/book\/reschedule\/000000000000000000000099\?token=abc/,
+    );
+
+    await page
+      .getByRole("button", { name: formatSlotButtonLabel(second.slotStart) })
+      .click();
+    await page.getByRole("button", { name: "Confirm" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(formatSlotWhenLabel(second.slotStart, timeZone)),
+    ).toBeVisible();
+    await expect(
+      page.getByText(formatSlotWhenLabel(first.slotStart, timeZone)),
+    ).toHaveCount(0);
+    expect(captured.reschedulePosts).toHaveLength(1);
+    expect(captured.reschedulePosts[0]).toMatchObject({
+      token: "abc",
+      slotStart: second.slotStart,
+    });
+  });
+
+  test("reaches Confirm with the keyboard", async ({ page }) => {
+    const { slotStart } = buildBookableSlot();
+    const captured = await preparePublicBookingReschedulePage(page);
+
+    await expect(
+      page.getByRole("heading", {
+        name: "Reschedule your booking with Tyler Dane",
+      }),
+    ).toBeFocused();
+
+    const slotButton = page.getByRole("button", {
+      name: formatSlotButtonLabel(slotStart),
+    });
+    await slotButton.focus();
+    await page.keyboard.press("Enter");
+
+    const confirm = page.getByRole("button", { name: "Confirm" });
+    await expect(confirm).toBeVisible();
+    for (let hop = 0; hop < 20; hop += 1) {
+      if (await confirm.evaluate((el) => el === document.activeElement)) {
+        break;
+      }
+      await page.keyboard.press("Tab");
+    }
+    await expect(confirm).toBeFocused();
+    await page.keyboard.press("Enter");
+
+    await expect(
+      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+    ).toBeVisible();
+    expect(captured.reschedulePosts).toHaveLength(1);
+    expect(captured.reschedulePosts[0]).toMatchObject({
+      token: "abc",
+      slotStart,
+    });
+  });
+
+  test("missing token is not-found and does not fetch slots", async ({
+    page,
+  }) => {
+    const captured = await preparePublicBookingReschedulePage(page, {
+      token: "",
+    });
+
+    await expect(
+      page.getByRole("heading", { name: "Booking not found" }),
+    ).toBeFocused();
+    await expect(
+      page.getByRole("heading", {
+        name: "Reschedule your booking with Tyler Dane",
+      }),
+    ).toHaveCount(0);
+    expect(captured.reservationSlotGets).toBe(0);
+    expect(captured.reschedulePosts).toHaveLength(0);
+  });
+});

--- a/e2e/booking/public-booking-reschedule.spec.ts
+++ b/e2e/booking/public-booking-reschedule.spec.ts
@@ -42,14 +42,14 @@ test.describe("public booking reschedule", () => {
 
     await page.getByRole("link", { name: "Reschedule this booking" }).click();
 
+    await expect(page).toHaveURL(
+      /\/book\/reschedule\/000000000000000000000099\?token=abc/,
+    );
     await expect(
       page.getByRole("heading", {
         name: "Reschedule your booking with Tyler Dane",
       }),
     ).toBeFocused();
-    await expect(page).toHaveURL(
-      /\/book\/reschedule\/000000000000000000000099\?token=abc/,
-    );
 
     await page
       .getByRole("button", { name: formatSlotButtonLabel(second.slotStart) })

--- a/e2e/booking/public-booking-reschedule.spec.ts
+++ b/e2e/booking/public-booking-reschedule.spec.ts
@@ -40,7 +40,16 @@ test.describe("public booking reschedule", () => {
       page.getByRole("link", { name: "Reschedule this booking" }),
     ).toBeVisible();
 
-    await page.getByRole("link", { name: "Reschedule this booking" }).click();
+    const rescheduleHref = await page
+      .getByRole("link", { name: "Reschedule this booking" })
+      .getAttribute("href");
+    expect(rescheduleHref).toContain(
+      "/book/reschedule/000000000000000000000099?token=abc",
+    );
+    // Create returns an absolute compasscalendar.com URL; follow its path on
+    // the Playwright origin instead of leaving the stubbed app.
+    const rescheduleUrl = new URL(rescheduleHref ?? "", page.url());
+    await page.goto(`${rescheduleUrl.pathname}${rescheduleUrl.search}`);
 
     await expect(page).toHaveURL(
       /\/book\/reschedule\/000000000000000000000099\?token=abc/,

--- a/packages/web/src/api/public-booking.api.ts
+++ b/packages/web/src/api/public-booking.api.ts
@@ -1,4 +1,6 @@
 import {
+  type BookingReservationSlotsQuery,
+  BookingReservationSlotsQuerySchema,
   type BookingSlotsQuery,
   BookingSlotsQuerySchema,
   type BookingSlotsResponse,
@@ -15,6 +17,10 @@ import {
   PublicGetBookingPageResponseSchema,
   type PublicGetBookingReservationResponse,
   PublicGetBookingReservationResponseSchema,
+  type RescheduleBookingReservationInput,
+  RescheduleBookingReservationInputSchema,
+  type RescheduleBookingReservationResponse,
+  RescheduleBookingReservationResponseSchema,
 } from "@core/types/booking.contracts";
 import { BaseApi } from "@web/api/base/base.api";
 import { getErrorStatus } from "@web/api/util/api.util";
@@ -120,6 +126,52 @@ const PublicBookingApi = {
       parsed,
       { skipSessionRecovery: true },
     );
+  },
+
+  async getReservationSlots(
+    reservationId: string,
+    query: BookingReservationSlotsQuery,
+    signal?: AbortSignal,
+  ): Promise<BookingSlotsResponse> {
+    const parsed = BookingReservationSlotsQuerySchema.parse(query);
+    const params = new URLSearchParams({
+      token: parsed.token,
+      start: parsed.start,
+      end: parsed.end,
+      timeZone: parsed.timeZone,
+    });
+    try {
+      const response = await BaseApi.get<unknown>(
+        `/booking/reservations/${encodeURIComponent(reservationId)}/slots?${params.toString()}`,
+        { skipSessionRecovery: true, signal },
+      );
+      return BookingSlotsResponseSchema.parse(response.data);
+    } catch (error) {
+      if (getErrorStatus(error) === 404) {
+        throw new PublicBookingNotFoundError();
+      }
+      throw error;
+    }
+  },
+
+  async rescheduleReservation(
+    reservationId: string,
+    input: RescheduleBookingReservationInput,
+  ): Promise<RescheduleBookingReservationResponse> {
+    const parsed = RescheduleBookingReservationInputSchema.parse(input);
+    try {
+      const response = await BaseApi.post<unknown>(
+        `/booking/reservations/${encodeURIComponent(reservationId)}/reschedule`,
+        parsed,
+        { skipSessionRecovery: true },
+      );
+      return RescheduleBookingReservationResponseSchema.parse(response.data);
+    } catch (error) {
+      if (getErrorStatus(error) === 404) {
+        throw new PublicBookingNotFoundError();
+      }
+      throw error;
+    }
   },
 };
 

--- a/packages/web/src/booking/PublicBookingConfirmationView.test.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmationView.test.tsx
@@ -11,6 +11,8 @@ const slotStart = "2026-09-15T15:00:00.000Z";
 const timeZone = "UTC";
 const cancelUrl =
   "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc";
+const rescheduleUrl =
+  "https://compasscalendar.com/book/reschedule/000000000000000000000099?token=abc";
 
 describe("PublicBookingConfirmationView", () => {
   it("shows the slot summary instead of a raw cancel URL", () => {
@@ -47,8 +49,55 @@ describe("PublicBookingConfirmationView", () => {
       screen.getByRole("button", { name: "Copy cancel link" }),
     ).toBeInTheDocument();
     expect(
+      screen.queryByRole("button", { name: "Copy reschedule link" }),
+    ).not.toBeInTheDocument();
+    expect(
       screen.getByText("A Google Meet invite is on its way to your email."),
     ).toBeInTheDocument();
+  });
+
+  it("shows cancel then reschedule actions when both URLs are present", async () => {
+    const user = userEvent.setup({ delay: null });
+    render(
+      <PublicBookingConfirmationView
+        cancelUrl={cancelUrl}
+        rescheduleUrl={rescheduleUrl}
+        durationMinutes={30}
+        hostDisplayName="Tyler Dane"
+        guestName="Ada Lovelace"
+        notes={null}
+        slotStart={slotStart}
+        timeZone={timeZone}
+      />,
+    );
+
+    const heading = screen.getByRole("heading", {
+      name: "You are booked with Tyler Dane",
+    });
+    expect(screen.queryByText(rescheduleUrl)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Reschedule this booking" }),
+    ).toHaveAttribute("href", rescheduleUrl);
+    expect(
+      screen.getByRole("button", { name: "Copy reschedule link" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("group", { name: "Booking actions" }),
+    ).toBeInTheDocument();
+
+    heading.focus();
+    await user.tab();
+    expect(
+      screen.getByRole("button", { name: "Copy cancel link" }),
+    ).toHaveFocus();
+    await user.tab();
+    expect(
+      screen.getByRole("link", { name: "Cancel this booking" }),
+    ).toHaveFocus();
+    await user.tab();
+    expect(
+      screen.getByRole("button", { name: "Copy reschedule link" }),
+    ).toHaveFocus();
   });
 
   it("promises a calendar invite when the destination cannot mint Meet", () => {
@@ -89,10 +138,16 @@ describe("PublicBookingConfirmationView", () => {
       screen.queryByRole("button", { name: "Copy cancel link" }),
     ).not.toBeInTheDocument();
     expect(
+      screen.queryByRole("button", { name: "Copy reschedule link" }),
+    ).not.toBeInTheDocument();
+    expect(
       screen.queryByRole("link", { name: "cancel this booking" }),
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("link", { name: "Cancel this booking" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Reschedule this booking" }),
     ).not.toBeInTheDocument();
     expect(
       screen.getByText("A Google Meet invite is on its way to your email."),
@@ -131,6 +186,44 @@ describe("PublicBookingConfirmationView", () => {
 
     expect(written).toEqual([cancelUrl]);
     expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Copied");
+  });
+
+  it("copies the reschedule URL from the secondary button", async () => {
+    const user = userEvent.setup({ delay: null });
+    const written: string[] = [];
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: mock((value: string) => {
+          written.push(value);
+          return Promise.resolve();
+        }),
+      },
+    });
+
+    render(
+      <PublicBookingConfirmationView
+        cancelUrl={cancelUrl}
+        rescheduleUrl={rescheduleUrl}
+        durationMinutes={30}
+        hostDisplayName="Tyler Dane"
+        guestName="Ada Lovelace"
+        notes={null}
+        slotStart={slotStart}
+        timeZone={timeZone}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Copy reschedule link" }),
+    );
+
+    expect(written).toEqual([rescheduleUrl]);
+    expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Copy cancel link" }),
+    ).toBeInTheDocument();
     expect(screen.getByRole("status")).toHaveTextContent("Copied");
   });
 

--- a/packages/web/src/booking/PublicBookingConfirmationView.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmationView.tsx
@@ -1,5 +1,6 @@
 import { CheckCircleIcon } from "@phosphor-icons/react";
 import { PublicBookingCopyCancelUrl } from "@web/booking/PublicBookingCopyCancelUrl";
+import { PublicBookingCopyRescheduleUrl } from "@web/booking/PublicBookingCopyRescheduleUrl";
 import { PublicBookingLayout } from "@web/booking/PublicBookingLayout";
 import { PublicBookingSlotSummary } from "@web/booking/PublicBookingSlotSummary";
 import { PUBLIC_BOOKING_HEADING_CLASS } from "@web/booking/PublicBookingStatusMessage";
@@ -14,6 +15,7 @@ interface PublicBookingConfirmationViewProps {
   timeZone: string;
   createsGoogleMeet?: boolean;
   cancelUrl?: string;
+  rescheduleUrl?: string;
   onEditDetails?: () => void;
 }
 
@@ -26,6 +28,7 @@ export function PublicBookingConfirmationView({
   timeZone,
   createsGoogleMeet = true,
   cancelUrl,
+  rescheduleUrl,
   onEditDetails,
 }: PublicBookingConfirmationViewProps) {
   const headingRef = useBookingHeadingFocus(hostDisplayName);
@@ -83,8 +86,19 @@ export function PublicBookingConfirmationView({
             Edit details
           </button>
         ) : null}
-        {cancelUrl ? (
-          <PublicBookingCopyCancelUrl cancelUrl={cancelUrl} />
+        {cancelUrl || rescheduleUrl ? (
+          <div
+            className="flex flex-col items-start gap-3"
+            role="group"
+            aria-label="Booking actions"
+          >
+            {cancelUrl ? (
+              <PublicBookingCopyCancelUrl cancelUrl={cancelUrl} />
+            ) : null}
+            {rescheduleUrl ? (
+              <PublicBookingCopyRescheduleUrl rescheduleUrl={rescheduleUrl} />
+            ) : null}
+          </div>
         ) : null}
       </section>
     </PublicBookingLayout>

--- a/packages/web/src/booking/PublicBookingConfirmedPage.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmedPage.tsx
@@ -18,7 +18,9 @@ import {
   resolvePublicBookingReservationView,
 } from "@web/booking/public-booking.view";
 import {
+  guestActionUrlFromHistory,
   publicCancelUrlForReservation,
+  publicRescheduleUrlForReservation,
   tokenFromGuestActionUrl,
 } from "@web/booking/public-booking-search";
 import { useBookingDocumentTitle } from "@web/booking/use-booking-document-title";
@@ -60,16 +62,11 @@ const resolveConfirmedPageView = (
   });
 
 function cancelUrlFromHistory(state: unknown): string | undefined {
-  if (
-    state &&
-    typeof state === "object" &&
-    "cancelUrl" in state &&
-    typeof state.cancelUrl === "string" &&
-    state.cancelUrl.length > 0
-  ) {
-    return state.cancelUrl;
-  }
-  return undefined;
+  return guestActionUrlFromHistory(state, "cancelUrl");
+}
+
+function rescheduleUrlFromHistory(state: unknown): string | undefined {
+  return guestActionUrlFromHistory(state, "rescheduleUrl");
 }
 
 export function PublicBookingConfirmedPage() {
@@ -82,13 +79,27 @@ export function PublicBookingConfirmedPage() {
   const historyCancelUrl = useRouterState({
     select: (routerState) => cancelUrlFromHistory(routerState.location.state),
   });
+  const historyRescheduleUrl = useRouterState({
+    select: (routerState) =>
+      rescheduleUrlFromHistory(routerState.location.state),
+  });
   const token =
     searchToken ||
-    (historyCancelUrl ? tokenFromGuestActionUrl(historyCancelUrl) : "");
+    (historyCancelUrl ? tokenFromGuestActionUrl(historyCancelUrl) : "") ||
+    (historyRescheduleUrl ? tokenFromGuestActionUrl(historyRescheduleUrl) : "");
   const cancelUrl =
     historyCancelUrl ??
     (token
       ? publicCancelUrlForReservation(
+          reservationId,
+          token,
+          window.location.origin,
+        )
+      : undefined);
+  const rescheduleUrl =
+    historyRescheduleUrl ??
+    (token
+      ? publicRescheduleUrlForReservation(
           reservationId,
           token,
           window.location.origin,
@@ -180,6 +191,7 @@ export function PublicBookingConfirmedPage() {
       timeZone={reservation.guestTimeZone}
       createsGoogleMeet={reservation.createsGoogleMeet}
       cancelUrl={cancelUrl}
+      rescheduleUrl={rescheduleUrl}
       onEditDetails={
         canEdit
           ? () => {

--- a/packages/web/src/booking/PublicBookingCopyCancelUrl.tsx
+++ b/packages/web/src/booking/PublicBookingCopyCancelUrl.tsx
@@ -1,4 +1,4 @@
-import { useCopiedFlag } from "@web/booking/use-copied-flag";
+import { PublicBookingCopyGuestAction } from "@web/booking/PublicBookingCopyGuestAction";
 
 interface PublicBookingCopyCancelUrlProps {
   cancelUrl: string;
@@ -7,26 +7,11 @@ interface PublicBookingCopyCancelUrlProps {
 export function PublicBookingCopyCancelUrl({
   cancelUrl,
 }: PublicBookingCopyCancelUrlProps) {
-  const { copied, copy } = useCopiedFlag(cancelUrl);
-
   return (
-    <div className="flex flex-col items-start gap-3">
-      <button
-        type="button"
-        onClick={copy}
-        className="c-button c-button-secondary"
-      >
-        {copied ? "Copied" : "Copy cancel link"}
-      </button>
-      <a
-        href={cancelUrl}
-        className="c-focus-ring text-accent text-sm underline"
-      >
-        Cancel this booking
-      </a>
-      <p role="status" className="sr-only">
-        {copied ? "Copied" : ""}
-      </p>
-    </div>
+    <PublicBookingCopyGuestAction
+      copyLabel="Copy cancel link"
+      linkLabel="Cancel this booking"
+      url={cancelUrl}
+    />
   );
 }

--- a/packages/web/src/booking/PublicBookingCopyGuestAction.tsx
+++ b/packages/web/src/booking/PublicBookingCopyGuestAction.tsx
@@ -1,0 +1,35 @@
+import { useCopiedFlag } from "@web/booking/use-copied-flag";
+
+interface PublicBookingCopyGuestActionProps {
+  url: string;
+  copyLabel: string;
+  linkLabel: string;
+}
+
+export function PublicBookingCopyGuestAction({
+  url,
+  copyLabel,
+  linkLabel,
+}: PublicBookingCopyGuestActionProps) {
+  const { copied, copy } = useCopiedFlag(url);
+
+  return (
+    <div className="flex flex-col items-start gap-3">
+      <button
+        type="button"
+        onClick={copy}
+        className="c-button c-button-secondary"
+      >
+        {copied ? "Copied" : copyLabel}
+      </button>
+      <a href={url} className="c-focus-ring text-accent text-sm underline">
+        {linkLabel}
+      </a>
+      {copied ? (
+        <p role="status" className="sr-only">
+          Copied
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/web/src/booking/PublicBookingCopyRescheduleUrl.tsx
+++ b/packages/web/src/booking/PublicBookingCopyRescheduleUrl.tsx
@@ -1,0 +1,17 @@
+import { PublicBookingCopyGuestAction } from "@web/booking/PublicBookingCopyGuestAction";
+
+interface PublicBookingCopyRescheduleUrlProps {
+  rescheduleUrl: string;
+}
+
+export function PublicBookingCopyRescheduleUrl({
+  rescheduleUrl,
+}: PublicBookingCopyRescheduleUrlProps) {
+  return (
+    <PublicBookingCopyGuestAction
+      copyLabel="Copy reschedule link"
+      linkLabel="Reschedule this booking"
+      url={rescheduleUrl}
+    />
+  );
+}

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -445,7 +445,13 @@ describe("PublicBookingPage", () => {
       screen.getByRole("button", { name: "Copy cancel link" }),
     ).toBeInTheDocument();
     expect(
+      screen.getByRole("button", { name: "Copy reschedule link" }),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole("link", { name: "Cancel this booking" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Reschedule this booking" }),
     ).toBeInTheDocument();
   });
 
@@ -1433,6 +1439,9 @@ describe("PublicBookingConfirmedPage", () => {
       screen.queryByRole("button", { name: "Copy cancel link" }),
     ).not.toBeInTheDocument();
     expect(
+      screen.queryByRole("button", { name: "Copy reschedule link" }),
+    ).not.toBeInTheDocument();
+    expect(
       screen.queryByRole("button", { name: "Edit details" }),
     ).not.toBeInTheDocument();
   });
@@ -1450,6 +1459,9 @@ describe("PublicBookingConfirmedPage", () => {
       screen.getByRole("button", { name: "Copy cancel link" }),
     ).toBeInTheDocument();
     expect(
+      screen.getByRole("button", { name: "Copy reschedule link" }),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole("button", { name: "Edit details" }),
     ).toBeInTheDocument();
     expect(
@@ -1457,6 +1469,12 @@ describe("PublicBookingConfirmedPage", () => {
     ).toHaveAttribute(
       "href",
       `${window.location.origin}/book/cancel/000000000000000000000099?token=abc`,
+    );
+    expect(
+      screen.getByRole("link", { name: "Reschedule this booking" }),
+    ).toHaveAttribute(
+      "href",
+      `${window.location.origin}/book/reschedule/000000000000000000000099?token=abc`,
     );
     expect(
       screen.getByText("A Google Meet invite is on its way to your email."),
@@ -1561,6 +1579,15 @@ describe("PublicBookingConfirmedPage", () => {
         name: "This booking was canceled",
       }),
     ).toHaveFocus();
+    expect(
+      screen.queryByRole("button", { name: "Copy cancel link" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Copy reschedule link" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Reschedule this booking" }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows a calm state for an unknown reservation", async () => {
@@ -1643,10 +1670,17 @@ describe("PublicBookingConfirmedPage", () => {
       "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
     );
     expect(
+      screen.getByRole("link", { name: "Reschedule this booking" }),
+    ).toHaveAttribute(
+      "href",
+      "https://compasscalendar.com/book/reschedule/000000000000000000000099?token=abc",
+    );
+    expect(
       screen.queryByRole("link", {
         name: "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
       }),
     ).not.toBeInTheDocument();
+    expect(screen.queryByText(/token=abc/)).not.toBeInTheDocument();
     await user.click(
       await screen.findByRole("button", { name: "Copy cancel link" }),
     );

--- a/packages/web/src/booking/PublicBookingReschedulePage.test.tsx
+++ b/packages/web/src/booking/PublicBookingReschedulePage.test.tsx
@@ -1,0 +1,287 @@
+import { HotkeysProvider } from "@tanstack/react-hotkeys";
+import {
+  createMemoryHistory,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { rest } from "msw";
+import { Status } from "@core/errors/status.codes";
+import { server } from "@web/__tests__/__mocks__/server/mock.server";
+import { createStoreWrapper } from "@web/__tests__/render-with-store";
+import { formatBookingSlotTime } from "@web/booking/public-booking.format";
+import { ENV_WEB } from "@web/common/constants/env.constants";
+import { routeTree } from "@web/routers/router.routes";
+import { describe, expect, it } from "bun:test";
+
+const reservationId = "000000000000000000000099";
+const reschedulePath = `/book/reschedule/${reservationId}?token=abc`;
+const slotStart = (() => {
+  const start = new Date(Date.now() + 48 * 60 * 60 * 1000);
+  start.setUTCMinutes(0, 0, 0);
+  start.setUTCHours(15, 0, 0, 0);
+  return start.toISOString();
+})();
+const slotEnd = new Date(Date.parse(slotStart) + 30 * 60 * 1000).toISOString();
+
+function reservationGetHandler(overrides: Record<string, unknown> = {}) {
+  return rest.get(
+    `${ENV_WEB.API_BASEURL}/booking/reservations/${reservationId}`,
+    (_req, res, ctx) =>
+      res(
+        ctx.status(Status.OK),
+        ctx.json({
+          slotStart,
+          guestTimeZone: "UTC",
+          durationMinutes: 30,
+          hostDisplayName: "Tyler Dane",
+          status: "confirmed",
+          bookingSlug: "tylerdane",
+          guestName: "Guest User",
+          notes: null,
+          ...overrides,
+        }),
+      ),
+  );
+}
+
+function pageHandler() {
+  return rest.get(
+    `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane`,
+    (_req, res, ctx) =>
+      res(
+        ctx.status(Status.OK),
+        ctx.json({
+          hostDisplayName: "Tyler Dane",
+          durationMinutes: 30,
+          timeZone: "America/Chicago",
+          enabled: true,
+          maxHorizonDays: 60,
+          welcomeText: null,
+        }),
+      ),
+  );
+}
+
+function reservationSlotsHandler(
+  onRequest?: (url: URL) => void,
+  slots = [{ slotStart, slotEnd }],
+) {
+  return rest.get(
+    `${ENV_WEB.API_BASEURL}/booking/reservations/${reservationId}/slots`,
+    (req, res, ctx) => {
+      onRequest?.(req.url);
+      return res(ctx.status(Status.OK), ctx.json({ bookable: true, slots }));
+    },
+  );
+}
+
+function renderRescheduleRoute(path: string) {
+  const router = createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [path] }),
+    defaultPendingMs: 0,
+  });
+  const { wrapper } = createStoreWrapper();
+  const result = render(
+    <HotkeysProvider>
+      <RouterProvider router={router} />
+    </HotkeysProvider>,
+    { wrapper },
+  );
+  return { ...result, router };
+}
+
+describe("PublicBookingReschedulePage", () => {
+  it("does not POST on load and sends one POST on Confirm", async () => {
+    const user = userEvent.setup({ delay: null });
+    const posts: unknown[] = [];
+
+    server.use(
+      reservationGetHandler(),
+      pageHandler(),
+      reservationSlotsHandler(),
+      rest.post(
+        `${ENV_WEB.API_BASEURL}/booking/reservations/${reservationId}/reschedule`,
+        async (req, res, ctx) => {
+          posts.push(await req.json());
+          return res(
+            ctx.status(Status.OK),
+            ctx.json({
+              reservationId,
+              slotStart,
+              slotEnd,
+              guestTimeZone: "UTC",
+              durationMinutes: 30,
+              hostDisplayName: "Tyler Dane",
+              status: "confirmed",
+              bookingSlug: "tylerdane",
+            }),
+          );
+        },
+      ),
+    );
+
+    const { router } = renderRescheduleRoute(reschedulePath);
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "Reschedule your booking with Tyler Dane",
+      }),
+    ).toHaveFocus();
+    expect(posts).toHaveLength(0);
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: formatBookingSlotTime(slotStart, "UTC"),
+      }),
+    );
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    await waitFor(() => {
+      expect(posts).toEqual([
+        { token: "abc", slotStart, guestTimeZone: "UTC" },
+      ]);
+    });
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe(
+        `/book/confirmed/${reservationId}`,
+      );
+    });
+    expect(router.state.location.state).toMatchObject({
+      cancelUrl: `${window.location.origin}/book/cancel/${reservationId}?token=abc`,
+      rescheduleUrl: `${window.location.origin}/book/reschedule/${reservationId}?token=abc`,
+    });
+  });
+
+  it("does not POST twice if Confirm is clicked while in flight", async () => {
+    const user = userEvent.setup({ delay: null });
+    let posts = 0;
+    let releasePost: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      releasePost = resolve;
+    });
+
+    server.use(
+      reservationGetHandler(),
+      pageHandler(),
+      reservationSlotsHandler(),
+      rest.post(
+        `${ENV_WEB.API_BASEURL}/booking/reservations/${reservationId}/reschedule`,
+        async (_req, res, ctx) => {
+          posts += 1;
+          await gate;
+          return res(
+            ctx.status(Status.OK),
+            ctx.json({
+              reservationId,
+              slotStart,
+              slotEnd,
+              guestTimeZone: "UTC",
+              durationMinutes: 30,
+              hostDisplayName: "Tyler Dane",
+              status: "confirmed",
+              bookingSlug: "tylerdane",
+            }),
+          );
+        },
+      ),
+    );
+
+    renderRescheduleRoute(reschedulePath);
+    await user.click(
+      await screen.findByRole("button", {
+        name: formatBookingSlotTime(slotStart, "UTC"),
+      }),
+    );
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+    await user.click(screen.getByRole("button", { name: "Confirming..." }));
+    releasePost?.();
+
+    await waitFor(() => {
+      expect(posts).toBe(1);
+    });
+  });
+
+  it("shows not-found without fetching slots when the token is missing", async () => {
+    let slotGets = 0;
+    server.use(
+      reservationGetHandler(),
+      pageHandler(),
+      reservationSlotsHandler(() => {
+        slotGets += 1;
+      }),
+    );
+
+    renderRescheduleRoute(`/book/reschedule/${reservationId}`);
+
+    expect(
+      await screen.findByRole("heading", { name: "Booking not found" }),
+    ).toHaveFocus();
+    expect(slotGets).toBe(0);
+    expect(
+      screen.queryByRole("heading", {
+        name: "Reschedule your booking with Tyler Dane",
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("stays on the picker and focuses the alert on 409", async () => {
+    const user = userEvent.setup({ delay: null });
+
+    server.use(
+      reservationGetHandler(),
+      pageHandler(),
+      reservationSlotsHandler(),
+      rest.post(
+        `${ENV_WEB.API_BASEURL}/booking/reservations/${reservationId}/reschedule`,
+        (_req, res, ctx) => res(ctx.status(Status.CONFLICT), ctx.json({})),
+      ),
+    );
+
+    const { router } = renderRescheduleRoute(reschedulePath);
+    await user.click(
+      await screen.findByRole("button", {
+        name: formatBookingSlotTime(slotStart, "UTC"),
+      }),
+    );
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    expect(await screen.findByRole("alert")).toHaveFocus();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "This time is no longer available. Pick another slot.",
+    );
+    expect(
+      screen.getByRole("heading", {
+        name: "Reschedule your booking with Tyler Dane",
+      }),
+    ).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe(
+      `/book/reschedule/${reservationId}`,
+    );
+  });
+
+  it("shows a calm canceled heading instead of the picker", async () => {
+    let slotGets = 0;
+    server.use(
+      reservationGetHandler({ status: "cancelled" }),
+      pageHandler(),
+      reservationSlotsHandler(() => {
+        slotGets += 1;
+      }),
+    );
+
+    renderRescheduleRoute(reschedulePath);
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "This booking was canceled",
+      }),
+    ).toHaveFocus();
+    expect(
+      screen.queryByRole("button", { name: "Confirm" }),
+    ).not.toBeInTheDocument();
+    expect(slotGets).toBe(0);
+  });
+});

--- a/packages/web/src/booking/PublicBookingReschedulePage.tsx
+++ b/packages/web/src/booking/PublicBookingReschedulePage.tsx
@@ -1,0 +1,197 @@
+import { PublicBookingNotFoundError } from "@web/api/public-booking.api";
+import { PublicBookingLayout } from "@web/booking/PublicBookingLayout";
+import { PublicBookingPicker } from "@web/booking/PublicBookingPicker";
+import { PublicBookingSkipLink } from "@web/booking/PublicBookingSkipLink";
+import { PublicBookingSlotSummary } from "@web/booking/PublicBookingSlotSummary";
+import {
+  PUBLIC_BOOKING_HEADING_CLASS,
+  PublicBookingStatusMessage,
+} from "@web/booking/PublicBookingStatusMessage";
+import { PublicBookingTimezoneControl } from "@web/booking/PublicBookingTimezoneControl";
+import { type usePublicBookingReservationQuery } from "@web/booking/public-booking.query";
+import {
+  type PublicBookingReservationView,
+  resolvePublicBookingReservationView,
+} from "@web/booking/public-booking.view";
+import { useBookingDocumentTitle } from "@web/booking/use-booking-document-title";
+import { useBookingHeadingFocus } from "@web/booking/use-booking-heading-focus";
+import { usePublicBookingRescheduleFlow } from "@web/booking/use-public-booking-reschedule-flow";
+
+const BOOKING_LOADING = {
+  title: "Loading booking",
+  description: "One moment while we load this booking.",
+} as const;
+
+const BOOKING_NOT_FOUND = {
+  title: "Booking not found",
+  description: "This reschedule link may be invalid or already used.",
+} as const;
+
+const BOOKING_LOAD_FAILED = {
+  title: "Could not load booking",
+  description: "Please refresh and try again.",
+} as const;
+
+const BOOKING_CANCELED = {
+  title: "This booking was canceled",
+  description:
+    "The appointment is no longer on the host calendar. You can close this page.",
+} as const;
+
+const STICKY_STEP_CLASS_NAME =
+  "sticky bottom-0 z-10 -mx-4 border-border border-t bg-background px-4 py-3 sm:static sm:mx-0 sm:border-0 sm:px-0 sm:py-0";
+
+export function PublicBookingReschedulePage() {
+  const flow = usePublicBookingRescheduleFlow();
+  const { reservationQuery, pageQuery, slotsQuery } = flow;
+  const reservationView = resolveReschedulePageView(
+    flow.canLoad,
+    reservationQuery,
+  );
+  const hostDisplayName =
+    reservationView.kind === "reservation"
+      ? reservationView.reservation.hostDisplayName
+      : "";
+  const headingRef = useBookingHeadingFocus(
+    reservationView.kind === "reservation" && pageQuery.isSuccess
+      ? hostDisplayName
+      : null,
+  );
+  useBookingDocumentTitle("Reschedule booking");
+
+  if (reservationView.kind === "status") {
+    return <PublicBookingStatusMessage {...reservationView} />;
+  }
+
+  const { reservation } = reservationView;
+
+  if (pageQuery.isLoading) {
+    return (
+      <PublicBookingStatusMessage
+        title="Loading booking page"
+        description="One moment while we load available times."
+      />
+    );
+  }
+
+  if (
+    pageQuery.error instanceof PublicBookingNotFoundError ||
+    (pageQuery.isSuccess && !pageQuery.data.enabled)
+  ) {
+    return <PublicBookingStatusMessage {...BOOKING_NOT_FOUND} />;
+  }
+
+  if (pageQuery.isError || !pageQuery.isSuccess || !pageQuery.data) {
+    return <PublicBookingStatusMessage {...BOOKING_LOAD_FAILED} />;
+  }
+
+  const page = pageQuery.data;
+  const busy = flow.rescheduleReservation.isPending;
+
+  if (slotsQuery.data && !slotsQuery.data.bookable) {
+    return (
+      <PublicBookingStatusMessage
+        title="Booking temporarily unavailable"
+        description="The host calendar is not ready for new bookings. Please try again later."
+      />
+    );
+  }
+
+  return (
+    <PublicBookingLayout wide>
+      <PublicBookingSkipLink
+        href="#booking-slots-heading"
+        label="Skip to open times"
+      />
+      <header className="flex flex-col gap-1">
+        <h1
+          className={PUBLIC_BOOKING_HEADING_CLASS}
+          id="booking-reschedule-heading"
+          ref={headingRef}
+          tabIndex={-1}
+        >
+          Reschedule your booking with {reservation.hostDisplayName}
+        </h1>
+        <p className="text-sm text-text-muted">Current time</p>
+        <PublicBookingSlotSummary
+          durationMinutes={reservation.durationMinutes}
+          slotStart={reservation.slotStart}
+          timeZone={reservation.guestTimeZone}
+        />
+        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-sm text-text-muted">
+          <p>Times shown in your timezone</p>
+          <PublicBookingTimezoneControl
+            timeZone={flow.guestTimeZone}
+            onChange={flow.handleTimeZoneChange}
+          />
+        </div>
+      </header>
+
+      {flow.alertMessage ? (
+        <p
+          ref={flow.alertRef}
+          role="alert"
+          tabIndex={-1}
+          className="rounded-md border border-warning/40 bg-surface-panel px-3 py-2 text-sm text-text focus:outline-none focus:ring-2 focus:ring-accent"
+        >
+          {flow.alertMessage}
+        </p>
+      ) : null}
+
+      <PublicBookingPicker
+        monthKey={flow.monthKey}
+        timeZone={flow.guestTimeZone}
+        maxHorizonDays={page.maxHorizonDays}
+        slots={slotsQuery.data?.slots ?? []}
+        slotsPending={flow.slotsPending}
+        slotsError={flow.slotsError}
+        slotsFetching={flow.slotsFetching}
+        selectedDateKey={flow.selectedDateKey}
+        selectedSlotStart={flow.selectedSlotStart}
+        slotsHeadingRef={flow.pickerHeadingRef}
+        onMonthChange={flow.handleMonthChange}
+        onPrefetchMonth={flow.handlePrefetchMonth}
+        onSelectDate={flow.handleSelectDay}
+        onSelectSlot={flow.handleSelectSlot}
+        onJumpToNextAvailable={() => {
+          void flow.handleJumpToNextAvailable();
+        }}
+        onRetrySlots={() => {
+          void slotsQuery.refetch();
+        }}
+      />
+
+      {flow.selectedSlotStart ? (
+        <div className={STICKY_STEP_CLASS_NAME}>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => {
+              void flow.handleConfirm();
+            }}
+            className="c-button c-button-primary"
+          >
+            {busy ? "Confirming..." : "Confirm"}
+          </button>
+        </div>
+      ) : (
+        <p className="text-sm text-text-muted">Select a time to continue.</p>
+      )}
+    </PublicBookingLayout>
+  );
+}
+
+const resolveReschedulePageView = (
+  canLoad: boolean,
+  reservationQuery: ReturnType<typeof usePublicBookingReservationQuery>,
+): PublicBookingReservationView => {
+  if (!canLoad) {
+    return { kind: "status", ...BOOKING_NOT_FOUND };
+  }
+  return resolvePublicBookingReservationView(reservationQuery, {
+    loading: BOOKING_LOADING,
+    notFound: BOOKING_NOT_FOUND,
+    loadFailed: BOOKING_LOAD_FAILED,
+    cancelled: BOOKING_CANCELED,
+  });
+};

--- a/packages/web/src/booking/public-booking-search.test.ts
+++ b/packages/web/src/booking/public-booking-search.test.ts
@@ -1,5 +1,7 @@
 import {
+  guestActionUrlFromHistory,
   publicCancelUrlForReservation,
+  publicRescheduleUrlForReservation,
   tokenFromGuestActionUrl,
   validateBookingCancelSearch,
   validatePublicBookingSearch,
@@ -99,5 +101,47 @@ describe("publicCancelUrlForReservation", () => {
     ).toBe(
       "https://staging.compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
     );
+  });
+});
+
+describe("publicRescheduleUrlForReservation", () => {
+  it("builds an origin-absolute reschedule URL", () => {
+    expect(
+      publicRescheduleUrlForReservation(
+        "000000000000000000000099",
+        "abc",
+        "https://staging.compasscalendar.com",
+      ),
+    ).toBe(
+      "https://staging.compasscalendar.com/book/reschedule/000000000000000000000099?token=abc",
+    );
+  });
+});
+
+describe("guestActionUrlFromHistory", () => {
+  it("reads cancel and reschedule URLs from history state", () => {
+    expect(
+      guestActionUrlFromHistory(
+        { cancelUrl: "https://example.com/cancel?token=a" },
+        "cancelUrl",
+      ),
+    ).toBe("https://example.com/cancel?token=a");
+    expect(
+      guestActionUrlFromHistory(
+        { rescheduleUrl: "https://example.com/reschedule?token=a" },
+        "rescheduleUrl",
+      ),
+    ).toBe("https://example.com/reschedule?token=a");
+  });
+
+  it("ignores missing, empty, and non-string values", () => {
+    expect(guestActionUrlFromHistory(undefined, "cancelUrl")).toBeUndefined();
+    expect(guestActionUrlFromHistory({}, "rescheduleUrl")).toBeUndefined();
+    expect(
+      guestActionUrlFromHistory({ cancelUrl: "" }, "cancelUrl"),
+    ).toBeUndefined();
+    expect(
+      guestActionUrlFromHistory({ cancelUrl: 12 }, "cancelUrl"),
+    ).toBeUndefined();
   });
 });

--- a/packages/web/src/booking/public-booking-search.test.ts
+++ b/packages/web/src/booking/public-booking-search.test.ts
@@ -4,6 +4,7 @@ import {
   publicRescheduleUrlForReservation,
   tokenFromGuestActionUrl,
   validateBookingCancelSearch,
+  validateBookingRescheduleSearch,
   validatePublicBookingSearch,
 } from "@web/booking/public-booking-search";
 import { describe, expect, it } from "bun:test";
@@ -66,6 +67,26 @@ describe("validateBookingCancelSearch", () => {
       token: undefined,
     });
     expect(validateBookingCancelSearch({})).toEqual({ token: undefined });
+  });
+});
+
+describe("validateBookingRescheduleSearch", () => {
+  it("keeps token and picker selection together", () => {
+    expect(
+      validateBookingRescheduleSearch({
+        token: "abc",
+        month: "2026-09",
+        date: "2026-09-07",
+        slot: "2026-09-07T10:00:00.000Z",
+        tz: "UTC",
+      }),
+    ).toEqual({
+      token: "abc",
+      month: "2026-09",
+      date: "2026-09-07",
+      slot: "2026-09-07T10:00:00.000Z",
+      tz: "UTC",
+    });
   });
 });
 

--- a/packages/web/src/booking/public-booking-search.ts
+++ b/packages/web/src/booking/public-booking-search.ts
@@ -71,7 +71,45 @@ export function publicCancelUrlForReservation(
   token: string,
   origin: string,
 ): string {
-  const url = new URL(`/book/cancel/${reservationId}`, origin);
+  return publicGuestActionUrlForReservation(
+    "cancel",
+    reservationId,
+    token,
+    origin,
+  );
+}
+
+export function publicRescheduleUrlForReservation(
+  reservationId: string,
+  token: string,
+  origin: string,
+): string {
+  return publicGuestActionUrlForReservation(
+    "reschedule",
+    reservationId,
+    token,
+    origin,
+  );
+}
+
+export function guestActionUrlFromHistory(
+  state: unknown,
+  key: "cancelUrl" | "rescheduleUrl",
+): string | undefined {
+  if (!state || typeof state !== "object") {
+    return undefined;
+  }
+  const value = (state as Record<string, unknown>)[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function publicGuestActionUrlForReservation(
+  action: "cancel" | "reschedule",
+  reservationId: string,
+  token: string,
+  origin: string,
+): string {
+  const url = new URL(`/book/${action}/${reservationId}`, origin);
   url.searchParams.set("token", token);
   return url.toString();
 }

--- a/packages/web/src/booking/public-booking-search.ts
+++ b/packages/web/src/booking/public-booking-search.ts
@@ -55,6 +55,19 @@ export function validateBookingCancelSearch(search: Record<string, unknown>): {
   };
 }
 
+export interface PublicBookingRescheduleSearch extends PublicBookingSearch {
+  token?: string;
+}
+
+export function validateBookingRescheduleSearch(
+  search: Record<string, unknown>,
+): PublicBookingRescheduleSearch {
+  return {
+    ...validatePublicBookingSearch(search),
+    ...validateBookingCancelSearch(search),
+  };
+}
+
 export function tokenFromGuestActionUrl(url: string): string {
   try {
     return (

--- a/packages/web/src/booking/public-booking.query.ts
+++ b/packages/web/src/booking/public-booking.query.ts
@@ -9,6 +9,7 @@ import {
   type BookingSlotsResponse,
   type CreateBookingReservationInput,
   type PatchBookingReservationInput,
+  type RescheduleBookingReservationInput,
 } from "@core/types/booking.contracts";
 import {
   PublicBookingApi,
@@ -33,6 +34,18 @@ export const publicBookingQueryKeys = {
     [...publicBookingQueryKeys.slotsAll(slug), monthKey, timeZone] as const,
   reservation: (reservationId: string) =>
     ["public-booking", "reservation", reservationId] as const,
+  reservationSlotsAll: (reservationId: string) =>
+    ["public-booking", "reservation-slots", reservationId] as const,
+  reservationSlots: (
+    reservationId: string,
+    monthKey: string,
+    timeZone: string,
+  ) =>
+    [
+      ...publicBookingQueryKeys.reservationSlotsAll(reservationId),
+      monthKey,
+      timeZone,
+    ] as const,
 };
 
 /** A page or reservation that is gone stays gone; retry once for anything else. */
@@ -49,7 +62,10 @@ function publicBookingPageQueryOptions(slug: string) {
 }
 
 export function usePublicBookingPageQuery(slug: string) {
-  return useQuery(publicBookingPageQueryOptions(slug));
+  return useQuery({
+    ...publicBookingPageQueryOptions(slug),
+    enabled: Boolean(slug),
+  });
 }
 
 function publicBookingReservationQueryOptions(reservationId: string) {
@@ -64,6 +80,64 @@ function publicBookingReservationQueryOptions(reservationId: string) {
 
 export function usePublicBookingReservationQuery(reservationId: string) {
   return useQuery(publicBookingReservationQueryOptions(reservationId));
+}
+
+export function publicBookingReservationSlotsQueryOptions(
+  reservationId: string,
+  token: string,
+  monthKey: string,
+  timeZone: string,
+  maxHorizonDays: number,
+) {
+  return queryOptions({
+    queryKey: publicBookingQueryKeys.reservationSlots(
+      reservationId,
+      monthKey,
+      timeZone,
+    ),
+    queryFn: ({ signal }) => {
+      const window = getPublicBookingMonthWindow(
+        monthKey,
+        timeZone,
+        maxHorizonDays,
+      );
+      if (!window) {
+        return { slots: [], bookable: true as const };
+      }
+      return PublicBookingApi.getReservationSlots(
+        reservationId,
+        { ...window, token },
+        signal,
+      );
+    },
+    staleTime: PUBLIC_BOOKING_SLOTS_STALE_TIME_MS,
+    retry: false,
+  });
+}
+
+export function usePublicBookingReservationSlotsQuery(
+  reservationId: string,
+  token: string,
+  monthKey: string,
+  maxHorizonDays: number | undefined,
+  timeZone: string,
+) {
+  const horizon = maxHorizonDays ?? 60;
+  const window = useMemo(
+    () => getPublicBookingMonthWindow(monthKey, timeZone, horizon),
+    [monthKey, timeZone, horizon],
+  );
+
+  return useQuery({
+    ...publicBookingReservationSlotsQueryOptions(
+      reservationId,
+      token,
+      monthKey,
+      timeZone,
+      horizon,
+    ),
+    enabled: Boolean(reservationId && token) && window != null,
+  });
 }
 
 export function publicBookingSlotsQueryOptions(
@@ -132,6 +206,33 @@ export function prefetchPublicBookingMonth(
   );
 }
 
+export function prefetchPublicBookingReservationMonth(
+  queryClient: ReturnType<typeof useQueryClient>,
+  reservationId: string,
+  token: string,
+  monthKey: string,
+  timeZone: string,
+  maxHorizonDays: number,
+) {
+  const window = getPublicBookingMonthWindow(
+    monthKey,
+    timeZone,
+    maxHorizonDays,
+  );
+  if (!window || !reservationId || !token) {
+    return;
+  }
+  return queryClient.prefetchQuery(
+    publicBookingReservationSlotsQueryOptions(
+      reservationId,
+      token,
+      monthKey,
+      timeZone,
+      maxHorizonDays,
+    ),
+  );
+}
+
 export function usePrefetchAdjacentBookingMonths(
   slug: string,
   monthKey: string,
@@ -169,6 +270,50 @@ export function usePrefetchAdjacentBookingMonths(
     queryClient,
     slug,
     timeZone,
+  ]);
+}
+
+export function usePrefetchAdjacentReservationMonths(
+  reservationId: string,
+  token: string,
+  monthKey: string,
+  timeZone: string,
+  maxHorizonDays: number | undefined,
+  enabled: boolean,
+) {
+  const queryClient = useQueryClient();
+  const previousMonthKey = shiftBookingMonthKey(monthKey, -1, timeZone);
+  const nextMonthKey = shiftBookingMonthKey(monthKey, 1, timeZone);
+
+  useEffect(() => {
+    if (!enabled || maxHorizonDays == null || !reservationId || !token) {
+      return;
+    }
+    void prefetchPublicBookingReservationMonth(
+      queryClient,
+      reservationId,
+      token,
+      previousMonthKey,
+      timeZone,
+      maxHorizonDays,
+    );
+    void prefetchPublicBookingReservationMonth(
+      queryClient,
+      reservationId,
+      token,
+      nextMonthKey,
+      timeZone,
+      maxHorizonDays,
+    );
+  }, [
+    enabled,
+    maxHorizonDays,
+    nextMonthKey,
+    previousMonthKey,
+    queryClient,
+    reservationId,
+    timeZone,
+    token,
   ]);
 }
 
@@ -232,6 +377,66 @@ export async function resolveNextAvailableBookingDate(
   return null;
 }
 
+export async function resolveNextAvailableReservationDate(
+  queryClient: ReturnType<typeof useQueryClient>,
+  reservationId: string,
+  token: string,
+  monthKey: string,
+  afterDateKey: string | null,
+  timeZone: string,
+  todayKey: string,
+  maxHorizonDays: number,
+): Promise<{ monthKey: string; dateKey: string } | null> {
+  const slotsByMonth = new Map<
+    string,
+    BookingSlotsResponse["slots"] | undefined
+  >();
+  let cursor = monthKey;
+  for (let offset = 0; offset < BOOKING_MONTH_SEARCH_LIMIT; offset += 1) {
+    const cached = queryClient.getQueryData<BookingSlotsResponse>(
+      publicBookingQueryKeys.reservationSlots(reservationId, cursor, timeZone),
+    );
+    if (cached) {
+      slotsByMonth.set(cursor, cached.slots);
+    }
+    cursor = shiftBookingMonthKey(cursor, 1, timeZone);
+  }
+
+  for (let attempt = 0; attempt < BOOKING_MONTH_SEARCH_LIMIT; attempt += 1) {
+    const next = findNextAvailableBookingDate(
+      monthKey,
+      afterDateKey,
+      slotsByMonth,
+      timeZone,
+      todayKey,
+      maxHorizonDays,
+    );
+    if (!next) {
+      return null;
+    }
+    if (next.dateKey) {
+      return { monthKey: next.monthKey, dateKey: next.dateKey };
+    }
+    await prefetchPublicBookingReservationMonth(
+      queryClient,
+      reservationId,
+      token,
+      next.monthKey,
+      timeZone,
+      maxHorizonDays,
+    );
+    const fetched = queryClient.getQueryData<BookingSlotsResponse>(
+      publicBookingQueryKeys.reservationSlots(
+        reservationId,
+        next.monthKey,
+        timeZone,
+      ),
+    );
+    slotsByMonth.set(next.monthKey, fetched?.slots ?? []);
+  }
+  return null;
+}
+
 export function useCreatePublicBookingReservationMutation(slug: string) {
   const queryClient = useQueryClient();
 
@@ -259,6 +464,25 @@ export function usePatchPublicBookingReservationMutation(
         publicBookingQueryKeys.reservation(reservationId),
         data,
       );
+    },
+  });
+}
+
+export function useReschedulePublicBookingReservationMutation(
+  reservationId: string,
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input: RescheduleBookingReservationInput) =>
+      PublicBookingApi.rescheduleReservation(reservationId, input),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: publicBookingQueryKeys.reservation(reservationId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: publicBookingQueryKeys.reservationSlotsAll(reservationId),
+      });
     },
   });
 }

--- a/packages/web/src/booking/use-public-booking-flow.ts
+++ b/packages/web/src/booking/use-public-booking-flow.ts
@@ -285,10 +285,14 @@ export function usePublicBookingFlow() {
         to: ROOT_ROUTES.BOOK_CONFIRMED,
         params: { reservationId: result.reservationId },
         search: token ? { token } : undefined,
-        // History state still carries the absolute cancel URL from confirm.
-        // The permalink also writes `?token=` so a reload or bookmark keeps
-        // cancel and edit without publishing the token on the public GET.
-        state: { cancelUrl: result.cancelUrl } as never,
+        // History state still carries the absolute cancel and reschedule URLs
+        // from confirm. The permalink also writes `?token=` so a reload or
+        // bookmark keeps guest actions and edit without publishing the token
+        // on the public GET.
+        state: {
+          cancelUrl: result.cancelUrl,
+          rescheduleUrl: result.rescheduleUrl,
+        } as never,
       });
     } catch (error) {
       if (isPublicBookingConflictError(error)) {

--- a/packages/web/src/booking/use-public-booking-reschedule-flow.ts
+++ b/packages/web/src/booking/use-public-booking-reschedule-flow.ts
@@ -1,0 +1,332 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { RescheduleBookingReservationInputSchema } from "@core/types/booking.contracts";
+import dayjs from "@core/util/date/dayjs";
+import { PublicBookingNotFoundError } from "@web/api/public-booking.api";
+import { getErrorStatus } from "@web/api/util/api.util";
+import {
+  formatBookingDateKey,
+  formatBookingMonthKey,
+  listBookingAvailableDateKeysInMonth,
+} from "@web/booking/public-booking.format";
+import {
+  isPublicBookingConflictError,
+  prefetchPublicBookingReservationMonth,
+  resolveNextAvailableReservationDate,
+  usePrefetchAdjacentReservationMonths,
+  usePublicBookingPageQuery,
+  usePublicBookingReservationQuery,
+  usePublicBookingReservationSlotsQuery,
+  useReschedulePublicBookingReservationMutation,
+} from "@web/booking/public-booking.query";
+import {
+  type PublicBookingRescheduleSearch,
+  publicCancelUrlForReservation,
+  publicRescheduleUrlForReservation,
+} from "@web/booking/public-booking-search";
+import { ROOT_ROUTES } from "@web/common/constants/routes";
+import { isHigherEscapeOwner } from "@web/shortcuts/escape-ownership";
+import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
+import { getBrowserTimeZone } from "@web/timezone/browser-timezone";
+
+const SLOT_CONFLICT_ALERT =
+  "This time is no longer available. Pick another slot.";
+
+export function usePublicBookingRescheduleFlow() {
+  const { reservationId } = useParams({
+    from: "/book/reschedule/$reservationId",
+  });
+  const search: PublicBookingRescheduleSearch = useSearch({
+    from: "/book/reschedule/$reservationId",
+  });
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const token = search.token ?? "";
+  const canLoad = Boolean(reservationId && token);
+
+  const reservationQuery = usePublicBookingReservationQuery(
+    canLoad ? reservationId : "",
+  );
+  const bookingSlug =
+    reservationQuery.data?.status === "confirmed"
+      ? (reservationQuery.data.bookingSlug ?? "")
+      : "";
+  const pageQuery = usePublicBookingPageQuery(bookingSlug);
+
+  const browserTimeZone = useMemo(getBrowserTimeZone, []);
+  const guestTimeZone = search.tz ?? browserTimeZone;
+  const selectedSlotStart = search.slot ?? null;
+  const slotDateKey = selectedSlotStart
+    ? formatBookingDateKey(selectedSlotStart, guestTimeZone)
+    : null;
+  const monthKey =
+    search.month ??
+    slotDateKey?.slice(0, 7) ??
+    formatBookingMonthKey(dayjs(), guestTimeZone);
+
+  const slotsQuery = usePublicBookingReservationSlotsQuery(
+    canLoad && reservationQuery.data?.status === "confirmed"
+      ? reservationId
+      : "",
+    token,
+    monthKey,
+    pageQuery.data?.maxHorizonDays,
+    guestTimeZone,
+  );
+  const rescheduleReservation =
+    useReschedulePublicBookingReservationMutation(reservationId);
+
+  const [alertMessage, setAlertMessage] = useState<string | null>(null);
+  const alertRef = useRef<HTMLParagraphElement>(null);
+  const pickerHeadingRef = useRef<HTMLHeadingElement>(null);
+  const submitInFlightRef = useRef(false);
+  const pendingPickerFocusRef = useRef(false);
+
+  useEffect(() => {
+    if (alertMessage) {
+      alertRef.current?.focus();
+    }
+  }, [alertMessage]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: jump remounts the picker heading
+  useEffect(() => {
+    if (pendingPickerFocusRef.current) {
+      pendingPickerFocusRef.current = false;
+      pickerHeadingRef.current?.focus();
+    }
+  }, [monthKey, search.date]);
+
+  usePrefetchAdjacentReservationMonths(
+    reservationId,
+    token,
+    monthKey,
+    guestTimeZone,
+    pageQuery.data?.maxHorizonDays,
+    canLoad &&
+      pageQuery.isSuccess &&
+      pageQuery.data.enabled &&
+      slotsQuery.isSuccess,
+  );
+
+  const todayKey = formatBookingDateKey(dayjs(), guestTimeZone);
+  const availableDateKeys = useMemo(
+    () =>
+      slotsQuery.data?.bookable
+        ? listBookingAvailableDateKeysInMonth(
+            slotsQuery.data.slots,
+            monthKey,
+            guestTimeZone,
+            todayKey,
+          )
+        : [],
+    [guestTimeZone, monthKey, slotsQuery.data, todayKey],
+  );
+
+  const selectedDateKey =
+    (search.date?.startsWith(monthKey) ? search.date : null) ??
+    (slotDateKey?.startsWith(monthKey) ? slotDateKey : null) ??
+    availableDateKeys[0] ??
+    null;
+
+  const slotsHasData = Boolean(slotsQuery.data);
+  const slotsFetching =
+    !slotsHasData && (slotsQuery.isPending || slotsQuery.isFetching);
+  const slotsError = Boolean(slotsQuery.isError && !slotsHasData);
+  const slotsPending = slotsFetching && !slotsError;
+
+  const updateSearch = (
+    patch: Partial<PublicBookingRescheduleSearch>,
+    { push = false }: { push?: boolean } = {},
+  ) => {
+    void navigate({
+      to: ".",
+      search: (previous: PublicBookingRescheduleSearch) => ({
+        ...previous,
+        ...patch,
+      }),
+      replace: !push,
+    });
+  };
+
+  const handleSelectSlot = (slotStart: string) => {
+    setAlertMessage(null);
+    updateSearch(
+      { slot: slotStart, date: formatBookingDateKey(slotStart, guestTimeZone) },
+      { push: true },
+    );
+  };
+
+  const handleSelectDay = (dateKey: string) => {
+    updateSearch({
+      date: dateKey,
+      slot: slotDateKey !== dateKey ? undefined : search.slot,
+    });
+  };
+
+  const handleMonthChange = (nextMonthKey: string) => {
+    setAlertMessage(null);
+    updateSearch({ month: nextMonthKey, date: undefined, slot: undefined });
+  };
+
+  const handleTimeZoneChange = (nextTimeZone: string) => {
+    if (nextTimeZone === guestTimeZone) {
+      return;
+    }
+    if (selectedSlotStart) {
+      updateSearch({ tz: nextTimeZone, month: undefined, date: undefined });
+      return;
+    }
+    const currentMonthInOldZone = formatBookingMonthKey(dayjs(), guestTimeZone);
+    updateSearch({
+      tz: nextTimeZone,
+      date: undefined,
+      month: monthKey === currentMonthInOldZone ? undefined : search.month,
+    });
+  };
+
+  useAppShortcut(
+    "Escape",
+    (event) => {
+      if (isHigherEscapeOwner()) {
+        return;
+      }
+      if (submitInFlightRef.current || !reservationId) {
+        return;
+      }
+      event.preventDefault();
+      void navigate({
+        to: ROOT_ROUTES.BOOK_CONFIRMED,
+        params: { reservationId },
+        search: token ? { token } : undefined,
+      });
+    },
+    {
+      enabled: canLoad && !rescheduleReservation.isPending,
+      ignoreInputs: false,
+    },
+  );
+
+  const handlePrefetchMonth = (nextMonthKey: string) => {
+    if (!pageQuery.data || !token) {
+      return;
+    }
+    void prefetchPublicBookingReservationMonth(
+      queryClient,
+      reservationId,
+      token,
+      nextMonthKey,
+      guestTimeZone,
+      pageQuery.data.maxHorizonDays,
+    );
+  };
+
+  const handleJumpToNextAvailable = async () => {
+    if (!pageQuery.data || !token) {
+      return;
+    }
+    const next = await resolveNextAvailableReservationDate(
+      queryClient,
+      reservationId,
+      token,
+      monthKey,
+      selectedDateKey,
+      guestTimeZone,
+      todayKey,
+      pageQuery.data.maxHorizonDays,
+    );
+    if (next) {
+      pendingPickerFocusRef.current = true;
+      setAlertMessage(null);
+      updateSearch({
+        month: next.monthKey,
+        date: next.dateKey,
+        slot: undefined,
+      });
+      return;
+    }
+    setAlertMessage(
+      `No open times in the next ${pageQuery.data.maxHorizonDays} days. Check back later.`,
+    );
+  };
+
+  const handleConfirm = async () => {
+    if (!selectedSlotStart || !token || submitInFlightRef.current) {
+      return;
+    }
+
+    submitInFlightRef.current = true;
+    setAlertMessage(null);
+
+    try {
+      await rescheduleReservation.mutateAsync(
+        RescheduleBookingReservationInputSchema.parse({
+          token,
+          slotStart: selectedSlotStart,
+          guestTimeZone,
+        }),
+      );
+      await navigate({
+        to: ROOT_ROUTES.BOOK_CONFIRMED,
+        params: { reservationId },
+        search: { token },
+        state: {
+          cancelUrl: publicCancelUrlForReservation(
+            reservationId,
+            token,
+            window.location.origin,
+          ),
+          rescheduleUrl: publicRescheduleUrlForReservation(
+            reservationId,
+            token,
+            window.location.origin,
+          ),
+        } as never,
+      });
+    } catch (error) {
+      if (isPublicBookingConflictError(error)) {
+        setAlertMessage(SLOT_CONFLICT_ALERT);
+        updateSearch({ slot: undefined });
+        await slotsQuery.refetch();
+        return;
+      }
+      if (
+        error instanceof PublicBookingNotFoundError ||
+        getErrorStatus(error) === 404
+      ) {
+        setAlertMessage("This booking is no longer available.");
+        await reservationQuery.refetch();
+        return;
+      }
+      setAlertMessage("Could not reschedule this booking. Please try again.");
+    } finally {
+      submitInFlightRef.current = false;
+    }
+  };
+
+  return {
+    canLoad,
+    token,
+    reservationQuery,
+    pageQuery,
+    slotsQuery,
+    rescheduleReservation,
+    guestTimeZone,
+    monthKey,
+    selectedSlotStart,
+    selectedDateKey,
+    alertMessage,
+    slotsPending,
+    slotsError,
+    slotsFetching,
+    alertRef,
+    pickerHeadingRef,
+    handleSelectSlot,
+    handleSelectDay,
+    handleMonthChange,
+    handleTimeZoneChange,
+    handlePrefetchMonth,
+    handleJumpToNextAvailable,
+    handleConfirm,
+  };
+}

--- a/packages/web/src/common/constants/routes.ts
+++ b/packages/web/src/common/constants/routes.ts
@@ -2,6 +2,7 @@ export const ROOT_ROUTES = {
   API: "/api",
   BOOK: "/book/$username",
   BOOK_CANCEL: "/book/cancel/$reservationId",
+  BOOK_RESCHEDULE: "/book/reschedule/$reservationId",
   BOOK_CONFIRMED: "/book/confirmed/$reservationId",
   CLEANUP: "/cleanup",
   GOOGLE_AUTH_CALLBACK: "/auth/google/callback",

--- a/packages/web/src/routers/index.test.tsx
+++ b/packages/web/src/routers/index.test.tsx
@@ -5,6 +5,7 @@ import {
   calendarShellRoute,
   lifeRoute,
   publicBookConfirmedRoute,
+  publicBookRescheduleRoute,
   publicBookRoute,
   rootRoute,
   routeTree,
@@ -31,6 +32,13 @@ describe("routeTree", () => {
       "/book/confirmed/$reservationId",
     );
     expect(publicBookConfirmedRoute.parentRoute).toBe(rootRoute);
+  });
+
+  it("registers /book/reschedule/$reservationId as a public route", () => {
+    expect(publicBookRescheduleRoute.fullPath).toBe(
+      "/book/reschedule/$reservationId",
+    );
+    expect(publicBookRescheduleRoute.parentRoute).toBe(rootRoute);
   });
 
   it("gates the authenticated layout behind loadAuthenticated inside the calendar shell", () => {

--- a/packages/web/src/routers/router.routes.tsx
+++ b/packages/web/src/routers/router.routes.tsx
@@ -5,6 +5,7 @@ import {
 } from "@tanstack/react-router";
 import {
   validateBookingCancelSearch,
+  validateBookingRescheduleSearch,
   validatePublicBookingSearch,
 } from "@web/booking/public-booking-search";
 import {
@@ -59,6 +60,16 @@ export const publicBookCancelRoute = createRoute({
   component: lazyRouteComponent(
     () => import("@web/booking/PublicBookingCancelPage"),
     "PublicBookingCancelPage",
+  ),
+});
+
+export const publicBookRescheduleRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: ROOT_ROUTES.BOOK_RESCHEDULE,
+  validateSearch: validateBookingRescheduleSearch,
+  component: lazyRouteComponent(
+    () => import("@web/booking/PublicBookingReschedulePage"),
+    "PublicBookingReschedulePage",
   ),
 });
 
@@ -175,7 +186,12 @@ const calendarShellChildren = calendarShellRoute.addChildren([
 export const routeTree = rootRoute.addChildren([
   calendarShellChildren,
   ...(IS_BOOKING_ENABLED
-    ? [publicBookConfirmedRoute, publicBookCancelRoute, publicBookRoute]
+    ? [
+        publicBookConfirmedRoute,
+        publicBookCancelRoute,
+        publicBookRescheduleRoute,
+        publicBookRoute,
+      ]
     : []),
   googleAuthCallbackRoute,
 ]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3115
Closes #3107

## Summary

WP-08 closeout for Booking v1.3. Playwright covers confirm → reschedule → new slot (confirmation shows the new time), a keyboard path to Confirm, and `/book/reschedule/:id` without a token as generic not-found with no slots fetch.

The booking a11y spec visits the reschedule picker, missing-token, canceled, and 409 conflict states. `docs/features/booking.md` marks v1.3 implemented, lists the reschedule page, copy control, routes, and `updateBookingEvent` in the implementation map, and replaces the old "no guest reschedule" wart with the real `expectedVersion: null` host-edit overwrite.

Does not flip `isBookingEnabled`. Does not edit `.github/`.

Stacked on #3321 (WP-07). E2e stubs the public APIs.

## Simplicity

Reschedule stubs follow the existing cancel-page harness. Confirm-to-reschedule follows the confirmation link path on the Playwright origin, because create still returns `compasscalendar.com` action URLs.

## Automated validation

```
bunx playwright install chromium
```

exit 0; Chromium 148.0.7778.96.

```
bun test:e2e
```

exit 0; 128 passed.

```
bun test:a11y
```

exit 0; 31 passed.

```
bun run verify
```

exit 0; selected web; checks test:web, type-check, lint, knip, test:a11y, test:e2e. All checks passed.

## Independent review

VERDICT: no confirmed findings

FINDINGS: none

## Test plan

Issue #3115 verify commands, quoted above. Tracking issue #3107 closes when this PR merges.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73143677-1949-45fd-81f9-f9974a68183e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73143677-1949-45fd-81f9-f9974a68183e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

