### PR TITLE
feat(sync): add Apple ICS to ProviderEventRead normalizer (WP-04)

### DIFF
--- a/.agents/handoffs/3257.md
+++ b/.agents/handoffs/3257.md
@@ -1,0 +1,39 @@
+---
+schema_version: 1
+task_id: "3257"
+from: Implementer
+to: GitHub
+owner: GitHub
+status: verifying
+artifact:
+  - path: packages/sync/src/providers/apple/apple-event.normalizer.ts
+  - path: packages/sync/src/providers/apple/apple-event.normalizer.test.ts
+  - path: packages/sync/src/providers/apple/apple-instance-id.ts
+  - path: packages/sync/src/providers/__contract__/normalizer.contract.ts
+  - path: packages/sync/src/providers/__contract__/apple.contract.test.ts
+  - path: packages/sync/src/safety/safety-canary.ts
+  - path: packages/sync/package.json
+evidence:
+  - command: bun test:sync
+    result: pass
+  - command: bun run type-check
+    result: pass
+  - command: bun lint
+    result: pass
+  - command: bun knip
+    result: pass
+  - command: bun run verify --strict
+    result: "VERDICT: PASS"
+assumptions:
+  - "Apple instance providerEventIds use the same {uid}_{originalStart} suffix pattern as Google for Compass projection alignment."
+  - "Normalizer contract cases live beside discovery until P0 WP-11 lands the full adapter corpus in #3236."
+open_risks:
+  - "Live iCloud ICS edge cases (nonstandard TZID strings, sparse exception-only resources) validated only via unit fixtures until A-05 reader lands."
+next_deadline: 2026-09-05T02:00:00Z
+retry: 0
+approval: allow
+waiting_on: null
+escalation: null
+---
+
+Providers A WP-04: ICS to ProviderEventRead normalizer using ical.js.

--- a/bun.lock
+++ b/bun.lock
@@ -117,6 +117,7 @@
         "express-rate-limit": "^7.5.0",
         "fast-xml-parser": "^5.11.1",
         "google-auth-library": "^10.6.2",
+        "ical.js": "^2.2.1",
         "mongodb": "^7.2.0",
         "rrule": "^2.7.2",
         "tslib": "^2.4.0",
@@ -1131,6 +1132,8 @@
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
+
+    "ical.js": ["ical.js@2.2.1", "", {}, "sha512-yK/UlPbEs316igb/tjRgbFA8ZV75rCsBJp/hWOatpyaPNlgw0dGDmU+FoicOcwX4xXkeXOkYiOmCqNPFpNPkQg=="],
 
     "iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -12,6 +12,7 @@
     "express-rate-limit": "^7.5.0",
     "fast-xml-parser": "^5.11.1",
     "google-auth-library": "^10.6.2",
+    "ical.js": "^2.2.1",
     "mongodb": "^7.2.0",
     "rrule": "^2.7.2",
     "tslib": "^2.4.0",

--- a/packages/sync/src/providers/__contract__/apple.contract.test.ts
+++ b/packages/sync/src/providers/__contract__/apple.contract.test.ts
@@ -1,5 +1,7 @@
 import { type DiscoveryContractCase } from "@sync/providers/__contract__/discovery.contract";
+import { type NormalizerContractCase } from "@sync/providers/__contract__/normalizer.contract";
 import { AppleCalendarAdapter } from "@sync/providers/apple/apple-calendar.adapter";
+import { normalizeAppleEventResource } from "@sync/providers/apple/apple-event.normalizer";
 import {
   type CaldavFetch,
   createCaldavClient,
@@ -143,6 +145,81 @@ describe("apple discovery contract", () => {
           createCaldavClient({ username, password }, discoveryFetch()),
       );
       await testCase.run(adapter);
+    });
+  }
+});
+
+const APPLE_NORMALIZER_CASES: NormalizerContractCase[] = [
+  {
+    name: "normalizes a timed master to a single event read",
+    input: {
+      ics: `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:contract-timed@icloud.com
+DTSTAMP:20250101T120000Z
+DTSTART:20250115T090000Z
+DTEND:20250115T100000Z
+SUMMARY:Contract timed
+END:VEVENT
+END:VCALENDAR`,
+      href: "/calendars/home/contract-timed.ics",
+      etag: '"contract-etag"',
+      connectionTimeZone: "UTC",
+    },
+    run: (reads) => {
+      expect(reads).toHaveLength(1);
+      expect(reads[0]?.kind).toBe("event");
+      if (reads[0]?.kind !== "event") return;
+      expect(reads[0].providerEventId).toBe("contract-timed@icloud.com");
+      expect(reads[0].providerVersion).toBe('"contract-etag"');
+      expect(reads[0].recurrence).toEqual({ kind: "single" });
+    },
+  },
+  {
+    name: "normalizes a recurring master and one exception",
+    input: {
+      ics: `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:contract-series@icloud.com
+DTSTAMP:20250101T120000Z
+DTSTART:20250115T090000Z
+DTEND:20250115T100000Z
+RRULE:FREQ=DAILY;COUNT=3
+SUMMARY:Contract series
+END:VEVENT
+BEGIN:VEVENT
+UID:contract-series@icloud.com
+DTSTAMP:20250101T120001Z
+DTSTART:20250116T100000Z
+DTEND:20250116T110000Z
+RECURRENCE-ID:20250116T090000Z
+SUMMARY:Contract exception
+END:VEVENT
+END:VCALENDAR`,
+      href: "/calendars/home/contract-series.ics",
+      etag: '"contract-series-etag"',
+      connectionTimeZone: "UTC",
+    },
+    run: (reads) => {
+      expect(reads).toHaveLength(2);
+      expect(reads[0]?.recurrence).toEqual({
+        kind: "seriesMaster",
+        rules: ["RRULE:FREQ=DAILY;COUNT=3"],
+      });
+      expect(reads[1]?.kind).toBe("event");
+      if (reads[1]?.kind !== "event") return;
+      expect(reads[1].recurrence.kind).toBe("instance");
+    },
+  },
+];
+
+describe("apple normalizer contract", () => {
+  for (const testCase of APPLE_NORMALIZER_CASES) {
+    it(testCase.name, async () => {
+      const reads = normalizeAppleEventResource(testCase.input);
+      await testCase.run(reads);
     });
   }
 });

