### PR TITLE
feat(booking): Apple destination booking without video link

### DIFF
--- a/.agents/handoffs/3264.md
+++ b/.agents/handoffs/3264.md
@@ -1,0 +1,28 @@
+---
+schema_version: 1
+task_id: "3264"
+from: Implementer
+to: GitHub
+owner: GitHub
+status: verifying
+artifact:
+  - path: packages/web/src/booking/booking-conference.copy.ts
+  - path: packages/web/src/booking/BookingSettingsSection.tsx
+  - path: packages/backend/src/booking/services/calendar-booking.service.ts
+  - path: packages/backend/src/booking/services/public-booking.service.ts
+  - path: e2e/booking/booking-harness.ts
+evidence:
+  - command: bun run verify --strict
+    result: "VERDICT: PASS (test:web, test:backend, type-check, lint, knip, test:a11y, test:e2e)"
+assumptions:
+  - "Apple destination chooser suffix and iCloud hint use provider apple plus conference none; other none destinations keep P0-10 generic warnings."
+  - "createConference is passed from destinationConference at confirm time; event content.conference stays null."
+open_risks: []
+next_deadline: 2026-09-05T12:00:00Z
+retry: 1
+approval: allow
+waiting_on: null
+escalation: null
+---
+
+Providers A WP-10: booking with an Apple destination and no video link.

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -6,7 +6,37 @@ export const BOOKING_CALENDAR_ID = "64b7f0a1c2d3e4f5a6b7c8d9";
 /** ObjectId-shaped id for the stubbed Compass-local calendar. */
 export const COMPASS_CALENDAR_ID = "64b7f0a1c2d3e4f5a6b7c8e0";
 
+/** ObjectId-shaped id for a stubbed Apple iCloud calendar. */
+export const APPLE_BOOKING_CALENDAR_ID = "64b7f0a1c2d3e4f5a6b7c8e1";
+
 export const HOST_ACCOUNT_EMAIL = "host@example.com";
+export const APPLE_ACCOUNT_EMAIL = "host@icloud.com";
+
+/** Stub calendar list entry for an Apple booking destination. */
+export const appleBookingCalendar = {
+  id: APPLE_BOOKING_CALENDAR_ID,
+  name: "Personal",
+  description: "",
+  timeZone: "America/Chicago",
+  foregroundColor: "#ffffff",
+  backgroundColor: "#8E8E93",
+  provider: "apple" as const,
+  access: "owner" as const,
+  capabilities: {
+    canReadAvailability: true,
+    canReadDetails: true,
+    canWrite: true,
+    canManage: true,
+    canWatchEvents: true,
+    canInviteAttendees: true,
+  },
+  isPrimary: true,
+  isVisible: true,
+  isActive: true,
+  createsGoogleMeet: false,
+  conference: "none" as const,
+  accountEmail: APPLE_ACCOUNT_EMAIL,
+};
 
 function jsonResponse(body: unknown, status = 200) {
   return {
@@ -222,6 +252,8 @@ export interface PublicBookingStubOptions {
   token?: string;
   guestName?: string;
   notes?: string | null;
+  conference?: "meet" | "teams" | "none";
+  createsGoogleMeet?: boolean;
 }
 
 export interface CapturedBookingRequests {
@@ -242,7 +274,10 @@ function reservationPayload(input: {
   bookingSlug: string;
   guestName: string;
   notes: string | null;
+  conference?: "meet" | "teams" | "none";
+  createsGoogleMeet?: boolean;
 }) {
+  const conference = input.conference ?? "meet";
   return {
     slotStart: input.slotStart,
     guestTimeZone: input.guestTimeZone,
@@ -252,6 +287,8 @@ function reservationPayload(input: {
     bookingSlug: input.bookingSlug,
     guestName: input.guestName,
     notes: input.notes,
+    conference,
+    createsGoogleMeet: input.createsGoogleMeet ?? conference === "meet",
   };
 }
 
@@ -292,6 +329,8 @@ export async function preparePublicBookingPage(
   const slots = options.slots ?? [slot];
   const hostDisplayName = options.hostDisplayName ?? "Tyler Dane";
   const durationMinutes = options.durationMinutes ?? 30;
+  const conference = options.conference ?? "meet";
+  const createsGoogleMeet = options.createsGoogleMeet ?? conference === "meet";
   let guestName = options.guestName ?? "Guest User";
   let notes = options.notes ?? null;
   let postedSlotStart = slot.slotStart;
@@ -312,6 +351,8 @@ export async function preparePublicBookingPage(
           enabled: true,
           maxHorizonDays: 60,
           welcomeText: options.welcomeText ?? null,
+          conference,
+          createsGoogleMeet,
         }),
       );
     }
@@ -460,6 +501,8 @@ export async function preparePublicBookingPage(
             bookingSlug: slug,
             guestName,
             notes,
+            conference,
+            createsGoogleMeet,
           }),
         ),
       );
