### PR TITLE
fix(web): use one shortcut for calendar refresh

### DIFF
--- a/packages/web/src/common/utils/toast/ToastActionButton.tsx
+++ b/packages/web/src/common/utils/toast/ToastActionButton.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode } from "react";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import {
+  type NoticeActionKey,
   TOAST_PRIMARY_ACTION_KEY,
   useNoticeActionShortcut,
 } from "@web/shortcuts/notice-focus/useNoticeActionShortcut";
@@ -8,11 +9,13 @@ import {
 export function ToastActionButton({
   children,
   onClick,
+  shortcutKey = TOAST_PRIMARY_ACTION_KEY,
 }: {
   children: ReactNode;
   onClick: () => void;
+  shortcutKey?: NoticeActionKey;
 }) {
-  useNoticeActionShortcut(TOAST_PRIMARY_ACTION_KEY, onClick);
+  useNoticeActionShortcut(shortcutKey, onClick);
 
   return (
     <button
@@ -21,7 +24,7 @@ export function ToastActionButton({
       type="button"
     >
       {children}
-      <ShortcutKeys keys={TOAST_PRIMARY_ACTION_KEY} />
+      <ShortcutKeys keys={shortcutKey} />
     </button>
   );
 }

--- a/packages/web/src/common/utils/toast/google-delayed.toast.test.tsx
+++ b/packages/web/src/common/utils/toast/google-delayed.toast.test.tsx
@@ -18,6 +18,7 @@ import {
   showGoogleDelayedToast,
 } from "@web/common/utils/toast/google-delayed.toast";
 import { registerToastPort } from "@web/common/utils/toast/toast.port";
+import { CalendarConnectionBanner } from "@web/components/CalendarConnectionBanner/CalendarConnectionBanner";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockRefresh = mock();
@@ -39,7 +40,7 @@ describe("GoogleDelayedToast", () => {
     registerToastPort(port);
   });
 
-  it("shows an S keycap and refreshes when S is pressed", () => {
+  it("shows a G keycap and refreshes when G is pressed", () => {
     render(
       <HotkeysProvider>
         <GoogleDelayedToast toastId="google-delayed" />
@@ -49,15 +50,56 @@ describe("GoogleDelayedToast", () => {
     expect(
       within(
         screen.getByRole("button", { name: "Refresh calendar" }),
-      ).getByText("S"),
+      ).getByText("G"),
     ).toBeTruthy();
     expect(screen.getByText("Press Esc to dismiss")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Dismiss" })).toBeNull();
 
-    pressKey("S");
+    pressKey("G");
 
     expect(mocks.dismiss).toHaveBeenCalledWith("google-delayed");
     expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not refresh with S, which other toasts use for Sign up / Sign in", () => {
+    render(
+      <HotkeysProvider>
+        <GoogleDelayedToast toastId="google-delayed" />
+      </HotkeysProvider>,
+    );
+
+    pressKey("S");
+
+    expect(mocks.dismiss).not.toHaveBeenCalled();
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+
+  it("shares G with the delayed banner so Refresh is one shortcut", () => {
+    const onBannerRefresh = mock();
+    render(
+      <HotkeysProvider>
+        <CalendarConnectionBanner kind="delayed" onAction={onBannerRefresh} />
+        <GoogleDelayedToast toastId="google-delayed" />
+      </HotkeysProvider>,
+    );
+
+    expect(
+      within(screen.getByRole("button", { name: /^Refresh$/ })).getByText("G"),
+    ).toBeTruthy();
+    expect(
+      within(
+        screen.getByRole("button", { name: "Refresh calendar" }),
+      ).getByText("G"),
+    ).toBeTruthy();
+
+    pressKey("S");
+    expect(onBannerRefresh).not.toHaveBeenCalled();
+    expect(mockRefresh).not.toHaveBeenCalled();
+
+    pressKey("G");
+    expect(onBannerRefresh).toHaveBeenCalled();
+    expect(mockRefresh).toHaveBeenCalled();
+    expect(mocks.dismiss).toHaveBeenCalledWith("google-delayed");
   });
 });
 

--- a/packages/web/src/common/utils/toast/google-delayed.toast.tsx
+++ b/packages/web/src/common/utils/toast/google-delayed.toast.tsx
@@ -14,6 +14,7 @@ import {
 import { ToastActionButton } from "@web/common/utils/toast/ToastActionButton";
 import { ToastNotice } from "@web/common/utils/toast/ToastNotice";
 import { getToast } from "@web/common/utils/toast/toast.port";
+import { CONNECTION_BANNER_SHORTCUT_KEY } from "@web/shortcuts/notice-focus/useNoticeActionShortcut";
 
 interface GoogleDelayedToastProps {
   toastId: Id;
@@ -39,7 +40,10 @@ export const GoogleDelayedToast = ({ toastId }: GoogleDelayedToastProps) => {
         Updates are taking longer than expected. Try Refresh, or reconnect if
         this continues.
       </p>
-      <ToastActionButton onClick={handleRefresh}>
+      <ToastActionButton
+        onClick={handleRefresh}
+        shortcutKey={CONNECTION_BANNER_SHORTCUT_KEY}
+      >
         Refresh calendar
       </ToastActionButton>
     </ToastNotice>

--- a/packages/web/src/common/utils/toast/google-reconnect.toast.test.tsx
+++ b/packages/web/src/common/utils/toast/google-reconnect.toast.test.tsx
@@ -106,18 +106,18 @@ describe("GoogleReconnectToast", () => {
     expect(mockConnect).toHaveBeenCalledTimes(1);
   });
 
-  it("shows an S keycap and reconnects when S is pressed", () => {
+  it("shows a G keycap and reconnects when G is pressed", () => {
     renderToast("lance@example.com");
 
     expect(
       within(
         screen.getByRole("button", { name: "Reconnect Google Calendar" }),
-      ).getByText("S"),
+      ).getByText("G"),
     ).toBeTruthy();
     expect(screen.getByText("Press Esc to dismiss")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Dismiss" })).toBeNull();
 
-    pressKey("S");
+    pressKey("G");
 
     expect(mocks.dismiss).toHaveBeenCalledWith("google-revoked-api");
     expect(mockConnect).toHaveBeenCalledTimes(1);
@@ -131,8 +131,16 @@ describe("GoogleReconnectToast", () => {
     expect(mockConnect).not.toHaveBeenCalled();
   });
 
-  it("does not reconnect with S while event jump is active", () => {
+  it("does not reconnect with G while event jump is active", () => {
     eventJumpActions.setActive(true);
+    renderToast();
+
+    pressKey("G");
+
+    expect(mockConnect).not.toHaveBeenCalled();
+  });
+
+  it("does not reconnect with S, which other toasts use for Sign up / Sign in", () => {
     renderToast();
 
     pressKey("S");

--- a/packages/web/src/common/utils/toast/google-reconnect.toast.tsx
+++ b/packages/web/src/common/utils/toast/google-reconnect.toast.tsx
@@ -20,6 +20,7 @@ import {
 import { ToastActionButton } from "@web/common/utils/toast/ToastActionButton";
 import { ToastNotice } from "@web/common/utils/toast/ToastNotice";
 import { getToast } from "@web/common/utils/toast/toast.port";
+import { CONNECTION_BANNER_SHORTCUT_KEY } from "@web/shortcuts/notice-focus/useNoticeActionShortcut";
 
 let hasShownReconnectToastThisLoad = false;
 let lastReconnectTarget: GoogleReconnectTarget = {};
@@ -103,7 +104,10 @@ export const GoogleReconnectToast = ({
           ? `Access for ${namedAccount} expired or was revoked. Your events are still safe in Google. Reconnect and Compass will re-import them.`
           : "This happens when access expires or is revoked. Your events are still safe in Google. Reconnect and Compass will re-import them."}
       </p>
-      <ToastActionButton onClick={handleReconnect}>
+      <ToastActionButton
+        onClick={handleReconnect}
+        shortcutKey={CONNECTION_BANNER_SHORTCUT_KEY}
+      >
         Reconnect Google Calendar
       </ToastActionButton>
     </ToastNotice>

--- a/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.test.tsx
+++ b/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.test.tsx
@@ -113,9 +113,12 @@ describe("CalendarConnectionBanner", () => {
     expect(onAction).toHaveBeenCalledTimes(1);
   });
 
-  it("runs Refresh with G", () => {
+  it("runs Refresh with G, the same letter as the delayed toast", () => {
     const onAction = mock();
     renderBanner("delayed", onAction);
+
+    const button = screen.getByRole("button", { name: "Refresh" });
+    expect(within(button).getByText("G")).toBeTruthy();
 
     pressKey("G");
 

--- a/packages/web/src/shortcuts/notice-focus/useNoticeActionShortcut.ts
+++ b/packages/web/src/shortcuts/notice-focus/useNoticeActionShortcut.ts
@@ -4,14 +4,17 @@ import { isEditSequenceArmed } from "@web/shortcuts/useEditSequenceShortcut";
 
 /** Action-toast CTA (Sign up / Sign in). Letter keys only: digits belong to
  * quick-time create (`1` = 1:00), except the series-scope toast which owns
- * 1/2 while it is visible. Same letter as the start-trial banner. */
+ * 1/2 while it is visible. Same letter as the start-trial banner. Google
+ * connection toasts use `CONNECTION_BANNER_SHORTCUT_KEY` instead so Refresh
+ * and Reconnect never advertise two different letters. */
 export const TOAST_PRIMARY_ACTION_KEY = "S" as const;
 
 /** Start-trial banner CTA. Same letter as the billing gate overlay. */
 export const START_TRIAL_SHORTCUT_KEY = "S" as const;
 
-/** Google connection banner CTA (Reconnect / Retry / Refresh). `G` matches
- * Continue with Google on the welcome and auth overlays. */
+/** Google connection notice CTA (banner and toast: Reconnect / Retry /
+ * Refresh). `G` matches Continue with Google on the welcome and auth
+ * overlays. */
 export const CONNECTION_BANNER_SHORTCUT_KEY = "G" as const;
 
 export type NoticeActionKey =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

The delayed-connection banner advertised `G` on Refresh while the delayed toast advertised `S` on Refresh calendar, the same action with two letters. Google connection toasts (delayed refresh and reconnect) now use the banner’s `G`, matching Continue with Google on the welcome and auth overlays. Sign up, Sign in, and Start trial stay on `S`.

## Verify

```
Selected packages: web
Checks run: test:web, type-check, lint, knip, test:e2e, test:a11y
Checks skipped: (none)
✓ All checks passed
VERDICT: PASS
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64c72e59-9662-4c40-a89c-c9137dfaff75?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64c72e59-9662-4c40-a89c-c9137dfaff75&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

