### PR TITLE
feat(booking): pin confirm duration and v1.4 recovery papercuts

### DIFF
--- a/.agents/handoffs/3118.md
+++ b/.agents/handoffs/3118.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+task_id: "3118"
+from: Implementer
+to: Verifier
+owner: Verifier
+status: running
+artifact:
+  - path: packages/core/src/types/booking.contracts.ts
+  - path: packages/backend/src/booking/services/public-booking.service.ts
+  - path: packages/web/src/booking/use-public-booking-flow.ts
+  - path: docs/features/booking.md
+evidence:
+  - command: bun test:core
+    result: pending
+  - command: bun test:backend
+    result: pending
+assumptions:
+  - "Reschedule POST already exists on main, so it uses the same durationMinutes pin as confirm"
+  - "This PR also lands WP-02 through WP-05 (#3119-#3122) so milestone 12 can close together"
+open_risks: []
+next_deadline: 2026-09-05T18:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-01: create and reschedule pin `durationMinutes`. Mismatch is 409 with
+no Google event. Spec named wart no longer re-prices in-flight confirms.

--- a/.agents/handoffs/3118.md
+++ b/.agents/handoffs/3118.md
@@ -1,20 +1,21 @@
 ---
 schema_version: 1
 task_id: "3118"
-from: Implementer
-to: Verifier
-owner: Verifier
-status: running
+from: Verifier
+to: Manager
+owner: Manager
+status: verifying
 artifact:
   - path: packages/core/src/types/booking.contracts.ts
   - path: packages/backend/src/booking/services/public-booking.service.ts
   - path: packages/web/src/booking/use-public-booking-flow.ts
   - path: docs/features/booking.md
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3330
 evidence:
-  - command: bun test:core
-    result: pending
-  - command: bun test:backend
-    result: pending
+  - command: bun run verify
+    result: "exit 0; selected core, web, backend; checks test:core, test:web, test:backend, type-check, lint, knip; 749 web pass"
+  - command: bunx playwright test e2e/booking e2e/accessibility/booking-a11y.spec.ts
+    result: "exit 0; 70 passed"
 assumptions:
   - "Reschedule POST already exists on main, so it uses the same durationMinutes pin as confirm"
   - "This PR also lands WP-02 through WP-05 (#3119-#3122) so milestone 12 can close together"
@@ -28,3 +29,5 @@ escalation: null
 
 WP-01: create and reschedule pin `durationMinutes`. Mismatch is 409 with
 no Google event. Spec named wart no longer re-prices in-flight confirms.
+
+Verifier: PASS. Review: no confirmed findings.

--- a/.agents/handoffs/3119.md
+++ b/.agents/handoffs/3119.md
@@ -1,0 +1,23 @@
+---
+schema_version: 1
+task_id: "3119"
+from: Implementer
+to: Verifier
+owner: Verifier
+status: running
+artifact:
+  - path: packages/web/src/booking/BookingSettingsSection.tsx
+evidence:
+  - command: bun test:web -- packages/web/src/booking/BookingSettingsSection.test.tsx
+    result: pending
+assumptions: []
+open_risks: []
+next_deadline: 2026-09-05T18:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-02: helper copy next to Guest can invite others. Default stays on.
+No description-builder change.

--- a/.agents/handoffs/3119.md
+++ b/.agents/handoffs/3119.md
@@ -1,15 +1,18 @@
 ---
 schema_version: 1
 task_id: "3119"
-from: Implementer
-to: Verifier
-owner: Verifier
-status: running
+from: Verifier
+to: Manager
+owner: Manager
+status: verifying
 artifact:
   - path: packages/web/src/booking/BookingSettingsSection.tsx
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3330
 evidence:
   - command: bun test:web -- packages/web/src/booking/BookingSettingsSection.test.tsx
-    result: pending
+    result: "exit 0; explains invite-others cancel tradeoff and RSVP-strict occupancy passed"
+  - command: bun run verify
+    result: "exit 0; selected core, web, backend; type-check, lint, knip passed"
 assumptions: []
 open_risks: []
 next_deadline: 2026-09-05T18:00:00Z
@@ -21,3 +24,5 @@ escalation: null
 
 WP-02: helper copy next to Guest can invite others. Default stays on.
 No description-builder change.
+
+Verifier: PASS. Review: no confirmed findings.

--- a/.agents/handoffs/3120.md
+++ b/.agents/handoffs/3120.md
@@ -1,0 +1,23 @@
+---
+schema_version: 1
+task_id: "3120"
+from: Implementer
+to: Verifier
+owner: Verifier
+status: running
+artifact:
+  - path: packages/web/src/booking/PublicBookingCancelPage.tsx
+evidence:
+  - command: bun test:web -- packages/web/src/booking/PublicBookingCancelPage.test.tsx
+    result: pending
+assumptions: []
+open_risks: []
+next_deadline: 2026-09-05T18:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-03: non-404 cancel failure shows Retry. Retry restores the confirm
+view and inFlightRef so a second POST can run. 404 stays not-found.

--- a/.agents/handoffs/3120.md
+++ b/.agents/handoffs/3120.md
@@ -1,15 +1,18 @@
 ---
 schema_version: 1
 task_id: "3120"
-from: Implementer
-to: Verifier
-owner: Verifier
-status: running
+from: Verifier
+to: Manager
+owner: Manager
+status: verifying
 artifact:
   - path: packages/web/src/booking/PublicBookingCancelPage.tsx
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3330
 evidence:
   - command: bun test:web -- packages/web/src/booking/PublicBookingCancelPage.test.tsx
-    result: pending
+    result: "exit 0; Retry after failed cancel and 404 without Retry passed"
+  - command: bun run verify
+    result: "exit 0"
 assumptions: []
 open_risks: []
 next_deadline: 2026-09-05T18:00:00Z
@@ -21,3 +24,5 @@ escalation: null
 
 WP-03: non-404 cancel failure shows Retry. Retry restores the confirm
 view and inFlightRef so a second POST can run. 404 stays not-found.
+
+Verifier: PASS. Review: no confirmed findings.

--- a/.agents/handoffs/3121.md
+++ b/.agents/handoffs/3121.md
@@ -1,0 +1,24 @@
+---
+schema_version: 1
+task_id: "3121"
+from: Implementer
+to: Verifier
+owner: Verifier
+status: running
+artifact:
+  - path: packages/web/src/booking/PublicBookingCancelPage.tsx
+evidence:
+  - command: bun test:web -- packages/web/src/booking/PublicBookingCancelPage.test.tsx
+    result: pending
+assumptions:
+  - "Public GET bookingSlug is optional so old payloads hide the rebook link instead of failing the page"
+open_risks: []
+next_deadline: 2026-09-05T18:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-04: cancelled views show Book another time to `/book/{bookingSlug}`
+when the slug is present. Tokens stay off that URL.