--- a/packages/sync/src/providers/__contract__/normalizer.contract.ts
+++ b/packages/sync/src/providers/__contract__/normalizer.contract.ts
@@ -1,0 +1,8 @@
+import { type AppleEventResourceInput } from "@sync/providers/apple/apple-event.normalizer";
+import { type ProviderEventRead } from "@sync/providers/provider-event.port";
+
+export interface NormalizerContractCase {
+  readonly name: string;
+  readonly input: AppleEventResourceInput;
+  readonly run: (reads: readonly ProviderEventRead[]) => void | Promise<void>;
+}

--- a/packages/sync/src/providers/apple/apple-event.normalizer.test.ts
+++ b/packages/sync/src/providers/apple/apple-event.normalizer.test.ts
@@ -1,0 +1,360 @@
+import {
+  type AppleEventResourceInput,
+  normalizeAppleEventResource,
+} from "@sync/providers/apple/apple-event.normalizer";
+import {
+  type ProviderEvent,
+  type ProviderEventCancellation,
+  ProviderEventError,
+} from "@sync/providers/provider-event.port";
+
+const NY_TIMEZONE = `BEGIN:VTIMEZONE
+TZID:America/New_York
+BEGIN:STANDARD
+DTSTART:20071104T020000
+RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
+TZOFFSETFROM:-0400
+TZOFFSETTO:-0500
+END:STANDARD
+BEGIN:DAYLIGHT
+DTSTART:20070311T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU
+TZOFFSETFROM:-0500
+TZOFFSETTO:-0400
+END:DAYLIGHT
+END:VTIMEZONE`;
+
+const resource = (
+  icsBody: string,
+  overrides: Partial<AppleEventResourceInput> = {},
+): AppleEventResourceInput => ({
+  ics: `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Compass//Test//EN
+${icsBody}
+END:VCALENDAR`,
+  href: "/calendars/home/abc.ics",
+  etag: '"etag-1"',
+  connectionTimeZone: "America/Los_Angeles",
+  ...overrides,
+});
+
+const asEvent = (
+  read: ReturnType<typeof normalizeAppleEventResource>[number],
+) => {
+  if (read.kind !== "event")
+    throw new Error(`expected event, got ${read.kind}`);
+  return read as ProviderEvent;
+};
+
+const asCancellation = (
+  read: ReturnType<typeof normalizeAppleEventResource>[number],
+) => {
+  if (read.kind !== "cancellation") {
+    throw new Error(`expected cancellation, got ${read.kind}`);
+  }
+  return read as ProviderEventCancellation;
+};
+
+describe("normalizeAppleEventResource", () => {
+  it("normalizes a timed event with VTIMEZONE", () => {
+    const [read] = normalizeAppleEventResource(
+      resource(`${NY_TIMEZONE}
+BEGIN:VEVENT
+UID:timed-uid@icloud.com
+DTSTAMP:20250101T120000Z
+LAST-MODIFIED:20250102T080000Z
+DTSTART;TZID=America/New_York:20250115T090000
+DTEND;TZID=America/New_York:20250115T100000
+SUMMARY:Standup
+DESCRIPTION:Daily sync
+LOCATION:Room A
+END:VEVENT`),
+    );
+    const event = asEvent(read);
+
+    expect(event.providerEventId).toBe("timed-uid@icloud.com");
+    expect(event.providerVersion).toBe('"etag-1"');
+    expect(event.providerUpdatedAt).toBe("2025-01-02T08:00:00.000Z");
+    expect(event.icalUid).toBe("timed-uid@icloud.com");
+    expect(event.busy).toBe(true);
+    expect(event.recurrence).toEqual({ kind: "single" });
+    expect(event.content.title).toBe("Standup");
+    expect(event.content.description).toBe("Daily sync");
+    expect(event.content.location).toBe("Room A");
+    expect(event.schedule.kind).toBe("timed");
+    if (event.schedule.kind !== "timed") throw new Error("expected timed");
+    expect(event.schedule.timeZone).toBe("America/New_York");
+    expect(Date.parse(event.schedule.start)).toBe(
+      Date.parse("2025-01-15T09:00:00-05:00"),
+    );
+  });
+
+  it("anchors floating times to the connection zone", () => {
+    const [read] = normalizeAppleEventResource(
+      resource(`BEGIN:VEVENT
+UID:float-uid@icloud.com
+DTSTAMP:20250101T120000Z
+DTSTART:20250115T090000
+DTEND:20250115T100000
+SUMMARY:Floating
+END:VEVENT`),
+    );
+    const event = asEvent(read);
+    if (event.schedule.kind !== "timed") throw new Error("expected timed");
+
+    expect(event.schedule.timeZone).toBe("America/Los_Angeles");
+    expect(event.schedule.start).toBe("2025-01-15T09:00:00-08:00");
+    expect(event.schedule.end).toBe("2025-01-15T10:00:00-08:00");
+  });
+
+  it("normalizes an all-day event", () => {
+    const [read] = normalizeAppleEventResource(
+      resource(`BEGIN:VEVENT
+UID:allday-uid@icloud.com
+DTSTAMP:20250101T120000Z
+DTSTART;VALUE=DATE:20250222
+DTEND;VALUE=DATE:20250223
+SUMMARY:Holiday
+TRANSP:TRANSPARENT
+END:VEVENT`),
+    );
+    const event = asEvent(read);
+
+    expect(event.busy).toBe(false);
+    expect(event.schedule).toEqual({
+      kind: "allDay",
+      start: "2025-02-22",
+      end: "2025-02-23",
+    });
+  });
+
+  it("maps RRULE with EXDATE onto the master", () => {
+    const [read] = normalizeAppleEventResource(
+      resource(`${NY_TIMEZONE}
+BEGIN:VEVENT
+UID:series-uid@icloud.com
+DTSTAMP:20250101T120000Z
+DTSTART;TZID=America/New_York:20250115T090000
+DTEND;TZID=America/New_York:20250115T100000
+RRULE:FREQ=WEEKLY;COUNT=4
+EXDATE;TZID=America/New_York:20250122T090000
+SUMMARY:Weekly
+END:VEVENT`),
+    );
+    const event = asEvent(read);
+
+    expect(event.recurrence).toEqual({
+      kind: "seriesMaster",
+      rules: [
+        "RRULE:FREQ=WEEKLY;COUNT=4",
+        "EXDATE;TZID=America/New_York:20250122T090000",
+      ],
+    });
+  });
+
+  it("normalizes a master plus two exceptions in one resource", () => {
+    const reads = normalizeAppleEventResource(
+      resource(`${NY_TIMEZONE}
+BEGIN:VEVENT
+UID:series-uid@icloud.com
+DTSTAMP:20250101T120000Z
+DTSTART;TZID=America/New_York:20250115T090000
+DTEND;TZID=America/New_York:20250115T100000
+RRULE:FREQ=WEEKLY;COUNT=4
+SUMMARY:Weekly
+END:VEVENT
+BEGIN:VEVENT
+UID:series-uid@icloud.com
+DTSTAMP:20250101T120001Z
+DTSTART;TZID=America/New_York:20250122T103000
+DTEND;TZID=America/New_York:20250122T113000
+RECURRENCE-ID;TZID=America/New_York:20250122T090000
+SUMMARY:Weekly moved
+END:VEVENT
+BEGIN:VEVENT
+UID:series-uid@icloud.com
+DTSTAMP:20250101T120002Z
+DTSTART;TZID=America/New_York:20250129T090000
+DTEND;TZID=America/New_York:20250129T100000
+RECURRENCE-ID;TZID=America/New_York:20250129T090000
+SUMMARY:Weekly note
+END:VEVENT`),
+    );
+
+    expect(reads).toHaveLength(3);
+    const master = asEvent(reads[0]!);
+    expect(master.providerEventId).toBe("series-uid@icloud.com");
+    expect(master.recurrence.kind).toBe("seriesMaster");
+
+    const firstException = asEvent(reads[1]!);
+    expect(firstException.providerEventId).toBe(
+      "series-uid@icloud.com_20250122T140000Z",
+    );
+    if (firstException.recurrence.kind !== "instance") {
+      throw new Error("expected instance");
+    }
+    expect(firstException.recurrence.seriesProviderId).toBe(
+      "series-uid@icloud.com",
+    );
+    expect(firstException.recurrence.recurrenceId).toBe(
+      new Date("2025-01-22T09:00:00-05:00").toISOString(),
+    );
+    expect(firstException.content.title).toBe("Weekly moved");
+
+    const secondException = asEvent(reads[2]!);
+    expect(secondException.content.title).toBe("Weekly note");
+  });
+
+  it("maps a cancelled exception to a cancellation with its series link", () => {
+    const reads = normalizeAppleEventResource(
+      resource(`${NY_TIMEZONE}
+BEGIN:VEVENT
+UID:series-uid@icloud.com
+DTSTAMP:20250101T120000Z
+DTSTART;TZID=America/New_York:20250115T090000
+DTEND;TZID=America/New_York:20250115T100000
+RRULE:FREQ=WEEKLY;COUNT=4
+SUMMARY:Weekly
+END:VEVENT
+BEGIN:VEVENT
+UID:series-uid@icloud.com
+DTSTAMP:20250101T120001Z
+RECURRENCE-ID;TZID=America/New_York:20250122T090000
+STATUS:CANCELLED
+END:VEVENT`),
+    );
+
+    const cancelled = asCancellation(reads[1]!);
+    expect(cancelled.providerEventId).toBe(
+      "series-uid@icloud.com_20250122T140000Z",
+    );
+    expect(cancelled.series).toEqual({
+      seriesProviderId: "series-uid@icloud.com",
+      recurrenceId: new Date("2025-01-22T09:00:00-05:00").toISOString(),
+    });
+  });
+
+  it("throws unmappableSchedule for RECURRENCE-ID RANGE=THISANDFUTURE", () => {
+    expect(() =>
+      normalizeAppleEventResource(
+        resource(`BEGIN:VEVENT
+UID:future-uid@icloud.com
+DTSTAMP:20250101T120000Z
+DTSTART:20250115T090000Z
+DTEND:20250115T100000Z
+RECURRENCE-ID;RANGE=THISANDFUTURE:20250115T090000Z
+END:VEVENT`),
+      ),
+    ).toThrow(ProviderEventError);
+  });
+
+  it("maps attendees with every PARTSTAT and strips mailto", () => {
+    const [read] = normalizeAppleEventResource(
+      resource(`BEGIN:VEVENT
+UID:guests-uid@icloud.com
+DTSTAMP:20250101T120000Z
+DTSTART:20250115T090000Z
+DTEND:20250115T100000Z
+ORGANIZER;CN=Host:mailto:host@example.com
+ATTENDEE;CN=Accepted;PARTSTAT=ACCEPTED:mailto:accepted@example.com
+ATTENDEE;CN=Declined;PARTSTAT=DECLINED:mailto:declined@example.com
+ATTENDEE;CN=Tentative;PARTSTAT=TENTATIVE:mailto:tentative@example.com
+ATTENDEE;CN=Pending;PARTSTAT=NEEDS-ACTION:mailto:pending@example.com
+ATTENDEE;CN=Delegated;PARTSTAT=DELEGATED:mailto:delegated@example.com
+ATTENDEE;CN=No Email:mailto:
+END:VEVENT`),
+    );
+    const event = asEvent(read);
+
+    expect(event.content.organizer).toEqual({
+      email: "host@example.com",
+      displayName: "Host",
+    });
+    expect(event.content.attendees).toEqual([
+      {
+        email: "accepted@example.com",
+        displayName: "Accepted",
+        responseStatus: "accepted",
+      },
+      {
+        email: "declined@example.com",
+        displayName: "Declined",
+        responseStatus: "declined",
+      },
+      {
+        email: "tentative@example.com",
+        displayName: "Tentative",
+        responseStatus: "tentative",
+      },
+      {
+        email: "pending@example.com",
+        displayName: "Pending",
+        responseStatus: "needsAction",
+      },
+      {
+        email: "delegated@example.com",
+        displayName: "Delegated",
+        responseStatus: "needsAction",
+      },
+    ]);
+  });
+
+  it("maps an https URL to a conference link", () => {
+    const [read] = normalizeAppleEventResource(
+      resource(`BEGIN:VEVENT
+UID:url-uid@icloud.com
+DTSTAMP:20250101T120000Z
+DTSTART:20250115T090000Z
+DTEND:20250115T100000Z
+URL:https://example.com/meet
+END:VEVENT`),
+    );
+
+    expect(asEvent(read).content.conference).toEqual({
+      url: "https://example.com/meet",
+      label: "Link",
+    });
+  });
+
+  it("skips malformed ICS with a ProviderEventError", () => {
+    expect(() =>
+      normalizeAppleEventResource({
+        ics: "not valid ics",
+        href: "/bad.ics",
+        etag: '"etag-1"',
+        connectionTimeZone: "UTC",
+      }),
+    ).toThrow(ProviderEventError);
+  });
+
+  it("uses DTSTAMP when LAST-MODIFIED is absent", () => {
+    const [read] = normalizeAppleEventResource(
+      resource(`BEGIN:VEVENT
+UID:stamp-uid@icloud.com
+DTSTAMP:20250103T101010Z
+DTSTART:20250115T090000Z
+DTEND:20250115T100000Z
+END:VEVENT`),
+    );
+
+    expect(asEvent(read).providerUpdatedAt).toBe("2025-01-03T10:10:10.000Z");
+  });
+
+  it("derives timed end from DURATION when DTEND is absent", () => {
+    const [read] = normalizeAppleEventResource(
+      resource(`BEGIN:VEVENT
+UID:duration-uid@icloud.com
+DTSTAMP:20250101T120000Z
+DTSTART:20250115T090000Z
+DURATION:PT1H30M
+END:VEVENT`),
+    );
+    const event = asEvent(read);
+    if (event.schedule.kind !== "timed") throw new Error("expected timed");
+
+    expect(
+      Date.parse(event.schedule.end) - Date.parse(event.schedule.start),
+    ).toBe(90 * 60 * 1000);
+  });
+});

