### PR TITLE
feat(sync): poll-only subscription short-circuit and per-provider reconcile cadence

### DIFF
--- a/.agents/handoffs/3228.md
+++ b/.agents/handoffs/3228.md
@@ -1,0 +1,37 @@
+---
+schema_version: 1
+task_id: "3228"
+from: Implementer
+to: GitHub
+owner: GitHub
+status: verifying
+artifact:
+  - path: packages/sync/src/domain/subscription-maintenance.service.ts
+  - path: packages/sync/src/domain/reconcile-sweep-rows.ts
+  - path: packages/sync/src/domain/reconcile-sweep-rows.test.ts
+  - path: packages/sync/src/storage/repositories/sync-resource.repository.ts
+  - path: packages/sync/src/config/sync.config.ts
+  - path: packages/sync/src/app.ts
+evidence:
+  - command: bun test:sync
+    result: pass (1257 tests)
+  - command: bun run type-check
+    result: pass
+  - command: bun lint
+    result: pass
+  - command: bun knip
+    result: pass
+  - command: bun run verify --strict
+    result: "VERDICT: PASS"
+assumptions:
+  - "Per-provider reconcile overrides use RECONCILE_STALE_AFTER_MS_<KIND> and RECONCILE_SWEEP_INTERVAL_MS_<KIND> env vars until compass.yaml fields land in a config WP."
+  - "Only providers registered without changeNotifications get a dedicated reconcile sweep row; with google-only registration behavior matches main."
+open_risks: []
+next_deadline: 2026-09-05T02:00:00Z
+retry: 0
+approval: allow
+waiting_on: null
+escalation: null
+---
+
+P0 WP-05: poll-only providers short-circuit subscription maintenance and get per-provider reconcile sweeps.

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -26,6 +26,10 @@ import {
   FAILED_JOB_MAX_REQUEUES,
   requeueFailedJobs,
 } from "@sync/domain/failed-job-requeue.service";
+import {
+  buildReconcileSweepRows,
+  listStaleEventsForRow,
+} from "@sync/domain/reconcile-sweep-rows";
 import { enqueueForResources } from "@sync/domain/resource-sweep-enqueue";
 import { retryStaleCommands } from "@sync/domain/stale-command-retry.service";
 import { SweepScheduler } from "@sync/domain/sweep-scheduler.service";
