### PR TITLE
feat(sync): ProviderRegistry replaces Google-only wiring (WP-03b)

### DIFF
--- a/.agents/handoffs/3226.md
+++ b/.agents/handoffs/3226.md
@@ -1,0 +1,34 @@
+---
+schema_version: 1
+task_id: "3226"
+from: Implementer
+to: Verifier
+owner: Verifier
+status: verifying
+artifact:
+  - path: packages/sync/src/providers/provider-registry.ts
+  - path: packages/sync/src/providers/provider-registry.test.ts
+  - path: packages/sync/src/app.ts
+  - path: packages/sync/src/config/sync.config.ts
+  - path: packages/sync/src/server/connection.routes.ts
+  - path: packages/sync/src/server/command.routes.ts
+  - path: packages/sync/src/server/contacts.routes.ts
+  - path: packages/sync/src/server/principal.routes.ts
+evidence:
+  - command: bun run verify --strict
+    result: "PASS"
+  - command: grep -rn 'new Google' packages/sync/src --include='*.ts' | grep -v providers/google | grep -v test
+    result: "empty (no matches outside providers/google)"
+  - command: bun test:sync
+    result: "1136 pass, 0 fail"
+assumptions:
+  - Microsoft and Apple registration lands in M-09 / A-08; config fields are read-only here.
+open_risks: []
+next_deadline: null
+retry: 0
+approval: allow
+waiting_on: null
+escalation: null
+---
+
+WP-03b introduces `ProviderRegistry` built from `SyncConfig`, replaces Google-only wiring in `app.ts` and internal routes, and reads Microsoft/credential config without registering those providers yet.

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -34,19 +34,11 @@ import { SyncScheduler } from "@sync/domain/sync-scheduler.service";
 import { ReadinessRegistry } from "@sync/lifecycle/readiness";
 import { ShutdownCoordinator } from "@sync/lifecycle/shutdown";
 import { deriveOAuthStateSecret } from "@sync/oauth/oauth-state";
+import { type ProviderAdapterOverrides } from "@sync/providers/google/build-provider-resolvers";
 import {
-  buildResolveAdapters,
-  buildResolveAuth,
-  googleProviderConfigured,
-  type ProviderAdapterOverrides,
-} from "@sync/providers/google/build-provider-resolvers";
-import { GoogleAuthAdapter } from "@sync/providers/google/google-auth.adapter";
-import { GoogleEventWriter } from "@sync/providers/google/google-event-writer.adapter";
-import { GooglePeopleAdapter } from "@sync/providers/google/google-people.adapter";
-import { type ResolveProviderAdapters } from "@sync/providers/provider-adapters";
-import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
-import { type ContactsPort } from "@sync/providers/provider-contacts.port";
-import { type ProviderEventWriter } from "@sync/providers/provider-event-writer.port";
+  buildProviderRegistry,
+  type ProviderRegistry,
+} from "@sync/providers/provider-registry";
 import { redactedCause } from "@sync/safety/redact-error";
 import { NOTIFICATIONS_PATH } from "@sync/server/notification.routes";
 import { buildSyncApp } from "@sync/server/sync.server";
@@ -99,16 +91,9 @@ export function createSyncService(
   config: SyncConfig,
   deps: {
     mongo?: SyncMongoService;
-    // Override the provider adapter (tests inject a fake to avoid the network);
-    // production builds it from config.
-    authAdapter?: ProviderAuthAdapter;
-    // Override the provider event writer (tests inject a fake); production
-    // builds it from config.
-    writer?: ProviderEventWriter;
-    // Override the provider contacts port (tests inject a fake); production
-    // builds it from config.
-    contacts?: ContactsPort;
-    resolveAdapters?: ResolveProviderAdapters;
+    registry?: ProviderRegistry;
+    // Per-kind adapter overrides for tests (merged into buildProviderRegistry).
+    adapterOverrides?: ProviderAdapterOverrides;
   } = {},
 ): SyncService {
   const identity = buildServiceIdentity({
@@ -129,18 +114,8 @@ export function createSyncService(
     );
   }
 
-  const adapterOverrides: ProviderAdapterOverrides =
-    deps.authAdapter || deps.writer || deps.contacts
-      ? {
-          google: {
-            auth: deps.authAdapter,
-            writer: deps.writer,
-            contacts: deps.contacts,
-          },
-        }
-      : {};
-  const resolveAdapters =
-    deps.resolveAdapters ?? buildResolveAdapters(config, adapterOverrides);
+  const registry =
+    deps.registry ?? buildProviderRegistry(config, deps.adapterOverrides ?? {});
 
   // The internal connection API mounts only when storage is provided. Its
   // routes read the connected db per request, so the app is still built before
@@ -155,16 +130,7 @@ export function createSyncService(
         }),
         mongo: deps.mongo,
         execution: config.EXECUTION,
-        resolveAdapters,
-        // The provider adapter is db-free, so it is built once here (gated on
-        // provider config); the per-request custody/repos build from the db.
-        authAdapter: deps.authAdapter ?? buildAuthAdapter(config),
-        // The event writer is likewise db-free and gated on provider config;
-        // the command routes use it for provider-targeted creates.
-        writer: deps.writer ?? buildEventWriter(config),
-        // The contacts port is likewise db-free and gated on provider config;
-        // the contacts routes use it for attendee suggestions.
-        contacts: deps.contacts ?? buildContactsPort(config),
+        registry,
         // The OAuth CSRF state is signed with a key derived from the service
         // secret (domain-separated from internal-auth signing); the callback
         // resolves against the public base URL.
@@ -194,39 +160,6 @@ export function createSyncService(
   };
 
   return { identity, readiness, shutdown, httpServer, stop };
-}
-
-// Build the provider authorization adapter when the provider is configured.
-// A passive deployment without provider credentials returns undefined, and the
-// connection API refuses provider-touching operations rather than failing.
-function buildAuthAdapter(config: SyncConfig): ProviderAuthAdapter | undefined {
-  if (!config.GOOGLE_CLIENT_ID || !config.GOOGLE_CLIENT_SECRET) {
-    return undefined;
-  }
-  return new GoogleAuthAdapter(
-    config.GOOGLE_CLIENT_ID,
-    config.GOOGLE_CLIENT_SECRET,
-  );
-}
-
-// Build the provider event writer when the provider is configured. Gated on the
-// same credentials as the auth adapter: a passive/unconfigured deployment
-// returns undefined, and provider-targeted commands stay pending.
-function buildEventWriter(config: SyncConfig): ProviderEventWriter | undefined {
-  if (!config.GOOGLE_CLIENT_ID || !config.GOOGLE_CLIENT_SECRET) {
-    return undefined;
-  }
-  return new GoogleEventWriter();
-}
-
-// Build the provider contacts port when the provider is configured. Gated on
-// the same credentials as the auth adapter: a passive/unconfigured deployment
-// returns undefined and the suggestions route refuses.
-function buildContactsPort(config: SyncConfig): ContactsPort | undefined {
-  if (!config.GOOGLE_CLIENT_ID || !config.GOOGLE_CLIENT_SECRET) {
-    return undefined;
-  }
-  return new GooglePeopleAdapter();
 }
 
 function closeHttpServer(httpServer: Server): Promise<void> {
@@ -501,10 +434,11 @@ function buildSchedulers(
   sweeps: ReadonlyArray<readonly [name: string, sweep: SweepScheduler]>;
 } | null {
   if (config.EXECUTION !== "active") return null;
-  if (!googleProviderConfigured(config)) return null;
+  const registry = buildProviderRegistry(config);
+  if (!registry.isConfigured()) return null;
 
-  const resolveAdapters = buildResolveAdapters(config);
-  const resolveAuth = buildResolveAuth(resolveAdapters);
+  const resolveAdapters = registry.resolveAdapters();
+  const resolveAuth = registry.resolveAuth();
 
   const repos = syncRepositories(mongo);
   const resources = repos.syncResources;

--- a/packages/sync/src/config/sync.config.db.test.ts
+++ b/packages/sync/src/config/sync.config.db.test.ts
@@ -102,6 +102,48 @@ describe("Sync service configuration", () => {
     });
   });
 
