### PR TITLE
feat(sync): Microsoft auth adapter (WP-01)

### DIFF
--- a/.agents/handoffs/3240.md
+++ b/.agents/handoffs/3240.md
@@ -1,0 +1,38 @@
+---
+schema_version: 1
+task_id: "3240"
+from: Implementer
+to: GitHub
+owner: GitHub
+status: verifying
+artifact:
+  - path: packages/sync/src/providers/microsoft/microsoft-auth.adapter.ts
+  - path: packages/sync/src/providers/microsoft/microsoft-scopes.ts
+  - path: packages/sync/src/providers/__contract__/microsoft.contract.test.ts
+  - path: packages/core/src/types/sync/connection.contracts.ts
+  - path: packages/sync/src/server/connection.routes.ts
+evidence:
+  - command: bun test:sync
+    result: pass
+  - command: bun test:core
+    result: pass
+  - command: bun run type-check
+    result: pass
+  - command: bun lint
+    result: pass
+  - command: bun knip
+    result: pass
+  - command: bun run verify --strict
+    result: "VERDICT: PASS"
+assumptions:
+  - "Microsoft is not registered in ProviderRegistry until M-09 (#3249)."
+  - "OAuth callback consentRequired redirect status is wired; web toast copy lands in WP-10."
+open_risks: []
+next_deadline: 2026-09-05T02:00:00Z
+retry: 0
+approval: allow
+waiting_on: null
+escalation: null
+---
+
+M WP-01: Microsoft auth adapter with scopes, consentRequired state, and auth contract cases.

--- a/bun.lock
+++ b/bun.lock
@@ -117,6 +117,7 @@
         "express-rate-limit": "^7.5.0",
         "fast-xml-parser": "^5.11.1",
         "google-auth-library": "^10.6.2",
+        "jose": "^5.9.6",
         "mongodb": "^7.2.0",
         "rrule": "^2.7.2",
         "tslib": "^2.4.0",
@@ -1238,7 +1239,7 @@
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
-    "jose": ["jose@4.15.9", "", {}, "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA=="],
+    "jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
 
     "js-levenshtein": ["js-levenshtein@1.1.6", "", {}, "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="],
 
@@ -2007,6 +2008,8 @@
     "supertest/cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
     "supertokens-node/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "supertokens-node/jose": ["jose@4.15.9", "", {}, "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA=="],
 
     "twilio/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 

