### PR TITLE
feat(web): split the welcome overlay into three one-action screens

### DIFF
--- a/docs/frontend/frontend-runtime-flow.md
+++ b/docs/frontend/frontend-runtime-flow.md
@@ -72,13 +72,25 @@ site; the calendar views stay keyboard-only.
 Welcome → signup → first-event contract:
 
 - unauthenticated users who have not seen welcome get `WelcomeModal`
-- the welcome CTA order is **Continue with Google** (`G`, when Google is
+- welcome is three screens in one dialog, each with one focused primary
+  button so Enter (or a click) is always the obvious next thing: **Get
+  started for free** (headline, tagline, one-sentence pitch) → **Next** over
+  the five FAQ rows (digits `1`–`5` toggle them, only on this screen) →
+  the auth choices. `Log in` (`i`) and a three-dot step indicator sit on
+  every screen. Escape, the backdrop and **Back** step back one screen and
+  are a no-op on the first, so a stray Escape never drops a first-timer into
+  the practice game
+- the welcome overlay is the one calendar surface where the mouse works
+  (`data-pointer-pass`): a landing page should behave like a normal site, and
+  keyboard-only starts once the visitor enters the calendar
+- the last screen's CTA order is **Continue with Google** (`G`, when Google is
   available), **Sign up with email** (`U`), then **Explore without an account**
-  (`S`). Google leads because the scopes Compass requests include the calendar,
-  so that one round trip signs the user up *and* connects it — the moment the
-  product starts being worth keeping
-- **Explore without an account**, the backdrop, and Escape start the Shortcut
-  Showcase (`entry: "welcome"`) after the welcome dialog unmounts
+  (`S`), with the social and legal links (`6`–`0`) below. Google leads
+  because the scopes Compass requests include the calendar, so that one round
+  trip signs the user up *and* connects it, the moment the product starts
+  being worth keeping
+- **Explore without an account** starts the Shortcut Showcase
+  (`entry: "welcome"`) after the welcome dialog unmounts
 - **Log in** opens the auth modal and leaves the showcase flags alone, so a
   returning user is not handed the practice or the first-event prompt
 - signing up (either route) defers a showcase offer via `showcase.storage.ts`;