@@ -483,6 +526,8 @@ export async function preparePublicBookingPage(
             bookingSlug: slug,
             guestName,
             notes,
+            conference,
+            createsGoogleMeet,
           }),
         ),
       );
@@ -509,6 +554,8 @@ export async function preparePublicBookingConfirmedPage(
   const hostDisplayName = options.hostDisplayName ?? "Tyler Dane";
   const durationMinutes = options.durationMinutes ?? 30;
   const slug = options.slug ?? "tylerdane";
+  const conference = options.conference ?? "meet";
+  const createsGoogleMeet = options.createsGoogleMeet ?? conference === "meet";
   let guestName = options.guestName ?? "Guest User";
   let notes = options.notes ?? null;
   const captured: CapturedBookingRequests = {
@@ -545,6 +592,8 @@ export async function preparePublicBookingConfirmedPage(
             bookingSlug: slug,
             guestName,
             notes,
+            conference,
+            createsGoogleMeet,
           }),
         ),
       );
@@ -571,6 +620,8 @@ export async function preparePublicBookingConfirmedPage(
             bookingSlug: slug,
             guestName,
             notes,
+            conference,
+            createsGoogleMeet,
           }),
         ),
       );

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import {
+  appleBookingCalendar,
   buildBookableSlot,
   buildSameDaySiblingSlot,
   buildUpcomingSaturdaySlot,
@@ -9,6 +10,37 @@ import {
 } from "./booking-harness";
 
 test.describe("public booking page", () => {
+  test("renders no-video copy for an Apple destination on the public page and confirmation", async ({
+    page,
+  }) => {
+    const { slotStart } = buildBookableSlot();
+    await preparePublicBookingPage(page, {
+      conference: appleBookingCalendar.conference,
+      createsGoogleMeet: appleBookingCalendar.createsGoogleMeet,
+    });
+
+    await expect(page.getByText("30 minutes")).toBeVisible();
+    await expect(page.getByText("30 minutes Google Meet")).toHaveCount(0);
+    await expect(page.getByText("30 minutes Microsoft Teams")).toHaveCount(0);
+
+    await page
+      .getByRole("button", { name: formatSlotButtonLabel(slotStart) })
+      .click();
+    await page.getByLabel("Name").fill("Guest User");
+    await page.getByLabel("Email").fill("guest@example.com");
+    await page.getByRole("button", { name: "Confirm booking" }).click();
+
+    await expect(
+      page.getByText("The calendar invite is on its way to your email."),
+    ).toBeVisible();
+    await expect(
+      page.getByText("A Google Meet invite is on its way to your email."),
+    ).toHaveCount(0);
+    await expect(
+      page.getByText("A Microsoft Teams invite is on its way to your email."),
+    ).toHaveCount(0);
+  });
+
   test("loads without login and shows the host heading", async ({ page }) => {
     await preparePublicBookingPage(page, {
       welcomeText: "30 minutes to talk through Compass Calendar.",

--- a/packages/backend/src/booking/services/calendar-booking.port.ts
+++ b/packages/backend/src/booking/services/calendar-booking.port.ts
@@ -29,6 +29,7 @@ export interface CalendarBookingCreateEventInput {
   timeZone: string;
   guest: BookingEventGuest;
   guestsCanInviteOthers: boolean;
+  createConference: boolean;
 }
 
 export interface CalendarBookingDeleteEventInput {

--- a/packages/backend/src/booking/services/calendar-booking.service.test.ts
+++ b/packages/backend/src/booking/services/calendar-booking.service.test.ts
@@ -158,6 +158,7 @@ describe("CalendarBookingService", () => {
       timeZone: "America/Denver",
       guest: { email: "ada@example.com", displayName: "Ada Lovelace" },
       guestsCanInviteOthers: true,
+      createConference: true,
     });
 
     expect(submitCommand).toHaveBeenCalledTimes(1);
@@ -176,6 +177,37 @@ describe("CalendarBookingService", () => {
         responseStatus: "needsAction",
       },
     ]);
+    expect(request.input.content.conference).toBeNull();
+  });
+
+  it("omits createConference when the destination cannot mint a link", async () => {
+    const submitCommand = mock(async () => ({
+      ok: true as const,
+      value: { commandId: faker.database.mongodbObjectId() },
+    }));
+    const service = new CalendarBookingService({
+      queryBusyAvailability: mock(async () => ({
+        ok: true as const,
+        value: busyResponse,
+      })),
+      submitCommand,
+    } as unknown as SyncServiceClient);
+
+    await service.createBookingEvent(userId(), {
+      calendarId: calendarId(),
+      title: "Ada and Tyler",
+      description: "Zoom: https://example.com/meet",
+      start: "2026-09-01T15:00:00.000Z",
+      end: "2026-09-01T15:30:00.000Z",
+      timeZone: "America/Denver",
+      guest: { email: "ada@example.com", displayName: "Ada Lovelace" },
+      guestsCanInviteOthers: true,
+      createConference: false,
+    });
+
+    expect(submitCommand).toHaveBeenCalledTimes(1);
+    const [, request] = submitCommand.mock.calls[0] ?? [];
+    expect(request.input.createConference).toBe(false);
     expect(request.input.content.conference).toBeNull();
   });
 
@@ -202,6 +234,7 @@ describe("CalendarBookingService", () => {
         timeZone: "America/Denver",
         guest: { email: "   ", displayName: null },
         guestsCanInviteOthers: false,
+        createConference: true,
       }),
     ).rejects.toMatchObject({ code: "INVALID_INPUT" });
     expect(submitCommand).not.toHaveBeenCalled();

--- a/packages/backend/src/booking/services/calendar-booking.service.ts
+++ b/packages/backend/src/booking/services/calendar-booking.service.ts
@@ -55,7 +55,7 @@ const toBookingCreateSubmitRequest = (
       clientEventId: ClientEventIdSchema.parse(eventId),
       invitation: "all",
       attendeesEdit: "replace",
-      createConference: true,
+      createConference: input.createConference,
       guestsCanInviteOthers: input.guestsCanInviteOthers,
       content: {
         title: input.title,

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -83,6 +83,16 @@ const healthyConnection = () => ({
   updatedAt: "2026-07-20T12:00:00.000Z",
 });
 
+const appleConnection = () => ({
+  ...healthyConnection(),
+  provider: "apple" as const,
+  account: {
+    providerAccountId: "apple-principal",
+    email: "host@icloud.com",
+    displayName: "Apple Host",
+  },
+});
+
 const samplePutInput = (overrides: Record<string, unknown> = {}) => {
   const destination = calendarId();
   return AdminPutBookingPageInputSchema.parse({
@@ -639,6 +649,66 @@ describe("PublicBookingService", () => {
       durationMinutes: 30,
     });
     const publicReservation = await service.getPublicReservation(
+      new ObjectId(created.reservationId),
+    );
+    expect(publicReservation.createsGoogleMeet).toBe(false);
+    expect(publicReservation.conference).toBe("none");
+  });
+
+  it("books through an Apple destination without a conference link", async () => {
+    const userId = await createNamedUser("Apple Host");
+    const calendar = writableCalendar();
+    const connection = appleConnection();
+    mockHealthySync([calendar], connection);
+    spyOn(billingGuard, "assertBillingAllowsWrites").mockResolvedValue(
+      undefined,
+    );
+    const page = await bookingPageService.putAdminPage(
+      userId,
+      samplePutInput({
+        destinationCalendarId: calendar.id,
+        blockingCalendarIds: [calendar.id],
+      }),
+    );
+    const slug = "slug" in page ? page.slug : "";
+
+    const publicPage = await service.getPublicPage(slug);
+    expect(publicPage.createsGoogleMeet).toBe(false);
+    expect(publicPage.conference).toBe("none");
+
+    const submitCommand = mock(async () => ({
+      ok: true as const,
+      value: { commandId: new ObjectId().toString() },
+    }));
+    spyOn(calendarService, "getLocalCalendar").mockResolvedValue(null);
+    const bookingService = new PublicBookingService(
+      new CalendarBookingService({
+        queryBusyAvailability: mock(async () => ({
+          ok: true as const,
+          value: busyResponse(true),
+        })),
+        submitCommand,
+      } as unknown as SyncServiceClient),
+    );
+
+    const created = await bookingService.createReservation(slug, {
+      slotStart: "2026-09-07T10:00:00.000Z",
+      guestName: "Ada Lovelace",
+      guestEmail: "ada@example.com",
+      notes: "Zoom: https://example.com/meet",
+      guestTimeZone: "Europe/London",
+      durationMinutes: 30,
+    });
+
+    expect(submitCommand).toHaveBeenCalledTimes(1);
+    const [, request] = submitCommand.mock.calls[0] ?? [];
+    expect(request.input.createConference).toBe(false);
+    expect(request.input.content.conference).toBeNull();
+    expect(request.input.content.description).toContain(
+      "Zoom: https://example.com/meet",
+    );
+
+    const publicReservation = await bookingService.getPublicReservation(
       new ObjectId(created.reservationId),
     );
     expect(publicReservation.createsGoogleMeet).toBe(false);

--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -583,6 +583,10 @@ export class PublicBookingService {
     await this.assertSlotAvailable(page, slotStart, slotEnd);
 
     const hostDisplayName = await getHostDisplayName(page.userId);
+    const conference = await destinationConference(
+      page.userId,
+      page.destinationCalendarId,
+    );
     const cancelToken = generateCancelToken();
     const reservationId = mongoService.objectId();
     const cancelUrl = buildGuestActionUrl(
@@ -620,6 +624,7 @@ export class PublicBookingService {
             displayName: input.guestName,
           },
           guestsCanInviteOthers: page.guestsCanInviteOthers,
+          createConference: conference !== "none",
         },
       );
 

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -17,6 +17,7 @@ import {
   BOOKING_SETTINGS_HINT_PARTS,
   BookingSettingsSection,
 } from "@web/booking/BookingSettingsSection";
+import { BOOKING_APPLE_DESTINATION_HINT } from "@web/booking/booking-conference.copy";
 import {
   BOOKING_FIELD_BY_KEY,
   BOOKING_SEQUENCE_FIELDS,
@@ -1092,6 +1093,60 @@ describe("BookingSettingsSection", () => {
     expect(
       screen.getByRole("combobox", { name: "Destination calendar" }),
     ).toHaveAccessibleDescription(warning);
+  });
+
+  it("labels an Apple destination with No video link and shows the iCloud hint", async () => {
+    const appleCalendar = createMockCalendar({
+      name: "Personal",
+      accountEmail: "host@icloud.com",
+      provider: "apple",
+      conference: "none",
+      createsGoogleMeet: false,
+    });
+
+    userMetadataActions.set({
+      google: {
+        connectionState: "HEALTHY" as const,
+        connections: [
+          createMockConnection("host@icloud.com", { provider: "apple" }),
+        ],
+      },
+    });
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(
+          ctx.json({
+            ...unconfiguredPage(),
+            destinationCalendarId: appleCalendar.id,
+            blockingCalendarIds: [appleCalendar.id],
+          }),
+        ),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [appleCalendar]);
+
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    const combobox = await screen.findByRole("combobox", {
+      name: "Destination calendar",
+    });
+    expect(within(combobox).getByRole("option").textContent).toBe(
+      "Personal (No video link)",
+    );
+    expect(
+      screen.getByText(BOOKING_APPLE_DESTINATION_HINT),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("combobox", { name: "Destination calendar" }),
+    ).toHaveAccessibleDescription(BOOKING_APPLE_DESTINATION_HINT);
   });
 
   it("does not warn when the destination can mint Meet", async () => {

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -44,7 +44,8 @@ import {
   toBookingPageInput,
 } from "@web/booking/booking.util";
 import {
-  BOOKING_NO_CONFERENCE_WARNING,
+  bookingDestinationConferenceHint,
+  formatBookingDestinationOptionLabel,
   resolveBookingConference,
 } from "@web/booking/booking-conference.copy";
 import {
@@ -358,6 +359,9 @@ export function BookingSettingsSection({
       )
     : "meet";
   const destinationCannotMintMeet = destinationConference === "none";
+  const destinationConferenceHint = destinationCalendar
+    ? bookingDestinationConferenceHint(destinationCalendar)
+    : null;
   const destinationMeetWarningId = "booking-destination-meet-warning";
   const updateForm = (patch: Partial<AdminPutBookingPageInput>) => {
     setForm((current) => ({ ...current, ...patch }));
@@ -555,26 +559,26 @@ export function BookingSettingsSection({
                     >
                       {group.calendars.map((calendar) => (
                         <option key={calendar.id} value={calendar.id}>
-                          {calendar.name}
+                          {formatBookingDestinationOptionLabel(calendar)}
                         </option>
                       ))}
                     </optgroup>
                   ))}
                 {writableUngrouped.map((calendar) => (
                   <option key={calendar.id} value={calendar.id}>
-                    {calendar.name}
+                    {formatBookingDestinationOptionLabel(calendar)}
                   </option>
                 ))}
               </>
             )}
           </select>
-          {destinationCannotMintMeet && destinationCalendar ? (
+          {destinationConferenceHint ? (
             <p
               className="mt-1 text-sm text-warning"
               id={destinationMeetWarningId}
               role="status"
             >
-              {BOOKING_NO_CONFERENCE_WARNING[destinationCalendar.provider]}
+              {destinationConferenceHint}
             </p>
           ) : null}
         </div>

--- a/packages/web/src/booking/booking-conference.copy.test.ts
+++ b/packages/web/src/booking/booking-conference.copy.test.ts
@@ -1,0 +1,72 @@
+import { type Calendar } from "@core/types/calendar.contracts";
+import {
+  BOOKING_APPLE_DESTINATION_HINT,
+  BOOKING_CONFERENCE_INVITE_COPY,
+  bookingDestinationConferenceHint,
+  formatBookingDestinationOptionLabel,
+  formatBookingDurationWithConference,
+  resolveBookingConference,
+} from "@web/booking/booking-conference.copy";
+import { describe, expect, it } from "bun:test";
+
+const calendar = (overrides: Partial<Calendar> = {}): Calendar =>
+  ({
+    id: "000000000000000000000001",
+    name: "Personal",
+    description: "",
+    timeZone: "UTC",
+    foregroundColor: "#000000",
+    backgroundColor: "#9e9e9e",
+    provider: "google",
+    access: "owner",
+    capabilities: {
+      canReadAvailability: true,
+      canReadDetails: true,
+      canWrite: true,
+      canManage: true,
+      canWatchEvents: true,
+      canInviteAttendees: true,
+    },
+    isPrimary: false,
+    isVisible: true,
+    isActive: true,
+    ...overrides,
+  }) as Calendar;
+
+describe("booking conference copy", () => {
+  it("formats duration without a conference suffix for none", () => {
+    expect(formatBookingDurationWithConference("30 minutes", "none")).toBe(
+      "30 minutes",
+    );
+  });
+
+  it("labels an Apple destination with No video link in the chooser", () => {
+    expect(
+      formatBookingDestinationOptionLabel(
+        calendar({ provider: "apple", conference: "none" }),
+      ),
+    ).toBe("Personal (No video link)");
+  });
+
+  it("keeps a Google destination label as the calendar name", () => {
+    expect(formatBookingDestinationOptionLabel(calendar())).toBe("Personal");
+  });
+
+  it("shows the iCloud hint for an Apple destination without video", () => {
+    expect(
+      bookingDestinationConferenceHint(
+        calendar({ provider: "apple", conference: "none" }),
+      ),
+    ).toBe(BOOKING_APPLE_DESTINATION_HINT);
+  });
+
+  it("uses guest none-branch invite copy on confirmation", () => {
+    expect(BOOKING_CONFERENCE_INVITE_COPY.none).toBe(
+      "The calendar invite is on its way to your email.",
+    );
+  });
+
+  it("resolves legacy createsGoogleMeet false to none", () => {
+    expect(resolveBookingConference(undefined, false)).toBe("none");
+  });
+});

--- a/packages/web/src/booking/booking-conference.copy.ts
+++ b/packages/web/src/booking/booking-conference.copy.ts
@@ -1,4 +1,5 @@
 import {
+  type Calendar,
   type CalendarConference,
   type CalendarProvider,
 } from "@core/types/calendar.contracts";
@@ -17,6 +18,11 @@ export const BOOKING_CONFERENCE_INVITE_COPY: Record<
   teams: "A Microsoft Teams invite is on its way to your email.",
   none: "The calendar invite is on its way to your email.",
 };
+
+export const BOOKING_DESTINATION_NO_VIDEO_SUFFIX = "No video link";
+
+export const BOOKING_APPLE_DESTINATION_HINT =
+  "Bookings on an iCloud calendar are created without a video link. Add one in the booking notes if you need it.";
 
 export const BOOKING_NO_CONFERENCE_WARNING: Record<CalendarProvider, string> = {
   local:
@@ -44,4 +50,32 @@ export function resolveBookingConference(
     return conference;
   }
   return createsGoogleMeet === false ? "none" : "meet";
+}
+
+export function formatBookingDestinationOptionLabel(
+  calendar: Calendar,
+): string {
+  const conference = resolveBookingConference(
+    calendar.conference,
+    calendar.createsGoogleMeet,
+  );
+  if (calendar.provider === "apple" && conference === "none") {
+    return `${calendar.name} (${BOOKING_DESTINATION_NO_VIDEO_SUFFIX})`;
+  }
+  return calendar.name;
+}
+
+export function bookingDestinationConferenceHint(
+  calendar: Calendar,
+): string | null {
+  const conference = resolveBookingConference(
+    calendar.conference,
+    calendar.createsGoogleMeet,
+  );
+  if (conference === "none") {
+    return calendar.provider === "apple"
+      ? BOOKING_APPLE_DESTINATION_HINT
+      : BOOKING_NO_CONFERENCE_WARNING[calendar.provider];
+  }
+  return null;
 }


### PR DESCRIPTION
Fixes #3264

## What and why

Apple iCloud calendars cannot mint a conference link. This work package completes the booking path for Apple destinations: settings label the destination and show iCloud-specific guidance, confirm skips `createConference`, guest notes still land in the event description, and public copy uses the existing `none` conference branch.

Spec: [docs/features/calendar-providers.md](https://github.com/KeepSoftwareSimple/compass-calendar/blob/main/docs/features/calendar-providers.md)

## Verify

```
VERDICT: PASS (test:web, test:backend, type-check, lint, knip, test:a11y, test:e2e)
```

Checks run via `bun run verify --strict`.