+  describe("Microsoft credentials (read only)", () => {
+    const withMicrosoft = (microsoft: Record<string, unknown> | undefined) =>
+      ({
+        runtime: { nodeEnv: "staging", timezone: "Etc/UTC" },
+        sync: baseSyncSection(),
+        microsoft,
+      }) as unknown as CompassConfig;
+
+    it("leaves Microsoft client unset when the section is absent", () => {
+      const config = parseSyncConfig(withMicrosoft(undefined));
+      expect(config.MICROSOFT_CLIENT_ID).toBeUndefined();
+      expect(config.MICROSOFT_CLIENT_SECRET).toBeUndefined();
+    });
+
+    it("reads Microsoft client id and secret when both are set", () => {
+      const config = parseSyncConfig(
+        withMicrosoft({
+          clientId: "ms-id",
+          clientSecret: "ms-secret",
+        }),
+      );
+      expect(config.MICROSOFT_CLIENT_ID).toBe("ms-id");
+      expect(config.MICROSOFT_CLIENT_SECRET).toBe("ms-secret");
+    });
+  });
+
+  describe("credential encryption key (read only)", () => {
+    it("reads sync.credentialEncryptionKey when set", () => {
+      const key =
+        "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCD";
+      const config = parseSyncConfig(
+        compassConfigWithSync({ credentialEncryptionKey: key }),
+      );
+      expect(config.CREDENTIAL_ENCRYPTION_KEY).toBe(key);
+    });
+
+    it("leaves credentialEncryptionKey unset when omitted", () => {
+      const config = parseSyncConfig(compassConfigWithSync());
+      expect(config.CREDENTIAL_ENCRYPTION_KEY).toBeUndefined();
+    });
+  });
+
   describe("required fields", () => {
     it("throws a clear error when the sync section is absent", () => {
       const config = { runtime: { nodeEnv: "staging", timezone: "Etc/UTC" } };

--- a/packages/sync/src/config/sync.config.ts
+++ b/packages/sync/src/config/sync.config.ts
@@ -66,6 +66,12 @@ export const SyncConfigSchema = z
     // the Google adapter refuses to construct when either is absent.
     GOOGLE_CLIENT_ID: z.string().trim().min(1).optional(),
     GOOGLE_CLIENT_SECRET: z.string().trim().min(1).optional(),
+    // Microsoft OAuth client (read only until M-09 registers the provider).
+    MICROSOFT_CLIENT_ID: z.string().trim().min(1).optional(),
+    MICROSOFT_CLIENT_SECRET: z.string().trim().min(1).optional(),
+    // 32-byte base64 key for password credentials at rest (Apple). Read only
+    // until A-08 registers the provider.
+    CREDENTIAL_ENCRYPTION_KEY: z.string().trim().min(1).optional(),
     // Optional PostHog credentials for sanitized sync_health_snapshot events.
     // When absent, the health emitter no-ops (local/dev without analytics).
     POSTHOG_KEY: z.string().trim().min(1).optional(),
@@ -102,6 +108,10 @@ export function parseSyncConfig(config: CompassConfig): SyncConfig {
     // Empty-string (unfilled deploy placeholder) or null coerces to absent.
     GOOGLE_CLIENT_ID: config.google?.clientId || undefined,
     GOOGLE_CLIENT_SECRET: config.google?.clientSecret || undefined,
+    MICROSOFT_CLIENT_ID: config.microsoft?.clientId || undefined,
+    MICROSOFT_CLIENT_SECRET: config.microsoft?.clientSecret || undefined,
+    CREDENTIAL_ENCRYPTION_KEY:
+      config.sync?.credentialEncryptionKey || undefined,
     POSTHOG_KEY: config.posthog?.key || undefined,
     POSTHOG_HOST: config.posthog?.host || undefined,
   });

--- a/packages/sync/src/providers/google/build-provider-resolvers.ts
+++ b/packages/sync/src/providers/google/build-provider-resolvers.ts
@@ -9,10 +9,7 @@ import { GooglePeopleAdapter } from "@sync/providers/google/google-people.adapte
 import {
   type ProviderAdapters,
   ProviderNotConfiguredError,
-  type ResolveProviderAdapters,
-  type ResolveProviderAuth,
 } from "@sync/providers/provider-adapters";
-import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
 
 export type ProviderAdapterOverrides = Partial<
   Record<ProviderKind, Partial<ProviderAdapters>>
@@ -22,7 +19,7 @@ function googleConfigured(config: SyncConfig): boolean {
   return Boolean(config.GOOGLE_CLIENT_ID && config.GOOGLE_CLIENT_SECRET);
 }
 
-function googleAdapters(
+export function googleAdapters(
   config: SyncConfig,
   override?: Partial<ProviderAdapters>,
 ): ProviderAdapters {
@@ -43,38 +40,4 @@ function googleAdapters(
     notifications: override?.notifications ?? new GoogleNotificationAdapter(),
     contacts: override?.contacts ?? new GooglePeopleAdapter(),
   };
-}
-
-export function buildResolveAdapters(
-  config: SyncConfig,
-  overrides: ProviderAdapterOverrides = {},
-): ResolveProviderAdapters {
-  return (provider) => {
-    if (provider === "google") {
-      return googleAdapters(config, overrides.google);
-    }
-    throw new ProviderNotConfiguredError(provider);
-  };
-}
-
-export function buildResolveAuth(
-  resolveAdapters: ResolveProviderAdapters,
-): ResolveProviderAuth {
-  return (provider) => resolveAdapters(provider).auth;
-}
-
-export function authResolverForAdapter(
-  adapter: ProviderAuthAdapter,
-  kind: ProviderKind = "google",
-): ResolveProviderAuth {
-  return (provider) => {
-    if (provider !== kind) {
-      throw new ProviderNotConfiguredError(provider);
-    }
-    return adapter;
-  };
-}
-
-export function googleProviderConfigured(config: SyncConfig): boolean {
-  return googleConfigured(config);
 }

--- a/packages/sync/src/providers/provider-registry.test.ts
+++ b/packages/sync/src/providers/provider-registry.test.ts
@@ -1,0 +1,76 @@
+import { type SyncConfig } from "@sync/config/sync.config";
+import {
+  CONTACTS_FEATURE_SCOPES,
+  GOOGLE_SCOPE_CALENDAR_EVENTS,
+} from "@sync/providers/google/google.scopes";
+import { googleCapabilitiesFromScopes } from "@sync/providers/google/google-capabilities";
+import { ProviderNotConfiguredError } from "@sync/providers/provider-adapters";
+import {
+  buildProviderRegistry,
+  ProviderRegistry,
+} from "@sync/providers/provider-registry";
+
+const googleConfig = (): SyncConfig =>
+  ({
+    NODE_ENV: "test",
+    MONGO_URI: "mongodb://localhost/compass_sync",
+    INTERNAL_AUTH_TOKEN: "token",
+    CALLBACK_BASE_URL: "http://localhost:3010",
+    EXECUTION: "passive",
+    MAX_CONCURRENCY: 4,
+    RESERVED_PULL_LANES: 1,
+    ENFORCE_LEAST_PRIVILEGE: false,
+    COMPASS_API_DATABASE: "prod_calendar",
+    GOOGLE_CLIENT_ID: "id.apps.googleusercontent.com",
+    GOOGLE_CLIENT_SECRET: "secret",
+  }) as SyncConfig;
+
+const unconfiguredConfig = (): SyncConfig =>
+  ({
+    ...googleConfig(),
+    GOOGLE_CLIENT_ID: undefined,
+    GOOGLE_CLIENT_SECRET: undefined,
+  }) as SyncConfig;
+
+describe("ProviderRegistry", () => {
+  it("throws ProviderNotConfiguredError for an unknown kind", () => {
+    const registry = buildProviderRegistry(googleConfig());
+    expect(() => registry.get("microsoft")).toThrow(ProviderNotConfiguredError);
+    expect(() => registry.get("microsoft")).toThrow(/microsoft/i);
+  });
+
+  it("lists only configured providers in kinds()", () => {
+    expect(buildProviderRegistry(googleConfig()).kinds()).toEqual(["google"]);
+    expect(buildProviderRegistry(unconfiguredConfig()).kinds()).toEqual([]);
+  });
+
+  it("returns capabilities per kind from granted scopes", () => {
+    const registry = buildProviderRegistry(googleConfig());
+    const google = registry.get("google");
+    expect(
+      google.capabilitiesFromScopes([GOOGLE_SCOPE_CALENDAR_EVENTS]),
+    ).toEqual(googleCapabilitiesFromScopes([GOOGLE_SCOPE_CALENDAR_EVENTS]));
+  });
+
+  it("maps contact features to provider scopes", () => {
+    const registry = buildProviderRegistry(googleConfig());
+    expect(registry.get("google").scopes.forFeatures(["contacts"])).toEqual(
+      CONTACTS_FEATURE_SCOPES,
+    );
+    expect(registry.get("google").scopes.forFeatures([])).toEqual([]);
+  });
+
+  it("exposes resolveAdapters and resolveAuth for configured kinds", () => {
+    const registry = buildProviderRegistry(googleConfig());
+    const adapters = registry.resolveAdapters()("google");
+    expect(adapters.auth).toBeDefined();
+    expect(registry.resolveAuth()("google")).toBe(adapters.auth);
+  });
+
+  it("starts empty before register()", () => {
+    const registry = new ProviderRegistry();
+    expect(registry.kinds()).toEqual([]);
+    expect(registry.has("google")).toBe(false);
+    expect(registry.isConfigured()).toBe(false);
+  });
+});

--- a/packages/sync/src/providers/provider-registry.ts
+++ b/packages/sync/src/providers/provider-registry.ts
@@ -1,0 +1,94 @@
+import { type ConnectionBeginFeatures } from "@core/types/sync/connection.contracts";
+import {
+  type ProviderCapability,
+  type ProviderKind,
+} from "@core/types/sync/identity.contracts";
+import { type SyncConfig } from "@sync/config/sync.config";
+import {
+  googleAdapters,
+  type ProviderAdapterOverrides,
+} from "@sync/providers/google/build-provider-resolvers";
+import { CONTACTS_FEATURE_SCOPES } from "@sync/providers/google/google.scopes";
+import { googleCapabilitiesFromScopes } from "@sync/providers/google/google-capabilities";
+import {
+  type ProviderAdapters,
+  ProviderNotConfiguredError,
+  type ResolveProviderAdapters,
+  type ResolveProviderAuth,
+} from "@sync/providers/provider-adapters";
+
+export interface ProviderScopes {
+  forFeatures(features: ConnectionBeginFeatures): readonly string[];
+}
+
+export interface ProviderRegistration {
+  adapters: ProviderAdapters;
+  scopes: ProviderScopes;
+  capabilitiesFromScopes: (granted: readonly string[]) => ProviderCapability[];
+  callbackPath: string;
+}
+
+export class ProviderRegistry {
+  readonly #entries = new Map<ProviderKind, ProviderRegistration>();
+
+  register(kind: ProviderKind, entry: ProviderRegistration): void {
+    this.#entries.set(kind, entry);
+  }
+
+  get(kind: ProviderKind): ProviderRegistration {
+    const entry = this.#entries.get(kind);
+    if (!entry) {
+      throw new ProviderNotConfiguredError(kind);
+    }
+    return entry;
+  }
+
+  has(kind: ProviderKind): boolean {
+    return this.#entries.has(kind);
+  }
+
+  kinds(): ProviderKind[] {
+    return [...this.#entries.keys()];
+  }
+
+  isConfigured(): boolean {
+    return this.#entries.size > 0;
+  }
+
+  resolveAdapters(): ResolveProviderAdapters {
+    return (provider) => this.get(provider).adapters;
+  }
+
+  resolveAuth(): ResolveProviderAuth {
+    return (provider) => this.get(provider).adapters.auth;
+  }
+}
+
+function googleConfigured(config: SyncConfig): boolean {
+  return Boolean(config.GOOGLE_CLIENT_ID && config.GOOGLE_CLIENT_SECRET);
+}
+
+export function buildProviderRegistry(
+  config: SyncConfig,
+  overrides: ProviderAdapterOverrides = {},
+): ProviderRegistry {
+  const registry = new ProviderRegistry();
+
+  if (googleConfigured(config) || overrides.google?.auth !== undefined) {
+    registry.register("google", {
+      adapters: googleAdapters(config, overrides.google),
+      scopes: {
+        forFeatures(features) {
+          if (features.includes("contacts")) {
+            return CONTACTS_FEATURE_SCOPES;
+          }
+          return [];
+        },
+      },
+      capabilitiesFromScopes: googleCapabilitiesFromScopes,
+      callbackPath: "/sync/google",
+    });
+  }
+
+  return registry;
+}

--- a/packages/sync/src/server/command.routes.db.test.ts
+++ b/packages/sync/src/server/command.routes.db.test.ts
@@ -705,8 +705,7 @@ describe("POST /internal/commands", () => {
     };
     service = createSyncService(testConfig({ EXECUTION: "active" }), {
       mongo,
-      writer,
-      authAdapter,
+      adapterOverrides: { google: { auth: authAdapter, writer } },
     });
     await new Promise<void>((resolve) => service.httpServer.listen(0, resolve));
     const { port } = service.httpServer.address() as AddressInfo;

--- a/packages/sync/src/server/command.routes.ts
+++ b/packages/sync/src/server/command.routes.ts
@@ -13,10 +13,7 @@ import {
   ProviderWriteUnavailableError,
   submitCloudCommand,
 } from "@sync/domain/cloud-command.service";
-import { buildResolveAuth } from "@sync/providers/google/build-provider-resolvers";
-import { type ResolveProviderAdapters } from "@sync/providers/provider-adapters";
-import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
-import { type ProviderEventWriter } from "@sync/providers/provider-event-writer.port";
+import { type ProviderRegistry } from "@sync/providers/provider-registry";
 import { redactedCause } from "@sync/safety/redact-error";
 import {
   ensureConnected,
@@ -38,24 +35,13 @@ export interface CommandApiDeps {
   // Whether provider work is enabled. A provider-targeted create executes only
   // when active; otherwise it is recorded pending.
   execution: SyncExecutionMode;
-  // Provider write + auth adapters, present only when a provider is configured.
-  // Both are needed to execute a provider create (the writer performs it, the
-  // auth adapter backs the per-request credential custody). Absent leaves
+  // Provider registry for per-connection adapter resolution. Absent leaves
   // provider-targeted commands pending.
-  writer?: ProviderEventWriter;
-  authAdapter?: ProviderAuthAdapter;
-  resolveAdapters?: ResolveProviderAdapters;
+  registry?: ProviderRegistry;
   // Injectable clock so local confirmation timestamps are deterministic in
   // tests.
   now?: () => number;
 }
-
-// Internal, authenticated command ingress. Durably records acknowledged user
-// intent for one event mutation. A cloud-only create is applied to the
-// canonical store and confirmed locally in the same request — no provider call
-// — so this is served in passive mode too. The tenant/principal come from the
-// signed auth context, never the body, so a caller only ever writes to its own
-// principal.
 export function registerCommandRoutes(
   app: Express,
   deps: CommandApiDeps,
@@ -81,16 +67,15 @@ export function registerCommandRoutes(
         // Build the provider write capability only when both adapters exist;
         // custody is per-request (it holds the request's db-backed credential
         // repo), the writer is shared.
-        const provider =
-          deps.resolveAdapters && deps.authAdapter
-            ? {
-                resolveAdapters: deps.resolveAdapters,
-                custody: new CredentialCustody(
-                  repos.credentials,
-                  buildResolveAuth(deps.resolveAdapters),
-                ),
-              }
-            : undefined;
+        const provider = deps.registry?.isConfigured()
+          ? {
+              resolveAdapters: deps.registry.resolveAdapters(),
+              custody: new CredentialCustody(
+                repos.credentials,
+                deps.registry.resolveAuth(),
+              ),
+            }
+          : undefined;
 
         const events = repos.events;
         // Snapshot calendarId before apply: a confirmed delete removes the

--- a/packages/sync/src/server/connection.routes.db.test.ts
+++ b/packages/sync/src/server/connection.routes.db.test.ts
@@ -185,7 +185,10 @@ describe("GET /internal/connections", () => {
     config: SyncConfig = testConfig(),
     authAdapter?: ProviderAuthAdapter,
   ) => {
-    service = createSyncService(config, { mongo, authAdapter });
+    service = createSyncService(config, {
+      mongo,
+      adapterOverrides: { google: { auth: authAdapter } },
+    });
     await new Promise<void>((resolve) => service.httpServer.listen(0, resolve));
     const { port } = service.httpServer.address() as AddressInfo;
     base = `http://127.0.0.1:${port}`;
@@ -341,7 +344,10 @@ describe("DELETE /internal/connections/:id", () => {
     config: SyncConfig,
     authAdapter?: ProviderAuthAdapter,
   ) => {
-    service = createSyncService(config, { mongo, authAdapter });
+    service = createSyncService(config, {
+      mongo,
+      adapterOverrides: { google: { auth: authAdapter } },
+    });
     await new Promise<void>((resolve) => service.httpServer.listen(0, resolve));
     const { port } = service.httpServer.address() as AddressInfo;
     base = `http://127.0.0.1:${port}`;
@@ -467,7 +473,10 @@ describe("POST /internal/connections/begin", () => {
     config: SyncConfig,
     authAdapter?: ProviderAuthAdapter,
   ) => {
-    service = createSyncService(config, { mongo, authAdapter });
+    service = createSyncService(config, {
+      mongo,
+      adapterOverrides: { google: { auth: authAdapter } },
+    });
     await new Promise<void>((resolve) => service.httpServer.listen(0, resolve));
     const { port } = service.httpServer.address() as AddressInfo;
     base = `http://127.0.0.1:${port}`;
@@ -690,7 +699,10 @@ describe("GET /sync/google", () => {
     config: SyncConfig,
     authAdapter?: ProviderAuthAdapter,
   ) => {
-    service = createSyncService(config, { mongo, authAdapter });
+    service = createSyncService(config, {
+      mongo,
+      adapterOverrides: { google: { auth: authAdapter } },
+    });
     await new Promise<void>((resolve) => service.httpServer.listen(0, resolve));
     const { port } = service.httpServer.address() as AddressInfo;
     base = `http://127.0.0.1:${port}`;
@@ -1018,7 +1030,7 @@ describe("POST /internal/connections/adopt-google-authorization", () => {
   const startService = async () => {
     service = createSyncService(testConfig({ EXECUTION: "active" }), {
       mongo,
-      authAdapter: new FakeAuthAdapter(),
+      adapterOverrides: { google: { auth: new FakeAuthAdapter() } },
     });
     await new Promise<void>((resolve) => service.httpServer.listen(0, resolve));
     const { port } = service.httpServer.address() as AddressInfo;

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -27,6 +27,8 @@ import {
   type ConnectionId,
   ConnectionIdSchema,
   type PrincipalId,
+  type ProviderKind,
+  ProviderKindSchema,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
 import dayjs from "@core/util/date/dayjs";
@@ -49,16 +51,8 @@ import {
   HORIZON_PAST_MONTHS,
 } from "@sync/domain/horizon";
 import { signOAuthState, verifyOAuthState } from "@sync/oauth/oauth-state";
-import {
-  authResolverForAdapter,
-  buildResolveAuth,
-} from "@sync/providers/google/build-provider-resolvers";
-import { CONTACTS_FEATURE_SCOPES } from "@sync/providers/google/google.scopes";
-import { googleCapabilitiesFromScopes } from "@sync/providers/google/google-capabilities";
-import { type ResolveProviderAdapters } from "@sync/providers/provider-adapters";
 import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
-import { type ContactsPort } from "@sync/providers/provider-contacts.port";
-import { type ProviderEventWriter } from "@sync/providers/provider-event-writer.port";
+import { type ProviderRegistry } from "@sync/providers/provider-registry";
 import { redactedCause } from "@sync/safety/redact-error";
 import {
   ensureConnected,
@@ -113,18 +107,8 @@ export interface ConnectionApiDeps {
   mongo: SyncMongoService;
   // Disconnect and begin make provider calls, so they are gated on execution.
   execution: SyncExecutionMode;
-  // The provider authorization adapter, present only when the provider is
-  // configured. Absent (or passive mode) means no provider work is possible.
-  authAdapter?: ProviderAuthAdapter;
-  resolveAdapters?: ResolveProviderAdapters;
-  // The provider event writer, present only when the provider is configured.
-  // Not used by the connection routes themselves; carried here because this is
-  // the shared bag the command routes are wired from.
-  writer?: ProviderEventWriter;
-  // The provider contacts port, present only when the provider is configured.
-  // Not used by the connection routes themselves; carried here because this is
-  // the shared bag the contacts routes are wired from.
-  contacts?: ContactsPort;
+  // Provider registry: adapters, scopes, and capabilities per kind.
+  registry?: ProviderRegistry;
   // Secret the OAuth CSRF state is signed with, and the public base URL the
   // provider callback resolves against.
   stateSecret: string;
@@ -510,10 +494,20 @@ export function registerConnectionRoutes(
       if (!ensureConnected(deps.mongo, res)) return;
       // Authorizing touches the provider, so a passive or unconfigured service
       // refuses rather than handing back a URL it could never complete.
-      if (deps.execution === "passive" || !deps.authAdapter) {
+      const provider = parseConnectProvider(
+        (req.body as { provider?: unknown })?.provider,
+      );
+      if (!provider.ok) {
+        res.status(Status.BAD_REQUEST).json({ error: "invalid_provider" });
+        return;
+      }
+      const providerKind = provider.data;
+      if (deps.execution === "passive" || !deps.registry?.has(providerKind)) {
         res.status(Status.CONFLICT).json({ error: "provider_work_disabled" });
         return;
       }
+      const registration = deps.registry.get(providerKind);
+      const authAdapter = registration.adapters.auth;
 
       // Optional connectionId means reconnect: validate it is a real id owned by
       // this principal, so the state cannot bind a flow to a foreign connection.
@@ -561,7 +555,7 @@ export function registerConnectionRoutes(
           return;
         }
         if (parsed.data.includes("contacts")) {
-          extraScopes = [...CONTACTS_FEATURE_SCOPES];
+          extraScopes = [...registration.scopes.forFeatures(parsed.data)];
         }
       }
 
@@ -592,9 +586,9 @@ export function registerConnectionRoutes(
         connectionId,
         issuedAt: (deps.now ?? Date.now)(),
       });
-      const authorizationUrl = deps.authAdapter.buildAuthorizationUrl({
+      const authorizationUrl = authAdapter.buildAuthorizationUrl({
         state,
-        redirectUri: `${deps.callbackBaseUrl}${OAUTH_CALLBACK_PATH}`,
+        redirectUri: `${deps.callbackBaseUrl}${registration.callbackPath}`,
         selectAccount,
         // Undefined (not an empty array) when no feature was asked for, so a
         // plain begin's adapter input — and therefore its consent URL — stays
@@ -616,7 +610,7 @@ export function registerConnectionRoutes(
       const auth = requireAuth(req, res);
       if (!auth) return;
       if (!ensureConnected(deps.mongo, res)) return;
-      if (deps.execution === "passive" || !deps.authAdapter) {
+      if (deps.execution === "passive" || !deps.registry?.has("google")) {
         res.status(Status.CONFLICT).json({ error: "provider_work_disabled" });
         return;
       }
@@ -640,7 +634,7 @@ export function registerConnectionRoutes(
         );
         await linkConnection(
           deps,
-          deps.authAdapter,
+          "google",
           {
             tenantId: auth.tenantId,
             principalId: auth.principalId,
@@ -720,9 +714,11 @@ export function registerConnectionRoutes(
     const redirect = (status: string) =>
       redirectAfterConnect(deps, res, status);
 
-    if (deps.execution === "passive" || !deps.authAdapter) {
+    if (deps.execution === "passive" || !deps.registry?.has("google")) {
       return redirect("error");
     }
+    const googleRegistration = deps.registry.get("google");
+    const authAdapter = googleRegistration.adapters.auth;
     if (!deps.mongo.isConnected) return redirect("error");
     // The user declined consent, or the provider returned an error.
     if (typeof req.query["error"] === "string") return redirect("declined");
@@ -744,10 +740,10 @@ export function registerConnectionRoutes(
       ReturnType<ProviderAuthAdapter["exchangeAuthorizationCode"]>
     >;
     try {
-      authorization = await deps.authAdapter.exchangeAuthorizationCode({
+      authorization = await authAdapter.exchangeAuthorizationCode({
         code,
         // Must match the redirect_uri begin used to build the consent URL.
-        redirectUri: `${deps.callbackBaseUrl}${OAUTH_CALLBACK_PATH}`,
+        redirectUri: `${deps.callbackBaseUrl}${googleRegistration.callbackPath}`,
       });
     } catch (error) {
       // Bad code, no refresh token, unverifiable identity — nothing to link.
@@ -763,9 +759,9 @@ export function registerConnectionRoutes(
     // resource, surfacing as "Couldn't update your calendar" with no mention
     // of the actual cause. Catch it here, before any connection is created.
     if (
-      !googleCapabilitiesFromScopes(authorization.grantedScopes).includes(
-        "readEvents",
-      )
+      !googleRegistration
+        .capabilitiesFromScopes(authorization.grantedScopes)
+        .includes("readEvents")
     ) {
       return redirect("missingScopes");
     }
@@ -773,12 +769,7 @@ export function registerConnectionRoutes(
     try {
       // authAdapter is non-null here (gated above); pass it so the helper needs
       // no assertion.
-      await linkConnection(
-        deps,
-        deps.authAdapter,
-        verified.payload,
-        authorization,
-      );
+      await linkConnection(deps, "google", verified.payload, authorization);
       return redirect("connected");
     } catch (error) {
       logger.error(
@@ -801,7 +792,7 @@ export function registerConnectionRoutes(
       // Disconnect revokes at the provider, so a passive service (or one with no
       // provider configured) must refuse rather than half-disconnect: delete the
       // credential locally while leaving live authority at the provider.
-      if (deps.execution === "passive" || !deps.authAdapter) {
+      if (deps.execution === "passive" || !deps.registry?.isConfigured()) {
         res.status(Status.CONFLICT).json({ error: "provider_work_disabled" });
         return;
       }
@@ -831,7 +822,7 @@ export function registerConnectionRoutes(
         // failure converges.
         const custody = new CredentialCustody(
           new CredentialRepository(deps.mongo.db),
-          resolveAuthForConnectionApi(deps),
+          deps.registry!.resolveAuth(),
         );
         await custody.disconnect(id.data);
         await connections.markDisconnected(
@@ -851,14 +842,17 @@ export function registerConnectionRoutes(
 // Redirect the browser to the server-configured post-connect URL with a coarse
 // status. The base is from config, never the request, so it can't be abused as
 // an open redirect; status is a fixed label, carrying no provider detail.
-function resolveAuthForConnectionApi(
-  deps: ConnectionApiDeps,
-  authAdapter: ProviderAuthAdapter = deps.authAdapter!,
-) {
-  if (deps.resolveAdapters) {
-    return buildResolveAuth(deps.resolveAdapters);
+function parseConnectProvider(
+  raw: unknown,
+): { ok: true; data: ProviderKind } | { ok: false; error: "invalid_provider" } {
+  if (raw === undefined || raw === null) {
+    return { ok: true, data: "google" };
   }
-  return authResolverForAdapter(authAdapter);
+  const parsed = ProviderKindSchema.safeParse(raw);
+  if (!parsed.success) {
+    return { ok: false, error: "invalid_provider" };
+  }
+  return { ok: true, data: parsed.data };
 }
 
 function redirectAfterConnect(
@@ -878,7 +872,7 @@ function redirectAfterConnect(
 // import has not finished is "importing", not set arbitrarily.
 async function linkConnection(
   deps: ConnectionApiDeps,
-  authAdapter: ProviderAuthAdapter,
+  provider: ProviderKind,
   state: {
     tenantId: TenantId;
     principalId: PrincipalId;
@@ -917,13 +911,16 @@ async function linkConnection(
   // the derivation always lands on the same result — inlined rather than
   // calling it with a wall of constant evidence.
   const derived: DerivedConnectionState = { state: "importing", reason: null };
+  const registration = deps.registry!.get(provider);
 
   const connection = await connections.upsertByProviderAccount({
     tenantId: state.tenantId,
     principalId: state.principalId,
-    provider: "google",
+    provider,
     account: authorization.account,
-    capabilities: googleCapabilitiesFromScopes(authorization.grantedScopes),
+    capabilities: registration.capabilitiesFromScopes(
+      authorization.grantedScopes,
+    ),
     state: derived.state,
     stateReason: derived.reason,
   });
@@ -931,11 +928,11 @@ async function linkConnection(
   try {
     const custody = new CredentialCustody(
       repos.credentials,
-      resolveAuthForConnectionApi(deps, authAdapter),
+      deps.registry!.resolveAuth(),
     );
     await custody.store({
       connectionId: connection._id,
-      provider: "google",
+      provider,
       refreshToken: authorization.refreshToken,
       scopes: [...authorization.grantedScopes],
     });

--- a/packages/sync/src/server/contacts.routes.db.test.ts
+++ b/packages/sync/src/server/contacts.routes.db.test.ts
@@ -109,7 +109,10 @@ describe("GET /internal/contacts/suggestions", () => {
   let contacts: FakeContactsPort;
 
   const startService = async (config: SyncConfig = testConfig()) => {
-    service = createSyncService(config, { mongo, authAdapter, contacts });
+    service = createSyncService(config, {
+      mongo,
+      adapterOverrides: { google: { auth: authAdapter, contacts } },
+    });
     await new Promise<void>((resolve) => service.httpServer.listen(0, resolve));
     const { port } = service.httpServer.address() as AddressInfo;
     base = `http://127.0.0.1:${port}`;

--- a/packages/sync/src/server/contacts.routes.ts
+++ b/packages/sync/src/server/contacts.routes.ts
@@ -10,19 +10,16 @@ import {
 } from "@core/types/contact.contracts";
 import { type SyncExecutionMode } from "@sync/config/sync.config";
 import { CredentialCustody } from "@sync/credentials/credential-custody.service";
-import { authResolverForAdapter } from "@sync/providers/google/build-provider-resolvers";
 import {
   GOOGLE_SCOPE_CONTACTS_OTHER_READONLY,
   GOOGLE_SCOPE_CONTACTS_READONLY,
 } from "@sync/providers/google/google.scopes";
-import {
-  type ProviderAuthAdapter,
-  ProviderAuthError,
-} from "@sync/providers/provider-auth.port";
+import { ProviderAuthError } from "@sync/providers/provider-auth.port";
 import {
   type ContactsPort,
   ContactsSearchError,
 } from "@sync/providers/provider-contacts.port";
+import { type ProviderRegistry } from "@sync/providers/provider-registry";
 import { redactedCause } from "@sync/safety/redact-error";
 import {
   ensureConnected,
@@ -44,10 +41,7 @@ export interface ContactsApiDeps {
   mongo: SyncMongoService;
   // Suggestions call the provider, so a passive deployment refuses.
   execution: SyncExecutionMode;
-  // Backs per-request credential custody; absent means no provider work.
-  authAdapter?: ProviderAuthAdapter;
-  // The provider contacts port, present only when the provider is configured.
-  contacts?: ContactsPort;
+  registry?: ProviderRegistry;
 }
 
 // Internal, authenticated attendee-suggestion lookup. Principal-scoped: the
@@ -69,7 +63,7 @@ export function registerContactsRoutes(
       if (!ensureConnected(deps.mongo, res)) return;
       // Suggestions always touch the provider (contacts are never cached), so
       // a passive or unconfigured service refuses like begin does.
-      if (deps.execution === "passive" || !deps.authAdapter || !deps.contacts) {
+      if (deps.execution === "passive" || !deps.registry?.isConfigured()) {
         res.status(Status.CONFLICT).json({ error: "provider_work_disabled" });
         return;
       }
@@ -112,12 +106,15 @@ export function registerContactsRoutes(
 
         const custody = new CredentialCustody(
           repos.credentials,
-          authResolverForAdapter(deps.authAdapter),
+          deps.registry.resolveAuth(),
         );
         const collected: ContactSuggestion[] = [];
         for (const connection of capable) {
+          const registration = deps.registry.get(connection.provider);
+          const contacts = registration.adapters.contacts;
+          if (!contacts) continue;
           const suggestions = await searchConnection(
-            deps.contacts,
+            contacts,
             custody,
             repos.credentials,
             connection,

--- a/packages/sync/src/server/principal.routes.db.test.ts
+++ b/packages/sync/src/server/principal.routes.db.test.ts
@@ -111,7 +111,9 @@ describe("DELETE /internal/principal", () => {
       options && "authAdapter" in options ? options.authAdapter : adapter;
     service = createSyncService(options?.config ?? testConfig(), {
       mongo,
-      authAdapter: authAdapter ?? undefined,
+      adapterOverrides: authAdapter
+        ? { google: { auth: authAdapter } }
+        : undefined,
     });
     await new Promise<void>((resolve) => service.httpServer.listen(0, resolve));
     const { port } = service.httpServer.address() as AddressInfo;

--- a/packages/sync/src/server/principal.routes.ts
+++ b/packages/sync/src/server/principal.routes.ts
@@ -4,8 +4,7 @@ import { Logger } from "@core/logger/winston.logger";
 import { PrincipalPurgeResponseSchema } from "@core/types/sync/principal.contracts";
 import { CredentialCustody } from "@sync/credentials/credential-custody.service";
 import { purgePrincipal } from "@sync/domain/principal-purge.service";
-import { authResolverForAdapter } from "@sync/providers/google/build-provider-resolvers";
-import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
+import { type ProviderRegistry } from "@sync/providers/provider-registry";
 import { redactedCause } from "@sync/safety/redact-error";
 import {
   ensureConnected,
@@ -23,10 +22,8 @@ export const PRINCIPAL_PATH = "/internal/principal";
 export interface PrincipalApiDeps {
   authMiddleware: RequestHandler;
   mongo: SyncMongoService;
-  // Optional: when present, credentials are revoked at the provider before
-  // local delete. Account deletion still proceeds without it (passive /
-  // unconfigured deployments) so Sync-held tokens are never stranded.
-  authAdapter?: ProviderAuthAdapter;
+  // When present, credentials are revoked at the provider before local delete.
+  registry?: ProviderRegistry;
 }
 
 // Hard-delete every Sync-held row for the signed principal. Served in passive
@@ -50,10 +47,10 @@ export function registerPrincipalRoutes(
         const counts = await purgePrincipal(
           {
             ...repos,
-            custody: deps.authAdapter
+            custody: deps.registry?.isConfigured()
               ? new CredentialCustody(
                   repos.credentials,
-                  authResolverForAdapter(deps.authAdapter),
+                  deps.registry.resolveAuth(),
                 )
               : undefined,
           },

--- a/packages/sync/src/server/sync.server.ts
+++ b/packages/sync/src/server/sync.server.ts
@@ -43,9 +43,7 @@ export function buildSyncApp(deps: {
       authMiddleware: deps.connectionApi.authMiddleware,
       mongo: deps.connectionApi.mongo,
       execution: deps.connectionApi.execution,
-      resolveAdapters: deps.connectionApi.resolveAdapters,
-      writer: deps.connectionApi.writer,
-      authAdapter: deps.connectionApi.authAdapter,
+      registry: deps.connectionApi.registry,
       now: deps.connectionApi.now,
     });
     // Attendee contact suggestions from the provider's People surfaces, gated
@@ -54,8 +52,7 @@ export function buildSyncApp(deps: {
       authMiddleware: deps.connectionApi.authMiddleware,
       mongo: deps.connectionApi.mongo,
       execution: deps.connectionApi.execution,
-      authAdapter: deps.connectionApi.authAdapter,
-      contacts: deps.connectionApi.contacts,
+      registry: deps.connectionApi.registry,
     });
     // Resumable invalidation outbox for Compass API → browser SSE (S40).
     registerChangeFeedRoutes(app, {
@@ -68,7 +65,7 @@ export function buildSyncApp(deps: {
     registerPrincipalRoutes(app, {
       authMiddleware: deps.connectionApi.authMiddleware,
       mongo: deps.connectionApi.mongo,
-      authAdapter: deps.connectionApi.authAdapter,
+      registry: deps.connectionApi.registry,
     });
     // Private support diagnostic lookup by non-user-facing connection key (S45).
     registerDiagnosticRoutes(app, {


### PR DESCRIPTION
Fixes #3226

## What and why

Introduces `ProviderRegistry` in `packages/sync/src/providers/provider-registry.ts`, built once from `SyncConfig`. Each configured provider kind maps to `{ adapters, scopes, capabilitiesFromScopes, callbackPath }`. Google registers when OAuth credentials are present (or tests inject auth overrides); Microsoft and Apple config fields are read in `sync.config.ts` but not registered yet.

Replaces the Google-only `buildAuthAdapter` / `buildEventWriter` / `buildContactsPort` helpers and per-route adapter bags with registry lookups in `app.ts`, connection/command/contacts/principal routes, and schedulers. Connect begin reads optional `provider` from the request (default `google`) and uses `scopes.forFeatures()` plus `capabilitiesFromScopes()` from the registry entry.

Spec: `docs/features/calendar-providers.md`

## Verify

```
Summary
Selected packages: sync
Checks run: test:sync, type-check, lint, knip
Checks skipped: (none)

✓ All checks passed
VERDICT: PASS
```

Evidence:
- `provider-registry.test.ts`: unknown kind throws `ProviderNotConfiguredError`; `kinds()` lists only configured providers; capabilities returned per kind
- `grep -rn 'new Google' packages/sync/src --include='*.ts' | grep -v providers/google | grep -v test` returns empty
- `bun test:sync`: 1136 pass, 0 fail (Google connect, discovery, import, push tests unchanged)