--- a/.agents/handoffs/3121.md
+++ b/.agents/handoffs/3121.md
@@ -1,15 +1,18 @@
 ---
 schema_version: 1
 task_id: "3121"
-from: Implementer
-to: Verifier
-owner: Verifier
-status: running
+from: Verifier
+to: Manager
+owner: Manager
+status: verifying
 artifact:
   - path: packages/web/src/booking/PublicBookingCancelPage.tsx
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3330
 evidence:
   - command: bun test:web -- packages/web/src/booking/PublicBookingCancelPage.test.tsx
-    result: pending
+    result: "exit 0; Book another time with slug, hidden without slug, same CTA after cancel and already-cancelled"
+  - command: bun run verify
+    result: "exit 0"
 assumptions:
   - "Public GET bookingSlug is optional so old payloads hide the rebook link instead of failing the page"
 open_risks: []
@@ -22,3 +25,5 @@ escalation: null
 
 WP-04: cancelled views show Book another time to `/book/{bookingSlug}`
 when the slug is present. Tokens stay off that URL.
+
+Verifier: PASS. Review: no confirmed findings.

--- a/.agents/handoffs/3122.md
+++ b/.agents/handoffs/3122.md
@@ -1,0 +1,25 @@
+---
+schema_version: 1
+task_id: "3122"
+from: Implementer
+to: Verifier
+owner: Verifier
+status: running
+artifact:
+  - path: packages/web/src/booking/BookingSettingsSection.tsx
+  - path: packages/core/src/booking/occupies-booking-slot.ts
+evidence:
+  - command: bun test:core -- packages/core/src/booking/occupies-booking-slot.test.ts
+    result: pending
+  - command: bun test:web -- packages/web/src/booking/BookingSettingsSection.test.tsx
+    result: pending
+assumptions: []
+open_risks: []
+next_deadline: 2026-09-05T18:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-05: Settings occupancy helper. occupiesBookingSlot is unchanged.

--- a/.agents/handoffs/3122.md
+++ b/.agents/handoffs/3122.md
@@ -1,18 +1,21 @@
 ---
 schema_version: 1
 task_id: "3122"
-from: Implementer
-to: Verifier
-owner: Verifier
-status: running
+from: Verifier
+to: Manager
+owner: Manager
+status: verifying
 artifact:
   - path: packages/web/src/booking/BookingSettingsSection.tsx
   - path: packages/core/src/booking/occupies-booking-slot.ts
+  - url: https://github.com/KeepSoftwareSimple/compass-calendar/pull/3330
 evidence:
-  - command: bun test:core -- packages/core/src/booking/occupies-booking-slot.test.ts
-    result: pending
+  - command: bun test packages/core/src/booking/occupies-booking-slot.test.ts
+    result: "exit 0; 6 pass, occupiesBookingSlot unchanged"
   - command: bun test:web -- packages/web/src/booking/BookingSettingsSection.test.tsx
-    result: pending
+    result: "exit 0; occupancy helper sentence found on Booking Settings"
+  - command: bun run verify
+    result: "exit 0"
 assumptions: []
 open_risks: []
 next_deadline: 2026-09-05T18:00:00Z
@@ -23,3 +26,5 @@ escalation: null
 ---
 
 WP-05: Settings occupancy helper. occupiesBookingSlot is unchanged.
+
+Verifier: PASS. Review: no confirmed findings.

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -292,8 +292,9 @@ There is no host reservation inbox.
   neither reschedule secret. Cancel and edit use `?token=` on the
   confirmation URL (see Guest cancel and edit details).
 - `/book/reschedule/:id?token=` reuses the public month/slot picker. Do
-  not re-collect name, email, or notes. Duration comes from current page
-  settings (same in-flight duration wart as confirm).
+  not re-collect name, email, or notes. Confirm and reschedule both pin
+  `durationMinutes` from the page the guest saw: a mismatch with the
+  current page duration is `409`.
 - In-place Google PATCH of the existing event: same `calendarEventId`,
   same Meet URL, same attendees. `invitation: "all"`,
   `attendeesEdit: "preserve"`. Compass still sends no email.
@@ -366,9 +367,10 @@ Unauthenticated:
   adjacent months). Window must be within the 60-day horizon. A host who
   cannot write is `{ slots: [], bookable: false }`.
 - `POST /api/booking/pages/:slug/reservations` — `{slotStart, guestName,
-  guestEmail, notes?, guestTimeZone}`. Re-checks billing and busy, then
-  creates. A host who cannot write is the same `409` as GET page and
-  submits no create command.
+  guestEmail, notes?, guestTimeZone, durationMinutes}`. `durationMinutes`
+  must match the page. Mismatch is `409` with no Google event. Re-checks
+  billing and busy, then creates. A host who cannot write is the same
+  `409` as GET page and submits no create command.
 - `GET /api/booking/reservations/:id` — public confirmation payload
   (`slotStart`, `guestTimeZone`, `durationMinutes`, `hostDisplayName`,
   `status`, `bookingSlug`, `guestName`, `notes`). `404` when missing. No
@@ -382,8 +384,9 @@ Unauthenticated:
   — bookable instants excluding this reservation from occupancy and
   max-per-day. Same window rules as the public page slots endpoint.
 - `POST /api/booking/reservations/:id/reschedule` — `{token, slotStart,
-  guestTimeZone}`. In-place calendar PATCH. Same slot is an idempotent
-  success. Create response includes `rescheduleUrl`.
+  guestTimeZone, durationMinutes}`. `durationMinutes` must match the page
+  (same pin as confirm). In-place calendar PATCH. Same slot is an
+  idempotent success. Create response includes `rescheduleUrl`.
 
 Authenticated (host session + writable billing, same as event writes):
 
@@ -463,11 +466,6 @@ Guest reschedule is **in scope for v1.3**, not v1 / v1.1.
   disappear and confirm returns `409`.
 - **Google-only destination** calendars; password-only hosts see a connect-Google
   prompt in Settings.
-- **A duration change re-prices in-flight confirms.** A guest who picked a
-  slot before the host changed the duration books at the new duration when
-  the engine still allows that start (the server recomputes `slotEnd` from
-  current settings); otherwise the re-check rejects with `409` and the guest
-  re-picks. Accepted for v1.
 
 ## Related docs
 

--- a/e2e/booking/public-booking-reschedule.spec.ts
+++ b/e2e/booking/public-booking-reschedule.spec.ts
@@ -78,6 +78,7 @@ test.describe("public booking reschedule", () => {
     expect(captured.reschedulePosts[0]).toMatchObject({
       token: "abc",
       slotStart: second.slotStart,
+      durationMinutes: 30,
     });
   });
 
