### PR TITLE
feat(sync): add Apple CalDAV event reader with sync-collection

### DIFF
--- a/.agents/handoffs/3258.md
+++ b/.agents/handoffs/3258.md
@@ -1,0 +1,41 @@
+---
+schema_version: 1
+task_id: "3258"
+from: Implementer
+to: GitHub
+owner: GitHub
+status: verifying
+artifact:
+  - path: packages/sync/src/providers/apple/apple-event-reader.adapter.ts
+  - path: packages/sync/src/providers/apple/apple-event-reader.adapter.test.ts
+  - path: packages/sync/src/providers/__contract__/apple-contract.factory.ts
+  - path: packages/sync/src/providers/__contract__/apple.adapter.contract.test.ts
+  - path: packages/sync/src/providers/provider-event.port.ts
+  - path: packages/sync/src/domain/provider-page-applier.ts
+  - path: packages/sync/src/domain/calendar-pull.service.ts
+  - path: packages/sync/src/storage/repositories/event.repository.ts
+evidence:
+  - command: bun test:sync
+    result: pass
+  - command: bun run type-check
+    result: pass
+  - command: bun lint
+    result: pass
+  - command: bun knip
+    result: pass
+  - command: bun run verify --strict
+    result: "VERDICT: PASS"
+assumptions:
+  - "CalDAV sync-collection deletions carry only href; import stores providerMetadata.href and pull resolves deletions by that href."
+  - "Initial-pass pageToken is a numeric multiget offset kept in adapter memory for the pass sequence."
+  - "connectionTimeZone defaults to UTC until WP-08 binds the connection zone at adapter construction."
+open_risks:
+  - "Live iCloud sync-collection truncation and valid-sync-token precondition shapes validated only via scripted fixtures until A-11."
+next_deadline: 2026-09-05T02:00:00Z
+retry: 0
+approval: allow
+waiting_on: null
+escalation: null
+---
+
+Providers A WP-05: CalDAV event reader with sync-collection on the A-01 client.

