### PR TITLE
feat(sync): add Microsoft Graph people suggestions adapter (WP-08)

### DIFF
--- a/.agents/handoffs/3248.md
+++ b/.agents/handoffs/3248.md
@@ -1,0 +1,29 @@
+# Handoff: #3248
+
+task_id: 3248
+status: verifying
+branch: cursor/microsoft-people-wp08-3248
+
+## Summary
+
+Implemented Microsoft Graph people suggestions via `ContactsPort.searchContacts`
+in `microsoft-people.adapter.ts`, scoped the contacts route to `People.Read`, and
+added route and adapter tests.
+
+## Deliverables
+
+- `microsoft-people.adapter.ts`: `GET /me/people?$search` with ranked suggestions
+- `microsoft-people.adapter.test.ts`: hit, empty, 401, 429 coverage
+- `contacts.routes.ts`: map `People.Read` to the contacts source for Microsoft
+- `contacts.routes.db.test.ts`: Microsoft connection suggestions case
+
+## Verify
+
+```
+bun test:sync
+bun run type-check
+bun lint
+bun knip
+```
+
+VERDICT: PASS

--- a/packages/sync/src/providers/microsoft/microsoft-people.adapter.test.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-people.adapter.test.ts
@@ -1,0 +1,144 @@
+import {
+  MicrosoftPeopleAdapter,
+  type MicrosoftPeopleApi,
+  type MicrosoftPeopleSearchPage,
+} from "@sync/providers/microsoft/microsoft-people.adapter";
+import { ContactsSearchError } from "@sync/providers/provider-contacts.port";
+import { describe, expect, it } from "bun:test";
+
+const page = (
+  ...people: Array<{
+    emails: Array<{ address: string; relevanceScore?: number }>;
+    name?: string;
+  }>
+): MicrosoftPeopleSearchPage => ({
+  value: people.map((person) => ({
+    displayName: person.name ?? null,
+    scoredEmailAddresses: person.emails.map(({ address, relevanceScore }) => ({
+      address,
+      relevanceScore: relevanceScore ?? null,
+    })),
+  })),
+});
+
+class FakePeopleApi implements MicrosoftPeopleApi {
+  calls: Array<{ query: string; top: number; select: string }> = [];
+  result: MicrosoftPeopleSearchPage = { value: [] };
+  error?: unknown;
+
+  async searchPeople(params: {
+    query: string;
+    top: number;
+    select: string;
+  }): Promise<MicrosoftPeopleSearchPage> {
+    this.calls.push(params);
+    if (this.error) throw this.error;
+    return this.result;
+  }
+}
+
+const adapterWith = (api: FakePeopleApi) => {
+  const tokens: string[] = [];
+  const adapter = new MicrosoftPeopleAdapter((accessToken) => {
+    tokens.push(accessToken);
+    return api;
+  });
+  return { adapter, tokens };
+};
+
+describe("MicrosoftPeopleAdapter", () => {
+  it("returns ranked suggestions from a Graph people search hit", async () => {
+    const api = new FakePeopleApi();
+    api.result = page(
+      {
+        emails: [{ address: "alice@example.com", relevanceScore: 10 }],
+        name: "Alice Doe",
+      },
+      { emails: [{ address: "alfred@example.com", relevanceScore: 5 }] },
+    );
+    const { adapter, tokens } = adapterWith(api);
+
+    const suggestions = await adapter.searchContacts({
+      accessToken: "short-lived-token",
+      query: "al",
+      sources: { contacts: true, otherContacts: false },
+    });
+
+    expect(tokens).toEqual(["short-lived-token"]);
+    expect(api.calls).toEqual([
+      {
+        query: "al",
+        top: 10,
+        select: "displayName,scoredEmailAddresses",
+      },
+    ]);
+    expect(suggestions).toEqual([
+      { email: "alice@example.com", displayName: "Alice Doe" },
+      { email: "alfred@example.com", displayName: null },
+    ]);
+  });
+
+  it("returns an empty list when Graph returns no people", async () => {
+    const api = new FakePeopleApi();
+    api.result = { value: [] };
+    const { adapter } = adapterWith(api);
+
+    const suggestions = await adapter.searchContacts({
+      accessToken: "token",
+      query: "zz",
+      sources: { contacts: true, otherContacts: false },
+    });
+
+    expect(suggestions).toEqual([]);
+    expect(api.calls).toHaveLength(1);
+  });
+
+  it("makes no call when the contacts source is not allowed", async () => {
+    const api = new FakePeopleApi();
+    const { adapter, tokens } = adapterWith(api);
+
+    const suggestions = await adapter.searchContacts({
+      accessToken: "token",
+      query: "al",
+      sources: { contacts: false, otherContacts: false },
+    });
+
+    expect(suggestions).toEqual([]);
+    expect(tokens).toEqual([]);
+    expect(api.calls).toHaveLength(0);
+  });
+
+  it("maps a 401 to an unauthorized ContactsSearchError", async () => {
+    const api = new FakePeopleApi();
+    api.error = Object.assign(new Error("Unauthorized"), {
+      response: { status: 401 },
+    });
+    const { adapter } = adapterWith(api);
+
+    const promise = adapter.searchContacts({
+      accessToken: "token",
+      query: "al",
+      sources: { contacts: true, otherContacts: false },
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(ContactsSearchError);
+    await expect(promise).rejects.toMatchObject({ reason: "unauthorized" });
+  });
+
+  it("maps a 429 to a typed retryable rateLimited error", async () => {
+    const api = new FakePeopleApi();
+    api.error = Object.assign(new Error("Too many requests"), {
+      response: { status: 429 },
+    });
+    const { adapter } = adapterWith(api);
+
+    const promise = adapter.searchContacts({
+      accessToken: "token",
+      query: "al",
+      sources: { contacts: true, otherContacts: false },
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(ContactsSearchError);
+    await expect(promise).rejects.toMatchObject({ reason: "rateLimited" });
+  });
+});

--- a/packages/sync/src/providers/microsoft/microsoft-people.adapter.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-people.adapter.ts
@@ -1,0 +1,190 @@
+import {
+  CONTACT_SUGGESTION_MAX_RESULTS,
+  type ContactSuggestion,
+} from "@core/types/contact.contracts";
+import {
+  microsoftFailureCause,
+  microsoftStatus,
+} from "@sync/providers/microsoft/microsoft-error";
+import {
+  MICROSOFT_GRAPH_BASE_URL,
+  MICROSOFT_REQUEST_TIMEOUT_MS,
+} from "@sync/providers/microsoft/microsoft-http.constants";
+import {
+  type ContactsPort,
+  ContactsSearchError,
+  type ContactsSearchInput,
+} from "@sync/providers/provider-contacts.port";
+
+export interface GraphScoredEmailAddress {
+  readonly address?: string | null;
+  readonly relevanceScore?: number | null;
+}
+
+export interface GraphPersonMatch {
+  readonly displayName?: string | null;
+  readonly scoredEmailAddresses?: readonly GraphScoredEmailAddress[] | null;
+}
+
+export interface MicrosoftPeopleSearchPage {
+  readonly value: readonly GraphPersonMatch[];
+}
+
+export interface MicrosoftPeopleApi {
+  searchPeople(params: {
+    query: string;
+    top: number;
+    select: string;
+  }): Promise<MicrosoftPeopleSearchPage>;
+}
+
+export type MicrosoftPeopleApiFactory = (
+  accessToken: string,
+) => MicrosoftPeopleApi;
+
+const PEOPLE_SELECT = "displayName,scoredEmailAddresses";
+
+const defaultApiFactory: MicrosoftPeopleApiFactory = (accessToken) =>
+  new FetchMicrosoftPeopleApi(accessToken);
+
+export class MicrosoftPeopleAdapter implements ContactsPort {
+  #makeApi: MicrosoftPeopleApiFactory;
+
+  constructor(makeApi: MicrosoftPeopleApiFactory = defaultApiFactory) {
+    this.#makeApi = makeApi;
+  }
+
+  async searchContacts(
+    input: ContactsSearchInput,
+  ): Promise<ContactSuggestion[]> {
+    if (!input.sources.contacts) return [];
+
+    const api = this.#makeApi(input.accessToken);
+    let page: MicrosoftPeopleSearchPage;
+    try {
+      page = await api.searchPeople({
+        query: input.query,
+        top: CONTACT_SUGGESTION_MAX_RESULTS,
+        select: PEOPLE_SELECT,
+      });
+    } catch (error) {
+      throw toContactsSearchError(error);
+    }
+
+    const candidates = page.value.flatMap((person) => toSuggestions(person));
+    return rankSuggestions(candidates, input.query).slice(
+      0,
+      CONTACT_SUGGESTION_MAX_RESULTS,
+    );
+  }
+}
+
+class FetchMicrosoftPeopleApi implements MicrosoftPeopleApi {
+  #accessToken: string;
+
+  constructor(accessToken: string) {
+    this.#accessToken = accessToken;
+  }
+
+  async searchPeople(params: {
+    query: string;
+    top: number;
+    select: string;
+  }): Promise<MicrosoftPeopleSearchPage> {
+    const query = new URLSearchParams({
+      $search: `"${params.query}"`,
+      $select: params.select,
+      $top: String(params.top),
+    });
+    const response = await fetch(
+      `${MICROSOFT_GRAPH_BASE_URL}/me/people?${query}`,
+      {
+        headers: {
+          Authorization: `Bearer ${this.#accessToken}`,
+          ConsistencyLevel: "eventual",
+        },
+        signal: AbortSignal.timeout(MICROSOFT_REQUEST_TIMEOUT_MS),
+      },
+    );
+
+    const data = (await response.json()) as {
+      value?: GraphPersonMatch[];
+      error?: { code?: string; message?: string };
+    };
+
+    if (!response.ok) {
+      throw Object.assign(
+        new Error(data.error?.message ?? "microsoft_people_search_failed"),
+        { response: { status: response.status, data } },
+      );
+    }
+
+    return { value: data.value ?? [] };
+  }
+}
+
+function toSuggestions(person: GraphPersonMatch): ContactSuggestion[] {
+  const rawName = (person.displayName ?? "").trim();
+  const displayName =
+    rawName.length > 0 && rawName.length <= 256 ? rawName : null;
+
+  const addresses = [...(person.scoredEmailAddresses ?? [])].sort(
+    (a, b) => (b.relevanceScore ?? 0) - (a.relevanceScore ?? 0),
+  );
+  const suggestions: ContactSuggestion[] = [];
+  for (const entry of addresses) {
+    const email = (entry.address ?? "").trim();
+    if (email.length === 0 || email.length > 320) continue;
+    suggestions.push({ email, displayName });
+  }
+  return suggestions;
+}
+
+function rankSuggestions(
+  candidates: readonly ContactSuggestion[],
+  query: string,
+): ContactSuggestion[] {
+  const needle = query.trim().toLowerCase();
+  const rank = (suggestion: ContactSuggestion): number => {
+    const email = suggestion.email.toLowerCase();
+    const name = suggestion.displayName?.toLowerCase() ?? "";
+    if (email.startsWith(needle) || name.startsWith(needle)) return 0;
+    if (email.includes(needle) || name.includes(needle)) return 1;
+    return 2;
+  };
+
+  const ranked = candidates
+    .map((suggestion, index) => ({ suggestion, index, rank: rank(suggestion) }))
+    .sort((a, b) => a.rank - b.rank || a.index - b.index);
+
+  const seen = new Set<string>();
+  const unique: ContactSuggestion[] = [];
+  for (const { suggestion } of ranked) {
+    const key = suggestion.email.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(suggestion);
+  }
+  return unique;
+}
+
+function toContactsSearchError(error: unknown): ContactsSearchError {
+  const status = microsoftStatus(error);
+  if (status === 429) {
+    return new ContactsSearchError(
+      "rateLimited",
+      "Microsoft throttled the contact search",
+      { cause: microsoftFailureCause(error) },
+    );
+  }
+  if (status === 401 || status === 403) {
+    return new ContactsSearchError(
+      "unauthorized",
+      "Microsoft refused the contact search credential or scope",
+      { cause: microsoftFailureCause(error) },
+    );
+  }
+  return new ContactsSearchError("searchFailed", "Contact search failed", {
+    cause: microsoftFailureCause(error),
+  });
+}

--- a/packages/sync/src/server/contacts.routes.db.test.ts
+++ b/packages/sync/src/server/contacts.routes.db.test.ts
@@ -19,6 +19,10 @@ import {
   GOOGLE_SCOPE_CONTACTS_READONLY,
 } from "@sync/providers/google/google.scopes";
 import {
+  MICROSOFT_SCOPE_CALENDARS_READWRITE,
+  MICROSOFT_SCOPE_PEOPLE_READ,
+} from "@sync/providers/microsoft/microsoft-scopes";
+import {
   type ProviderAuthAdapter,
   type ProviderAuthorization,
   type RefreshedCredential,
@@ -28,6 +32,10 @@ import {
   ContactsSearchError,
   type ContactsSearchInput,
 } from "@sync/providers/provider-contacts.port";
+import {
+  buildProviderRegistry,
+  ProviderRegistry,
+} from "@sync/providers/provider-registry";
 import { CONTACTS_SUGGESTIONS_PATH } from "@sync/server/contacts.routes";
 import { CredentialRepository } from "@sync/storage/repositories/credential.repository";
 import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
@@ -113,8 +121,16 @@ describe("GET /internal/contacts/suggestions", () => {
   let authAdapter: FakeAuthAdapter;
   let contacts: FakeContactsPort;
 
-  const startService = async (config: SyncConfig = testConfig()) => {
-    service = createSyncService(config, { mongo, authAdapter, contacts });
+  const startService = async (
+    config: SyncConfig = testConfig(),
+    registry?: ProviderRegistry,
+  ) => {
+    service = createSyncService(config, {
+      mongo,
+      authAdapter,
+      contacts,
+      registry,
+    });
     await new Promise<void>((resolve) => service.httpServer.listen(0, resolve));
     const { port } = service.httpServer.address() as AddressInfo;
     base = `http://127.0.0.1:${port}`;
@@ -145,6 +161,53 @@ describe("GET /internal/contacts/suggestions", () => {
       scopes,
     });
     return connection;
+  };
+
+  const seedMicrosoftContactsConnection = async (
+    tenantId: string,
+    principalId: string,
+    scopes: string[],
+  ) => {
+    const connection = await connections.upsertByProviderAccount({
+      tenantId: tenantId as TenantId,
+      principalId: principalId as PrincipalId,
+      provider: "microsoft",
+      account: {
+        providerAccountId: objectId(),
+        email: "me@outlook.com",
+        displayName: null,
+      },
+      capabilities: ["readEvents", "suggestContacts"],
+      state: "healthy",
+      stateReason: null,
+    });
+    await seedOauthCredential(credentials, {
+      connectionId: connection._id,
+      provider: "microsoft",
+      refreshToken: "stored-refresh-token",
+      scopes,
+    });
+    return connection;
+  };
+
+  const registryWithMicrosoft = () => {
+    const google = buildProviderRegistry(testConfig(), {
+      google: { auth: authAdapter, contacts },
+    }).get("google");
+    return new ProviderRegistry(
+      new Map([
+        ["google", google],
+        [
+          "microsoft",
+          {
+            ...google,
+            callbackPath: "/sync/microsoft",
+            notificationsCallbackPath: "/sync/notifications/microsoft",
+            adapters: { ...google.adapters, auth: authAdapter, contacts },
+          },
+        ],
+      ]),
+    );
   };
 
   const suggest = (tenantId: string, principalId: string, q?: string) =>
@@ -278,6 +341,31 @@ describe("GET /internal/contacts/suggestions", () => {
 
     expect(res.status).toBe(403);
     expect(contacts.calls).toHaveLength(0);
+  });
+
+  it("returns suggestions for a Microsoft connection scoped by People.Read", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    await seedMicrosoftContactsConnection(tenantId, principalId, [
+      MICROSOFT_SCOPE_CALENDARS_READWRITE,
+      MICROSOFT_SCOPE_PEOPLE_READ,
+    ]);
+    contacts.result = [{ email: "bob@example.com", displayName: "Bob Smith" }];
+    await startService(testConfig(), registryWithMicrosoft());
+
+    const res = await suggest(tenantId, principalId, "bo");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      suggestions: [{ email: "bob@example.com", displayName: "Bob Smith" }],
+    });
+    expect(contacts.calls).toEqual([
+      {
+        accessToken: "minted-access-token",
+        query: "bo",
+        sources: { contacts: true, otherContacts: false },
+      },
+    ]);
   });
 
   it("maps a provider rate-limit to a typed retryable 429", async () => {

--- a/packages/sync/src/server/contacts.routes.ts
+++ b/packages/sync/src/server/contacts.routes.ts
@@ -14,6 +14,7 @@ import {
   GOOGLE_SCOPE_CONTACTS_OTHER_READONLY,
   GOOGLE_SCOPE_CONTACTS_READONLY,
 } from "@sync/providers/google/google.scopes";
+import { MICROSOFT_SCOPE_PEOPLE_READ } from "@sync/providers/microsoft/microsoft-scopes";
 import { ProviderAuthError } from "@sync/providers/provider-auth.port";
 import {
   type ContactsPort,
@@ -197,14 +198,27 @@ async function searchConnection(
   const credential = await credentials.findByConnection(connection._id);
   if (!credential || !isOauthRefreshCredential(credential)) return [];
   const granted = new Set(credential.scopes);
-  const sources = {
-    contacts: granted.has(GOOGLE_SCOPE_CONTACTS_READONLY),
-    otherContacts: granted.has(GOOGLE_SCOPE_CONTACTS_OTHER_READONLY),
-  };
+  const sources = contactsSourcesFor(connection.provider, granted);
   if (!sources.contacts && !sources.otherContacts) return [];
 
   const accessToken = await custody.getValidAccessToken(connection._id);
   return contacts.searchContacts({ accessToken, query, sources });
+}
+
+function contactsSourcesFor(
+  provider: ProviderConnectionRecord["provider"],
+  granted: Set<string>,
+): { contacts: boolean; otherContacts: boolean } {
+  if (provider === "microsoft") {
+    return {
+      contacts: granted.has(MICROSOFT_SCOPE_PEOPLE_READ),
+      otherContacts: false,
+    };
+  }
+  return {
+    contacts: granted.has(GOOGLE_SCOPE_CONTACTS_READONLY),
+    otherContacts: granted.has(GOOGLE_SCOPE_CONTACTS_OTHER_READONLY),
+  };
 }
 
 // Across connections the same address can appear twice; keep the first


### PR DESCRIPTION
Fixes #3248

## What and why

Implements `ContactsPort.searchContacts` for Microsoft Graph using `GET /me/people?$search` with `displayName` and `scoredEmailAddresses`. The contacts suggestions route now maps `People.Read` to the contacts source for Microsoft connections. Microsoft registration in `ProviderRegistry` remains deferred to M-09 (#3249); this WP delivers the adapter and route scope wiring only.

Spec: [docs/features/calendar-providers.md](https://github.com/KeepSoftwareSimple/compass-calendar/blob/main/docs/features/calendar-providers.md)

## Verify

```
bun test:sync
bun run type-check
bun lint
bun knip
```

VERDICT: PASS