--- a/packages/sync/src/providers/apple/apple-event.normalizer.ts
+++ b/packages/sync/src/providers/apple/apple-event.normalizer.ts
@@ -1,0 +1,442 @@
+import ICAL from "ical.js";
+import { EventScheduleSchema } from "@core/types/event.contracts";
+import {
+  type Attendee,
+  type Conference,
+  ConferenceSchema,
+  type Organizer,
+} from "@core/types/event-attendance.contracts";
+import { SyncEventContentSchema } from "@core/types/sync/event.contracts";
+import { TimezoneSchema } from "@core/types/type.utils";
+import dayjs from "@core/util/date/dayjs";
+import { appleInstanceEventId } from "@sync/providers/apple/apple-instance-id";
+import {
+  ProviderEventError,
+  type ProviderEventRead,
+  type ProviderEventRecurrence,
+} from "@sync/providers/provider-event.port";
+
+const RFC3339_OFFSET = dayjs.DateFormat.RFC3339_OFFSET;
+const COMPACT_DATE = dayjs.DateFormat.YEAR_MONTH_DAY_COMPACT_FORMAT;
+const DATE_ONLY = dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT;
+
+export interface AppleEventResourceInput {
+  readonly ics: string;
+  readonly href: string;
+  readonly etag: string;
+  /** Wall-clock zone for floating DTSTART/DTEND (the connection's zone). */
+  readonly connectionTimeZone: string;
+}
+
+interface AppleResourceContext {
+  readonly href: string;
+  readonly etag: string;
+  readonly connectionTimeZone: string;
+}
+
+// Normalize one CalDAV ICS resource (one master VEVENT plus zero or more
+// RECURRENCE-ID siblings) into provider-neutral reads. Throws
+// ProviderEventError only when a VEVENT is structurally unusable; the reader
+// counts those as skipped.
+export function normalizeAppleEventResource(
+  input: AppleEventResourceInput,
+): ProviderEventRead[] {
+  let component: ICAL.Component;
+  try {
+    component = new ICAL.Component(ICAL.parse(input.ics));
+  } catch (error) {
+    throw new ProviderEventError(
+      "unmappableSchedule",
+      "ICS could not be parsed",
+      {
+        cause: error,
+      },
+    );
+  }
+
+  for (const timezone of component.getAllSubcomponents("vtimezone")) {
+    ICAL.TimezoneService.register(timezone);
+  }
+
+  const vevents = component.getAllSubcomponents("vevent");
+  if (vevents.length === 0) {
+    throw new ProviderEventError(
+      "missingIdentity",
+      "ICS resource had no VEVENT",
+    );
+  }
+
+  const context: AppleResourceContext = {
+    href: input.href,
+    etag: input.etag,
+    connectionTimeZone: input.connectionTimeZone,
+  };
+
+  const masters = vevents.filter(
+    (vevent) => !vevent.hasProperty("recurrence-id"),
+  );
+  const exceptions = vevents.filter((vevent) =>
+    vevent.hasProperty("recurrence-id"),
+  );
+
+  const reads: ProviderEventRead[] = [];
+  for (const master of masters) {
+    reads.push(normalizeAppleVevent(master, context, null));
+  }
+  for (const exception of exceptions) {
+    reads.push(
+      normalizeAppleVevent(
+        exception,
+        context,
+        masters[0]?.getFirstPropertyValue("uid") as string | undefined,
+      ),
+    );
+  }
+  return reads;
+}
+
+function normalizeAppleVevent(
+  vevent: ICAL.Component,
+  context: AppleResourceContext,
+  masterUid: string | null | undefined,
+): ProviderEventRead {
+  const recurrenceIdProp = vevent.getFirstProperty("recurrence-id");
+  if (recurrenceIdProp?.getParameter("range") === "THISANDFUTURE") {
+    throw new ProviderEventError(
+      "unmappableSchedule",
+      "RECURRENCE-ID RANGE=THISANDFUTURE is not supported",
+    );
+  }
+
+  const uid = requireUid(vevent);
+  const isException = Boolean(recurrenceIdProp);
+  const providerEventId = isException
+    ? instanceProviderEventId(
+        uid,
+        recurrenceIdProp!,
+        context.connectionTimeZone,
+      )
+    : uid;
+  const status = vevent.getFirstPropertyValue("status") as string | undefined;
+
+  if (status === "CANCELLED") {
+    return {
+      kind: "cancellation",
+      providerEventId,
+      providerVersion: context.etag,
+      series: cancellationSeries(
+        uid,
+        isException,
+        recurrenceIdProp ?? undefined,
+        context,
+      ),
+    };
+  }
+
+  const event = new ICAL.Event(vevent);
+  const providerUpdatedAt = mapProviderUpdatedAt(vevent);
+
+  return {
+    kind: "event",
+    providerEventId,
+    providerVersion: context.etag,
+    providerUpdatedAt,
+    content: mapContent(event),
+    schedule: mapSchedule(event, context.connectionTimeZone),
+    busy: vevent.getFirstPropertyValue("transp") !== "TRANSPARENT",
+    icalUid: uid,
+    recurrence: mapRecurrence(
+      vevent,
+      uid,
+      isException,
+      recurrenceIdProp ?? undefined,
+      context,
+      masterUid,
+    ),
+  };
+}
+
+function requireUid(vevent: ICAL.Component): string {
+  const uid = vevent.getFirstPropertyValue("uid");
+  if (typeof uid !== "string" || uid.trim().length === 0) {
+    throw new ProviderEventError("missingIdentity", "VEVENT carried no UID");
+  }
+  return uid;
+}
+
+function instanceProviderEventId(
+  uid: string,
+  recurrenceIdProp: ICAL.Property,
+  connectionTimeZone: string,
+): string {
+  const recurrenceTime = recurrenceIdProp.getFirstValue() as ICAL.Time;
+  const scheduleKind = recurrenceTime.isDate ? "allDay" : "timed";
+  const recurrenceId = toCanonicalRecurrenceId(
+    recurrenceTime,
+    scheduleKind,
+    connectionTimeZone,
+  );
+  return appleInstanceEventId(uid, recurrenceId, scheduleKind);
+}
+
+function cancellationSeries(
+  uid: string,
+  isException: boolean,
+  recurrenceIdProp: ICAL.Property | undefined,
+  context: AppleResourceContext,
+): { seriesProviderId: string; recurrenceId: string } | null {
+  if (!isException || !recurrenceIdProp) return null;
+  const recurrenceTime = recurrenceIdProp.getFirstValue() as ICAL.Time;
+  const scheduleKind = recurrenceTime.isDate ? "allDay" : "timed";
+  return {
+    seriesProviderId: uid,
+    recurrenceId: toCanonicalRecurrenceId(
+      recurrenceTime,
+      scheduleKind,
+      context.connectionTimeZone,
+    ),
+  };
+}
+
+function mapProviderUpdatedAt(vevent: ICAL.Component): string | null {
+  const lastModified = vevent.getFirstPropertyValue("last-modified") as
+    | ICAL.Time
+    | undefined;
+  if (lastModified) {
+    return lastModified.toJSDate().toISOString();
+  }
+  const dtstamp = vevent.getFirstPropertyValue("dtstamp") as
+    | ICAL.Time
+    | undefined;
+  return dtstamp ? dtstamp.toJSDate().toISOString() : null;
+}
+
+function mapContent(event: ICAL.Event) {
+  const parsed = SyncEventContentSchema.safeParse({
+    title: event.summary ?? "",
+    description: event.description ?? "",
+    location: event.location ?? "",
+    organizer: mapOrganizer(event),
+    attendees: mapAttendees(event),
+    conference: mapConference(event),
+  });
+  if (!parsed.success) {
+    throw new ProviderEventError(
+      "unmappableContent",
+      "Event content failed the neutral contract",
+      { cause: parsed.error },
+    );
+  }
+  return parsed.data;
+}
+
+function mapOrganizer(event: ICAL.Event): Organizer | null {
+  const property = event.component.getFirstProperty("organizer");
+  if (!property) return null;
+  const email = stripMailto(property.getFirstValue() as string);
+  if (!email) return null;
+  const displayName = stringParam(property, "cn")?.trim();
+  return {
+    email,
+    displayName: displayName || null,
+  };
+}
+
+const KNOWN_RESPONSES = new Set(["accepted", "declined", "tentative"]);
+
+function mapAttendees(event: ICAL.Event): Attendee[] {
+  return event.component
+    .getAllProperties("attendee")
+    .map((property) => {
+      const email = stripMailto(property.getFirstValue() as string);
+      if (!email) return null;
+      const partstat = stringParam(property, "partstat")?.toLowerCase();
+      const displayName = stringParam(property, "cn")?.trim();
+      return {
+        email,
+        displayName: displayName || null,
+        responseStatus: KNOWN_RESPONSES.has(partstat ?? "")
+          ? (partstat as Attendee["responseStatus"])
+          : "needsAction",
+      };
+    })
+    .filter((attendee): attendee is Attendee => attendee !== null);
+}
+
+function mapConference(event: ICAL.Event): Conference | null {
+  const url = event.component.getFirstPropertyValue("url");
+  if (typeof url !== "string" || !url.startsWith("https://")) return null;
+  const parsed = ConferenceSchema.safeParse({ url, label: "Link" });
+  return parsed.success ? parsed.data : null;
+}
+
+function mapSchedule(event: ICAL.Event, connectionTimeZone: string) {
+  const start = event.startDate;
+  const end = event.endDate;
+  if (!start || !end) {
+    throw new ProviderEventError(
+      "unmappableSchedule",
+      "VEVENT has no start or end",
+    );
+  }
+
+  if (start.isDate && end.isDate) {
+    return parseSchedule({
+      kind: "allDay",
+      start: compactDateToDateOnly(start.toICALString()),
+      end: compactDateToDateOnly(end.toICALString()),
+    });
+  }
+
+  if (!start.isDate && !end.isDate) {
+    const timeZone = resolveTimeZone(start, connectionTimeZone);
+    return parseSchedule({
+      kind: "timed",
+      start: toOffsetIso(start, timeZone, connectionTimeZone),
+      end: toOffsetIso(end, timeZone, connectionTimeZone),
+      timeZone,
+    });
+  }
+
+  throw new ProviderEventError(
+    "unmappableSchedule",
+    "VEVENT start/end mixes date and dateTime",
+  );
+}
+
+function mapRecurrence(
+  vevent: ICAL.Component,
+  uid: string,
+  isException: boolean,
+  recurrenceIdProp: ICAL.Property | undefined,
+  context: AppleResourceContext,
+  masterUid: string | null | undefined,
+): ProviderEventRecurrence {
+  if (isException && recurrenceIdProp) {
+    const recurrenceTime = recurrenceIdProp.getFirstValue() as ICAL.Time;
+    const scheduleKind = recurrenceTime.isDate ? "allDay" : "timed";
+    return {
+      kind: "instance",
+      seriesProviderId: masterUid ?? uid,
+      recurrenceId: toCanonicalRecurrenceId(
+        recurrenceTime,
+        scheduleKind,
+        context.connectionTimeZone,
+      ),
+    };
+  }
+
+  const rules = collectRecurrenceRules(vevent);
+  if (rules.length > 0) {
+    return { kind: "seriesMaster", rules };
+  }
+  return { kind: "single" };
+}
+
+function collectRecurrenceRules(vevent: ICAL.Component): readonly string[] {
+  const rules: string[] = [];
+  const rrule = vevent.getFirstProperty("rrule");
+  if (rrule) rules.push(rrule.toICALString());
+  for (const exdate of vevent.getAllProperties("exdate")) {
+    rules.push(exdate.toICALString());
+  }
+  for (const rdate of vevent.getAllProperties("rdate")) {
+    rules.push(rdate.toICALString());
+  }
+  return rules;
+}
+
+function compactDateToDateOnly(compact: string): string {
+  const parsed = dayjs.utc(compact, COMPACT_DATE, true);
+  if (!parsed.isValid()) {
+    throw new ProviderEventError(
+      "unmappableSchedule",
+      "All-day date could not be parsed",
+    );
+  }
+  return parsed.format(DATE_ONLY);
+}
+
+function resolveTimeZone(time: ICAL.Time, connectionTimeZone: string): string {
+  const tzid = time.zone?.tzid;
+  if (!tzid || tzid === "floating") {
+    return toIanaTimeZone(connectionTimeZone);
+  }
+  return toIanaTimeZone(tzid);
+}
+
+function toIanaTimeZone(timeZone: string): string {
+  return TimezoneSchema.safeParse(timeZone).success ? timeZone : "UTC";
+}
+
+function toOffsetIso(
+  time: ICAL.Time,
+  timeZone: string,
+  connectionTimeZone: string,
+): string {
+  if (time.isDate) {
+    return dayjs
+      .utc(compactDateToDateOnly(time.toICALString()))
+      .format(RFC3339_OFFSET);
+  }
+
+  if (time.zone?.tzid === "floating") {
+    const wallClock = time.toICALString();
+    const anchored = dayjs.tz(wallClock, "YYYYMMDDTHHmmss", connectionTimeZone);
+    if (!anchored.isValid()) {
+      throw new ProviderEventError(
+        "unmappableSchedule",
+        "Floating date-time could not be anchored",
+      );
+    }
+    return anchored.format(RFC3339_OFFSET);
+  }
+
+  const anchored = dayjs(time.toJSDate()).tz(timeZone);
+  return anchored.format(RFC3339_OFFSET);
+}
+
+function toCanonicalRecurrenceId(
+  time: ICAL.Time,
+  scheduleKind: "timed" | "allDay",
+  connectionTimeZone = "UTC",
+): string {
+  if (scheduleKind === "allDay") {
+    return dayjs
+      .utc(compactDateToDateOnly(time.toICALString()))
+      .toDate()
+      .toISOString();
+  }
+  const offset = toOffsetIso(
+    time,
+    resolveTimeZone(time, connectionTimeZone),
+    connectionTimeZone,
+  );
+  return new Date(offset).toISOString();
+}
+
+function stripMailto(value: string | undefined): string | null {
+  if (!value) return null;
+  const email = value.replace(/^mailto:/i, "").trim();
+  return email.length > 0 ? email : null;
+}
+
+function stringParam(
+  property: ICAL.Property,
+  name: string,
+): string | undefined {
+  const value = property.getParameter(name);
+  return typeof value === "string" ? value : undefined;
+}
+
+function parseSchedule(candidate: unknown) {
+  const parsed = EventScheduleSchema.safeParse(candidate);
+  if (!parsed.success) {
+    throw new ProviderEventError(
+      "unmappableSchedule",
+      "Event start/end could not be resolved to a schedule",
+      { cause: parsed.error },
+    );
+  }
+  return parsed.data;
+}