--- a/packages/sync/src/domain/calendar-pull.service.ts
+++ b/packages/sync/src/domain/calendar-pull.service.ts
@@ -227,7 +227,7 @@ async function applyDeletions(
 ): Promise<number> {
   let deleted = 0;
   for (const cancellation of cancellations) {
-    const event = await deps.events.findByProviderIdentity(
+    let event = await deps.events.findByProviderIdentity(
       calendar.tenantId,
       calendar.principalId,
       {
@@ -238,6 +238,17 @@ async function applyDeletions(
         >,
       },
     );
+    if (!event) {
+      event = await deps.events.findByProviderResourceHref(
+        calendar.tenantId,
+        calendar.principalId,
+        {
+          connectionId: calendar.connectionId,
+          calendarId: calendar._id,
+          href: cancellation.providerEventId,
+        },
+      );
+    }
     // Already gone (a prior pull removed it) or never stored — nothing to do.
     if (!event) continue;
     // A local edit/create is still in flight for this event; keep it so the

--- a/packages/sync/src/domain/provider-page-applier.ts
+++ b/packages/sync/src/domain/provider-page-applier.ts
@@ -32,6 +32,7 @@ function providerMetadataFor(
   const metadata = {
     ...(read.busy ? {} : { transparency: "transparent" }),
     ...(read.icalUid ? { iCalUID: read.icalUid } : {}),
+    ...(read.resourceHref ? { href: read.resourceHref } : {}),
   };
   return Object.keys(metadata).length > 0 ? metadata : null;
 }

--- a/packages/sync/src/providers/__contract__/apple-contract.factory.ts
+++ b/packages/sync/src/providers/__contract__/apple-contract.factory.ts
@@ -1,0 +1,183 @@
+import {
+  AppleEventReaderAdapter,
+  type AppleEventReaderApi,
+  type AppleEventResource,
+  MULTIGET_BATCH_SIZE,
+} from "@sync/providers/apple/apple-event-reader.adapter";
+import {
+  ProviderEventReadError,
+  type ProviderEventReader,
+} from "@sync/providers/provider-event-reader.port";
+
+interface ReaderCorpus {
+  readonly initialHrefs: readonly string[];
+  readonly initialResources: Record<string, AppleEventResource>;
+  readonly expiredCursor: string;
+}
+
+const TIMED_ICS = (uid: string, summary: string) => `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:${uid}
+DTSTAMP:20250101T120000Z
+DTSTART:20250115T090000Z
+DTEND:20250115T100000Z
+SUMMARY:${summary}
+END:VEVENT
+END:VCALENDAR`;
+
+const SERIES_ICS = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:series-1@icloud.com
+DTSTAMP:20250101T120000Z
+DTSTART:20250115T090000Z
+DTEND:20250115T100000Z
+RRULE:FREQ=DAILY;COUNT=3
+SUMMARY:Contract series
+END:VEVENT
+BEGIN:VEVENT
+UID:series-1@icloud.com
+DTSTAMP:20250101T120001Z
+DTSTART:20250116T100000Z
+DTEND:20250116T110000Z
+RECURRENCE-ID:20250116T090000Z
+SUMMARY:Contract exception
+END:VEVENT
+END:VCALENDAR`;
+
+const ALL_DAY_ICS = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:allday@icloud.com
+DTSTAMP:20250101T120000Z
+DTSTART;VALUE=DATE:20250222
+DTEND;VALUE=DATE:20250223
+SUMMARY:All day
+TRANSP:TRANSPARENT
+END:VEVENT
+END:VCALENDAR`;
+
+const ATTENDEE_ICS = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:attendee@icloud.com
+DTSTAMP:20250101T120000Z
+DTSTART:20250115T140000Z
+DTEND:20250115T143000Z
+SUMMARY:Standup
+URL:https://meet.example.com/abc
+ATTENDEE;CN=A;PARTSTAT=ACCEPTED:mailto:a@example.com
+END:VEVENT
+END:VCALENDAR`;
+
+const CANCELLED_ICS = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:cancelled@icloud.com
+DTSTAMP:20250101T120000Z
+DTSTART:20250115T090000Z
+DTEND:20250115T100000Z
+STATUS:CANCELLED
+SUMMARY:Cancelled
+END:VEVENT
+END:VCALENDAR`;
+
+const UNUSABLE_ICS = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+SUMMARY:No uid
+END:VEVENT
+END:VCALENDAR`;
+
+function resource(
+  href: string,
+  ics: string,
+  etag = '"etag"',
+): AppleEventResource {
+  return { href, etag, ics };
+}
+
+function defaultReaderCorpus(): ReaderCorpus {
+  const initialHrefs = Array.from(
+    { length: MULTIGET_BATCH_SIZE + 1 },
+    (_, index) => `/123/calendars/home/event-${index}.ics`,
+  );
+  const initialResources: Record<string, AppleEventResource> = {
+    [initialHrefs[0]!]: resource(
+      initialHrefs[0]!,
+      TIMED_ICS("timed@icloud.com", "Timed master"),
+    ),
+    [initialHrefs[1]!]: resource(initialHrefs[1]!, ALL_DAY_ICS),
+    [initialHrefs[2]!]: resource(initialHrefs[2]!, SERIES_ICS, '"series-etag"'),
+    [initialHrefs[3]!]: resource(initialHrefs[3]!, ATTENDEE_ICS),
+    [initialHrefs[4]!]: resource(initialHrefs[4]!, CANCELLED_ICS),
+    [initialHrefs[5]!]: resource(initialHrefs[5]!, UNUSABLE_ICS),
+  };
+  for (const href of initialHrefs.slice(6, MULTIGET_BATCH_SIZE)) {
+    initialResources[href] = resource(
+      href,
+      TIMED_ICS(`bulk-${href}`, "Bulk event"),
+    );
+  }
+  return {
+    initialHrefs,
+    initialResources,
+    expiredCursor: "expired-sync-token",
+  };
+}
+
+class CorpusAppleEventReaderApi implements AppleEventReaderApi {
+  constructor(private readonly corpus: ReaderCorpus) {}
+
+  async calendarQuery(): Promise<readonly string[]> {
+    return this.corpus.initialHrefs;
+  }
+
+  async calendarMultiget(
+    _calendarUrl: string,
+    hrefs: readonly string[],
+  ): Promise<readonly AppleEventResource[]> {
+    return hrefs.map(
+      (href) =>
+        this.corpus.initialResources[href] ??
+        resource(href, TIMED_ICS(`paged-${href}`, "Paged event")),
+    );
+  }
+
+  async syncCollection(
+    _calendarUrl: string,
+    syncToken: string,
+  ): Promise<{
+    changedHrefs: readonly string[];
+    deletedHrefs: readonly string[];
+    nextSyncToken: string | null;
+    truncated: boolean;
+  }> {
+    if (syncToken === this.corpus.expiredCursor) {
+      throw new ProviderEventReadError(
+        "cursorExpired",
+        "Apple sync token is no longer valid",
+      );
+    }
+    return {
+      changedHrefs: [],
+      deletedHrefs: [],
+      nextSyncToken: "sync-token-2",
+      truncated: false,
+    };
+  }
+
+  async fetchSyncToken(): Promise<string | null> {
+    return "sync-token-1";
+  }
+}
+
+export function appleRecordedReader(_corpusDir: string): ProviderEventReader {
+  const readerCorpus = defaultReaderCorpus();
+  return new AppleEventReaderAdapter("user@icloud.com", {
+    connectionTimeZone: "UTC",
+    makeApi: () => new CorpusAppleEventReaderApi(readerCorpus),
+    log: { warn: () => {} },
+  });
+}

--- a/packages/sync/src/providers/__contract__/apple.adapter.contract.test.ts
+++ b/packages/sync/src/providers/__contract__/apple.adapter.contract.test.ts
@@ -1,0 +1,85 @@
+import {
+  CONTRACT_EVENT_ID,
+  defaultCorpusDir,
+} from "@sync/providers/__contract__/adapter-contract";
+import { appleRecordedReader } from "@sync/providers/__contract__/apple-contract.factory";
+import { type ProviderEventReadError } from "@sync/providers/provider-event-reader.port";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+describe("apple reader contract", () => {
+  const corpusDir = defaultCorpusDir("apple");
+  const calendarId = "/123456789/calendars/home/";
+  const accessToken = "contract-access-token";
+  const expiredCursor = "expired-sync-token";
+  let reader = appleRecordedReader(corpusDir);
+
+  beforeEach(() => {
+    reader = appleRecordedReader(corpusDir);
+  });
+
+  it("pages, yields nextSyncToken only at the end, and counts skipped events", async () => {
+    const first = await reader.listEventPage({
+      accessToken,
+      calendarId,
+    });
+    expect(first.skipped).toBeGreaterThanOrEqual(1);
+
+    let page = first;
+    let pages = 1;
+    while (page.nextPageToken) {
+      expect(page.nextSyncToken).toBeNull();
+      page = await reader.listEventPage({
+        accessToken,
+        calendarId,
+        pageToken: page.nextPageToken,
+      });
+      pages += 1;
+    }
+    expect(pages).toBeGreaterThanOrEqual(1);
+    expect(page.nextPageToken).toBeNull();
+    expect(
+      page.nextSyncToken === null || typeof page.nextSyncToken === "string",
+    ).toBe(true);
+  });
+
+  it("maps an expired cursor to cursorExpired", async () => {
+    try {
+      await reader.listEventPage({
+        accessToken,
+        calendarId,
+        cursor: expiredCursor,
+      });
+      throw new Error("expected cursorExpired");
+    } catch (caught) {
+      expect((caught as ProviderEventReadError).reason).toBe("cursorExpired");
+    }
+  });
+
+  it("keeps masters and exceptions and does not expand occurrences", async () => {
+    const events = [];
+    let pageToken: string | null = null;
+    do {
+      const page = await reader.listEventPage({
+        accessToken,
+        calendarId,
+        pageToken,
+      });
+      events.push(...page.events);
+      pageToken = page.nextPageToken;
+    } while (pageToken);
+
+    const masters = events.filter(
+      (event) =>
+        event.kind === "event" && event.recurrence.kind === "seriesMaster",
+    );
+    const instances = events.filter(
+      (event) => event.kind === "event" && event.recurrence.kind === "instance",
+    );
+    expect(masters.length).toBeGreaterThanOrEqual(1);
+    expect(instances.length).toBeGreaterThanOrEqual(1);
+    expect(instances.length).toBeLessThan(5);
+    expect(events.some((event) => event.kind === "cancellation")).toBe(true);
+    expect(events.some((event) => event.kind === "event")).toBe(true);
+    void CONTRACT_EVENT_ID;
+  });
+});

--- a/packages/sync/src/providers/apple/apple-event-reader.adapter.test.ts
+++ b/packages/sync/src/providers/apple/apple-event-reader.adapter.test.ts
@@ -1,0 +1,319 @@
+import {
+  AppleEventReaderAdapter,
+  type AppleEventReaderApi,
+  type AppleEventResource,
+  type AppleSyncCollectionPage,
+  MULTIGET_BATCH_SIZE,
+} from "@sync/providers/apple/apple-event-reader.adapter";
+import { ProviderEventReadError } from "@sync/providers/provider-event-reader.port";
+
+class ScriptedAppleEventReaderApi implements AppleEventReaderApi {
+  calls: Array<{ method: string; args: unknown[] }> = [];
+  #handlers: Partial<
+    Record<
+      keyof AppleEventReaderApi,
+      (...args: unknown[]) => Promise<unknown> | unknown
+    >
+  >;
+
+  constructor(
+    handlers: Partial<
+      Record<
+        keyof AppleEventReaderApi,
+        (...args: unknown[]) => Promise<unknown> | unknown
+      >
+    >,
+  ) {
+    this.#handlers = handlers;
+  }
+
+  calendarQuery(
+    calendarUrl: string,
+    window: { timeMin: string; timeMax: string },
+  ): Promise<readonly string[]> {
+    this.calls.push({ method: "calendarQuery", args: [calendarUrl, window] });
+    return Promise.resolve(
+      (this.#handlers.calendarQuery?.(calendarUrl, window) as
+        | readonly string[]
+        | undefined) ?? [],
+    );
+  }
+
+  calendarMultiget(
+    calendarUrl: string,
+    hrefs: readonly string[],
+  ): Promise<readonly AppleEventResource[]> {
+    this.calls.push({ method: "calendarMultiget", args: [calendarUrl, hrefs] });
+    return Promise.resolve(
+      (this.#handlers.calendarMultiget?.(calendarUrl, hrefs) as
+        | readonly AppleEventResource[]
+        | undefined) ?? [],
+    );
+  }
+
+  syncCollection(
+    calendarUrl: string,
+    syncToken: string,
+  ): Promise<AppleSyncCollectionPage> {
+    this.calls.push({
+      method: "syncCollection",
+      args: [calendarUrl, syncToken],
+    });
+    const result = this.#handlers.syncCollection?.(calendarUrl, syncToken);
+    if (!result) {
+      throw new Error("syncCollection not scripted");
+    }
+    return Promise.resolve(result as AppleSyncCollectionPage);
+  }
+
+  fetchSyncToken(calendarUrl: string): Promise<string | null> {
+    this.calls.push({ method: "fetchSyncToken", args: [calendarUrl] });
+    return Promise.resolve(
+      (this.#handlers.fetchSyncToken?.(calendarUrl) as
+        | string
+        | null
+        | undefined) ?? null,
+    );
+  }
+}
+
+const timedIcs = (uid: string, summary: string) => `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:${uid}
+DTSTAMP:20250101T120000Z
+DTSTART:20250115T090000Z
+DTEND:20250115T100000Z
+SUMMARY:${summary}
+END:VEVENT
+END:VCALENDAR`;
+
+const unusableIcs = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+SUMMARY:No uid
+END:VEVENT
+END:VCALENDAR`;
+
+function resource(
+  href: string,
+  uid: string,
+  summary: string,
+): AppleEventResource {
+  return {
+    href,
+    etag: `"etag-${uid}"`,
+    ics: timedIcs(uid, summary),
+  };
+}
+
+function makeHrefs(count: number): string[] {
+  return Array.from(
+    { length: count },
+    (_, index) => `/123/calendars/home/event-${index}.ics`,
+  );
+}
+
+function adapterWith(api: AppleEventReaderApi) {
+  return new AppleEventReaderAdapter("user@icloud.com", {
+    connectionTimeZone: "UTC",
+    makeApi: () => api,
+    log: { warn: () => {} },
+  });
+}
+
+describe("AppleEventReaderAdapter", () => {
+  it("replays initial calendar-query plus multiget in two batches", async () => {
+    const hrefs = makeHrefs(MULTIGET_BATCH_SIZE + 3);
+    const api = new ScriptedAppleEventReaderApi({
+      calendarQuery: async () => hrefs,
+      calendarMultiget: async (_calendarUrl, batch) =>
+        batch.map((href, index) =>
+          resource(href, `uid-${index}`, `Event ${index}`),
+        ),
+      fetchSyncToken: async () => "sync-token-final",
+    });
+    const adapter = adapterWith(api);
+
+    const first = await adapter.listEventPage({
+      accessToken: "secret",
+      calendarId: "/123/calendars/home/",
+    });
+
+    expect(first.events).toHaveLength(MULTIGET_BATCH_SIZE);
+    expect(first.nextPageToken).toBe(String(MULTIGET_BATCH_SIZE));
+    expect(first.nextSyncToken).toBeNull();
+
+    const second = await adapter.listEventPage({
+      accessToken: "secret",
+      calendarId: "/123/calendars/home/",
+      pageToken: first.nextPageToken,
+    });
+
+    expect(second.events).toHaveLength(3);
+    expect(second.nextPageToken).toBeNull();
+    expect(second.nextSyncToken).toBe("sync-token-final");
+    expect(
+      api.calls.filter((call) => call.method === "calendarQuery"),
+    ).toHaveLength(1);
+    expect(
+      api.calls.filter((call) => call.method === "calendarMultiget"),
+    ).toHaveLength(2);
+  });
+
+  it("replays sync-collection with one change and one deletion", async () => {
+    const api = new ScriptedAppleEventReaderApi({
+      syncCollection: async () => ({
+        changedHrefs: ["/123/calendars/home/changed.ics"],
+        deletedHrefs: ["/123/calendars/home/deleted.ics"],
+        nextSyncToken: "sync-token-2",
+        truncated: false,
+      }),
+      calendarMultiget: async () => [
+        resource(
+          "/123/calendars/home/changed.ics",
+          "changed@icloud.com",
+          "Changed",
+        ),
+      ],
+    });
+    const adapter = adapterWith(api);
+
+    const page = await adapter.listEventPage({
+      accessToken: "secret",
+      calendarId: "/123/calendars/home/",
+      cursor: "sync-token-1",
+    });
+
+    expect(page.events.map((event) => event.kind)).toEqual([
+      "event",
+      "cancellation",
+    ]);
+    expect(
+      page.events[0]?.kind === "event" && page.events[0].resourceHref,
+    ).toBe("/123/calendars/home/changed.ics");
+    expect(
+      page.events[1]?.kind === "cancellation" && page.events[1].providerEventId,
+    ).toBe("/123/calendars/home/deleted.ics");
+    expect(page.nextSyncToken).toBe("sync-token-2");
+  });
+
+  it("returns nextPageToken for a truncated sync-collection", async () => {
+    const api = new ScriptedAppleEventReaderApi({
+      syncCollection: async () => ({
+        changedHrefs: ["/123/calendars/home/partial.ics"],
+        deletedHrefs: [],
+        nextSyncToken: "sync-token-partial",
+        truncated: true,
+      }),
+      calendarMultiget: async () => [
+        resource(
+          "/123/calendars/home/partial.ics",
+          "partial@icloud.com",
+          "Partial",
+        ),
+      ],
+    });
+    const adapter = adapterWith(api);
+
+    const page = await adapter.listEventPage({
+      accessToken: "secret",
+      calendarId: "/123/calendars/home/",
+      cursor: "sync-token-1",
+    });
+
+    expect(page.nextPageToken).toBe("sync-token-partial");
+    expect(page.nextSyncToken).toBeNull();
+  });
+
+  it("maps an invalid sync-token to cursorExpired", async () => {
+    const api = new ScriptedAppleEventReaderApi({
+      syncCollection: async () => {
+        throw new ProviderEventReadError(
+          "cursorExpired",
+          "Apple sync token is no longer valid",
+        );
+      },
+    });
+    const adapter = adapterWith(api);
+
+    await expect(
+      adapter.listEventPage({
+        accessToken: "secret",
+        calendarId: "/123/calendars/home/",
+        cursor: "stale-sync-token",
+      }),
+    ).rejects.toMatchObject({ reason: "cursorExpired" });
+  });
+
+  it("maps 503 to transient", async () => {
+    const api = new ScriptedAppleEventReaderApi({
+      syncCollection: async () => {
+        throw new ProviderEventReadError(
+          "transient",
+          "Apple CalDAV throttled or unavailable (503)",
+        );
+      },
+    });
+    const adapter = adapterWith(api);
+
+    await expect(
+      adapter.listEventPage({
+        accessToken: "secret",
+        calendarId: "/123/calendars/home/",
+        cursor: "sync-token-1",
+      }),
+    ).rejects.toMatchObject({ reason: "transient" });
+  });
+
+  it("counts skipped resources that fail normalization", async () => {
+    const api = new ScriptedAppleEventReaderApi({
+      calendarQuery: async () => ["/123/calendars/home/bad.ics"],
+      calendarMultiget: async () => [
+        {
+          href: "/123/calendars/home/bad.ics",
+          etag: '"bad"',
+          ics: unusableIcs,
+        },
+      ],
+      fetchSyncToken: async () => "sync-token-final",
+    });
+    const adapter = adapterWith(api);
+
+    const page = await adapter.listEventPage({
+      accessToken: "secret",
+      calendarId: "/123/calendars/home/",
+    });
+
+    expect(page.skipped).toBe(1);
+    expect(page.events).toHaveLength(0);
+  });
+
+  it("does not return a sync token for a windowed pass", async () => {
+    const api = new ScriptedAppleEventReaderApi({
+      calendarQuery: async () => ["/123/calendars/home/window.ics"],
+      calendarMultiget: async () => [
+        resource(
+          "/123/calendars/home/window.ics",
+          "window@icloud.com",
+          "Window",
+        ),
+      ],
+    });
+    const adapter = adapterWith(api);
+
+    const page = await adapter.listEventPage({
+      accessToken: "secret",
+      calendarId: "/123/calendars/home/",
+      window: {
+        timeMin: "2026-01-01T00:00:00Z",
+        timeMax: "2026-06-01T00:00:00Z",
+      },
+    });
+
+    expect(page.nextSyncToken).toBeNull();
+    expect(api.calls.some((call) => call.method === "fetchSyncToken")).toBe(
+      false,
+    );
+  });
+});

--- a/packages/sync/src/providers/apple/apple-event-reader.adapter.ts
+++ b/packages/sync/src/providers/apple/apple-event-reader.adapter.ts
@@ -1,0 +1,562 @@
+import { Logger } from "@core/logger/winston.logger";
+import dayjs from "@core/util/date/dayjs";
+import { syncHorizon } from "@sync/domain/horizon";
+import { type AppleCalendarClientFactory } from "@sync/providers/apple/apple-calendar.adapter";
+import { normalizeAppleEventResource } from "@sync/providers/apple/apple-event.normalizer";
+import {
+  type CaldavClient,
+  type CaldavResponse,
+  createCaldavClient,
+  type ParsedMultistatus,
+  type ParsedResponse,
+} from "@sync/providers/apple/caldav-client";
+import {
+  ProviderEventError,
+  type ProviderEventRead,
+} from "@sync/providers/provider-event.port";
+import {
+  type EventWindow,
+  type ProviderEventPage,
+  ProviderEventReadError,
+  type ProviderEventReader,
+  type ProviderEventReadInput,
+} from "@sync/providers/provider-event-reader.port";
+
+const logger = Logger("sync:apple-event-reader");
+
+export const MULTIGET_BATCH_SIZE = 50;
+export const SYNC_COLLECTION_LIMIT = 100;
+const CALDAV_ORIGIN = "https://caldav.icloud.com";
+
+export interface AppleEventResource {
+  readonly href: string;
+  readonly etag: string;
+  readonly ics: string;
+}
+
+export interface AppleEventReaderApi {
+  calendarQuery(
+    calendarUrl: string,
+    window: EventWindow,
+  ): Promise<readonly string[]>;
+  calendarMultiget(
+    calendarUrl: string,
+    hrefs: readonly string[],
+  ): Promise<readonly AppleEventResource[]>;
+  syncCollection(
+    calendarUrl: string,
+    syncToken: string,
+  ): Promise<AppleSyncCollectionPage>;
+  fetchSyncToken(calendarUrl: string): Promise<string | null>;
+}
+
+export interface AppleSyncCollectionPage {
+  readonly changedHrefs: readonly string[];
+  readonly deletedHrefs: readonly string[];
+  readonly nextSyncToken: string | null;
+  readonly truncated: boolean;
+}
+
+export type AppleEventReaderApiFactory = (
+  accessToken: string,
+) => AppleEventReaderApi;
+
+interface InitialPassState {
+  readonly hrefs: readonly string[];
+  readonly window: EventWindow | null;
+  readonly fetchSyncToken: boolean;
+}
+
+export class AppleEventReaderAdapter implements ProviderEventReader {
+  #connectionTimeZone: string;
+  #makeApi: AppleEventReaderApiFactory;
+  #initialPassState = new Map<string, InitialPassState>();
+  #log: { warn: (message: string) => void };
+
+  constructor(
+    username: string,
+    options: {
+      connectionTimeZone?: string;
+      makeApi?: AppleEventReaderApiFactory;
+      log?: { warn: (message: string) => void };
+    } = {},
+  ) {
+    this.#connectionTimeZone = options.connectionTimeZone ?? "UTC";
+    this.#makeApi =
+      options.makeApi ??
+      ((accessToken) =>
+        createDefaultAppleEventReaderApi(username, accessToken));
+    this.#log = options.log ?? logger;
+  }
+
+  async listEventPage(
+    input: ProviderEventReadInput,
+  ): Promise<ProviderEventPage> {
+    const api = this.#makeApi(input.accessToken);
+    const calendarUrl = resolveCalendarUrl(input.calendarId);
+
+    if (input.window) {
+      return this.#readInitialPass(api, calendarUrl, input, {
+        window: input.window,
+        fetchSyncToken: false,
+      });
+    }
+
+    if (input.cursor) {
+      return this.#readIncremental(api, calendarUrl, input);
+    }
+
+    return this.#readInitialPass(api, calendarUrl, input, {
+      window: null,
+      fetchSyncToken: true,
+    });
+  }
+
+  async #readInitialPass(
+    api: AppleEventReaderApi,
+    calendarUrl: string,
+    input: ProviderEventReadInput,
+    pass: { window: EventWindow | null; fetchSyncToken: boolean },
+  ): Promise<ProviderEventPage> {
+    const stateKey = initialPassKey(input.calendarId, input.accessToken, pass);
+    let hrefs = this.#initialPassState.get(stateKey)?.hrefs;
+    const offset = parseInitialOffset(input.pageToken);
+
+    if (hrefs === undefined) {
+      if (pass.window) {
+        hrefs = await this.#queryHrefs(api, calendarUrl, pass.window);
+      } else {
+        hrefs = await this.#queryHrefs(api, calendarUrl, fullHorizonWindow());
+      }
+      this.#initialPassState.set(stateKey, {
+        hrefs,
+        window: pass.window,
+        fetchSyncToken: pass.fetchSyncToken,
+      });
+    }
+
+    const batch = hrefs.slice(offset, offset + MULTIGET_BATCH_SIZE);
+    const resources =
+      batch.length > 0 ? await api.calendarMultiget(calendarUrl, batch) : [];
+    const normalized = this.#normalizeResources(resources);
+
+    const nextOffset = offset + batch.length;
+    const hasMore = nextOffset < hrefs.length;
+    if (hasMore) {
+      return {
+        ...normalized,
+        nextPageToken: String(nextOffset),
+        nextSyncToken: null,
+      };
+    }
+
+    this.#initialPassState.delete(stateKey);
+    const nextSyncToken = pass.fetchSyncToken
+      ? await api.fetchSyncToken(calendarUrl)
+      : null;
+    return {
+      ...normalized,
+      nextPageToken: null,
+      nextSyncToken,
+    };
+  }
+
+  async #readIncremental(
+    api: AppleEventReaderApi,
+    calendarUrl: string,
+    input: ProviderEventReadInput,
+  ): Promise<ProviderEventPage> {
+    const syncToken = input.pageToken ?? input.cursor ?? "";
+    const page = await this.#syncCollection(api, calendarUrl, syncToken);
+
+    const changed =
+      page.changedHrefs.length > 0
+        ? await api.calendarMultiget(calendarUrl, page.changedHrefs)
+        : [];
+    const normalized = this.#normalizeResources(changed);
+    const deletions = page.deletedHrefs.map((href) => ({
+      kind: "cancellation" as const,
+      providerEventId: href,
+      providerVersion: "",
+      series: null,
+    }));
+
+    return {
+      events: [...normalized.events, ...deletions],
+      skipped: normalized.skipped,
+      nextPageToken: page.truncated ? (page.nextSyncToken ?? syncToken) : null,
+      nextSyncToken: page.truncated ? null : page.nextSyncToken,
+    };
+  }
+
+  async #queryHrefs(
+    api: AppleEventReaderApi,
+    calendarUrl: string,
+    window: EventWindow,
+  ): Promise<readonly string[]> {
+    try {
+      return await api.calendarQuery(calendarUrl, window);
+    } catch (error) {
+      throw classifyReadError(error, "CalDAV calendar-query failed");
+    }
+  }
+
+  async #syncCollection(
+    api: AppleEventReaderApi,
+    calendarUrl: string,
+    syncToken: string,
+  ): Promise<AppleSyncCollectionPage> {
+    try {
+      return await api.syncCollection(calendarUrl, syncToken);
+    } catch (error) {
+      throw classifyReadError(error, "CalDAV sync-collection failed");
+    }
+  }
+
+  #normalizeResources(
+    resources: readonly AppleEventResource[],
+  ): Pick<ProviderEventPage, "events" | "skipped"> {
+    const events: ProviderEventRead[] = [];
+    let skipped = 0;
+
+    for (const resource of resources) {
+      try {
+        const reads = normalizeAppleEventResource({
+          ics: resource.ics,
+          href: resource.href,
+          etag: resource.etag,
+          connectionTimeZone: this.#connectionTimeZone,
+        });
+        for (const read of reads) {
+          if (read.kind === "event") {
+            events.push({ ...read, resourceHref: resource.href });
+          } else {
+            events.push(read);
+          }
+        }
+      } catch (error) {
+        if (error instanceof ProviderEventError) {
+          skipped += 1;
+          this.#log.warn(
+            `Skipped unusable Apple event ${resource.href} (${error.reason})`,
+          );
+          continue;
+        }
+        throw error;
+      }
+    }
+
+    return { events, skipped };
+  }
+}
+
+export function createDefaultAppleEventReaderApi(
+  username: string,
+  accessToken: string,
+  makeClient: AppleCalendarClientFactory = (username, password) =>
+    createCaldavClient({ username, password }),
+): AppleEventReaderApi {
+  const client = makeClient(username, accessToken);
+  return new CaldavAppleEventReaderApi(client);
+}
+
+class CaldavAppleEventReaderApi implements AppleEventReaderApi {
+  constructor(private readonly client: CaldavClient) {}
+
+  async calendarQuery(
+    calendarUrl: string,
+    window: EventWindow,
+  ): Promise<readonly string[]> {
+    const body = buildCalendarQueryBody(window);
+    const response = await this.client.report(calendarUrl, body, 1);
+    assertReadStatus(response);
+    return extractSuccessfulHrefs(response.multistatus);
+  }
+
+  async calendarMultiget(
+    calendarUrl: string,
+    hrefs: readonly string[],
+  ): Promise<readonly AppleEventResource[]> {
+    if (hrefs.length === 0) return [];
+    const body = buildCalendarMultigetBody(hrefs);
+    const response = await this.client.report(calendarUrl, body, 1);
+    assertReadStatus(response);
+    return extractMultigetResources(response.multistatus, calendarUrl);
+  }
+
+  async syncCollection(
+    calendarUrl: string,
+    syncToken: string,
+  ): Promise<AppleSyncCollectionPage> {
+    const body = buildSyncCollectionBody(syncToken);
+    const response = await this.client.report(calendarUrl, body, 1);
+    if (response.status === 507) {
+      return parseSyncCollectionTruncation(response);
+    }
+    assertReadStatus(response);
+    return parseSyncCollectionPage(response);
+  }
+
+  async fetchSyncToken(calendarUrl: string): Promise<string | null> {
+    const response = await this.client.propfind(calendarUrl, ["sync-token"], 0);
+    assertReadStatus(response);
+    return extractSyncToken(response.multistatus);
+  }
+}
+
+function buildCalendarQueryBody(window: EventWindow): string {
+  return `<?xml version="1.0" encoding="utf-8"?>
+<C:calendar-query xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
+  <D:prop>
+    <D:getetag/>
+  </D:prop>
+  <C:filter>
+    <C:comp-filter name="VCALENDAR">
+      <C:comp-filter name="VEVENT">
+        <C:time-range start="${toCalDavUtc(window.timeMin)}" end="${toCalDavUtc(window.timeMax)}"/>
+      </C:comp-filter>
+    </C:comp-filter>
+  </C:filter>
+</C:calendar-query>`;
+}
+
+function buildCalendarMultigetBody(hrefs: readonly string[]): string {
+  const hrefElements = hrefs
+    .map((href) => `<D:href>${escapeXml(href)}</D:href>`)
+    .join("");
+  return `<?xml version="1.0" encoding="utf-8"?>
+<C:calendar-multiget xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
+  <D:prop>
+    <D:getetag/>
+    <C:calendar-data/>
+  </D:prop>
+  ${hrefElements}
+</C:calendar-multiget>`;
+}
+
+function buildSyncCollectionBody(syncToken: string): string {
+  return `<?xml version="1.0" encoding="utf-8"?>
+<D:sync-collection xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
+  <D:sync-token>${escapeXml(syncToken)}</D:sync-token>
+  <D:sync-level>1</D:sync-level>
+  <D:limit>${SYNC_COLLECTION_LIMIT}</D:limit>
+  <D:prop>
+    <D:getetag/>
+  </D:prop>
+</D:sync-collection>`;
+}
+
+function parseSyncCollectionPage(
+  response: CaldavResponse,
+): AppleSyncCollectionPage {
+  const multistatus = response.multistatus;
+  const changedHrefs: string[] = [];
+  const deletedHrefs: string[] = [];
+
+  for (const item of multistatus?.responses ?? []) {
+    const status = primaryPropstatStatus(item);
+    if (status === 404) {
+      deletedHrefs.push(normalizeHref(item.href));
+      continue;
+    }
+    if (status >= 200 && status < 300) {
+      changedHrefs.push(normalizeHref(item.href));
+    }
+  }
+
+  return {
+    changedHrefs,
+    deletedHrefs,
+    nextSyncToken: extractSyncToken(multistatus),
+    truncated: hasTruncationMarker(response.body, multistatus),
+  };
+}
+
+function parseSyncCollectionTruncation(
+  response: CaldavResponse,
+): AppleSyncCollectionPage {
+  const page = parseSyncCollectionPage(response);
+  return { ...page, truncated: true };
+}
+
+function hasTruncationMarker(
+  body: string,
+  multistatus: ParsedMultistatus | null,
+): boolean {
+  if (body.includes("number-of-matches-within-limits")) return true;
+  for (const response of multistatus?.responses ?? []) {
+    for (const propstat of response.propstats) {
+      if ("number-of-matches-within-limits" in propstat.props) return true;
+    }
+  }
+  return false;
+}
+
+function extractMultigetResources(
+  multistatus: ParsedMultistatus | null,
+  calendarUrl: string,
+): AppleEventResource[] {
+  const resources: AppleEventResource[] = [];
+  for (const response of multistatus?.responses ?? []) {
+    const status = primaryPropstatStatus(response);
+    if (status < 200 || status >= 300) continue;
+    const props = successfulProps(response);
+    const ics = stringProp(props["calendar-data"]);
+    const etag = stringProp(props["getetag"]);
+    if (!ics || !etag) continue;
+    resources.push({
+      href: resolveResourceHref(response.href, calendarUrl),
+      etag,
+      ics,
+    });
+  }
+  return resources;
+}
+
+function extractSuccessfulHrefs(
+  multistatus: ParsedMultistatus | null,
+): string[] {
+  const hrefs: string[] = [];
+  for (const response of multistatus?.responses ?? []) {
+    const status = primaryPropstatStatus(response);
+    if (status >= 200 && status < 300) {
+      hrefs.push(normalizeHref(response.href));
+    }
+  }
+  return hrefs;
+}
+
+function extractSyncToken(
+  multistatus: ParsedMultistatus | null,
+): string | null {
+  for (const response of multistatus?.responses ?? []) {
+    const props = successfulProps(response);
+    const token = stringProp(props["sync-token"]);
+    if (token) return token;
+  }
+  return null;
+}
+
+function assertReadStatus(response: CaldavResponse): void {
+  if (response.status === 401) {
+    throw new ProviderEventReadError(
+      "authExpired",
+      "Apple rejected the credentials",
+    );
+  }
+  if (response.status === 403 && hasValidSyncTokenPrecondition(response)) {
+    throw new ProviderEventReadError(
+      "cursorExpired",
+      "Apple sync token is no longer valid",
+    );
+  }
+  if (response.status === 429 || response.status === 503) {
+    throw new ProviderEventReadError(
+      "transient",
+      `Apple CalDAV throttled or unavailable (${response.status})`,
+    );
+  }
+  if (response.status === 507) return;
+  if (response.status < 200 || response.status >= 300) {
+    throw new ProviderEventReadError(
+      "readFailed",
+      `Apple CalDAV read failed (${response.status})`,
+    );
+  }
+}
+
+function classifyReadError(
+  error: unknown,
+  message: string,
+): ProviderEventReadError {
+  if (error instanceof ProviderEventReadError) return error;
+  return new ProviderEventReadError("readFailed", message, { cause: error });
+}
+
+function hasValidSyncTokenPrecondition(response: CaldavResponse): boolean {
+  const body = response.body.toLowerCase();
+  return (
+    body.includes("valid-sync-token") ||
+    body.includes("valid sync token") ||
+    body.includes("sync-token-ok")
+  );
+}
+
+function successfulProps(response: ParsedResponse): Record<string, unknown> {
+  for (const propstat of response.propstats) {
+    if (propstat.status >= 200 && propstat.status < 300) {
+      return propstat.props;
+    }
+  }
+  return {};
+}
+
+function primaryPropstatStatus(response: ParsedResponse): number {
+  return response.propstats[0]?.status ?? 0;
+}
+
+function stringProp(value: unknown): string | null {
+  if (typeof value === "string" && value.length > 0) return value;
+  if (typeof value === "number") return String(value);
+  return null;
+}
+
+function resolveCalendarUrl(calendarId: string): string {
+  if (calendarId.startsWith("http://") || calendarId.startsWith("https://")) {
+    return calendarId;
+  }
+  return new URL(calendarId, CALDAV_ORIGIN).href;
+}
+
+function resolveResourceHref(href: string, calendarUrl: string): string {
+  if (href.startsWith("http://") || href.startsWith("https://")) return href;
+  return new URL(href, calendarUrl).href;
+}
+
+function normalizeHref(href: string): string {
+  return href.startsWith("/") ? href : `/${href}`;
+}
+
+function initialPassKey(
+  calendarId: string,
+  accessToken: string,
+  pass: { window: EventWindow | null; fetchSyncToken: boolean },
+): string {
+  const windowKey = pass.window
+    ? `${pass.window.timeMin}:${pass.window.timeMax}`
+    : "full";
+  return `${calendarId}:${accessToken}:${windowKey}:${pass.fetchSyncToken ? "sync" : "nosync"}`;
+}
+
+function parseInitialOffset(pageToken: string | null | undefined): number {
+  if (!pageToken) return 0;
+  const offset = Number(pageToken);
+  if (!Number.isInteger(offset) || offset < 0) {
+    throw new ProviderEventReadError(
+      "readFailed",
+      "Apple initial pass page token is invalid",
+    );
+  }
+  return offset;
+}
+
+function fullHorizonWindow(): EventWindow {
+  const horizon = syncHorizon(new Date());
+  return {
+    timeMin: horizon.start.toISOString(),
+    timeMax: horizon.end.toISOString(),
+  };
+}
+
+function toCalDavUtc(iso: string): string {
+  return dayjs(iso).utc().format("YYYYMMDD[T]HHmmss[Z]");
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}

