### PR TITLE
feat(web): cut block party to 11 tasks without repeated keys

### DIFF
--- a/docs/frontend/frontend-runtime-flow.md
+++ b/docs/frontend/frontend-runtime-flow.md
@@ -102,8 +102,10 @@ Welcome → signup → first-event contract:
   page jump, and `Mod+K` palette, all simulated inside the arena) against a
   ghost target slot, with scoring and streaks; task keycaps derive from the
   application's keymap and the exact next key pulses on the task card. The
-  first run is untimed; the end screen offers a timed rematch, and a timed
-  run whose clock expires keeps going with the score frozen at the buzzer.
+  queue is authored one task per primitive with one press per key and never
+  the same key twice in a row. The first run is untimed; the end screen
+  offers a timed rematch, and a timed run whose clock expires keeps going
+  with the score frozen at the buzzer.
   Esc skips the current task (leaving mid-run is the two-click Leave button),
   anonymous players get signup as the end screen's primary CTA, and
   graduation hands off to `FirstEventPrompt`. A reload mid-run re-offers a

--- a/e2e/onboarding/shortcut-showcase.spec.ts
+++ b/e2e/onboarding/shortcut-showcase.spec.ts
@@ -32,7 +32,7 @@ const startPracticing = async (page: Page) => {
     showcase.getByRole("button", { name: "Start practicing" }),
   ).toBeVisible();
   await page.keyboard.press("Enter");
-  await expect(showcase).toContainText("Task 1/14");
+  await expect(showcase).toContainText("Task 1/11");
   // The first run is untimed practice: no countdown anywhere.
   await expect(showcase.getByRole("timer")).toHaveCount(0);
   await expect(showcase).toContainText("Practice");
@@ -54,7 +54,7 @@ const pressTimes = async (page: Page, key: string, times: number) => {
   }
 };
 
