### PR TITLE
feat(ci): add nightly live-provider smoke against compass-smoke

### DIFF
--- a/.agents/handoffs/3272.md
+++ b/.agents/handoffs/3272.md
@@ -1,0 +1,34 @@
+---
+schema_version: 1
+task_id: "3272"
+from: Implementer
+to: GitHub
+owner: GitHub
+status: verifying
+artifact:
+  - path: .github/workflows/live-provider-smoke.yml
+  - path: .github/scripts/live-provider-smoke.sh
+  - path: docs/CI-CD/live-provider-smoke.md
+  - path: packages/sync/src/providers/__contract__/live-provider-smoke.ts
+evidence:
+  - command: bun test:sync
+    result: pass (1236 pass, 2 skip)
+  - command: bun run type-check
+    result: pass
+  - command: bun lint
+    result: pass
+  - command: bun knip
+    result: pass
+assumptions:
+  - "GitHub Environment provider-smoke is created on first workflow use or by the founder; SMOKE_* tokens are not invented here."
+  - "Microsoft and Apple live factories skip until M-12 / A-11."
+open_risks:
+  - "Depends on #3236 (PR #3363) still in the merge queue."
+next_deadline: 2026-09-05T03:00:00Z
+retry: 0
+approval: human
+waiting_on: "3236 merge"
+escalation: null
+---
+
+L WP-10: nightly live-provider smoke against compass-smoke. Dispatch after merge to prove skipped providers when SMOKE_* tokens are absent.

--- a/.github/scripts/live-provider-smoke.sh
+++ b/.github/scripts/live-provider-smoke.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Run the live adapter contract / smoke suite for each provider whose
+# provider-smoke Environment secrets are present. A missing secret is a skip,
+# not a failure, so the job is green before Microsoft and Apple exist.
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+cd "$ROOT"
+
+FAILED_PROVIDERS=()
+SKIPPED_PROVIDERS=()
+PASSED_PROVIDERS=()
+
+run_kind() {
+  local kind=$1
+  echo "::group::LIVE_PROVIDER=${kind}"
+  if LIVE_PROVIDER="$kind" bun test:sync -- \
+    packages/sync/src/providers/__contract__/live-provider.smoke.test.ts \
+    packages/sync/src/providers/__contract__/live-provider.contract.test.ts; then
+    PASSED_PROVIDERS+=("$kind")
+    echo "${kind}: pass"
+  else
+    FAILED_PROVIDERS+=("$kind")
+    echo "${kind}: fail"
+  fi
+  echo "::endgroup::"
+}
+
+google_ready() {
+  [ -n "${SMOKE_GOOGLE_REFRESH_TOKEN:-}" ] &&
+    { [ -n "${GOOGLE_CLIENT_ID:-}" ] || [ -n "${SMOKE_GOOGLE_CLIENT_ID:-}" ]; } &&
+    { [ -n "${GOOGLE_CLIENT_SECRET:-}" ] || [ -n "${SMOKE_GOOGLE_CLIENT_SECRET:-}" ]; }
+}
+
+microsoft_ready() {
+  [ -n "${SMOKE_MICROSOFT_REFRESH_TOKEN:-}" ] &&
+    [ -n "${MICROSOFT_CLIENT_ID:-}" ] &&
+    [ -n "${MICROSOFT_CLIENT_SECRET:-}" ]
+}
+
+apple_ready() {
+  [ -n "${SMOKE_APPLE_EMAIL:-}" ] && [ -n "${SMOKE_APPLE_APP_PASSWORD:-}" ]
+}
+
+if google_ready; then
+  run_kind google
+else
+  SKIPPED_PROVIDERS+=("google")
+  echo "google skipped: SMOKE_GOOGLE_REFRESH_TOKEN or Google client id/secret absent"
+fi
+
+if microsoft_ready; then
+  run_kind microsoft
+else
+  SKIPPED_PROVIDERS+=("microsoft")
+  echo "microsoft skipped: SMOKE_MICROSOFT_REFRESH_TOKEN or Microsoft client id/secret absent"
+fi
+
+if apple_ready; then
+  run_kind apple
+else
+  SKIPPED_PROVIDERS+=("apple")
+  echo "apple skipped: SMOKE_APPLE_EMAIL or SMOKE_APPLE_APP_PASSWORD absent"
+fi
+
+passed="${PASSED_PROVIDERS[*]-}"
+skipped="${SKIPPED_PROVIDERS[*]-}"
+failed="${FAILED_PROVIDERS[*]-}"
+echo "live-provider-smoke passed=${passed:-none} skipped=${skipped:-none} failed=${failed:-none}"
+
+if [ "${#FAILED_PROVIDERS[@]}" -gt 0 ]; then
+  if [ -x "$ROOT/.github/scripts/discord-notify.sh" ]; then
+    bash "$ROOT/.github/scripts/discord-notify.sh" \
+      "live-provider-smoke failed: ${FAILED_PROVIDERS[*]} (skipped ${SKIPPED_PROVIDERS[*]:-none})"
+  fi
+  exit 1
+fi

