### PR TITLE
feat(sync,core): add password credential kind with at-rest encryption

### DIFF
--- a/.agents/handoffs/3229.md
+++ b/.agents/handoffs/3229.md
@@ -10,10 +10,12 @@ artifact:
   - path: packages/sync/src/storage/contracts/credential.contracts.ts
   - path: packages/sync/src/credentials/credential-custody.service.ts
 evidence:
-  - command: bun test:sync -- packages/sync/src/storage/contracts/credential.contracts.test.ts packages/sync/src/storage/repositories/credential.repository.db.test.ts packages/sync/src/credentials/credential-custody.service.db.test.ts packages/sync/src/safety/safety-canary.test.ts packages/sync/src/domain/connection-state-refresh.service.db.test.ts
-    result: pass (44 tests)
-  - command: bun test:core -- packages/core/src/security/credential-at-rest.test.ts
-    result: pass (3 tests)
+  - command: bun run verify --strict
+    result: pass (test:core, test:sync, type-check, lint, knip)
+  - command: bun test:sync
+    result: pass (1141 tests)
+  - command: bun test:core
+    result: pass
 assumptions:
   - "Existing credential documents without credentialKind parse as oauthRefresh; no migration."
   - "Password custody uses sync.credentialEncryptionKey; key rotation is out of scope."

--- a/.agents/handoffs/3229.md
+++ b/.agents/handoffs/3229.md
@@ -1,0 +1,29 @@
+---
+schema_version: 1
+task_id: "3229"
+from: Implementer
+to: Verifier
+owner: cursor-p0-wp06-8f41
+status: verifying
+artifact:
+  - path: packages/core/src/security/credential-at-rest.ts
+  - path: packages/sync/src/storage/contracts/credential.contracts.ts
+  - path: packages/sync/src/credentials/credential-custody.service.ts
+evidence:
+  - command: bun test:sync -- packages/sync/src/storage/contracts/credential.contracts.test.ts packages/sync/src/storage/repositories/credential.repository.db.test.ts packages/sync/src/credentials/credential-custody.service.db.test.ts packages/sync/src/safety/safety-canary.test.ts packages/sync/src/domain/connection-state-refresh.service.db.test.ts
+    result: pass (44 tests)
+  - command: bun test:core -- packages/core/src/security/credential-at-rest.test.ts
+    result: pass (3 tests)
+assumptions:
+  - "Existing credential documents without credentialKind parse as oauthRefresh; no migration."
+  - "Password custody uses sync.credentialEncryptionKey; key rotation is out of scope."
+  - "CredentialCustody keeps positional constructor args so existing tests pass; the encryption key is the 5th argument."
+open_risks: []
+next_deadline: 2026-09-05T03:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+P0 WP-06: password credential kind with AES-256-GCM encryption at rest.

--- a/packages/core/src/security/credential-at-rest.test.ts
+++ b/packages/core/src/security/credential-at-rest.test.ts
@@ -1,0 +1,29 @@
+import {
+  decryptCredentialAtRest,
+  encryptCredentialAtRest,
+} from "./credential-at-rest";
+import { describe, expect, it } from "bun:test";
+import { randomBytes } from "node:crypto";
+
+const key = randomBytes(32).toString("base64");
+
+describe("credential at rest", () => {
+  it("round-trips a password secret", () => {
+    const secret = "apple-app-password-fixture";
+    const sealed = encryptCredentialAtRest(key, secret);
+    expect(sealed.ciphertext).not.toContain(secret);
+    expect(decryptCredentialAtRest(key, sealed)).toBe(secret);
+  });
+
+  it("rejects a modified authentication tag", () => {
+    const sealed = encryptCredentialAtRest(key, "secret");
+    const tampered = { ...sealed, tag: `${sealed.tag.slice(0, -2)}AA` };
+    expect(() => decryptCredentialAtRest(key, tampered)).toThrow();
+  });
+
+  it("rejects a different key", () => {
+    const sealed = encryptCredentialAtRest(key, "secret");
+    const otherKey = randomBytes(32).toString("base64");
+    expect(() => decryptCredentialAtRest(otherKey, sealed)).toThrow();
+  });
+});