-/** The winning script: clears all fourteen tasks with the taught keys. */
+/** The winning script: clears all eleven tasks with the taught keys. */
 const clearTheQueue = async (page: Page) => {
   const showcase = page.getByRole("region", { name: "Shortcut practice" });
 
@@ -62,50 +62,38 @@ const clearTheQueue = async (page: Page) => {
   await page.keyboard.press("c");
   await page.keyboard.press("ArrowLeft");
   await page.keyboard.press("Enter");
-  await expect(showcase).toContainText("Task 2/14");
+  await expect(showcase).toContainText("Task 2/11");
 
-  // quicktime-lunch: type the time, lock.
-  await page.keyboard.type("1230");
+  // quicktime-coffee: type the time, lock.
+  await page.keyboard.type("930");
   await page.keyboard.press("Enter");
-  await expect(showcase).toContainText("Task 3/14");
+  await expect(showcase).toContainText("Task 3/11");
 
-  // place-review: two days right, lock.
-  await page.keyboard.press("c");
-  await pressTimes(page, "ArrowRight", 2);
-  await page.keyboard.press("Enter");
-  await expect(showcase).toContainText("Task 4/14");
+  // nudge-standup: 9:00 -> 9:15 in one 15-minute step.
+  await page.keyboard.press("Shift+ArrowDown");
+  await expect(showcase).toContainText("Task 4/11");
 
-  // nudge-standup: 9:00 -> 10:00 in 15-minute steps.
-  await pressTimes(page, "Shift+ArrowDown", 4);
-  await expect(showcase).toContainText("Task 5/14");
-
-  // resize-one-on-one: Tab to the end edge, stretch 10:30 -> 11:00.
+  // resize-one-on-one: Tab to the start edge, Shift+Up 10:00 -> 9:45.
   await page.keyboard.press("Tab");
-  await page.keyboard.press("Tab");
-  await pressTimes(page, "Shift+ArrowDown", 2);
-  await expect(showcase).toContainText("Task 6/14");
-
-  // quicktime-focus
-  await page.keyboard.type("1600");
-  await page.keyboard.press("Enter");
-  await expect(showcase).toContainText("Task 7/14");
+  await page.keyboard.press("Shift+ArrowUp");
+  await expect(showcase).toContainText("Task 5/11");
 
   // delete-gym, undo-gym
   await page.keyboard.press("Delete");
-  await expect(showcase).toContainText("Task 8/14");
+  await expect(showcase).toContainText("Task 6/11");
   await holdModAndPress(page, "z");
-  await expect(showcase).toContainText("Task 9/14");
+  await expect(showcase).toContainText("Task 7/11");
 
-  // legend-peek: ? opens the practice legend, ? closes it again.
+  // legend-peek: ? opens the practice legend, Esc closes it.
   await page.keyboard.press("?");
   await expect(showcase).toContainText("Shortcuts");
-  await page.keyboard.press("?");
-  await expect(showcase).toContainText("Task 10/14");
+  await page.keyboard.press("Escape");
+  await expect(showcase).toContainText("Task 8/11");
 
   // jump-to-kickoff: H reveals jump letters, S is on Team kickoff.
   await page.keyboard.press("h");
   await page.keyboard.press("s");
-  await expect(showcase).toContainText("Task 11/14");
+  await expect(showcase).toContainText("Task 9/11");
 
   // page-jump-peek: hold Mod alone until the numbers appear, then Mod+1.
   await page.keyboard.down("Control");
@@ -114,21 +102,17 @@ const clearTheQueue = async (page: Page) => {
   await page.keyboard.press("1");
   await page.keyboard.up("Meta");
   await page.keyboard.up("Control");
-  await expect(showcase).toContainText("Task 12/14");
+  await expect(showcase).toContainText("Task 10/11");
 
   // palette-peek: Mod+K opens the practice palette, Esc closes it.
   await holdModAndPress(page, "k");
   await expect(showcase).toContainText("Type a command...");
   await page.keyboard.press("Escape");
-  await expect(showcase).toContainText("Task 13/14");
-
-  // nudge-review: one day left.
-  await page.keyboard.press("Shift+ArrowLeft");
-  await expect(showcase).toContainText("Task 14/14");
+  await expect(showcase).toContainText("Task 11/11");
 
   // place-party: down to 5pm, lock.
   await page.keyboard.press("c");
-  await pressTimes(page, "ArrowDown", 2);
+  await page.keyboard.press("ArrowDown");
   await page.keyboard.press("Enter");
   await expect(showcase).toContainText("You cleared the week!");
 };
@@ -177,7 +161,7 @@ test("a full run clears the queue, shows the score, and graduates", async ({
 
   await clearTheQueue(page);
 
-  await expect(showcase).toContainText("14/14 tasks cleared");
+  await expect(showcase).toContainText("11/11 tasks cleared");
   await expect(showcase).toContainText("Moves you learned");
   await expect(
     showcase.getByRole("button", { name: /Sign up to keep your calendar/ }),
@@ -216,11 +200,11 @@ test("the end screen's rematch races the clock with a full timer", async ({
   await startPracticing(page);
 
   // Esc-skip the whole queue: the fastest road to the end screen.
-  await pressTimes(page, "Escape", 14);
+  await pressTimes(page, "Escape", 11);
   await expect(showcase).toContainText("You cleared the week!");
 
   await page.keyboard.press("p");
-  await expect(showcase).toContainText("Task 1/14");
+  await expect(showcase).toContainText("Task 1/11");
   await expect(showcase.getByRole("timer")).toBeVisible();
   await expect(showcase.getByRole("timer")).toContainText("2:00");
 });
@@ -267,7 +251,7 @@ test("Escape mid-run skips one task and keeps the game up", async ({
   const showcase = page.getByRole("region", { name: "Shortcut practice" });
   // Mid-run, Escape skips the current task and the game stays up.
   await page.keyboard.press("Escape");
-  await expect(showcase).toContainText("Task 2/14");
+  await expect(showcase).toContainText("Task 2/11");
   await expect(showcase).toBeVisible();
 });
 
@@ -307,7 +291,7 @@ test("reloading mid-game re-offers a fresh run from the how-to card", async ({
   await page.keyboard.press("c");
   await page.keyboard.press("ArrowLeft");
   await page.keyboard.press("Enter");
-  await expect(showcase).toContainText("Task 2/14");
+  await expect(showcase).toContainText("Task 2/11");
 
   await page.reload({ waitUntil: "domcontentloaded" });
   const resumed = page.getByRole("region", { name: "Shortcut practice" });

--- a/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
+++ b/packages/web/src/components/ShortcutShowcase/ShortcutShowcase.test.tsx
@@ -62,30 +62,20 @@ const playWinningRun = async () => {
   pressKey("c");
   pressKey("ArrowLeft");
   pressKey("Enter");
-  // quicktime-lunch
-  typeDigits("1230");
-  pressKey("Enter");
-  // place-review
-  pressKey("c");
-  pressKey("ArrowRight");
-  pressKey("ArrowRight");
+  // quicktime-coffee
+  typeDigits("930");
   pressKey("Enter");
   // nudge-standup
-  for (let i = 0; i < 4; i += 1) pressKey("ArrowDown", { shiftKey: true });
+  pressKey("ArrowDown", { shiftKey: true });
   // resize-one-on-one
   pressKey("Tab");
-  pressKey("Tab");
-  pressKey("ArrowDown", { shiftKey: true });
-  pressKey("ArrowDown", { shiftKey: true });
-  // quicktime-focus
-  typeDigits("1600");
-  pressKey("Enter");
+  pressKey("ArrowUp", { shiftKey: true });
   // delete-gym, undo-gym
   pressKey("Delete");
   pressKey("z", modInit());
-  // legend-peek: open the practice legend, close it again
+  // legend-peek: open the practice legend, Esc closes it
   pressKey("?", { shiftKey: true });
-  pressKey("?", { shiftKey: true });
+  pressKey("Escape");
   // jump-to-kickoff: reveal jump letters, take the kickoff one
   pressKey("h");
   pressKey("s");
@@ -96,11 +86,9 @@ const playWinningRun = async () => {
   // palette-peek: open the practice palette, Esc closes it
   pressKey("k", modInit());
   pressKey("Escape");
-  // nudge-review
-  pressKey("ArrowLeft", { shiftKey: true });
   // place-party
   pressKey("c");
-  for (let i = 0; i < 2; i += 1) pressKey("ArrowDown");
+  pressKey("ArrowDown");
   pressKey("Enter");
 };
 
@@ -209,7 +197,7 @@ describe("ShortcutShowcase", () => {
 
     // Esc-skip to the jump task. With every board task skipped, letters run
     // over the three seed events alone, so kickoff's chip is A here.
-    for (let i = 0; i < 9; i += 1) pressKey("Escape");
+    for (let i = 0; i < 7; i += 1) pressKey("Escape");
     expect(screen.getByText("Fly across the board")).toBeTruthy();
     expect(screen.getByText("A")).toBeTruthy();
     pressKey("h");
@@ -368,7 +356,7 @@ describe("ShortcutShowcase", () => {
     act(() => shortcutShowcaseActions.replay());
     pressKey("Enter");
     // Esc through the board tasks until the legend task is up.
-    for (let i = 0; i < 8; i += 1) pressKey("Escape");
+    for (let i = 0; i < 6; i += 1) pressKey("Escape");
     expect(screen.getByText("Blanking on a move?")).toBeTruthy();
 
     pressKey("?", { shiftKey: true });

--- a/packages/web/src/components/ShortcutShowcase/game.state.test.ts
+++ b/packages/web/src/components/ShortcutShowcase/game.state.test.ts
@@ -21,6 +21,7 @@ import {
   TASK_BASE_POINTS,
   TIME_BONUS_PER_SECOND,
 } from "@web/components/ShortcutShowcase/game.tasks";
+import { PRACTICE_NUDGE_MIN } from "@web/components/ShortcutShowcase/practice.state";
 import { describe, expect, it } from "bun:test";
 
 const T0 = 1_000_000;
@@ -46,45 +47,28 @@ const key = {
   ): GameKey => ({ type: "arrow", direction, shift }),
 };
 
-/** The one keyboard script that clears the whole queue. */
+/** The one keyboard script that clears the whole queue: 11 tasks, 23 keys. */
 const WINNING_SCRIPT: GameKey[] = [
   // place-standup: spawn Tue 9:00, walk left, lock
   key.create,
   key.arrow("left"),
   key.enter,
-  // quicktime-lunch: type 1230, lock
-  key.digit("1"),
-  key.digit("2"),
+  // quicktime-coffee: type 930, lock
+  key.digit("9"),
   key.digit("3"),
   key.digit("0"),
   key.enter,
-  // place-review: spawn Mon 2pm, two days right, lock
-  key.create,
-  key.arrow("right"),
-  key.arrow("right"),
-  key.enter,
-  // nudge-standup: 9:00 -> 10:00
+  // nudge-standup: 9:00 -> 9:15
   key.arrow("down", true),
-  key.arrow("down", true),
-  key.arrow("down", true),
-  key.arrow("down", true),
-  // resize-one-on-one: Tab to end edge, stretch 10:30 -> 11:00
+  // resize-one-on-one: Tab to start edge, Shift+Up 10:00 -> 9:45
   key.tab,
-  key.tab,
-  key.arrow("down", true),
-  key.arrow("down", true),
-  // quicktime-focus: type 1600, lock
-  key.digit("1"),
-  key.digit("6"),
-  key.digit("0"),
-  key.digit("0"),
-  key.enter,
+  key.arrow("up", true),
   // delete-gym, undo-gym
   key.del,
   key.undo,
-  // legend-peek: open, then close
+  // legend-peek: open, then Esc closes
   key.legend,
-  key.legend,
+  key.closeOverlay,
   // jump-to-kickoff: reveal chips, jump by letter (kickoff is "s" by board order)
   key.jump,
   key.letter("s"),
@@ -94,11 +78,8 @@ const WINNING_SCRIPT: GameKey[] = [
   // palette-peek: open, then Esc closes
   key.palette,
   key.closeOverlay,
-  // nudge-review: Wed -> Tue
-  key.arrow("left", true),
-  // place-party: spawn Wed 4:30pm, walk down to 5pm, lock
+  // place-party: spawn Wed 4:45pm, walk down to 5pm, lock
   key.create,
-  key.arrow("down"),
   key.arrow("down"),
   key.enter,
 ];
@@ -184,7 +165,7 @@ describe("task skip", () => {
     const scoreBefore = state.score;
 
     const skipped = skipCurrentTask(state, T0 + 1_000);
-    expect(currentTask(skipped)?.id).toBe("place-review");
+    expect(currentTask(skipped)?.id).toBe("nudge-standup");
     expect(skipped.score).toBe(scoreBefore);
     expect(skipped.tasksSkipped).toBe(1);
     expect(skipped.streak).toBe(0);
@@ -218,7 +199,7 @@ describe("scoring", () => {
   it("pays the speed bonus and multiplies streaks of fast clears", () => {
     let state = startRun(createInitialGameState(), T0);
     // Three instant clears: 150, 150, then streak hits 3 -> x2.
-    state = playKeys(state, WINNING_SCRIPT.slice(0, 12), T0);
+    state = playKeys(state, WINNING_SCRIPT.slice(0, 8), T0);
     expect(state.tasksDone).toBe(3);
     const fast = TASK_BASE_POINTS + SPEED_BONUS_POINTS;
     expect(state.score).toBe(fast + fast + fast * 2);
@@ -241,7 +222,7 @@ describe("task validation", () => {
     // On target but still placing.
     expect(currentTask(state)?.id).toBe("place-standup");
     state = handleGameKey(state, key.enter, T0);
-    expect(currentTask(state)?.id).toBe("quicktime-lunch");
+    expect(currentTask(state)?.id).toBe("quicktime-coffee");
   });
 
   it("lets a piece locked in the wrong slot be nudged home afterwards", () => {
@@ -254,41 +235,30 @@ describe("task validation", () => {
     expect(handleGameKey(state, key.create, T0)).toBe(beforeRespawn);
     // Shift+Left walks the locked block home and completes the task.
     state = handleGameKey(state, key.arrow("left", true), T0);
-    expect(currentTask(state)?.id).toBe("quicktime-lunch");
+    expect(currentTask(state)?.id).toBe("quicktime-coffee");
   });
 
-  it("requires the end edge for the resize task: whole-block moves fail", () => {
+  it("requires the start edge for the resize task: whole-block moves fail", () => {
     let state = startRun(createInitialGameState(), T0);
-    state = playKeys(state, WINNING_SCRIPT.slice(0, 16), T0);
+    state = playKeys(state, WINNING_SCRIPT.slice(0, 8), T0);
     expect(currentTask(state)?.id).toBe("resize-one-on-one");
 
-    // Whole-block Shift+Down twice moves 10:00 -> 10:30; not a resize.
-    state = playKeys(
-      state,
-      [key.arrow("down", true), key.arrow("down", true)],
-      T0,
-    );
+    // Whole-block Shift+Up moves 10:00-10:30 -> 9:45-10:15; not a resize.
+    state = handleGameKey(state, key.arrow("up", true), T0);
     expect(currentTask(state)?.id).toBe("resize-one-on-one");
 
-    // Recover, then do it properly via the end edge.
+    // Recover, then do it properly via the start edge.
     state = playKeys(
       state,
-      [
-        key.arrow("up", true),
-        key.arrow("up", true),
-        key.tab,
-        key.tab,
-        key.arrow("down", true),
-        key.arrow("down", true),
-      ],
+      [key.arrow("down", true), key.tab, key.arrow("up", true)],
       T0,
     );
-    expect(currentTask(state)?.id).toBe("quicktime-focus");
+    expect(currentTask(state)?.id).toBe("delete-gym");
   });
 
   it("restores the scripted delete with undo", () => {
     let state = startRun(createInitialGameState(), T0);
-    state = playKeys(state, WINNING_SCRIPT.slice(0, 25), T0);
+    state = playKeys(state, WINNING_SCRIPT.slice(0, 10), T0);
     expect(currentTask(state)?.id).toBe("delete-gym");
 
     state = handleGameKey(state, key.del, T0);
@@ -306,7 +276,7 @@ describe("discovery tasks", () => {
   const reachLegend = () =>
     playKeys(
       startRun(createInitialGameState(), T0),
-      WINNING_SCRIPT.slice(0, 27),
+      WINNING_SCRIPT.slice(0, 12),
       T0,
     );
 
@@ -335,7 +305,7 @@ describe("discovery tasks", () => {
     // A letter with no block is a no-op; a wrong block closes the chips
     // but leaves the task open.
     expect(handleGameKey(state, key.letter("z"), T0)).toBe(state);
-    state = handleGameKey(state, key.letter("j"), T0);
+    state = handleGameKey(state, key.letter("g"), T0);
     expect(currentTask(state)?.id).toBe("jump-to-kickoff");
 
     state = playKeys(state, [key.jump, key.letter("s")], T0);
@@ -384,21 +354,21 @@ describe("keycap progress", () => {
     const task = currentTask(state) as NonNullable<
       ReturnType<typeof currentTask>
     >;
-    expect(task.id).toBe("quicktime-lunch");
+    expect(task.id).toBe("quicktime-coffee");
     expect(getNextKeycapIndex(task, state)).toBe(0);
 
-    state = playKeys(state, [key.digit("1"), key.digit("2")], T0);
+    state = playKeys(state, [key.digit("9"), key.digit("3")], T0);
     expect(getNextKeycapIndex(task, state)).toBe(2);
 
-    state = playKeys(state, [key.digit("3"), key.digit("0")], T0);
-    // Spawned at 12:30, still placing: Enter is the last chip.
+    state = handleGameKey(state, key.digit("0"), T0);
+    // Spawned at 9:30, still placing: Enter is the last chip.
     expect(getNextKeycapIndex(task, state)).toBe(task.keycaps.length - 1);
   });
 
-  it("walks both Tab chips, then the Shift+Down chips, on the resize card", () => {
+  it("tabs once to the start edge, then pulses Shift+Up on the last chip", () => {
     let state = playKeys(
       startRun(createInitialGameState(), T0),
-      WINNING_SCRIPT.slice(0, 16),
+      WINNING_SCRIPT.slice(0, 8),
       T0,
     );
     const task = currentTask(state) as NonNullable<
@@ -408,72 +378,29 @@ describe("keycap progress", () => {
     expect(getNextKeycapIndex(task, state)).toBe(0);
 
     state = handleGameKey(state, key.tab, T0);
-    // Start edge focused: the second Tab chip is next.
-    expect(getNextKeycapIndex(task, state)).toBe(1);
-
-    state = handleGameKey(state, key.tab, T0);
-    // End edge focused: first Down chip, past the held Shift at index 2.
-    expect(getNextKeycapIndex(task, state)).toBe(3);
-
-    state = handleGameKey(state, key.arrow("down", true), T0);
-    expect(getNextKeycapIndex(task, state)).toBe(4);
-  });
-
-  it("walks the doubled arrow chips on place-review and self-corrects", () => {
-    let state = playKeys(
-      startRun(createInitialGameState(), T0),
-      WINNING_SCRIPT.slice(0, 8),
-      T0,
-    );
-    const task = currentTask(state) as NonNullable<
-      ReturnType<typeof currentTask>
-    >;
-    expect(task.id).toBe("place-review");
-    expect(getNextKeycapIndex(task, state)).toBe(0);
-
-    state = handleGameKey(state, key.create, T0);
-    expect(getNextKeycapIndex(task, state)).toBe(1);
-
-    state = handleGameKey(state, key.arrow("right"), T0);
-    expect(getNextKeycapIndex(task, state)).toBe(2);
-
-    // A wrong turn walks the pulse back: distance, not press count.
-    state = handleGameKey(state, key.arrow("left"), T0);
-    expect(getNextKeycapIndex(task, state)).toBe(1);
-
-    state = playKeys(state, [key.arrow("right"), key.arrow("right")], T0);
-    // On target: Enter is the last chip.
+    // Start edge focused: past the held Shift, onto the last chip.
     expect(getNextKeycapIndex(task, state)).toBe(task.keycaps.length - 1);
+    expect(getNextKeycapIndex(task, state)).toBe(2);
   });
 
-  it("counts the nudge presses across the doubled Down chips", () => {
-    let state = playKeys(
+  it("pulses the Shift+Down chip on the one-press nudge card", () => {
+    const state = playKeys(
       startRun(createInitialGameState(), T0),
-      WINNING_SCRIPT.slice(0, 12),
+      WINNING_SCRIPT.slice(0, 7),
       T0,
     );
     const task = currentTask(state) as NonNullable<
       ReturnType<typeof currentTask>
     >;
     expect(task.id).toBe("nudge-standup");
-    // Four presses to go: the first Down chip, past the held Shift.
+    // One press to go: the Down chip, past the held Shift.
     expect(getNextKeycapIndex(task, state)).toBe(1);
-
-    state = handleGameKey(state, key.arrow("down", true), T0);
-    expect(getNextKeycapIndex(task, state)).toBe(2);
-
-    state = playKeys(
-      state,
-      [key.arrow("down", true), key.arrow("down", true)],
-      T0,
-    );
-    expect(getNextKeycapIndex(task, state)).toBe(4);
   });
 
   it("shows the jump target's live letter on the card and pulses it after H", () => {
     let state = playKeys(
       startRun(createInitialGameState(), T0),
-      WINNING_SCRIPT.slice(0, 29),
+      WINNING_SCRIPT.slice(0, 14),
       T0,
     );
     const task = currentTask(state) as NonNullable<
@@ -491,7 +418,7 @@ describe("keycap progress", () => {
   it("swaps the palette card's hint to Esc while the sim palette is open", () => {
     let state = playKeys(
       startRun(createInitialGameState(), T0),
-      WINNING_SCRIPT.slice(0, 33),
+      WINNING_SCRIPT.slice(0, 18),
       T0,
     );
     const task = currentTask(state) as NonNullable<
@@ -504,6 +431,23 @@ describe("keycap progress", () => {
     expect(getDisplayKeycaps(task, state)).toEqual(["Esc"]);
     expect(getNextKeycapIndex(task, state)).toBe(0);
   });
+
+  it("swaps the legend card's hint to Esc while the sim legend is open", () => {
+    let state = playKeys(
+      startRun(createInitialGameState(), T0),
+      WINNING_SCRIPT.slice(0, 12),
+      T0,
+    );
+    const task = currentTask(state) as NonNullable<
+      ReturnType<typeof currentTask>
+    >;
+    expect(task.id).toBe("legend-peek");
+    expect(getDisplayKeycaps(task, state)).toEqual(["?"]);
+
+    state = handleGameKey(state, key.legend, T0);
+    expect(getDisplayKeycaps(task, state)).toEqual(["Esc"]);
+    expect(getNextKeycapIndex(task, state)).toBe(0);
+  });
 });
 
 describe("typed times", () => {
@@ -511,6 +455,7 @@ describe("typed times", () => {
     expect(resolveTypedTime("1230")).toBe(12 * 60 + 30);
     expect(resolveTypedTime("830")).toBe(8 * 60 + 30);
     expect(resolveTypedTime("915")).toBe(9 * 60 + 15);
+    expect(resolveTypedTime("930")).toBe(9 * 60 + 30);
     // Not quarter-hour aligned, or outside the 8am-6pm grid.
     expect(resolveTypedTime("1234")).toBeNull();
     expect(resolveTypedTime("0700")).toBeNull();
@@ -520,30 +465,30 @@ describe("typed times", () => {
   it("keeps a promising buffer and clears a hopeless one", () => {
     let state = startRun(createInitialGameState(), T0);
     state = playKeys(state, WINNING_SCRIPT.slice(0, 3), T0);
-    expect(currentTask(state)?.id).toBe("quicktime-lunch");
+    expect(currentTask(state)?.id).toBe("quicktime-coffee");
 
-    state = playKeys(state, [key.digit("1"), key.digit("2")], T0);
-    expect(state.digitBuffer).toBe("12");
-    // "129" cannot extend to any valid quarter-hour time.
-    state = handleGameKey(state, key.digit("9"), T0);
+    state = playKeys(state, [key.digit("9"), key.digit("3")], T0);
+    expect(state.digitBuffer).toBe("93");
+    // "931" cannot extend to any valid quarter-hour time.
+    state = handleGameKey(state, key.digit("1"), T0);
     expect(state.digitBuffer).toBe("");
   });
 
   it("commits a short hour buffer with Enter", () => {
     let state = startRun(createInitialGameState(), T0);
     state = playKeys(state, WINNING_SCRIPT.slice(0, 3), T0);
-    state = playKeys(state, [key.digit("1"), key.digit("2"), key.enter], T0);
-    // Spawned at 12:00 (placing); not yet at the 12:30 target.
-    const lunch = state.practice.events.find((e) => e.id === "piece-lunch");
-    expect(lunch?.startMin).toBe(12 * 60);
-    expect(state.practice.placingId).toBe("piece-lunch");
+    state = playKeys(state, [key.digit("9"), key.enter], T0);
+    // Spawned at 9:00 (placing); not yet at the 9:30 target.
+    const coffee = state.practice.events.find((e) => e.id === "piece-coffee");
+    expect(coffee?.startMin).toBe(9 * 60);
+    expect(state.practice.placingId).toBe("piece-coffee");
 
     state = playKeys(
       state,
       [key.arrow("down"), key.arrow("down"), key.enter],
       T0,
     );
-    expect(currentTask(state)?.id).toBe("place-review");
+    expect(currentTask(state)?.id).toBe("nudge-standup");
   });
 });
 
@@ -561,6 +506,67 @@ describe("winning script sanity", () => {
   it("every task carries a stall hint", () => {
     for (const task of RUN_TASKS) {
       expect(task.hint.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("never repeats a key and arrow chips match spawn-to-target distance", () => {
+    expect(WINNING_SCRIPT).toHaveLength(23);
+    expect(RUN_TASKS).toHaveLength(11);
+
+    for (const task of RUN_TASKS) {
+      for (let i = 1; i < task.keycaps.length; i += 1) {
+        expect(task.keycaps[i]).not.toBe(task.keycaps[i - 1]);
+      }
+    }
+
+    let state = startRun(createInitialGameState(), T0);
+    let keyIndex = 0;
+    for (const task of RUN_TASKS) {
+      if (task.type === "place") {
+        const arrowCount = task.keycaps.length - 2;
+        const distance =
+          Math.abs(task.spawn.dayIndex - task.target.dayIndex) +
+          Math.abs(task.spawn.startMin - task.target.startMin) /
+            PRACTICE_NUDGE_MIN;
+        expect(arrowCount).toBe(distance);
+      }
+      if (task.type === "nudge" || task.type === "resize") {
+        const block = state.practice.events.find(
+          (event) => event.id === task.targetEventId,
+        );
+        expect(block).toBeTruthy();
+        if (!block) return;
+        const shiftIndex = task.keycaps.indexOf("Shift");
+        const arrowCount = task.keycaps.length - shiftIndex - 1;
+        const fromMin =
+          task.type === "resize" && task.edge === "start"
+            ? block.startMin
+            : task.type === "resize"
+              ? block.endMin
+              : block.startMin;
+        const toMin =
+          task.type === "resize" && task.edge === "start"
+            ? task.target.startMin
+            : task.type === "resize"
+              ? task.target.endMin
+              : task.target.startMin;
+        const distance =
+          Math.abs(block.dayIndex - task.target.dayIndex) +
+          Math.abs(fromMin - toMin) / PRACTICE_NUDGE_MIN;
+        expect(arrowCount).toBe(distance);
+      }
+
+      const startIndex = state.taskIndex;
+      while (
+        state.taskIndex === startIndex &&
+        keyIndex < WINNING_SCRIPT.length
+      ) {
+        const nextKey = WINNING_SCRIPT[keyIndex];
+        if (!nextKey) break;
+        state = handleGameKey(state, nextKey, T0);
+        keyIndex += 1;
+      }
+      expect(state.taskIndex).toBe(startIndex + 1);
     }
   });
 });

--- a/packages/web/src/components/ShortcutShowcase/game.state.ts
+++ b/packages/web/src/components/ShortcutShowcase/game.state.ts
@@ -528,7 +528,7 @@ export const handleGameKey = (
  * The chips the task card shows. Usually the task's static keycaps, but a
  * card can change chips as the move unfolds: the jump card carries the
  * target's live letter (assigned by board order, so it shifts with skips),
- * and the palette card's hint becomes the Esc that closes it.
+ * and the palette and legend cards swap to Esc once those overlays are open.
  */
 export const getDisplayKeycaps = (
   task: GameTask,
@@ -538,7 +538,10 @@ export const getDisplayKeycaps = (
     const letter = getJumpLetters(state.practice)[task.targetEventId];
     return letter ? [...task.keycaps, letter.toUpperCase()] : task.keycaps;
   }
-  if (task.type === "palette" && state.simOverlay === "palette") {
+  if (
+    (task.type === "palette" && state.simOverlay === "palette") ||
+    (task.type === "legend" && state.simOverlay === "legend")
+  ) {
     return ["Esc"];
   }
   return task.keycaps;
@@ -595,20 +598,23 @@ export const getNextKeycapIndex = (
       );
     }
     case "resize": {
-      const onEndEdge =
-        practice.focusedId === task.targetEventId && practice.edge === "end";
-      if (!onEndEdge) {
-        // Walk the Tab chips: second Tab once the start edge is focused.
-        return practice.focusedId === task.targetEventId &&
-          practice.edge === "start"
-          ? 1
+      const tabCount = task.keycaps.indexOf("Shift");
+      const tabsDone =
+        practice.focusedId === task.targetEventId
+          ? ([null, "start", "end"] as const).indexOf(practice.edge)
           : 0;
+      if (practice.edge !== task.edge) {
+        // Overshooting to the far edge wraps to chip 0: Tab again.
+        return Math.min(tabsDone, tabCount - 1);
       }
       const block = blockById(practice, task.targetEventId);
-      const shiftIndex = task.keycaps.indexOf("Shift");
+      const shiftIndex = tabCount;
       if (!block) return shiftIndex + 1;
       const remaining =
-        Math.abs(block.endMin - task.target.endMin) / PRACTICE_NUDGE_MIN;
+        Math.abs(
+          (task.edge === "start" ? block.startMin : block.endMin) -
+            (task.edge === "start" ? task.target.startMin : task.target.endMin),
+        ) / PRACTICE_NUDGE_MIN;
       return Math.min(
         Math.max(task.keycaps.length - remaining, shiftIndex + 1),
         task.keycaps.length - 1,

--- a/packages/web/src/components/ShortcutShowcase/game.tasks.ts
+++ b/packages/web/src/components/ShortcutShowcase/game.tasks.ts
@@ -80,9 +80,16 @@ export type GameTask =
       target: GameSlot;
     })
   | (GameTaskBase & {
-      type: "nudge" | "resize";
+      type: "nudge";
       targetEventId: string;
       target: GameSlot;
+    })
+  | (GameTaskBase & {
+      type: "resize";
+      targetEventId: string;
+      target: GameSlot;
+      /** Which edge Tab must land on before Shift+Arrow resizes it. */
+      edge: "start" | "end";
     })
   | (GameTaskBase & { type: "delete"; targetEventId: string })
   | (GameTaskBase & {
@@ -139,67 +146,36 @@ export const RUN_TASKS: readonly GameTask[] = [
     target: { dayIndex: 0, startMin: t(9), endMin: t(9, 30) },
   },
   {
-    id: "quicktime-lunch",
+    id: "quicktime-coffee",
     type: "quickTime",
-    title: "Lunch",
-    instruction: "Just type the time, then lock it in.",
-    hint: "Type 1 2 3 0 and the piece appears at 12:30. Enter locks it.",
-    keycaps: ["1", "2", "3", "0", "Enter"],
-    piece: { id: "piece-lunch", title: "Lunch", color: "mint" },
-    target: { dayIndex: 0, startMin: t(12, 30), endMin: t(13) },
-  },
-  {
-    id: "place-review",
-    type: "place",
-    title: "Design review",
-    instruction: "Wednesday afternoon. You know the drill.",
-    hint: "Each Right tap moves the piece one day. Two taps reach Wednesday.",
-    keycaps: [
-      ...KEYMAP.createEvent.keycaps,
-      "ArrowRight",
-      "ArrowRight",
-      "Enter",
-    ],
-    piece: { id: "piece-review", title: "Design review", color: "indigo" },
-    spawn: { dayIndex: 0, startMin: t(14), endMin: t(15) },
-    target: { dayIndex: 2, startMin: t(14), endMin: t(15) },
+    title: "Coffee",
+    instruction: "Type 930 for 9:30, then lock it in.",
+    hint: "Type 9 3 0 and Coffee appears at 9:30. Enter locks it.",
+    keycaps: ["9", "3", "0", "Enter"],
+    piece: { id: "piece-coffee", title: "Coffee", color: "mint" },
+    target: { dayIndex: 2, startMin: t(9, 30), endMin: t(10) },
   },
   {
     id: "nudge-standup",
     type: "nudge",
     title: "Standup moved",
-    instruction: "Push it down to 10:00. Hold Shift and tap the arrow.",
-    hint: "Keep tapping. Each Shift Down tap moves it 15 minutes; four taps reach 10:00.",
-    keycaps: ["Shift", "ArrowDown", "ArrowDown", "ArrowDown", "ArrowDown"],
+    instruction: "Hold Shift and tap Down to reach 9:15.",
+    hint: "Hold Shift and tap Down once. Each tap moves it 15 minutes.",
+    keycaps: ["Shift", "ArrowDown"],
     targetEventId: "piece-standup",
-    target: { dayIndex: 0, startMin: t(10), endMin: t(10, 30) },
+    target: { dayIndex: 0, startMin: t(9, 15), endMin: t(9, 45) },
   },
   {
     id: "resize-one-on-one",
     type: "resize",
     title: "1:1 running long",
     instruction:
-      "Press Tab until the bottom edge lights up, then hold Shift and tap Down to reach 11:00.",
-    hint: "Tab cycles what your arrows grab: whole block, top edge, bottom edge. Tab again until the bottom edge lights up, then Shift Down twice.",
-    keycaps: [
-      KEYMAP.edgeFocus.hotkey,
-      KEYMAP.edgeFocus.hotkey,
-      "Shift",
-      "ArrowDown",
-      "ArrowDown",
-    ],
+      "Press Tab to light the top edge, then hold Shift and tap Up to start at 9:45.",
+    hint: "Tab cycles what your arrows grab: whole block, top edge, bottom edge. Tab once for the top edge, then Shift Up.",
+    keycaps: [KEYMAP.edgeFocus.hotkey, "Shift", "ArrowUp"],
     targetEventId: "game-one-on-one",
-    target: { dayIndex: 1, startMin: t(10), endMin: t(11) },
-  },
-  {
-    id: "quicktime-focus",
-    type: "quickTime",
-    title: "Focus block",
-    instruction: "Guard Tuesday at 4. Just type the time.",
-    hint: "Times here are 24-hour. Type 1 6 0 0 for 4:00 pm, then Enter.",
-    keycaps: ["1", "6", "0", "0", "Enter"],
-    piece: { id: "piece-focus", title: "Deep work", color: "slate" },
-    target: { dayIndex: 1, startMin: t(16), endMin: t(17) },
+    target: { dayIndex: 1, startMin: t(9, 45), endMin: t(10, 30) },
+    edge: "start",
   },
   {
     id: "delete-gym",
@@ -224,7 +200,8 @@ export const RUN_TASKS: readonly GameTask[] = [
     id: "legend-peek",
     type: "legend",
     title: "Blanking on a move?",
-    instruction: "The legend lists every shortcut. Open it, then close it.",
+    instruction:
+      "The legend lists every shortcut. Open it, then close it with Esc.",
     hint: "The ? key is Shift and /. Open the legend, take a peek, then Esc closes it.",
     keycaps: ["?"],
   },
@@ -256,24 +233,14 @@ export const RUN_TASKS: readonly GameTask[] = [
     keycaps: KEYMAP.commandPalette.keycaps,
   },
   {
-    id: "nudge-review",
-    type: "nudge",
-    title: "Review slid to Tuesday",
-    instruction: "Walk it one day left.",
-    hint: "Hold Shift and tap Left once. Sideways moves shift whole days.",
-    keycaps: ["Shift", "ArrowLeft"],
-    targetEventId: "piece-review",
-    target: { dayIndex: 1, startMin: t(14), endMin: t(15) },
-  },
-  {
     id: "place-party",
     type: "place",
     title: "Ship-it party",
     instruction: "Wednesday at 5. Bring it home.",
-    hint: "Press C to drop it, tap Down to reach 5:00, then Enter. Last one.",
-    keycaps: [...KEYMAP.createEvent.keycaps, "ArrowDown", "ArrowDown", "Enter"],
+    hint: "Press C to drop it, tap Down once to reach 5:00, then Enter. Last one.",
+    keycaps: [...KEYMAP.createEvent.keycaps, "ArrowDown", "Enter"],
     piece: { id: "piece-party", title: "Ship-it party", color: "coral" },
-    spawn: { dayIndex: 2, startMin: t(16, 30), endMin: t(17, 30) },
+    spawn: { dayIndex: 2, startMin: t(16, 45), endMin: t(17, 45) },
     target: { dayIndex: 2, startMin: t(17), endMin: t(18) },
   },
 ];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Block Party's first run taught 14 tasks in 38 presses, with four repeated-key beats and three re-taught primitives. New players skip at a flat ~40% across every task (last 60 days, n=14), which reads as the run feeling long. The queue is now 11 tasks and 23 presses: one task per primitive, one press per key, never the same key twice in a row.

Coffee uses a 3-digit `930` (the sandbox grid is 8am-6pm, so 3-digit hours 8 and 9 are the valid ones). The 1:1 resize teaches the start edge with one Tab and Shift+Up. Legend chips swap to Esc while open, matching the palette card.

Removed task ids `quicktime-lunch`, `place-review`, `quicktime-focus`, and `nudge-review` stop firing; `quicktime-coffee` starts. Any saved PostHog insight filtered on those ids should be repointed (n is tiny).

![Task 2 Coffee ghost on Wednesday 9:30](https://cursor.com/artifacts/c/art-dee6a1eb-7b69-4d4d-9262-2e5794c7115a)
![Task 3 Standup nudge one slot down](https://cursor.com/artifacts/c/art-0b47d78d-f933-42b3-b5fa-50e939e26ead)
![Task 4 1:1 start-edge resize ghost](https://cursor.com/artifacts/c/art-65616cb4-b4e0-41dd-a01b-6d8abeaca5a2)
![Task 11 Ship-it party one slot down](https://cursor.com/artifacts/c/art-82b6391a-70e2-4530-bf46-8c1e32a22d0f)

## Verify

VERDICT: PASS
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3924edae-f54f-442a-bc52-32ccf2244eb7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3924edae-f54f-442a-bc52-32ccf2244eb7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

