### PR TITLE
feat(sync): add shared adapter contract suite with recorded google corpus

### DIFF
--- a/.agents/handoffs/3236.md
+++ b/.agents/handoffs/3236.md
@@ -1,0 +1,34 @@
+---
+schema_version: 1
+task_id: "3236"
+from: Implementer
+to: GitHub
+owner: GitHub
+status: verifying
+artifact:
+  - path: packages/sync/src/providers/__contract__/adapter-contract.ts
+  - path: packages/sync/src/providers/__contract__/google.contract.test.ts
+  - path: packages/sync/src/providers/__contract__/google-contract.factory.ts
+  - path: packages/sync/src/providers/__contract__/recording-api.ts
+  - path: packages/sync/src/providers/__contract__/README.md
+evidence:
+  - command: bun test:sync
+    result: pass (1236 pass, 1 skip)
+  - command: bun run type-check
+    result: pass
+  - command: bun lint
+    result: pass
+  - command: bun knip
+    result: pass
+assumptions:
+  - "LIVE_PROVIDER=google skips auth exchange, revoked refresh, and watch so L-10 does not revoke the smoke grant or open a channel without a public callback."
+  - "Apple stays on discovery-only cases until A-11 wires the rest of the adapter set."
+open_risks: []
+next_deadline: 2026-09-05T02:00:00Z
+retry: 0
+approval: none
+waiting_on: null
+escalation: null
+---
+
+P0 WP-11: shared adapter contract suite with a recorded Google fixture corpus.

--- a/knip.json
+++ b/knip.json
@@ -23,7 +23,11 @@
         "src/app.ts",
         "src/__tests__/sync.preload.ts",
         "src/__tests__/sync.preload.fast.ts",
-        "src/__tests__/helpers/mongo-memory.ts"
+        "src/__tests__/helpers/mongo-memory.ts",
+        "src/providers/__contract__/adapter-contract.ts",
+        "src/providers/__contract__/google-contract.factory.ts",
+        "src/providers/__contract__/recording-api.ts",
+        "src/providers/__contract__/discovery.contract.ts"
       ],
       "project": ["src/**/*.ts!"]
     },

--- a/packages/sync/src/providers/__contract__/README.md
+++ b/packages/sync/src/providers/__contract__/README.md
@@ -1,30 +1,29 @@
 # Provider adapter contract suite
 
-Shared discovery checks run every registered adapter against the same bar.
-Add a provider by listing `DiscoveryContractCase` entries in
-`<kind>.contract.test.ts` and replaying request/response pairs through the
-adapter's injectable narrow API (for Apple, the CalDAV client's `fetch`).
+Shared checks that every calendar adapter must pass. Google runs against a
+recorded fixture corpus under `fixtures/google/` (synthesized from the
+existing adapter tests; no live account). Set `LIVE_PROVIDER=<kind>` to run
+the same cases against the real API factory (L-10).
 