--- a/packages/core/src/security/credential-at-rest.ts
+++ b/packages/core/src/security/credential-at-rest.ts
@@ -1,0 +1,65 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+export const CREDENTIAL_AT_REST_KEY_VERSION = 1;
+
+const ALGORITHM = "aes-256-gcm";
+const IV_LENGTH = 12;
+const KEY_LENGTH = 32;
+
+export type CredentialAtRest = {
+  ciphertext: string;
+  iv: string;
+  tag: string;
+  keyVersion: number;
+};
+
+export function decodeCredentialAtRestKey(keyBase64: string): Buffer {
+  const key = Buffer.from(keyBase64, "base64");
+  if (key.length !== KEY_LENGTH) {
+    throw new Error("credential at-rest key must be 32 bytes of base64");
+  }
+  return key;
+}
+
+function additionalAuthenticatedData(keyVersion: number): Buffer {
+  return Buffer.from(`compass.credential-at-rest.v${keyVersion}`);
+}
+
+export function encryptCredentialAtRest(
+  keyBase64: string,
+  plaintext: string,
+  keyVersion: number = CREDENTIAL_AT_REST_KEY_VERSION,
+): CredentialAtRest {
+  const key = decodeCredentialAtRestKey(keyBase64);
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  cipher.setAAD(additionalAuthenticatedData(keyVersion));
+  const ciphertext = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  return {
+    ciphertext: ciphertext.toString("base64"),
+    iv: iv.toString("base64"),
+    tag: cipher.getAuthTag().toString("base64"),
+    keyVersion,
+  };
+}
+
+export function decryptCredentialAtRest(
+  keyBase64: string,
+  payload: CredentialAtRest,
+): string {
+  const key = decodeCredentialAtRestKey(keyBase64);
+  const decipher = createDecipheriv(
+    ALGORITHM,
+    key,
+    Buffer.from(payload.iv, "base64"),
+  );
+  decipher.setAAD(additionalAuthenticatedData(payload.keyVersion));
+  decipher.setAuthTag(Buffer.from(payload.tag, "base64"));
+  return Buffer.concat([
+    decipher.update(Buffer.from(payload.ciphertext, "base64")),
+    decipher.final(),
+  ]).toString("utf8");
+}

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -161,6 +161,7 @@ export function createSyncService(
         // resolves against the public base URL.
         stateSecret: deriveOAuthStateSecret(config.INTERNAL_AUTH_TOKEN),
         credentialEncryptionSecret: config.INTERNAL_AUTH_TOKEN,
+        credentialAtRestKey: config.CREDENTIAL_ENCRYPTION_KEY,
         callbackBaseUrl: config.CALLBACK_BASE_URL,
         // Fall back to the callback base when no explicit redirect is set.
         postConnectRedirectUrl:
@@ -490,7 +491,13 @@ function buildSchedulers(
         resolveAdapters,
         commands: repos.commands,
         jobs,
-        custody: new CredentialCustody(repos.credentials, resolveAuth),
+        custody: new CredentialCustody(
+          repos.credentials,
+          resolveAuth,
+          undefined,
+          undefined,
+          config.CREDENTIAL_ENCRYPTION_KEY,
+        ),
         // Where the provider posts change notifications back; the callback route
         // verifies them against the stored subscription.
         callbackUrl: `${config.CALLBACK_BASE_URL}${NOTIFICATIONS_PATH}`,
@@ -734,7 +741,13 @@ function buildSchedulers(
             execution: config.EXECUTION,
             provider: {
               resolveAdapters,
-              custody: new CredentialCustody(repos.credentials, resolveAuth),
+              custody: new CredentialCustody(
+                repos.credentials,
+                resolveAuth,
+                undefined,
+                undefined,
+                config.CREDENTIAL_ENCRYPTION_KEY,
+              ),
             },
             onRetryError: (error, commandId) =>
               logger.error(

--- a/packages/sync/src/credentials/credential-custody.service.db.test.ts
+++ b/packages/sync/src/credentials/credential-custody.service.db.test.ts
@@ -8,8 +8,10 @@ import {
   ProviderAuthError,
   type RefreshedCredential,
 } from "@sync/providers/provider-auth.port";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import { type CredentialUpsert } from "@sync/storage/contracts/credential.contracts";
 import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { randomBytes } from "node:crypto";
 
 const objectId = () => faker.database.mongodbObjectId();
 
@@ -92,7 +94,10 @@ describe("CredentialCustody", () => {
     expect(token).toBe("fresh-token");
     expect(adapter.refreshCalls).toBe(1);
     const cached = await repo.findByConnection(connectionId);
-    expect(cached?.accessToken).toBe("fresh-token");
+    expect(cached).toMatchObject({
+      credentialKind: "oauthRefresh",
+      accessToken: "fresh-token",
+    });
   });
 
   it("serves the cached token without refreshing when it is still valid", async () => {
@@ -254,8 +259,11 @@ describe("CredentialCustody", () => {
       custody.getValidAccessToken(connectionId),
     ).rejects.toMatchObject({ reason: "refreshFailed" });
     const after = await repo.findByConnection(connectionId);
-    expect(after?.refreshFailureCount).toBe(1);
-    expect(after?.refreshToken).toBe("stored-refresh-token");
+    expect(after).toMatchObject({
+      credentialKind: "oauthRefresh",
+      refreshFailureCount: 1,
+      refreshToken: "stored-refresh-token",
+    });
   });
 
   it("discardRevoked deletes the credential and is idempotent", async () => {
@@ -340,6 +348,48 @@ describe("CredentialCustody", () => {
 
     await custody.disconnect(objectId() as ConnectionId);
 
+    expect(adapter.revokedTokens).toEqual([]);
+  });
+
+  it("returns a password secret without refreshing and never revokes on disconnect", async () => {
+    const connectionId = objectId() as ConnectionId;
+    const adapter = new FakeAdapter();
+    const key = randomBytes(32).toString("base64");
+    const secret = "apple-app-password-fixture";
+    const custody = new CredentialCustody(
+      repo,
+      () => adapter,
+      fixedNow,
+      undefined,
+      key,
+    );
+
+    await custody.storePassword(
+      connectionId,
+      "apple",
+      "user@icloud.com",
+      secret,
+    );
+
+    const token = await custody.getValidAccessToken(connectionId);
+    expect(token).toBe(secret);
+    expect(adapter.refreshCalls).toBe(0);
+
+    await custody.invalidateAccessToken(connectionId);
+    expect(await custody.getValidAccessToken(connectionId)).toBe(secret);
+    expect(adapter.refreshCalls).toBe(0);
+
+    const raw = await db
+      .collection(SYNC_COLLECTIONS.credentials)
+      .findOne({ _id: connectionId });
+    expect(raw).not.toBeNull();
+    const serialized = JSON.stringify(raw);
+    expect(serialized).not.toContain(secret);
+    expect(raw).not.toHaveProperty("refreshToken");
+    expect(raw).toHaveProperty("secretCiphertext");
+
+    await custody.disconnect(connectionId);
+    expect(await repo.findByConnection(connectionId)).toBeNull();
     expect(adapter.revokedTokens).toEqual([]);
   });
 });

--- a/packages/sync/src/credentials/credential-custody.service.ts
+++ b/packages/sync/src/credentials/credential-custody.service.ts
@@ -1,4 +1,12 @@
-import { type ConnectionId } from "@core/types/sync/identity.contracts";
+import {
+  decodeCredentialAtRestKey,
+  decryptCredentialAtRest,
+  encryptCredentialAtRest,
+} from "@core/security/credential-at-rest";
+import {
+  type ConnectionId,
+  type ProviderKind,
+} from "@core/types/sync/identity.contracts";
 import { type ResolveProviderAuth } from "@sync/providers/provider-adapters";
 import {
   type ProviderAuthAdapter,
@@ -7,6 +15,8 @@ import {
 import {
   type CredentialRecord,
   type CredentialUpsert,
+  isPasswordCredential,
+  type PasswordCredentialRecord,
 } from "@sync/storage/contracts/credential.contracts";
 import { type CredentialRepository } from "@sync/storage/repositories/credential.repository";
 
@@ -15,31 +25,64 @@ import { type CredentialRepository } from "@sync/storage/repositories/credential
 // expires in flight.
 const DEFAULT_REFRESH_SKEW_MS = 60_000;
 
+const MISSING_AT_REST_KEY =
+  "password credentials require sync.credentialEncryptionKey";
+
 // Owns the credential lifecycle for one provider: store the durable refresh
-// token, serve valid access tokens (refreshing on demand), and revoke + delete
-// on disconnect. It is the only component that touches raw credentials, and it
-// never logs their values.
+// token (or sealed password), serve valid access tokens (refreshing on demand),
+// and revoke + delete on disconnect. It is the only component that touches raw
+// credentials, and it never logs their values.
 export class CredentialCustody {
   // In-process coalescing: concurrent access-token requests for the same
   // connection share a single refresh instead of each hitting the provider.
   // Cross-replica refreshes are NOT coalesced — Google tolerates concurrent
   // refresh-token use, so this only de-duplicates within a process.
   readonly #inflight = new Map<ConnectionId, Promise<string>>();
+  readonly #credentialEncryptionKey: string | null;
 
   constructor(
     private readonly credentials: CredentialRepository,
     private readonly resolveAuth: ResolveProviderAuth,
     private readonly now: () => Date = () => new Date(),
     private readonly refreshSkewMs: number = DEFAULT_REFRESH_SKEW_MS,
-  ) {}
+    credentialEncryptionKey: string | null = null,
+  ) {
+    this.#credentialEncryptionKey = credentialEncryptionKey;
+    if (this.#credentialEncryptionKey) {
+      decodeCredentialAtRestKey(this.#credentialEncryptionKey);
+    }
+  }
 
-  // Persist a freshly authorized credential (or replace an existing one).
+  // Persist a freshly authorized OAuth credential (or replace an existing one).
   async store(input: CredentialUpsert): Promise<CredentialRecord> {
     return this.credentials.store(input);
   }
 
+  // Seal and persist an app-specific password. The plaintext secret never
+  // leaves this method except as the AES-256-GCM payload written to storage.
+  async storePassword(
+    connectionId: ConnectionId,
+    provider: ProviderKind,
+    username: string,
+    secret: string,
+  ): Promise<PasswordCredentialRecord> {
+    const key = this.#requireAtRestKey();
+    const sealed = encryptCredentialAtRest(key, secret);
+    return this.credentials.storePassword({
+      connectionId,
+      provider,
+      username,
+      secretCiphertext: sealed.ciphertext,
+      secretIv: sealed.iv,
+      secretTag: sealed.tag,
+      keyVersion: sealed.keyVersion,
+    });
+  }
+
   // Return a currently-valid access token for the connection, refreshing from
   // the stored refresh token when the cached one is absent or near expiry.
+  // For password credentials, decrypts the sealed secret (the "access token"
+  // adapters receive is the password) and never calls refresh.
   // Rejects with a ProviderAuthError: `missingRefreshToken` if no credential
   // exists, or `authorizationRevoked` if the refresh token is no longer valid.
   getValidAccessToken(connectionId: ConnectionId): Promise<string> {
@@ -57,11 +100,12 @@ export class CredentialCustody {
 
   // Delete the stored credential and best-effort revoke it at the provider.
   // The delete happens regardless of whether revocation succeeds, so a broken
-  // provider endpoint can never leave a credential stranded.
+  // provider endpoint can never leave a credential stranded. Password
+  // credentials have no revoke endpoint, so revoke is skipped.
   async disconnect(connectionId: ConnectionId): Promise<void> {
     const credential = await this.credentials.findByConnection(connectionId);
     await this.credentials.deleteByConnection(connectionId);
-    if (credential) {
+    if (credential && !isPasswordCredential(credential)) {
       await this.resolveAuth(credential.provider).revoke({
         token: credential.refreshToken,
       });
@@ -78,7 +122,10 @@ export class CredentialCustody {
   // getValidAccessToken call is forced to refresh instead of replaying the
   // same dead token. Without this, every retry of a job that hit a stale
   // cached token reuses it, burning the whole retry ladder for nothing.
+  // Password credentials have no access-token cache; this is a no-op.
   async invalidateAccessToken(connectionId: ConnectionId): Promise<void> {
+    const credential = await this.credentials.findByConnection(connectionId);
+    if (credential && isPasswordCredential(credential)) return;
     await this.credentials.clearCachedAccessToken(connectionId);
   }
 
@@ -89,6 +136,15 @@ export class CredentialCustody {
         "missingRefreshToken",
         "No stored credential for this connection",
       );
+    }
+
+    if (isPasswordCredential(credential)) {
+      return decryptCredentialAtRest(this.#requireAtRestKey(), {
+        ciphertext: credential.secretCiphertext,
+        iv: credential.secretIv,
+        tag: credential.secretTag,
+        keyVersion: credential.keyVersion,
+      });
     }
 
     if (
@@ -143,5 +199,12 @@ export class CredentialCustody {
 
   #isExpiring(expiresAt: Date): boolean {
     return expiresAt.getTime() - this.now().getTime() <= this.refreshSkewMs;
+  }
+
+  #requireAtRestKey(): string {
+    if (!this.#credentialEncryptionKey) {
+      throw new Error(MISSING_AT_REST_KEY);
+    }
+    return this.#credentialEncryptionKey;
   }
 }

--- a/packages/sync/src/domain/connection-state-refresh.service.db.test.ts
+++ b/packages/sync/src/domain/connection-state-refresh.service.db.test.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import { encryptCredentialAtRest } from "@core/security/credential-at-rest";
 import {
   type ProviderCalendarId,
   type ProviderCalendarSourceId,
@@ -13,6 +14,7 @@ import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-
 import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 import { beforeEach, describe, expect, it } from "bun:test";
+import { randomBytes } from "node:crypto";
 
 const objectId = () => faker.database.mongodbObjectId();
 
@@ -753,6 +755,27 @@ describe("refreshConnectionState", () => {
     const after = await refreshConnectionState(deps(), connection);
     expect(after.state).toBe("actionRequired");
     expect(after.stateReason).toBe("authorizationRevoked");
+  });
+
+  it("does not treat a password credential as revoked", async () => {
+    const connection = await seedImportingConnection();
+    await credentials.deleteByConnection(connection._id);
+    const sealed = encryptCredentialAtRest(
+      randomBytes(32).toString("base64"),
+      "apple-app-password-fixture",
+    );
+    await credentials.storePassword({
+      connectionId: connection._id,
+      provider: "apple",
+      username: "user@icloud.com",
+      secretCiphertext: sealed.ciphertext,
+      secretIv: sealed.iv,
+      secretTag: sealed.tag,
+      keyVersion: sealed.keyVersion,
+    });
+
+    const after = await refreshConnectionState(deps(), connection);
+    expect(after.stateReason).not.toBe("authorizationRevoked");
   });
 
   it("derives actionRequired/authorizationExpired after consecutive refresh failures", async () => {

--- a/packages/sync/src/domain/connection-state-refresh.service.ts
+++ b/packages/sync/src/domain/connection-state-refresh.service.ts
@@ -185,7 +185,9 @@ export async function gatherConnectionStateEvidence(
 function credentialState(
   credential: Awaited<ReturnType<CredentialRepository["findByConnection"]>>,
 ): CredentialState {
-  if (!credential?.refreshToken) return "revoked";
+  if (!credential) return "revoked";
+  if (credential.credentialKind === "password") return "valid";
+  if (!credential.refreshToken) return "revoked";
   if (credential.refreshFailureCount >= MAX_REFRESH_FAILED_ATTEMPTS) {
     return "expired";
   }

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -162,7 +162,10 @@ export async function dispatchSyncJob(
       const credential = await deps.credentials.findByConnection(
         job.connectionId,
       );
-      const refreshFailures = credential?.refreshFailureCount ?? 0;
+      const refreshFailures =
+        credential?.credentialKind === "oauthRefresh"
+          ? credential.refreshFailureCount
+          : 0;
       if (refreshFailures >= MAX_REFRESH_FAILED_ATTEMPTS) {
         await refreshConnectionStateAfterJob(deps, job, now);
         return {

--- a/packages/sync/src/safety/safety-canary.test.ts
+++ b/packages/sync/src/safety/safety-canary.test.ts
@@ -16,6 +16,14 @@ const PROVIDER_MARKER_SAMPLES: Record<
   apple: ["BEGIN:VEVENT\nUID:1\nEND:VEVENT"],
 };
 
+describe("SECRET_PATTERNS", () => {
+  it("trips the canary for the Apple app-password fixture", () => {
+    expect(findSafetyCanaryHit("apple-app-password-fixture")).toMatch(
+      /^secret:/,
+    );
+  });
+});
+
 describe("PROVIDER_LEAK_MARKERS", () => {
   it("trips the canary for a marker from every registered provider", () => {
     for (const [provider, patterns] of Object.entries(PROVIDER_LEAK_MARKERS)) {

--- a/packages/sync/src/safety/safety-canary.ts
+++ b/packages/sync/src/safety/safety-canary.ts
@@ -11,6 +11,7 @@ const SECRET_PATTERNS: readonly RegExp[] = [
   /refresh_token\s*=\s*\S+/i,
   /"access_token"\s*:\s*"[^"]+"/i,
   /"refresh_token"\s*:\s*"[^"]+"/i,
+  /apple-app-password-fixture/,
 ];
 
 /** Provider-native payload shapes that must not leak into logs or SSE. */

--- a/packages/sync/src/server/command.routes.ts
+++ b/packages/sync/src/server/command.routes.ts
@@ -42,6 +42,9 @@ export interface CommandApiDeps {
   // Provider registry, present only when at least one provider is configured.
   // A provider-targeted create executes through the connection's kind.
   registry: ProviderRegistry;
+  // AES-256-GCM key for password credentials at rest. Optional so Google-only
+  // tests keep constructing custody without a key.
+  credentialAtRestKey?: string;
   // Injectable clock so local confirmation timestamps are deterministic in
   // tests.
   now?: () => number;
@@ -85,6 +88,9 @@ export function registerCommandRoutes(
                 custody: new CredentialCustody(
                   repos.credentials,
                   resolveAuthFrom(deps.registry),
+                  undefined,
+                  undefined,
+                  deps.credentialAtRestKey,
                 ),
               }
             : undefined;

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -122,6 +122,9 @@ export interface ConnectionApiDeps {
   now?: () => number;
   // Shared secret that encrypts credentials on the Compass API → Sync hop.
   credentialEncryptionSecret: string;
+  // AES-256-GCM key for password credentials at rest. Absent when yaml omits
+  // it (Google-only deployments); storePassword then refuses.
+  credentialAtRestKey?: string;
 }
 
 // Internal, authenticated connection endpoints. The tenant/principal comes from
@@ -832,6 +835,9 @@ export function registerConnectionRoutes(
         const custody = new CredentialCustody(
           new CredentialRepository(deps.mongo.db),
           resolveAuthFrom(deps.registry),
+          undefined,
+          undefined,
+          deps.credentialAtRestKey,
         );
         await custody.disconnect(id.data);
         await connections.markDisconnected(
@@ -927,6 +933,9 @@ async function linkConnection(
     const custody = new CredentialCustody(
       repos.credentials,
       resolveAuthForConnectionApi(deps),
+      undefined,
+      undefined,
+      deps.credentialAtRestKey,
     );
     await custody.store({
       connectionId: connection._id,

--- a/packages/sync/src/server/contacts.routes.ts
+++ b/packages/sync/src/server/contacts.routes.ts
@@ -30,6 +30,7 @@ import {
   requireAuth,
   respondInternalError,
 } from "@sync/server/internal-http";
+import { isOauthRefreshCredential } from "@sync/storage/contracts/credential.contracts";
 import { type ProviderConnectionRecord } from "@sync/storage/contracts/provider-connection.contracts";
 import { type CredentialRepository } from "@sync/storage/repositories/credential.repository";
 import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
@@ -45,6 +46,7 @@ export interface ContactsApiDeps {
   // Suggestions call the provider, so a passive deployment refuses.
   execution: SyncExecutionMode;
   registry: ProviderRegistry;
+  credentialAtRestKey?: string;
 }
 
 // Internal, authenticated attendee-suggestion lookup. Principal-scoped: the
@@ -110,6 +112,9 @@ export function registerContactsRoutes(
         const custody = new CredentialCustody(
           repos.credentials,
           resolveAuthFrom(deps.registry),
+          undefined,
+          undefined,
+          deps.credentialAtRestKey,
         );
         const collected: ContactSuggestion[] = [];
         for (const connection of capable) {
@@ -190,7 +195,7 @@ async function searchConnection(
   query: string,
 ): Promise<ContactSuggestion[]> {
   const credential = await credentials.findByConnection(connection._id);
-  if (!credential) return [];
+  if (!credential || !isOauthRefreshCredential(credential)) return [];
   const granted = new Set(credential.scopes);
   const sources = {
     contacts: granted.has(GOOGLE_SCOPE_CONTACTS_READONLY),

--- a/packages/sync/src/server/principal.routes.ts
+++ b/packages/sync/src/server/principal.routes.ts
@@ -30,6 +30,7 @@ export interface PrincipalApiDeps {
   // it (passive / unconfigured deployments) so Sync-held tokens are never
   // stranded.
   registry: ProviderRegistry;
+  credentialAtRestKey?: string;
 }
 
 // Hard-delete every Sync-held row for the signed principal. Served in passive
@@ -58,6 +59,9 @@ export function registerPrincipalRoutes(
                 ? new CredentialCustody(
                     repos.credentials,
                     resolveAuthFrom(deps.registry),
+                    undefined,
+                    undefined,
+                    deps.credentialAtRestKey,
                   )
                 : undefined,
           },

--- a/packages/sync/src/server/sync.server.ts
+++ b/packages/sync/src/server/sync.server.ts
@@ -44,6 +44,7 @@ export function buildSyncApp(deps: {
       mongo: deps.connectionApi.mongo,
       execution: deps.connectionApi.execution,
       registry: deps.connectionApi.registry,
+      credentialAtRestKey: deps.connectionApi.credentialAtRestKey,
       now: deps.connectionApi.now,
     });
     // Attendee contact suggestions from the provider's People surfaces, gated
@@ -53,6 +54,7 @@ export function buildSyncApp(deps: {
       mongo: deps.connectionApi.mongo,
       execution: deps.connectionApi.execution,
       registry: deps.connectionApi.registry,
+      credentialAtRestKey: deps.connectionApi.credentialAtRestKey,
     });
     // Resumable invalidation outbox for Compass API → browser SSE (S40).
     registerChangeFeedRoutes(app, {
@@ -66,6 +68,7 @@ export function buildSyncApp(deps: {
       authMiddleware: deps.connectionApi.authMiddleware,
       mongo: deps.connectionApi.mongo,
       registry: deps.connectionApi.registry,
+      credentialAtRestKey: deps.connectionApi.credentialAtRestKey,
     });
     // Private support diagnostic lookup by non-user-facing connection key (S45).
     registerDiagnosticRoutes(app, {

--- a/packages/sync/src/storage/contracts/credential.contracts.test.ts
+++ b/packages/sync/src/storage/contracts/credential.contracts.test.ts
@@ -1,0 +1,70 @@
+import { faker } from "@faker-js/faker";
+import { type ConnectionId } from "@core/types/sync/identity.contracts";
+import {
+  CredentialRecordSchema,
+  PasswordCredentialRecordSchema,
+} from "./credential.contracts";
+import { describe, expect, it } from "bun:test";
+
+const objectId = () => faker.database.mongodbObjectId() as ConnectionId;
+
+const oauthDoc = {
+  _id: objectId(),
+  provider: "google" as const,
+  refreshToken: "refresh-token-secret",
+  accessToken: null,
+  accessTokenExpiresAt: null,
+  refreshFailureCount: 0,
+  scopes: ["https://www.googleapis.com/auth/calendar.events"],
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  updatedAt: new Date("2026-01-01T00:00:00Z"),
+};
+
+describe("CredentialRecordSchema", () => {
+  it("parses an existing fixture without credentialKind as oauthRefresh", () => {
+    const parsed = CredentialRecordSchema.parse(oauthDoc);
+    expect(parsed.credentialKind).toBe("oauthRefresh");
+    if (parsed.credentialKind !== "oauthRefresh") {
+      throw new Error("expected oauthRefresh");
+    }
+    expect(parsed.refreshToken).toBe("refresh-token-secret");
+  });
+
+  it("rejects a password row without ciphertext fields", () => {
+    const result = CredentialRecordSchema.safeParse({
+      credentialKind: "password",
+      _id: objectId(),
+      provider: "apple",
+      username: "user@icloud.com",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    expect(result.success).toBe(false);
+    expect(
+      PasswordCredentialRecordSchema.safeParse({
+        credentialKind: "password",
+        _id: objectId(),
+        provider: "apple",
+        username: "user@icloud.com",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }).success,
+    ).toBe(false);
+  });
+
+  it("parses a password row with ciphertext fields", () => {
+    const parsed = CredentialRecordSchema.parse({
+      credentialKind: "password",
+      _id: objectId(),
+      provider: "apple",
+      username: "user@icloud.com",
+      secretCiphertext: "cipher",
+      secretIv: "iv",
+      secretTag: "tag",
+      keyVersion: 1,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    expect(parsed.credentialKind).toBe("password");
+  });
+});

--- a/packages/sync/src/storage/contracts/credential.contracts.ts
+++ b/packages/sync/src/storage/contracts/credential.contracts.ts
@@ -9,10 +9,16 @@ import {
 // can ever return credential material — reading a connection never touches this
 // collection. Only the Sync database user can read it.
 //
-// The refresh token is the durable secret; the access token is a short-lived
-// cache re-minted from it on demand. Both are token-shaped and must never reach
-// a log or error — use `redactCredential` for any diagnostic output.
-export const CredentialRecordSchema = z.strictObject({
+// Discriminated on credentialKind. `oauthRefresh` is the Google/Microsoft
+// grant: the refresh token is the durable secret and the access token is a
+// short-lived cache. `password` is the Apple app-specific password: a static
+// secret sealed with AES-256-GCM, no refresh, no scopes, no revoke. Existing
+// documents without credentialKind parse as oauthRefresh (no migration).
+// Token-shaped fields must never reach a log or error — use `redactCredential`
+// for any diagnostic output.
+
+export const OauthRefreshCredentialRecordSchema = z.strictObject({
+  credentialKind: z.literal("oauthRefresh").default("oauthRefresh"),
   // One credential document per connection; the connection id is the key.
   _id: ConnectionIdSchema,
   provider: ProviderKindSchema,
@@ -31,19 +37,84 @@ export const CredentialRecordSchema = z.strictObject({
   createdAt: z.date(),
   updatedAt: z.date(),
 });
+export type OauthRefreshCredentialRecord = z.infer<
+  typeof OauthRefreshCredentialRecordSchema
+>;
+
+export const PasswordCredentialRecordSchema = z.strictObject({
+  credentialKind: z.literal("password"),
+  _id: ConnectionIdSchema,
+  provider: ProviderKindSchema,
+  username: z.string().min(1),
+  secretCiphertext: z.string().min(1),
+  secretIv: z.string().min(1),
+  secretTag: z.string().min(1),
+  keyVersion: z.number().int().positive(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+export type PasswordCredentialRecord = z.infer<
+  typeof PasswordCredentialRecordSchema
+>;
+
+function defaultOauthCredentialKind(value: unknown): unknown {
+  if (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    !("credentialKind" in value)
+  ) {
+    return { ...value, credentialKind: "oauthRefresh" };
+  }
+  return value;
+}
+
+export const CredentialRecordSchema = z.preprocess(
+  defaultOauthCredentialKind,
+  z.discriminatedUnion("credentialKind", [
+    OauthRefreshCredentialRecordSchema,
+    PasswordCredentialRecordSchema,
+  ]),
+);
 export type CredentialRecord = z.infer<typeof CredentialRecordSchema>;
 
-// What a caller provides to store or replace a connection's credential. Sync
-// owns _id, createdAt, and updatedAt; _id doubles as connectionId, so it is
-// picked back in under that name rather than omitted. Storing a fresh refresh
-// token clears any cached access token so a stale one can never be served
-// after re-authorization.
-export const CredentialUpsertSchema = CredentialRecordSchema.pick({
-  provider: true,
-  refreshToken: true,
-  scopes: true,
-}).extend({ connectionId: ConnectionIdSchema });
+export function isOauthRefreshCredential(
+  record: CredentialRecord,
+): record is OauthRefreshCredentialRecord {
+  return record.credentialKind === "oauthRefresh";
+}
+
+export function isPasswordCredential(
+  record: CredentialRecord,
+): record is PasswordCredentialRecord {
+  return record.credentialKind === "password";
+}
+
+// What a caller provides to store or replace an OAuth credential. Sync owns
+// _id, createdAt, and updatedAt; _id doubles as connectionId, so it is picked
+// back in under that name rather than omitted. Storing a fresh refresh token
+// clears any cached access token so a stale one can never be served after
+// re-authorization.
+export const CredentialUpsertSchema = z.strictObject({
+  connectionId: ConnectionIdSchema,
+  provider: ProviderKindSchema,
+  refreshToken: z.string().min(1),
+  scopes: z.array(z.string()),
+});
 export type CredentialUpsert = z.infer<typeof CredentialUpsertSchema>;
+
+export const PasswordCredentialUpsertSchema = z.strictObject({
+  connectionId: ConnectionIdSchema,
+  provider: ProviderKindSchema,
+  username: z.string().min(1),
+  secretCiphertext: z.string().min(1),
+  secretIv: z.string().min(1),
+  secretTag: z.string().min(1),
+  keyVersion: z.number().int().positive(),
+});
+export type PasswordCredentialUpsert = z.infer<
+  typeof PasswordCredentialUpsertSchema
+>;
 
 // A log-safe view of a credential. Token-shaped fields are reduced to presence
 // booleans so a diagnostic can say "has a refresh token, access token expired"
@@ -52,18 +123,34 @@ export type CredentialUpsert = z.infer<typeof CredentialUpsertSchema>;
 export interface RedactedCredential {
   readonly connectionId: string;
   readonly provider: string;
+  readonly credentialKind: "oauthRefresh" | "password";
   readonly hasRefreshToken: boolean;
   readonly hasAccessToken: boolean;
+  readonly hasPasswordSecret: boolean;
   readonly accessTokenExpiresAt: Date | null;
   readonly scopeCount: number;
 }
 
 export function redactCredential(record: CredentialRecord): RedactedCredential {
+  if (record.credentialKind === "password") {
+    return {
+      connectionId: record._id,
+      provider: record.provider,
+      credentialKind: "password",
+      hasRefreshToken: false,
+      hasAccessToken: false,
+      hasPasswordSecret: true,
+      accessTokenExpiresAt: null,
+      scopeCount: 0,
+    };
+  }
   return {
     connectionId: record._id,
     provider: record.provider,
+    credentialKind: "oauthRefresh",
     hasRefreshToken: record.refreshToken.length > 0,
     hasAccessToken: record.accessToken !== null,
+    hasPasswordSecret: false,
     accessTokenExpiresAt: record.accessTokenExpiresAt,
     scopeCount: record.scopes.length,
   };

--- a/packages/sync/src/storage/repositories/credential.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/credential.repository.db.test.ts
@@ -41,7 +41,10 @@ describe("CredentialRepository", () => {
     expect(stored.createdAt).toBeInstanceOf(Date);
 
     const read = await repo.findByConnection(input.connectionId);
-    expect(read?.refreshToken).toBe("refresh-token-secret");
+    expect(read).toMatchObject({
+      credentialKind: "oauthRefresh",
+      refreshToken: "refresh-token-secret",
+    });
   });
 
   it("returns null when no credential exists for the connection", async () => {
@@ -128,5 +131,52 @@ describe("CredentialRepository", () => {
     const serialized = JSON.stringify(redacted);
     expect(serialized).not.toContain("refresh-token-secret");
     expect(serialized).not.toContain("access-token-value");
+  });
+
+  it("parses a document stored without credentialKind as oauthRefresh", async () => {
+    const connectionId = objectId() as ConnectionId;
+    await db.collection(SYNC_COLLECTIONS.credentials).insertOne({
+      _id: connectionId,
+      provider: "google",
+      refreshToken: "legacy-refresh",
+      accessToken: null,
+      accessTokenExpiresAt: null,
+      refreshFailureCount: 0,
+      scopes: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const read = await repo.findByConnection(connectionId);
+    expect(read).toMatchObject({
+      credentialKind: "oauthRefresh",
+      refreshToken: "legacy-refresh",
+    });
+  });
+
+  it("stores a password credential without mixing oauth fields", async () => {
+    const connectionId = objectId() as ConnectionId;
+    const stored = await repo.storePassword({
+      connectionId,
+      provider: "apple",
+      username: "user@icloud.com",
+      secretCiphertext: "cipher",
+      secretIv: "iv",
+      secretTag: "tag",
+      keyVersion: 1,
+    });
+    expect(stored.credentialKind).toBe("password");
+    expect(stored.username).toBe("user@icloud.com");
+
+    expect(
+      await repo.cacheAccessToken(connectionId, "should-not-write", new Date()),
+    ).toBeNull();
+    expect(await repo.incrementRefreshFailure(connectionId)).toBe(0);
+
+    const raw = await db
+      .collection(SYNC_COLLECTIONS.credentials)
+      .findOne({ _id: connectionId });
+    expect(raw).not.toHaveProperty("refreshToken");
+    expect(raw).not.toHaveProperty("accessToken");
   });
 });

--- a/packages/sync/src/storage/repositories/credential.repository.ts
+++ b/packages/sync/src/storage/repositories/credential.repository.ts
@@ -1,4 +1,4 @@
-import { type Collection, type Db } from "mongodb";
+import { type Collection, type Db, type Document } from "mongodb";
 import { type ConnectionId } from "@core/types/sync/identity.contracts";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import {
@@ -6,25 +6,48 @@ import {
   CredentialRecordSchema,
   type CredentialUpsert,
   CredentialUpsertSchema,
+  type OauthRefreshCredentialRecord,
+  OauthRefreshCredentialRecordSchema,
+  type PasswordCredentialRecord,
+  PasswordCredentialRecordSchema,
+  type PasswordCredentialUpsert,
+  PasswordCredentialUpsertSchema,
 } from "@sync/storage/contracts/credential.contracts";
+
+const OAUTH_ONLY_FILTER = { credentialKind: { $ne: "password" as const } };
+
+const PASSWORD_FIELDS = {
+  username: "",
+  secretCiphertext: "",
+  secretIv: "",
+  secretTag: "",
+  keyVersion: "",
+} as const;
+
+const OAUTH_FIELDS = {
+  refreshToken: "",
+  accessToken: "",
+  accessTokenExpiresAt: "",
+  refreshFailureCount: "",
+  scopes: "",
+} as const;
 
 // Repository for `credentials`. One document per connection, keyed by the
 // connection id. This is the ONLY place provider credentials are read or
 // written; no connection query touches this collection, so a connection read
 // can never surface a token. The repository never logs credential material.
 export class CredentialRepository {
-  private readonly collection: Collection<CredentialRecord>;
+  private readonly collection: Collection<Document>;
 
   constructor(db: Db) {
-    this.collection = db.collection<CredentialRecord>(
-      SYNC_COLLECTIONS.credentials,
-    );
+    this.collection = db.collection(SYNC_COLLECTIONS.credentials);
   }
 
-  // Store or replace a connection's credential. A new refresh token clears any
-  // cached access token, so a token minted from a superseded grant can never be
-  // served after re-authorization.
-  async store(input: CredentialUpsert): Promise<CredentialRecord> {
+  // Store or replace a connection's OAuth credential. A new refresh token
+  // clears any cached access token, so a token minted from a superseded grant
+  // can never be served after re-authorization. Password fields from a prior
+  // kind are unset so the document cannot mix kinds.
+  async store(input: CredentialUpsert): Promise<OauthRefreshCredentialRecord> {
     const fields = CredentialUpsertSchema.parse(input);
     const now = new Date();
 
@@ -32,6 +55,7 @@ export class CredentialRepository {
       { _id: fields.connectionId },
       {
         $set: {
+          credentialKind: "oauthRefresh",
           provider: fields.provider,
           refreshToken: fields.refreshToken,
           scopes: fields.scopes,
@@ -40,6 +64,7 @@ export class CredentialRepository {
           refreshFailureCount: 0,
           updatedAt: now,
         },
+        $unset: PASSWORD_FIELDS,
         // _id comes from the query filter on insert; setting it here too would
         // touch the immutable field.
         $setOnInsert: { createdAt: now },
@@ -50,7 +75,41 @@ export class CredentialRepository {
     if (!result) {
       throw new Error("Credential store did not return a record");
     }
-    return CredentialRecordSchema.parse(result);
+    return OauthRefreshCredentialRecordSchema.parse(result);
+  }
+
+  // Store or replace a password credential. OAuth fields from a prior kind
+  // are unset so the document cannot mix kinds. The caller seals the secret
+  // before this write; the repository never sees plaintext.
+  async storePassword(
+    input: PasswordCredentialUpsert,
+  ): Promise<PasswordCredentialRecord> {
+    const fields = PasswordCredentialUpsertSchema.parse(input);
+    const now = new Date();
+
+    const result = await this.collection.findOneAndUpdate(
+      { _id: fields.connectionId },
+      {
+        $set: {
+          credentialKind: "password",
+          provider: fields.provider,
+          username: fields.username,
+          secretCiphertext: fields.secretCiphertext,
+          secretIv: fields.secretIv,
+          secretTag: fields.secretTag,
+          keyVersion: fields.keyVersion,
+          updatedAt: now,
+        },
+        $unset: OAUTH_FIELDS,
+        $setOnInsert: { createdAt: now },
+      },
+      { upsert: true, returnDocument: "after" },
+    );
+
+    if (!result) {
+      throw new Error("Password credential store did not return a record");
+    }
+    return PasswordCredentialRecordSchema.parse(result);
   }
 
   async findByConnection(
@@ -61,15 +120,16 @@ export class CredentialRepository {
   }
 
   // Cache a freshly-minted access token and its expiry. Returns null if the
-  // credential was deleted concurrently (e.g. a disconnect landed mid-refresh),
-  // so a caller never resurrects a revoked credential.
+  // credential was deleted concurrently (e.g. a disconnect landed mid-refresh)
+  // or is a password credential, so a caller never resurrects a revoked
+  // credential or writes an access-token cache onto a password row.
   async cacheAccessToken(
     connectionId: ConnectionId,
     accessToken: string,
     expiresAt: Date,
-  ): Promise<CredentialRecord | null> {
+  ): Promise<OauthRefreshCredentialRecord | null> {
     const result = await this.collection.findOneAndUpdate(
-      { _id: connectionId },
+      { _id: connectionId, ...OAUTH_ONLY_FILTER },
       {
         $set: {
           accessToken,
@@ -80,15 +140,16 @@ export class CredentialRepository {
       },
       { returnDocument: "after" },
     );
-    return result ? CredentialRecordSchema.parse(result) : null;
+    return result ? OauthRefreshCredentialRecordSchema.parse(result) : null;
   }
 
   // Clear a cached access token without touching the refresh token, so the
   // next getValidAccessToken call is forced to mint a fresh one. Used when a
-  // provider rejects the cached token with a 401 mid-job.
+  // provider rejects the cached token with a 401 mid-job. A no-op for
+  // password credentials (they have no access-token cache).
   async clearCachedAccessToken(connectionId: ConnectionId): Promise<void> {
     await this.collection.updateOne(
-      { _id: connectionId },
+      { _id: connectionId, ...OAUTH_ONLY_FILTER },
       {
         $set: {
           accessToken: null,
@@ -100,10 +161,11 @@ export class CredentialRepository {
   }
 
   // Count a transient token-endpoint failure against the consecutive budget.
-  // Returns the new count, or 0 if the credential was deleted concurrently.
+  // Returns the new count, or 0 if the credential was deleted concurrently or is
+  // a password credential (which has no refresh budget).
   async incrementRefreshFailure(connectionId: ConnectionId): Promise<number> {
     const result = await this.collection.findOneAndUpdate(
-      { _id: connectionId },
+      { _id: connectionId, ...OAUTH_ONLY_FILTER },
       {
         $inc: { refreshFailureCount: 1 },
         $set: { updatedAt: new Date() },
@@ -111,7 +173,7 @@ export class CredentialRepository {
       { returnDocument: "after" },
     );
     if (!result) return 0;
-    return CredentialRecordSchema.parse(result).refreshFailureCount;
+    return OauthRefreshCredentialRecordSchema.parse(result).refreshFailureCount;
   }
 
   // Remove a connection's credential (disconnect / account deletion). Returns


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3229

## What and why

P0 WP-06: Apple app-specific passwords are a static secret with no refresh, scopes, or revoke. Discriminate `CredentialRecordSchema` on `credentialKind: "oauthRefresh" | "password"` (existing rows without the field still parse as `oauthRefresh`). Password rows store AES-256-GCM ciphertext keyed from `sync.credentialEncryptionKey`. Custody decrypts that secret as the adapter "access token", skips provider revoke on disconnect, and treats `invalidateAccessToken` as a no-op. Spec: [`docs/features/calendar-providers.md`](https://github.com/KeepSoftwareSimple/compass-calendar/blob/main/docs/features/calendar-providers.md).

## Verify

VERDICT: PASS

Checks run: test:core, test:sync, type-check, lint, knip

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c551c3bd-a8a5-402b-abd1-9edd46fe8f41?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c551c3bd-a8a5-402b-abd1-9edd46fe8f41&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

