### PR TITLE
feat(sync): minimal CalDAV client and iCloud discovery

### DIFF
--- a/.agents/handoffs/3254.md
+++ b/.agents/handoffs/3254.md
@@ -1,0 +1,40 @@
+---
+schema_version: 1
+task_id: "3254"
+from: Implementer
+to: GitHub
+owner: GitHub
+status: verifying
+artifact:
+  - path: packages/sync/src/providers/apple/caldav-client.ts
+  - path: packages/sync/src/providers/apple/caldav-client.test.ts
+  - path: packages/sync/src/providers/apple/apple-calendar.adapter.ts
+  - path: packages/sync/src/providers/apple/apple-calendar.adapter.test.ts
+  - path: packages/sync/src/providers/__contract__/discovery.contract.ts
+  - path: packages/sync/src/providers/__contract__/apple.contract.test.ts
+  - path: packages/sync/src/providers/__contract__/README.md
+evidence:
+  - command: bun test:sync
+    result: pass
+  - command: bun run type-check
+    result: pass
+  - command: bun lint
+    result: pass
+  - command: bun knip
+    result: pass
+  - command: bun run verify --strict
+    result: "VERDICT: PASS"
+assumptions:
+  - "Hand-rolled CalDAV client (~520 lines) covers iCloud discovery without tsdav."
+  - "ProviderCalendarAdapter receives the app-specific password as accessToken; username is bound at adapter construction."
+  - "Discovery contract suite carries discovery cases only; full P0 WP-11 corpus lands in #3236."
+open_risks:
+  - "Live iCloud partition redirects and throttling behavior validated only via scripted fixtures until A-11."
+next_deadline: 2026-09-05T02:00:00Z
+retry: 0
+approval: allow
+waiting_on: null
+escalation: null
+---
+
+Providers A WP-01: minimal CalDAV client and iCloud discovery.

--- a/bun.lock
+++ b/bun.lock
@@ -115,6 +115,7 @@
         "@googleapis/people": "^8.0.0",
         "express": "^4.17.1",
         "express-rate-limit": "^7.5.0",
+        "fast-xml-parser": "^5.11.1",
         "google-auth-library": "^10.6.2",
         "mongodb": "^7.2.0",
         "rrule": "^2.7.2",
@@ -342,6 +343,8 @@
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.2.1", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3", "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3" } }, "sha512-KjZdi8Q1wh89gsVmghvbrMgWl6ZWmRmHV6wjB7/g4Zf0dyO+hH3neZUtuDNPO00qq5YE5RITVWvrIZKRaAmzGQ=="],
 
     "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@nodable/entities": ["@nodable/entities@3.0.0", "", {}, "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw=="],
 
     "@open-draft/until": ["@open-draft/until@1.0.3", "", {}, "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q=="],
 
@@ -747,6 +750,8 @@
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
+    "anynum": ["anynum@1.0.1", "", {}, "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A=="],
+
     "arch": ["arch@2.2.0", "", {}, "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ=="],
 
     "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
@@ -1019,6 +1024,10 @@
 
     "fast-uri": ["fast-uri@3.1.7", "", {}, "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg=="],
 
