### PR TITLE
feat(sync): Microsoft Graph event writer create, patch, delete, fetch (WP-06a)

### DIFF
--- a/.agents/handoffs/3245.md
+++ b/.agents/handoffs/3245.md
@@ -1,0 +1,30 @@
+# Handoff: #3245
+
+task_id: 3245
+status: verifying
+branch: cursor/graph-event-writer-3245
+
+## Summary
+
+Implemented Microsoft Graph event writer (`microsoft-event-writer.adapter.ts`) with
+injectable `MicrosoftEventWriteApi`. Create, patch, delete, and fetch are covered;
+`fetchInstanceAt` and conference creation remain deferred to M-06b.
+
+## Deliverables
+
+- `microsoft-event-writer.adapter.ts`: Graph create/patch/delete/fetch with transactionId idempotency
+- `microsoft-event-writer.adapter.test.ts`: timed, all-day, recurring, attendees, errors
+- `fixtures/microsoft/writer.json`: contract corpus for writer replay
+- `microsoft-contract.factory.ts`: `microsoftRecordedWriter` factory
+- `microsoft.contract.test.ts`: writer contract cases (minus fetchInstanceAt)
+
+## Verify
+
+```
+bun test:sync
+bun run type-check
+bun lint
+bun knip
+```
+
+VERDICT: PASS

--- a/packages/sync/src/providers/__contract__/fixtures/microsoft/writer.json
+++ b/packages/sync/src/providers/__contract__/fixtures/microsoft/writer.json
@@ -1,0 +1,37 @@
+{
+  "create": {
+    "id": "abc12deadbeef00000000000",
+    "@odata.etag": "W/\"graph-create-etag\"",
+    "type": "singleInstance",
+    "subject": "Contract create",
+    "body": {
+      "contentType": "text",
+      "content": "WP-11 contract suite"
+    },
+    "start": {
+      "dateTime": "2025-01-15T14:00:00.0000000",
+      "timeZone": "UTC"
+    },
+    "end": {
+      "dateTime": "2025-01-15T15:00:00.0000000",
+      "timeZone": "UTC"
+    },
+    "showAs": "busy"
+  },
+  "fetch": {
+    "id": "abc12deadbeef00000000000",
+    "@odata.etag": "W/\"graph-fetch-etag\"",
+    "type": "singleInstance",
+    "subject": "Contract create",
+    "bodyPreview": "WP-11 contract suite",
+    "start": {
+      "dateTime": "2025-01-15T14:00:00.0000000",
+      "timeZone": "UTC"
+    },
+    "end": {
+      "dateTime": "2025-01-15T15:00:00.0000000",
+      "timeZone": "UTC"
+    },
+    "showAs": "busy"
+  }
+}

--- a/packages/sync/src/providers/__contract__/microsoft-contract.factory.ts
+++ b/packages/sync/src/providers/__contract__/microsoft-contract.factory.ts
@@ -1,9 +1,14 @@
+import { type GraphEvent } from "@sync/providers/microsoft/microsoft-event.normalizer";
 import {
   type GraphEventDeltaItem,
   type MicrosoftEventListApi,
   type MicrosoftEventListPage,
   MicrosoftEventReaderAdapter,
 } from "@sync/providers/microsoft/microsoft-event-reader.adapter";