--- a/e2e/onboarding/first-run.spec.ts
+++ b/e2e/onboarding/first-run.spec.ts
@@ -28,6 +28,22 @@ test("welcomes a first-time user and seeds sample events", async ({
   });
   await expect(welcomeDialog).toBeVisible();
 
+  // The welcome overlay is the one calendar surface where the mouse works,
+  // so the first screen's only action is proven by a real click. Escape
+  // steps back a screen; the second Enter reaches the auth choices.
+  await welcomeDialog
+    .getByRole("button", { name: "Get started for free" })
+    .click();
+  await expect(
+    welcomeDialog.getByRole("button", { name: "Who is Compass for?" }),
+  ).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(
+    welcomeDialog.getByRole("button", { name: "Get started for free" }),
+  ).toBeFocused();
+  await page.keyboard.press("Enter");
+  await page.keyboard.press("Enter");
+
   // The welcome modal advertises S for this action; prove the shortcut.
   await expect(
     welcomeDialog.getByRole("button", { name: "Explore without an account" }),

--- a/e2e/onboarding/shortcut-showcase.spec.ts
+++ b/e2e/onboarding/shortcut-showcase.spec.ts
@@ -9,6 +9,15 @@ const leaveWelcome = async (page: Page) => {
     name: "Welcome to Compass Calendar",
   });
   await expect(welcomeDialog).toBeVisible();
+  // Three screens, one primary action each: Enter advances.
+  await expect(
+    welcomeDialog.getByRole("button", { name: "Get started for free" }),
+  ).toBeFocused();
+  await page.keyboard.press("Enter");
+  await expect(
+    welcomeDialog.getByRole("button", { name: "Who is Compass for?" }),
+  ).toBeVisible();
+  await page.keyboard.press("Enter");
   await expect(
     welcomeDialog.getByRole("button", { name: "Explore without an account" }),
   ).toBeVisible();

--- a/packages/web/src/auth/posthog/track.ts
+++ b/packages/web/src/auth/posthog/track.ts
@@ -3,6 +3,7 @@ import { getPosthogClient } from "@web/auth/posthog/posthog.bootstrap";
 export type ProductEvent =
   | "welcome_modal_shown"
   | "welcome_modal_dismissed"
+  | "welcome_step_viewed"
   | "signup_started"
   | "signup_completed"
   | "google_oauth_redirect_started"

--- a/packages/web/src/components/WelcomeModal/WelcomeFaqList.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeFaqList.tsx
@@ -1,0 +1,82 @@
+import classNames from "classnames";
+import { useId } from "react";
+import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
+import { pointerShortcutAttributes } from "@web/shortcuts/keyboard-only/pointer-action";
+import { ShortcutTipParts } from "@web/shortcuts/tips/ShortcutTipParts";
+import { FAQ_ITEMS } from "./faq";
+import { flashedShortcutClass } from "./useFlashedWelcomeShortcut";
+
+/**
+ * The FAQ disclosure rows. Digits 1-5 toggle them; state lives in the caller
+ * (useFaqDisclosure) so the digit listener can be mounted once per surface.
+ */
+export function WelcomeFaqList({
+  expanded,
+  onToggle,
+  flashedKey,
+  describedById,
+}: {
+  expanded: Set<string>;
+  onToggle: (question: string) => void;
+  flashedKey: string | null;
+  describedById?: string;
+}) {
+  const disclosureIdPrefix = useId();
+
+  return (
+    <div
+      aria-describedby={describedById}
+      className="flex w-full flex-col divide-y divide-border"
+    >
+      {FAQ_ITEMS.map((item, index) => {
+        const isExpanded = expanded.has(item.question);
+        const answerId = `${disclosureIdPrefix}-faq-answer-${index}`;
+        const state = isExpanded ? "open" : "closed";
+        const digit = String(index + 1);
+
+        return (
+          <div key={item.question} className="py-3">
+            <div
+              className="flex items-center justify-between gap-3"
+              {...pointerShortcutAttributes(digit)}
+            >
+              <button
+                type="button"
+                aria-controls={answerId}
+                aria-expanded={isExpanded}
+                className="c-focus-ring w-full cursor-pointer select-none text-left font-medium text-sm text-text transition-colors hover:text-text-lightest"
+                onClick={() => onToggle(item.question)}
+              >
+                {item.question}
+              </button>
+              <span
+                className={classNames(
+                  "shrink-0",
+                  flashedShortcutClass(flashedKey, digit),
+                )}
+              >
+                <ShortcutHint>{digit}</ShortcutHint>
+              </span>
+            </div>
+            <div
+              id={answerId}
+              aria-hidden={!isExpanded}
+              className="c-disclosure-content"
+              data-state={state}
+            >
+              <div>
+                <div className="mt-2 text-sm text-text-muted leading-relaxed">
+                  {typeof item.answer === "string" ? (
+                    item.answer
+                  ) : (
+                    <ShortcutTipParts parts={item.answer} />
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/web/src/components/WelcomeModal/WelcomeGuideBody.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeGuideBody.tsx
@@ -1,13 +1,10 @@
-import classNames from "classnames";
-import { type ReactNode, useCallback, useId, useState } from "react";
-import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
-import { pointerShortcutAttributes } from "@web/shortcuts/keyboard-only/pointer-action";
-import { ShortcutTipParts } from "@web/shortcuts/tips/ShortcutTipParts";
-import { FAQ_ITEMS } from "./faq";
-import { flashedShortcutClass } from "./useFlashedWelcomeShortcut";
+import { type ReactNode, useId } from "react";
+import { useFaqDisclosure } from "./useFaqDisclosure";
 import { useWelcomeJumpShortcuts } from "./useWelcomeJumpShortcuts";
+import { WelcomeFaqList } from "./WelcomeFaqList";
 import { WelcomeLinks } from "./WelcomeLinks";
 
+/** The signed-in welcome guide: headline, FAQ, and footer links on one screen. */
 export function WelcomeGuideBody({
   children,
   flashedKey,
@@ -15,35 +12,9 @@ export function WelcomeGuideBody({
   children?: ReactNode;
   flashedKey: string | null;
 }) {
-  const disclosureIdPrefix = useId();
-  const faqHintId = `${disclosureIdPrefix}-faq-hint`;
-  const [expandedFaqs, setExpandedFaqs] = useState<Set<string>>(
-    () => new Set(),
-  );
-
-  const toggleFaq = useCallback((question: string) => {
-    setExpandedFaqs((currentFaqs) => {
-      const nextFaqs = new Set(currentFaqs);
-
-      if (nextFaqs.has(question)) {
-        nextFaqs.delete(question);
-      } else {
-        nextFaqs.add(question);
-      }
-
-      return nextFaqs;
-    });
-  }, []);
-
-  const toggleFaqAt = useCallback(
-    (index: number) => {
-      const item = FAQ_ITEMS[index];
-      if (item) toggleFaq(item.question);
-    },
-    [toggleFaq],
-  );
-
-  useWelcomeJumpShortcuts(toggleFaqAt);
+  const faqHintId = `${useId()}-faq-hint`;
+  const faq = useFaqDisclosure();
+  useWelcomeJumpShortcuts(faq.toggleAt);
 
   return (
     <>
@@ -57,60 +28,12 @@ export function WelcomeGuideBody({
         </p>
       </div>
 
-      <div
-        aria-describedby={faqHintId}
-        className="flex w-full flex-col divide-y divide-border"
-      >
-        {FAQ_ITEMS.map((item, index) => {
-          const isExpanded = expandedFaqs.has(item.question);
-          const answerId = `${disclosureIdPrefix}-faq-answer-${index}`;
-          const state = isExpanded ? "open" : "closed";
-          const digit = String(index + 1);
-
-          return (
-            <div key={item.question} className="py-3">
-              <div
-                className="flex items-center justify-between gap-3"
-                {...pointerShortcutAttributes(digit)}
-              >
-                <button
-                  type="button"
-                  aria-controls={answerId}
-                  aria-expanded={isExpanded}
-                  className="c-focus-ring w-full cursor-pointer select-none text-left font-medium text-sm text-text transition-colors hover:text-text-lightest"
-                  onClick={() => toggleFaq(item.question)}
-                >
-                  {item.question}
-                </button>
-                <span
-                  className={classNames(
-                    "shrink-0",
-                    flashedShortcutClass(flashedKey, digit),
-                  )}
-                >
-                  <ShortcutHint>{digit}</ShortcutHint>
-                </span>
-              </div>
-              <div
-                id={answerId}
-                aria-hidden={!isExpanded}
-                className="c-disclosure-content"
-                data-state={state}
-              >
-                <div>
-                  <div className="mt-2 text-sm text-text-muted leading-relaxed">
-                    {typeof item.answer === "string" ? (
-                      item.answer
-                    ) : (
-                      <ShortcutTipParts parts={item.answer} />
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
-          );
-        })}
-      </div>
+      <WelcomeFaqList
+        describedById={faqHintId}
+        expanded={faq.expanded}
+        flashedKey={flashedKey}
+        onToggle={faq.toggle}
+      />
 
       <p id={faqHintId} className="text-text-muted text-xs leading-relaxed">
         Tip: Press a number to open a question or a link.

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -68,6 +68,18 @@ const { STORAGE_KEYS } =
 const { useShortcutShowcaseStore, initialShortcutShowcaseState } =
   require("@web/components/ShortcutShowcase/showcase.store") as typeof import("@web/components/ShortcutShowcase/showcase.store");
 
+const WELCOME_DIALOG = { name: "Welcome to Compass Calendar" };
+
+// Screens 1 and 2 each seat focus on one primary button, and Enter is its
+// native activation. Two presses reach the screen with the auth choices.
+const goToChooseScreen = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.keyboard("{Enter}");
+  await user.keyboard("{Enter}");
+  expect(
+    screen.getByRole("button", { name: "Explore without an account" }),
+  ).toBeTruthy();
+};
+
 describe("WelcomeModal", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -129,7 +141,9 @@ describe("WelcomeModal", () => {
         <WelcomeModal />
       </>,
     );
-    expect(screen.getByRole("button", { name: "Sign up" })).toHaveFocus();
+    expect(
+      screen.getByRole("button", { name: "Get started for free" }),
+    ).toHaveFocus();
 
     await user.click(screen.getByRole("button", { name: "Log in" }));
     authModalState.isOpen = true;
@@ -166,10 +180,107 @@ describe("WelcomeModal", () => {
     ).toBeTruthy();
   });
 
-  it("expands and collapses FAQ answers", async () => {
+  it("opens on a single Get started action with the headline as the page heading", () => {
+    render(<WelcomeModal />);
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "The Keyboard Calendar" }),
+    ).toBeTruthy();
+    expect(screen.getByText("Step 1 of 3")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Get started for free" }),
+    ).toHaveFocus();
+    expect(screen.getByText("No account needed.")).toBeTruthy();
+    for (const name of [
+      "Sign up",
+      "Continue with Google",
+      "Explore without an account",
+      "Who is Compass for?",
+    ]) {
+      expect(screen.queryByRole("button", { name })).toBeNull();
+    }
+    expect(screen.queryByRole("link", { name: "Terms" })).toBeNull();
+  });
+
+  it("advances with Enter or a click, and Escape steps back", async () => {
+    const user = userEvent.setup();
+    render(<WelcomeModal />);
+
+    await user.keyboard("{Enter}");
+    expect(screen.getByText("Step 2 of 3")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Who is Compass for?" }),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Next" })).toHaveFocus();
+
+    await user.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByText("Step 3 of 3")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Terms" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Sign up" })).toHaveFocus();
+
+    await user.keyboard("{Escape}");
+    expect(screen.getByText("Step 2 of 3")).toBeTruthy();
+    await user.click(screen.getByRole("button", { name: "Back" }));
+    expect(screen.getByText("Step 1 of 3")).toBeTruthy();
+
+    // Escape on the first screen is a no-op: the dialog stays and nothing
+    // starts the practice game behind the visitor's back.
+    await user.keyboard("{Escape}");
+    expect(screen.getByRole("dialog", WELCOME_DIALOG)).toBeTruthy();
+    expect(screen.getByText("Step 1 of 3")).toBeTruthy();
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
+    expect(localStorage.getItem(STORAGE_KEYS.HAS_SEEN_WELCOME)).toBeNull();
+  });
+
+  it("ignores the auth shortcuts before the last screen, except Log in", async () => {
+    const user = userEvent.setup();
+    render(<WelcomeModal />);
+
+    await user.keyboard("s");
+    await user.keyboard("u");
+    await user.keyboard("g");
+
+    expect(mockOpenModal).not.toHaveBeenCalled();
+    expect(useShortcutShowcaseStore.getState().isActive).toBe(false);
+    expect(localStorage.getItem(STORAGE_KEYS.HAS_SEEN_WELCOME)).toBeNull();
+    expect(screen.getByText("Step 1 of 3")).toBeTruthy();
+
+    await user.keyboard("i");
+    expect(mockOpenModal).toHaveBeenCalledWith("login");
+  });
+
+  it("toggles FAQ with digits only on the second screen", async () => {
+    const user = userEvent.setup();
+    render(<WelcomeModal />);
+
+    await user.keyboard("1");
+    await user.keyboard("{Enter}");
+
+    // The press on screen 1 did not pre-open the row.
+    const question = screen.getByRole("button", {
+      name: "Who is Compass for?",
+    });
+    expect(question).toHaveAttribute("aria-expanded", "false");
+
+    await user.keyboard("1");
+    expect(question).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("lets the mouse through on the welcome overlay", () => {
+    render(<WelcomeModal />);
+
+    expect(
+      screen
+        .getByRole("button", { name: "Get started for free" })
+        .closest("[data-pointer-pass]"),
+    ).not.toBeNull();
+  });
+
+  it("expands and collapses FAQ answers on the second screen", async () => {
     const user = userEvent.setup();
 
     render(<WelcomeModal />);
+    await user.keyboard("{Enter}");
 
     const questionButton = screen.getByRole("button", {
       name: "Who is Compass for?",
@@ -198,8 +309,10 @@ describe("WelcomeModal", () => {
     expect(answer).toHaveAttribute("data-state", "closed");
   });
 
-  it("shows shortcut keycaps on auth and explore actions without hover", () => {
+  it("shows shortcut keycaps on auth and explore actions without hover", async () => {
+    const user = userEvent.setup();
     render(<WelcomeModal />);
+    await goToChooseScreen(user);
 
     for (const [name, key] of [
       ["Sign up", "U"],
@@ -214,6 +327,7 @@ describe("WelcomeModal", () => {
   it("opens sign up with the U shortcut", async () => {
     const user = userEvent.setup();
     render(<WelcomeModal />);
+    await goToChooseScreen(user);
 
     await user.keyboard("u");
 
@@ -235,6 +349,7 @@ describe("WelcomeModal", () => {
     const user = userEvent.setup();
 
     render(<WelcomeModal />);
+    await goToChooseScreen(user);
 
     await user.keyboard("s");
 
@@ -254,6 +369,7 @@ describe("WelcomeModal", () => {
   it("cancels a pending practice start when login opens during dismiss", async () => {
     const user = userEvent.setup();
     const { rerender } = render(<WelcomeModal />);
+    await goToChooseScreen(user);
 
     await user.keyboard("s");
     await user.keyboard("i");
@@ -283,6 +399,7 @@ describe("WelcomeModal", () => {
   it("does not start practice if explore is pressed after login before auth opens", async () => {
     const user = userEvent.setup();
     render(<WelcomeModal />);
+    await goToChooseScreen(user);
 
     await user.keyboard("i");
     expect(mockOpenModal).toHaveBeenCalledWith("login");
@@ -317,6 +434,7 @@ describe("WelcomeModal", () => {
   it("defers the practice offer to after signup", async () => {
     const user = userEvent.setup();
     render(<WelcomeModal />);
+    await goToChooseScreen(user);
 
     await user.click(screen.getByRole("button", { name: "Sign up" }));
 
@@ -331,11 +449,13 @@ describe("WelcomeModal", () => {
 
   it("ignores KeyboardEvents with no key instead of throwing", () => {
     render(<WelcomeModal />);
-    const signUp = screen.getByRole("button", { name: "Sign up" });
+    const getStarted = screen.getByRole("button", {
+      name: "Get started for free",
+    });
 
     expect(() => {
       act(() => {
-        dispatchMissingKey("keydown", signUp);
+        dispatchMissingKey("keydown", getStarted);
       });
     }).not.toThrow();
 
@@ -362,6 +482,8 @@ describe("WelcomeModal", () => {
         <WelcomeModal />
       </>,
     );
+
+    await goToChooseScreen(user);
 
     // Not the panel's first focusable (Log in): the primary action is signing
     // up, so that is where focus lands.
@@ -402,8 +524,10 @@ describe("WelcomeModal", () => {
       resetGoogleAvailabilityForTests();
     });
 
-    it("leads with the Google round trip that also connects the calendar", () => {
+    it("leads with the Google round trip that also connects the calendar", async () => {
+      const user = userEvent.setup();
       render(<WelcomeModal />);
+      await goToChooseScreen(user);
 
       expect(
         screen.getByRole("button", { name: "Continue with Google" }),
@@ -425,6 +549,7 @@ describe("WelcomeModal", () => {
     it("starts Google auth from the button and queues the practice offer", async () => {
       const user = userEvent.setup();
       render(<WelcomeModal />);
+      await goToChooseScreen(user);
 
       await user.click(
         screen.getByRole("button", { name: "Continue with Google" }),
@@ -440,6 +565,7 @@ describe("WelcomeModal", () => {
     it("starts Google auth with the G shortcut", async () => {
       const user = userEvent.setup();
       render(<WelcomeModal />);
+      await goToChooseScreen(user);
 
       await user.keyboard("g");
 

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { useContext, useEffect, useRef, useState } from "react";
+import { useContext, useEffect, useId, useRef, useState } from "react";
 import { SessionContext } from "@web/auth/compass/session/session.context";
 import { useStartGoogleAuthorization } from "@web/auth/google/authorization/useStartGoogleAuthorization";
 import { useIsGoogleAvailable } from "@web/auth/google/hooks/useIsGoogleAvailable/useIsGoogleAvailable";
@@ -13,15 +13,43 @@ import { hasPlayDeepLink } from "@web/components/ShortcutShowcase/play-link";
 import { shortcutShowcaseActions } from "@web/components/ShortcutShowcase/showcase.store";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 import { keyboardKey } from "@web/shortcuts/is-bare-letter-key";
-import { pointerShortcutAttributes } from "@web/shortcuts/keyboard-only/pointer-action";
+import { pointerPassAttributes } from "@web/shortcuts/keyboard-only/pointer-action";
 import { PixelPirate } from "./PixelPirate";
-import {
-  flashedShortcutClass,
-  useFlashedWelcomeShortcut,
-} from "./useFlashedWelcomeShortcut";
-import { WelcomeGuideBody } from "./WelcomeGuideBody";
+import { useFaqDisclosure } from "./useFaqDisclosure";
+import { useWelcomeJumpShortcuts } from "./useWelcomeJumpShortcuts";
+import { WelcomeFaqList } from "./WelcomeFaqList";
+import { WelcomeLinks } from "./WelcomeLinks";
 import { welcomeGuideActions } from "./welcome.guide.store";
 import { hasSeenWelcome, markWelcomeSeen } from "./welcome.modal.util";
+
+/** Commit (1) → learn (2) → choose how to start (3). */
+type WelcomeStep = 1 | 2 | 3;
+const WELCOME_STEPS: readonly WelcomeStep[] = [1, 2, 3];
+
+const PRIMARY_CTA_CLASS =
+  "c-button c-button-primary c-button-elevated inline-flex h-10 w-full items-center justify-center rounded-full";
+const TEXT_CTA_CLASS =
+  "c-focus-ring inline-flex items-center rounded-md px-2 py-1 text-text-muted text-xs hover:bg-surface-overlay hover:text-text";
+
+function WelcomeSteps({ step }: { step: WelcomeStep }) {
+  return (
+    <div className="flex w-full items-center justify-center gap-2">
+      <span className="sr-only">
+        Step {step} of {WELCOME_STEPS.length}
+      </span>
+      {WELCOME_STEPS.map((dot) => (
+        <span
+          key={dot}
+          aria-hidden
+          className={classNames(
+            "h-1.5 w-1.5 rounded-full transition-colors",
+            dot === step ? "bg-text" : "bg-border",
+          )}
+        />
+      ))}
+    </div>
+  );
+}
 
 export function WelcomeModal() {
   const { authenticated } = useContext(SessionContext);
@@ -35,6 +63,7 @@ export function WelcomeModal() {
   const [isOpen, setIsOpen] = useState(
     () => !authenticated && !hasSeenWelcome() && !hasPlayDeepLink(),
   );
+  const [step, setStep] = useState<WelcomeStep>(1);
   const { closing, beginDismiss, cancelDismiss } =
     useDismissTransition(MODAL_DISMISS_MS);
   // Suppress OverlayPanel's unmount restore when handing off to Auth — Auth
@@ -49,11 +78,15 @@ export function WelcomeModal() {
   const [hidingForAuth, setHidingForAuth] = useState(false);
   const hidingForAuthRef = useRef(false);
   const googleHandoffRef = useRef(false);
-  // Seat focus on the email signup button rather than the panel's first
-  // focusable (now Log in) or the Google button: Enter on an OAuth redirect
-  // would fling a first-time visitor off-site before they read anything.
-  const signUpButtonRef = useRef<HTMLButtonElement>(null);
-  const flashedKey = useFlashedWelcomeShortcut();
+  // Each screen has one primary button, and Enter is its native activation.
+  // On the last screen that is email signup rather than Google: Enter on an
+  // OAuth redirect would fling a first-time visitor off-site.
+  const primaryRef = useRef<HTMLButtonElement>(null);
+  const faqHintId = `${useId()}-faq-hint`;
+  const faq = useFaqDisclosure();
+  // Digits 1-5 only toggle FAQ on the screen that shows it; 6-0 no-op until
+  // the footer links mount on the last screen.
+  useWelcomeJumpShortcuts(step === 2 ? faq.toggleAt : undefined);
 
   // The auth modal's openness lives in the URL (?auth=), so the welcome
   // screen simply hides while it is open and reappears when the browser
@@ -83,6 +116,18 @@ export function WelcomeModal() {
     }
   }, [visible]);
 
+  // Each screen seats its own primary button (OverlayPanel only seats focus
+  // once, on mount) so Enter keeps meaning "the obvious next thing", and
+  // counts as viewed once no matter how often Back revisits it.
+  const viewedStepsRef = useRef(new Set<WelcomeStep>());
+  useEffect(() => {
+    if (!visible) return;
+    primaryRef.current?.focus();
+    if (viewedStepsRef.current.has(step)) return;
+    viewedStepsRef.current.add(step);
+    track("welcome_step_viewed", { step });
+  }, [step, visible]);
+
   useEffect(() => {
     welcomeGuideActions.setFirstVisitOpen(visible);
     return () => welcomeGuideActions.setFirstVisitOpen(false);
@@ -90,19 +135,32 @@ export function WelcomeModal() {
 
   if (!visible) return null;
 
+  // Auth handoffs win over everything else. The explore fade (`closing`) is
+  // not one of them: a login during that fade must still cancel the pending
+  // practice start, so only the step and explore actions check it.
+  const isHandingOff = () =>
+    hidingForAuthRef.current || googleHandoffRef.current || isGoogleAuthLoading;
+
+  const advance = () => {
+    if (closing || isHandingOff()) return;
+    setStep((current) => (current < 3 ? ((current + 1) as WelcomeStep) : 3));
+  };
+
+  // Escape, backdrop and the Back button all step back one screen. On the
+  // first screen they do nothing: a stray Escape must not drop a first-time
+  // visitor into the practice game before they chose anything.
+  const goBack = () => {
+    if (closing || isHandingOff()) return;
+    setStep((current) => (current > 1 ? ((current - 1) as WelcomeStep) : 1));
+  };
+
   // Fade the backdrop and gently scale the panel before unmounting, so the
   // first reveal of the sidebar underneath feels smooth rather than abrupt.
-  const dismiss = (cta: "explore" | "dismissed" = "dismissed") => {
-    if (
-      closing ||
-      hidingForAuthRef.current ||
-      googleHandoffRef.current ||
-      isGoogleAuthLoading
-    )
-      return;
+  const explore = () => {
+    if (closing || isHandingOff()) return;
     skipFocusRestoreRef.current = true;
     markWelcomeSeen();
-    track("welcome_modal_dismissed", { cta });
+    track("welcome_modal_dismissed", { cta: "explore" });
     startShowcaseAfterDismissRef.current = true;
     // Start after this dialog unmounts so the practice takeover does not
     // share a focus trap with the fading welcome overlay.
@@ -151,28 +209,39 @@ export function WelcomeModal() {
   };
 
   const handleShortcutKey = (e: React.KeyboardEvent) => {
-    if (
-      hidingForAuthRef.current ||
-      googleHandoffRef.current ||
-      isGoogleAuthLoading
-    )
+    // A held Enter auto-repeats native button clicks, which would blast
+    // through all three screens and into signup. Only the first press counts.
+    if (e.key === "Enter" && e.repeat) {
+      e.preventDefault();
       return;
+    }
+    if (isHandingOff()) return;
     if (e.metaKey || e.ctrlKey || e.altKey) return;
     const key = keyboardKey(e).toLowerCase();
+    if (key === "i") {
+      e.preventDefault();
+      handOffToAuth("log_in");
+      return;
+    }
+    if (step !== 3) return;
     if (key === "g" && isGoogleAvailable) {
       e.preventDefault();
       handOffToGoogle();
     } else if (key === "u") {
       e.preventDefault();
       handOffToAuth("sign_up");
-    } else if (key === "i") {
-      e.preventDefault();
-      handOffToAuth("log_in");
     } else if (key === "s") {
       e.preventDefault();
-      dismiss("explore");
+      explore();
     }
   };
+
+  const backButton = (
+    <button type="button" onClick={goBack} className={TEXT_CTA_CLASS}>
+      Back
+      <ShortcutHint className="ml-2">Esc</ShortcutHint>
+    </button>
+  );
 
   return (
     <OverlayPanel
@@ -180,14 +249,22 @@ export function WelcomeModal() {
       ariaLabel="Welcome to Compass Calendar"
       backdropClassName="overflow-y-auto py-8"
       closing={closing}
-      initialFocusRef={signUpButtonRef}
-      onDismiss={dismiss}
+      initialFocusRef={primaryRef}
+      onDismiss={goBack}
       skipFocusRestoreRef={skipFocusRestoreRef}
       widthClassName="w-120"
     >
+      {/* The welcome overlay is the one calendar surface where the mouse
+          works: a landing page should behave like a normal site. Keyboard-only
+          starts once the visitor enters the calendar. */}
       {/* biome-ignore lint/a11y/noStaticElementInteractions: keydown here is a modal-scoped shortcut layer, not an interactive element in its own right */}
-      <div className="flex w-full flex-col gap-6" onKeyDown={handleShortcutKey}>
-        {/* Top row: pirate top-left, auth pills top-right */}
+      <div
+        className="flex w-full flex-col gap-6"
+        onKeyDown={handleShortcutKey}
+        {...pointerPassAttributes}
+      >
+        {/* Top row: pirate top-left, Log in top-right, on every screen so a
+            returning user is never walked through the pitch. */}
         <div className="flex items-center justify-between">
           <div className="group relative flex items-center">
             <PixelPirate className="h-14 w-14 shrink-0" />
@@ -206,36 +283,93 @@ export function WelcomeModal() {
               type="button"
               onClick={() => handOffToAuth("log_in")}
               className="c-button-compact c-button-secondary rounded-3xl px-4 py-1.5 text-xs"
-              {...pointerShortcutAttributes("i")}
             >
               Log in
-              <ShortcutHint
-                className={classNames(
-                  "ml-2",
-                  flashedShortcutClass(flashedKey, "i"),
-                )}
-              >
-                i
-              </ShortcutHint>
+              <ShortcutHint className="ml-2">i</ShortcutHint>
             </button>
           </div>
         </div>
 
-        <WelcomeGuideBody flashedKey={flashedKey}>
-          {/* CTA: connecting a calendar is the moment Compass starts being
-              useful, so the Google round trip - which signs up and grants
-              calendar access at once - leads, and everything else is a fallback
-              from it. */}
-          <div className="flex w-full flex-col items-center gap-3">
-            {isGoogleAvailable && (
-              <>
-                <div
-                  className={classNames(
-                    "w-full",
-                    flashedKey?.toLowerCase() === "g" && "c-shortcut-flash",
-                  )}
-                  {...pointerShortcutAttributes("G")}
-                >
+        {step === 1 && (
+          <>
+            <div className="flex w-full flex-col gap-2">
+              <h1 className="font-bold text-2xl text-text leading-snug">
+                The Keyboard Calendar
+              </h1>
+              <p className="text-text-muted">
+                Rediscover the joy of shortcuts as you build your perfect
+                schedule. No clicks allowed.
+              </p>
+              <p className="text-sm text-text-muted">
+                Compass is a faster, simpler, open-source calendar for busy
+                professionals who live at their keyboard.
+              </p>
+            </div>
+            <div className="flex w-full flex-col items-center gap-3">
+              <button
+                type="button"
+                ref={primaryRef}
+                onClick={advance}
+                className={PRIMARY_CTA_CLASS}
+              >
+                Get started for free
+                <ShortcutHint className="ml-2">Enter</ShortcutHint>
+              </button>
+              <p className="text-center text-text-muted text-xs">
+                No account needed.
+              </p>
+            </div>
+          </>
+        )}
+
+        {step === 2 && (
+          <>
+            <div className="flex w-full flex-col gap-2">
+              <h2 className="font-bold text-2xl text-text leading-snug">
+                How Compass works
+              </h2>
+              <p id={faqHintId} className="text-text-muted">
+                Press a number to open a question.
+              </p>
+            </div>
+            <WelcomeFaqList
+              describedById={faqHintId}
+              expanded={faq.expanded}
+              flashedKey={null}
+              onToggle={faq.toggle}
+            />
+            <div className="flex w-full flex-col items-center gap-3">
+              <button
+                type="button"
+                ref={primaryRef}
+                onClick={advance}
+                className={PRIMARY_CTA_CLASS}
+              >
+                Next
+                <ShortcutHint className="ml-2">Enter</ShortcutHint>
+              </button>
+              {backButton}
+            </div>
+          </>
+        )}
+
+        {step === 3 && (
+          <>
+            <div className="flex w-full flex-col gap-2">
+              <h2 className="font-bold text-2xl text-text leading-snug">
+                Ready when you are
+              </h2>
+              <p className="text-text-muted">
+                Pick how you want to start. You can sign up later.
+              </p>
+            </div>
+            {/* Connecting a calendar is the moment Compass starts being
+                useful, so the Google round trip, which signs up and grants
+                calendar access at once, leads; everything else is a fallback
+                from it. */}
+            <div className="flex w-full flex-col items-center gap-3">
+              {isGoogleAvailable && (
+                <>
                   <GoogleButton
                     onClick={handOffToGoogle}
                     disabled={isGoogleAuthLoading}
@@ -243,47 +377,36 @@ export function WelcomeModal() {
                     shortcutKey="G"
                     style={{ width: "100%" }}
                   />
-                </div>
-                <p className="text-center text-text-muted text-xs">
-                  Signs you up and connects your Google Calendar.
-                </p>
-              </>
-            )}
-            <button
-              type="button"
-              ref={signUpButtonRef}
-              onClick={() => handOffToAuth("sign_up")}
-              className="c-button c-button-primary c-button-elevated inline-flex h-10 w-full items-center justify-center rounded-full"
-              {...pointerShortcutAttributes("U")}
-            >
-              {isGoogleAvailable ? "Sign up with email" : "Sign up"}
-              <ShortcutHint
-                className={classNames(
-                  "ml-2",
-                  flashedShortcutClass(flashedKey, "U"),
-                )}
+                  <p className="text-center text-text-muted text-xs">
+                    Signs you up and connects your Google Calendar.
+                  </p>
+                </>
+              )}
+              <button
+                type="button"
+                ref={primaryRef}
+                onClick={() => handOffToAuth("sign_up")}
+                className={PRIMARY_CTA_CLASS}
               >
-                U
-              </ShortcutHint>
-            </button>
-            <button
-              type="button"
-              onClick={() => dismiss("explore")}
-              className="c-focus-ring inline-flex items-center rounded-md px-2 py-1 text-text-muted text-xs hover:bg-surface-overlay hover:text-text"
-              {...pointerShortcutAttributes("S")}
-            >
-              Explore without an account
-              <ShortcutHint
-                className={classNames(
-                  "ml-2",
-                  flashedShortcutClass(flashedKey, "S"),
-                )}
+                {isGoogleAvailable ? "Sign up with email" : "Sign up"}
+                <ShortcutHint className="ml-2">U</ShortcutHint>
+              </button>
+              <button
+                type="button"
+                onClick={explore}
+                className={TEXT_CTA_CLASS}
               >
-                S
-              </ShortcutHint>
-            </button>
-          </div>
-        </WelcomeGuideBody>
+                Explore without an account
+                <ShortcutHint className="ml-2">S</ShortcutHint>
+              </button>
+              {backButton}
+            </div>
+          </>
+        )}
+
+        <WelcomeSteps step={step} />
+
+        {step === 3 && <WelcomeLinks flashedKey={null} />}
       </div>
     </OverlayPanel>
   );

--- a/packages/web/src/components/WelcomeModal/useFaqDisclosure.ts
+++ b/packages/web/src/components/WelcomeModal/useFaqDisclosure.ts
@@ -1,0 +1,29 @@
+import { useCallback, useState } from "react";
+import { FAQ_ITEMS } from "./faq";
+
+/** Which FAQ rows are open, keyed by question, plus toggles by question or index. */
+export function useFaqDisclosure() {
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+
+  const toggle = useCallback((question: string) => {
+    setExpanded((current) => {
+      const next = new Set(current);
+      if (next.has(question)) {
+        next.delete(question);
+      } else {
+        next.add(question);
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleAt = useCallback(
+    (index: number) => {
+      const item = FAQ_ITEMS[index];
+      if (item) toggle(item.question);
+    },
+    [toggle],
+  );
+
+  return { expanded, toggle, toggleAt };
+}

--- a/packages/web/src/components/WelcomeModal/useWelcomeJumpShortcuts.ts
+++ b/packages/web/src/components/WelcomeModal/useWelcomeJumpShortcuts.ts
@@ -9,9 +9,11 @@ export const WELCOME_JUMP_ATTR = "data-welcome-jump";
  * Press a number (with or without Mod) to toggle that FAQ or open a footer
  * link. Bare digits work because browsers steal Cmd/Ctrl+1–8 for tab switching.
  *
- * 1–5 toggle FAQ items. 6–0 activate matching `[data-welcome-jump]` links.
+ * 1–5 toggle FAQ items when `toggleFaqAt` is given (omit it on a screen with
+ * no FAQ). 6–0 activate matching `[data-welcome-jump]` links, and no-op when
+ * none is mounted.
  */
-export function useWelcomeJumpShortcuts(toggleFaqAt: (index: number) => void) {
+export function useWelcomeJumpShortcuts(toggleFaqAt?: (index: number) => void) {
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (isEditableKeyboardTarget(event)) return;
@@ -20,6 +22,7 @@ export function useWelcomeJumpShortcuts(toggleFaqAt: (index: number) => void) {
       if (index === null) return;
 
       if (index < FAQ_ITEMS.length) {
+        if (!toggleFaqAt) return;
         event.preventDefault();
         toggleFaqAt(index);
         return;

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -29,7 +29,7 @@
     <title>Compass Calendar</title>
     <meta
       name="description"
-      content="Compass is a small but mighty calendar for busy minimalists: a simple, keyboard-first way to plan your week around what matters."
+      content="Compass is the keyboard calendar: a faster, simpler, open-source calendar for busy professionals who live at their keyboard. No clicks allowed."
     />
     <meta name="robots" content="index, follow" />
     <link rel="canonical" href="https://www.compasscalendar.com/" />
@@ -39,11 +39,11 @@
     <meta property="og:site_name" content="Compass Calendar" />
     <meta
       property="og:title"
-      content="Compass Calendar: simple, keyboard-first weekly planning"
+      content="Compass: The Keyboard Calendar"
     />
     <meta
       property="og:description"
-      content="A small but mighty calendar for busy minimalists. Plan your week around what matters."
+      content="Rediscover the joy of shortcuts as you build your perfect schedule. No clicks allowed."
     />
     <meta property="og:url" content="https://www.compasscalendar.com/" />
     <meta
@@ -57,11 +57,11 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta
       name="twitter:title"
-      content="Compass Calendar: simple, keyboard-first weekly planning"
+      content="Compass: The Keyboard Calendar"
     />
     <meta
       name="twitter:description"
-      content="A small but mighty calendar and to-do app for busy minimalists. Plan your week around what matters, simply."
+      content="Rediscover the joy of shortcuts as you build your perfect schedule. No clicks allowed."
     />
     <meta
       name="twitter:image"


### PR DESCRIPTION
## Why

The unauthenticated landing overlay showed everything at once (headline, five FAQ rows with digit keys, three auth CTAs, Log in, five footer links). New visitors froze and left without acting.

## What

The welcome dialog is now three screens with one focused primary button each, so Enter or a click is always the obvious next thing:

1. **Commit:** headline (`h1`), tagline, one-sentence pitch, "Get started for free" + `Enter`
2. **Learn:** "How Compass works" with the five FAQ rows (digits `1`-`5`) and Next
3. **Choose:** Continue with Google `G` / Sign up with email `U` / Explore without an account `S`, social and legal links (`6`-`0`) below

- Log in (`i`) and a three-dot step indicator on every screen
- Escape, backdrop and Back step back one screen; no-op on screen 1 so a stray Escape never starts the practice game
- The overlay opts out of pointer suppression (`data-pointer-pass`): the mouse works on the landing page, keyboard-only starts in the calendar
- FAQ state lifted into `useFaqDisclosure` + `WelcomeFaqList` so one digit listener serves the modal and the signed-in guide; digits are only live on the screen showing their targets
- Held Enter is ignored so key-repeat can't blast through to signup
- New `welcome_step_viewed { step }` analytics event; existing welcome events unchanged
- `index.html` meta description and og/twitter copy aligned with the screen-1 pitch
- Docs contract and both onboarding e2e specs updated

## Verification

- `bun run lint`, `bun run type-check` clean
- WelcomeModal / WelcomeGuideBody / RootShell / useGlobalShortcuts unit tests: 59 pass (5 new)
- `e2e/onboarding` first-run + shortcut-showcase: 11 pass, including a real mouse click on Get started
- Preview pane: all three screens rendered, mouse clicks advanced screens and expanded an FAQ row

Known: the page now has two `h1`s (calendar month heading + welcome headline). A backdrop click is still outside the pass subtree, so it pulses the keyboard-only hint rather than stepping back; Escape and Back cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
