### PR TITLE
feat(sync): parameterize oauth and notification public paths by provider

### DIFF
--- a/.agents/handoffs/3227.md
+++ b/.agents/handoffs/3227.md
@@ -1,0 +1,36 @@
+---
+schema_version: 1
+task_id: "3227"
+from: Implementer
+to: GitHub
+owner: GitHub
+status: verifying
+artifact:
+  - path: packages/sync/src/oauth/oauth-state.ts
+  - path: packages/sync/src/server/connection.routes.ts
+  - path: packages/sync/src/server/notification.routes.ts
+  - path: packages/sync/src/providers/provider-registry.ts
+  - path: packages/sync/src/providers/provider-notifications.port.ts
+evidence:
+  - command: bun test:sync
+    result: pass (1139 tests)
+  - command: bun run type-check
+    result: pass
+  - command: bun lint
+    result: pass
+  - command: bun knip
+    result: pass
+  - command: bun run verify --strict
+    result: pass (test:sync, type-check, lint, knip)
+assumptions:
+  - "Legacy OAuth states without a provider field decode as google for backward compatibility."
+  - "Microsoft registration in production lands in M-09; tests inject a fake microsoft registration for routing acceptance."
+open_risks: []
+next_deadline: 2026-09-05T02:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+P0 WP-04: provider-parameterized public paths and parseNotification port method.

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -45,7 +45,6 @@ import {
   resolveAuthFrom,
 } from "@sync/providers/provider-registry";
 import { redactedCause } from "@sync/safety/redact-error";
-import { NOTIFICATIONS_PATH } from "@sync/server/notification.routes";
 import { buildSyncApp } from "@sync/server/sync.server";
 import { buildServiceIdentity } from "@sync/service-identity";
 import {
@@ -493,7 +492,8 @@ function buildSchedulers(
         custody: new CredentialCustody(repos.credentials, resolveAuth),
         // Where the provider posts change notifications back; the callback route
         // verifies them against the stored subscription.
-        callbackUrl: `${config.CALLBACK_BASE_URL}${NOTIFICATIONS_PATH}`,
+        callbackUrlFor: (kind) =>
+          registry.callbackUrlFor(config.CALLBACK_BASE_URL, kind),
         invalidations: repos.invalidations,
         log: logger,
       },

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -196,7 +196,7 @@ describe("dispatchSyncJob", () => {
     jobs,
     commands,
     custody,
-    callbackUrl: "https://sync.example/sync/notifications/google",
+    callbackUrlFor: () => "https://sync.example/sync/notifications/google",
     invalidations,
   });
 

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -1,3 +1,4 @@
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
 import { MAX_REFRESH_FAILED_ATTEMPTS } from "@sync/credentials/refresh-failure.constants";
 import { importCalendarEvents } from "@sync/domain/calendar-import.service";
 import { syncCalendarList } from "@sync/domain/calendar-list-sync.service";
@@ -5,7 +6,10 @@ import { pullCalendarChanges } from "@sync/domain/calendar-pull.service";
 import { repairCalendar } from "@sync/domain/calendar-repair.service";
 import { refreshConnectionStateAfterJob } from "@sync/domain/connection-state-refresh.service";
 import { type AccessTokenSource } from "@sync/domain/provider-write-ladder";
-import { maintainSubscription } from "@sync/domain/subscription-maintenance.service";
+import {
+  maintainSubscription,
+  type SubscriptionMaintenanceDeps,
+} from "@sync/domain/subscription-maintenance.service";
 import {
   type ProviderAdapters,
   ProviderNotConfiguredError,
@@ -53,7 +57,7 @@ export interface SyncJobDispatchDeps {
   // pullCalendarChanges consults pending commands before deleting an event.
   commands: CommandRepository;
   custody: AccessTokenSource;
-  callbackUrl: string;
+  callbackUrlFor: (provider: ProviderKind) => string;
   // Content-free outbox so Compass API can push typed browser SSE after a
   // provider pull. Without this, incremental pulls update Sync storage but the
   // open SPA never refetches (S40 gap).
@@ -348,7 +352,12 @@ async function runSyncJob(
         reason: "calendar-list resource only accepts subscriptionMaintain",
       };
     }
-    await maintainSubscription(executionDeps, null, resource, now);
+    await maintainSubscription(
+      subscriptionDeps(executionDeps, deps, connection.provider),
+      null,
+      resource,
+      now,
+    );
     return { result: "done" };
   }
   if (!resource.calendarId) {
@@ -576,7 +585,7 @@ async function runSyncJob(
       // including durable watchFailed, which maintainSubscription folds into
       // unsupported. A transient watch failure throws and the worker retries.
       const subscription = await maintainSubscription(
-        executionDeps,
+        subscriptionDeps(executionDeps, deps, connection.provider),
         calendar,
         resource,
         now,
@@ -766,4 +775,17 @@ async function appendCalendarInvalidation(
     },
     emittedAt,
   });
+}
+
+function subscriptionDeps(
+  executionDeps: SyncJobExecutionDeps,
+  deps: SyncJobDispatchDeps,
+  provider: ProviderKind,
+): SubscriptionMaintenanceDeps {
+  return {
+    resources: executionDeps.resources,
+    notifications: executionDeps.notifications,
+    custody: executionDeps.custody,
+    callbackUrl: deps.callbackUrlFor(provider),
+  };
 }

--- a/packages/sync/src/domain/sync-job-worker.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.db.test.ts
@@ -114,7 +114,7 @@ describe("SyncJobWorker", () => {
     commands,
     jobs,
     custody: tokenSource,
-    callbackUrl: "https://sync.example/sync/notifications/google",
+    callbackUrlFor: () => "https://sync.example/sync/notifications/google",
     invalidations,
   });
 

--- a/packages/sync/src/oauth/oauth-state.test.ts
+++ b/packages/sync/src/oauth/oauth-state.test.ts
@@ -21,6 +21,7 @@ const payload = (
   tenantId: objectId() as TenantId,
   principalId: objectId() as PrincipalId,
   connectionId: null,
+  provider: "google",
   issuedAt: 1_000_000,
   ...overrides,
 });