--- a/packages/sync/src/providers/apple/apple-instance-id.ts
+++ b/packages/sync/src/providers/apple/apple-instance-id.ts
@@ -1,0 +1,19 @@
+import dayjs from "@core/util/date/dayjs";
+
+// Apple recurring-instance ids mirror Google's `{seriesId}_{originalStart}`
+// suffix so sparse cancellations and reader href mappings stay aligned with
+// Compass projection recurrenceIds. iCloud shares one UID across master and
+// exception VEVENTs in a resource; the suffix disambiguates instances.
+
+export function appleInstanceEventId(
+  seriesProviderEventId: string,
+  originalStartAt: string,
+  scheduleKind: "timed" | "allDay",
+): string {
+  const instant = dayjs.utc(originalStartAt);
+  const suffix =
+    scheduleKind === "allDay"
+      ? instant.format(dayjs.DateFormat.YEAR_MONTH_DAY_COMPACT_FORMAT)
+      : instant.format(dayjs.DateFormat.RFC5545);
+  return `${seriesProviderEventId}_${suffix}`;
+}

--- a/packages/sync/src/safety/safety-canary.test.ts
+++ b/packages/sync/src/safety/safety-canary.test.ts
@@ -13,7 +13,10 @@ const PROVIDER_MARKER_SAMPLES: Record<
     { "@odata.etag": 'W/"abc"' },
     { onlineMeeting: { joinUrl: "https://teams.example.com/join" } },
   ],
