### PR TITLE
feat(sync): Microsoft Graph event reader with delta (WP-05)

### DIFF
--- a/.agents/handoffs/3244.md
+++ b/.agents/handoffs/3244.md
@@ -1,0 +1,40 @@
+---
+schema_version: 1
+task_id: "3244"
+from: Implementer
+to: GitHub
+owner: GitHub
+status: verifying
+artifact:
+  - path: packages/sync/src/providers/microsoft/microsoft-event-reader.adapter.ts
+  - path: packages/sync/src/providers/microsoft/microsoft-event-reader.adapter.test.ts
+  - path: packages/sync/src/providers/microsoft/microsoft-http.constants.ts
+  - path: packages/sync/src/providers/microsoft/microsoft-error.ts
+  - path: packages/sync/src/providers/__contract__/fixtures/microsoft/reader.json
+  - path: packages/sync/src/providers/__contract__/microsoft-contract.factory.ts
+  - path: docs/features/calendar-providers.md
+evidence:
+  - command: bun test:sync
+    result: pass
+  - command: bun run type-check
+    result: pass
+  - command: bun lint
+    result: pass
+  - command: bun knip
+    result: pass
+  - command: bun run verify --strict
+    result: "VERDICT: PASS"
+assumptions:
+  - "events/delta returns seriesMaster and exception rows per Graph documentation; occurrence rows are skipped when calendarView/delta is used for windowed passes."
+  - "Microsoft is not registered in ProviderRegistry until M-09 (#3249)."
+open_risks: []
+next_deadline: 2026-09-05T04:00:00Z
+retry: 0
+approval: allow
+waiting_on: null
+escalation: null
+---
+
+M WP-05: Graph event reader with delta (`ProviderEventReader.listEventPage`).
+
+Spike recorded in `docs/features/calendar-providers.md` Microsoft Graph event reads section.

--- a/docs/features/calendar-providers.md
+++ b/docs/features/calendar-providers.md
@@ -265,6 +265,32 @@ Each alias names the release that removes it.
 - Microsoft category colors are read but never written back.
 - Apple freshness depends on polling and is bounded by iCloud rate limits.
 
