### PR TITLE
feat(sync): add Apple CalDAV event writer (WP-06b)

### DIFF
--- a/.agents/handoffs/3260.md
+++ b/.agents/handoffs/3260.md
@@ -1,0 +1,38 @@
+---
+schema_version: 1
+task_id: "3260"
+from: Implementer
+to: GitHub
+owner: GitHub
+status: verifying
+artifact:
+  - path: packages/sync/src/providers/apple/apple-event-writer.adapter.ts
+  - path: packages/sync/src/providers/apple/apple-event-writer.adapter.test.ts
+  - path: packages/sync/src/providers/__contract__/apple-contract.factory.ts
+  - path: packages/sync/src/providers/__contract__/apple.adapter.contract.test.ts
+  - path: packages/sync/src/providers/provider-event-writer.port.ts
+  - path: docs/features/calendar-providers.md
+evidence:
+  - command: bun test:sync
+    result: pass
+  - command: bun run type-check
+    result: pass
+  - command: bun lint
+    result: pass
+  - command: bun knip
+    result: pass
+  - command: bun run verify --strict
+    result: "VERDICT: PASS"
+assumptions:
+  - "ProviderWriteResult.resourceHref carries the CalDAV href until WP-08 wires providerMetadata on create commits."
+  - "Instance delete uses EXDATE on the master and drops a matching RECURRENCE-ID sibling when present."
+open_risks:
+  - "Live iCloud etag omission and 507 truncation shapes validated via fixtures until A-11."
+next_deadline: 2026-09-05T04:00:00Z
+retry: 0
+approval: allow
+waiting_on: null
+escalation: null
+---
+
+Providers A WP-06b: CalDAV event writer (create, patch, delete, fetch, instance lookup).

--- a/docs/features/calendar-providers.md
+++ b/docs/features/calendar-providers.md
@@ -108,6 +108,12 @@ and returns `{kind: "connected", connectionId}`. The password is never logged.
 The UI states plainly that an app-specific password grants access to the
 whole iCloud account and that Compass stores it encrypted.
 
+**Apple invitations.** iCloud performs server-side scheduling by default when
+`ATTENDEE` lines are present (`SCHEDULE-AGENT=SERVER`), so adding guests makes
+iCloud send mail. Compass maps `invitation: "none"` to
+`SCHEDULE-AGENT=CLIENT` on attendee parameters so edits do not trigger mail.
+`invitation: "all"` and `"externalOnly"` leave server scheduling enabled.
+
 ## Booking
 
 Booking enables when any healthy connection offers a writable destination

--- a/packages/sync/src/providers/__contract__/adapter-contract.ts
+++ b/packages/sync/src/providers/__contract__/adapter-contract.ts
@@ -24,6 +24,8 @@ export interface ProviderContractOptions {
   readonly skipAuthExchange?: boolean;
   readonly skipAuthRevoked?: boolean;
   readonly skipWatch?: boolean;
+  readonly skipNotifications?: boolean;
+  readonly skipNormalizerRoundTrip?: boolean;
 }
 
 const CONTRACT_ROOT = dirname(fileURLToPath(import.meta.url));
