### PR TITLE
feat(sync): add Microsoft Graph event normalizer (WP-04)

### DIFF
--- a/.agents/handoffs/3243.md
+++ b/.agents/handoffs/3243.md
@@ -1,0 +1,27 @@
+# Handoff: #3243
+
+task_id: 3243
+status: verifying
+branch: cursor/graph-event-normalizer-3243
+
+## Summary
+
+Implemented Microsoft Graph event normalizer (`microsoft-event.normalizer.ts`) mapping
+Graph `event` JSON to `ProviderEventRead`, mirroring Google's normalizer error reasons.
+
+## Deliverables
+
+- `microsoft-event.normalizer.ts`: timed, all-day, recurrence, cancellation, conference, categories
+- `microsoft-event.normalizer.test.ts`: unit coverage per acceptance criteria
+- `fixtures/microsoft/normalizer.json`: Graph documentation-derived contract corpus
+- `microsoft.contract.test.ts`: normalizer contract cases
+- `safety-canary.ts`: added `seriesMasterId` to Microsoft leak markers
+
+## Verify
+
+```
+bun test:sync
+bun run type-check
+bun lint
+bun knip
+```

--- a/packages/sync/src/providers/__contract__/fixtures/microsoft/normalizer.json
+++ b/packages/sync/src/providers/__contract__/fixtures/microsoft/normalizer.json
@@ -1,0 +1,98 @@
+{
+  "timed": {
+    "id": "AAMkAGI2TG93AAA=",
+    "@odata.etag": "W/\"graph-timed-etag\"",
+    "type": "singleInstance",
+    "subject": "Graph timed contract",
+    "bodyPreview": "Preview text",
+    "lastModifiedDateTime": "2025-01-10T12:00:00.0000000Z",
+    "iCalUId": "040000008200E00074C5B7101A82E00800000000000000000000000000000000000000000000000000",
+    "location": { "displayName": "Conference Room" },
+    "organizer": {
+      "emailAddress": { "name": "Organizer", "address": "org@example.com" }
+    },
+    "showAs": "busy",
+    "start": { "dateTime": "2025-01-15T14:00:00.0000000", "timeZone": "UTC" },
+    "end": { "dateTime": "2025-01-15T15:00:00.0000000", "timeZone": "UTC" }
+  },
+  "allDay": {
+    "id": "AAMkAGI2TG94AAA=",
+    "@odata.etag": "W/\"graph-allday-etag\"",
+    "type": "singleInstance",
+    "subject": "Graph all-day contract",
+    "isAllDay": true,
+    "showAs": "free",
+    "start": { "dateTime": "2022-02-22T00:00:00.0000000", "timeZone": "UTC" },
+    "end": { "dateTime": "2022-02-23T00:00:00.0000000", "timeZone": "UTC" }
+  },
+  "seriesMaster": {
+    "id": "AAMkAGI2TG95AAA=",
+    "@odata.etag": "W/\"graph-series-etag\"",
+    "type": "seriesMaster",
+    "subject": "Graph series contract",
+    "start": { "dateTime": "2025-09-07T01:30:00.0000000", "timeZone": "UTC" },
+    "end": { "dateTime": "2025-09-07T02:30:00.0000000", "timeZone": "UTC" },
+    "recurrence": {
+      "pattern": { "type": "daily", "interval": 1 },
+      "range": {
+        "type": "endDate",
+        "startDate": "2025-09-07",
+        "endDate": "2025-09-16"
+      }
+    }
+  },
+  "exception": {
+    "id": "AAMkAGI2TG96AAA=",
+    "@odata.etag": "W/\"graph-exception-etag\"",
+    "type": "exception",
+    "subject": "Graph exception contract",
+    "seriesMasterId": "AAMkAGI2TG95AAA=",
+    "originalStart": "2025-09-08T01:30:00.0000000Z",
+    "start": { "dateTime": "2025-09-08T02:00:00.0000000", "timeZone": "UTC" },
+    "end": { "dateTime": "2025-09-08T03:00:00.0000000", "timeZone": "UTC" }
+  },
+  "cancelledException": {
+    "id": "AAMkAGI2TG97AAA=",
+    "@odata.etag": "W/\"graph-cancelled-etag\"",
+    "type": "exception",
+    "isCancelled": true,
+    "seriesMasterId": "AAMkAGI2TG95AAA=",
+    "originalStart": "2013-05-08T22:00:00.0000000Z"
+  },
+  "occurrence": {
+    "id": "AAMkAGI2TG98AAA=",
+    "@odata.etag": "W/\"graph-occurrence-etag\"",
+    "type": "occurrence",
+    "seriesMasterId": "AAMkAGI2TG95AAA=",
+    "start": { "dateTime": "2025-09-09T01:30:00.0000000", "timeZone": "UTC" },
+    "end": { "dateTime": "2025-09-09T02:30:00.0000000", "timeZone": "UTC" }
+  },
+  "attendeesAndConference": {
+    "id": "AAMkAGI2TG99AAA=",
+    "@odata.etag": "W/\"graph-attendees-etag\"",
+    "type": "singleInstance",
+    "subject": "Graph attendees contract",
+    "categories": ["Blue category"],
+    "onlineMeeting": {
+      "joinUrl": "https://teams.microsoft.com/l/meetup-join/abc"
+    },
+    "onlineMeetingProvider": "teamsForBusiness",
+    "attendees": [
+      {
+        "type": "required",
+        "emailAddress": { "address": "a@x.com", "name": "A" },
+        "status": { "response": "accepted" }
+      },
+      {
+        "type": "required",
+        "emailAddress": { "address": "b@x.com" },
+        "status": { "response": "declined" }
+      }
+    ],
+    "start": { "dateTime": "2025-01-15T14:00:00.0000000", "timeZone": "UTC" },
+    "end": { "dateTime": "2025-01-15T15:00:00.0000000", "timeZone": "UTC" }
+  },
+  "masterCategories": {
+    "Blue category": "#0078D4"
+  }
+}