+import {
+  type MicrosoftEventWriteApi,
+  MicrosoftEventWriter,
+} from "@sync/providers/microsoft/microsoft-event-writer.adapter";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -21,6 +26,11 @@ export interface MicrosoftReaderCorpus {
   readonly page2: ReaderCorpusPage;
   readonly expiredDeltaLink: string;
   readonly masterCategories: Record<string, string>;
+}
+
+interface WriterCorpus {
+  readonly create: GraphEvent;
+  readonly fetch: GraphEvent;
 }
 
 class CorpusEventListApi implements MicrosoftEventListApi {
@@ -57,6 +67,63 @@ function loadJson<T>(corpusDir: string, name: string): T {
   return JSON.parse(readFileSync(join(corpusDir, `${name}.json`), "utf8")) as T;
 }
 
+class CorpusEventWriteApi implements MicrosoftEventWriteApi {
+  #etag: string;
+  #deleted = new Set<string>();
+  #transactionEvents = new Map<string, GraphEvent>();
+
+  constructor(private readonly corpus: WriterCorpus) {
+    this.#etag = corpus.create["@odata.etag"] ?? 'W/"graph-v1"';
+  }
+
+  async create(
+    params: Parameters<MicrosoftEventWriteApi["create"]>[0],
+  ): Promise<GraphEvent> {
+    const transactionId = params.body.transactionId;
+    if (transactionId && this.#transactionEvents.has(transactionId)) {
+      return this.#transactionEvents.get(transactionId)!;
+    }
+    const created = {
+      ...this.corpus.create,
+      id: transactionId ?? this.corpus.create.id,
+      "@odata.etag": this.#etag,
+    };
+    if (transactionId) this.#transactionEvents.set(transactionId, created);
+    return created;
+  }
+
+  async patch(
+    params: Parameters<MicrosoftEventWriteApi["patch"]>[0],
+  ): Promise<GraphEvent> {
+    if (params.ifMatch && params.ifMatch !== this.#etag) {
+      throw httpError(412);
+    }
+    this.#etag = 'W/"graph-v2"';
+    return {
+      ...this.corpus.create,
+      id: params.eventId,
+      "@odata.etag": this.#etag,
+    };
+  }
+
+  async delete(
+    params: Parameters<MicrosoftEventWriteApi["delete"]>[0],
+  ): Promise<void> {
+    if (this.#deleted.has(params.eventId)) throw httpError(404);
+    this.#deleted.add(params.eventId);
+  }
+
+  async get(
+    params: Parameters<MicrosoftEventWriteApi["get"]>[0],
+  ): Promise<GraphEvent> {
+    return {
+      ...this.corpus.fetch,
+      id: params.eventId,
+      "@odata.etag": this.#etag,
+    };
+  }
+}
+
 /** Replay `fixtures/microsoft/reader.json` through the event reader adapter. */
 export function microsoftRecordedReader(
   corpusDir: string,
@@ -78,4 +145,12 @@ export function microsoftReaderMasterCategories(): Map<string, string> {
   return new Map(
     Object.entries(defaultMicrosoftReaderCorpus().masterCategories),
   );
+}
+
+/** Replay `fixtures/microsoft/writer.json` through the event writer adapter. */
+export function microsoftRecordedWriter(
+  corpusDir: string,
+): MicrosoftEventWriter {
+  const writer = loadJson<WriterCorpus>(corpusDir, "writer");
+  return new MicrosoftEventWriter(() => new CorpusEventWriteApi(writer));
 }

--- a/packages/sync/src/providers/__contract__/microsoft.contract.test.ts
+++ b/packages/sync/src/providers/__contract__/microsoft.contract.test.ts
@@ -1,5 +1,11 @@
 import { generateKeyPair, type KeyLike, SignJWT } from "jose";
-import { defaultCorpusDir } from "@sync/providers/__contract__/adapter-contract";
+import {
+  assertWriterRejectsStaleVersion,
+  CONTRACT_CONTENT,
+  CONTRACT_EVENT_ID,
+  CONTRACT_SCHEDULE,
+  defaultCorpusDir,
+} from "@sync/providers/__contract__/adapter-contract";
 import { type AuthContractCase } from "@sync/providers/__contract__/auth.contract";
 import exchangeFixture from "@sync/providers/__contract__/fixtures/microsoft/exchange-success.json";
 import normalizerFixture from "@sync/providers/__contract__/fixtures/microsoft/normalizer.json";
@@ -9,6 +15,7 @@ import {
   defaultMicrosoftReaderCorpus,
   microsoftReaderMasterCategories,
   microsoftRecordedReader,
+  microsoftRecordedWriter,
 } from "@sync/providers/__contract__/microsoft-contract.factory";
 import {
   MicrosoftAuthAdapter,
@@ -26,6 +33,7 @@ import {
   type ProviderEventReadError,
   type ProviderEventReader,
 } from "@sync/providers/provider-event-reader.port";
+import { ProviderWriteError } from "@sync/providers/provider-event-writer.port";
 
 const CLIENT_ID = "microsoft-client-id";
 const CLIENT_SECRET = "microsoft-client-secret";
@@ -278,6 +286,7 @@ describe("microsoft normalizer contract", () => {
 const readerCorpusDir = defaultCorpusDir("microsoft");
 const readerAdapter = microsoftRecordedReader(readerCorpusDir);
 const readerCorpus = defaultMicrosoftReaderCorpus();
+const writerAdapter = microsoftRecordedWriter(readerCorpusDir);
 
 describe("microsoft reader contract", () => {
   it("pages, yields nextSyncToken only at the end, and counts skipped events", async () => {
@@ -330,6 +339,58 @@ describe("microsoft reader contract", () => {
     expect(masters.length).toBeGreaterThanOrEqual(1);
     expect(instances.length).toBeGreaterThanOrEqual(1);
     expect(instances.length).toBeLessThan(5);
+  });
+});
+
+describe("microsoft writer contract", () => {
+  it("create returns id and version, stale patch conflicts, delete is idempotent", async () => {
+    const created = await writerAdapter.createEvent({
+      accessToken: "contract-access-token",
+      calendarId: "primary",
+      providerEventId: CONTRACT_EVENT_ID,
+      content: CONTRACT_CONTENT,
+      schedule: CONTRACT_SCHEDULE,
+      recurrence: { kind: "single" },
+      invitation: "none",
+    });
+    expect(created.providerEventId.length).toBeGreaterThan(0);
+    expect(created.providerVersion.length).toBeGreaterThan(0);
+
+    await assertWriterRejectsStaleVersion(writerAdapter, {
+      accessToken: "contract-access-token",
+      calendarId: "primary",
+      skipCreate: true,
+      providerEventId: created.providerEventId,
+    });
+
+    await writerAdapter.deleteEvent({
+      accessToken: "contract-access-token",
+      calendarId: "primary",
+      providerEventId: created.providerEventId,
+      expectedVersion: null,
+      invitation: "none",
+    });
+    await writerAdapter.deleteEvent({
+      accessToken: "contract-access-token",
+      calendarId: "primary",
+      providerEventId: created.providerEventId,
+      expectedVersion: null,
+      invitation: "none",
+    });
+  });
+
+  it("fetchInstanceAt remains unsupported until M-06b", async () => {
+    const error = await writerAdapter
+      .fetchInstanceAt({
+        accessToken: "contract-access-token",
+        calendarId: "primary",
+        seriesProviderEventId: "series-1",
+        originalStartAt: "2025-01-15T14:00:00.000Z",
+        scheduleKind: "timed",
+      })
+      .catch((caught) => caught);
+    expect(error).toBeInstanceOf(ProviderWriteError);
+    expect((error as ProviderWriteError).reason).toBe("unsupportedCapability");
   });
 });
 

--- a/packages/sync/src/providers/microsoft/microsoft-event-writer.adapter.test.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-event-writer.adapter.test.ts
@@ -1,0 +1,470 @@
+import { type EventSchedule } from "@core/types/event.contracts";
+import { type SyncEventContent } from "@core/types/sync/event.contracts";
+import {
+  type GraphEvent,
+  type MicrosoftEventWriteApi,
+  MicrosoftEventWriter,
+} from "@sync/providers/microsoft/microsoft-event-writer.adapter";
+import { type ProviderWriteError } from "@sync/providers/provider-event-writer.port";
+
+const msError = (status: number, code?: string) =>
+  Object.assign(new Error(`microsoft error ${status}`), {
+    response: {
+      status,
+      data: code ? { error: { code, message: code } } : undefined,
+    },
+    config: { headers: { Authorization: "Bearer super-secret-token" } },
+  });
+
+const scriptedEvent = (id: string, etag = 'W/"graph-v1"'): GraphEvent => ({
+  id,
+  "@odata.etag": etag,
+  type: "singleInstance",
+  subject: "Title",
+  start: { dateTime: "2025-01-15T14:00:00.0000000", timeZone: "UTC" },
+  end: { dateTime: "2025-01-15T15:00:00.0000000", timeZone: "UTC" },
+});
+
+type Behavior = GraphEvent | Error | undefined;
+
+class FakeWriteApi implements MicrosoftEventWriteApi {
+  calls = {
+    create: [] as Parameters<MicrosoftEventWriteApi["create"]>[0][],
+    patch: [] as Parameters<MicrosoftEventWriteApi["patch"]>[0][],
+    delete: [] as Parameters<MicrosoftEventWriteApi["delete"]>[0][],
+    get: [] as Parameters<MicrosoftEventWriteApi["get"]>[0][],
+  };
+
+  #etag: string;
+  #deleted = new Set<string>();
+  #transactionEvents = new Map<string, GraphEvent>();
+
+  constructor(
+    private readonly behavior: {
+      create?: Behavior;
+      patch?: Behavior;
+      delete?: Behavior;
+      get?: Behavior;
+    } = {},
+    initialEtag = 'W/"graph-v1"',
+  ) {
+    this.#etag = initialEtag;
+  }
+
+  async create(
+    params: Parameters<MicrosoftEventWriteApi["create"]>[0],
+  ): Promise<GraphEvent> {
+    this.calls.create.push(params);
+    const transactionId = params.body.transactionId;
+    if (transactionId && this.#transactionEvents.has(transactionId)) {
+      return this.#transactionEvents.get(transactionId)!;
+    }
+    const result = this.#settle("create", () =>
+      scriptedEvent(transactionId ?? "created-id"),
+    );
+    if (transactionId) this.#transactionEvents.set(transactionId, result);
+    return result;
+  }
+
+  async patch(
+    params: Parameters<MicrosoftEventWriteApi["patch"]>[0],
+  ): Promise<GraphEvent> {
+    this.calls.patch.push(params);
+    if (params.ifMatch && params.ifMatch !== this.#etag) {
+      throw msError(412);
+    }
+    this.#etag = 'W/"graph-v2"';
+    return this.#settle("patch", () =>
+      scriptedEvent(params.eventId, this.#etag),
+    );
+  }
+
+  async delete(
+    params: Parameters<MicrosoftEventWriteApi["delete"]>[0],
+  ): Promise<void> {
+    this.calls.delete.push(params);
+    if (this.behavior.delete instanceof Error) throw this.behavior.delete;
+    if (this.#deleted.has(params.eventId)) throw msError(404);
+    this.#deleted.add(params.eventId);
+  }
+
+  async get(
+    params: Parameters<MicrosoftEventWriteApi["get"]>[0],
+  ): Promise<GraphEvent> {
+    this.calls.get.push(params);
+    return this.#settle("get", () =>
+      scriptedEvent(params.eventId, 'W/"graph-get"'),
+    );
+  }
+
+  #settle(method: "create" | "patch" | "get", fallback: () => GraphEvent) {
+    const scripted = this.behavior[method];
+    if (scripted instanceof Error) throw scripted;
+    return scripted ?? fallback();
+  }
+}
+
+const writerWith = (api: MicrosoftEventWriteApi) => {
+  const tokens: string[] = [];
+  const writer = new MicrosoftEventWriter((accessToken) => {
+    tokens.push(accessToken);
+    return api;
+  });
+  return { writer, tokens };
+};
+
+const content = (overrides: Partial<SyncEventContent> = {}): SyncEventContent =>
+  ({
+    title: "Title",
+    description: "Desc",
+    location: null,
+    organizer: null,
+    attendees: [],
+    conference: null,
+    ...overrides,
+  }) as SyncEventContent;
+
+const timedSchedule = {
+  kind: "timed",
+  start: "2025-01-15T09:00:00-05:00",
+  end: "2025-01-15T10:00:00-05:00",
+  timeZone: "America/New_York",
+} as unknown as EventSchedule;
+
+const allDaySchedule = {
+  kind: "allDay",
+  start: "2025-01-15",
+  end: "2025-01-16",
+} as unknown as EventSchedule;
+
+const baseCreate = {
+  accessToken: "at",
+  calendarId: "AAMkADAwATM0MDAAMS0zMDAwLTAwMDAtMDAwMDAwMABGAAAAAAA",
+  providerEventId: "abc12deadbeef00000000000",
+  content: content(),
+  schedule: timedSchedule,
+  recurrence: { kind: "single" } as const,
+  invitation: "none" as const,
+};
+
+const basePatch = {
+  accessToken: "at",
+  calendarId: "AAMkADAwATM0MDAAMS0zMDAwLTAwMDAtMDAwMDAwMABGAAAAAAA",
+  providerEventId: "abc12deadbeef00000000000",
+  expectedVersion: null,
+  content: content(),
+  schedule: timedSchedule,
+  recurrence: { kind: "single" } as const,
+  invitation: "none" as const,
+};
+
+describe("MicrosoftEventWriter", () => {
+  it("creates with transactionId and returns provider identity", async () => {
+    const api = new FakeWriteApi();
+    const { writer, tokens } = writerWith(api);
+
+    const result = await writer.createEvent(baseCreate);
+
+    expect(tokens).toEqual(["at"]);
+    expect(api.calls.create[0]?.body.transactionId).toBe(
+      "abc12deadbeef00000000000",
+    );
+    expect(result).toEqual({
+      providerEventId: "abc12deadbeef00000000000",
+      providerVersion: 'W/"graph-v1"',
+    });
+  });
+
+  it("writes timed schedule, text body, and showAs busy", async () => {
+    const api = new FakeWriteApi();
+    const { writer } = writerWith(api);
+
+    await writer.createEvent(baseCreate);
+
+    expect(api.calls.create[0]?.body).toMatchObject({
+      subject: "Title",
+      body: { contentType: "text", content: "Desc" },
+      isAllDay: false,
+      showAs: "busy",
+      start: { timeZone: "UTC" },
+      end: { timeZone: "UTC" },
+    });
+  });
+
+  it("writes all-day bounds with isAllDay and UTC date-only datetimes", async () => {
+    const api = new FakeWriteApi();
+    const { writer } = writerWith(api);
+
+    await writer.createEvent({ ...baseCreate, schedule: allDaySchedule });
+
+    expect(api.calls.create[0]?.body).toMatchObject({
+      isAllDay: true,
+      start: { dateTime: "2025-01-15T00:00:00.000", timeZone: "UTC" },
+      end: { dateTime: "2025-01-16T00:00:00.000", timeZone: "UTC" },
+    });
+  });
+
+  it("writes recurrence for a series create", async () => {
+    const api = new FakeWriteApi();
+    const { writer } = writerWith(api);
+
+    await writer.createEvent({
+      ...baseCreate,
+      recurrence: { kind: "series", rules: ["RRULE:FREQ=DAILY"] },
+    });
+
+    expect(api.calls.create[0]?.body.recurrence).toEqual({
+      pattern: { type: "daily", interval: 1 },
+      range: { type: "noEnd", startDate: "2025-01-15" },
+    });
+  });
+
+  it("returns the same event when create is retried with the same transactionId", async () => {
+    const api = new FakeWriteApi();
+    const { writer } = writerWith(api);
+
+    const first = await writer.createEvent(baseCreate);
+    const second = await writer.createEvent(baseCreate);
+
+    expect(api.calls.create).toHaveLength(2);
+    expect(second).toEqual(first);
+  });
+
+  it("writes attendees with responseRequested when invitation is not none", async () => {
+    const api = new FakeWriteApi();
+    const { writer } = writerWith(api);
+
+    await writer.createEvent({
+      ...baseCreate,
+      invitation: "all",
+      attendees: [
+        {
+          email: "guest@example.com",
+          displayName: "Guest",
+          responseStatus: "needsAction",
+        },
+      ],
+    });
+
+    expect(api.calls.create[0]?.body).toMatchObject({
+      responseRequested: true,
+      attendees: [
+        {
+          type: "required",
+          emailAddress: { address: "guest@example.com", name: "Guest" },
+          status: { response: "notResponded" },
+        },
+      ],
+    });
+  });
+
+  it("sets responseRequested false for invitation none with attendees", async () => {
+    const api = new FakeWriteApi();
+    const { writer } = writerWith(api);
+
+    await writer.createEvent({
+      ...baseCreate,
+      invitation: "none",
+      attendees: [
+        {
+          email: "guest@example.com",
+          displayName: null,
+          responseStatus: "accepted",
+        },
+      ],
+    });
+
+    expect(api.calls.create[0]?.body.responseRequested).toBe(false);
+  });
+
+  it("replaces the whole attendees array on patch when present", async () => {
+    const api = new FakeWriteApi();
+    const { writer } = writerWith(api);
+
+    await writer.patchEvent({
+      ...basePatch,
+      attendees: [
+        {
+          email: "solo@example.com",
+          displayName: null,
+          responseStatus: "tentative",
+        },
+      ],
+    });
+
+    expect(api.calls.patch[0]?.body.attendees).toEqual([
+      {
+        type: "required",
+        emailAddress: { address: "solo@example.com" },
+        status: { response: "tentativelyAccepted" },
+      },
+    ]);
+  });
+
+  it("omits attendees when the write does not intend a guest edit", async () => {
+    const api = new FakeWriteApi();
+    const { writer } = writerWith(api);
+
+    await writer.patchEvent(basePatch);
+
+    expect(api.calls.patch[0]?.body).not.toHaveProperty("attendees");
+  });
+
+  it("clears recurrence with null on a single patch", async () => {
+    const api = new FakeWriteApi();
+    const { writer } = writerWith(api);
+
+    await writer.patchEvent({ ...basePatch, recurrence: { kind: "single" } });
+
+    expect(api.calls.patch[0]?.body.recurrence).toBeNull();
+  });
+
+  it("omits recurrence when patching a resolved instance", async () => {
+    const api = new FakeWriteApi();
+    const { writer } = writerWith(api);
+
+    await writer.patchEvent({ ...basePatch, recurrence: { kind: "instance" } });
+
+    expect(api.calls.patch[0]?.body).not.toHaveProperty("recurrence");
+  });
+
+  it("maps a stale etag to versionConflict", async () => {
+    const api = new FakeWriteApi({ patch: msError(412) });
+    const { writer } = writerWith(api);
+
+    const error = (await writer
+      .patchEvent({ ...basePatch, expectedVersion: 'W/"stale"' })
+      .catch((e) => e)) as ProviderWriteError;
+
+    expect(error.reason).toBe("versionConflict");
+  });
+
+  it("treats deleting an already-absent event as success", async () => {
+    const api = new FakeWriteApi({ delete: msError(404) });
+    const { writer } = writerWith(api);
+
+    await writer.deleteEvent({
+      accessToken: "at",
+      calendarId: "cal",
+      providerEventId: "gone-id",
+      expectedVersion: null,
+      invitation: "none",
+    });
+  });
+
+  it("maps 401 to authorizationRevoked", async () => {
+    const api = new FakeWriteApi({ patch: msError(401) });
+    const error = (await writerWith(api)
+      .writer.patchEvent(basePatch)
+      .catch((e) => e)) as ProviderWriteError;
+    expect(error.reason).toBe("authorizationRevoked");
+  });
+
+  it("maps 403 to readOnlyCalendar", async () => {
+    const api = new FakeWriteApi({ patch: msError(403, "ErrorAccessDenied") });
+    const error = (await writerWith(api)
+      .writer.patchEvent(basePatch)
+      .catch((e) => e)) as ProviderWriteError;
+    expect(error.reason).toBe("readOnlyCalendar");
+  });
+
+  it("maps 429 and 5xx to transient", async () => {
+    const throttled = new FakeWriteApi({ patch: msError(429) });
+    const server = new FakeWriteApi({ patch: msError(503) });
+    const network = new FakeWriteApi({ patch: new Error("ECONNRESET") });
+
+    const a = (await writerWith(throttled)
+      .writer.patchEvent(basePatch)
+      .catch((e) => e)) as ProviderWriteError;
+    const b = (await writerWith(server)
+      .writer.patchEvent(basePatch)
+      .catch((e) => e)) as ProviderWriteError;
+    const c = (await writerWith(network)
+      .writer.patchEvent(basePatch)
+      .catch((e) => e)) as ProviderWriteError;
+
+    expect(a.reason).toBe("transient");
+    expect(b.reason).toBe("transient");
+    expect(c.reason).toBe("transient");
+  });
+
+  it("maps unsupported recurrence to permanentProviderError", async () => {
+    const api = new FakeWriteApi();
+    const { writer } = writerWith(api);
+
+    const error = (await writer
+      .createEvent({
+        ...baseCreate,
+        recurrence: {
+          kind: "series",
+          rules: ["RRULE:FREQ=HOURLY"],
+        },
+      })
+      .catch((e) => e)) as ProviderWriteError;
+
+    expect(error.reason).toBe("permanentProviderError");
+    expect(error.message).toContain("Hourly");
+  });
+
+  it("fetches an event back as a normalized read, or null when absent", async () => {
+    const present = new FakeWriteApi({
+      get: {
+        ...scriptedEvent("abc12deadbeef00000000000"),
+        subject: "Fetched",
+        bodyPreview: "Fetched body",
+      },
+    });
+    const absent = new FakeWriteApi({ get: msError(404) });
+
+    const read = await writerWith(present).writer.fetchEvent({
+      accessToken: "at",
+      calendarId: "cal",
+      providerEventId: "abc12deadbeef00000000000",
+    });
+    const missing = await writerWith(absent).writer.fetchEvent({
+      accessToken: "at",
+      calendarId: "cal",
+      providerEventId: "missing",
+    });
+
+    expect(read?.kind).toBe("event");
+    expect(read?.providerEventId).toBe("abc12deadbeef00000000000");
+    expect(missing).toBeNull();
+  });
+
+  it("fetchInstanceAt is unsupported until M-06b", async () => {
+    const { writer } = writerWith(new FakeWriteApi());
+
+    const error = (await writer
+      .fetchInstanceAt({
+        accessToken: "at",
+        calendarId: "cal",
+        seriesProviderEventId: "series-1",
+        originalStartAt: "2025-01-15T14:00:00.000Z",
+        scheduleKind: "timed",
+      })
+      .catch((e) => e)) as ProviderWriteError;
+
+    expect(error.reason).toBe("unsupportedCapability");
+  });
+
+  it("never leaks the bearer token onto a thrown error cause", async () => {
+    const api = new FakeWriteApi({ patch: msError(500) });
+    const error = (await writerWith(api)
+      .writer.patchEvent(basePatch)
+      .catch((e) => e)) as ProviderWriteError;
+
+    expect(JSON.stringify(error.cause ?? {})).not.toContain(
+      "super-secret-token",
+    );
+  });
+
+  it("rejects a create whose returned event lacks identity", async () => {
+    const api = new FakeWriteApi({ create: { type: "singleInstance" } });
+    const error = (await writerWith(api)
+      .writer.createEvent(baseCreate)
+      .catch((e) => e)) as ProviderWriteError;
+
+    expect(error.reason).toBe("permanentProviderError");
+  });
+});

--- a/packages/sync/src/providers/microsoft/microsoft-event-writer.adapter.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-event-writer.adapter.ts
@@ -1,0 +1,497 @@
+import { type EventSchedule } from "@core/types/event.contracts";
+import { type Attendee } from "@core/types/event-attendance.contracts";
+import { type SyncEventContent } from "@core/types/sync/event.contracts";
+import dayjs from "@core/util/date/dayjs";
+import {
+  isMicrosoftTransient,
+  microsoftFailureCause,
+  microsoftStatus,
+} from "@sync/providers/microsoft/microsoft-error";
+import {
+  type GraphEvent,
+  normalizeMicrosoftEvent,
+} from "@sync/providers/microsoft/microsoft-event.normalizer";
+import {
+  MICROSOFT_EVENT_SELECT,
+  MICROSOFT_GRAPH_BASE_URL,
+  MICROSOFT_REQUEST_TIMEOUT_MS,
+} from "@sync/providers/microsoft/microsoft-http.constants";
+import { fromRRule } from "@sync/providers/microsoft/microsoft-recurrence";
+import { UnsupportedRecurrenceError } from "@sync/providers/microsoft/microsoft-recurrence.error";
+import {
+  type GraphPatternedRecurrence,
+  type MicrosoftRecurrenceWriteContext,
+} from "@sync/providers/microsoft/microsoft-recurrence.types";
+import {
+  ProviderEventError,
+  type ProviderEventRead,
+} from "@sync/providers/provider-event.port";
+import {
+  type InvitationIntent,
+  type ProviderCreateInput,
+  type ProviderDeleteInput,
+  type ProviderEventWriter,
+  type ProviderFetchInput,
+  type ProviderInstanceFetchInput,
+  type ProviderPatchInput,
+  ProviderWriteError,
+  type ProviderWriteRecurrence,
+  type ProviderWriteResult,
+} from "@sync/providers/provider-event-writer.port";
+import { redactedCause } from "@sync/safety/redact-error";
+
+const GRAPH_DATETIME = "YYYY-MM-DD[T]HH:mm:ss.SSS";
+
+// Graph attendee response values Compass writes back on a guest-list edit.
+const COMPASS_TO_GRAPH_RESPONSE: Readonly<
+  Record<Attendee["responseStatus"], string>
+> = {
+  accepted: "accepted",
+  declined: "declined",
+  tentative: "tentativelyAccepted",
+  needsAction: "notResponded",
+};
+
+interface GraphAttendeeWrite {
+  readonly type: "required";
+  readonly emailAddress: {
+    readonly address: string;
+    readonly name?: string;
+  };
+  readonly status?: { readonly response: string };
+}
+
+export interface GraphEventWriteBody {
+  readonly subject?: string;
+  readonly body?: { readonly contentType: "text"; readonly content: string };
+  readonly location?: { readonly displayName: string };
+  readonly start?: { readonly dateTime: string; readonly timeZone: "UTC" };
+  readonly end?: { readonly dateTime: string; readonly timeZone: "UTC" };
+  readonly isAllDay?: boolean;
+  readonly showAs?: "free" | "busy" | "tentative" | "oof" | "workingElsewhere";
+  readonly recurrence?: GraphPatternedRecurrence | null;
+  readonly attendees?: readonly GraphAttendeeWrite[];
+  readonly responseRequested?: boolean;
+  readonly transactionId?: string;
+}
+
+export interface MicrosoftEventWriteApi {
+  create(params: {
+    calendarId: string;
+    body: GraphEventWriteBody;
+  }): Promise<GraphEvent>;
+  patch(params: {
+    eventId: string;
+    body: GraphEventWriteBody;
+    ifMatch: string | null;
+  }): Promise<GraphEvent>;
+  delete(params: { eventId: string; ifMatch: string | null }): Promise<void>;
+  get(params: { eventId: string }): Promise<GraphEvent>;
+}
+
+export type MicrosoftEventWriteApiFactory = (
+  accessToken: string,
+) => MicrosoftEventWriteApi;
+
+const defaultApiFactory: MicrosoftEventWriteApiFactory = (accessToken) =>
+  new FetchMicrosoftEventWriteApi(accessToken);
+
+// Microsoft Graph implementation of the event mutation port. Create is
+// idempotent via transactionId, patch and delete can be conditioned on etag,
+// and provider errors are classified into neutral, caller-actionable reasons.
+//
+// Named wart: Graph sends attendee mail on create and on attendee changes even
+// when responseRequested is false (invitation "none"). Compass honors "none" by
+// setting responseRequested false, but Outlook may still notify attendees.
+export class MicrosoftEventWriter implements ProviderEventWriter {
+  #makeApi: MicrosoftEventWriteApiFactory;
+
+  constructor(makeApi: MicrosoftEventWriteApiFactory = defaultApiFactory) {
+    this.#makeApi = makeApi;
+  }
+
+  async createEvent(input: ProviderCreateInput): Promise<ProviderWriteResult> {
+    if (input.createConference) {
+      // Teams conference creation lands in M-06b; booking copy handles null URL.
+    }
+
+    const api = this.#makeApi(input.accessToken);
+    const body = toGraphCreateBody(input);
+
+    try {
+      const created = await api.create({
+        calendarId: input.calendarId,
+        body,
+      });
+      return toResult(created);
+    } catch (error) {
+      throw classifyWriteError(error);
+    }
+  }
+
+  async patchEvent(input: ProviderPatchInput): Promise<ProviderWriteResult> {
+    const api = this.#makeApi(input.accessToken);
+    try {
+      const patched = await api.patch({
+        eventId: input.providerEventId,
+        body: toGraphPatchBody(input),
+        ifMatch: input.expectedVersion,
+      });
+      return toResult(patched);
+    } catch (error) {
+      throw classifyWriteError(error);
+    }
+  }
+
+  async deleteEvent(input: ProviderDeleteInput): Promise<void> {
+    const api = this.#makeApi(input.accessToken);
+    try {
+      await api.delete({
+        eventId: input.providerEventId,
+        ifMatch: input.expectedVersion,
+      });
+    } catch (error) {
+      if (isNotFound(error)) return;
+      throw classifyWriteError(error);
+    }
+  }
+
+  async fetchEvent(
+    input: ProviderFetchInput,
+  ): Promise<ProviderEventRead | null> {
+    const api = this.#makeApi(input.accessToken);
+    try {
+      const event = await api.get({ eventId: input.providerEventId });
+      return normalizeMicrosoftEvent(event);
+    } catch (error) {
+      if (isNotFound(error)) return null;
+      throw classifyWriteError(error);
+    }
+  }
+
+  async fetchInstanceAt(
+    _input: ProviderInstanceFetchInput,
+  ): Promise<ProviderEventRead | null> {
+    throw new ProviderWriteError(
+      "unsupportedCapability",
+      "Microsoft instance resolution lands in M-06b",
+    );
+  }
+}
+
+function toGraphCreateBody(input: ProviderCreateInput): GraphEventWriteBody {
+  return {
+    transactionId: input.providerEventId,
+    ...toGraphWriteBody(
+      input.content,
+      input.schedule,
+      input.recurrence,
+      input.invitation,
+      input.attendees,
+    ),
+  };
+}
+
+function toGraphPatchBody(input: ProviderPatchInput): GraphEventWriteBody {
+  return toGraphWriteBody(
+    input.content,
+    input.schedule,
+    input.recurrence,
+    input.invitation,
+    input.attendees,
+  );
+}
+
+function toGraphWriteBody(
+  content: SyncEventContent,
+  schedule: EventSchedule,
+  recurrence: ProviderWriteRecurrence,
+  invitation: InvitationIntent,
+  attendees?: readonly Attendee[],
+): GraphEventWriteBody {
+  return {
+    subject: content.title,
+    body: {
+      contentType: "text",
+      content: content.description ?? "",
+    },
+    location: { displayName: content.location ?? "" },
+    ...scheduleFields(schedule),
+    showAs: "busy",
+    ...recurrenceField(recurrence, schedule),
+    ...attendeesField(attendees, invitation),
+  };
+}
+
+function scheduleFields(
+  schedule: EventSchedule,
+): Pick<GraphEventWriteBody, "start" | "end" | "isAllDay"> {
+  if (schedule.kind === "allDay") {
+    return {
+      isAllDay: true,
+      start: {
+        dateTime: `${schedule.start}T00:00:00.000`,
+        timeZone: "UTC",
+      },
+      end: {
+        dateTime: `${schedule.end}T00:00:00.000`,
+        timeZone: "UTC",
+      },
+    };
+  }
+
+  return {
+    isAllDay: false,
+    start: {
+      dateTime: dayjs(schedule.start).utc().format(GRAPH_DATETIME),
+      timeZone: "UTC",
+    },
+    end: {
+      dateTime: dayjs(schedule.end).utc().format(GRAPH_DATETIME),
+      timeZone: "UTC",
+    },
+  };
+}
+
+function recurrenceField(
+  recurrence: ProviderWriteRecurrence,
+  schedule: EventSchedule,
+): Pick<GraphEventWriteBody, "recurrence"> | Record<string, never> {
+  if (recurrence.kind === "instance") return {};
+  if (recurrence.kind === "single") return { recurrence: null };
+  try {
+    return {
+      recurrence: fromRRule(recurrence.rules, recurrenceWriteContext(schedule)),
+    };
+  } catch (error) {
+    if (error instanceof UnsupportedRecurrenceError) {
+      throw new ProviderWriteError("permanentProviderError", error.message, {
+        cause: redactedCause(error),
+      });
+    }
+    throw error;
+  }
+}
+
+function recurrenceWriteContext(
+  schedule: EventSchedule,
+): MicrosoftRecurrenceWriteContext {
+  if (schedule.kind === "allDay") {
+    return { startDate: schedule.start };
+  }
+  return {
+    startDate: dayjs(schedule.start)
+      .tz(schedule.timeZone)
+      .format(dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT),
+    ianaTimeZone: schedule.timeZone,
+  };
+}
+
+function attendeesField(
+  attendees: readonly Attendee[] | undefined,
+  invitation: InvitationIntent,
+):
+  | Pick<GraphEventWriteBody, "attendees" | "responseRequested">
+  | Record<string, never> {
+  if (!attendees) return {};
+  if (attendees.length === 0) {
+    return { attendees: attendees.map(toGraphAttendee) };
+  }
+  return {
+    attendees: attendees.map(toGraphAttendee),
+    responseRequested: invitation !== "none",
+  };
+}
+
+function toGraphAttendee(attendee: Attendee): GraphAttendeeWrite {
+  return {
+    type: "required",
+    emailAddress: {
+      address: attendee.email,
+      ...(attendee.displayName ? { name: attendee.displayName } : {}),
+    },
+    status: {
+      response: COMPASS_TO_GRAPH_RESPONSE[attendee.responseStatus],
+    },
+  };
+}
+
+function toResult(event: GraphEvent): ProviderWriteResult {
+  if (!event.id || !event["@odata.etag"]) {
+    throw new ProviderWriteError(
+      "permanentProviderError",
+      "Microsoft returned an event without an id or etag",
+    );
+  }
+  return {
+    providerEventId: event.id,
+    providerVersion: event["@odata.etag"],
+    ...(event.iCalUId ? { icalUid: event.iCalUId } : {}),
+  };
+}
+
+function classifyWriteError(error: unknown): ProviderWriteError {
+  if (error instanceof ProviderWriteError) return error;
+  if (error instanceof ProviderEventError) {
+    return new ProviderWriteError("permanentProviderError", error.message, {
+      cause: redactedCause(error),
+    });
+  }
+
+  const status = microsoftStatus(error);
+  const cause = microsoftFailureCause(error);
+
+  if (status === 412) {
+    return new ProviderWriteError(
+      "versionConflict",
+      "The event was modified since the expected version",
+      { cause },
+    );
+  }
+  if (status === 401) {
+    return new ProviderWriteError(
+      "authorizationRevoked",
+      "Microsoft rejected the credential",
+      { cause },
+    );
+  }
+  if (status === 403) {
+    return new ProviderWriteError(
+      "readOnlyCalendar",
+      "The calendar cannot be written",
+      { cause },
+    );
+  }
+  if (
+    status === undefined ||
+    status === 429 ||
+    isMicrosoftTransient(error, status)
+  ) {
+    return new ProviderWriteError("transient", "The write failed transiently", {
+      cause,
+    });
+  }
+  return new ProviderWriteError(
+    "permanentProviderError",
+    "Microsoft rejected the write",
+    { cause },
+  );
+}
+
+function isNotFound(error: unknown): boolean {
+  const status = microsoftStatus(error);
+  return status === 404 || status === 410;
+}
+
+class FetchMicrosoftEventWriteApi implements MicrosoftEventWriteApi {
+  #accessToken: string;
+
+  constructor(accessToken: string) {
+    this.#accessToken = accessToken;
+  }
+
+  create(params: {
+    calendarId: string;
+    body: GraphEventWriteBody;
+  }): Promise<GraphEvent> {
+    const calendarId = encodeURIComponent(params.calendarId);
+    return this.#request(
+      "POST",
+      `${MICROSOFT_GRAPH_BASE_URL}/me/calendars/${calendarId}/events`,
+      params.body,
+    );
+  }
+
+  patch(params: {
+    eventId: string;
+    body: GraphEventWriteBody;
+    ifMatch: string | null;
+  }): Promise<GraphEvent> {
+    const eventId = encodeURIComponent(params.eventId);
+    return this.#request(
+      "PATCH",
+      `${MICROSOFT_GRAPH_BASE_URL}/me/events/${eventId}`,
+      params.body,
+      params.ifMatch,
+    );
+  }
+
+  async delete(params: {
+    eventId: string;
+    ifMatch: string | null;
+  }): Promise<void> {
+    const eventId = encodeURIComponent(params.eventId);
+    await this.#request(
+      "DELETE",
+      `${MICROSOFT_GRAPH_BASE_URL}/me/events/${eventId}`,
+      undefined,
+      params.ifMatch,
+    );
+  }
+
+  get(params: { eventId: string }): Promise<GraphEvent> {
+    const eventId = encodeURIComponent(params.eventId);
+    const query = new URLSearchParams({ $select: MICROSOFT_EVENT_SELECT });
+    return this.#request(
+      "GET",
+      `${MICROSOFT_GRAPH_BASE_URL}/me/events/${eventId}?${query}`,
+    );
+  }
+
+  async #request(
+    method: "GET" | "POST" | "PATCH" | "DELETE",
+    url: string,
+    body?: GraphEventWriteBody,
+    ifMatch: string | null = null,
+  ): Promise<GraphEvent> {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.#accessToken}`,
+      Prefer: 'outlook.timezone="UTC"',
+    };
+    if (ifMatch) headers["If-Match"] = ifMatch;
+    if (body !== undefined) headers["Content-Type"] = "application/json";
+
+    const response = await fetch(url, {
+      method,
+      headers,
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      signal: AbortSignal.timeout(MICROSOFT_REQUEST_TIMEOUT_MS),
+    });
+
+    if (method === "DELETE") {
+      if (response.ok) return {} as GraphEvent;
+      const deleteError = await parseErrorBody(response);
+      throw Object.assign(
+        new Error(deleteError.message ?? "microsoft_event_write_failed"),
+        { response: { status: response.status, data: deleteError.data } },
+      );
+    }
+
+    const data = (await response.json()) as GraphEvent & {
+      error?: { code?: string; message?: string };
+    };
+
+    if (!response.ok) {
+      throw Object.assign(
+        new Error(data.error?.message ?? "microsoft_event_write_failed"),
+        { response: { status: response.status, data } },
+      );
+    }
+
+    return data;
+  }
+}
+
+async function parseErrorBody(response: Response): Promise<{
+  message?: string;
+  data?: unknown;
+}> {
+  try {
+    const data = (await response.json()) as {
+      error?: { message?: string };
+    };
+    return { message: data.error?.message, data };
+  } catch {
+    return {};
+  }
+}


### PR DESCRIPTION
Fixes #3245

## What and why

Implements `ProviderEventWriter` for Microsoft Graph with injectable `MicrosoftEventWriteApi`. Create uses `transactionId` for idempotent retries; patch honors `If-Match` etags; delete is idempotent on 404; fetch normalizes via M-04. Graph attendee mail on `invitation: "none"` is documented as a named wart (`responseRequested: false` still may notify). `fetchInstanceAt` and conference creation remain deferred to M-06b.

## Verify

```
bun test:sync
bun run type-check
bun lint
bun knip
```

VERDICT: PASS