### PR TITLE
feat(sync): encrypt OAuth refresh tokens at rest

### DIFF
--- a/.agents/handoffs/3271.md
+++ b/.agents/handoffs/3271.md
@@ -1,0 +1,32 @@
+---
+schema_version: 1
+task_id: "3271"
+from: Implementer
+to: Verifier
+owner: cursor-providers-c-wp04-3271
+status: verifying
+artifact:
+  - path: packages/core/src/security/credential-at-rest.ts
+  - path: packages/sync/src/credentials/oauth-refresh-at-rest.ts
+  - path: packages/sync/src/credentials/credential-custody.service.ts
+  - path: packages/sync/src/storage/repositories/credential.repository.ts
+  - path: packages/scripts/src/commands/encrypt-credentials.ts
+evidence:
+  - command: bun test:sync
+    result: pass (1264 tests)
+  - command: bun test:scripts
+    result: pass (132 tests)
+assumptions:
+  - "Plaintext oauth refresh acceptance remains until founder confirms prod backfill; follow-up PR drops it."
+  - "sync.credentialEncryptionKey is required for new OAuth writes; legacy plaintext reads work until lazy re-encrypt or backfill."
+  - "Key rotation tooling is documented only; implementation deferred."
+open_risks:
+  - "Founder must run encrypt-credentials on staging then prod and confirm convergence before the plaintext-removal follow-up."
+next_deadline: 2026-09-05T03:00:00Z
+retry: 0
+approval: allow
+waiting_on: null
+escalation: null
+---
+
+Providers C WP-04: encrypt OAuth refresh tokens at rest with backfill CLI.

--- a/docs/Config/README.md
+++ b/docs/Config/README.md
@@ -108,7 +108,7 @@ database and must not share the backend's database user/data.
 | `sync.maxConcurrency` | No | Job concurrency hint for Sync workers. |
 | `sync.enforceLeastPrivilege` | No | When `true`, Sync verifies its Mongo user cannot read the API database. |
 | `sync.compassApiDatabase` | No | API database name the least-privilege check must be denied access to. |
-| `sync.credentialEncryptionKey` | No | 32-byte base64 key that encrypts password credentials at rest. Required to enable Apple calendar connect. |
+| `sync.credentialEncryptionKey` | No | 32-byte base64 key that encrypts password and OAuth refresh credentials at rest. Required to enable Apple calendar connect and OAuth token storage. |
 
 ## Optional Integrations
 

--- a/docs/development/cli.md
+++ b/docs/development/cli.md
@@ -18,7 +18,29 @@ Primary file:
 | `bun run cli backfill-billing [--apply] [--batch-size 500] [--cutoff ISO]` | `packages/scripts/src/commands/backfill-billing.ts` | Places existing accounts without billing status into awaiting_checkout. Defaults to dry-run. |
 | `bun run cli purge-corrupt-sync-events [--apply]` | `packages/scripts/src/commands/purge-corrupt-sync-events.ts` | Deletes invalid Sync event documents. Defaults to dry-run. |
 | `bun run cli refresh-connection-states [--apply]` | `packages/scripts/src/commands/refresh-connection-states.ts` | Re-derives Sync connection state. Defaults to dry-run. |
+| `bun run cli encrypt-credentials [--apply] [--batch-size 200]` | `packages/scripts/src/commands/encrypt-credentials.ts` | Encrypts legacy plaintext OAuth refresh tokens in Sync credentials. Defaults to dry-run. |
 | `bun run cli manage-failed-jobs <list\|clear\|requeue> …` | `packages/scripts/src/commands/manage-failed-jobs.ts` | Operator tooling for Sync jobs that exhausted the self-heal requeue budget. Defaults to dry-run; pass `--apply` to persist. |
+
+### Encrypt OAuth refresh tokens at rest
+
+Requires `SYNC_MONGO_URI` or `sync.mongoUri`, and `SYNC_CREDENTIAL_ENCRYPTION_KEY` or `sync.credentialEncryptionKey`.
+
+```bash
+export SYNC_MONGO_URI='…'
+export SYNC_CREDENTIAL_ENCRYPTION_KEY='…'
+
+# Inventory plaintext rows (JSON to stdout)
+bun run cli encrypt-credentials
+
+# Write encrypted rows
+bun run cli encrypt-credentials --apply
+```
+
+Run on staging, confirm the report shows zero matched rows, then run on production. After production converges, a follow-up release can drop plaintext acceptance.
+
+#### Key rotation (procedure only)
+
+Each encrypted field carries a `keyVersion` (currently `1`). Rotating `sync.credentialEncryptionKey` is not automated in v1: decrypt with the old key and re-seal with the new key under a higher version, then deploy the new key. Implementing rotation tooling is deferred.
 
 ### Manage exhausted Sync jobs
 

--- a/docs/features/calendar-providers.md
+++ b/docs/features/calendar-providers.md
@@ -127,8 +127,7 @@ by Google or Microsoft."
 
 ## Named warts
 
-- OAuth refresh tokens are stored in plaintext today; only password credentials
-  are encrypted at rest until milestone C closes the gap.
+- OAuth refresh tokens are encrypted at rest with `sync.credentialEncryptionKey` as of milestone C; legacy plaintext rows are backfilled with `encrypt-credentials` and lazily re-encrypted on refresh until the follow-up release drops plaintext acceptance.
 - `GOOGLE_REVOKED` stays as an alias of `CONNECTION_REVOKED` on the SSE wire
   until every client reads the new code.
 - The health snapshot reports `provider: "google"` for the whole fleet until

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -1,6 +1,7 @@
 import { CliValidator } from "@scripts/cli.validator";
 import { runAuditConnectionIdentity } from "@scripts/commands/audit-connection-identity";
 import { runBackfillBilling } from "@scripts/commands/backfill-billing";
+import { runEncryptCredentials } from "@scripts/commands/encrypt-credentials";
 import { runManageFailedJobs } from "@scripts/commands/manage-failed-jobs";
 import { runPurgeUser } from "@scripts/commands/purge-user";
 import { Command } from "commander";
