### PR TITLE
perf(api): harden shared HTTP boundaries

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -2,16 +2,15 @@ import { ensureBillingIndexes } from "@backend/billing/billing-indexes";
 import { ensureBookingIndexes } from "@backend/booking/booking-indexes";
 import { CONFIG } from "@backend/common/constants/config.constants";
 import mongoService from "@backend/common/services/mongo.service";
-import { initExpressServer } from "@backend/servers/express/express.server";
+import { createBackendHttpServer } from "@backend/servers/express/express.server";
 import { foregroundSyncRefresh } from "@backend/servers/sse/foreground-sync-refresh";
 import { syncChangeFeedBridge } from "@backend/servers/sse/sync-change-feed.bridge";
 import userService from "@backend/user/services/user.service";
 import { logger } from "./init"; //must be first import
 import { stopPostHogLogs } from "./logging/posthog-logs";
-import { createServer, type Server } from "node:http";
+import { type Server } from "node:http";
 
-const app = initExpressServer();
-const httpServer: Server = createServer(app);
+const httpServer: Server = createBackendHttpServer();
 
 function onClose() {
   logger.info(`Http server terminated`);

--- a/packages/backend/src/calendar/controllers/calendar.controller.ts
+++ b/packages/backend/src/calendar/controllers/calendar.controller.ts
@@ -13,6 +13,7 @@ import calendarService from "@backend/calendar/services/calendar.service";
 import { AuthError } from "@backend/common/errors/auth/auth.errors";
 import { GenericError } from "@backend/common/errors/generic/generic.errors";
 import { error } from "@backend/common/errors/handlers/error.handler";
+import { parseCommaSeparatedQueryParam } from "@backend/common/helpers/query-param";
 import { syncCalendarsToBrowser } from "@backend/common/services/sync-service/calendar-list.translation";
 import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
 import { throwSyncProxyFailure } from "@backend/common/services/sync-service/sync-proxy-error";
@@ -44,17 +45,11 @@ const assertBoundedAvailabilityRange = (query: AvailabilityQuery) => {
   }
 };
 