-  apple: ["BEGIN:VEVENT\nUID:1\nEND:VEVENT"],
+  apple: [
+    "BEGIN:VEVENT\nUID:1\nEND:VEVENT",
+    "BEGIN:VCALENDAR\nVERSION:2.0\nEND:VCALENDAR",
+  ],
 };
 
 describe("PROVIDER_LEAK_MARKERS", () => {

--- a/packages/sync/src/safety/safety-canary.ts
+++ b/packages/sync/src/safety/safety-canary.ts
@@ -17,7 +17,7 @@ const SECRET_PATTERNS: readonly RegExp[] = [
 export const PROVIDER_LEAK_MARKERS: Record<ProviderKind, readonly RegExp[]> = {
   google: [/"conferenceData"\s*:/i, /"hangoutLink"\s*:/i],
   microsoft: [/"@odata\.etag"\s*:/i, /"onlineMeeting"\s*:/i],
-  apple: [/BEGIN:VEVENT/i],
+  apple: [/BEGIN:VEVENT/i, /BEGIN:VCALENDAR/i],
 };
 
 const SHARED_EVENT_CONTENT_PATTERNS: readonly RegExp[] = [


### PR DESCRIPTION
Fixes #3257

## What and why

Adds `normalizeAppleEventResource` in `packages/sync/src/providers/apple/` using `ical.js` to turn one CalDAV ICS resource (master VEVENT plus RECURRENCE-ID siblings) into provider-neutral `ProviderEventRead` values. Schedule, recurrence, attendees, conference links, and cancellation semantics mirror the Google normalizer's skippable `ProviderEventError` reasons so the A-05 reader can count `skipped`. Also extends Apple safety-canary markers and adds normalizer contract cases.

## Verify

```
bun run verify --strict
Selected packages: sync
Checks run: test:sync:fast, type-check, lint, knip
VERDICT: PASS
```