### PR TITLE
docs(providers): match p0 architecture names in the spec

### DIFF
--- a/.agents/handoffs/3238.md
+++ b/.agents/handoffs/3238.md
@@ -13,7 +13,7 @@ artifact:
   - path: README.md
 evidence:
   - command: bun run verify --strict
-    result: pending
+    result: "VERDICT: PASS (type-check, lint, knip)"
 assumptions:
   - "WP-09 (#3234) is still open; architecture names do not depend on its copy pass."
   - "Apple credential-form connect is not mounted; the spec names the connected response kind but not a fake route."

--- a/.agents/handoffs/3238.md
+++ b/.agents/handoffs/3238.md
@@ -1,0 +1,67 @@
+---
+schema_version: 1
+task_id: "3238"
+from: Implementer
+to: GitHub
+owner: GitHub
+status: verifying
+artifact:
+  - path: docs/features/calendar-providers.md
+  - path: docs/features/google-sync-and-sse-flow.md
+  - path: docs/architecture/event-domain-model.md
+  - path: docs/README.md
+  - path: README.md
+evidence:
+  - command: bun run verify --strict
+    result: pending
+assumptions:
+  - "WP-09 (#3234) is still open; architecture names do not depend on its copy pass."
+  - "Apple credential-form connect is not mounted; the spec names the connected response kind but not a fake route."
+open_risks: []
+next_deadline: 2026-09-05T12:00:00Z
+retry: 0
+approval: allow
+waiting_on: null
+escalation: null
+---
+
+P0 WP-13: spec and architecture doc closeout.
+
+## Tracking Deferred that became wrong
+
+Tracking #3207 Deferred:
+
+- Encrypting OAuth refresh tokens at rest (milestone C): **wrong as a
+  not-done item**. `CredentialCustody.store` already seals new OAuth refresh
+  tokens with `sync.credentialEncryptionKey`. C still drops plaintext acceptance
+  (`encrypt-credentials` backfill plus lazy re-encrypt on refresh).
+- Removing the `GOOGLE_REVOKED` SSE alias (milestone C): still correct.
+- Per-provider health snapshot counts (`health-snapshot.service.ts:48`):
+  still correct (`provider: "google"`).
+- Sign-in changes of any kind (milestone I): still correct.
+
+## Greps (named routes, port methods, config keys)
+
+```
+rg 'class ProviderRegistry|function buildProviderRegistry' packages/sync/src/providers/provider-registry.ts
+rg 'OAUTH_CALLBACK_PARAM_PATH|NOTIFICATIONS_PARAM_PATH|GOOGLE_CALLBACK_PATH|GOOGLE_NOTIFICATIONS_PATH' packages/sync
+rg 'buildAuthorizationUrl|exchangeAuthorizationCode|refreshAccessToken|revoke\\(' packages/sync/src/providers/provider-auth.port.ts
+rg 'discoverCalendars' packages/sync/src/providers/provider-calendar.port.ts
+rg 'listEventPage' packages/sync/src/providers/provider-event-reader.port.ts
+rg 'createEvent|patchEvent|deleteEvent|fetchEvent|fetchInstanceAt' packages/sync/src/providers/provider-event-writer.port.ts
+rg 'parseNotification' packages/sync/src/providers/provider-notifications.port.ts
+rg 'searchContacts' packages/sync/src/providers/provider-contacts.port.ts
+rg '/api/auth/connections/begin|/api/auth/google/connect/begin' packages/backend/src/auth/auth.routes.config.ts
+rg 'BEGIN_PATH|AVAILABILITY_BUSY_PATH|ADOPT_GOOGLE_AUTHORIZATION' packages/sync/src/server/connection.routes.ts
+rg '/internal/contacts/suggestions' packages/sync/src/server/contacts.routes.ts
+rg '/internal/commands' packages/sync/src/server/command.routes.ts
+rg '/internal/principal' packages/sync/src/server/principal.routes.ts
+rg '/internal/changes' packages/sync/src/server/change-feed.routes.ts
+rg 'credentialEncryptionKey' packages/core/src/config/compass.config.ts
+rg 'microsoft:' packages/core/src/config/compass.config.ts
+rg 'credentialKind' packages/sync/src/storage/contracts/credential.contracts.ts
+rg 'provider: "google"' packages/sync/src/telemetry/health-snapshot.service.ts
+rg 'revokedConnectionServerMessages|CONNECTION_REVOKED|GOOGLE_REVOKED' packages/core/src/types/server-message.contracts.ts
+rg 'CONFERENCE_BY_PROVIDER|conferenceForProvider' packages/core/src/types/calendar.contracts.ts
+rg 'CALENDAR_NOT_CONNECTED|GOOGLE_NOT_CONNECTED|DESTINATION_NOT_WRITABLE' packages/backend/src/booking/booking.error.ts
+```

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Things you can't do in Compass (yet):
 - Multiple booking event types or a standalone booking product
 - See your Outlook events
 
