### PR TITLE
feat(sync): replace google-only wiring with a ProviderRegistry

### DIFF
--- a/.agents/handoffs/3226.md
+++ b/.agents/handoffs/3226.md
@@ -2,9 +2,9 @@
 schema_version: 1
 task_id: "3226"
 from: Implementer
-to: Verifier
-owner: cursor-p0-wp03b-8f41
-status: running
+to: GitHub
+owner: GitHub
+status: verifying
 artifact:
   - path: packages/sync/src/providers/provider-registry.ts
   - path: packages/sync/src/providers/provider-registry.test.ts
@@ -12,9 +12,15 @@ artifact:
   - path: packages/sync/src/config/sync.config.ts
 evidence:
   - command: bun test:sync
-    result: pending
+    result: pass (1132 tests)
   - command: bun run type-check
-    result: pending
+    result: pass
+  - command: bun lint
+    result: pass
+  - command: bun knip
+    result: pass
+  - command: bun run verify
+    result: pass (test:core, test:sync, type-check, lint, knip)
 assumptions:
   - "Microsoft and Apple credentials are read into SyncConfig but not registered until M-09 / A-08."
   - "createSyncService still accepts authAdapter/writer/contacts as google per-kind overrides so existing tests keep working."

--- a/.agents/handoffs/3226.md
+++ b/.agents/handoffs/3226.md
@@ -1,0 +1,30 @@
+---
+schema_version: 1
+task_id: "3226"
+from: Implementer
+to: Verifier
+owner: cursor-p0-wp03b-8f41
+status: running
+artifact:
+  - path: packages/sync/src/providers/provider-registry.ts
+  - path: packages/sync/src/providers/provider-registry.test.ts
+  - path: packages/sync/src/app.ts
+  - path: packages/sync/src/config/sync.config.ts
+evidence:
+  - command: bun test:sync
+    result: pending
+  - command: bun run type-check
+    result: pending
+assumptions:
+  - "Microsoft and Apple credentials are read into SyncConfig but not registered until M-09 / A-08."
+  - "createSyncService still accepts authAdapter/writer/contacts as google per-kind overrides so existing tests keep working."
+open_risks:
+  - "Launch-next has #3237 (sync-core + scripts) in flight; this WP also touches packages/sync."
+next_deadline: 2026-09-05T02:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+P0 WP-03b: ProviderRegistry replaces Google-only wiring in app.ts and routes.

--- a/packages/core/src/types/sync/connection.contracts.test.ts
+++ b/packages/core/src/types/sync/connection.contracts.test.ts
@@ -210,6 +210,18 @@ describe("Sync connection contracts", () => {
           .success,
       ).toBe(false);
     });
