### PR TITLE
feat(sync): add Apple ICS event serializer for CalDAV writes

### DIFF
--- a/.agents/handoffs/3259.md
+++ b/.agents/handoffs/3259.md
@@ -1,0 +1,34 @@
+---
+schema_version: 1
+task_id: "3259"
+from: Implementer
+to: GitHub
+owner: GitHub
+status: verifying
+artifact:
+  - path: packages/sync/src/providers/apple/apple-event.serializer.ts
+  - path: packages/sync/src/providers/apple/apple-event.serializer.test.ts
+evidence:
+  - command: bun test:sync
+    result: pass
+  - command: bun run type-check
+    result: pass
+  - command: bun lint
+    result: pass
+  - command: bun knip
+    result: pass
+  - command: bun run verify --strict
+    result: "VERDICT: PASS"
+assumptions:
+  - "Timed writes serialize schedule instants in UTC Z form without VTIMEZONE; round-trip fixtures use UTC reads."
+  - "Instance exception VEVENTs reuse the master UID and address instances by RECURRENCE-ID instant equality."
+open_risks:
+  - "Patch field selection is explicit via patchFields; WP-06b writer must pass the correct delta set."
+next_deadline: 2026-09-05T02:00:00Z
+retry: 0
+approval: allow
+waiting_on: null
+escalation: null
+---
+
+Providers A WP-06a: ICS serializer for CalDAV writes (create, patch, instance).

