### PR TITLE
feat(booking): enable on any healthy writable destination

### DIFF
--- a/.agents/handoffs/3235.md
+++ b/.agents/handoffs/3235.md
@@ -15,7 +15,7 @@ artifact:
   - path: docs/features/booking.md
 evidence:
   - command: bun run verify --strict
-    result: pending
+    result: "VERDICT: PASS (test:core, test:web, test:backend, type-check, lint, knip, test:a11y, test:e2e)"
 assumptions:
   - "GOOGLE_NOT_CONNECTED stays in the booking error enum as a one-release wire alias; the service throws CALENDAR_NOT_CONNECTED."
   - "conference is derived from CONFERENCE_BY_PROVIDER plus createsGoogleMeet; no provider === name branches."

--- a/.agents/handoffs/3235.md
+++ b/.agents/handoffs/3235.md
@@ -1,0 +1,32 @@
+---
+schema_version: 1
+task_id: "3235"
+from: Implementer
+to: GitHub
+owner: GitHub
+status: verifying
+artifact:
+  - path: packages/backend/src/booking/services/booking-page.service.ts
+  - path: packages/backend/src/booking/booking.error.ts
+  - path: packages/core/src/types/calendar.contracts.ts
+  - path: packages/core/src/types/booking.contracts.ts
+  - path: packages/web/src/booking/booking-conference.copy.ts
+  - path: packages/web/src/booking/BookingSettingsSection.tsx
+  - path: docs/features/booking.md
+evidence:
+  - command: bun run verify --strict
+    result: pending
+assumptions:
+  - "GOOGLE_NOT_CONNECTED stays in the booking error enum as a one-release wire alias; the service throws CALENDAR_NOT_CONNECTED."
+  - "conference is derived from CONFERENCE_BY_PROVIDER plus createsGoogleMeet; no provider === name branches."
+  - "Empty booking settings still show the Google connect prompt; the enable gate accepts any HEALTHY connection."
+open_risks: []
+next_deadline: 2026-09-05T12:00:00Z
+retry: 0
+approval: allow
+waiting_on: null
+escalation: null
+---
+
+P0 WP-10: booking enables on any healthy writable destination and names the
+conference kind (meet, teams, none).

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -83,10 +83,10 @@ appointment types are a later collection, not a v1 field.
 
 ### Host
 
-The host must be an authenticated, Google-connected, writable Compass
-user. Anonymous IndexedDB users do not get a booking link.
-Password-only users see a connect-Google prompt in Settings, not a
-broken public page.
+The host must be an authenticated Compass user with a healthy,
+writable calendar connection. Anonymous IndexedDB users do not get a
+booking link. Password-only users see a connect-Google prompt in
+Settings, not a broken public page.
 
 Host administration lives in Settings as a Booking page
 (`SettingsPage` includes `"booking"` in
@@ -177,12 +177,13 @@ holds the app lock first.
 
 ### Outcome
 
-On confirm, Compass creates a timed Google Calendar event on the
-host's destination calendar, invites the guest, auto-adds a Google
-Meet link, and Google emails the invite. Compass shows a confirmation
-screen with the booked time (guest timezone). Cancel and edit-details
-are present when the permalink carries `?token=`. Reschedule links stay
-history state only (v1.3).
+On confirm, Compass creates a timed event on the host's destination
+calendar, invites the guest, and adds a conference link when the
+destination supports one (Google Meet, Microsoft Teams, or none). The
+provider emails the invite. Compass shows a confirmation screen with the
+booked time (guest timezone) and names that conference kind. Cancel and
+edit-details are present when the permalink carries `?token=`.
+Reschedule links stay history state only (v1.3).
 
 **Event title:** `{Guest name} and {Host name}`.
 
@@ -199,7 +200,7 @@ One booking-page record per user.
 | Input | v1 rule |
 | --- | --- |
 | Duration | `15` / `30` / `45` / `60` minutes. Default `30`. Custom minutes later. |
-| Destination calendar | Writable Google calendar (`canWrite`). Receives the created event. |
+| Destination calendar | Writable calendar (`canWriteEvents`) on a healthy connection. Receives the created event. |
 | Blocking calendars | Calendars whose busy intervals occupy slots. Any calendar the host can read availability for, including `freeBusyReader`. Default: every imported calendar on the destination account. |
 | General availability | Weekly intervals in the **host booking timezone**. Empty weekday = unavailable. Default timezone: the timezone currently in the host's calendar view when they first enable booking, not UTC. An unconfigured admin GET uses the host's primary calendar timezone. |
 | Welcome text | Optional host-authored line (max 500 characters) shown under the public name. |
@@ -341,7 +342,8 @@ flowchart LR
 - Confirm path: compute slots from availability + busy; on submit,
   re-query Sync with `purpose: "booking_confirmation"`, then
   `Calendar.createEvent` with the guest as attendee, `invitation: "all"`,
-  Meet create-request, and `guestsCanInviteOthers` from the page setting.
+  `createConference: true` when the destination conference is not
+  `none`, and `guestsCanInviteOthers` from the page setting.
   A race on the same slot: the second confirm fails; no double event.
   Reschedule re-queries the same way, PATCHes the existing event
   (`invitation: "all"`, `attendeesEdit: "preserve"`), and keeps
@@ -393,7 +395,8 @@ Authenticated (host session + writable billing, same as event writes):
 - `GET /api/booking/page` — host page, including slug and copyable URL.
 - `PUT /api/booking/page` — replace settings. Allocates slug on first
   enable.
-- Enabling without a healthy Google connection is a typed `403`.
+- Enabling without a healthy calendar connection is a typed `403`
+  (`CALENDAR_NOT_CONNECTED`; `GOOGLE_NOT_CONNECTED` remains an alias).
 
 ## Out of v1 / v1.1
 
@@ -409,7 +412,6 @@ Guest reschedule is **in scope for v1.3**, not v1 / v1.1.
 - Standalone booking brand, domain, or deployable
 - Production billing packaging specific to booking (uses the existing
   calendar write gate)
-- Non-Google destination calendars
 - Flipping the production gate
 - Host reservation inbox
 - Meet URL on the confirmation screen (Google creates conference

--- a/packages/backend/src/booking/booking.error.test.ts
+++ b/packages/backend/src/booking/booking.error.test.ts
@@ -18,6 +18,25 @@ describe("toBookingErrorResponse", () => {
     });
   });
 