-The full suite (auth, reader, writer, notifications, normalizer) lands in P0
-WP-11 (#3236). This directory currently carries discovery cases only.
-
-## Add Apple-style discovery coverage
+## Add a provider (under 30 lines)
 
 ```typescript
-import { type DiscoveryContractCase } from "@sync/providers/__contract__/discovery.contract";
+import { describeProviderContract } from "@sync/providers/__contract__/adapter-contract";
+import { type ProviderAdapters } from "@sync/providers/provider-adapters";
 
-const CASES: DiscoveryContractCase[] = [
-  {
-    name: "detects primary",
-    username: email,
-    password: secret,
-    run: async (adapter) => {
-      const result = await adapter.discoverCalendars({ accessToken: secret });
-      expect(result.cursor).toBeNull();
-    },
-  },
-];
+export function microsoftRecordedFactory(corpusDir: string): ProviderAdapters {
+  return replayFrom(corpusDir); // replay fixtures/microsoft/*.json
+}
+
+describeProviderContract("microsoft", microsoftRecordedFactory);
 ```
 
-Record live fixtures with the founder account in A-11 (#3275); redact secrets
-before committing.
+Record live request/response pairs with `recordingApi(realApi, corpusDir, caseName)`
+(used by M-12 / A-11). Redact before committing:
+
+- `Authorization` headers and any `*token*`, `*secret*`, `*password*` keys
+- email addresses
+- `Bearer …` values
+
+Apple discovery-only cases stay in `apple.contract.test.ts` until the rest of
+the Apple adapter set lands (A-11).

--- a/packages/sync/src/providers/__contract__/adapter-contract.ts
+++ b/packages/sync/src/providers/__contract__/adapter-contract.ts
@@ -1,0 +1,415 @@
+import { EventScheduleSchema } from "@core/types/event.contracts";
+import { SyncEventContentSchema } from "@core/types/sync/event.contracts";
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+import { type ProviderAdapters } from "@sync/providers/provider-adapters";
+import { ProviderAuthError } from "@sync/providers/provider-auth.port";
+import { type ProviderEventReadError } from "@sync/providers/provider-event-reader.port";
+import {
+  type ProviderEventWriter,
+  ProviderWriteError,
+} from "@sync/providers/provider-event-writer.port";
+import { beforeEach, describe, expect, it } from "bun:test";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export type ProviderContractFactory = (corpusDir: string) => ProviderAdapters;
+
+export interface ProviderContractOptions {
+  readonly corpusDir?: string;
+  readonly accessToken?: string;
+  readonly calendarId?: string;
+  readonly refreshToken?: string;
+  readonly revokedRefreshToken?: string;
+  readonly expiredCursor?: string;
+  readonly skipAuthExchange?: boolean;
+  readonly skipAuthRevoked?: boolean;
+  readonly skipWatch?: boolean;
+}
+
+const CONTRACT_ROOT = dirname(fileURLToPath(import.meta.url));
+
+export const CONTRACT_EVENT_ID = "abc12deadbeef00000000000";
+
+export const CONTRACT_CONTENT = SyncEventContentSchema.parse({
+  title: "Contract create",
+  description: "WP-11 contract suite",
+  location: null,
+  organizer: null,
+  attendees: [],
+  conference: null,
+});
+
+export const CONTRACT_SCHEDULE = EventScheduleSchema.parse({
+  kind: "timed",
+  start: "2025-01-15T09:00:00-05:00",
+  end: "2025-01-15T10:00:00-05:00",
+  timeZone: "America/New_York",
+});
+
+const ACCESS_ROLES = new Set(["owner", "editor", "viewer", "busyOnly"]);
+
+export function defaultCorpusDir(kind: ProviderKind): string {
+  return join(CONTRACT_ROOT, "fixtures", kind);
+}
+
+/**
+ * Run the shared adapter contract against one provider. `factory` builds
+ * the adapter set from a recorded fixture corpus (or, when `LIVE_PROVIDER`
+ * is set, from the real API constructors).
+ */
+export function describeProviderContract(
+  kind: ProviderKind,
+  factory: ProviderContractFactory,
+  options: ProviderContractOptions = {},
+): void {
+  const corpusDir = options.corpusDir ?? defaultCorpusDir(kind);
+  const token = () =>
+    process.env["LIVE_ACCESS_TOKEN"] ??
+    options.accessToken ??
+    "contract-access-token";
+  const calendarId =
+    process.env["LIVE_CALENDAR_ID"] ?? options.calendarId ?? "primary";
+  const refreshToken =
+    options.refreshToken ??
+    process.env["SMOKE_GOOGLE_REFRESH_TOKEN"] ??
+    "refresh-token-value";
+  const revokedRefreshToken = options.revokedRefreshToken ?? "revoked";
+  const expiredCursor = options.expiredCursor ?? "expired-sync-token";
+
+  describe(`${kind} adapter contract`, () => {
+    let adapters: ProviderAdapters;
+    let accessToken: string;
+
+    beforeEach(() => {
+      adapters = factory(corpusDir);
+      accessToken = token();
+    });
+
+    describe("auth", () => {
+      const exchange = options.skipAuthExchange ? it.skip : it;
+      const revoked = options.skipAuthRevoked ? it.skip : it;
+
+      exchange("exchange yields identity and a refresh token", async () => {
+        const result = await adapters.auth.exchangeAuthorizationCode({
+          code: "auth-code",
+          redirectUri: "https://example.com/sync/google",
+        });
+        expect(result.account.providerAccountId.length).toBeGreaterThan(0);
+        expect(result.refreshToken.length).toBeGreaterThan(0);
+      });
+
+      it("refresh mints an access token", async () => {
+        const result = await adapters.auth.refreshAccessToken({
+          refreshToken,
+        });
+        expect(result.accessToken.length).toBeGreaterThan(0);
+        expect(result.expiresAt.getTime()).toBeGreaterThan(Date.now() - 60_000);
+      });
+
+      revoked("revoked grant maps to authorizationRevoked", async () => {
+        const error = await adapters.auth
+          .refreshAccessToken({ refreshToken: revokedRefreshToken })
+          .catch((caught: unknown) => caught);
+        expect(error).toBeInstanceOf(ProviderAuthError);
+        expect((error as ProviderAuthError).reason).toBe(
+          "authorizationRevoked",
+        );
+      });
+    });
+
+    describe("discovery", () => {
+      it("detects a primary calendar, colors, access roles, and a cursor", async () => {
+        const result = await adapters.calendars.discoverCalendars({
+          accessToken,
+        });
+        const primary = result.calendars.filter((calendar) => calendar.primary);
+        expect(primary).toHaveLength(1);
+        expect(
+          result.calendars.some((calendar) => calendar.color !== null),
+        ).toBe(true);
+        for (const calendar of result.calendars) {
+          expect(ACCESS_ROLES.has(calendar.accessRole)).toBe(true);
+        }
+        expect(
+          result.cursor === null || typeof result.cursor === "string",
+        ).toBe(true);
+      });
+    });
+
+    describe("reader", () => {
+      it("pages, yields nextSyncToken only at the end, and counts skipped events", async () => {
+        const first = await adapters.reader.listEventPage({
+          accessToken,
+          calendarId,
+        });
+        expect(first.skipped).toBeGreaterThanOrEqual(1);
+
+        let page = first;
+        let pages = 1;
+        while (page.nextPageToken) {
+          expect(page.nextSyncToken).toBeNull();
+          page = await adapters.reader.listEventPage({
+            accessToken,
+            calendarId,
+            pageToken: page.nextPageToken,
+          });
+          pages += 1;
+        }
+        expect(pages).toBeGreaterThanOrEqual(1);
+        expect(page.nextPageToken).toBeNull();
+        expect(
+          page.nextSyncToken === null || typeof page.nextSyncToken === "string",
+        ).toBe(true);
+      });
+
+      it("maps an expired cursor to cursorExpired", async () => {
+        try {
+          await adapters.reader.listEventPage({
+            accessToken,
+            calendarId,
+            cursor: expiredCursor,
+          });
+          throw new Error("expected cursorExpired");
+        } catch (caught) {
+          expect((caught as ProviderEventReadError).reason).toBe(
+            "cursorExpired",
+          );
+        }
+      });
+
+      it("keeps masters and exceptions and does not expand occurrences", async () => {
+        const events = await collectEvents(adapters, accessToken, calendarId);
+        const masters = events.filter(
+          (event) =>
+            event.kind === "event" && event.recurrence.kind === "seriesMaster",
+        );
+        const instances = events.filter(
+          (event) =>
+            event.kind === "event" && event.recurrence.kind === "instance",
+        );
+        expect(masters.length).toBeGreaterThanOrEqual(1);
+        expect(instances.length).toBeGreaterThanOrEqual(1);
+        // A daily series must not be expanded into one row per day.
+        expect(instances.length).toBeLessThan(5);
+      });
+    });
+
+    describe("writer", () => {
+      it("create returns id and version, stale patch conflicts, delete is idempotent, fetchInstanceAt resolves", async () => {
+        const created = await adapters.writer.createEvent({
+          accessToken,
+          calendarId,
+          providerEventId: CONTRACT_EVENT_ID,
+          content: CONTRACT_CONTENT,
+          schedule: CONTRACT_SCHEDULE,
+          recurrence: { kind: "single" },
+          invitation: "none",
+        });
+        expect(created.providerEventId.length).toBeGreaterThan(0);
+        expect(created.providerVersion.length).toBeGreaterThan(0);
+
+        await assertWriterRejectsStaleVersion(adapters.writer, {
+          accessToken,
+          calendarId,
+          skipCreate: true,
+          providerEventId: created.providerEventId,
+        });
+
+        await adapters.writer.deleteEvent({
+          accessToken,
+          calendarId,
+          providerEventId: created.providerEventId,
+          expectedVersion: null,
+          invitation: "none",
+        });
+        await adapters.writer.deleteEvent({
+          accessToken,
+          calendarId,
+          providerEventId: created.providerEventId,
+          expectedVersion: null,
+          invitation: "none",
+        });
+
+        const instance = await adapters.writer.fetchInstanceAt({
+          accessToken,
+          calendarId,
+          seriesProviderEventId: "series-1",
+          originalStartAt: "2025-01-15T14:00:00.000Z",
+          scheduleKind: "timed",
+        });
+        expect(instance).not.toBeNull();
+        expect(instance?.providerEventId.length).toBeGreaterThan(0);
+      });
+    });
+
+    describe("notifications", () => {
+      const watch = options.skipWatch ? it.skip : it;
+      watch("watch returns a channel", async () => {
+        const channel = await adapters.notifications.watch({
+          accessToken,
+          calendarId,
+          channelId: "chan-1",
+          token: "chan-token",
+          callbackUrl: "https://sync.example.com/callbacks/google",
+        });
+        expect(channel.channelId).toBe("chan-1");
+        expect(channel.resourceId.length).toBeGreaterThan(0);
+        expect(channel.expiresAt).toBeInstanceOf(Date);
+      });
+
+      it("parseNotification accepts a valid callback, rejects tampered, and handles validation", () => {
+        const valid = adapters.notifications.parseNotification({
+          headers: {
+            "x-goog-channel-id": "chan-1",
+            "x-goog-channel-token": "chan-token",
+            "x-goog-resource-id": "res-1",
+            "x-goog-resource-state": "exists",
+          },
+          body: {},
+          query: {},
+        });
+        expect(valid).not.toBeNull();
+        if (valid && "kind" in valid && valid.kind === "validation") {
+          throw new Error(
+            "valid Google callback must not be a validation handshake",
+          );
+        }
+        expect(valid && "channelId" in valid ? valid.channelId : null).toBe(
+          "chan-1",
+        );
+
+        const tampered = adapters.notifications.parseNotification({
+          headers: { "x-goog-resource-id": "res-1" },
+          body: {},
+          query: {},
+        });
+        expect(tampered).toBeNull();
+
+        const validation = adapters.notifications.parseNotification({
+          headers: {},
+          body: {},
+          query: { validationToken: "echo-me" },
+        });
+        if (
+          validation &&
+          "kind" in validation &&
+          validation.kind === "validation"
+        ) {
+          expect(validation.body.length).toBeGreaterThan(0);
+        } else {
+          // Google has no Graph validation handshake; null is the correct miss.
+          expect(validation).toBeNull();
+        }
+      });
+    });
+
+    describe("normalizer round-trips", () => {
+      it("covers timed, all-day, recurring, exception, cancelled, attendees, conference, and color", async () => {
+        const events = await collectEvents(adapters, accessToken, calendarId);
+        const active = events.filter((event) => event.kind === "event");
+        const cancelled = events.filter(
+          (event) => event.kind === "cancellation",
+        );
+
+        expect(active.some((event) => event.schedule.kind === "timed")).toBe(
+          true,
+        );
+        expect(active.some((event) => event.schedule.kind === "allDay")).toBe(
+          true,
+        );
+        expect(
+          active.some((event) => event.recurrence.kind === "seriesMaster"),
+        ).toBe(true);
+        expect(
+          active.some((event) => event.recurrence.kind === "instance"),
+        ).toBe(true);
+        expect(cancelled.length).toBeGreaterThanOrEqual(1);
+        expect(active.some((event) => event.content.attendees.length > 0)).toBe(
+          true,
+        );
+        expect(active.some((event) => event.content.conference !== null)).toBe(
+          true,
+        );
+        expect(
+          active.some(
+            (event) =>
+              event.content.color !== undefined ||
+              event.content.colorHex !== undefined,
+          ),
+        ).toBe(true);
+      });
+    });
+  });
+}
+
+async function collectEvents(
+  adapters: ProviderAdapters,
+  accessToken: string,
+  calendarId: string,
+) {
+  const events = [];
+  let pageToken: string | null = null;
+  do {
+    const page = await adapters.reader.listEventPage({
+      accessToken,
+      calendarId,
+      pageToken,
+    });
+    events.push(...page.events);
+    pageToken = page.nextPageToken;
+  } while (pageToken);
+  return events;
+}
+
+export async function assertWriterRejectsStaleVersion(
+  writer: ProviderEventWriter,
+  options: {
+    readonly accessToken?: string;
+    readonly calendarId?: string;
+    readonly skipCreate?: boolean;
+    readonly providerEventId?: string;
+  } = {},
+): Promise<void> {
+  const accessToken = options.accessToken ?? "contract-access-token";
+  const calendarId = options.calendarId ?? "primary";
+  let providerEventId = options.providerEventId ?? CONTRACT_EVENT_ID;
+
+  if (!options.skipCreate) {
+    const created = await writer.createEvent({
+      accessToken,
+      calendarId,
+      providerEventId,
+      content: CONTRACT_CONTENT,
+      schedule: CONTRACT_SCHEDULE,
+      recurrence: { kind: "single" },
+      invitation: "none",
+    });
+    providerEventId = created.providerEventId;
+  }
+
+  try {
+    await writer.patchEvent({
+      accessToken,
+      calendarId,
+      providerEventId,
+      expectedVersion: "stale-version-that-must-conflict",
+      content: CONTRACT_CONTENT,
+      schedule: CONTRACT_SCHEDULE,
+      recurrence: { kind: "single" },
+      invitation: "none",
+    });
+  } catch (error) {
+    if (
+      error instanceof ProviderWriteError &&
+      error.reason === "versionConflict"
+    ) {
+      return;
+    }
+    const reason =
+      error instanceof ProviderWriteError ? error.reason : String(error);
+    throw new Error(`expected versionConflict, got ${reason}`);
+  }
+  throw new Error(
+    "writer returned success for a stale expectedVersion; the contract requires versionConflict",
+  );
+}

--- a/packages/sync/src/providers/__contract__/cheating-writer.contract.test.ts
+++ b/packages/sync/src/providers/__contract__/cheating-writer.contract.test.ts
@@ -1,0 +1,73 @@
+import {
+  assertWriterRejectsStaleVersion,
+  CONTRACT_CONTENT,
+  CONTRACT_EVENT_ID,
+  CONTRACT_SCHEDULE,
+} from "@sync/providers/__contract__/adapter-contract";
+import { googleRecordedFactory } from "@sync/providers/__contract__/google-contract.factory";
+import { type ProviderEventRead } from "@sync/providers/provider-event.port";
+import {
+  type ProviderCreateInput,
+  type ProviderDeleteInput,
+  type ProviderEventWriter,
+  type ProviderFetchInput,
+  type ProviderInstanceFetchInput,
+  type ProviderPatchInput,
+  type ProviderWriteResult,
+} from "@sync/providers/provider-event-writer.port";
+import { describe, expect, it } from "bun:test";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const corpusDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "fixtures",
+  "google",
+);
+
+class CheatingWriter implements ProviderEventWriter {
+  async createEvent(input: ProviderCreateInput): Promise<ProviderWriteResult> {
+    return {
+      providerEventId: input.providerEventId,
+      providerVersion: '"v1"',
+    };
+  }
+
+  async patchEvent(input: ProviderPatchInput): Promise<ProviderWriteResult> {
+    return {
+      providerEventId: input.providerEventId,
+      providerVersion: '"v2"',
+    };
+  }
+
+  async deleteEvent(_input: ProviderDeleteInput): Promise<void> {}
+
+  async fetchEvent(
+    _input: ProviderFetchInput,
+  ): Promise<ProviderEventRead | null> {
+    return null;
+  }
+
+  async fetchInstanceAt(
+    _input: ProviderInstanceFetchInput,
+  ): Promise<ProviderEventRead | null> {
+    return null;
+  }
+}
+
+describe("adapter contract writer canary", () => {
+  it("fails when a fake writer returns success for a stale version", async () => {
+    await expect(
+      assertWriterRejectsStaleVersion(new CheatingWriter()),
+    ).rejects.toThrow(/stale expectedVersion/);
+  });
+
+  it("passes for the recorded Google writer", async () => {
+    await assertWriterRejectsStaleVersion(
+      googleRecordedFactory(corpusDir).writer,
+    );
+    expect(CONTRACT_EVENT_ID).toBeTruthy();
+    expect(CONTRACT_CONTENT.title).toBe("Contract create");
+    expect(CONTRACT_SCHEDULE.kind).toBe("timed");
+  });
+});

--- a/packages/sync/src/providers/__contract__/fixtures/google/auth.json
+++ b/packages/sync/src/providers/__contract__/fixtures/google/auth.json
@@ -1,0 +1,25 @@
+{
+  "exchange": {
+    "tokens": {
+      "refresh_token": "refresh-token-value",
+      "access_token": "access-token-value",
+      "id_token": "id-token-value",
+      "scope": "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/calendar"
+    },
+    "payload": {
+      "iss": "https://accounts.google.com",
+      "aud": "client-id.apps.googleusercontent.com",
+      "iat": 0,
+      "exp": 0,
+      "sub": "google-subject-123",
+      "email": "user@example.com",
+      "name": "Ada Lovelace"
+    }
+  },
+  "refresh": {
+    "access_token": "new-access-token",
+    "expiry_date": 1893456000000,
+    "scope": "https://www.googleapis.com/auth/calendar"
+  },
+  "revokedRefreshToken": "revoked"
+}

--- a/packages/sync/src/providers/__contract__/fixtures/google/discovery.json
+++ b/packages/sync/src/providers/__contract__/fixtures/google/discovery.json
@@ -1,0 +1,35 @@
+{
+  "pages": [
+    {
+      "items": [
+        {
+          "kind": "calendar#calendarListEntry",
+          "id": "primary-cal",
+          "summary": "Primary",
+          "primary": true,
+          "backgroundColor": "#112233",
+          "accessRole": "owner"
+        },
+        {
+          "kind": "calendar#calendarListEntry",
+          "id": "work-cal",
+          "summary": "Work",
+          "backgroundColor": "#AABBCC",
+          "accessRole": "writer"
+        },
+        {
+          "kind": "calendar#calendarListEntry",
+          "id": "holidays",
+          "summary": "Holidays",
+          "backgroundColor": "#FFD700",
+          "accessRole": "reader"
+        }
+      ],
+      "nextPageToken": null,
+      "nextSyncToken": "sync-token-1"
+    }
+  ],
+  "labelsById": {
+    "primary-cal": [{ "id": "label-1", "hex": "#009688" }]
+  }
+}

--- a/packages/sync/src/providers/__contract__/fixtures/google/notifications.json
+++ b/packages/sync/src/providers/__contract__/fixtures/google/notifications.json
@@ -1,0 +1,23 @@
+{
+  "watch": {
+    "resourceId": "res-1",
+    "expiration": "1767312000000"
+  },
+  "valid": {
+    "headers": {
+      "x-goog-channel-id": "chan-1",
+      "x-goog-channel-token": "chan-token",
+      "x-goog-resource-id": "res-1",
+      "x-goog-resource-state": "exists"
+    }
+  },
+  "tampered": {
+    "headers": {
+      "x-goog-resource-id": "res-1"
+    }
+  },
+  "validation": {
+    "headers": {},
+    "query": { "validationToken": "echo-me" }
+  }
+}

--- a/packages/sync/src/providers/__contract__/fixtures/google/reader.json
+++ b/packages/sync/src/providers/__contract__/fixtures/google/reader.json
@@ -1,0 +1,153 @@
+{
+  "page1": {
+    "items": [
+      {
+        "kind": "calendar#event",
+        "etag": "\"2702446420000000\"",
+        "id": "kjatossbl8ctt7ub64363pibek",
+        "status": "confirmed",
+        "summary": "Meeting with Stan",
+        "description": "Sign Lease and pick apartment",
+        "location": "PH",
+        "updated": "2012-10-26T03:46:50.000Z",
+        "organizer": {
+          "email": "foo@gmail.com",
+          "displayName": "foo user",
+          "self": true
+        },
+        "start": {
+          "dateTime": "2012-10-26T13:00:00-06:00",
+          "timeZone": "America/Chicago"
+        },
+        "end": {
+          "dateTime": "2012-10-26T14:00:00-06:00",
+          "timeZone": "America/Chicago"
+        },
+        "iCalUID": "kjatossbl8ctt7ub64363pibek@google.com"
+      },
+      {
+        "kind": "calendar#event",
+        "etag": "\"3291861297900000\"",
+        "id": "1evdi8c1s5knlt5ofhncl654u9",
+        "status": "confirmed",
+        "summary": "Feb 22",
+        "start": { "date": "2022-02-22" },
+        "end": { "date": "2022-02-23" },
+        "transparency": "transparent",
+        "iCalUID": "1evdi8c1s5knlt5ofhncl654u9@google.com"
+      },
+      {
+        "kind": "calendar#event",
+        "etag": "\"3515450151133918\"",
+        "id": "15chil19v5nskedvmo93ei4nl8",
+        "status": "confirmed",
+        "summary": "recurring event",
+        "start": {
+          "dateTime": "2025-09-07T02:30:00+01:00",
+          "timeZone": "Africa/Lagos"
+        },
+        "end": {
+          "dateTime": "2025-09-07T03:30:00+01:00",
+          "timeZone": "Africa/Lagos"
+        },
+        "recurrence": ["RRULE:FREQ=DAILY;UNTIL=20250916T225959Z"],
+        "iCalUID": "15chil19v5nskedvmo93ei4nl8@google.com"
+      },
+      {
+        "kind": "calendar#event",
+        "etag": "\"3515450151133918\"",
+        "id": "15chil19v5nskedvmo93ei4nl8_20250908T013000Z",
+        "status": "confirmed",
+        "summary": "recurring event (exception)",
+        "recurringEventId": "15chil19v5nskedvmo93ei4nl8",
+        "originalStartTime": {
+          "dateTime": "2025-09-08T02:30:00+01:00",
+          "timeZone": "Africa/Lagos"
+        },
+        "start": {
+          "dateTime": "2025-09-08T03:00:00+01:00",
+          "timeZone": "Africa/Lagos"
+        },
+        "end": {
+          "dateTime": "2025-09-08T04:00:00+01:00",
+          "timeZone": "Africa/Lagos"
+        }
+      },
+      {
+        "kind": "calendar#event",
+        "etag": "\"2734519593376000\"",
+        "id": "tlf9q8uk5vjl2i2868q36dpi28_20130508T220000Z",
+        "status": "cancelled",
+        "recurringEventId": "tlf9q8uk5vjl2i2868q36dpi28",
+        "originalStartTime": {
+          "dateTime": "2013-05-08T16:00:00-06:00"
+        }
+      },
+      {
+        "kind": "calendar#event",
+        "etag": "\"v-guests\"",
+        "id": "attendee-conference-color",
+        "status": "confirmed",
+        "summary": "Standup",
+        "colorId": "7",
+        "hangoutLink": "https://meet.google.com/abc-defg-hij",
+        "attendees": [
+          {
+            "email": "a@x.com",
+            "displayName": "A",
+            "responseStatus": "accepted"
+          }
+        ],
+        "conferenceData": {
+          "conferenceSolution": { "name": "Google Meet" }
+        },
+        "start": {
+          "dateTime": "2025-01-15T09:00:00-05:00",
+          "timeZone": "America/New_York"
+        },
+        "end": {
+          "dateTime": "2025-01-15T09:30:00-05:00",
+          "timeZone": "America/New_York"
+        }
+      },
+      {
+        "kind": "calendar#event",
+        "id": "no-etag",
+        "status": "confirmed",
+        "summary": "structurally unusable",
+        "start": {
+          "dateTime": "2025-01-15T09:00:00-05:00",
+          "timeZone": "America/New_York"
+        },
+        "end": {
+          "dateTime": "2025-01-15T10:00:00-05:00",
+          "timeZone": "America/New_York"
+        }
+      }
+    ],
+    "nextPageToken": "page-2",
+    "nextSyncToken": null
+  },
+  "page2": {
+    "items": [
+      {
+        "kind": "calendar#event",
+        "etag": "\"page2\"",
+        "id": "paged-event",
+        "status": "confirmed",
+        "summary": "Second page",
+        "start": {
+          "dateTime": "2025-02-01T09:00:00-05:00",
+          "timeZone": "America/New_York"
+        },
+        "end": {
+          "dateTime": "2025-02-01T10:00:00-05:00",
+          "timeZone": "America/New_York"
+        }
+      }
+    ],
+    "nextPageToken": null,
+    "nextSyncToken": "sync-1"
+  },
+  "expiredCursor": "expired-sync-token"
+}

--- a/packages/sync/src/providers/__contract__/fixtures/google/writer.json
+++ b/packages/sync/src/providers/__contract__/fixtures/google/writer.json
@@ -1,0 +1,37 @@
+{
+  "insert": {
+    "kind": "calendar#event",
+    "id": "abc12deadbeef00000000000",
+    "etag": "\"v1\"",
+    "status": "confirmed",
+    "summary": "Contract create",
+    "start": {
+      "dateTime": "2025-01-15T09:00:00-05:00",
+      "timeZone": "America/New_York"
+    },
+    "end": {
+      "dateTime": "2025-01-15T10:00:00-05:00",
+      "timeZone": "America/New_York"
+    }
+  },
+  "instance": {
+    "kind": "calendar#event",
+    "id": "series-1_20250115T140000Z",
+    "etag": "\"v1\"",
+    "status": "confirmed",
+    "summary": "T",
+    "recurringEventId": "series-1",
+    "originalStartTime": {
+      "dateTime": "2025-01-15T09:00:00-05:00",
+      "timeZone": "America/New_York"
+    },
+    "start": {
+      "dateTime": "2025-01-15T09:00:00-05:00",
+      "timeZone": "America/New_York"
+    },
+    "end": {
+      "dateTime": "2025-01-15T10:00:00-05:00",
+      "timeZone": "America/New_York"
+    }
+  }
+}

--- a/packages/sync/src/providers/__contract__/google-contract.factory.ts
+++ b/packages/sync/src/providers/__contract__/google-contract.factory.ts
@@ -1,0 +1,273 @@
+import { type calendar_v3 } from "@googleapis/calendar";
+import { type Credentials, type TokenPayload } from "google-auth-library";
+import { type gSchema$Event } from "@core/types/gcal";
+import {
+  GoogleAuthAdapter,
+  type GoogleOAuthClient,
+} from "@sync/providers/google/google-auth.adapter";
+import {
+  GoogleCalendarAdapter,
+  type GoogleCalendarListApi,
+  type GoogleCalendarListPage,
+  type GoogleEventLabel,
+} from "@sync/providers/google/google-calendar.adapter";
+import {
+  type GoogleEventListApi,
+  type GoogleEventListPage,
+  GoogleEventReaderAdapter,
+} from "@sync/providers/google/google-event-reader.adapter";
+import {
+  type GoogleEventsApi,
+  GoogleEventWriter,
+} from "@sync/providers/google/google-event-writer.adapter";
+import {
+  type GoogleChannelsApi,
+  GoogleNotificationAdapter,
+} from "@sync/providers/google/google-notifications.adapter";
+import { type ProviderAdapters } from "@sync/providers/provider-adapters";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+interface AuthCorpus {
+  readonly exchange: {
+    readonly tokens: Credentials;
+    readonly payload: TokenPayload;
+  };
+  readonly refresh: Credentials;
+  readonly revokedRefreshToken: string;
+}
+
+interface DiscoveryCorpus {
+  readonly pages: GoogleCalendarListPage[];
+  readonly labelsById?: Record<string, readonly GoogleEventLabel[]>;
+}
+
+interface ReaderCorpus {
+  readonly page1: GoogleEventListPage;
+  readonly page2: GoogleEventListPage;
+  readonly expiredCursor: string;
+}
+
+interface WriterCorpus {
+  readonly insert: gSchema$Event;
+  readonly instance: gSchema$Event;
+}
+
+interface NotificationsCorpus {
+  readonly watch: calendar_v3.Schema$Channel;
+}
+
+function loadJson<T>(corpusDir: string, name: string): T {
+  return JSON.parse(readFileSync(join(corpusDir, `${name}.json`), "utf8")) as T;
+}
+
+function httpError(status: number, body?: unknown): Error {
+  return Object.assign(new Error(`google error ${status}`), {
+    response: { status, data: body },
+  });
+}
+
+class CorpusCalendarListApi implements GoogleCalendarListApi {
+  constructor(private readonly corpus: DiscoveryCorpus) {}
+
+  async listPage(): Promise<GoogleCalendarListPage> {
+    const page = this.corpus.pages[0];
+    if (!page) throw new Error("discovery corpus has no pages");
+    return page;
+  }
+
+  async getEventLabels(
+    calendarId: string,
+  ): Promise<readonly GoogleEventLabel[]> {
+    return this.corpus.labelsById?.[calendarId] ?? [];
+  }
+}
+
+class CorpusEventListApi implements GoogleEventListApi {
+  constructor(private readonly corpus: ReaderCorpus) {}
+
+  async listPage(
+    params: Parameters<GoogleEventListApi["listPage"]>[0],
+  ): Promise<GoogleEventListPage> {
+    if (params.syncToken === this.corpus.expiredCursor) {
+      throw httpError(410);
+    }
+    if (params.pageToken) return this.corpus.page2;
+    return this.corpus.page1;
+  }
+}
+
+class CorpusEventsApi implements GoogleEventsApi {
+  #deleted = new Set<string>();
+  #etag: string;
+
+  constructor(private readonly corpus: WriterCorpus) {
+    this.#etag = corpus.insert.etag ?? '"v1"';
+  }
+
+  async insert(
+    params: Parameters<GoogleEventsApi["insert"]>[0],
+  ): Promise<gSchema$Event> {
+    return {
+      ...this.corpus.insert,
+      id: params.requestBody.id as string,
+      etag: this.#etag,
+    };
+  }
+
+  async patch(
+    params: Parameters<GoogleEventsApi["patch"]>[0],
+  ): Promise<gSchema$Event> {
+    if (params.ifMatch && params.ifMatch !== this.#etag) {
+      throw httpError(412);
+    }
+    this.#etag = '"v2"';
+    return {
+      ...this.corpus.insert,
+      id: params.eventId,
+      etag: this.#etag,
+    };
+  }
+
+  async delete(
+    params: Parameters<GoogleEventsApi["delete"]>[0],
+  ): Promise<void> {
+    if (this.#deleted.has(params.eventId)) throw httpError(404);
+    this.#deleted.add(params.eventId);
+  }
+
+  async get(
+    params: Parameters<GoogleEventsApi["get"]>[0],
+  ): Promise<gSchema$Event> {
+    return { ...this.corpus.insert, id: params.eventId, etag: this.#etag };
+  }
+
+  async instances(
+    params: Parameters<GoogleEventsApi["instances"]>[0],
+  ): Promise<{ items?: gSchema$Event[] }> {
+    return {
+      items: [
+        {
+          ...this.corpus.instance,
+          recurringEventId: params.eventId,
+          originalStartTime: { dateTime: params.originalStart },
+        },
+      ],
+    };
+  }
+}
+
+class CorpusChannelsApi implements GoogleChannelsApi {
+  constructor(private readonly corpus: NotificationsCorpus) {}
+
+  async watchEvents(): Promise<calendar_v3.Schema$Channel> {
+    return this.corpus.watch;
+  }
+
+  async watchCalendarList(): Promise<calendar_v3.Schema$Channel> {
+    return this.corpus.watch;
+  }
+
+  async stopChannel(): Promise<void> {}
+}
+
+/**
+ * Build Google adapters that replay `fixtures/google/*.json`. Synthesized
+ * from the existing Google adapter tests; no live account is required.
+ */
+export function googleRecordedFactory(corpusDir: string): ProviderAdapters {
+  const auth = loadJson<AuthCorpus>(corpusDir, "auth");
+  const discovery = loadJson<DiscoveryCorpus>(corpusDir, "discovery");
+  const reader = loadJson<ReaderCorpus>(corpusDir, "reader");
+  const writer = loadJson<WriterCorpus>(corpusDir, "writer");
+  const notifications = loadJson<NotificationsCorpus>(
+    corpusDir,
+    "notifications",
+  );
+
+  return {
+    auth: new GoogleAuthAdapter(
+      "client-id.apps.googleusercontent.com",
+      "client-secret",
+      (redirectUri) => {
+        // Refresh/revoke pass no redirect URI; the revoked-token case uses a
+        // dedicated client so a live-looking refresh of the good token still works.
+        void redirectUri;
+        return new TokenAwareClient(auth);
+      },
+    ),
+    calendars: new GoogleCalendarAdapter(
+      () => new CorpusCalendarListApi(discovery),
+    ),
+    reader: new GoogleEventReaderAdapter(() => new CorpusEventListApi(reader), {
+      warn: () => {},
+    }),
+    writer: new GoogleEventWriter(() => new CorpusEventsApi(writer)),
+    notifications: new GoogleNotificationAdapter(
+      () => new CorpusChannelsApi(notifications),
+      () => new Date("2026-01-01T00:00:00Z"),
+    ),
+  };
+}
+
+class TokenAwareClient implements GoogleOAuthClient {
+  #refreshToken: string | null = null;
+
+  constructor(private readonly corpus: AuthCorpus) {}
+
+  generateAuthUrl(): string {
+    return "https://accounts.google.com/o/oauth2/v2/auth";
+  }
+
+  async getToken(_code: string): Promise<{ tokens: Credentials }> {
+    return { tokens: this.corpus.exchange.tokens };
+  }
+
+  async verifyIdToken(): Promise<{ getPayload(): TokenPayload | undefined }> {
+    return { getPayload: () => this.corpus.exchange.payload };
+  }
+
+  setCredentials(credentials: { refresh_token: string }): void {
+    this.#refreshToken = credentials.refresh_token;
+  }
+
+  async refreshAccessToken(): Promise<{ credentials: Credentials }> {
+    if (this.#refreshToken === this.corpus.revokedRefreshToken) {
+      throw httpError(400, { error: "invalid_grant" });
+    }
+    return { credentials: this.corpus.refresh };
+  }
+
+  async revokeToken(_token: string): Promise<unknown> {
+    return {};
+  }
+}
+
+export function googleLiveFactory(_corpusDir: string): ProviderAdapters {
+  const clientId =
+    process.env["SMOKE_GOOGLE_CLIENT_ID"] ??
+    process.env["GOOGLE_CLIENT_ID"] ??
+    "";
+  const clientSecret =
+    process.env["SMOKE_GOOGLE_CLIENT_SECRET"] ??
+    process.env["GOOGLE_CLIENT_SECRET"] ??
+    "";
+  return {
+    auth: new GoogleAuthAdapter(clientId, clientSecret),
+    calendars: new GoogleCalendarAdapter(),
+    reader: new GoogleEventReaderAdapter(),
+    writer: new GoogleEventWriter(),
+    notifications: new GoogleNotificationAdapter(),
+  };
+}
+
+export function hasGoogleLiveCredentials(): boolean {
+  const clientId =
+    process.env["SMOKE_GOOGLE_CLIENT_ID"] ?? process.env["GOOGLE_CLIENT_ID"];
+  const clientSecret =
+    process.env["SMOKE_GOOGLE_CLIENT_SECRET"] ??
+    process.env["GOOGLE_CLIENT_SECRET"];
+  return Boolean(
+    clientId && clientSecret && process.env["SMOKE_GOOGLE_REFRESH_TOKEN"],
+  );
+}

--- a/packages/sync/src/providers/__contract__/google.contract.test.ts
+++ b/packages/sync/src/providers/__contract__/google.contract.test.ts
@@ -1,0 +1,4 @@
+import { describeProviderContract } from "@sync/providers/__contract__/adapter-contract";
+import { googleRecordedFactory } from "@sync/providers/__contract__/google-contract.factory";
+
+describeProviderContract("google", googleRecordedFactory);

--- a/packages/sync/src/providers/__contract__/live-provider.contract.test.ts
+++ b/packages/sync/src/providers/__contract__/live-provider.contract.test.ts
@@ -1,0 +1,27 @@
+import { describeProviderContract } from "@sync/providers/__contract__/adapter-contract";
+import {
+  googleLiveFactory,
+  hasGoogleLiveCredentials,
+} from "@sync/providers/__contract__/google-contract.factory";
+import { describe, it } from "bun:test";
+
+const liveKind = process.env["LIVE_PROVIDER"];
+
+if (!liveKind) {
+  describe.skip("live provider contract", () => {
+    it("set LIVE_PROVIDER=<kind> to run against the real API", () => {});
+  });
+} else if (liveKind === "google" && hasGoogleLiveCredentials()) {
+  describeProviderContract("google", googleLiveFactory, {
+    accessToken: "unused-until-refresh",
+    calendarId: process.env["LIVE_CALENDAR_ID"] ?? "primary",
+    refreshToken: process.env["SMOKE_GOOGLE_REFRESH_TOKEN"],
+    skipAuthExchange: true,
+    skipAuthRevoked: true,
+    skipWatch: true,
+  });
+} else {
+  describe.skip(`live provider contract (${liveKind})`, () => {
+    it("skipped: secrets absent or live factory not wired for this provider", () => {});
+  });
+}

--- a/packages/sync/src/providers/__contract__/recording-api.test.ts
+++ b/packages/sync/src/providers/__contract__/recording-api.test.ts
@@ -1,0 +1,40 @@
+import {
+  recordingApi,
+  redactValue,
+} from "@sync/providers/__contract__/recording-api";
+import { describe, expect, it } from "bun:test";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+describe("recordingApi redaction", () => {
+  it("redacts tokens, emails, and Authorization headers before writing the corpus", async () => {
+    const corpusDir = await mkdtemp(join(tmpdir(), "contract-record-"));
+    const inner = {
+      async echo(input: {
+        access_token: string;
+        Authorization: string;
+        email: string;
+        summary: string;
+      }) {
+        return { ok: true, email: input.email };
+      },
+    };
+    const recorded = recordingApi(inner, corpusDir, "echo");
+    await recorded.echo({
+      access_token: "ya29.secret",
+      Authorization: "Bearer ya29.secret",
+      email: "founder@example.com",
+      summary: "keep me",
+    });
+
+    const written = JSON.parse(
+      await readFile(join(corpusDir, "echo.json"), "utf8"),
+    ) as Array<{ args: unknown; result: unknown }>;
+    const serialized = JSON.stringify(written);
+    expect(serialized).not.toContain("ya29.secret");
+    expect(serialized).not.toContain("founder@example.com");
+    expect(serialized).toContain("keep me");
+    expect(redactValue("Bearer abc")).toBe("Bearer [REDACTED]");
+  });
+});

--- a/packages/sync/src/providers/__contract__/recording-api.ts
+++ b/packages/sync/src/providers/__contract__/recording-api.ts
@@ -1,0 +1,68 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const SECRET_KEY =
+  /^(authorization|access[_-]?token|refresh[_-]?token|id[_-]?token|password|app[_-]?password|client[_-]?secret|cookie)$/i;
+
+const SECRET_SUBSTRING = /token|secret|password|authorization/i;
+
+const EMAIL = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi;
+
+const BEARER = /Bearer\s+\S+/gi;
+
+/**
+ * Wrap a real narrow API and append each call's redacted request/response to
+ * `corpusDir/<caseName>.json`. M-12 / A-11 record founder-account corpora
+ * with this; the recorded JSON is what the contract fakes replay.
+ */
+export function recordingApi<T extends object>(
+  inner: T,
+  corpusDir: string,
+  caseName: string,
+): T {
+  const calls: unknown[] = [];
+  return new Proxy(inner, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value !== "function") return value;
+      return (...args: unknown[]) => {
+        const invoke = async () => {
+          const result = await (
+            value as (...innerArgs: unknown[]) => unknown
+          ).apply(target, args);
+          calls.push({
+            method: String(prop),
+            args: redactValue(args),
+            result: redactValue(result),
+          });
+          await mkdir(corpusDir, { recursive: true });
+          await writeFile(
+            join(corpusDir, `${caseName}.json`),
+            `${JSON.stringify(calls, null, 2)}\n`,
+          );
+          return result;
+        };
+        return invoke();
+      };
+    },
+  }) as T;
+}
+
+export function redactValue(value: unknown): unknown {
+  if (typeof value === "string") {
+    return value.replace(BEARER, "Bearer [REDACTED]").replace(EMAIL, "[email]");
+  }
+  if (Array.isArray(value)) return value.map(redactValue);
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value)) {
+      if (SECRET_KEY.test(key) || SECRET_SUBSTRING.test(key)) {
+        out[key] = "[REDACTED]";
+      } else {
+        out[key] = redactValue(nested);
+      }
+    }
+    return out;
+  }
+  return value;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3236

## What and why

P0 WP-11: there was no test that runs one specification against every adapter. This adds `describeProviderContract(kind, factory)` under `packages/sync/src/providers/__contract__/`, covering auth, discovery, reader, writer, notifications, and normalizer round-trips. Google passes against a recorded fixture corpus synthesized from the existing adapter tests (no live account). A canary test fails when a fake writer returns success for a stale version. `LIVE_PROVIDER=<kind>` runs the same cases against the real API factory (consumed by L WP-10). Spec: `docs/features/calendar-providers.md`.

## Verify

VERDICT: PASS
Checks run: test:sync:fast, type-check, lint, knip
Also ran `bun test:sync` (1236 pass, 1 skip).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c551c3bd-a8a5-402b-abd1-9edd46fe8f41?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c551c3bd-a8a5-402b-abd1-9edd46fe8f41&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

