### PR TITLE
fix(ci): let the merge queue own strategy in both merge guards

### DIFF
--- a/.github/scripts/agent-loop-merge-guard.sh
+++ b/.github/scripts/agent-loop-merge-guard.sh
@@ -242,11 +242,14 @@ check_and_merge() {
     return 0
   fi
 
-  if ! gh pr merge "$pr_number" --repo "$REPO" --auto --squash --delete-branch; then
+  # The ruleset merge queue owns the strategy (SQUASH) and the repo deletes
+  # branches on merge; passing --squash or --delete-branch here is rejected
+  # ("Cannot use --delete-branch when merge queue enabled", 2026-09-04).
+  if ! gh pr merge "$pr_number" --repo "$REPO" --auto; then
     notify "Agent-loop PR #${pr_number} passed verification but \`gh pr merge --auto\` failed: https://github.com/${REPO}/pull/${pr_number}"
     return 0
   fi
-  printf 'enabled auto-merge on agent PR #%s; GitHub squash-merges when required checks pass\n' "$pr_number"
+  printf 'enabled auto-merge on agent PR #%s; the merge queue squash-merges when required checks pass\n' "$pr_number"
 }
 
 main() {

--- a/.github/scripts/autofix-merge-guard.sh
+++ b/.github/scripts/autofix-merge-guard.sh
@@ -101,7 +101,8 @@ main() {
     return 0
   fi
 
-  if ! gh pr merge "$pr_number" --repo "$REPO" --auto --squash --delete-branch; then
+  # Merge queue owns the strategy and the repo deletes branches on merge.
+  if ! gh pr merge "$pr_number" --repo "$REPO" --auto; then
     notify "Autofix PR #${pr_number} (issue #${ISSUE_NUMBER}) passed the merge guard but \`gh pr merge --auto\` failed — needs a human to enable merge manually — https://github.com/${REPO}/pull/${pr_number}"
     return 0
   fi

--- a/docs/CI-CD/agent-loop-routine.md
+++ b/docs/CI-CD/agent-loop-routine.md
@@ -127,7 +127,8 @@ both channels are configured).
    is under the rails, no sensitive path is in the diff (unless a
    per-milestone allowlist re-allows that prefix), and the latest `main`
    Unit and E2E push runs are not red, enable GitHub auto-merge
-   (`gh pr merge --auto --squash`). GitHub squash-merges when the required
+   (`gh pr merge --auto`; the ruleset merge queue squash-merges and the
+   repo deletes the branch). GitHub squash-merges when the required
    checks pass. Otherwise add `agent-loop-needs-human` and stop; a red
    `main` just waits for the scheduled sweep. The guard never holds a
    runner waiting on CI.

--- a/packages/scripts/src/testing/agent-loop-routine.test.ts
+++ b/packages/scripts/src/testing/agent-loop-routine.test.ts
@@ -78,7 +78,9 @@ describe("agent-loop Routine contract", () => {
       ".github/scripts/agent-loop-merge-guard.sh",
       "utf8",
     );
-    expect(guard).toContain("--auto --squash --delete-branch");
+    expect(guard).toMatch(/gh pr merge "\$pr_number" --repo "\$REPO" --auto;/);
+    // The merge queue rejects an explicit strategy or branch deletion.
+    expect(guard).not.toMatch(/gh pr merge[^\n]*(--squash|--delete-branch)/);
     expect(guard).not.toContain("gh pr checks");
     expect(guard).toContain("main_is_red");
     expect(guard).toContain("--disable-auto");


### PR DESCRIPTION
Fixes the merge guard for the merge queue Tyler enabled on ruleset 8388539 today.

## What and why

`agent-loop-merge-guard.sh` and `autofix-merge-guard.sh` call `gh pr merge --auto --squash --delete-branch`. With a merge queue on `main`, GitHub rejects that with "Cannot use `-d` or `--delete-branch` when merge queue enabled", so every PR that passes the guard ends with a Discord notify and no merge. Observed on #3332 at 20:28Z today. The queue already squash-merges (`merge_method: SQUASH`) and the repo has `delete_branch_on_merge`, so the guards now pass only `--auto`.

The routine test asserted the old flag string; it now asserts the new command and that `--delete-branch` is gone. The routine doc's one mention is updated.

## Needs a human merge

Touches `.github/scripts/`.

## Verify

- `bash -n` on both scripts.
- `bun test packages/scripts/src/testing/agent-loop-routine.test.ts` passes.
- The guard's own shell test cannot run on macOS (bash 3.2 lacks `mapfile`); CI's `unit (scripts)` exercises the guard through `agent-loop-launch.test.ts` on ubuntu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
