### PR TITLE
feat(sync): thread per-connection ProviderAdapters through dispatch and custody (WP-03a)

### DIFF
--- a/.agents/handoffs/3225.md
+++ b/.agents/handoffs/3225.md
@@ -1,0 +1,31 @@
+---
+schema_version: 1
+task_id: "3225"
+from: Implementer
+to: Verifier
+owner: Verifier
+status: verifying
+artifact:
+  - path: packages/sync/src/providers/provider-adapters.ts
+  - path: packages/sync/src/providers/google/build-provider-resolvers.ts
+  - path: packages/sync/src/domain/sync-job-dispatch.service.ts
+  - path: packages/sync/src/credentials/credential-custody.service.ts
+evidence:
+  - command: bun run verify
+    result: "PASS — sync: test:sync 1125 pass, type-check, lint, knip"
+  - command: grep -rn 'new Google' packages/sync/src --include='*.ts' | grep -v providers/google | grep -v test
+    result: "only packages/sync/src/app.ts (3 lines)"
+  - command: bun test:sync (providerNotConfigured test)
+    result: "sync-job-dispatch.service.db.test.ts providerNotConfigured case passes"
+assumptions:
+  - WP-03b will add registry/routes/config; this WP keeps Google behavior byte-identical via resolver.
+open_risks:
+  - createSyncService test overrides require partial google adapter overrides without GOOGLE_CLIENT_ID in testConfig (handled in build-provider-resolvers).
+next_deadline: null
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-03a threads `ProviderAdapters` and `resolveAuth` through dispatch, custody, command routes, and app schedulers. Resource jobs resolve the connection provider before adapter lookup; unknown providers fail permanently with `providerNotConfigured`.

--- a/packages/sync/src/__tests__/helpers/fixtures.ts
+++ b/packages/sync/src/__tests__/helpers/fixtures.ts
@@ -1,5 +1,9 @@
 import { faker } from "@faker-js/faker";
 import {
+  type ProviderAdapters,
+  type ResolveProviderAdapters,
+} from "@sync/providers/provider-adapters";
+import {
   type ProviderEvent,
   type ProviderEventRead,
 } from "@sync/providers/provider-event.port";
@@ -177,3 +181,67 @@ export const fakeTokenSource = {
   discardRevoked: async () => {},
   invalidateAccessToken: async () => {},
 };
+
+const noopAuthAdapter = {
+  refreshAccessToken: async () => ({
+    accessToken: "access-token",
+    expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+  }),
+  revoke: async () => {},
+};
+
+const noopWriter = {
+  createEvent: async () => {
+    throw new Error("FakeWriter: createEvent not scripted");
+  },
+  fetchEvent: async () => {
+    throw new Error("FakeWriter: fetchEvent not scripted");
+  },
+  patchEvent: async () => {
+    throw new Error("FakeWriter: patchEvent not scripted");
+  },
+  deleteEvent: async () => {},
+  fetchInstanceAt: async () => {
+    throw new Error("FakeWriter: fetchInstanceAt not scripted");
+  },
+};
+
+const noopNotifications = {
+  watch: async (input: { channelId: string }) => ({
+    channelId: input.channelId,
+    resourceId: "provider-resource",
+    expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+  }),
+  stopChannel: async () => {},
+};
+
+const noopDiscovery = {
+  discoverCalendars: async () => ({
+    calendars: [],
+    cursor: null,
+  }),
+};
+
+// One adapter bundle for dispatch and custody tests. Override any port; reader
+// is required because most db tests script event pages through FakeReader.
+export function fakeAdapters(
+  reader: ProviderEventReader,
+  overrides: Partial<Omit<ProviderAdapters, "reader">> = {},
+): ProviderAdapters {
+  return {
+    auth: overrides.auth ?? noopAuthAdapter,
+    calendars: overrides.calendars ?? noopDiscovery,
+    reader,
+    writer: overrides.writer ?? noopWriter,
+    notifications: overrides.notifications ?? noopNotifications,
+    contacts: overrides.contacts,
+  };
+}
+
+export function fakeResolveAdapters(
+  reader: ProviderEventReader,
+  overrides: Partial<Omit<ProviderAdapters, "reader">> = {},
+): ResolveProviderAdapters {
+  const adapters = fakeAdapters(reader, overrides);
+  return () => adapters;
+}

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -34,12 +34,16 @@ import { SyncScheduler } from "@sync/domain/sync-scheduler.service";
 import { ReadinessRegistry } from "@sync/lifecycle/readiness";
 import { ShutdownCoordinator } from "@sync/lifecycle/shutdown";
 import { deriveOAuthStateSecret } from "@sync/oauth/oauth-state";
+import {
+  buildResolveAdapters,
+  buildResolveAuth,
+  googleProviderConfigured,
+  type ProviderAdapterOverrides,
+} from "@sync/providers/google/build-provider-resolvers";
 import { GoogleAuthAdapter } from "@sync/providers/google/google-auth.adapter";
-import { GoogleCalendarAdapter } from "@sync/providers/google/google-calendar.adapter";
-import { GoogleEventReaderAdapter } from "@sync/providers/google/google-event-reader.adapter";
 import { GoogleEventWriter } from "@sync/providers/google/google-event-writer.adapter";
-import { GoogleNotificationAdapter } from "@sync/providers/google/google-notifications.adapter";
 import { GooglePeopleAdapter } from "@sync/providers/google/google-people.adapter";
+import { type ResolveProviderAdapters } from "@sync/providers/provider-adapters";
 import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
 import { type ContactsPort } from "@sync/providers/provider-contacts.port";
 import { type ProviderEventWriter } from "@sync/providers/provider-event-writer.port";