--- a/.github/workflows/live-provider-smoke.yml
+++ b/.github/workflows/live-provider-smoke.yml
@@ -1,0 +1,56 @@
+name: Live provider smoke
+
+# Nightly and manual only. Never on pull requests. Secrets come from the
+# `provider-smoke` Environment, not from staging/production deploy secrets.
+# Contract: docs/CI-CD/live-provider-smoke.md
+on:
+  workflow_dispatch:
+  schedule:
+    # 06:20 UTC, offset from the top-of-hour scheduled-workflow stampede.
+    - cron: "20 6 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: live-provider-smoke
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Live adapter contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: provider-smoke
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v6
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install Dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run live provider smoke
+        env:
+          DISCORD_ERRORS_WEBHOOK_URL: ${{ secrets.DISCORD_ERRORS_WEBHOOK_URL }}
+          GOOGLE_CLIENT_ID: ${{ vars.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          MICROSOFT_CLIENT_ID: ${{ vars.MICROSOFT_CLIENT_ID }}
+          MICROSOFT_CLIENT_SECRET: ${{ secrets.MICROSOFT_CLIENT_SECRET }}
+          SMOKE_GOOGLE_REFRESH_TOKEN: ${{ secrets.SMOKE_GOOGLE_REFRESH_TOKEN }}
+          SMOKE_MICROSOFT_REFRESH_TOKEN: ${{ secrets.SMOKE_MICROSOFT_REFRESH_TOKEN }}
+          SMOKE_APPLE_EMAIL: ${{ secrets.SMOKE_APPLE_EMAIL }}
+          SMOKE_APPLE_APP_PASSWORD: ${{ secrets.SMOKE_APPLE_APP_PASSWORD }}
+        run: bash .github/scripts/live-provider-smoke.sh

--- a/docs/CI-CD/live-provider-smoke.md
+++ b/docs/CI-CD/live-provider-smoke.md
@@ -1,0 +1,59 @@
+# Live provider smoke
+
+Nightly (and `workflow_dispatch`) run of the shared adapter contract suite
+against real Google, Microsoft, and Apple test accounts. It never runs on
+pull requests. Workflow: [`.github/workflows/live-provider-smoke.yml`](../../.github/workflows/live-provider-smoke.yml).
+
+The job uses GitHub Environment `provider-smoke`. It does not read staging
+or production deploy secrets. A provider whose secrets are absent is skipped,
+so the job is green before Microsoft and Apple exist.
+
+Events are created only on a calendar named `compass-smoke`. Every created
+event's description carries the GitHub run id. A teardown step deletes
+leftovers older than one day. Failure posts to the Discord errors webhook
+with the provider name.
+
+## Create the Environment
+
+GitHub → Settings → Environments → New environment → `provider-smoke`.
+Do not grant it access to staging or production secrets.
+
+Copy the staging Google (and later Microsoft) OAuth client into this
+Environment as well: the smoke process calls the provider APIs directly.
+
+## Secrets and variables to paste
+
+Environment secrets:
+
+| Name | Value |
+|---|---|
+| `SMOKE_GOOGLE_REFRESH_TOKEN` | Refresh token for the Google test account that owns `compass-smoke` |
+| `SMOKE_MICROSOFT_REFRESH_TOKEN` | Refresh token for the Microsoft test account (after M-12) |
+| `SMOKE_APPLE_EMAIL` | iCloud email for the Apple test account (after A-11) |
+| `SMOKE_APPLE_APP_PASSWORD` | iCloud app-specific password (after A-11) |
+| `GOOGLE_CLIENT_SECRET` | Same Google OAuth client secret as staging |
+| `MICROSOFT_CLIENT_SECRET` | Same Entra client secret as staging (after M-12) |
+| `DISCORD_ERRORS_WEBHOOK_URL` | Discord errors webhook (duplicate of the repo secret so this Environment does not read repo secrets) |
+
+Environment variables:
+
+| Name | Value |
+|---|---|
+| `GOOGLE_CLIENT_ID` | Same Google OAuth client id as staging |
+| `MICROSOFT_CLIENT_ID` | Same Entra client id as staging (after M-12) |
+
+## Test calendar
+
+On each connected account, create a calendar named exactly `compass-smoke`
+and leave it writable. The suite refuses to run if that calendar is missing
+and never writes to any other calendar.
+
+## Dispatch
+
+```bash
+gh workflow run live-provider-smoke.yml
+```
+
+With only Google secrets present, the run passes and reports Microsoft and
+Apple as skipped. Once M-12 and A-11 land, all three providers report in one
+run.

--- a/docs/CI-CD/workflows.md
+++ b/docs/CI-CD/workflows.md
@@ -18,6 +18,7 @@ Compass uses GitHub Actions for continuous integration, Docker Hub for image dis
 | Deploy production | Manual dispatch | Deploys a release tag to production, then runs cloud deploy health checks |
 | Deploy health check | Reusable workflow | Validates the deployed staging stack and alerts Discord on failure |
 | Sync docs to compass-docs | Push to `main` touching `docs/**` | Mirrors this `docs/` directory to docs.compasscalendar.com |
+| Live provider smoke (`live-provider-smoke.yml`) | Nightly schedule / `workflow_dispatch` only (never on PRs) | Live adapter contract against `compass-smoke` test calendars; see [live-provider-smoke.md](./live-provider-smoke.md) |
 
 Error autofix is a governed Routine. Contract, drills, and recovery packet:
 [error-autofix-routine.md](./error-autofix-routine.md). Kill switch

--- a/knip.json
+++ b/knip.json
@@ -27,7 +27,8 @@
         "src/providers/__contract__/adapter-contract.ts",
         "src/providers/__contract__/google-contract.factory.ts",
         "src/providers/__contract__/recording-api.ts",
-        "src/providers/__contract__/discovery.contract.ts"
+        "src/providers/__contract__/discovery.contract.ts",
+        "src/providers/__contract__/live-provider-smoke.ts"
       ],
       "project": ["src/**/*.ts!"]
     },