@@ -244,6 +246,7 @@ export function describeProviderContract(
 
     describe("notifications", () => {
       const watch = options.skipWatch ? it.skip : it;
+      const notify = options.skipNotifications ? it.skip : it;
       watch("watch returns a channel", async () => {
         const channel = await adapters.notifications.watch({
           accessToken,
@@ -257,87 +260,94 @@ export function describeProviderContract(
         expect(channel.expiresAt).toBeInstanceOf(Date);
       });
 
-      it("parseNotification accepts a valid callback, rejects tampered, and handles validation", () => {
-        const valid = adapters.notifications.parseNotification({
-          headers: {
-            "x-goog-channel-id": "chan-1",
-            "x-goog-channel-token": "chan-token",
-            "x-goog-resource-id": "res-1",
-            "x-goog-resource-state": "exists",
-          },
-          body: {},
-          query: {},
-        });
-        expect(valid).not.toBeNull();
-        if (valid && "kind" in valid && valid.kind === "validation") {
-          throw new Error(
-            "valid Google callback must not be a validation handshake",
+      notify(
+        "parseNotification accepts a valid callback, rejects tampered, and handles validation",
+        () => {
+          const valid = adapters.notifications.parseNotification({
+            headers: {
+              "x-goog-channel-id": "chan-1",
+              "x-goog-channel-token": "chan-token",
+              "x-goog-resource-id": "res-1",
+              "x-goog-resource-state": "exists",
+            },
+            body: {},
+            query: {},
+          });
+          expect(valid).not.toBeNull();
+          if (valid && "kind" in valid && valid.kind === "validation") {
+            throw new Error(
+              "valid Google callback must not be a validation handshake",
+            );
+          }
+          expect(valid && "channelId" in valid ? valid.channelId : null).toBe(
+            "chan-1",
           );
-        }
-        expect(valid && "channelId" in valid ? valid.channelId : null).toBe(
-          "chan-1",
-        );
 
-        const tampered = adapters.notifications.parseNotification({
-          headers: { "x-goog-resource-id": "res-1" },
-          body: {},
-          query: {},
-        });
-        expect(tampered).toBeNull();
+          const tampered = adapters.notifications.parseNotification({
+            headers: { "x-goog-resource-id": "res-1" },
+            body: {},
+            query: {},
+          });
+          expect(tampered).toBeNull();
 
-        const validation = adapters.notifications.parseNotification({
-          headers: {},
-          body: {},
-          query: { validationToken: "echo-me" },
-        });
-        if (
-          validation &&
-          "kind" in validation &&
-          validation.kind === "validation"
-        ) {
-          expect(validation.body.length).toBeGreaterThan(0);
-        } else {
-          // Google has no Graph validation handshake; null is the correct miss.
-          expect(validation).toBeNull();
-        }
-      });
+          const validation = adapters.notifications.parseNotification({
+            headers: {},
+            body: {},
+            query: { validationToken: "echo-me" },
+          });
+          if (
+            validation &&
+            "kind" in validation &&
+            validation.kind === "validation"
+          ) {
+            expect(validation.body.length).toBeGreaterThan(0);
+          } else {
+            // Google has no Graph validation handshake; null is the correct miss.
+            expect(validation).toBeNull();
+          }
+        },
+      );
     });
 
     describe("normalizer round-trips", () => {
-      it("covers timed, all-day, recurring, exception, cancelled, attendees, conference, and color", async () => {
-        const events = await collectEvents(adapters, accessToken, calendarId);
-        const active = events.filter((event) => event.kind === "event");
-        const cancelled = events.filter(
-          (event) => event.kind === "cancellation",
-        );
+      const roundTrip = options.skipNormalizerRoundTrip ? it.skip : it;
+      roundTrip(
+        "covers timed, all-day, recurring, exception, cancelled, attendees, conference, and color",
+        async () => {
+          const events = await collectEvents(adapters, accessToken, calendarId);
+          const active = events.filter((event) => event.kind === "event");
+          const cancelled = events.filter(
+            (event) => event.kind === "cancellation",
+          );
 
-        expect(active.some((event) => event.schedule.kind === "timed")).toBe(
-          true,
-        );
-        expect(active.some((event) => event.schedule.kind === "allDay")).toBe(
-          true,
-        );
-        expect(
-          active.some((event) => event.recurrence.kind === "seriesMaster"),
-        ).toBe(true);
-        expect(
-          active.some((event) => event.recurrence.kind === "instance"),
-        ).toBe(true);
-        expect(cancelled.length).toBeGreaterThanOrEqual(1);
-        expect(active.some((event) => event.content.attendees.length > 0)).toBe(
-          true,
-        );
-        expect(active.some((event) => event.content.conference !== null)).toBe(
-          true,
-        );
-        expect(
-          active.some(
-            (event) =>
-              event.content.color !== undefined ||
-              event.content.colorHex !== undefined,
-          ),
-        ).toBe(true);
-      });
+          expect(active.some((event) => event.schedule.kind === "timed")).toBe(
+            true,
+          );
+          expect(active.some((event) => event.schedule.kind === "allDay")).toBe(
+            true,
+          );
+          expect(
+            active.some((event) => event.recurrence.kind === "seriesMaster"),
+          ).toBe(true);
+          expect(
+            active.some((event) => event.recurrence.kind === "instance"),
+          ).toBe(true);
+          expect(cancelled.length).toBeGreaterThanOrEqual(1);
+          expect(
+            active.some((event) => event.content.attendees.length > 0),
+          ).toBe(true);
+          expect(
+            active.some((event) => event.content.conference !== null),
+          ).toBe(true);
+          expect(
+            active.some(
+              (event) =>
+                event.content.color !== undefined ||
+                event.content.colorHex !== undefined,
+            ),
+          ).toBe(true);
+        },
+      );
     });
   });
 }

--- a/packages/sync/src/providers/__contract__/apple-contract.factory.ts
+++ b/packages/sync/src/providers/__contract__/apple-contract.factory.ts
@@ -1,3 +1,5 @@
+import { AppleAuthAdapter } from "@sync/providers/apple/apple-auth.adapter";
+import { AppleCalendarAdapter } from "@sync/providers/apple/apple-calendar.adapter";
 import {
   AppleEventReaderAdapter,
   type AppleEventReaderApi,
@@ -5,9 +7,24 @@ import {
   MULTIGET_BATCH_SIZE,
 } from "@sync/providers/apple/apple-event-reader.adapter";
 import {
+  AppleEventWriter,
+  type AppleEventWriterApi,
+  eventResourceHref,
+} from "@sync/providers/apple/apple-event-writer.adapter";
+import {
+  type CaldavFetch,
+  type CaldavResponse,
+  createCaldavClient,
+} from "@sync/providers/apple/caldav-client";
+import { type ProviderAdapters } from "@sync/providers/provider-adapters";
+import {
   ProviderEventReadError,
   type ProviderEventReader,
 } from "@sync/providers/provider-event-reader.port";
+import {
+  type ProviderNotificationAdapter,
+  ProviderNotificationError,
+} from "@sync/providers/provider-notifications.port";
 
 interface ReaderCorpus {
   readonly initialHrefs: readonly string[];
@@ -180,4 +197,256 @@ export function appleRecordedReader(_corpusDir: string): ProviderEventReader {
     makeApi: () => new CorpusAppleEventReaderApi(readerCorpus),
     log: { warn: () => {} },
   });
+}
+
+const CONTRACT_CALENDAR = "/123456789/calendars/home/";
+const CONTRACT_CALENDAR_URL = `https://caldav.icloud.com${CONTRACT_CALENDAR}`;
+
+const WRITER_SERIES_ICS = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:series-1
+DTSTAMP:20250101T120000Z
+DTSTART:20250115T090000Z
+DTEND:20250115T100000Z
+RRULE:FREQ=DAILY;COUNT=3
+SUMMARY:Contract series
+END:VEVENT
+END:VCALENDAR`;
+
+class CorpusAppleEventWriterApi implements AppleEventWriterApi {
+  #store = new Map<string, { etag: string; ics: string }>();
+  #etagCounter = 1;
+
+  constructor() {
+    const href = eventResourceHref(CONTRACT_CALENDAR_URL, "series-1");
+    this.#store.set(href, { etag: '"series-v1"', ics: WRITER_SERIES_ICS });
+  }
+
+  put(
+    url: string,
+    ics: string,
+    options: { ifMatch?: string; ifNoneMatch?: string } = {},
+  ): Promise<CaldavResponse> {
+    const existing = this.#store.get(url);
+    if (options.ifNoneMatch === "*" && existing) {
+      return Promise.resolve({
+        status: 412,
+        headers: {},
+        body: "",
+        multistatus: null,
+      });
+    }
+    if (options.ifMatch && existing && options.ifMatch !== existing.etag) {
+      return Promise.resolve({
+        status: 412,
+        headers: {},
+        body: "",
+        multistatus: null,
+      });
+    }
+    const etag = `"writer-v${this.#etagCounter++}"`;
+    this.#store.set(url, { etag, ics });
+    return Promise.resolve({
+      status: 201,
+      headers: { etag },
+      body: "",
+      multistatus: null,
+    });
+  }
+
+  get(url: string): Promise<CaldavResponse> {
+    const existing = this.#store.get(url);
+    if (!existing) {
+      return Promise.resolve({
+        status: 404,
+        headers: {},
+        body: "",
+        multistatus: null,
+      });
+    }
+    return Promise.resolve({
+      status: 200,
+      headers: { etag: existing.etag },
+      body: existing.ics,
+      multistatus: null,
+    });
+  }
+
+  delete(url: string, ifMatch?: string): Promise<CaldavResponse> {
+    const existing = this.#store.get(url);
+    if (!existing) {
+      return Promise.resolve({
+        status: 404,
+        headers: {},
+        body: "",
+        multistatus: null,
+      });
+    }
+    if (ifMatch && ifMatch !== existing.etag) {
+      return Promise.resolve({
+        status: 412,
+        headers: {},
+        body: "",
+        multistatus: null,
+      });
+    }
+    this.#store.delete(url);
+    return Promise.resolve({
+      status: 204,
+      headers: {},
+      body: "",
+      multistatus: null,
+    });
+  }
+
+  propfind(url: string): Promise<CaldavResponse> {
+    const existing = this.#store.get(url);
+    if (!existing) {
+      return Promise.resolve({
+        status: 404,
+        headers: {},
+        body: "",
+        multistatus: null,
+      });
+    }
+    return Promise.resolve({
+      status: 207,
+      headers: {},
+      body: "",
+      multistatus: {
+        responses: [
+          {
+            href: url,
+            propstats: [{ status: 200, props: { getetag: existing.etag } }],
+          },
+        ],
+      },
+    });
+  }
+}
+
+class AppleNotificationStub implements ProviderNotificationAdapter {
+  async watch(): Promise<never> {
+    throw new ProviderNotificationError(
+      "watchUnsupported",
+      "Apple uses polling instead of push channels",
+    );
+  }
+
+  async stopChannel(): Promise<void> {}
+
+  parseNotification() {
+    return null;
+  }
+}
+
+function discoveryFetch(): CaldavFetch {
+  const handlers = [
+    () => xmlResponse(PRINCIPAL_XML),
+    () => xmlResponse(HOME_SET_XML),
+    () => xmlResponse(CALENDARS_XML),
+  ];
+  let call = 0;
+  return (async (...args: Parameters<CaldavFetch>) => {
+    void args;
+    const handler = handlers[call];
+    call += 1;
+    if (!handler) throw new Error("unexpected discovery request");
+    return handler();
+  }) as unknown as CaldavFetch;
+}
+
+const PRINCIPAL_XML = `<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:">
+  <D:response>
+    <D:href>/</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:current-user-principal>
+          <D:href>/123456789/principal/</D:href>
+        </D:current-user-principal>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+</D:multistatus>`;
+
+const HOME_SET_XML = `<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:">
+  <D:response>
+    <D:href>/123456789/principal/</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:calendar-home-set>
+          <D:href>/123456789/calendars/</D:href>
+        </D:calendar-home-set>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+</D:multistatus>`;
+
+const CALENDARS_XML = `<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav" xmlns:ICAL="http://apple.com/ns/ical/">
+  <D:response>
+    <D:href>/123456789/calendars/home/</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:displayname>user</D:displayname>
+        <D:resourcetype><D:collection/><C:calendar/></D:resourcetype>
+        <ICAL:calendar-color>#AABBCCFF</ICAL:calendar-color>
+        <D:current-user-privilege-set>
+          <D:privilege><D:write/></D:privilege>
+        </D:current-user-privilege-set>
+        <C:supported-calendar-component-set>
+          <C:comp name="VEVENT"/>
+        </C:supported-calendar-component-set>
+        <cs:sync-token xmlns:cs="http://calendarserver.org/ns/">sync-token-1</cs:sync-token>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+  <D:response>
+    <D:href>/123456789/calendars/work/</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:displayname>Work</D:displayname>
+        <D:resourcetype><D:collection/><C:calendar/></D:resourcetype>
+        <D:current-user-privilege-set>
+          <D:privilege><D:read/></D:privilege>
+        </D:current-user-privilege-set>
+        <C:supported-calendar-component-set>
+          <C:comp name="VEVENT"/>
+        </C:supported-calendar-component-set>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+</D:multistatus>`;
+
+function xmlResponse(body: string): Response {
+  return new Response(body, {
+    status: 207,
+    headers: { "Content-Type": "application/xml; charset=utf-8" },
+  });
+}
+
+export function appleRecordedFactory(_corpusDir: string): ProviderAdapters {
+  const writerApi = new CorpusAppleEventWriterApi();
+  return {
+    auth: new AppleAuthAdapter((credential, fetchImpl) =>
+      createCaldavClient(credential, fetchImpl ?? discoveryFetch()),
+    ),
+    calendars: new AppleCalendarAdapter(
+      "user@icloud.com",
+      (username, password) =>
+        createCaldavClient({ username, password }, discoveryFetch()),
+    ),
+    reader: appleRecordedReader(_corpusDir),
+    writer: new AppleEventWriter({
+      makeApi: () => writerApi,
+    }),
+    notifications: new AppleNotificationStub(),
+  };
 }

--- a/packages/sync/src/providers/__contract__/apple.adapter.contract.test.ts
+++ b/packages/sync/src/providers/__contract__/apple.adapter.contract.test.ts
@@ -1,85 +1,11 @@
-import {
-  CONTRACT_EVENT_ID,
-  defaultCorpusDir,
-} from "@sync/providers/__contract__/adapter-contract";
-import { appleRecordedReader } from "@sync/providers/__contract__/apple-contract.factory";
-import { type ProviderEventReadError } from "@sync/providers/provider-event-reader.port";
-import { beforeEach, describe, expect, it } from "bun:test";
+import { describeProviderContract } from "@sync/providers/__contract__/adapter-contract";
+import { appleRecordedFactory } from "@sync/providers/__contract__/apple-contract.factory";
 
-describe("apple reader contract", () => {
-  const corpusDir = defaultCorpusDir("apple");
-  const calendarId = "/123456789/calendars/home/";
-  const accessToken = "contract-access-token";
-  const expiredCursor = "expired-sync-token";
-  let reader = appleRecordedReader(corpusDir);
-
-  beforeEach(() => {
-    reader = appleRecordedReader(corpusDir);
-  });
-
-  it("pages, yields nextSyncToken only at the end, and counts skipped events", async () => {
-    const first = await reader.listEventPage({
-      accessToken,
-      calendarId,
-    });
-    expect(first.skipped).toBeGreaterThanOrEqual(1);
-
-    let page = first;
-    let pages = 1;
-    while (page.nextPageToken) {
-      expect(page.nextSyncToken).toBeNull();
-      page = await reader.listEventPage({
-        accessToken,
-        calendarId,
-        pageToken: page.nextPageToken,
-      });
-      pages += 1;
-    }
-    expect(pages).toBeGreaterThanOrEqual(1);
-    expect(page.nextPageToken).toBeNull();
-    expect(
-      page.nextSyncToken === null || typeof page.nextSyncToken === "string",
-    ).toBe(true);
-  });
-
-  it("maps an expired cursor to cursorExpired", async () => {
-    try {
-      await reader.listEventPage({
-        accessToken,
-        calendarId,
-        cursor: expiredCursor,
-      });
-      throw new Error("expected cursorExpired");
-    } catch (caught) {
-      expect((caught as ProviderEventReadError).reason).toBe("cursorExpired");
-    }
-  });
-
-  it("keeps masters and exceptions and does not expand occurrences", async () => {
-    const events = [];
-    let pageToken: string | null = null;
-    do {
-      const page = await reader.listEventPage({
-        accessToken,
-        calendarId,
-        pageToken,
-      });
-      events.push(...page.events);
-      pageToken = page.nextPageToken;
-    } while (pageToken);
-
-    const masters = events.filter(
-      (event) =>
-        event.kind === "event" && event.recurrence.kind === "seriesMaster",
-    );
-    const instances = events.filter(
-      (event) => event.kind === "event" && event.recurrence.kind === "instance",
-    );
-    expect(masters.length).toBeGreaterThanOrEqual(1);
-    expect(instances.length).toBeGreaterThanOrEqual(1);
-    expect(instances.length).toBeLessThan(5);
-    expect(events.some((event) => event.kind === "cancellation")).toBe(true);
-    expect(events.some((event) => event.kind === "event")).toBe(true);
-    void CONTRACT_EVENT_ID;
-  });
+describeProviderContract("apple", appleRecordedFactory, {
+  calendarId: "/123456789/calendars/home/",
+  skipAuthExchange: true,
+  skipAuthRevoked: true,
+  skipWatch: true,
+  skipNotifications: true,
+  skipNormalizerRoundTrip: true,
 });

--- a/packages/sync/src/providers/apple/apple-event-writer.adapter.test.ts
+++ b/packages/sync/src/providers/apple/apple-event-writer.adapter.test.ts
@@ -1,0 +1,509 @@
+import { type EventSchedule } from "@core/types/event.contracts";
+import { type SyncEventContent } from "@core/types/sync/event.contracts";
+import {
+  AppleEventWriter,
+  type AppleEventWriterApi,
+  appendExdateToMaster,
+  eventResourceHref,
+  parseAppleInstanceId,
+} from "@sync/providers/apple/apple-event-writer.adapter";
+import { type CaldavResponse } from "@sync/providers/apple/caldav-client";
+
+const CALENDAR = "https://caldav.icloud.com/123/calendars/home/";
+const TOKEN = "secret";
+
+function response(
+  status: number,
+  options: {
+    body?: string;
+    etag?: string;
+    multistatus?: CaldavResponse["multistatus"];
+  } = {},
+): CaldavResponse {
+  const headers: Record<string, string> = {};
+  if (options.etag) headers.etag = options.etag;
+  return {
+    status,
+    headers,
+    body: options.body ?? "",
+    multistatus: options.multistatus ?? null,
+  };
+}
+
+const MASTER_ICS = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:series-1
+DTSTAMP:20250101T120000Z
+DTSTART:20250115T090000Z
+DTEND:20250115T100000Z
+RRULE:FREQ=DAILY;COUNT=3
+SUMMARY:Series
+END:VEVENT
+END:VCALENDAR`;
+
+class FakeWriterApi implements AppleEventWriterApi {
+  calls = {
+    put: [] as Array<{
+      url: string;
+      ics: string;
+      ifMatch?: string;
+      ifNoneMatch?: string;
+    }>,
+    get: [] as string[],
+    delete: [] as Array<{ url: string; ifMatch?: string }>,
+    propfind: [] as string[],
+  };
+
+  #store = new Map<string, { etag: string; ics: string }>();
+  #etagCounter = 1;
+
+  constructor(initial?: Record<string, { etag: string; ics: string }>) {
+    for (const [url, value] of Object.entries(initial ?? {})) {
+      this.#store.set(url, value);
+    }
+  }
+
+  put(
+    url: string,
+    ics: string,
+    options: { ifMatch?: string; ifNoneMatch?: string } = {},
+  ): Promise<CaldavResponse> {
+    this.calls.put.push({ url, ics, ...options });
+    const existing = this.#store.get(url);
+
+    if (options.ifNoneMatch === "*" && existing) {
+      return Promise.resolve(response(412));
+    }
+    if (options.ifMatch && existing && options.ifMatch !== existing.etag) {
+      return Promise.resolve(response(412));
+    }
+
+    const etag = `"v${this.#etagCounter++}"`;
+    this.#store.set(url, { etag, ics });
+    return Promise.resolve(response(201, { etag }));
+  }
+
+  get(url: string): Promise<CaldavResponse> {
+    this.calls.get.push(url);
+    const existing = this.#store.get(url);
+    if (!existing) return Promise.resolve(response(404));
+    return Promise.resolve(
+      response(200, { body: existing.ics, etag: existing.etag }),
+    );
+  }
+
+  delete(url: string, ifMatch?: string): Promise<CaldavResponse> {
+    this.calls.delete.push({ url, ifMatch });
+    const existing = this.#store.get(url);
+    if (!existing) return Promise.resolve(response(404));
+    if (ifMatch && ifMatch !== existing.etag) {
+      return Promise.resolve(response(412));
+    }
+    this.#store.delete(url);
+    return Promise.resolve(response(204));
+  }
+
+  propfind(url: string): Promise<CaldavResponse> {
+    this.calls.propfind.push(url);
+    const existing = this.#store.get(url);
+    if (!existing) return Promise.resolve(response(404));
+    return Promise.resolve(
+      response(207, {
+        multistatus: {
+          responses: [
+            {
+              href: url,
+              propstats: [
+                {
+                  status: 200,
+                  props: { getetag: existing.etag },
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+  }
+}
+
+const writerWith = (api: AppleEventWriterApi) =>
+  new AppleEventWriter({ makeApi: () => api });
+
+const content = (
+  overrides: Partial<SyncEventContent> = {},
+): SyncEventContent => ({
+  title: "Title",
+  description: "Desc",
+  location: null,
+  organizer: null,
+  attendees: [],
+  conference: null,
+  ...overrides,
+});
+
+const schedule: EventSchedule = {
+  kind: "timed",
+  start: "2025-01-15T09:00:00-05:00",
+  end: "2025-01-15T10:00:00-05:00",
+  timeZone: "America/New_York",
+};
+
+describe("AppleEventWriter createEvent", () => {
+  it("PUTs a new resource with If-None-Match and returns etag from the response", async () => {
+    const api = new FakeWriterApi();
+    const writer = writerWith(api);
+
+    const result = await writer.createEvent({
+      accessToken: TOKEN,
+      calendarId: CALENDAR,
+      providerEventId: "abc12deadbeef00000000000",
+      content: content(),
+      schedule,
+      recurrence: { kind: "single" },
+      invitation: "none",
+    });
+
+    expect(result.providerEventId).toBe("abc12deadbeef00000000000");
+    expect(result.providerVersion).toBe('"v1"');
+    expect(result.resourceHref).toBe(
+      eventResourceHref(CALENDAR, "abc12deadbeef00000000000"),
+    );
+    expect(api.calls.put[0]).toEqual({
+      url: eventResourceHref(CALENDAR, "abc12deadbeef00000000000"),
+      ics: expect.stringContaining("UID:abc12deadbeef00000000000"),
+      ifNoneMatch: "*",
+    });
+  });
+
+  it("follows PROPFIND when the PUT response omits an etag", async () => {
+    class NoEtagPutApi implements AppleEventWriterApi {
+      calls = { propfind: [] as string[] };
+      #store = new Map<string, { etag: string; ics: string }>();
+
+      put(url: string, ics: string): Promise<CaldavResponse> {
+        const etag = '"propfind-etag"';
+        this.#store.set(url, { etag, ics });
+        return Promise.resolve(response(204));
+      }
+
+      get(url: string): Promise<CaldavResponse> {
+        const existing = this.#store.get(url);
+        if (!existing) return Promise.resolve(response(404));
+        return Promise.resolve(
+          response(200, { body: existing.ics, etag: existing.etag }),
+        );
+      }
+
+      delete(): Promise<CaldavResponse> {
+        return Promise.resolve(response(404));
+      }
+
+      propfind(url: string): Promise<CaldavResponse> {
+        this.calls.propfind.push(url);
+        return Promise.resolve(
+          response(207, {
+            multistatus: {
+              responses: [
+                {
+                  href: url,
+                  propstats: [
+                    { status: 200, props: { getetag: '"propfind-etag"' } },
+                  ],
+                },
+              ],
+            },
+          }),
+        );
+      }
+    }
+
+    const api = new NoEtagPutApi();
+    const writer = writerWith(api);
+    const result = await writer.createEvent({
+      accessToken: TOKEN,
+      calendarId: CALENDAR,
+      providerEventId: "new-uid",
+      content: content(),
+      schedule,
+      recurrence: { kind: "single" },
+      invitation: "none",
+    });
+
+    expect(result.providerVersion).toBe('"propfind-etag"');
+    expect(api.calls.propfind).toHaveLength(1);
+  });
+
+  it("reads back an existing resource when create hits a duplicate", async () => {
+    const href = eventResourceHref(CALENDAR, "dup-uid");
+    const api = new FakeWriterApi({
+      [href]: { etag: '"existing"', ics: MASTER_ICS },
+    });
+    const writer = writerWith(api);
+
+    const result = await writer.createEvent({
+      accessToken: TOKEN,
+      calendarId: CALENDAR,
+      providerEventId: "dup-uid",
+      content: content(),
+      schedule,
+      recurrence: { kind: "single" },
+      invitation: "none",
+    });
+
+    expect(result.providerVersion).toBe('"existing"');
+    expect(api.calls.get).toContain(href);
+  });
+});
+
+describe("AppleEventWriter patchEvent", () => {
+  it("returns versionConflict for a stale etag", async () => {
+    const href = eventResourceHref(CALENDAR, "patch-uid");
+    const api = new FakeWriterApi({
+      [href]: {
+        etag: '"current"',
+        ics: `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:patch-uid
+DTSTAMP:20250101T120000Z
+DTSTART:20250115T090000Z
+DTEND:20250115T100000Z
+SUMMARY:Old
+END:VEVENT
+END:VCALENDAR`,
+      },
+    });
+    const writer = writerWith(api);
+
+    await expect(
+      writer.patchEvent({
+        accessToken: TOKEN,
+        calendarId: CALENDAR,
+        providerEventId: "patch-uid",
+        expectedVersion: "stale-version-that-must-conflict",
+        content: content({ title: "New" }),
+        schedule,
+        recurrence: { kind: "single" },
+        invitation: "none",
+      }),
+    ).rejects.toMatchObject({ reason: "versionConflict" });
+  });
+});
+
+describe("AppleEventWriter deleteEvent", () => {
+  it("writes EXDATE on the master when deleting one instance", async () => {
+    const href = eventResourceHref(CALENDAR, "series-1");
+    const api = new FakeWriterApi({
+      [href]: { etag: '"series"', ics: MASTER_ICS },
+    });
+    const writer = writerWith(api);
+    const instanceId = "series-1_20250116T090000Z";
+
+    await writer.deleteEvent({
+      accessToken: TOKEN,
+      calendarId: CALENDAR,
+      providerEventId: instanceId,
+      expectedVersion: '"series"',
+      invitation: "none",
+    });
+
+    expect(api.calls.delete).toHaveLength(0);
+    expect(api.calls.put).toHaveLength(1);
+    expect(api.calls.put[0]?.ics).toContain("EXDATE:20250116T090000Z");
+  });
+
+  it("treats deleting an absent standalone event as success", async () => {
+    const api = new FakeWriterApi();
+    const writer = writerWith(api);
+
+    await writer.deleteEvent({
+      accessToken: TOKEN,
+      calendarId: CALENDAR,
+      providerEventId: "missing-uid",
+      expectedVersion: null,
+      invitation: "none",
+    });
+
+    expect(api.calls.delete[0]?.url).toBe(
+      eventResourceHref(CALENDAR, "missing-uid"),
+    );
+  });
+});
+
+describe("AppleEventWriter invitation scheduling", () => {
+  it("maps invitation none to SCHEDULE-AGENT=CLIENT on attendees", async () => {
+    const api = new FakeWriterApi();
+    const writer = writerWith(api);
+
+    await writer.createEvent({
+      accessToken: TOKEN,
+      calendarId: CALENDAR,
+      providerEventId: "guest-uid",
+      content: content({
+        attendees: [
+          {
+            email: "guest@example.com",
+            displayName: "Guest",
+            responseStatus: "needsAction",
+          },
+        ],
+      }),
+      schedule,
+      recurrence: { kind: "single" },
+      invitation: "none",
+      attendees: [
+        {
+          email: "guest@example.com",
+          displayName: "Guest",
+          responseStatus: "needsAction",
+        },
+      ],
+    });
+
+    expect(api.calls.put[0]?.ics).toContain("SCHEDULE-AGENT=CLIENT");
+  });
+
+  it("maps invitation all to SCHEDULE-AGENT=SERVER on attendees", async () => {
+    const api = new FakeWriterApi();
+    const writer = writerWith(api);
+
+    await writer.createEvent({
+      accessToken: TOKEN,
+      calendarId: CALENDAR,
+      providerEventId: "guest-server",
+      content: content(),
+      schedule,
+      recurrence: { kind: "single" },
+      invitation: "all",
+      attendees: [
+        {
+          email: "guest@example.com",
+          displayName: null,
+          responseStatus: "needsAction",
+        },
+      ],
+    });
+
+    expect(api.calls.put[0]?.ics).toContain("SCHEDULE-AGENT=SERVER");
+  });
+});
+
+describe("AppleEventWriter error mapping", () => {
+  it.each([
+    [401, "authorizationRevoked"],
+    [403, "readOnlyCalendar"],
+    [429, "transient"],
+    [503, "transient"],
+    [507, "permanentProviderError"],
+  ] as const)("maps HTTP %i to %s on create", async (status, reason) => {
+    class StatusApi extends FakeWriterApi {
+      put(): Promise<CaldavResponse> {
+        return Promise.resolve(response(status));
+      }
+    }
+
+    const writer = writerWith(new StatusApi());
+    await expect(
+      writer.createEvent({
+        accessToken: TOKEN,
+        calendarId: CALENDAR,
+        providerEventId: "err-uid",
+        content: content(),
+        schedule,
+        recurrence: { kind: "single" },
+        invitation: "none",
+      }),
+    ).rejects.toMatchObject({ reason });
+  });
+
+  it("maps HTTP 412 to versionConflict on patch", async () => {
+    const href = eventResourceHref(CALENDAR, "conflict-uid");
+    const api = new FakeWriterApi({
+      [href]: {
+        etag: '"current"',
+        ics: `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:conflict-uid
+DTSTAMP:20250101T120000Z
+DTSTART:20250115T090000Z
+DTEND:20250115T100000Z
+SUMMARY:Old
+END:VEVENT
+END:VCALENDAR`,
+      },
+    });
+    const writer = writerWith(api);
+
+    await expect(
+      writer.patchEvent({
+        accessToken: TOKEN,
+        calendarId: CALENDAR,
+        providerEventId: "conflict-uid",
+        expectedVersion: "stale-version-that-must-conflict",
+        content: content({ title: "New" }),
+        schedule,
+        recurrence: { kind: "single" },
+        invitation: "none",
+      }),
+    ).rejects.toMatchObject({ reason: "versionConflict" });
+  });
+});
+
+describe("AppleEventWriter fetchInstanceAt", () => {
+  it("returns a synthesized instance from the series master", async () => {
+    const href = eventResourceHref(CALENDAR, "series-1");
+    const api = new FakeWriterApi({
+      [href]: { etag: '"series"', ics: MASTER_ICS },
+    });
+    const writer = writerWith(api);
+
+    const instance = await writer.fetchInstanceAt({
+      accessToken: TOKEN,
+      calendarId: CALENDAR,
+      seriesProviderEventId: "series-1",
+      originalStartAt: "2025-01-15T14:00:00.000Z",
+      scheduleKind: "timed",
+    });
+
+    expect(instance?.providerEventId).toBe("series-1_20250115T140000Z");
+    expect(instance?.providerVersion).toBe('"series"');
+  });
+});
+
+describe("parseAppleInstanceId", () => {
+  it("parses timed instance ids", () => {
+    expect(parseAppleInstanceId("series-1_20250116T090000Z")).toEqual({
+      seriesUid: "series-1",
+      originalStartAt: new Date("2025-01-16T09:00:00.000Z").toISOString(),
+      scheduleKind: "timed",
+    });
+  });
+});
+
+describe("appendExdateToMaster", () => {
+  it("adds EXDATE and removes a matching exception VEVENT", () => {
+    const withException = `${MASTER_ICS.replace(
+      "END:VCALENDAR",
+      `BEGIN:VEVENT
+UID:series-1
+RECURRENCE-ID:20250116T090000Z
+DTSTART:20250116T100000Z
+DTEND:20250116T110000Z
+SUMMARY:Moved
+END:VEVENT
+END:VCALENDAR`,
+    )}`;
+
+    const patched = appendExdateToMaster(
+      withException,
+      "2025-01-16T09:00:00.000Z",
+      "timed",
+    );
+
+    expect(patched).toContain("EXDATE:20250116T090000Z");
+    expect(patched).not.toContain("SUMMARY:Moved");
+  });
+});

--- a/packages/sync/src/providers/apple/apple-event-writer.adapter.ts
+++ b/packages/sync/src/providers/apple/apple-event-writer.adapter.ts
@@ -1,0 +1,851 @@
+import ICAL from "ical.js";
+import { type EventSchedule } from "@core/types/event.contracts";
+import { type Attendee } from "@core/types/event-attendance.contracts";
+import { type SyncEventContent } from "@core/types/sync/event.contracts";
+import dayjs from "@core/util/date/dayjs";
+import { normalizeAppleEventResource } from "@sync/providers/apple/apple-event.normalizer";
+import {
+  type AppleEventPatchField,
+  serializeAppleEventCreate,
+  serializeAppleEventInstance,
+  serializeAppleEventPatch,
+} from "@sync/providers/apple/apple-event.serializer";
+import { appleInstanceEventId } from "@sync/providers/apple/apple-instance-id";
+import {
+  type CaldavClient,
+  type CaldavResponse,
+  createCaldavClient,
+} from "@sync/providers/apple/caldav-client";
+import {
+  type ProviderEvent,
+  ProviderEventError,
+  type ProviderEventRead,
+} from "@sync/providers/provider-event.port";
+import {
+  type InvitationIntent,
+  type ProviderCreateInput,
+  type ProviderDeleteInput,
+  type ProviderEventWriter,
+  type ProviderFetchInput,
+  type ProviderInstanceFetchInput,
+  type ProviderPatchInput,
+  ProviderWriteError,
+  type ProviderWriteRecurrence,
+  type ProviderWriteResult,
+} from "@sync/providers/provider-event-writer.port";
+import { redactedCause } from "@sync/safety/redact-error";
+
+const CALDAV_ORIGIN = "https://caldav.icloud.com";
+const RFC5545 = dayjs.DateFormat.RFC5545;
+const DATE_ONLY = dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT;
+
+export interface AppleEventResourceRef {
+  readonly href: string;
+  readonly etag: string;
+  readonly ics: string;
+}
+
+export interface AppleEventWriterApi {
+  put(
+    url: string,
+    ics: string,
+    options?: { ifMatch?: string; ifNoneMatch?: string },
+  ): Promise<CaldavResponse>;
+  get(url: string): Promise<CaldavResponse>;
+  delete(url: string, ifMatch?: string): Promise<CaldavResponse>;
+  propfind(url: string, props: readonly string[]): Promise<CaldavResponse>;
+}
+
+export type AppleEventWriterApiFactory = (
+  accessToken: string,
+) => AppleEventWriterApi;
+
+export class AppleEventWriter implements ProviderEventWriter {
+  #connectionTimeZone: string;
+  #makeApi: AppleEventWriterApiFactory;
+
+  constructor(
+    options: {
+      connectionTimeZone?: string;
+      makeApi?: AppleEventWriterApiFactory;
+    } = {},
+  ) {
+    this.#connectionTimeZone = options.connectionTimeZone ?? "UTC";
+    this.#makeApi =
+      options.makeApi ??
+      ((accessToken) => createDefaultAppleEventWriterApi(accessToken));
+  }
+
+  async createEvent(input: ProviderCreateInput): Promise<ProviderWriteResult> {
+    if (input.createConference) {
+      // Apple has no conference capability; booking copy handles the null URL.
+    }
+
+    const api = this.#makeApi(input.accessToken);
+    const calendarUrl = resolveCalendarUrl(input.calendarId);
+    const uid = input.providerEventId;
+    const href = eventResourceHref(calendarUrl, uid);
+    const ics = applyInvitationIntent(
+      serializeAppleEventCreate({
+        providerEventId: uid,
+        content: input.content,
+        schedule: input.schedule,
+        recurrence: input.recurrence,
+        busy: true,
+        attendees: input.attendees,
+      }),
+      input.invitation,
+      input.attendees,
+    );
+
+    try {
+      const response = await api.put(href, ics, { ifNoneMatch: "*" });
+      if (response.status === 412) {
+        const existing = await this.#loadResource(api, href);
+        if (!existing) {
+          throw new ProviderWriteError(
+            "permanentProviderError",
+            "Apple reported a duplicate event that could not be read back",
+          );
+        }
+        return toWriteResult(uid, existing.etag, href);
+      }
+      assertWriteStatus(response);
+      const etag = await resolveEtag(api, href, response);
+      return toWriteResult(uid, etag, href);
+    } catch (error) {
+      if (error instanceof ProviderWriteError) throw error;
+      throw classifyWriteError(error);
+    }
+  }
+
+  async patchEvent(input: ProviderPatchInput): Promise<ProviderWriteResult> {
+    const api = this.#makeApi(input.accessToken);
+    const calendarUrl = resolveCalendarUrl(input.calendarId);
+    const parsedInstance = parseAppleInstanceId(input.providerEventId);
+
+    if (input.recurrence.kind === "instance" || parsedInstance) {
+      return this.#patchInstance(api, calendarUrl, input, parsedInstance);
+    }
+
+    const href = eventResourceHref(calendarUrl, input.providerEventId);
+    const current = await this.#loadResource(api, href);
+    if (!current) {
+      throw new ProviderWriteError(
+        "permanentProviderError",
+        "Apple event to patch was not found",
+      );
+    }
+
+    const reads = this.#normalizeResource(current);
+    const master = reads.find(
+      (read) => read.kind === "event" && read.recurrence.kind !== "instance",
+    );
+    if (!master || master.kind !== "event") {
+      throw new ProviderWriteError(
+        "permanentProviderError",
+        "Apple event resource had no patchable master",
+      );
+    }
+
+    const delta = computePatchDelta(master, input);
+    const ics = applyInvitationIntent(
+      serializeAppleEventPatch({
+        providerEventId: input.providerEventId,
+        existingIcs: current.ics,
+        patchFields: delta.patchFields,
+        scheduleChanged: delta.scheduleChanged,
+        attendeesChanged: delta.attendeesChanged,
+        content: input.content,
+        schedule: input.schedule,
+        recurrence: input.recurrence,
+        busy: master.busy,
+        attendees: input.attendees,
+      }),
+      input.invitation,
+      input.attendees ?? input.content.attendees,
+    );
+
+    try {
+      const response = await api.put(href, ics, {
+        ifMatch: input.expectedVersion ?? undefined,
+      });
+      assertWriteStatus(response);
+      const etag = await resolveEtag(api, href, response);
+      return toWriteResult(input.providerEventId, etag, href);
+    } catch (error) {
+      if (error instanceof ProviderWriteError) throw error;
+      throw classifyWriteError(error);
+    }
+  }
+
+  async deleteEvent(input: ProviderDeleteInput): Promise<void> {
+    const api = this.#makeApi(input.accessToken);
+    const calendarUrl = resolveCalendarUrl(input.calendarId);
+    const parsedInstance = parseAppleInstanceId(input.providerEventId);
+
+    if (parsedInstance) {
+      await this.#deleteInstance(api, calendarUrl, input, parsedInstance);
+      return;
+    }
+
+    const href = eventResourceHref(calendarUrl, input.providerEventId);
+    try {
+      const response = await api.delete(
+        href,
+        input.expectedVersion ?? undefined,
+      );
+      if (response.status === 404) return;
+      assertWriteStatus(response);
+    } catch (error) {
+      if (responseStatus(error) === 404) return;
+      if (error instanceof ProviderWriteError) throw error;
+      throw classifyWriteError(error);
+    }
+  }
+
+  async fetchEvent(
+    input: ProviderFetchInput,
+  ): Promise<ProviderEventRead | null> {
+    const api = this.#makeApi(input.accessToken);
+    const calendarUrl = resolveCalendarUrl(input.calendarId);
+    const parsedInstance = parseAppleInstanceId(input.providerEventId);
+
+    if (parsedInstance) {
+      return this.fetchInstanceAt({
+        accessToken: input.accessToken,
+        calendarId: input.calendarId,
+        seriesProviderEventId: parsedInstance.seriesUid,
+        originalStartAt: parsedInstance.originalStartAt,
+        scheduleKind: parsedInstance.scheduleKind,
+      });
+    }
+
+    const href = eventResourceHref(calendarUrl, input.providerEventId);
+    const resource = await this.#loadResource(api, href);
+    if (!resource) return null;
+
+    const reads = this.#normalizeResource(resource);
+    const master = reads.find(
+      (read) =>
+        read.kind === "event" && read.providerEventId === input.providerEventId,
+    );
+    return master ?? reads.find((read) => read.kind === "event") ?? null;
+  }
+
+  async fetchInstanceAt(
+    input: ProviderInstanceFetchInput,
+  ): Promise<ProviderEventRead | null> {
+    const api = this.#makeApi(input.accessToken);
+    const calendarUrl = resolveCalendarUrl(input.calendarId);
+    const href = eventResourceHref(calendarUrl, input.seriesProviderEventId);
+    const resource = await this.#loadResource(api, href);
+    if (!resource) return null;
+
+    const reads = this.#normalizeResource(resource);
+    const recurrenceId = input.originalStartAt;
+    const instance = reads.find(
+      (read) =>
+        read.kind === "event" &&
+        read.recurrence.kind === "instance" &&
+        read.recurrence.recurrenceId === recurrenceId,
+    );
+    if (instance) return instance;
+
+    const master = reads.find(
+      (read) =>
+        read.kind === "event" &&
+        read.recurrence.kind === "seriesMaster" &&
+        read.providerEventId === input.seriesProviderEventId,
+    );
+    if (!master || master.kind !== "event") return null;
+
+    return synthesizeInstanceFromMaster(master, input, resource.etag);
+  }
+
+  async #patchInstance(
+    api: AppleEventWriterApi,
+    calendarUrl: string,
+    input: ProviderPatchInput,
+    parsedInstance: ParsedAppleInstanceId | null,
+  ): Promise<ProviderWriteResult> {
+    const instanceId =
+      parsedInstance ?? parseAppleInstanceId(input.providerEventId);
+    if (!instanceId) {
+      throw new ProviderWriteError(
+        "permanentProviderError",
+        "Apple instance patch could not resolve the series identity",
+      );
+    }
+
+    const href = eventResourceHref(calendarUrl, instanceId.seriesUid);
+    const current = await this.#loadResource(api, href);
+    if (!current) {
+      throw new ProviderWriteError(
+        "permanentProviderError",
+        "Apple series master for the instance was not found",
+      );
+    }
+
+    const reads = this.#normalizeResource(current);
+    const existingInstance = reads.find(
+      (read) =>
+        read.kind === "event" && read.providerEventId === input.providerEventId,
+    );
+    const master = reads.find(
+      (read) =>
+        read.kind === "event" && read.recurrence.kind === "seriesMaster",
+    );
+    const baseline =
+      existingInstance?.kind === "event"
+        ? existingInstance
+        : master?.kind === "event"
+          ? master
+          : null;
+    if (!baseline) {
+      throw new ProviderWriteError(
+        "permanentProviderError",
+        "Apple instance patch had no baseline event",
+      );
+    }
+
+    const delta = computePatchDelta(baseline, input);
+    const ics = applyInvitationIntent(
+      serializeAppleEventInstance({
+        providerEventId: input.providerEventId,
+        existingIcs: current.ics,
+        instanceRecurrenceId: instanceId.originalStartAt,
+        scheduleChanged: delta.scheduleChanged,
+        attendeesChanged: delta.attendeesChanged,
+        content: input.content,
+        schedule: input.schedule,
+        recurrence: { kind: "instance" },
+        busy: baseline.busy,
+        attendees: input.attendees,
+      }),
+      input.invitation,
+      input.attendees ?? input.content.attendees,
+    );
+
+    try {
+      const response = await api.put(href, ics, {
+        ifMatch: input.expectedVersion ?? undefined,
+      });
+      assertWriteStatus(response);
+      const etag = await resolveEtag(api, href, response);
+      return toWriteResult(input.providerEventId, etag, href);
+    } catch (error) {
+      if (error instanceof ProviderWriteError) throw error;
+      throw classifyWriteError(error);
+    }
+  }
+
+  async #deleteInstance(
+    api: AppleEventWriterApi,
+    calendarUrl: string,
+    input: ProviderDeleteInput,
+    parsedInstance: ParsedAppleInstanceId,
+  ): Promise<void> {
+    const href = eventResourceHref(calendarUrl, parsedInstance.seriesUid);
+    const current = await this.#loadResource(api, href);
+    if (!current) return;
+
+    const ics = appendExdateToMaster(
+      current.ics,
+      parsedInstance.originalStartAt,
+      parsedInstance.scheduleKind,
+    );
+
+    try {
+      const response = await api.put(href, ics, {
+        ifMatch: input.expectedVersion ?? undefined,
+      });
+      if (response.status === 404) return;
+      assertWriteStatus(response);
+    } catch (error) {
+      if (responseStatus(error) === 404) return;
+      if (error instanceof ProviderWriteError) throw error;
+      throw classifyWriteError(error);
+    }
+  }
+
+  async #loadResource(
+    api: AppleEventWriterApi,
+    href: string,
+  ): Promise<AppleEventResourceRef | null> {
+    try {
+      const response = await api.get(href);
+      if (response.status === 404) return null;
+      assertWriteStatus(response);
+      const etag = headerEtag(response) ?? (await fetchEtag(api, href));
+      if (!etag) {
+        throw new ProviderWriteError(
+          "permanentProviderError",
+          "Apple returned an event without an etag",
+        );
+      }
+      return { href, etag, ics: response.body };
+    } catch (error) {
+      if (responseStatus(error) === 404) return null;
+      if (error instanceof ProviderWriteError) throw error;
+      throw classifyWriteError(error);
+    }
+  }
+
+  #normalizeResource(resource: AppleEventResourceRef): ProviderEventRead[] {
+    try {
+      return normalizeAppleEventResource({
+        ics: resource.ics,
+        href: resource.href,
+        etag: resource.etag,
+        connectionTimeZone: this.#connectionTimeZone,
+      });
+    } catch (error) {
+      if (error instanceof ProviderEventError) {
+        throw new ProviderWriteError("permanentProviderError", error.message, {
+          cause: redactedCause(error),
+        });
+      }
+      throw error;
+    }
+  }
+}
+
+export function createDefaultAppleEventWriterApi(
+  accessToken: string,
+  makeClient: (username: string, password: string) => CaldavClient = (
+    username,
+    password,
+  ) => createCaldavClient({ username, password }),
+  username = "user@icloud.com",
+): AppleEventWriterApi {
+  const client = makeClient(username, accessToken);
+  return new CaldavAppleEventWriterApi(client);
+}
+
+class CaldavAppleEventWriterApi implements AppleEventWriterApi {
+  constructor(private readonly client: CaldavClient) {}
+
+  put(
+    url: string,
+    ics: string,
+    options?: { ifMatch?: string; ifNoneMatch?: string },
+  ): Promise<CaldavResponse> {
+    return this.client.put(url, ics, options);
+  }
+
+  get(url: string): Promise<CaldavResponse> {
+    return this.client.get(url);
+  }
+
+  delete(url: string, ifMatch?: string): Promise<CaldavResponse> {
+    return this.client.delete(url, ifMatch);
+  }
+
+  propfind(url: string, props: readonly string[]): Promise<CaldavResponse> {
+    return this.client.propfind(url, [...props], 0);
+  }
+}
+
+interface ParsedAppleInstanceId {
+  readonly seriesUid: string;
+  readonly originalStartAt: string;
+  readonly scheduleKind: "timed" | "allDay";
+}
+
+export function parseAppleInstanceId(
+  providerEventId: string,
+): ParsedAppleInstanceId | null {
+  const timedMatch = /^(.+)_(\d{8}T\d{6}Z)$/.exec(providerEventId);
+  if (timedMatch) {
+    const suffix = timedMatch[2]!;
+    const instant = dayjs.utc(suffix, RFC5545, true);
+    if (!instant.isValid()) return null;
+    return {
+      seriesUid: timedMatch[1]!,
+      originalStartAt: instant.toDate().toISOString(),
+      scheduleKind: "timed",
+    };
+  }
+
+  const allDayMatch = /^(.+)_(\d{8})$/.exec(providerEventId);
+  if (allDayMatch) {
+    const suffix = allDayMatch[2]!;
+    const instant = dayjs.utc(
+      suffix,
+      dayjs.DateFormat.YEAR_MONTH_DAY_COMPACT_FORMAT,
+      true,
+    );
+    if (!instant.isValid()) return null;
+    return {
+      seriesUid: allDayMatch[1]!,
+      originalStartAt: instant.toDate().toISOString(),
+      scheduleKind: "allDay",
+    };
+  }
+
+  return null;
+}
+
+export function eventResourceHref(calendarUrl: string, uid: string): string {
+  const base = calendarUrl.endsWith("/") ? calendarUrl : `${calendarUrl}/`;
+  return `${base}${uid}.ics`;
+}
+
+function resolveCalendarUrl(calendarId: string): string {
+  if (calendarId.startsWith("http://") || calendarId.startsWith("https://")) {
+    return calendarId.endsWith("/") ? calendarId : `${calendarId}/`;
+  }
+  const path = calendarId.startsWith("/") ? calendarId : `/${calendarId}`;
+  const normalized = path.endsWith("/") ? path : `${path}/`;
+  return new URL(normalized, CALDAV_ORIGIN).href;
+}
+
+function toWriteResult(
+  providerEventId: string,
+  providerVersion: string,
+  resourceHref: string,
+): ProviderWriteResult {
+  return {
+    providerEventId,
+    providerVersion,
+    icalUid: providerEventId,
+    resourceHref,
+  };
+}
+
+function headerEtag(response: CaldavResponse): string | null {
+  return response.headers["etag"] ?? null;
+}
+
+async function resolveEtag(
+  api: AppleEventWriterApi,
+  href: string,
+  response: CaldavResponse,
+): Promise<string> {
+  const fromHeader = headerEtag(response);
+  if (fromHeader) return fromHeader;
+  const fetched = await fetchEtag(api, href);
+  if (!fetched) {
+    throw new ProviderWriteError(
+      "permanentProviderError",
+      "Apple write succeeded without an etag",
+    );
+  }
+  return fetched;
+}
+
+async function fetchEtag(
+  api: AppleEventWriterApi,
+  href: string,
+): Promise<string | null> {
+  const response = await api.propfind(href, ["getetag"]);
+  assertWriteStatus(response);
+  for (const item of response.multistatus?.responses ?? []) {
+    for (const propstat of item.propstats) {
+      if (propstat.status < 200 || propstat.status >= 300) continue;
+      const etag = propstat.props["getetag"];
+      if (typeof etag === "string" && etag.length > 0) return etag;
+    }
+  }
+  return null;
+}
+
+function assertWriteStatus(response: CaldavResponse): void {
+  if (response.status === 401) {
+    throw new ProviderWriteError(
+      "authorizationRevoked",
+      "Apple rejected the credentials",
+    );
+  }
+  if (response.status === 403) {
+    throw new ProviderWriteError(
+      "readOnlyCalendar",
+      "The calendar cannot be written",
+    );
+  }
+  if (response.status === 412) {
+    throw new ProviderWriteError(
+      "versionConflict",
+      "The event was modified since the expected version",
+    );
+  }
+  if (response.status === 429 || response.status === 503) {
+    throw new ProviderWriteError(
+      "transient",
+      "Apple CalDAV throttled the write",
+    );
+  }
+  if (response.status === 507) {
+    throw new ProviderWriteError(
+      "permanentProviderError",
+      "Apple rejected the write with insufficient storage",
+    );
+  }
+  if (response.status < 200 || response.status >= 300) {
+    throw new ProviderWriteError(
+      "permanentProviderError",
+      `Apple CalDAV write failed (${response.status})`,
+    );
+  }
+}
+
+function classifyWriteError(error: unknown): ProviderWriteError {
+  if (error instanceof ProviderWriteError) return error;
+  const cause = redactedCause(error);
+  const status = responseStatus(error);
+
+  if (status === 412) {
+    return new ProviderWriteError(
+      "versionConflict",
+      "The event was modified since the expected version",
+      { cause },
+    );
+  }
+  if (status === 401) {
+    return new ProviderWriteError(
+      "authorizationRevoked",
+      "Apple rejected the credentials",
+      { cause },
+    );
+  }
+  if (status === 403) {
+    return new ProviderWriteError(
+      "readOnlyCalendar",
+      "The calendar cannot be written",
+      { cause },
+    );
+  }
+  if (status === 507) {
+    return new ProviderWriteError(
+      "permanentProviderError",
+      "Apple rejected the write with insufficient storage",
+      { cause },
+    );
+  }
+  if (status === undefined || status === 429 || status >= 500) {
+    return new ProviderWriteError("transient", "The write failed transiently", {
+      cause,
+    });
+  }
+  return new ProviderWriteError(
+    "permanentProviderError",
+    "Apple rejected the write",
+    { cause },
+  );
+}
+
+function responseStatus(error: unknown): number | undefined {
+  return (error as { status?: number })?.status;
+}
+
+function computePatchDelta(
+  current: ProviderEvent,
+  input: ProviderPatchInput,
+): {
+  patchFields: AppleEventPatchField[];
+  scheduleChanged: boolean;
+  attendeesChanged: boolean;
+} {
+  const patchFields = new Set<AppleEventPatchField>();
+  const content = input.content;
+
+  if (current.content.title !== content.title) patchFields.add("title");
+  if (current.content.description !== content.description) {
+    patchFields.add("description");
+  }
+  if ((current.content.location ?? "") !== (content.location ?? "")) {
+    patchFields.add("location");
+  }
+  if (!organizersEqual(current.content.organizer, content.organizer)) {
+    patchFields.add("organizer");
+  }
+  if (!conferencesEqual(current.content.conference, content.conference)) {
+    patchFields.add("conference");
+  }
+  if (!schedulesEqual(current.schedule, input.schedule)) {
+    patchFields.add("schedule");
+  }
+  if (!recurrencesEqual(current.recurrence, input.recurrence)) {
+    patchFields.add("recurrence");
+  }
+
+  const attendees = input.attendees ?? content.attendees;
+  const attendeesChanged = !attendeesEqual(
+    current.content.attendees,
+    attendees,
+  );
+  if (attendeesChanged) patchFields.add("attendees");
+
+  return {
+    patchFields: [...patchFields],
+    scheduleChanged: patchFields.has("schedule"),
+    attendeesChanged,
+  };
+}
+
+function organizersEqual(
+  left: SyncEventContent["organizer"],
+  right: SyncEventContent["organizer"],
+): boolean {
+  if (!left && !right) return true;
+  if (!left || !right) return false;
+  return left.email === right.email && left.displayName === right.displayName;
+}
+
+function conferencesEqual(
+  left: SyncEventContent["conference"],
+  right: SyncEventContent["conference"],
+): boolean {
+  return (left?.url ?? null) === (right?.url ?? null);
+}
+
+function schedulesEqual(left: EventSchedule, right: EventSchedule): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function recurrencesEqual(
+  current: ProviderEvent["recurrence"],
+  write: ProviderWriteRecurrence,
+): boolean {
+  if (write.kind === "instance") return false;
+  if (write.kind === "single") {
+    return current.kind === "single";
+  }
+  if (current.kind !== "seriesMaster") return true;
+  return (
+    JSON.stringify([...current.rules].sort()) ===
+    JSON.stringify([...write.rules].sort())
+  );
+}
+
+function attendeesEqual(
+  left: readonly Attendee[],
+  right: readonly Attendee[],
+): boolean {
+  if (left.length !== right.length) return false;
+  for (let index = 0; index < left.length; index += 1) {
+    const a = left[index]!;
+    const b = right[index]!;
+    if (
+      a.email !== b.email ||
+      a.displayName !== b.displayName ||
+      a.responseStatus !== b.responseStatus
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function applyInvitationIntent(
+  ics: string,
+  invitation: InvitationIntent,
+  attendees: readonly Attendee[] | undefined,
+): string {
+  if (!attendees || attendees.length === 0) return ics;
+  const component = new ICAL.Component(ICAL.parse(ics));
+  for (const vevent of component.getAllSubcomponents("vevent")) {
+    for (const property of vevent.getAllProperties("attendee")) {
+      if (invitation === "none") {
+        property.setParameter("schedule-agent", "CLIENT");
+      } else {
+        property.setParameter("schedule-agent", "SERVER");
+      }
+    }
+  }
+  return component.toString();
+}
+
+export function appendExdateToMaster(
+  existingIcs: string,
+  originalStartAt: string,
+  scheduleKind: "timed" | "allDay",
+): string {
+  const calendar = new ICAL.Component(ICAL.parse(existingIcs));
+  const master = calendar
+    .getAllSubcomponents("vevent")
+    .find((vevent) => !vevent.hasProperty("recurrence-id"));
+  if (!master) {
+    throw new Error("ICS resource had no master VEVENT");
+  }
+
+  const exdate = exdateLine(originalStartAt, scheduleKind);
+  const existing = master
+    .getAllProperties("exdate")
+    .some((property) => property.toICALString() === exdate);
+  if (!existing) {
+    master.addProperty(ICAL.Property.fromString(exdate));
+  }
+
+  const recurrenceId = recurrenceIdTime(originalStartAt, scheduleKind);
+  for (const vevent of calendar.getAllSubcomponents("vevent")) {
+    const property = vevent.getFirstProperty("recurrence-id");
+    if (!property) continue;
+    const value = property.getFirstValue() as ICAL.Time;
+    if (recurrenceTimesEqual(value, recurrenceId)) {
+      calendar.removeSubcomponent(vevent);
+    }
+  }
+
+  return calendar.toString();
+}
+
+function exdateLine(
+  originalStartAt: string,
+  scheduleKind: "timed" | "allDay",
+): string {
+  if (scheduleKind === "allDay") {
+    const dateOnly = dayjs.utc(originalStartAt).format(DATE_ONLY);
+    return `EXDATE;VALUE=DATE:${dateOnly.replaceAll("-", "")}`;
+  }
+  return `EXDATE:${dayjs.utc(originalStartAt).format(RFC5545)}`;
+}
+
+function recurrenceIdTime(
+  originalStartAt: string,
+  scheduleKind: "timed" | "allDay",
+): ICAL.Time {
+  if (scheduleKind === "allDay") {
+    const time = ICAL.Time.fromDateString(
+      dayjs.utc(originalStartAt).format(DATE_ONLY),
+    );
+    time.isDate = true;
+    return time;
+  }
+  return ICAL.Time.fromJSDate(new Date(originalStartAt), true);
+}
+
+function recurrenceTimesEqual(a: ICAL.Time, b: ICAL.Time): boolean {
+  if (a.isDate !== b.isDate) return false;
+  if (a.isDate) return a.toICALString() === b.toICALString();
+  return a.toJSDate().getTime() === b.toJSDate().getTime();
+}
+
+function synthesizeInstanceFromMaster(
+  master: ProviderEvent,
+  input: ProviderInstanceFetchInput,
+  etag: string,
+): ProviderEventRead | null {
+  if (master.recurrence.kind !== "seriesMaster") return null;
+  const providerEventId = appleInstanceEventId(
+    input.seriesProviderEventId,
+    input.originalStartAt,
+    input.scheduleKind,
+  );
+  return {
+    kind: "event",
+    providerEventId,
+    providerVersion: etag,
+    providerUpdatedAt: master.providerUpdatedAt,
+    content: master.content,
+    schedule: master.schedule,
+    busy: master.busy,
+    icalUid: master.icalUid,
+    recurrence: {
+      kind: "instance",
+      seriesProviderId: input.seriesProviderEventId,
+      recurrenceId: input.originalStartAt,
+    },
+  };
+}

--- a/packages/sync/src/providers/provider-event-writer.port.ts
+++ b/packages/sync/src/providers/provider-event-writer.port.ts
@@ -101,6 +101,8 @@ export interface ProviderInstanceFetchInput {
 export interface ProviderWriteResult {
   readonly providerEventId: string;
   readonly providerVersion: string;
+  // CalDAV resource href for sync-collection deletion mapping and later writes.
+  readonly resourceHref?: string;
   // Google's cross-copy correlation key when the write response includes it.
   // Optional so non-Google writers and older fixtures stay valid.
   readonly icalUid?: string;


### PR DESCRIPTION
Fixes #3260

## What and why

Implements the Apple iCloud CalDAV event writer behind `ProviderEventWriter`: create via PUT with `If-None-Match: *`, conditional patch/delete with etag preconditions, instance delete as master EXDATE, `fetchEvent`/`fetchInstanceAt` through ICS normalization, and attendee `SCHEDULE-AGENT` mapping for invitation intent. Extends the shared adapter contract with Apple writer coverage and documents iCloud invitation behavior in the calendar providers spec.

## Verify

```
bun test:sync
bun run type-check
bun lint
bun knip
bun run verify --strict
VERDICT: PASS
```