+## Microsoft Graph event reads
+
+WP-05 spike (Graph documentation, confirmed against the normalizer fixture corpus):
+
+| Endpoint | `type` values returned | Compass use |
+|---|---|---|
+| `GET /me/calendars/{id}/events/delta` | `singleInstance`, `seriesMaster`, `exception` (no `occurrence`) | Primary incremental reader |
+| `GET /me/calendars/{id}/calendarView/delta` | `singleInstance`, `occurrence`, `exception` (expanded instances) | Windowed bootstrap pass only |
+
+Compass reads masters and exceptions, never occurrences. The reader uses
+`events/delta` for full and incremental passes (`startDateTime` bounded to the
+sync horizon: 12 months past through 18 months future). When the import worker
+supplies a bounded working window with both ends, the reader uses
+`calendarView/delta` because `events/delta` does not accept `endDateTime`.
+Occurrence rows from `calendarView/delta` are skipped and counted in `skipped`.
+
+Initial and incremental requests send `Prefer: odata.maxpagesize=200` and
+`outlook.timezone="UTC"`. `@odata.nextLink` becomes `nextPageToken`;
+`@odata.deltaLink` becomes `nextSyncToken` (stored as `syncCursor`). Removed
+items arrive as `{id, "@removed": {reason}}` and map to cancellations. A `410`
+or `syncStateNotFound` response maps to `cursorExpired`.
+
+If a future Graph change returns occurrence-only rows from `events/delta`, fall
+back to `calendarView/delta` over the horizon plus a `GET /me/events/{seriesMasterId}`
+hop for masters, and update this section.
+
 ## Apple polling cadence
 
 Apple has no push channel (`changeNotifications` is absent from the

--- a/packages/sync/src/providers/__contract__/fixtures/microsoft/reader.json
+++ b/packages/sync/src/providers/__contract__/fixtures/microsoft/reader.json
@@ -1,0 +1,150 @@
+{
+  "page1": {
+    "items": [
+      {
+        "id": "AAMkAGI2TG93AAA=",
+        "@odata.etag": "W/\"graph-timed-etag\"",
+        "type": "singleInstance",
+        "subject": "Graph timed contract",
+        "bodyPreview": "Preview text",
+        "lastModifiedDateTime": "2025-01-10T12:00:00.0000000Z",
+        "iCalUId": "040000008200E00074C5B7101A82E00800000000000000000000000000000000000000000000000000",
+        "location": { "displayName": "Conference Room" },
+        "organizer": {
+          "emailAddress": { "name": "Organizer", "address": "org@example.com" }
+        },
+        "showAs": "busy",
+        "start": {
+          "dateTime": "2025-01-15T14:00:00.0000000",
+          "timeZone": "UTC"
+        },
+        "end": { "dateTime": "2025-01-15T15:00:00.0000000", "timeZone": "UTC" }
+      },
+      {
+        "id": "AAMkAGI2TG94AAA=",
+        "@odata.etag": "W/\"graph-allday-etag\"",
+        "type": "singleInstance",
+        "subject": "Graph all-day contract",
+        "isAllDay": true,
+        "showAs": "free",
+        "start": {
+          "dateTime": "2022-02-22T00:00:00.0000000",
+          "timeZone": "UTC"
+        },
+        "end": { "dateTime": "2022-02-23T00:00:00.0000000", "timeZone": "UTC" }
+      },
+      {
+        "id": "AAMkAGI2TG95AAA=",
+        "@odata.etag": "W/\"graph-series-etag\"",
+        "type": "seriesMaster",
+        "subject": "Graph series contract",
+        "start": {
+          "dateTime": "2025-09-07T01:30:00.0000000",
+          "timeZone": "UTC"
+        },
+        "end": { "dateTime": "2025-09-07T02:30:00.0000000", "timeZone": "UTC" },
+        "recurrence": {
+          "pattern": { "type": "daily", "interval": 1 },
+          "range": {
+            "type": "endDate",
+            "startDate": "2025-09-07",
+            "endDate": "2025-09-16"
+          }
+        }
+      },
+      {
+        "id": "AAMkAGI2TG96AAA=",
+        "@odata.etag": "W/\"graph-exception-etag\"",
+        "type": "exception",
+        "subject": "Graph exception contract",
+        "seriesMasterId": "AAMkAGI2TG95AAA=",
+        "originalStart": "2025-09-08T01:30:00.0000000Z",
+        "start": {
+          "dateTime": "2025-09-08T02:00:00.0000000",
+          "timeZone": "UTC"
+        },
+        "end": { "dateTime": "2025-09-08T03:00:00.0000000", "timeZone": "UTC" }
+      },
+      {
+        "id": "AAMkAGI2TG97AAA=",
+        "@odata.etag": "W/\"graph-cancelled-etag\"",
+        "type": "exception",
+        "isCancelled": true,
+        "seriesMasterId": "AAMkAGI2TG95AAA=",
+        "originalStart": "2013-05-08T22:00:00.0000000Z"
+      },
+      {
+        "id": "AAMkAGI2TG98AAA=",
+        "@odata.etag": "W/\"graph-occurrence-etag\"",
+        "type": "occurrence",
+        "seriesMasterId": "AAMkAGI2TG95AAA=",
+        "start": {
+          "dateTime": "2025-09-09T01:30:00.0000000",
+          "timeZone": "UTC"
+        },
+        "end": { "dateTime": "2025-09-09T02:30:00.0000000", "timeZone": "UTC" }
+      },
+      {
+        "id": "AAMkAGI2TG99AAA=",
+        "@odata.etag": "W/\"graph-attendees-etag\"",
+        "type": "singleInstance",
+        "subject": "Graph attendees contract",
+        "categories": ["Blue category"],
+        "onlineMeeting": {
+          "joinUrl": "https://teams.microsoft.com/l/meetup-join/abc"
+        },
+        "onlineMeetingProvider": "teamsForBusiness",
+        "attendees": [
+          {
+            "type": "required",
+            "emailAddress": { "address": "a@x.com", "name": "A" },
+            "status": { "response": "accepted" }
+          },
+          {
+            "type": "required",
+            "emailAddress": { "address": "b@x.com" },
+            "status": { "response": "declined" }
+          }
+        ],
+        "start": {
+          "dateTime": "2025-01-15T14:00:00.0000000",
+          "timeZone": "UTC"
+        },
+        "end": { "dateTime": "2025-01-15T15:00:00.0000000", "timeZone": "UTC" }
+      },
+      {
+        "id": "AAMkAGI2TG9aAAA=",
+        "type": "singleInstance",
+        "subject": "structurally unusable",
+        "start": {
+          "dateTime": "2025-01-15T14:00:00.0000000",
+          "timeZone": "UTC"
+        },
+        "end": { "dateTime": "2025-01-15T15:00:00.0000000", "timeZone": "UTC" }
+      }
+    ],
+    "nextLink": "https://graph.microsoft.com/v1.0/me/calendars/primary/events/delta?$skiptoken=page-2",
+    "deltaLink": null
+  },
+  "page2": {
+    "items": [
+      {
+        "id": "AAMkAGI2TG9bAAA=",
+        "@odata.etag": "W/\"graph-page2-etag\"",
+        "type": "singleInstance",
+        "subject": "Second page",
+        "start": {
+          "dateTime": "2025-02-01T14:00:00.0000000",
+          "timeZone": "UTC"
+        },
+        "end": { "dateTime": "2025-02-01T15:00:00.0000000", "timeZone": "UTC" }
+      }
+    ],
+    "nextLink": null,
+    "deltaLink": "https://graph.microsoft.com/v1.0/me/calendars/primary/events/delta?$deltatoken=sync-1"
+  },
+  "expiredDeltaLink": "https://graph.microsoft.com/v1.0/me/calendars/primary/events/delta?$deltatoken=expired-sync-token",
+  "masterCategories": {
+    "Blue category": "#0078D4"
+  }
+}

--- a/packages/sync/src/providers/__contract__/microsoft-contract.factory.ts
+++ b/packages/sync/src/providers/__contract__/microsoft-contract.factory.ts
@@ -1,0 +1,81 @@
+import {
+  type GraphEventDeltaItem,
+  type MicrosoftEventListApi,
+  type MicrosoftEventListPage,
+  MicrosoftEventReaderAdapter,
+} from "@sync/providers/microsoft/microsoft-event-reader.adapter";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CONTRACT_ROOT = dirname(fileURLToPath(import.meta.url));
+
+interface ReaderCorpusPage {
+  readonly items: readonly GraphEventDeltaItem[];
+  readonly nextLink?: string | null;
+  readonly deltaLink?: string | null;
+}
+
+export interface MicrosoftReaderCorpus {
+  readonly page1: ReaderCorpusPage;
+  readonly page2: ReaderCorpusPage;
+  readonly expiredDeltaLink: string;
+  readonly masterCategories: Record<string, string>;
+}
+
+class CorpusEventListApi implements MicrosoftEventListApi {
+  constructor(private readonly corpus: MicrosoftReaderCorpus) {}
+
+  async listPage(
+    params: Parameters<MicrosoftEventListApi["listPage"]>[0],
+  ): Promise<MicrosoftEventListPage> {
+    if (params.deltaLink === this.corpus.expiredDeltaLink) {
+      throw httpError(410);
+    }
+    if (params.pageLink) {
+      return normalizePage(this.corpus.page2);
+    }
+    return normalizePage(this.corpus.page1);
+  }
+}
+
+function normalizePage(page: ReaderCorpusPage): MicrosoftEventListPage {
+  return {
+    items: page.items,
+    nextLink: page.nextLink ?? null,
+    deltaLink: page.deltaLink ?? null,
+  };
+}
+
+function httpError(status: number, body?: unknown): Error {
+  return Object.assign(new Error(`microsoft error ${status}`), {
+    response: { status, data: body },
+  });
+}
+
+function loadJson<T>(corpusDir: string, name: string): T {
+  return JSON.parse(readFileSync(join(corpusDir, `${name}.json`), "utf8")) as T;
+}
+
+/** Replay `fixtures/microsoft/reader.json` through the event reader adapter. */
+export function microsoftRecordedReader(
+  corpusDir: string,
+): MicrosoftEventReaderAdapter {
+  const reader = loadJson<MicrosoftReaderCorpus>(corpusDir, "reader");
+  return new MicrosoftEventReaderAdapter(() => new CorpusEventListApi(reader), {
+    warn: () => {},
+  });
+}
+
+export function defaultMicrosoftReaderCorpus(): MicrosoftReaderCorpus {
+  return loadJson<MicrosoftReaderCorpus>(
+    join(CONTRACT_ROOT, "fixtures", "microsoft"),
+    "reader",
+  );
+}
+
+export function microsoftReaderMasterCategories(): Map<string, string> {
+  return new Map(
+    Object.entries(defaultMicrosoftReaderCorpus().masterCategories),
+  );
+}

--- a/packages/sync/src/providers/__contract__/microsoft.contract.test.ts
+++ b/packages/sync/src/providers/__contract__/microsoft.contract.test.ts
@@ -1,9 +1,15 @@
 import { generateKeyPair, type KeyLike, SignJWT } from "jose";
+import { defaultCorpusDir } from "@sync/providers/__contract__/adapter-contract";
 import { type AuthContractCase } from "@sync/providers/__contract__/auth.contract";
 import exchangeFixture from "@sync/providers/__contract__/fixtures/microsoft/exchange-success.json";
 import normalizerFixture from "@sync/providers/__contract__/fixtures/microsoft/normalizer.json";
 import refreshRevokedFixture from "@sync/providers/__contract__/fixtures/microsoft/refresh-invalid-grant.json";
 import refreshSuccessFixture from "@sync/providers/__contract__/fixtures/microsoft/refresh-success.json";
+import {
+  defaultMicrosoftReaderCorpus,
+  microsoftReaderMasterCategories,
+  microsoftRecordedReader,
+} from "@sync/providers/__contract__/microsoft-contract.factory";
 import {
   MicrosoftAuthAdapter,
   type MicrosoftIdTokenVerifier,
@@ -16,6 +22,10 @@ import {
 } from "@sync/providers/microsoft/microsoft-event.normalizer";
 import { ProviderAuthError } from "@sync/providers/provider-auth.port";
 import { ProviderEventError } from "@sync/providers/provider-event.port";
+import {
+  type ProviderEventReadError,
+  type ProviderEventReader,
+} from "@sync/providers/provider-event-reader.port";
 
 const CLIENT_ID = "microsoft-client-id";
 const CLIENT_SECRET = "microsoft-client-secret";
@@ -264,3 +274,77 @@ describe("microsoft normalizer contract", () => {
     expect(read.content.colorHex).toBe("#0078D4");
   });
 });
