### PR TITLE
feat(sync): add Apple credential validation auth adapter

### DIFF
--- a/.agents/handoffs/3255.md
+++ b/.agents/handoffs/3255.md
@@ -1,0 +1,37 @@
+---
+schema_version: 1
+task_id: "3255"
+from: Implementer
+to: GitHub
+owner: GitHub
+status: verifying
+artifact:
+  - path: packages/sync/src/providers/apple/apple-auth.adapter.ts
+  - path: packages/sync/src/providers/apple/apple-auth.adapter.test.ts
+  - path: packages/sync/src/providers/__contract__/auth.contract.ts
+  - path: packages/sync/src/providers/__contract__/apple.contract.test.ts
+  - path: packages/sync/src/providers/provider-auth.port.ts
+evidence:
+  - command: bun test:sync
+    result: pass
+  - command: bun run type-check
+    result: pass
+  - command: bun lint
+    result: pass
+  - command: bun knip
+    result: pass
+  - command: bun run verify --strict
+    result: "VERDICT: PASS"
+assumptions:
+  - "validateCredential runs the same CalDAV discovery path as A-01; connect route (A-03) will call it before storePassword."
+  - "OAuth auth contract cases stay stubbed until P0 WP-11 (#3236) wires the Google corpus."
+open_risks:
+  - "Live iCloud throttling during credential validation validated only via scripted fixtures until A-11."
+next_deadline: 2026-09-05T02:00:00Z
+retry: 0
+approval: allow
+waiting_on: null
+escalation: null
+---
+
+Providers A WP-02: Apple credential validation adapter.

--- a/packages/sync/src/providers/__contract__/README.md
+++ b/packages/sync/src/providers/__contract__/README.md
@@ -6,7 +6,9 @@ Add a provider by listing `DiscoveryContractCase` entries in
 adapter's injectable narrow API (for Apple, the CalDAV client's `fetch`).
 
 The full suite (auth, reader, writer, notifications, normalizer) lands in P0