--- a/packages/sync/src/providers/apple/apple-event.serializer.test.ts
+++ b/packages/sync/src/providers/apple/apple-event.serializer.test.ts
@@ -1,0 +1,387 @@
+import { type EventSchedule } from "@core/types/event.contracts";
+import {
+  type AppleEventResourceInput,
+  normalizeAppleEventResource,
+} from "@sync/providers/apple/apple-event.normalizer";
+import {
+  type AppleEventSerializeInput,
+  escapeIcsText,
+  foldIcsLine,
+  serializeAppleEventCreate,
+  serializeAppleEventInstance,
+  serializeAppleEventPatch,
+} from "@sync/providers/apple/apple-event.serializer";
+import {
+  type ProviderEvent,
+  type ProviderEventRead,
+  type ProviderEventRecurrence,
+} from "@sync/providers/provider-event.port";
+import { type ProviderWriteRecurrence } from "@sync/providers/provider-event-writer.port";
+
+const resource = (
+  icsBody: string,
+  overrides: Partial<AppleEventResourceInput> = {},
+): AppleEventResourceInput => ({
+  ics: icsBody.startsWith("BEGIN:VCALENDAR")
+    ? icsBody
+    : `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Compass//Test//EN
+${icsBody}
+END:VCALENDAR`,
+  href: "/calendars/home/event.ics",
+  etag: '"etag-1"',
+  connectionTimeZone: "UTC",
+  ...overrides,
+});
+
+const asEvent = (read: ProviderEventRead): ProviderEvent => {
+  if (read.kind !== "event")
+    throw new Error(`expected event, got ${read.kind}`);
+  return read;
+};
+
+function recurrenceToWrite(
+  recurrence: ProviderEventRecurrence,
+): ProviderWriteRecurrence {
+  switch (recurrence.kind) {
+    case "single":
+      return { kind: "single" };
+    case "seriesMaster":
+      return { kind: "series", rules: recurrence.rules };
+    case "instance":
+      return { kind: "instance" };
+  }
+}
+
+function eventToSerializeInput(event: ProviderEvent): AppleEventSerializeInput {
+  return {
+    providerEventId: event.providerEventId,
+    content: event.content,
+    schedule: event.schedule,
+    recurrence: recurrenceToWrite(event.recurrence),
+    busy: event.busy,
+    attendees: event.content.attendees,
+    dtstamp: event.providerUpdatedAt ?? undefined,
+  };
+}
+
+function roundTripEvent(icsBody: string): ProviderEvent {
+  const [read] = normalizeAppleEventResource(resource(icsBody));
+  const event = asEvent(read);
+  const serialized = serializeAppleEventCreate(eventToSerializeInput(event));
+  const [roundTripped] = normalizeAppleEventResource(
+    resource(serialized, { etag: event.providerVersion }),
+  );
+  return asEvent(roundTripped);
+}
+
+function expectEventsEqual(
+  actual: ProviderEvent,
+  expected: ProviderEvent,
+): void {
+  expect(actual).toEqual(expected);
+}
+
+describe("serializeAppleEventCreate", () => {
+  it("emits Compass PRODID and VERSION 2.0", () => {
+    const ics = serializeAppleEventCreate({
+      providerEventId: "uid@icloud.com",
+      content: {
+        title: "Test",
+        description: "",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+      },
+      schedule: {
+        kind: "timed",
+        start: "2025-01-15T09:00:00Z",
+        end: "2025-01-15T10:00:00Z",
+        timeZone: "UTC",
+      },
+      recurrence: { kind: "single" },
+      busy: true,
+      dtstamp: "2025-01-01T12:00:00Z",
+    });
+
+    expect(ics).toContain("VERSION:2.0");
+    expect(ics).toContain("PRODID:-//Compass//NONSGML Compass Calendar//EN");
+  });
+
+  it.each([
+    {
+      name: "timed",
+      body: `BEGIN:VEVENT
+UID:timed-uid@icloud.com
+DTSTAMP:20250101T120000Z
+DTSTART:20250115T090000Z
+DTEND:20250115T100000Z
+SUMMARY:Standup
+DESCRIPTION:Daily sync
+LOCATION:Room A
+END:VEVENT`,
+    },
+    {
+      name: "all-day",
+      body: `BEGIN:VEVENT
+UID:allday-uid@icloud.com
+DTSTAMP:20250101T120000Z
+DTSTART;VALUE=DATE:20250222
+DTEND;VALUE=DATE:20250223
+SUMMARY:Holiday
+TRANSP:TRANSPARENT
+END:VEVENT`,
+    },
+    {
+      name: "recurring",
+      body: `BEGIN:VEVENT
+UID:series-uid@icloud.com
+DTSTAMP:20250101T120000Z
+DTSTART:20250115T090000Z
+DTEND:20250115T100000Z
+RRULE:FREQ=WEEKLY;COUNT=4
+EXDATE:20250122T090000Z
+SUMMARY:Weekly
+END:VEVENT`,
+    },
+    {
+      name: "attendees",
+      body: `BEGIN:VEVENT
+UID:guests-uid@icloud.com
+DTSTAMP:20250101T120000Z
+DTSTART:20250115T090000Z
+DTEND:20250115T100000Z
+ORGANIZER;CN=Host:mailto:host@example.com
+ATTENDEE;CN=Accepted;PARTSTAT=ACCEPTED:mailto:accepted@example.com
+ATTENDEE;CN=Declined;PARTSTAT=DECLINED:mailto:declined@example.com
+SUMMARY:Guests
+END:VEVENT`,
+    },
+    {
+      name: "conference",
+      body: `BEGIN:VEVENT
+UID:url-uid@icloud.com
+DTSTAMP:20250101T120000Z
+DTSTART:20250115T090000Z
+DTEND:20250115T100000Z
+URL:https://example.com/meet
+SUMMARY:Call
+END:VEVENT`,
+    },
+  ])("round-trips a $name event through normalize", ({ body }) => {
+    const [read] = normalizeAppleEventResource(resource(body));
+    const event = asEvent(read);
+    const roundTripped = roundTripEvent(body);
+    expectEventsEqual(roundTripped, event);
+  });
+});
+
+describe("serializeAppleEventPatch", () => {
+  it("preserves X-APPLE-* properties when patching title only", () => {
+    const existing = resource(`BEGIN:VEVENT
+UID:apple-uid@icloud.com
+DTSTAMP:20250101T120000Z
+DTSTART:20250115T090000Z
+DTEND:20250115T100000Z
+SUMMARY:Original
+X-APPLE-TRAVEL-ADVISORY-BEHAVIOR:AUTOMATIC
+SEQUENCE:2
+END:VEVENT`);
+
+    const patched = serializeAppleEventPatch({
+      providerEventId: "apple-uid@icloud.com",
+      existingIcs: existing.ics,
+      patchFields: ["title"],
+      scheduleChanged: false,
+      attendeesChanged: false,
+      content: {
+        title: "Updated",
+        description: "ignored",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+      },
+      schedule: {
+        kind: "timed",
+        start: "2025-01-15T09:00:00Z",
+        end: "2025-01-15T10:00:00Z",
+        timeZone: "UTC",
+      },
+      recurrence: { kind: "single" },
+      busy: true,
+    });
+
+    expect(patched).toContain("SUMMARY:Updated");
+    expect(patched).toContain("X-APPLE-TRAVEL-ADVISORY-BEHAVIOR:AUTOMATIC");
+    expect(patched).not.toContain("DESCRIPTION:ignored");
+    expect(patched).toContain("SEQUENCE:2");
+  });
+
+  it("increments SEQUENCE when schedule changes", () => {
+    const existing = resource(`BEGIN:VEVENT
+UID:seq-uid@icloud.com
+DTSTAMP:20250101T120000Z
+DTSTART:20250115T090000Z
+DTEND:20250115T100000Z
+SUMMARY:Move me
+SEQUENCE:4
+END:VEVENT`);
+
+    const patched = serializeAppleEventPatch({
+      providerEventId: "seq-uid@icloud.com",
+      existingIcs: existing.ics,
+      patchFields: ["schedule"],
+      scheduleChanged: true,
+      attendeesChanged: false,
+      content: {
+        title: "Move me",
+        description: "",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+      },
+      schedule: {
+        kind: "timed",
+        start: "2025-01-15T10:00:00Z",
+        end: "2025-01-15T11:00:00Z",
+        timeZone: "UTC",
+      },
+      recurrence: { kind: "single" },
+      busy: true,
+    });
+
+    expect(patched).toContain("DTSTART:20250115T100000Z");
+    expect(patched).toContain("SEQUENCE:5");
+  });
+});
+
+describe("serializeAppleEventInstance", () => {
+  it("adds a second VEVENT with the matching RECURRENCE-ID", () => {
+    const masterOnly = resource(`BEGIN:VEVENT
+UID:series-uid@icloud.com
+DTSTAMP:20250101T120000Z
+DTSTART:20250115T090000Z
+DTEND:20250115T100000Z
+RRULE:FREQ=DAILY;COUNT=3
+SUMMARY:Series
+END:VEVENT`);
+
+    const serialized = serializeAppleEventInstance({
+      providerEventId: "series-uid@icloud.com_20250116T090000Z",
+      existingIcs: masterOnly.ics,
+      instanceRecurrenceId: new Date("2025-01-16T09:00:00Z").toISOString(),
+      scheduleChanged: true,
+      attendeesChanged: false,
+      content: {
+        title: "Moved instance",
+        description: "",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+      },
+      schedule: {
+        kind: "timed",
+        start: "2025-01-16T10:00:00Z",
+        end: "2025-01-16T11:00:00Z",
+        timeZone: "UTC",
+      },
+      recurrence: { kind: "instance" },
+      busy: true,
+      dtstamp: "2025-01-01T12:00:01.000Z",
+    });
+
+    const reads = normalizeAppleEventResource(
+      resource(serialized, { etag: '"etag-2"' }),
+    );
+    expect(reads).toHaveLength(2);
+    const exception = asEvent(reads[1]!);
+    expect(exception.content.title).toBe("Moved instance");
+    expect(exception.recurrence).toEqual({
+      kind: "instance",
+      seriesProviderId: "series-uid@icloud.com",
+      recurrenceId: new Date("2025-01-16T09:00:00Z").toISOString(),
+    });
+    expect(serialized).toContain("RECURRENCE-ID:20250116T090000Z");
+  });
+});
+
+describe("RFC 5545 text handling", () => {
+  it("escapes commas, semicolons, backslashes, and newlines", () => {
+    expect(escapeIcsText("Comma, semicolon; backslash\\ newline\nhere")).toBe(
+      "Comma\\, semicolon\\; backslash\\\\ newline\\nhere",
+    );
+  });
+
+  it("folds long lines at 75 octets", () => {
+    const folded = foldIcsLine(`DESCRIPTION:${"A".repeat(90)}`);
+    const lines = folded.split("\r\n ");
+    expect(lines[0]?.length).toBeLessThanOrEqual(75);
+    expect(lines[1]?.startsWith("A")).toBe(true);
+    expect(new TextEncoder().encode(lines[0]!).length).toBeLessThanOrEqual(75);
+  });
+
+  it("folds multibyte characters without splitting code points", () => {
+    const folded = foldIcsLine(`SUMMARY:${"😀".repeat(30)}`);
+    expect(folded).toContain("\r\n ");
+  });
+});
+
+describe("serializeAppleEventCreate schedule encoding", () => {
+  it("writes timed events in UTC Z form without VTIMEZONE", () => {
+    const ics = serializeAppleEventCreate({
+      providerEventId: "utc-uid@icloud.com",
+      content: {
+        title: "UTC",
+        description: "",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+      },
+      schedule: {
+        kind: "timed",
+        start: "2025-01-15T09:00:00-05:00",
+        end: "2025-01-15T10:00:00-05:00",
+        timeZone: "America/New_York",
+      },
+      recurrence: { kind: "single" },
+      busy: true,
+      dtstamp: "2025-01-01T12:00:00Z",
+    });
+
+    expect(ics).toContain("DTSTART:20250115T140000Z");
+    expect(ics).toContain("DTEND:20250115T150000Z");
+    expect(ics).not.toContain("VTIMEZONE");
+  });
+
+  it("writes all-day events with VALUE=DATE", () => {
+    const ics = serializeAppleEventCreate({
+      providerEventId: "day-uid@icloud.com",
+      content: {
+        title: "Day",
+        description: "",
+        location: null,
+        organizer: null,
+        attendees: [],
+        conference: null,
+      },
+      schedule: {
+        kind: "allDay",
+        start: "2025-02-22",
+        end: "2025-02-23",
+      } satisfies EventSchedule,
+      recurrence: { kind: "single" },
+      busy: false,
+      dtstamp: "2025-01-01T12:00:00Z",
+    });
+
+    expect(ics).toContain("DTSTART;VALUE=DATE:20250222");
+    expect(ics).toContain("DTEND;VALUE=DATE:20250223");
+    expect(ics).toContain("TRANSP:TRANSPARENT");
+  });
+});