+
+const readerCorpusDir = defaultCorpusDir("microsoft");
+const readerAdapter = microsoftRecordedReader(readerCorpusDir);
+const readerCorpus = defaultMicrosoftReaderCorpus();
+
+describe("microsoft reader contract", () => {
+  it("pages, yields nextSyncToken only at the end, and counts skipped events", async () => {
+    const first = await readerAdapter.listEventPage({
+      accessToken: "contract-access-token",
+      calendarId: "primary",
+      colorLabels: microsoftReaderMasterCategories(),
+    });
+    expect(first.skipped).toBeGreaterThanOrEqual(1);
+
+    let page = first;
+    let pages = 1;
+    while (page.nextPageToken) {
+      expect(page.nextSyncToken).toBeNull();
+      page = await readerAdapter.listEventPage({
+        accessToken: "contract-access-token",
+        calendarId: "primary",
+        pageToken: page.nextPageToken,
+        colorLabels: microsoftReaderMasterCategories(),
+      });
+      pages += 1;
+    }
+    expect(pages).toBe(2);
+    expect(page.nextPageToken).toBeNull();
+    expect(page.nextSyncToken).toBe(readerCorpus.page2.deltaLink);
+  });
+
+  it("maps an expired cursor to cursorExpired", async () => {
+    try {
+      await readerAdapter.listEventPage({
+        accessToken: "contract-access-token",
+        calendarId: "primary",
+        cursor: readerCorpus.expiredDeltaLink,
+      });
+      throw new Error("expected cursorExpired");
+    } catch (caught) {
+      expect((caught as ProviderEventReadError).reason).toBe("cursorExpired");
+    }
+  });
+
+  it("keeps masters and exceptions and does not expand occurrences", async () => {
+    const events = await collectReaderEvents(readerAdapter);
+    const masters = events.filter(
+      (event) =>
+        event.kind === "event" && event.recurrence.kind === "seriesMaster",
+    );
+    const instances = events.filter(
+      (event) => event.kind === "event" && event.recurrence.kind === "instance",
+    );
+    expect(masters.length).toBeGreaterThanOrEqual(1);
+    expect(instances.length).toBeGreaterThanOrEqual(1);
+    expect(instances.length).toBeLessThan(5);
+  });
+});
+
+async function collectReaderEvents(reader: ProviderEventReader) {
+  const events = [];
+  let pageToken: string | null = null;
+  do {
+    const page = await reader.listEventPage({
+      accessToken: "contract-access-token",
+      calendarId: "primary",
+      pageToken,
+      colorLabels: microsoftReaderMasterCategories(),
+    });
+    events.push(...page.events);
+    pageToken = page.nextPageToken;
+  } while (pageToken);
+  return events;
+}