@@ -97,6 +98,35 @@ describe("oauth-state", () => {
       ok: false,
       reason: "expired",
     });
+  });
+
+  it("rejects a state minted for one provider on another provider's callback", () => {
+    const original = payload({ provider: "google" });
+    const token = signOAuthState(SECRET, original);
+
+    expect(
+      verifyOAuthState(SECRET, token, original.issuedAt, {
+        expectedProvider: "microsoft",
+      }),
+    ).toEqual({ ok: false, reason: "stateMismatch" });
+  });
+
+  it("defaults legacy payloads without a provider field to google", () => {
+    const encoded = Buffer.from(
+      JSON.stringify({
+        t: objectId(),
+        p: objectId(),
+        c: null,
+        i: 1_000_000,
+      }),
+    ).toString("base64url");
+    const signature = createHmac("sha256", SECRET)
+      .update(encoded)
+      .digest("hex");
+    const token = `${encoded}.${signature}`;
+
+    const result = verifyOAuthState(SECRET, token, 1_000_000);
+    expect(result.ok && result.payload.provider).toBe("google");
   });
 
   it("rejects a structurally malformed token", () => {

--- a/packages/sync/src/oauth/oauth-state.ts
+++ b/packages/sync/src/oauth/oauth-state.ts
@@ -3,6 +3,8 @@ import {
   ConnectionIdSchema,
   type PrincipalId,
   PrincipalIdSchema,
+  type ProviderKind,
+  ProviderKindSchema,
   type TenantId,
   TenantIdSchema,
 } from "@core/types/sync/identity.contracts";
@@ -21,6 +23,9 @@ export interface OAuthStatePayload {
   // Present when re-authorizing a specific existing connection (reconnect),
   // absent for a first-time connect.
   readonly connectionId: ConnectionId | null;
+  // Which provider kind this consent flow was minted for. Callback routes
+  // reject a state presented on a different provider's path (stateMismatch).
+  readonly provider: ProviderKind;
   // Milliseconds since the epoch when the state was issued.
   readonly issuedAt: number;
 }
@@ -49,18 +54,28 @@ export function signOAuthState(
   return `${encoded}.${sign(secret, encoded)}`;
 }
 
-export type OAuthStateFailure = "malformed" | "invalidSignature" | "expired";
+export type OAuthStateFailure =
+  | "malformed"
+  | "invalidSignature"
+  | "expired"
+  | "stateMismatch";
 
 export type OAuthStateResult =
   | { readonly ok: true; readonly payload: OAuthStatePayload }
   | { readonly ok: false; readonly reason: OAuthStateFailure };
 
+export interface VerifyOAuthStateOptions {
+  ttlMs?: number;
+  expectedProvider?: ProviderKind;
+}
+
 export function verifyOAuthState(
   secret: string,
   token: string,
   now: number,
-  ttlMs: number = DEFAULT_OAUTH_STATE_TTL_MS,
+  options: VerifyOAuthStateOptions = {},
 ): OAuthStateResult {
+  const ttlMs = options.ttlMs ?? DEFAULT_OAUTH_STATE_TTL_MS;
   const dot = token.indexOf(".");
   if (dot <= 0 || dot === token.length - 1) {
     return { ok: false, reason: "malformed" };
@@ -79,6 +94,12 @@ export function verifyOAuthState(
   if (now - payload.issuedAt > ttlMs || payload.issuedAt > now) {
     return { ok: false, reason: "expired" };
   }
+  if (
+    options.expectedProvider !== undefined &&
+    payload.provider !== options.expectedProvider
+  ) {
+    return { ok: false, reason: "stateMismatch" };
+  }
   return { ok: true, payload };
 }
 
@@ -96,6 +117,7 @@ function encodePayload(payload: OAuthStatePayload): string {
     t: payload.tenantId,
     p: payload.principalId,
     c: payload.connectionId,
+    k: payload.provider,
     i: payload.issuedAt,
   });
   return Buffer.from(json, "utf8").toString("base64url");
@@ -128,10 +150,15 @@ function decodePayload(encoded: string): OAuthStatePayload | null {
     connectionId = parsed.data;
   }
 
+  // States minted before provider was bound to the payload default to google.
+  const providerParsed = ProviderKindSchema.safeParse(record["k"] ?? "google");
+  if (!providerParsed.success) return null;
+
   return {
     tenantId: tenantId.data,
     principalId: principalId.data,
     connectionId,
+    provider: providerParsed.data,
     issuedAt,
   };
 }

--- a/packages/sync/src/providers/google/google-notifications.adapter.ts
+++ b/packages/sync/src/providers/google/google-notifications.adapter.ts
@@ -185,6 +185,14 @@ export class GoogleNotificationAdapter implements ProviderNotificationAdapter {
       throw classifyWatchError(error);
     }
   }
+
+  parseNotification(request: {
+    headers: Record<string, string | undefined>;
+    body: unknown;
+    query: Record<string, unknown>;
+  }): ProviderNotification | null {
+    return parseGoogleNotification(request.headers);
+  }
 }
 
 // Normalize Google callback headers into a ProviderNotification, or null if

--- a/packages/sync/src/providers/provider-notifications.port.ts
+++ b/packages/sync/src/providers/provider-notifications.port.ts
@@ -25,6 +25,17 @@ export interface ProviderNotification {
   readonly state: NotificationState;
 }
 
+export type NotificationParseResult =
+  | ProviderNotification
+  | { readonly kind: "validation"; readonly body: string }
+  | null;
+
+export interface NotificationRequest {
+  readonly headers: Record<string, string | undefined>;
+  readonly body: unknown;
+  readonly query: Record<string, unknown>;
+}
+
 // A provider-neutral notification port. Channel lifecycle (watch/stop) and the
 // provider-specific callback header shapes stay inside the adapter; the domain
 // works with the normalized ProviderNotification and the verification verdict.
@@ -50,6 +61,11 @@ export interface ProviderNotificationAdapter {
     readonly channelId: string;
     readonly resourceId: string;
   }): Promise<void>;
+
+  // Normalize an inbound callback into a ProviderNotification, a provider
+  // validation handshake (Microsoft's subscription echo), or null when the
+  // request is not recognizable.
+  parseNotification(request: NotificationRequest): NotificationParseResult;
 }
 
 // Why a mutation of a channel could not complete.

