### PR TITLE
fix(sync): keep legacy credentials usable without encryption key

### DIFF
--- a/packages/sync/src/credentials/credential-custody.service.db.test.ts
+++ b/packages/sync/src/credentials/credential-custody.service.db.test.ts
@@ -385,6 +385,41 @@ describe("CredentialCustody", () => {
     expect(adapter.refreshCalls).toBe(1);
   });
 
+  it("keeps legacy plaintext credentials usable when encryption is not configured", async () => {
+    const connectionId = objectId() as ConnectionId;
+    const adapter = new FakeAdapter({
+      refreshed: {
+        accessToken: "fresh-token",
+        expiresAt: new Date("2026-01-01T01:00:00Z"),
+        grantedScopes: [],
+      },
+    });
+    const custody = new CredentialCustody(repo, () => adapter, fixedNow);
+    await db.collection(SYNC_COLLECTIONS.credentials).insertOne({
+      _id: connectionId,
+      credentialKind: "oauthRefresh",
+      provider: "google",
+      refreshToken: "legacy-plaintext-token",
+      accessToken: null,
+      accessTokenExpiresAt: null,
+      refreshFailureCount: 0,
+      scopes: ["https://www.googleapis.com/auth/calendar.events"],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await expect(custody.getValidAccessToken(connectionId)).resolves.toBe(
+      "fresh-token",
+    );
+
+    const raw = await db
+      .collection(SYNC_COLLECTIONS.credentials)
+      .findOne({ _id: connectionId });
+    expect(raw?.refreshToken).toBe("legacy-plaintext-token");
+    expect(raw).not.toHaveProperty("refreshTokenCiphertext");
+    expect(adapter.refreshCalls).toBe(1);
+  });
+
   it("deletes the credential and revokes it on disconnect", async () => {
     const connectionId = objectId() as ConnectionId;
     const adapter = new FakeAdapter();

--- a/packages/sync/src/credentials/credential-custody.service.ts
+++ b/packages/sync/src/credentials/credential-custody.service.ts
@@ -122,7 +122,7 @@ export class CredentialCustody {
     await this.credentials.deleteByConnection(connectionId);
     if (credential && !isPasswordCredential(credential)) {
       await this.resolveAuth(credential.provider).revoke({
-        token: openOauthRefreshToken(this.#requireAtRestKey(), credential),
+        token: openOauthRefreshToken(this.#credentialEncryptionKey, credential),
       });
     }
   }
@@ -163,7 +163,7 @@ export class CredentialCustody {
     }
 
     const refreshToken = openOauthRefreshToken(
-      this.#requireAtRestKey(),
+      this.#credentialEncryptionKey,
       credential,
     );
 
@@ -214,9 +214,9 @@ export class CredentialCustody {
         "Credential was removed during refresh",
       );
     }
-    if (isPlaintextOauthRefresh(credential)) {
+    if (isPlaintextOauthRefresh(credential) && this.#credentialEncryptionKey) {
       const sealed = sealOauthRefreshToken(
-        this.#requireAtRestKey(),
+        this.#credentialEncryptionKey,
         refreshToken,
       );
       await this.credentials.reencryptOauthRefresh(credential._id, {

--- a/packages/sync/src/credentials/oauth-refresh-at-rest.ts
+++ b/packages/sync/src/credentials/oauth-refresh-at-rest.ts
@@ -15,7 +15,7 @@ export function sealOauthRefreshToken(
 }
 
 export function openOauthRefreshToken(
-  keyBase64: string,
+  keyBase64: string | null,
   record: OauthRefreshCredentialRecord,
 ): string {
   if (record.refreshToken) {
@@ -27,6 +27,11 @@ export function openOauthRefreshToken(
     record.refreshTokenTag &&
     record.keyVersion
   ) {
+    if (!keyBase64) {
+      throw new Error(
+        "stored credentials require sync.credentialEncryptionKey",
+      );
+    }
     return decryptCredentialAtRest(keyBase64, {
       ciphertext: record.refreshTokenCiphertext,
       iv: record.refreshTokenIv,


### PR DESCRIPTION
Fixes #3369
Fixes #3370
Fixes #3379

## What and why

The OAuth encryption rollout made credential custody demand `sync.credentialEncryptionKey` before it checked whether an existing OAuth row still held its legacy plaintext refresh token. Environments rolling through the documented lazy migration therefore sent healthy Google sync jobs through the retry ladder and into PostHog. Read and revoke paths now accept those legacy rows without a key, retain plaintext until a key is configured, and continue to require the key for encrypted rows and all new credential writes.

## Verify

VERDICT: PASS

- `mise exec bun@1.3.14 -- bun run verify --strict`
- `mise exec bun@1.3.14 -- bun test:sync -- packages/sync/src/credentials/credential-custody.service.db.test.ts`
- `mise exec bun@1.3.14 -- bun type-check`
- `mise exec bun@1.3.14 -- bun lint`
- `git diff --check`