--- a/packages/sync/src/providers/__contract__/microsoft.contract.test.ts
+++ b/packages/sync/src/providers/__contract__/microsoft.contract.test.ts
@@ -1,6 +1,7 @@
 import { generateKeyPair, type KeyLike, SignJWT } from "jose";
 import { type AuthContractCase } from "@sync/providers/__contract__/auth.contract";
 import exchangeFixture from "@sync/providers/__contract__/fixtures/microsoft/exchange-success.json";
+import normalizerFixture from "@sync/providers/__contract__/fixtures/microsoft/normalizer.json";
 import refreshRevokedFixture from "@sync/providers/__contract__/fixtures/microsoft/refresh-invalid-grant.json";
 import refreshSuccessFixture from "@sync/providers/__contract__/fixtures/microsoft/refresh-success.json";
 import {
@@ -9,7 +10,12 @@ import {
   type MicrosoftTokenEndpoint,
   type MicrosoftTokenResponse,
 } from "@sync/providers/microsoft/microsoft-auth.adapter";
+import {
+  type GraphEvent,
+  normalizeMicrosoftEvent,
+} from "@sync/providers/microsoft/microsoft-event.normalizer";
 import { ProviderAuthError } from "@sync/providers/provider-auth.port";
+import { ProviderEventError } from "@sync/providers/provider-event.port";
 
 const CLIENT_ID = "microsoft-client-id";
 const CLIENT_SECRET = "microsoft-client-secret";
@@ -172,3 +178,89 @@ describeAuthCases(
     },
   ],
 );
+
+interface NormalizerCorpus {
+  readonly timed: GraphEvent;
+  readonly allDay: GraphEvent;
+  readonly seriesMaster: GraphEvent;
+  readonly exception: GraphEvent;
+  readonly cancelledException: GraphEvent;
+  readonly occurrence: GraphEvent;
+  readonly attendeesAndConference: GraphEvent;
+  readonly masterCategories: Record<string, string>;
+}
+
+const normalizerCorpus = normalizerFixture as NormalizerCorpus;
+const masterCategories = new Map(
+  Object.entries(normalizerCorpus.masterCategories),
+);
+
+describe("microsoft normalizer contract", () => {
+  it("normalizes a timed event from the Graph fixture corpus", () => {
+    const read = normalizeMicrosoftEvent(normalizerCorpus.timed);
+    expect(read.kind).toBe("event");
+    if (read.kind !== "event") return;
+    expect(read.providerEventId).toBe("AAMkAGI2TG93AAA=");
+    expect(read.schedule.kind).toBe("timed");
+    expect(read.recurrence).toEqual({ kind: "single" });
+  });
+
+  it("normalizes an all-day free event from the Graph fixture corpus", () => {
+    const read = normalizeMicrosoftEvent(normalizerCorpus.allDay);
+    expect(read.kind).toBe("event");
+    if (read.kind !== "event") return;
+    expect(read.busy).toBe(false);
+    expect(read.schedule).toEqual({
+      kind: "allDay",
+      start: "2022-02-22",
+      end: "2022-02-23",
+    });
+  });
+
+  it("normalizes a series master and exception from the Graph fixture corpus", () => {
+    const master = normalizeMicrosoftEvent(normalizerCorpus.seriesMaster);
+    expect(master.kind).toBe("event");
+    if (master.kind !== "event") return;
+    expect(master.recurrence.kind).toBe("seriesMaster");
+
+    const exception = normalizeMicrosoftEvent(normalizerCorpus.exception);
+    expect(exception.kind).toBe("event");
+    if (exception.kind !== "event") return;
+    expect(exception.recurrence).toEqual({
+      kind: "instance",
+      seriesProviderId: "AAMkAGI2TG95AAA=",
+      recurrenceId: "2025-09-08T01:30:00.000Z",
+    });
+  });
+
+  it("normalizes a cancelled exception from the Graph fixture corpus", () => {
+    const read = normalizeMicrosoftEvent(normalizerCorpus.cancelledException);
+    expect(read.kind).toBe("cancellation");
+    if (read.kind !== "cancellation") return;
+    expect(read.series).toEqual({
+      seriesProviderId: "AAMkAGI2TG95AAA=",
+      recurrenceId: "2013-05-08T22:00:00.000Z",
+    });
+  });
+
+  it("skips occurrence rows from the Graph fixture corpus", () => {
+    expect(() => normalizeMicrosoftEvent(normalizerCorpus.occurrence)).toThrow(
+      ProviderEventError,
+    );
+  });
+
+  it("normalizes attendees, conference, and category color from the Graph fixture corpus", () => {
+    const read = normalizeMicrosoftEvent(
+      normalizerCorpus.attendeesAndConference,
+      masterCategories,
+    );
+    expect(read.kind).toBe("event");
+    if (read.kind !== "event") return;
+    expect(read.content.attendees.length).toBe(2);
+    expect(read.content.conference).toEqual({
+      url: "https://teams.microsoft.com/l/meetup-join/abc",
+      label: "Microsoft Teams",
+    });
+    expect(read.content.colorHex).toBe("#0078D4");
+  });
+});

