### PR TITLE
feat(scripts,sync): per-provider audit CLI and safety canary markers

### DIFF
--- a/.agents/handoffs/3237.md
+++ b/.agents/handoffs/3237.md
@@ -1,0 +1,31 @@
+---
+schema_version: 1
+task_id: "3237"
+from: Implementer
+to: Verifier
+owner: Verifier
+status: verifying
+artifact:
+  - path: packages/scripts/src/commands/audit-connection-identity/audit.ts
+  - path: packages/scripts/src/commands/audit-connection-identity.ts
+  - path: packages/sync/src/safety/safety-canary.ts
+evidence:
+  - command: bun run verify --strict
+    result: "VERDICT: PASS — test:scripts, test:sync:fast, type-check, lint, knip"
+  - command: bun test packages/scripts/src/commands/audit-connection-identity/audit.test.ts
+    result: "provider filter db tests pass (--provider microsoft, default all)"
+  - command: bun test packages/sync/src/safety/safety-canary.test.ts
+    result: "PROVIDER_LEAK_MARKERS trips canary for google, microsoft, apple"
+assumptions:
+  - Report field rename usersWithGoogleLogin → loginIdentitiesIndexed is acceptable (CLI JSON only consumer).
+  - Microsoft/apple markers pre-registered for M-04/A-04 even though those adapters are not live yet.
+open_risks:
+  - user.identities[] is read when present but not yet written by milestone I.
+next_deadline: null
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+WP-12 adds `--provider` to audit-connection-identity (default all providers), keys login collisions by `(provider, subjectId)` from `google.googleId` and future `identities[]`, and splits safety-canary provider payload markers into `PROVIDER_LEAK_MARKERS`.

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -62,7 +62,7 @@ export default class CompassCLI {
       .helpOption(false)
       .allowUnknownOption(true)
       .description(
-        "Report connected Google accounts that are another Compass user's login identity (read-only)",
+        "Report connected provider accounts that are another Compass user's login identity (read-only; optional --provider)",
       );
 
     program

--- a/packages/scripts/src/commands/audit-connection-identity.ts
+++ b/packages/scripts/src/commands/audit-connection-identity.ts
@@ -1,6 +1,10 @@
-import { auditConnectionIdentity } from "@scripts/commands/audit-connection-identity/audit";
+import {
+  type AuditConnectionIdentityOptions,
+  auditConnectionIdentity,
+} from "@scripts/commands/audit-connection-identity/audit";
 import { loadCompassConfig } from "@core/config/compass.config";
 import { Logger } from "@core/logger/winston.logger";
+import { ProviderKindSchema } from "@core/types/sync/identity.contracts";
 import mongoService from "@backend/common/services/mongo.service";
 import { SyncMongoService } from "@sync/storage/sync-mongo.service";
 
@@ -18,17 +22,38 @@ function syncMongoUri(): string {
   return uri;
 }
 
+export function parseAuditConnectionIdentityArgs(
+  argv: string[],
+): AuditConnectionIdentityOptions {
+  const providerFlag = argv.indexOf("--provider");
+  if (providerFlag < 0) {
+    return {};
+  }
+  const raw = argv[providerFlag + 1]?.trim();
+  if (!raw) {
+    throw new Error("audit-connection-identity --provider requires a value");
+  }
+  const parsed = ProviderKindSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error(
+      `audit-connection-identity --provider must be one of ${ProviderKindSchema.options.join(", ")}`,
+    );
+  }
+  return { provider: parsed.data };
+}
+
 /**
- * Reports any connected Google account that is actually another Compass
+ * Reports any connected provider account that is actually another Compass
  * user's sign-in identity - added accounts are meant to be data-only (A2),
  * so this should normally report zero. Read-only; safe to run anytime,
  * including on a schedule.
  *
- *   bun run cli audit-connection-identity
+ *   bun run cli audit-connection-identity [--provider google|microsoft|apple]
  */
 export async function runAuditConnectionIdentity(): Promise<void> {
   const syncMongo = new SyncMongoService();
   try {
+    const options = parseAuditConnectionIdentityArgs(process.argv.slice(3));
     await mongoService.start();
     await syncMongo.connect({
       uri: syncMongoUri(),
@@ -36,7 +61,11 @@ export async function runAuditConnectionIdentity(): Promise<void> {
       forbiddenDatabaseName: "prod_calendar",
     });
 
-    const report = await auditConnectionIdentity(mongoService.db, syncMongo.db);
+    const report = await auditConnectionIdentity(
+      mongoService.db,
+      syncMongo.db,
+      options,
+    );
 
     process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
     if (report.collisions.length > 0) {

--- a/packages/scripts/src/commands/audit-connection-identity/audit.db.test.ts
+++ b/packages/scripts/src/commands/audit-connection-identity/audit.db.test.ts
@@ -83,6 +83,7 @@ describe("auditConnectionIdentity (db)", () => {
       {
         connectingUserId: attacker,
         connectionId: expect.any(String),
+        provider: "google",
         accountEmail: "victim@example.com",
         loginOwnerUserId: victim,
         loginOwnerEmail: "victim@example.com",
@@ -124,7 +125,7 @@ describe("auditConnectionIdentity (db)", () => {
 
     const report = await run();
 
-    expect(report.usersWithGoogleLogin).toBe(1);
+    expect(report.loginIdentitiesIndexed).toBe(1);
     expect(report.collisions).toEqual([]);
   });
 });

--- a/packages/scripts/src/commands/audit-connection-identity/audit.test.ts
+++ b/packages/scripts/src/commands/audit-connection-identity/audit.test.ts
@@ -1,0 +1,181 @@
+import { parseAuditConnectionIdentityArgs } from "@scripts/commands/audit-connection-identity";
+import {
+  auditConnectionIdentity,
+  resolveProvidersToAudit,
+} from "@scripts/commands/audit-connection-identity/audit";
+import { ObjectId } from "mongodb";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import mongoService from "@backend/common/services/mongo.service";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+
+describe("auditConnectionIdentity provider filter (db)", () => {
+  const syncStorage = setupSyncStorage(import.meta.url);
+  let connections: ProviderConnectionRepository;
+
+  beforeAll(() => setupTestDb(import.meta.url));
+  afterEach(async () => {
+    await cleanupCollections();
+    await mongoService.user.deleteMany({});
+  });
+  afterAll(cleanupTestDb);
+
+  const seedLoginUser = async (
+    email: string,
+    identities: {
+      googleId?: string;
+      microsoft?: { subjectId: string; email?: string };
+    },
+  ): Promise<string> => {
+    const userId = new ObjectId();
+    await mongoService.user.insertOne({
+      _id: userId,
+      email,
+      name: email,
+      firstName: email,
+      lastName: "",
+      locale: "not provided",
+      ...(identities.googleId
+        ? {
+            google: {
+              googleId: identities.googleId,
+              picture: "",
+              gRefreshToken: "refresh-token",
+            },
+          }
+        : {}),
+      ...(identities.microsoft
+        ? {
+            identities: [
+              {
+                provider: "microsoft",
+                subjectId: identities.microsoft.subjectId,
+                email: identities.microsoft.email ?? email,
+              },
+            ],
+          }
+        : {}),
+    });
+    return userId.toHexString();
+  };
+
+  const seedConnection = async (
+    principalId: string,
+    provider: "google" | "microsoft",
+    providerAccountId: string,
+    email: string,
+  ) => {
+    connections = new ProviderConnectionRepository(syncStorage.db());
+    return connections.upsertByProviderAccount({
+      tenantId: principalId,
+      principalId,
+      provider,
+      account: { providerAccountId, email, displayName: null },
+      capabilities: ["readEvents", "readBusy", "writeEvents"],
+      state: "healthy",
+      stateReason: null,
+    });
+  };
+
+  it("defaults to auditing every provider kind", async () => {
+    const googleUser = await seedLoginUser("google@example.com", {
+      googleId: "google-sub-1",
+    });
+    const microsoftUser = await seedLoginUser("microsoft@example.com", {
+      microsoft: { subjectId: "ms-sub-1" },
+    });
+    await seedConnection(
+      googleUser,
+      "google",
+      "google-sub-1",
+      "google@example.com",
+    );
+    await seedConnection(
+      microsoftUser,
+      "microsoft",
+      "ms-sub-1",
+      "microsoft@example.com",
+    );
+
+    const report = await auditConnectionIdentity(
+      mongoService.db,
+      syncStorage.db(),
+    );
+
+    expect(report.providersAudited).toEqual(["google", "microsoft", "apple"]);
+    expect(report.connectionsChecked).toBe(2);
+    expect(report.collisions).toEqual([]);
+  });
+
+  it("selects only Microsoft connections when --provider microsoft is passed", async () => {
+    const googleUser = await seedLoginUser("google@example.com", {
+      googleId: "google-sub-1",
+    });
+    const microsoftUser = await seedLoginUser("microsoft@example.com", {
+      microsoft: { subjectId: "ms-sub-1" },
+    });
+    const other = await seedLoginUser("other@example.com", {
+      googleId: "google-sub-2",
+    });
+    await seedConnection(
+      googleUser,
+      "google",
+      "google-sub-1",
+      "google@example.com",
+    );
+    await seedConnection(
+      microsoftUser,
+      "microsoft",
+      "ms-sub-1",
+      "microsoft@example.com",
+    );
+    await seedConnection(
+      other,
+      "microsoft",
+      "ms-sub-1",
+      "microsoft@example.com",
+    );
+
+    const report = await auditConnectionIdentity(
+      mongoService.db,
+      syncStorage.db(),
+      { provider: "microsoft" },
+    );
+
+    expect(report.providersAudited).toEqual(["microsoft"]);
+    expect(report.connectionsChecked).toBe(2);
+    expect(report.collisions).toEqual([
+      {
+        connectingUserId: other,
+        connectionId: expect.any(String),
+        provider: "microsoft",
+        accountEmail: "microsoft@example.com",
+        loginOwnerUserId: microsoftUser,
+        loginOwnerEmail: "microsoft@example.com",
+      },
+    ]);
+  });
+
+  it("parses --provider microsoft from CLI argv", () => {
+    expect(
+      parseAuditConnectionIdentityArgs([
+        "audit-connection-identity",
+        "--provider",
+        "microsoft",
+      ]),
+    ).toEqual({ provider: "microsoft" });
+    expect(
+      parseAuditConnectionIdentityArgs(["audit-connection-identity"]),
+    ).toEqual({});
+    expect(resolveProvidersToAudit(undefined)).toEqual([
+      "google",
+      "microsoft",
+      "apple",
+    ]);
+  });
+});

--- a/packages/scripts/src/commands/audit-connection-identity/audit.ts
+++ b/packages/scripts/src/commands/audit-connection-identity/audit.ts
@@ -1,4 +1,8 @@
 import { type Db } from "mongodb";
+import {
+  type ProviderKind,
+  ProviderKindSchema,
+} from "@core/types/sync/identity.contracts";
 import { Collections } from "@backend/common/constants/collections";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 
@@ -6,61 +10,138 @@ export type ConnectionIdentityCollision = {
   // The Compass user who added the connection (data-only, per A2).
   connectingUserId: string;
   connectionId: string;
-  // The connected Google account.
+  provider: ProviderKind;
+  // The connected provider account.
   accountEmail: string | null;
-  // The Compass user whose SIGN-IN identity that Google account is.
+  // The Compass user whose SIGN-IN identity that account is.
   loginOwnerUserId: string;
   loginOwnerEmail: string;
 };
 
 export type ConnectionIdentityAuditReport = {
   generatedAt: string;
-  usersWithGoogleLogin: number;
+  providersAudited: ProviderKind[];
+  loginIdentitiesIndexed: number;
   connectionsChecked: number;
   collisions: ConnectionIdentityCollision[];
 };
 
-interface UserGoogleLoginDoc {
+export type AuditConnectionIdentityOptions = {
+  /** When omitted, every provider kind is audited. */
+  provider?: ProviderKind;
+};
+
+interface UserLoginIdentityDoc {
+  provider: ProviderKind;
+  subjectId: string;
+  email?: string;
+}
+
+interface UserLoginDoc {
   _id: unknown;
   email: string;
   google?: { googleId?: string };
+  identities?: UserLoginIdentityDoc[];
 }
 
 interface ConnectionDoc {
   _id: unknown;
   principalId: string;
+  provider: ProviderKind;
   account: { providerAccountId: string; email: string | null };
 }
 
+export const ALL_PROVIDER_KINDS: readonly ProviderKind[] =
+  ProviderKindSchema.options;
+
+export function resolveProvidersToAudit(
+  provider?: ProviderKind,
+): readonly ProviderKind[] {
+  return provider ? [provider] : ALL_PROVIDER_KINDS;
+}
+
+export function loginIdentityMapKey(
+  provider: ProviderKind,
+  subjectId: string,
+): string {
+  return `${provider}\0${subjectId}`;
+}
+
+function userLoginQuery(providers: readonly ProviderKind[]) {
+  const clauses: Record<string, unknown>[] = [];
+  if (providers.includes("google")) {
+    clauses.push({ "google.googleId": { $exists: true } });
+  }
+  const identityProviders = providers.filter((kind) => kind !== "google");
+  if (identityProviders.length > 0) {
+    clauses.push({
+      identities: {
+        $elemMatch: { provider: { $in: identityProviders } },
+      },
+    });
+  }
+  return clauses.length === 1 ? clauses[0]! : { $or: clauses };
+}
+
+function connectionQuery(providers: readonly ProviderKind[]) {
+  return {
+    provider: providers.length === 1 ? providers[0]! : { $in: [...providers] },
+    disconnectedAt: null,
+  };
+}
+
+function indexUserLoginIdentities(
+  user: UserLoginDoc,
+  providers: ReadonlySet<ProviderKind>,
+  loginByKey: Map<string, { userId: string; email: string }>,
+): void {
+  const userId = String(user._id);
+  if (providers.has("google")) {
+    const googleId = user.google?.googleId;
+    if (googleId) {
+      loginByKey.set(loginIdentityMapKey("google", googleId), {
+        userId,
+        email: user.email,
+      });
+    }
+  }
+  for (const identity of user.identities ?? []) {
+    if (!providers.has(identity.provider)) continue;
+    loginByKey.set(loginIdentityMapKey(identity.provider, identity.subjectId), {
+      userId,
+      email: identity.email ?? user.email,
+    });
+  }
+}
+
 /**
- * Read-only: finds every connected Google account that is actually another
+ * Read-only: finds every connected provider account that is actually another
  * Compass user's SIGN-IN identity - the collision A2 says a connect attempt
  * should reject going forward, and this reports for anything that already
  * slipped through (there was a window before that guard existed, and any
  * future regression in it).
  *
- * Never writes. Matches by `providerAccountId` (Google's stable subject id),
- * never email - email is mutable display data on both sides
- * (ProviderAccountFactsSchema's own doc comment), so an email match alone
- * would be a false positive whenever two different Google accounts have ever
+ * Never writes. Matches by `(provider, providerAccountId)` (the provider's
+ * stable subject id), never email - email is mutable display data on both
+ * sides (ProviderAccountFactsSchema's own doc comment), so an email match
+ * alone would be a false positive whenever two different accounts have ever
  * shared an address (a common re-registration pattern), and a false negative
  * whenever the same account's email changed.
  */
 export async function auditConnectionIdentity(
   compassDb: Db,
   syncDb: Db,
+  options: AuditConnectionIdentityOptions = {},
 ): Promise<ConnectionIdentityAuditReport> {
-  const loginByGoogleId = new Map<string, { userId: string; email: string }>();
+  const providers = resolveProvidersToAudit(options.provider);
+  const providerSet = new Set(providers);
+  const loginByKey = new Map<string, { userId: string; email: string }>();
+
   const users = compassDb
-    .collection<UserGoogleLoginDoc>(Collections.USER)
-    .find({ "google.googleId": { $exists: true } });
+    .collection<UserLoginDoc>(Collections.USER)
+    .find(userLoginQuery(providers));
   for await (const user of users) {
-    const googleId = user.google?.googleId;
-    if (!googleId) continue;
-    loginByGoogleId.set(googleId, {
-      userId: String(user._id),
-      email: user.email,
-    });
+    indexUserLoginIdentities(user, providerSet, loginByKey);
   }
 
   const collisions: ConnectionIdentityCollision[] = [];
@@ -68,11 +149,14 @@ export async function auditConnectionIdentity(
 
   const connections = syncDb
     .collection<ConnectionDoc>(SYNC_COLLECTIONS.providerConnections)
-    .find({ provider: "google", disconnectedAt: null });
+    .find(connectionQuery(providers));
   for await (const connection of connections) {
     connectionsChecked += 1;
-    const loginOwner = loginByGoogleId.get(
-      connection.account.providerAccountId,
+    const loginOwner = loginByKey.get(
+      loginIdentityMapKey(
+        connection.provider,
+        connection.account.providerAccountId,
+      ),
     );
     if (!loginOwner) continue;
     // Reconnecting/re-adding your OWN login account as a data connection is
@@ -82,6 +166,7 @@ export async function auditConnectionIdentity(
     collisions.push({
       connectingUserId: connection.principalId,
       connectionId: String(connection._id),
+      provider: connection.provider,
       accountEmail: connection.account.email,
       loginOwnerUserId: loginOwner.userId,
       loginOwnerEmail: loginOwner.email,
@@ -90,7 +175,8 @@ export async function auditConnectionIdentity(
 
   return {
     generatedAt: new Date().toISOString(),
-    usersWithGoogleLogin: loginByGoogleId.size,
+    providersAudited: [...providers],
+    loginIdentitiesIndexed: loginByKey.size,
     connectionsChecked,
     collisions,
   };

--- a/packages/sync/src/safety/safety-canary.test.ts
+++ b/packages/sync/src/safety/safety-canary.test.ts
@@ -1,0 +1,34 @@
+import { findSafetyCanaryHit, PROVIDER_LEAK_MARKERS } from "./safety-canary";
+import { describe, expect, it } from "bun:test";
+
+const PROVIDER_MARKER_SAMPLES: Record<
+  keyof typeof PROVIDER_LEAK_MARKERS,
+  unknown[]
+> = {
+  google: [
+    { conferenceData: {} },
+    { hangoutLink: "https://meet.example.com/abc" },
+  ],
+  microsoft: [
+    { "@odata.etag": 'W/"abc"' },
+    { onlineMeeting: { joinUrl: "https://teams.example.com/join" } },
+  ],
+  apple: ["BEGIN:VEVENT\nUID:1\nEND:VEVENT"],
+};
+
+describe("PROVIDER_LEAK_MARKERS", () => {
+  it("trips the canary for a marker from every registered provider", () => {
+    for (const [provider, patterns] of Object.entries(PROVIDER_LEAK_MARKERS)) {
+      expect(patterns.length).toBeGreaterThan(0);
+      const samples =
+        PROVIDER_MARKER_SAMPLES[provider as keyof typeof PROVIDER_LEAK_MARKERS];
+      expect(samples.length).toBeGreaterThanOrEqual(patterns.length);
+      for (let index = 0; index < patterns.length; index += 1) {
+        const pattern = patterns[index]!;
+        const sample = samples[index]!;
+        expect(findSafetyCanaryHit(sample)).toMatch(/^eventContent:/);
+        expect(pattern.test(JSON.stringify(sample))).toBe(true);
+      }
+    }
+  });
+});

--- a/packages/sync/src/safety/safety-canary.ts
+++ b/packages/sync/src/safety/safety-canary.ts
@@ -1,3 +1,5 @@
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+
 /**
  * Patterns that must never appear in Sync operational logs, SSE payloads, or
  * error cause chains (R-SEC / S43). Used by tests as canaries; not a runtime
@@ -11,12 +13,17 @@ const SECRET_PATTERNS: readonly RegExp[] = [
   /"refresh_token"\s*:\s*"[^"]+"/i,
 ];
 
-const EVENT_CONTENT_PATTERNS: readonly RegExp[] = [
+/** Provider-native payload shapes that must not leak into logs or SSE. */
+export const PROVIDER_LEAK_MARKERS: Record<ProviderKind, readonly RegExp[]> = {
+  google: [/"conferenceData"\s*:/i, /"hangoutLink"\s*:/i],
+  microsoft: [/"@odata\.etag"\s*:/i, /"onlineMeeting"\s*:/i],
+  apple: [/BEGIN:VEVENT/i],
+};
+
+const SHARED_EVENT_CONTENT_PATTERNS: readonly RegExp[] = [
   /"title"\s*:\s*"[^"]+"/i,
   /"description"\s*:\s*"[^"]+"/i,
   /"attendees"\s*:\s*\[/i,
-  /"conferenceData"\s*:/i,
-  /"hangoutLink"\s*:/i,
   // People API shapes (WP-05 contact suggestions). A person payload or a
   // suggestion list serialized into a log/error is a contact-data leak.
   /"emailAddresses"\s*:/i,
@@ -33,6 +40,17 @@ function serializeForCanary(value: unknown): string {
   }
 }
 
+function findProviderLeakMarkerHit(text: string): string | null {
+  for (const patterns of Object.values(PROVIDER_LEAK_MARKERS)) {
+    for (const pattern of patterns) {
+      if (pattern.test(text)) {
+        return `eventContent:${pattern.source}`;
+      }
+    }
+  }
+  return null;
+}
+
 /** Return the first matching canary pattern label, or null if clean. */
 export function findSafetyCanaryHit(
   value: unknown,
@@ -47,7 +65,9 @@ export function findSafetyCanaryHit(
     }
   }
   if (kinds.includes("eventContent")) {
-    for (const pattern of EVENT_CONTENT_PATTERNS) {
+    const providerHit = findProviderLeakMarkerHit(text);
+    if (providerHit) return providerHit;
+    for (const pattern of SHARED_EVENT_CONTENT_PATTERNS) {
       if (pattern.test(text)) {
         return `eventContent:${pattern.source}`;
       }


### PR DESCRIPTION
Fixes #3237

## What and why

Providers P0 WP-12 makes the connection-identity audit CLI provider-aware and prepares the safety canary for multi-provider payload leak detection.

- `audit-connection-identity` accepts `--provider google|microsoft|apple` (default: all). Login identities are keyed by `(provider, subjectId)` from `user.google.googleId` today and `user.identities[]` when milestone I lands.
- `PROVIDER_LEAK_MARKERS` holds per-provider payload shapes (Google conference fields, Graph etag/meeting, ICS VEVENT) so M-04 and A-04 can extend markers without touching canary logic.

Spec: `docs/features/calendar-providers.md`

## Verify

```
bun run verify --strict
```

```
Summary
Selected packages: sync, scripts
Checks run: test:sync:fast, test:scripts, type-check, lint, knip
Checks skipped: (none)

✓ All checks passed
VERDICT: PASS
```