### PR TITLE
feat(web): migrate settings, sidebar, banners and toasts to provider layer (WP-08b)

### DIFF
--- a/.agents/handoffs/3232.md
+++ b/.agents/handoffs/3232.md
@@ -1,0 +1,31 @@
+---
+schema_version: 1
+task_id: "3232"
+from: Implementer
+to: GitHub
+owner: GitHub
+status: verifying
+artifact:
+  - path: packages/web/src/auth/providers/ConnectProviderChooser.tsx
+  - path: packages/web/src/auth/providers/useAvailableConnectProviders.ts
+  - path: packages/web/src/auth/providers/connection-provider.util.ts
+  - path: packages/web/src/auth/state/user-metadata.store.ts
+  - path: packages/web/src/components/Settings/SettingsModal.tsx
+  - path: packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+  - path: packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.tsx
+evidence:
+  - command: bun run verify --strict
+    result: "VERDICT: PASS"
+  - command: grep metadata.google scoped dirs
+    result: no matches under Settings, Sidebar, Banner, PointerHint, toast
+assumptions:
+  - "Legacy metadata without connections[] still falls back to google.connections in selectSyncConnections."
+open_risks: []
+next_deadline: 2026-09-05T12:00:00Z
+retry: 0
+approval: allow
+waiting_on: null
+escalation: null
+---
+
+P0 WP-08b: migrate Settings, sidebar, banners and toasts to the provider layer.

--- a/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
+++ b/packages/web/src/auth/google/hooks/useConnectGoogle/useConnectGoogle.util.ts
@@ -1,4 +1,8 @@
 import { ArrowsClockwiseIcon, CloudArrowUpIcon } from "@phosphor-icons/react";