--- a/packages/sync/src/providers/microsoft/microsoft-error.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-error.ts
@@ -1,0 +1,36 @@
+import { redactedCause } from "@sync/safety/redact-error";
+
+export function microsoftStatus(error: unknown): number | undefined {
+  const status = (error as { response?: { status?: number } })?.response
+    ?.status;
+  return typeof status === "number" ? status : undefined;
+}
+
+export function microsoftErrorCode(error: unknown): string | undefined {
+  const code = (
+    error as { response?: { data?: { error?: { code?: unknown } } } }
+  )?.response?.data?.error?.code;
+  return typeof code === "string" ? code : undefined;
+}
+
+export function isMicrosoftTransient(
+  error: unknown,
+  status: number | undefined = microsoftStatus(error),
+): boolean {
+  if (status === undefined || status === 429 || status >= 500) return true;
+  return false;
+}
+
+export function microsoftFailureCause(error: unknown): Error | undefined {
+  const status = microsoftStatus(error);
+  const code = microsoftErrorCode(error);
+  const facts = [
+    ...(status === undefined ? [] : [`HTTP ${status}`]),
+    ...(code ? [code] : []),
+  ];
+  if (facts.length === 0) return redactedCause(error);
+  const message = error instanceof Error ? error.message : null;
+  return new Error(
+    message ? `${message} (${facts.join(", ")})` : facts.join(", "),
+  );
+}