@@ -304,8 +308,6 @@ async function start(): Promise<void> {
 // at least this long — long enough that a real provider outage has had a
 // chance to clear before we burn another retry ladder on it.
 const FAILED_JOB_REQUEUE_COOLDOWN_MS = 30 * 60_000;
-// A resource not synced within this window is swept for a reconcile pull.
-const RECONCILE_STALE_AFTER_MS = 15 * 60_000;
 // The bootstrap-recovery sweep below and connection-state's own bootstrapOverdue
 // evidence share BOOTSTRAP_STALLED_AFTER_MS (imported from connection-state.ts)
 // so the UI and the self-heal sweep agree on which resources are stuck.
@@ -501,6 +503,7 @@ function buildSchedulers(
         // verifies them against the stored subscription.
         callbackUrlFor: (kind) =>
           registry.callbackUrlFor(config.CALLBACK_BASE_URL, kind),
+        providerCapabilities: (kind) => registry.get(kind).capabilities,
         invalidations: repos.invalidations,
         log: logger,
       },
@@ -575,6 +578,38 @@ function buildSchedulers(
         error,
       );
 
+  const reconcileSweepRows = buildReconcileSweepRows(registry, config).map(
+    (row) => ({
+      name: row.name,
+      windowMs: row.windowMs,
+      intervalMs: row.intervalMs,
+      run: async (before: Date) => {
+        const enqueued = await enqueueForResources(
+          { jobs, onEnqueueError: onEnqueueError(row.name) },
+          listStaleEventsForRow(resources, row),
+          (r, n) => resourceJob(r, "incrementalPull", n()),
+          before,
+          () => new Date(),
+        );
+        if (enqueued > 0) {
+          logger.info(`Sync ${row.name} sweep enqueued ${enqueued} pull(s)`);
+        }
+        if (row.name === "reconcile") {
+          await captureSafely(posthog, {
+            event: SYNC_RECONCILE_SWEEP_EVENT,
+            distinctId: "compass-sync",
+            properties: SyncReconcileSweepEventSchema.parse({
+              environment: identity.environment,
+              service: "compass-sync",
+              enqueued,
+            }),
+          });
+        }
+        return enqueued;
+      },
+    }),
+  );
+
   // One row per background sweep: `run` is the sweep's whole distinctive body
   // (finder, job kind, and its own logging/telemetry — they genuinely differ,
   // which is why #2588 stopped short of a fully shared implementation).
@@ -583,45 +618,10 @@ function buildSchedulers(
   const sweepRows: ReadonlyArray<{
     name: string;
     windowMs: number;
+    intervalMs?: number;
     run: (before: Date) => Promise<number>;
   }> = [
-    {
-      // The reconcile fallback looks BACK: enqueue a pull for any events
-      // resource not synced within the stale window (negative offset from now).
-      name: "reconcile",
-      windowMs: -RECONCILE_STALE_AFTER_MS,
-      run: async (before) => {
-        const enqueued = await enqueueForResources(
-          { jobs, onEnqueueError: onEnqueueError("reconcile") },
-          (b, l) => resources.listStaleEvents(b, l),
-          (r, n) => resourceJob(r, "incrementalPull", n()),
-          before,
-          () => new Date(),
-        );
-        // One line per cycle with work: silence here previously meant either
-        // "all fresh" or "sweep dead", indistinguishably.
-        if (enqueued > 0) {
-          logger.info(`Sync reconcile sweep enqueued ${enqueued} pull(s)`);
-        }
-        // Captured on every cycle, including enqueued: 0 — this is a
-        // liveness heartbeat, not a backlog report (the health snapshot's
-        // jobs.pending already covers backlog, and is too coarse a sample
-        // rate to catch a queue that drains in seconds; see the event's own
-        // doc comment). An alert built on "N of these landed in the last
-        // hour" can't be fooled by sampling gaps the way a periodic gauge
-        // read can.
-        await captureSafely(posthog, {
-          event: SYNC_RECONCILE_SWEEP_EVENT,
-          distinctId: "compass-sync",
-          properties: SyncReconcileSweepEventSchema.parse({
-            environment: identity.environment,
-            service: "compass-sync",
-            enqueued,
-          }),
-        });
-        return enqueued;
-      },
-    },
+    ...reconcileSweepRows,
     {
       // Subscription maintenance looks AHEAD: enqueue a renewal for any push
       // channel expiring within the renew window (positive offset from now),
@@ -796,13 +796,14 @@ function buildSchedulers(
   ];
 
   const sweeps = sweepRows.map(
-    ({ name, windowMs, run }) =>
+    ({ name, windowMs, intervalMs, run }) =>
       [
         name,
         new SweepScheduler(
           { sweep: run },
           {
             windowMs,
+            ...(intervalMs !== undefined ? { intervalMs } : {}),
             startupJitterMs: STARTUP_SWEEP_JITTER_MS,
             onError: (error) =>
               logSyncLoopError(`Sync ${name} sweep failed`, error),

--- a/packages/sync/src/config/sync.config.ts
+++ b/packages/sync/src/config/sync.config.ts
@@ -4,6 +4,7 @@ import {
   loadCompassConfig,
 } from "@core/config/compass.config";
 import { NodeEnv } from "@core/constants/core.constants";
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
 
 // Validated configuration for the Compass Sync service.
 // Execution defaults to `passive`: the service starts, serves health, and
@@ -14,6 +15,29 @@ import { NodeEnv } from "@core/constants/core.constants";
 const SYNC_PORT_DEFAULT = 3010;
 const SYNC_MAX_CONCURRENCY_DEFAULT = 4;
 const SYNC_RESERVED_PULL_LANES_DEFAULT = 1;
+export const RECONCILE_STALE_AFTER_MS_DEFAULT = 15 * 60_000;
+const RECONCILE_SWEEP_INTERVAL_MS_DEFAULT = 10 * 60_000;
+
+const PROVIDER_KINDS = [
+  "google",
+  "microsoft",
+  "apple",
+] as const satisfies readonly ProviderKind[];
+
+function perProviderIntFromEnv(
+  prefix: string,
+): Partial<Record<ProviderKind, number>> {
+  const out: Partial<Record<ProviderKind, number>> = {};
+  for (const kind of PROVIDER_KINDS) {
+    const raw = process.env[`${prefix}_${kind.toUpperCase()}`];
+    if (raw === undefined || raw.trim() === "") continue;
+    const parsed = Number(raw);
+    if (Number.isInteger(parsed) && parsed > 0) {
+      out[kind] = parsed;
+    }
+  }
+  return out;
+}
 
 export const SyncExecutionModeSchema = z.enum(["passive", "active"]);
 export type SyncExecutionMode = z.infer<typeof SyncExecutionModeSchema>;
@@ -76,6 +100,15 @@ export const SyncConfigSchema = z
     // When absent, the health emitter no-ops (local/dev without analytics).
     POSTHOG_KEY: z.string().trim().min(1).optional(),
     POSTHOG_HOST: z.url().optional(),
+    RECONCILE_STALE_AFTER_MS: PositiveIntFromInput.default(
+      RECONCILE_STALE_AFTER_MS_DEFAULT,
+    ),
+    reconcileStaleAfterMsByKind: z
+      .partialRecord(z.enum(PROVIDER_KINDS), PositiveIntFromInput)
+      .default({}),
+    reconcileSweepIntervalMsByKind: z
+      .partialRecord(z.enum(PROVIDER_KINDS), PositiveIntFromInput)
+      .default({}),
   })
   .refine((cfg) => cfg.RESERVED_PULL_LANES < cfg.MAX_CONCURRENCY, {
     message: "sync.reservedPullLanes must be less than sync.maxConcurrency",
@@ -113,7 +146,32 @@ export function parseSyncConfig(config: CompassConfig): SyncConfig {
     CREDENTIAL_ENCRYPTION_KEY: config.sync.credentialEncryptionKey || undefined,
     POSTHOG_KEY: config.posthog?.key || undefined,
     POSTHOG_HOST: config.posthog?.host || undefined,
+    reconcileStaleAfterMsByKind: {
+      ...perProviderIntFromEnv("RECONCILE_STALE_AFTER_MS"),
+    },
+    reconcileSweepIntervalMsByKind: {
+      ...perProviderIntFromEnv("RECONCILE_SWEEP_INTERVAL_MS"),
+    },
   });
+}
+
+export function reconcileStaleAfterMsFor(
+  config: SyncConfig,
+  kind: ProviderKind,
+): number {
+  return (
+    config.reconcileStaleAfterMsByKind[kind] ?? config.RECONCILE_STALE_AFTER_MS
+  );
+}
+
+export function reconcileSweepIntervalMsFor(
+  config: SyncConfig,
+  kind: ProviderKind,
+): number {
+  return (
+    config.reconcileSweepIntervalMsByKind[kind] ??
+    RECONCILE_SWEEP_INTERVAL_MS_DEFAULT
+  );
 }
 
 export function loadSyncConfig(): SyncConfig {

--- a/packages/sync/src/domain/reconcile-sweep-rows.test.ts
+++ b/packages/sync/src/domain/reconcile-sweep-rows.test.ts
@@ -1,0 +1,130 @@
+import {
+  type ProviderCapability,
+  type ProviderKind,
+} from "@core/types/sync/identity.contracts";
+import {
+  RECONCILE_STALE_AFTER_MS_DEFAULT,
+  SyncConfigSchema,
+} from "@sync/config/sync.config";
+import {
+  buildReconcileSweepRows,
+  pollOnlyProviderKinds,
+} from "@sync/domain/reconcile-sweep-rows";
+import { SweepScheduler } from "@sync/domain/sweep-scheduler.service";
+import {
+  type ProviderRegistration,
+  ProviderRegistry,
+} from "@sync/providers/provider-registry";
+
+function fakeRegistration(
+  capabilities: readonly ProviderCapability[],
+): ProviderRegistration {
+  return {
+    adapters: {} as ProviderRegistration["adapters"],
+    scopes: { forFeatures: () => [] },
+    capabilities,
+    callbackPath: "/sync/test",
+    notificationsCallbackPath: "/sync/notifications/test",
+    capabilitiesFromScopes: () => [...capabilities],
+  };
+}
+
+function fakeRegistry(
+  entries: Partial<Record<ProviderKind, readonly ProviderCapability[]>>,
+): ProviderRegistry {
+  const registrations = new Map<ProviderKind, ProviderRegistration>();
+  for (const kind of Object.keys(entries) as ProviderKind[]) {
+    const capabilities = entries[kind];
+    if (capabilities) {
+      registrations.set(kind, fakeRegistration(capabilities));
+    }
+  }
+  return new ProviderRegistry(registrations);
+}
+
+describe("buildReconcileSweepRows", () => {
+  const baseConfig = SyncConfigSchema.parse({
+    NODE_ENV: "development",
+    MONGO_URI: "mongodb://localhost/compass_sync",
+    INTERNAL_AUTH_TOKEN: "token",
+    CALLBACK_BASE_URL: "http://localhost:3010",
+  });
+
+  it("returns one default row when every registered provider supports push", () => {
+    const registry = fakeRegistry({
+      google: ["readEvents", "changeNotifications"],
+    });
+
+    expect(buildReconcileSweepRows(registry, baseConfig)).toEqual([
+      {
+        name: "reconcile",
+        windowMs: -RECONCILE_STALE_AFTER_MS_DEFAULT,
+        listOptions: {},
+      },
+    ]);
+  });
+
+  it("splits poll-only providers into dedicated rows with distinct cadence", () => {
+    const config = SyncConfigSchema.parse({
+      ...baseConfig,
+      reconcileStaleAfterMsByKind: { apple: 90_000 },
+      reconcileSweepIntervalMsByKind: { apple: 60_000 },
+    });
+    const registry = fakeRegistry({
+      google: ["readEvents", "changeNotifications"],
+      apple: ["readEvents", "incrementalChanges"],
+    });
+
+    const rows = buildReconcileSweepRows(registry, config);
+
+    expect(pollOnlyProviderKinds(registry)).toEqual(["apple"]);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      name: "reconcile",
+      windowMs: -RECONCILE_STALE_AFTER_MS_DEFAULT,
+      listOptions: { excludeProviders: ["apple"] },
+    });
+    expect(rows[1]).toMatchObject({
+      name: "reconcile-apple",
+      windowMs: -90_000,
+      intervalMs: 60_000,
+      listOptions: { provider: "apple" },
+    });
+    expect(rows[0]?.intervalMs).not.toBe(rows[1]?.intervalMs);
+  });
+
+  it("runs default and poll-only reconcile schedulers on separate intervals", async () => {
+    const config = SyncConfigSchema.parse({
+      ...baseConfig,
+      reconcileSweepIntervalMsByKind: { apple: 30_000 },
+    });
+    const registry = fakeRegistry({
+      google: ["readEvents", "changeNotifications"],
+      apple: ["readEvents"],
+    });
+    const rows = buildReconcileSweepRows(registry, config);
+    const ran: string[] = [];
+
+    for (const row of rows) {
+      const scheduler = new SweepScheduler(
+        {
+          sweep: async () => {
+            ran.push(row.name);
+            return 0;
+          },
+        },
+        {
+          intervalMs: row.intervalMs ?? 600_000,
+          random: () => 0,
+        },
+      );
+      scheduler.start();
+      await scheduler.stop();
+    }
+
+    expect(ran).toEqual(["reconcile", "reconcile-apple"]);
+    expect(rows.map((row) => row.intervalMs ?? 600_000)).toEqual([
+      600_000, 30_000,
+    ]);
+  });
+});

--- a/packages/sync/src/domain/reconcile-sweep-rows.ts
+++ b/packages/sync/src/domain/reconcile-sweep-rows.ts
@@ -1,0 +1,63 @@
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+import {
+  reconcileStaleAfterMsFor,
+  reconcileSweepIntervalMsFor,
+  type SyncConfig,
+} from "@sync/config/sync.config";
+import { type ProviderRegistry } from "@sync/providers/provider-registry";
+import {
+  type ListStaleEventsOptions,
+  type SyncResourceRepository,
+} from "@sync/storage/repositories/sync-resource.repository";
+
+export interface ReconcileSweepRowSpec {
+  readonly name: string;
+  readonly windowMs: number;
+  readonly intervalMs?: number;
+  readonly listOptions: ListStaleEventsOptions;
+}
+
+export function pollOnlyProviderKinds(
+  registry: ProviderRegistry,
+): ProviderKind[] {
+  return registry
+    .kinds()
+    .filter(
+      (kind) =>
+        !registry.get(kind).capabilities.includes("changeNotifications"),
+    );
+}
+
+export function buildReconcileSweepRows(
+  registry: ProviderRegistry,
+  config: SyncConfig,
+): ReconcileSweepRowSpec[] {
+  const pollOnly = pollOnlyProviderKinds(registry);
+  const rows: ReconcileSweepRowSpec[] = [
+    {
+      name: "reconcile",
+      windowMs: -config.RECONCILE_STALE_AFTER_MS,
+      listOptions: pollOnly.length > 0 ? { excludeProviders: pollOnly } : {},
+    },
+  ];
+  for (const kind of pollOnly) {
+    rows.push({
+      name: `reconcile-${kind}`,
+      windowMs: -reconcileStaleAfterMsFor(config, kind),
+      intervalMs: reconcileSweepIntervalMsFor(config, kind),
+      listOptions: { provider: kind },
+    });
+  }
+  return rows;
+}
+
+export function listStaleEventsForRow(
+  resources: SyncResourceRepository,
+  row: ReconcileSweepRowSpec,
+): (
+  before: Date,
+  limit: number,
+) => ReturnType<SyncResourceRepository["listStaleEvents"]> {
+  return (before, limit) =>
+    resources.listStaleEvents(before, limit, row.listOptions);
+}

--- a/packages/sync/src/domain/subscription-maintenance.service.db.test.ts
+++ b/packages/sync/src/domain/subscription-maintenance.service.db.test.ts
@@ -83,6 +83,17 @@ describe("maintainSubscription", () => {
   const storage = setupSyncStorage(import.meta.url);
   let resources: SyncResourceRepository;
 
+  const maintenanceDeps = (
+    notifications: FakeNotifications,
+    supportsChangeNotifications = true,
+  ) => ({
+    resources,
+    notifications,
+    custody,
+    callbackUrl: "https://sync/cb",
+    supportsChangeNotifications,
+  });
+
   beforeEach(() => {
     resources = new SyncResourceRepository(storage.db());
   });
@@ -158,7 +169,7 @@ describe("maintainSubscription", () => {
     });
 
     const outcome = await maintainSubscription(
-      { resources, notifications, custody, callbackUrl: "https://sync/cb" },
+      maintenanceDeps(notifications),
       cal,
       resource,
       now,
@@ -188,7 +199,7 @@ describe("maintainSubscription", () => {
     });
 
     const outcome = await maintainSubscription(
-      { resources, notifications, custody, callbackUrl: "https://sync/cb" },
+      maintenanceDeps(notifications),
       cal,
       resource,
       now,
@@ -216,7 +227,7 @@ describe("maintainSubscription", () => {
     });
 
     const outcome = await maintainSubscription(
-      { resources, notifications, custody, callbackUrl: "https://sync/cb" },
+      maintenanceDeps(notifications),
       cal,
       resource,
       now,
@@ -239,7 +250,7 @@ describe("maintainSubscription", () => {
     });
 
     const outcome = await maintainSubscription(
-      { resources, notifications, custody, callbackUrl: "https://sync/cb" },
+      maintenanceDeps(notifications),
       cal,
       resource,
       now,
@@ -265,18 +276,15 @@ describe("maintainSubscription", () => {
     );
 
     const outcome = await maintainSubscription(
-      {
-        resources,
-        notifications: new FakeNotifications({
+      maintenanceDeps(
+        new FakeNotifications({
           channel: {
             channelId: "",
             resourceId: "res-retry",
             expiresAt: new Date("2026-07-17T00:00:00.000Z"),
           },
         }),
-        custody,
-        callbackUrl: "https://sync/cb",
-      },
+      ),
       cal,
       resource,
       now,
@@ -313,10 +321,8 @@ describe("maintainSubscription", () => {
 
     const outcome = await maintainSubscription(
       {
-        resources,
-        notifications,
+        ...maintenanceDeps(notifications),
         custody: discardingCustody,
-        callbackUrl: "https://sync/cb",
       },
       cal,
       resource,
@@ -338,12 +344,7 @@ describe("maintainSubscription", () => {
     });
 
     await expect(
-      maintainSubscription(
-        { resources, notifications, custody, callbackUrl: "https://sync/cb" },
-        cal,
-        resource,
-        now,
-      ),
+      maintainSubscription(maintenanceDeps(notifications), cal, resource, now),
     ).rejects.toThrow("try later");
   });
 
@@ -363,7 +364,7 @@ describe("maintainSubscription", () => {
     });
 
     const outcome = await maintainSubscription(
-      { resources, notifications, custody, callbackUrl: "https://sync/cb" },
+      maintenanceDeps(notifications),
       cal,
       resource,
       now,
@@ -387,7 +388,7 @@ describe("maintainSubscription", () => {
     });
 
     const outcome = await maintainSubscription(
-      { resources, notifications, custody, callbackUrl: "https://sync/cb" },
+      maintenanceDeps(notifications),
       cal,
       resource,
       now,
@@ -415,7 +416,7 @@ describe("maintainSubscription", () => {
     });
 
     const outcome = await maintainSubscription(
-      { resources, notifications, custody, callbackUrl: "https://sync/cb" },
+      maintenanceDeps(notifications),
       null,
       resource,
       now,
@@ -427,5 +428,30 @@ describe("maintainSubscription", () => {
     ]);
     const saved = await resources.findById(tenantId, principalId, resource._id);
     expect(saved?.subscriptionResourceId).toBe("res-list");
+  });
+
+  it("returns unsupported without calling watch when changeNotifications is false", async () => {
+    const cal = calendar(objectId());
+    const resource = await seedResource(cal);
+    const notifications = new FakeNotifications({
+      channel: {
+        channelId: "",
+        resourceId: "res-poll",
+        expiresAt: new Date("2026-07-17T00:00:00.000Z"),
+      },
+    });
+
+    const outcome = await maintainSubscription(
+      maintenanceDeps(notifications, false),
+      cal,
+      resource,
+      now,
+    );
+
+    expect(outcome).toEqual({ status: "unsupported" });
+    expect(notifications.watched).toHaveLength(0);
+    const saved = await reload(resource);
+    expect(saved?.watchUnsupportedAt).toEqual(now());
+    expect(saved?.subscriptionId).toBeNull();
   });
 });

--- a/packages/sync/src/domain/subscription-maintenance.service.ts
+++ b/packages/sync/src/domain/subscription-maintenance.service.ts
@@ -16,6 +16,9 @@ export interface SubscriptionMaintenanceDeps {
   // the notifications route). Passed to the provider on watch; the callback then
   // arrives here and is matched to the stored subscription.
   callbackUrl: string;
+  // From the connection provider's registry capabilities. Poll-only providers
+  // (changeNotifications: false) short-circuit before any adapter call.
+  supportsChangeNotifications: boolean;
 }
 
 export interface SubscriptionMaintenanceOptions {
@@ -83,6 +86,23 @@ export async function maintainSubscription(
     resource.subscriptionExpiresAt.getTime() - now().getTime() > renewBeforeMs
   ) {
     return { status: "current" };
+  }
+
+  if (!deps.supportsChangeNotifications) {
+    if (resource.subscriptionId) {
+      await deps.resources.clearSubscription(
+        resource.tenantId,
+        resource.principalId,
+        resource._id,
+      );
+    }
+    await deps.resources.markWatchUnsupported(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+      now(),
+    );
+    return { status: "unsupported" };
   }
 
   const accessToken = await deps.custody.getValidAccessToken(

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -123,6 +123,15 @@ const defaultGoogleConnection = (
   updatedAt: now(),
 });
 
+const googleProviderCapabilities = [
+  "readEvents",
+  "writeEvents",
+  "readBusy",
+  "inviteAttendees",
+  "changeNotifications",
+  "incrementalChanges",
+] as const;
+
 describe("dispatchSyncJob", () => {
   const storage = setupSyncStorage(import.meta.url);
   let events: EventRepository;
@@ -197,6 +206,7 @@ describe("dispatchSyncJob", () => {
     commands,
     custody,
     callbackUrlFor: () => "https://sync.example/sync/notifications/google",
+    providerCapabilities: () => googleProviderCapabilities,
     invalidations,
   });
 
@@ -1078,6 +1088,52 @@ describe("dispatchSyncJob", () => {
     // One from the import's own windowed-pass/full-finish notifications, one
     // more from unsupported completing bootstrap.
     expect(feed.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("completes bootstrap to ready when the provider lacks changeNotifications", async () => {
+    const calendar = await seedCalendar();
+    const resource = await seedResource(calendar, null);
+    notifications.watched = [];
+    const pollOnlyNotifications = {
+      ...notifications,
+      watch: async () => {
+        throw new Error("watch must not run for poll-only providers");
+      },
+    };
+
+    const importOutcome = await dispatchSyncJob(
+      deps(
+        new FakeReader([
+          page([single("imported")]),
+          page([single("imported")], { nextSyncToken: "cursor-1" }),
+        ]),
+      ),
+      jobFor(resource, "initialImport"),
+      now,
+    );
+    expect(importOutcome).toMatchObject({
+      result: "done",
+      followup: { kind: "subscriptionMaintain" },
+    });
+
+    const subscriptionOutcome = await dispatchSyncJob(
+      {
+        ...deps(new FakeReader([]), tokenSource, pollOnlyNotifications),
+        providerCapabilities: () => ["readEvents", "incrementalChanges"],
+      },
+      jobFor(resource, "subscriptionMaintain"),
+      now,
+    );
+    expect(subscriptionOutcome).toEqual({ result: "done" });
+    expect(notifications.watched).toHaveLength(0);
+
+    const saved = await resources.findById(
+      resource.tenantId,
+      resource.principalId,
+      resource._id,
+    );
+    expect(saved?.bootstrapState).toBe("ready");
+    expect(saved?.subscriptionId).toBeNull();
   });
 
   it("completes bootstrap on durable watchFailed instead of burning retries", async () => {

--- a/packages/sync/src/domain/sync-job-dispatch.service.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.ts
@@ -1,4 +1,7 @@
-import { type ProviderKind } from "@core/types/sync/identity.contracts";
+import {
+  type ProviderCapability,
+  type ProviderKind,
+} from "@core/types/sync/identity.contracts";
 import { MAX_REFRESH_FAILED_ATTEMPTS } from "@sync/credentials/refresh-failure.constants";
 import { importCalendarEvents } from "@sync/domain/calendar-import.service";
 import { syncCalendarList } from "@sync/domain/calendar-list-sync.service";
@@ -58,6 +61,9 @@ export interface SyncJobDispatchDeps {
   commands: CommandRepository;
   custody: AccessTokenSource;
   callbackUrlFor: (provider: ProviderKind) => string;
+  providerCapabilities: (
+    provider: ProviderKind,
+  ) => readonly ProviderCapability[];
   // Content-free outbox so Compass API can push typed browser SSE after a
   // provider pull. Without this, incremental pulls update Sync storage but the
   // open SPA never refetches (S40 gap).
@@ -790,5 +796,8 @@ function subscriptionDeps(
     notifications: executionDeps.notifications,
     custody: executionDeps.custody,
     callbackUrl: deps.callbackUrlFor(provider),
+    supportsChangeNotifications: deps
+      .providerCapabilities(provider)
+      .includes("changeNotifications"),
   };
 }

--- a/packages/sync/src/domain/sync-job-worker.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.db.test.ts
@@ -115,6 +115,7 @@ describe("SyncJobWorker", () => {
     jobs,
     custody: tokenSource,
     callbackUrlFor: () => "https://sync.example/sync/notifications/google",
+    providerCapabilities: () => googleProviderCapabilities,
     invalidations,
   });
 

--- a/packages/sync/src/storage/repositories/sync-resource.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.db.test.ts
@@ -3,6 +3,7 @@ import { type Db } from "mongodb";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import { type SyncResourceUpsert } from "@sync/storage/contracts/sync-resource.contracts";
+import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 
 const objectId = () => faker.database.mongodbObjectId();
@@ -499,5 +500,73 @@ describe("SyncResourceRepository", () => {
     );
     expect(byConnection).toHaveLength(1);
     expect(byConnection[0]?._id).toBe(resource._id);
+  });
+
+  describe("listStaleEvents provider filter", () => {
+    let credentials: CredentialRepository;
+    const staleBefore = new Date("2026-07-09T00:00:00.000Z");
+
+    beforeEach(() => {
+      credentials = new CredentialRepository(db);
+    });
+
+    const seedStale = async (
+      provider: "google" | "apple",
+    ): Promise<{ _id: string }> => {
+      const tenantId = objectId() as SyncResourceUpsert["tenantId"];
+      const principalId = objectId() as SyncResourceUpsert["principalId"];
+      const connectionId = objectId() as SyncResourceUpsert["connectionId"];
+      const resource = await repo.ensure(
+        upsert({ tenantId, principalId, connectionId }),
+      );
+      if (provider === "google") {
+        await credentials.store({
+          connectionId,
+          provider: "google",
+          refreshToken: "google-refresh",
+          scopes: [],
+        });
+      } else {
+        await credentials.storePassword({
+          connectionId,
+          provider: "apple",
+          username: "user@icloud.com",
+          secretCiphertext: "cipher",
+          secretIv: "iv",
+          secretTag: "tag",
+          keyVersion: 1,
+        });
+      }
+      await repo.advanceCursor(
+        tenantId,
+        principalId,
+        resource._id,
+        "cursor",
+        new Date("2026-07-01T00:00:00.000Z"),
+      );
+      return resource;
+    };
+
+    it("returns only apple resources when provider is apple", async () => {
+      const apple = await seedStale("apple");
+      await seedStale("google");
+
+      const results = await repo.listStaleEvents(staleBefore, 10, {
+        provider: "apple",
+      });
+
+      expect(results.map((r) => r._id)).toEqual([apple._id]);
+    });
+
+    it("excludes providers listed in excludeProviders on the default call", async () => {
+      await seedStale("apple");
+      const google = await seedStale("google");
+
+      const results = await repo.listStaleEvents(staleBefore, 10, {
+        excludeProviders: ["apple"],
+      });
+
+      expect(results.map((r) => r._id)).toEqual([google._id]);
+    });
   });
 });

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -4,6 +4,7 @@ import {
   type ConnectionId,
   type PrincipalId,
   type ProviderCalendarId,
+  type ProviderKind,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
@@ -31,7 +32,7 @@ import {
 // resources that already hold a live channel, which a credential-less
 // connection cannot renew into existence in the first place, and a renewal
 // attempt on one settles as a credential drop rather than burning a ladder.
-const EXCLUDE_CREDENTIALLESS_STAGES = [
+const CREDENTIAL_LOOKUP_STAGES = [
   {
     $lookup: {
       from: SYNC_COLLECTIONS.credentials,
@@ -41,8 +42,29 @@ const EXCLUDE_CREDENTIALLESS_STAGES = [
     },
   },
   { $match: { "_credential.0": { $exists: true } } },
-  { $project: { _credential: 0 } },
-];
+] as const;
+
+export interface ListStaleEventsOptions {
+  provider?: ProviderKind;
+  excludeProviders?: readonly ProviderKind[];
+}
+
+function credentialFilterStages(
+  options: ListStaleEventsOptions = {},
+): Record<string, unknown>[] {
+  const stages: Record<string, unknown>[] = [...CREDENTIAL_LOOKUP_STAGES];
+  if (options.provider !== undefined) {
+    stages.push({ $match: { "_credential.0.provider": options.provider } });
+  } else if (options.excludeProviders && options.excludeProviders.length > 0) {
+    stages.push({
+      $match: {
+        "_credential.0.provider": { $nin: [...options.excludeProviders] },
+      },
+    });
+  }
+  stages.push({ $project: { _credential: 0 } });
+  return stages;
+}
 
 interface SubscriptionInput {
   subscriptionId: string;
@@ -85,11 +107,12 @@ export class SyncResourceRepository {
     match: Record<string, unknown>,
     sort: Record<string, 1 | -1>,
     limit: number,
+    credentialFilter: ListStaleEventsOptions = {},
   ): Promise<SyncResourceRecord[]> {
     const records = await this.collection
       .aggregate<SyncResourceRecord>([
         { $match: match },
-        ...EXCLUDE_CREDENTIALLESS_STAGES,
+        ...credentialFilterStages(credentialFilter),
         { $sort: sort },
         { $limit: limit },
       ])
@@ -583,6 +606,7 @@ export class SyncResourceRepository {
   async listStaleEvents(
     before: Date,
     limit: number,
+    options: ListStaleEventsOptions = {},
   ): Promise<SyncResourceRecord[]> {
     // Round-robin by ATTEMPT, not success: never-attempted first (null sorts
     // lowest), then least-recently-attempted, so a resource that fails without
@@ -596,6 +620,7 @@ export class SyncResourceRepository {
       },
       { lastAttemptAt: 1, lastSuccessAt: 1 },
       limit,
+      options,
     );
   }
 


### PR DESCRIPTION
Fixes #3228

## What and why

Poll-only calendar providers (Apple, when registered) must not call the notifications adapter during subscription maintenance. This change short-circuits to `unsupported` when the registry reports `changeNotifications: false`, matching the existing dispatch path that completes bootstrap to `ready` and relies on reconcile polling.

The reconcile sweep now supports provider-scoped selection via credential lookup filters. The default sweep excludes providers that have their own row; each poll-only provider gets a dedicated sweep with configurable `RECONCILE_STALE_AFTER_MS_<KIND>` and `RECONCILE_SWEEP_INTERVAL_MS_<KIND>` env overrides (defaulting to the global stale window and 10 minute interval). Google-only deployments behave unchanged.

Spec: [`docs/features/calendar-providers.md`](https://github.com/KeepSoftwareSimple/compass-calendar/blob/main/docs/features/calendar-providers.md)

## Verify

```
bun test:sync
bun run type-check
bun lint
bun knip
bun run verify --strict
```

Summary
Selected packages: sync
Checks run: test:sync, type-check, lint, knip
Checks skipped: (none)

✓ All checks passed
VERDICT: PASS