-// calendarIds travels as a single comma-separated query param -
-// the web api client (availability.api.ts) must format requests this way.
 const parseAvailabilityQuery = (query: SessionRequest["query"]) => {
-  const calendarIdsParam = query["calendarIds"];
-  const calendarIds =
-    typeof calendarIdsParam === "string" && calendarIdsParam.length > 0
-      ? calendarIdsParam.split(",")
-      : [];
+  const calendarIds = parseCommaSeparatedQueryParam(query["calendarIds"]);
 
   return AvailabilityQuerySchema.parse({
-    calendarIds,
+    calendarIds: calendarIds ?? [],
     start: query["start"],
     end: query["end"],
   });

--- a/packages/backend/src/common/helpers/query-param.test.ts
+++ b/packages/backend/src/common/helpers/query-param.test.ts
@@ -1,0 +1,23 @@
+import { parseCommaSeparatedQueryParam } from "@backend/common/helpers/query-param";
+import { describe, expect, it } from "bun:test";
+
+describe("parseCommaSeparatedQueryParam", () => {
+  it("parses comma-separated values", () => {
+    expect(parseCommaSeparatedQueryParam("a,b")).toEqual(["a", "b"]);
+  });
+
+  it("parses repeated values and mixed comma-separated values", () => {
+    expect(parseCommaSeparatedQueryParam(["a,b", "c"])).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+
+  it("leaves absent and structurally invalid values for schema validation", () => {
+    expect(parseCommaSeparatedQueryParam(undefined)).toBeUndefined();
+    expect(
+      parseCommaSeparatedQueryParam(["a", { nested: "b" }]),
+    ).toBeUndefined();
+  });
+});

--- a/packages/backend/src/common/helpers/query-param.ts
+++ b/packages/backend/src/common/helpers/query-param.ts
@@ -1,0 +1,16 @@
+/**
+ * Accept both common array encodings used by HTTP clients:
+ * `calendarIds=a,b` and `calendarIds=a&calendarIds=b`.
+ *
+ * Empty entries are retained so the owning Zod contract rejects malformed
+ * input rather than silently changing its meaning.
+ */
+export function parseCommaSeparatedQueryParam(
+  value: unknown,
+): string[] | undefined {
+  if (typeof value === "string") return value.split(",");
+  if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
+    return value.flatMap((item) => item.split(","));
+  }
+  return undefined;
+}

--- a/packages/backend/src/event/controllers/event.controller.ts
+++ b/packages/backend/src/event/controllers/event.controller.ts
@@ -25,6 +25,7 @@ import {
 } from "@core/types/sync/event.contracts";
 import { assertBillingAllowsWrites } from "@backend/billing/billing.guard";
 import calendarService from "@backend/calendar/services/calendar.service";
+import { parseCommaSeparatedQueryParam } from "@backend/common/helpers/query-param";
 import { assertCloudMutationsAllowed } from "@backend/common/services/sync-service/cloud-mutation-mode";
 import {
   toCreateSubmitRequest,
@@ -120,11 +121,7 @@ const send = (res: Response, e: unknown) => {
 };
 
 const parseListQuery = (query: Request["query"]): EventListQuery => {
-  const calendarIdsParam = query["calendarIds"];
-  const calendarIds =
-    typeof calendarIdsParam === "string" && calendarIdsParam.length > 0
-      ? calendarIdsParam.split(",")
-      : undefined;
+  const calendarIds = parseCommaSeparatedQueryParam(query["calendarIds"]);
 
   return EventListQuerySchema.parse({
     kind: "range",

--- a/packages/backend/src/servers/express/express.server.test.ts
+++ b/packages/backend/src/servers/express/express.server.test.ts
@@ -1,9 +1,24 @@
-import { initExpressServer } from "@backend/servers/express/express.server";
+import { HTTP_SERVER_LIMITS } from "@core/server/http-server";
+import {
+  createBackendHttpServer,
+  initExpressServer,
+} from "@backend/servers/express/express.server";
 import { describe, expect, it } from "bun:test";
 
 describe("initExpressServer", () => {
   it("trusts one proxy hop so Caddy X-Forwarded-For does not collapse rate-limit keys", () => {
     const app = initExpressServer();
     expect(app.get("trust proxy")).toBe(1);
+  });
+
+  it("uses the flat query parser so repeated parameters remain arrays", () => {
+    const app = initExpressServer();
+    expect(app.get("query parser")).toBe("simple");
+  });
+
+  it("creates an HTTP server with bounded connection limits", () => {
+    const server = createBackendHttpServer();
+    expect(server.requestTimeout).toBe(HTTP_SERVER_LIMITS.requestTimeoutMs);
+    expect(server.headersTimeout).toBe(HTTP_SERVER_LIMITS.headersTimeoutMs);
   });
 });

--- a/packages/backend/src/servers/express/express.server.ts
+++ b/packages/backend/src/servers/express/express.server.ts
@@ -4,6 +4,7 @@ import {
   errorHandler as supertokensErrorHandler,
   middleware as supertokensMiddleware,
 } from "supertokens-node/framework/express";
+import { configureHttpServer } from "@core/server/http-server";
 import { AuthRoutes } from "@backend/auth/auth.routes.config";
 import {
   BillingRoutes,
@@ -25,6 +26,7 @@ import { EventRoutes } from "@backend/event/event.routes.config";
 import { HealthRoutes } from "@backend/health/health.routes.config";
 import { EventsRoutes } from "@backend/servers/sse/events-stream.routes.config";
 import { UserRoutes } from "@backend/user/user.routes.config";
+import { createServer } from "node:http";
 
 export const initExpressServer = () => {
   /* Express Configuration */
@@ -32,6 +34,10 @@ export const initExpressServer = () => {
   // Caddy terminates TLS and proxies `/api/*` with X-Forwarded-For. One hop
   // of trust keeps express-rate-limit from treating every visitor as Caddy.
   app.set("trust proxy", 1);
+  // All supported query parameters are flat. The simple parser preserves
+  // repeated keys as arrays without qs's nesting work or array-size quirks,
+  // which also makes native-client encodings behave consistently with sync.
+  app.set("query parser", "simple");
 
   initSupertokens();
 
@@ -65,3 +71,6 @@ export const initExpressServer = () => {
 
   return app;
 };
+
+export const createBackendHttpServer = () =>
+  configureHttpServer(createServer(initExpressServer()));

--- a/packages/core/src/server/http-server.test.ts
+++ b/packages/core/src/server/http-server.test.ts
@@ -1,0 +1,20 @@
+import {
+  configureHttpServer,
+  HTTP_SERVER_LIMITS,
+} from "@core/server/http-server";
+import { describe, expect, it } from "bun:test";
+import { createServer } from "node:http";
+
+describe("configureHttpServer", () => {
+  it("applies bounded, keep-alive-friendly limits", () => {
+    const server = configureHttpServer(createServer());
+
+    expect(server.headersTimeout).toBe(HTTP_SERVER_LIMITS.headersTimeoutMs);
+    expect(server.requestTimeout).toBe(HTTP_SERVER_LIMITS.requestTimeoutMs);
+    expect(server.keepAliveTimeout).toBe(HTTP_SERVER_LIMITS.keepAliveTimeoutMs);
+    expect(server.maxHeadersCount).toBe(HTTP_SERVER_LIMITS.maxHeadersCount);
+    expect(server.maxRequestsPerSocket).toBe(
+      HTTP_SERVER_LIMITS.maxRequestsPerSocket,
+    );
+  });
+});

--- a/packages/core/src/server/http-server.ts
+++ b/packages/core/src/server/http-server.ts
@@ -1,0 +1,22 @@
+import { type Server } from "node:http";
+
+// Keep the public API and the independently deployed sync service on the same
+// connection policy. Node's defaults are intentionally general purpose (for
+// example, a five-minute request timeout), which is too permissive for these
+// small JSON APIs and lets slow clients occupy sockets far longer than useful.
+export const HTTP_SERVER_LIMITS = {
+  headersTimeoutMs: 15_000,
+  requestTimeoutMs: 60_000,
+  keepAliveTimeoutMs: 5_000,
+  maxHeadersCount: 100,
+  maxRequestsPerSocket: 1_000,
+} as const;
+
+export function configureHttpServer(server: Server): Server {
+  server.headersTimeout = HTTP_SERVER_LIMITS.headersTimeoutMs;
+  server.requestTimeout = HTTP_SERVER_LIMITS.requestTimeoutMs;
+  server.keepAliveTimeout = HTTP_SERVER_LIMITS.keepAliveTimeoutMs;
+  server.maxHeadersCount = HTTP_SERVER_LIMITS.maxHeadersCount;
+  server.maxRequestsPerSocket = HTTP_SERVER_LIMITS.maxRequestsPerSocket;
+  return server;
+}

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -1,5 +1,6 @@
 import { startOtelLogs, stopOtelLogs } from "@core/logger/otel-logs";
 import { Logger } from "@core/logger/winston.logger";
+import { configureHttpServer } from "@core/server/http-server";
 import {
   SYNC_JOB_TERMINAL_FAILURE_EVENT,
   SYNC_RECONCILE_SWEEP_EVENT,
@@ -173,7 +174,7 @@ export function createSyncService(
     : undefined;
 
   const app = buildSyncApp({ identity, readiness, connectionApi });
-  const httpServer = createServer(app);
+  const httpServer = configureHttpServer(createServer(app));
 
   const stop = async (): Promise<void> => {
     // Phase 1: stop accepting new connections before anything drains, so no

--- a/packages/sync/src/server/sync.server.test.ts
+++ b/packages/sync/src/server/sync.server.test.ts
@@ -1,4 +1,5 @@
 import { NodeEnv } from "@core/constants/core.constants";
+import { HTTP_SERVER_LIMITS } from "@core/server/http-server";
 import { createSyncService, type SyncService } from "@sync/app";
 import { type SyncConfig } from "@sync/config/sync.config";
 import { ReadinessRegistry } from "@sync/lifecycle/readiness";
@@ -43,6 +44,16 @@ describe("Sync HTTP server health endpoints", () => {
 
   afterEach(async () => {
     await service.stop();
+  });
+
+  it("uses the shared bounded HTTP connection limits", () => {
+    service = createSyncService(testConfig());
+    expect(service.httpServer.requestTimeout).toBe(
+      HTTP_SERVER_LIMITS.requestTimeoutMs,
+    );
+    expect(service.httpServer.headersTimeout).toBe(
+      HTTP_SERVER_LIMITS.headersTimeoutMs,
+    );
   });
 
   it("serves liveness with structured, content-free identity", async () => {


### PR DESCRIPTION
## Summary
- apply one bounded HTTP connection policy to the Compass API and sync service
- use Express's flat query parser at the API edge
- accept both comma-separated and repeated `calendarIds` query parameters for web and native clients
- add focused regression coverage for server limits and query normalization

## Why
Node's general-purpose request defaults allow slow clients to hold service sockets much longer than these JSON APIs require. The API also used Express's nested `qs` parser while sync used the flat parser, leaving repeated query parameters inconsistent across service boundaries and client implementations.

## Verification
- Focused core, backend, and sync tests: PASS
- `bun type-check`: PASS
- `bun lint`: PASS
- `git diff --check`: PASS
- GitHub Unit, E2E, static, and CodeQL checks: PASS

VERDICT: PASS (GitHub required checks)