+import {
+  type ProviderKind,
+  providerDisplayName,
+} from "@core/types/sync/identity.contracts";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import {
   isAccountReconnectRequired,
@@ -158,13 +162,21 @@ export type GoogleConnectionConfigOptions = {
   // Refresh was requested and the degraded state did not improve — stop
   // offering the same Refresh button; offer reconnect + support instead.
   refreshGaveUp?: boolean;
+  provider?: ProviderKind;
 };
+
+const connectCalendarLabel = (provider: ProviderKind): string =>
+  `Connect ${providerDisplayName(provider)} Calendar`;
+
+const reconnectCalendarLabel = (provider: ProviderKind): string =>
+  `Reconnect ${providerDisplayName(provider)} Calendar`;
 
 export const getGoogleConnectionConfig = (
   state: GoogleUiState,
   handlers: GoogleConnectionHandlers,
   options: GoogleConnectionConfigOptions = {},
 ): GoogleUiConfig => {
+  const provider = options.provider ?? "google";
   switch (state) {
     case "checking":
     case "IMPORTING":
@@ -174,7 +186,7 @@ export const getGoogleConnectionConfig = (
       if (options.refreshGaveUp) {
         return {
           commandAction: {
-            label: "Reconnect Google Calendar",
+            label: reconnectCalendarLabel(provider),
             icon: CONNECT_ICON,
             onSelect: handlers.onConnectGoogle,
           },
@@ -190,7 +202,7 @@ export const getGoogleConnectionConfig = (
     case "NOT_CONNECTED":
       return {
         commandAction: {
-          label: "Connect Google Calendar",
+          label: connectCalendarLabel(provider),
           icon: CONNECT_ICON,
           onSelect: handlers.onConnectGoogle,
         },
@@ -198,13 +210,17 @@ export const getGoogleConnectionConfig = (
     case "RECONNECT_REQUIRED":
       return {
         commandAction: {
-          label: "Reconnect Google Calendar",
+          label: reconnectCalendarLabel(provider),
           icon: CONNECT_ICON,
           onSelect: handlers.onConnectGoogle,
         },
       };
   }
 };
+
+export const calendarReconnectBannerMessage = (
+  provider: ProviderKind,
+): string => `${providerDisplayName(provider)} Calendar needs reconnecting.`;
 
 const delayedSettingsStatus = (
   connection: GoogleSyncConnectionSummary,

--- a/packages/web/src/auth/providers/ConnectProviderChooser.tsx
+++ b/packages/web/src/auth/providers/ConnectProviderChooser.tsx
@@ -1,0 +1,178 @@
+import { CaretDownIcon } from "@phosphor-icons/react";
+import classNames from "classnames";
+import { type FC, useEffect, useId, useRef, useState } from "react";
+import {
+  type ProviderKind,
+  providerDisplayName,
+} from "@core/types/sync/identity.contracts";
+import { openingProviderLabel } from "@web/auth/providers/connection-provider.util";
+import { useAvailableConnectProviders } from "@web/auth/providers/useAvailableConnectProviders";
+import { useConnectProvider } from "@web/auth/providers/useConnectProvider";
+import { focusOnPointerEnter } from "@web/common/utils/focus-on-pointer-enter";
+import { OverlayPanelActionButton } from "@web/components/OverlayPanel/OverlayPanel";
+
+const SIDEBAR_PRIMARY_CLASSNAME =
+  "c-button-compact c-button-primary mb-2 w-full rounded-xs px-2 py-1.5 text-left text-xs";
+
+type ConnectProviderChooserProps = {
+  idleLabel: string;
+  newAccount?: boolean;
+  variant?: "overlay-primary" | "sidebar-primary";
+  showShortcut?: boolean;
+  shortcut?: string;
+  shortcutAttrs?: Record<string, string>;
+};
+
+export const ConnectProviderChooser: FC<ConnectProviderChooserProps> = ({
+  idleLabel,
+  newAccount,
+  variant = "overlay-primary",
+  showShortcut = false,
+  shortcut,
+  shortcutAttrs,
+}) => {
+  const available = useAvailableConnectProviders();
+  const google = useConnectProvider("google", { newAccount });
+  const microsoft = useConnectProvider("microsoft", { newAccount });
+  const apple = useConnectProvider("apple", { newAccount });
+  const byKind: Record<ProviderKind, ReturnType<typeof useConnectProvider>> = {
+    google,
+    microsoft,
+    apple,
+  };
+  const menuId = useId();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const connectingKind = available.find((kind) => byKind[kind].isConnecting);
+  const isConnecting = connectingKind != null;
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onPointerDown = (event: MouseEvent) => {
+      if (
+        rootRef.current &&
+        event.target instanceof Node &&
+        !rootRef.current.contains(event.target)
+      ) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [menuOpen]);
+
+  if (available.length === 0) return null;
+
+  const buttonLabel = isConnecting
+    ? openingProviderLabel(connectingKind ?? "google")
+    : idleLabel;
+
+  const runConnect = (kind: ProviderKind) => {
+    setMenuOpen(false);
+    byKind[kind].connect();
+  };
+
+  if (available.length === 1) {
+    const kind = available[0];
+    const singleLabel = isConnecting
+      ? buttonLabel
+      : (byKind[kind].commandAction?.label ?? idleLabel);
+    if (variant === "sidebar-primary") {
+      return (
+        <button
+          aria-busy={isConnecting || undefined}
+          className={SIDEBAR_PRIMARY_CLASSNAME}
+          disabled={isConnecting}
+          onClick={() => runConnect(kind)}
+          type="button"
+          {...shortcutAttrs}
+        >
+          {singleLabel}
+        </button>
+      );
+    }
+    return (
+      <OverlayPanelActionButton
+        aria-busy={isConnecting || undefined}
+        disabled={isConnecting}
+        onClick={() => runConnect(kind)}
+        shortcut={shortcut}
+        showShortcut={showShortcut}
+        variant="primary"
+        {...shortcutAttrs}
+      >
+        {singleLabel}
+      </OverlayPanelActionButton>
+    );
+  }
+
+  const menu = menuOpen ? (
+    <div
+      className="absolute top-full z-10 mt-1 min-w-full rounded border border-border bg-surface-overlay py-1 shadow-lg"
+      id={menuId}
+      role="menu"
+    >
+      {available.map((kind) => (
+        <button
+          className="c-focus-ring block w-full px-3 py-1.5 text-left text-sm text-text hover:bg-surface-panel"
+          key={kind}
+          onClick={() => runConnect(kind)}
+          onPointerEnter={focusOnPointerEnter}
+          role="menuitem"
+          type="button"
+        >
+          {providerDisplayName(kind)}
+        </button>
+      ))}
+    </div>
+  ) : null;
+
+  if (variant === "sidebar-primary") {
+    return (
+      <div className="relative" ref={rootRef}>
+        <button
+          aria-busy={isConnecting || undefined}
+          aria-controls={menuId}
+          aria-expanded={menuOpen}
+          aria-haspopup="menu"
+          className={classNames(
+            SIDEBAR_PRIMARY_CLASSNAME,
+            "inline-flex items-center gap-1",
+          )}
+          disabled={isConnecting}
+          onClick={() => setMenuOpen((open) => !open)}
+          type="button"
+          {...shortcutAttrs}
+        >
+          {buttonLabel}
+          <CaretDownIcon aria-hidden size={12} />
+        </button>
+        {menu}
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative" ref={rootRef}>
+      <OverlayPanelActionButton
+        aria-busy={isConnecting || undefined}
+        aria-controls={menuId}
+        aria-expanded={menuOpen}
+        aria-haspopup="menu"
+        disabled={isConnecting}
+        onClick={() => setMenuOpen((open) => !open)}
+        shortcut={shortcut}
+        showShortcut={showShortcut}
+        variant="primary"
+        {...shortcutAttrs}
+      >
+        <span className="inline-flex items-center gap-1">
+          {buttonLabel}
+          <CaretDownIcon aria-hidden size={12} />
+        </span>
+      </OverlayPanelActionButton>
+      {menu}
+    </div>
+  );
+};

--- a/packages/web/src/auth/providers/connection-provider.util.ts
+++ b/packages/web/src/auth/providers/connection-provider.util.ts
@@ -1,0 +1,21 @@
+import {
+  type ProviderKind,
+  providerDisplayName,
+} from "@core/types/sync/identity.contracts";
+import { type SyncConnectionSummary } from "@core/types/user.types";
+
+export const ALL_PROVIDER_KINDS: ProviderKind[] = [
+  "google",
+  "microsoft",
+  "apple",
+];
+
+/** Missing `provider` on legacy payloads means Google. */
+export const connectionProviderKind = (
+  connection?: Pick<SyncConnectionSummary, "provider"> | null,
+): ProviderKind => connection?.provider ?? "google";
+
+export const openingProviderLabel = (kind: ProviderKind): string =>
+  kind === "google"
+    ? "Opening Google…"
+    : `Opening ${providerDisplayName(kind)}…`;

--- a/packages/web/src/auth/providers/useAvailableConnectProviders.ts
+++ b/packages/web/src/auth/providers/useAvailableConnectProviders.ts
@@ -1,0 +1,16 @@
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+import { ALL_PROVIDER_KINDS } from "@web/auth/providers/connection-provider.util";
+import { useIsProviderAvailable } from "@web/auth/providers/useIsProviderAvailable";
+
+/** Provider kinds whose connect flow is configured on this deployment. */
+export const useAvailableConnectProviders = (): ProviderKind[] => {
+  const google = useIsProviderAvailable("google", "connect");
+  const microsoft = useIsProviderAvailable("microsoft", "connect");
+  const apple = useIsProviderAvailable("apple", "connect");
+  const ready: Record<ProviderKind, boolean> = {
+    google,
+    microsoft,
+    apple,
+  };
+  return ALL_PROVIDER_KINDS.filter((kind) => ready[kind]);
+};

--- a/packages/web/src/auth/providers/useConnectProvider.ts
+++ b/packages/web/src/auth/providers/useConnectProvider.ts
@@ -182,6 +182,7 @@ export const useConnectProvider = (
       },
       {
         refreshGaveUp: refreshSnapshot.gaveUp,
+        provider: kind,
       },
     ),
     connect: onOpenAuth,

--- a/packages/web/src/auth/state/user-metadata.store.ts
+++ b/packages/web/src/auth/state/user-metadata.store.ts
@@ -3,6 +3,7 @@ import { devtools } from "zustand/middleware";
 import {
   type GoogleConnectionState,
   type GoogleSyncConnectionSummary,
+  type SyncConnectionSummary,
   type UserMetadata,
 } from "@core/types/user.types";
 import { IS_DEV } from "@web/common/constants/env.constants";
@@ -55,16 +56,35 @@ export const userMetadataActions = {
   removeConnection: (connectionId: string) =>
     useUserMetadataStore.setState(
       (state) => {
-        if (!state.current?.google) return state;
+        if (!state.current) return state;
+        const filter = (connections: SyncConnectionSummary[] | undefined) =>
+          (connections ?? []).filter(
+            (connection) => connection.id !== connectionId,
+          );
+        const nextConnections = filter(state.current.connections);
+        const nextGoogleConnections = state.current.google
+          ? filter(state.current.google.connections)
+          : undefined;
+        if (
+          nextConnections === state.current.connections &&
+          nextGoogleConnections === state.current.google?.connections
+        ) {
+          return state;
+        }
         return {
           current: {
             ...state.current,
-            google: {
-              ...state.current.google,
-              connections: (state.current.google.connections ?? []).filter(
-                (connection) => connection.id !== connectionId,
-              ),
-            },
+            ...(state.current.connections
+              ? { connections: nextConnections }
+              : {}),
+            ...(state.current.google
+              ? {
+                  google: {
+                    ...state.current.google,
+                    connections: nextGoogleConnections,
+                  },
+                }
+              : {}),
           },
         };
       },
@@ -101,17 +121,24 @@ export const selectGoogleConnectionState = (
 
 // Stable identity so the selector below never hands the store a fresh array
 // (which would re-render on every state change; see the note above the hook).
-const NO_CONNECTIONS: GoogleSyncConnectionSummary[] = [];
+const NO_CONNECTIONS: SyncConnectionSummary[] = [];
 
 /**
  * Every connected provider account, in connection order. Empty when metadata
- * hasn't loaded, no account is connected, or the payload predates the plural
- * field.
+ * hasn't loaded or no account is connected. Falls back to the legacy
+ * `google.connections` copy until every client reads `connections[]`.
  */
+export const selectSyncConnections = (
+  state: UserMetadataState,
+): SyncConnectionSummary[] =>
+  state.current?.connections ??
+  state.current?.google?.connections ??
+  NO_CONNECTIONS;
+
+/** @deprecated Prefer {@link selectSyncConnections}. */
 export const selectGoogleSyncConnections = (
   state: UserMetadataState,
-): GoogleSyncConnectionSummary[] =>
-  state.current?.google?.connections ?? NO_CONNECTIONS;
+): GoogleSyncConnectionSummary[] => selectSyncConnections(state);
 
 /**
  * True when ANY connected account granted the optional contacts scopes, so
@@ -120,7 +147,7 @@ export const selectGoogleSyncConnections = (
  * backend (field absent) reading as "not granted" rather than crashing.
  */
 export const selectCanSuggestContacts = (state: UserMetadataState): boolean =>
-  (state.current?.google?.connections ?? NO_CONNECTIONS).some(
+  selectSyncConnections(state).some(
     (connection) => connection.canSuggestContacts === true,
   );
 

--- a/packages/web/src/calendars/calendar.util.ts
+++ b/packages/web/src/calendars/calendar.util.ts
@@ -1,5 +1,5 @@
 import { type Calendar } from "@core/types/calendar.contracts";
-import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
+import { type SyncConnectionSummary } from "@core/types/user.types";
 import { isCalendarReconnectRequired } from "@web/auth/google/state/google.reconnect.calendar";
 
 export function getLocalCalendar(calendars: Calendar[]): Calendar | undefined {
@@ -112,7 +112,7 @@ export function spansMultipleAccounts(calendars: Calendar[]): boolean {
 
 export interface AccountGroup {
   accountEmail: string;
-  connection: GoogleSyncConnectionSummary | undefined;
+  connection: SyncConnectionSummary | undefined;
   calendars: Calendar[];
 }
 
@@ -130,7 +130,7 @@ export interface AccountGroup {
  */
 export function groupCalendarsByAccount(
   calendars: Calendar[],
-  connections: GoogleSyncConnectionSummary[],
+  connections: SyncConnectionSummary[],
   compassEmail?: string | null,
 ): { groups: AccountGroup[]; ungrouped: Calendar[] } {
   const groups: AccountGroup[] = [];

--- a/packages/web/src/common/utils/toast/google-reconnect.toast.test.tsx
+++ b/packages/web/src/common/utils/toast/google-reconnect.toast.test.tsx
@@ -3,7 +3,8 @@ import { fireEvent, render, screen, within } from "@testing-library/react";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
 import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
-import * as realConnectGoogle from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
+import * as realConnectProvider from "@web/auth/providers/useConnectProvider";
+import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import {
   isBillingGateOwningScreen,
   resetBillingGateAttentionForTests,
@@ -29,18 +30,12 @@ import { eventJumpActions } from "@web/shortcuts/shift-hint/event-jump.store";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const mockConnect = mock();
-const mockUseConnectGoogle = mock(() => ({ connect: mockConnect }));
+const mockUseConnectProvider = mock(() => ({ connect: mockConnect }));
 
-// useConnectGoogle owns the flush-pending-events -> delegation-fork ->
-// legacy-popup-or-sync-redirect logic (the exact thing that drifted out of
-// sync here before: this toast used to reimplement a legacy-only copy of it
-// directly). Mocking the hook keeps this file testing only what it owns —
-// that a click dismisses the toast and calls connect() — not re-deriving
-// useConnectGoogle's own behavior.
 mockModuleForFile(
-  "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle",
-  realConnectGoogle,
-  { useConnectGoogle: mockUseConnectGoogle },
+  "@web/auth/providers/useConnectProvider",
+  realConnectProvider,
+  { useConnectProvider: mockUseConnectProvider },
 );
 
 describe("GoogleReconnectToast", () => {
@@ -50,8 +45,9 @@ describe("GoogleReconnectToast", () => {
     HotkeyManager.resetInstance();
     document.body.removeAttribute("data-app-locked");
     eventJumpActions.reset();
+    userMetadataActions.clear();
     mockConnect.mockClear();
-    mockUseConnectGoogle.mockClear();
+    mockUseConnectProvider.mockClear();
     mocks.error.mockClear();
     mocks.dismiss.mockClear();
     mocks.isActive.mockReturnValue(false);
@@ -92,6 +88,41 @@ describe("GoogleReconnectToast", () => {
       screen.getByText(
         "This happens when access expires or is revoked. Your events are still safe in Google. Reconnect and Compass will re-import them.",
       ),
+    ).toBeInTheDocument();
+  });
+
+  it("shows Microsoft reconnect copy for a Microsoft connection", () => {
+    userMetadataActions.set({
+      connections: [
+        {
+          id: "conn-1",
+          provider: "microsoft",
+          state: "actionRequired",
+          stateReason: "authorizationRevoked",
+          lastSyncedAt: null,
+          lastHealthyAt: null,
+          accountEmail: "user@outlook.com",
+          connectionState: "RECONNECT_REQUIRED",
+          canSuggestContacts: false,
+        },
+      ],
+    });
+
+    render(
+      <HotkeysProvider>
+        <GoogleReconnectToast
+          accountEmail="user@outlook.com"
+          connectionId="conn-1"
+          toastId="google-revoked-api"
+        />
+      </HotkeysProvider>,
+    );
+
+    expect(
+      screen.getByText("Microsoft Calendar disconnected (user@outlook.com)"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Reconnect Microsoft Calendar" }),
     ).toBeInTheDocument();
   });
 

--- a/packages/web/src/common/utils/toast/google-reconnect.toast.tsx
+++ b/packages/web/src/common/utils/toast/google-reconnect.toast.tsx
@@ -1,10 +1,15 @@
 import { createElement } from "react";
 import { type Id } from "react-toastify";
-import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
-import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
-import { type GoogleReconnectTarget } from "@web/auth/google/state/google.reconnect.state";
 import {
-  selectGoogleSyncConnections,
+  type ProviderKind,
+  providerDisplayName,
+} from "@core/types/sync/identity.contracts";
+import { type SyncConnectionSummary } from "@core/types/user.types";
+import { type GoogleReconnectTarget } from "@web/auth/google/state/google.reconnect.state";
+import { connectionProviderKind } from "@web/auth/providers/connection-provider.util";
+import { useConnectProvider } from "@web/auth/providers/useConnectProvider";
+import {
+  selectSyncConnections,
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
 import {
@@ -47,43 +52,61 @@ interface GoogleReconnectToastProps {
 const toastScopedConnection = (
   connectionId: string | null | undefined,
   accountEmail: string | null | undefined,
-): GoogleSyncConnectionSummary => ({
+  provider: ProviderKind = "google",
+): SyncConnectionSummary => ({
   id: connectionId?.trim() || "reconnect-target",
+  provider,
   state: "actionRequired",
   stateReason: "authorizationRevoked",
   lastSyncedAt: null,
   lastHealthyAt: null,
   accountEmail: accountEmail ?? null,
   connectionState: "RECONNECT_REQUIRED",
-  // A synthetic reconnect target, not a real summary — the credential is
-  // broken, so no capability can be assumed granted.
   canSuggestContacts: false,
 });
 
-// Shown when Google reports invalid_grant, which covers both "access expired"
-// and "user revoked access" with no way to tell them apart, so the copy must
-// stay accurate for either cause. Hooks are fine here: ToastContainer renders
-// inside GoogleOAuthProvider (CompassProvider).
-//
-// Delegates to useConnectGoogle's connect() — the same trigger the command
-// palette uses — rather than driving the OAuth redirect flow directly, so
-// this toast can't drift out of sync with the one place that flow lives.
+const reconnectToastTitle = (
+  provider: ProviderKind,
+  namedAccount?: string,
+): string => {
+  const calendarName = `${providerDisplayName(provider)} Calendar`;
+  return namedAccount
+    ? `${calendarName} disconnected (${namedAccount})`
+    : `${calendarName} disconnected`;
+};
+
+const reconnectToastBody = (
+  provider: ProviderKind,
+  namedAccount?: string,
+): string => {
+  const host = providerDisplayName(provider);
+  if (namedAccount) {
+    return `Access for ${namedAccount} expired or was revoked. Your events are still safe in ${host}. Reconnect and Compass will re-import them.`;
+  }
+  return `This happens when access expires or is revoked. Your events are still safe in ${host}. Reconnect and Compass will re-import them.`;
+};
+
+const reconnectActionLabel = (provider: ProviderKind): string =>
+  `Reconnect ${providerDisplayName(provider)} Calendar`;
+
 export const GoogleReconnectToast = ({
   toastId,
   accountEmail,
   connectionId,
 }: GoogleReconnectToastProps) => {
-  const connections = useUserMetadataStore(selectGoogleSyncConnections);
+  const connections = useUserMetadataStore(selectSyncConnections);
   const connectionFromStore =
     connections.find((entry) => entry.id === connectionId) ??
     connections.find((entry) => entry.accountEmail === accountEmail) ??
     null;
-  // Props keep the target even while metadata is refetching, so Reconnect
-  // still binds OAuth to the broken connectionId instead of adding a new one.
   const connection =
     connectionFromStore ??
     (connectionId ? toastScopedConnection(connectionId, accountEmail) : null);
-  const { connect } = useConnectGoogle(connection ? { connection } : undefined);
+  const provider = connectionProviderKind(connection);
+  const { connect } = useConnectProvider(
+    provider,
+    connection ? { connection } : undefined,
+  );
 
   const handleReconnect = () => {
     getToast().dismiss(toastId);
@@ -95,20 +118,16 @@ export const GoogleReconnectToast = ({
   return (
     <ToastNotice>
       <p className="font-medium text-sm text-text">
-        {namedAccount
-          ? `Google Calendar disconnected (${namedAccount})`
-          : "Google Calendar disconnected"}
+        {reconnectToastTitle(provider, namedAccount || undefined)}
       </p>
       <p className="text-sm text-text">
-        {namedAccount
-          ? `Access for ${namedAccount} expired or was revoked. Your events are still safe in Google. Reconnect and Compass will re-import them.`
-          : "This happens when access expires or is revoked. Your events are still safe in Google. Reconnect and Compass will re-import them."}
+        {reconnectToastBody(provider, namedAccount || undefined)}
       </p>
       <ToastActionButton
         onClick={handleReconnect}
         shortcutKey={CONNECTION_BANNER_SHORTCUT_KEY}
       >
-        Reconnect Google Calendar
+        {reconnectActionLabel(provider)}
       </ToastActionButton>
     </ToastNotice>
   );

--- a/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.test.tsx
+++ b/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.test.tsx
@@ -48,6 +48,23 @@ describe("CalendarConnectionBanner", () => {
     expect(onAction).toHaveBeenCalledTimes(1);
   });
 
+  it("shows Microsoft reconnect copy for a Microsoft connection", () => {
+    const onAction = mock();
+    render(
+      <HotkeysProvider>
+        <CalendarConnectionBanner
+          kind="reconnect"
+          onAction={onAction}
+          provider="microsoft"
+        />
+      </HotkeysProvider>,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Microsoft Calendar needs reconnecting.",
+    );
+  });
+
   it("shows a G keycap and reconnects when G is pressed", () => {
     const onAction = mock();
     renderBanner("reconnect", onAction);

--- a/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.tsx
+++ b/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.tsx
@@ -1,9 +1,14 @@
 import { type FC } from "react";
-import { type CalendarConnectionBannerKind } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+import {
+  type CalendarConnectionBannerKind,
+  calendarReconnectBannerMessage,
+} from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import {
   POINTER_ACTION_ATTRIBUTE,
   POINTER_ACTIONS,
+  POINTER_PROVIDER_ATTRIBUTE,
   pointerShortcutAttributes,
 } from "@web/shortcuts/keyboard-only/pointer-action";
 import {
@@ -11,14 +16,10 @@ import {
   useNoticeActionShortcut,
 } from "@web/shortcuts/notice-focus/useNoticeActionShortcut";
 
-const COPY: Record<
-  CalendarConnectionBannerKind,
+const STATIC_COPY: Record<
+  Exclude<CalendarConnectionBannerKind, "reconnect">,
   { message: string; action: string }
 > = {
-  reconnect: {
-    message: "Google Calendar needs reconnecting.",
-    action: "Reconnect",
-  },
   importFailed: {
     message: "Couldn't add your calendar.",
     action: "Retry",
@@ -32,13 +33,21 @@ const COPY: Record<
 interface CalendarConnectionBannerProps {
   kind: CalendarConnectionBannerKind;
   onAction: () => void;
+  provider?: ProviderKind;
 }
 
 export const CalendarConnectionBanner: FC<CalendarConnectionBannerProps> = ({
   kind,
   onAction,
+  provider = "google",
 }) => {
-  const { message, action } = COPY[kind];
+  const { message, action } =
+    kind === "reconnect"
+      ? {
+          message: calendarReconnectBannerMessage(provider),
+          action: "Reconnect",
+        }
+      : STATIC_COPY[kind];
   const isError = kind === "reconnect" || kind === "importFailed";
   const pointerAction =
     kind === "reconnect" ? POINTER_ACTIONS.reconnectGoogle : undefined;
@@ -62,7 +71,10 @@ export const CalendarConnectionBanner: FC<CalendarConnectionBannerProps> = ({
         type="button"
         {...pointerShortcutAttributes(CONNECTION_BANNER_SHORTCUT_KEY)}
         {...(pointerAction
-          ? { [POINTER_ACTION_ATTRIBUTE]: pointerAction }
+          ? {
+              [POINTER_ACTION_ATTRIBUTE]: pointerAction,
+              [POINTER_PROVIDER_ATTRIBUTE]: provider,
+            }
           : {})}
       >
         {action}

--- a/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBannerGate.tsx
+++ b/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBannerGate.tsx
@@ -1,10 +1,22 @@
 import { type FC } from "react";
-import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import { getCalendarConnectionBannerKind } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
+import { connectionProviderKind } from "@web/auth/providers/connection-provider.util";
+import { useConnectProvider } from "@web/auth/providers/useConnectProvider";
+import {
+  selectPrimaryGoogleSyncConnection,
+  useUserMetadataStore,
+} from "@web/auth/state/user-metadata.store";
 import { CalendarConnectionBanner } from "@web/components/CalendarConnectionBanner/CalendarConnectionBanner";
 
 export const CalendarConnectionBannerGate: FC = () => {
-  const { connect, connection, refresh, state } = useConnectGoogle();
+  const primaryConnection = useUserMetadataStore(
+    selectPrimaryGoogleSyncConnection,
+  );
+  const provider = connectionProviderKind(primaryConnection);
+  const { connect, connection, refresh, state } = useConnectProvider(
+    provider,
+    primaryConnection ? { connection: primaryConnection } : undefined,
+  );
   const kind = getCalendarConnectionBannerKind(state, connection);
   if (!kind) return null;
 
@@ -12,6 +24,7 @@ export const CalendarConnectionBannerGate: FC = () => {
     <CalendarConnectionBanner
       kind={kind}
       onAction={kind === "reconnect" ? connect : () => refresh()}
+      provider={connectionProviderKind(connection)}
     />
   );
 };

--- a/packages/web/src/components/PointerHint/PointerHint.tsx
+++ b/packages/web/src/components/PointerHint/PointerHint.tsx
@@ -1,5 +1,9 @@
 import { X } from "@phosphor-icons/react";
 import { type FC, type ReactNode, useEffect, useState } from "react";
+import {
+  type ProviderKind,
+  providerDisplayName,
+} from "@core/types/sync/identity.contracts";
 import { Z_INDEX_TOOLTIP } from "@web/common/constants/web.constants";
 import IconButton from "@web/components/IconButton/IconButton";
 import {
@@ -123,10 +127,11 @@ const pointerHintMessage = ({
   }
 
   if (attempt?.actionId === POINTER_ACTIONS.reconnectGoogle) {
+    const provider: ProviderKind = attempt.provider ?? "google";
     return (
       <>
-        Press <Key>{CONNECTION_BANNER_SHORTCUT_KEY}</Key> to reconnect Google
-        Calendar.
+        Press <Key>{CONNECTION_BANNER_SHORTCUT_KEY}</Key> to reconnect{" "}
+        {providerDisplayName(provider)} Calendar.
       </>
     );
   }

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -511,7 +511,32 @@ describe("SettingsModal", () => {
 
     const combobox = screen.getByRole("combobox", { name: "Default Calendar" });
     expect(
-      within(combobox).getByRole("group", { name: "ahab@pequod.com" }),
+      within(combobox).getByRole("group", { name: "ahab@pequod.com (Google)" }),
+    ).toBeInTheDocument();
+  });
+
+  it("labels a Microsoft account optgroup with Microsoft provider copy", () => {
+    const work = createMockCalendar({
+      name: "Work",
+      accountEmail: "user@outlook.com",
+    });
+
+    renderSettings({
+      connections: [
+        connection({
+          id: "ms-conn",
+          accountEmail: "user@outlook.com",
+          provider: "microsoft",
+        }),
+      ],
+      calendars: [work],
+    });
+
+    const combobox = screen.getByRole("combobox", { name: "Default Calendar" });
+    expect(
+      within(combobox).getByRole("group", {
+        name: "user@outlook.com (Microsoft)",
+      }),
     ).toBeInTheDocument();
   });
 

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -1,9 +1,9 @@
 import { type FC, Suspense, useEffect, useRef, useState } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
-import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
+import { providerDisplayName } from "@core/types/sync/identity.contracts";
+import { type SyncConnectionSummary } from "@core/types/user.types";
 import { useSession } from "@web/auth/compass/session/useSession";
-import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import {
   formatLastSyncedLabel,
   getGoogleSyncStatus,
@@ -12,8 +12,10 @@ import {
 } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
 import { useDisconnectGoogleAccount } from "@web/auth/google/hooks/useDisconnectGoogleAccount";
 import { useGoogleSyncRefreshSnapshot } from "@web/auth/google/state/google.sync.refresh";
+import { ConnectProviderChooser } from "@web/auth/providers/ConnectProviderChooser";
+import { connectionProviderKind } from "@web/auth/providers/connection-provider.util";
 import {
-  selectGoogleSyncConnections,
+  selectSyncConnections,
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
 import { PlanSection } from "@web/billing/PlanSection";
@@ -131,7 +133,7 @@ export const SettingsModal: FC = () => {
   }, [page]);
 
   const { data } = useCalendarsQuery();
-  const connections = useUserMetadataStore(selectGoogleSyncConnections);
+  const connections = useUserMetadataStore(selectSyncConnections);
   const accountEmailOrder = useConnectedAccountEmails();
   // useDefaultTargetCalendar subscribes to session reconnect overrides, so
   // writableCalendars recomputes when a 410 lands before Sync metadata catches up.
@@ -312,7 +314,7 @@ export const SettingsModal: FC = () => {
 
 interface DefaultCalendarPickerProps {
   calendars: Calendar[];
-  connections: GoogleSyncConnectionSummary[];
+  connections: SyncConnectionSummary[];
   resolvedDefault: Calendar | undefined;
 }
 
@@ -345,7 +347,10 @@ const DefaultCalendarPicker: FC<DefaultCalendarPickerProps> = ({
         {groups
           .filter((group) => group.calendars.length > 0)
           .map((group) => (
-            <optgroup key={group.accountEmail} label={group.accountEmail}>
+            <optgroup
+              key={group.accountEmail}
+              label={`${group.accountEmail} (${providerDisplayName(connectionProviderKind(group.connection))})`}
+            >
               {group.calendars.map((calendar) => (
                 <option key={calendar.id} value={calendar.id}>
                   {calendar.name}
@@ -365,7 +370,7 @@ const DefaultCalendarPicker: FC<DefaultCalendarPickerProps> = ({
 
 interface AccountsSectionProps {
   confirmingId: string | null;
-  connections: GoogleSyncConnectionSummary[];
+  connections: SyncConnectionSummary[];
   resolvedDefault: Calendar | undefined;
   setConfirmingId: (id: string | null) => void;
   showShortcuts: boolean;
@@ -378,9 +383,6 @@ const AccountsSection: FC<AccountsSectionProps> = ({
   setConfirmingId,
   showShortcuts,
 }) => {
-  const { connect, isAvailable, isConnecting } = useConnectGoogle({
-    newAccount: true,
-  });
   const { disconnect, disconnectingId } = useDisconnectGoogleAccount();
 
   return (
@@ -407,27 +409,22 @@ const AccountsSection: FC<AccountsSectionProps> = ({
         )}
       </div>
 
-      {isAvailable ? (
-        <OverlayPanelActions align="start">
-          <OverlayPanelActionButton
-            aria-busy={isConnecting || undefined}
-            disabled={isConnecting}
-            onClick={connect}
-            shortcut="A"
-            showShortcut={showShortcuts}
-            variant="primary"
-            {...settingsShortcutAttrs("add-account")}
-          >
-            {isConnecting ? "Opening Google…" : "Add account"}
-          </OverlayPanelActionButton>
-        </OverlayPanelActions>
-      ) : null}
+      <OverlayPanelActions align="start">
+        <ConnectProviderChooser
+          idleLabel="Add account"
+          newAccount
+          showShortcut={showShortcuts}
+          shortcut="A"
+          shortcutAttrs={settingsShortcutAttrs("add-account")}
+          variant="overlay-primary"
+        />
+      </OverlayPanelActions>
     </div>
   );
 };
 
 interface AccountRowProps {
-  connection: GoogleSyncConnectionSummary;
+  connection: SyncConnectionSummary;
   disconnect: (connectionId: string, accountEmail: string) => Promise<void>;
   isConfirming: boolean;
   isDefault: boolean;

--- a/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
+import { type SyncConnectionSummary } from "@core/types/user.types";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
 import { createMockConnection } from "@web/__tests__/utils/factories/calendar.factory";
 import { type GoogleUiState } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.types";
@@ -10,26 +10,32 @@ import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const EMAIL = "ahab@pequod.com";
 
-// mock.module is process-wide and not reliably restorable, so - as in
-// CalendarList.test.tsx - the real hook is captured up front and a flag
-// (flipped in afterAll) decides which one runs, leaving later files with the
-// real hook. Without a mock here this file would instead inherit whichever
-// other file's useConnectGoogle mock loaded last.
-const actualUseConnectGoogle = (
-  await import("@web/auth/google/hooks/useConnectGoogle/useConnectGoogle")
-).useConnectGoogle;
-let isConnectGoogleMocked = true;
+const actualUseConnectProvider = (
+  await import("@web/auth/providers/useConnectProvider")
+).useConnectProvider;
+let isConnectProviderMocked = true;
 let googleState: GoogleUiState = "HEALTHY";
 const onSelect = mock();
-const commandActionFor = (state: GoogleUiState) =>
+const commandActionFor = (state: GoogleUiState, provider = "google") =>
   state === "RECONNECT_REQUIRED"
-    ? { label: "Reconnect Google Calendar", onSelect }
+    ? {
+        label: `Reconnect ${provider === "google" ? "Google" : "Microsoft"} Calendar`,
+        onSelect,
+      }
     : null;
-mock.module("@web/auth/google/hooks/useConnectGoogle/useConnectGoogle", () => ({
-  useConnectGoogle: (...args: Parameters<typeof actualUseConnectGoogle>) =>
-    isConnectGoogleMocked
+mock.module("@web/auth/providers/useConnectProvider", () => ({
+  useConnectProvider: (
+    kind: "google" | "microsoft" | "apple",
+    ...args: Parameters<typeof actualUseConnectProvider> extends [
+      infer _K,
+      ...infer Rest,
+    ]
+      ? Rest
+      : never
+  ) =>
+    isConnectProviderMocked
       ? {
-          commandAction: commandActionFor(googleState),
+          commandAction: commandActionFor(googleState, kind),
           connect: mock(),
           refresh: mock(),
           isAvailable: true,
@@ -37,11 +43,11 @@ mock.module("@web/auth/google/hooks/useConnectGoogle/useConnectGoogle", () => ({
           isRefreshing: false,
           state: googleState,
         }
-      : actualUseConnectGoogle(...args),
+      : actualUseConnectProvider(kind, ...args),
 }));
 
 afterAll(() => {
-  isConnectGoogleMocked = false;
+  isConnectProviderMocked = false;
 });
 
 const headerModuleUrl = new URL(
@@ -52,9 +58,7 @@ const { AccountSectionHeader } = (await import(
   headerModuleUrl.href
 )) as typeof import("./AccountSectionHeader");
 
-const renderHeader = (
-  overrides: Partial<GoogleSyncConnectionSummary> = {},
-): void => {
+const renderHeader = (overrides: Partial<SyncConnectionSummary> = {}): void => {
   const { wrapper } = createStoreWrapper();
   render(
     <AccountSectionHeader
@@ -117,15 +121,30 @@ describe("AccountSectionHeader", () => {
       connectionState: "RECONNECT_REQUIRED",
     });
 
-    // The status text itself now lives in the pinned SidebarStatusBar, not
-    // inline here - see SidebarStatusBar.test.tsx.
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
 
-    // Named per account, so two broken accounts give a screen reader two
-    // distinguishable buttons.
     await user.click(
       screen.getByRole("button", {
         name: `Reconnect Google Calendar for ${EMAIL}`,
+      }),
+    );
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows Microsoft reconnect copy for a Microsoft connection", async () => {
+    const user = userEvent.setup({ delay: null });
+    googleState = "RECONNECT_REQUIRED";
+
+    renderHeader({
+      provider: "microsoft",
+      state: "actionRequired",
+      stateReason: "authorizationRevoked",
+      connectionState: "RECONNECT_REQUIRED",
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: `Reconnect Microsoft Calendar for ${EMAIL}`,
       }),
     );
     expect(onSelect).toHaveBeenCalledTimes(1);

--- a/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.tsx
@@ -1,7 +1,7 @@
 import { CaretDownIcon } from "@phosphor-icons/react";
 import classNames from "classnames";
 import { type FC } from "react";
-import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
+import { type SyncConnectionSummary } from "@core/types/user.types";
 import {
   accountCalendarListId,
   toggleAccountCollapsed,
@@ -22,7 +22,7 @@ import { useAccountHeaderStatus } from "./useAccountHeaderStatus";
  */
 export const AccountSectionHeader: FC<{
   accountEmail: string;
-  connection: GoogleSyncConnectionSummary | undefined;
+  connection: SyncConnectionSummary | undefined;
 }> = ({ accountEmail, connection }) => {
   const {
     actionLabel,

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
@@ -3,9 +3,9 @@ import { type Calendar } from "@core/types/calendar.contracts";
 import { shouldShowContextualLoadError } from "@web/api/util/api.util";
 import { useSession } from "@web/auth/compass/session/useSession";
 import { useUser } from "@web/auth/compass/user/hooks/useUser";
-import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
+import { useAvailableConnectProviders } from "@web/auth/providers/useAvailableConnectProviders";
 import {
-  selectGoogleSyncConnections,
+  selectSyncConnections,
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
@@ -30,11 +30,11 @@ import { CalendarListHeader } from "./CalendarListHeader";
 export const CalendarList: FC = () => {
   const { authenticated } = useSession();
   const { email } = useUser();
-  const { isAvailable, state } = useConnectGoogle();
+  const availableProviders = useAvailableConnectProviders();
+  const connections = useUserMetadataStore(selectSyncConnections);
   const { data, error, isPending, isError, refetch } = useCalendarsQuery();
   const { toggleCalendarVisibility, failureAnnouncement } =
     useCalendarVisibility();
-  const connections = useUserMetadataStore(selectGoogleSyncConnections);
   const accountEmailOrder = useConnectedAccountEmails();
   const collapsedKeys = useCollapsedAccountKeys();
 
@@ -103,8 +103,10 @@ export const CalendarList: FC = () => {
         </div>
       ) : calendars.length === 0 && groups.length === 0 ? (
         <p className="text-text-muted text-xs">
-          {authenticated && state === "NOT_CONNECTED" && isAvailable
-            ? "Connect Google to see your calendars."
+          {authenticated &&
+          connections.length === 0 &&
+          availableProviders.length > 0
+            ? "Connect a calendar provider to see your calendars."
             : "No calendars yet."}
         </p>
       ) : (

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
@@ -5,8 +5,9 @@ import userEvent from "@testing-library/user-event";
 import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
 import * as realAuthStateUtil from "@web/auth/compass/state/auth.state.util";
 import * as realUserHook from "@web/auth/compass/user/hooks/useUser";
-import * as realConnectGoogle from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
 import { type GoogleUiState } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.types";
+import * as realAvailableProviders from "@web/auth/providers/useAvailableConnectProviders";
+import * as realConnectProvider from "@web/auth/providers/useConnectProvider";
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import * as realAuthModal from "@web/components/AuthModal/hooks/useAuthModal";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
@@ -15,30 +16,31 @@ const mockOpenModal = mock();
 let mockEmail: string | undefined;
 let mockGoogleState: GoogleUiState = "NOT_CONNECTED";
 let mockIsAnonymousDirty = false;
-const mockConnectGoogle = mock();
+let mockIsConnecting = false;
+let mockIsRefreshing = false;
+const mockConnect = mock();
 const googleCommandActionFor = (state: GoogleUiState) => {
   switch (state) {
     case "NOT_CONNECTED":
-      return { label: "Connect Google Calendar", onSelect: mockConnectGoogle };
+      return { label: "Connect Google Calendar", onSelect: mockConnect };
     case "RECONNECT_REQUIRED":
       return {
         label: "Reconnect Google Calendar",
-        onSelect: mockConnectGoogle,
+        onSelect: mockConnect,
       };
     case "ATTENTION":
-      return { label: "Refresh calendar", onSelect: mockConnectGoogle };
+      return { label: "Refresh calendar", onSelect: mockConnect };
     default:
       return null;
   }
 };
-let mockIsConnecting = false;
-let mockIsRefreshing = false;
-const mockUseConnectGoogle = mock(() => ({
+const mockUseConnectProvider = mock(() => ({
   state: mockGoogleState,
   isAvailable: true,
   isConnecting: mockIsConnecting,
   isRefreshing: mockIsRefreshing,
   commandAction: googleCommandActionFor(mockGoogleState),
+  connect: mockConnect,
 }));
 
 mockModuleForFile(
@@ -55,9 +57,15 @@ mockModuleForFile("@web/auth/compass/user/hooks/useUser", realUserHook, {
 });
 
 mockModuleForFile(
-  "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle",
-  realConnectGoogle,
-  { useConnectGoogle: mockUseConnectGoogle },
+  "@web/auth/providers/useConnectProvider",
+  realConnectProvider,
+  { useConnectProvider: mockUseConnectProvider },
+);
+
+mockModuleForFile(
+  "@web/auth/providers/useAvailableConnectProviders",
+  realAvailableProviders,
+  { useAvailableConnectProviders: () => ["google"] as const },
 );
 
 mockModuleForFile(
@@ -96,8 +104,8 @@ describe("CalendarListHeader", () => {
     mockIsRefreshing = false;
     mockIsAnonymousDirty = false;
     mockOpenModal.mockClear();
-    mockUseConnectGoogle.mockClear();
-    mockConnectGoogle.mockClear();
+    mockUseConnectProvider.mockClear();
+    mockConnect.mockClear();
     userMetadataActions.clear();
   });
 
@@ -115,7 +123,7 @@ describe("CalendarListHeader", () => {
       name: "Connect Google Calendar",
     });
     await user.click(connectButton);
-    expect(mockConnectGoogle).toHaveBeenCalledTimes(1);
+    expect(mockConnect).toHaveBeenCalledTimes(1);
   });
 
   it("stays quiet (no status line) when Google is healthy, to cut sidebar noise", async () => {
@@ -169,7 +177,7 @@ describe("CalendarListHeader", () => {
       name: "Refresh calendar",
     });
     await user.click(syncButton);
-    expect(mockConnectGoogle).toHaveBeenCalledTimes(1);
+    expect(mockConnect).toHaveBeenCalledTimes(1);
   });
 
   it("shows a reconnect Google button when reconnect is required", async () => {
@@ -189,7 +197,7 @@ describe("CalendarListHeader", () => {
     expect(reconnectButton).toBeEnabled();
     expect(reconnectButton).not.toHaveAttribute("aria-busy");
     await user.click(reconnectButton);
-    expect(mockConnectGoogle).toHaveBeenCalledTimes(1);
+    expect(mockConnect).toHaveBeenCalledTimes(1);
   });
 
   it("shows an immediate reconnecting state while Google OAuth is starting", () => {
@@ -217,7 +225,7 @@ describe("CalendarListHeader", () => {
     renderHeader();
 
     const connectButton = screen.getByRole("button", {
-      name: "Connecting…",
+      name: "Opening Google…",
     });
     expect(connectButton).toBeDisabled();
     expect(connectButton).toHaveAttribute("aria-busy", "true");
@@ -302,7 +310,7 @@ describe("CalendarListHeader", () => {
 
     renderHeader();
 
-    expect(mockUseConnectGoogle).toHaveBeenCalledWith({
+    expect(mockUseConnectProvider).toHaveBeenCalledWith("google", {
       connection: ownConnection,
     });
   });

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx
@@ -1,8 +1,10 @@
 import classNames from "classnames";
 import { type FC, useMemo } from "react";
 import { useUser } from "@web/auth/compass/user/hooks/useUser";
+import { ConnectProviderChooser } from "@web/auth/providers/ConnectProviderChooser";
+import { useAvailableConnectProviders } from "@web/auth/providers/useAvailableConnectProviders";
 import {
-  selectGoogleSyncConnections,
+  selectSyncConnections,
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
 import { useAccountHeaderStatus } from "./useAccountHeaderStatus";
@@ -10,7 +12,7 @@ import { useAccountHeaderStatus } from "./useAccountHeaderStatus";
 const HEADING_CLASSNAME =
   "flex min-w-0 flex-1 font-semibold text-sm leading-none";
 
-const CONNECT_GOOGLE_BUTTON_CLASSNAME =
+const CONNECT_ACTION_BUTTON_CLASSNAME =
   "c-button-compact c-button-primary mb-2 w-full rounded-xs px-2 py-1.5 text-left text-xs";
 
 /**
@@ -36,7 +38,8 @@ const CalendarListHeaderContent: FC<{ email: string }> = ({ email }) => {
   // second account's problem flashes under the first account's name for as
   // long as that gap lasts (2026-08-04, caught disconnecting one of two live
   // accounts).
-  const connections = useUserMetadataStore(selectGoogleSyncConnections);
+  const connections = useUserMetadataStore(selectSyncConnections);
+  const availableProviders = useAvailableConnectProviders();
   const ownConnection = useMemo(
     () => connections.find((c) => c.accountEmail === email) ?? null,
     [connections, email],
@@ -47,8 +50,12 @@ const CalendarListHeaderContent: FC<{ email: string }> = ({ email }) => {
     isAvailable,
     isConnecting,
     isRefreshing,
+    state,
     syncStatus,
   } = useAccountHeaderStatus(ownConnection);
+
+  const showChooser =
+    state === "NOT_CONNECTED" && availableProviders.length > 0;
 
   return (
     <>
@@ -65,10 +72,15 @@ const CalendarListHeaderContent: FC<{ email: string }> = ({ email }) => {
           {email}
         </span>
       </h2>
-      {isAvailable && commandAction != null && actionLabel != null ? (
+      {showChooser ? (
+        <ConnectProviderChooser
+          idleLabel={commandAction?.label ?? "Connect calendar"}
+          variant="sidebar-primary"
+        />
+      ) : isAvailable && commandAction != null && actionLabel != null ? (
         <button
           aria-busy={isConnecting || isRefreshing || undefined}
-          className={CONNECT_GOOGLE_BUTTON_CLASSNAME}
+          className={CONNECT_ACTION_BUTTON_CLASSNAME}
           disabled={isConnecting || isRefreshing}
           onClick={commandAction.onSelect}
           type="button"

--- a/packages/web/src/components/Sidebar/CalendarList/useAccountHeaderStatus.ts
+++ b/packages/web/src/components/Sidebar/CalendarList/useAccountHeaderStatus.ts
@@ -1,16 +1,18 @@
-import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
-import { useConnectGoogle } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle";
+import { type SyncConnectionSummary } from "@core/types/user.types";
 import { getSidebarSyncStatus } from "@web/auth/google/hooks/useConnectGoogle/useConnectGoogle.util";
+import { connectionProviderKind } from "@web/auth/providers/connection-provider.util";
+import { useConnectProvider } from "@web/auth/providers/useConnectProvider";
 
 /**
  * Shared by AccountSectionHeader and CalendarListHeader: this account's sync
  * status plus the label for its connect/reconnect/refresh action, if any.
  */
 export function useAccountHeaderStatus(
-  connection: GoogleSyncConnectionSummary | null | undefined,
+  connection: SyncConnectionSummary | null | undefined,
 ) {
+  const provider = connectionProviderKind(connection);
   const { commandAction, isAvailable, isConnecting, isRefreshing, state } =
-    useConnectGoogle({ connection });
+    useConnectProvider(provider, { connection });
   const syncStatus = getSidebarSyncStatus({ connection, isConnecting, state });
   const actionLabel =
     commandAction == null
@@ -30,5 +32,6 @@ export function useAccountHeaderStatus(
     isConnecting,
     isRefreshing,
     syncStatus,
+    state,
   };
 }

--- a/packages/web/src/shortcuts/keyboard-only/pointer-action.ts
+++ b/packages/web/src/shortcuts/keyboard-only/pointer-action.ts
@@ -1,4 +1,8 @@
 import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
+import {
+  type ProviderKind,
+  ProviderKindSchema,
+} from "@core/types/sync/identity.contracts";
 import dayjs from "@core/util/date/dayjs";
 import {
   DATA_TIMED_GRID_ROW,
@@ -15,6 +19,7 @@ import { getEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 export const POINTER_ACTION_ATTRIBUTE = "data-pointer-action";
 export const POINTER_EVENT_ID_ATTRIBUTE = "data-pointer-event-id";
 export const POINTER_SHORTCUT_ATTRIBUTE = "data-pointer-shortcut";
+export const POINTER_PROVIDER_ATTRIBUTE = "data-pointer-provider";
 /** Opt a subtree out of capture-phase pointer suppression (MobileGate). */
 export const POINTER_PASS_ATTRIBUTE = "data-pointer-pass";
 export const POINTER_EVENT_JUMP_REQUEST = "compass:pointer-event-jump";
@@ -43,6 +48,7 @@ export type BlockedPointerAttempt = {
   gridDate?: string;
   gridTimeKey?: string;
   gridTimeLabel?: string;
+  provider?: ProviderKind;
 };
 
 const POINTER_ACTION_IDS = new Set<string>(Object.values(POINTER_ACTIONS));
@@ -56,6 +62,7 @@ export const resolveBlockedPointerAttempt = (
   let actionId: PointerActionId | "unknown" = "unknown";
   let eventId: string | undefined;
   let shortcutKey: PointerShortcutKey | undefined;
+  let provider: ProviderKind | undefined;
 
   for (const target of path) {
     if (!(target instanceof HTMLElement)) continue;
@@ -64,6 +71,11 @@ export const resolveBlockedPointerAttempt = (
       if (action && isPointerActionId(action)) {
         actionId = action;
         eventId = target.getAttribute(POINTER_EVENT_ID_ATTRIBUTE) ?? undefined;
+        const providerRaw = target.getAttribute(POINTER_PROVIDER_ATTRIBUTE);
+        const providerResult = ProviderKindSchema.safeParse(providerRaw);
+        if (providerResult.success) {
+          provider = providerResult.data;
+        }
       }
     }
     if (shortcutKey === undefined) {
@@ -77,6 +89,7 @@ export const resolveBlockedPointerAttempt = (
     actionId,
     ...(eventId ? { eventId } : {}),
     ...(shortcutKey ? { shortcutKey } : {}),
+    ...(provider ? { provider } : {}),
   };
 };
 


### PR DESCRIPTION
Fixes #3232

## What and why

First consumer batch for the provider-neutral web layer (WP-08b). Settings, sidebar headers, connection banners, pointer hints, and reconnect toasts now read `metadata.connections[]` and name the affected provider. Google copy stays byte-identical when the provider is Google. Add-account flows use a provider chooser when more than one connect-capable provider is available.

Spec: [docs/features/calendar-providers.md](https://github.com/KeepSoftwareSimple/compass-calendar/blob/main/docs/features/calendar-providers.md)

## Verify

```
bun run verify --strict
```

Selected packages: web
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)

VERDICT: PASS