--- a/packages/backend/src/common/services/sync-service/connection-state.translation.test.ts
+++ b/packages/backend/src/common/services/sync-service/connection-state.translation.test.ts
@@ -41,7 +41,11 @@ describe("toGoogleConnectionState", () => {
   });
 
   it("maps actionRequired with a non-re-auth reason to ATTENTION", () => {
-    for (const reason of ["providerErrors", "workOverdue"] as const) {
+    for (const reason of [
+      "providerErrors",
+      "workOverdue",
+      "consentRequired",
+    ] as const) {
       expect(
         toGoogleConnectionState([connection("actionRequired", reason)]),
       ).toBe("ATTENTION");

--- a/packages/core/src/types/sync/connection.contracts.test.ts
+++ b/packages/core/src/types/sync/connection.contracts.test.ts
@@ -93,6 +93,15 @@ describe("Sync connection contracts", () => {
       expect(ProviderConnectionSchema.safeParse(connection).success).toBe(true);
     });
 
+    it("accepts actionRequired with consentRequired", () => {
+      const connection = {
+        ...validConnection(),
+        state: "actionRequired",
+        stateReason: "consentRequired",
+      };
+      expect(ProviderConnectionSchema.safeParse(connection).success).toBe(true);
+    });
+
     it("rejects actionRequired without a reason", () => {
       const connection = { ...validConnection(), state: "actionRequired" };
       expect(ProviderConnectionSchema.safeParse(connection).success).toBe(

--- a/packages/core/src/types/sync/connection.contracts.ts
+++ b/packages/core/src/types/sync/connection.contracts.ts
@@ -35,6 +35,7 @@ export const ConnectionStateReasonSchema = z.enum([
   "authorizationRevoked",
   "authorizationExpired",
   "insufficientScopes",
+  "consentRequired",
   "workOverdue",
   "providerErrors",
 ]);

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -12,6 +12,7 @@
     "express-rate-limit": "^7.5.0",
     "fast-xml-parser": "^5.11.1",
     "google-auth-library": "^10.6.2",
+    "jose": "^5.9.6",
     "mongodb": "^7.2.0",
     "rrule": "^2.7.2",
     "tslib": "^2.4.0",

--- a/packages/sync/src/providers/__contract__/auth.contract.ts
+++ b/packages/sync/src/providers/__contract__/auth.contract.ts
@@ -1,0 +1,6 @@
+import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
+
+export interface AuthContractCase {
+  readonly name: string;
+  run(adapter: ProviderAuthAdapter): Promise<void>;
+}

--- a/packages/sync/src/providers/__contract__/fixtures/microsoft/exchange-success.json
+++ b/packages/sync/src/providers/__contract__/fixtures/microsoft/exchange-success.json
@@ -1,0 +1,14 @@
+{
+  "tokenResponse": {
+    "refresh_token": "microsoft-refresh-token",
+    "access_token": "microsoft-access-token",
+    "scope": "openid profile email offline_access User.Read Calendars.ReadWrite",
+    "expires_in": 3600,
+    "token_type": "Bearer"
+  },
+  "idTokenClaims": {
+    "oid": "microsoft-oid-123",
+    "preferred_username": "user@contoso.com",
+    "name": "Contoso User"
+  }
+}

--- a/packages/sync/src/providers/__contract__/fixtures/microsoft/refresh-invalid-grant.json
+++ b/packages/sync/src/providers/__contract__/fixtures/microsoft/refresh-invalid-grant.json
@@ -1,0 +1,4 @@
+{
+  "error": "invalid_grant",
+  "error_description": "AADSTS70000: The refresh token has expired."
+}

--- a/packages/sync/src/providers/__contract__/fixtures/microsoft/refresh-success.json
+++ b/packages/sync/src/providers/__contract__/fixtures/microsoft/refresh-success.json
@@ -1,0 +1,6 @@
+{
+  "access_token": "fresh-access-token",
+  "scope": "Calendars.ReadWrite User.Read",
+  "expires_in": 3600,
+  "token_type": "Bearer"
+}

--- a/packages/sync/src/providers/__contract__/microsoft.contract.test.ts
+++ b/packages/sync/src/providers/__contract__/microsoft.contract.test.ts
@@ -1,0 +1,171 @@
+import { generateKeyPair, type KeyLike, SignJWT } from "jose";
+import { type AuthContractCase } from "@sync/providers/__contract__/auth.contract";
+import exchangeFixture from "@sync/providers/__contract__/fixtures/microsoft/exchange-success.json";
+import refreshRevokedFixture from "@sync/providers/__contract__/fixtures/microsoft/refresh-invalid-grant.json";
+import refreshSuccessFixture from "@sync/providers/__contract__/fixtures/microsoft/refresh-success.json";
+import {
+  MicrosoftAuthAdapter,
+  type MicrosoftIdTokenVerifier,
+  type MicrosoftTokenEndpoint,
+  type MicrosoftTokenResponse,
+} from "@sync/providers/microsoft/microsoft-auth.adapter";
+import { ProviderAuthError } from "@sync/providers/provider-auth.port";
+
+const CLIENT_ID = "microsoft-client-id";
+const CLIENT_SECRET = "microsoft-client-secret";
+
+interface ExchangeSuccessFixture {
+  readonly tokenResponse: MicrosoftTokenResponse;
+  readonly idTokenClaims: {
+    readonly oid: string;
+    readonly preferred_username?: string;
+    readonly email?: string;
+    readonly name?: string;
+  };
+}
+
+class FixtureTokenEndpoint implements MicrosoftTokenEndpoint {
+  constructor(
+    private readonly exchangeResponse: MicrosoftTokenResponse,
+    private readonly refreshResponses: readonly MicrosoftTokenResponse[],
+  ) {}
+
+  exchangeAuthorizationCode(): Promise<MicrosoftTokenResponse> {
+    return Promise.resolve(this.exchangeResponse);
+  }
+
+  refreshAccessToken(): Promise<MicrosoftTokenResponse> {
+    const next = this.refreshResponses[0];
+    if (!next) throw new Error("unexpected refresh call");
+    return Promise.resolve(next);
+  }
+}
+
+class StaticIdTokenVerifier implements MicrosoftIdTokenVerifier {
+  constructor(private readonly claims: Record<string, unknown>) {}
+
+  verify(): Promise<Record<string, unknown>> {
+    return Promise.resolve(this.claims);
+  }
+}
+
+async function signedIdToken(
+  privateKey: KeyLike,
+  claims: Record<string, unknown>,
+): Promise<string> {
+  return new SignJWT(claims)
+    .setProtectedHeader({ alg: "RS256" })
+    .setAudience(CLIENT_ID)
+    .setIssuedAt()
+    .setExpirationTime("2h")
+    .sign(privateKey);
+}
+
+async function buildAdapter(
+  refreshResponses: readonly MicrosoftTokenResponse[] = [],
+): Promise<MicrosoftAuthAdapter> {
+  const fixture = exchangeFixture as ExchangeSuccessFixture;
+  const { privateKey } = await generateKeyPair("RS256");
+  const idToken = await signedIdToken(privateKey, fixture.idTokenClaims);
+  const tokenEndpoint = new FixtureTokenEndpoint(
+    { ...fixture.tokenResponse, id_token: idToken },
+    refreshResponses,
+  );
+  return new MicrosoftAuthAdapter(
+    CLIENT_ID,
+    CLIENT_SECRET,
+    () => tokenEndpoint,
+    () => new StaticIdTokenVerifier(fixture.idTokenClaims),
+  );
+}
+
+function describeAuthCases(
+  kind: string,
+  buildAdapter: () => Promise<MicrosoftAuthAdapter>,
+  cases: readonly AuthContractCase[],
+): void {
+  describe(`${kind} auth contract`, () => {
+    for (const testCase of cases) {
+      it(testCase.name, async () => {
+        const adapter = await buildAdapter();
+        await testCase.run(adapter);
+      });
+    }
+  });
+}
+
+describeAuthCases("microsoft", () => buildAdapter(), [
+  {
+    name: "exchange yields oid-keyed identity, a refresh token, and granted scopes",
+    async run(auth) {
+      const result = await auth.exchangeAuthorizationCode({
+        code: "auth-code",
+        redirectUri: "https://staging.example.com/sync/microsoft",
+      });
+      const fixture = exchangeFixture as ExchangeSuccessFixture;
+      expect(result.account.providerAccountId).toBe(fixture.idTokenClaims.oid);
+      expect(result.refreshToken).toBe(fixture.tokenResponse.refresh_token);
+      expect(result.grantedScopes).toEqual([
+        "openid",
+        "profile",
+        "email",
+        "offline_access",
+        "User.Read",
+        "Calendars.ReadWrite",
+      ]);
+    },
+  },
+]);
+
+describeAuthCases(
+  "microsoft",
+  () => buildAdapter([refreshSuccessFixture as MicrosoftTokenResponse]),
+  [
+    {
+      name: "refresh mints a fresh access token and expiry",
+      async run(auth) {
+        const fixture = exchangeFixture as ExchangeSuccessFixture;
+        await auth.exchangeAuthorizationCode({
+          code: "auth-code",
+          redirectUri: "https://staging.example.com/sync/microsoft",
+        });
+        const refreshed = await auth.refreshAccessToken({
+          refreshToken: fixture.tokenResponse.refresh_token!,
+        });
+        expect(refreshed.accessToken).toBe(
+          (refreshSuccessFixture as MicrosoftTokenResponse).access_token,
+        );
+        expect(refreshed.grantedScopes).toEqual([
+          "Calendars.ReadWrite",
+          "User.Read",
+        ]);
+      },
+    },
+  ],
+);
+
+describeAuthCases(
+  "microsoft",
+  () => buildAdapter([refreshRevokedFixture as MicrosoftTokenResponse]),
+  [
+    {
+      name: "maps invalid_grant to authorizationRevoked",
+      async run(auth) {
+        const fixture = exchangeFixture as ExchangeSuccessFixture;
+        await auth.exchangeAuthorizationCode({
+          code: "auth-code",
+          redirectUri: "https://staging.example.com/sync/microsoft",
+        });
+        const error = await auth
+          .refreshAccessToken({
+            refreshToken: fixture.tokenResponse.refresh_token!,
+          })
+          .catch((e) => e);
+        expect(error).toBeInstanceOf(ProviderAuthError);
+        expect((error as ProviderAuthError).reason).toBe(
+          "authorizationRevoked",
+        );
+      },
+    },
+  ],
+);

--- a/packages/sync/src/providers/microsoft/microsoft-auth.adapter.test.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-auth.adapter.test.ts
@@ -1,0 +1,505 @@
+import { generateKeyPair, type KeyLike, SignJWT } from "jose";
+import {
+  MICROSOFT_AUTHORIZE_URL,
+  MicrosoftAuthAdapter,
+  type MicrosoftIdTokenClaims,
+  type MicrosoftIdTokenVerifier,
+  type MicrosoftTokenEndpoint,
+  type MicrosoftTokenResponse,
+} from "@sync/providers/microsoft/microsoft-auth.adapter";
+import { isMicrosoftConsentRequired } from "@sync/providers/microsoft/microsoft-consent";
+import {
+  CONTACTS_FEATURE_SCOPES,
+  MICROSOFT_SCOPES,
+} from "@sync/providers/microsoft/microsoft-scopes";
+import { ProviderAuthError } from "@sync/providers/provider-auth.port";
+
+class FakeTokenEndpoint implements MicrosoftTokenEndpoint {
+  exchangeInputs: Parameters<
+    MicrosoftTokenEndpoint["exchangeAuthorizationCode"]
+  >[] = [];
+  refreshInputs: Parameters<MicrosoftTokenEndpoint["refreshAccessToken"]>[] =
+    [];
+
+  constructor(
+    private readonly behavior: {
+      exchangeResponse?: MicrosoftTokenResponse;
+      exchangeError?: unknown;
+      refreshResponse?: MicrosoftTokenResponse;
+      refreshError?: unknown;
+    } = {},
+  ) {}
+
+  exchangeAuthorizationCode(
+    input: Parameters<MicrosoftTokenEndpoint["exchangeAuthorizationCode"]>[0],
+  ): Promise<MicrosoftTokenResponse> {
+    this.exchangeInputs.push(input);
+    if (this.behavior.exchangeError) {
+      return Promise.reject(this.behavior.exchangeError);
+    }
+    return Promise.resolve(this.behavior.exchangeResponse ?? {});
+  }
+
+  refreshAccessToken(
+    input: Parameters<MicrosoftTokenEndpoint["refreshAccessToken"]>[0],
+  ): Promise<MicrosoftTokenResponse> {
+    this.refreshInputs.push(input);
+    if (this.behavior.refreshError) {
+      return Promise.reject(this.behavior.refreshError);
+    }
+    return Promise.resolve(this.behavior.refreshResponse ?? {});
+  }
+}
+
+class FakeIdTokenVerifier implements MicrosoftIdTokenVerifier {
+  verifyCalls: Array<{ idToken: string; audience: string }> = [];
+
+  constructor(
+    private readonly behavior: {
+      claims?: MicrosoftIdTokenClaims;
+      verifyError?: unknown;
+    } = {},
+  ) {}
+
+  verify(idToken: string, audience: string): Promise<MicrosoftIdTokenClaims> {
+    this.verifyCalls.push({ idToken, audience });
+    if (this.behavior.verifyError) {
+      return Promise.reject(this.behavior.verifyError);
+    }
+    return Promise.resolve(this.behavior.claims ?? {});
+  }
+}
+
+const CLIENT_ID = "microsoft-client-id";
+const CLIENT_SECRET = "microsoft-client-secret";
+
+function makeClaims(
+  overrides: Partial<MicrosoftIdTokenClaims> = {},
+): MicrosoftIdTokenClaims {
+  return {
+    oid: "microsoft-oid-123",
+    preferred_username: "user@contoso.com",
+    name: "Contoso User",
+    ...overrides,
+  };
+}
+
+function adapterWith(
+  tokenEndpoint: FakeTokenEndpoint,
+  idVerifier: FakeIdTokenVerifier,
+) {
+  return new MicrosoftAuthAdapter(
+    CLIENT_ID,
+    CLIENT_SECRET,
+    () => tokenEndpoint,
+    () => idVerifier,
+  );
+}
+
+async function signedIdToken(
+  privateKey: KeyLike,
+  claims: MicrosoftIdTokenClaims,
+): Promise<string> {
+  return new SignJWT(claims)
+    .setProtectedHeader({ alg: "RS256" })
+    .setAudience(CLIENT_ID)
+    .setIssuedAt()
+    .setExpirationTime("2h")
+    .sign(privateKey);
+}
+
+describe("isMicrosoftConsentRequired", () => {
+  it.each([
+    "consent_required",
+    "interaction_required",
+  ] as const)("detects %s", (error) => {
+    expect(isMicrosoftConsentRequired(error)).toBe(true);
+  });
+
+  it("detects AADSTS65001 in the description", () => {
+    expect(
+      isMicrosoftConsentRequired(
+        "invalid_grant",
+        "AADSTS65001: The user or administrator has not consented",
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("MicrosoftAuthAdapter", () => {
+  it("refuses to construct without a client id and secret", () => {
+    expect(() => new MicrosoftAuthAdapter("", CLIENT_SECRET)).toThrow(
+      /client id and secret/,
+    );
+    expect(() => new MicrosoftAuthAdapter(CLIENT_ID, "")).toThrow(
+      /client id and secret/,
+    );
+  });
+
+  describe("buildAuthorizationUrl", () => {
+    it("builds the /common authorize URL with the base scopes", () => {
+      const adapter = adapterWith(
+        new FakeTokenEndpoint(),
+        new FakeIdTokenVerifier(),
+      );
+
+      const url = new URL(
+        adapter.buildAuthorizationUrl({
+          state: "opaque-state",
+          redirectUri: "https://staging.example.com/sync/microsoft",
+        }),
+      );
+
+      expect(url.origin + url.pathname).toBe(MICROSOFT_AUTHORIZE_URL);
+      expect(url.searchParams.get("client_id")).toBe(CLIENT_ID);
+      expect(url.searchParams.get("response_type")).toBe("code");
+      expect(url.searchParams.get("response_mode")).toBe("query");
+      expect(url.searchParams.get("state")).toBe("opaque-state");
+      expect(url.searchParams.get("redirect_uri")).toBe(
+        "https://staging.example.com/sync/microsoft",
+      );
+      expect(url.searchParams.get("prompt")).toBeNull();
+      expect(url.searchParams.get("scope")?.split(" ")).toEqual([
+        ...MICROSOFT_SCOPES,
+      ]);
+    });
+
+    it("forces the account chooser when adding an account", () => {
+      const adapter = adapterWith(
+        new FakeTokenEndpoint(),
+        new FakeIdTokenVerifier(),
+      );
+
+      const url = new URL(
+        adapter.buildAuthorizationUrl({
+          state: "opaque-state",
+          redirectUri: "https://staging.example.com/sync/microsoft",
+          selectAccount: true,
+        }),
+      );
+
+      expect(url.searchParams.get("prompt")).toBe("select_account");
+    });
+
+    it("appends optional feature scopes after the base scopes", () => {
+      const adapter = adapterWith(
+        new FakeTokenEndpoint(),
+        new FakeIdTokenVerifier(),
+      );
+
+      const url = new URL(
+        adapter.buildAuthorizationUrl({
+          state: "opaque-state",
+          redirectUri: "https://staging.example.com/sync/microsoft",
+          extraScopes: CONTACTS_FEATURE_SCOPES,
+        }),
+      );
+
+      expect(url.searchParams.get("scope")?.split(" ")).toEqual([
+        ...MICROSOFT_SCOPES,
+        "People.Read",
+      ]);
+    });
+  });
+
+  describe("exchangeAuthorizationCode", () => {
+    const validExchange: MicrosoftTokenResponse = {
+      refresh_token: "refresh-token-value",
+      access_token: "access-token-value",
+      id_token: "id-token-value",
+      scope:
+        "openid profile email offline_access User.Read Calendars.ReadWrite",
+    };
+
+    it("returns oid-keyed identity, the refresh token, and granted scopes with a signed id token", async () => {
+      const { privateKey, publicKey } = await generateKeyPair("RS256");
+      const claims = makeClaims();
+      const idToken = await signedIdToken(privateKey, claims);
+      const tokenEndpoint = new FakeTokenEndpoint({
+        exchangeResponse: { ...validExchange, id_token: idToken },
+      });
+      const idVerifier = new FakeIdTokenVerifier({ claims: makeClaims() });
+      const adapter = new MicrosoftAuthAdapter(
+        CLIENT_ID,
+        CLIENT_SECRET,
+        () => tokenEndpoint,
+        () => idVerifier,
+      );
+
+      const result = await adapter.exchangeAuthorizationCode({
+        code: "auth-code",
+        redirectUri: "https://staging.example.com/sync/microsoft",
+      });
+
+      expect(result.account.providerAccountId).toBe("microsoft-oid-123");
+      expect(result.account.email).toBe("user@contoso.com");
+      expect(result.account.displayName).toBe("Contoso User");
+      expect(result.refreshToken).toBe("refresh-token-value");
+      expect(result.grantedScopes).toEqual([
+        "openid",
+        "profile",
+        "email",
+        "offline_access",
+        "User.Read",
+        "Calendars.ReadWrite",
+      ]);
+      expect(tokenEndpoint.exchangeInputs[0]?.redirectUri).toBe(
+        "https://staging.example.com/sync/microsoft",
+      );
+      expect(idVerifier.verifyCalls).toHaveLength(1);
+      expect(publicKey).toBeDefined();
+    });
+
+    it("falls back to email when preferred_username is absent", async () => {
+      const tokenEndpoint = new FakeTokenEndpoint({
+        exchangeResponse: validExchange,
+      });
+      const adapter = adapterWith(
+        tokenEndpoint,
+        new FakeIdTokenVerifier({
+          claims: makeClaims({
+            preferred_username: undefined,
+            email: "fallback@contoso.com",
+          }),
+        }),
+      );
+
+      const result = await adapter.exchangeAuthorizationCode({
+        code: "auth-code",
+        redirectUri: "https://staging.example.com/sync/microsoft",
+      });
+
+      expect(result.account.email).toBe("fallback@contoso.com");
+    });
+
+    it("maps admin-consent errors to consentRequired", async () => {
+      const adapter = adapterWith(
+        new FakeTokenEndpoint({
+          exchangeResponse: {
+            error: "invalid_grant",
+            error_description: "AADSTS65001: Admin consent required",
+          },
+        }),
+        new FakeIdTokenVerifier(),
+      );
+
+      const error = await adapter
+        .exchangeAuthorizationCode({
+          code: "auth-code",
+          redirectUri: "https://staging.example.com/sync/microsoft",
+        })
+        .catch((e) => e);
+
+      expect(error).toBeInstanceOf(ProviderAuthError);
+      expect((error as ProviderAuthError).reason).toBe("consentRequired");
+    });
+
+    it.each([
+      "consent_required",
+      "interaction_required",
+    ] as const)("maps %s to consentRequired", async (oauthError) => {
+      const adapter = adapterWith(
+        new FakeTokenEndpoint({
+          exchangeResponse: { error: oauthError },
+        }),
+        new FakeIdTokenVerifier(),
+      );
+
+      const error = await adapter
+        .exchangeAuthorizationCode({
+          code: "auth-code",
+          redirectUri: "https://staging.example.com/sync/microsoft",
+        })
+        .catch((e) => e);
+
+      expect((error as ProviderAuthError).reason).toBe("consentRequired");
+    });
+
+    it("treats a failed code exchange as exchangeFailed", async () => {
+      const adapter = adapterWith(
+        new FakeTokenEndpoint({ exchangeError: new Error("network down") }),
+        new FakeIdTokenVerifier(),
+      );
+
+      const error = await adapter
+        .exchangeAuthorizationCode({
+          code: "bad-code",
+          redirectUri: "https://staging.example.com/sync/microsoft",
+        })
+        .catch((e) => e);
+
+      expect((error as ProviderAuthError).reason).toBe("exchangeFailed");
+    });
+
+    it("requires a refresh token", async () => {
+      const adapter = adapterWith(
+        new FakeTokenEndpoint({
+          exchangeResponse: { ...validExchange, refresh_token: undefined },
+        }),
+        new FakeIdTokenVerifier({ claims: makeClaims() }),
+      );
+
+      const error = await adapter
+        .exchangeAuthorizationCode({
+          code: "auth-code",
+          redirectUri: "https://staging.example.com/sync/microsoft",
+        })
+        .catch((e) => e);
+
+      expect((error as ProviderAuthError).reason).toBe("missingRefreshToken");
+    });
+
+    it("requires an id token to identify the account", async () => {
+      const adapter = adapterWith(
+        new FakeTokenEndpoint({
+          exchangeResponse: { ...validExchange, id_token: undefined },
+        }),
+        new FakeIdTokenVerifier(),
+      );
+
+      const error = await adapter
+        .exchangeAuthorizationCode({
+          code: "auth-code",
+          redirectUri: "https://staging.example.com/sync/microsoft",
+        })
+        .catch((e) => e);
+
+      expect((error as ProviderAuthError).reason).toBe("invalidIdToken");
+    });
+
+    it("treats a failed id-token verification as invalidIdToken", async () => {
+      const adapter = adapterWith(
+        new FakeTokenEndpoint({ exchangeResponse: validExchange }),
+        new FakeIdTokenVerifier({ verifyError: new Error("bad signature") }),
+      );
+
+      const error = await adapter
+        .exchangeAuthorizationCode({
+          code: "auth-code",
+          redirectUri: "https://staging.example.com/sync/microsoft",
+        })
+        .catch((e) => e);
+
+      expect((error as ProviderAuthError).reason).toBe("invalidIdToken");
+    });
+
+    it("rejects a verified token that carries no oid", async () => {
+      const adapter = adapterWith(
+        new FakeTokenEndpoint({ exchangeResponse: validExchange }),
+        new FakeIdTokenVerifier({ claims: makeClaims({ oid: undefined }) }),
+      );
+
+      const error = await adapter
+        .exchangeAuthorizationCode({
+          code: "auth-code",
+          redirectUri: "https://staging.example.com/sync/microsoft",
+        })
+        .catch((e) => e);
+
+      expect((error as ProviderAuthError).reason).toBe("missingIdentity");
+    });
+  });
+
+  describe("refreshAccessToken", () => {
+    it("mints a fresh access token, expiry, and scopes from the refresh token", async () => {
+      const tokenEndpoint = new FakeTokenEndpoint({
+        refreshResponse: {
+          access_token: "fresh-access-token",
+          expires_in: 3600,
+          scope: "Calendars.ReadWrite User.Read",
+        },
+      });
+      const adapter = adapterWith(tokenEndpoint, new FakeIdTokenVerifier());
+
+      const result = await adapter.refreshAccessToken({
+        refreshToken: "stored-refresh-token",
+      });
+
+      expect(tokenEndpoint.refreshInputs[0]?.refreshToken).toBe(
+        "stored-refresh-token",
+      );
+      expect(result.accessToken).toBe("fresh-access-token");
+      expect(result.expiresAt.getTime()).toBeGreaterThan(Date.now());
+      expect(result.grantedScopes).toEqual([
+        "Calendars.ReadWrite",
+        "User.Read",
+      ]);
+    });
+
+    it("classifies invalid_grant as authorizationRevoked", async () => {
+      const adapter = adapterWith(
+        new FakeTokenEndpoint({
+          refreshResponse: {
+            error: "invalid_grant",
+            error_description: "The refresh token has expired",
+          },
+        }),
+        new FakeIdTokenVerifier(),
+      );
+
+      const error = await adapter
+        .refreshAccessToken({ refreshToken: "revoked" })
+        .catch((e) => e);
+
+      expect((error as ProviderAuthError).reason).toBe("authorizationRevoked");
+    });
+
+    it("classifies HTTP 503 refresh failures as refreshFailed", async () => {
+      const adapter = adapterWith(
+        new FakeTokenEndpoint({
+          refreshError: { response: { status: 503 } },
+        }),
+        new FakeIdTokenVerifier(),
+      );
+
+      const error = await adapter
+        .refreshAccessToken({ refreshToken: "rt" })
+        .catch((e) => e);
+
+      expect((error as ProviderAuthError).reason).toBe("refreshFailed");
+    });
+
+    it("maps admin-consent refresh errors to consentRequired", async () => {
+      const adapter = adapterWith(
+        new FakeTokenEndpoint({
+          refreshResponse: {
+            error: "interaction_required",
+          },
+        }),
+        new FakeIdTokenVerifier(),
+      );
+
+      const error = await adapter
+        .refreshAccessToken({ refreshToken: "rt" })
+        .catch((e) => e);
+
+      expect((error as ProviderAuthError).reason).toBe("consentRequired");
+    });
+
+    it("fails when the provider returns no access token or expiry", async () => {
+      const adapter = adapterWith(
+        new FakeTokenEndpoint({
+          refreshResponse: { access_token: "tok" },
+        }),
+        new FakeIdTokenVerifier(),
+      );
+
+      const error = await adapter
+        .refreshAccessToken({ refreshToken: "rt" })
+        .catch((e) => e);
+
+      expect((error as ProviderAuthError).reason).toBe("refreshFailed");
+    });
+  });
+
+  describe("revoke", () => {
+    it("never throws because Microsoft has no revocation endpoint", async () => {
+      const adapter = adapterWith(
+        new FakeTokenEndpoint(),
+        new FakeIdTokenVerifier(),
+      );
+
+      await expect(adapter.revoke({ token: "token" })).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/sync/src/providers/microsoft/microsoft-auth.adapter.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-auth.adapter.ts
@@ -1,0 +1,358 @@
+import { createRemoteJWKSet, type JWTPayload, jwtVerify } from "jose";
+import { ProviderAccountFactsSchema } from "@core/types/sync/connection.contracts";
+import { isMicrosoftConsentRequired } from "@sync/providers/microsoft/microsoft-consent";
+import { MICROSOFT_SCOPES } from "@sync/providers/microsoft/microsoft-scopes";
+import {
+  type ProviderAuthAdapter,
+  ProviderAuthError,
+  type ProviderAuthorization,
+  type RefreshedCredential,
+} from "@sync/providers/provider-auth.port";
+import { redactedCause } from "@sync/safety/redact-error";
+
+export const MICROSOFT_AUTHORIZE_URL =
+  "https://login.microsoftonline.com/common/oauth2/v2.0/authorize";
+export const MICROSOFT_TOKEN_URL =
+  "https://login.microsoftonline.com/common/oauth2/v2.0/token";
+export const MICROSOFT_JWKS_URL =
+  "https://login.microsoftonline.com/common/discovery/v2.0/keys";
+
+export interface MicrosoftTokenResponse {
+  readonly access_token?: string;
+  readonly refresh_token?: string;
+  readonly id_token?: string;
+  readonly scope?: string;
+  readonly expires_in?: number;
+  readonly token_type?: string;
+  readonly error?: string;
+  readonly error_description?: string;
+}
+
+export interface MicrosoftIdTokenClaims extends JWTPayload {
+  readonly oid?: string;
+  readonly preferred_username?: string;
+  readonly email?: string;
+  readonly name?: string;
+}
+
+// Narrow token-endpoint surface the adapter depends on. Tests inject a fake
+// that replays fixture responses without network access.
+export interface MicrosoftTokenEndpoint {
+  exchangeAuthorizationCode(input: {
+    code: string;
+    redirectUri: string;
+    clientId: string;
+    clientSecret: string;
+  }): Promise<MicrosoftTokenResponse>;
+
+  refreshAccessToken(input: {
+    refreshToken: string;
+    clientId: string;
+    clientSecret: string;
+  }): Promise<MicrosoftTokenResponse>;
+}
+
+export interface MicrosoftIdTokenVerifier {
+  verify(idToken: string, audience: string): Promise<MicrosoftIdTokenClaims>;
+}
+
+export type MicrosoftTokenEndpointFactory = () => MicrosoftTokenEndpoint;
+export type MicrosoftIdTokenVerifierFactory = (
+  clientId: string,
+) => MicrosoftIdTokenVerifier;
+
+// Microsoft implementation of the provider authorization port. Identity is the
+// verified id-token `oid` — never the email, which is mutable and reassignable.
+export class MicrosoftAuthAdapter implements ProviderAuthAdapter {
+  #clientId: string;
+  #clientSecret: string;
+  #makeTokenEndpoint: MicrosoftTokenEndpointFactory;
+  #makeIdTokenVerifier: MicrosoftIdTokenVerifierFactory;
+
+  constructor(
+    clientId: string,
+    clientSecret: string,
+    makeTokenEndpoint: MicrosoftTokenEndpointFactory = () =>
+      new FetchMicrosoftTokenEndpoint(),
+    makeIdTokenVerifier: MicrosoftIdTokenVerifierFactory = () =>
+      new JwksMicrosoftIdTokenVerifier(),
+  ) {
+    if (!clientId || !clientSecret) {
+      throw new Error(
+        "MicrosoftAuthAdapter requires a Microsoft client id and secret",
+      );
+    }
+    this.#clientId = clientId;
+    this.#clientSecret = clientSecret;
+    this.#makeTokenEndpoint = makeTokenEndpoint;
+    this.#makeIdTokenVerifier = makeIdTokenVerifier;
+  }
+
+  buildAuthorizationUrl(input: {
+    state: string;
+    redirectUri: string;
+    selectAccount?: boolean;
+    extraScopes?: readonly string[];
+  }): string {
+    const url = new URL(MICROSOFT_AUTHORIZE_URL);
+    url.searchParams.set("client_id", this.#clientId);
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("response_mode", "query");
+    url.searchParams.set(
+      "scope",
+      [...MICROSOFT_SCOPES, ...(input.extraScopes ?? [])].join(" "),
+    );
+    url.searchParams.set("state", input.state);
+    url.searchParams.set("redirect_uri", input.redirectUri);
+    if (input.selectAccount) {
+      url.searchParams.set("prompt", "select_account");
+    }
+    return url.toString();
+  }
+
+  async exchangeAuthorizationCode(input: {
+    code: string;
+    redirectUri: string;
+  }): Promise<ProviderAuthorization> {
+    const tokenEndpoint = this.#makeTokenEndpoint();
+    let response: MicrosoftTokenResponse;
+    try {
+      response = await tokenEndpoint.exchangeAuthorizationCode({
+        code: input.code,
+        redirectUri: input.redirectUri,
+        clientId: this.#clientId,
+        clientSecret: this.#clientSecret,
+      });
+    } catch (error) {
+      throw new ProviderAuthError(
+        "exchangeFailed",
+        "Microsoft rejected the authorization code exchange",
+        { cause: redactedCause(error) },
+      );
+    }
+
+    if (response.error) {
+      throw consentOrExchangeError(
+        response.error,
+        response.error_description,
+        "Microsoft rejected the authorization code exchange",
+      );
+    }
+
+    if (!response.refresh_token) {
+      throw new ProviderAuthError(
+        "missingRefreshToken",
+        "Microsoft returned no refresh token; re-consent is required",
+      );
+    }
+    if (!response.id_token) {
+      throw new ProviderAuthError(
+        "invalidIdToken",
+        "Microsoft returned no id token to identify the account",
+      );
+    }
+
+    const claims = await this.verifyIdToken(response.id_token);
+    if (!claims.oid) {
+      throw new ProviderAuthError(
+        "missingIdentity",
+        "Microsoft id token carried no subject to identify the account",
+      );
+    }
+
+    const account = ProviderAccountFactsSchema.parse({
+      providerAccountId: claims.oid,
+      email: claims.preferred_username || claims.email || null,
+      displayName: claims.name || null,
+    });
+
+    return {
+      account,
+      refreshToken: response.refresh_token,
+      grantedScopes: parseGrantedScopes(response.scope),
+    };
+  }
+
+  async refreshAccessToken(input: {
+    refreshToken: string;
+  }): Promise<RefreshedCredential> {
+    const tokenEndpoint = this.#makeTokenEndpoint();
+    let response: MicrosoftTokenResponse;
+    try {
+      response = await tokenEndpoint.refreshAccessToken({
+        refreshToken: input.refreshToken,
+        clientId: this.#clientId,
+        clientSecret: this.#clientSecret,
+      });
+    } catch (error) {
+      throw new ProviderAuthError(
+        isRefreshPermanentlyRejected(error)
+          ? "authorizationRevoked"
+          : "refreshFailed",
+        "Microsoft rejected the refresh token",
+        { cause: redactedCause(error) },
+      );
+    }
+
+    if (response.error) {
+      throw consentOrExchangeError(
+        response.error,
+        response.error_description,
+        "Microsoft rejected the refresh token",
+        isRefreshPermanentlyRejectedResponse(response)
+          ? "authorizationRevoked"
+          : "refreshFailed",
+      );
+    }
+
+    if (!response.access_token || response.expires_in === undefined) {
+      throw new ProviderAuthError(
+        "refreshFailed",
+        "Microsoft returned no access token or expiry on refresh",
+      );
+    }
+
+    return {
+      accessToken: response.access_token,
+      expiresAt: new Date(Date.now() + response.expires_in * 1000),
+      grantedScopes: parseGrantedScopes(response.scope),
+    };
+  }
+
+  async revoke(_input: { token: string }): Promise<void> {
+    // Microsoft Entra has no token-revocation endpoint for delegated OAuth
+    // tokens. Disconnect removes the stored credential locally; this is a
+    // documented no-op so callers can still invoke revoke uniformly.
+  }
+
+  private async verifyIdToken(
+    idToken: string,
+  ): Promise<MicrosoftIdTokenClaims> {
+    try {
+      return await this.#makeIdTokenVerifier(this.#clientId).verify(
+        idToken,
+        this.#clientId,
+      );
+    } catch (error) {
+      throw new ProviderAuthError(
+        "invalidIdToken",
+        "Microsoft id token failed verification",
+        { cause: redactedCause(error) },
+      );
+    }
+  }
+}
+
+class FetchMicrosoftTokenEndpoint implements MicrosoftTokenEndpoint {
+  async exchangeAuthorizationCode(input: {
+    code: string;
+    redirectUri: string;
+    clientId: string;
+    clientSecret: string;
+  }): Promise<MicrosoftTokenResponse> {
+    return postTokenEndpoint({
+      client_id: input.clientId,
+      client_secret: input.clientSecret,
+      code: input.code,
+      redirect_uri: input.redirectUri,
+      grant_type: "authorization_code",
+    });
+  }
+
+  async refreshAccessToken(input: {
+    refreshToken: string;
+    clientId: string;
+    clientSecret: string;
+  }): Promise<MicrosoftTokenResponse> {
+    return postTokenEndpoint({
+      client_id: input.clientId,
+      client_secret: input.clientSecret,
+      refresh_token: input.refreshToken,
+      grant_type: "refresh_token",
+    });
+  }
+}
+
+class JwksMicrosoftIdTokenVerifier implements MicrosoftIdTokenVerifier {
+  #jwks = createRemoteJWKSet(new URL(MICROSOFT_JWKS_URL));
+
+  async verify(
+    idToken: string,
+    audience: string,
+  ): Promise<MicrosoftIdTokenClaims> {
+    const { payload } = await jwtVerify(idToken, this.#jwks, {
+      audience,
+    });
+    return payload as MicrosoftIdTokenClaims;
+  }
+}
+
+async function postTokenEndpoint(
+  body: Record<string, string>,
+): Promise<MicrosoftTokenResponse> {
+  const response = await fetch(MICROSOFT_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(body),
+  });
+  const data = (await response.json()) as MicrosoftTokenResponse;
+  if (!response.ok && !data.error) {
+    throw Object.assign(new Error("token_endpoint_error"), {
+      response: { status: response.status, data },
+    });
+  }
+  return data;
+}
+
+function consentOrExchangeError(
+  error: string,
+  description: string | undefined,
+  message: string,
+  fallbackReason:
+    | "exchangeFailed"
+    | "refreshFailed"
+    | "authorizationRevoked" = "exchangeFailed",
+): never {
+  if (isMicrosoftConsentRequired(error, description)) {
+    throw new ProviderAuthError(
+      "consentRequired",
+      "Microsoft requires admin consent before Compass can connect",
+    );
+  }
+  throw new ProviderAuthError(fallbackReason, message);
+}
+
+const PERMANENT_REFRESH_ERRORS = new Set(["invalid_grant"]);
+
+function tokenEndpointErrorCode(error: unknown): string | undefined {
+  const data = (
+    error as {
+      response?: { data?: { error?: unknown } };
+    }
+  )?.response?.data;
+  return typeof data?.error === "string" ? data.error : undefined;
+}
+
+function tokenEndpointStatus(error: unknown): number | undefined {
+  return (error as { response?: { status?: number } })?.response?.status;
+}
+
+function isRefreshPermanentlyRejected(error: unknown): boolean {
+  const code = tokenEndpointErrorCode(error);
+  if (code && PERMANENT_REFRESH_ERRORS.has(code)) return true;
+  const status = tokenEndpointStatus(error);
+  return status === 400 || status === 401;
+}
+
+function isRefreshPermanentlyRejectedResponse(
+  response: MicrosoftTokenResponse,
+): boolean {
+  return Boolean(
+    response.error && PERMANENT_REFRESH_ERRORS.has(response.error),
+  );
+}
+
+function parseGrantedScopes(scope: string | null | undefined): string[] {
+  if (!scope) return [];
+  return scope.split(/\s+/).filter(Boolean);
+}

--- a/packages/sync/src/providers/microsoft/microsoft-consent.test.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-consent.test.ts
@@ -1,0 +1,18 @@
+import { isMicrosoftConsentRequired } from "@sync/providers/microsoft/microsoft-consent";
+
+describe("Microsoft OAuth callback consent errors", () => {
+  it.each([
+    ["consent_required", undefined],
+    ["interaction_required", undefined],
+    [
+      "invalid_grant",
+      "AADSTS65001: The user or administrator has not consented to use the application",
+    ],
+  ] as const)("detects admin consent for %s", (error, description) => {
+    expect(isMicrosoftConsentRequired(error, description)).toBe(true);
+  });
+
+  it("does not treat a user cancellation as admin consent", () => {
+    expect(isMicrosoftConsentRequired("access_denied")).toBe(false);
+  });
+});

--- a/packages/sync/src/providers/microsoft/microsoft-consent.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-consent.ts
@@ -1,0 +1,18 @@
+// Microsoft Entra consent and interaction errors. Tenants that require admin
+// approval surface these instead of a usable authorization code.
+const ADMIN_CONSENT_ERROR_CODE = "AADSTS65001";
+
+export function isMicrosoftConsentRequired(
+  error?: string | null,
+  description?: string | null,
+): boolean {
+  const normalizedError = error?.trim().toLowerCase();
+  if (
+    normalizedError === "consent_required" ||
+    normalizedError === "interaction_required"
+  ) {
+    return true;
+  }
+  if (!description) return false;
+  return description.includes(ADMIN_CONSENT_ERROR_CODE);
+}

--- a/packages/sync/src/providers/microsoft/microsoft-scopes.test.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-scopes.test.ts
@@ -1,0 +1,45 @@
+import { type ProviderCapability } from "@core/types/sync/identity.contracts";
+import {
+  MICROSOFT_PROVIDER_CAPABILITIES,
+  MICROSOFT_SCOPE_CALENDARS_READWRITE,
+  MICROSOFT_SCOPE_PEOPLE_READ,
+  microsoftCapabilitiesFromScopes,
+  microsoftScopesForFeatures,
+} from "@sync/providers/microsoft/microsoft-scopes";
+
+describe("microsoftScopesForFeatures", () => {
+  it("returns People.Read only when contacts is requested", () => {
+    expect(microsoftScopesForFeatures(["contacts"])).toEqual([
+      MICROSOFT_SCOPE_PEOPLE_READ,
+    ]);
+    expect(microsoftScopesForFeatures([])).toEqual([]);
+  });
+});
+
+describe("microsoftCapabilitiesFromScopes", () => {
+  it("derives calendar and contacts capabilities from granted scopes", () => {
+    expect(
+      microsoftCapabilitiesFromScopes([
+        MICROSOFT_SCOPE_CALENDARS_READWRITE,
+        MICROSOFT_SCOPE_PEOPLE_READ,
+      ]),
+    ).toEqual([
+      "readEvents",
+      "readBusy",
+      "changeNotifications",
+      "incrementalChanges",
+      "writeEvents",
+      "inviteAttendees",
+      "suggestContacts",
+    ] satisfies ProviderCapability[]);
+  });
+
+  it("returns no capabilities when calendar access was withheld", () => {
+    expect(microsoftCapabilitiesFromScopes(["openid", "profile"])).toEqual([]);
+  });
+
+  it("matches MICROSOFT_PROVIDER_CAPABILITIES for the full scope set", () => {
+    expect(MICROSOFT_PROVIDER_CAPABILITIES).toContain("readEvents");
+    expect(MICROSOFT_PROVIDER_CAPABILITIES).toContain("suggestContacts");
+  });
+});

--- a/packages/sync/src/providers/microsoft/microsoft-scopes.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-scopes.ts
@@ -1,0 +1,67 @@
+import { type ProviderCapability } from "@core/types/sync/identity.contracts";
+
+export const MICROSOFT_SCOPE_OPENID = "openid";
+export const MICROSOFT_SCOPE_PROFILE = "profile";
+export const MICROSOFT_SCOPE_EMAIL = "email";
+export const MICROSOFT_SCOPE_OFFLINE_ACCESS = "offline_access";
+export const MICROSOFT_SCOPE_USER_READ = "User.Read";
+export const MICROSOFT_SCOPE_CALENDARS_READWRITE = "Calendars.ReadWrite";
+export const MICROSOFT_SCOPE_PEOPLE_READ = "People.Read";
+
+// Scopes Sync requests from Microsoft on every connect flow. Contacts are
+// optional feature scopes (below), added only when the caller asks for the
+// feature, and never required for a connection to work.
+export const MICROSOFT_SCOPES: readonly string[] = [
+  MICROSOFT_SCOPE_OPENID,
+  MICROSOFT_SCOPE_PROFILE,
+  MICROSOFT_SCOPE_EMAIL,
+  MICROSOFT_SCOPE_OFFLINE_ACCESS,
+  MICROSOFT_SCOPE_USER_READ,
+  MICROSOFT_SCOPE_CALENDARS_READWRITE,
+];
+
+// Optional scope backing attendee contact suggestions. Requested only when a
+// connect/reconnect begins with the "contacts" feature; the user can decline
+// it and the connection still works — capabilities are derived from what was
+// actually granted.
+export const CONTACTS_FEATURE_SCOPES: readonly string[] = [
+  MICROSOFT_SCOPE_PEOPLE_READ,
+];
+
+export function microsoftScopesForFeatures(
+  features: readonly string[],
+): readonly string[] {
+  return features.includes("contacts") ? CONTACTS_FEATURE_SCOPES : [];
+}
+
+// Derive connection capabilities from the scopes Microsoft actually granted
+// (which may be a subset of those requested). Calendars.ReadWrite covers read,
+// write, push subscriptions, and delta sync; People.Read covers suggestions.
+export function microsoftCapabilitiesFromScopes(
+  scopes: readonly string[],
+): ProviderCapability[] {
+  const granted = new Set(scopes);
+  const capabilities: ProviderCapability[] = [];
+
+  if (granted.has(MICROSOFT_SCOPE_CALENDARS_READWRITE)) {
+    capabilities.push(
+      "readEvents",
+      "readBusy",
+      "changeNotifications",
+      "incrementalChanges",
+      "writeEvents",
+      "inviteAttendees",
+    );
+  }
+  if (granted.has(MICROSOFT_SCOPE_PEOPLE_READ)) {
+    capabilities.push("suggestContacts");
+  }
+
+  return capabilities;
+}
+
+export const MICROSOFT_PROVIDER_CAPABILITIES: readonly ProviderCapability[] =
+  microsoftCapabilitiesFromScopes([
+    ...MICROSOFT_SCOPES,
+    ...CONTACTS_FEATURE_SCOPES,
+  ]);

--- a/packages/sync/src/providers/provider-auth.port.ts
+++ b/packages/sync/src/providers/provider-auth.port.ts
@@ -76,6 +76,7 @@ export type ProviderAuthErrorReason =
   | "missingRefreshToken" // no refresh token returned (e.g. prior consent)
   | "missingIdentity" // the account could not be identified from the grant
   | "invalidIdToken" // the id token was absent or failed verification
+  | "consentRequired" // the tenant requires admin consent before the app can connect
   | "authorizationRevoked" // the refresh token is no longer valid (revoked/expired)
   | "refreshFailed"; // the token refresh failed for a transient/unknown reason
 

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -56,7 +56,11 @@ import {
   HORIZON_PAST_MONTHS,
 } from "@sync/domain/horizon";
 import { signOAuthState, verifyOAuthState } from "@sync/oauth/oauth-state";
-import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
+import { isMicrosoftConsentRequired } from "@sync/providers/microsoft/microsoft-consent";
+import {
+  type ProviderAuthAdapter,
+  ProviderAuthError,
+} from "@sync/providers/provider-auth.port";
 import {
   GOOGLE_CALLBACK_PATH,
   OAUTH_CALLBACK_PARAM_PATH,
@@ -732,8 +736,20 @@ export function registerConnectionRoutes(
         return redirect("error");
       }
       if (!deps.mongo.isConnected) return redirect("error");
-      // The user declined consent, or the provider returned an error.
-      if (typeof req.query["error"] === "string") return redirect("declined");
+      const oauthError = req.query["error"];
+      const oauthDescription = req.query["error_description"];
+      if (typeof oauthError === "string") {
+        if (
+          routeProvider === "microsoft" &&
+          isMicrosoftConsentRequired(
+            oauthError,
+            typeof oauthDescription === "string" ? oauthDescription : undefined,
+          )
+        ) {
+          return redirect("consentRequired");
+        }
+        return redirect("declined");
+      }
 
       const code = req.query["code"];
       const state = req.query["state"];
@@ -765,6 +781,12 @@ export function registerConnectionRoutes(
             redirectUri: `${deps.callbackBaseUrl}${registration.callbackPath}`,
           });
       } catch (error) {
+        if (
+          error instanceof ProviderAuthError &&
+          error.reason === "consentRequired"
+        ) {
+          return redirect("consentRequired");
+        }
         // Bad code, no refresh token, unverifiable identity — nothing to link.
         logger.error("OAuth code exchange failed", redactedCause(error));
         return redirect("error");


### PR DESCRIPTION
Fixes #3240

## What and why

Implements the Microsoft Entra auth adapter behind `ProviderAuthAdapter`, mirroring the Google pattern with an injectable token-endpoint interface and JWKS id_token verification. Adds `microsoft-scopes.ts` with base scopes, optional `People.Read` contacts feature scopes, and `capabilitiesFromScopes`. Admin-consent-required tenants surface a typed `consentRequired` reason (callback query errors, token exchange, and refresh) that `connection.routes` redirects as `status=consentRequired` for Microsoft OAuth callbacks.

Spec: [`docs/features/calendar-providers.md`](https://github.com/KeepSoftwareSimple/compass-calendar/blob/main/docs/features/calendar-providers.md)

## Verify

```
Summary
Selected packages: core, sync, backend
Checks run: test:core, test:sync:fast, test:backend:fast, type-check, lint, knip
Checks skipped: (none)

✓ All checks passed
VERDICT: PASS
```

Checks run: `bun test:sync`, `bun test:core`, `bun run type-check`, `bun lint`, `bun knip`, `bun run verify --strict`