-WP-11 (#3236). This directory currently carries discovery cases only.
+WP-11 (#3236). This directory currently carries discovery, normalizer, and
+OAuth auth contract scaffolding. Password-only providers mark OAuth auth cases
+not-applicable via `AuthContractCapabilities.oauthRedirect`.
 
 ## Add Apple-style discovery coverage
 

--- a/packages/sync/src/providers/__contract__/apple.contract.test.ts
+++ b/packages/sync/src/providers/__contract__/apple.contract.test.ts
@@ -1,11 +1,18 @@
+import {
+  type AuthContractCapabilities,
+  type AuthContractCase,
+  OAUTH_AUTH_CONTRACT_CASES,
+} from "@sync/providers/__contract__/auth.contract";
 import { type DiscoveryContractCase } from "@sync/providers/__contract__/discovery.contract";
 import { type NormalizerContractCase } from "@sync/providers/__contract__/normalizer.contract";
+import { AppleAuthAdapter } from "@sync/providers/apple/apple-auth.adapter";
 import { AppleCalendarAdapter } from "@sync/providers/apple/apple-calendar.adapter";
 import { normalizeAppleEventResource } from "@sync/providers/apple/apple-event.normalizer";
 import {
   type CaldavFetch,
   createCaldavClient,
 } from "@sync/providers/apple/caldav-client";
+import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
 
 const PRINCIPAL_XML = `<?xml version="1.0" encoding="utf-8"?>
 <D:multistatus xmlns:D="DAV:">
@@ -148,6 +155,34 @@ describe("apple discovery contract", () => {
     });
   }
 });
+
+describeOAuthAuthContract(
+  "apple",
+  { oauthRedirect: false },
+  OAUTH_AUTH_CONTRACT_CASES,
+  () => new AppleAuthAdapter(),
+);
+
+function describeOAuthAuthContract(
+  label: string,
+  capabilities: AuthContractCapabilities,
+  cases: AuthContractCase[],
+  factory: () => ProviderAuthAdapter,
+): void {
+  describe(`${label} oauth auth contract`, () => {
+    for (const testCase of cases) {
+      if (!capabilities[testCase.requires]) {
+        it(`${testCase.name} [not applicable: ${testCase.requires} unsupported]`, () => {
+          expect(capabilities[testCase.requires]).toBe(false);
+        });
+        continue;
+      }
+      it(testCase.name, async () => {
+        await testCase.run(factory());
+      });
+    }
+  });
+}
 
 const APPLE_NORMALIZER_CASES: NormalizerContractCase[] = [
   {

--- a/packages/sync/src/providers/__contract__/auth.contract.ts
+++ b/packages/sync/src/providers/__contract__/auth.contract.ts
@@ -1,0 +1,39 @@
+import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
+
+// Which auth flows a provider implements. Password-only providers (Apple) set
+// oauthRedirect false; OAuth redirect providers (Google, Microsoft) set it true.
+export interface AuthContractCapabilities {
+  readonly oauthRedirect: boolean;
+}
+
+export interface AuthContractCase {
+  readonly name: string;
+  readonly requires: keyof AuthContractCapabilities;
+  readonly run: (adapter: ProviderAuthAdapter) => Promise<void>;
+}
+
+// Shared OAuth redirect cases from P0 WP-11 (#3236). Providers that lack a
+// capability mark matching cases not-applicable instead of skipping them.
+export const OAUTH_AUTH_CONTRACT_CASES: AuthContractCase[] = [
+  {
+    name: "exchange yields identity and refresh token",
+    requires: "oauthRedirect",
+    run: async () => {
+      throw new Error("OAuth auth contract corpus not wired for this provider");
+    },
+  },
+  {
+    name: "refresh mints a short-lived access token",
+    requires: "oauthRedirect",
+    run: async () => {
+      throw new Error("OAuth auth contract corpus not wired for this provider");
+    },
+  },
+  {
+    name: "revoked refresh maps to authorizationRevoked",
+    requires: "oauthRedirect",
+    run: async () => {
+      throw new Error("OAuth auth contract corpus not wired for this provider");
+    },
+  },
+];

--- a/packages/sync/src/providers/apple/apple-auth.adapter.test.ts
+++ b/packages/sync/src/providers/apple/apple-auth.adapter.test.ts
@@ -1,0 +1,180 @@
+import {
+  AppleAuthAdapter,
+  isPasswordCredentialAuthAdapter,
+} from "@sync/providers/apple/apple-auth.adapter";
+import {
+  type CaldavFetch,
+  createCaldavClient,
+} from "@sync/providers/apple/caldav-client";
+import { ProviderAuthError } from "@sync/providers/provider-auth.port";
+
+const PRINCIPAL_XML = `<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:">
+  <D:response>
+    <D:href>/</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:current-user-principal>
+          <D:href>/123456789/principal/</D:href>
+        </D:current-user-principal>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+</D:multistatus>`;
+
+const HOME_SET_XML = `<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:">
+  <D:response>
+    <D:href>/123456789/principal/</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:calendar-home-set>
+          <D:href>/123456789/calendars/</D:href>
+        </D:calendar-home-set>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+</D:multistatus>`;
+
+const CALENDARS_XML = `<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
+  <D:response>
+    <D:href>/123456789/calendars/home/</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:displayname>home</D:displayname>
+        <D:resourcetype><D:collection/><C:calendar/></D:resourcetype>
+        <D:current-user-privilege-set>
+          <D:privilege><D:write/></D:privilege>
+        </D:current-user-privilege-set>
+        <C:supported-calendar-component-set>
+          <C:comp name="VEVENT"/>
+        </C:supported-calendar-component-set>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+</D:multistatus>`;
+
+function xmlResponse(body: string, status = 207): Response {
+  return new Response(body, {
+    status,
+    headers: { "Content-Type": "application/xml; charset=utf-8" },
+  });
+}
+
+function discoveryFetch(): CaldavFetch {
+  const handlers = [
+    () => xmlResponse(PRINCIPAL_XML),
+    () => xmlResponse(HOME_SET_XML),
+    () => xmlResponse(CALENDARS_XML),
+  ];
+  let call = 0;
+  return async () => {
+    const handler = handlers[call];
+    call += 1;
+    if (!handler) throw new Error("unexpected discovery request");
+    return handler();
+  };
+}
+
+describe("AppleAuthAdapter", () => {
+  it("validates a credential by running CalDAV discovery", async () => {
+    const adapter = new AppleAuthAdapter((credential, fetchImpl) =>
+      createCaldavClient(credential, fetchImpl ?? discoveryFetch()),
+    );
+
+    await expect(
+      adapter.validateCredential({
+        username: "user@icloud.com",
+        secret: "app-specific",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("maps a wrong password to authorizationRevoked", async () => {
+    const fetchImpl: CaldavFetch = async () =>
+      new Response("", { status: 401 });
+    const adapter = new AppleAuthAdapter((credential, injectedFetch) =>
+      createCaldavClient(credential, injectedFetch ?? fetchImpl),
+    );
+
+    await expect(
+      adapter.validateCredential({
+        username: "user@icloud.com",
+        secret: "wrong",
+      }),
+    ).rejects.toMatchObject({
+      reason: "authorizationRevoked",
+    });
+    await expect(
+      adapter.validateCredential({
+        username: "user@icloud.com",
+        secret: "wrong",
+      }),
+    ).rejects.toBeInstanceOf(ProviderAuthError);
+  });
+
+  it("maps throttling to refreshFailed", async () => {
+    const fetchImpl: CaldavFetch = async () =>
+      new Response("", { status: 503 });
+    const adapter = new AppleAuthAdapter((credential, injectedFetch) =>
+      createCaldavClient(credential, injectedFetch ?? fetchImpl),
+    );
+
+    await expect(
+      adapter.validateCredential({
+        username: "user@icloud.com",
+        secret: "secret",
+      }),
+    ).rejects.toMatchObject({
+      reason: "refreshFailed",
+    });
+  });
+
+  it("rejects OAuth redirect with unsupported", () => {
+    const adapter = new AppleAuthAdapter();
+    expect(() =>
+      adapter.buildAuthorizationUrl({
+        state: "state",
+        redirectUri: "https://example.com/callback",
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        reason: "unsupported",
+      }),
+    );
+  });
+
+  it("rejects authorization code exchange with unsupported", async () => {
+    const adapter = new AppleAuthAdapter();
+    await expect(
+      adapter.exchangeAuthorizationCode({
+        code: "code",
+        redirectUri: "https://example.com/callback",
+      }),
+    ).rejects.toMatchObject({ reason: "unsupported" });
+  });
+
+  it("returns the password unchanged with a far-future expiry on refresh", async () => {
+    const adapter = new AppleAuthAdapter();
+    const refreshed = await adapter.refreshAccessToken({
+      refreshToken: "app-specific",
+    });
+    expect(refreshed.accessToken).toBe("app-specific");
+    expect(refreshed.grantedScopes).toEqual([]);
+    expect(refreshed.expiresAt.getFullYear()).toBeGreaterThanOrEqual(2099);
+  });
+
+  it("revokes without calling the provider", async () => {
+    const adapter = new AppleAuthAdapter();
+    await expect(adapter.revoke({ token: "secret" })).resolves.toBeUndefined();
+  });
+
+  it("exposes validateCredential through the password auth adapter guard", () => {
+    const adapter = new AppleAuthAdapter();
+    expect(isPasswordCredentialAuthAdapter(adapter)).toBe(true);
+  });
+});

--- a/packages/sync/src/providers/apple/apple-auth.adapter.ts
+++ b/packages/sync/src/providers/apple/apple-auth.adapter.ts
@@ -1,0 +1,106 @@
+import {
+  CaldavClientError,
+  type CaldavClientFactory,
+  createCaldavClient,
+  discoverCalendars,
+} from "@sync/providers/apple/caldav-client";
+import {
+  type ProviderAuthAdapter,
+  ProviderAuthError,
+  type ProviderAuthorization,
+  type RefreshedCredential,
+} from "@sync/providers/provider-auth.port";
+
+// Password credentials do not expire; custody never calls refresh for them, but
+// the port still requires a far-future expiry when it does.
+const PASSWORD_CREDENTIAL_EXPIRY = new Date("2099-12-31T23:59:59.999Z");
+
+export interface CredentialValidationInput {
+  readonly username: string;
+  readonly secret: string;
+}
+
+export interface PasswordCredentialAuthAdapter extends ProviderAuthAdapter {
+  validateCredential(input: CredentialValidationInput): Promise<void>;
+}
+
+export function isPasswordCredentialAuthAdapter(
+  adapter: ProviderAuthAdapter,
+): adapter is PasswordCredentialAuthAdapter {
+  return "validateCredential" in adapter;
+}
+
+export class AppleAuthAdapter implements PasswordCredentialAuthAdapter {
+  #makeClient: CaldavClientFactory;
+
+  constructor(makeClient: CaldavClientFactory = createCaldavClient) {
+    this.#makeClient = makeClient;
+  }
+
+  buildAuthorizationUrl(_input: {
+    state: string;
+    redirectUri: string;
+    selectAccount?: boolean;
+    extraScopes?: readonly string[];
+  }): string {
+    throw new ProviderAuthError(
+      "unsupported",
+      "Apple calendar connect does not use OAuth redirect",
+    );
+  }
+
+  async exchangeAuthorizationCode(_input: {
+    code: string;
+    redirectUri: string;
+  }): Promise<ProviderAuthorization> {
+    throw new ProviderAuthError(
+      "unsupported",
+      "Apple calendar connect does not use OAuth redirect",
+    );
+  }
+
+  async refreshAccessToken(input: {
+    refreshToken: string;
+  }): Promise<RefreshedCredential> {
+    return {
+      accessToken: input.refreshToken,
+      expiresAt: PASSWORD_CREDENTIAL_EXPIRY,
+      grantedScopes: [],
+    };
+  }
+
+  async revoke(_input: { token: string }): Promise<void> {
+    // Apple app-specific passwords have no revoke endpoint.
+  }
+
+  async validateCredential(input: CredentialValidationInput): Promise<void> {
+    const client = this.#makeClient({
+      username: input.username,
+      password: input.secret,
+    });
+    try {
+      await discoverCalendars(client, {
+        username: input.username,
+        password: input.secret,
+      });
+    } catch (error) {
+      if (error instanceof CaldavClientError) {
+        if (error.reason === "authExpired") {
+          throw new ProviderAuthError(
+            "authorizationRevoked",
+            "Apple rejected the app-specific password",
+            { cause: error },
+          );
+        }
+        if (error.reason === "transient") {
+          throw new ProviderAuthError(
+            "refreshFailed",
+            "Apple CalDAV throttled or refused credential validation",
+            { cause: error },
+          );
+        }
+      }
+      throw error;
+    }
+  }
+}

--- a/packages/sync/src/providers/provider-auth.port.ts
+++ b/packages/sync/src/providers/provider-auth.port.ts
@@ -77,6 +77,7 @@ export type ProviderAuthErrorReason =
   | "missingIdentity" // the account could not be identified from the grant
   | "invalidIdToken" // the id token was absent or failed verification
   | "authorizationRevoked" // the refresh token is no longer valid (revoked/expired)
-  | "refreshFailed"; // the token refresh failed for a transient/unknown reason
+  | "refreshFailed" // the token refresh failed for a transient/unknown reason
+  | "unsupported"; // the operation does not apply to this provider's auth model
 
 export class ProviderAuthError extends ProviderError<ProviderAuthErrorReason> {}


### PR DESCRIPTION
Fixes #3255

## What and why

Apple calendar connect uses an app-specific password, not OAuth. This adds `AppleAuthAdapter` with `validateCredential` that runs CalDAV discovery to verify credentials before storage (consumed by A-03). OAuth redirect methods throw `ProviderAuthError("unsupported")`, `refreshAccessToken` returns the password with a far-future expiry, and `revoke` is a no-op. OAuth auth contract cases are explicitly marked not-applicable for Apple via `AuthContractCapabilities.oauthRedirect`.

## Verify

```
Summary
Selected packages: sync
Checks run: test:sync:fast, type-check, lint, knip
Checks skipped: (none)

✓ All checks passed
VERDICT: PASS
```