@@ -115,6 +116,7 @@ test.describe("public booking reschedule", () => {
     expect(captured.reschedulePosts[0]).toMatchObject({
       token: "abc",
       slotStart,
+      durationMinutes: 30,
     });
   });
 

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -125,6 +125,7 @@ test.describe("public booking page", () => {
       slotStart,
       guestName: "Guest User",
       guestEmail: "guest@example.com",
+      durationMinutes: 30,
     });
   });
 

--- a/packages/backend/src/booking/booking.rate-limit.db.test.ts
+++ b/packages/backend/src/booking/booking.rate-limit.db.test.ts
@@ -69,6 +69,7 @@ describe("Public booking rate limits", () => {
           token: "a".repeat(64),
           slotStart: "2026-09-07T11:00:00.000Z",
           guestTimeZone: "UTC",
+          durationMinutes: 30,
         })
         .expect(Status.NOT_FOUND);
     }
@@ -78,6 +79,7 @@ describe("Public booking rate limits", () => {
         token: "a".repeat(64),
         slotStart: "2026-09-07T11:00:00.000Z",
         guestTimeZone: "UTC",
+        durationMinutes: 30,
       });
     expect(throttled.status).toBe(429);
   });

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -245,6 +245,7 @@ describe("PublicBookingService", () => {
       guestName: "Ada Lovelace",
       guestEmail: "ada@example.com",
       guestTimeZone: "Europe/London",
+      durationMinutes: 30,
     });
 
     expect(createBookingEvent).toHaveBeenCalledTimes(1);
@@ -258,6 +259,72 @@ describe("PublicBookingService", () => {
     expect(response.rescheduleUrl).toContain("/book/reschedule/");
   });
 
+  it("confirms at the pinned duration and calls createBookingEvent once", async () => {
+    const { slug } = await enableBookingPage();
+    const slotStart = "2026-09-07T10:00:00.000Z";
+
+    const response = await service.createReservation(slug, {
+      slotStart,
+      guestName: "Ada Lovelace",
+      guestEmail: "ada@example.com",
+      guestTimeZone: "Europe/London",
+      durationMinutes: 30,
+    });
+
+    expect(createBookingEvent).toHaveBeenCalledTimes(1);
+    expect(createBookingEvent.mock.calls[0]?.[1]).toMatchObject({
+      start: slotStart,
+      end: "2026-09-07T10:30:00.000Z",
+    });
+    expect(response.slotStart).toBe(slotStart);
+    expect(response.slotEnd).toBe("2026-09-07T10:30:00.000Z");
+  });
+
+  it("rejects confirm when pinned duration does not match the page", async () => {
+    const { slug, userId, calendarId } = await enableBookingPage();
+    spyOn(billingGuard, "assertBillingAllowsWrites").mockResolvedValue(
+      undefined,
+    );
+    await bookingPageService.putAdminPage(
+      userId,
+      samplePutInput({
+        destinationCalendarId: calendarId,
+        blockingCalendarIds: [calendarId],
+        durationMinutes: 45,
+      }),
+    );
+
+    await expect(
+      service.createReservation(slug, {
+        slotStart: "2026-09-07T10:00:00.000Z",
+        guestName: "Ada Lovelace",
+        guestEmail: "ada@example.com",
+        guestTimeZone: "Europe/London",
+        durationMinutes: 30,
+      }),
+    ).rejects.toMatchObject({
+      bookingCode: "SLOT_UNAVAILABLE",
+      statusCode: Status.CONFLICT,
+    });
+    expect(createBookingEvent).not.toHaveBeenCalled();
+  });
+
+  it("rejects confirm extra keys before creating an event", async () => {
+    const { slug } = await enableBookingPage();
+
+    await expect(
+      service.createReservation(slug, {
+        slotStart: "2026-09-07T10:00:00.000Z",
+        guestName: "Ada Lovelace",
+        guestEmail: "ada@example.com",
+        guestTimeZone: "Europe/London",
+        durationMinutes: 30,
+        extra: true,
+      }),
+    ).rejects.toThrow();
+    expect(createBookingEvent).not.toHaveBeenCalled();
+  });
+
   it("rejects confirm when bookable is false without creating an event", async () => {
     const { slug } = await enableBookingPage();
     getAvailability.mockImplementation(async () => busyResponse(false));
@@ -268,6 +335,7 @@ describe("PublicBookingService", () => {
         guestName: "Ada Lovelace",
         guestEmail: "ada@example.com",
         guestTimeZone: "Europe/London",
+        durationMinutes: 30,
       }),
     ).rejects.toMatchObject({ bookingCode: "SLOT_UNAVAILABLE" });
 
@@ -289,6 +357,7 @@ describe("PublicBookingService", () => {
         guestName: "Ada Lovelace",
         guestEmail: "ada@example.com",
         guestTimeZone: "Europe/London",
+        durationMinutes: 30,
       })
       .catch((caught: unknown) => caught);
 
@@ -361,6 +430,7 @@ describe("PublicBookingService", () => {
         guestName: "Ada Lovelace",
         guestEmail: "ada@example.com",
         guestTimeZone: "Europe/London",
+        durationMinutes: 30,
       }),
     ).rejects.toMatchObject({ bookingCode: "SLOT_UNAVAILABLE" });
 
@@ -509,6 +579,7 @@ describe("PublicBookingService", () => {
         guestName: "Ada Lovelace",
         guestEmail: "ada@example.com",
         guestTimeZone: "Europe/London",
+        durationMinutes: 30,
       }),
     ).rejects.toMatchObject({ bookingCode: "SLOT_UNAVAILABLE" });
     expect(createBookingEvent).not.toHaveBeenCalled();