--- a/packages/sync/src/providers/microsoft/microsoft-event-reader.adapter.test.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-event-reader.adapter.test.ts
@@ -1,0 +1,315 @@
+import {
+  type GraphEventDeltaItem,
+  type MicrosoftEventListApi,
+  type MicrosoftEventListPage,
+  MicrosoftEventReaderAdapter,
+} from "@sync/providers/microsoft/microsoft-event-reader.adapter";
+import { ProviderEventReadError } from "@sync/providers/provider-event-reader.port";
+
+class FakeEventListApi implements MicrosoftEventListApi {
+  calls: Array<Parameters<MicrosoftEventListApi["listPage"]>[0]> = [];
+  #pages: MicrosoftEventListPage[];
+  #error?: unknown;
+
+  constructor(pages: MicrosoftEventListPage[], error?: unknown) {
+    this.#pages = pages;
+    this.#error = error;
+  }
+
+  async listPage(
+    params: Parameters<MicrosoftEventListApi["listPage"]>[0],
+  ): Promise<MicrosoftEventListPage> {
+    this.calls.push(params);
+    if (this.#error) throw this.#error;
+    const page = this.#pages.shift();
+    if (!page) throw new Error("FakeEventListApi: no page scripted");
+    return page;
+  }
+}
+
+const mEvent = (
+  overrides: Partial<GraphEventDeltaItem> = {},
+): GraphEventDeltaItem => ({
+  id: "evt-id",
+  "@odata.etag": 'W/"v1"',
+  type: "singleInstance",
+  subject: "Title",
+  start: { dateTime: "2025-01-15T14:00:00.0000000", timeZone: "UTC" },
+  end: { dateTime: "2025-01-15T15:00:00.0000000", timeZone: "UTC" },
+  ...overrides,
+});
+
+const page = (
+  overrides: Partial<MicrosoftEventListPage>,
+): MicrosoftEventListPage => ({
+  items: [],
+  nextLink: null,
+  deltaLink: null,
+  ...overrides,
+});
+
+function adapterWith(
+  api: MicrosoftEventListApi,
+  log: { warn: (message: string) => void } = { warn: () => {} },
+) {
+  const tokensSeen: string[] = [];
+  const adapter = new MicrosoftEventReaderAdapter((accessToken) => {
+    tokensSeen.push(accessToken);
+    return api;
+  }, log);
+  return { adapter, tokensSeen };
+}
+
+describe("MicrosoftEventReaderAdapter", () => {
+  it("normalizes a page's events and returns its page and delta tokens", async () => {
+    const api = new FakeEventListApi([
+      page({
+        items: [
+          mEvent({ id: "a", subject: "A" }),
+          mEvent({ id: "b", subject: "B" }),
+        ],
+        deltaLink: "https://graph.microsoft.com/delta?$deltatoken=sync-1",
+      }),
+    ]);
+    const { adapter, tokensSeen } = adapterWith(api);
+
+    const result = await adapter.listEventPage({
+      accessToken: "tok",
+      calendarId: "cal-1",
+    });
+
+    expect(tokensSeen).toEqual(["tok"]);
+    expect(result.events.map((e) => e.providerEventId)).toEqual(["a", "b"]);
+    expect(result.skipped).toBe(0);
+    expect(result.nextPageToken).toBeNull();
+    expect(result.nextSyncToken).toBe(
+      "https://graph.microsoft.com/delta?$deltatoken=sync-1",
+    );
+  });
+
+  it("uses calendarView delta when a bounded window is provided", async () => {
+    const api = new FakeEventListApi([page({})]);
+    const { adapter } = adapterWith(api);
+
+    await adapter.listEventPage({
+      accessToken: "tok",
+      calendarId: "cal-1",
+      window: {
+        timeMin: "2026-06-01T00:00:00Z",
+        timeMax: "2026-09-01T00:00:00Z",
+      },
+    });
+
+    expect(api.calls[0]?.strategy).toBe("calendarView");
+    expect(api.calls[0]?.window).toEqual({
+      timeMin: "2026-06-01T00:00:00Z",
+      timeMax: "2026-09-01T00:00:00Z",
+    });
+  });
+
+  it("forwards the stored delta link and page link for a resumed pass", async () => {
+    const api = new FakeEventListApi([page({})]);
+    const { adapter } = adapterWith(api);
+    const deltaLink = "https://graph.microsoft.com/delta?$deltatoken=stored";
+    const pageLink = "https://graph.microsoft.com/delta?$skiptoken=page-2";
+
+    await adapter.listEventPage({
+      accessToken: "tok",
+      calendarId: "cal-1",
+      cursor: deltaLink,
+      pageToken: pageLink,
+    });
+
+    expect(api.calls[0]?.deltaLink).toBe(deltaLink);
+    expect(api.calls[0]?.pageLink).toBe(pageLink);
+  });
+
+  it("maps removed items to cancellations", async () => {
+    const api = new FakeEventListApi([
+      page({
+        items: [
+          mEvent({ id: "live", subject: "Live" }),
+          { id: "gone", "@removed": { reason: "deleted" } },
+        ],
+      }),
+    ]);
+    const { adapter } = adapterWith(api);
+
+    const result = await adapter.listEventPage({
+      accessToken: "tok",
+      calendarId: "cal-1",
+    });
+
+    expect(result.events.map((e) => e.kind)).toEqual(["event", "cancellation"]);
+  });
+
+  it("skips occurrence rows and counts them in skipped", async () => {
+    const api = new FakeEventListApi([
+      page({
+        items: [
+          mEvent({ id: "ok", subject: "OK" }),
+          mEvent({
+            id: "occ-1",
+            type: "occurrence",
+            seriesMasterId: "series-1",
+          }),
+        ],
+      }),
+    ]);
+    const { adapter } = adapterWith(api);
+
+    const result = await adapter.listEventPage({
+      accessToken: "tok",
+      calendarId: "cal-1",
+    });
+
+    expect(result.events.map((e) => e.providerEventId)).toEqual(["ok"]);
+    expect(result.skipped).toBe(1);
+  });
+
+  it("drops and counts a structurally unusable event without failing the page", async () => {
+    const api = new FakeEventListApi([
+      page({
+        items: [
+          mEvent({ id: "ok", subject: "OK" }),
+          mEvent({ id: "no-etag", "@odata.etag": undefined }),
+        ],
+      }),
+    ]);
+    const { adapter } = adapterWith(api);
+
+    const result = await adapter.listEventPage({
+      accessToken: "tok",
+      calendarId: "cal-1",
+    });
+
+    expect(result.events.map((e) => e.providerEventId)).toEqual(["ok"]);
+    expect(result.skipped).toBe(1);
+  });
+
+  it("threads colorLabels through as Outlook category colors", async () => {
+    const api = new FakeEventListApi([
+      page({
+        items: [
+          mEvent({
+            id: "labeled",
+            categories: ["Blue category"],
+          }),
+        ],
+      }),
+    ]);
+    const { adapter } = adapterWith(api);
+
+    const result = await adapter.listEventPage({
+      accessToken: "tok",
+      calendarId: "cal-1",
+      colorLabels: new Map([["Blue category", "#0078D4"]]),
+    });
+
+    expect(result.events[0]).toMatchObject({
+      content: { colorHex: "#0078D4" },
+    });
+  });
+
+  it("maps an expired delta token (410) to cursorExpired", async () => {
+    const api = new FakeEventListApi([], { response: { status: 410 } });
+    const { adapter } = adapterWith(api);
+
+    await expect(
+      adapter.listEventPage({
+        accessToken: "tok",
+        calendarId: "cal-1",
+        cursor: "https://graph.microsoft.com/delta?$deltatoken=stale",
+      }),
+    ).rejects.toMatchObject({ reason: "cursorExpired" });
+  });
+
+  it("maps syncStateNotFound to cursorExpired", async () => {
+    const api = new FakeEventListApi([], {
+      response: {
+        status: 404,
+        data: { error: { code: "syncStateNotFound" } },
+      },
+    });
+    const { adapter } = adapterWith(api);
+
+    await expect(
+      adapter.listEventPage({
+        accessToken: "tok",
+        calendarId: "cal-1",
+        cursor: "https://graph.microsoft.com/delta?$deltatoken=stale",
+      }),
+    ).rejects.toMatchObject({ reason: "cursorExpired" });
+  });
+
+  it("maps a rate limit and a server error to transient", async () => {
+    for (const status of [429, 503]) {
+      const api = new FakeEventListApi([], { response: { status } });
+      const { adapter } = adapterWith(api);
+      await expect(
+        adapter.listEventPage({
+          accessToken: "tok",
+          calendarId: "cal-1",
+        }),
+      ).rejects.toMatchObject({ reason: "transient" });
+    }
+  });
+
+  it("maps a 401 to authExpired", async () => {
+    const api = new FakeEventListApi([], { response: { status: 401 } });
+    const { adapter } = adapterWith(api);
+
+    await expect(
+      adapter.listEventPage({
+        accessToken: "tok",
+        calendarId: "cal-1",
+      }),
+    ).rejects.toMatchObject({ reason: "authExpired" });
+  });
+
+  it("maps an unrecoverable 4xx to readFailed", async () => {
+    const api = new FakeEventListApi([], { response: { status: 404 } });
+    const { adapter } = adapterWith(api);
+
+    await expect(
+      adapter.listEventPage({
+        accessToken: "tok",
+        calendarId: "cal-1",
+      }),
+    ).rejects.toMatchObject({ reason: "readFailed" });
+  });
+
+  it("keeps the HTTP status on the cause for triage", async () => {
+    const rejected = Object.assign(new Error("Not Found"), {
+      response: {
+        status: 404,
+        data: { error: { code: "ErrorItemNotFound" } },
+      },
+    });
+    const api = new FakeEventListApi([], rejected);
+    const { adapter } = adapterWith(api);
+
+    const error = await adapter
+      .listEventPage({ accessToken: "tok", calendarId: "cal-1" })
+      .catch((e) => e as ProviderEventReadError);
+
+    expect((error.cause as Error)?.message).toContain("HTTP 404");
+    expect((error.cause as Error)?.message).toContain("ErrorItemNotFound");
+  });
+
+  it("never leaks the access token onto a thrown error's cause", async () => {
+    const leaky = new Error("boom") as Error & { config?: unknown };
+    leaky.config = { headers: { Authorization: "Bearer super-secret-token" } };
+    const api = new FakeEventListApi([], leaky);
+    const { adapter } = adapterWith(api);
+
+    const error = await adapter
+      .listEventPage({ accessToken: "tok", calendarId: "cal-1" })
+      .catch((e) => e as ProviderEventReadError);
+
+    expect(error).toBeInstanceOf(ProviderEventReadError);
+    expect(JSON.stringify(error.cause ?? {})).not.toContain(
+      "super-secret-token",
+    );
+  });
+});

--- a/packages/sync/src/providers/microsoft/microsoft-event-reader.adapter.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-event-reader.adapter.ts
@@ -1,0 +1,250 @@
+import { Logger } from "@core/logger/winston.logger";
+import { syncHorizon } from "@sync/domain/horizon";
+import {
+  isMicrosoftTransient,
+  microsoftErrorCode,
+  microsoftFailureCause,
+  microsoftStatus,
+} from "@sync/providers/microsoft/microsoft-error";
+import {
+  type GraphEvent,
+  normalizeMicrosoftEvent,
+} from "@sync/providers/microsoft/microsoft-event.normalizer";
+import {
+  MICROSOFT_EVENT_PAGE_SIZE,
+  MICROSOFT_EVENT_SELECT,
+  MICROSOFT_GRAPH_BASE_URL,
+  MICROSOFT_REQUEST_TIMEOUT_MS,
+} from "@sync/providers/microsoft/microsoft-http.constants";
+import { ProviderEventError } from "@sync/providers/provider-event.port";
+import {
+  type EventWindow,
+  type ProviderEventPage,
+  ProviderEventReadError,
+  type ProviderEventReader,
+  type ProviderEventReadInput,
+} from "@sync/providers/provider-event-reader.port";
+
+export interface GraphEventDeltaItem extends GraphEvent {
+  readonly ["@removed"]?: { readonly reason?: string };
+}
+
+export interface MicrosoftEventListPage {
+  readonly items: readonly GraphEventDeltaItem[];
+  readonly nextLink: string | null;
+  readonly deltaLink: string | null;
+}
+
+export interface MicrosoftEventListApi {
+  listPage(params: {
+    calendarId: string;
+    window?: EventWindow | null;
+    deltaLink?: string;
+    pageLink?: string;
+    strategy?: MicrosoftEventListStrategy;
+  }): Promise<MicrosoftEventListPage>;
+}
+
+export type MicrosoftEventListApiFactory = (
+  accessToken: string,
+) => MicrosoftEventListApi;
+
+export type MicrosoftEventListStrategy = "events" | "calendarView";
+
+const logger = Logger("sync:microsoft-event-reader");
+
+const defaultApiFactory: MicrosoftEventListApiFactory = (accessToken) =>
+  new FetchMicrosoftEventListApi(accessToken);
+
+// Microsoft Graph implementation of the event-read port. Reads one page of a
+// calendar's events through events/delta (masters and exceptions, never
+// occurrences) or, when a bounded window needs an end date, calendarView/delta.
+export class MicrosoftEventReaderAdapter implements ProviderEventReader {
+  #makeApi: MicrosoftEventListApiFactory;
+  #log: { warn: (message: string) => void };
+
+  constructor(
+    makeApi: MicrosoftEventListApiFactory = defaultApiFactory,
+    log?: { warn: (message: string) => void },
+  ) {
+    this.#makeApi = makeApi;
+    this.#log = log ?? logger;
+  }
+
+  async listEventPage(
+    input: ProviderEventReadInput,
+  ): Promise<ProviderEventPage> {
+    const api = this.#makeApi(input.accessToken);
+    const page = await this.#listPage(api, {
+      calendarId: input.calendarId,
+      window: input.window ?? null,
+      deltaLink: input.cursor ?? undefined,
+      pageLink: input.pageToken ?? undefined,
+      strategy: resolveListStrategy(input),
+    });
+
+    const events = [];
+    let skipped = 0;
+    for (const item of page.items) {
+      if (item["@removed"]) {
+        if (!item.id) {
+          skipped++;
+          this.#log.warn(
+            "Skipped unusable Microsoft removal row (missingIdentity)",
+          );
+          continue;
+        }
+        events.push({
+          kind: "cancellation" as const,
+          providerEventId: item.id,
+          providerVersion: "",
+          series: null,
+        });
+        continue;
+      }
+
+      if (item.type === "occurrence") {
+        skipped++;
+        this.#log.warn(
+          `Skipped Microsoft occurrence row ${item.id ?? "(no id)"} (unmappableContent)`,
+        );
+        continue;
+      }
+
+      try {
+        events.push(
+          normalizeMicrosoftEvent(item, input.colorLabels ?? new Map()),
+        );
+      } catch (error) {
+        if (error instanceof ProviderEventError) {
+          skipped++;
+          this.#log.warn(
+            `Skipped unusable Microsoft event ${item.id ?? "(no id)"} (${error.reason})`,
+          );
+          continue;
+        }
+        throw error;
+      }
+    }
+
+    return {
+      events,
+      skipped,
+      nextPageToken: page.nextLink,
+      nextSyncToken: page.deltaLink,
+    };
+  }
+
+  async #listPage(
+    api: MicrosoftEventListApi,
+    params: Parameters<MicrosoftEventListApi["listPage"]>[0],
+  ): Promise<MicrosoftEventListPage> {
+    try {
+      return await api.listPage(params);
+    } catch (error) {
+      throw new ProviderEventReadError(
+        classifyReadError(error),
+        "Microsoft rejected the events delta read",
+        { cause: microsoftFailureCause(error) },
+      );
+    }
+  }
+}
+
+function resolveListStrategy(
+  input: ProviderEventReadInput,
+): MicrosoftEventListStrategy {
+  if (input.cursor || input.pageToken) return "events";
+  if (input.window?.timeMin && input.window.timeMax) return "calendarView";
+  return "events";
+}
+
+function classifyReadError(
+  error: unknown,
+): "cursorExpired" | "authExpired" | "transient" | "readFailed" {
+  const status = microsoftStatus(error);
+  const code = microsoftErrorCode(error);
+  if (status === 410 || code === "syncStateNotFound") return "cursorExpired";
+  if (status === 401) return "authExpired";
+  if (status === 429 || isMicrosoftTransient(error, status)) return "transient";
+  if (status !== undefined && status >= 400 && status < 500) {
+    return "readFailed";
+  }
+  return "transient";
+}
+
+class FetchMicrosoftEventListApi implements MicrosoftEventListApi {
+  #accessToken: string;
+
+  constructor(accessToken: string) {
+    this.#accessToken = accessToken;
+  }
+
+  async listPage(
+    params: Parameters<MicrosoftEventListApi["listPage"]>[0],
+  ): Promise<MicrosoftEventListPage> {
+    const url = resolveRequestUrl(params);
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${this.#accessToken}`,
+        Prefer: `odata.maxpagesize=${MICROSOFT_EVENT_PAGE_SIZE}, outlook.timezone="UTC"`,
+      },
+      signal: AbortSignal.timeout(MICROSOFT_REQUEST_TIMEOUT_MS),
+    });
+
+    const data = (await response.json()) as {
+      value?: GraphEventDeltaItem[];
+      "@odata.nextLink"?: string;
+      "@odata.deltaLink"?: string;
+      error?: { code?: string; message?: string };
+    };
+
+    if (!response.ok) {
+      throw Object.assign(
+        new Error(data.error?.message ?? "microsoft_event_delta_failed"),
+        { response: { status: response.status, data } },
+      );
+    }
+
+    return {
+      items: data.value ?? [],
+      nextLink: data["@odata.nextLink"] ?? null,
+      deltaLink: data["@odata.deltaLink"] ?? null,
+    };
+  }
+}
+
+function resolveRequestUrl(
+  params: Parameters<MicrosoftEventListApi["listPage"]>[0],
+): string {
+  if (params.pageLink) return params.pageLink;
+  if (params.deltaLink) return params.deltaLink;
+
+  const calendarId = encodeURIComponent(params.calendarId);
+  if (params.strategy === "calendarView") {
+    const window = requireWindow(params.window);
+    const query = new URLSearchParams({
+      startDateTime: window.timeMin,
+      endDateTime: window.timeMax,
+    });
+    return `${MICROSOFT_GRAPH_BASE_URL}/me/calendars/${calendarId}/calendarView/delta?${query}`;
+  }
+
+  const query = new URLSearchParams({
+    $select: MICROSOFT_EVENT_SELECT,
+    startDateTime: resolveStartDateTime(params.window),
+  });
+  return `${MICROSOFT_GRAPH_BASE_URL}/me/calendars/${calendarId}/events/delta?${query}`;
+}
+
+function requireWindow(window: EventWindow | null | undefined): EventWindow {
+  if (!window?.timeMin || !window.timeMax) {
+    throw new Error("calendarView delta requires a bounded window");
+  }
+  return window;
+}
+
+function resolveStartDateTime(window: EventWindow | null | undefined): string {
+  if (window?.timeMin) return window.timeMin;
+  return syncHorizon(new Date()).start.toISOString();
+}