+
+    it("accepts an optional provider, defaulting to omit", () => {
+      expect(
+        ConnectionBeginRequestSchema.parse({ provider: "google" }),
+      ).toEqual({ provider: "google" });
+      expect(
+        ConnectionBeginRequestSchema.parse({ provider: "microsoft" }),
+      ).toEqual({ provider: "microsoft" });
+      expect(
+        ConnectionBeginRequestSchema.safeParse({ provider: "yahoo" }).success,
+      ).toBe(false);
+    });
   });
 
   describe("ProviderAccountFactsSchema", () => {

--- a/packages/core/src/types/sync/connection.contracts.ts
+++ b/packages/core/src/types/sync/connection.contracts.ts
@@ -196,6 +196,10 @@ export type ConnectionListResponse = z.infer<
 export const ConnectionBeginRequestSchema = z.strictObject({
   connectionId: ConnectionIdSchema.optional(),
   features: ConnectionBeginFeaturesSchema.optional(),
+  // Defaults to google at the route when omitted so existing callers stay
+  // byte-identical. Other kinds are accepted here and resolved against the
+  // provider registry.
+  provider: ProviderKindSchema.optional(),
 });
 export type ConnectionBeginRequest = z.infer<
   typeof ConnectionBeginRequestSchema

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -34,19 +34,16 @@ import { SyncScheduler } from "@sync/domain/sync-scheduler.service";
 import { ReadinessRegistry } from "@sync/lifecycle/readiness";
 import { ShutdownCoordinator } from "@sync/lifecycle/shutdown";
 import { deriveOAuthStateSecret } from "@sync/oauth/oauth-state";
-import {
-  buildResolveAdapters,
-  buildResolveAuth,
-  googleProviderConfigured,
-  type ProviderAdapterOverrides,
-} from "@sync/providers/google/build-provider-resolvers";
-import { GoogleAuthAdapter } from "@sync/providers/google/google-auth.adapter";
-import { GoogleEventWriter } from "@sync/providers/google/google-event-writer.adapter";
-import { GooglePeopleAdapter } from "@sync/providers/google/google-people.adapter";
-import { type ResolveProviderAdapters } from "@sync/providers/provider-adapters";
+import { type ProviderAdapterOverrides } from "@sync/providers/google/build-provider-resolvers";
 import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
 import { type ContactsPort } from "@sync/providers/provider-contacts.port";
 import { type ProviderEventWriter } from "@sync/providers/provider-event-writer.port";
+import {
+  buildProviderRegistry,
+  type ProviderRegistry,
+  resolveAdaptersFrom,
+  resolveAuthFrom,
+} from "@sync/providers/provider-registry";
 import { redactedCause } from "@sync/safety/redact-error";
 import { NOTIFICATIONS_PATH } from "@sync/server/notification.routes";
 import { buildSyncApp } from "@sync/server/sync.server";
@@ -108,7 +105,9 @@ export function createSyncService(
     // Override the provider contacts port (tests inject a fake); production
     // builds it from config.
     contacts?: ContactsPort;
-    resolveAdapters?: ResolveProviderAdapters;
+    // Full registry replacement (tests inject a fake set of kinds).
+    registry?: ProviderRegistry;
+    adapterOverrides?: ProviderAdapterOverrides;
   } = {},
 ): SyncService {
   const identity = buildServiceIdentity({
@@ -130,7 +129,8 @@ export function createSyncService(
   }
 
   const adapterOverrides: ProviderAdapterOverrides =
-    deps.authAdapter || deps.writer || deps.contacts
+    deps.adapterOverrides ??
+    (deps.authAdapter || deps.writer || deps.contacts
       ? {
           google: {
             auth: deps.authAdapter,
@@ -138,9 +138,9 @@ export function createSyncService(
             contacts: deps.contacts,
           },
         }
-      : {};
-  const resolveAdapters =
-    deps.resolveAdapters ?? buildResolveAdapters(config, adapterOverrides);
+      : {});
+  const registry =
+    deps.registry ?? buildProviderRegistry(config, adapterOverrides);
 
   // The internal connection API mounts only when storage is provided. Its
   // routes read the connected db per request, so the app is still built before
@@ -155,16 +155,7 @@ export function createSyncService(
         }),
         mongo: deps.mongo,
         execution: config.EXECUTION,
-        resolveAdapters,
-        // The provider adapter is db-free, so it is built once here (gated on
-        // provider config); the per-request custody/repos build from the db.
-        authAdapter: deps.authAdapter ?? buildAuthAdapter(config),
-        // The event writer is likewise db-free and gated on provider config;
-        // the command routes use it for provider-targeted creates.
-        writer: deps.writer ?? buildEventWriter(config),
-        // The contacts port is likewise db-free and gated on provider config;
-        // the contacts routes use it for attendee suggestions.
-        contacts: deps.contacts ?? buildContactsPort(config),
+        registry,
         // The OAuth CSRF state is signed with a key derived from the service
         // secret (domain-separated from internal-auth signing); the callback
         // resolves against the public base URL.
@@ -194,39 +185,6 @@ export function createSyncService(
   };
 
   return { identity, readiness, shutdown, httpServer, stop };
-}
-
-// Build the provider authorization adapter when the provider is configured.
-// A passive deployment without provider credentials returns undefined, and the
-// connection API refuses provider-touching operations rather than failing.
-function buildAuthAdapter(config: SyncConfig): ProviderAuthAdapter | undefined {
-  if (!config.GOOGLE_CLIENT_ID || !config.GOOGLE_CLIENT_SECRET) {
-    return undefined;
-  }
-  return new GoogleAuthAdapter(
-    config.GOOGLE_CLIENT_ID,
-    config.GOOGLE_CLIENT_SECRET,
-  );
-}
-
-// Build the provider event writer when the provider is configured. Gated on the
-// same credentials as the auth adapter: a passive/unconfigured deployment
-// returns undefined, and provider-targeted commands stay pending.
-function buildEventWriter(config: SyncConfig): ProviderEventWriter | undefined {
-  if (!config.GOOGLE_CLIENT_ID || !config.GOOGLE_CLIENT_SECRET) {
-    return undefined;
-  }
-  return new GoogleEventWriter();
-}
-
-// Build the provider contacts port when the provider is configured. Gated on
-// the same credentials as the auth adapter: a passive/unconfigured deployment
-// returns undefined and the suggestions route refuses.
-function buildContactsPort(config: SyncConfig): ContactsPort | undefined {
-  if (!config.GOOGLE_CLIENT_ID || !config.GOOGLE_CLIENT_SECRET) {
-    return undefined;
-  }
-  return new GooglePeopleAdapter();
 }
 
 function closeHttpServer(httpServer: Server): Promise<void> {
@@ -501,10 +459,11 @@ function buildSchedulers(
   sweeps: ReadonlyArray<readonly [name: string, sweep: SweepScheduler]>;
 } | null {
   if (config.EXECUTION !== "active") return null;
-  if (!googleProviderConfigured(config)) return null;
+  const registry = buildProviderRegistry(config);
+  if (registry.kinds().length === 0) return null;
 
-  const resolveAdapters = buildResolveAdapters(config);
-  const resolveAuth = buildResolveAuth(resolveAdapters);
+  const resolveAdapters = resolveAdaptersFrom(registry);
+  const resolveAuth = resolveAuthFrom(registry);
 
   const repos = syncRepositories(mongo);
   const resources = repos.syncResources;

--- a/packages/sync/src/config/sync.config.db.test.ts
+++ b/packages/sync/src/config/sync.config.db.test.ts
@@ -102,6 +102,33 @@ describe("Sync service configuration", () => {
     });
   });
 
+  describe("Microsoft credentials and encryption key (read-only)", () => {
+    it("leaves microsoft and the encryption key unset when absent", () => {
+      const config = parseSyncConfig(compassConfigWithSync());
+      expect(config.MICROSOFT_CLIENT_ID).toBeUndefined();
+      expect(config.MICROSOFT_CLIENT_SECRET).toBeUndefined();
+      expect(config.CREDENTIAL_ENCRYPTION_KEY).toBeUndefined();
+    });
+
+    it("reads microsoft client credentials from the microsoft section", () => {
+      const config = parseSyncConfig({
+        runtime: { nodeEnv: "staging", timezone: "Etc/UTC" },
+        sync: baseSyncSection(),
+        microsoft: { clientId: "ms-id", clientSecret: "ms-secret" },
+      } as unknown as CompassConfig);
+      expect(config.MICROSOFT_CLIENT_ID).toBe("ms-id");
+      expect(config.MICROSOFT_CLIENT_SECRET).toBe("ms-secret");
+    });
+
+    it("reads credentialEncryptionKey from the sync section", () => {
+      const key = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+      const config = parseSyncConfig(
+        compassConfigWithSync({ credentialEncryptionKey: key }),
+      );
+      expect(config.CREDENTIAL_ENCRYPTION_KEY).toBe(key);
+    });
+  });
+
   describe("required fields", () => {
     it("throws a clear error when the sync section is absent", () => {
       const config = { runtime: { nodeEnv: "staging", timezone: "Etc/UTC" } };

--- a/packages/sync/src/config/sync.config.ts
+++ b/packages/sync/src/config/sync.config.ts
@@ -66,6 +66,12 @@ export const SyncConfigSchema = z
     // the Google adapter refuses to construct when either is absent.
     GOOGLE_CLIENT_ID: z.string().trim().min(1).optional(),
     GOOGLE_CLIENT_SECRET: z.string().trim().min(1).optional(),
+    // Microsoft OAuth client. Read-only in this WP; registration is M-09.
+    MICROSOFT_CLIENT_ID: z.string().trim().min(1).optional(),
+    MICROSOFT_CLIENT_SECRET: z.string().trim().min(1).optional(),
+    // AES-256-GCM key for password credentials at rest (Apple). Read-only in
+    // this WP; custody encryption is WP-06.
+    CREDENTIAL_ENCRYPTION_KEY: z.string().trim().min(1).optional(),
     // Optional PostHog credentials for sanitized sync_health_snapshot events.
     // When absent, the health emitter no-ops (local/dev without analytics).
     POSTHOG_KEY: z.string().trim().min(1).optional(),
@@ -102,6 +108,9 @@ export function parseSyncConfig(config: CompassConfig): SyncConfig {
     // Empty-string (unfilled deploy placeholder) or null coerces to absent.
     GOOGLE_CLIENT_ID: config.google?.clientId || undefined,
     GOOGLE_CLIENT_SECRET: config.google?.clientSecret || undefined,
+    MICROSOFT_CLIENT_ID: config.microsoft?.clientId || undefined,
+    MICROSOFT_CLIENT_SECRET: config.microsoft?.clientSecret || undefined,
+    CREDENTIAL_ENCRYPTION_KEY: config.sync.credentialEncryptionKey || undefined,
     POSTHOG_KEY: config.posthog?.key || undefined,
     POSTHOG_HOST: config.posthog?.host || undefined,
   });

--- a/packages/sync/src/providers/google/build-provider-resolvers.ts
+++ b/packages/sync/src/providers/google/build-provider-resolvers.ts
@@ -9,10 +9,7 @@ import { GooglePeopleAdapter } from "@sync/providers/google/google-people.adapte
 import {
   type ProviderAdapters,
   ProviderNotConfiguredError,
-  type ResolveProviderAdapters,
-  type ResolveProviderAuth,
 } from "@sync/providers/provider-adapters";
-import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
 
 export type ProviderAdapterOverrides = Partial<
   Record<ProviderKind, Partial<ProviderAdapters>>
@@ -22,7 +19,7 @@ function googleConfigured(config: SyncConfig): boolean {
   return Boolean(config.GOOGLE_CLIENT_ID && config.GOOGLE_CLIENT_SECRET);
 }
 
-function googleAdapters(
+export function googleAdapters(
   config: SyncConfig,
   override?: Partial<ProviderAdapters>,
 ): ProviderAdapters {
@@ -42,36 +39,6 @@ function googleAdapters(
     writer: override?.writer ?? new GoogleEventWriter(),
     notifications: override?.notifications ?? new GoogleNotificationAdapter(),
     contacts: override?.contacts ?? new GooglePeopleAdapter(),
-  };
-}
-
-export function buildResolveAdapters(
-  config: SyncConfig,
-  overrides: ProviderAdapterOverrides = {},
-): ResolveProviderAdapters {
-  return (provider) => {
-    if (provider === "google") {
-      return googleAdapters(config, overrides.google);
-    }
-    throw new ProviderNotConfiguredError(provider);
-  };
-}
-
-export function buildResolveAuth(
-  resolveAdapters: ResolveProviderAdapters,
-): ResolveProviderAuth {
-  return (provider) => resolveAdapters(provider).auth;
-}
-
-export function authResolverForAdapter(
-  adapter: ProviderAuthAdapter,
-  kind: ProviderKind = "google",
-): ResolveProviderAuth {
-  return (provider) => {
-    if (provider !== kind) {
-      throw new ProviderNotConfiguredError(provider);
-    }
-    return adapter;
   };
 }
 

--- a/packages/sync/src/providers/google/google-capabilities.ts
+++ b/packages/sync/src/providers/google/google-capabilities.ts
@@ -2,8 +2,10 @@ import { type ProviderCapability } from "@core/types/sync/identity.contracts";
 import {
   GOOGLE_SCOPE_CALENDAR_EVENTS as CALENDAR_EVENTS,
   GOOGLE_SCOPE_CALENDAR_READONLY as CALENDAR_READONLY,
+  CONTACTS_FEATURE_SCOPES,
   GOOGLE_SCOPE_CONTACTS_OTHER_READONLY as CONTACTS_OTHER_READONLY,
   GOOGLE_SCOPE_CONTACTS_READONLY as CONTACTS_READONLY,
+  GOOGLE_SCOPES,
 } from "@sync/providers/google/google.scopes";
 
 // Derive connection capabilities from the scopes Google actually granted (which
@@ -38,3 +40,6 @@ export function googleCapabilitiesFromScopes(
 
   return capabilities;
 }
+
+export const GOOGLE_PROVIDER_CAPABILITIES: readonly ProviderCapability[] =
+  googleCapabilitiesFromScopes([...GOOGLE_SCOPES, ...CONTACTS_FEATURE_SCOPES]);

--- a/packages/sync/src/providers/google/google.scopes.test.ts
+++ b/packages/sync/src/providers/google/google.scopes.test.ts
@@ -3,6 +3,7 @@ import {
   GOOGLE_SCOPE_CONTACTS_OTHER_READONLY,
   GOOGLE_SCOPE_CONTACTS_READONLY,
   GOOGLE_SCOPES,
+  googleScopesForFeatures,
 } from "@sync/providers/google/google.scopes";
 import { describe, expect, it } from "bun:test";
 
@@ -23,10 +24,11 @@ describe("google scopes", () => {
     expect(GOOGLE_SCOPES).not.toContain(GOOGLE_SCOPE_CONTACTS_OTHER_READONLY);
   });
 
-  it("bundles both contacts scopes into the contacts feature", () => {
-    expect(CONTACTS_FEATURE_SCOPES).toEqual([
-      "https://www.googleapis.com/auth/contacts.readonly",
-      "https://www.googleapis.com/auth/contacts.other.readonly",
-    ]);
+  it("maps the contacts feature to the optional contacts scopes", () => {
+    expect(googleScopesForFeatures(["contacts"])).toEqual(
+      CONTACTS_FEATURE_SCOPES,
+    );
+    expect(googleScopesForFeatures([])).toEqual([]);
+    expect(googleScopesForFeatures(["other"])).toEqual([]);
   });
 });

--- a/packages/sync/src/providers/google/google.scopes.ts
+++ b/packages/sync/src/providers/google/google.scopes.ts
@@ -37,3 +37,9 @@ export const CONTACTS_FEATURE_SCOPES: readonly string[] = [
   GOOGLE_SCOPE_CONTACTS_READONLY,
   GOOGLE_SCOPE_CONTACTS_OTHER_READONLY,
 ];
+
+export function googleScopesForFeatures(
+  features: readonly string[],
+): readonly string[] {
+  return features.includes("contacts") ? CONTACTS_FEATURE_SCOPES : [];
+}

--- a/packages/sync/src/providers/provider-registry.test.ts
+++ b/packages/sync/src/providers/provider-registry.test.ts
@@ -1,0 +1,108 @@
+import { NodeEnv } from "@core/constants/core.constants";
+import { type SyncConfig } from "@sync/config/sync.config";
+import { ProviderNotConfiguredError } from "@sync/providers/provider-adapters";
+import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
+import {
+  buildProviderRegistry,
+  GOOGLE_CALLBACK_PATH,
+} from "@sync/providers/provider-registry";
+import { describe, expect, it } from "bun:test";
+
+const baseConfig = (overrides: Partial<SyncConfig> = {}): SyncConfig =>
+  ({
+    NODE_ENV: NodeEnv.Test,
+    PORT: 3010,
+    MONGO_URI: "mongodb://localhost/test",
+    INTERNAL_AUTH_TOKEN: "token",
+    CALLBACK_BASE_URL: "https://example.test",
+    EXECUTION: "passive",
+    MAX_CONCURRENCY: 4,
+    RESERVED_PULL_LANES: 1,
+    ENFORCE_LEAST_PRIVILEGE: false,
+    COMPASS_API_DATABASE: "prod_calendar",
+    ...overrides,
+  }) as SyncConfig;
+
+const fakeAuth = (): ProviderAuthAdapter => ({
+  buildAuthorizationUrl: () => "https://example.test/auth",
+  exchangeAuthorizationCode: async () => {
+    throw new Error("unused");
+  },
+  refreshAccessToken: async () => {
+    throw new Error("unused");
+  },
+  revoke: async () => {},
+});
+
+describe("ProviderRegistry", () => {
+  it("throws ProviderNotConfiguredError for an unknown kind", () => {
+    const registry = buildProviderRegistry(
+      baseConfig({
+        GOOGLE_CLIENT_ID: "id",
+        GOOGLE_CLIENT_SECRET: "secret",
+      }),
+    );
+    expect(() => registry.get("microsoft")).toThrow(ProviderNotConfiguredError);
+    expect(() => registry.get("apple")).toThrow(ProviderNotConfiguredError);
+    try {
+      registry.get("microsoft");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProviderNotConfiguredError);
+      expect((error as ProviderNotConfiguredError).provider).toBe("microsoft");
+    }
+  });
+
+  it("lists only configured providers in kinds()", () => {
+    expect(buildProviderRegistry(baseConfig()).kinds()).toEqual([]);
+    expect(
+      buildProviderRegistry(
+        baseConfig({
+          GOOGLE_CLIENT_ID: "id",
+          GOOGLE_CLIENT_SECRET: "secret",
+          MICROSOFT_CLIENT_ID: "ms-id",
+          MICROSOFT_CLIENT_SECRET: "ms-secret",
+        }),
+      ).kinds(),
+    ).toEqual(["google"]);
+  });
+
+  it("returns capabilities per kind", () => {
+    const registry = buildProviderRegistry(
+      baseConfig({
+        GOOGLE_CLIENT_ID: "id",
+        GOOGLE_CLIENT_SECRET: "secret",
+      }),
+    );
+    const google = registry.get("google");
+    expect(google.callbackPath).toBe(GOOGLE_CALLBACK_PATH);
+    expect(google.capabilities).toEqual(
+      expect.arrayContaining([
+        "readEvents",
+        "writeEvents",
+        "readBusy",
+        "inviteAttendees",
+        "changeNotifications",
+        "incrementalChanges",
+        "suggestContacts",
+      ]),
+    );
+    expect(
+      google.capabilitiesFromScopes([
+        "https://www.googleapis.com/auth/calendar.events",
+      ]),
+    ).toContain("writeEvents");
+    expect(google.scopes.forFeatures(["contacts"])).toEqual([
+      "https://www.googleapis.com/auth/contacts.readonly",
+      "https://www.googleapis.com/auth/contacts.other.readonly",
+    ]);
+    expect(google.scopes.forFeatures([])).toEqual([]);
+  });
+
+  it("registers google from a test auth override without yaml credentials", () => {
+    const registry = buildProviderRegistry(baseConfig(), {
+      google: { auth: fakeAuth() },
+    });
+    expect(registry.has("google")).toBe(true);
+    expect(registry.kinds()).toEqual(["google"]);
+  });
+});

--- a/packages/sync/src/providers/provider-registry.ts
+++ b/packages/sync/src/providers/provider-registry.ts
@@ -1,0 +1,92 @@
+import {
+  type ProviderCapability,
+  type ProviderKind,
+} from "@core/types/sync/identity.contracts";
+import { type SyncConfig } from "@sync/config/sync.config";
+import {
+  googleAdapters,
+  googleProviderConfigured,
+  type ProviderAdapterOverrides,
+} from "@sync/providers/google/build-provider-resolvers";
+import { googleScopesForFeatures } from "@sync/providers/google/google.scopes";
+import {
+  GOOGLE_PROVIDER_CAPABILITIES,
+  googleCapabilitiesFromScopes,
+} from "@sync/providers/google/google-capabilities";
+import {
+  type ProviderAdapters,
+  ProviderNotConfiguredError,
+  type ResolveProviderAdapters,
+  type ResolveProviderAuth,
+} from "@sync/providers/provider-adapters";
+
+export interface ProviderScopes {
+  forFeatures(features: readonly string[]): readonly string[];
+}
+
+export interface ProviderRegistration {
+  adapters: ProviderAdapters;
+  scopes: ProviderScopes;
+  capabilities: readonly ProviderCapability[];
+  callbackPath: string;
+  capabilitiesFromScopes(granted: readonly string[]): ProviderCapability[];
+}
+
+export class ProviderRegistry {
+  constructor(
+    private readonly registrations: ReadonlyMap<
+      ProviderKind,
+      ProviderRegistration
+    >,
+  ) {}
+
+  get(kind: ProviderKind): ProviderRegistration {
+    const registration = this.registrations.get(kind);
+    if (!registration) {
+      throw new ProviderNotConfiguredError(kind);
+    }
+    return registration;
+  }
+
+  has(kind: ProviderKind): boolean {
+    return this.registrations.has(kind);
+  }
+
+  kinds(): ProviderKind[] {
+    return [...this.registrations.keys()];
+  }
+}
+
+export const GOOGLE_CALLBACK_PATH = "/sync/google";
+
+export function buildProviderRegistry(
+  config: SyncConfig,
+  overrides: ProviderAdapterOverrides = {},
+): ProviderRegistry {
+  const registrations = new Map<ProviderKind, ProviderRegistration>();
+  // Microsoft and Apple registration lands in M-09 / A-08. Config for those
+  // kinds is read into SyncConfig in this WP but does not register them yet.
+  const googleOverride = overrides.google;
+  if (googleProviderConfigured(config) || googleOverride?.auth !== undefined) {
+    registrations.set("google", {
+      adapters: googleAdapters(config, googleOverride),
+      scopes: { forFeatures: googleScopesForFeatures },
+      capabilities: GOOGLE_PROVIDER_CAPABILITIES,
+      callbackPath: GOOGLE_CALLBACK_PATH,
+      capabilitiesFromScopes: googleCapabilitiesFromScopes,
+    });
+  }
+  return new ProviderRegistry(registrations);
+}
+
+export function resolveAdaptersFrom(
+  registry: ProviderRegistry,
+): ResolveProviderAdapters {
+  return (kind) => registry.get(kind).adapters;
+}
+
+export function resolveAuthFrom(
+  registry: ProviderRegistry,
+): ResolveProviderAuth {
+  return (kind) => registry.get(kind).adapters.auth;
+}

--- a/packages/sync/src/server/command.routes.ts
+++ b/packages/sync/src/server/command.routes.ts
@@ -13,10 +13,11 @@ import {
   ProviderWriteUnavailableError,
   submitCloudCommand,
 } from "@sync/domain/cloud-command.service";
-import { buildResolveAuth } from "@sync/providers/google/build-provider-resolvers";
-import { type ResolveProviderAdapters } from "@sync/providers/provider-adapters";
-import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
-import { type ProviderEventWriter } from "@sync/providers/provider-event-writer.port";
+import {
+  type ProviderRegistry,
+  resolveAdaptersFrom,
+  resolveAuthFrom,
+} from "@sync/providers/provider-registry";
 import { redactedCause } from "@sync/safety/redact-error";
 import {
   ensureConnected,
@@ -38,13 +39,9 @@ export interface CommandApiDeps {
   // Whether provider work is enabled. A provider-targeted create executes only
   // when active; otherwise it is recorded pending.
   execution: SyncExecutionMode;
-  // Provider write + auth adapters, present only when a provider is configured.
-  // Both are needed to execute a provider create (the writer performs it, the
-  // auth adapter backs the per-request credential custody). Absent leaves
-  // provider-targeted commands pending.
-  writer?: ProviderEventWriter;
-  authAdapter?: ProviderAuthAdapter;
-  resolveAdapters?: ResolveProviderAdapters;
+  // Provider registry, present only when at least one provider is configured.
+  // A provider-targeted create executes through the connection's kind.
+  registry: ProviderRegistry;
   // Injectable clock so local confirmation timestamps are deterministic in
   // tests.
   now?: () => number;
@@ -82,12 +79,12 @@ export function registerCommandRoutes(
         // custody is per-request (it holds the request's db-backed credential
         // repo), the writer is shared.
         const provider =
-          deps.resolveAdapters && deps.authAdapter
+          deps.registry.kinds().length > 0
             ? {
-                resolveAdapters: deps.resolveAdapters,
+                resolveAdapters: resolveAdaptersFrom(deps.registry),
                 custody: new CredentialCustody(
                   repos.credentials,
-                  buildResolveAuth(deps.resolveAdapters),
+                  resolveAuthFrom(deps.registry),
                 ),
               }
             : undefined;

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -27,6 +27,8 @@ import {
   type ConnectionId,
   ConnectionIdSchema,
   type PrincipalId,
+  type ProviderKind,
+  ProviderKindSchema,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
 import dayjs from "@core/util/date/dayjs";
@@ -49,16 +51,11 @@ import {
   HORIZON_PAST_MONTHS,
 } from "@sync/domain/horizon";
 import { signOAuthState, verifyOAuthState } from "@sync/oauth/oauth-state";
-import {
-  authResolverForAdapter,
-  buildResolveAuth,
-} from "@sync/providers/google/build-provider-resolvers";
-import { CONTACTS_FEATURE_SCOPES } from "@sync/providers/google/google.scopes";
-import { googleCapabilitiesFromScopes } from "@sync/providers/google/google-capabilities";
-import { type ResolveProviderAdapters } from "@sync/providers/provider-adapters";
 import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
-import { type ContactsPort } from "@sync/providers/provider-contacts.port";
-import { type ProviderEventWriter } from "@sync/providers/provider-event-writer.port";
+import {
+  type ProviderRegistry,
+  resolveAuthFrom,
+} from "@sync/providers/provider-registry";
 import { redactedCause } from "@sync/safety/redact-error";
 import {
   ensureConnected,
@@ -113,18 +110,7 @@ export interface ConnectionApiDeps {
   mongo: SyncMongoService;
   // Disconnect and begin make provider calls, so they are gated on execution.
   execution: SyncExecutionMode;
-  // The provider authorization adapter, present only when the provider is
-  // configured. Absent (or passive mode) means no provider work is possible.
-  authAdapter?: ProviderAuthAdapter;
-  resolveAdapters?: ResolveProviderAdapters;
-  // The provider event writer, present only when the provider is configured.
-  // Not used by the connection routes themselves; carried here because this is
-  // the shared bag the command routes are wired from.
-  writer?: ProviderEventWriter;
-  // The provider contacts port, present only when the provider is configured.
-  // Not used by the connection routes themselves; carried here because this is
-  // the shared bag the contacts routes are wired from.
-  contacts?: ContactsPort;
+  registry: ProviderRegistry;
   // Secret the OAuth CSRF state is signed with, and the public base URL the
   // provider callback resolves against.
   stateSecret: string;
@@ -510,10 +496,26 @@ export function registerConnectionRoutes(
       if (!ensureConnected(deps.mongo, res)) return;
       // Authorizing touches the provider, so a passive or unconfigured service
       // refuses rather than handing back a URL it could never complete.
-      if (deps.execution === "passive" || !deps.authAdapter) {
+      if (deps.execution === "passive") {
         res.status(Status.CONFLICT).json({ error: "provider_work_disabled" });
         return;
       }
+
+      let provider: ProviderKind = "google";
+      const rawProvider = (req.body as { provider?: unknown })?.provider;
+      if (rawProvider !== undefined && rawProvider !== null) {
+        const parsedProvider = ProviderKindSchema.safeParse(rawProvider);
+        if (!parsedProvider.success) {
+          res.status(Status.BAD_REQUEST).json({ error: "invalid_provider" });
+          return;
+        }
+        provider = parsedProvider.data;
+      }
+      if (!deps.registry.has(provider)) {
+        res.status(Status.CONFLICT).json({ error: "provider_work_disabled" });
+        return;
+      }
+      const registration = deps.registry.get(provider);
 
       // Optional connectionId means reconnect: validate it is a real id owned by
       // this principal, so the state cannot bind a flow to a foreign connection.
@@ -560,9 +562,7 @@ export function registerConnectionRoutes(
           res.status(Status.BAD_REQUEST).json({ error: "invalid_features" });
           return;
         }
-        if (parsed.data.includes("contacts")) {
-          extraScopes = [...CONTACTS_FEATURE_SCOPES];
-        }
+        extraScopes = [...registration.scopes.forFeatures(parsed.data)];
       }
 
       // A fresh connect by a principal that already has connections is an
@@ -592,15 +592,17 @@ export function registerConnectionRoutes(
         connectionId,
         issuedAt: (deps.now ?? Date.now)(),
       });
-      const authorizationUrl = deps.authAdapter.buildAuthorizationUrl({
-        state,
-        redirectUri: `${deps.callbackBaseUrl}${OAUTH_CALLBACK_PATH}`,
-        selectAccount,
-        // Undefined (not an empty array) when no feature was asked for, so a
-        // plain begin's adapter input — and therefore its consent URL — stays
-        // byte-identical to before features existed.
-        ...(extraScopes.length > 0 ? { extraScopes } : {}),
-      });
+      const authorizationUrl = registration.adapters.auth.buildAuthorizationUrl(
+        {
+          state,
+          redirectUri: `${deps.callbackBaseUrl}${registration.callbackPath}`,
+          selectAccount,
+          // Undefined (not an empty array) when no feature was asked for, so a
+          // plain begin's adapter input — and therefore its consent URL — stays
+          // byte-identical to before features existed.
+          ...(extraScopes.length > 0 ? { extraScopes } : {}),
+        },
+      );
       res.status(Status.OK).json({ authorizationUrl });
     },
   );
@@ -616,7 +618,7 @@ export function registerConnectionRoutes(
       const auth = requireAuth(req, res);
       if (!auth) return;
       if (!ensureConnected(deps.mongo, res)) return;
-      if (deps.execution === "passive" || !deps.authAdapter) {
+      if (deps.execution === "passive" || !deps.registry.has("google")) {
         res.status(Status.CONFLICT).json({ error: "provider_work_disabled" });
         return;
       }
@@ -640,7 +642,6 @@ export function registerConnectionRoutes(
         );
         await linkConnection(
           deps,
-          deps.authAdapter,
           {
             tenantId: auth.tenantId,
             principalId: auth.principalId,
@@ -720,7 +721,7 @@ export function registerConnectionRoutes(
     const redirect = (status: string) =>
       redirectAfterConnect(deps, res, status);
 
-    if (deps.execution === "passive" || !deps.authAdapter) {
+    if (deps.execution === "passive" || !deps.registry.has("google")) {
       return redirect("error");
     }
     if (!deps.mongo.isConnected) return redirect("error");
@@ -740,14 +741,15 @@ export function registerConnectionRoutes(
     );
     if (!verified.ok) return redirect("error");
 
+    const google = deps.registry.get("google");
     let authorization: Awaited<
       ReturnType<ProviderAuthAdapter["exchangeAuthorizationCode"]>
     >;
     try {
-      authorization = await deps.authAdapter.exchangeAuthorizationCode({
+      authorization = await google.adapters.auth.exchangeAuthorizationCode({
         code,
         // Must match the redirect_uri begin used to build the consent URL.
-        redirectUri: `${deps.callbackBaseUrl}${OAUTH_CALLBACK_PATH}`,
+        redirectUri: `${deps.callbackBaseUrl}${google.callbackPath}`,
       });
     } catch (error) {
       // Bad code, no refresh token, unverifiable identity — nothing to link.
@@ -763,22 +765,15 @@ export function registerConnectionRoutes(
     // resource, surfacing as "Couldn't update your calendar" with no mention
     // of the actual cause. Catch it here, before any connection is created.
     if (
-      !googleCapabilitiesFromScopes(authorization.grantedScopes).includes(
-        "readEvents",
-      )
+      !google
+        .capabilitiesFromScopes(authorization.grantedScopes)
+        .includes("readEvents")
     ) {
       return redirect("missingScopes");
     }
 
     try {
-      // authAdapter is non-null here (gated above); pass it so the helper needs
-      // no assertion.
-      await linkConnection(
-        deps,
-        deps.authAdapter,
-        verified.payload,
-        authorization,
-      );
+      await linkConnection(deps, verified.payload, authorization);
       return redirect("connected");
     } catch (error) {
       logger.error(
@@ -801,7 +796,7 @@ export function registerConnectionRoutes(
       // Disconnect revokes at the provider, so a passive service (or one with no
       // provider configured) must refuse rather than half-disconnect: delete the
       // credential locally while leaving live authority at the provider.
-      if (deps.execution === "passive" || !deps.authAdapter) {
+      if (deps.execution === "passive" || deps.registry.kinds().length === 0) {
         res.status(Status.CONFLICT).json({ error: "provider_work_disabled" });
         return;
       }
@@ -826,12 +821,17 @@ export function registerConnectionRoutes(
           return;
         }
 
+        if (!deps.registry.has(connection.provider)) {
+          res.status(Status.CONFLICT).json({ error: "provider_work_disabled" });
+          return;
+        }
+
         // Revoke + delete the credential first (the security-critical step), then
         // record the disconnect. Both are idempotent, so a retry after a partial
         // failure converges.
         const custody = new CredentialCustody(
           new CredentialRepository(deps.mongo.db),
-          resolveAuthForConnectionApi(deps),
+          resolveAuthFrom(deps.registry),
         );
         await custody.disconnect(id.data);
         await connections.markDisconnected(
@@ -851,14 +851,8 @@ export function registerConnectionRoutes(
 // Redirect the browser to the server-configured post-connect URL with a coarse
 // status. The base is from config, never the request, so it can't be abused as
 // an open redirect; status is a fixed label, carrying no provider detail.
-function resolveAuthForConnectionApi(
-  deps: ConnectionApiDeps,
-  authAdapter: ProviderAuthAdapter = deps.authAdapter!,
-) {
-  if (deps.resolveAdapters) {
-    return buildResolveAuth(deps.resolveAdapters);
-  }
-  return authResolverForAdapter(authAdapter);
+function resolveAuthForConnectionApi(deps: ConnectionApiDeps) {
+  return resolveAuthFrom(deps.registry);
 }
 
 function redirectAfterConnect(
@@ -878,7 +872,6 @@ function redirectAfterConnect(
 // import has not finished is "importing", not set arbitrarily.
 async function linkConnection(
   deps: ConnectionApiDeps,
-  authAdapter: ProviderAuthAdapter,
   state: {
     tenantId: TenantId;
     principalId: PrincipalId;
@@ -923,7 +916,9 @@ async function linkConnection(
     principalId: state.principalId,
     provider: "google",
     account: authorization.account,
-    capabilities: googleCapabilitiesFromScopes(authorization.grantedScopes),
+    capabilities: deps.registry
+      .get("google")
+      .capabilitiesFromScopes(authorization.grantedScopes),
     state: derived.state,
     stateReason: derived.reason,
   });
@@ -931,7 +926,7 @@ async function linkConnection(
   try {
     const custody = new CredentialCustody(
       repos.credentials,
-      resolveAuthForConnectionApi(deps, authAdapter),
+      resolveAuthForConnectionApi(deps),
     );
     await custody.store({
       connectionId: connection._id,

--- a/packages/sync/src/server/contacts.routes.ts
+++ b/packages/sync/src/server/contacts.routes.ts
@@ -10,19 +10,19 @@ import {
 } from "@core/types/contact.contracts";
 import { type SyncExecutionMode } from "@sync/config/sync.config";
 import { CredentialCustody } from "@sync/credentials/credential-custody.service";
-import { authResolverForAdapter } from "@sync/providers/google/build-provider-resolvers";
 import {
   GOOGLE_SCOPE_CONTACTS_OTHER_READONLY,
   GOOGLE_SCOPE_CONTACTS_READONLY,
 } from "@sync/providers/google/google.scopes";
-import {
-  type ProviderAuthAdapter,
-  ProviderAuthError,
-} from "@sync/providers/provider-auth.port";
+import { ProviderAuthError } from "@sync/providers/provider-auth.port";
 import {
   type ContactsPort,
   ContactsSearchError,
 } from "@sync/providers/provider-contacts.port";
+import {
+  type ProviderRegistry,
+  resolveAuthFrom,
+} from "@sync/providers/provider-registry";
 import { redactedCause } from "@sync/safety/redact-error";
 import {
   ensureConnected,
@@ -44,10 +44,7 @@ export interface ContactsApiDeps {
   mongo: SyncMongoService;
   // Suggestions call the provider, so a passive deployment refuses.
   execution: SyncExecutionMode;
-  // Backs per-request credential custody; absent means no provider work.
-  authAdapter?: ProviderAuthAdapter;
-  // The provider contacts port, present only when the provider is configured.
-  contacts?: ContactsPort;
+  registry: ProviderRegistry;
 }
 
 // Internal, authenticated attendee-suggestion lookup. Principal-scoped: the
@@ -69,7 +66,7 @@ export function registerContactsRoutes(
       if (!ensureConnected(deps.mongo, res)) return;
       // Suggestions always touch the provider (contacts are never cached), so
       // a passive or unconfigured service refuses like begin does.
-      if (deps.execution === "passive" || !deps.authAdapter || !deps.contacts) {
+      if (deps.execution === "passive" || deps.registry.kinds().length === 0) {
         res.status(Status.CONFLICT).json({ error: "provider_work_disabled" });
         return;
       }
@@ -112,12 +109,16 @@ export function registerContactsRoutes(
 
         const custody = new CredentialCustody(
           repos.credentials,
-          authResolverForAdapter(deps.authAdapter),
+          resolveAuthFrom(deps.registry),
         );
         const collected: ContactSuggestion[] = [];
         for (const connection of capable) {
+          if (!deps.registry.has(connection.provider)) continue;
+          const contacts = deps.registry.get(connection.provider).adapters
+            .contacts;
+          if (!contacts) continue;
           const suggestions = await searchConnection(
-            deps.contacts,
+            contacts,
             custody,
             repos.credentials,
             connection,

--- a/packages/sync/src/server/principal.routes.ts
+++ b/packages/sync/src/server/principal.routes.ts
@@ -4,8 +4,10 @@ import { Logger } from "@core/logger/winston.logger";
 import { PrincipalPurgeResponseSchema } from "@core/types/sync/principal.contracts";
 import { CredentialCustody } from "@sync/credentials/credential-custody.service";
 import { purgePrincipal } from "@sync/domain/principal-purge.service";
-import { authResolverForAdapter } from "@sync/providers/google/build-provider-resolvers";
-import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
+import {
+  type ProviderRegistry,
+  resolveAuthFrom,
+} from "@sync/providers/provider-registry";
 import { redactedCause } from "@sync/safety/redact-error";
 import {
   ensureConnected,
@@ -23,10 +25,11 @@ export const PRINCIPAL_PATH = "/internal/principal";
 export interface PrincipalApiDeps {
   authMiddleware: RequestHandler;
   mongo: SyncMongoService;
-  // Optional: when present, credentials are revoked at the provider before
-  // local delete. Account deletion still proceeds without it (passive /
-  // unconfigured deployments) so Sync-held tokens are never stranded.
-  authAdapter?: ProviderAuthAdapter;
+  // Optional: when present with at least one kind, credentials are revoked at
+  // the provider before local delete. Account deletion still proceeds without
+  // it (passive / unconfigured deployments) so Sync-held tokens are never
+  // stranded.
+  registry: ProviderRegistry;
 }
 
 // Hard-delete every Sync-held row for the signed principal. Served in passive
@@ -50,12 +53,13 @@ export function registerPrincipalRoutes(
         const counts = await purgePrincipal(
           {
             ...repos,
-            custody: deps.authAdapter
-              ? new CredentialCustody(
-                  repos.credentials,
-                  authResolverForAdapter(deps.authAdapter),
-                )
-              : undefined,
+            custody:
+              deps.registry.kinds().length > 0
+                ? new CredentialCustody(
+                    repos.credentials,
+                    resolveAuthFrom(deps.registry),
+                  )
+                : undefined,
           },
           auth.tenantId,
           auth.principalId,

--- a/packages/sync/src/server/sync.server.ts
+++ b/packages/sync/src/server/sync.server.ts
@@ -43,9 +43,7 @@ export function buildSyncApp(deps: {
       authMiddleware: deps.connectionApi.authMiddleware,
       mongo: deps.connectionApi.mongo,
       execution: deps.connectionApi.execution,
-      resolveAdapters: deps.connectionApi.resolveAdapters,
-      writer: deps.connectionApi.writer,
-      authAdapter: deps.connectionApi.authAdapter,
+      registry: deps.connectionApi.registry,
       now: deps.connectionApi.now,
     });
     // Attendee contact suggestions from the provider's People surfaces, gated
@@ -54,8 +52,7 @@ export function buildSyncApp(deps: {
       authMiddleware: deps.connectionApi.authMiddleware,
       mongo: deps.connectionApi.mongo,
       execution: deps.connectionApi.execution,
-      authAdapter: deps.connectionApi.authAdapter,
-      contacts: deps.connectionApi.contacts,
+      registry: deps.connectionApi.registry,
     });
     // Resumable invalidation outbox for Compass API → browser SSE (S40).
     registerChangeFeedRoutes(app, {
@@ -68,7 +65,7 @@ export function buildSyncApp(deps: {
     registerPrincipalRoutes(app, {
       authMiddleware: deps.connectionApi.authMiddleware,
       mongo: deps.connectionApi.mongo,
-      authAdapter: deps.connectionApi.authAdapter,
+      registry: deps.connectionApi.registry,
     });
     // Private support diagnostic lookup by non-user-facing connection key (S45).
     registerDiagnosticRoutes(app, {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3226

## What and why

Introduce `ProviderRegistry` so the sync service maps a `ProviderKind` to adapters, scopes, capabilities, and callback path. `app.ts` and the command, connection, contacts, and principal routes resolve per kind instead of constructing Google adapters inline. Microsoft client credentials and `CREDENTIAL_ENCRYPTION_KEY` are read from compass config (WP-02) but those providers are not registered yet (M-09 / A-08). Connect-begin reads optional `provider` from the request and defaults to `google`.

Spec: `docs/features/calendar-providers.md`

## Verify

`VERDICT: PASS`

Checks run: test:core, test:sync, type-check, lint, knip

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c551c3bd-a8a5-402b-abd1-9edd46fe8f41?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c551c3bd-a8a5-402b-abd1-9edd46fe8f41&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