+  it("maps both calendar-not-connected codes to forbidden", () => {
+    const next = toBookingErrorResponse(
+      bookingError(
+        "CALENDAR_NOT_CONNECTED",
+        "Connect a healthy calendar account before enabling booking",
+      ),
+    );
+    const alias = toBookingErrorResponse(
+      bookingError(
+        "GOOGLE_NOT_CONNECTED",
+        "Connect a healthy Google account before enabling booking",
+      ),
+    );
+    expect(next.status).toBe(Status.FORBIDDEN);
+    expect(next.body.code).toBe("CALENDAR_NOT_CONNECTED");
+    expect(alias.status).toBe(Status.FORBIDDEN);
+    expect(alias.body.code).toBe("GOOGLE_NOT_CONNECTED");
+  });
+
   it("returns a generic message for ZodError without leaking issue paths", () => {
     const result = z
       .strictObject({ cancelTokenHash: z.string() })

--- a/packages/backend/src/booking/booking.error.ts
+++ b/packages/backend/src/booking/booking.error.ts
@@ -6,6 +6,7 @@ import { Logger } from "@core/logger/winston.logger";
 const logger = Logger("app:booking.error");
 
 export const BookingErrorCodeSchema = z.enum([
+  "CALENDAR_NOT_CONNECTED",
   "GOOGLE_NOT_CONNECTED",
   "DESTINATION_NOT_WRITABLE",
   "TIMEZONE_REQUIRED",
@@ -20,6 +21,7 @@ export const BookingErrorCodeSchema = z.enum([
 export type BookingErrorCode = z.infer<typeof BookingErrorCodeSchema>;
 
 const STATUS_BY_CODE: Record<BookingErrorCode, Status> = {
+  CALENDAR_NOT_CONNECTED: Status.FORBIDDEN,
   GOOGLE_NOT_CONNECTED: Status.FORBIDDEN,
   DESTINATION_NOT_WRITABLE: Status.FORBIDDEN,
   TIMEZONE_REQUIRED: Status.BAD_REQUEST,

--- a/packages/backend/src/booking/services/booking-page.service.db.test.ts
+++ b/packages/backend/src/booking/services/booking-page.service.db.test.ts
@@ -118,23 +118,29 @@ describe("BookingPageService", () => {
 
   const mockHealthySync = (
     calendars: ReturnType<typeof writableCalendar>[],
+    connection: ReturnType<typeof healthyConnection> = healthyConnection(),
   ) => {
+    const wired = calendars.map((calendar) => ({
+      ...calendar,
+      connectionId: connection.id,
+    }));
     syncSpies.push(
       spyOn(syncServiceFactory, "getSyncServiceClient").mockReturnValue({
         listConnections: mock(() =>
           Promise.resolve({
             ok: true as const,
-            value: { connections: [healthyConnection()] },
+            value: { connections: [connection] },
           }),
         ),
         listCalendars: mock(() =>
           Promise.resolve({
             ok: true as const,
-            value: { calendars },
+            value: { calendars: wired },
           }),
         ),
       } as never),
     );
+    return { connection, calendars: wired };
   };
 
   it("returns defaults on GET before any PUT without inserting a row", async () => {
@@ -316,7 +322,7 @@ describe("BookingPageService", () => {
     expect("slug" in secondPage && secondPage.slug).toBe("week3");
   });
 
-  it("rejects enable without a healthy Google connection", async () => {
+  it("rejects enable without a healthy calendar connection", async () => {
     const { user } = await UtilDriver.setupTestUser();
     syncSpies.push(
       spyOn(syncServiceFactory, "getSyncServiceClient").mockReturnValue({
@@ -335,8 +341,31 @@ describe("BookingPageService", () => {
     await expect(
       bookingPageService.putAdminPage(user._id, samplePutInput()),
     ).rejects.toMatchObject({
-      bookingCode: "GOOGLE_NOT_CONNECTED",
+      bookingCode: "CALENDAR_NOT_CONNECTED",
     });
+  });
+
+  it("enables with a healthy Microsoft connection and a writable destination", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const connection = {
+      ...healthyConnection(),
+      provider: "microsoft" as const,
+    };
+    const calendar = writableCalendar();
+    mockHealthySync([calendar], connection);
+    const input = samplePutInput({
+      destinationCalendarId: calendar.id,
+      blockingCalendarIds: [calendar.id],
+    });
+
+    const saved = await bookingPageService.putAdminPage(user._id, input);
+
+    expect(saved).toEqual(
+      expect.objectContaining({
+        enabled: true,
+        destinationCalendarId: calendar.id,
+      }),
+    );
   });
 
   it("rejects enable when billing forbids writes", async () => {

--- a/packages/backend/src/booking/services/booking-page.service.ts
+++ b/packages/backend/src/booking/services/booking-page.service.ts
@@ -18,9 +18,12 @@ import {
 import { bookingPageRepository } from "@backend/booking/booking-page.repository";
 import calendarService from "@backend/calendar/services/calendar.service";
 import mongoService from "@backend/common/services/mongo.service";
-import { resolveGoogleConnectionFromSync } from "@backend/common/services/sync-service/google-connection-status";
 import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
 import { throwSyncProxyFailure } from "@backend/common/services/sync-service/sync-proxy-error";
+import {
+  type SyncPrincipal,
+  type SyncServiceClient,
+} from "@backend/common/services/sync-service/sync-service.client";
 import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
 
 const SLUG_ALLOCATION_MAX_ATTEMPTS = 8;
@@ -58,51 +61,56 @@ const assertTimeZoneForEnable = (rawInput: unknown): void => {
   }
 };
 
-const assertHealthyGoogleForEnable = async (userId: string): Promise<void> => {
-  const client = getSyncServiceClient();
-  const connection = await resolveGoogleConnectionFromSync(
-    client,
-    toSyncPrincipal(userId),
-  );
-  if (connection.connectionState !== "HEALTHY") {
-    throw bookingError(
-      "GOOGLE_NOT_CONNECTED",
-      "Connect a healthy Google account before enabling booking",
-    );
-  }
-};
-
-const listSyncCalendars = async (
+const listSyncContext = async (
   userId: string,
-): Promise<readonly ProviderCalendar[]> => {
-  const client = getSyncServiceClient();
-  const result = await client.listCalendars(toSyncPrincipal(userId));
-  if (!result.ok) {
+): Promise<{
+  calendars: readonly ProviderCalendar[];
+  healthyConnectionIds: ReadonlySet<string>;
+}> => {
+  const client: Pick<SyncServiceClient, "listCalendars" | "listConnections"> =
+    getSyncServiceClient();
+  const principal: SyncPrincipal = toSyncPrincipal(userId);
+  const [calendarsResult, connectionsResult] = await Promise.all([
+    client.listCalendars(principal),
+    client.listConnections(principal),
+  ]);
+  if (!calendarsResult.ok) {
     throwSyncProxyFailure(
-      result.error.kind,
-      `Failed to list calendars from sync (${result.error.kind})`,
-      result.error.detail,
+      calendarsResult.error.kind,
+      `Failed to list calendars from sync (${calendarsResult.error.kind})`,
+      calendarsResult.error.detail,
     );
   }
-  return result.value.calendars;
+  const healthyConnectionIds = new Set(
+    (connectionsResult.ok ? connectionsResult.value.connections : [])
+      .filter((connection) => connection.state === "healthy")
+      .map((connection) => connection.id as string),
+  );
+  return { calendars: calendarsResult.value.calendars, healthyConnectionIds };
 };
 
-const assertCalendarsForEnable = async (
+const assertHealthyWritableDestinationForEnable = async (
   userId: string,
   input: AdminPutBookingPageInput,
 ): Promise<void> => {
-  const calendars = await listSyncCalendars(userId);
-  const writable = calendars.filter(
-    (calendar) => calendar.capabilities.canWriteEvents,
-  );
-  const destination = writable.find(
+  const { calendars, healthyConnectionIds } = await listSyncContext(userId);
+  if (healthyConnectionIds.size === 0) {
+    throw bookingError(
+      "CALENDAR_NOT_CONNECTED",
+      "Connect a healthy calendar account before enabling booking",
+    );
+  }
+
+  const destination = calendars.find(
     (calendar) =>
-      (calendar.id as string) === (input.destinationCalendarId as string),
+      (calendar.id as string) === (input.destinationCalendarId as string) &&
+      calendar.capabilities.canWriteEvents &&
+      healthyConnectionIds.has(calendar.connectionId as string),
   );
   if (!destination) {
     throw bookingError(
       "DESTINATION_NOT_WRITABLE",
-      "Destination calendar must be a writable Google calendar",
+      "Destination calendar must be writable",
     );
   }
 
@@ -174,8 +182,7 @@ class BookingPageService {
 
     if (input.enabled) {
       await assertBillingAllowsWrites(userId.toString());
-      await assertHealthyGoogleForEnable(userId.toString());
-      await assertCalendarsForEnable(userId.toString(), input);
+      await assertHealthyWritableDestinationForEnable(userId.toString(), input);
     }
 
     const existing = await bookingPageRepository.findByUserId(userId);

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -830,6 +830,7 @@ describe("PublicBookingService", () => {
       guestName: "Ada Lovelace",
       notes: "secret notes",
       createsGoogleMeet: true,
+      conference: "meet",
     });
     expect(publicReservation).not.toHaveProperty("guestEmail");
     expect(publicReservation).not.toHaveProperty("cancelUrl");
@@ -1795,6 +1796,7 @@ describe("Public booking routes", () => {
       guestName: "Ada Lovelace",
       notes: "secret notes",
       createsGoogleMeet: true,
+      conference: "meet",
     });
     expect(response.body).not.toHaveProperty("guestEmail");
     expect(response.body).not.toHaveProperty("cancelUrl");

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -153,23 +153,29 @@ describe("PublicBookingService", () => {
 
   const mockHealthySync = (
     calendars: ReturnType<typeof writableCalendar>[],
+    connection: ReturnType<typeof healthyConnection> = healthyConnection(),
   ) => {
+    const wired = calendars.map((calendar) => ({
+      ...calendar,
+      connectionId: connection.id,
+    }));
     syncSpies.push(
       spyOn(syncServiceFactory, "getSyncServiceClient").mockReturnValue({
         listConnections: mock(() =>
           Promise.resolve({
             ok: true as const,
-            value: { connections: [healthyConnection()] },
+            value: { connections: [connection] },
           }),
         ),
         listCalendars: mock(() =>
           Promise.resolve({
             ok: true as const,
-            value: { calendars },
+            value: { calendars: wired },
           }),
         ),
       } as never),
     );
+    return { connection, calendars: wired };
   };
 
   const enableBookingPage = async (
@@ -602,6 +608,7 @@ describe("PublicBookingService", () => {
     const { slug } = await enableBookingPage();
     const page = await service.getPublicPage(slug);
     expect(page.createsGoogleMeet).toBe(true);
+    expect(page.conference).toBe("meet");
   });
 
   it("carries createsGoogleMeet false when the destination cannot mint Meet", async () => {
@@ -622,6 +629,7 @@ describe("PublicBookingService", () => {
 
     const publicPage = await service.getPublicPage(slug);
     expect(publicPage.createsGoogleMeet).toBe(false);
+    expect(publicPage.conference).toBe("none");
 
     const created = await service.createReservation(slug, {
       slotStart: "2026-09-07T10:00:00.000Z",
@@ -634,6 +642,7 @@ describe("PublicBookingService", () => {
       new ObjectId(created.reservationId),
     );
     expect(publicReservation.createsGoogleMeet).toBe(false);
+    expect(publicReservation.conference).toBe("none");
   });
 
   it("clamps a requested window that extends past the host horizon", async () => {
@@ -1660,19 +1669,24 @@ describe("Public booking routes", () => {
   const mockHealthySync = (
     calendars: ReturnType<typeof writableCalendar>[],
     availability = busyResponse(true),
+    connection: ReturnType<typeof healthyConnection> = healthyConnection(),
   ) => {
+    const wired = calendars.map((calendar) => ({
+      ...calendar,
+      connectionId: connection.id,
+    }));
     syncSpies.push(
       spyOn(syncServiceFactory, "getSyncServiceClient").mockReturnValue({
         listConnections: mock(() =>
           Promise.resolve({
             ok: true as const,
-            value: { connections: [healthyConnection()] },
+            value: { connections: [connection] },
           }),
         ),
         listCalendars: mock(() =>
           Promise.resolve({
             ok: true as const,
-            value: { calendars },
+            value: { calendars: wired },
           }),
         ),
         queryBusyAvailability: mock(async () => ({
@@ -1685,6 +1699,7 @@ describe("Public booking routes", () => {
         })),
       } as never),
     );
+    return { connection, calendars: wired };
   };
 
   it("GET public page returns host info for enabled slug", async () => {

--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -25,6 +25,10 @@ import {
   RescheduleBookingReservationResponseSchema,
   toPublicBookingPage,
 } from "@core/types/booking.contracts";
+import {
+  type CalendarConference,
+  conferenceForProvider,
+} from "@core/types/calendar.contracts";
 import { DateTimeSchema, type EventId } from "@core/types/domain-primitives";
 import {
   BUSY_QUERY_MAX_WINDOW_MS,
@@ -272,8 +276,12 @@ const presentReservation = async (
   reservation: BookingReservationRecord,
   page: BookingPageRecord & { bookingSlug: string },
   hostDisplayName: string,
-): Promise<PublicGetBookingReservationResponse> =>
-  PublicGetBookingReservationResponseSchema.parse({
+): Promise<PublicGetBookingReservationResponse> => {
+  const conference = await destinationConference(
+    page.userId,
+    page.destinationCalendarId,
+  );
+  return PublicGetBookingReservationResponseSchema.parse({
     slotStart: reservation.slotStart.toISOString(),
     guestTimeZone: reservation.guestTimeZone,
     durationMinutes: durationMinutesForReservation(
@@ -285,11 +293,10 @@ const presentReservation = async (
     bookingSlug: page.bookingSlug,
     guestName: reservation.guestName,
     notes: reservation.notes,
-    createsGoogleMeet: await destinationCreatesGoogleMeet(
-      page.userId,
-      page.destinationCalendarId,
-    ),
+    createsGoogleMeet: conference === "meet",
+    conference,
   });
+};
 
 const nextGuestNotes = (
   incoming: string | undefined,
@@ -301,27 +308,38 @@ const nextGuestNotes = (
   return incoming.length > 0 ? incoming : null;
 };
 
-const destinationCreatesGoogleMeet = async (
+const destinationConference = async (
   userId: ObjectId,
   destinationCalendarId: string,
-): Promise<boolean> => {
+): Promise<CalendarConference> => {
   const local = await calendarService.getLocalCalendar(userId);
   if (local && local._id.toHexString() === destinationCalendarId) {
-    return false;
+    return "none";
   }
 
   const client = getSyncServiceClient();
-  const result = await client.listCalendars(toSyncPrincipal(userId.toString()));
-  if (!result.ok) {
-    return true;
+  const principal = toSyncPrincipal(userId.toString());
+  const calendarsResult = await client.listCalendars(principal);
+  if (!calendarsResult.ok) {
+    return "meet";
   }
-  const destination = result.value.calendars.find(
+  const destination = calendarsResult.value.calendars.find(
     (calendar) => (calendar.id as string) === destinationCalendarId,
   );
   if (!destination) {
-    return false;
+    return "none";
   }
-  return destination.createsGoogleMeet !== false;
+
+  const connectionsResult = await client.listConnections(principal);
+  const connection = connectionsResult.ok
+    ? connectionsResult.value.connections.find(
+        (candidate) => candidate.id === destination.connectionId,
+      )
+    : undefined;
+  return conferenceForProvider(
+    connection?.provider ?? "google",
+    destination.createsGoogleMeet !== false,
+  );
 };
 
 /**
@@ -368,12 +386,12 @@ export class PublicBookingService {
     const page = await resolveEnabledPage(slug);
     await assertHostAllowsGuestWrites(page.userId);
     const hostDisplayName = await getHostDisplayName(page.userId);
-    const createsGoogleMeet = await destinationCreatesGoogleMeet(
+    const conference = await destinationConference(
       page.userId,
       page.destinationCalendarId,
     );
     return PublicBookingPageSchema.parse(
-      toPublicBookingPage(page, hostDisplayName, createsGoogleMeet),
+      toPublicBookingPage(page, hostDisplayName, conference),
     );
   }
 

--- a/packages/backend/src/calendar/calendar.record.mapper.test.ts
+++ b/packages/backend/src/calendar/calendar.record.mapper.test.ts
@@ -60,10 +60,12 @@ describe("mapCalendarRecord", () => {
       buildRecord({ source: { provider: "local" } }),
     );
     expect(calendar.createsGoogleMeet).toBe(false);
+    expect(calendar.conference).toBe("none");
   });
 
   it("marks a google-sourced calendar as Meet-capable by default", () => {
     const calendar = mapCalendarRecord(buildRecord());
     expect(calendar.createsGoogleMeet).toBe(true);
+    expect(calendar.conference).toBe("meet");
   });
 });

--- a/packages/backend/src/calendar/calendar.record.mapper.ts
+++ b/packages/backend/src/calendar/calendar.record.mapper.ts
@@ -1,22 +1,27 @@
 import {
   type Calendar,
+  conferenceForProvider,
   getCalendarCapabilities,
 } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
 import { type CalendarRecord } from "@backend/calendar/calendar.record";
 
-export const mapCalendarRecord = (record: CalendarRecord): Calendar => ({
-  id: record._id.toHexString() as CalendarId,
-  name: record.name,
-  description: record.description,
-  timeZone: record.timeZone,
-  foregroundColor: record.foregroundColor,
-  backgroundColor: record.backgroundColor,
-  provider: record.source.provider,
-  access: record.access,
-  capabilities: getCalendarCapabilities(record.access),
-  isPrimary: record.isPrimary,
-  isVisible: record.isVisible,
-  isActive: record.isActive,
-  createsGoogleMeet: record.source.provider === "google",
-});
+export const mapCalendarRecord = (record: CalendarRecord): Calendar => {
+  const conference = conferenceForProvider(record.source.provider);
+  return {
+    id: record._id.toHexString() as CalendarId,
+    name: record.name,
+    description: record.description,
+    timeZone: record.timeZone,
+    foregroundColor: record.foregroundColor,
+    backgroundColor: record.backgroundColor,
+    provider: record.source.provider,
+    access: record.access,
+    capabilities: getCalendarCapabilities(record.access),
+    isPrimary: record.isPrimary,
+    isVisible: record.isVisible,
+    isActive: record.isActive,
+    createsGoogleMeet: conference === "meet",
+    conference,
+  };
+};

--- a/packages/backend/src/common/services/sync-service/calendar-list.translation.test.ts
+++ b/packages/backend/src/common/services/sync-service/calendar-list.translation.test.ts
@@ -194,4 +194,20 @@ describe("syncCalendarToBrowser", () => {
       true,
     );
   });
+
+  it("derives conference from the owning connection's provider", () => {
+    expect(syncCalendarToBrowser(providerCalendar()).conference).toBe("meet");
+    expect(
+      syncCalendarToBrowser(providerCalendar({ createsGoogleMeet: false }))
+        .conference,
+    ).toBe("none");
+    expect(
+      syncCalendarToBrowser(providerCalendar(), { provider: "microsoft" })
+        .conference,
+    ).toBe("teams");
+    expect(
+      syncCalendarToBrowser(providerCalendar(), { provider: "apple" })
+        .conference,
+    ).toBe("none");
+  });
 });

--- a/packages/backend/src/common/services/sync-service/calendar-list.translation.ts
+++ b/packages/backend/src/common/services/sync-service/calendar-list.translation.ts
@@ -2,6 +2,7 @@ import {
   type Calendar,
   type CalendarAccess,
   CalendarSchema,
+  conferenceForProvider,
   getCalendarCapabilities,
 } from "@core/types/calendar.contracts";
 import { HexColorSchema } from "@core/types/domain-primitives";
@@ -56,6 +57,10 @@ const syncCalendarToBrowser = (
   accountEmail?: string,
 ): Calendar => {
   const access = mapCalendarAccessRole(calendar.accessRole);
+  const conference = conferenceForProvider(
+    provider,
+    calendar.createsGoogleMeet !== false,
+  );
   // Sync stores the provider colour as a loose string; the browser Calendar
   // requires a hex colour. Fall back to the default rather than 500 the whole
   // list if a provider ever hands back a non-hex value.
@@ -79,7 +84,8 @@ const syncCalendarToBrowser = (
     isPrimary: calendar.primary,
     isVisible: true,
     isActive: calendar.active,
-    createsGoogleMeet: calendar.createsGoogleMeet !== false,
+    createsGoogleMeet: conference === "meet",
+    conference,
     ...(accountEmail ? { accountEmail } : {}),
   });
 };

--- a/packages/core/src/types/booking.contracts.test.ts
+++ b/packages/core/src/types/booking.contracts.test.ts
@@ -414,7 +414,7 @@ describe("HTTP booking contracts", () => {
     ).toBe(true);
     expect(
       PublicGetBookingReservationResponseSchema.parse(publicGet).conference,
-    ).toBe("meet");
+    ).toBeUndefined();
     expect(
       PublicGetBookingReservationResponseSchema.safeParse({
         slotStart: "2026-09-01T15:00:00.000Z",

--- a/packages/core/src/types/booking.contracts.test.ts
+++ b/packages/core/src/types/booking.contracts.test.ts
@@ -170,12 +170,13 @@ describe("PublicBookingPageSchema", () => {
       "maxHorizonDays",
       "welcomeText",
       "createsGoogleMeet",
+      "conference",
     ]);
   });
 
   it("projects an admin page without calendar ids or date overrides", () => {
     const admin = BookingPageSchema.parse(fullAdminPage());
-    const pub = toPublicBookingPage(admin, "Tyler Dane", true);
+    const pub = toPublicBookingPage(admin, "Tyler Dane", "meet");
 
     expect(PublicBookingPageSchema.safeParse(pub).success).toBe(true);
     expect(pub).toEqual({
@@ -186,6 +187,7 @@ describe("PublicBookingPageSchema", () => {
       maxHorizonDays: 60,
       welcomeText: null,
       createsGoogleMeet: true,
+      conference: "meet",
     });
     expect(Object.keys(pub)).not.toContain("destinationCalendarId");
     expect(Object.keys(pub)).not.toContain("blockingCalendarIds");
@@ -410,6 +412,9 @@ describe("HTTP booking contracts", () => {
       PublicGetBookingReservationResponseSchema.parse(publicGet)
         .createsGoogleMeet,
     ).toBe(true);
+    expect(
+      PublicGetBookingReservationResponseSchema.parse(publicGet).conference,
+    ).toBe("meet");
     expect(
       PublicGetBookingReservationResponseSchema.safeParse({
         slotStart: "2026-09-01T15:00:00.000Z",

--- a/packages/core/src/types/booking.contracts.ts
+++ b/packages/core/src/types/booking.contracts.ts
@@ -220,7 +220,7 @@ export const PublicBookingPageSchema = z.strictObject({
   maxHorizonDays: z.number().int().positive().max(BOOKING_MAX_HORIZON_DAYS),
   welcomeText: BookingWelcomeTextSchema.nullable().default(null),
   createsGoogleMeet: z.boolean().default(true),
-  conference: CalendarConferenceSchema.default("meet"),
+  conference: CalendarConferenceSchema.optional(),
 });
 export type PublicBookingPage = z.infer<typeof PublicBookingPageSchema>;
 
@@ -320,7 +320,7 @@ export const PublicGetBookingReservationResponseSchema = z.strictObject({
   guestName: z.string().trim().min(1).max(256),
   notes: z.string().trim().max(4000).nullable(),
   createsGoogleMeet: z.boolean().default(true),
-  conference: CalendarConferenceSchema.default("meet"),
+  conference: CalendarConferenceSchema.optional(),
 });
 export type PublicGetBookingReservationResponse = z.infer<
   typeof PublicGetBookingReservationResponseSchema

--- a/packages/core/src/types/booking.contracts.ts
+++ b/packages/core/src/types/booking.contracts.ts
@@ -1,5 +1,9 @@
 import { z } from "zod/v4";
 import {
+  type CalendarConference,
+  CalendarConferenceSchema,
+} from "@core/types/calendar.contracts";
+import {
   CalendarIdSchema,
   DateTimeSchema,
   TimeZoneSchema,
@@ -216,6 +220,7 @@ export const PublicBookingPageSchema = z.strictObject({
   maxHorizonDays: z.number().int().positive().max(BOOKING_MAX_HORIZON_DAYS),
   welcomeText: BookingWelcomeTextSchema.nullable().default(null),
   createsGoogleMeet: z.boolean().default(true),
+  conference: CalendarConferenceSchema.default("meet"),
 });
 export type PublicBookingPage = z.infer<typeof PublicBookingPageSchema>;
 
@@ -229,7 +234,7 @@ export const toPublicBookingPage = (
     | "welcomeText"
   >,
   hostDisplayName: string,
-  createsGoogleMeet: boolean,
+  conference: CalendarConference,
 ): PublicBookingPage =>
   PublicBookingPageSchema.parse({
     hostDisplayName,
@@ -238,7 +243,8 @@ export const toPublicBookingPage = (
     enabled: page.enabled,
     maxHorizonDays: page.maxHorizonDays,
     welcomeText: page.welcomeText ?? null,
-    createsGoogleMeet,
+    conference,
+    createsGoogleMeet: conference === "meet",
   });
 
 export const BookingReservationStatusSchema = z.enum([
@@ -314,6 +320,7 @@ export const PublicGetBookingReservationResponseSchema = z.strictObject({
   guestName: z.string().trim().min(1).max(256),
   notes: z.string().trim().max(4000).nullable(),
   createsGoogleMeet: z.boolean().default(true),
+  conference: CalendarConferenceSchema.default("meet"),
 });
 export type PublicGetBookingReservationResponse = z.infer<
   typeof PublicGetBookingReservationResponseSchema

--- a/packages/core/src/types/calendar.contracts.test.ts
+++ b/packages/core/src/types/calendar.contracts.test.ts
@@ -3,6 +3,8 @@ import {
   type CalendarAccess,
   CalendarListResponseSchema,
   CalendarSchema,
+  CONFERENCE_BY_PROVIDER,
+  conferenceForProvider,
   getCalendarCapabilities,
 } from "@core/types/calendar.contracts";
 
@@ -53,6 +55,29 @@ describe("Calendar Contracts", () => {
         CalendarSchema.parse({ ...validCalendar, createsGoogleMeet: false })
           .createsGoogleMeet,
       ).toBe(false);
+    });
+
+    it("accepts conference and omits it when absent", () => {
+      expect(CalendarSchema.parse(validCalendar).conference).toBe(undefined);
+      expect(
+        CalendarSchema.parse({ ...validCalendar, conference: "teams" })
+          .conference,
+      ).toBe("teams");
+    });
+  });
+
+  describe("conferenceForProvider", () => {
+    it("maps every provider through CONFERENCE_BY_PROVIDER", () => {
+      expect(conferenceForProvider("google")).toBe("meet");
+      expect(conferenceForProvider("microsoft")).toBe("teams");
+      expect(conferenceForProvider("apple")).toBe("none");
+      expect(conferenceForProvider("local")).toBe("none");
+      expect(CONFERENCE_BY_PROVIDER.google).toBe("meet");
+    });
+
+    it("returns none when the calendar cannot create a conference", () => {
+      expect(conferenceForProvider("google", false)).toBe("none");
+      expect(conferenceForProvider("microsoft", false)).toBe("none");
     });
   });
 

--- a/packages/core/src/types/calendar.contracts.ts
+++ b/packages/core/src/types/calendar.contracts.ts
@@ -13,6 +13,26 @@ export const CalendarProviderSchema = z.enum([
 ]);
 export type CalendarProvider = z.infer<typeof CalendarProviderSchema>;
 
+export const CalendarConferenceSchema = z.enum(["meet", "teams", "none"]);
+export type CalendarConference = z.infer<typeof CalendarConferenceSchema>;
+
+export const CONFERENCE_BY_PROVIDER = {
+  local: "none",
+  google: "meet",
+  microsoft: "teams",
+  apple: "none",
+} as const satisfies Record<CalendarProvider, CalendarConference>;
+
+export function conferenceForProvider(
+  provider: CalendarProvider,
+  canCreateConference = true,
+): CalendarConference {
+  if (!canCreateConference) {
+    return "none";
+  }
+  return CONFERENCE_BY_PROVIDER[provider];
+}
+
 export const CalendarAccessSchema = z.enum([
   "owner",
   "writer",
@@ -45,8 +65,12 @@ export const CalendarSchema = z.strictObject({
   isVisible: z.boolean(),
   isActive: z.boolean(),
   // Whether this calendar can mint a Google Meet URL. Local calendars are
-  // false. Omitted or true keeps the current Meet promise.
+  // false. Omitted or true keeps the current Meet promise. Prefer `conference`.
   createsGoogleMeet: z.boolean().optional(),
+  // Conference kind the destination can mint on create. Derived from the
+  // calendar's provider (`CONFERENCE_BY_PROVIDER`) and whether that calendar
+  // can actually create a conference link.
+  conference: CalendarConferenceSchema.optional(),
   // Email of the connected provider account this calendar belongs to. This is
   // the calendar's only account identity on the wire: emails are unique per
   // user (one Google account = one connection), so grouping and labelling key

--- a/packages/web/src/__tests__/utils/factories/calendar.factory.ts
+++ b/packages/web/src/__tests__/utils/factories/calendar.factory.ts
@@ -1,5 +1,6 @@
 import {
   type Calendar,
+  conferenceForProvider,
   getCalendarCapabilities,
 } from "@core/types/calendar.contracts";
 import { CalendarIdSchema } from "@core/types/domain-primitives";
@@ -28,13 +29,17 @@ export function createMockCalendar(
     isVisible: true,
     isActive: true,
     createsGoogleMeet: true,
+    conference: "meet",
     ...overrides,
   };
-  if (
-    calendar.provider === "local" &&
-    overrides.createsGoogleMeet === undefined
-  ) {
-    calendar.createsGoogleMeet = false;
+  if (overrides.conference === undefined) {
+    calendar.conference = conferenceForProvider(
+      calendar.provider,
+      calendar.createsGoogleMeet !== false,
+    );
+  }
+  if (overrides.createsGoogleMeet === undefined) {
+    calendar.createsGoogleMeet = calendar.conference === "meet";
   }
   return calendar;
 }
@@ -53,6 +58,7 @@ export function createMockConnection(
     accountEmail,
     connectionState: "HEALTHY",
     canSuggestContacts: false,
+    provider: "google",
     ...overrides,
   };
 }

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -162,6 +162,54 @@ describe("BookingSettingsSection", () => {
     expect(screen.queryByLabelText("Duration")).not.toBeInTheDocument();
   });
 
+  it("shows booking settings when a healthy non-google connection exists", async () => {
+    userMetadataActions.set({
+      google: {
+        connectionState: "NOT_CONNECTED",
+        connections: [],
+      },
+      connections: [
+        createMockConnection("user@outlook.com", { provider: "microsoft" }),
+      ],
+    });
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(
+          ctx.json({
+            ...unconfiguredPage(),
+            destinationCalendarId: writableCalendar.id,
+            blockingCalendarIds: [writableCalendar.id],
+          }),
+        ),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [
+      createMockCalendar({
+        id: writableCalendar.id,
+        name: writableCalendar.name,
+        provider: "microsoft",
+        accountEmail: "user@outlook.com",
+      }),
+    ]);
+
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    expect(await screen.findByLabelText("Duration")).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        /Connect a Google account to enable your booking page/,
+      ),
+    ).not.toBeInTheDocument();
+  });
+
   it("saves 30-minute duration and shows the copyable booking link", async () => {
     const user = userEvent.setup({ delay: null });
     const slug = "hostuser";
@@ -1188,8 +1236,9 @@ describe("BookingSettingsSection", () => {
         res(
           ctx.status(403),
           ctx.json({
-            code: "GOOGLE_NOT_CONNECTED",
-            message: "Connect a healthy Google account before enabling booking",
+            code: "CALENDAR_NOT_CONNECTED",
+            message:
+              "Connect a healthy calendar account before enabling booking",
           }),
         ),
       ),

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -17,7 +17,7 @@ import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId, TimeZoneSchema } from "@core/types/domain-primitives";
 import {
   selectGoogleConnectionState,
-  selectGoogleSyncConnections,
+  selectSyncConnections,
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
 import { useAppAccess } from "@web/billing/useAppAccess";
@@ -43,6 +43,10 @@ import {
   resolveWritableCalendars,
   toBookingPageInput,
 } from "@web/booking/booking.util";
+import {
+  BOOKING_NO_CONFERENCE_WARNING,
+  resolveBookingConference,
+} from "@web/booking/booking-conference.copy";
 import {
   BOOKING_FIELD_BY_KEY,
   BOOKING_SEQUENCE_FIELDS,
@@ -207,8 +211,11 @@ export function BookingSettingsSection({
   const googleConnectionState = useUserMetadataStore(
     selectGoogleConnectionState,
   );
-  const connections = useUserMetadataStore(selectGoogleSyncConnections);
-  const isGoogleHealthy = googleConnectionState === "HEALTHY";
+  const connections = useUserMetadataStore(selectSyncConnections);
+  const hasHealthyConnection =
+    connections.some(
+      (connection) => connection.connectionState === "HEALTHY",
+    ) || googleConnectionState === "HEALTHY";
   const access = useAppAccess();
   const isReadOnly = access.kind === "server" && access.isReadOnly;
   const effectiveTimeZone = useEffectiveTimeZone();
@@ -228,7 +235,8 @@ export function BookingSettingsSection({
       ),
     [accountEmailOrder, calendars],
   );
-  const { data: serverPage, isPending } = useBookingPageQuery(isGoogleHealthy);
+  const { data: serverPage, isPending } =
+    useBookingPageQuery(hasHealthyConnection);
   const saveMutation = useSaveBookingPageMutation();
   const [form, setForm] = useState<AdminPutBookingPageInput>(() =>
     buildInitialForm(
@@ -323,7 +331,7 @@ export function BookingSettingsSection({
     };
   }, [dismissGuardRef]);
 
-  if (!isGoogleHealthy) {
+  if (!hasHealthyConnection) {
     return <BookingConnectGooglePrompt />;
   }
 
@@ -343,8 +351,13 @@ export function BookingSettingsSection({
   const destinationCalendar = writableCalendars.find(
     (calendar) => calendar.id === form.destinationCalendarId,
   );
-  const destinationCannotMintMeet =
-    destinationCalendar?.createsGoogleMeet === false;
+  const destinationConference = destinationCalendar
+    ? resolveBookingConference(
+        destinationCalendar.conference,
+        destinationCalendar.createsGoogleMeet,
+      )
+    : "meet";
+  const destinationCannotMintMeet = destinationConference === "none";
   const destinationMeetWarningId = "booking-destination-meet-warning";
   const updateForm = (patch: Partial<AdminPutBookingPageInput>) => {
     setForm((current) => ({ ...current, ...patch }));
@@ -555,14 +568,13 @@ export function BookingSettingsSection({
               </>
             )}
           </select>
-          {destinationCannotMintMeet ? (
+          {destinationCannotMintMeet && destinationCalendar ? (
             <p
               className="mt-1 text-sm text-warning"
               id={destinationMeetWarningId}
               role="status"
             >
-              This calendar cannot create a Google Meet link. Guests will get a
-              calendar invite without a Meet URL.
+              {BOOKING_NO_CONFERENCE_WARNING[destinationCalendar.provider]}
             </p>
           ) : null}
         </div>

--- a/packages/web/src/booking/PublicBookingConfirmationView.test.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmationView.test.tsx
@@ -115,7 +115,51 @@ describe("PublicBookingConfirmationView", () => {
     );
 
     expect(
-      screen.getByText("A calendar invite is on its way to your email."),
+      screen.getByText("The calendar invite is on its way to your email."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("A Google Meet invite is on its way to your email."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("promises a Teams invite when the destination conference is teams", () => {
+    render(
+      <PublicBookingConfirmationView
+        cancelUrl={cancelUrl}
+        conference="teams"
+        durationMinutes={30}
+        hostDisplayName="Tyler Dane"
+        guestName="Ada Lovelace"
+        notes={null}
+        slotStart={slotStart}
+        timeZone={timeZone}
+      />,
+    );
+
+    expect(
+      screen.getByText("A Microsoft Teams invite is on its way to your email."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("A Google Meet invite is on its way to your email."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("promises a calendar invite when the destination conference is none", () => {
+    render(
+      <PublicBookingConfirmationView
+        cancelUrl={cancelUrl}
+        conference="none"
+        durationMinutes={30}
+        hostDisplayName="Tyler Dane"
+        guestName="Ada Lovelace"
+        notes={null}
+        slotStart={slotStart}
+        timeZone={timeZone}
+      />,
+    );
+
+    expect(
+      screen.getByText("The calendar invite is on its way to your email."),
     ).toBeInTheDocument();
     expect(
       screen.queryByText("A Google Meet invite is on its way to your email."),

--- a/packages/web/src/booking/PublicBookingConfirmationView.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmationView.tsx
@@ -1,4 +1,9 @@
 import { CheckCircleIcon } from "@phosphor-icons/react";
+import { type CalendarConference } from "@core/types/calendar.contracts";
+import {
+  BOOKING_CONFERENCE_INVITE_COPY,
+  resolveBookingConference,
+} from "@web/booking/booking-conference.copy";
 import { PublicBookingCopyCancelUrl } from "@web/booking/PublicBookingCopyCancelUrl";
 import { PublicBookingCopyRescheduleUrl } from "@web/booking/PublicBookingCopyRescheduleUrl";
 import { PublicBookingLayout } from "@web/booking/PublicBookingLayout";
@@ -13,6 +18,7 @@ interface PublicBookingConfirmationViewProps {
   durationMinutes: number;
   slotStart: string;
   timeZone: string;
+  conference?: CalendarConference;
   createsGoogleMeet?: boolean;
   cancelUrl?: string;
   rescheduleUrl?: string;
@@ -26,6 +32,7 @@ export function PublicBookingConfirmationView({
   durationMinutes,
   slotStart,
   timeZone,
+  conference,
   createsGoogleMeet = true,
   cancelUrl,
   rescheduleUrl,
@@ -73,9 +80,11 @@ export function PublicBookingConfirmationView({
           ) : null}
         </dl>
         <p className="text-sm text-text">
-          {createsGoogleMeet
-            ? "A Google Meet invite is on its way to your email."
-            : "A calendar invite is on its way to your email."}
+          {
+            BOOKING_CONFERENCE_INVITE_COPY[
+              resolveBookingConference(conference, createsGoogleMeet)
+            ]
+          }
         </p>
         {onEditDetails ? (
           <button

--- a/packages/web/src/booking/PublicBookingConfirmedPage.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmedPage.tsx
@@ -189,6 +189,7 @@ export function PublicBookingConfirmedPage() {
       durationMinutes={reservation.durationMinutes}
       slotStart={reservation.slotStart}
       timeZone={reservation.guestTimeZone}
+      conference={reservation.conference}
       createsGoogleMeet={reservation.createsGoogleMeet}
       cancelUrl={cancelUrl}
       rescheduleUrl={rescheduleUrl}

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -354,6 +354,51 @@ describe("PublicBookingPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("names Teams on the duration line when the destination conference is teams", async () => {
+    server.use(
+      rest.get(
+        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane`,
+        (_req, res, ctx) =>
+          res(
+            ctx.status(Status.OK),
+            ctx.json(publicPagePayload({ conference: "teams" })),
+          ),
+      ),
+      slotsInWindow([currentSlot]),
+    );
+
+    renderBookingRoute("/book/tylerdane");
+
+    expect(
+      await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("30 minutes Microsoft Teams")).toBeInTheDocument();
+    expect(screen.queryByText(/Google Meet/)).not.toBeInTheDocument();
+  });
+
+  it("omits a conference name when the destination conference is none", async () => {
+    server.use(
+      rest.get(
+        `${ENV_WEB.API_BASEURL}/booking/pages/tylerdane`,
+        (_req, res, ctx) =>
+          res(
+            ctx.status(Status.OK),
+            ctx.json(publicPagePayload({ conference: "none" })),
+          ),
+      ),
+      slotsInWindow([currentSlot]),
+    );
+
+    renderBookingRoute("/book/tylerdane");
+
+    expect(
+      await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("30 minutes")).toBeInTheDocument();
+    expect(screen.queryByText(/Google Meet/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Microsoft Teams/)).not.toBeInTheDocument();
+  });
+
   it("labels times in the guest timezone and confirms a booking", async () => {
     const user = userEvent.setup({ delay: null });
     let postedBody: unknown;
@@ -1495,7 +1540,7 @@ describe("PublicBookingConfirmedPage", () => {
       }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("A calendar invite is on its way to your email."),
+      screen.getByText("The calendar invite is on its way to your email."),
     ).toBeInTheDocument();
     expect(
       screen.queryByText(/To cancel, use the link in that invite/),

--- a/packages/web/src/booking/PublicBookingPage.tsx
+++ b/packages/web/src/booking/PublicBookingPage.tsx
@@ -1,6 +1,10 @@
 import { useParams } from "@tanstack/react-router";
 import { useEffect, useRef } from "react";
 import { PublicBookingNotFoundError } from "@web/api/public-booking.api";
+import {
+  formatBookingDurationWithConference,
+  resolveBookingConference,
+} from "@web/booking/booking-conference.copy";
 import { PublicBookingDetailsStep } from "@web/booking/PublicBookingDetailsStep";
 import { PublicBookingGuestForm } from "@web/booking/PublicBookingGuestForm";
 import { PublicBookingLayout } from "@web/booking/PublicBookingLayout";
@@ -111,7 +115,10 @@ export function PublicBookingPage() {
           Book with {page.hostDisplayName}
         </h1>
         <p className="text-sm text-text-muted">
-          {formatDurationMinutes(page.durationMinutes)} Google Meet
+          {formatBookingDurationWithConference(
+            formatDurationMinutes(page.durationMinutes),
+            resolveBookingConference(page.conference, page.createsGoogleMeet),
+          )}
         </p>
         {page.welcomeText ? (
           <p className="text-sm text-text">{page.welcomeText}</p>

--- a/packages/web/src/booking/booking-conference.copy.ts
+++ b/packages/web/src/booking/booking-conference.copy.ts
@@ -1,0 +1,47 @@
+import {
+  type CalendarConference,
+  type CalendarProvider,
+} from "@core/types/calendar.contracts";
+
+const BOOKING_CONFERENCE_DURATION_SUFFIX: Record<CalendarConference, string> = {
+  meet: " Google Meet",
+  teams: " Microsoft Teams",
+  none: "",
+};
+
+export const BOOKING_CONFERENCE_INVITE_COPY: Record<
+  CalendarConference,
+  string
+> = {
+  meet: "A Google Meet invite is on its way to your email.",
+  teams: "A Microsoft Teams invite is on its way to your email.",
+  none: "The calendar invite is on its way to your email.",
+};
+
+export const BOOKING_NO_CONFERENCE_WARNING: Record<CalendarProvider, string> = {
+  local:
+    "This calendar cannot create a video meeting link. Guests will get a calendar invite without a meeting URL.",
+  google:
+    "This calendar cannot create a Google Meet link. Guests will get a calendar invite without a Meet URL.",
+  microsoft:
+    "This calendar cannot create a Microsoft Teams link. Guests will get a calendar invite without a Teams URL.",
+  apple:
+    "This calendar cannot create a video meeting link. Guests will get a calendar invite without a meeting URL.",
+};
+
+export function formatBookingDurationWithConference(
+  durationLabel: string,
+  conference: CalendarConference,
+): string {
+  return `${durationLabel}${BOOKING_CONFERENCE_DURATION_SUFFIX[conference]}`;
+}
+
+export function resolveBookingConference(
+  conference?: CalendarConference,
+  createsGoogleMeet?: boolean,
+): CalendarConference {
+  if (conference !== undefined) {
+    return conference;
+  }
+  return createsGoogleMeet === false ? "none" : "meet";
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3235.

## What and why

Booking enable required a collapsed Google `HEALTHY` connection and a "writable Google calendar". Availability, event creation, and `createConference` were already provider-agnostic. This WP:

- Enables booking when any connection is `healthy` and the chosen destination is writable on that connection
- Renames `GOOGLE_NOT_CONNECTED` to `CALENDAR_NOT_CONNECTED` (old code stays as a one-release wire alias)
- Adds `conference: meet | teams | none` on the browser calendar and public booking wires, derived from `CONFERENCE_BY_PROVIDER` (Google: Meet; Microsoft: Teams; Apple/local: none)
- Names that conference kind on the public duration line and confirmation copy

Spec: `docs/features/calendar-providers.md` (Booking) and `docs/features/booking.md`.

## Verify

```
Selected packages: core, web, backend
Checks run: test:core, test:web, test:backend, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)

VERDICT: PASS
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e10c8f83-8623-43cb-99e3-58a63384cc19?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e10c8f83-8623-43cb-99e3-58a63384cc19&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