--- a/packages/sync/src/providers/microsoft/microsoft-http.constants.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-http.constants.ts
@@ -1,0 +1,31 @@
+// Graph requests use fetch with no default timeout, so a hung socket blocks the
+// job worker until the lease expires. 30s bounds the worst case while covering
+// normal Graph latency.
+export const MICROSOFT_GRAPH_BASE_URL = "https://graph.microsoft.com/v1.0";
+export const MICROSOFT_REQUEST_TIMEOUT_MS = 30_000;
+export const MICROSOFT_EVENT_PAGE_SIZE = 200;
+
+// Fields the M-04 normalizer reads from a Graph event resource.
+export const MICROSOFT_EVENT_SELECT = [
+  "id",
+  "type",
+  "subject",
+  "body",
+  "bodyPreview",
+  "start",
+  "end",
+  "isAllDay",
+  "showAs",
+  "isCancelled",
+  "recurrence",
+  "seriesMasterId",
+  "originalStart",
+  "organizer",
+  "attendees",
+  "location",
+  "onlineMeeting",
+  "onlineMeetingProvider",
+  "categories",
+  "lastModifiedDateTime",
+  "iCalUId",
+].join(",");


### PR DESCRIPTION
Fixes #3244

## What and why

Implements `ProviderEventReader.listEventPage` for Microsoft Graph (M WP-05). The reader uses `events/delta` for full and incremental passes (masters and exceptions, never occurrences) and `calendarView/delta` only when the import worker supplies a bounded window that needs an end date. Removed Graph rows map to cancellations; occurrence rows are skipped. The WP-05 spike outcome is recorded in `docs/features/calendar-providers.md`.

## Verify

```
bun test:sync
bun run type-check
bun lint
bun knip
bun run verify --strict
```

VERDICT: PASS