+Calendar hosts (Google, Microsoft, Apple) are specified in
+[docs/features/calendar-providers.md](./docs/features/calendar-providers.md).
+Outlook and iCloud stay non-goals until those milestones land.
+
 ## Tech stack
 
 - **Frontend**: React, Zustand, TanStack, Tailwind

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,13 +23,15 @@ Internal documentation for engineers and agents working in the Compass repo.
 - Backend routes and API behavior: [Backend Route Map](./backend/README.md), [Backend Request Flow](./backend/backend-request-flow.md), [Backend Error Handling](./backend/backend-error-handling.md)
 - Trial, pricing, or Stripe: [Billing And Trial](./features/billing.md)
 - Public booking pages or availability rules: [Compass Calendar Booking (v1)](./features/booking.md)
-- A new calendar integration or Google-sync behavior: [Google Sync And SSE Flow](./features/google-sync-and-sse-flow.md), the `packages/sync` domain code directly
+- A new calendar integration or Google-sync behavior: [Calendar providers](./features/calendar-providers.md), [Google Sync And SSE Flow](./features/google-sync-and-sse-flow.md), the `packages/sync` domain code directly
 
 ## Architecture And Domain
 
 - [Repo Architecture](./architecture/repo-architecture.md)
 - [Product Suite Boundaries](./architecture/product-suite-boundaries.md)
 - [Event Domain Model](./architecture/event-domain-model.md)
+- [Calendar providers](./features/calendar-providers.md)
+- [Multi-account Sync](./architecture/multi-account-sync.md)
 - [Multi-account Sync](./architecture/multi-account-sync.md)
 - [Glossary](./architecture/glossary.md)
 

--- a/docs/architecture/event-domain-model.md
+++ b/docs/architecture/event-domain-model.md
@@ -7,32 +7,32 @@ The event domain is the most cross-cutting part of Compass. Read this before cha
 The runtime uses the strict calendar-owned contracts everywhere: Mongo
 storage, the HTTP API, SSE, IndexedDB, and the web data/state layers. The
 pre-cutover legacy event model (and its `event.legacy-bridge.ts` conversion
-shim) has been fully removed — the sections below describe the current model
+shim) has been fully removed: the sections below describe the current model
 only.
 
-- `packages/core/src/types/domain-primitives.ts` — branded ids, `DateOnly`,
+- `packages/core/src/types/domain-primitives.ts`: branded ids, `DateOnly`,
   `DateTime` (RFC 3339 with offset), `TimeZone`, `SortOrder`, `RRule`.
-- `packages/core/src/types/event.contracts.ts` — canonical `Event`: required
+- `packages/core/src/types/event.contracts.ts`: canonical `Event`: required
   `calendarId`, discriminated `content` (`details` | `busy`), `schedule`
   (`timed` | `allDay`, exclusive all-day ends), `recurrence`
   (`single` | `series` | `occurrence`), plus `BusyPeriod` for free/busy-only
   calendars.