--- a/packages/sync/src/providers/provider-registry.test.ts
+++ b/packages/sync/src/providers/provider-registry.test.ts
@@ -5,6 +5,7 @@ import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
 import {
   buildProviderRegistry,
   GOOGLE_CALLBACK_PATH,
+  GOOGLE_NOTIFICATIONS_PATH,
 } from "@sync/providers/provider-registry";
 import { describe, expect, it } from "bun:test";
 
@@ -75,6 +76,10 @@ describe("ProviderRegistry", () => {
     );
     const google = registry.get("google");
     expect(google.callbackPath).toBe(GOOGLE_CALLBACK_PATH);
+    expect(google.notificationsCallbackPath).toBe(GOOGLE_NOTIFICATIONS_PATH);
+    expect(registry.callbackUrlFor("https://example.test", "google")).toBe(
+      "https://example.test/sync/notifications/google",
+    );
     expect(google.capabilities).toEqual(
       expect.arrayContaining([
         "readEvents",

--- a/packages/sync/src/providers/provider-registry.ts
+++ b/packages/sync/src/providers/provider-registry.ts
@@ -29,6 +29,7 @@ export interface ProviderRegistration {
   scopes: ProviderScopes;
   capabilities: readonly ProviderCapability[];
   callbackPath: string;
+  notificationsCallbackPath: string;
   capabilitiesFromScopes(granted: readonly string[]): ProviderCapability[];
 }
 
@@ -55,9 +56,16 @@ export class ProviderRegistry {
   kinds(): ProviderKind[] {
     return [...this.registrations.keys()];
   }
+
+  callbackUrlFor(baseUrl: string, kind: ProviderKind): string {
+    return `${baseUrl}${this.get(kind).notificationsCallbackPath}`;
+  }
 }
 
 export const GOOGLE_CALLBACK_PATH = "/sync/google";
+export const GOOGLE_NOTIFICATIONS_PATH = "/sync/notifications/google";
+export const OAUTH_CALLBACK_PARAM_PATH = "/sync/:provider";
+export const NOTIFICATIONS_PARAM_PATH = "/sync/notifications/:provider";
 
 export function buildProviderRegistry(
   config: SyncConfig,
@@ -73,6 +81,7 @@ export function buildProviderRegistry(
       scopes: { forFeatures: googleScopesForFeatures },
       capabilities: GOOGLE_PROVIDER_CAPABILITIES,
       callbackPath: GOOGLE_CALLBACK_PATH,
+      notificationsCallbackPath: GOOGLE_NOTIFICATIONS_PATH,
       capabilitiesFromScopes: googleCapabilitiesFromScopes,
     });
   }

--- a/packages/sync/src/server/connection.routes.db.test.ts
+++ b/packages/sync/src/server/connection.routes.db.test.ts
@@ -28,6 +28,10 @@ import {
   type ProviderAuthorization,
   type RefreshedCredential,
 } from "@sync/providers/provider-auth.port";
+import {
+  buildProviderRegistry,
+  ProviderRegistry,
+} from "@sync/providers/provider-registry";
 import { COMMANDS_PATH } from "@sync/server/command.routes";
 import {
   ADOPT_GOOGLE_AUTHORIZATION_PATH,
@@ -689,8 +693,9 @@ describe("GET /sync/google", () => {
   const startService = async (
     config: SyncConfig,
     authAdapter?: ProviderAuthAdapter,
+    registry?: ProviderRegistry,
   ) => {
-    service = createSyncService(config, { mongo, authAdapter });
+    service = createSyncService(config, { mongo, authAdapter, registry });
     await new Promise<void>((resolve) => service.httpServer.listen(0, resolve));
     const { port } = service.httpServer.address() as AddressInfo;
     base = `http://127.0.0.1:${port}`;
@@ -701,6 +706,7 @@ describe("GET /sync/google", () => {
       tenantId: tenantId as TenantId,
       principalId: principalId as PrincipalId,
       connectionId: null,
+      provider: "google",
       issuedAt: Date.now(),
     });
 
@@ -888,6 +894,7 @@ describe("GET /sync/google", () => {
       tenantId: tenantId as TenantId,
       principalId: principalId as PrincipalId,
       connectionId: connectionId as ConnectionId,
+      provider: "google",
       issuedAt: Date.now(),
     });
 
@@ -986,6 +993,47 @@ describe("GET /sync/google", () => {
     );
 
     expect(statusOf(res)).toBe("error");
+    expect(
+      await connections.listByPrincipal(
+        tenantId as TenantId,
+        principalId as PrincipalId,
+      ),
+    ).toHaveLength(0);
+  });
+
+  const registryWithMicrosoft = (authAdapter: ProviderAuthAdapter) => {
+    const config = activeConfig();
+    const google = buildProviderRegistry(config, {
+      google: { auth: authAdapter },
+    }).get("google");
+    return new ProviderRegistry(
+      new Map([
+        ["google", google],
+        [
+          "microsoft",
+          {
+            ...google,
+            callbackPath: "/sync/microsoft",
+            notificationsCallbackPath: "/sync/notifications/microsoft",
+          },
+        ],
+      ]),
+    );
+  };
+
+  it("rejects a google state presented on another provider callback with stateMismatch", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    await startService(activeConfig(), adapter, registryWithMicrosoft(adapter));
+
+    const res = await fetch(
+      `${base}/sync/microsoft?code=auth-code&state=${encodeURIComponent(validState(tenantId, principalId))}`,
+      { redirect: "manual" },
+    );
+
+    expect(res.status).toBe(302);
+    expect(statusOf(res)).toBe("stateMismatch");
+    expect(adapter.exchanges).toHaveLength(0);
     expect(
       await connections.listByPrincipal(
         tenantId as TenantId,

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -1,4 +1,9 @@
-import { type Express, type RequestHandler, type Response } from "express";
+import {
+  type Express,
+  type Request,
+  type RequestHandler,
+  type Response,
+} from "express";
 import { Status } from "@core/errors/status.codes";
 import { Logger } from "@core/logger/winston.logger";
 import { decryptInternalCredential } from "@core/security/internal-credential-envelope";
@@ -53,6 +58,8 @@ import {
 import { signOAuthState, verifyOAuthState } from "@sync/oauth/oauth-state";
 import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
 import {
+  GOOGLE_CALLBACK_PATH,
+  OAUTH_CALLBACK_PARAM_PATH,
   type ProviderRegistry,
   resolveAuthFrom,
 } from "@sync/providers/provider-registry";
@@ -90,9 +97,9 @@ export const ADOPT_GOOGLE_AUTHORIZATION_PATH =
   "/internal/connections/adopt-google-authorization";
 // Where the provider redirects the browser after consent; `begin` builds the
 // redirect_uri from it and the public callback route below mounts on it.
-// Public reverse-proxy path (Caddy `/sync/*` → sync). Must match the Google
-// OAuth client authorized redirect URI (`/sync/google`).
-export const OAUTH_CALLBACK_PATH = "/sync/google";
+// Legacy alias: Google OAuth callback path (also registered under
+// OAUTH_CALLBACK_PARAM_PATH with provider=google).
+export const OAUTH_CALLBACK_PATH = GOOGLE_CALLBACK_PATH;
 
 // The rolling window Sync materializes occurrences for (shared with the
 // projection layer via @sync/domain/horizon). A query's range is clamped to it
@@ -590,6 +597,7 @@ export function registerConnectionRoutes(
         tenantId: auth.tenantId,
         principalId: auth.principalId,
         connectionId,
+        provider,
         issuedAt: (deps.now ?? Date.now)(),
       });
       const authorizationUrl = registration.adapters.auth.buildAuthorizationUrl(
@@ -646,6 +654,7 @@ export function registerConnectionRoutes(
             tenantId: auth.tenantId,
             principalId: auth.principalId,
             connectionId: null,
+            provider: "google",
           },
           { ...parsed.data, refreshToken },
         );
@@ -711,77 +720,85 @@ export function registerConnectionRoutes(
     },
   );
 
-  // The public OAuth callback the provider redirects the browser to after
-  // consent. It carries NO internal-auth — the signed state is the only trust,
-  // so it is verified before any work. On every outcome the browser is sent to
-  // a server-configured URL (never a request-controlled one), so there is no
-  // open-redirect surface. Nothing here pulls provider data; it only links the
-  // account and stores the credential.
-  app.get(OAUTH_CALLBACK_PATH, internalRateLimit, async (req, res) => {
-    const redirect = (status: string) =>
-      redirectAfterConnect(deps, res, status);
+  const handleOAuthCallback =
+    (routeProvider: ProviderKind) => async (req: Request, res: Response) => {
+      const redirect = (status: string) =>
+        redirectAfterConnect(deps, res, routeProvider, status);
 
-    if (deps.execution === "passive" || !deps.registry.has("google")) {
-      return redirect("error");
-    }
-    if (!deps.mongo.isConnected) return redirect("error");
-    // The user declined consent, or the provider returned an error.
-    if (typeof req.query["error"] === "string") return redirect("declined");
+      if (deps.execution === "passive" || !deps.registry.has(routeProvider)) {
+        return redirect("error");
+      }
+      if (!deps.mongo.isConnected) return redirect("error");
+      // The user declined consent, or the provider returned an error.
+      if (typeof req.query["error"] === "string") return redirect("declined");
 
-    const code = req.query["code"];
-    const state = req.query["state"];
-    if (typeof code !== "string" || typeof state !== "string") {
-      return redirect("error");
-    }
+      const code = req.query["code"];
+      const state = req.query["state"];
+      if (typeof code !== "string" || typeof state !== "string") {
+        return redirect("error");
+      }
 
-    const verified = verifyOAuthState(
-      deps.stateSecret,
-      state,
-      (deps.now ?? Date.now)(),
-    );
-    if (!verified.ok) return redirect("error");
-
-    const google = deps.registry.get("google");
-    let authorization: Awaited<
-      ReturnType<ProviderAuthAdapter["exchangeAuthorizationCode"]>
-    >;
-    try {
-      authorization = await google.adapters.auth.exchangeAuthorizationCode({
-        code,
-        // Must match the redirect_uri begin used to build the consent URL.
-        redirectUri: `${deps.callbackBaseUrl}${google.callbackPath}`,
-      });
-    } catch (error) {
-      // Bad code, no refresh token, unverifiable identity — nothing to link.
-      logger.error("OAuth code exchange failed", redactedCause(error));
-      return redirect("error");
-    }
-
-    // Google grants a SUBSET of the requested scopes when the user unchecks
-    // one on the consent screen (e.g. leaves the calendar box unticked).
-    // Unlike the signup path (complete-google-authorization.ts, which checks
-    // client-side before ever reaching here), this route previously linked
-    // the connection anyway - discovery would then 403 and durably fail the
-    // resource, surfacing as "Couldn't update your calendar" with no mention
-    // of the actual cause. Catch it here, before any connection is created.
-    if (
-      !google
-        .capabilitiesFromScopes(authorization.grantedScopes)
-        .includes("readEvents")
-    ) {
-      return redirect("missingScopes");
-    }
-
-    try {
-      await linkConnection(deps, verified.payload, authorization);
-      return redirect("connected");
-    } catch (error) {
-      logger.error(
-        "Failed to link connection after OAuth consent",
-        redactedCause(error),
+      const verified = verifyOAuthState(
+        deps.stateSecret,
+        state,
+        (deps.now ?? Date.now)(),
+        { expectedProvider: routeProvider },
       );
-      return redirect("error");
+      if (!verified.ok) {
+        return redirect(
+          verified.reason === "stateMismatch" ? "stateMismatch" : "error",
+        );
+      }
+
+      const registration = deps.registry.get(routeProvider);
+      let authorization: Awaited<
+        ReturnType<ProviderAuthAdapter["exchangeAuthorizationCode"]>
+      >;
+      try {
+        authorization =
+          await registration.adapters.auth.exchangeAuthorizationCode({
+            code,
+            // Must match the redirect_uri begin used to build the consent URL.
+            redirectUri: `${deps.callbackBaseUrl}${registration.callbackPath}`,
+          });
+      } catch (error) {
+        // Bad code, no refresh token, unverifiable identity — nothing to link.
+        logger.error("OAuth code exchange failed", redactedCause(error));
+        return redirect("error");
+      }
+
+      if (
+        !registration
+          .capabilitiesFromScopes(authorization.grantedScopes)
+          .includes("readEvents")
+      ) {
+        return redirect("missingScopes");
+      }
+
+      try {
+        await linkConnection(deps, verified.payload, authorization);
+        return redirect("connected");
+      } catch (error) {
+        logger.error(
+          "Failed to link connection after OAuth consent",
+          redactedCause(error),
+        );
+        return redirect("error");
+      }
+    };
+
+  app.get(
+    OAUTH_CALLBACK_PATH,
+    internalRateLimit,
+    handleOAuthCallback("google"),
+  );
+  app.get(OAUTH_CALLBACK_PARAM_PATH, internalRateLimit, (req, res) => {
+    const parsed = ProviderKindSchema.safeParse(req.params["provider"]);
+    if (!parsed.success || !deps.registry.has(parsed.data)) {
+      res.status(Status.NOT_FOUND).end();
+      return;
     }
+    return handleOAuthCallback(parsed.data)(req, res);
   });
 
   app.delete(
@@ -858,10 +875,11 @@ function resolveAuthForConnectionApi(deps: ConnectionApiDeps) {
 function redirectAfterConnect(
   deps: ConnectionApiDeps,
   res: Response,
+  provider: ProviderKind,
   status: string,
 ): void {
   const url = new URL(deps.postConnectRedirectUrl);
-  url.searchParams.set("provider", "google");
+  url.searchParams.set("provider", provider);
   url.searchParams.set("status", status);
   res.redirect(url.toString());
 }
@@ -876,6 +894,7 @@ async function linkConnection(
     tenantId: TenantId;
     principalId: PrincipalId;
     connectionId: ConnectionId | null;
+    provider: ProviderKind;
   },
   authorization: Awaited<
     ReturnType<ProviderAuthAdapter["exchangeAuthorizationCode"]>
@@ -883,6 +902,7 @@ async function linkConnection(
 ): Promise<void> {
   const repos = syncRepositories(deps.mongo);
   const connections = repos.connections;
+  const registration = deps.registry.get(state.provider);
 
   // Reconnect: the state named a specific connection to re-authorize. Require
   // the account Google just returned to match that connection's account.
@@ -914,11 +934,11 @@ async function linkConnection(
   const connection = await connections.upsertByProviderAccount({
     tenantId: state.tenantId,
     principalId: state.principalId,
-    provider: "google",
+    provider: state.provider,
     account: authorization.account,
-    capabilities: deps.registry
-      .get("google")
-      .capabilitiesFromScopes(authorization.grantedScopes),
+    capabilities: registration.capabilitiesFromScopes(
+      authorization.grantedScopes,
+    ),
     state: derived.state,
     stateReason: derived.reason,
   });
@@ -930,7 +950,7 @@ async function linkConnection(
     );
     await custody.store({
       connectionId: connection._id,
-      provider: "google",
+      provider: state.provider,
       refreshToken: authorization.refreshToken,
       scopes: [...authorization.grantedScopes],
     });

--- a/packages/sync/src/server/notification.routes.db.test.ts
+++ b/packages/sync/src/server/notification.routes.db.test.ts
@@ -8,6 +8,14 @@ import {
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { createSyncService, type SyncService } from "@sync/app";
 import { type SyncConfig } from "@sync/config/sync.config";
+import { parseGoogleNotification } from "@sync/providers/google/google-notifications.adapter";
+import { type ProviderNotificationAdapter } from "@sync/providers/provider-notifications.port";
+import {
+  buildProviderRegistry,
+  NOTIFICATIONS_PARAM_PATH,
+  ProviderRegistry,
+  type ProviderRegistry as ProviderRegistryType,
+} from "@sync/providers/provider-registry";
 import { NOTIFICATIONS_PATH } from "@sync/server/notification.routes";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
@@ -25,6 +33,8 @@ const testConfig = (overrides: Partial<SyncConfig> = {}): SyncConfig =>
     MONGO_URI: uri,
     INTERNAL_AUTH_TOKEN: "secret",
     CALLBACK_BASE_URL: "http://localhost:3010",
+    GOOGLE_CLIENT_ID: "test-client",
+    GOOGLE_CLIENT_SECRET: "test-secret",
     EXECUTION: "active",
     MAX_CONCURRENCY: 4,
     ...overrides,
@@ -50,8 +60,11 @@ describe("POST /sync/notifications/google", () => {
   let service: SyncService;
   let base: string;
 
-  const startService = async (config: SyncConfig = testConfig()) => {
-    service = createSyncService(config, { mongo });
+  const startService = async (
+    config: SyncConfig = testConfig(),
+    registry?: ProviderRegistryType,
+  ) => {
+    service = createSyncService(config, { mongo, registry });
     await new Promise<void>((resolve) => service.httpServer.listen(0, resolve));
     const { port } = service.httpServer.address() as AddressInfo;
     base = `http://127.0.0.1:${port}`;
@@ -81,8 +94,37 @@ describe("POST /sync/notifications/google", () => {
     return resource;
   };
 
-  const post = (headers: Record<string, string>) =>
-    fetch(`${base}${NOTIFICATIONS_PATH}`, { method: "POST", headers });
+  const post = (path: string, headers: Record<string, string>) =>
+    fetch(`${base}${path}`, { method: "POST", headers });
+
+  const registryWithMicrosoft = (
+    notifications: ProviderNotificationAdapter,
+  ) => {
+    const google = buildProviderRegistry(testConfig()).get("google");
+    return new ProviderRegistry(
+      new Map([
+        ["google", google],
+        [
+          "microsoft",
+          {
+            ...google,
+            callbackPath: "/sync/microsoft",
+            notificationsCallbackPath: "/sync/notifications/microsoft",
+            adapters: { ...google.adapters, notifications },
+          },
+        ],
+      ]),
+    );
+  };
+
+  const microsoftNotificationsFromGoogleHeaders =
+    (): ProviderNotificationAdapter => ({
+      watch: async () => {
+        throw new Error("unused in route test");
+      },
+      stopChannel: async () => {},
+      parseNotification: (request) => parseGoogleNotification(request.headers),
+    });
 
   const jobCount = (coalescingKey: string) =>
     mongo.db
@@ -102,8 +144,8 @@ describe("POST /sync/notifications/google", () => {
     const { _id: resourceId } = await seedSubscription();
     await startService();
 
-    const first = await post(googHeaders());
-    const second = await post(googHeaders()); // duplicate delivery
+    const first = await post(NOTIFICATIONS_PATH, googHeaders());
+    const second = await post(NOTIFICATIONS_PATH, googHeaders()); // duplicate delivery
 
     expect(first.status).toBe(200);
     expect(second.status).toBe(200);
@@ -119,7 +161,7 @@ describe("POST /sync/notifications/google", () => {
     const { _id: resourceId } = await seedSubscription();
     await startService();
 
-    const res = await post(googHeaders());
+    const res = await post(NOTIFICATIONS_PATH, googHeaders());
 
     expect(res.status).toBe(200);
     const stored = await mongo.db
@@ -132,7 +174,10 @@ describe("POST /sync/notifications/google", () => {
     const { _id: resourceId } = await seedSubscription();
     await startService();
 
-    await post(googHeaders({ "x-goog-channel-token": "wrong" }));
+    await post(
+      NOTIFICATIONS_PATH,
+      googHeaders({ "x-goog-channel-token": "wrong" }),
+    );
 
     const stored = await mongo.db
       .collection(SYNC_COLLECTIONS.syncResources)
@@ -144,7 +189,10 @@ describe("POST /sync/notifications/google", () => {
     const { _id: resourceId } = await seedSubscription();
     await startService();
 
-    const res = await post(googHeaders({ "x-goog-resource-state": "sync" }));
+    const res = await post(
+      NOTIFICATIONS_PATH,
+      googHeaders({ "x-goog-resource-state": "sync" }),
+    );
 
     expect(res.status).toBe(200);
     expect(await jobCount(`incrementalPull:${resourceId}`)).toBe(0);
@@ -154,7 +202,10 @@ describe("POST /sync/notifications/google", () => {
     const { _id: resourceId } = await seedSubscription();
     await startService();
 
-    const res = await post(googHeaders({ "x-goog-channel-token": "wrong" }));
+    const res = await post(
+      NOTIFICATIONS_PATH,
+      googHeaders({ "x-goog-channel-token": "wrong" }),
+    );
 
     // 200 so a spoofer learns nothing and triggers no retry — but no work.
     expect(res.status).toBe(200);
@@ -164,7 +215,10 @@ describe("POST /sync/notifications/google", () => {
   it("enqueues nothing for an unknown channel", async () => {
     await startService();
 
-    const res = await post(googHeaders({ "x-goog-channel-id": "unknown" }));
+    const res = await post(
+      NOTIFICATIONS_PATH,
+      googHeaders({ "x-goog-channel-id": "unknown" }),
+    );
 
     expect(res.status).toBe(200);
     expect(
@@ -176,7 +230,10 @@ describe("POST /sync/notifications/google", () => {
     const { _id: resourceId } = await seedSubscription();
     await startService();
 
-    const res = await post(googHeaders({ "x-goog-resource-id": "other-res" }));
+    const res = await post(
+      NOTIFICATIONS_PATH,
+      googHeaders({ "x-goog-resource-id": "other-res" }),
+    );
 
     expect(res.status).toBe(200);
     expect(await jobCount(`incrementalPull:${resourceId}`)).toBe(0);
@@ -188,7 +245,7 @@ describe("POST /sync/notifications/google", () => {
     );
     await startService();
 
-    const res = await post(googHeaders());
+    const res = await post(NOTIFICATIONS_PATH, googHeaders());
 
     expect(res.status).toBe(200);
     expect(await jobCount(`incrementalPull:${resourceId}`)).toBe(0);
@@ -197,7 +254,9 @@ describe("POST /sync/notifications/google", () => {
   it("rejects a request with no recognizable notification headers", async () => {
     await startService();
 
-    const res = await post({ "x-goog-resource-state": "exists" });
+    const res = await post(NOTIFICATIONS_PATH, {
+      "x-goog-resource-state": "exists",
+    });
 
     expect(res.status).toBe(400);
   });
@@ -210,7 +269,7 @@ describe("POST /sync/notifications/google", () => {
     );
     await startService();
 
-    const res = await post(googHeaders());
+    const res = await post(NOTIFICATIONS_PATH, googHeaders());
 
     expect(res.status).toBe(200);
     expect(await jobCount(`calendarListSync:${resource.connectionId}`)).toBe(1);
@@ -238,7 +297,7 @@ describe("POST /sync/notifications/google", () => {
     );
     await startService();
 
-    await post(googHeaders());
+    await post(NOTIFICATIONS_PATH, googHeaders());
 
     const stored = await mongo.db
       .collection(SYNC_COLLECTIONS.syncResources)
@@ -264,7 +323,7 @@ describe("POST /sync/notifications/google", () => {
     );
     await startService();
 
-    await post(googHeaders());
+    await post(NOTIFICATIONS_PATH, googHeaders());
 
     const stored = await mongo.db
       .collection(SYNC_COLLECTIONS.syncResources)
@@ -289,7 +348,10 @@ describe("POST /sync/notifications/google", () => {
     );
     await startService();
 
-    await post(googHeaders({ "x-goog-channel-token": "wrong" }));
+    await post(
+      NOTIFICATIONS_PATH,
+      googHeaders({ "x-goog-channel-token": "wrong" }),
+    );
 
     const stored = await mongo.db
       .collection(SYNC_COLLECTIONS.syncResources)
@@ -316,8 +378,8 @@ describe("POST /sync/notifications/google", () => {
     );
     await startService();
 
-    await post(googHeaders());
-    await post(googHeaders()); // duplicate delivery, coalesces
+    await post(NOTIFICATIONS_PATH, googHeaders());
+    await post(NOTIFICATIONS_PATH, googHeaders()); // duplicate delivery, coalesces
 
     expect(await jobCount(`calendarListSync:${resource.connectionId}`)).toBe(1);
     const stored = await mongo.db
@@ -330,9 +392,53 @@ describe("POST /sync/notifications/google", () => {
     const { _id: resourceId } = await seedSubscription();
     await startService(testConfig({ EXECUTION: "passive" }));
 
-    const res = await post(googHeaders());
+    const res = await post(NOTIFICATIONS_PATH, googHeaders());
 
     expect(res.status).toBe(200);
     expect(await jobCount(`incrementalPull:${resourceId}`)).toBe(0);
+  });
+
+  it("routes a google-shaped push on the microsoft path through verification", async () => {
+    const { _id: resourceId } = await seedSubscription();
+    await startService(
+      testConfig(),
+      registryWithMicrosoft(microsoftNotificationsFromGoogleHeaders()),
+    );
+
+    const res = await post("/sync/notifications/microsoft", googHeaders());
+
+    expect(res.status).toBe(200);
+    expect(await jobCount(`incrementalPull:${resourceId}`)).toBe(1);
+  });
+
+  it("returns 404 for an unknown provider notification path", async () => {
+    await startService();
+
+    const res = await post(
+      `${NOTIFICATIONS_PARAM_PATH.replace(":provider", "apple")}`,
+      googHeaders(),
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it("echoes a validation handshake as text/plain", async () => {
+    const validationAdapter: ProviderNotificationAdapter = {
+      watch: async () => {
+        throw new Error("unused in route test");
+      },
+      stopChannel: async () => {},
+      parseNotification: () => ({
+        kind: "validation",
+        body: "validation-token",
+      }),
+    };
+    await startService(testConfig(), registryWithMicrosoft(validationAdapter));
+
+    const res = await post("/sync/notifications/microsoft", {});
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/plain");
+    expect(await res.text()).toBe("validation-token");
   });
 });

--- a/packages/sync/src/server/notification.routes.ts
+++ b/packages/sync/src/server/notification.routes.ts
@@ -1,10 +1,19 @@
-import { type Express } from "express";
+import { type Express, type Request, type Response } from "express";
 import { rateLimit } from "express-rate-limit";
 import { Status } from "@core/errors/status.codes";
 import { Logger } from "@core/logger/winston.logger";
+import { ProviderKindSchema } from "@core/types/sync/identity.contracts";
 import { type SyncExecutionMode } from "@sync/config/sync.config";
 import { verifyNotification } from "@sync/notifications/notification-verification";
-import { parseGoogleNotification } from "@sync/providers/google/google-notifications.adapter";
+import {
+  type NotificationParseResult,
+  type ProviderNotification,
+} from "@sync/providers/provider-notifications.port";
+import {
+  GOOGLE_NOTIFICATIONS_PATH,
+  NOTIFICATIONS_PARAM_PATH,
+  type ProviderRegistry,
+} from "@sync/providers/provider-registry";
 import { redactedCause } from "@sync/safety/redact-error";
 import {
   calendarListSyncJob,
@@ -14,9 +23,9 @@ import { JobRepository } from "@sync/storage/repositories/job.repository";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 
-// Public reverse-proxy path under the same `/sync/*` prefix as the OAuth
-// callback (no Google Console registration required for webhooks).
-export const NOTIFICATIONS_PATH = "/sync/notifications/google";
+// Legacy alias: Google push ingress (also registered under
+// NOTIFICATIONS_PARAM_PATH with provider=google).
+export const NOTIFICATIONS_PATH = GOOGLE_NOTIFICATIONS_PATH;
 
 // Public callbacks arrive fast and in bursts (Google fans out per change); this
 // backstop bounds a flood or a spoof storm without shaping normal delivery.
@@ -32,6 +41,7 @@ const logger = Logger("sync:notification.routes");
 export interface NotificationApiDeps {
   mongo: SyncMongoService;
   execution: SyncExecutionMode;
+  registry: ProviderRegistry;
   now?: () => number;
 }
 
@@ -45,93 +55,110 @@ export function registerNotificationRoutes(
   app: Express,
   deps: NotificationApiDeps,
 ): void {
-  app.post(NOTIFICATIONS_PATH, notificationRateLimit, async (req, res) => {
-    const notification = parseGoogleNotification(
-      req.headers as Record<string, string | undefined>,
-    );
-    if (!notification) {
-      res.status(Status.BAD_REQUEST).end();
-      return;
-    }
+  const handleNotification =
+    (routeProvider: ReturnType<typeof ProviderKindSchema.parse>) =>
+    async (req: Request, res: Response) => {
+      const parsed = deps.registry
+        .get(routeProvider)
+        .adapters.notifications.parseNotification({
+          headers: req.headers as Record<string, string | undefined>,
+          body: req.body,
+          query: req.query as Record<string, unknown>,
+        });
 
-    // A passive service has no subscriptions to match; accept and drop.
-    if (deps.execution === "passive" || !deps.mongo.isConnected) {
-      res.status(Status.OK).end();
-      return;
-    }
-
-    try {
-      const resources = new SyncResourceRepository(deps.mongo.db);
-      const resource = await resources.findBySubscriptionId(
-        notification.channelId,
-      );
-      const now = new Date((deps.now ?? Date.now)());
-      const verdict = verifyNotification(notification, resource, now);
-
-      // Never reveal the verdict to the caller (response stays 200 either
-      // way), but a rejection is still worth a quiet log line - a fleet-wide
-      // channel/resource desync (e.g. every callback suddenly unknownChannel)
-      // would otherwise be invisible until reconcile's 15-min fallback masks
-      // the symptom.
-      if (verdict.status === "rejected") {
-        logger.warn(
-          `Rejected notification for channel ${notification.channelId}: ${verdict.reason}`,
-        );
+      if (parsed === null) {
+        res.status(Status.BAD_REQUEST).end();
+        return;
+      }
+      if (isValidationHandshake(parsed)) {
+        res.status(Status.OK).type("text/plain").send(parsed.body);
+        return;
+      }
+      if (!("channelId" in parsed)) {
+        res.status(Status.BAD_REQUEST).end();
+        return;
       }
 
-      // Only an authentic change schedules work. Coalescing on the resource
-      // collapses duplicate deliveries of the same change into one job.
-      if (verdict.status === "process" && resource) {
-        // A calendarList notification means the LIST itself changed, so make the
-        // resulting pass re-enumerate instead of listing incrementally from the
-        // stored cursor. Clearing the cursor is the one existing mechanism for
-        // that (syncCalendarList reads it fresh at execution time), so this works
-        // whether the pass comes from the enqueue below or from a job that
-        // already coalesced on this connection's key.
-        //
-        // Scoped to calendarList: clearing an events cursor would force a full
-        // re-import. Done first because its failure mode is the harmless one — a
-        // cleared cursor with no job just means the next pass runs full, whereas
-        // a stamped marker with no clear would strand the change on the sweep.
-        if (resource.resourceKind === "calendarList") {
-          await resources.clearSyncCursor(
-            resource.tenantId,
-            resource.principalId,
-            resource._id,
-          );
-        }
-        // Stamp BEFORE enqueuing. The enqueue below no-ops whenever a job
-        // already holds this coalescing key — including the CLAIMED row of a
-        // job already in flight, which may have read the provider before this
-        // change existed. The marker is what survives that: the running job's
-        // compare-and-clear (events pull and calendar-list sync alike) fails
-        // against it and the job goes round again. Stamping first also keeps
-        // the ordering safe if the enqueue throws — a marker with no job is
-        // recovered by the sweeps, whereas a job with no marker could clear a
-        // change it never read.
-        await resources.markChangeNotified(
+      await processNotification(deps, parsed, res);
+    };
+
+  app.post(
+    NOTIFICATIONS_PATH,
+    notificationRateLimit,
+    handleNotification("google"),
+  );
+  app.post(NOTIFICATIONS_PARAM_PATH, notificationRateLimit, (req, res) => {
+    const parsed = ProviderKindSchema.safeParse(req.params["provider"]);
+    if (!parsed.success || !deps.registry.has(parsed.data)) {
+      res.status(Status.NOT_FOUND).end();
+      return;
+    }
+    return handleNotification(parsed.data)(req, res);
+  });
+}
+
+function isValidationHandshake(
+  parsed: NotificationParseResult,
+): parsed is { kind: "validation"; body: string } {
+  return (
+    typeof parsed === "object" &&
+    parsed !== null &&
+    "kind" in parsed &&
+    parsed.kind === "validation"
+  );
+}
+
+async function processNotification(
+  deps: NotificationApiDeps,
+  notification: ProviderNotification,
+  res: Response,
+): Promise<void> {
+  // A passive service has no subscriptions to match; accept and drop.
+  if (deps.execution === "passive" || !deps.mongo.isConnected) {
+    res.status(Status.OK).end();
+    return;
+  }
+
+  try {
+    const resources = new SyncResourceRepository(deps.mongo.db);
+    const resource = await resources.findBySubscriptionId(
+      notification.channelId,
+    );
+    const now = new Date((deps.now ?? Date.now)());
+    const verdict = verifyNotification(notification, resource, now);
+
+    if (verdict.status === "rejected") {
+      logger.warn(
+        `Rejected notification for channel ${notification.channelId}: ${verdict.reason}`,
+      );
+    }
+
+    if (verdict.status === "process" && resource) {
+      if (resource.resourceKind === "calendarList") {
+        await resources.clearSyncCursor(
           resource.tenantId,
           resource.principalId,
           resource._id,
-          now,
         );
-        // Background priority on purpose: webhooks are provider-paced.
-        // Promoting them to user priority would make the entire steady state
-        // urgent and defeat the tier that protects Refresh / post-OAuth work.
-        const job =
-          resource.resourceKind === "calendarList"
-            ? calendarListSyncJob(resource, now)
-            : resourceJob(resource, "incrementalPull", now);
-        await new JobRepository(deps.mongo.db).enqueue(job);
       }
-      res.status(Status.OK).end();
-    } catch (error) {
-      // A storage failure is the one case worth a retry, so signal it.
-      logger.error(
-        `Failed to process notification for channel ${notification.channelId}`,
-        redactedCause(error),
+      await resources.markChangeNotified(
+        resource.tenantId,
+        resource.principalId,
+        resource._id,
+        now,
       );
-      res.status(Status.INTERNAL_SERVER).end();
+      const job =
+        resource.resourceKind === "calendarList"
+          ? calendarListSyncJob(resource, now)
+          : resourceJob(resource, "incrementalPull", now);
+      await new JobRepository(deps.mongo.db).enqueue(job);
     }
-  });
+    res.status(Status.OK).end();
+  } catch (error) {
+    logger.error(
+      `Failed to process notification for channel ${notification.channelId}`,
+      redactedCause(error),
+    );
+    res.status(Status.INTERNAL_SERVER).end();
+  }
 }

--- a/packages/sync/src/server/sync.server.ts
+++ b/packages/sync/src/server/sync.server.ts
@@ -77,6 +77,7 @@ export function buildSyncApp(deps: {
     registerNotificationRoutes(app, {
       mongo: deps.connectionApi.mongo,
       execution: deps.connectionApi.execution,
+      registry: deps.connectionApi.registry,
       now: deps.connectionApi.now,
     });
   }


### PR DESCRIPTION
Fixes #3227

## What and why

Provider-plural foundation work: public OAuth and push-notification ingress now route through `ProviderRegistry` instead of hard-coded Google paths. OAuth state carries the provider kind and rejects cross-provider replay (`stateMismatch`). The notification port gains `parseNotification` (including Microsoft's validation handshake), and subscription maintenance resolves callback URLs per provider via `registry.callbackUrlFor`. Legacy `/sync/google` and `/sync/notifications/google` paths remain byte-identical entry points.

Spec: [`docs/features/calendar-providers.md`](https://github.com/KeepSoftwareSimple/compass-calendar/blob/main/docs/features/calendar-providers.md)

## Verify

```
Summary
Selected packages: sync
Checks run: test:sync, type-check, lint, knip
Checks skipped: (none)

✓ All checks passed
VERDICT: PASS
```