### PR TITLE
feat(web): gate attendees on capabilities and neutralize provider copy

### DIFF
--- a/.agents/handoffs/3234.md
+++ b/.agents/handoffs/3234.md
@@ -1,0 +1,28 @@
+---
+schema_version: 1
+task_id: "3234"
+from: Implementer
+to: GitHub
+owner: GitHub
+status: verifying
+artifact:
+  - path: packages/web/src/views/Forms/EventForm/EventForm.tsx
+  - path: packages/web/src/views/Forms/hooks/useSaveEventForm.ts
+  - path: packages/web/src/calendars/calendar.util.ts
+  - path: packages/backend/src/event/controllers/event.controller.ts
+evidence:
+  - command: bun run verify --strict
+    result: pending
+assumptions:
+  - "RSVP still keys off accountEmail, not canInviteAttendees, so viewer-access calendars can answer invitations."
+  - "Google Meet and Google Maps product names stay; they are host products, not calendar-provider copy."
+  - "Booking connect-Google prompt stays with WP-08c. Booking destination copy was already neutralized by WP-10."
+open_risks: []
+next_deadline: 2026-09-05T12:00:00Z
+retry: 0
+approval: allow
+waiting_on: null
+escalation: null
+---
+
+P0 WP-09: capability gates replace provider checks; provider-neutral copy pass.

--- a/.agents/handoffs/3234.md
+++ b/.agents/handoffs/3234.md
@@ -12,7 +12,7 @@ artifact:
   - path: packages/backend/src/event/controllers/event.controller.ts
 evidence:
   - command: bun run verify --strict
-    result: pending
+    result: "VERDICT: PASS (test:web, test:backend:fast, type-check, lint, knip, test:a11y, test:e2e)"
 assumptions:
   - "RSVP still keys off accountEmail, not canInviteAttendees, so viewer-access calendars can answer invitations."
   - "Google Meet and Google Maps product names stay; they are host products, not calendar-provider copy."

--- a/docs/features/google-sync-and-sse-flow.md
+++ b/docs/features/google-sync-and-sse-flow.md
@@ -1,5 +1,10 @@
 # Google Sync And Server-Sent Events (SSE)
 
+Provider-neutral contracts, connection API, and capability gates live in
+the [calendar providers spec](./calendar-providers.md). This document is the
+Google-shaped sync and SSE walkthrough; new provider work should follow that
+spec instead of adding Google-only branches here.
+
 Google Calendar sync is owned entirely by the standalone **Sync service**
 (`packages/sync`) — the backend has no Google API calls or sync logic of its
 own. The backend's role is: proxy sync-related reads/writes to Sync, poll

--- a/packages/backend/src/event/controllers/event.controller.test.ts
+++ b/packages/backend/src/event/controllers/event.controller.test.ts
@@ -341,7 +341,7 @@ describe("EventController", () => {
     expect(json).toHaveBeenCalled();
   });
 