@@ -30,6 +31,9 @@ export default class CompassCLI {
         break;
       case cmd === "audit-connection-identity":
         await runAuditConnectionIdentity();
+        break;
+      case cmd === "encrypt-credentials":
+        await runEncryptCredentials();
         break;
       default:
         this.validator.exitHelpfully(`${cmd as string} is not a supported cmd`);
@@ -63,6 +67,14 @@ export default class CompassCLI {
       .allowUnknownOption(true)
       .description(
         "Report connected provider accounts that are another Compass user's login identity (read-only; optional --provider)",
+      );
+
+    program
+      .command("encrypt-credentials")
+      .helpOption(false)
+      .allowUnknownOption(true)
+      .description(
+        "Encrypt legacy plaintext OAuth refresh tokens in Sync credentials (--apply to write)",
       );
 
     program

--- a/packages/scripts/src/commands/encrypt-credentials.db.test.ts
+++ b/packages/scripts/src/commands/encrypt-credentials.db.test.ts
@@ -1,0 +1,113 @@
+import { encryptCredentials } from "@scripts/commands/encrypt-credentials/backfill";
+import { decryptCredentialAtRest } from "@core/security/credential-at-rest";
+import { type ConnectionId } from "@core/types/sync/identity.contracts";
+import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import { SYNC_COLLECTIONS } from "@sync/storage/collections";
+import { describe, expect, it } from "bun:test";
+import { randomBytes } from "node:crypto";
+
+const KEY = randomBytes(32).toString("base64");
+const NOW = new Date("2026-09-04T12:00:00.000Z");
+
+describe("encrypt-credentials (db)", () => {
+  const storage = setupSyncStorage(import.meta.url);
+
+  it("dry-run reports matches without writing", async () => {
+    const connectionId = "conn-1" as ConnectionId;
+    await storage.db().collection(SYNC_COLLECTIONS.credentials).insertOne({
+      _id: connectionId,
+      credentialKind: "oauthRefresh",
+      provider: "google",
+      refreshToken: "legacy-token",
+      accessToken: null,
+      accessTokenExpiresAt: null,
+      refreshFailureCount: 0,
+      scopes: [],
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+
+    const report = await encryptCredentials(
+      storage.db().collection(SYNC_COLLECTIONS.credentials),
+      { dryRun: true, batchSize: 50, encryptionKey: KEY, now: NOW },
+    );
+
+    expect(report.matched).toBe(1);
+    expect(report.modified).toBe(0);
+    const raw = await storage
+      .db()
+      .collection(SYNC_COLLECTIONS.credentials)
+      .findOne({ _id: connectionId });
+    expect(raw?.refreshToken).toBe("legacy-token");
+    expect(raw).not.toHaveProperty("refreshTokenCiphertext");
+  });
+
+  it("encrypts plaintext rows and is idempotent and resumable", async () => {
+    const firstId = "conn-a" as ConnectionId;
+    const secondId = "conn-b" as ConnectionId;
+    const collection = storage.db().collection(SYNC_COLLECTIONS.credentials);
+    await collection.insertMany([
+      {
+        _id: firstId,
+        credentialKind: "oauthRefresh",
+        provider: "google",
+        refreshToken: "token-a",
+        accessToken: null,
+        accessTokenExpiresAt: null,
+        refreshFailureCount: 0,
+        scopes: [],
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+      {
+        _id: secondId,
+        credentialKind: "oauthRefresh",
+        provider: "microsoft",
+        refreshToken: "token-b",
+        accessToken: null,
+        accessTokenExpiresAt: null,
+        refreshFailureCount: 0,
+        scopes: [],
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+    ]);
+
+    const first = await encryptCredentials(collection, {
+      dryRun: false,
+      batchSize: 1,
+      encryptionKey: KEY,
+      now: NOW,
+      sleep: async () => undefined,
+    });
+    expect(first.modified).toBe(2);
+
+    const second = await encryptCredentials(collection, {
+      dryRun: false,
+      batchSize: 50,
+      encryptionKey: KEY,
+      now: NOW,
+      sleep: async () => undefined,
+    });
+    expect(second.modified).toBe(0);
+    expect(second.matched).toBe(0);
+
+    for (const [connectionId, plaintext] of [
+      [firstId, "token-a"],
+      [secondId, "token-b"],
+    ] as const) {
+      const raw = await collection.findOne({ _id: connectionId });
+      expect(raw).not.toHaveProperty("refreshToken");
+      expect(raw?.refreshTokenCiphertext).toBeString();
+      expect(
+        decryptCredentialAtRest(KEY, {
+          ciphertext: String(raw?.refreshTokenCiphertext),
+          iv: String(raw?.refreshTokenIv),
+          tag: String(raw?.refreshTokenTag),
+          keyVersion: Number(raw?.keyVersion),
+        }),
+      ).toBe(plaintext);
+      expect(JSON.stringify(raw)).not.toContain(plaintext);
+    }
+  });
+});

--- a/packages/scripts/src/commands/encrypt-credentials.ts
+++ b/packages/scripts/src/commands/encrypt-credentials.ts
@@ -1,0 +1,93 @@
+import { encryptCredentials } from "@scripts/commands/encrypt-credentials/backfill";
+import { loadCompassConfig } from "@core/config/compass.config";
+import { Logger } from "@core/logger/winston.logger";
+import { decodeCredentialAtRestKey } from "@core/security/credential-at-rest";
+import { SyncMongoService } from "@sync/storage/sync-mongo.service";
+
+const logger = Logger("scripts.commands.encrypt-credentials");
+
+function syncMongoUri(): string {
+  const fromEnv = process.env["SYNC_MONGO_URI"]?.trim();
+  if (fromEnv) return fromEnv;
+  const uri = loadCompassConfig().sync?.mongoUri?.trim();
+  if (!uri) {
+    throw new Error(
+      "Set SYNC_MONGO_URI or add sync.mongoUri to compass.yaml before encrypt-credentials",
+    );
+  }
+  return uri;
+}
+
+function credentialEncryptionKey(): string {
+  const fromEnv = process.env["SYNC_CREDENTIAL_ENCRYPTION_KEY"]?.trim();
+  if (fromEnv) {
+    decodeCredentialAtRestKey(fromEnv);
+    return fromEnv;
+  }
+  const key = loadCompassConfig().sync?.credentialEncryptionKey?.trim();
+  if (!key) {
+    throw new Error(
+      "Set SYNC_CREDENTIAL_ENCRYPTION_KEY or add sync.credentialEncryptionKey to compass.yaml before encrypt-credentials",
+    );
+  }
+  decodeCredentialAtRestKey(key);
+  return key;
+}
+
+function parseArgs(argv: string[]): { dryRun: boolean; batchSize: number } {
+  const batchFlag = argv.indexOf("--batch-size");
+  const batchSize = batchFlag >= 0 ? Number(argv[batchFlag + 1]) : 200;
+  if (!Number.isFinite(batchSize) || batchSize < 1) {
+    throw new Error(
+      "encrypt-credentials --batch-size must be a positive number",
+    );
+  }
+  return { dryRun: !argv.includes("--apply"), batchSize };
+}
+
+/**
+ * Encrypt legacy plaintext OAuth refresh tokens in the Sync credentials
+ * collection. Dry-run by default; pass `--apply` to write.
+ *
+ * Usage:
+ *   bun run cli encrypt-credentials [--apply] [--batch-size 200]
+ */
+export async function runEncryptCredentials(): Promise<void> {
+  const syncMongo = new SyncMongoService();
+  try {
+    const { dryRun, batchSize } = parseArgs(process.argv.slice(3));
+    const encryptionKey = credentialEncryptionKey();
+    await syncMongo.connect({
+      uri: syncMongoUri(),
+      enforceLeastPrivilege: false,
+      forbiddenDatabaseName: "prod_calendar",
+    });
+
+    logger.info(`encrypt-credentials dryRun=${dryRun} batchSize=${batchSize}`);
+
+    const report = await encryptCredentials(
+      syncMongo.db.collection("credentials"),
+      {
+        dryRun,
+        batchSize,
+        encryptionKey,
+      },
+    );
+
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    logger.info(
+      `encrypt-credentials dryRun=${report.dryRun} matched=${report.matched} modified=${report.modified} skippedAlreadyEncrypted=${report.skippedAlreadyEncrypted}`,
+    );
+
+    await syncMongo.disconnect();
+    process.exit(0);
+  } catch (error) {
+    logger.error(error);
+    try {
+      await syncMongo.disconnect();
+    } catch {
+      // ignore
+    }
+    process.exit(1);
+  }
+}

--- a/packages/scripts/src/commands/encrypt-credentials/backfill.ts
+++ b/packages/scripts/src/commands/encrypt-credentials/backfill.ts
@@ -1,0 +1,103 @@
+import { type Collection, type Document } from "mongodb";
+import { encryptCredentialAtRest } from "@core/security/credential-at-rest";
+import { type ConnectionId } from "@core/types/sync/identity.contracts";
+
+export type EncryptCredentialsReport = {
+  dryRun: boolean;
+  matched: number;
+  modified: number;
+  skippedAlreadyEncrypted: number;
+};
+
+type PlaintextOauthCredentialRow = {
+  _id: ConnectionId;
+  refreshToken: string;
+};
+
+export async function encryptCredentials(
+  credentials: Collection<Document>,
+  options: {
+    dryRun: boolean;
+    batchSize: number;
+    encryptionKey: string;
+    now?: Date;
+    sleep?: (ms: number) => Promise<void>;
+  },
+): Promise<EncryptCredentialsReport> {
+  const filter = {
+    credentialKind: { $ne: "password" as const },
+    refreshToken: { $type: "string" as const },
+  };
+
+  const matched = await credentials.countDocuments(filter);
+  if (options.dryRun || matched === 0) {
+    return {
+      dryRun: options.dryRun,
+      matched,
+      modified: 0,
+      skippedAlreadyEncrypted: 0,
+    };
+  }
+
+  let modified = 0;
+  let skippedAlreadyEncrypted = 0;
+  let lastId: ConnectionId | undefined;
+
+  for (;;) {
+    const batchFilter: Document = lastId
+      ? { ...filter, _id: { $gt: lastId } }
+      : filter;
+    const batch = (await credentials
+      .find(batchFilter)
+      .sort({ _id: 1 })
+      .limit(options.batchSize)
+      .project({ _id: 1, refreshToken: 1 })
+      .toArray()) as PlaintextOauthCredentialRow[];
+
+    if (batch.length === 0) break;
+
+    for (const row of batch) {
+      const existing = await credentials.findOne({
+        _id: row._id,
+        refreshToken: { $type: "string" },
+      });
+      if (!existing || typeof existing["refreshToken"] !== "string") {
+        skippedAlreadyEncrypted += 1;
+        continue;
+      }
+
+      const plaintext = existing["refreshToken"];
+      const sealed = encryptCredentialAtRest(options.encryptionKey, plaintext);
+      const result = await credentials.updateOne(
+        { _id: row._id, refreshToken: plaintext },
+        {
+          $set: {
+            refreshTokenCiphertext: sealed.ciphertext,
+            refreshTokenIv: sealed.iv,
+            refreshTokenTag: sealed.tag,
+            keyVersion: sealed.keyVersion,
+            updatedAt: options.now ?? new Date(),
+          },
+          $unset: { refreshToken: "" },
+        },
+      );
+      if (result.modifiedCount === 1) {
+        modified += 1;
+      } else {
+        skippedAlreadyEncrypted += 1;
+      }
+    }
+
+    const last = batch[batch.length - 1];
+    if (!last) break;
+    lastId = last._id;
+    if (options.sleep) await options.sleep(50);
+  }
+
+  return {
+    dryRun: false,
+    matched,
+    modified,
+    skippedAlreadyEncrypted,
+  };
+}

--- a/packages/sync/src/__tests__/helpers/credential-encryption.ts
+++ b/packages/sync/src/__tests__/helpers/credential-encryption.ts
@@ -1,0 +1,38 @@
+import { sealOauthRefreshToken } from "@sync/credentials/oauth-refresh-at-rest";
+import {
+  type CredentialUpsert,
+  type OauthRefreshCredentialRecord,
+  type OauthRefreshStoredUpsert,
+} from "@sync/storage/contracts/credential.contracts";
+import { type CredentialRepository } from "@sync/storage/repositories/credential.repository";
+import { Buffer } from "node:buffer";
+
+// Stable 32-byte key for sync db tests that store encrypted credentials.
+export const TEST_CREDENTIAL_ENCRYPTION_KEY = Buffer.alloc(32, 7).toString(
+  "base64",
+);
+
+export function toStoredOauthCredentialUpsert(
+  keyBase64: string,
+  input: CredentialUpsert,
+): OauthRefreshStoredUpsert {
+  const sealed = sealOauthRefreshToken(keyBase64, input.refreshToken);
+  return {
+    connectionId: input.connectionId,
+    provider: input.provider,
+    scopes: input.scopes,
+    refreshTokenCiphertext: sealed.ciphertext,
+    refreshTokenIv: sealed.iv,
+    refreshTokenTag: sealed.tag,
+    keyVersion: sealed.keyVersion,
+  };
+}
+
+export async function seedOauthCredential(
+  repo: CredentialRepository,
+  input: CredentialUpsert,
+): Promise<OauthRefreshCredentialRecord> {
+  return repo.store(
+    toStoredOauthCredentialUpsert(TEST_CREDENTIAL_ENCRYPTION_KEY, input),
+  );
+}

--- a/packages/sync/src/credentials/credential-custody.service.db.test.ts
+++ b/packages/sync/src/credentials/credential-custody.service.db.test.ts
@@ -1,6 +1,7 @@
 import { faker } from "@faker-js/faker";
 import { type Db } from "mongodb";
 import { type ConnectionId } from "@core/types/sync/identity.contracts";
+import { TEST_CREDENTIAL_ENCRYPTION_KEY } from "@sync/__tests__/helpers/credential-encryption";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { CredentialCustody } from "@sync/credentials/credential-custody.service";
 import {
@@ -76,6 +77,17 @@ describe("CredentialCustody", () => {
   });
 
   const fixedNow = () => new Date("2026-01-01T00:00:00Z");
+  const makeCustody = (
+    adapter: FakeAdapter,
+    refreshSkewMs?: number,
+  ): CredentialCustody =>
+    new CredentialCustody(
+      repo,
+      () => adapter,
+      fixedNow,
+      refreshSkewMs,
+      TEST_CREDENTIAL_ENCRYPTION_KEY,
+    );
 
   it("refreshes and caches an access token when none is cached", async () => {
     const connectionId = objectId() as ConnectionId;
@@ -86,7 +98,7 @@ describe("CredentialCustody", () => {
         grantedScopes: [],
       },
     });
-    const custody = new CredentialCustody(repo, () => adapter, fixedNow);
+    const custody = makeCustody(adapter);
     await custody.store(baseCredential(connectionId));
 
     const token = await custody.getValidAccessToken(connectionId);
@@ -103,7 +115,7 @@ describe("CredentialCustody", () => {
   it("serves the cached token without refreshing when it is still valid", async () => {
     const connectionId = objectId() as ConnectionId;
     const adapter = new FakeAdapter();
-    const custody = new CredentialCustody(repo, () => adapter, fixedNow);
+    const custody = makeCustody(adapter);
     await custody.store(baseCredential(connectionId));
     await repo.cacheAccessToken(
       connectionId,
@@ -126,7 +138,7 @@ describe("CredentialCustody", () => {
         grantedScopes: [],
       },
     });
-    const custody = new CredentialCustody(repo, () => adapter, fixedNow);
+    const custody = makeCustody(adapter);
     await custody.store(baseCredential(connectionId));
     await repo.cacheAccessToken(
       connectionId,
@@ -150,12 +162,7 @@ describe("CredentialCustody", () => {
         grantedScopes: [],
       },
     });
-    const custody = new CredentialCustody(
-      repo,
-      () => adapter,
-      fixedNow,
-      60_000,
-    );
+    const custody = makeCustody(adapter, 60_000);
     await custody.store(baseCredential(connectionId));
     // Expires 30s after now — inside the 60s skew, so it must be refreshed.
     await repo.cacheAccessToken(
@@ -185,7 +192,7 @@ describe("CredentialCustody", () => {
       // Hold the refresh open until both callers are queued.
       onRefresh: () => gate,
     });
-    const custody = new CredentialCustody(repo, () => adapter, fixedNow);
+    const custody = makeCustody(adapter);
     await custody.store(baseCredential(connectionId));
 
     const first = custody.getValidAccessToken(connectionId);
@@ -208,7 +215,7 @@ describe("CredentialCustody", () => {
         grantedScopes: [],
       },
     });
-    const custody = new CredentialCustody(repo, () => adapter, fixedNow);
+    const custody = makeCustody(adapter);
     await custody.store(baseCredential(connectionId));
 
     await custody.getValidAccessToken(connectionId);
@@ -219,7 +226,7 @@ describe("CredentialCustody", () => {
 
   it("rejects with missingRefreshToken when no credential exists", async () => {
     const adapter = new FakeAdapter();
-    const custody = new CredentialCustody(repo, () => adapter, fixedNow);
+    const custody = makeCustody(adapter);
 
     const error = (await custody
       .getValidAccessToken(objectId() as ConnectionId)
@@ -235,7 +242,7 @@ describe("CredentialCustody", () => {
     const adapter = new FakeAdapter({
       refreshError: new ProviderAuthError("authorizationRevoked", "revoked"),
     });
-    const custody = new CredentialCustody(repo, () => adapter, fixedNow);
+    const custody = makeCustody(adapter);
     await custody.store(baseCredential(connectionId));
 
     const error = (await custody
@@ -252,7 +259,7 @@ describe("CredentialCustody", () => {
     const adapter = new FakeAdapter({
       refreshError: new ProviderAuthError("refreshFailed", "blip"),
     });
-    const custody = new CredentialCustody(repo, () => adapter, fixedNow);
+    const custody = makeCustody(adapter);
     await custody.store(baseCredential(connectionId));
 
     await expect(
@@ -262,14 +269,14 @@ describe("CredentialCustody", () => {
     expect(after).toMatchObject({
       credentialKind: "oauthRefresh",
       refreshFailureCount: 1,
-      refreshToken: "stored-refresh-token",
     });
+    expect(after).toHaveProperty("refreshTokenCiphertext");
   });
 
   it("discardRevoked deletes the credential and is idempotent", async () => {
     const connectionId = objectId() as ConnectionId;
     const adapter = new FakeAdapter();
-    const custody = new CredentialCustody(repo, () => adapter, fixedNow);
+    const custody = makeCustody(adapter);
     await custody.store(baseCredential(connectionId));
 
     await custody.discardRevoked(connectionId);
@@ -307,7 +314,7 @@ describe("CredentialCustody", () => {
         return gate;
       },
     });
-    const custody = new CredentialCustody(repo, () => adapter, fixedNow);
+    const custody = makeCustody(adapter);
     await custody.store(baseCredential(connectionId));
 
     // Start a refresh; the rejection handler attaches immediately so the
@@ -330,10 +337,58 @@ describe("CredentialCustody", () => {
     expect(await repo.findByConnection(connectionId)).toBeNull();
   });
 
+  it("stores oauth refresh tokens encrypted at rest", async () => {
+    const connectionId = objectId() as ConnectionId;
+    const adapter = new FakeAdapter();
+    const custody = makeCustody(adapter);
+    await custody.store(baseCredential(connectionId));
+
+    const raw = await db
+      .collection(SYNC_COLLECTIONS.credentials)
+      .findOne({ _id: connectionId });
+    expect(raw).not.toHaveProperty("refreshToken");
+    expect(raw?.refreshTokenCiphertext).toBeString();
+    expect(JSON.stringify(raw)).not.toContain("stored-refresh-token");
+  });
+
+  it("re-encrypts a legacy plaintext refresh token after a successful refresh", async () => {
+    const connectionId = objectId() as ConnectionId;
+    const adapter = new FakeAdapter({
+      refreshed: {
+        accessToken: "fresh-token",
+        expiresAt: new Date("2026-01-01T01:00:00Z"),
+        grantedScopes: [],
+      },
+    });
+    const custody = makeCustody(adapter);
+    await db.collection(SYNC_COLLECTIONS.credentials).insertOne({
+      _id: connectionId,
+      credentialKind: "oauthRefresh",
+      provider: "google",
+      refreshToken: "legacy-plaintext-token",
+      accessToken: null,
+      accessTokenExpiresAt: null,
+      refreshFailureCount: 0,
+      scopes: ["https://www.googleapis.com/auth/calendar.events"],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await custody.getValidAccessToken(connectionId);
+
+    const raw = await db
+      .collection(SYNC_COLLECTIONS.credentials)
+      .findOne({ _id: connectionId });
+    expect(raw).not.toHaveProperty("refreshToken");
+    expect(raw?.refreshTokenCiphertext).toBeString();
+    expect(JSON.stringify(raw)).not.toContain("legacy-plaintext-token");
+    expect(adapter.refreshCalls).toBe(1);
+  });
+
   it("deletes the credential and revokes it on disconnect", async () => {
     const connectionId = objectId() as ConnectionId;
     const adapter = new FakeAdapter();
-    const custody = new CredentialCustody(repo, () => adapter, fixedNow);
+    const custody = makeCustody(adapter);
     await custody.store(baseCredential(connectionId));
 
     await custody.disconnect(connectionId);
@@ -344,7 +399,7 @@ describe("CredentialCustody", () => {
 
   it("disconnecting an unknown connection revokes nothing and does not throw", async () => {
     const adapter = new FakeAdapter();
-    const custody = new CredentialCustody(repo, () => adapter, fixedNow);
+    const custody = makeCustody(adapter);
 
     await custody.disconnect(objectId() as ConnectionId);
 

--- a/packages/sync/src/credentials/credential-custody.service.ts
+++ b/packages/sync/src/credentials/credential-custody.service.ts
@@ -7,6 +7,11 @@ import {
   type ConnectionId,
   type ProviderKind,
 } from "@core/types/sync/identity.contracts";
+import {
+  isPlaintextOauthRefresh,
+  openOauthRefreshToken,
+  sealOauthRefreshToken,
+} from "@sync/credentials/oauth-refresh-at-rest";
 import { type ResolveProviderAuth } from "@sync/providers/provider-adapters";
 import {
   type ProviderAuthAdapter,
@@ -26,7 +31,7 @@ import { type CredentialRepository } from "@sync/storage/repositories/credential
 const DEFAULT_REFRESH_SKEW_MS = 60_000;
 
 const MISSING_AT_REST_KEY =
-  "password credentials require sync.credentialEncryptionKey";
+  "stored credentials require sync.credentialEncryptionKey";
 
 // Owns the credential lifecycle for one provider: store the durable refresh
 // token (or sealed password), serve valid access tokens (refreshing on demand),
@@ -55,7 +60,17 @@ export class CredentialCustody {
 
   // Persist a freshly authorized OAuth credential (or replace an existing one).
   async store(input: CredentialUpsert): Promise<CredentialRecord> {
-    return this.credentials.store(input);
+    const key = this.#requireAtRestKey();
+    const sealed = sealOauthRefreshToken(key, input.refreshToken);
+    return this.credentials.store({
+      connectionId: input.connectionId,
+      provider: input.provider,
+      scopes: input.scopes,
+      refreshTokenCiphertext: sealed.ciphertext,
+      refreshTokenIv: sealed.iv,
+      refreshTokenTag: sealed.tag,
+      keyVersion: sealed.keyVersion,
+    });
   }
 
   // Seal and persist an app-specific password. The plaintext secret never
@@ -107,7 +122,7 @@ export class CredentialCustody {
     await this.credentials.deleteByConnection(connectionId);
     if (credential && !isPasswordCredential(credential)) {
       await this.resolveAuth(credential.provider).revoke({
-        token: credential.refreshToken,
+        token: openOauthRefreshToken(this.#requireAtRestKey(), credential),
       });
     }
   }
@@ -147,6 +162,11 @@ export class CredentialCustody {
       });
     }
 
+    const refreshToken = openOauthRefreshToken(
+      this.#requireAtRestKey(),
+      credential,
+    );
+
     if (
       credential.accessToken &&
       credential.accessTokenExpiresAt &&
@@ -163,7 +183,7 @@ export class CredentialCustody {
       refreshed = await this.resolveAuth(
         credential.provider,
       ).refreshAccessToken({
-        refreshToken: credential.refreshToken,
+        refreshToken,
       });
     } catch (error) {
       if (
@@ -193,6 +213,18 @@ export class CredentialCustody {
         "missingRefreshToken",
         "Credential was removed during refresh",
       );
+    }
+    if (isPlaintextOauthRefresh(credential)) {
+      const sealed = sealOauthRefreshToken(
+        this.#requireAtRestKey(),
+        refreshToken,
+      );
+      await this.credentials.reencryptOauthRefresh(credential._id, {
+        refreshTokenCiphertext: sealed.ciphertext,
+        refreshTokenIv: sealed.iv,
+        refreshTokenTag: sealed.tag,
+        keyVersion: sealed.keyVersion,
+      });
     }
     return refreshed.accessToken;
   }

--- a/packages/sync/src/credentials/oauth-refresh-at-rest.ts
+++ b/packages/sync/src/credentials/oauth-refresh-at-rest.ts
@@ -1,0 +1,58 @@
+import {
+  type CredentialAtRest,
+  decryptCredentialAtRest,
+  encryptCredentialAtRest,
+} from "@core/security/credential-at-rest";
+import { type OauthRefreshCredentialRecord } from "@sync/storage/contracts/credential.contracts";
+
+export type SealedOauthRefreshToken = CredentialAtRest;
+
+export function sealOauthRefreshToken(
+  keyBase64: string,
+  refreshToken: string,
+): SealedOauthRefreshToken {
+  return encryptCredentialAtRest(keyBase64, refreshToken);
+}
+
+export function openOauthRefreshToken(
+  keyBase64: string,
+  record: OauthRefreshCredentialRecord,
+): string {
+  if (record.refreshToken) {
+    return record.refreshToken;
+  }
+  if (
+    record.refreshTokenCiphertext &&
+    record.refreshTokenIv &&
+    record.refreshTokenTag &&
+    record.keyVersion
+  ) {
+    return decryptCredentialAtRest(keyBase64, {
+      ciphertext: record.refreshTokenCiphertext,
+      iv: record.refreshTokenIv,
+      tag: record.refreshTokenTag,
+      keyVersion: record.keyVersion,
+    });
+  }
+  throw new Error("oauth refresh credential has no stored refresh token");
+}
+
+export function hasStoredOauthRefreshToken(
+  record: OauthRefreshCredentialRecord,
+): boolean {
+  if (record.refreshToken && record.refreshToken.length > 0) {
+    return true;
+  }
+  return Boolean(
+    record.refreshTokenCiphertext &&
+      record.refreshTokenIv &&
+      record.refreshTokenTag &&
+      record.keyVersion,
+  );
+}
+
+export function isPlaintextOauthRefresh(
+  record: OauthRefreshCredentialRecord,
+): boolean {
+  return Boolean(record.refreshToken && record.refreshToken.length > 0);
+}

--- a/packages/sync/src/domain/calendar-list-rediscovery.db.test.ts
+++ b/packages/sync/src/domain/calendar-list-rediscovery.db.test.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import { seedOauthCredential } from "@sync/__tests__/helpers/credential-encryption";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { rediscoverStaleCalendarLists } from "@sync/domain/calendar-list-rediscovery.service";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
@@ -57,7 +58,7 @@ describe("calendar-list rediscovery sweep (rediscoverStaleCalendarLists)", () =>
       calendarId: null,
     });
     if (options.withCredential ?? true) {
-      await credentials.store({
+      await seedOauthCredential(credentials, {
         connectionId,
         provider: "google",
         refreshToken: "refresh-token",
@@ -214,7 +215,7 @@ describe("calendar-list rediscovery sweep (rediscoverStaleCalendarLists)", () =>
       resourceKind: "calendarList",
       calendarId: null,
     });
-    await credentials.store({
+    await seedOauthCredential(credentials, {
       connectionId,
       provider: "google",
       refreshToken: "refresh-token",

--- a/packages/sync/src/domain/connection-state-refresh.service.db.test.ts
+++ b/packages/sync/src/domain/connection-state-refresh.service.db.test.ts
@@ -4,6 +4,7 @@ import {
   type ProviderCalendarId,
   type ProviderCalendarSourceId,
 } from "@core/types/sync/identity.contracts";
+import { seedOauthCredential } from "@sync/__tests__/helpers/credential-encryption";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { BOOTSTRAP_STALLED_AFTER_MS } from "@sync/domain/connection-state";
 import { refreshConnectionState } from "@sync/domain/connection-state-refresh.service";
@@ -50,7 +51,7 @@ describe("refreshConnectionState", () => {
       state: "importing",
       stateReason: null,
     });
-    await credentials.store({
+    await seedOauthCredential(credentials, {
       connectionId: connection._id,
       provider: "google",
       refreshToken: "refresh",

--- a/packages/sync/src/domain/connection-state-refresh.service.ts
+++ b/packages/sync/src/domain/connection-state-refresh.service.ts
@@ -1,3 +1,4 @@
+import { hasStoredOauthRefreshToken } from "@sync/credentials/oauth-refresh-at-rest";
 import { MAX_REFRESH_FAILED_ATTEMPTS } from "@sync/credentials/refresh-failure.constants";
 import {
   BOOTSTRAP_STALLED_AFTER_MS,
@@ -187,7 +188,7 @@ function credentialState(
 ): CredentialState {
   if (!credential) return "revoked";
   if (credential.credentialKind === "password") return "valid";
-  if (!credential.refreshToken) return "revoked";
+  if (!hasStoredOauthRefreshToken(credential)) return "revoked";
   if (credential.refreshFailureCount >= MAX_REFRESH_FAILED_ATTEMPTS) {
     return "expired";
   }

--- a/packages/sync/src/domain/provider-command.service.db.test.ts
+++ b/packages/sync/src/domain/provider-command.service.db.test.ts
@@ -9,6 +9,10 @@ import {
   type PrincipalId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
+import {
+  seedOauthCredential,
+  TEST_CREDENTIAL_ENCRYPTION_KEY,
+} from "@sync/__tests__/helpers/credential-encryption";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { CredentialCustody } from "@sync/credentials/credential-custody.service";
 import { truncateRulesBefore } from "@sync/domain/occurrence-projection";
@@ -128,7 +132,7 @@ const storeCredential = async (
   connectionId: ConnectionId,
   accessToken?: { token: string; expiresAt: Date },
 ) => {
-  await credentials.store({
+  await seedOauthCredential(credentials, {
     connectionId,
     provider: "google",
     refreshToken: "stored-refresh-token",
@@ -492,6 +496,9 @@ describe("executeProviderCreate", () => {
             "revoked",
           ),
         }),
+      undefined,
+      undefined,
+      TEST_CREDENTIAL_ENCRYPTION_KEY,
     );
 
     const result = await executeProviderCreate(
@@ -932,6 +939,9 @@ describe("executeProviderUpdate", () => {
     const custody = new CredentialCustody(
       credentials,
       () => new RevokedAuthAdapter(),
+      undefined,
+      undefined,
+      TEST_CREDENTIAL_ENCRYPTION_KEY,
     );
     const writer = new FakeUpdateWriter();
     writer.fetchError = new ProviderWriteError(

--- a/packages/sync/src/domain/resource-sweep-enqueue.bootstrap-recovery.db.test.ts
+++ b/packages/sync/src/domain/resource-sweep-enqueue.bootstrap-recovery.db.test.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import { seedOauthCredential } from "@sync/__tests__/helpers/credential-encryption";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { enqueueForResources } from "@sync/domain/resource-sweep-enqueue";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
@@ -72,7 +73,7 @@ describe("bootstrap-recovery sweep (enqueueForResources + listStalledBootstraps)
       calendarId: objectId() as SyncResourceRecord["calendarId"],
     });
     if (options.withCredential ?? true) {
-      await credentials.store({
+      await seedOauthCredential(credentials, {
         connectionId,
         provider: "google",
         refreshToken: "refresh-token",

--- a/packages/sync/src/domain/resource-sweep-enqueue.reconcile.db.test.ts
+++ b/packages/sync/src/domain/resource-sweep-enqueue.reconcile.db.test.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import { seedOauthCredential } from "@sync/__tests__/helpers/credential-encryption";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { enqueueForResources } from "@sync/domain/resource-sweep-enqueue";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
@@ -69,7 +70,7 @@ describe("reconcile sweep (enqueueForResources + listStaleEvents)", () => {
       calendarId: objectId() as SyncResourceRecord["calendarId"],
     });
     if (options.withCredential ?? true) {
-      await credentials.store({
+      await seedOauthCredential(credentials, {
         connectionId,
         provider: "google",
         refreshToken: "refresh-token",

--- a/packages/sync/src/domain/subscription-maintenance.service.db.test.ts
+++ b/packages/sync/src/domain/subscription-maintenance.service.db.test.ts
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { type ConnectionId } from "@core/types/sync/identity.contracts";
+import { seedOauthCredential } from "@sync/__tests__/helpers/credential-encryption";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { maintainSubscription } from "@sync/domain/subscription-maintenance.service";
 import {
@@ -302,7 +303,7 @@ describe("maintainSubscription", () => {
       expiresAt: new Date("2026-07-10T01:00:00.000Z"),
     });
     const credentials = new CredentialRepository(storage.db());
-    await credentials.store({
+    await seedOauthCredential(credentials, {
       connectionId,
       provider: "google",
       refreshToken: "stored-refresh-token",

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import { seedOauthCredential } from "@sync/__tests__/helpers/credential-encryption";
 import {
   ensureEventsResource,
   FakeReader,
@@ -786,7 +787,7 @@ describe("dispatchSyncJob", () => {
   it("drops a job after consecutive refreshFailed attempts so 401s do not burn the ladder", async () => {
     const calendar = await seedCalendar();
     const resource = await seedResource(calendar, "cursor-0");
-    await credentials.store({
+    await seedOauthCredential(credentials, {
       connectionId: calendar.connectionId,
       provider: "google",
       refreshToken: "refresh",
@@ -825,7 +826,7 @@ describe("dispatchSyncJob", () => {
   it("does not drop a refreshFailed job just because other retries already ran", async () => {
     const calendar = await seedCalendar();
     const resource = await seedResource(calendar, "cursor-0");
-    await credentials.store({
+    await seedOauthCredential(credentials, {
       connectionId: calendar.connectionId,
       provider: "google",
       refreshToken: "refresh",
@@ -1199,7 +1200,7 @@ describe("dispatchSyncJob", () => {
       state: "importing",
       stateReason: null,
     });
-    await credentials.store({
+    await seedOauthCredential(credentials, {
       connectionId: connection._id,
       provider: "google",
       refreshToken: "refresh",

--- a/packages/sync/src/domain/sync-job-worker.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.db.test.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import { seedOauthCredential } from "@sync/__tests__/helpers/credential-encryption";
 import {
   ensureEventsResource,
   FakeReader,
@@ -242,7 +243,7 @@ describe("SyncJobWorker", () => {
       stateReason: "providerErrors",
     });
     const credentials = new CredentialRepository(storage.db());
-    await credentials.store({
+    await seedOauthCredential(credentials, {
       connectionId: connection._id,
       provider: "google",
       refreshToken: "refresh",

--- a/packages/sync/src/server/command.routes.db.test.ts
+++ b/packages/sync/src/server/command.routes.db.test.ts
@@ -5,6 +5,10 @@ import {
   type PrincipalId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
+import {
+  seedOauthCredential,
+  TEST_CREDENTIAL_ENCRYPTION_KEY,
+} from "@sync/__tests__/helpers/credential-encryption";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { createSyncService, type SyncService } from "@sync/app";
 import { signInternalRequest } from "@sync/auth/internal-auth";
@@ -42,6 +46,7 @@ const testConfig = (overrides: Partial<SyncConfig> = {}): SyncConfig =>
     CALLBACK_BASE_URL: "http://localhost:3010",
     EXECUTION: "passive",
     MAX_CONCURRENCY: 4,
+    CREDENTIAL_ENCRYPTION_KEY: TEST_CREDENTIAL_ENCRYPTION_KEY,
     ...overrides,
   }) as SyncConfig;
 
@@ -613,7 +618,7 @@ describe("POST /internal/commands", () => {
       },
     });
     const credentials = new CredentialRepository(mongo.db);
-    await credentials.store({
+    await seedOauthCredential(credentials, {
       connectionId: connection._id,
       provider: "google",
       refreshToken: "stored-refresh-token",

--- a/packages/sync/src/server/connection.routes.db.test.ts
+++ b/packages/sync/src/server/connection.routes.db.test.ts
@@ -8,6 +8,10 @@ import {
 } from "@core/types/sync/identity.contracts";
 import dayjs from "@core/util/date/dayjs";
 import {
+  seedOauthCredential,
+  TEST_CREDENTIAL_ENCRYPTION_KEY,
+} from "@sync/__tests__/helpers/credential-encryption";
+import {
   ensureEventsResource,
   seedProviderCalendar,
 } from "@sync/__tests__/helpers/fixtures";
@@ -18,6 +22,7 @@ import {
   signServiceRequest,
 } from "@sync/auth/internal-auth";
 import { type SyncConfig } from "@sync/config/sync.config";
+import { openOauthRefreshToken } from "@sync/credentials/oauth-refresh-at-rest";
 import {
   deriveOAuthStateSecret,
   signOAuthState,
@@ -77,6 +82,7 @@ const testConfig = (overrides: Partial<SyncConfig> = {}): SyncConfig =>
     CALLBACK_BASE_URL: "http://localhost:3010",
     EXECUTION: "passive",
     MAX_CONCURRENCY: 4,
+    CREDENTIAL_ENCRYPTION_KEY: TEST_CREDENTIAL_ENCRYPTION_KEY,
     ...overrides,
   }) as SyncConfig;
 
@@ -204,7 +210,7 @@ describe("GET /internal/connections", () => {
     email: string,
   ) => {
     const connection = await seedConnection(repo, tenantId, principalId, email);
-    await credentials.store({
+    await seedOauthCredential(credentials, {
       connectionId: connection._id,
       provider: "google",
       refreshToken: "stored-refresh-token",
@@ -369,7 +375,7 @@ describe("DELETE /internal/connections/:id", () => {
       principalId,
       "connected@example.com",
     );
-    await credentials.store({
+    await seedOauthCredential(credentials, {
       connectionId: connection._id,
       provider: "google",
       refreshToken: "stored-refresh-token",
@@ -753,7 +759,11 @@ describe("GET /sync/google", () => {
     expect(linked[0].capabilities).toContain("writeEvents");
 
     const stored = await credentials.findByConnection(linked[0]._id);
-    expect(stored?.refreshToken).toBe("granted-refresh-token");
+    expect(
+      stored?.credentialKind === "oauthRefresh"
+        ? openOauthRefreshToken(TEST_CREDENTIAL_ENCRYPTION_KEY, stored)
+        : null,
+    ).toBe("granted-refresh-token");
   });
 
   it("derives suggestContacts when the callback's grant includes a contacts scope", async () => {
@@ -1125,7 +1135,11 @@ describe("POST /internal/connections/adopt-google-authorization", () => {
       "google-sub-from-signin",
     );
     const stored = await credentials.findByConnection(connection!._id);
-    expect(stored?.refreshToken).toBe("server-exchanged-refresh-token");
+    expect(
+      stored?.credentialKind === "oauthRefresh"
+        ? openOauthRefreshToken(TEST_CREDENTIAL_ENCRYPTION_KEY, stored)
+        : null,
+    ).toBe("server-exchanged-refresh-token");
     const job = await mongo.db.collection(SYNC_COLLECTIONS.jobs).findOne({
       coalescingKey: `calendarListSync:${connection!._id}`,
     });

--- a/packages/sync/src/server/contacts.routes.db.test.ts
+++ b/packages/sync/src/server/contacts.routes.db.test.ts
@@ -5,6 +5,10 @@ import {
   type PrincipalId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
+import {
+  seedOauthCredential,
+  TEST_CREDENTIAL_ENCRYPTION_KEY,
+} from "@sync/__tests__/helpers/credential-encryption";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { createSyncService, type SyncService } from "@sync/app";
 import { signInternalRequest } from "@sync/auth/internal-auth";
@@ -45,6 +49,7 @@ const testConfig = (overrides: Partial<SyncConfig> = {}): SyncConfig =>
     CALLBACK_BASE_URL: "http://localhost:3010",
     EXECUTION: "active",
     MAX_CONCURRENCY: 4,
+    CREDENTIAL_ENCRYPTION_KEY: TEST_CREDENTIAL_ENCRYPTION_KEY,
     ...overrides,
   }) as SyncConfig;
 
@@ -133,7 +138,7 @@ describe("GET /internal/contacts/suggestions", () => {
       state: "healthy",
       stateReason: null,
     });
-    await credentials.store({
+    await seedOauthCredential(credentials, {
       connectionId: connection._id,
       provider: "google",
       refreshToken: "stored-refresh-token",

--- a/packages/sync/src/server/principal.routes.db.test.ts
+++ b/packages/sync/src/server/principal.routes.db.test.ts
@@ -6,6 +6,10 @@ import {
   type TenantId,
 } from "@core/types/sync/identity.contracts";
 import { type PrincipalPurgeResponse } from "@core/types/sync/principal.contracts";
+import {
+  seedOauthCredential,
+  TEST_CREDENTIAL_ENCRYPTION_KEY,
+} from "@sync/__tests__/helpers/credential-encryption";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { createSyncService, type SyncService } from "@sync/app";
 import { signInternalRequest } from "@sync/auth/internal-auth";
@@ -41,6 +45,7 @@ const testConfig = (overrides: Partial<SyncConfig> = {}): SyncConfig =>
     CALLBACK_BASE_URL: "http://localhost:3010",
     EXECUTION: "passive",
     MAX_CONCURRENCY: 4,
+    CREDENTIAL_ENCRYPTION_KEY: TEST_CREDENTIAL_ENCRYPTION_KEY,
     ...overrides,
   }) as SyncConfig;
 
@@ -141,13 +146,13 @@ describe("DELETE /internal/principal", () => {
 
     const mine = await seedConnection(connections, tenantId, principalId);
     const theirs = await seedConnection(connections, tenantId, stranger);
-    await credentials.store({
+    await seedOauthCredential(credentials, {
       connectionId: mine._id,
       provider: "google",
       refreshToken: "mine-refresh",
       scopes: ["https://www.googleapis.com/auth/calendar.events"],
     });
-    await credentials.store({
+    await seedOauthCredential(credentials, {
       connectionId: theirs._id,
       provider: "google",
       refreshToken: "theirs-refresh",
@@ -233,7 +238,7 @@ describe("DELETE /internal/principal", () => {
     const connections = new ProviderConnectionRepository(mongo.db);
     const credentials = new CredentialRepository(mongo.db);
     const connection = await seedConnection(connections, tenantId, principalId);
-    await credentials.store({
+    await seedOauthCredential(credentials, {
       connectionId: connection._id as ConnectionId,
       provider: "google",
       refreshToken: "local-only",

--- a/packages/sync/src/storage/contracts/credential.contracts.test.ts
+++ b/packages/sync/src/storage/contracts/credential.contracts.test.ts
@@ -30,6 +30,50 @@ describe("CredentialRecordSchema", () => {
     expect(parsed.refreshToken).toBe("refresh-token-secret");
   });
 
+  it("parses an encrypted oauth refresh row", () => {
+    const parsed = CredentialRecordSchema.parse({
+      credentialKind: "oauthRefresh",
+      _id: objectId(),
+      provider: "google",
+      refreshTokenCiphertext: "cipher",
+      refreshTokenIv: "iv",
+      refreshTokenTag: "tag",
+      keyVersion: 1,
+      accessToken: null,
+      accessTokenExpiresAt: null,
+      refreshFailureCount: 0,
+      scopes: [],
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+      updatedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+    expect(parsed.credentialKind).toBe("oauthRefresh");
+    if (parsed.credentialKind !== "oauthRefresh") {
+      throw new Error("expected oauthRefresh");
+    }
+    expect(parsed.refreshTokenCiphertext).toBe("cipher");
+    expect(parsed.refreshToken).toBeUndefined();
+  });
+
+  it("rejects oauth rows with both plaintext and ciphertext refresh tokens", () => {
+    const result = CredentialRecordSchema.safeParse({
+      credentialKind: "oauthRefresh",
+      _id: objectId(),
+      provider: "google",
+      refreshToken: "plain",
+      refreshTokenCiphertext: "cipher",
+      refreshTokenIv: "iv",
+      refreshTokenTag: "tag",
+      keyVersion: 1,
+      accessToken: null,
+      accessTokenExpiresAt: null,
+      refreshFailureCount: 0,
+      scopes: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    expect(result.success).toBe(false);
+  });
+
   it("rejects a password row without ciphertext fields", () => {
     const result = CredentialRecordSchema.safeParse({
       credentialKind: "password",

--- a/packages/sync/src/storage/contracts/credential.contracts.ts
+++ b/packages/sync/src/storage/contracts/credential.contracts.ts
@@ -17,26 +17,48 @@ import {
 // Token-shaped fields must never reach a log or error — use `redactCredential`
 // for any diagnostic output.
 
-export const OauthRefreshCredentialRecordSchema = z.strictObject({
-  credentialKind: z.literal("oauthRefresh").default("oauthRefresh"),
-  // One credential document per connection; the connection id is the key.
-  _id: ConnectionIdSchema,
-  provider: ProviderKindSchema,
-  refreshToken: z.string().min(1),
-  // Cached access token and its absolute expiry. Null until first refresh, and
-  // whenever the cached token has been invalidated.
-  accessToken: z.string().min(1).nullable(),
-  accessTokenExpiresAt: z.date().nullable(),
-  // Consecutive token-endpoint refreshFailed counts. Reset on a successful
-  // mint. After MAX_REFRESH_FAILED_ATTEMPTS the connection is treated as
-  // authorizationExpired so the UI can prompt reconnect instead of looping
-  // 401s. Defaulted: docs predating this field must still parse.
-  refreshFailureCount: z.number().int().min(0).default(0),
-  // The scopes the credential was granted, for capability checks.
-  scopes: z.array(z.string()),
-  createdAt: z.date(),
-  updatedAt: z.date(),
-});
+export const OauthRefreshCredentialRecordSchema = z
+  .strictObject({
+    credentialKind: z.literal("oauthRefresh").default("oauthRefresh"),
+    // One credential document per connection; the connection id is the key.
+    _id: ConnectionIdSchema,
+    provider: ProviderKindSchema,
+    // Legacy plaintext refresh token. New writes store ciphertext fields only.
+    refreshToken: z.string().min(1).optional(),
+    refreshTokenCiphertext: z.string().min(1).optional(),
+    refreshTokenIv: z.string().min(1).optional(),
+    refreshTokenTag: z.string().min(1).optional(),
+    keyVersion: z.number().int().positive().optional(),
+    // Cached access token and its absolute expiry. Null until first refresh, and
+    // whenever the cached token has been invalidated.
+    accessToken: z.string().min(1).nullable(),
+    accessTokenExpiresAt: z.date().nullable(),
+    // Consecutive token-endpoint refreshFailed counts. Reset on a successful
+    // mint. After MAX_REFRESH_FAILED_ATTEMPTS the connection is treated as
+    // authorizationExpired so the UI can prompt reconnect instead of looping
+    // 401s. Defaulted: docs predating this field must still parse.
+    refreshFailureCount: z.number().int().min(0).default(0),
+    // The scopes the credential was granted, for capability checks.
+    scopes: z.array(z.string()),
+    createdAt: z.date(),
+    updatedAt: z.date(),
+  })
+  .superRefine((value, ctx) => {
+    const hasPlaintext = Boolean(value.refreshToken);
+    const hasCiphertext = Boolean(
+      value.refreshTokenCiphertext &&
+        value.refreshTokenIv &&
+        value.refreshTokenTag &&
+        value.keyVersion,
+    );
+    if (hasPlaintext === hasCiphertext) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          "oauth refresh credential must store either plaintext refreshToken or encrypted refreshTokenCiphertext fields, not both or neither",
+      });
+    }
+  });
 export type OauthRefreshCredentialRecord = z.infer<
   typeof OauthRefreshCredentialRecordSchema
 >;
@@ -90,6 +112,20 @@ export function isPasswordCredential(
   return record.credentialKind === "password";
 }
 
+function oauthRefreshTokenIsStored(
+  record: OauthRefreshCredentialRecord,
+): boolean {
+  if (record.refreshToken && record.refreshToken.length > 0) {
+    return true;
+  }
+  return Boolean(
+    record.refreshTokenCiphertext &&
+      record.refreshTokenIv &&
+      record.refreshTokenTag &&
+      record.keyVersion,
+  );
+}
+
 // What a caller provides to store or replace an OAuth credential. Sync owns
 // _id, createdAt, and updatedAt; _id doubles as connectionId, so it is picked
 // back in under that name rather than omitted. Storing a fresh refresh token
@@ -102,6 +138,19 @@ export const CredentialUpsertSchema = z.strictObject({
   scopes: z.array(z.string()),
 });
 export type CredentialUpsert = z.infer<typeof CredentialUpsertSchema>;
+
+export const OauthRefreshStoredUpsertSchema = z.strictObject({
+  connectionId: ConnectionIdSchema,
+  provider: ProviderKindSchema,
+  refreshTokenCiphertext: z.string().min(1),
+  refreshTokenIv: z.string().min(1),
+  refreshTokenTag: z.string().min(1),
+  keyVersion: z.number().int().positive(),
+  scopes: z.array(z.string()),
+});
+export type OauthRefreshStoredUpsert = z.infer<
+  typeof OauthRefreshStoredUpsertSchema
+>;
 
 export const PasswordCredentialUpsertSchema = z.strictObject({
   connectionId: ConnectionIdSchema,
@@ -148,7 +197,7 @@ export function redactCredential(record: CredentialRecord): RedactedCredential {
     connectionId: record._id,
     provider: record.provider,
     credentialKind: "oauthRefresh",
-    hasRefreshToken: record.refreshToken.length > 0,
+    hasRefreshToken: oauthRefreshTokenIsStored(record),
     hasAccessToken: record.accessToken !== null,
     hasPasswordSecret: false,
     accessTokenExpiresAt: record.accessTokenExpiresAt,

--- a/packages/sync/src/storage/repositories/credential.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/credential.repository.db.test.ts
@@ -1,6 +1,11 @@
 import { faker } from "@faker-js/faker";
 import { type Db } from "mongodb";
+import { decryptCredentialAtRest } from "@core/security/credential-at-rest";
 import { type ConnectionId } from "@core/types/sync/identity.contracts";
+import {
+  TEST_CREDENTIAL_ENCRYPTION_KEY,
+  toStoredOauthCredentialUpsert,
+} from "@sync/__tests__/helpers/credential-encryption";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import {
@@ -33,18 +38,26 @@ describe("CredentialRepository", () => {
 
   it("stores and reads back a credential keyed by connection id", async () => {
     const input = baseCredential();
-    const stored = await repo.store(input);
+    const stored = await repo.store(
+      toStoredOauthCredentialUpsert(TEST_CREDENTIAL_ENCRYPTION_KEY, input),
+    );
 
     expect(stored._id).toBe(input.connectionId);
-    expect(stored.refreshToken).toBe("refresh-token-secret");
+    expect(stored.refreshTokenCiphertext).toBeString();
     expect(stored.accessToken).toBeNull();
     expect(stored.createdAt).toBeInstanceOf(Date);
 
     const read = await repo.findByConnection(input.connectionId);
     expect(read).toMatchObject({
       credentialKind: "oauthRefresh",
-      refreshToken: "refresh-token-secret",
+      refreshTokenCiphertext: stored.refreshTokenCiphertext,
     });
+
+    const raw = await db
+      .collection(SYNC_COLLECTIONS.credentials)
+      .findOne({ _id: input.connectionId });
+    expect(raw).not.toHaveProperty("refreshToken");
+    expect(JSON.stringify(raw)).not.toContain("refresh-token-secret");
   });
 
   it("returns null when no credential exists for the connection", async () => {
@@ -53,7 +66,9 @@ describe("CredentialRepository", () => {
 
   it("caches an access token and clears it when a new refresh token is stored", async () => {
     const input = baseCredential();
-    await repo.store(input);
+    await repo.store(
+      toStoredOauthCredentialUpsert(TEST_CREDENTIAL_ENCRYPTION_KEY, input),
+    );
 
     const expiresAt = new Date(Date.now() + 3600_000);
     const cached = await repo.cacheAccessToken(
@@ -64,20 +79,63 @@ describe("CredentialRepository", () => {
     expect(cached?.accessToken).toBe("access-token-value");
     expect(cached?.accessTokenExpiresAt).toEqual(expiresAt);
 
-    // Re-authorizing (new refresh token) must invalidate the cached access
-    // token so a token from the superseded grant is never served.
-    const reAuthed = await repo.store({
-      ...input,
-      refreshToken: "rotated-refresh-token",
-    });
-    expect(reAuthed.refreshToken).toBe("rotated-refresh-token");
+    const reAuthed = await repo.store(
+      toStoredOauthCredentialUpsert(TEST_CREDENTIAL_ENCRYPTION_KEY, {
+        ...input,
+        refreshToken: "rotated-refresh-token",
+      }),
+    );
+    expect(reAuthed.refreshTokenCiphertext).toBeString();
     expect(reAuthed.accessToken).toBeNull();
     expect(reAuthed.accessTokenExpiresAt).toBeNull();
   });
 
+  it("reencrypts a legacy plaintext refresh token", async () => {
+    const input = baseCredential();
+    await db.collection(SYNC_COLLECTIONS.credentials).insertOne({
+      _id: input.connectionId,
+      credentialKind: "oauthRefresh",
+      provider: input.provider,
+      refreshToken: input.refreshToken,
+      accessToken: null,
+      accessTokenExpiresAt: null,
+      refreshFailureCount: 0,
+      scopes: input.scopes,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const sealed = toStoredOauthCredentialUpsert(
+      TEST_CREDENTIAL_ENCRYPTION_KEY,
+      input,
+    );
+    const updated = await repo.reencryptOauthRefresh(input.connectionId, {
+      refreshTokenCiphertext: sealed.refreshTokenCiphertext,
+      refreshTokenIv: sealed.refreshTokenIv,
+      refreshTokenTag: sealed.refreshTokenTag,
+      keyVersion: sealed.keyVersion,
+    });
+
+    expect(updated?.refreshTokenCiphertext).toBe(sealed.refreshTokenCiphertext);
+    const raw = await db
+      .collection(SYNC_COLLECTIONS.credentials)
+      .findOne({ _id: input.connectionId });
+    expect(raw).not.toHaveProperty("refreshToken");
+    expect(
+      decryptCredentialAtRest(TEST_CREDENTIAL_ENCRYPTION_KEY, {
+        ciphertext: String(raw?.refreshTokenCiphertext),
+        iv: String(raw?.refreshTokenIv),
+        tag: String(raw?.refreshTokenTag),
+        keyVersion: Number(raw?.keyVersion),
+      }),
+    ).toBe("refresh-token-secret");
+  });
+
   it("does not resurrect a credential that was deleted mid-refresh", async () => {
     const input = baseCredential();
-    await repo.store(input);
+    await repo.store(
+      toStoredOauthCredentialUpsert(TEST_CREDENTIAL_ENCRYPTION_KEY, input),
+    );
     await repo.deleteByConnection(input.connectionId);
 
     const result = await repo.cacheAccessToken(
@@ -91,7 +149,9 @@ describe("CredentialRepository", () => {
 
   it("reports whether a delete removed anything", async () => {
     const input = baseCredential();
-    await repo.store(input);
+    await repo.store(
+      toStoredOauthCredentialUpsert(TEST_CREDENTIAL_ENCRYPTION_KEY, input),
+    );
 
     expect(await repo.deleteByConnection(input.connectionId)).toBe(true);
     expect(await repo.deleteByConnection(input.connectionId)).toBe(false);
@@ -99,10 +159,10 @@ describe("CredentialRepository", () => {
 
   it("keeps credentials out of the provider_connections collection", async () => {
     const input = baseCredential();
-    await repo.store(input);
+    await repo.store(
+      toStoredOauthCredentialUpsert(TEST_CREDENTIAL_ENCRYPTION_KEY, input),
+    );
 
-    // Credentials live in their own collection; nothing about a connection
-    // read touches them.
     const inConnections = await db
       .collection(SYNC_COLLECTIONS.providerConnections)
       .findOne({ _id: input.connectionId });
@@ -115,7 +175,10 @@ describe("CredentialRepository", () => {
   });
 
   it("redacts token-shaped fields for logging", async () => {
-    const stored = await repo.store(baseCredential());
+    const input = baseCredential();
+    const stored = await repo.store(
+      toStoredOauthCredentialUpsert(TEST_CREDENTIAL_ENCRYPTION_KEY, input),
+    );
     await repo.cacheAccessToken(
       stored._id,
       "access-token-value",
@@ -127,7 +190,6 @@ describe("CredentialRepository", () => {
     expect(redacted.hasRefreshToken).toBe(true);
     expect(redacted.hasAccessToken).toBe(true);
     expect(redacted.scopeCount).toBe(1);
-    // No token value can appear anywhere in the log-safe view.
     const serialized = JSON.stringify(redacted);
     expect(serialized).not.toContain("refresh-token-secret");
     expect(serialized).not.toContain("access-token-value");

--- a/packages/sync/src/storage/repositories/credential.repository.ts
+++ b/packages/sync/src/storage/repositories/credential.repository.ts
@@ -4,10 +4,10 @@ import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import {
   type CredentialRecord,
   CredentialRecordSchema,
-  type CredentialUpsert,
-  CredentialUpsertSchema,
   type OauthRefreshCredentialRecord,
   OauthRefreshCredentialRecordSchema,
+  type OauthRefreshStoredUpsert,
+  OauthRefreshStoredUpsertSchema,
   type PasswordCredentialRecord,
   PasswordCredentialRecordSchema,
   type PasswordCredentialUpsert,
@@ -21,16 +21,20 @@ const PASSWORD_FIELDS = {
   secretCiphertext: "",
   secretIv: "",
   secretTag: "",
-  keyVersion: "",
 } as const;
 
 const OAUTH_FIELDS = {
   refreshToken: "",
+  refreshTokenCiphertext: "",
+  refreshTokenIv: "",
+  refreshTokenTag: "",
   accessToken: "",
   accessTokenExpiresAt: "",
   refreshFailureCount: "",
   scopes: "",
 } as const;
+
+const PLAINTEXT_REFRESH_TOKEN_FIELD = { refreshToken: "" } as const;
 
 // Repository for `credentials`. One document per connection, keyed by the
 // connection id. This is the ONLY place provider credentials are read or
@@ -43,12 +47,15 @@ export class CredentialRepository {
     this.collection = db.collection(SYNC_COLLECTIONS.credentials);
   }
 
-  // Store or replace a connection's OAuth credential. A new refresh token
-  // clears any cached access token, so a token minted from a superseded grant
-  // can never be served after re-authorization. Password fields from a prior
-  // kind are unset so the document cannot mix kinds.
-  async store(input: CredentialUpsert): Promise<OauthRefreshCredentialRecord> {
-    const fields = CredentialUpsertSchema.parse(input);
+  // Store or replace a connection's OAuth credential with encrypted refresh
+  // token fields. A new refresh token clears any cached access token, so a
+  // token minted from a superseded grant can never be served after
+  // re-authorization. Password fields from a prior kind are unset so the
+  // document cannot mix kinds.
+  async store(
+    input: OauthRefreshStoredUpsert,
+  ): Promise<OauthRefreshCredentialRecord> {
+    const fields = OauthRefreshStoredUpsertSchema.parse(input);
     const now = new Date();
 
     const result = await this.collection.findOneAndUpdate(
@@ -57,14 +64,17 @@ export class CredentialRepository {
         $set: {
           credentialKind: "oauthRefresh",
           provider: fields.provider,
-          refreshToken: fields.refreshToken,
+          refreshTokenCiphertext: fields.refreshTokenCiphertext,
+          refreshTokenIv: fields.refreshTokenIv,
+          refreshTokenTag: fields.refreshTokenTag,
+          keyVersion: fields.keyVersion,
           scopes: fields.scopes,
           accessToken: null,
           accessTokenExpiresAt: null,
           refreshFailureCount: 0,
           updatedAt: now,
         },
-        $unset: PASSWORD_FIELDS,
+        $unset: { ...PASSWORD_FIELDS, ...PLAINTEXT_REFRESH_TOKEN_FIELD },
         // _id comes from the query filter on insert; setting it here too would
         // touch the immutable field.
         $setOnInsert: { createdAt: now },
@@ -76,6 +86,36 @@ export class CredentialRepository {
       throw new Error("Credential store did not return a record");
     }
     return OauthRefreshCredentialRecordSchema.parse(result);
+  }
+
+  // Replace a legacy plaintext refresh token with encrypted fields after a
+  // successful refresh. Idempotent when the row is already encrypted.
+  async reencryptOauthRefresh(
+    connectionId: ConnectionId,
+    input: Omit<
+      OauthRefreshStoredUpsert,
+      "connectionId" | "provider" | "scopes"
+    >,
+  ): Promise<OauthRefreshCredentialRecord | null> {
+    const result = await this.collection.findOneAndUpdate(
+      {
+        _id: connectionId,
+        ...OAUTH_ONLY_FILTER,
+        refreshToken: { $type: "string" },
+      },
+      {
+        $set: {
+          refreshTokenCiphertext: input.refreshTokenCiphertext,
+          refreshTokenIv: input.refreshTokenIv,
+          refreshTokenTag: input.refreshTokenTag,
+          keyVersion: input.keyVersion,
+          updatedAt: new Date(),
+        },
+        $unset: PLAINTEXT_REFRESH_TOKEN_FIELD,
+      },
+      { returnDocument: "after" },
+    );
+    return result ? OauthRefreshCredentialRecordSchema.parse(result) : null;
   }
 
   // Store or replace a password credential. OAuth fields from a prior kind

--- a/packages/sync/src/storage/repositories/sync-resource.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.db.test.ts
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { type Db } from "mongodb";
+import { seedOauthCredential } from "@sync/__tests__/helpers/credential-encryption";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import { type SyncResourceUpsert } from "@sync/storage/contracts/sync-resource.contracts";
@@ -520,7 +521,7 @@ describe("SyncResourceRepository", () => {
         upsert({ tenantId, principalId, connectionId }),
       );
       if (provider === "google") {
-        await credentials.store({
+        await seedOauthCredential(credentials, {
           connectionId,
           provider: "google",
           refreshToken: "google-refresh",


### PR DESCRIPTION
Fixes #3271

## What and why

Closes Providers C WP-04: OAuth refresh tokens were the last credential material still stored in plaintext. New writes now seal refresh tokens with the same AES-256-GCM helper as password credentials (`credential-at-rest.ts`), legacy plaintext rows still parse, and a successful refresh lazily re-encrypts any remaining plaintext row. Operators can backfill rows that never refresh via `bun run cli encrypt-credentials` (dry-run by default). Plaintext acceptance removal and a startup guard stay in a follow-up PR after founder confirms prod backfill convergence.

## Verify

```
bun run verify --strict
```

Selected packages: sync, scripts
Checks run: test:sync, test:scripts, type-check, lint, knip
Checks skipped: (none)

VERDICT: PASS