### PR TITLE
ci: let the loop merge CI-speed changes and lint workflows in static

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,6 +1,0 @@
-requiredHeaders:
-  - Prerequisites
-  - Expected Behavior
-  - Current Behavior
-  - Possible Solution
-  - Your Environment

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,27 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
+# Dependabot PRs target main so the required checks run on them; the
+# `dependencies` side branch they used to target had no checks and nobody
+# drained it. Weekly, grouped, capped, so the queue is not flooded.
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    target-branch: "dependencies"
-    commit-message:
-      prefix: "⬆️"
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/scripts/agent-loop-merge-guard.sh
+++ b/.github/scripts/agent-loop-merge-guard.sh
@@ -23,8 +23,16 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/agent-loop-lib.sh"
 
 PR_NUMBER=${1:-}
 
+# .github/ is refused only where a change could reach secrets, deploys, or
+# the agents themselves: deploy and release workflows, the loop and autofix
+# workflows, their scripts and prompts, allowlists, and Docker build context.
+# Test, e2e, and perf workflows, detect-code-changes.sh, templates,
+# dependabot, and stale config may auto-merge; actionlint and the loop
+# script tests gate them in the `static` job.
 NO_AUTOMERGE_PATH_PATTERNS=(
-  '^\.github/'
+  '^\.github/workflows/(deploy-|_deploy-environment|publish-docker-images|release-on-main|sync-docs|agent-loop|agent-review|error-autofix)'
+  '^\.github/scripts/(agent-loop|autofix|deploy-|discord-)'
+  '^\.github/(agent-loop|prompts|docker)/'
   '^self-host/'
   '^packages/backend/src/auth/'
   '^packages/web/src/auth/'

--- a/.github/scripts/agent-loop-merge-guard.test.sh
+++ b/.github/scripts/agent-loop-merge-guard.test.sh
@@ -60,6 +60,38 @@ out=$(run_guard $'packages/sync/src/providers/microsoft/foo.ts\npackages/sync/sr
 assert_contains "$out" "downgrade:" "mixed diff still refuses telemetry"
 assert_not_contains "$out" "proceed" "mixed diff does not proceed"
 
+# .github/ self-service: CI-speed files may merge, agent and deploy files may not.
+for allowed in \
+  ".github/workflows/test-unit.yml" \
+  ".github/workflows/test-e2e.yml" \
+  ".github/workflows/perf-budget.yml" \
+  ".github/scripts/detect-code-changes.sh" \
+  ".github/dependabot.yml" \
+  ".github/ISSUE_TEMPLATE/3-agent-task.yml"; do
+  out=$(run_guard "$allowed" "$MS_M")
+  assert_contains "$out" "proceed" "${allowed} proceeds"
+  assert_not_contains "$out" "downgrade:" "${allowed} is not refused"
+done
+
+for refused in \
+  ".github/workflows/deploy-production.yml" \
+  ".github/workflows/_deploy-environment.yml" \
+  ".github/workflows/release-on-main.yml" \
+  ".github/workflows/agent-loop.yml" \
+  ".github/workflows/agent-review.yml" \
+  ".github/workflows/error-autofix.yml" \
+  ".github/scripts/agent-loop-merge-guard.sh" \
+  ".github/scripts/autofix-preflight.sh" \
+  ".github/scripts/deploy-health-check.sh" \
+  ".github/scripts/discord-notify.sh" \
+  ".github/prompts/agent-loop.md" \
+  ".github/agent-loop/allowlists/providers-m.txt" \
+  ".github/docker/Dockerfile.web"; do
+  out=$(run_guard "$refused" "$MS_M")
+  assert_contains "$out" "downgrade:" "${refused} is refused"
+  assert_not_contains "$out" "proceed" "${refused} does not proceed"
+done
+
 echo
 echo "passed=${PASS} failed=${FAIL}"
 if [ "$FAIL" -ne 0 ]; then

--- a/.github/scripts/autofix-merge-guard.sh
+++ b/.github/scripts/autofix-merge-guard.sh
@@ -106,11 +106,10 @@ main() {
     notify "Autofix PR #${pr_number} (issue #${ISSUE_NUMBER}) passed the merge guard but \`gh pr merge --auto\` failed — needs a human to enable merge manually — https://github.com/${REPO}/pull/${pr_number}"
     return 0
   fi
+  # Do not watch CI here: this job runs under a cancel-in-progress:false
+  # queue, so a runner sitting in `gh pr checks --watch` blocked the next
+  # PostHog issue for up to 15 minutes. GitHub merges when checks pass.
   printf 'enabled auto-merge on PR #%s\n' "$pr_number"
-
-  if ! gh pr checks "$pr_number" --repo "$REPO" --watch --fail-fast; then
-    notify "Autofix PR #${pr_number} (issue #${ISSUE_NUMBER}) failed CI after auto-merge was enabled — https://github.com/${REPO}/pull/${pr_number}"
-  fi
 }
 
 main

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,6 +8,11 @@ exemptLabels:
   - discussion
   - e2e
   - enhancement
+  - agent-ready
+  - agent-loop-running
+  - agent-loop-waiting-for-credits
+  - agent-loop-needs-human
+  - autofix
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had

--- a/.github/workflows/perf-budget.yml
+++ b/.github/workflows/perf-budget.yml
@@ -81,7 +81,7 @@ jobs:
         # 2026-09-03.
         run: |
           bunx serve -s build/web -l 9161 --no-clipboard &
-          for i in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             if curl -sf -o /dev/null http://localhost:9161/; then exit 0; fi
             sleep 1
           done

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -50,9 +50,11 @@ jobs:
           image_version="${release_tag#v}"
           minor_tag="${image_version%.*}"
 
-          echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
-          echo "image_version=${image_version}" >> "$GITHUB_OUTPUT"
-          echo "minor_tag=${minor_tag}" >> "$GITHUB_OUTPUT"
+          {
+            echo "release_tag=${release_tag}"
+            echo "image_version=${image_version}"
+            echo "minor_tag=${minor_tag}"
+          } >> "$GITHUB_OUTPUT"
 
           echo "Release tag: ${release_tag}"
           echo "Image version: ${image_version}"

--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -9,6 +9,12 @@ on:
       - "**/*.md"
       - "docs/**"
 
+# Two merges landing close together raced on the tag and the deploy; the
+# retry loop in tag-release was the only protection. Queue releases instead.
+concurrency:
+  group: release-on-main
+  cancel-in-progress: false
+
 permissions:
   contents: write
   # publish-docker-images.yml exports type=gha layer cache; the reusable

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -108,7 +108,10 @@ jobs:
       - name: Lint workflows
         run: |
           docker run --rm -v "${GITHUB_WORKSPACE}:/repo" -w /repo \
-            rhysd/actionlint:1.7.7 -color
+            rhysd/actionlint:1.7.7 -color \
+            -ignore 'unexpected key "queue" for "concurrency" section'
+          # `queue:` is a real concurrency key (_deploy-environment.yml) that
+          # this actionlint release does not know yet; drop the ignore on upgrade.
 
       # The loop scripts' own tests (gh stub, dry-run guard). They need bash 4+.
       - name: Test agent-loop scripts

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -102,6 +102,21 @@ jobs:
         run: |
           bun run type-check
 
+      # Workflow files may auto-merge (see NO_AUTOMERGE_PATH_PATTERNS in
+      # agent-loop-merge-guard.sh), so they are linted here instead of by a
+      # human. Pinned; the image bundles shellcheck for run: steps.
+      - name: Lint workflows
+        run: |
+          docker run --rm -v "${GITHUB_WORKSPACE}:/repo" -w /repo \
+            rhysd/actionlint:1.7.7 -color
+
+      # The loop scripts' own tests (gh stub, dry-run guard). They need bash 4+.
+      - name: Test agent-loop scripts
+        run: |
+          bash -n .github/scripts/*.sh
+          bash .github/scripts/agent-loop-next.test.sh
+          bash .github/scripts/agent-loop-merge-guard.test.sh
+
   # A skipped MATRIX job collapses to one check run, so the `unit` rollup
   # below would see `skipped` for a docs-only PR only if every leg started.
   # Let the legs start and skip every step instead: each reports in a few

--- a/docs/CI-CD/agent-loop-routine.md
+++ b/docs/CI-CD/agent-loop-routine.md
@@ -159,7 +159,12 @@ written, the equivalent is `strict_required_status_checks_policy: true`.
 The agent may *author* the code. The merge guard refuses to merge if the
 PR touches:
 
-- `.github/`
+- `.github/`: deploy, release, docs-sync, agent-loop, agent-review, and
+  error-autofix workflows; the `agent-loop-*`, `autofix-*`, `deploy-*`, and
+  `discord-*` scripts; `prompts/`, `agent-loop/` allowlists, and `docker/`.
+  Test, e2e, and perf workflows, `detect-code-changes.sh`, issue and PR
+  templates, dependabot, and stale config may auto-merge; `actionlint` and
+  the loop script tests run in the `static` job.
 - `self-host/`
 - `packages/backend/src/auth/`
 - `packages/web/src/auth/`
@@ -213,7 +218,7 @@ Alias notes: `booking-automerge`, `booking-loop-running`,
 `booking-loop-waiting-for-credits`, and `booking-loop-needs-human`
 still count for one release.
 
-## Local tests
+## Script tests (also run in the `static` CI job)
 
 Picker and merge-guard shell tests run from `bun test:scripts` via
 `packages/scripts/src/testing/agent-loop-next.test.ts`.

--- a/packages/scripts/src/testing/agent-loop-routine.test.ts
+++ b/packages/scripts/src/testing/agent-loop-routine.test.ts
@@ -33,6 +33,9 @@ describe("agent-loop Routine contract", () => {
       "utf8",
     );
     for (const pattern of [
+      "'^\\.github/workflows/(deploy-|_deploy-environment|publish-docker-images|release-on-main|sync-docs|agent-loop|agent-review|error-autofix)'",
+      "'^\\.github/scripts/(agent-loop|autofix|deploy-|discord-)'",
+      "'^\\.github/(agent-loop|prompts|docker)/'",
       "'^self-host/'",
       "'^packages/backend/src/auth/'",
       "'^packages/web/src/auth/'",
@@ -43,6 +46,19 @@ describe("agent-loop Routine contract", () => {
     ]) {
       expect(guard).toContain(pattern);
     }
+  });
+
+  it("lets CI-speed workflow files auto-merge but never the agent or deploy ones", () => {
+    const guard = readFileSync(
+      ".github/scripts/agent-loop-merge-guard.sh",
+      "utf8",
+    );
+    // A blanket '^\.github/' made every CI change a human merge; the three
+    // slowest merges of 2026-09-04 were CI-speed PRs waiting 10+ hours.
+    expect(guard).not.toContain("'^\\.github/'");
+    const unit = readFileSync(".github/workflows/test-unit.yml", "utf8");
+    expect(unit).toContain("rhysd/actionlint");
+    expect(unit).toContain("agent-loop-merge-guard.test.sh");
   });
 
   it("launches the next WP on merge with per-job concurrency", () => {


### PR DESCRIPTION
Tier 1.1 of the agent-only transition plan, plus the `.github/` housekeeping from the same audit.

## What and why

- **Merge guard narrows `^\.github/`** to what can actually reach secrets, deploys, or the agents: deploy/release/docs-sync/agent-loop/agent-review/error-autofix workflows; `agent-loop-*`, `autofix-*`, `deploy-*`, `discord-*` scripts; `prompts/`, `agent-loop/` allowlists, `docker/`. `test-unit.yml`, `test-e2e.yml`, `perf-budget.yml`, `detect-code-changes.sh`, templates, dependabot, and stale config may auto-merge. The three slowest merges yesterday (771 / 608 / 587 min) were CI-speed PRs waiting on this rule.
- **`static` gains `actionlint`** (pinned `rhysd/actionlint:1.7.7`, bundles shellcheck) and runs `agent-loop-next.test.sh` and `agent-loop-merge-guard.test.sh`, which previously ran nowhere in CI. The guard's dry-run test now covers six allowed and thirteen refused `.github/` paths.
- **Autofix guard** stops holding a runner in `gh pr checks --watch` under its `cancel-in-progress: false` queue.
- **`release-on-main`** gets a `concurrency` group; two close merges used to race on the tag.
- **Dependabot** targets `main` weekly, grouped, capped at 5, plus GitHub Actions updates; the `dependencies` side branch had no checks.
- **`stale.yml`** exempts `agent-ready` and the `agent-loop-*` / `autofix` labels. **`.github/config.yml`** (config for the PR-body check deleted in #2889) removed.

## Needs a human merge

Touches the merge guard itself. `actionlint` runs for the first time on this PR; if it flags pre-existing workflow issues, fixes follow in this branch.

## Verify

- `bun run lint`: pass. `bun test` on `agent-loop-routine`, `error-autofix-routine`, `detect-code-changes`: 19 pass.
- `bash -n` on the changed scripts. The guard shell test needs bash 4+ (`mapfile`) and runs in CI's `static` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