--- a/packages/sync/src/providers/apple/apple-event.serializer.ts
+++ b/packages/sync/src/providers/apple/apple-event.serializer.ts
@@ -1,0 +1,425 @@
+import ICAL from "ical.js";
+import { type EventSchedule } from "@core/types/event.contracts";
+import {
+  type Attendee,
+  type Organizer,
+} from "@core/types/event-attendance.contracts";
+import { type SyncEventContent } from "@core/types/sync/event.contracts";
+import dayjs from "@core/util/date/dayjs";
+import { type ProviderWriteRecurrence } from "@sync/providers/provider-event-writer.port";
+
+const COMPASS_PRODID = "-//Compass//NONSGML Compass Calendar//EN";
+const DATE_ONLY = dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT;
+
+export interface AppleEventSerializeInput {
+  readonly providerEventId: string;
+  readonly content: SyncEventContent;
+  readonly schedule: EventSchedule;
+  readonly recurrence: ProviderWriteRecurrence;
+  readonly busy: boolean;
+  readonly attendees?: readonly Attendee[];
+  readonly dtstamp?: string;
+  readonly sequence?: number;
+}
+
+export type AppleEventPatchField =
+  | "title"
+  | "description"
+  | "location"
+  | "conference"
+  | "organizer"
+  | "schedule"
+  | "recurrence"
+  | "busy"
+  | "attendees";
+
+export interface AppleEventSerializePatchInput
+  extends AppleEventSerializeInput {
+  readonly existingIcs: string;
+  readonly patchFields: readonly AppleEventPatchField[];
+  readonly scheduleChanged: boolean;
+  readonly attendeesChanged: boolean;
+}
+
+export interface AppleEventSerializeInstanceInput
+  extends AppleEventSerializeInput {
+  readonly existingIcs: string;
+  readonly instanceRecurrenceId: string;
+  readonly scheduleChanged: boolean;
+  readonly attendeesChanged: boolean;
+}
+
+// Serialize a new CalDAV ICS resource for PUT (create).
+export function serializeAppleEventCreate(
+  input: AppleEventSerializeInput,
+): string {
+  const calendar = newCalendarShell();
+  const vevent = new ICAL.Component("vevent");
+  calendar.addSubcomponent(vevent);
+  applyIdentity(
+    vevent,
+    input.providerEventId,
+    input.dtstamp,
+    input.sequence ?? 0,
+  );
+  applyFullWrite(vevent, input);
+  return calendar.toString();
+}
+
+// Merge changed fields onto an existing resource, preserving unknown properties.
+export function serializeAppleEventPatch(
+  input: AppleEventSerializePatchInput,
+): string {
+  const calendar = parseCalendar(input.existingIcs);
+  const vevent = findMasterVevent(calendar);
+  applySequence(
+    vevent,
+    readSequence(vevent),
+    input.scheduleChanged,
+    input.attendeesChanged,
+  );
+  applyPatchFields(vevent, input);
+  return calendar.toString();
+}
+
+// Add or replace one RECURRENCE-ID sibling inside the master's resource.
+export function serializeAppleEventInstance(
+  input: AppleEventSerializeInstanceInput,
+): string {
+  const calendar = parseCalendar(input.existingIcs);
+  const master = findMasterVevent(calendar);
+  const masterUid = master.getFirstPropertyValue("uid");
+  if (typeof masterUid !== "string" || masterUid.trim().length === 0) {
+    throw new Error("Master VEVENT carried no UID");
+  }
+  const recurrenceTime = recurrenceIdToICalTime(
+    input.instanceRecurrenceId,
+    input.schedule.kind,
+  );
+  const exception =
+    findExceptionVevent(calendar, recurrenceTime) ??
+    new ICAL.Component("vevent");
+  if (!exception.parent) {
+    calendar.addSubcomponent(exception);
+  }
+  applyIdentity(
+    exception,
+    masterUid,
+    input.dtstamp,
+    applySequence(
+      exception,
+      readSequence(exception) ?? readSequence(master),
+      input.scheduleChanged,
+      input.attendeesChanged,
+    ),
+  );
+  setRecurrenceId(exception, recurrenceTime);
+  applyFullWrite(exception, input);
+  return calendar.toString();
+}
+
+function newCalendarShell(): ICAL.Component {
+  const calendar = new ICAL.Component("vcalendar");
+  calendar.updatePropertyWithValue("version", "2.0");
+  calendar.updatePropertyWithValue("prodid", COMPASS_PRODID);
+  return calendar;
+}
+
+function parseCalendar(ics: string): ICAL.Component {
+  return new ICAL.Component(ICAL.parse(ics));
+}
+
+function findMasterVevent(calendar: ICAL.Component): ICAL.Component {
+  const masters = calendar
+    .getAllSubcomponents("vevent")
+    .filter((vevent) => !vevent.hasProperty("recurrence-id"));
+  const master = masters[0];
+  if (!master) {
+    throw new Error("ICS resource had no master VEVENT");
+  }
+  return master;
+}
+
+function findExceptionVevent(
+  calendar: ICAL.Component,
+  recurrenceTime: ICAL.Time,
+): ICAL.Component | null {
+  for (const vevent of calendar.getAllSubcomponents("vevent")) {
+    const property = vevent.getFirstProperty("recurrence-id");
+    if (!property) continue;
+    const value = property.getFirstValue() as ICAL.Time;
+    if (recurrenceTimesEqual(value, recurrenceTime)) {
+      return vevent;
+    }
+  }
+  return null;
+}
+
+function applyIdentity(
+  vevent: ICAL.Component,
+  uid: string,
+  dtstamp: string | undefined,
+  sequence: number,
+): void {
+  vevent.updatePropertyWithValue("uid", uid);
+  vevent.updatePropertyWithValue(
+    "dtstamp",
+    ICAL.Time.fromJSDate(new Date(dtstamp ?? Date.now()), true),
+  );
+  vevent.updatePropertyWithValue("sequence", sequence);
+}
+
+function applyFullWrite(
+  vevent: ICAL.Component,
+  input: AppleEventSerializeInput,
+): void {
+  applyContentField(vevent, "title", input.content.title, (value) => {
+    vevent.updatePropertyWithValue("summary", value);
+  });
+  applyContentField(
+    vevent,
+    "description",
+    input.content.description,
+    (value) => {
+      vevent.updatePropertyWithValue("description", value);
+    },
+  );
+  applyContentField(
+    vevent,
+    "location",
+    input.content.location ?? "",
+    (value) => {
+      if (value.length === 0) {
+        vevent.removeAllProperties("location");
+        return;
+      }
+      vevent.updatePropertyWithValue("location", value);
+    },
+  );
+  applyOrganizer(vevent, input.content.organizer);
+  applyConference(vevent, input.content.conference);
+  applyAttendees(vevent, input.attendees ?? input.content.attendees);
+  applySchedule(vevent, input.schedule);
+  applyRecurrence(vevent, input.recurrence);
+  applyBusy(vevent, input.busy);
+}
+
+function applyPatchFields(
+  vevent: ICAL.Component,
+  input: AppleEventSerializePatchInput,
+): void {
+  const fields = new Set(input.patchFields);
+  if (fields.has("title")) {
+    vevent.updatePropertyWithValue("summary", input.content.title);
+  }
+  if (fields.has("description")) {
+    vevent.updatePropertyWithValue("description", input.content.description);
+  }
+  if (fields.has("location")) {
+    if ((input.content.location ?? "").length === 0) {
+      vevent.removeAllProperties("location");
+    } else {
+      vevent.updatePropertyWithValue("location", input.content.location);
+    }
+  }
+  if (fields.has("organizer")) {
+    applyOrganizer(vevent, input.content.organizer);
+  }
+  if (fields.has("conference")) {
+    applyConference(vevent, input.content.conference);
+  }
+  if (fields.has("attendees")) {
+    applyAttendees(vevent, input.attendees ?? input.content.attendees);
+  }
+  if (fields.has("schedule")) {
+    applySchedule(vevent, input.schedule);
+  }
+  if (fields.has("recurrence")) {
+    applyRecurrence(vevent, input.recurrence);
+  }
+  if (fields.has("busy")) {
+    applyBusy(vevent, input.busy);
+  }
+}
+
+function applyContentField<T>(
+  _vevent: ICAL.Component,
+  _field: string,
+  value: T,
+  apply: (value: T) => void,
+): void {
+  apply(value);
+}
+
+function applySchedule(vevent: ICAL.Component, schedule: EventSchedule): void {
+  vevent.removeAllProperties("dtstart");
+  vevent.removeAllProperties("dtend");
+  vevent.removeAllProperties("duration");
+
+  if (schedule.kind === "allDay") {
+    vevent.addPropertyWithValue("dtstart", dateOnlyToICalTime(schedule.start));
+    vevent.addPropertyWithValue("dtend", dateOnlyToICalTime(schedule.end));
+    return;
+  }
+
+  vevent.addPropertyWithValue("dtstart", dateTimeToUtcICalTime(schedule.start));
+  vevent.addPropertyWithValue("dtend", dateTimeToUtcICalTime(schedule.end));
+}
+
+function applyRecurrence(
+  vevent: ICAL.Component,
+  recurrence: ProviderWriteRecurrence,
+): void {
+  vevent.removeAllProperties("rrule");
+  vevent.removeAllProperties("exdate");
+  vevent.removeAllProperties("rdate");
+  if (recurrence.kind !== "series") return;
+  for (const rule of recurrence.rules) {
+    vevent.addProperty(ICAL.Property.fromString(rule));
+  }
+}
+
+function applyBusy(vevent: ICAL.Component, busy: boolean): void {
+  vevent.updatePropertyWithValue("transp", busy ? "OPAQUE" : "TRANSPARENT");
+}
+
+function applyOrganizer(
+  vevent: ICAL.Component,
+  organizer: Organizer | null,
+): void {
+  vevent.removeAllProperties("organizer");
+  if (!organizer) return;
+  const property = new ICAL.Property("organizer");
+  property.setValue(`mailto:${organizer.email}`);
+  if (organizer.displayName) {
+    property.setParameter("cn", organizer.displayName);
+  }
+  vevent.addProperty(property);
+}
+
+function applyAttendees(
+  vevent: ICAL.Component,
+  attendees: readonly Attendee[],
+): void {
+  vevent.removeAllProperties("attendee");
+  for (const attendee of attendees) {
+    vevent.addProperty(attendeeToProperty(attendee));
+  }
+}
+
+function attendeeToProperty(attendee: Attendee): ICAL.Property {
+  const property = new ICAL.Property("attendee");
+  property.setValue(`mailto:${attendee.email}`);
+  if (attendee.displayName) {
+    property.setParameter("cn", attendee.displayName);
+  }
+  property.setParameter(
+    "partstat",
+    partstatFromResponse(attendee.responseStatus),
+  );
+  property.setParameter("rsvp", "TRUE");
+  return property;
+}
+
+function applyConference(
+  vevent: ICAL.Component,
+  conference: SyncEventContent["conference"],
+): void {
+  vevent.removeAllProperties("url");
+  if (!conference?.url) return;
+  vevent.updatePropertyWithValue("url", conference.url);
+}
+
+function setRecurrenceId(
+  vevent: ICAL.Component,
+  recurrenceTime: ICAL.Time,
+): void {
+  vevent.removeAllProperties("recurrence-id");
+  vevent.addPropertyWithValue("recurrence-id", recurrenceTime);
+}
+
+function readSequence(vevent: ICAL.Component): number {
+  const value = vevent.getFirstPropertyValue("sequence");
+  return typeof value === "number" ? value : 0;
+}
+
+function applySequence(
+  vevent: ICAL.Component,
+  current: number,
+  scheduleChanged: boolean,
+  attendeesChanged: boolean,
+): number {
+  const next = scheduleChanged || attendeesChanged ? current + 1 : current;
+  vevent.updatePropertyWithValue("sequence", next);
+  return next;
+}
+
+function dateOnlyToICalTime(dateOnly: string): ICAL.Time {
+  const time = ICAL.Time.fromDateString(
+    dayjs(dateOnly, DATE_ONLY, true).format("YYYY-MM-DD"),
+  );
+  time.isDate = true;
+  return time;
+}
+
+function dateTimeToUtcICalTime(dateTime: string): ICAL.Time {
+  return ICAL.Time.fromJSDate(new Date(dateTime), true);
+}
+
+function recurrenceIdToICalTime(
+  recurrenceId: string,
+  scheduleKind: EventSchedule["kind"],
+): ICAL.Time {
+  if (scheduleKind === "allDay") {
+    const dateOnly = dayjs.utc(recurrenceId).format(DATE_ONLY);
+    return dateOnlyToICalTime(dateOnly);
+  }
+  return dateTimeToUtcICalTime(recurrenceId);
+}
+
+function recurrenceTimesEqual(a: ICAL.Time, b: ICAL.Time): boolean {
+  if (a.isDate !== b.isDate) return false;
+  if (a.isDate) return a.toICALString() === b.toICALString();
+  return a.toJSDate().getTime() === b.toJSDate().getTime();
+}
+
+function partstatFromResponse(status: Attendee["responseStatus"]): string {
+  switch (status) {
+    case "accepted":
+      return "ACCEPTED";
+    case "declined":
+      return "DECLINED";
+    case "tentative":
+      return "TENTATIVE";
+    default:
+      return "NEEDS-ACTION";
+  }
+}
+
+// Fold a content line at 75 octets per RFC 5545 section 3.1.
+export function foldIcsLine(line: string): string {
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode(line);
+  if (bytes.length <= 75) return line;
+
+  const parts: string[] = [];
+  let offset = 0;
+  while (offset < bytes.length) {
+    let chunkEnd = Math.min(offset + 75, bytes.length);
+    while (chunkEnd > offset && (bytes[chunkEnd]! & 0xc0) === 0x80) {
+      chunkEnd -= 1;
+    }
+    parts.push(new TextDecoder().decode(bytes.slice(offset, chunkEnd)));
+    offset = chunkEnd;
+  }
+  return parts.join("\r\n ");
+}
+
+// Escape text per RFC 5545 section 3.3.11.
+export function escapeIcsText(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/\n/g, "\\n")
+    .replace(/;/g, "\\;")
+    .replace(/,/g, "\\,");
+}


### PR DESCRIPTION
Fixes #3259

## What and why

Adds `apple-event.serializer.ts`, the inverse of the A-04 normalizer: given writer input and optional existing ICS, it produces CalDAV PUT documents with Compass PRODID, UTC Z timed dates, VALUE=DATE all-day dates, recurrence rules, attendees, conference URLs, SEQUENCE increments on schedule/attendee changes, patch semantics that preserve `X-APPLE-*` properties, and instance writes that add or replace RECURRENCE-ID sibling VEVENTs.

Spec: [docs/features/calendar-providers.md](https://github.com/KeepSoftwareSimple/compass-calendar/blob/main/docs/features/calendar-providers.md)

## Verify

```
Checks run: test:sync:fast, type-check, lint, knip
Checks skipped: (none)

✓ All checks passed
VERDICT: PASS
```

Commands run: `bun test:sync`, `bun run type-check`, `bun lint`, `bun knip`, `bun run verify --strict`