+    "fast-xml-builder": ["fast-xml-builder@1.3.1", "", { "dependencies": { "path-expression-matcher": "^1.6.2", "xml-naming": "^0.3.0" } }, "sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.11.1", "", { "dependencies": { "@nodable/entities": "^3.0.0", "fast-xml-builder": "^1.2.0", "is-unsafe": "^2.0.0", "path-expression-matcher": "^1.6.2", "strnum": "^2.4.2", "xml-naming": "^0.3.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-TBw6K/fxoQGGjCmZDw9w/ZwP3uDcnTM4YH/g+PFRWr8sbe5idXtxNN6vITh4+1ruCZaho6uBFurElsA7F0zzgw=="],
+
     "fd-package-json": ["fd-package-json@2.0.0", "", { "dependencies": { "walk-up-path": "^4.0.0" } }, "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
@@ -1202,6 +1211,8 @@
     "is-typed-array": ["is-typed-array@1.1.15", "", { "dependencies": { "which-typed-array": "^1.1.16" } }, "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ=="],
 
     "is-unicode-supported": ["is-unicode-supported@0.1.0", "", {}, "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="],
+
+    "is-unsafe": ["is-unsafe@2.0.2", "", {}, "sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ=="],
 
     "is-weakmap": ["is-weakmap@2.0.2", "", {}, "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w=="],
 
@@ -1426,6 +1437,8 @@
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-expression-matcher": ["path-expression-matcher@1.6.2", "", {}, "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ=="],
 
     "path-is-inside": ["path-is-inside@1.0.2", "", {}, "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w=="],
 
@@ -1657,6 +1670,8 @@
 
     "stripe": ["stripe@18.5.0", "", { "dependencies": { "qs": "^6.11.0" }, "peerDependencies": { "@types/node": ">=12.x.x" }, "optionalPeers": ["@types/node"] }, "sha512-Hp+wFiEQtCB0LlNgcFh5uVyKznpDjzyUZ+CNVEf+I3fhlYvh7rZruIg+jOwzJRCpy0ZTPMjlzm7J2/M2N6d+DA=="],
 
+    "strnum": ["strnum@2.4.2", "", { "dependencies": { "anynum": "^1.0.1" } }, "sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw=="],
+
     "stylis": ["stylis@4.2.0", "", {}, "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="],
 
     "superagent": ["superagent@10.3.0", "", { "dependencies": { "component-emitter": "^1.3.1", "cookiejar": "^2.1.4", "debug": "^4.3.7", "fast-safe-stringify": "^2.1.1", "form-data": "^4.0.5", "formidable": "^3.5.4", "methods": "^1.1.2", "mime": "2.6.0", "qs": "^6.14.1" } }, "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ=="],
@@ -1794,6 +1809,8 @@
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xml-naming": ["xml-naming@0.3.0", "", {}, "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ=="],
 
     "xmlbuilder": ["xmlbuilder@13.0.2", "", {}, "sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ=="],
 

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -10,6 +10,7 @@
     "@googleapis/people": "^8.0.0",
     "express": "^4.17.1",
     "express-rate-limit": "^7.5.0",
+    "fast-xml-parser": "^5.11.1",
     "google-auth-library": "^10.6.2",
     "mongodb": "^7.2.0",
     "rrule": "^2.7.2",

--- a/packages/sync/src/providers/__contract__/README.md
+++ b/packages/sync/src/providers/__contract__/README.md
@@ -1,0 +1,30 @@
+# Provider adapter contract suite
+
+Shared discovery checks run every registered adapter against the same bar.
+Add a provider by listing `DiscoveryContractCase` entries in
+`<kind>.contract.test.ts` and replaying request/response pairs through the
+adapter's injectable narrow API (for Apple, the CalDAV client's `fetch`).
+
+The full suite (auth, reader, writer, notifications, normalizer) lands in P0
+WP-11 (#3236). This directory currently carries discovery cases only.
+
+## Add Apple-style discovery coverage
+
+```typescript
+import { type DiscoveryContractCase } from "@sync/providers/__contract__/discovery.contract";
+
+const CASES: DiscoveryContractCase[] = [
+  {
+    name: "detects primary",
+    username: email,
+    password: secret,
+    run: async (adapter) => {
+      const result = await adapter.discoverCalendars({ accessToken: secret });
+      expect(result.cursor).toBeNull();
+    },
+  },
+];
+```
+
+Record live fixtures with the founder account in A-11 (#3275); redact secrets
+before committing.

--- a/packages/sync/src/providers/__contract__/apple.contract.test.ts
+++ b/packages/sync/src/providers/__contract__/apple.contract.test.ts
@@ -1,0 +1,148 @@
+import { type DiscoveryContractCase } from "@sync/providers/__contract__/discovery.contract";
+import { AppleCalendarAdapter } from "@sync/providers/apple/apple-calendar.adapter";
+import {
+  type CaldavFetch,
+  createCaldavClient,
+} from "@sync/providers/apple/caldav-client";
+
+const PRINCIPAL_XML = `<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:">
+  <D:response>
+    <D:href>/</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:current-user-principal>
+          <D:href>/123456789/principal/</D:href>
+        </D:current-user-principal>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+</D:multistatus>`;
+
+const HOME_SET_XML = `<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:">
+  <D:response>
+    <D:href>/123456789/principal/</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:calendar-home-set>
+          <D:href>/123456789/calendars/</D:href>
+        </D:calendar-home-set>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+</D:multistatus>`;
+
+const CALENDARS_XML = `<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav" xmlns:ICAL="http://apple.com/ns/ical/">
+  <D:response>
+    <D:href>/123456789/calendars/home/</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:displayname>user</D:displayname>
+        <D:resourcetype><D:collection/><C:calendar/></D:resourcetype>
+        <ICAL:calendar-color>#AABBCCFF</ICAL:calendar-color>
+        <D:current-user-privilege-set>
+          <D:privilege><D:write/></D:privilege>
+        </D:current-user-privilege-set>
+        <C:supported-calendar-component-set>
+          <C:comp name="VEVENT"/>
+        </C:supported-calendar-component-set>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+  <D:response>
+    <D:href>/123456789/calendars/work/</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:displayname>Work</D:displayname>
+        <D:resourcetype><D:collection/><C:calendar/></D:resourcetype>
+        <D:current-user-privilege-set>
+          <D:privilege><D:read/></D:privilege>
+        </D:current-user-privilege-set>
+        <C:supported-calendar-component-set>
+          <C:comp name="VEVENT"/>
+        </C:supported-calendar-component-set>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+</D:multistatus>`;
+
+function xmlResponse(body: string): Response {
+  return new Response(body, {
+    status: 207,
+    headers: { "Content-Type": "application/xml; charset=utf-8" },
+  });
+}
+
+function discoveryFetch(): CaldavFetch {
+  const handlers = [
+    () => xmlResponse(PRINCIPAL_XML),
+    () => xmlResponse(HOME_SET_XML),
+    () => xmlResponse(CALENDARS_XML),
+  ];
+  let call = 0;
+  return async () => {
+    const handler = handlers[call];
+    call += 1;
+    if (!handler) throw new Error("unexpected discovery request");
+    return handler();
+  };
+}
+
+const APPLE_DISCOVERY_CASES: DiscoveryContractCase[] = [
+  {
+    name: "detects the account-default calendar as primary",
+    username: "user@icloud.com",
+    password: "secret",
+    run: async (adapter) => {
+      const result = await adapter.discoverCalendars({
+        accessToken: "secret",
+      });
+      expect(
+        result.calendars.find((calendar) => calendar.primary)?.displayName,
+      ).toBe("user");
+    },
+  },
+  {
+    name: "maps calendar colors and access roles",
+    username: "user@icloud.com",
+    password: "secret",
+    run: async (adapter) => {
+      const result = await adapter.discoverCalendars({
+        accessToken: "secret",
+      });
+      expect(result.calendars[0]?.color).toBe("#AABBCC");
+      expect(result.calendars[0]?.accessRole).toBe("editor");
+      expect(result.calendars[1]?.accessRole).toBe("viewer");
+    },
+  },
+  {
+    name: "returns a null incremental cursor",
+    username: "user@icloud.com",
+    password: "secret",
+    run: async (adapter) => {
+      const result = await adapter.discoverCalendars({
+        accessToken: "secret",
+      });
+      expect(result.cursor).toBeNull();
+    },
+  },
+];
+
+describe("apple discovery contract", () => {
+  for (const testCase of APPLE_DISCOVERY_CASES) {
+    it(testCase.name, async () => {
+      const adapter = new AppleCalendarAdapter(
+        "user@icloud.com",
+        (username, password) =>
+          createCaldavClient({ username, password }, discoveryFetch()),
+      );
+      await testCase.run(adapter);
+    });
+  }
+});

--- a/packages/sync/src/providers/__contract__/discovery.contract.ts
+++ b/packages/sync/src/providers/__contract__/discovery.contract.ts
@@ -1,0 +1,8 @@
+import { type ProviderCalendarAdapter } from "@sync/providers/provider-calendar.port";
+
+export interface DiscoveryContractCase {
+  readonly name: string;
+  readonly username: string;
+  readonly password: string;
+  readonly run: (adapter: ProviderCalendarAdapter) => Promise<void>;
+}

--- a/packages/sync/src/providers/apple/apple-calendar.adapter.test.ts
+++ b/packages/sync/src/providers/apple/apple-calendar.adapter.test.ts
@@ -1,0 +1,195 @@
+import { AppleCalendarAdapter } from "@sync/providers/apple/apple-calendar.adapter";
+import {
+  type CaldavFetch,
+  createCaldavClient,
+} from "@sync/providers/apple/caldav-client";
+
+const PRINCIPAL_XML = `<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:">
+  <D:response>
+    <D:href>/</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:current-user-principal>
+          <D:href>/123456789/principal/</D:href>
+        </D:current-user-principal>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+</D:multistatus>`;
+
+const HOME_SET_XML = `<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:">
+  <D:response>
+    <D:href>/123456789/principal/</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:calendar-home-set>
+          <D:href>/123456789/calendars/</D:href>
+        </D:calendar-home-set>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+</D:multistatus>`;
+
+const CALENDARS_WITH_REMINDERS_XML = `<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav" xmlns:ICAL="http://apple.com/ns/ical/">
+  <D:response>
+    <D:href>/123456789/calendars/home/</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:displayname>user</D:displayname>
+        <D:resourcetype><D:collection/><C:calendar/></D:resourcetype>
+        <ICAL:calendar-color>#AABBCCFF</ICAL:calendar-color>
+        <D:current-user-privilege-set>
+          <D:privilege><D:write/></D:privilege>
+        </D:current-user-privilege-set>
+        <C:supported-calendar-component-set>
+          <C:comp name="VEVENT"/>
+        </C:supported-calendar-component-set>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+  <D:response>
+    <D:href>/123456789/calendars/reminders/</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:displayname>Reminders</D:displayname>
+        <D:resourcetype><D:collection/><C:calendar/></D:resourcetype>
+        <D:current-user-privilege-set>
+          <D:privilege><D:write/></D:privilege>
+        </D:current-user-privilege-set>
+        <C:supported-calendar-component-set>
+          <C:comp name="VTODO"/>
+        </C:supported-calendar-component-set>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+  <D:response>
+    <D:href>/123456789/calendars/work/</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:displayname>Work</D:displayname>
+        <D:resourcetype><D:collection/><C:calendar/></D:resourcetype>
+        <D:current-user-privilege-set>
+          <D:privilege><D:read/></D:privilege>
+        </D:current-user-privilege-set>
+        <C:supported-calendar-component-set>
+          <C:comp name="VEVENT"/>
+        </C:supported-calendar-component-set>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+</D:multistatus>`;
+
+function scriptedFetch(
+  handlers: Array<
+    (url: string, init?: RequestInit) => Response | Promise<Response>
+  >,
+): CaldavFetch {
+  let call = 0;
+  return async (url, init) => {
+    const handler = handlers[call];
+    if (!handler) {
+      throw new Error(`No handler scripted for request ${call} to ${url}`);
+    }
+    call += 1;
+    return handler(String(url), init);
+  };
+}
+
+function xmlResponse(body: string): Response {
+  return new Response(body, {
+    status: 207,
+    headers: { "Content-Type": "application/xml; charset=utf-8" },
+  });
+}
+
+function adapterWithFetch(fetchImpl: CaldavFetch) {
+  return new AppleCalendarAdapter("user@icloud.com", (username, password) =>
+    createCaldavClient({ username, password }, fetchImpl),
+  );
+}
+
+describe("AppleCalendarAdapter", () => {
+  it("maps privilege, color alpha stripping, and primary by account default", async () => {
+    const fetchImpl = scriptedFetch([
+      () => xmlResponse(PRINCIPAL_XML),
+      () => xmlResponse(HOME_SET_XML),
+      () => xmlResponse(CALENDARS_WITH_REMINDERS_XML),
+    ]);
+    const adapter = adapterWithFetch(fetchImpl);
+
+    const result = await adapter.discoverCalendars({ accessToken: "secret" });
+
+    expect(result.cursor).toBeNull();
+    expect(result.calendars.map((calendar) => calendar.displayName)).toEqual([
+      "user",
+      "Work",
+    ]);
+    expect(result.calendars[0]).toMatchObject({
+      color: "#AABBCC",
+      primary: true,
+      accessRole: "editor",
+      capabilities: { canWriteEvents: true, canInviteAttendees: true },
+      createsGoogleMeet: false,
+      eventLabels: [],
+    });
+    expect(result.calendars[1]).toMatchObject({
+      primary: false,
+      accessRole: "viewer",
+      capabilities: { canWriteEvents: false, canInviteAttendees: false },
+    });
+  });
+
+  it("excludes VTODO-only collections such as Reminders", async () => {
+    const fetchImpl = scriptedFetch([
+      () => xmlResponse(PRINCIPAL_XML),
+      () => xmlResponse(HOME_SET_XML),
+      () => xmlResponse(CALENDARS_WITH_REMINDERS_XML),
+    ]);
+    const adapter = adapterWithFetch(fetchImpl);
+
+    const result = await adapter.discoverCalendars({ accessToken: "secret" });
+
+    expect(
+      result.calendars.some((calendar) => calendar.displayName === "Reminders"),
+    ).toBe(false);
+  });
+
+  it("marks the first writable calendar primary when no name matches the account default", async () => {
+    const noDefaultMatchXml = CALENDARS_WITH_REMINDERS_XML.replace(
+      "<D:displayname>user</D:displayname>",
+      "<D:displayname>Personal</D:displayname>",
+    );
+    const fetchImpl = scriptedFetch([
+      () => xmlResponse(PRINCIPAL_XML),
+      () => xmlResponse(HOME_SET_XML),
+      () => xmlResponse(noDefaultMatchXml),
+    ]);
+    const adapter = adapterWithFetch(fetchImpl);
+
+    const result = await adapter.discoverCalendars({ accessToken: "secret" });
+
+    expect(
+      result.calendars.find((calendar) => calendar.primary)?.displayName,
+    ).toBe("Personal");
+  });
+
+  it("maps CalDAV auth failures to ProviderCalendarError authExpired", async () => {
+    const fetchImpl = scriptedFetch([() => new Response("", { status: 401 })]);
+    const adapter = adapterWithFetch(fetchImpl);
+
+    await expect(
+      adapter.discoverCalendars({ accessToken: "wrong" }),
+    ).rejects.toMatchObject({
+      reason: "authExpired",
+      name: "ProviderCalendarError",
+    });
+  });
+});

--- a/packages/sync/src/providers/apple/apple-calendar.adapter.ts
+++ b/packages/sync/src/providers/apple/apple-calendar.adapter.ts
@@ -1,0 +1,152 @@
+import {
+  type CalendarAccessRole,
+  type SyncCalendarCapabilities,
+} from "@core/types/sync/connection.contracts";
+import {
+  type CaldavClient,
+  CaldavClientError,
+  type CaldavClientErrorReason,
+  createCaldavClient,
+  type DiscoveredCaldavCalendar,
+  discoverCalendars as discoverCaldavCalendars,
+} from "@sync/providers/apple/caldav-client";
+import {
+  type CalendarDiscovery,
+  type DiscoveredCalendar,
+  type ProviderCalendarAdapter,
+  ProviderCalendarError,
+} from "@sync/providers/provider-calendar.port";
+
+export type AppleCalendarClientFactory = (
+  username: string,
+  password: string,
+) => CaldavClient;
+
+const defaultClientFactory: AppleCalendarClientFactory = (username, password) =>
+  createCaldavClient({ username, password });
+
+const CAPABILITIES_BY_ROLE: Record<
+  CalendarAccessRole,
+  SyncCalendarCapabilities
+> = {
+  owner: {
+    canReadEvents: true,
+    canWriteEvents: true,
+    canReadBusy: true,
+    canInviteAttendees: true,
+  },
+  editor: {
+    canReadEvents: true,
+    canWriteEvents: true,
+    canReadBusy: true,
+    canInviteAttendees: true,
+  },
+  viewer: {
+    canReadEvents: true,
+    canWriteEvents: false,
+    canReadBusy: true,
+    canInviteAttendees: false,
+  },
+  busyOnly: {
+    canReadEvents: false,
+    canWriteEvents: false,
+    canReadBusy: true,
+    canInviteAttendees: false,
+  },
+};
+
+// Apple iCloud implementation of the calendar-discovery port. The access token
+// custody hands in is the app-specific password; the account email is bound
+// when the adapter is constructed for a connection.
+export class AppleCalendarAdapter implements ProviderCalendarAdapter {
+  #username: string;
+  #makeClient: AppleCalendarClientFactory;
+
+  constructor(
+    username: string,
+    makeClient: AppleCalendarClientFactory = defaultClientFactory,
+  ) {
+    this.#username = username;
+    this.#makeClient = makeClient;
+  }
+
+  async discoverCalendars(input: {
+    accessToken: string;
+    cursor?: string;
+  }): Promise<CalendarDiscovery> {
+    const client = this.#makeClient(this.#username, input.accessToken);
+    try {
+      const discovered = await discoverCaldavCalendars(client, {
+        username: this.#username,
+        password: input.accessToken,
+      });
+      const calendars = mapDiscoveredCalendars(
+        discovered,
+        accountDefaultName(this.#username),
+      );
+      return { calendars, cursor: null };
+    } catch (error) {
+      if (error instanceof CaldavClientError) {
+        throw new ProviderCalendarError(
+          mapDiscoveryReason(error.reason),
+          error.message,
+          { cause: error },
+        );
+      }
+      throw error;
+    }
+  }
+}
+
+function mapDiscoveredCalendars(
+  calendars: readonly DiscoveredCaldavCalendar[],
+  defaultName: string,
+): DiscoveredCalendar[] {
+  const mapped = calendars.map((calendar) => mapCalendar(calendar));
+  if (mapped.length === 0) return mapped;
+
+  const primaryByName = mapped.find(
+    (calendar) =>
+      calendar.displayName.localeCompare(defaultName, undefined, {
+        sensitivity: "accent",
+      }) === 0,
+  );
+  const primaryByWritable = mapped.find(
+    (calendar) => calendar.capabilities.canWriteEvents,
+  );
+  const primary = primaryByName ?? primaryByWritable ?? mapped[0]!;
+
+  return mapped.map((calendar) => ({
+    ...calendar,
+    primary: calendar.providerCalendarId === primary.providerCalendarId,
+  }));
+}
+
+function mapCalendar(calendar: DiscoveredCaldavCalendar): DiscoveredCalendar {
+  const accessRole: CalendarAccessRole = calendar.writable
+    ? "editor"
+    : "viewer";
+  return {
+    providerCalendarId: calendar.providerCalendarId,
+    displayName: calendar.displayName,
+    color: calendar.color,
+    eventLabels: [],
+    primary: false,
+    active: true,
+    accessRole,
+    capabilities: CAPABILITIES_BY_ROLE[accessRole],
+    createsGoogleMeet: false,
+  };
+}
+
+function accountDefaultName(username: string): string {
+  const at = username.indexOf("@");
+  if (at <= 0) return username;
+  return username.slice(0, at);
+}
+
+function mapDiscoveryReason(
+  reason: CaldavClientErrorReason,
+): "authExpired" | "transient" | "discoveryFailed" {
+  return reason;
+}

--- a/packages/sync/src/providers/apple/caldav-client.test.ts
+++ b/packages/sync/src/providers/apple/caldav-client.test.ts
@@ -1,0 +1,300 @@
+import {
+  CaldavClientError,
+  type CaldavFetch,
+  createCaldavClient,
+  discoverCalendars,
+  stripAppleColorAlpha,
+} from "@sync/providers/apple/caldav-client";
+
+const PRINCIPAL_XML = `<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:">
+  <D:response>
+    <D:href>/</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:current-user-principal>
+          <D:href>/123456789/principal/</D:href>
+        </D:current-user-principal>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+</D:multistatus>`;
+
+const HOME_SET_XML = `<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:">
+  <D:response>
+    <D:href>/123456789/principal/</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:calendar-home-set>
+          <D:href>/123456789/calendars/</D:href>
+        </D:calendar-home-set>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+</D:multistatus>`;
+
+const CALENDARS_XML = `<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav" xmlns:ICAL="http://apple.com/ns/ical/" xmlns:CS="http://calendarserver.org/ns/">
+  <D:response>
+    <D:href>/123456789/calendars/</D:href>
+    <D:propstat>
+      <D:prop/>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+  <D:response>
+    <D:href>/123456789/calendars/home/</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:displayname>home</D:displayname>
+        <D:resourcetype><D:collection/><C:calendar/></D:resourcetype>
+        <ICAL:calendar-color>#FFCC00FF</ICAL:calendar-color>
+        <D:current-user-privilege-set>
+          <D:privilege><D:write/></D:privilege>
+          <D:privilege><D:read/></D:privilege>
+        </D:current-user-privilege-set>
+        <C:supported-calendar-component-set>
+          <C:comp name="VEVENT"/>
+        </C:supported-calendar-component-set>
+        <CS:getctag>ctag-home</CS:getctag>
+        <D:sync-token>sync-home</D:sync-token>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+  <D:response>
+    <D:href>/123456789/calendars/work/</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:displayname>Work</D:displayname>
+        <D:resourcetype><D:collection/><C:calendar/></D:resourcetype>
+        <ICAL:calendar-color>#336699FF</ICAL:calendar-color>
+        <D:current-user-privilege-set>
+          <D:privilege><D:read/></D:privilege>
+        </D:current-user-privilege-set>
+        <C:supported-calendar-component-set>
+          <C:comp name="VEVENT"/>
+        </C:supported-calendar-component-set>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+  <D:response>
+    <D:href>/123456789/calendars/inbox/</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:displayname>Inbox</D:displayname>
+        <D:resourcetype><D:collection/><C:schedule-inbox/></D:resourcetype>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+</D:multistatus>`;
+
+function scriptedFetch(
+  handlers: Array<
+    (url: string, init?: RequestInit) => Response | Promise<Response>
+  >,
+): CaldavFetch {
+  let call = 0;
+  return async (url, init) => {
+    const handler = handlers[call];
+    if (!handler) {
+      throw new Error(`No handler scripted for request ${call} to ${url}`);
+    }
+    call += 1;
+    return handler(String(url), init);
+  };
+}
+
+function xmlResponse(body: string, status = 207): Response {
+  return new Response(body, {
+    status,
+    headers: { "Content-Type": "application/xml; charset=utf-8" },
+  });
+}
+
+describe("caldav-client", () => {
+  it("discovers principal, home, and writable calendars", async () => {
+    const fetchImpl = scriptedFetch([
+      () => xmlResponse(PRINCIPAL_XML),
+      () => xmlResponse(HOME_SET_XML),
+      () => xmlResponse(CALENDARS_XML),
+    ]);
+    const client = createCaldavClient(
+      { username: "user@icloud.com", password: "app-specific" },
+      fetchImpl,
+    );
+
+    const calendars = await discoverCalendars(client, {
+      username: "user@icloud.com",
+      password: "app-specific",
+    });
+
+    expect(calendars).toHaveLength(2);
+    expect(calendars.map((calendar) => calendar.displayName)).toEqual([
+      "home",
+      "Work",
+    ]);
+    expect(calendars[0]?.writable).toBe(true);
+    expect(calendars[0]?.color).toBe("#FFCC00");
+    expect(calendars[1]?.writable).toBe(false);
+  });
+
+  it("follows a partition redirect before replaying the request", async () => {
+    const fetchImpl = scriptedFetch([
+      () =>
+        new Response("", {
+          status: 301,
+          headers: {
+            Location: "https://p42-caldav.icloud.com/",
+          },
+        }),
+      () => xmlResponse(PRINCIPAL_XML),
+      () => xmlResponse(HOME_SET_XML),
+      () => xmlResponse(CALENDARS_XML),
+    ]);
+    const client = createCaldavClient(
+      { username: "user@icloud.com", password: "secret" },
+      fetchImpl,
+    );
+
+    await discoverCalendars(client, {
+      username: "user@icloud.com",
+      password: "secret",
+    });
+  });
+
+  it("maps 401 to authExpired", async () => {
+    const fetchImpl = scriptedFetch([() => new Response("", { status: 401 })]);
+    const client = createCaldavClient(
+      { username: "user@icloud.com", password: "wrong" },
+      fetchImpl,
+    );
+
+    await expect(
+      discoverCalendars(client, {
+        username: "user@icloud.com",
+        password: "wrong",
+      }),
+    ).rejects.toMatchObject({ reason: "authExpired" });
+  });
+
+  it("maps 503 to transient", async () => {
+    const fetchImpl = scriptedFetch([() => new Response("", { status: 503 })]);
+    const client = createCaldavClient(
+      { username: "user@icloud.com", password: "secret" },
+      fetchImpl,
+    );
+
+    await expect(
+      discoverCalendars(client, {
+        username: "user@icloud.com",
+        password: "secret",
+      }),
+    ).rejects.toMatchObject({ reason: "transient" });
+  });
+
+  it("redacts Authorization from thrown errors", async () => {
+    const fetchImpl = async () => {
+      throw new Error("network failed with Authorization: Basic c2VjcmV0");
+    };
+    const client = createCaldavClient(
+      { username: "user@icloud.com", password: "secret" },
+      fetchImpl,
+    );
+
+    try {
+      await client.propfind("https://caldav.icloud.com/", ["displayname"], 0);
+      throw new Error("expected propfind to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(CaldavClientError);
+      expect(String(error)).not.toContain("Basic c2VjcmV0");
+    }
+  });
+
+  it("skips VTODO-only collections such as Reminders", async () => {
+    const remindersOnlyXml = `<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
+  <D:response>
+    <D:href>/123456789/calendars/reminders/</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:displayname>Reminders</D:displayname>
+        <D:resourcetype><D:collection/><C:calendar/></D:resourcetype>
+        <C:supported-calendar-component-set>
+          <C:comp name="VTODO"/>
+        </C:supported-calendar-component-set>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+</D:multistatus>`;
+    const fetchImpl = scriptedFetch([
+      () => xmlResponse(PRINCIPAL_XML),
+      () => xmlResponse(HOME_SET_XML),
+      () => xmlResponse(remindersOnlyXml),
+    ]);
+    const client = createCaldavClient(
+      { username: "user@icloud.com", password: "secret" },
+      fetchImpl,
+    );
+
+    const calendars = await discoverCalendars(client, {
+      username: "user@icloud.com",
+      password: "secret",
+    });
+
+    expect(calendars).toEqual([]);
+  });
+
+  it("supports put, delete, get, and report helpers", async () => {
+    const fetchImpl = scriptedFetch([
+      () =>
+        new Response("", {
+          status: 200,
+          headers: { etag: '"etag-1"' },
+        }),
+      () => new Response("", { status: 204 }),
+      () => new Response("BEGIN:VCALENDAR", { status: 200 }),
+      () => xmlResponse("<multistatus/>"),
+    ]);
+    const client = createCaldavClient(
+      { username: "user@icloud.com", password: "secret" },
+      fetchImpl,
+    );
+
+    const put = await client.put("https://caldav.icloud.com/event.ics", "ICS", {
+      ifMatch: '"etag-1"',
+    });
+    expect(put.status).toBe(200);
+    expect(put.headers.etag).toBe('"etag-1"');
+
+    const del = await client.delete(
+      "https://caldav.icloud.com/event.ics",
+      '"etag-1"',
+    );
+    expect(del.status).toBe(204);
+
+    const get = await client.get("https://caldav.icloud.com/event.ics");
+    expect(get.body).toBe("BEGIN:VCALENDAR");
+
+    const report = await client.report(
+      "https://caldav.icloud.com/",
+      "<report/>",
+      1,
+    );
+    expect(report.status).toBe(207);
+  });
+});
+
+describe("stripAppleColorAlpha", () => {
+  it("strips the alpha channel from Apple calendar colors", () => {
+    expect(stripAppleColorAlpha("#FFCC00FF")).toBe("#FFCC00");
+    expect(stripAppleColorAlpha("#336699")).toBe("#336699");
+    expect(stripAppleColorAlpha(null)).toBeNull();
+  });
+});

--- a/packages/sync/src/providers/apple/caldav-client.ts
+++ b/packages/sync/src/providers/apple/caldav-client.ts
@@ -1,0 +1,520 @@
+import { XMLParser } from "fast-xml-parser";
+
+export interface CaldavCredential {
+  readonly username: string;
+  readonly password: string;
+}
+
+export interface CaldavResponse {
+  readonly status: number;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly body: string;
+  readonly multistatus: ParsedMultistatus | null;
+}
+
+export interface ParsedMultistatus {
+  readonly responses: readonly ParsedResponse[];
+}
+
+export interface ParsedResponse {
+  readonly href: string;
+  readonly propstats: readonly ParsedPropstat[];
+}
+
+export interface ParsedPropstat {
+  readonly status: number;
+  readonly props: Record<string, unknown>;
+}
+
+export type CaldavFetch = typeof fetch;
+
+export type CaldavClientErrorReason =
+  | "authExpired"
+  | "transient"
+  | "discoveryFailed";
+
+export class CaldavClientError extends Error {
+  constructor(
+    readonly reason: CaldavClientErrorReason,
+    message: string,
+    options?: { cause?: unknown },
+  ) {
+    super(message, options);
+    this.name = "CaldavClientError";
+  }
+}
+
+const CALDAV_ORIGIN = "https://caldav.icloud.com";
+const MAX_REDIRECTS = 5;
+
+const XML_PARSER = new XMLParser({
+  ignoreAttributes: false,
+  removeNSPrefix: true,
+  attributeNamePrefix: "",
+  isArray: (name) =>
+    name === "response" || name === "propstat" || name === "href",
+});
+
+export interface CaldavClient {
+  propfind(
+    url: string,
+    props: readonly string[],
+    depth: 0 | 1,
+  ): Promise<CaldavResponse>;
+  report(url: string, bodyXml: string, depth: 0 | 1): Promise<CaldavResponse>;
+  put(
+    url: string,
+    ics: string,
+    options?: { ifMatch?: string; ifNoneMatch?: string },
+  ): Promise<CaldavResponse>;
+  delete(url: string, ifMatch?: string): Promise<CaldavResponse>;
+  get(url: string): Promise<CaldavResponse>;
+}
+
+export type CaldavClientFactory = (
+  credential: CaldavCredential,
+  fetchImpl?: CaldavFetch,
+) => CaldavClient;
+
+export function createCaldavClient(
+  credential: CaldavCredential,
+  fetchImpl: CaldavFetch = fetch,
+): CaldavClient {
+  return new CaldavClientImpl(credential, fetchImpl);
+}
+
+class CaldavClientImpl implements CaldavClient {
+  constructor(
+    private readonly credential: CaldavCredential,
+    private readonly fetchImpl: CaldavFetch,
+  ) {}
+
+  propfind(
+    url: string,
+    props: readonly string[],
+    depth: 0 | 1,
+  ): Promise<CaldavResponse> {
+    const body = buildPropfindBody(props);
+    return this.#request("PROPFIND", url, {
+      body,
+      depth: String(depth),
+      contentType: "application/xml; charset=utf-8",
+    });
+  }
+
+  report(url: string, bodyXml: string, depth: 0 | 1): Promise<CaldavResponse> {
+    return this.#request("REPORT", url, {
+      body: bodyXml,
+      depth: String(depth),
+      contentType: "application/xml; charset=utf-8",
+    });
+  }
+
+  put(
+    url: string,
+    ics: string,
+    options: { ifMatch?: string; ifNoneMatch?: string } = {},
+  ): Promise<CaldavResponse> {
+    const headers: Record<string, string> = {
+      "Content-Type": "text/calendar; charset=utf-8",
+    };
+    if (options.ifMatch) headers["If-Match"] = options.ifMatch;
+    if (options.ifNoneMatch) headers["If-None-Match"] = options.ifNoneMatch;
+    return this.#request("PUT", url, { body: ics, extraHeaders: headers });
+  }
+
+  delete(url: string, ifMatch?: string): Promise<CaldavResponse> {
+    const extraHeaders: Record<string, string> = {};
+    if (ifMatch) extraHeaders["If-Match"] = ifMatch;
+    return this.#request("DELETE", url, { extraHeaders });
+  }
+
+  get(url: string): Promise<CaldavResponse> {
+    return this.#request("GET", url, {});
+  }
+
+  async #request(
+    method: string,
+    url: string,
+    options: {
+      body?: string;
+      depth?: string;
+      contentType?: string;
+      extraHeaders?: Record<string, string>;
+    },
+  ): Promise<CaldavResponse> {
+    const headers: Record<string, string> = {
+      Authorization: basicAuthHeader(this.credential),
+      ...options.extraHeaders,
+    };
+    if (options.contentType) headers["Content-Type"] = options.contentType;
+    if (options.depth) headers["Depth"] = options.depth;
+
+    let currentUrl = url;
+    for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects++) {
+      let response: Response;
+      try {
+        response = await this.fetchImpl(currentUrl, {
+          method,
+          headers,
+          body: options.body,
+          redirect: "manual",
+        });
+      } catch (error) {
+        throw redactAuthError(
+          new CaldavClientError("transient", "CalDAV request failed", {
+            cause: error,
+          }),
+        );
+      }
+
+      if (
+        (response.status === 301 ||
+          response.status === 302 ||
+          response.status === 307 ||
+          response.status === 308) &&
+        redirects < MAX_REDIRECTS
+      ) {
+        const location = response.headers.get("Location");
+        if (!location) break;
+        currentUrl = new URL(location, currentUrl).href;
+        continue;
+      }
+
+      const body = await response.text();
+      const parsedHeaders = headersToRecord(response.headers);
+      return {
+        status: response.status,
+        headers: parsedHeaders,
+        body,
+        multistatus: parseMultistatus(body),
+      };
+    }
+
+    throw redactAuthError(
+      new CaldavClientError(
+        "transient",
+        "CalDAV redirect loop exceeded the limit",
+      ),
+    );
+  }
+}
+
+export interface DiscoveredCaldavCalendar {
+  readonly href: string;
+  readonly providerCalendarId: string;
+  readonly displayName: string;
+  readonly color: string | null;
+  readonly writable: boolean;
+  readonly supportsVevent: boolean;
+  readonly getctag: string | null;
+  readonly syncToken: string | null;
+}
+
+export async function discoverCalendars(
+  client: CaldavClient,
+  _credential: CaldavCredential,
+): Promise<readonly DiscoveredCaldavCalendar[]> {
+  const principalResponse = await client.propfind(
+    `${CALDAV_ORIGIN}/`,
+    ["current-user-principal"],
+    0,
+  );
+  assertDiscoveryStatus(principalResponse.status);
+
+  const principalHref = extractHrefProp(
+    principalResponse.multistatus,
+    "current-user-principal",
+  );
+  if (!principalHref) {
+    throw new CaldavClientError(
+      "discoveryFailed",
+      "CalDAV principal discovery returned no current-user-principal",
+    );
+  }
+
+  const principalUrl = resolveHref(principalHref, CALDAV_ORIGIN);
+  const homeResponse = await client.propfind(
+    principalUrl,
+    ["calendar-home-set"],
+    0,
+  );
+  assertDiscoveryStatus(homeResponse.status);
+
+  const homeHref = extractHrefProp(
+    homeResponse.multistatus,
+    "calendar-home-set",
+  );
+  if (!homeHref) {
+    throw new CaldavClientError(
+      "discoveryFailed",
+      "CalDAV principal discovery returned no calendar-home-set",
+    );
+  }
+
+  const homeUrl = resolveHref(homeHref, principalUrl);
+  const calendarsResponse = await client.propfind(
+    homeUrl,
+    [
+      "displayname",
+      "resourcetype",
+      "calendar-color",
+      "current-user-privilege-set",
+      "supported-calendar-component-set",
+      "getctag",
+      "sync-token",
+    ],
+    1,
+  );
+  assertDiscoveryStatus(calendarsResponse.status);
+
+  return parseCalendarCollections(calendarsResponse.multistatus, homeUrl);
+}
+
+function assertDiscoveryStatus(status: number): void {
+  if (status === 401) {
+    throw new CaldavClientError(
+      "authExpired",
+      "CalDAV rejected the credentials",
+    );
+  }
+  if (status === 403 || status === 429 || status === 503) {
+    throw new CaldavClientError(
+      "transient",
+      `CalDAV throttled or refused discovery (${status})`,
+    );
+  }
+  if (status < 200 || status >= 300) {
+    throw new CaldavClientError(
+      "discoveryFailed",
+      `CalDAV discovery failed (${status})`,
+    );
+  }
+}
+
+function buildPropfindBody(props: readonly string[]): string {
+  const propElements = props.map((prop) => `<d:${prop}/>`).join("");
+  return `<?xml version="1.0" encoding="utf-8"?>
+<d:propfind xmlns:d="DAV:" xmlns:cal="urn:ietf:params:xml:ns:caldav" xmlns:cs="http://calendarserver.org/ns/" xmlns:ical="http://apple.com/ns/ical/">
+  <d:prop>${propElements}</d:prop>
+</d:propfind>`;
+}
+
+function parseMultistatus(body: string): ParsedMultistatus | null {
+  const trimmed = body.trim();
+  if (!trimmed.startsWith("<?xml") && !trimmed.startsWith("<")) return null;
+  try {
+    const parsed = XML_PARSER.parse(trimmed) as Record<string, unknown>;
+    const multistatus = parsed["multistatus"] as
+      | Record<string, unknown>
+      | undefined;
+    if (!multistatus) return null;
+    const responsesRaw = multistatus["response"];
+    const responses = asArray(responsesRaw).map(parseResponse);
+    return { responses };
+  } catch {
+    return null;
+  }
+}
+
+function parseResponse(raw: unknown): ParsedResponse {
+  const response = raw as Record<string, unknown>;
+  const href = firstHref(response["href"]);
+  const propstats = asArray(response["propstat"]).map(parsePropstat);
+  return { href, propstats };
+}
+
+function parsePropstat(raw: unknown): ParsedPropstat {
+  const propstat = raw as Record<string, unknown>;
+  const statusText = String(propstat["status"] ?? "");
+  const status = parseStatusCode(statusText);
+  const prop = (propstat["prop"] as Record<string, unknown> | undefined) ?? {};
+  return { status, props: prop };
+}
+
+function parseCalendarCollections(
+  multistatus: ParsedMultistatus | null,
+  homeUrl: string,
+): DiscoveredCaldavCalendar[] {
+  if (!multistatus) return [];
+  const calendars: DiscoveredCaldavCalendar[] = [];
+
+  for (const response of multistatus.responses) {
+    if (!isCalendarCollection(response)) continue;
+    if (isSkippedCollection(response.href)) continue;
+
+    const props = successfulProps(response);
+    const displayName =
+      stringProp(props["displayname"]) ?? basename(response.href);
+    const color = stripAppleColorAlpha(stringProp(props["calendar-color"]));
+    const writable = hasWritePrivilege(props["current-user-privilege-set"]);
+    const supportsVevent = supportsVeventComponent(
+      props["supported-calendar-component-set"],
+    );
+    if (!supportsVevent) continue;
+
+    calendars.push({
+      href: resolveHref(response.href, homeUrl),
+      providerCalendarId: response.href,
+      displayName,
+      color,
+      writable,
+      supportsVevent,
+      getctag: stringProp(props["getctag"]),
+      syncToken: stringProp(props["sync-token"]),
+    });
+  }
+
+  return calendars;
+}
+
+function isCalendarCollection(response: ParsedResponse): boolean {
+  const props = successfulProps(response);
+  const resourceType = props["resourcetype"];
+  if (!resourceType || typeof resourceType !== "object") return false;
+  const type = resourceType as Record<string, unknown>;
+  return "calendar" in type;
+}
+
+function isSkippedCollection(href: string): boolean {
+  const lower = href.toLowerCase();
+  return (
+    lower.includes("inbox") ||
+    lower.includes("outbox") ||
+    lower.includes("notification")
+  );
+}
+
+function supportsVeventComponent(componentSet: unknown): boolean {
+  if (!componentSet || typeof componentSet !== "object") return true;
+  const set = componentSet as Record<string, unknown>;
+  const comps = asArray(set["comp"]);
+  if (comps.length === 0) return true;
+  const names = comps.map((comp) => {
+    if (typeof comp === "object" && comp !== null && "name" in comp) {
+      return String(
+        (comp as Record<string, unknown>)["name"] ?? "",
+      ).toUpperCase();
+    }
+    return String(comp).toUpperCase();
+  });
+  return names.includes("VEVENT");
+}
+
+function hasWritePrivilege(privilegeSet: unknown): boolean {
+  if (!privilegeSet || typeof privilegeSet !== "object") return false;
+  const set = privilegeSet as Record<string, unknown>;
+  const privileges = collectPrivileges(set["privilege"]);
+  return privileges.some((privilege) => privilege.endsWith("write"));
+}
+
+function collectPrivileges(raw: unknown): string[] {
+  const results: string[] = [];
+  for (const privilege of asArray(raw)) {
+    if (typeof privilege === "string") {
+      results.push(privilege.toLowerCase());
+      continue;
+    }
+    if (typeof privilege === "object" && privilege !== null) {
+      for (const key of Object.keys(privilege as Record<string, unknown>)) {
+        results.push(key.toLowerCase());
+      }
+    }
+  }
+  return results;
+}
+
+function successfulProps(response: ParsedResponse): Record<string, unknown> {
+  for (const propstat of response.propstats) {
+    if (propstat.status >= 200 && propstat.status < 300) {
+      return propstat.props;
+    }
+  }
+  return {};
+}
+
+function extractHrefProp(
+  multistatus: ParsedMultistatus | null,
+  propName: string,
+): string | null {
+  if (!multistatus) return null;
+  for (const response of multistatus.responses) {
+    const props = successfulProps(response);
+    const value = props[propName];
+    if (!value || typeof value !== "object") continue;
+    const href = firstHref((value as Record<string, unknown>)["href"]);
+    if (href) return href;
+  }
+  return null;
+}
+
+export function stripAppleColorAlpha(color: string | null): string | null {
+  if (!color) return null;
+  const match = /^#([0-9a-fA-F]{8})$/.exec(color);
+  if (match) return `#${match[1]!.slice(0, 6)}`;
+  return color;
+}
+
+function basicAuthHeader(credential: CaldavCredential): string {
+  const encoded = Buffer.from(
+    `${credential.username}:${credential.password}`,
+  ).toString("base64");
+  return `Basic ${encoded}`;
+}
+
+function redactAuthError<T extends Error>(error: T): T {
+  if (error.message.includes("Basic ")) {
+    error.message = error.message.replace(
+      /Basic [A-Za-z0-9+/=]+/g,
+      "Basic [REDACTED]",
+    );
+  }
+  if (error.cause instanceof Error) {
+    error.cause.message = error.cause.message.replace(
+      /Basic [A-Za-z0-9+/=]+/g,
+      "Basic [REDACTED]",
+    );
+  }
+  return error;
+}
+
+function headersToRecord(headers: Headers): Record<string, string> {
+  const record: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    record[key.toLowerCase()] = value;
+  });
+  return record;
+}
+
+function resolveHref(href: string, base: string): string {
+  if (href.startsWith("http://") || href.startsWith("https://")) return href;
+  return new URL(href, base).href;
+}
+
+function firstHref(raw: unknown): string {
+  if (typeof raw === "string") return raw;
+  if (Array.isArray(raw) && typeof raw[0] === "string") return raw[0];
+  return "";
+}
+
+function stringProp(value: unknown): string | null {
+  if (typeof value === "string" && value.length > 0) return value;
+  if (typeof value === "number") return String(value);
+  return null;
+}
+
+function basename(href: string): string {
+  const trimmed = href.endsWith("/") ? href.slice(0, -1) : href;
+  const parts = trimmed.split("/");
+  return parts[parts.length - 1] ?? href;
+}
+
+function parseStatusCode(statusText: string): number {
+  const match = /(\d{3})/.exec(statusText);
+  return match ? Number(match[1]) : 0;
+}
+
+function asArray<T>(value: T | T[] | undefined | null): T[] {
+  if (value == null) return [];
+  return Array.isArray(value) ? value : [value];
+}


### PR DESCRIPTION
Fixes #3254

## What and why

Adds the Apple iCloud CalDAV transport and calendar-discovery adapter for Providers A WP-01. A hand-rolled client (`caldav-client.ts`) handles PROPFIND/REPORT/PUT/DELETE/GET with injectable fetch, Basic auth, partition redirect following, and multistatus parsing via `fast-xml-parser`. `AppleCalendarAdapter` maps discovery to `DiscoveredCalendar` (Reminders/VTODO exclusion, `#RRGGBBAA` color stripping, write/read privilege mapping, `cursor: null`, `createsGoogleMeet: false`). Discovery contract cases for `apple` live under `__contract__/`.

Spec: `docs/features/calendar-providers.md`

## Verify

```
bun run verify --strict
```

Selected packages: sync
Checks run: test:sync:fast, type-check, lint, knip

VERDICT: PASS