@@ -104,6 +108,7 @@ export function createSyncService(
     // Override the provider contacts port (tests inject a fake); production
     // builds it from config.
     contacts?: ContactsPort;
+    resolveAdapters?: ResolveProviderAdapters;
   } = {},
 ): SyncService {
   const identity = buildServiceIdentity({
@@ -124,6 +129,19 @@ export function createSyncService(
     );
   }
 
+  const adapterOverrides: ProviderAdapterOverrides =
+    deps.authAdapter || deps.writer || deps.contacts
+      ? {
+          google: {
+            auth: deps.authAdapter,
+            writer: deps.writer,
+            contacts: deps.contacts,
+          },
+        }
+      : {};
+  const resolveAdapters =
+    deps.resolveAdapters ?? buildResolveAdapters(config, adapterOverrides);
+
   // The internal connection API mounts only when storage is provided. Its
   // routes read the connected db per request, so the app is still built before
   // Mongo connects (liveness-first startup).
@@ -137,6 +155,7 @@ export function createSyncService(
         }),
         mongo: deps.mongo,
         execution: config.EXECUTION,
+        resolveAdapters,
         // The provider adapter is db-free, so it is built once here (gated on
         // provider config); the per-request custody/repos build from the db.
         authAdapter: deps.authAdapter ?? buildAuthAdapter(config),
@@ -482,10 +501,10 @@ function buildSchedulers(
   sweeps: ReadonlyArray<readonly [name: string, sweep: SweepScheduler]>;
 } | null {
   if (config.EXECUTION !== "active") return null;
-  const authAdapter = buildAuthAdapter(config);
-  if (!authAdapter) return null;
-  const eventWriter = buildEventWriter(config);
-  if (!eventWriter) return null;
+  if (!googleProviderConfigured(config)) return null;
+
+  const resolveAdapters = buildResolveAdapters(config);
+  const resolveAuth = buildResolveAuth(resolveAdapters);
 
   const repos = syncRepositories(mongo);
   const resources = repos.syncResources;
@@ -509,12 +528,10 @@ function buildSchedulers(
         calendars: repos.calendars,
         connections: repos.connections,
         credentials: repos.credentials,
-        discovery: new GoogleCalendarAdapter(),
+        resolveAdapters,
         commands: repos.commands,
         jobs,
-        reader: new GoogleEventReaderAdapter(),
-        custody: new CredentialCustody(repos.credentials, authAdapter),
-        notifications: new GoogleNotificationAdapter(),
+        custody: new CredentialCustody(repos.credentials, resolveAuth),
         // Where the provider posts change notifications back; the callback route
         // verifies them against the stored subscription.
         callbackUrl: `${config.CALLBACK_BASE_URL}${NOTIFICATIONS_PATH}`,
@@ -757,8 +774,8 @@ function buildSchedulers(
             markers: repos.deletionMarkers,
             execution: config.EXECUTION,
             provider: {
-              writer: eventWriter,
-              custody: new CredentialCustody(repos.credentials, authAdapter),
+              resolveAdapters,
+              custody: new CredentialCustody(repos.credentials, resolveAuth),
             },
             onRetryError: (error, commandId) =>
               logger.error(

--- a/packages/sync/src/credentials/credential-custody.service.db.test.ts
+++ b/packages/sync/src/credentials/credential-custody.service.db.test.ts
@@ -84,7 +84,7 @@ describe("CredentialCustody", () => {
         grantedScopes: [],
       },
     });
-    const custody = new CredentialCustody(repo, adapter, fixedNow);
+    const custody = new CredentialCustody(repo, () => adapter, fixedNow);
     await custody.store(baseCredential(connectionId));
 
     const token = await custody.getValidAccessToken(connectionId);
@@ -98,7 +98,7 @@ describe("CredentialCustody", () => {
   it("serves the cached token without refreshing when it is still valid", async () => {
     const connectionId = objectId() as ConnectionId;
     const adapter = new FakeAdapter();
-    const custody = new CredentialCustody(repo, adapter, fixedNow);
+    const custody = new CredentialCustody(repo, () => adapter, fixedNow);
     await custody.store(baseCredential(connectionId));
     await repo.cacheAccessToken(
       connectionId,
@@ -121,7 +121,7 @@ describe("CredentialCustody", () => {
         grantedScopes: [],
       },
     });
-    const custody = new CredentialCustody(repo, adapter, fixedNow);
+    const custody = new CredentialCustody(repo, () => adapter, fixedNow);
     await custody.store(baseCredential(connectionId));
     await repo.cacheAccessToken(
       connectionId,
@@ -145,7 +145,12 @@ describe("CredentialCustody", () => {
         grantedScopes: [],
       },
     });
-    const custody = new CredentialCustody(repo, adapter, fixedNow, 60_000);
+    const custody = new CredentialCustody(
+      repo,
+      () => adapter,
+      fixedNow,
+      60_000,
+    );
     await custody.store(baseCredential(connectionId));
     // Expires 30s after now — inside the 60s skew, so it must be refreshed.
     await repo.cacheAccessToken(
@@ -175,7 +180,7 @@ describe("CredentialCustody", () => {
       // Hold the refresh open until both callers are queued.
       onRefresh: () => gate,
     });
-    const custody = new CredentialCustody(repo, adapter, fixedNow);
+    const custody = new CredentialCustody(repo, () => adapter, fixedNow);
     await custody.store(baseCredential(connectionId));
 
     const first = custody.getValidAccessToken(connectionId);
@@ -198,7 +203,7 @@ describe("CredentialCustody", () => {
         grantedScopes: [],
       },
     });
-    const custody = new CredentialCustody(repo, adapter, fixedNow);
+    const custody = new CredentialCustody(repo, () => adapter, fixedNow);
     await custody.store(baseCredential(connectionId));
 
     await custody.getValidAccessToken(connectionId);
@@ -209,7 +214,7 @@ describe("CredentialCustody", () => {
 
   it("rejects with missingRefreshToken when no credential exists", async () => {
     const adapter = new FakeAdapter();
-    const custody = new CredentialCustody(repo, adapter, fixedNow);
+    const custody = new CredentialCustody(repo, () => adapter, fixedNow);
 
     const error = (await custody
       .getValidAccessToken(objectId() as ConnectionId)
@@ -225,7 +230,7 @@ describe("CredentialCustody", () => {
     const adapter = new FakeAdapter({
       refreshError: new ProviderAuthError("authorizationRevoked", "revoked"),
     });
-    const custody = new CredentialCustody(repo, adapter, fixedNow);
+    const custody = new CredentialCustody(repo, () => adapter, fixedNow);
     await custody.store(baseCredential(connectionId));
 
     const error = (await custody
@@ -242,7 +247,7 @@ describe("CredentialCustody", () => {
     const adapter = new FakeAdapter({
       refreshError: new ProviderAuthError("refreshFailed", "blip"),
     });
-    const custody = new CredentialCustody(repo, adapter, fixedNow);
+    const custody = new CredentialCustody(repo, () => adapter, fixedNow);
     await custody.store(baseCredential(connectionId));
 
     await expect(
@@ -256,7 +261,7 @@ describe("CredentialCustody", () => {
   it("discardRevoked deletes the credential and is idempotent", async () => {
     const connectionId = objectId() as ConnectionId;
     const adapter = new FakeAdapter();
-    const custody = new CredentialCustody(repo, adapter, fixedNow);
+    const custody = new CredentialCustody(repo, () => adapter, fixedNow);
     await custody.store(baseCredential(connectionId));
 
     await custody.discardRevoked(connectionId);
@@ -294,7 +299,7 @@ describe("CredentialCustody", () => {
         return gate;
       },
     });
-    const custody = new CredentialCustody(repo, adapter, fixedNow);
+    const custody = new CredentialCustody(repo, () => adapter, fixedNow);
     await custody.store(baseCredential(connectionId));
 
     // Start a refresh; the rejection handler attaches immediately so the
@@ -320,7 +325,7 @@ describe("CredentialCustody", () => {
   it("deletes the credential and revokes it on disconnect", async () => {
     const connectionId = objectId() as ConnectionId;
     const adapter = new FakeAdapter();
-    const custody = new CredentialCustody(repo, adapter, fixedNow);
+    const custody = new CredentialCustody(repo, () => adapter, fixedNow);
     await custody.store(baseCredential(connectionId));
 
     await custody.disconnect(connectionId);
@@ -331,7 +336,7 @@ describe("CredentialCustody", () => {
 
   it("disconnecting an unknown connection revokes nothing and does not throw", async () => {
     const adapter = new FakeAdapter();
-    const custody = new CredentialCustody(repo, adapter, fixedNow);
+    const custody = new CredentialCustody(repo, () => adapter, fixedNow);
 
     await custody.disconnect(objectId() as ConnectionId);
 

--- a/packages/sync/src/credentials/credential-custody.service.ts
+++ b/packages/sync/src/credentials/credential-custody.service.ts
@@ -1,4 +1,5 @@
 import { type ConnectionId } from "@core/types/sync/identity.contracts";
+import { type ResolveProviderAuth } from "@sync/providers/provider-adapters";
 import {
   type ProviderAuthAdapter,
   ProviderAuthError,
@@ -27,7 +28,7 @@ export class CredentialCustody {
 
   constructor(
     private readonly credentials: CredentialRepository,
-    private readonly adapter: ProviderAuthAdapter,
+    private readonly resolveAuth: ResolveProviderAuth,
     private readonly now: () => Date = () => new Date(),
     private readonly refreshSkewMs: number = DEFAULT_REFRESH_SKEW_MS,
   ) {}
@@ -61,7 +62,9 @@ export class CredentialCustody {
     const credential = await this.credentials.findByConnection(connectionId);
     await this.credentials.deleteByConnection(connectionId);
     if (credential) {
-      await this.adapter.revoke({ token: credential.refreshToken });
+      await this.resolveAuth(credential.provider).revoke({
+        token: credential.refreshToken,
+      });
     }
   }
 
@@ -101,7 +104,9 @@ export class CredentialCustody {
       ReturnType<ProviderAuthAdapter["refreshAccessToken"]>
     >;
     try {
-      refreshed = await this.adapter.refreshAccessToken({
+      refreshed = await this.resolveAuth(
+        credential.provider,
+      ).refreshAccessToken({
         refreshToken: credential.refreshToken,
       });
     } catch (error) {

--- a/packages/sync/src/domain/cloud-command.service.db.test.ts
+++ b/packages/sync/src/domain/cloud-command.service.db.test.ts
@@ -7,11 +7,13 @@ import {
   type PrincipalId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
+import { fakeAdapters } from "@sync/__tests__/helpers/fixtures";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import {
   ProviderWriteUnavailableError,
   submitCloudCommand,
 } from "@sync/domain/cloud-command.service";
+import { type ProviderConnectionLookup } from "@sync/domain/provider-command.service";
 import { reprojectOccurrences } from "@sync/domain/reproject";
 import { type ProviderEvent } from "@sync/providers/provider-event.port";
 import {
@@ -29,6 +31,7 @@ import { DeletionMarkerRepository } from "@sync/storage/repositories/deletion-ma
 import { EventRepository } from "@sync/storage/repositories/event.repository";
 import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 import { beforeEach, describe, expect, it, spyOn } from "bun:test";
@@ -109,7 +112,15 @@ class FakeWriter implements ProviderEventWriter {
 }
 
 const provider = (writer: ProviderEventWriter) => ({
-  writer,
+  resolveAdapters: () =>
+    fakeAdapters(
+      {
+        listEventPage: async () => {
+          throw new Error("reader unused in cloud-command tests");
+        },
+      },
+      { writer },
+    ),
   custody: {
     getValidAccessToken: async () => "access-token",
     discardRevoked: async () => {},
@@ -125,6 +136,13 @@ describe("submitCloudCommand provider dispatch", () => {
   let resources: SyncResourceRepository;
   let calendars: ProviderCalendarRepository;
   let markers: DeletionMarkerRepository;
+
+  const connections: ProviderConnectionLookup = {
+    findById: async () => ({
+      account: { email: "user@example.com" },
+      provider: "google",
+    }),
+  };
 
   const now = () => new Date("2026-07-10T00:00:00.000Z");
 
@@ -146,6 +164,22 @@ describe("submitCloudCommand provider dispatch", () => {
         canInviteAttendees: true,
       },
     });
+
+  const commandDeps = (
+    writer?: FakeWriter,
+    extra: Record<string, unknown> = {},
+  ) => ({
+    commands,
+    events,
+    calendars,
+    occurrences,
+    resources,
+    markers,
+    connections,
+    execution: "active" as const,
+    ...(writer ? { provider: provider(writer) } : {}),
+    ...extra,
+  });
 
   const submitFor = (
     tenantId: TenantId,
@@ -196,16 +230,7 @@ describe("submitCloudCommand provider dispatch", () => {
     const writer = new FakeWriter();
 
     const { command } = await submitCloudCommand(
-      {
-        commands,
-        events,
-        calendars,
-        occurrences,
-        resources,
-        markers,
-        execution: "active",
-        provider: provider(writer),
-      },
+      commandDeps(writer),
       submitFor(tenantId, principalId, calendar._id),
       now,
     );
@@ -224,16 +249,7 @@ describe("submitCloudCommand provider dispatch", () => {
     const writer = new FakeWriter();
 
     const submit = submitCloudCommand(
-      {
-        commands,
-        events,
-        calendars,
-        occurrences,
-        resources,
-        markers,
-        execution: "passive",
-        provider: provider(writer),
-      },
+      commandDeps(writer, { execution: "passive" }),
       submitFor(tenantId, principalId, calendar._id),
       now,
     );
@@ -248,15 +264,7 @@ describe("submitCloudCommand provider dispatch", () => {
     const calendar = await seedProviderCalendar(tenantId, principalId);
 
     const submit = submitCloudCommand(
-      {
-        commands,
-        events,
-        calendars,
-        occurrences,
-        resources,
-        markers,
-        execution: "active",
-      },
+      commandDeps(undefined, { provider: undefined }),
       submitFor(tenantId, principalId, calendar._id),
       now,
     );
@@ -270,16 +278,7 @@ describe("submitCloudCommand provider dispatch", () => {
     const writer = new FakeWriter();
 
     const { command } = await submitCloudCommand(
-      {
-        commands,
-        events,
-        calendars,
-        occurrences,
-        resources,
-        markers,
-        execution: "active",
-        provider: provider(writer),
-      },
+      commandDeps(writer),
       // A calendar id with no provider_calendars row is a Compass cloud calendar.
       submitFor(tenantId, principalId, objectId()),
       now,
@@ -309,15 +308,7 @@ describe("submitCloudCommand provider dispatch", () => {
     };
 
     const { command } = await submitCloudCommand(
-      {
-        commands,
-        events,
-        calendars,
-        occurrences,
-        resources,
-        markers,
-        execution: "active",
-      },
+      commandDeps(undefined, { provider: undefined }),
       submit,
       now,
     );
@@ -339,15 +330,7 @@ describe("submitCloudCommand provider dispatch", () => {
     };
 
     const { command } = await submitCloudCommand(
-      {
-        commands,
-        events,
-        calendars,
-        occurrences,
-        resources,
-        markers,
-        execution: "active",
-      },
+      commandDeps(undefined, { provider: undefined }),
       submit,
       now,
     );
@@ -470,16 +453,7 @@ describe("submitCloudCommand provider dispatch", () => {
     const writer = new FakeWriter();
 
     const { command } = await submitCloudCommand(
-      {
-        commands,
-        events,
-        calendars,
-        occurrences,
-        resources,
-        markers,
-        execution: "active",
-        provider: provider(writer),
-      },
+      commandDeps(writer),
       {
         tenantId,
         principalId,
@@ -529,16 +503,7 @@ describe("submitCloudCommand provider dispatch", () => {
     const writer = new FakeWriter();
 
     const { command } = await submitCloudCommand(
-      {
-        commands,
-        events,
-        calendars,
-        occurrences,
-        resources,
-        markers,
-        execution: "active",
-        provider: provider(writer),
-      },
+      commandDeps(writer),
       deleteFor(tenantId, principalId, eventId),
       now,
     );
@@ -572,16 +537,7 @@ describe("submitCloudCommand provider dispatch", () => {
     const writer = new FakeWriter();
 
     const { command } = await submitCloudCommand(
-      {
-        commands,
-        events,
-        calendars,
-        occurrences,
-        resources,
-        markers,
-        execution: "active",
-        provider: provider(writer),
-      },
+      commandDeps(writer),
       deleteFor(tenantId, principalId, eventId, "all"),
       now,
     );
@@ -607,16 +563,7 @@ describe("submitCloudCommand provider dispatch", () => {
     const writer = new FakeWriter();
 
     const { command } = await submitCloudCommand(
-      {
-        commands,
-        events,
-        calendars,
-        occurrences,
-        resources,
-        markers,
-        execution: "active",
-        provider: provider(writer),
-      },
+      commandDeps(writer),
       deleteFor(
         tenantId,
         principalId,
@@ -669,7 +616,10 @@ describe("submitCloudCommand provider dispatch", () => {
   });
 
   const selfConnection = {
-    findById: async () => ({ account: { email: "self@example.com" } }),
+    findById: async () => ({
+      account: { email: "self@example.com" },
+      provider: "google" as const,
+    }),
   };
 
   it("routes a provider-linked rsvp to the provider executor when active", async () => {
@@ -926,16 +876,7 @@ describe("submitCloudCommand provider dispatch", () => {
     const writer = new FakeWriter();
 
     const { command } = await submitCloudCommand(
-      {
-        commands,
-        events,
-        calendars,
-        occurrences,
-        resources,
-        markers,
-        execution: "active",
-        provider: provider(writer),
-      },
+      commandDeps(writer),
       updateSeriesFor(tenantId, principalId, eventId, "all"),
       now,
     );
@@ -984,16 +925,7 @@ describe("submitCloudCommand provider dispatch", () => {
     const writer = new FakeWriter();
 
     const { command } = await submitCloudCommand(
-      {
-        commands,
-        events,
-        calendars,
-        occurrences,
-        resources,
-        markers,
-        execution: "active",
-        provider: provider(writer),
-      },
+      commandDeps(writer),
       updateSeriesFor(
         tenantId,
         principalId,
@@ -1768,16 +1700,7 @@ describe("submitCloudCommand provider dispatch", () => {
         deliveryState: "confirmed",
       });
       const writer = new FakeWriter();
-      const activeDeps = {
-        commands,
-        events,
-        calendars,
-        occurrences,
-        resources,
-        markers,
-        execution: "active" as const,
-        provider: provider(writer),
-      };
+      const activeDeps = commandDeps(writer);
       const submit = deleteFor(tenantId, principalId, eventId);
 
       const first = await submitCloudCommand(activeDeps, submit, now);
@@ -1816,16 +1739,7 @@ describe("submitCloudCommand provider dispatch", () => {
         deliveryState: "confirmed",
       });
       const writer = new FakeWriter();
-      const activeDeps = {
-        commands,
-        events,
-        calendars,
-        occurrences,
-        resources,
-        markers,
-        execution: "active" as const,
-        provider: provider(writer),
-      };
+      const activeDeps = commandDeps(writer);
       const submit = deleteFor(tenantId, principalId, eventId);
 
       await submitCloudCommand(activeDeps, submit, now);

--- a/packages/sync/src/domain/cloud-command.service.db.test.ts
+++ b/packages/sync/src/domain/cloud-command.service.db.test.ts
@@ -31,7 +31,6 @@ import { DeletionMarkerRepository } from "@sync/storage/repositories/deletion-ma
 import { EventRepository } from "@sync/storage/repositories/event.repository";
 import { EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
-import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 import { beforeEach, describe, expect, it, spyOn } from "bun:test";

--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -38,6 +38,10 @@ import {
   remainderMasterId,
   reprojectMaster,
 } from "@sync/domain/series-exception";
+import {
+  ProviderNotConfiguredError,
+  type ResolveProviderAdapters,
+} from "@sync/providers/provider-adapters";
 import { type ProviderEventWriter } from "@sync/providers/provider-event-writer.port";
 import {
   type CommandRecord,
@@ -89,7 +93,7 @@ export interface CloudCommandDeps {
   // provider work is enabled. Absent means a provider-targeted command is
   // refused (see ProviderWriteUnavailableError) rather than left pending.
   provider?: {
-    writer: ProviderEventWriter;
+    resolveAdapters: ResolveProviderAdapters;
     custody: CredentialCustody;
   };
 }
@@ -224,6 +228,25 @@ export async function retryCloudMutation(
   return applyCloudMutation(deps, command, now);
 }
 
+async function resolveProviderWriter(
+  deps: CloudCommandDeps,
+  calendar: ProviderCalendarRecord,
+): Promise<ProviderEventWriter | null> {
+  if (!deps.provider) return null;
+  const connection = await deps.connections.findById(
+    calendar.tenantId,
+    calendar.principalId,
+    calendar.connectionId,
+  );
+  if (!connection) return null;
+  try {
+    return deps.provider.resolveAdapters(connection.provider).writer;
+  } catch (error) {
+    if (error instanceof ProviderNotConfiguredError) return null;
+    throw error;
+  }
+}
+
 async function applyCloudCreateOrProvider(
   deps: CloudCommandDeps,
   command: CommandRecord,
@@ -239,6 +262,8 @@ async function applyCloudCreateOrProvider(
   );
   if (providerCalendar) {
     if (deps.execution === "active" && deps.provider) {
+      const writer = await resolveProviderWriter(deps, providerCalendar);
+      if (!writer) throw new ProviderWriteUnavailableError();
       return executeProviderCreate(
         {
           commands: deps.commands,
@@ -246,7 +271,7 @@ async function applyCloudCreateOrProvider(
           occurrences: deps.occurrences,
           resources: deps.resources,
           connections: deps.connections,
-          writer: deps.provider.writer,
+          writer,
           custody: deps.provider.custody,
         },
         command,
@@ -525,6 +550,8 @@ async function dispatchProviderMutation(
     event.calendarId as ProviderCalendarId,
   );
   if (!calendar) throw new ProviderWriteUnavailableError();
+  const writer = await resolveProviderWriter(deps, calendar);
+  if (!writer) throw new ProviderWriteUnavailableError();
   return execute(
     {
       commands: deps.commands,
@@ -532,7 +559,7 @@ async function dispatchProviderMutation(
       occurrences: deps.occurrences,
       resources: deps.resources,
       connections: deps.connections,
-      writer: deps.provider.writer,
+      writer,
       custody: deps.provider.custody,
       markers: deps.markers,
     },

--- a/packages/sync/src/domain/provider-command.service.db.test.ts
+++ b/packages/sync/src/domain/provider-command.service.db.test.ts
@@ -485,9 +485,13 @@ describe("executeProviderCreate", () => {
     await storeCredential(credentials, calendar.connectionId);
     const custody = new CredentialCustody(
       credentials,
-      new RevokedAuthAdapter({
-        refreshError: new ProviderAuthError("authorizationRevoked", "revoked"),
-      }),
+      () =>
+        new RevokedAuthAdapter({
+          refreshError: new ProviderAuthError(
+            "authorizationRevoked",
+            "revoked",
+          ),
+        }),
     );
 
     const result = await executeProviderCreate(
@@ -927,7 +931,7 @@ describe("executeProviderUpdate", () => {
     });
     const custody = new CredentialCustody(
       credentials,
-      new RevokedAuthAdapter(),
+      () => new RevokedAuthAdapter(),
     );
     const writer = new FakeUpdateWriter();
     writer.fetchError = new ProviderWriteError(
@@ -2989,7 +2993,7 @@ describe("attendeesEdit replace", () => {
   });
 
   const connectionsWith = (email: string | null): ProviderConnectionLookup => ({
-    findById: async () => ({ account: { email } }),
+    findById: async () => ({ account: { email }, provider: "google" }),
   });
   const missingConnection: ProviderConnectionLookup = {
     findById: async () => null,
@@ -3691,7 +3695,7 @@ describe("executeProviderRsvp", () => {
   });
 
   const connectionsWith = (email: string | null): ProviderConnectionLookup => ({
-    findById: async () => ({ account: { email } }),
+    findById: async () => ({ account: { email }, provider: "google" }),
   });
   const missingConnection: ProviderConnectionLookup = {
     findById: async () => null,

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -15,6 +15,7 @@ import {
   type ConnectionId,
   type PrincipalId,
   type ProviderEventId,
+  type ProviderKind,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
 import {
@@ -66,6 +67,7 @@ export interface ProviderConnectionLookup {
     id: ConnectionId,
   ): Promise<{
     readonly account: { readonly email: string | null };
+    readonly provider: ProviderKind;
   } | null>;
 }
 

--- a/packages/sync/src/domain/stale-command-retry.service.db.test.ts
+++ b/packages/sync/src/domain/stale-command-retry.service.db.test.ts
@@ -6,9 +6,13 @@ import {
   type PrincipalId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
-import { seedProviderCalendar } from "@sync/__tests__/helpers/fixtures";
+import {
+  fakeAdapters,
+  seedProviderCalendar,
+} from "@sync/__tests__/helpers/fixtures";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { submitCloudCommand } from "@sync/domain/cloud-command.service";
+import { type ProviderConnectionLookup } from "@sync/domain/provider-command.service";
 import { retryStaleCommands } from "@sync/domain/stale-command-retry.service";
 import { type ProviderEvent } from "@sync/providers/provider-event.port";
 import {
@@ -106,6 +110,13 @@ describe("retryStaleCommands", () => {
     timeZone: "America/Denver",
   };
 
+  const connections: ProviderConnectionLookup = {
+    findById: async () => ({
+      account: { email: "user@example.com" },
+      provider: "google",
+    }),
+  };
+
   const baseDeps = (writer: ProviderEventWriter) => ({
     commands,
     events,
@@ -113,8 +124,20 @@ describe("retryStaleCommands", () => {
     occurrences,
     resources,
     markers,
+    connections,
     execution: "active" as const,
-    provider: { writer, custody: tokenSource() },
+    provider: {
+      resolveAdapters: () =>
+        fakeAdapters(
+          {
+            listEventPage: async () => {
+              throw new Error("reader unused in stale-command-retry tests");
+            },
+          },
+          { writer },
+        ),
+      custody: tokenSource(),
+    },
   });
 
   // Seed a provider-linked event stuck deletionPending, plus its still-pending

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -2,6 +2,7 @@ import { faker } from "@faker-js/faker";
 import {
   ensureEventsResource,
   FakeReader,
+  fakeResolveAdapters,
   pageOf as page,
   seedProviderCalendar,
   singleEvent as single,
@@ -12,8 +13,12 @@ import {
   dispatchSyncJob,
   type SyncJobDispatchDeps,
 } from "@sync/domain/sync-job-dispatch.service";
+import { ProviderNotConfiguredError } from "@sync/providers/provider-adapters";
 import { ProviderAuthError } from "@sync/providers/provider-auth.port";
-import { ProviderCalendarError } from "@sync/providers/provider-calendar.port";
+import {
+  type ProviderCalendarAdapter,
+  ProviderCalendarError,
+} from "@sync/providers/provider-calendar.port";
 import {
   ProviderEventReadError,
   type ProviderEventReader,
@@ -86,6 +91,38 @@ const discovery = {
   }),
 };
 
+const defaultGoogleConnection = (
+  tenantId: ProviderConnectionRecord["tenantId"],
+  principalId: ProviderConnectionRecord["principalId"],
+  id: ProviderConnectionRecord["_id"],
+): ProviderConnectionRecord => ({
+  _id: id,
+  tenantId,
+  principalId,
+  provider: "google",
+  account: {
+    email: "user@example.com",
+    displayName: "User",
+    providerAccountId: "google-subject",
+  },
+  capabilities: [
+    "readEvents",
+    "writeEvents",
+    "readBusy",
+    "inviteAttendees",
+    "changeNotifications",
+    "incrementalChanges",
+  ],
+  state: "healthy",
+  stateReason: null,
+  diagnosticKey: "0123456789abcdef0123456789abcdef",
+  disconnectedAt: null,
+  lastSyncedAt: null,
+  lastHealthyAt: null,
+  createdAt: now(),
+  updatedAt: now(),
+});
+
 describe("dispatchSyncJob", () => {
   const storage = setupSyncStorage(import.meta.url);
   let events: EventRepository;
@@ -98,7 +135,8 @@ describe("dispatchSyncJob", () => {
   let credentials: CredentialRepository;
   // Dispatch resolves the connection for a calendarListSync job; a test sets what
   // findById returns without seeding a full connection record.
-  let stubbedConnection: ProviderConnectionRecord | null;
+  // undefined: synthesize a google connection; null: no connection; else: use stub.
+  let stubbedConnection: ProviderConnectionRecord | null | undefined;
 
   beforeEach(() => {
     events = new EventRepository(storage.db());
@@ -109,11 +147,19 @@ describe("dispatchSyncJob", () => {
     jobs = new JobRepository(storage.db());
     invalidations = new InvalidationRepository(storage.db());
     credentials = new CredentialRepository(storage.db());
-    stubbedConnection = null;
+    stubbedConnection = undefined;
   });
 
   const connections = {
-    findById: async () => stubbedConnection,
+    findById: async (
+      tenantId: ProviderConnectionRecord["tenantId"],
+      principalId: ProviderConnectionRecord["principalId"],
+      id: ProviderConnectionRecord["_id"],
+    ) => {
+      if (stubbedConnection === null) return null;
+      if (stubbedConnection) return stubbedConnection;
+      return defaultGoogleConnection(tenantId, principalId, id);
+    },
     updateDerivedState: async (
       tenantId: ProviderConnectionRecord["tenantId"],
       principalId: ProviderConnectionRecord["principalId"],
@@ -134,8 +180,8 @@ describe("dispatchSyncJob", () => {
   const deps = (
     reader: FakeReader,
     custody: SyncJobDispatchDeps["custody"] = tokenSource,
-    notificationsOverride: SyncJobDispatchDeps["notifications"] = notifications,
-    discoveryOverride: SyncJobDispatchDeps["discovery"] = discovery,
+    notificationsOverride = notifications,
+    discoveryOverride = discovery,
   ): SyncJobDispatchDeps => ({
     events,
     occurrences,
@@ -143,12 +189,13 @@ describe("dispatchSyncJob", () => {
     calendars,
     connections,
     credentials,
-    discovery: discoveryOverride,
+    resolveAdapters: fakeResolveAdapters(reader, {
+      calendars: discoveryOverride,
+      notifications: notificationsOverride,
+    }),
     jobs,
     commands,
-    reader,
     custody,
-    notifications: notificationsOverride,
     callbackUrl: "https://sync.example/sync/notifications/google",
     invalidations,
   });
@@ -281,7 +328,10 @@ describe("dispatchSyncJob", () => {
     };
 
     await dispatchSyncJob(
-      { ...deps(new FakeReader([])), reader },
+      {
+        ...deps(new FakeReader([])),
+        resolveAdapters: fakeResolveAdapters(reader),
+      },
       jobFor(resource, "incrementalPull"),
       now,
     );
@@ -321,7 +371,7 @@ describe("dispatchSyncJob", () => {
     await dispatchSyncJob(
       {
         ...deps(new FakeReader([])),
-        reader,
+        resolveAdapters: fakeResolveAdapters(reader),
         log: { warn: (message) => warnings.push(message) },
       },
       jobFor(resource, "incrementalPull"),
@@ -1187,7 +1237,15 @@ describe("dispatchSyncJob", () => {
     const failingDeps: SyncJobDispatchDeps = {
       ...deps(new FakeReader([page([], { nextSyncToken: "cursor-2" })])),
       connections: {
-        findById: async () => stubbedConnection,
+        findById: async (
+          tenantId: ProviderConnectionRecord["tenantId"],
+          principalId: ProviderConnectionRecord["principalId"],
+          id: ProviderConnectionRecord["_id"],
+        ) => {
+          if (stubbedConnection === null) return null;
+          if (stubbedConnection) return stubbedConnection;
+          return defaultGoogleConnection(tenantId, principalId, id);
+        },
         updateDerivedState: async () => {
           throw new Error("derived-state write failed");
         },
@@ -1287,7 +1345,7 @@ describe("dispatchSyncJob", () => {
     // provider (its enqueue coalesced onto this very job and vanished); the
     // moved marker must make dispatch go round again.
     let calls = 0;
-    const restlessDiscovery: SyncJobDispatchDeps["discovery"] = {
+    const restlessDiscovery: ProviderCalendarAdapter = {
       discoverCalendars: async () => {
         calls += 1;
         if (calls === 1) {
@@ -1422,8 +1480,9 @@ describe("dispatchSyncJob", () => {
       _id: connectionId,
       tenantId,
       principalId,
+      provider: "google",
     } as ProviderConnectionRecord;
-    const failingDiscovery: SyncJobDispatchDeps["discovery"] = {
+    const failingDiscovery: ProviderCalendarAdapter = {
       discoverCalendars: async () => {
         throw new ProviderCalendarError(
           "discoveryFailed",
@@ -1467,8 +1526,9 @@ describe("dispatchSyncJob", () => {
       _id: connectionId,
       tenantId,
       principalId,
+      provider: "google",
     } as ProviderConnectionRecord;
-    const transientDiscovery: SyncJobDispatchDeps["discovery"] = {
+    const transientDiscovery: ProviderCalendarAdapter = {
       discoverCalendars: async () => {
         throw new ProviderCalendarError(
           "transient",
@@ -1490,5 +1550,50 @@ describe("dispatchSyncJob", () => {
         now,
       ),
     ).rejects.toMatchObject({ reason: "transient" });
+  });
+
+  it("fails a resource job with providerNotConfigured without touching the resource", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, null);
+    const before = await resources.findById(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+    );
+    stubbedConnection = defaultGoogleConnection(
+      resource.tenantId,
+      resource.principalId,
+      resource.connectionId,
+    );
+    stubbedConnection = {
+      ...stubbedConnection,
+      provider: "microsoft",
+    };
+
+    const reader = new FakeReader([]);
+    const outcome = await dispatchSyncJob(
+      {
+        ...deps(reader),
+        resolveAdapters: (provider) => {
+          if (provider === "microsoft") {
+            throw new ProviderNotConfiguredError("microsoft");
+          }
+          return fakeResolveAdapters(reader)();
+        },
+      },
+      jobFor(resource, "initialImport"),
+      now,
+    );
+
+    expect(outcome).toEqual({
+      result: "fail",
+      reason: "providerNotConfigured",
+    });
+    const after = await resources.findById(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+    );
+    expect(after).toEqual(before);
   });
 });

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -6,6 +6,11 @@ import { repairCalendar } from "@sync/domain/calendar-repair.service";
 import { refreshConnectionStateAfterJob } from "@sync/domain/connection-state-refresh.service";
 import { type AccessTokenSource } from "@sync/domain/provider-write-ladder";
 import { maintainSubscription } from "@sync/domain/subscription-maintenance.service";
+import {
+  type ProviderAdapters,
+  ProviderNotConfiguredError,
+  type ResolveProviderAdapters,
+} from "@sync/providers/provider-adapters";
 import { ProviderAuthError } from "@sync/providers/provider-auth.port";
 import {
   type ProviderCalendarAdapter,
@@ -22,6 +27,7 @@ import {
   resourceJob,
 } from "@sync/storage/contracts/job.contracts";
 import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
+import { type ProviderConnectionRecord } from "@sync/storage/contracts/provider-connection.contracts";
 import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";
 import { type CommandRepository } from "@sync/storage/repositories/command.repository";
 import { type CredentialRepository } from "@sync/storage/repositories/credential.repository";
@@ -42,15 +48,11 @@ export interface SyncJobDispatchDeps {
   // discovers its calendars, and enqueues an initial import per active calendar.
   connections: ProviderConnectionRepository;
   credentials: CredentialRepository;
-  discovery: ProviderCalendarAdapter;
+  resolveAdapters: ResolveProviderAdapters;
   jobs: JobRepository;
   // pullCalendarChanges consults pending commands before deleting an event.
   commands: CommandRepository;
-  reader: ProviderEventReader;
   custody: AccessTokenSource;
-  // maintainSubscription opens/renews the calendar's push channel; the callback
-  // url is where the provider posts change notifications back to this service.
-  notifications: ProviderNotificationAdapter;
   callbackUrl: string;
   // Content-free outbox so Compass API can push typed browser SSE after a
   // provider pull. Without this, incremental pulls update Sync storage but the
@@ -67,6 +69,42 @@ export interface SyncJobDispatchDeps {
   };
 }
 
+// Per-connection adapter ports resolved from the connection's provider kind.
+export interface SyncJobExecutionDeps extends SyncJobDispatchDeps {
+  reader: ProviderEventReader;
+  discovery: ProviderCalendarAdapter;
+  notifications: ProviderNotificationAdapter;
+}
+
+export function executionDepsForAdapters(
+  deps: SyncJobDispatchDeps,
+  adapters: ProviderAdapters,
+): SyncJobExecutionDeps {
+  return {
+    ...deps,
+    reader: adapters.reader,
+    discovery: adapters.calendars,
+    notifications: adapters.notifications,
+  };
+}
+
+function resolveConnectionAdapters(
+  deps: SyncJobDispatchDeps,
+  connection: ProviderConnectionRecord,
+): SyncJobExecutionDeps | { result: "fail"; reason: "providerNotConfigured" } {
+  try {
+    return executionDepsForAdapters(
+      deps,
+      deps.resolveAdapters(connection.provider),
+    );
+  } catch (error) {
+    if (error instanceof ProviderNotConfiguredError) {
+      return { result: "fail", reason: "providerNotConfigured" };
+    }
+    throw error;
+  }
+}
+
 // The decision a dispatch makes about a claimed job. The worker loop (a later
 // slice) owns the lease and turns this into a JobRepository call; keeping the
 // decision pure keeps dispatch trivially testable without a queue.
@@ -78,7 +116,9 @@ export type SyncJobOutcome =
   | { readonly result: "retry"; readonly reason: string }
   // Nothing to act on — the job's target vanished (resource/calendar deleted) or
   // the job is malformed for its kind. Settle complete; retrying can't help.
-  | { readonly result: "drop"; readonly reason: string };
+  | { readonly result: "drop"; readonly reason: string }
+  // The connection's provider has no configured adapter set; retrying cannot help.
+  | { readonly result: "fail"; readonly reason: "providerNotConfigured" };
 
 // Run one claimed sync job (calendarListSync / initialImport / incrementalPull /
 // repair / subscriptionMaintain) and report how to settle it. calendarListSync
@@ -238,13 +278,15 @@ async function runSyncJob(
     if (!connection) {
       return { result: "drop", reason: "connection no longer exists" };
     }
+    const executionDeps = resolveConnectionAdapters(deps, connection);
+    if ("result" in executionDeps) return executionDeps;
     // Re-list while notifications land mid-pass, mirroring pullUntilQuiet: a
     // webhook that arrives while this job is CLAIMED coalesces onto it and
     // vanishes, so the moved change marker is the only signal that this pass
     // listed a snapshot from before the change. On giving up the marker stays
     // set and the daily rediscovery sweep covers the remainder.
     const { last: list, gaveUp } = await repeatWhileChanged(
-      () => syncCalendarList(deps, connection, now),
+      () => syncCalendarList(executionDeps, connection, now),
       (result) => result.changedDuringSync,
       (pass) =>
         deps.log?.info?.(
@@ -277,6 +319,17 @@ async function runSyncJob(
     return { result: "done" };
   }
 
+  const connection = await deps.connections.findById(
+    job.tenantId,
+    job.principalId,
+    job.connectionId,
+  );
+  if (!connection) {
+    return { result: "drop", reason: "connection no longer exists" };
+  }
+  const executionDeps = resolveConnectionAdapters(deps, connection);
+  if ("result" in executionDeps) return executionDeps;
+
   if (!job.resourceId) {
     return { result: "drop", reason: "job has no resourceId" };
   }
@@ -295,7 +348,7 @@ async function runSyncJob(
         reason: "calendar-list resource only accepts subscriptionMaintain",
       };
     }
-    await maintainSubscription(deps, null, resource, now);
+    await maintainSubscription(executionDeps, null, resource, now);
     return { result: "done" };
   }
   if (!resource.calendarId) {
@@ -378,7 +431,7 @@ async function runSyncJob(
       // Idempotent: a resource that already holds a cursor no-ops inside.
       // Notify the browser after the windowed horizon pass so events in the
       // current view can appear before the full historical scrape finishes.
-      await importCalendarEvents(deps, calendar, now, {
+      await importCalendarEvents(executionDeps, calendar, now, {
         onWindowedPassComplete: async () => {
           await appendCalendarInvalidation(deps, calendar, now());
         },
@@ -407,7 +460,7 @@ async function runSyncJob(
       };
     }
     case "incrementalPull": {
-      const pull = await pullUntilQuiet(deps, calendar, now);
+      const pull = await pullUntilQuiet(executionDeps, calendar, now);
       if (pull.status === "applied") {
         // The stored cursor worked, so whatever streak it had is over. Guarded
         // so the overwhelmingly common healthy pull writes nothing.
@@ -471,7 +524,7 @@ async function runSyncJob(
       // provider watch durable. It deliberately has its own job kind so an
       // unrelated reconcile/manual pull can never make a new connection look
       // ready before watch setup has completed.
-      const pull = await pullUntilQuiet(deps, calendar, now);
+      const pull = await pullUntilQuiet(executionDeps, calendar, now);
       if (pull.status === "applied") {
         await deps.resources.setBootstrapState(
           resource.tenantId,
@@ -498,7 +551,7 @@ async function runSyncJob(
       };
     }
     case "repair": {
-      const repair = await repairCalendar(deps, calendar, now);
+      const repair = await repairCalendar(executionDeps, calendar, now);
       // An incomplete repair (the pass yielded no durable cursor) left the old
       // generation intact; retry the whole rebuild later rather than settle.
       if (repair.status === "repaired") {
@@ -523,7 +576,7 @@ async function runSyncJob(
       // including durable watchFailed, which maintainSubscription folds into
       // unsupported. A transient watch failure throws and the worker retries.
       const subscription = await maintainSubscription(
-        deps,
+        executionDeps,
         calendar,
         resource,
         now,
@@ -636,7 +689,7 @@ async function repeatWhileChanged<T>(
 }
 
 async function pullUntilQuiet(
-  deps: SyncJobDispatchDeps,
+  deps: SyncJobExecutionDeps,
   calendar: ProviderCalendarRecord,
   now: () => Date,
 ): Promise<Awaited<ReturnType<typeof pullCalendarChanges>>> {

--- a/packages/sync/src/domain/sync-job-worker.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.db.test.ts
@@ -1,6 +1,8 @@
 import { faker } from "@faker-js/faker";
 import {
+  ensureEventsResource,
   FakeReader,
+  fakeResolveAdapters,
   pageOf,
   seedProviderCalendar,
   singleEvent as single,
@@ -11,7 +13,10 @@ import {
   SyncJobWorker,
   type SyncJobWorkerDeps,
 } from "@sync/domain/sync-job-worker.service";
-import { ProviderCalendarError } from "@sync/providers/provider-calendar.port";
+import {
+  type ProviderCalendarAdapter,
+  ProviderCalendarError,
+} from "@sync/providers/provider-calendar.port";
 import { ProviderEventReadError } from "@sync/providers/provider-event-reader.port";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import { type JobRecord } from "@sync/storage/contracts/job.contracts";
@@ -53,14 +58,49 @@ describe("SyncJobWorker", () => {
     invalidations = new InvalidationRepository(storage.db());
   });
 
-  const defaultDiscovery: SyncJobWorkerDeps["discovery"] = {
-    provider: "google",
+  const defaultDiscovery: ProviderCalendarAdapter = {
     discoverCalendars: async () => ({ calendars: [], cursor: null }),
+  };
+
+  const seedCalendar = async (
+    overrides: Parameters<typeof seedProviderCalendar>[1] = {},
+  ): Promise<ProviderCalendarRecord> => {
+    const tenantId =
+      overrides.tenantId ?? (objectId() as ProviderCalendarRecord["tenantId"]);
+    const principalId =
+      overrides.principalId ??
+      (objectId() as ProviderCalendarRecord["principalId"]);
+    const connection = await connections.upsertByProviderAccount({
+      tenantId,
+      principalId,
+      provider: "google",
+      account: {
+        email: "user@example.com",
+        displayName: "User",
+        providerAccountId: "google-subject",
+      },
+      capabilities: [
+        "readEvents",
+        "writeEvents",
+        "readBusy",
+        "inviteAttendees",
+        "changeNotifications",
+        "incrementalChanges",
+      ],
+      state: "healthy",
+      stateReason: null,
+    });
+    return seedProviderCalendar(calendars, {
+      tenantId,
+      principalId,
+      connectionId: connection._id,
+      ...overrides,
+    });
   };
 
   const deps = (
     reader: FakeReader,
-    discoveryOverride: SyncJobWorkerDeps["discovery"] = defaultDiscovery,
+    discoveryOverride: ProviderCalendarAdapter = defaultDiscovery,
   ): SyncJobWorkerDeps => ({
     events,
     occurrences,
@@ -68,17 +108,12 @@ describe("SyncJobWorker", () => {
     calendars,
     connections,
     credentials: new CredentialRepository(storage.db()),
-    discovery: discoveryOverride,
+    resolveAdapters: fakeResolveAdapters(reader, {
+      calendars: discoveryOverride,
+    }),
     commands,
     jobs,
-    reader,
     custody: tokenSource,
-    notifications: {
-      watch: async () => {
-        throw new Error("watch not used in worker tests");
-      },
-      stopChannel: async () => {},
-    },
     callbackUrl: "https://sync.example/sync/notifications/google",
     invalidations,
   });
@@ -90,7 +125,7 @@ describe("SyncJobWorker", () => {
   // was taken (and why) rather than only that the job row vanished.
   const workerRecordingDrops = (
     reader: FakeReader,
-    discoveryOverride: SyncJobWorkerDeps["discovery"] = defaultDiscovery,
+    discoveryOverride: ProviderCalendarAdapter = defaultDiscovery,
   ) => {
     const drops: string[] = [];
     const w = new SyncJobWorker(deps(reader, discoveryOverride), OWNER, {
@@ -118,33 +153,14 @@ describe("SyncJobWorker", () => {
     options: { maxAttempts?: number; random?: () => number },
   ) => new SyncJobWorker(deps(reader), OWNER, { now, ...options });
 
-  const seedCalendar = (
-    overrides: Parameters<typeof seedProviderCalendar>[1] = {},
-  ): Promise<ProviderCalendarRecord> =>
-    seedProviderCalendar(calendars, overrides);
-
   const seedResource = async (
     calendar: ProviderCalendarRecord,
     cursor: string | null,
-  ): Promise<SyncResourceRecord> => {
-    const resource = await resources.ensure({
-      tenantId: calendar.tenantId,
-      principalId: calendar.principalId,
-      connectionId: calendar.connectionId,
-      resourceKind: "events",
-      calendarId: calendar._id,
+  ): Promise<SyncResourceRecord> =>
+    ensureEventsResource(resources, calendar, {
+      cursor: cursor ?? undefined,
+      now,
     });
-    if (cursor) {
-      await resources.advanceCursor(
-        calendar.tenantId,
-        calendar.principalId,
-        resource._id,
-        cursor,
-        now(),
-      );
-    }
-    return resource;
-  };
 
   const enqueue = (
     resource: Pick<

--- a/packages/sync/src/domain/sync-job-worker.service.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.ts
@@ -234,6 +234,16 @@ export class SyncJobWorker {
         await this.#deps.jobs.complete(job._id, this.#owner);
         await refreshConnectionStateAfterJob(this.#deps, job, this.#now);
         return;
+      case "fail":
+        this.#onFail(job, new Error(outcome.reason));
+        await this.#deps.jobs.fail(
+          job._id,
+          this.#owner,
+          outcome.reason,
+          this.#now(),
+        );
+        await refreshConnectionStateAfterJob(this.#deps, job, this.#now);
+        return;
       case "retry":
         await this.#settleFailure(job, new Error(outcome.reason));
         return;

--- a/packages/sync/src/providers/google/build-provider-resolvers.ts
+++ b/packages/sync/src/providers/google/build-provider-resolvers.ts
@@ -1,0 +1,80 @@
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+import { type SyncConfig } from "@sync/config/sync.config";
+import { GoogleAuthAdapter } from "@sync/providers/google/google-auth.adapter";
+import { GoogleCalendarAdapter } from "@sync/providers/google/google-calendar.adapter";
+import { GoogleEventReaderAdapter } from "@sync/providers/google/google-event-reader.adapter";
+import { GoogleEventWriter } from "@sync/providers/google/google-event-writer.adapter";
+import { GoogleNotificationAdapter } from "@sync/providers/google/google-notifications.adapter";
+import { GooglePeopleAdapter } from "@sync/providers/google/google-people.adapter";
+import {
+  type ProviderAdapters,
+  ProviderNotConfiguredError,
+  type ResolveProviderAdapters,
+  type ResolveProviderAuth,
+} from "@sync/providers/provider-adapters";
+import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
+
+export type ProviderAdapterOverrides = Partial<
+  Record<ProviderKind, Partial<ProviderAdapters>>
+>;
+
+function googleConfigured(config: SyncConfig): boolean {
+  return Boolean(config.GOOGLE_CLIENT_ID && config.GOOGLE_CLIENT_SECRET);
+}
+
+function googleAdapters(
+  config: SyncConfig,
+  override?: Partial<ProviderAdapters>,
+): ProviderAdapters {
+  // Tests inject partial overrides (auth/writer only) without real OAuth config.
+  if (!googleConfigured(config) && override?.auth === undefined) {
+    throw new ProviderNotConfiguredError("google");
+  }
+  return {
+    auth:
+      override?.auth ??
+      new GoogleAuthAdapter(
+        config.GOOGLE_CLIENT_ID!,
+        config.GOOGLE_CLIENT_SECRET!,
+      ),
+    calendars: override?.calendars ?? new GoogleCalendarAdapter(),
+    reader: override?.reader ?? new GoogleEventReaderAdapter(),
+    writer: override?.writer ?? new GoogleEventWriter(),
+    notifications: override?.notifications ?? new GoogleNotificationAdapter(),
+    contacts: override?.contacts ?? new GooglePeopleAdapter(),
+  };
+}
+
+export function buildResolveAdapters(
+  config: SyncConfig,
+  overrides: ProviderAdapterOverrides = {},
+): ResolveProviderAdapters {
+  return (provider) => {
+    if (provider === "google") {
+      return googleAdapters(config, overrides.google);
+    }
+    throw new ProviderNotConfiguredError(provider);
+  };
+}
+
+export function buildResolveAuth(
+  resolveAdapters: ResolveProviderAdapters,
+): ResolveProviderAuth {
+  return (provider) => resolveAdapters(provider).auth;
+}
+
+export function authResolverForAdapter(
+  adapter: ProviderAuthAdapter,
+  kind: ProviderKind = "google",
+): ResolveProviderAuth {
+  return (provider) => {
+    if (provider !== kind) {
+      throw new ProviderNotConfiguredError(provider);
+    }
+    return adapter;
+  };
+}
+
+export function googleProviderConfigured(config: SyncConfig): boolean {
+  return googleConfigured(config);
+}

--- a/packages/sync/src/providers/provider-adapters.ts
+++ b/packages/sync/src/providers/provider-adapters.ts
@@ -1,0 +1,34 @@
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
+import { type ProviderCalendarAdapter } from "@sync/providers/provider-calendar.port";
+import { type ContactsPort } from "@sync/providers/provider-contacts.port";
+import { type ProviderEventReader } from "@sync/providers/provider-event-reader.port";
+import { type ProviderEventWriter } from "@sync/providers/provider-event-writer.port";
+import { type ProviderNotificationAdapter } from "@sync/providers/provider-notifications.port";
+
+export interface ProviderAdapters {
+  auth: ProviderAuthAdapter;
+  calendars: ProviderCalendarAdapter;
+  reader: ProviderEventReader;
+  writer: ProviderEventWriter;
+  notifications: ProviderNotificationAdapter;
+  contacts?: ContactsPort;
+}
+
+export type ResolveProviderAdapters = (
+  provider: ProviderKind,
+) => ProviderAdapters;
+
+export type ResolveProviderAuth = (
+  provider: ProviderKind,
+) => ProviderAuthAdapter;
+
+export class ProviderNotConfiguredError extends Error {
+  readonly provider: ProviderKind;
+
+  constructor(provider: ProviderKind) {
+    super(`Provider ${provider} is not configured`);
+    this.name = "ProviderNotConfiguredError";
+    this.provider = provider;
+  }
+}

--- a/packages/sync/src/server/command.routes.ts
+++ b/packages/sync/src/server/command.routes.ts
@@ -13,6 +13,8 @@ import {
   ProviderWriteUnavailableError,
   submitCloudCommand,
 } from "@sync/domain/cloud-command.service";
+import { buildResolveAuth } from "@sync/providers/google/build-provider-resolvers";
+import { type ResolveProviderAdapters } from "@sync/providers/provider-adapters";
 import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
 import { type ProviderEventWriter } from "@sync/providers/provider-event-writer.port";
 import { redactedCause } from "@sync/safety/redact-error";
@@ -42,6 +44,7 @@ export interface CommandApiDeps {
   // provider-targeted commands pending.
   writer?: ProviderEventWriter;
   authAdapter?: ProviderAuthAdapter;
+  resolveAdapters?: ResolveProviderAdapters;
   // Injectable clock so local confirmation timestamps are deterministic in
   // tests.
   now?: () => number;
@@ -79,12 +82,12 @@ export function registerCommandRoutes(
         // custody is per-request (it holds the request's db-backed credential
         // repo), the writer is shared.
         const provider =
-          deps.writer && deps.authAdapter
+          deps.resolveAdapters && deps.authAdapter
             ? {
-                writer: deps.writer,
+                resolveAdapters: deps.resolveAdapters,
                 custody: new CredentialCustody(
                   repos.credentials,
-                  deps.authAdapter,
+                  buildResolveAuth(deps.resolveAdapters),
                 ),
               }
             : undefined;

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -49,8 +49,13 @@ import {
   HORIZON_PAST_MONTHS,
 } from "@sync/domain/horizon";
 import { signOAuthState, verifyOAuthState } from "@sync/oauth/oauth-state";
+import {
+  authResolverForAdapter,
+  buildResolveAuth,
+} from "@sync/providers/google/build-provider-resolvers";
 import { CONTACTS_FEATURE_SCOPES } from "@sync/providers/google/google.scopes";
 import { googleCapabilitiesFromScopes } from "@sync/providers/google/google-capabilities";
+import { type ResolveProviderAdapters } from "@sync/providers/provider-adapters";
 import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
 import { type ContactsPort } from "@sync/providers/provider-contacts.port";
 import { type ProviderEventWriter } from "@sync/providers/provider-event-writer.port";
@@ -111,6 +116,7 @@ export interface ConnectionApiDeps {
   // The provider authorization adapter, present only when the provider is
   // configured. Absent (or passive mode) means no provider work is possible.
   authAdapter?: ProviderAuthAdapter;
+  resolveAdapters?: ResolveProviderAdapters;
   // The provider event writer, present only when the provider is configured.
   // Not used by the connection routes themselves; carried here because this is
   // the shared bag the command routes are wired from.
@@ -825,7 +831,7 @@ export function registerConnectionRoutes(
         // failure converges.
         const custody = new CredentialCustody(
           new CredentialRepository(deps.mongo.db),
-          deps.authAdapter,
+          resolveAuthForConnectionApi(deps),
         );
         await custody.disconnect(id.data);
         await connections.markDisconnected(
@@ -845,6 +851,16 @@ export function registerConnectionRoutes(
 // Redirect the browser to the server-configured post-connect URL with a coarse
 // status. The base is from config, never the request, so it can't be abused as
 // an open redirect; status is a fixed label, carrying no provider detail.
+function resolveAuthForConnectionApi(
+  deps: ConnectionApiDeps,
+  authAdapter: ProviderAuthAdapter = deps.authAdapter!,
+) {
+  if (deps.resolveAdapters) {
+    return buildResolveAuth(deps.resolveAdapters);
+  }
+  return authResolverForAdapter(authAdapter);
+}
+
 function redirectAfterConnect(
   deps: ConnectionApiDeps,
   res: Response,
@@ -913,7 +929,10 @@ async function linkConnection(
   });
 
   try {
-    const custody = new CredentialCustody(repos.credentials, authAdapter);
+    const custody = new CredentialCustody(
+      repos.credentials,
+      resolveAuthForConnectionApi(deps, authAdapter),
+    );
     await custody.store({
       connectionId: connection._id,
       provider: "google",

--- a/packages/sync/src/server/contacts.routes.ts
+++ b/packages/sync/src/server/contacts.routes.ts
@@ -10,6 +10,7 @@ import {
 } from "@core/types/contact.contracts";
 import { type SyncExecutionMode } from "@sync/config/sync.config";
 import { CredentialCustody } from "@sync/credentials/credential-custody.service";
+import { authResolverForAdapter } from "@sync/providers/google/build-provider-resolvers";
 import {
   GOOGLE_SCOPE_CONTACTS_OTHER_READONLY,
   GOOGLE_SCOPE_CONTACTS_READONLY,
@@ -111,7 +112,7 @@ export function registerContactsRoutes(
 
         const custody = new CredentialCustody(
           repos.credentials,
-          deps.authAdapter,
+          authResolverForAdapter(deps.authAdapter),
         );
         const collected: ContactSuggestion[] = [];
         for (const connection of capable) {

--- a/packages/sync/src/server/principal.routes.ts
+++ b/packages/sync/src/server/principal.routes.ts
@@ -4,6 +4,7 @@ import { Logger } from "@core/logger/winston.logger";
 import { PrincipalPurgeResponseSchema } from "@core/types/sync/principal.contracts";
 import { CredentialCustody } from "@sync/credentials/credential-custody.service";
 import { purgePrincipal } from "@sync/domain/principal-purge.service";
+import { authResolverForAdapter } from "@sync/providers/google/build-provider-resolvers";
 import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
 import { redactedCause } from "@sync/safety/redact-error";
 import {
@@ -50,7 +51,10 @@ export function registerPrincipalRoutes(
           {
             ...repos,
             custody: deps.authAdapter
-              ? new CredentialCustody(repos.credentials, deps.authAdapter)
+              ? new CredentialCustody(
+                  repos.credentials,
+                  authResolverForAdapter(deps.authAdapter),
+                )
               : undefined,
           },
           auth.tenantId,

--- a/packages/sync/src/server/sync.server.ts
+++ b/packages/sync/src/server/sync.server.ts
@@ -43,6 +43,7 @@ export function buildSyncApp(deps: {
       authMiddleware: deps.connectionApi.authMiddleware,
       mongo: deps.connectionApi.mongo,
       execution: deps.connectionApi.execution,
+      resolveAdapters: deps.connectionApi.resolveAdapters,
       writer: deps.connectionApi.writer,
       authAdapter: deps.connectionApi.authAdapter,
       now: deps.connectionApi.now,


### PR DESCRIPTION
Fixes #3225

## Summary

WP-03a prepares sync dispatch and credential custody to resolve provider adapters per connection instead of wiring one Google adapter set per process.

- Added `ProviderAdapters`, `ResolveProviderAdapters`, `ResolveProviderAuth`, and `ProviderNotConfiguredError` in `packages/sync/src/providers/provider-adapters.ts`.
- `SyncJobDispatchDeps` now takes `resolveAdapters(provider)`; resource-family jobs look up the connection and resolve adapters from `connection.provider`.
- `CredentialCustody` takes `resolveAuth(provider)` and resolves auth from the credential row's `provider` on refresh and revoke.
- `app.ts` and route wiring supply `buildResolveAdapters` / `buildResolveAuth` from `packages/sync/src/providers/google/build-provider-resolvers.ts`.
- Test helpers gained `fakeAdapters()` / `fakeResolveAdapters()`; dispatch tests cover permanent `providerNotConfigured` for unknown providers.

## Simplicity

Google construction stays under `providers/google/`; `app.ts` keeps legacy `buildAuthAdapter` / `buildEventWriter` / `buildContactsPort` for connection API overrides. Domain code uses capabilities and resolver indirection, not `provider === "google"` branches.

## Automated validation

- `bun test:sync`: 1125 pass, 0 fail
- Acceptance grep: only `app.ts` contains `new Google` outside `providers/google` and tests
- New test: resource job for Microsoft provider returns `{ result: "fail", reason: "providerNotConfigured" }` without mutating the resource

## Independent review

VERDICT: no confirmed findings

Reviewed resolver wiring, custody auth resolution from credential provider, permanent fail path for unknown providers, and test coverage for the new contract. No provider-specific branching added in domain services.

Handoff: `.agents/handoffs/3225.md`

## Test plan

- [x] `bun run verify` (sync: test:sync, type-check, lint, knip) — PASS
- [x] `bun test:sync` — 1125 pass
- [x] `grep -rn 'new Google' packages/sync/src --include='*.ts' | grep -v providers/google | grep -v test` — only `app.ts`