### PR TITLE
feat(sync): Graph event writer Teams conferencing and instance fetch (WP-06b)

### DIFF
--- a/.agents/handoffs/3246.md
+++ b/.agents/handoffs/3246.md
@@ -1,0 +1,33 @@
+# Handoff: #3246
+
+task_id: 3246
+status: verifying
+branch: cursor/wp-06b-teams-conference-instance-fetch
+
+## Summary
+
+Implemented Microsoft Graph Teams conferencing on create and `fetchInstanceAt` for
+series instance resolution in the event writer (WP-06b).
+
+## Deliverables
+
+- `microsoft-meeting-providers.ts`: Teams provider selection and cached
+  `GET /me/calendar` meeting settings (5 min TTL)
+- `microsoft-event-writer.adapter.ts`: `isOnlineMeeting` / `onlineMeetingProvider`
+  on create when Teams is available; instance lookup via
+  `GET /me/events/{id}/instances`; conference URL read-back from `onlineMeeting.joinUrl`
+- `microsoft-event.normalizer.ts`: export `mapConference`; `allowOccurrence` option
+  for writer instance reads
+- Tests for Teams default, Teams allowed-not-default, no Teams, instance hit/miss
+- Contract corpus/factory updated for `fetchInstanceAt`
+
+## Verify
+
+```
+bun test:sync
+bun run type-check
+bun lint
+bun knip
+```
+
+VERDICT: PASS

--- a/packages/sync/src/providers/__contract__/fixtures/microsoft/writer.json
+++ b/packages/sync/src/providers/__contract__/fixtures/microsoft/writer.json
@@ -33,5 +33,26 @@
       "timeZone": "UTC"
     },
     "showAs": "busy"
+  },
+  "instance": {
+    "id": "AAMkAGI2TG96AAA=",
+    "@odata.etag": "W/\"graph-instance-etag\"",
+    "type": "occurrence",
+    "subject": "Contract instance",
+    "seriesMasterId": "series-1",
+    "originalStart": "2025-01-15T14:00:00.0000000Z",
+    "start": {
+      "dateTime": "2025-01-15T14:00:00.0000000",
+      "timeZone": "UTC"
+    },
+    "end": {
+      "dateTime": "2025-01-15T15:00:00.0000000",
+      "timeZone": "UTC"
+    },
+    "showAs": "busy"
+  },
+  "meetingSettings": {
+    "defaultOnlineMeetingProvider": "teamsForBusiness",
+    "allowedOnlineMeetingProviders": ["teamsForBusiness"]
   }
 }

--- a/packages/sync/src/providers/__contract__/microsoft-contract.factory.ts
+++ b/packages/sync/src/providers/__contract__/microsoft-contract.factory.ts
@@ -31,6 +31,11 @@ export interface MicrosoftReaderCorpus {
 interface WriterCorpus {
   readonly create: GraphEvent;
   readonly fetch: GraphEvent;
+  readonly instance: GraphEvent;
+  readonly meetingSettings: {
+    readonly defaultOnlineMeetingProvider?: string;
+    readonly allowedOnlineMeetingProviders?: readonly string[];
+  };
 }
 
 class CorpusEventListApi implements MicrosoftEventListApi {
@@ -121,6 +126,25 @@ class CorpusEventWriteApi implements MicrosoftEventWriteApi {
       id: params.eventId,
       "@odata.etag": this.#etag,
     };
+  }
+
+  async listInstances(
+    params: Parameters<MicrosoftEventWriteApi["listInstances"]>[0],
+  ): Promise<readonly GraphEvent[]> {
+    if (params.seriesMasterId !== "series-1") return [];
+    return [
+      {
+        ...this.corpus.instance,
+        seriesMasterId: params.seriesMasterId,
+      },
+    ];
+  }
+
+  async getCalendarMeetingSettings(): Promise<{
+    defaultOnlineMeetingProvider?: string;
+    allowedOnlineMeetingProviders?: readonly string[];
+  }> {
+    return this.corpus.meetingSettings;
   }
 }
 