--- a/packages/sync/src/providers/microsoft/microsoft-event.normalizer.test.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-event.normalizer.test.ts
@@ -1,0 +1,368 @@
+import {
+  type GraphEvent,
+  normalizeMicrosoftEvent,
+} from "@sync/providers/microsoft/microsoft-event.normalizer";
+import {
+  type ProviderEvent,
+  type ProviderEventCancellation,
+  ProviderEventError,
+} from "@sync/providers/provider-event.port";
+
+const mEvent = (overrides: Partial<GraphEvent> = {}): GraphEvent => ({
+  id: "evt-id",
+  "@odata.etag": 'W/"v1"',
+  type: "singleInstance",
+  subject: "Title",
+  start: { dateTime: "2025-01-15T14:00:00.0000000", timeZone: "UTC" },
+  end: { dateTime: "2025-01-15T15:00:00.0000000", timeZone: "UTC" },
+  ...overrides,
+});
+
+const asProviderEvent = (read: ReturnType<typeof normalizeMicrosoftEvent>) => {
+  if (read.kind !== "event")
+    throw new Error(`expected event, got ${read.kind}`);
+  return read as ProviderEvent;
+};
+
+const asCancellation = (read: ReturnType<typeof normalizeMicrosoftEvent>) => {
+  if (read.kind !== "cancellation") {
+    throw new Error(`expected cancellation, got ${read.kind}`);
+  }
+  return read as ProviderEventCancellation;
+};
+
+describe("normalizeMicrosoftEvent", () => {
+  it("normalizes a timed event with content and identity", () => {
+    const read = asProviderEvent(
+      normalizeMicrosoftEvent(
+        mEvent({
+          id: "AAMkAGI2TG93AAA=",
+          "@odata.etag": 'W/"abc123"',
+          lastModifiedDateTime: "2025-01-10T12:00:00.0000000Z",
+          subject: "Team sync",
+          bodyPreview: "Agenda items",
+          iCalUId:
+            "040000008200E00074C5B7101A82E00800000000000000000000000000000000000000000000000000",
+          location: { displayName: "Room 4" },
+          organizer: {
+            emailAddress: { name: "Organizer", address: "org@example.com" },
+          },
+          showAs: "busy",
+        }),
+      ),
+    );
+
+    expect(read.providerEventId).toBe("AAMkAGI2TG93AAA=");
+    expect(read.providerVersion).toBe('W/"abc123"');
+    expect(read.providerUpdatedAt).toBe("2025-01-10T12:00:00.0000000Z");
+    expect(read.busy).toBe(true);
+    expect(read.recurrence).toEqual({ kind: "single" });
+    expect(read.content.title).toBe("Team sync");
+    expect(read.content.description).toBe("Agenda items");
+    expect(read.content.location).toBe("Room 4");
+    expect(read.content.organizer).toEqual({
+      email: "org@example.com",
+      displayName: "Organizer",
+    });
+    expect(read.schedule.kind).toBe("timed");
+    expect(read.icalUid).toBe(
+      "040000008200E00074C5B7101A82E00800000000000000000000000000000000000000000000000000",
+    );
+  });
+
+  it("normalizes an all-day free event", () => {
+    const read = asProviderEvent(
+      normalizeMicrosoftEvent(
+        mEvent({
+          isAllDay: true,
+          showAs: "free",
+          start: { dateTime: "2022-02-22T00:00:00.0000000", timeZone: "UTC" },
+          end: { dateTime: "2022-02-23T00:00:00.0000000", timeZone: "UTC" },
+        }),
+      ),
+    );
+
+    expect(read.busy).toBe(false);
+    expect(read.schedule).toEqual({
+      kind: "allDay",
+      start: "2022-02-22",
+      end: "2022-02-23",
+    });
+  });
+
+  it("strips HTML from body content", () => {
+    const read = asProviderEvent(
+      normalizeMicrosoftEvent(
+        mEvent({
+          bodyPreview: "Preview only",
+          body: {
+            contentType: "html",
+            content: "<p>Hello <b>world</b></p><br/>Line two",
+          },
+        }),
+      ),
+    );
+
+    expect(read.content.description).toBe("Hello world\n\nLine two");
+  });
+
+  it("uses plain text body content when contentType is text", () => {
+    const read = asProviderEvent(
+      normalizeMicrosoftEvent(
+        mEvent({
+          body: { contentType: "text", content: "Plain description" },
+        }),
+      ),
+    );
+
+    expect(read.content.description).toBe("Plain description");
+  });
+
+  it("maps a series master to RRULE rules", () => {
+    const read = asProviderEvent(
+      normalizeMicrosoftEvent(
+        mEvent({
+          type: "seriesMaster",
+          recurrence: {
+            pattern: { type: "daily", interval: 1 },
+            range: {
+              type: "endDate",
+              startDate: "2025-09-07",
+              endDate: "2025-09-16",
+            },
+          },
+        }),
+      ),
+    );
+
+    expect(read.recurrence).toEqual({
+      kind: "seriesMaster",
+      rules: ["RRULE:FREQ=DAILY;UNTIL=20250916T235959Z"],
+    });
+  });
+
+  it("maps an exception to its series link and recurrence id", () => {
+    const read = asProviderEvent(
+      normalizeMicrosoftEvent(
+        mEvent({
+          type: "exception",
+          seriesMasterId: "series-master-id",
+          originalStart: "2025-09-08T01:30:00.0000000Z",
+          subject: "Moved occurrence",
+        }),
+      ),
+    );
+
+    expect(read.recurrence).toEqual({
+      kind: "instance",
+      seriesProviderId: "series-master-id",
+      recurrenceId: "2025-09-08T01:30:00.000Z",
+    });
+  });
+
+  it("maps a cancelled exception to a cancellation with its series link", () => {
+    const read = asCancellation(
+      normalizeMicrosoftEvent(
+        mEvent({
+          isCancelled: true,
+          type: "exception",
+          seriesMasterId: "series-master-id",
+          originalStart: "2013-05-08T22:00:00.0000000Z",
+        }),
+      ),
+    );
+
+    expect(read.series).toEqual({
+      seriesProviderId: "series-master-id",
+      recurrenceId: "2013-05-08T22:00:00.000Z",
+    });
+  });
+
+  it("keeps a cancelled event even when etag is absent", () => {
+    const read = asCancellation(
+      normalizeMicrosoftEvent(
+        mEvent({
+          isCancelled: true,
+          "@odata.etag": undefined,
+        }),
+      ),
+    );
+
+    expect(read.providerVersion).toBe("");
+  });
+
+  it("throws unmappableContent for occurrence rows", () => {
+    expect(() =>
+      normalizeMicrosoftEvent(mEvent({ type: "occurrence" })),
+    ).toThrow(ProviderEventError);
+
+    try {
+      normalizeMicrosoftEvent(mEvent({ type: "occurrence" }));
+    } catch (error) {
+      expect((error as ProviderEventError).reason).toBe("unmappableContent");
+    }
+  });
+
+  it("maps every attendee response value and skips resource attendees", () => {
+    const read = asProviderEvent(
+      normalizeMicrosoftEvent(
+        mEvent({
+          attendees: [
+            {
+              type: "required",
+              emailAddress: { address: "a@x.com", name: "A" },
+              status: { response: "accepted" },
+            },
+            {
+              type: "optional",
+              emailAddress: { address: "b@x.com" },
+              status: { response: "declined" },
+            },
+            {
+              type: "required",
+              emailAddress: { address: "c@x.com" },
+              status: { response: "tentativelyAccepted" },
+            },
+            {
+              type: "required",
+              emailAddress: { address: "d@x.com" },
+              status: { response: "none" },
+            },
+            {
+              type: "required",
+              emailAddress: { address: "e@x.com" },
+              status: { response: "notResponded" },
+            },
+            {
+              type: "required",
+              emailAddress: { address: "f@x.com" },
+              status: { response: "organizer" },
+            },
+            {
+              type: "required",
+              emailAddress: { address: "g@x.com" },
+              status: { response: "bogus" },
+            },
+            {
+              type: "resource",
+              emailAddress: { address: "room@x.com", name: "Room" },
+              status: { response: "accepted" },
+            },
+            { type: "required", emailAddress: { name: "No email" } },
+          ],
+        }),
+      ),
+    );
+
+    expect(read.content.attendees).toEqual([
+      { email: "a@x.com", displayName: "A", responseStatus: "accepted" },
+      { email: "b@x.com", displayName: null, responseStatus: "declined" },
+      { email: "c@x.com", displayName: null, responseStatus: "tentative" },
+      { email: "d@x.com", displayName: null, responseStatus: "needsAction" },
+      { email: "e@x.com", displayName: null, responseStatus: "needsAction" },
+      { email: "f@x.com", displayName: null, responseStatus: "accepted" },
+      { email: "g@x.com", displayName: null, responseStatus: "needsAction" },
+    ]);
+  });
+
+  it("maps a Teams online meeting to conference url and label", () => {
+    const read = asProviderEvent(
+      normalizeMicrosoftEvent(
+        mEvent({
+          onlineMeeting: {
+            joinUrl: "https://teams.microsoft.com/l/meetup-join/abc",
+          },
+          onlineMeetingProvider: "teamsForBusiness",
+        }),
+      ),
+    );
+
+    expect(read.content.conference).toEqual({
+      url: "https://teams.microsoft.com/l/meetup-join/abc",
+      label: "Microsoft Teams",
+    });
+  });
+
+  it("drops a malformed conference url instead of failing the read", () => {
+    const read = asProviderEvent(
+      normalizeMicrosoftEvent(
+        mEvent({
+          onlineMeeting: { joinUrl: "not-a-url" },
+          onlineMeetingProvider: "teamsForBusiness",
+        }),
+      ),
+    );
+
+    expect(read.content.conference).toBeNull();
+  });
+
+  it("resolves category color from masterCategories", () => {
+    const masterCategories = new Map([["Blue category", "#0078D4"]]);
+    const read = asProviderEvent(
+      normalizeMicrosoftEvent(
+        mEvent({ categories: ["Blue category"] }),
+        masterCategories,
+      ),
+    );
+
+    expect(read.content.colorHex).toBe("#0078D4");
+  });
+
+  it("omits colorHex when the category has no matching color", () => {
+    const read = asProviderEvent(
+      normalizeMicrosoftEvent(
+        mEvent({ categories: ["Unknown"] }),
+        new Map([["Other", "#123456"]]),
+      ),
+    );
+
+    expect(read.content).not.toHaveProperty("colorHex");
+  });
+
+  it("throws missingIdentity when id or etag is absent on active events", () => {
+    expect(() => normalizeMicrosoftEvent(mEvent({ id: undefined }))).toThrow(
+      ProviderEventError,
+    );
+    expect(() =>
+      normalizeMicrosoftEvent(mEvent({ "@odata.etag": undefined })),
+    ).toThrow(ProviderEventError);
+  });
+
+  it("treats showAs values other than free as busy", () => {
+    for (const showAs of [
+      "tentative",
+      "busy",
+      "oof",
+      "workingElsewhere",
+      "unknown",
+    ]) {
+      const read = asProviderEvent(normalizeMicrosoftEvent(mEvent({ showAs })));
+      expect(read.busy).toBe(true);
+    }
+  });
+
+  it("throws a skippable ProviderEventError when content exceeds the contract", () => {
+    const error = (() => {
+      try {
+        normalizeMicrosoftEvent(
+          mEvent({
+            attendees: [
+              {
+                type: "required",
+                emailAddress: {
+                  address: "guest@example.com",
+                  name: "x".repeat(300),
+                },
+              },
+            ],
+          }),
+        );
+      } catch (e) {
+        return e;
+      }
+    })() as ProviderEventError;
+
+    expect(error).toBeInstanceOf(ProviderEventError);
+    expect(error.reason).toBe("unmappableContent");
+  });
+});