@@ -557,6 +628,7 @@ describe("PublicBookingService", () => {
       guestName: "Ada Lovelace",
       guestEmail: "ada@example.com",
       guestTimeZone: "Europe/London",
+      durationMinutes: 30,
     });
     const publicReservation = await service.getPublicReservation(
       new ObjectId(created.reservationId),
@@ -634,6 +706,7 @@ describe("PublicBookingService", () => {
       guestName: "Ada Lovelace",
       guestEmail: "ada@example.com",
       guestTimeZone: "Europe/London",
+      durationMinutes: 30,
     });
 
     const token = new URL(created.cancelUrl).searchParams.get("token");
@@ -656,6 +729,7 @@ describe("PublicBookingService", () => {
       guestName: "Ada Lovelace",
       guestEmail: "ada@example.com",
       guestTimeZone: "Europe/London",
+      durationMinutes: 30,
     });
     const token = new URL(created.cancelUrl).searchParams.get("token");
     expect(token).toBeTruthy();
@@ -683,6 +757,7 @@ describe("PublicBookingService", () => {
       guestName: "Grace Hopper",
       guestEmail: "grace@example.com",
       guestTimeZone: "America/New_York",
+      durationMinutes: 30,
     });
     expect(retry.reservationId).toBeTruthy();
 
@@ -729,6 +804,7 @@ describe("PublicBookingService", () => {
       guestEmail: "ada@example.com",
       notes: "secret notes",
       guestTimeZone: "Europe/London",
+      durationMinutes: 30,
     });
 
     const publicReservation = await service.getPublicReservation(
@@ -759,6 +835,7 @@ describe("PublicBookingService", () => {
       guestEmail: "ada@example.com",
       notes: "secret notes",
       guestTimeZone: "Europe/London",
+      durationMinutes: 30,
     });
 
     spyOn(billingGuard, "assertBillingAllowsWrites").mockResolvedValue(
@@ -786,6 +863,7 @@ describe("PublicBookingService", () => {
       guestName: "Ada Lovelace",
       guestEmail: "ada@example.com",
       guestTimeZone: "Europe/London",
+      durationMinutes: 30,
     });
     const token = new URL(created.cancelUrl).searchParams.get("token");
     await service.cancelReservation(new ObjectId(created.reservationId), {
@@ -813,6 +891,7 @@ describe("PublicBookingService", () => {
       guestName: "Ada Lovelace",
       guestEmail: "ada@example.com",
       guestTimeZone: "Europe/London",
+      durationMinutes: 30,
     });
 
     const response = await service.getSlots(slug, {
@@ -951,6 +1030,7 @@ describe("PublicBookingService", () => {
       guestName: "Ada Lovelace",
       guestEmail: "ada@example.com",
       guestTimeZone: "Europe/London",
+      durationMinutes: 30,
     });
 
     const second = await service.createReservation(slug, {
@@ -958,6 +1038,7 @@ describe("PublicBookingService", () => {
       guestName: "Grace Hopper",
       guestEmail: "grace@example.com",
       guestTimeZone: "America/New_York",
+      durationMinutes: 30,
     });
 
     expect(second.reservationId).toBeTruthy();
@@ -984,6 +1065,7 @@ describe("PublicBookingService", () => {
         guestName: "Ada Lovelace",
         guestEmail: "ada@example.com",
         guestTimeZone: "Europe/London",
+        durationMinutes: 30,
       }),
     ).rejects.toMatchObject({ bookingCode: "SLOT_UNAVAILABLE" });
 
@@ -1027,6 +1109,7 @@ describe("PublicBookingService", () => {
           guestName: "Ada Lovelace",
           guestEmail: "ada@example.com",
           guestTimeZone: "Europe/London",
+          durationMinutes: 30,
         }),
       ).rejects.toMatchObject({ bookingCode: "SLOT_UNAVAILABLE" });
 
@@ -1070,6 +1153,7 @@ describe("PublicBookingService", () => {
         guestName: "Ada Lovelace",
         guestEmail: "ada@example.com",
         guestTimeZone: "Europe/London",
+        durationMinutes: 30,
       }),
     ).rejects.toMatchObject({ bookingCode: "SLOT_UNAVAILABLE" });
 
@@ -1085,6 +1169,7 @@ describe("PublicBookingService", () => {
       guestEmail: "ada@example.com",
       notes: "bring coffee",
       guestTimeZone: "Europe/London",
+      durationMinutes: 30,
     });
 
     const eventInput = createBookingEvent.mock.calls[0]?.[1] as {
@@ -1105,6 +1190,7 @@ describe("PublicBookingService", () => {
       guestName: "Ada Lovelace",
       guestEmail: "ada@example.com",
       guestTimeZone: "Europe/London",
+      durationMinutes: 30,
     });
 
     const eventInput = createBookingEvent.mock.calls[0]?.[1] as {
@@ -1138,6 +1224,7 @@ describe("PublicBookingService", () => {
       guestName: "Ada Lovelace",
       guestEmail: "ada@example.com",
       guestTimeZone: "Europe/London",
+      durationMinutes: 30,
     });
 
     expect(submitCommand).toHaveBeenCalledTimes(1);
@@ -1154,6 +1241,7 @@ describe("PublicBookingService", () => {
       guestEmail: "ada@example.com",
       notes: "bring coffee",
       guestTimeZone: "Europe/London",
+      durationMinutes: 30,
     });
     const token = new URL(created.cancelUrl).searchParams.get("token");
     const reservationId = new ObjectId(created.reservationId);
@@ -1185,6 +1273,7 @@ describe("PublicBookingService", () => {
       guestEmail: "ada@example.com",
       notes: "bring coffee",
       guestTimeZone: "Europe/London",
+      durationMinutes: 30,
     });
     const reservationId = new ObjectId(created.reservationId);
 
@@ -1209,6 +1298,7 @@ describe("PublicBookingService", () => {
       guestEmail: "ada@example.com",
       notes: "bring coffee",
       guestTimeZone: "Europe/London",
+      durationMinutes: 30,
     });
     const token = new URL(created.cancelUrl).searchParams.get("token");
     const reservationId = new ObjectId(created.reservationId);
@@ -1265,6 +1355,7 @@ describe("PublicBookingService", () => {
         guestName: "Ada Lovelace",
         guestEmail: "not-an-email",
         guestTimeZone: "Europe/London",
+        durationMinutes: 30,
       }),
     ).rejects.toMatchObject({ bookingCode: "INVALID_INPUT" });
   });
@@ -1276,6 +1367,7 @@ describe("PublicBookingService", () => {
       guestName: "Ada Lovelace",
       guestEmail: "ada@example.com",
       guestTimeZone: "Europe/London",
+      durationMinutes: 30,
     });
     const token = new URL(created.cancelUrl).searchParams.get("token");
     const reservationId = new ObjectId(created.reservationId);
@@ -1286,6 +1378,7 @@ describe("PublicBookingService", () => {
       token,
       slotStart: "2026-09-07T11:00:00.000Z",
       guestTimeZone: "America/Denver",
+      durationMinutes: 30,
     });
 
     expect(updateBookingEvent).toHaveBeenCalledTimes(1);
@@ -1305,6 +1398,46 @@ describe("PublicBookingService", () => {
     expect(stored?.calendarEventId).toBeTruthy();
   });
 
+  it("rejects reschedule when pinned duration does not match the page", async () => {
+    const { slug, userId, calendarId } = await enableBookingPage();
+    const created = await service.createReservation(slug, {
+      slotStart: "2026-09-07T10:00:00.000Z",
+      guestName: "Ada Lovelace",
+      guestEmail: "ada@example.com",
+      guestTimeZone: "Europe/London",
+      durationMinutes: 30,
+    });
+    const token = new URL(created.cancelUrl).searchParams.get("token");
+    const reservationId = new ObjectId(created.reservationId);
+    spyOn(billingGuard, "assertBillingAllowsWrites").mockResolvedValue(
+      undefined,
+    );
+    await bookingPageService.putAdminPage(
+      userId,
+      samplePutInput({
+        destinationCalendarId: calendarId,
+        blockingCalendarIds: [calendarId],
+        durationMinutes: 45,
+      }),
+    );
+    createBookingEvent.mockClear();
+    updateBookingEvent.mockClear();
+
+    await expect(
+      service.rescheduleReservation(reservationId, {
+        token,
+        slotStart: "2026-09-07T11:00:00.000Z",
+        guestTimeZone: "Europe/London",
+        durationMinutes: 30,
+      }),
+    ).rejects.toMatchObject({
+      bookingCode: "SLOT_UNAVAILABLE",
+      statusCode: Status.CONFLICT,
+    });
+    expect(updateBookingEvent).not.toHaveBeenCalled();
+    expect(createBookingEvent).not.toHaveBeenCalled();
+  });
+
   it("treats a second reschedule to the same slot as idempotent", async () => {
     const { slug } = await enableBookingPage();
     const created = await service.createReservation(slug, {
@@ -1312,6 +1445,7 @@ describe("PublicBookingService", () => {
       guestName: "Ada Lovelace",
       guestEmail: "ada@example.com",
       guestTimeZone: "Europe/London",
+      durationMinutes: 30,
     });
     const token = new URL(created.cancelUrl).searchParams.get("token");
     const reservationId = new ObjectId(created.reservationId);
@@ -1319,6 +1453,7 @@ describe("PublicBookingService", () => {
       token,
       slotStart: "2026-09-07T11:00:00.000Z",
       guestTimeZone: "America/Denver",
+      durationMinutes: 30,
     });
     updateBookingEvent.mockClear();
 
@@ -1326,6 +1461,7 @@ describe("PublicBookingService", () => {
       token,
       slotStart: "2026-09-07T11:00:00.000Z",
       guestTimeZone: "UTC",
+      durationMinutes: 30,
     });
 
     expect(updateBookingEvent).not.toHaveBeenCalled();
@@ -1340,6 +1476,7 @@ describe("PublicBookingService", () => {
       guestName: "Ada Lovelace",
       guestEmail: "ada@example.com",
       guestTimeZone: "Europe/London",
+      durationMinutes: 30,
     });
     await seedConfirmedReservation(
       pageId,
@@ -1355,6 +1492,7 @@ describe("PublicBookingService", () => {
         token,
         slotStart: "2026-09-07T11:00:00.000Z",
         guestTimeZone: "Europe/London",
+        durationMinutes: 30,
       }),
     ).rejects.toMatchObject({ bookingCode: "SLOT_UNAVAILABLE" });
     expect(updateBookingEvent).not.toHaveBeenCalled();
@@ -1367,6 +1505,7 @@ describe("PublicBookingService", () => {
       guestName: "Ada Lovelace",
       guestEmail: "ada@example.com",
       guestTimeZone: "Europe/London",
+      durationMinutes: 30,
     });
     const token = new URL(created.cancelUrl).searchParams.get("token");
     const reservationId = new ObjectId(created.reservationId);
@@ -1378,6 +1517,7 @@ describe("PublicBookingService", () => {
         token,
         slotStart: "2026-09-07T11:00:00.000Z",
         guestTimeZone: "Europe/London",
+        durationMinutes: 30,
       }),
     ).rejects.toMatchObject({ bookingCode: "RESERVATION_NOT_FOUND" });
     expect(updateBookingEvent).not.toHaveBeenCalled();
@@ -1390,6 +1530,7 @@ describe("PublicBookingService", () => {
       guestName: "Ada Lovelace",
       guestEmail: "ada@example.com",
       guestTimeZone: "Europe/London",
+      durationMinutes: 30,
     });
     const reservationId = new ObjectId(created.reservationId);
     updateBookingEvent.mockClear();
@@ -1399,12 +1540,14 @@ describe("PublicBookingService", () => {
         token: "not-the-token",
         slotStart: "2026-09-07T11:00:00.000Z",
         guestTimeZone: "Europe/London",
+        durationMinutes: 30,
       }),
     ).rejects.toMatchObject({ bookingCode: "RESERVATION_NOT_FOUND" });
     await expect(
       service.rescheduleReservation(reservationId, {
         slotStart: "2026-09-07T11:00:00.000Z",
         guestTimeZone: "Europe/London",
+        durationMinutes: 30,
       }),
     ).rejects.toMatchObject({ bookingCode: "RESERVATION_NOT_FOUND" });
     await expect(
@@ -1412,6 +1555,7 @@ describe("PublicBookingService", () => {
         token: "a".repeat(32),
         slotStart: "2026-09-07T11:00:00.000Z",
         guestTimeZone: "Europe/London",
+        durationMinutes: 30,
       }),
     ).rejects.toMatchObject({ bookingCode: "RESERVATION_NOT_FOUND" });
     expect(updateBookingEvent).not.toHaveBeenCalled();
@@ -1424,6 +1568,7 @@ describe("PublicBookingService", () => {
       guestName: "Ada Lovelace",
       guestEmail: "ada@example.com",
       guestTimeZone: "Europe/London",
+      durationMinutes: 30,
     });
     const token = new URL(created.cancelUrl).searchParams.get("token");
     const reservationId = new ObjectId(created.reservationId);
@@ -1459,6 +1604,7 @@ describe("PublicBookingService", () => {
       guestName: "Ada Lovelace",
       guestEmail: "ada@example.com",
       guestTimeZone: "Europe/London",
+      durationMinutes: 30,
     });
     const token = new URL(created.cancelUrl).searchParams.get("token");
     getAvailability.mockImplementation(async () => ({
@@ -1664,6 +1810,7 @@ describe("Public booking routes", () => {
         guestName: "Ada Lovelace",
         guestEmail: "ada@example.com",
         guestTimeZone: "Europe/London",
+        durationMinutes: 30,
       })
       .expect(Status.CONFLICT);
   });

--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -182,6 +182,18 @@ const parseSlotsQuery = (rawQuery: unknown) => {
 const slotEndForStart = (slotStart: Date, durationMinutes: number): Date =>
   new Date(slotStart.getTime() + durationMinutes * 60_000);
 
+const assertPinnedDuration = (
+  requestedMinutes: number,
+  pageDurationMinutes: number,
+): void => {
+  if (requestedMinutes !== pageDurationMinutes) {
+    throw bookingError(
+      "SLOT_UNAVAILABLE",
+      "Selected slot is no longer available",
+    );
+  }
+};
+
 const bookingEventDescription = (
   notes: string | null | undefined,
   guestsCanInviteOthers: boolean,
@@ -546,9 +558,10 @@ export class PublicBookingService {
     await assertHostAllowsGuestWrites(page.userId);
     const input = CreateBookingReservationInputSchema.parse(rawInput);
     assertGuestEmail(input.guestEmail);
+    assertPinnedDuration(input.durationMinutes, page.durationMinutes);
 
     const slotStart = new Date(input.slotStart);
-    const slotEnd = slotEndForStart(slotStart, page.durationMinutes);
+    const slotEnd = slotEndForStart(slotStart, input.durationMinutes);
     await this.assertSlotAvailable(page, slotStart, slotEnd);
 
     const hostDisplayName = await getHostDisplayName(page.userId);
@@ -754,9 +767,10 @@ export class PublicBookingService {
     }
     const page = await resolveReservationPublicPage(reservation);
     await assertHostAllowsGuestWrites(page.userId);
+    assertPinnedDuration(input.durationMinutes, page.durationMinutes);
 
     const slotStart = new Date(input.slotStart);
-    const slotEnd = slotEndForStart(slotStart, page.durationMinutes);
+    const slotEnd = slotEndForStart(slotStart, input.durationMinutes);
     const hostDisplayName = await getHostDisplayName(page.userId);
     const cancelUrl = buildGuestActionUrl(
       "cancel",

--- a/packages/core/src/types/booking.contracts.test.ts
+++ b/packages/core/src/types/booking.contracts.test.ts
@@ -360,14 +360,36 @@ describe("HTTP booking contracts", () => {
   });
 
   it("parses create reservation input", () => {
+    const valid = {
+      slotStart: "2026-09-01T15:00:00.000Z",
+      guestName: "Ada Lovelace",
+      guestEmail: "ada@example.com",
+      guestTimeZone: "Europe/London",
+      durationMinutes: 30 as const,
+    };
+    expect(CreateBookingReservationInputSchema.safeParse(valid).success).toBe(
+      true,
+    );
     expect(
       CreateBookingReservationInputSchema.safeParse({
-        slotStart: "2026-09-01T15:00:00.000Z",
-        guestName: "Ada Lovelace",
-        guestEmail: "ada@example.com",
-        guestTimeZone: "Europe/London",
+        slotStart: valid.slotStart,
+        guestName: valid.guestName,
+        guestEmail: valid.guestEmail,
+        guestTimeZone: valid.guestTimeZone,
       }).success,
-    ).toBe(true);
+    ).toBe(false);
+    expect(
+      CreateBookingReservationInputSchema.safeParse({
+        ...valid,
+        extra: true,
+      }).success,
+    ).toBe(false);
+    expect(
+      CreateBookingReservationInputSchema.safeParse({
+        ...valid,
+        durationMinutes: 20,
+      }).success,
+    ).toBe(false);
   });
 
   it("parses a public reservation GET with name and notes, not email", () => {
@@ -404,6 +426,17 @@ describe("HTTP booking contracts", () => {
         guestEmail: "ada@example.com",
       }).success,
     ).toBe(false);
+    expect(
+      PublicGetBookingReservationResponseSchema.safeParse({
+        slotStart: publicGet.slotStart,
+        guestTimeZone: publicGet.guestTimeZone,
+        durationMinutes: publicGet.durationMinutes,
+        hostDisplayName: publicGet.hostDisplayName,
+        status: publicGet.status,
+        guestName: publicGet.guestName,
+        notes: publicGet.notes,
+      }).success,
+    ).toBe(true);
   });
 
   it("parses a guest details PATCH and rejects email or empty edits", () => {
@@ -465,6 +498,7 @@ describe("HTTP booking contracts", () => {
         token: "abc",
         slotStart: "2026-09-01T15:00:00.000Z",
         guestTimeZone: "Europe/London",
+        durationMinutes: 30,
       }).success,
     ).toBe(true);
     expect(
@@ -472,6 +506,14 @@ describe("HTTP booking contracts", () => {
         token: "abc",
         slotStart: "2026-09-01T15:00:00.000Z",
         guestTimeZone: "Europe/London",
+      }).success,
+    ).toBe(false);
+    expect(
+      RescheduleBookingReservationInputSchema.safeParse({
+        token: "abc",
+        slotStart: "2026-09-01T15:00:00.000Z",
+        guestTimeZone: "Europe/London",
+        durationMinutes: 30,
         notes: "extra",
       }).success,
     ).toBe(false);

--- a/packages/core/src/types/booking.contracts.ts
+++ b/packages/core/src/types/booking.contracts.ts
@@ -286,6 +286,7 @@ export const CreateBookingReservationInputSchema = z.strictObject({
   guestEmail: z.string().trim().min(1).max(320),
   notes: z.string().trim().max(4000).optional(),
   guestTimeZone: TimeZoneSchema,
+  durationMinutes: BookingDurationMinutesSchema,
 });
 export type CreateBookingReservationInput = z.infer<
   typeof CreateBookingReservationInputSchema
@@ -309,7 +310,7 @@ export const PublicGetBookingReservationResponseSchema = z.strictObject({
   durationMinutes: BookingDurationMinutesSchema,
   hostDisplayName: z.string().trim().min(1).max(256),
   status: BookingReservationStatusSchema,
-  bookingSlug: BookingSlugSchema,
+  bookingSlug: BookingSlugSchema.optional(),
   guestName: z.string().trim().min(1).max(256),
   notes: z.string().trim().max(4000).nullable(),
   createsGoogleMeet: z.boolean().default(true),
@@ -352,6 +353,7 @@ export const RescheduleBookingReservationInputSchema = z.strictObject({
   token: z.string().trim().min(1).max(256),
   slotStart: DateTimeSchema,
   guestTimeZone: TimeZoneSchema,
+  durationMinutes: BookingDurationMinutesSchema,
 });
 export type RescheduleBookingReservationInput = z.infer<
   typeof RescheduleBookingReservationInputSchema

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -424,6 +424,63 @@ describe("BookingSettingsSection", () => {
     ]);
   });
 
+  it("explains invite-others cancel tradeoff and RSVP-strict occupancy", async () => {
+    const user = userEvent.setup({ delay: null });
+    let savedBody: unknown;
+    userMetadataActions.set(healthyGoogleMetadata);
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+      rest.put(bookingPageUrl, async (req, res, ctx) => {
+        savedBody = await req.json();
+        return res(
+          ctx.json({
+            ...(savedBody as object),
+            id: createObjectIdString(),
+            slug: "hostuser",
+            hostUserId: createObjectIdString(),
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            bookingUrl: "https://compasscalendar.com/book/hostuser",
+          }),
+        );
+      }),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    expect(
+      await screen.findByRole("checkbox", { name: "Guest can invite others" }),
+    ).toBeChecked();
+    expect(
+      screen.getByText(
+        "When this is on, Compass cannot put the cancel link in the calendar description. Guests keep it from the confirmation page.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Pending, maybe, and declined invites do not hold booking times. Accepted invites and events the host organizes do.",
+      ),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Save booking settings" }),
+    );
+    await waitFor(() => {
+      expect(savedBody).toMatchObject({ guestsCanInviteOthers: true });
+    });
+  });
+
   it("seeds the booking timezone from the user's zone when never configured", async () => {
     userMetadataActions.set(healthyGoogleMetadata);
     // Pinned rather than relying on the browser zone: CI runs at TZ=UTC, where

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -594,6 +594,10 @@ export function BookingSettingsSection({
               {ungrouped.map(renderBlockingCalendar)}
             </>
           )}
+          <p className="text-text-muted text-xs">
+            Pending, maybe, and declined invites do not hold booking times.
+            Accepted invites and events the host organizes do.
+          </p>
         </fieldset>
 
         <div {...bookingFieldAttrs("timezone")}>
@@ -731,6 +735,10 @@ export function BookingSettingsSection({
           >
             Guest can invite others
           </BookingCheckboxRow>
+          <p className="text-text-muted text-xs">
+            When this is on, Compass cannot put the cancel link in the calendar
+            description. Guests keep it from the confirmation page.
+          </p>
         </fieldset>
 
         <div className={BOOKING_SETTINGS_SAVE_BAR_CLASS_NAME}>

--- a/packages/web/src/booking/PublicBookingCancelPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingCancelPage.test.tsx
@@ -333,4 +333,140 @@ describe("PublicBookingCancelPage", () => {
       `/book/cancel/${reservationId}`,
     );
   });
+
+  it("offers Retry after a failed cancel and sends a second POST", async () => {
+    const user = userEvent.setup({ delay: null });
+    const tokens: string[] = [];
+    let failNext = true;
+
+    server.use(
+      reservationGetHandler(),
+      rest.post(
+        `${ENV_WEB.API_BASEURL}/booking/reservations/${reservationId}/cancel`,
+        async (req, res, ctx) => {
+          const body = (await req.json()) as { token?: string };
+          tokens.push(body.token ?? "");
+          if (failNext) {
+            failNext = false;
+            return res(ctx.status(Status.INTERNAL_SERVER), ctx.json({}));
+          }
+          return res(ctx.status(Status.OK), ctx.json({ ok: true }));
+        },
+      ),
+    );
+
+    renderCancelRoute(cancelPath);
+    await user.click(
+      await screen.findByRole("button", { name: "Cancel this booking" }),
+    );
+    expect(
+      await screen.findByRole("heading", { name: "Could not cancel booking" }),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+    expect(
+      await screen.findByRole("heading", { name: "Cancel this booking?" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("When")).toBeInTheDocument();
+    expect(screen.getByText("Duration")).toBeInTheDocument();
+    expect(screen.getByText("Timezone")).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: "Cancel this booking" }),
+    );
+    expect(
+      await screen.findByRole("heading", { name: "Booking canceled" }),
+    ).toBeInTheDocument();
+    expect(tokens).toEqual(["abc", "abc"]);
+  });
+
+  it("does not offer Retry after a 404 cancel", async () => {
+    const user = userEvent.setup({ delay: null });
+    let cancelPosts = 0;
+    server.use(
+      reservationGetHandler(),
+      rest.post(
+        `${ENV_WEB.API_BASEURL}/booking/reservations/${reservationId}/cancel`,
+        (_req, res, ctx) => {
+          cancelPosts += 1;
+          return res(ctx.status(Status.NOT_FOUND), ctx.json({}));
+        },
+      ),
+    );
+
+    renderCancelRoute(cancelPath);
+    await user.click(
+      await screen.findByRole("button", { name: "Cancel this booking" }),
+    );
+    expect(
+      await screen.findByRole("heading", { name: "Booking not found" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Retry" }),
+    ).not.toBeInTheDocument();
+    expect(cancelPosts).toBe(1);
+  });
+
+  it("links Book another time after cancel when bookingSlug is present", async () => {
+    const user = userEvent.setup({ delay: null });
+    server.use(
+      reservationGetHandler(),
+      rest.post(
+        `${ENV_WEB.API_BASEURL}/booking/reservations/${reservationId}/cancel`,
+        (_req, res, ctx) => res(ctx.status(Status.OK), ctx.json({ ok: true })),
+      ),
+    );
+
+    renderCancelRoute(cancelPath);
+    await user.click(
+      await screen.findByRole("button", { name: "Cancel this booking" }),
+    );
+    const rebook = await screen.findByRole("link", {
+      name: "Book another time",
+    });
+    expect(rebook).toHaveAttribute("href", "/book/tylerdane");
+    expect(rebook.getAttribute("href")).not.toContain("token");
+  });
+
+  it("shows Book another time on an already-cancelled reservation", async () => {
+    server.use(reservationGetHandler({ status: "cancelled" }));
+
+    renderCancelRoute(cancelPath);
+
+    expect(
+      await screen.findByRole("heading", { name: "Booking canceled" }),
+    ).toBeInTheDocument();
+    const rebook = screen.getByRole("link", { name: "Book another time" });
+    expect(rebook).toHaveAttribute("href", "/book/tylerdane");
+    expect(rebook.getAttribute("href")).not.toContain("token");
+    expect(rebook.getAttribute("href")).not.toContain(reservationId);
+  });
+
+  it("hides Book another time when bookingSlug is missing", async () => {
+    server.use(
+      rest.get(
+        `${ENV_WEB.API_BASEURL}/booking/reservations/${reservationId}`,
+        (_req, res, ctx) =>
+          res(
+            ctx.status(Status.OK),
+            ctx.json({
+              slotStart,
+              guestTimeZone: "UTC",
+              durationMinutes: 30,
+              hostDisplayName: "Tyler Dane",
+              status: "cancelled",
+              guestName: "Guest User",
+              notes: null,
+            }),
+          ),
+      ),
+    );
+
+    renderCancelRoute(cancelPath);
+
+    expect(
+      await screen.findByRole("heading", { name: "Booking canceled" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Book another time" }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/packages/web/src/booking/PublicBookingCancelPage.tsx
+++ b/packages/web/src/booking/PublicBookingCancelPage.tsx
@@ -96,8 +96,14 @@ export function PublicBookingCancelPage() {
         setAction("not-found");
         return;
       }
+      inFlightRef.current = false;
       setAction("error");
     }
+  };
+
+  const handleRetry = () => {
+    inFlightRef.current = false;
+    setAction("idle");
   };
 
   const view = resolveCancelPageView(canLoad, action, reservationQuery);
@@ -126,7 +132,35 @@ export function PublicBookingCancelPage() {
   );
 
   if (view.kind === "status") {
-    return <PublicBookingStatusMessage {...view} />;
+    const bookingSlug = reservationQuery.data?.bookingSlug;
+    const showRetry = action === "error";
+    const showRebook =
+      (action === "cancelled" ||
+        reservationQuery.data?.status === "cancelled") &&
+      action !== "error" &&
+      action !== "not-found" &&
+      Boolean(bookingSlug);
+    return (
+      <PublicBookingStatusMessage {...view}>
+        {showRetry ? (
+          <button
+            type="button"
+            className="c-button c-button-primary mt-6"
+            onClick={handleRetry}
+          >
+            Retry
+          </button>
+        ) : null}
+        {showRebook && bookingSlug ? (
+          <a
+            href={`/book/${bookingSlug}`}
+            className="c-focus-ring mt-4 inline-block text-accent text-sm underline"
+          >
+            Book another time
+          </a>
+        ) : null}
+      </PublicBookingStatusMessage>
+    );
   }
 
   const { reservation } = view;

--- a/packages/web/src/booking/PublicBookingConfirmedPage.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmedPage.tsx
@@ -115,7 +115,7 @@ export function PublicBookingConfirmedPage() {
 
   const view = resolveConfirmedPageView(reservationQuery);
   const bookingSlug =
-    view.kind === "reservation" ? view.reservation.bookingSlug : "";
+    view.kind === "reservation" ? (view.reservation.bookingSlug ?? "") : "";
   const canEdit = view.kind === "reservation" && token.length > 0;
 
   // Escape returns to the host's public page. OverlayPanel peels first.

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -440,6 +440,7 @@ describe("PublicBookingPage", () => {
       guestName: "Guest User",
       guestEmail: "guest@example.com",
       guestTimeZone: "UTC",
+      durationMinutes: 30,
     });
     expect(
       screen.getByRole("button", { name: "Copy cancel link" }),

--- a/packages/web/src/booking/PublicBookingReschedulePage.test.tsx
+++ b/packages/web/src/booking/PublicBookingReschedulePage.test.tsx
@@ -141,7 +141,7 @@ describe("PublicBookingReschedulePage", () => {
 
     await waitFor(() => {
       expect(posts).toEqual([
-        { token: "abc", slotStart, guestTimeZone: "UTC" },
+        { token: "abc", slotStart, guestTimeZone: "UTC", durationMinutes: 30 },
       ]);
     });
     await waitFor(() => {

--- a/packages/web/src/booking/PublicBookingStatusMessage.tsx
+++ b/packages/web/src/booking/PublicBookingStatusMessage.tsx
@@ -1,3 +1,4 @@
+import { type ReactNode } from "react";
 import { PublicBookingLayout } from "@web/booking/PublicBookingLayout";
 import { useBookingHeadingFocus } from "@web/booking/use-booking-heading-focus";
 
@@ -7,11 +8,13 @@ export const PUBLIC_BOOKING_HEADING_CLASS =
 interface PublicBookingStatusMessageProps {
   title: string;
   description: string;
+  children?: ReactNode;
 }
 
 export function PublicBookingStatusMessage({
   title,
   description,
+  children,
 }: PublicBookingStatusMessageProps) {
   const headingRef = useBookingHeadingFocus(title);
 
@@ -27,6 +30,7 @@ export function PublicBookingStatusMessage({
           {title}
         </h1>
         <p className="mt-2 text-sm text-text-muted">{description}</p>
+        {children}
       </section>
     </PublicBookingLayout>
   );

--- a/packages/web/src/booking/use-public-booking-flow.ts
+++ b/packages/web/src/booking/use-public-booking-flow.ts
@@ -263,7 +263,7 @@ export function usePublicBookingFlow() {
   };
 
   const handleSubmit = async (values: PublicBookingGuestFormValues) => {
-    if (!selectedSlotStart || submitInFlightRef.current) {
+    if (!selectedSlotStart || !pageQuery.data || submitInFlightRef.current) {
       return;
     }
 
@@ -278,6 +278,7 @@ export function usePublicBookingFlow() {
           guestEmail: values.guestEmail,
           notes: values.notes || undefined,
           guestTimeZone: values.guestTimeZone,
+          durationMinutes: pageQuery.data.durationMinutes,
         }),
       );
       const token = tokenFromGuestActionUrl(result.cancelUrl);

--- a/packages/web/src/booking/use-public-booking-reschedule-flow.ts
+++ b/packages/web/src/booking/use-public-booking-reschedule-flow.ts
@@ -251,7 +251,12 @@ export function usePublicBookingRescheduleFlow() {
   };
 
   const handleConfirm = async () => {
-    if (!selectedSlotStart || !token || submitInFlightRef.current) {
+    if (
+      !selectedSlotStart ||
+      !token ||
+      !pageQuery.data ||
+      submitInFlightRef.current
+    ) {
       return;
     }
 
@@ -264,6 +269,7 @@ export function usePublicBookingRescheduleFlow() {
           token,
           slotStart: selectedSlotStart,
           guestTimeZone,
+          durationMinutes: pageQuery.data.durationMinutes,
         }),
       );
       await navigate({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3118
Fixes #3119
Fixes #3120
Fixes #3121
Fixes #3122
Closes #3117

## Summary

Booking v1.4 honesty and recovery papercuts after guest reschedule.

- Confirm and reschedule require `durationMinutes`. A mismatch with the page’s current duration returns `409` and creates no Google event. Matching duration books `slotEnd` from that value. Guests stay on the picker with the existing conflict alert.
- Booking Settings explains the invite-others cancel-link tradeoff. Default stays on. Description builder is unchanged.
- A failed (non-404) cancel shows Retry. Retry restores the confirm view and resets `inFlightRef` so a second POST can run. 404 stays the generic not-found page.
- Cancelled views show Book another time to `/book/{bookingSlug}` when public GET includes the slug. Tokens stay off that URL.
- Settings states RSVP-strict occupancy. `occupiesBookingSlot` is unchanged.

Production gate stays off. `isBookingEnabled` is unchanged.

## Simplicity

Duration pin is one compare before slot work on both confirm and reschedule. Settings helpers are muted copy next to the existing controls. Cancel recovery reuses `PublicBookingStatusMessage` children instead of a second page.

## Automated validation

- `bun run verify`: PASS. Selected core, web, backend. Checks: `test:core`, `test:web`, `test:backend`, `type-check`, `lint`, `knip`.
- Focused WP tests: duration pin 409 with zero `createBookingEvent` calls; Retry then second cancel POST; Book another time with and without `bookingSlug`; Settings helper copy with `guestsCanInviteOthers: true`.
- `bunx playwright test e2e/booking e2e/accessibility/booking-a11y.spec.ts`: 70 passed.

## Independent review

`.agents/handoffs/3118.md` through `.agents/handoffs/3122.md`. Verdict: no confirmed findings.

## Test plan

- `bun run verify` (core, web, backend, type-check, lint, knip)
- `bunx playwright test e2e/booking e2e/accessibility/booking-a11y.spec.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3dd772a-3d4e-482f-9e23-211969c52746?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3dd772a-3d4e-482f-9e23-211969c52746&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