-- `packages/core/src/types/event-command.contracts.ts` — create (optional
+- `packages/core/src/types/event-command.contracts.ts`: create (optional
   client id), full-replace, delete, list and availability queries.
-- `packages/core/src/types/calendar.contracts.ts` — `Calendar` read model with
+- `packages/core/src/types/calendar.contracts.ts`: `Calendar` read model with
   provider/access and derived capabilities (`getCalendarCapabilities`).
-- `packages/core/src/types/server-message.contracts.ts` — the discriminated
+- `packages/core/src/types/server-message.contracts.ts`: the discriminated
   SSE union every backend publish site must emit.
 - `packages/backend/src/calendar/calendar.record.ts`,
-  `packages/backend/src/event/event.record.ts` — the backend's own record
+  `packages/backend/src/event/event.record.ts`: the backend's own record
   shapes, now vestigial for events (the backend delegates event storage to
   Sync; its own `event.record.ts` survives only for the calendar-cascade
   delete path).
-- `packages/sync/src/storage/contracts/event.contracts.ts` — the actual
+- `packages/sync/src/storage/contracts/event.contracts.ts`: the actual
   canonical event record Sync persists (`SyncEventSchema` in
   `packages/core/src/types/sync/event.contracts.ts` is its wire-facing
   counterpart). Google↔record mapping lives in `packages/sync/src/providers/google/`.
-- `packages/web/src/events/event-draft.types.ts` + `event-draft.parser.ts` —
+- `packages/web/src/events/event-draft.types.ts` + `event-draft.parser.ts`:
   the only intentionally incomplete event shape and the single parser that can
   turn it into a command.
 
@@ -45,20 +45,23 @@ assumption log that anchors the carve-out, so a future v2 effort starts from
 the recorded reasoning instead of rediscovering it:
 
 - **Cross-calendar event moves.** An existing event's `calendarId` is
-  immutable once created (A6) — creating and duplicating pick a calendar,
+  immutable once created (A6): creating and duplicating pick a calendar,
   editing shows it as read-only text, and there is no move control. General
   cross-calendar moves need their own Google and recurrence
   semantics (what happens to a moved recurring series, a moved event's
   provider identity) that v1 never had to answer.
-- **Non-Google providers.** `Calendar` and event provider identity are
-  discriminated unions with exactly one live member: Google (plus the
-  Compass-local calendar) (A1, A23). Outlook and iCalendar adapters would add
-  new discriminant members rather than change the shape — the extension point
-  is deliberately in place, but no second adapter is implemented.
-- **Shared-calendar administration.** Compass reads Google's CalendarList and
-  lets a user change Compass-local visibility, but never creates, deletes, or
+- **Non-Google providers.** `CalendarProviderSchema` is `local | google |
+  microsoft | apple`. Sync resolves adapters through `ProviderRegistry`
+  (`packages/sync/src/providers/provider-registry.ts`). Google is the
+  registered kind. Microsoft and Apple adapter sets live under
+  `packages/sync/src/providers/<kind>/` and register in M-09 / A-08. Domain
+  and web code must not branch on `provider === "x"`; they use
+  `ProviderCapabilitySchema` and calendar capabilities. See
+  [Calendar providers](../features/calendar-providers.md).
+- **Shared-calendar administration.** Compass reads the provider calendar list
+  and lets a user change Compass-local visibility, but never creates, deletes, or
   manages sharing/ACLs on a provider calendar (A1, A15). Calendar lifecycle
-  stays server-owned and Google-authoritative in v1.
+  stays server-owned and provider-authoritative in v1.
 
 ## Core Event Schema
 
@@ -70,14 +73,14 @@ Important event fields:
 
 - `id`: Compass event id
 - `calendarId`: required, immutable once created (see Deferred Beyond V1)
-- `content`: discriminated union — `details` (`title` + `description` +
+- `content`: discriminated union: `details` (`title` + `description` +
   optional `color` as an `EventColorSlot`) or `busy` (free/busy-only
   calendars). `color` maps 1:1 onto Google's 11 event `colorId` values; when
   absent, the card keeps the theme-flat fill and calendar identity stays the
   accent stripe.
-- `schedule`: discriminated union — `timed` (`start`/`end`/`timeZone`) or
+- `schedule`: discriminated union: `timed` (`start`/`end`/`timeZone`) or
   `allDay` (`DateOnly` `start`/`end`, exclusive end)
-- `recurrence`: discriminated union — `single` (standalone event), `series`
+- `recurrence`: discriminated union: `single` (standalone event), `series`
   (recurring base, carries `rules`), or `occurrence` (references its parent
   via `seriesId`)
 - `createdAt`, `updatedAt`
@@ -98,7 +101,7 @@ events to visible buckets:
 These are UI-facing categories, not storage categories.
 
 Recurrence planning, projection, and Google propagation are owned entirely
-by Sync now — see [Common Change Recipes](../development/common-change-recipes.md#change-recurring-event-behavior)
+by Sync now: see [Common Change Recipes](../development/common-change-recipes.md#change-recurring-event-behavior)
 for the current file list.
 
 ## Update Scopes
@@ -122,7 +125,7 @@ The backend's event contract mirrors Sync's recurrence model:
   `"exception"` internally) referencing the series via `seriesId`
 
 Sync projects occurrences into the rolling sync horizon rather than
-persisting every future instance — see
+persisting every future instance: see
 `packages/sync/src/domain/occurrence-projection.ts` and `reproject.ts`.
 
 ## Optimistic IDs

--- a/docs/features/calendar-providers.md
+++ b/docs/features/calendar-providers.md
@@ -14,8 +14,10 @@ created where the host supports them, and per-connection health is honest.
 
 ## Status
 
-Not implemented. Work is tracked across six GitHub milestones, each with a
-tracking issue:
+P0 foundation is in the tree. Google is the registered adapter. Microsoft and
+Apple adapters live under `packages/sync/src/providers/<kind>/` and register in
+M-09 / A-08. Work is tracked across six GitHub milestones, each with a tracking
+issue:
 
 | Milestone | Purpose |
 |---|---|
@@ -24,7 +26,7 @@ tracking issue:
 | Providers M: Microsoft (Outlook) | Microsoft Graph adapter set and Connect Microsoft UI. |
 | Providers A: Apple (iCloud) | CalDAV adapter set, password credential, Connect iCloud UI. |
 | Providers I: identity decoupling | Sign in with Microsoft and Apple; login is not calendar hosting. |
-| Providers C: closeout | Cross-provider verification, docs, refresh-token encryption. |
+| Providers C: closeout | Drop plaintext OAuth rows, per-provider health snapshot, drop `GOOGLE_REVOKED`. |
 
 ## Locked decisions
 
@@ -56,7 +58,7 @@ tracking issue:
 | Event colors | 11 slots plus labels | categories read as hex; no write in v1 | calendar color only |
 | Attendees and invitations | yes | yes | yes, server-side scheduling |
 | Contact suggestions | People API | `/me/people` | none |
-| Booking destination | yes | yes | yes, without a conference link |
+| Booking destination | yes | yes | yes, without a video link |
 
 Capabilities are the intersection of the granted permission, the calendar's
 access role, the provider's semantics, and the transport's real behavior. An
@@ -64,48 +66,149 @@ owning role never manufactures `canWatchEvents` on a transport without push.
 
 ## Architecture
 
-The sync service (`packages/sync`) already has provider-neutral ports in
-`packages/sync/src/providers/*.port.ts` (auth, calendar discovery, event
-reader, event writer, notifications, contacts). Free/busy is computed locally
-from stored occurrences, so no provider free/busy API is called.
+The names in this section match the code that landed in P0. Grep each one;
+they exist.
 
-Foundation work adds:
+The sync service (`packages/sync`) has provider-neutral ports in
+`packages/sync/src/providers/*.port.ts`. Free/busy is computed locally from
+stored occurrences, so no provider free/busy API is called.
 
-- `ProviderKindSchema` = `google | microsoft | apple` and a matching
-  `CalendarProviderSchema` (`local` plus the three).
-- A `ProviderRegistry` mapping a kind to its adapter set, scopes and
-  capabilities. The job worker, routes and credential custody resolve adapters
-  per connection instead of one adapter set per process.
-- Public paths `/sync/:provider` (OAuth callback) and
-  `/sync/notifications/:provider` (push ingress). The notification port gains
-  `parseNotification`, which also answers Microsoft's validation handshake.
-- Poll-only providers: subscription maintenance settles `unsupported` when the
-  registry says `changeNotifications: false`, and a per-provider reconcile
-  sweep row sets the polling cadence. Apple uses a dedicated row with a 60 s
-  stale window, a 30 s sweep interval (±20% jitter), and a batch limit of 500
-  calendars per cycle.
-- Credentials discriminated on `credentialKind: "oauthRefresh" | "password"`.
-  Password credentials are encrypted at rest with `sync.credentialEncryptionKey`.
+### Kinds and capabilities
+
+- `ProviderKindSchema` = `google | microsoft | apple`
+  (`packages/core/src/types/sync/identity.contracts.ts`).
+- `CalendarProviderSchema` = `local` plus those three
+  (`packages/core/src/types/calendar.contracts.ts`).
+- `ProviderCapabilitySchema`: `readEvents`, `writeEvents`, `readBusy`,
+  `inviteAttendees`, `changeNotifications`, `incrementalChanges`,
+  `suggestContacts`.
+- Display names: `PROVIDER_DISPLAY_NAMES` / `providerDisplayName(kind)`.
+- Conference kind on a calendar: `CalendarConferenceSchema` =
+  `meet | teams | none`, derived by `conferenceForProvider` from
+  `CONFERENCE_BY_PROVIDER` (not a `provider ===` branch).
+
+### Registry
+
+`ProviderRegistry` (`packages/sync/src/providers/provider-registry.ts`) maps a
+kind to a `ProviderRegistration`: `adapters`, `scopes`, `capabilities`,
+`callbackPath`, `notificationsCallbackPath`, `capabilitiesFromScopes`.
+`buildProviderRegistry(config)` is the factory. `app.ts`, job dispatch,
+credential custody, and the public routes resolve adapters per connection
+through `registry.get(kind)`.
+
+Google registers when `google.clientId` / `google.clientSecret` are set.
+Microsoft and Apple config is read into `SyncConfig` but those kinds are not
+registered until M-09 / A-08.
+
+`ProviderAdapters` on a registration:
+
+| Field | Port | Methods |
+|---|---|---|
+| `auth` | `ProviderAuthAdapter` | `buildAuthorizationUrl`, `exchangeAuthorizationCode`, `refreshAccessToken`, `revoke` |
+| `calendars` | `ProviderCalendarAdapter` | `discoverCalendars` |
+| `reader` | `ProviderEventReader` | `listEventPage` |
+| `writer` | `ProviderEventWriter` | `createEvent`, `patchEvent`, `deleteEvent`, `fetchEvent`, `fetchInstanceAt` |
+| `notifications` | `ProviderNotificationAdapter` | `watch`, `stopChannel`, `parseNotification` |
+| `contacts` | `ContactsPort` (optional) | `searchContacts` |
+
+`parseNotification` returns a `ProviderNotification`, a Microsoft
+validation handshake `{kind: "validation", body}`, or `null`.
 
 Provider code lives under `packages/sync/src/providers/<kind>/`. Each adapter
-takes an injectable narrow API interface so tests script results without
-network access. A shared contract suite under
-`packages/sync/src/providers/__contract__/` runs every adapter against a
-recorded fixture corpus.
+takes an injectable narrow API so tests script results without network access.
+The shared contract suite under `packages/sync/src/providers/__contract__/`
+runs every adapter against a recorded fixture corpus.
+
+### Public sync paths
+
+Constants: `OAUTH_CALLBACK_PARAM_PATH`, `NOTIFICATIONS_PARAM_PATH`, plus Google
+aliases `GOOGLE_CALLBACK_PATH` and `GOOGLE_NOTIFICATIONS_PATH`.
+
+| Path | Role |
+|---|---|
+| `GET /sync/:provider` | OAuth callback |
+| `GET /sync/google` | Google alias of the callback |
+| `POST /sync/notifications/:provider` | Push ingress |
+| `POST /sync/notifications/google` | Google alias of push ingress |
+
+### Compass API connection paths
+
+| Path | Role |
+|---|---|
+| `POST /api/auth/connections/begin` | Start OAuth; body `{provider?, connectionId?, features?}` |
+| `POST /api/auth/connections/refresh` | User-triggered catch-up |
+| `DELETE /api/auth/connections/:connectionId` | Disconnect |
+| `POST /api/auth/google/connect/begin` | Google alias of begin (one release) |
+| `DELETE /api/auth/google/connect/:connectionId` | Google alias of disconnect (one release) |
+| `POST /api/auth/google/sync/refresh` | Google alias of refresh (one release) |
+
+Begin returns `{kind: "redirect", authorizationUrl}`. The connected response
+kind `{kind: "connected", connectionId}` is on
+`ConnectionBeginResponseSchema` for Apple WP-03; that credential-form
+route is not mounted yet.
+
+Sync-internal counterparts: `GET /internal/connections`,
+`POST /internal/connections/begin`, `POST /internal/connections/refresh`,
+`POST /internal/connections/foreground-refresh`,
+`POST /internal/connections/adopt-google-authorization`,
+`DELETE /internal/connections/:id`, `GET /internal/calendars`,
+`GET /internal/events/full`, `POST /internal/availability/busy`,
+`GET /internal/contacts/suggestions`, `POST /internal/commands`,
+`DELETE /internal/principal`, `GET /internal/changes`.
+
+### Config keys
+
+| Key | Role |
+|---|---|
+| `google.clientId`, `google.clientSecret` | Google OAuth (sign-in and calendar) |
+| `microsoft.clientId`, `microsoft.clientSecret` | Microsoft OAuth (all-or-none) |
+| `apple.signIn.servicesId`, `apple.signIn.teamId`, `apple.signIn.keyId`, `apple.signIn.privateKey` | Sign in with Apple (all-four-or-none; milestone I) |
+| `sync.credentialEncryptionKey` | 32-byte base64 AES-256-GCM key for credentials at rest |
+| `sync.callbackBaseUrl` | Public base for OAuth redirects and webhooks |
+| `sync.postConnectRedirectUrl` | Browser redirect after connect; defaults to callback base |
+| `sync.execution` | `passive` or `active` |
+| `sync.serviceUrl`, `sync.internalAuthToken`, `sync.mongoUri` | Backend-to-sync and Sync storage |
+
+Apple polling env overrides (see Apple polling cadence):
+`RECONCILE_STALE_AFTER_MS_APPLE`, `RECONCILE_SWEEP_INTERVAL_MS_APPLE`,
+`RECONCILE_SWEEP_LIMIT_APPLE`.
+
+### Credentials
+
+Discriminated on `credentialKind: "oauthRefresh" | "password"`. Documents
+without `credentialKind` parse as `oauthRefresh`.
+
+Password credentials are always sealed at rest. New OAuth refresh tokens are
+also sealed by `CredentialCustody.store` with the same
+`sync.credentialEncryptionKey`. Legacy plaintext `refreshToken` rows remain
+readable and are lazily re-encrypted on refresh. Storing a new credential
+requires the key.
+
+### Poll-only providers
+
+Subscription maintenance settles `unsupported` when the registry
+capabilities omit `changeNotifications`. `buildReconcileSweepRows` adds a
+`reconcile-<kind>` row per poll-only kind. Apple defaults: 60 s stale window,
+30 s sweep interval (±20% jitter), batch limit 500.
+
+### User metadata overlap
+
+`UserMetadata.connections[]` is the provider-neutral list. `metadata.google`
+(including `metadata.google.connections`) stays as an overlap copy so clients
+that have not migrated still work.
 
 ## Connect flows
 
 **Google and Microsoft (redirect).** `POST /api/auth/connections/begin
 {provider}` returns `{kind: "redirect", authorizationUrl}`. The browser
 navigates there, the provider redirects to the sync service's
-`/sync/:provider` callback, sync links the connection and enqueues calendar
+`GET /sync/:provider` callback, sync links the connection and enqueues calendar
 list discovery, then redirects back with `?provider=<kind>&status=<status>`.
 
-**Apple (credential form).** The user creates an app-specific password at
-appleid.apple.com and submits email plus password in Compass.
-`POST /api/auth/connections/credential {provider: "apple", envelope}` carries
-the secret in the existing encrypted transit envelope. Sync validates it by
-running CalDAV discovery, stores the encrypted credential, enqueues discovery
+**Apple (credential form, Apple WP-03).** The user creates an app-specific
+password at appleid.apple.com and submits email plus password in Compass. The
+secret travels in the existing encrypted transit envelope. Sync validates it
+by running CalDAV discovery, stores the encrypted credential, enqueues discovery
 and returns `{kind: "connected", connectionId}`. The password is never logged.
 The UI states plainly that an app-specific password grants access to the
 whole iCloud account and that Compass stores it encrypted.
@@ -119,34 +222,54 @@ iCloud send mail. Compass maps `invitation: "none"` to
 ## Booking
 
 Booking enables when any healthy connection offers a writable destination
-calendar. The confirmation copy names the conference kind the destination
-supports (`meet`, `teams`, `none`). An Apple destination creates the event
-without a video link and says so.
+calendar (`canWriteEvents`). Empty healthy set is `CALENDAR_NOT_CONNECTED`.
+A destination that cannot be written is `DESTINATION_NOT_WRITABLE`.
+`GOOGLE_NOT_CONNECTED` remains a one-release wire alias of
+`CALENDAR_NOT_CONNECTED`.
+
+The confirmation copy names the conference kind the destination supports
+(`meet`, `teams`, `none`). An Apple destination creates the event without a
+video link and says so.
 
 ## Identity
 
-`user.identities[]` records `{provider, subjectId, email}` per login method.
-The same verified email across methods resolves to one Compass user through
-SuperTokens account linking. Sign in with Apple identifies by `sub`, because
-private-relay addresses are not the calendar account address. After signup with
-a method that grants no calendar, onboarding asks which service hosts the
-calendar: "If you view your calendar in Apple Calendar, it may still be hosted
-by Google or Microsoft."
+`user.identities[]` records `{provider, subjectId, email}` per login method
+(milestone I). The same verified email across methods resolves to one Compass
+user through SuperTokens account linking. Sign in with Apple identifies by
+`sub`, because private-relay addresses are not the calendar account address.
+After signup with a method that grants no calendar, onboarding asks which
+service hosts the calendar: "If you view your calendar in Apple Calendar, it
+may still be hosted by Google or Microsoft."
 
 ## Named warts
 
-- OAuth refresh tokens are encrypted at rest with `sync.credentialEncryptionKey` as of milestone C; legacy plaintext rows are backfilled with `encrypt-credentials` and lazily re-encrypted on refresh until the follow-up release drops plaintext acceptance.
-- `GOOGLE_REVOKED` stays as an alias of `CONNECTION_REVOKED` on the SSE wire
-  until every client reads the new code.
-- The health snapshot reports `provider: "google"` for the whole fleet until
-  milestone C splits it per provider.
+Each alias names the release that removes it.
+
+- **OAuth plaintext rows.** New OAuth refresh tokens are encrypted at rest with
+  `sync.credentialEncryptionKey`. Legacy plaintext `refreshToken` rows stay
+  readable and are lazily re-encrypted on refresh. `encrypt-credentials`
+  backfills the rest. Milestone C drops plaintext acceptance. (The tracking
+  issue still listed "encrypt OAuth at rest" as C work; that is already
+  done for new stores.)
+- **`GOOGLE_REVOKED`.** Alias of `CONNECTION_REVOKED` on the SSE and HTTP
+  wires. `revokedConnectionServerMessages` emits both. Event mutations still
+  return HTTP 410 `GOOGLE_REVOKED`. Milestone C removes `GOOGLE_REVOKED` after
+  every client reads `CONNECTION_REVOKED`.
+- **Health snapshot fleet label.** `health-snapshot.service.ts` hard-codes
+  `provider: "google"` for the whole fleet. Milestone C splits the snapshot per
+  provider.
+- **`metadata.google` overlap.** `UserMetadata.connections[]` is the
+  provider-neutral list; `metadata.google` (and `metadata.google.connections`)
+  stays until WP-08c clients read `connections[]`. Drop the overlap in
+  milestone C.
 - Microsoft category colors are read but never written back.
 - Apple freshness depends on polling and is bounded by iCloud rate limits.
 
 ## Apple polling cadence
 
-Apple has no push channel (`changeNotifications: false`). Freshness comes from
-the dedicated `reconcile-apple` sweep row in the sync service.
+Apple has no push channel (`changeNotifications` is absent from the
+registration). Freshness comes from the dedicated `reconcile-apple` sweep row
+in the sync service.
 
 | Setting | Default | Env override |
 |---|---|---|

--- a/docs/features/google-sync-and-sse-flow.md
+++ b/docs/features/google-sync-and-sse-flow.md
@@ -1,7 +1,11 @@
 # Google Sync And Server-Sent Events (SSE)
 
+Product-wide provider behavior, capability gates, and connect flows are
+specified in [`calendar-providers.md`](./calendar-providers.md). This document
+covers the Google sync path and SSE wiring.
+
 Google Calendar sync is owned entirely by the standalone **Sync service**
-(`packages/sync`) — the backend has no Google API calls or sync logic of its
+(`packages/sync`). The backend has no Google API calls or sync logic of its
 own. The backend's role is: proxy sync-related reads/writes to Sync, poll
 Sync's change feed, and translate what it learns into browser SSE.
 
@@ -33,7 +37,7 @@ flowchart LR
   Stream -->|subscribe + replay| Srv
   Bridge -->|poll| Feed
   Bridge -->|publish| Srv
-  Err -->|GOOGLE_REVOKED| Srv
+  Err -->|CONNECTION_REVOKED / GOOGLE_REVOKED| Srv
   Srv -->|SSE over HTTP, one "message" event| ES
   Prov --> ES
   Ev --> ES
@@ -63,8 +67,8 @@ sequenceDiagram
 
 Source:
 
-- `packages/core/src/constants/sse.constants.ts` — the SSE transport
-- `packages/core/src/types/server-message.contracts.ts` — the message union
+- `packages/core/src/constants/sse.constants.ts`: the SSE transport
+- `packages/core/src/types/server-message.contracts.ts`: the message union
 
 The server publishes **one** SSE event name, `message` (`SSE_MESSAGE_EVENT`).
 Its `data` is a JSON-serialized `ServerMessage` union member; clients parse
@@ -75,7 +79,7 @@ signal (`EVENT_CHANGED`, `IMPORT_GCAL_START`, etc. are retired).
 | ---------------------- | ------------------------------------------------- |
 | `eventsChanged`         | Calendar grid data should be refetched            |
 | `calendarsChanged`      | Calendar list should be refetched                 |
-| `syncStatusChanged`     | Google connection health changed (syncing/healthy/attention) |
+| `syncStatusChanged`     | Connection health changed (syncing/healthy/attention) |
 | `importCompleted`       | A full/incremental/repair import finished          |
 | `userMetadataChanged`   | Replay / push SuperTokens + sync metadata         |
 
@@ -83,7 +87,7 @@ signal (`EVENT_CHANGED`, `IMPORT_GCAL_START`, etc. are retired).
 named `publish*` convenience method per message type, plus a generic
 `publish()`. A completeness test
 (`packages/backend/src/servers/sse/sse.server.test.ts`) enforces that every
-`publish*` method emits a schema-valid frame — keep it exhaustive when the
+`publish*` method emits a schema-valid frame. Keep it exhaustive when the
 `ServerMessage` union grows.
 
 ## Outbound Flow: User Changes An Event In Compass
@@ -93,7 +97,7 @@ named `publish*` convenience method per message type, plus a generic
 3. The mutation's `mutationFn` writes through the selected repository.
 4. Remote event writes hit backend event routes, which submit a command to
    the Sync service (see [Backend](../backend/README.md#event-writes)).
-5. The backend does not publish `eventsChanged` for its own write — the
+5. The backend does not publish `eventsChanged` for its own write. The
    client already applied the change optimistically. Confirmation and
    cross-tab/cross-device fan-out come from the change-feed poll below.
 
@@ -115,20 +119,24 @@ learns about changes by polling Sync's own change feed:
    polls `GET /internal/changes` on the Sync service every ~2s.
 2. Each page of invalidations is translated to zero or more `ServerMessage`s
    by `syncInvalidationToServerMessages`
-   (`packages/backend/src/servers/sse/sync-invalidation.to-server-message.ts`) —
-   e.g. a Sync `event` invalidation becomes an `eventsChanged` message, an
-   `importProgress` invalidation becomes `syncStatusChanged`/`importCompleted`.
+   (`packages/backend/src/servers/sse/sync-invalidation.to-server-message.ts`).
+   A Sync `event` invalidation becomes an `eventsChanged` message. A
+   `connection` invalidation becomes `calendarsChanged` plus `eventsChanged`.
+   An `importProgress` invalidation becomes `syncStatusChanged` /
+   `importCompleted`.
 3. The backend publishes each translated message over SSE.
-4. Separately, `pruneGoogleDataAndNotifyRevoked`
-   (`packages/backend/src/common/services/gcal/google-revoked.util.ts`)
-   publishes `syncStatusChanged` with `code: "GOOGLE_REVOKED"` directly when
-   the backend itself detects a revoked/missing Google grant.
+4. Revocation on the mutation path is HTTP 410 `GOOGLE_REVOKED`
+   (`event.controller.ts` maps Sync `authorizationRevoked`). The SSE attention
+   codes are `CONNECTION_REVOKED` (with `connectionId`) and the one-release
+   alias `GOOGLE_REVOKED`. Helper `revokedConnectionServerMessages` in
+   `packages/core/src/types/server-message.contracts.ts` emits both. Milestone
+   C drops `GOOGLE_REVOKED` after every client reads `CONNECTION_REVOKED`.
 
 Primary files:
 
 - `packages/backend/src/servers/sse/sync-change-feed.bridge.ts`
 - `packages/backend/src/servers/sse/sync-invalidation.to-server-message.ts`
-- `packages/backend/src/common/services/gcal/google-revoked.util.ts`
+- `packages/core/src/types/server-message.contracts.ts`
 - `packages/core/src/types/sync/change-feed.contracts.ts` (the Sync-side invalidation shapes)
 
 ## SSE Server Responsibilities
@@ -164,7 +172,7 @@ The client:
 - opens `EventSource` when a session exists (`SessionProvider` + `SSEProvider`)
 - refetches events when `eventsChanged` arrives (by invalidating the matching event query scopes)
 - tracks Google sync/import status from `syncStatusChanged`/`importCompleted` and `userMetadataChanged`
-- handles the `GOOGLE_REVOKED` `syncStatusChanged` code consistently with REST error payloads
+- handles the `GOOGLE_REVOKED` `syncStatusChanged` code consistently with REST 410 payloads. `CONNECTION_REVOKED` is the provider-neutral alias on the same wire; clients must treat both until milestone C drops `GOOGLE_REVOKED`
 - auto-refreshes Google Calendar sync on app focus (below)
 
 Refetches are driven by TanStack Query invalidation keyed to the message
@@ -192,13 +200,21 @@ Constraints:
 Without this, a user can stare at a stale “Updated …” label until they
 remember to click **Refresh calendar**.
 
-## Revoked Token And Reconnect Lifecycle
+## Revoked Token And Reconnect Lifecycle (`CONNECTION_REVOKED`)
 
-1. Backend detects missing/invalid Google refresh token (middleware or Google API error handling) or Sync reports it via the change feed.
-2. Backend prunes Google-origin data and publishes a `syncStatusChanged` message with `code: "GOOGLE_REVOKED"`.
-3. Web app marks Google as revoked in session memory.
-4. User initiates re-consent via the OAuth flow (proxied to Sync).
-5. Sync completes the OAuth exchange; the backend's next metadata fetch/change-feed poll picks up the reconnected state.
+1. Sync classifies a dead grant as `authorizationRevoked`, discards the
+   credential, and derives connection state `actionRequired`. A `connection`
+   invalidation fans out as `calendarsChanged` / `eventsChanged`. Event
+   mutations against a revoked grant return HTTP 410 `GOOGLE_REVOKED`.
+2. The SSE attention payload may carry `CONNECTION_REVOKED` (with
+   `connectionId`) and the alias `GOOGLE_REVOKED` (see
+   `revokedConnectionServerMessages`). Clients that only read `GOOGLE_REVOKED`
+   still work until milestone C.
+3. Web app marks the connection as revoked in session memory.
+4. User initiates re-consent via the OAuth flow (`POST /api/auth/connections/begin`,
+   proxied to Sync).
+5. Sync completes the OAuth exchange; the backend's next metadata fetch /
+   change-feed poll picks up the reconnected state.
 
 ## Failed Job Self-Heal (Sync Operator Path)
 
@@ -210,7 +226,7 @@ Nothing else requeues that row unless the **failed-job self-heal** sweep runs
 1. After a ~30 minute cooldown, the sweep requeues cooled-down failed jobs with
    a fresh attempt budget (up to `FAILED_JOB_MAX_REQUEUES`, currently 3).
 2. Jobs that keep failing past that budget are **exhausted** and need an
-   operator — see [manage-failed-jobs](../development/cli.md#manage-exhausted-sync-jobs).
+   operator. See [manage-failed-jobs](../development/cli.md#manage-exhausted-sync-jobs).
 3. Exhausted jobs whose connection already has a durable provider read-failure
    marker (`lastReadFailureAt`, for example Google `notACalendarUser`) are
    **auto-cleared** so their coalescing key no longer blocks rediscovery /


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3238

## What and why

P0 WP-13 closeout: the calendar-providers spec Architecture section now names the landed `ProviderRegistry`, port methods, config keys, public and Compass connection routes, and credential kinds. Named warts record the release that removes each alias (`GOOGLE_REVOKED`, health-snapshot `provider: "google"`, `metadata.google` overlap, plaintext OAuth rows). SSE docs cover `CONNECTION_REVOKED`. Event-domain-model no longer says only Google is implemented. README keeps the Outlook non-goal and points at the providers spec.

Tracking #3207 Deferred that became wrong: encrypting OAuth refresh tokens at rest is already done for new stores; C still drops plaintext acceptance.

## Verify

`VERDICT: PASS`

Checks run: type-check, lint, knip

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e10c8f83-8623-43cb-99e3-58a63384cc19?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e10c8f83-8623-43cb-99e3-58a63384cc19&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