-  it("rejects attendees on a calendar sync does not list as writable Google, before any submit", async () => {
+  it("rejects attendees on a calendar sync does not list as writable and inviting, before any submit", async () => {
     // A create targeting the Compass local calendar (never in sync's list)
     // or any unknown id: the guest list has nowhere to be delivered, so this
     // must be a typed 4xx with NO command submitted.
@@ -354,7 +354,10 @@ describe("EventController", () => {
             calendars: [
               {
                 id: objectId(), // a different (writable) calendar
-                capabilities: { canWriteEvents: true },
+                capabilities: {
+                  canWriteEvents: true,
+                  canInviteAttendees: true,
+                },
               },
             ],
           },
@@ -384,13 +387,13 @@ describe("EventController", () => {
     expect(json).toHaveBeenCalledWith({
       code: "ATTENDEES_UNSUPPORTED",
       message:
-        "Guests can only be added to events on a writable Google calendar",
+        "Guests can only be added to events on a writable calendar that can invite attendees",
       retryable: false,
     });
     expect(submitCommand).not.toHaveBeenCalled();
   });
 
-  it("rejects a replace carrying attendees when the user has no writable Google calendar", async () => {
+  it("rejects a replace carrying attendees when the user has no writable inviting calendar", async () => {
     const submitCommand = mock();
     spyOn(syncServiceFactory, "getSyncServiceClient").mockReturnValue({
       listCalendars: mock(() =>
@@ -398,8 +401,14 @@ describe("EventController", () => {
           ok: true as const,
           value: {
             calendars: [
-              // Read-only Google calendar: listed, but not writable.
-              { id: objectId(), capabilities: { canWriteEvents: false } },
+              // Read-only calendar: listed, but not writable.
+              {
+                id: objectId(),
+                capabilities: {
+                  canWriteEvents: false,
+                  canInviteAttendees: false,
+                },
+              },
             ],
           },
         }),
@@ -442,7 +451,55 @@ describe("EventController", () => {
     expect(submitCommand).not.toHaveBeenCalled();
   });
 
-  it("submits attendees + invitation for a writable Google calendar and echoes the guests optimistically", async () => {
+  it("rejects attendees on a writable calendar that cannot invite", async () => {
+    const calendarId = objectId();
+    const submitCommand = mock();
+    spyOn(syncServiceFactory, "getSyncServiceClient").mockReturnValue({
+      listCalendars: mock(() =>
+        Promise.resolve({
+          ok: true as const,
+          value: {
+            calendars: [
+              {
+                id: calendarId,
+                capabilities: {
+                  canWriteEvents: true,
+                  canInviteAttendees: false,
+                },
+              },
+            ],
+          },
+        }),
+      ),
+      submitCommand,
+    } as never);
+
+    const { res, json } = jsonRes();
+    const body = sampleCreateBody();
+    await eventController.create(
+      sessionReq(objectId(), {
+        body: {
+          ...body,
+          calendarId,
+          content: {
+            ...body.content,
+            attendees: [{ email: "ada@example.com", displayName: null }],
+          },
+        },
+      }),
+      res,
+    );
+
+    expect((res.status as ReturnType<typeof mock>).mock.calls[0]?.[0]).toBe(
+      Status.FORBIDDEN,
+    );
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "ATTENDEES_UNSUPPORTED" }),
+    );
+    expect(submitCommand).not.toHaveBeenCalled();
+  });
+
+  it("submits attendees + invitation for a writable calendar that can invite and echoes the guests optimistically", async () => {
     const calendarId = objectId();
     const submitCommand = mock(() =>
       Promise.resolve({
@@ -464,7 +521,13 @@ describe("EventController", () => {
           ok: true as const,
           value: {
             calendars: [
-              { id: calendarId, capabilities: { canWriteEvents: true } },
+              {
+                id: calendarId,
+                capabilities: {
+                  canWriteEvents: true,
+                  canInviteAttendees: true,
+                },
+              },
             ],
           },
         }),
@@ -544,7 +607,13 @@ describe("EventController", () => {
           ok: true as const,
           value: {
             calendars: [
-              { id: calendarId, capabilities: { canWriteEvents: true } },
+              {
+                id: calendarId,
+                capabilities: {
+                  canWriteEvents: true,
+                  canInviteAttendees: true,
+                },
+              },
             ],
           },
         }),
@@ -651,7 +720,7 @@ describe("EventController", () => {
     expect(json).toHaveBeenCalledWith({
       code: "GOOGLE_REVOKED",
       message:
-        "Google Calendar access expired or was revoked. Reconnect Google Calendar in Compass to resume syncing.",
+        "Calendar access expired or was revoked. Reconnect your calendar in Compass to resume syncing.",
       retryable: false,
     });
   });
@@ -683,7 +752,7 @@ describe("EventController", () => {
     expect(json).toHaveBeenCalledWith({
       code: "UNSUPPORTED_OPERATION",
       message:
-        "Google doesn't allow this change for this event (for example birthday or holiday events). Try deleting the entire series, or manage it in Google Calendar.",
+        "This calendar doesn't allow this change for this event (for example birthday or holiday events). Try deleting the entire series, or manage it in your calendar.",
       retryable: false,
     });
   });

--- a/packages/backend/src/event/controllers/event.controller.ts
+++ b/packages/backend/src/event/controllers/event.controller.ts
@@ -232,18 +232,20 @@ const readAllFromSync = async (userId: string, query: EventListQuery) => {
 };
 
 // Gate for guest-list edits (`content.attendees` present): only a writable
-// Google calendar can deliver a guest list, so anything else — the Compass
-// local calendar, a read-only Google calendar, an unknown id — is a typed
-// refusal BEFORE any command is submitted. Reuses the same sync calendar
-// lookup the read path performs (active calendars only; the local calendar is
-// never in sync's list, so it fails the membership check by construction).
+// calendar that can invite attendees can deliver a guest list, so anything
+// else — the Compass local calendar, a read-only calendar, an unknown id —
+// is a typed refusal BEFORE any command is submitted. Reuses the same sync
+// calendar lookup the read path performs (active calendars only; the local
+// calendar is never in sync's list, so it fails the membership check by
+// construction).
 //
 // `calendarId` is the create path's exact target. A replace carries no
 // calendarId (cross-calendar moves are rejected before this), so the check
-// degrades to "the principal has at least one writable Google calendar":
-// the browser only offers the editor on the event's own writable Google
-// calendar (WP-04) and sync's organizer guard refuses per-event misuse, so
-// this coarser backstop is about local-only/read-only accounts, not routing.
+// degrades to "the principal has at least one writable calendar that can
+// invite attendees": the browser only offers the editor on the event's own
+// writable inviting calendar (WP-04) and sync's organizer guard refuses
+// per-event misuse, so this coarser backstop is about local-only/read-only
+// accounts, not routing.
 const assertAttendeesSupported = async (
   client: SyncServiceClient,
   userId: string,
@@ -263,12 +265,13 @@ const assertAttendeesSupported = async (
   const supported = result.value.calendars.some(
     (calendar) =>
       calendar.capabilities.canWriteEvents &&
+      calendar.capabilities.canInviteAttendees &&
       (calendarId === undefined || calendar.id === calendarId),
   );
   if (!supported) {
     throw eventMutationError(
       "ATTENDEES_UNSUPPORTED",
-      "Guests can only be added to events on a writable Google calendar",
+      "Guests can only be added to events on a writable calendar that can invite attendees",
     );
   }
 };
@@ -285,7 +288,7 @@ const mapSyncFailure = (reason: SyncCommandFailureReason) => {
     case "authorizationRevoked":
       return eventMutationError(
         "GOOGLE_REVOKED",
-        "Google Calendar access expired or was revoked. Reconnect Google Calendar in Compass to resume syncing.",
+        "Calendar access expired or was revoked. Reconnect your calendar in Compass to resume syncing.",
       );
     case "unsupportedCapability":
       // The provider declined the operation for this specific event (e.g.
@@ -294,7 +297,7 @@ const mapSyncFailure = (reason: SyncCommandFailureReason) => {
       // PROVIDER_FAILURE's retryable 502.
       return eventMutationError(
         "UNSUPPORTED_OPERATION",
-        "Google doesn't allow this change for this event (for example birthday or holiday events). Try deleting the entire series, or manage it in Google Calendar.",
+        "This calendar doesn't allow this change for this event (for example birthday or holiday events). Try deleting the entire series, or manage it in your calendar.",
       );
     case "permanentProviderError":
       return eventMutationError(

--- a/packages/backend/src/event/event.error.ts
+++ b/packages/backend/src/event/event.error.ts
@@ -35,7 +35,7 @@ const STATUS_BY_CODE: Record<EventMutationErrorCode, Status> = {
   // provider outage, so never the retryable 502 it used to surface as.
   UNSUPPORTED_OPERATION: Status.FORBIDDEN,
   // 403 like the capability refusals above: guests can only be written to a
-  // writable Google calendar, and retrying cannot change that.
+  // writable calendar that can invite attendees, and retrying cannot change that.
   ATTENDEES_UNSUPPORTED: Status.FORBIDDEN,
 };
 

--- a/packages/web/src/api/util/api.util.test.ts
+++ b/packages/web/src/api/util/api.util.test.ts
@@ -337,7 +337,7 @@ describe("handleErrorResponse", () => {
     expect(onGoogleRevoked).not.toHaveBeenCalled();
   });
 
-  it("fails clearly when the Google revocation handler is not configured", async () => {
+  it("fails clearly when the calendar revocation handler is not configured", async () => {
     const error = createApiError({
       data: { code: "GOOGLE_REVOKED" },
       status: Status.UNAUTHORIZED,
@@ -345,7 +345,7 @@ describe("handleErrorResponse", () => {
 
     await expect(
       handleErrorResponse(error, { onGoogleRevoked: undefined }),
-    ).rejects.toThrow("Google revocation handler is not configured");
+    ).rejects.toThrow("Calendar revocation handler is not configured");
   });
 
   it("does not sign the user out on a 404 from a data endpoint", async () => {

--- a/packages/web/src/api/util/api.util.ts
+++ b/packages/web/src/api/util/api.util.ts
@@ -205,7 +205,7 @@ export const handleErrorResponse = async (
     getApiErrorCode(error) === "GOOGLE_REVOKED"
   ) {
     if (!onGoogleRevoked) {
-      throw new Error("Google revocation handler is not configured");
+      throw new Error("Calendar revocation handler is not configured");
     }
 
     onGoogleRevoked({

--- a/packages/web/src/calendars/calendar.util.test.ts
+++ b/packages/web/src/calendars/calendar.util.test.ts
@@ -4,6 +4,7 @@ import {
 } from "@core/types/calendar.contracts";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import {
+  canInviteOnCalendar,
   compareCalendars,
   getDefaultTargetCalendar,
   getLocalCalendar,
@@ -78,6 +79,17 @@ describe("getWritableCalendars", () => {
     ).toEqual([google]);
   });
 
+  it("includes a writable microsoft calendar once an account is connected", () => {
+    const local = makeCalendar({ provider: "local" });
+    const microsoft = makeCalendar({
+      provider: "microsoft",
+      id: "507f1f77bcf86cd799439015" as Calendar["id"],
+    });
+    expect(
+      getWritableCalendars([local, microsoft], { hasConnectedAccount: true }),
+    ).toEqual([microsoft]);
+  });
+
   it("excludes calendars whose Google account needs reconnect", () => {
     const broken = makeCalendar({
       provider: "google",
@@ -98,6 +110,37 @@ describe("getWritableCalendars", () => {
   });
 });
 
+describe("canInviteOnCalendar", () => {
+  it("is true when the calendar can write and invite attendees", () => {
+    expect(
+      canInviteOnCalendar(
+        makeCalendar({
+          provider: "microsoft",
+          capabilities: getCalendarCapabilities("owner"),
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("is false when the calendar cannot invite, even if writable", () => {
+    expect(
+      canInviteOnCalendar(
+        makeCalendar({
+          provider: "google",
+          capabilities: {
+            ...getCalendarCapabilities("owner"),
+            canInviteAttendees: false,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("is false for an undefined calendar", () => {
+    expect(canInviteOnCalendar(undefined)).toBe(false);
+  });
+});
+
 describe("getDefaultTargetCalendar", () => {
   it("prefers the primary writable google calendar", () => {
     const local = makeCalendar({ provider: "local" });
@@ -108,6 +151,18 @@ describe("getDefaultTargetCalendar", () => {
     });
     expect(getDefaultTargetCalendar([local, primaryGoogle])).toBe(
       primaryGoogle,
+    );
+  });
+
+  it("prefers a writable microsoft primary the same way", () => {
+    const local = makeCalendar({ provider: "local" });
+    const primaryMicrosoft = makeCalendar({
+      provider: "microsoft",
+      isPrimary: true,
+      id: "507f1f77bcf86cd799439014" as Calendar["id"],
+    });
+    expect(getDefaultTargetCalendar([local, primaryMicrosoft])).toBe(
+      primaryMicrosoft,
     );
   });
 

--- a/packages/web/src/calendars/calendar.util.ts
+++ b/packages/web/src/calendars/calendar.util.ts
@@ -217,18 +217,24 @@ export interface DefaultTargetCalendarOptions {
   reconnectRequiredEmails?: ReadonlySet<string> | readonly string[];
 }
 
-const isWritableGoogleCalendar = (
+const isWritableProviderCalendar = (
   calendar: Calendar,
   reconnectRequiredEmails: ReadonlySet<string> | null,
 ): boolean =>
-  calendar.provider === "google" &&
+  calendar.provider !== "local" &&
   calendar.capabilities.canWrite &&
   !calendarNeedsReconnect(calendar, reconnectRequiredEmails);
+
+/** True when the write path can deliver a guest list for this calendar. */
+export const canInviteOnCalendar = (calendar: Calendar | undefined): boolean =>
+  Boolean(
+    calendar?.capabilities.canInviteAttendees && calendar.capabilities.canWrite,
+  );
 
 /**
  * Where a new event lands: the user's chosen default if it is still usable,
  * else the primary calendar of the oldest-connected account, else the local
- * calendar while disconnected (anonymous / no Google account). Once any
+ * calendar while disconnected (anonymous / no connected account). Once any
  * account is connected, local is never the create target - matching the
  * writable picker and day-view column filter.
  */
@@ -248,7 +254,7 @@ export function getDefaultTargetCalendar(
     ? calendars.find((calendar) => calendar.id === preferredCalendarId)
     : undefined;
   // The local calendar is a valid explicit choice while disconnected, even
-  // though it is not a writable *Google* calendar.
+  // though it is not a writable provider calendar.
   if (
     preferred?.capabilities.canWrite &&
     !calendarNeedsReconnect(preferred, reconnectRequiredEmails) &&
@@ -260,7 +266,7 @@ export function getDefaultTargetCalendar(
   const primaries = calendars.filter(
     (calendar) =>
       calendar.isPrimary &&
-      isWritableGoogleCalendar(calendar, reconnectRequiredEmails),
+      isWritableProviderCalendar(calendar, reconnectRequiredEmails),
   );
   const byConnectionOrder = accountEmailOrder
     .map((email) =>

--- a/packages/web/src/common/storage/migrations/external/demo-data-seed.ts
+++ b/packages/web/src/common/storage/migrations/external/demo-data-seed.ts
@@ -30,9 +30,9 @@ function createEventRecord(overrides: {
     | { kind: "timed"; start: string; end: string; timeZone: string }
     | { kind: "allDay"; start: string; end: string };
   // Read-only, provider-sourced fields on a real synced event - only
-  // showcased here so first-time users (who never connect Google before
+  // showcased here so first-time users (who never connect a calendar before
   // seeing the calendar) discover the meeting-link/location/attendees UI at
-  // all, since it otherwise only ever renders for Google-synced events.
+  // all, since it otherwise only ever renders for synced events.
   location?: string;
   organizer?: Organizer;
   attendees?: Attendee[];
@@ -139,8 +139,8 @@ function generateDemoData() {
         timeZone,
       },
       // Showcases the meeting-link and attendee UI (normally only populated
-      // from a synced Google event) for first-time users who haven't
-      // connected Google yet.
+      // from a synced event) for first-time users who haven't connected a
+      // calendar yet.
       conference: {
         url: "https://meet.google.com/abc-defg-hij",
         label: "Google Meet",
@@ -172,7 +172,7 @@ function generateDemoData() {
     createEventRecord({
       title: "Try Compass",
       description:
-        "Welcome! Click any empty time slot to create an event, or press C. When you're ready to sync Google Calendar, use the Connect Google Calendar button in the sidebar.",
+        "Welcome! Click any empty time slot to create an event, or press C. When you're ready to sync your calendar, use the connect button in the sidebar.",
       schedule: {
         kind: "timed",
         start: todayAt(10, 0),

--- a/packages/web/src/common/storage/offline-data/export-user-data.util.test.ts
+++ b/packages/web/src/common/storage/offline-data/export-user-data.util.test.ts
@@ -49,13 +49,13 @@ describe("collectExportData", () => {
     expect(typeof result.exportedAt).toBe("string");
   });
 
-  it("explains what the export contains and why Google-synced events are absent", async () => {
+  it("explains what the export contains and why synced events are absent", async () => {
     const result = await collectExportData();
 
     expect(result.about.whatThisIs.toLowerCase()).toContain("indexeddb");
-    expect(result.about.whatThisIs.toLowerCase()).toContain("google calendar");
+    expect(result.about.whatThisIs.toLowerCase()).toContain("calendar dump");
     expect(result.about.events.toLowerCase()).toContain("locally");
-    expect(result.about.events.toLowerCase()).toContain("google calendar");
+    expect(result.about.events.toLowerCase()).toContain("your calendar");
     expect(result.about.tasks.toLowerCase()).toContain("tasks");
   });
 

--- a/packages/web/src/common/storage/offline-data/export-user-data.util.ts
+++ b/packages/web/src/common/storage/offline-data/export-user-data.util.ts
@@ -8,9 +8,9 @@ import {
 
 const EXPORT_ABOUT = {
   whatThisIs:
-    "Snapshot of data Compass stores in this browser (IndexedDB). It is not a full account or Google Calendar dump.",
+    "Snapshot of data Compass stores in this browser (IndexedDB). It is not a full account or calendar dump.",
   events:
-    "Only calendar events still stored locally in this browser. If you connected Google Calendar, those events live in Google Calendar (and on Compass's servers when signed in), so they will not appear here.",
+    "Only calendar events still stored locally in this browser. If you connected a calendar, those events live in your calendar (and on Compass's servers when signed in), so they will not appear here.",
   tasks:
     "Legacy to-do items from a Tasks feature we removed. Any still retained in this browser are listed below; they are cleared after a successful export.",
   someday:

--- a/packages/web/src/common/utils/event/event.util.test.ts
+++ b/packages/web/src/common/utils/event/event.util.test.ts
@@ -208,7 +208,7 @@ describe("handleError", () => {
     expect(mockCaptureException).not.toHaveBeenCalled();
     expect(mocks.error).toHaveBeenCalledTimes(1);
     const [message] = mocks.error.mock.calls[0] ?? [];
-    expect(message).toContain("Google doesn't allow this change");
+    expect(message).toContain("This calendar doesn't allow this change");
     expect(message).not.toBe(
       "Something went wrong behind the scenes. Please try again later.",
     );

--- a/packages/web/src/common/utils/event/event.util.ts
+++ b/packages/web/src/common/utils/event/event.util.ts
@@ -224,13 +224,13 @@ const MUTATION_ERROR_TOAST_MESSAGES: Partial<
   Record<EventMutationError["code"], string>
 > = {
   UNSUPPORTED_OPERATION:
-    "Google doesn't allow this change for this event (like birthdays or holidays). Try deleting the entire series, or manage it in Google Calendar.",
+    "This calendar doesn't allow this change for this event (like birthdays or holidays). Try deleting the entire series, or manage it in your calendar.",
   CALENDAR_READ_ONLY:
     "This calendar is read-only, so its events can't be changed from Compass.",
   RECURRENCE_CONFLICT:
     "This event was changed somewhere else. Refresh to load the latest version, then try again.",
   GOOGLE_REVOKED:
-    "Google Calendar access expired or was revoked. Reconnect Google Calendar in Compass to resume syncing.",
+    "Calendar access expired or was revoked. Reconnect your calendar in Compass to resume syncing.",
 };
 
 const showCatchallToast = (message: string) =>

--- a/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationDialog.test.tsx
+++ b/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationDialog.test.tsx
@@ -41,11 +41,11 @@ describe("DeleteAccountConfirmationDialog", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
-  it("tells the user their Google Calendar data is left alone", () => {
+  it("tells the user their connected calendars are left alone", () => {
     setup();
 
     expect(screen.getByRole("dialog")).toHaveTextContent(
-      /Your Google Calendar is not affected/i,
+      /Your connected calendars are not affected/i,
     );
   });
 

--- a/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationDialog.tsx
+++ b/packages/web/src/components/DeleteAccountConfirmation/DeleteAccountConfirmationDialog.tsx
@@ -10,7 +10,7 @@ export const DELETE_ACCOUNT_PHRASE = "Delete my Compass account";
 const INTRO_TEXT = [
   "This deletes your Compass account and data: your calendars, events, and settings. It can't be undone.",
   "If you have a Compass trial or subscription, it is canceled immediately and your saved payment details are removed. Previous payments aren't refunded automatically.",
-  "Your Google Calendar is not affected. Nothing there gets deleted, Compass just loses its access to it.",
+  "Your connected calendars are not affected. Nothing there gets deleted, Compass just loses its access to them.",
 ].join("\n\n");
 
 interface DeleteAccountConfirmationDialogProps {

--- a/packages/web/src/views/Forms/EventForm/EventForm.attendees.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.attendees.test.tsx
@@ -17,11 +17,11 @@ import { EventForm } from "@web/views/Forms/EventForm/EventForm";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 // WP-04 attendee-editor gating: the guest combobox renders wherever the whole
-// write path can deliver a guest edit — a writable Google calendar and an
-// event the user organizes — repeating events included, where the edit is
-// series-wide and the field says so. Everyone else keeps the read-only guest
-// list. Sibling to EventForm.readOnly.test.tsx (full form, no subcomponent
-// mocks) for the same isolation reasons.
+// write path can deliver a guest edit — a writable calendar that can invite
+// attendees and an event the user organizes — repeating events included, where
+// the edit is series-wide and the field says so. Everyone else keeps the
+// read-only guest list. Sibling to EventForm.readOnly.test.tsx (full form, no
+// subcomponent mocks) for the same isolation reasons.
 
 const ACCOUNT_EMAIL = "me@example.com";
 
@@ -120,7 +120,7 @@ describe("EventForm attendee editor gating", () => {
     document.body.removeAttribute("data-app-locked");
   });
 
-  it("renders the guest combobox (and not the read-only list) for an organized event on a writable Google calendar", () => {
+  it("renders the guest combobox (and not the read-only list) for an organized event on a writable calendar that can invite", () => {
     const calendar = makeCalendar();
     const draft = editDraftOrThrow(makeMeetingEvent(calendar.id));
 
@@ -228,7 +228,16 @@ describe("EventForm attendee editor gating", () => {
     ).toBeInTheDocument();
   });
 
-  it("keeps the read-only guest list on a read-only calendar", () => {
+  it("shows the editor on a microsoft calendar that can invite attendees", () => {
+    const calendar = makeCalendar({ provider: "microsoft" });
+    const draft = editDraftOrThrow(makeMeetingEvent(calendar.id));
+
+    renderEventForm(draft, [calendar]);
+
+    expect(screen.getByRole("combobox", { name: "Guests" })).toBeEnabled();
+  });
+
+  it("keeps the read-only guest list on a google calendar that cannot invite", () => {
     const calendar = makeCalendar({
       access: "reader",
       capabilities: getCalendarCapabilities("reader"),
@@ -249,10 +258,18 @@ describe("EventForm attendee editor gating", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows no editor on a non-Google (local) calendar", () => {
+  it("shows no editor on a local calendar", () => {
     const calendar = makeCalendar({
       provider: "local",
       accountEmail: undefined,
+      capabilities: {
+        canReadAvailability: true,
+        canReadDetails: true,
+        canWrite: true,
+        canManage: false,
+        canWatchEvents: false,
+        canInviteAttendees: false,
+      },
     });
     const event = createMockEvent({
       calendarId: calendar.id,

--- a/packages/web/src/views/Forms/EventForm/EventForm.rsvp.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.rsvp.test.tsx
@@ -113,6 +113,15 @@ describe("EventForm RSVP control gating", () => {
     expect(screen.getByRole("radio", { name: "Going" })).toBeInTheDocument();
   });
 
+  it("shows the control on a microsoft calendar the same way", () => {
+    const calendar = makeCalendar({ provider: "microsoft" });
+    renderEventForm(editDraftOrThrow(makeInvitedEvent(calendar.id)), [
+      calendar,
+    ]);
+
+    expect(queryRsvpGroup()).toBeInTheDocument();
+  });
+
   it("shows the control on a viewer-access (read-only) calendar — RSVP is not a calendar write", () => {
     const calendar = makeCalendar({
       access: "reader",
@@ -165,7 +174,7 @@ describe("EventForm RSVP control gating", () => {
     expect(queryRsvpGroup()).not.toBeInTheDocument();
   });
 
-  it("hides the control on a local (non-Google) event", () => {
+  it("hides the control on a local event", () => {
     const calendar = makeCalendar({
       provider: "local",
       accountEmail: undefined,

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -17,6 +17,7 @@ import { type CalendarId } from "@core/types/domain-primitives";
 import { type AttendeeInput } from "@core/types/event-attendance.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
+import { canInviteOnCalendar } from "@web/calendars/calendar.util";
 import {
   isEventReadOnly,
   useCalendarLookup,
@@ -293,8 +294,8 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
     const liveDetails =
       rsvpSource?.content.kind === "details" ? rsvpSource.content : undefined;
     // Attendee-editor gate (WP-04): guests are editable everywhere the whole
-    // write path can deliver them — a writable Google calendar and an event
-    // the user organizes. Repeating events included: sync refuses
+    // write path can deliver them — a writable calendar that can invite and an
+    // event the user organizes. Repeating events included: sync refuses
     // per-occurrence guest replacements, so a guest change on any instance
     // is saved series-wide (resolveRecurrenceScopeDecision widens the whole
     // save to "all"), and the field says so.
@@ -306,7 +307,7 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
           ? calendarLookup.get(draft.values.calendarId)
           : defaultTargetCalendar
         : calendarLookup.get(draft.source.calendarId);
-    // Google auto-sets the organizer to the creating account, so "the user
+    // The host auto-sets the organizer to the creating account, so "the user
     // organizes this event" is organizer-email == calendar-account-email.
     // A missing organizer means Compass created the event on this account
     // (organizes it); a missing account email fails closed — sync refuses
@@ -318,10 +319,7 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
         sourceDetails.organizer.email.toLowerCase() ===
           attendeeCalendar.accountEmail.toLowerCase());
     const showAttendeeEditor =
-      !isReadOnly &&
-      attendeeCalendar?.provider === "google" &&
-      attendeeCalendar.capabilities.canWrite &&
-      organizesEvent;
+      !isReadOnly && canInviteOnCalendar(attendeeCalendar) && organizesEvent;
     const guestEditIsSeriesWide =
       draft.kind === "edit" && draft.source.recurrence.kind !== "single";
     // RSVP gate (WP-08): show Going / Maybe / Decline when the calendar's
@@ -330,10 +328,7 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
     // not an attendee or the event is local (no provider account email).
     // Deliberately NOT gated on writability: answering an invitation is
     // allowed on viewer-access calendars.
-    const rsvpAccountEmail =
-      attendeeCalendar?.provider === "google"
-        ? attendeeCalendar.accountEmail
-        : undefined;
+    const rsvpAccountEmail = attendeeCalendar?.accountEmail;
     const showRsvpControl =
       rsvpSource !== null &&
       rsvpAccountEmail !== undefined &&

--- a/packages/web/src/views/Forms/EventForm/SendInvitationsDialog.tsx
+++ b/packages/web/src/views/Forms/EventForm/SendInvitationsDialog.tsx
@@ -12,10 +12,10 @@ type SendInvitationsDialogProps = {
 
 /**
  * Save-time "Send invitation emails?" choice, shown only when a save changed
- * the guest set. Send (the default, focused on open) has Google email the
+ * the guest set. Send (the default, focused on open) has the host email the
  * affected guests (`invitation: "all"`); Don't send saves silently
  * (`"none"`). Dismissing (Escape / backdrop) cancels the save and returns to
- * the form. Compass never sends email itself — Google does, via sendUpdates.
+ * the form. Compass never sends email itself — the calendar host does.
  */
 export function SendInvitationsDialog({ prompt }: SendInvitationsDialogProps) {
   const sendButtonRef = useRef<HTMLButtonElement>(null);
@@ -25,7 +25,7 @@ export function SendInvitationsDialog({ prompt }: SendInvitationsDialogProps) {
   return (
     <OverlayPanel
       title="Send invitation emails?"
-      message="Google will email the affected guests about this event."
+      message={`${prompt.hostLabel} will email the affected guests about this event.`}
       onDismiss={prompt.onCancel}
       initialFocusRef={sendButtonRef}
       variant="modal"

--- a/packages/web/src/views/Forms/hooks/useSaveEventForm.attendees.test.tsx
+++ b/packages/web/src/views/Forms/hooks/useSaveEventForm.attendees.test.tsx
@@ -66,11 +66,11 @@ const meetingEvent = (overrides: Partial<Event> = {}): Event =>
     ...overrides,
   });
 
-function createWrapper() {
+function createWrapper(calendar: Calendar = googleCalendar()) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
-  queryClient.setQueryData(calendarQueryKeys.all, [googleCalendar()]);
+  queryClient.setQueryData(calendarQueryKeys.all, [calendar]);
 
   function Wrapper({ children }: PropsWithChildren) {
     return (
@@ -157,6 +157,7 @@ describe("useSaveEventForm guest edits", () => {
 
     // Nothing saved yet - the invitation choice comes first.
     expect(result.current.invitationPrompt).not.toBeNull();
+    expect(result.current.invitationPrompt?.hostLabel).toBe("Google");
     expect(queryClient.getMutationCache().getAll()).toHaveLength(0);
 
     act(() => {
@@ -332,5 +333,66 @@ describe("useSaveEventForm guest edits", () => {
     expect(variables?.input.scope).toBe("all");
     expect(variables?.input.content.attendees).toHaveLength(2);
     expect(variables?.input.invitation).toBe("all");
+  });
+
+  it("keeps attendee edits for a microsoft calendar that can invite", () => {
+    const { queryClient, Wrapper } = createWrapper(
+      googleCalendar({ provider: "microsoft" }),
+    );
+    const { result } = renderHook(() => useSaveEventForm(), {
+      wrapper: Wrapper,
+    });
+    const draft = editDraftOrThrow(meetingEvent());
+    draft.values.attendees = [
+      { email: "guest@example.com", displayName: null },
+      { email: "new-guest@example.com", displayName: null },
+    ];
+
+    act(() => {
+      result.current.saveEventForm(draft);
+    });
+
+    expect(result.current.invitationPrompt).not.toBeNull();
+    expect(result.current.invitationPrompt?.hostLabel).toBe("Microsoft");
+
+    act(() => {
+      result.current.invitationPrompt?.onSend();
+    });
+
+    const variables = replaceVariables(queryClient);
+    expect(variables?.input.content.attendees).toHaveLength(2);
+    expect(variables?.input.invitation).toBe("all");
+  });
+
+  it("drops a create guest edit when the target calendar cannot invite", () => {
+    const { queryClient, Wrapper } = createWrapper(
+      googleCalendar({
+        access: "reader",
+        capabilities: getCalendarCapabilities("reader"),
+      }),
+    );
+    const { result } = renderHook(() => useSaveEventForm(), {
+      wrapper: Wrapper,
+    });
+    const draft = createGridEventDraft(
+      timedGridSchedule(
+        new Date("2026-05-20T10:00:00.000Z"),
+        new Date("2026-05-20T11:00:00.000Z"),
+      ),
+      undefined,
+      calendarId,
+    );
+    draft.values.attendees = [
+      { email: "new-guest@example.com", displayName: null },
+    ];
+
+    act(() => {
+      result.current.saveEventForm(draft);
+    });
+
+    expect(result.current.invitationPrompt).toBeNull();
+    const variables = createVariables(queryClient);
+    expect(variables?.input.content).not.toContainKey("attendees");
+    expect(variables?.input).not.toContainKey("invitation");
   });
 });

--- a/packages/web/src/views/Forms/hooks/useSaveEventForm.ts
+++ b/packages/web/src/views/Forms/hooks/useSaveEventForm.ts
@@ -1,7 +1,10 @@
 import { useCallback, useMemo, useState } from "react";
+import { type Calendar } from "@core/types/calendar.contracts";
 import { EventIdSchema } from "@core/types/domain-primitives";
 import { type CreateEventInput } from "@core/types/event-command.contracts";
+import { providerDisplayName } from "@core/types/sync/identity.contracts";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
+import { canInviteOnCalendar } from "@web/calendars/calendar.util";
 import { useDefaultTargetCalendar } from "@web/calendars/useDefaultTargetCalendar";
 import { RecurringEventUpdateScope } from "@web/common/types/web.event.types";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
@@ -27,7 +30,15 @@ export type EventInvitationPrompt = {
   onSend: () => void;
   onDontSend: () => void;
   onCancel: () => void;
+  hostLabel: string;
 } | null;
+
+const INVITATION_HOST_LABEL: Record<Calendar["provider"], string> = {
+  google: providerDisplayName("google"),
+  microsoft: providerDisplayName("microsoft"),
+  apple: providerDisplayName("apple"),
+  local: "Your calendar",
+};
 
 export function useSaveEventForm() {
   const closeEventForm = useCloseEventForm();
@@ -47,7 +58,7 @@ export function useSaveEventForm() {
   // Belt behind the editor's own render gates: a guest edit that could never
   // deliver is dropped back to preserve semantics instead of submitting a
   // command sync/backend will refuse. The UI cannot reach these states — the
-  // editor only renders on writable Google calendars the user organizes, and
+  // editor only renders on writable calendars that can invite attendees, and
   // a guest-changed recurring edit is saved as "all" automatically, whether
   // it started from the series base or from one occurrence — so this only
   // defends replayed or hand-built drafts.
@@ -76,11 +87,11 @@ export function useSaveEventForm() {
         return draft;
       }
 
-      // Create: guests only deliver to a writable Google calendar
+      // Create: guests only deliver to a writable calendar that can invite
       // (ATTENDEES_UNSUPPORTED backstop server-side).
       const calendarId = draft.values.calendarId ?? defaultTargetCalendarId;
       const calendar = calendars?.find((entry) => entry.id === calendarId);
-      if (calendar?.provider !== "google" || !calendar.capabilities.canWrite) {
+      if (!canInviteOnCalendar(calendar)) {
         console.warn(
           "[useSaveEventForm] dropped guest edit: target calendar cannot deliver a guest list",
         );
@@ -186,8 +197,8 @@ export function useSaveEventForm() {
       const normalized = normalizeGuestEdit(draft, applyTo);
 
       // A membership-changing guest edit needs the save-time invitation
-      // choice first — Google emails the guests itself via sendUpdates, so
-      // this is the one moment the user decides whether it should.
+      // choice first — the calendar host emails the guests itself via
+      // sendUpdates, so this is the one moment the user decides whether it should.
       if (gridDraftGuestsChanged(normalized)) {
         setPendingInvitationSave({ draft: normalized, applyTo });
         return;
@@ -201,6 +212,11 @@ export function useSaveEventForm() {
   const invitationPrompt: EventInvitationPrompt = useMemo(() => {
     if (!pendingInvitationSave) return null;
     const { draft, applyTo } = pendingInvitationSave;
+    const calendarId =
+      draft.kind === "create"
+        ? (draft.values.calendarId ?? defaultTargetCalendarId)
+        : draft.source.calendarId;
+    const calendar = calendars?.find((entry) => entry.id === calendarId);
     const resolve = (invitation: InvitationIntentValue) => {
       setPendingInvitationSave(null);
       commitSave(draft, applyTo, invitation);
@@ -209,8 +225,9 @@ export function useSaveEventForm() {
       onSend: () => resolve("all"),
       onDontSend: () => resolve("none"),
       onCancel: () => setPendingInvitationSave(null),
+      hostLabel: INVITATION_HOST_LABEL[calendar?.provider ?? "local"],
     };
-  }, [commitSave, pendingInvitationSave]);
+  }, [calendars, commitSave, defaultTargetCalendarId, pendingInvitationSave]);
 
   return { saveEventForm, fieldErrors, clearFieldErrors, invitationPrompt };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3234

## What and why

Capability gates replace `provider === "google"` in the event form, save path, and default-target calendar picker. Guest editing follows `canInviteAttendees` and `canWrite`. User-facing copy outside `auth/` now uses the host name when known, or "your calendar". Google Meet and Google Maps names stay. Booking connect-Google prompt stays with WP-08c; destination copy was already neutralized by WP-10.

Merged `main` after WP-13 so the SSE docs pointer is not duplicated. Auto-merge was blocked on that conflict.

## Verify

VERDICT: PASS
Checks run: test:web, test:backend:fast, type-check, lint, knip, test:a11y, test:e2e

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e10c8f83-8623-43cb-99e3-58a63384cc19?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e10c8f83-8623-43cb-99e3-58a63384cc19&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