--- a/packages/sync/src/providers/microsoft/microsoft-event.normalizer.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-event.normalizer.ts
@@ -1,0 +1,360 @@
+import { EventScheduleSchema } from "@core/types/event.contracts";
+import {
+  type Attendee,
+  type Conference,
+  ConferenceSchema,
+  type Organizer,
+} from "@core/types/event-attendance.contracts";
+import { withColorHex } from "@core/types/event-color.contracts";
+import { SyncEventContentSchema } from "@core/types/sync/event.contracts";
+import { TimezoneSchema } from "@core/types/type.utils";
+import dayjs from "@core/util/date/dayjs";
+import { toRRule } from "@sync/providers/microsoft/microsoft-recurrence";
+import { UnsupportedRecurrenceError } from "@sync/providers/microsoft/microsoft-recurrence.error";
+import { type GraphPatternedRecurrence } from "@sync/providers/microsoft/microsoft-recurrence.types";
+import {
+  ProviderEventError,
+  type ProviderEventRead,
+  type ProviderEventRecurrence,
+} from "@sync/providers/provider-event.port";
+
+const RFC3339_OFFSET = dayjs.DateFormat.RFC3339_OFFSET;
+const DATE_ONLY = dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT;
+
+const NO_CATEGORY_COLORS: ReadonlyMap<string, string> = new Map();
+
+const MEETING_PROVIDER_LABELS: Readonly<Record<string, string>> = {
+  teamsForBusiness: "Microsoft Teams",
+  skypeForBusiness: "Skype for Business",
+  skypeForConsumer: "Skype",
+};
+
+export interface GraphDateTimeTimeZone {
+  readonly dateTime?: string;
+  readonly timeZone?: string;
+}
+
+export interface GraphEmailAddress {
+  readonly name?: string;
+  readonly address?: string;
+}
+
+export interface GraphAttendee {
+  readonly type?: string;
+  readonly emailAddress?: GraphEmailAddress;
+  readonly status?: { readonly response?: string };
+}
+
+export interface GraphItemBody {
+  readonly contentType?: string;
+  readonly content?: string;
+}
+
+export interface GraphOnlineMeeting {
+  readonly joinUrl?: string;
+}
+
+export interface GraphEvent {
+  readonly id?: string;
+  readonly ["@odata.etag"]?: string;
+  readonly lastModifiedDateTime?: string;
+  readonly iCalUId?: string;
+  readonly subject?: string;
+  readonly bodyPreview?: string;
+  readonly body?: GraphItemBody;
+  readonly location?: { readonly displayName?: string };
+  readonly organizer?: { readonly emailAddress?: GraphEmailAddress };
+  readonly attendees?: readonly GraphAttendee[];
+  readonly isCancelled?: boolean;
+  readonly showAs?: string;
+  readonly isAllDay?: boolean;
+  readonly start?: GraphDateTimeTimeZone;
+  readonly end?: GraphDateTimeTimeZone;
+  readonly type?: string;
+  readonly recurrence?: GraphPatternedRecurrence;
+  readonly seriesMasterId?: string;
+  readonly originalStart?: string;
+  readonly onlineMeeting?: GraphOnlineMeeting;
+  readonly onlineMeetingProvider?: string;
+  readonly categories?: readonly string[];
+  readonly isReminderOn?: boolean;
+}
+
+// Normalize one Microsoft Graph event read into a provider-neutral read. A
+// cancelled event becomes a cancellation; an active event becomes a full read.
+// Throws ProviderEventError only when the read is structurally unusable, never
+// for merely sparse events.
+//
+// `masterCategories` maps the owning calendar's Outlook category display names
+// to hex colors (like Google's colorLabels). Omit when none are known; a
+// category name absent from the map simply leaves the event uncolored.
+export function normalizeMicrosoftEvent(
+  item: GraphEvent,
+  masterCategories: ReadonlyMap<string, string> = NO_CATEGORY_COLORS,
+): ProviderEventRead {
+  if (item.type === "occurrence") {
+    throw new ProviderEventError(
+      "unmappableContent",
+      "Occurrence rows must not be normalized; the reader must not request them",
+    );
+  }
+
+  const providerEventId = requireId(item);
+
+  if (item.isCancelled) {
+    return {
+      kind: "cancellation",
+      providerEventId,
+      providerVersion: item["@odata.etag"] ?? "",
+      series: cancellationSeries(item),
+    };
+  }
+
+  const providerVersion = requireVersion(item);
+
+  return {
+    kind: "event",
+    providerEventId,
+    providerVersion,
+    providerUpdatedAt: item.lastModifiedDateTime ?? null,
+    content: mapContent(item, masterCategories),
+    schedule: mapSchedule(item),
+    busy: item.showAs !== "free",
+    ...(item.iCalUId ? { icalUid: item.iCalUId } : {}),
+    recurrence: mapRecurrence(item),
+  };
+}
+
+function requireId(item: GraphEvent): string {
+  if (!item.id) {
+    throw new ProviderEventError("missingIdentity", "Event carried no id");
+  }
+  return item.id;
+}
+
+function requireVersion(item: GraphEvent): string {
+  if (!item["@odata.etag"]) {
+    throw new ProviderEventError("missingIdentity", "Event carried no etag");
+  }
+  return item["@odata.etag"];
+}
+
+function cancellationSeries(
+  item: GraphEvent,
+): { seriesProviderId: string; recurrenceId: string } | null {
+  if (item.seriesMasterId && item.originalStart) {
+    return {
+      seriesProviderId: item.seriesMasterId,
+      recurrenceId: toCanonicalRecurrenceId(item.originalStart),
+    };
+  }
+  return null;
+}
+
+function mapContent(
+  item: GraphEvent,
+  masterCategories: ReadonlyMap<string, string>,
+) {
+  const colorHex = item.categories?.[0]
+    ? masterCategories.get(item.categories[0])
+    : undefined;
+  const parsed = SyncEventContentSchema.safeParse({
+    title: item.subject ?? "",
+    description: mapDescription(item),
+    location: item.location?.displayName ?? "",
+    organizer: mapOrganizer(item.organizer),
+    attendees: mapAttendees(item.attendees),
+    conference: mapConference(item),
+    ...withColorHex(colorHex),
+  });
+  if (!parsed.success) {
+    throw new ProviderEventError(
+      "unmappableContent",
+      "Event content failed the neutral contract",
+      { cause: parsed.error },
+    );
+  }
+  return parsed.data;
+}
+
+function mapDescription(item: GraphEvent): string {
+  const body = item.body;
+  if (body?.content !== undefined) {
+    if (body.contentType?.toLowerCase() === "html") {
+      return stripHtml(body.content);
+    }
+    return body.content;
+  }
+  return item.bodyPreview ?? "";
+}
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/p>/gi, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .trim();
+}
+
+function mapOrganizer(organizer: GraphEvent["organizer"]): Organizer | null {
+  const email = organizer?.emailAddress?.address;
+  if (!email) return null;
+  return {
+    email,
+    displayName: organizer.emailAddress?.name?.trim() || null,
+  };
+}
+
+const GRAPH_RESPONSE_TO_COMPASS: Readonly<
+  Record<string, Attendee["responseStatus"]>
+> = {
+  accepted: "accepted",
+  declined: "declined",
+  tentativelyAccepted: "tentative",
+  none: "needsAction",
+  notResponded: "needsAction",
+  organizer: "accepted",
+};
+
+function mapAttendees(attendees: GraphEvent["attendees"]): Attendee[] {
+  return (attendees ?? [])
+    .filter((attendee) => attendee.type !== "resource")
+    .filter((attendee) => Boolean(attendee.emailAddress?.address))
+    .map((attendee) => ({
+      email: attendee.emailAddress!.address as string,
+      displayName: attendee.emailAddress?.name?.trim() || null,
+      responseStatus:
+        GRAPH_RESPONSE_TO_COMPASS[attendee.status?.response ?? ""] ??
+        "needsAction",
+    }));
+}
+
+function mapConference(item: GraphEvent): Conference | null {
+  const url = item.onlineMeeting?.joinUrl;
+  if (!url) return null;
+
+  const label =
+    (item.onlineMeetingProvider
+      ? MEETING_PROVIDER_LABELS[item.onlineMeetingProvider]
+      : undefined) ?? null;
+
+  const parsed = ConferenceSchema.safeParse({ url, label });
+  return parsed.success ? parsed.data : null;
+}
+
+function mapSchedule(item: GraphEvent) {
+  const { start, end } = item;
+  if (!start || !end) {
+    throw new ProviderEventError(
+      "unmappableSchedule",
+      "Event has no start or end",
+    );
+  }
+
+  if (item.isAllDay) {
+    const startDate = extractDatePart(start);
+    const endDate = extractDatePart(end);
+    if (!startDate || !endDate) {
+      throw new ProviderEventError(
+        "unmappableSchedule",
+        "All-day event start/end could not be resolved to dates",
+      );
+    }
+    return parseSchedule({
+      kind: "allDay",
+      start: startDate,
+      end: endDate,
+    });
+  }
+
+  if (start.dateTime && end.dateTime) {
+    const timeZone = toIanaTimeZone(start.timeZone ?? end.timeZone ?? "UTC");
+    return parseSchedule({
+      kind: "timed",
+      start: toOffsetIso(start, timeZone),
+      end: toOffsetIso(end, timeZone),
+      timeZone,
+    });
+  }
+
+  throw new ProviderEventError(
+    "unmappableSchedule",
+    "Event start/end could not be resolved to a schedule",
+  );
+}
+
+function extractDatePart(value: GraphDateTimeTimeZone): string | null {
+  if (!value.dateTime) return null;
+  const parsed = dayjs.utc(value.dateTime);
+  if (!parsed.isValid()) return null;
+  return parsed.format(DATE_ONLY);
+}
+
+function toIanaTimeZone(timeZone: string): string {
+  return TimezoneSchema.safeParse(timeZone).success ? timeZone : "UTC";
+}
+
+function parseSchedule(candidate: unknown) {
+  const parsed = EventScheduleSchema.safeParse(candidate);
+  if (!parsed.success) {
+    throw new ProviderEventError(
+      "unmappableSchedule",
+      "Event start/end could not be resolved to a schedule",
+      { cause: parsed.error },
+    );
+  }
+  return parsed.data;
+}
+
+function mapRecurrence(item: GraphEvent): ProviderEventRecurrence {
+  if (item.type === "seriesMaster" && item.recurrence) {
+    try {
+      return { kind: "seriesMaster", rules: toRRule(item.recurrence) };
+    } catch (error) {
+      if (error instanceof UnsupportedRecurrenceError) {
+        throw new ProviderEventError(
+          "unmappableContent",
+          "Event recurrence could not be converted to RRULE",
+          { cause: error },
+        );
+      }
+      throw error;
+    }
+  }
+  if (item.type === "exception" && item.seriesMasterId && item.originalStart) {
+    return {
+      kind: "instance",
+      seriesProviderId: item.seriesMasterId,
+      recurrenceId: toCanonicalRecurrenceId(item.originalStart),
+    };
+  }
+  if (item.seriesMasterId && item.originalStart) {
+    return {
+      kind: "instance",
+      seriesProviderId: item.seriesMasterId,
+      recurrenceId: toCanonicalRecurrenceId(item.originalStart),
+    };
+  }
+  return { kind: "single" };
+}
+
+function toCanonicalRecurrenceId(originalStart: string): string {
+  return new Date(originalStart).toISOString();
+}
+
+function toOffsetIso(value: GraphDateTimeTimeZone, timeZone: string): string {
+  if (!value.dateTime) {
+    throw new ProviderEventError(
+      "unmappableSchedule",
+      "Event date-time had no dateTime",
+    );
+  }
+  const anchored = dayjs(value.dateTime).tz(timeZone);
+  return anchored.format(RFC3339_OFFSET);
+}