--- a/packages/sync/src/providers/__contract__/README.md
+++ b/packages/sync/src/providers/__contract__/README.md
@@ -26,4 +26,5 @@ Record live request/response pairs with `recordingApi(realApi, corpusDir, caseNa
 - `Bearer …` values
 
 Apple discovery-only cases stay in `apple.contract.test.ts` until the rest of
-the Apple adapter set lands (A-11).
+the Apple adapter set lands (A-11). Nightly live runs are documented in
+[`docs/CI-CD/live-provider-smoke.md`](../../../../docs/CI-CD/live-provider-smoke.md).

--- a/packages/sync/src/providers/__contract__/live-provider-smoke.ts
+++ b/packages/sync/src/providers/__contract__/live-provider-smoke.ts
@@ -1,0 +1,339 @@
+import { EventScheduleSchema } from "@core/types/event.contracts";
+import { SyncEventContentSchema } from "@core/types/sync/event.contracts";
+import { googleLiveFactory } from "@sync/providers/__contract__/google-contract.factory";
+import { type ProviderAdapters } from "@sync/providers/provider-adapters";
+import { type CalendarDiscovery } from "@sync/providers/provider-calendar.port";
+import {
+  type ProviderEvent,
+  type ProviderEventRead,
+} from "@sync/providers/provider-event.port";
+import {
+  type ProviderEventWriter,
+  type ProviderWriteResult,
+} from "@sync/providers/provider-event-writer.port";
+import { randomBytes } from "node:crypto";
+
+export const SMOKE_CALENDAR_NAME = "compass-smoke";
+export const SMOKE_DESCRIPTION_PREFIX = "compass-live-smoke";
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+export class LiveSmokeError extends Error {
+  constructor(
+    readonly provider: string,
+    readonly contractCase: string,
+    message: string,
+  ) {
+    super(`${provider} live smoke failed (${contractCase}): ${message}`);
+    this.name = "LiveSmokeError";
+  }
+}
+
+export async function runGoogleLiveSmoke(input: {
+  readonly runId: string;
+  readonly refreshToken: string;
+}): Promise<void> {
+  const adapters = googleLiveFactory("");
+  const refreshed = await adapters.auth.refreshAccessToken({
+    refreshToken: input.refreshToken,
+  });
+  const accessToken = refreshed.accessToken;
+  const calendarId = await findSmokeCalendar(adapters, accessToken);
+  process.env["LIVE_ACCESS_TOKEN"] = accessToken;
+  process.env["LIVE_CALENDAR_ID"] = calendarId;
+
+  await teardownStaleSmokeEvents(
+    adapters,
+    accessToken,
+    calendarId,
+    input.runId,
+  );
+
+  const eventId = randomBytes(12).toString("hex");
+  const createdAt = new Date().toISOString();
+  const description = `${SMOKE_DESCRIPTION_PREFIX} run=${input.runId} created=${createdAt}`;
+  const start = new Date(Date.now() + 2 * 60 * 60 * 1000);
+  const end = new Date(start.getTime() + 30 * 60 * 1000);
+  const schedule = EventScheduleSchema.parse({
+    kind: "timed",
+    start: start.toISOString(),
+    end: end.toISOString(),
+    timeZone: "UTC",
+  });
+  const content = SyncEventContentSchema.parse({
+    title: `compass-smoke ${input.runId}`,
+    description,
+    location: null,
+    organizer: null,
+    attendees: [],
+    conference: null,
+  });
+
+  let created: ProviderWriteResult;
+  try {
+    created = await adapters.writer.createEvent({
+      accessToken,
+      calendarId,
+      providerEventId: eventId,
+      content,
+      schedule,
+      recurrence: { kind: "single" },
+      invitation: "none",
+    });
+  } catch (error) {
+    throw new LiveSmokeError(
+      "google",
+      "create",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+
+  try {
+    const readBack = await adapters.writer.fetchEvent({
+      accessToken,
+      calendarId,
+      providerEventId: created.providerEventId,
+    });
+    if (readBack?.kind !== "event") {
+      throw new LiveSmokeError(
+        "google",
+        "read-back",
+        "created event was not readable",
+      );
+    }
+    if (!readBack.content.description.includes(input.runId)) {
+      throw new LiveSmokeError(
+        "google",
+        "read-back",
+        "created event did not carry the run id",
+      );
+    }
+
+    const patched = await adapters.writer.patchEvent({
+      accessToken,
+      calendarId,
+      providerEventId: created.providerEventId,
+      expectedVersion: created.providerVersion,
+      content: { ...content, title: `compass-smoke ${input.runId} updated` },
+      schedule,
+      recurrence: { kind: "single" },
+      invitation: "none",
+    });
+    if (
+      !patched.providerVersion ||
+      patched.providerVersion === created.providerVersion
+    ) {
+      throw new LiveSmokeError(
+        "google",
+        "update",
+        "patch did not change version",
+      );
+    }
+
+    await runExceptionCase(
+      adapters.writer,
+      accessToken,
+      calendarId,
+      input.runId,
+    );
+
+    await adapters.writer.deleteEvent({
+      accessToken,
+      calendarId,
+      providerEventId: created.providerEventId,
+      expectedVersion: null,
+      invitation: "none",
+    });
+    const gone = await adapters.writer.fetchEvent({
+      accessToken,
+      calendarId,
+      providerEventId: created.providerEventId,
+    });
+    if (gone !== null) {
+      throw new LiveSmokeError(
+        "google",
+        "delete",
+        "event still present after delete",
+      );
+    }
+  } finally {
+    await adapters.writer
+      .deleteEvent({
+        accessToken,
+        calendarId,
+        providerEventId: created.providerEventId,
+        expectedVersion: null,
+        invitation: "none",
+      })
+      .catch(() => undefined);
+  }
+}
+
+async function findSmokeCalendar(
+  adapters: ProviderAdapters,
+  accessToken: string,
+): Promise<string> {
+  let discovery: CalendarDiscovery;
+  try {
+    discovery = await adapters.calendars.discoverCalendars({ accessToken });
+  } catch (error) {
+    throw new LiveSmokeError(
+      "google",
+      "discover",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+  const smoke = discovery.calendars.find(
+    (calendar) =>
+      calendar.displayName === SMOKE_CALENDAR_NAME &&
+      calendar.active &&
+      calendar.capabilities.canWriteEvents,
+  );
+  if (!smoke) {
+    throw new LiveSmokeError(
+      "google",
+      "discover",
+      `no writable calendar named ${SMOKE_CALENDAR_NAME}`,
+    );
+  }
+  return smoke.providerCalendarId;
+}
+
+async function teardownStaleSmokeEvents(
+  adapters: ProviderAdapters,
+  accessToken: string,
+  calendarId: string,
+  runId: string,
+): Promise<void> {
+  const cutoff = Date.now() - ONE_DAY_MS;
+  let pageToken: string | null = null;
+  do {
+    const page = await adapters.reader.listEventPage({
+      accessToken,
+      calendarId,
+      pageToken,
+    });
+    for (const event of page.events) {
+      if (event.kind !== "event") continue;
+      if (!shouldTeardown(event, runId, cutoff)) continue;
+      await adapters.writer
+        .deleteEvent({
+          accessToken,
+          calendarId,
+          providerEventId: event.providerEventId,
+          expectedVersion: null,
+          invitation: "none",
+        })
+        .catch(() => undefined);
+    }
+    pageToken = page.nextPageToken;
+  } while (pageToken);
+}
+
+function shouldTeardown(
+  event: ProviderEvent,
+  runId: string,
+  cutoff: number,
+): boolean {
+  const description = event.content.description;
+  if (!description.startsWith(SMOKE_DESCRIPTION_PREFIX)) return false;
+  if (description.includes(`run=${runId}`)) return true;
+  const created = /created=([^\s]+)/.exec(description)?.[1];
+  if (!created) return false;
+  const stamp = Date.parse(created);
+  return Number.isFinite(stamp) && stamp < cutoff;
+}
+
+async function runExceptionCase(
+  writer: ProviderEventWriter,
+  accessToken: string,
+  calendarId: string,
+  runId: string,
+): Promise<void> {
+  const seriesId = randomBytes(12).toString("hex");
+  const start = new Date(Date.now() + 3 * 60 * 60 * 1000);
+  const end = new Date(start.getTime() + 30 * 60 * 1000);
+  const schedule = EventScheduleSchema.parse({
+    kind: "timed",
+    start: start.toISOString(),
+    end: end.toISOString(),
+    timeZone: "UTC",
+  });
+  const content = SyncEventContentSchema.parse({
+    title: `compass-smoke series ${runId}`,
+    description: `${SMOKE_DESCRIPTION_PREFIX} run=${runId} created=${start.toISOString()}`,
+    location: null,
+    organizer: null,
+    attendees: [],
+    conference: null,
+  });
+
+  const created = await writer.createEvent({
+    accessToken,
+    calendarId,
+    providerEventId: seriesId,
+    content,
+    schedule,
+    recurrence: { kind: "series", rules: ["RRULE:FREQ=DAILY;COUNT=3"] },
+    invitation: "none",
+  });
+
+  try {
+    const instance = await retryInstance(
+      writer,
+      accessToken,
+      calendarId,
+      created.providerEventId,
+      start.toISOString(),
+    );
+    if (!instance || instance.kind !== "event") {
+      throw new LiveSmokeError(
+        "google",
+        "exception",
+        "fetchInstanceAt returned no occurrence",
+      );
+    }
+    await writer.patchEvent({
+      accessToken,
+      calendarId,
+      providerEventId: instance.providerEventId,
+      expectedVersion: instance.providerVersion,
+      content: { ...content, title: `compass-smoke exception ${runId}` },
+      schedule: instance.schedule,
+      recurrence: { kind: "instance" },
+      invitation: "none",
+    });
+  } finally {
+    await writer
+      .deleteEvent({
+        accessToken,
+        calendarId,
+        providerEventId: created.providerEventId,
+        expectedVersion: null,
+        invitation: "none",
+      })
+      .catch(() => undefined);
+  }
+}
+
+async function retryInstance(
+  writer: ProviderEventWriter,
+  accessToken: string,
+  calendarId: string,
+  seriesProviderEventId: string,
+  originalStartAt: string,
+): Promise<ProviderEventRead | null> {
+  let last: ProviderEventRead | null = null;
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    last = await writer.fetchInstanceAt({
+      accessToken,
+      calendarId,
+      seriesProviderEventId,
+      originalStartAt,
+      scheduleKind: "timed",
+    });
+    if (last) return last;
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+  }
+  return last;
+}

--- a/packages/sync/src/providers/__contract__/live-provider.contract.test.ts
+++ b/packages/sync/src/providers/__contract__/live-provider.contract.test.ts
@@ -6,15 +6,15 @@ import {
 import { describe, it } from "bun:test";
 
 const liveKind = process.env["LIVE_PROVIDER"];
+const calendarId = process.env["LIVE_CALENDAR_ID"];
 
 if (!liveKind) {
   describe.skip("live provider contract", () => {
     it("set LIVE_PROVIDER=<kind> to run against the real API", () => {});
   });
-} else if (liveKind === "google" && hasGoogleLiveCredentials()) {
+} else if (liveKind === "google" && hasGoogleLiveCredentials() && calendarId) {
   describeProviderContract("google", googleLiveFactory, {
-    accessToken: "unused-until-refresh",
-    calendarId: process.env["LIVE_CALENDAR_ID"] ?? "primary",
+    calendarId,
     refreshToken: process.env["SMOKE_GOOGLE_REFRESH_TOKEN"],
     skipAuthExchange: true,
     skipAuthRevoked: true,
@@ -22,6 +22,6 @@ if (!liveKind) {
   });
 } else {
   describe.skip(`live provider contract (${liveKind})`, () => {
-    it("skipped: secrets absent or live factory not wired for this provider", () => {});
+    it("skipped: secrets absent, LIVE_CALENDAR_ID unset, or live factory not wired", () => {});
   });
 }

--- a/packages/sync/src/providers/__contract__/live-provider.smoke.test.ts
+++ b/packages/sync/src/providers/__contract__/live-provider.smoke.test.ts
@@ -1,0 +1,27 @@
+import { hasGoogleLiveCredentials } from "@sync/providers/__contract__/google-contract.factory";
+import { runGoogleLiveSmoke } from "@sync/providers/__contract__/live-provider-smoke";
+import { describe, expect, it } from "bun:test";
+
+const liveKind = process.env["LIVE_PROVIDER"];
+
+if (!liveKind) {
+  describe.skip("live provider smoke", () => {
+    it("set LIVE_PROVIDER=<kind> to mutate compass-smoke on a real account", () => {});
+  });
+} else if (liveKind === "google" && hasGoogleLiveCredentials()) {
+  describe("google live provider smoke", () => {
+    it("creates, reads, updates, exceptions, and deletes only on compass-smoke", async () => {
+      const refreshToken = process.env["SMOKE_GOOGLE_REFRESH_TOKEN"];
+      if (!refreshToken) throw new Error("SMOKE_GOOGLE_REFRESH_TOKEN missing");
+      await runGoogleLiveSmoke({
+        runId: process.env["GITHUB_RUN_ID"] ?? `local-${Date.now()}`,
+        refreshToken,
+      });
+      expect(process.env["LIVE_CALENDAR_ID"]).toBeTruthy();
+    });
+  });
+} else {
+  describe.skip(`live provider smoke (${liveKind})`, () => {
+    it("skipped: secrets absent or live factory not wired for this provider", () => {});
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3272

## What and why

L WP-10: agents cannot reach real Google, Microsoft, or Apple accounts, so adapter work is verified against recorded fixtures (P0-11). Real APIs drift. This adds `.github/workflows/live-provider-smoke.yml` (nightly + `workflow_dispatch` only, never on PRs) that runs the live adapter contract against a dedicated `compass-smoke` calendar. Providers whose Environment secrets are absent are skipped, so the job is green before Microsoft and Apple exist. Spec: `docs/features/calendar-providers.md`. Secret names: `docs/CI-CD/live-provider-smoke.md`.

## Verify

VERDICT: PASS
Checks run: test:sync:fast, type-check, lint, knip
Also ran `bun test:sync` (1236 pass, 2 skip).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c551c3bd-a8a5-402b-abd1-9edd46fe8f41?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c551c3bd-a8a5-402b-abd1-9edd46fe8f41&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