--- a/packages/sync/src/providers/__contract__/microsoft.contract.test.ts
+++ b/packages/sync/src/providers/__contract__/microsoft.contract.test.ts
@@ -33,7 +33,6 @@ import {
   type ProviderEventReadError,
   type ProviderEventReader,
 } from "@sync/providers/provider-event-reader.port";
-import { ProviderWriteError } from "@sync/providers/provider-event-writer.port";
 
 const CLIENT_ID = "microsoft-client-id";
 const CLIENT_SECRET = "microsoft-client-secret";
@@ -343,7 +342,7 @@ describe("microsoft reader contract", () => {
 });
 
 describe("microsoft writer contract", () => {
-  it("create returns id and version, stale patch conflicts, delete is idempotent", async () => {
+  it("create returns id and version, stale patch conflicts, delete is idempotent, fetchInstanceAt resolves", async () => {
     const created = await writerAdapter.createEvent({
       accessToken: "contract-access-token",
       calendarId: "primary",
@@ -377,20 +376,16 @@ describe("microsoft writer contract", () => {
       expectedVersion: null,
       invitation: "none",
     });
-  });
 
-  it("fetchInstanceAt remains unsupported until M-06b", async () => {
-    const error = await writerAdapter
-      .fetchInstanceAt({
-        accessToken: "contract-access-token",
-        calendarId: "primary",
-        seriesProviderEventId: "series-1",
-        originalStartAt: "2025-01-15T14:00:00.000Z",
-        scheduleKind: "timed",
-      })
-      .catch((caught) => caught);
-    expect(error).toBeInstanceOf(ProviderWriteError);
-    expect((error as ProviderWriteError).reason).toBe("unsupportedCapability");
+    const instance = await writerAdapter.fetchInstanceAt({
+      accessToken: "contract-access-token",
+      calendarId: "primary",
+      seriesProviderEventId: "series-1",
+      originalStartAt: "2025-01-15T14:00:00.000Z",
+      scheduleKind: "timed",
+    });
+    expect(instance).not.toBeNull();
+    expect(instance?.providerEventId.length).toBeGreaterThan(0);
   });
 });
 

--- a/packages/sync/src/providers/microsoft/microsoft-event-writer.adapter.test.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-event-writer.adapter.test.ts
@@ -5,6 +5,7 @@ import {
   type MicrosoftEventWriteApi,
   MicrosoftEventWriter,
 } from "@sync/providers/microsoft/microsoft-event-writer.adapter";
+import { clearMeetingSettingsCacheForTests } from "@sync/providers/microsoft/microsoft-meeting-providers";
 import { type ProviderWriteError } from "@sync/providers/provider-event-writer.port";
 
 const msError = (status: number, code?: string) =>
@@ -33,7 +34,17 @@ class FakeWriteApi implements MicrosoftEventWriteApi {
     patch: [] as Parameters<MicrosoftEventWriteApi["patch"]>[0][],
     delete: [] as Parameters<MicrosoftEventWriteApi["delete"]>[0][],
     get: [] as Parameters<MicrosoftEventWriteApi["get"]>[0][],
+    listInstances: [] as Parameters<
+      MicrosoftEventWriteApi["listInstances"]
+    >[0][],
+    getCalendarMeetingSettings: [] as unknown[],
   };
+
+  #meetingSettings = {
+    defaultOnlineMeetingProvider: "teamsForBusiness",
+    allowedOnlineMeetingProviders: ["teamsForBusiness"],
+  };
+  #instances: readonly GraphEvent[] = [];
 
   #etag: string;
   #deleted = new Set<string>();
@@ -45,10 +56,28 @@ class FakeWriteApi implements MicrosoftEventWriteApi {
       patch?: Behavior;
       delete?: Behavior;
       get?: Behavior;
+      listInstances?: Behavior | readonly GraphEvent[];
+      meetingSettings?: {
+        defaultOnlineMeetingProvider?: string;
+        allowedOnlineMeetingProviders?: string[];
+      };
     } = {},
     initialEtag = 'W/"graph-v1"',
   ) {
     this.#etag = initialEtag;
+    if (behavior.meetingSettings) {
+      this.#meetingSettings = {
+        defaultOnlineMeetingProvider:
+          behavior.meetingSettings.defaultOnlineMeetingProvider ??
+          this.#meetingSettings.defaultOnlineMeetingProvider,
+        allowedOnlineMeetingProviders:
+          behavior.meetingSettings.allowedOnlineMeetingProviders ??
+          this.#meetingSettings.allowedOnlineMeetingProviders,
+      };
+    }
+    if (Array.isArray(behavior.listInstances)) {
+      this.#instances = behavior.listInstances;
+    }
   }
 
   async create(
@@ -95,6 +124,24 @@ class FakeWriteApi implements MicrosoftEventWriteApi {
     return this.#settle("get", () =>
       scriptedEvent(params.eventId, 'W/"graph-get"'),
     );
+  }
+
+  async listInstances(
+    params: Parameters<MicrosoftEventWriteApi["listInstances"]>[0],
+  ): Promise<readonly GraphEvent[]> {
+    this.calls.listInstances.push(params);
+    const scripted = this.behavior.listInstances;
+    if (scripted instanceof Error) throw scripted;
+    if (Array.isArray(scripted)) return scripted;
+    return this.#instances;
+  }
+
+  async getCalendarMeetingSettings(): Promise<{
+    defaultOnlineMeetingProvider?: string;
+    allowedOnlineMeetingProviders?: string[];
+  }> {
+    this.calls.getCalendarMeetingSettings.push({});
+    return this.#meetingSettings;
   }
 
   #settle(method: "create" | "patch" | "get", fallback: () => GraphEvent) {
@@ -159,6 +206,10 @@ const basePatch = {
 };
 
 describe("MicrosoftEventWriter", () => {
+  afterEach(() => {
+    clearMeetingSettingsCacheForTests();
+  });
+
   it("creates with transactionId and returns provider identity", async () => {
     const api = new FakeWriteApi();
     const { writer, tokens } = writerWith(api);
@@ -432,20 +483,149 @@ describe("MicrosoftEventWriter", () => {
     expect(missing).toBeNull();
   });
 
-  it("fetchInstanceAt is unsupported until M-06b", async () => {
-    const { writer } = writerWith(new FakeWriteApi());
+  it("adds Teams online meeting fields when createConference and default Teams provider", async () => {
+    const api = new FakeWriteApi({
+      create: {
+        ...scriptedEvent("abc12deadbeef00000000000"),
+        onlineMeeting: {
+          joinUrl: "https://teams.microsoft.com/l/meetup-join/abc",
+        },
+        onlineMeetingProvider: "teamsForBusiness",
+      },
+      meetingSettings: {
+        defaultOnlineMeetingProvider: "teamsForBusiness",
+        allowedOnlineMeetingProviders: ["teamsForBusiness"],
+      },
+    });
+    const { writer } = writerWith(api);
 
-    const error = (await writer
-      .fetchInstanceAt({
-        accessToken: "at",
-        calendarId: "cal",
-        seriesProviderEventId: "series-1",
-        originalStartAt: "2025-01-15T14:00:00.000Z",
-        scheduleKind: "timed",
-      })
-      .catch((e) => e)) as ProviderWriteError;
+    const result = await writer.createEvent({
+      ...baseCreate,
+      createConference: true,
+    });
 
-    expect(error.reason).toBe("unsupportedCapability");
+    expect(api.calls.getCalendarMeetingSettings).toHaveLength(1);
+    expect(api.calls.create[0]?.body).toMatchObject({
+      isOnlineMeeting: true,
+      onlineMeetingProvider: "teamsForBusiness",
+    });
+    expect(result.conference).toEqual({
+      url: "https://teams.microsoft.com/l/meetup-join/abc",
+      label: "Microsoft Teams",
+    });
+  });
+
+  it("uses the first allowed Teams provider when default is not Teams", async () => {
+    const api = new FakeWriteApi({
+      meetingSettings: {
+        defaultOnlineMeetingProvider: "skypeForConsumer",
+        allowedOnlineMeetingProviders: ["skypeForConsumer", "teamsForConsumer"],
+      },
+    });
+    const { writer } = writerWith(api);
+
+    await writer.createEvent({ ...baseCreate, createConference: true });
+
+    expect(api.calls.create[0]?.body).toMatchObject({
+      isOnlineMeeting: true,
+      onlineMeetingProvider: "teamsForConsumer",
+    });
+  });
+
+  it("creates without a conference when no Teams provider is allowed", async () => {
+    const api = new FakeWriteApi({
+      meetingSettings: {
+        defaultOnlineMeetingProvider: "skypeForConsumer",
+        allowedOnlineMeetingProviders: ["skypeForConsumer"],
+      },
+    });
+    const { writer } = writerWith(api);
+
+    const result = await writer.createEvent({
+      ...baseCreate,
+      createConference: true,
+    });
+
+    expect(api.calls.create[0]?.body).not.toHaveProperty("isOnlineMeeting");
+    expect(result.conference).toBeUndefined();
+  });
+
+  it("caches calendar meeting settings for the same access token", async () => {
+    const api = new FakeWriteApi();
+    const { writer } = writerWith(api);
+
+    await writer.createEvent({ ...baseCreate, createConference: true });
+    await writer.createEvent({ ...baseCreate, createConference: true });
+
+    expect(api.calls.getCalendarMeetingSettings).toHaveLength(1);
+  });
+
+  it("resolves one series instance by originalStart within a one-day window", async () => {
+    const api = new FakeWriteApi({
+      listInstances: [
+        {
+          ...scriptedEvent("instance-1"),
+          type: "occurrence",
+          seriesMasterId: "series-1",
+          originalStart: "2025-01-15T14:00:00.0000000Z",
+          subject: "Occurrence",
+        },
+      ],
+    });
+    const { writer } = writerWith(api);
+
+    const read = await writer.fetchInstanceAt({
+      accessToken: "at",
+      calendarId: "cal",
+      seriesProviderEventId: "series-1",
+      originalStartAt: "2025-01-15T14:00:00.000Z",
+      scheduleKind: "timed",
+    });
+
+    expect(api.calls.listInstances[0]).toMatchObject({
+      seriesMasterId: "series-1",
+      startDateTime: "2025-01-15T02:00:00.000",
+      endDateTime: "2025-01-16T02:00:00.000",
+    });
+    expect(read?.kind).toBe("event");
+    expect(read?.providerEventId).toBe("instance-1");
+    if (read?.kind === "event") {
+      expect(read.recurrence).toEqual({
+        kind: "instance",
+        seriesProviderId: "series-1",
+        recurrenceId: "2025-01-15T14:00:00.000Z",
+      });
+    }
+  });
+
+  it("returns null when no instance matches the original start", async () => {
+    const api = new FakeWriteApi({ listInstances: [] });
+    const { writer } = writerWith(api);
+
+    const read = await writer.fetchInstanceAt({
+      accessToken: "at",
+      calendarId: "cal",
+      seriesProviderEventId: "series-1",
+      originalStartAt: "2025-01-15T14:00:00.000Z",
+      scheduleKind: "timed",
+    });
+
+    expect(read).toBeNull();
+  });
+
+  it("returns null when the series itself is gone", async () => {
+    const api = new FakeWriteApi({ listInstances: msError(404) });
+    const { writer } = writerWith(api);
+
+    const read = await writer.fetchInstanceAt({
+      accessToken: "at",
+      calendarId: "cal",
+      seriesProviderEventId: "gone",
+      originalStartAt: "2025-01-15T14:00:00.000Z",
+      scheduleKind: "timed",
+    });
+
+    expect(read).toBeNull();
   });
 
   it("never leaks the bearer token onto a thrown error cause", async () => {

--- a/packages/sync/src/providers/microsoft/microsoft-event-writer.adapter.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-event-writer.adapter.ts
@@ -9,6 +9,7 @@ import {
 } from "@sync/providers/microsoft/microsoft-error";
 import {
   type GraphEvent,
+  mapConference,
   normalizeMicrosoftEvent,
 } from "@sync/providers/microsoft/microsoft-event.normalizer";
 import {
@@ -16,6 +17,11 @@ import {
   MICROSOFT_GRAPH_BASE_URL,
   MICROSOFT_REQUEST_TIMEOUT_MS,
 } from "@sync/providers/microsoft/microsoft-http.constants";
+import {
+  type GraphCalendarMeetingSettings,
+  pickTeamsOnlineMeetingProvider,
+  readCachedCalendarMeetingSettings,
+} from "@sync/providers/microsoft/microsoft-meeting-providers";
 import { fromRRule } from "@sync/providers/microsoft/microsoft-recurrence";
 import { UnsupportedRecurrenceError } from "@sync/providers/microsoft/microsoft-recurrence.error";
 import {
@@ -73,6 +79,8 @@ export interface GraphEventWriteBody {
   readonly attendees?: readonly GraphAttendeeWrite[];
   readonly responseRequested?: boolean;
   readonly transactionId?: string;
+  readonly isOnlineMeeting?: boolean;
+  readonly onlineMeetingProvider?: string;
 }
 
 export interface MicrosoftEventWriteApi {
@@ -87,6 +95,12 @@ export interface MicrosoftEventWriteApi {
   }): Promise<GraphEvent>;
   delete(params: { eventId: string; ifMatch: string | null }): Promise<void>;
   get(params: { eventId: string }): Promise<GraphEvent>;
+  listInstances(params: {
+    seriesMasterId: string;
+    startDateTime: string;
+    endDateTime: string;
+  }): Promise<readonly GraphEvent[]>;
+  getCalendarMeetingSettings(): Promise<GraphCalendarMeetingSettings>;
 }
 
 export type MicrosoftEventWriteApiFactory = (
@@ -111,12 +125,30 @@ export class MicrosoftEventWriter implements ProviderEventWriter {
   }
 
   async createEvent(input: ProviderCreateInput): Promise<ProviderWriteResult> {
+    const api = this.#makeApi(input.accessToken);
+    let conferenceFields: Pick<
+      GraphEventWriteBody,
+      "isOnlineMeeting" | "onlineMeetingProvider"
+    > = {};
+
     if (input.createConference) {
-      // Teams conference creation lands in M-06b; booking copy handles null URL.
+      const settings = await readCachedCalendarMeetingSettings(
+        input.accessToken,
+        api,
+      );
+      const provider = pickTeamsOnlineMeetingProvider(settings);
+      if (provider) {
+        conferenceFields = {
+          isOnlineMeeting: true,
+          onlineMeetingProvider: provider,
+        };
+      }
     }
 
-    const api = this.#makeApi(input.accessToken);
-    const body = toGraphCreateBody(input);
+    const body = {
+      ...toGraphCreateBody(input),
+      ...conferenceFields,
+    };
 
     try {
       const created = await api.create({
@@ -170,12 +202,27 @@ export class MicrosoftEventWriter implements ProviderEventWriter {
   }
 
   async fetchInstanceAt(
-    _input: ProviderInstanceFetchInput,
+    input: ProviderInstanceFetchInput,
   ): Promise<ProviderEventRead | null> {
-    throw new ProviderWriteError(
-      "unsupportedCapability",
-      "Microsoft instance resolution lands in M-06b",
-    );
+    const api = this.#makeApi(input.accessToken);
+    try {
+      const window = instanceLookupWindow(input.originalStartAt);
+      const instances = await api.listInstances({
+        seriesMasterId: input.seriesProviderEventId,
+        startDateTime: window.startDateTime,
+        endDateTime: window.endDateTime,
+      });
+      const match = instances.find((item) =>
+        originalStartMatches(item, input.originalStartAt),
+      );
+      if (!match) return null;
+      return normalizeMicrosoftEvent(match, undefined, {
+        allowOccurrence: true,
+      });
+    } catch (error) {
+      if (isNotFound(error)) return null;
+      throw classifyWriteError(error);
+    }
   }
 }
 
@@ -323,11 +370,39 @@ function toResult(event: GraphEvent): ProviderWriteResult {
       "Microsoft returned an event without an id or etag",
     );
   }
+  const conference = mapConference(event);
   return {
     providerEventId: event.id,
     providerVersion: event["@odata.etag"],
     ...(event.iCalUId ? { icalUid: event.iCalUId } : {}),
+    ...(conference ? { conference } : {}),
   };
+}
+
+function instanceLookupWindow(originalStartAt: string): {
+  startDateTime: string;
+  endDateTime: string;
+} {
+  const center = dayjs.utc(originalStartAt);
+  return {
+    startDateTime: center.subtract(12, "hour").format(GRAPH_DATETIME),
+    endDateTime: center.add(12, "hour").format(GRAPH_DATETIME),
+  };
+}
+
+function originalStartMatches(
+  item: GraphEvent,
+  originalStartAt: string,
+): boolean {
+  if (!item.originalStart) return false;
+  return (
+    toCanonicalRecurrenceId(item.originalStart) ===
+    toCanonicalRecurrenceId(originalStartAt)
+  );
+}
+
+function toCanonicalRecurrenceId(originalStart: string): string {
+  return new Date(originalStart).toISOString();
 }
 
 function classifyWriteError(error: unknown): ProviderWriteError {
@@ -438,6 +513,33 @@ class FetchMicrosoftEventWriteApi implements MicrosoftEventWriteApi {
     );
   }
 
+  listInstances(params: {
+    seriesMasterId: string;
+    startDateTime: string;
+    endDateTime: string;
+  }): Promise<readonly GraphEvent[]> {
+    const eventId = encodeURIComponent(params.seriesMasterId);
+    const query = new URLSearchParams({
+      startDateTime: params.startDateTime,
+      endDateTime: params.endDateTime,
+      $select: MICROSOFT_EVENT_SELECT,
+    });
+    return this.#requestCollection(
+      "GET",
+      `${MICROSOFT_GRAPH_BASE_URL}/me/events/${eventId}/instances?${query}`,
+    );
+  }
+
+  getCalendarMeetingSettings(): Promise<GraphCalendarMeetingSettings> {
+    const query = new URLSearchParams({
+      $select: "allowedOnlineMeetingProviders,defaultOnlineMeetingProvider",
+    });
+    return this.#requestJson(
+      "GET",
+      `${MICROSOFT_GRAPH_BASE_URL}/me/calendar?${query}`,
+    );
+  }
+
   async #request(
     method: "GET" | "POST" | "PATCH" | "DELETE",
     url: string,
@@ -468,6 +570,62 @@ class FetchMicrosoftEventWriteApi implements MicrosoftEventWriteApi {
     }
 
     const data = (await response.json()) as GraphEvent & {
+      error?: { code?: string; message?: string };
+    };
+
+    if (!response.ok) {
+      throw Object.assign(
+        new Error(data.error?.message ?? "microsoft_event_write_failed"),
+        { response: { status: response.status, data } },
+      );
+    }
+
+    return data;
+  }
+
+  async #requestCollection(
+    method: "GET",
+    url: string,
+  ): Promise<readonly GraphEvent[]> {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.#accessToken}`,
+      Prefer: 'outlook.timezone="UTC"',
+    };
+
+    const response = await fetch(url, {
+      method,
+      headers,
+      signal: AbortSignal.timeout(MICROSOFT_REQUEST_TIMEOUT_MS),
+    });
+
+    const data = (await response.json()) as {
+      value?: GraphEvent[];
+      error?: { code?: string; message?: string };
+    };
+
+    if (!response.ok) {
+      throw Object.assign(
+        new Error(data.error?.message ?? "microsoft_event_write_failed"),
+        { response: { status: response.status, data } },
+      );
+    }
+
+    return data.value ?? [];
+  }
+
+  async #requestJson<T>(method: "GET", url: string): Promise<T> {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.#accessToken}`,
+      Prefer: 'outlook.timezone="UTC"',
+    };
+
+    const response = await fetch(url, {
+      method,
+      headers,
+      signal: AbortSignal.timeout(MICROSOFT_REQUEST_TIMEOUT_MS),
+    });
+
+    const data = (await response.json()) as T & {
       error?: { code?: string; message?: string };
     };
 

--- a/packages/sync/src/providers/microsoft/microsoft-event.normalizer.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-event.normalizer.ts
@@ -25,9 +25,14 @@ const NO_CATEGORY_COLORS: ReadonlyMap<string, string> = new Map();
 
 const MEETING_PROVIDER_LABELS: Readonly<Record<string, string>> = {
   teamsForBusiness: "Microsoft Teams",
+  teamsForConsumer: "Microsoft Teams",
   skypeForBusiness: "Skype for Business",
   skypeForConsumer: "Skype",
 };
+
+export interface NormalizeMicrosoftEventOptions {
+  readonly allowOccurrence?: boolean;
+}
 
 export interface GraphDateTimeTimeZone {
   readonly dateTime?: string;
@@ -91,8 +96,9 @@ export interface GraphEvent {
 export function normalizeMicrosoftEvent(
   item: GraphEvent,
   masterCategories: ReadonlyMap<string, string> = NO_CATEGORY_COLORS,
+  options: NormalizeMicrosoftEventOptions = {},
 ): ProviderEventRead {
-  if (item.type === "occurrence") {
+  if (item.type === "occurrence" && !options.allowOccurrence) {
     throw new ProviderEventError(
       "unmappableContent",
       "Occurrence rows must not be normalized; the reader must not request them",
@@ -235,7 +241,7 @@ function mapAttendees(attendees: GraphEvent["attendees"]): Attendee[] {
     }));
 }
 
-function mapConference(item: GraphEvent): Conference | null {
+export function mapConference(item: GraphEvent): Conference | null {
   const url = item.onlineMeeting?.joinUrl;
   if (!url) return null;
 

--- a/packages/sync/src/providers/microsoft/microsoft-meeting-providers.test.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-meeting-providers.test.ts
@@ -1,0 +1,69 @@
+import {
+  clearMeetingSettingsCacheForTests,
+  pickTeamsOnlineMeetingProvider,
+} from "@sync/providers/microsoft/microsoft-meeting-providers";
+
+describe("pickTeamsOnlineMeetingProvider", () => {
+  it("uses the default when it is a Teams provider", () => {
+    expect(
+      pickTeamsOnlineMeetingProvider({
+        defaultOnlineMeetingProvider: "teamsForBusiness",
+        allowedOnlineMeetingProviders: ["teamsForBusiness", "skypeForConsumer"],
+      }),
+    ).toBe("teamsForBusiness");
+  });
+
+  it("uses the first allowed Teams provider when the default is not Teams", () => {
+    expect(
+      pickTeamsOnlineMeetingProvider({
+        defaultOnlineMeetingProvider: "skypeForConsumer",
+        allowedOnlineMeetingProviders: ["skypeForConsumer", "teamsForConsumer"],
+      }),
+    ).toBe("teamsForConsumer");
+  });
+
+  it("returns null when no Teams provider is allowed", () => {
+    expect(
+      pickTeamsOnlineMeetingProvider({
+        defaultOnlineMeetingProvider: "skypeForConsumer",
+        allowedOnlineMeetingProviders: ["skypeForConsumer"],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("readCachedCalendarMeetingSettings", () => {
+  afterEach(() => {
+    clearMeetingSettingsCacheForTests();
+  });
+
+  it("fetches meeting settings once per access token within the TTL", async () => {
+    const { readCachedCalendarMeetingSettings } = await import(
+      "@sync/providers/microsoft/microsoft-meeting-providers"
+    );
+    let calls = 0;
+    const api = {
+      async getCalendarMeetingSettings() {
+        calls += 1;
+        return {
+          defaultOnlineMeetingProvider: "teamsForBusiness",
+          allowedOnlineMeetingProviders: ["teamsForBusiness"],
+        };
+      },
+    };
+
+    const first = await readCachedCalendarMeetingSettings(
+      "token-a",
+      api,
+      () => 0,
+    );
+    const second = await readCachedCalendarMeetingSettings(
+      "token-a",
+      api,
+      () => 1,
+    );
+
+    expect(first).toEqual(second);
+    expect(calls).toBe(1);
+  });
+});

--- a/packages/sync/src/providers/microsoft/microsoft-meeting-providers.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-meeting-providers.ts
@@ -1,0 +1,59 @@
+export interface GraphCalendarMeetingSettings {
+  readonly allowedOnlineMeetingProviders?: readonly string[];
+  readonly defaultOnlineMeetingProvider?: string;
+}
+
+export interface MicrosoftMeetingProvidersApi {
+  getCalendarMeetingSettings(): Promise<GraphCalendarMeetingSettings>;
+}
+
+const TEAMS_PROVIDERS = new Set(["teamsForBusiness", "teamsForConsumer"]);
+
+export const MICROSOFT_MEETING_SETTINGS_CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface CachedMeetingSettings {
+  readonly expiresAtMs: number;
+  readonly settings: GraphCalendarMeetingSettings;
+}
+
+const meetingSettingsCache = new Map<string, CachedMeetingSettings>();
+
+export function isTeamsOnlineMeetingProvider(provider: string): boolean {
+  return TEAMS_PROVIDERS.has(provider);
+}
+
+export function pickTeamsOnlineMeetingProvider(
+  settings: GraphCalendarMeetingSettings,
+): string | null {
+  const defaultProvider = settings.defaultOnlineMeetingProvider;
+  if (defaultProvider && isTeamsOnlineMeetingProvider(defaultProvider)) {
+    return defaultProvider;
+  }
+  return (
+    settings.allowedOnlineMeetingProviders?.find(
+      isTeamsOnlineMeetingProvider,
+    ) ?? null
+  );
+}
+
+export async function readCachedCalendarMeetingSettings(
+  accessToken: string,
+  api: MicrosoftMeetingProvidersApi,
+  nowMs: () => number = () => Date.now(),
+): Promise<GraphCalendarMeetingSettings> {
+  const cached = meetingSettingsCache.get(accessToken);
+  if (cached && cached.expiresAtMs > nowMs()) {
+    return cached.settings;
+  }
+
+  const settings = await api.getCalendarMeetingSettings();
+  meetingSettingsCache.set(accessToken, {
+    settings,
+    expiresAtMs: nowMs() + MICROSOFT_MEETING_SETTINGS_CACHE_TTL_MS,
+  });
+  return settings;
+}
+
+export function clearMeetingSettingsCacheForTests(): void {
+  meetingSettingsCache.clear();
+}


### PR DESCRIPTION
Fixes #3246

## What and why

Completes Microsoft Graph event writer WP-06b: when booking requests `createConference`, the writer reads the mailbox's allowed/default online meeting providers once per connection (5 min cache), sets `isOnlineMeeting` with a Teams provider when available, and returns `onlineMeeting.joinUrl` on the write result. Also implements `fetchInstanceAt` via `GET /me/events/{seriesMasterId}/instances` over a one-day window around the target instant, normalizing the matching occurrence as an instance.

Spec: [`docs/features/calendar-providers.md`](https://github.com/KeepSoftwareSimple/compass-calendar/blob/main/docs/features/calendar-providers.md)

## Verify

```
bun run verify --strict
```

Selected packages: sync
Checks run: test:sync:fast, type-check, lint, knip

VERDICT: PASS