--- a/packages/sync/src/safety/safety-canary.test.ts
+++ b/packages/sync/src/safety/safety-canary.test.ts
@@ -12,6 +12,7 @@ const PROVIDER_MARKER_SAMPLES: Record<
   microsoft: [
     { "@odata.etag": 'W/"abc"' },
     { onlineMeeting: { joinUrl: "https://teams.example.com/join" } },
+    { seriesMasterId: "series-master-id" },
   ],
   apple: [
     "BEGIN:VEVENT\nUID:1\nEND:VEVENT",

--- a/packages/sync/src/safety/safety-canary.ts
+++ b/packages/sync/src/safety/safety-canary.ts
@@ -17,7 +17,11 @@ const SECRET_PATTERNS: readonly RegExp[] = [
 /** Provider-native payload shapes that must not leak into logs or SSE. */
 export const PROVIDER_LEAK_MARKERS: Record<ProviderKind, readonly RegExp[]> = {
   google: [/"conferenceData"\s*:/i, /"hangoutLink"\s*:/i],
-  microsoft: [/"@odata\.etag"\s*:/i, /"onlineMeeting"\s*:/i],
+  microsoft: [
+    /"@odata\.etag"\s*:/i,
+    /"onlineMeeting"\s*:/i,
+    /"seriesMasterId"\s*:/i,
+  ],
   apple: [/BEGIN:VEVENT/i, /BEGIN:VCALENDAR/i],
 };
 


### PR DESCRIPTION
Fixes #3243

## What and why

Implements `normalizeMicrosoftEvent` to map Microsoft Graph `event` JSON into the provider-neutral `ProviderEventRead` contract, mirroring the Google normalizer's error reasons and skip semantics. This unlocks the Microsoft event reader (M-05) by handling timed and all-day schedules, series masters (via `toRRule`), exceptions, cancellations, Teams conference links, Outlook category colors, and occurrence rows that must be skipped.

Spec: [`docs/features/calendar-providers.md`](https://github.com/KeepSoftwareSimple/compass-calendar/blob/main/docs/features/calendar-providers.md)

## Verify

```
bun run verify --strict
```

Selected packages: sync
Checks run: test:sync:fast, type-check, lint, knip
Checks skipped: (none)

✓ All checks passed
VERDICT: PASS