--- a/packages/sync/src/providers/provider-event.port.ts
+++ b/packages/sync/src/providers/provider-event.port.ts
@@ -36,6 +36,8 @@ export interface ProviderEvent {
   // the same meeting on different accounts share it, unlike providerEventId.
   // Absent when the provider reported none.
   readonly icalUid?: string;
+  // CalDAV resource href for resolving sync-collection deletions.
+  readonly resourceHref?: string;
   readonly recurrence: ProviderEventRecurrence;
 }
 

--- a/packages/sync/src/storage/repositories/event.repository.ts
+++ b/packages/sync/src/storage/repositories/event.repository.ts
@@ -328,6 +328,28 @@ export class EventRepository {
     return record ? EventRecordSchema.parse(record) : null;
   }
 
+  // Resolve a CalDAV resource href to a stored provider event. Incremental
+  // sync-collection deletions report only the href; import stores it in
+  // providerMetadata.href so pulls can map back to providerEventId.
+  async findByProviderResourceHref(
+    tenantId: TenantId,
+    principalId: PrincipalId,
+    identity: {
+      connectionId: NonNullable<EventRecord["connectionId"]>;
+      calendarId: EventRecord["calendarId"];
+      href: string;
+    },
+  ): Promise<EventRecord | null> {
+    const record = await this.collection.findOne({
+      tenantId,
+      principalId,
+      connectionId: identity.connectionId,
+      calendarId: identity.calendarId,
+      "providerMetadata.href": identity.href,
+    });
+    return record ? EventRecordSchema.parse(record) : null;
+  }
+
   // Remove one event by id, scoped to its owner so a caller can only delete its
   // own event. Idempotent: deleting an already-absent event is a no-op, so a
   // retried delete converges. Returns whether a document was removed.


### PR DESCRIPTION
Fixes #3258

## What and why

Implements `ProviderEventReader.listEventPage` for iCloud CalDAV on the A-01 client. Initial passes use horizon-bounded `calendar-query` (getetag only) followed by batched `calendar-multiget` for ICS payloads; incremental passes use RFC 6578 `sync-collection`. Import stores each resource href in `providerMetadata.href` so sync-collection 404 deletions resolve on pull.

Spec: [`docs/features/calendar-providers.md`](https://github.com/KeepSoftwareSimple/compass-calendar/blob/main/docs/features/calendar-providers.md)

## Verify

```
bun test:sync
bun run type-check
bun lint
bun knip
bun run verify --strict
```

VERDICT: PASS