### PR TITLE
feat(booking): support Microsoft Teams destinations and conference kinds

### DIFF
--- a/.agents/handoffs/3251.md
+++ b/.agents/handoffs/3251.md
@@ -1,0 +1,29 @@
+---
+schema_version: 1
+task_id: "3251"
+from: Implementer
+to: GitHub
+owner: GitHub
+status: verifying
+artifact:
+  - path: packages/core/src/types/calendar.contracts.ts
+  - path: packages/core/src/types/sync/identity.contracts.ts
+  - path: packages/backend/src/common/services/sync-service/calendar-list.translation.ts
+  - path: packages/backend/src/booking/services/public-booking.service.ts
+  - path: packages/web/src/booking/booking-conference.copy.ts
+  - path: e2e/booking/booking-harness.ts
+evidence:
+  - command: bun run verify --strict
+    result: "VERDICT: PASS (test:core, test:web, test:backend, type-check, lint, knip, test:a11y, test:e2e)"
+assumptions:
+  - "Microsoft Teams availability is signaled by createTeamsMeeting on the connection; sync will populate it from M-06b meeting settings when calendar discovery lands."
+  - "Conference URL read-back on confirm stays in sync provider-command + Graph writer (#3137 / #3246); this WP wires booking copy and createConference gating only."
+open_risks: []
+next_deadline: 2026-09-05T12:00:00Z
+retry: 1
+approval: allow
+waiting_on: null
+escalation: null
+---
+
+Providers M WP-11: booking with a Microsoft destination and Teams links.

--- a/e2e/attendees/attendee-harness.ts
+++ b/e2e/attendees/attendee-harness.ts
@@ -33,6 +33,7 @@ const googleCalendar = {
     canManage: true,
     canWatchEvents: true,
     canInviteAttendees: true,
+    conferenceKinds: ["meet"],
   },
   isPrimary: true,
   isVisible: true,

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -9,8 +9,12 @@ export const COMPASS_CALENDAR_ID = "64b7f0a1c2d3e4f5a6b7c8e0";
 /** ObjectId-shaped id for a stubbed Apple iCloud calendar. */
 export const APPLE_BOOKING_CALENDAR_ID = "64b7f0a1c2d3e4f5a6b7c8e1";
 
+/** ObjectId-shaped id for a stubbed Microsoft Outlook calendar. */
+export const MICROSOFT_BOOKING_CALENDAR_ID = "64b7f0a1c2d3e4f5a6b7c8e2";
+
 export const HOST_ACCOUNT_EMAIL = "host@example.com";
 export const APPLE_ACCOUNT_EMAIL = "host@icloud.com";
+export const MICROSOFT_ACCOUNT_EMAIL = "host@outlook.com";
 
 /** Stub calendar list entry for an Apple booking destination. */
 export const appleBookingCalendar = {
@@ -29,6 +33,7 @@ export const appleBookingCalendar = {
     canManage: true,
     canWatchEvents: true,
     canInviteAttendees: true,
+    conferenceKinds: [],
   },
   isPrimary: true,
   isVisible: true,
@@ -36,6 +41,33 @@ export const appleBookingCalendar = {
   createsGoogleMeet: false,
   conference: "none" as const,
   accountEmail: APPLE_ACCOUNT_EMAIL,
+};
+
+/** Stub calendar list entry for a Microsoft booking destination with Teams. */
+export const microsoftBookingCalendar = {
+  id: MICROSOFT_BOOKING_CALENDAR_ID,
+  name: "Work",
+  description: "",
+  timeZone: "America/Chicago",
+  foregroundColor: "#ffffff",
+  backgroundColor: "#0078D4",
+  provider: "microsoft" as const,
+  access: "owner" as const,
+  capabilities: {
+    canReadAvailability: true,
+    canReadDetails: true,
+    canWrite: true,
+    canManage: true,
+    canWatchEvents: true,
+    canInviteAttendees: true,
+    conferenceKinds: ["teams"] as const,
+  },
+  isPrimary: true,
+  isVisible: true,
+  isActive: true,
+  createsGoogleMeet: false,
+  conference: "teams" as const,
+  accountEmail: MICROSOFT_ACCOUNT_EMAIL,
 };
 
 function jsonResponse(body: unknown, status = 200) {
@@ -62,6 +94,7 @@ const googleCalendar = {
     canManage: true,
     canWatchEvents: true,
     canInviteAttendees: true,
+    conferenceKinds: ["meet"],
   },
   isPrimary: true,
   isVisible: true,
@@ -85,6 +118,7 @@ const compassCalendar = {
     canManage: true,
     canWatchEvents: true,
     canInviteAttendees: true,
+    conferenceKinds: [],
   },
   isPrimary: false,
   isVisible: true,

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -5,11 +5,39 @@ import {
   buildSameDaySiblingSlot,
   buildUpcomingSaturdaySlot,
   formatSlotButtonLabel,
+  microsoftBookingCalendar,
   preparePublicBookingConfirmedPage,
   preparePublicBookingPage,
 } from "./booking-harness";
 
 test.describe("public booking page", () => {
+  test("renders Teams copy for a Microsoft destination on the public page and confirmation", async ({
+    page,
+  }) => {
+    const { slotStart } = buildBookableSlot();
+    await preparePublicBookingPage(page, {
+      conference: microsoftBookingCalendar.conference,
+      createsGoogleMeet: microsoftBookingCalendar.createsGoogleMeet,
+    });
+
+    await expect(page.getByText("30 minutes Microsoft Teams")).toBeVisible();
+    await expect(page.getByText("30 minutes Google Meet")).toHaveCount(0);
+
+    await page
+      .getByRole("button", { name: formatSlotButtonLabel(slotStart) })
+      .click();
+    await page.getByLabel("Name").fill("Guest User");
+    await page.getByLabel("Email").fill("guest@example.com");
+    await page.getByRole("button", { name: "Confirm booking" }).click();
+
+    await expect(
+      page.getByText("A Microsoft Teams invite is on its way to your email."),
+    ).toBeVisible();
+    await expect(
+      page.getByText("A Google Meet invite is on its way to your email."),
+    ).toHaveCount(0);
+  });
+
   test("renders no-video copy for an Apple destination on the public page and confirmation", async ({
     page,
   }) => {

--- a/e2e/calendars/account-page-jump.spec.ts
+++ b/e2e/calendars/account-page-jump.spec.ts
@@ -23,6 +23,7 @@ const ownerCapabilities = {
   canManage: true,
   canWatchEvents: true,
   canInviteAttendees: true,
+  conferenceKinds: ["meet"],
 };
 
 const connection = (id: string, accountEmail: string) => ({

--- a/e2e/calendars/calendar-experience.spec.ts
+++ b/e2e/calendars/calendar-experience.spec.ts
@@ -47,6 +47,7 @@ const CAPABILITIES = {
     canManage: true,
     canWatchEvents: true,
     canInviteAttendees: true,
+    conferenceKinds: ["meet"],
   },
   reader: {
     canReadAvailability: true,
@@ -55,6 +56,7 @@ const CAPABILITIES = {
     canManage: false,
     canWatchEvents: true,
     canInviteAttendees: false,
+    conferenceKinds: [],
   },
 };
 
@@ -68,11 +70,18 @@ function calendar(overrides: {
   isPrimary: boolean;
   isVisible: boolean;
 }) {
+  const base = CAPABILITIES[overrides.access];
   return {
     ...overrides,
     description: "",
     foregroundColor: "#ffffff",
-    capabilities: CAPABILITIES[overrides.access],
+    capabilities: {
+      ...base,
+      conferenceKinds:
+        overrides.provider === "google" && overrides.access === "owner"
+          ? ["meet"]
+          : [],
+    },
     isActive: true,
   };
 }

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -93,6 +93,19 @@ const appleConnection = () => ({
   },
 });
 
+const microsoftConnection = (withTeams = true) => ({
+  ...healthyConnection(),
+  provider: "microsoft" as const,
+  account: {
+    providerAccountId: "microsoft-principal",
+    email: "host@outlook.com",
+    displayName: "Microsoft Host",
+  },
+  capabilities: withTeams
+    ? (["readEvents", "writeEvents", "createTeamsMeeting"] as const)
+    : (["readEvents", "writeEvents"] as const),
+});
+
 const samplePutInput = (overrides: Record<string, unknown> = {}) => {
   const destination = calendarId();
   return AdminPutBookingPageInputSchema.parse({
@@ -713,6 +726,110 @@ describe("PublicBookingService", () => {
     );
     expect(publicReservation.createsGoogleMeet).toBe(false);
     expect(publicReservation.conference).toBe("none");
+  });
+
+  it("books through a Microsoft destination with Teams conferencing", async () => {
+    const userId = await createNamedUser("Teams Host");
+    const calendar = writableCalendar();
+    const connection = microsoftConnection(true);
+    mockHealthySync([calendar], connection);
+    spyOn(billingGuard, "assertBillingAllowsWrites").mockResolvedValue(
+      undefined,
+    );
+    const page = await bookingPageService.putAdminPage(
+      userId,
+      samplePutInput({
+        destinationCalendarId: calendar.id,
+        blockingCalendarIds: [calendar.id],
+      }),
+    );
+    const slug = "slug" in page ? page.slug : "";
+
+    const publicPage = await service.getPublicPage(slug);
+    expect(publicPage.createsGoogleMeet).toBe(false);
+    expect(publicPage.conference).toBe("teams");
+
+    const submitCommand = mock(async () => ({
+      ok: true as const,
+      value: { commandId: new ObjectId().toString() },
+    }));
+    spyOn(calendarService, "getLocalCalendar").mockResolvedValue(null);
+    const bookingService = new PublicBookingService(
+      new CalendarBookingService({
+        queryBusyAvailability: mock(async () => ({
+          ok: true as const,
+          value: busyResponse(true),
+        })),
+        submitCommand,
+      } as unknown as SyncServiceClient),
+    );
+
+    const created = await bookingService.createReservation(slug, {
+      slotStart: "2026-09-07T10:00:00.000Z",
+      guestName: "Ada Lovelace",
+      guestEmail: "ada@example.com",
+      guestTimeZone: "Europe/London",
+      durationMinutes: 30,
+    });
+
+    expect(submitCommand).toHaveBeenCalledTimes(1);
+    const [, request] = submitCommand.mock.calls[0] ?? [];
+    expect(request.input.createConference).toBe(true);
+    expect(request.input.content.conference).toBeNull();
+
+    const publicReservation = await bookingService.getPublicReservation(
+      new ObjectId(created.reservationId),
+    );
+    expect(publicReservation.conference).toBe("teams");
+  });
+
+  it("books through a Microsoft destination without Teams conferencing", async () => {
+    const userId = await createNamedUser("No Teams Host");
+    const calendar = writableCalendar();
+    const connection = microsoftConnection(false);
+    mockHealthySync([calendar], connection);
+    spyOn(billingGuard, "assertBillingAllowsWrites").mockResolvedValue(
+      undefined,
+    );
+    const page = await bookingPageService.putAdminPage(
+      userId,
+      samplePutInput({
+        destinationCalendarId: calendar.id,
+        blockingCalendarIds: [calendar.id],
+      }),
+    );
+    const slug = "slug" in page ? page.slug : "";
+
+    const publicPage = await service.getPublicPage(slug);
+    expect(publicPage.conference).toBe("none");
+
+    const submitCommand = mock(async () => ({
+      ok: true as const,
+      value: { commandId: new ObjectId().toString() },
+    }));
+    spyOn(calendarService, "getLocalCalendar").mockResolvedValue(null);
+    const bookingService = new PublicBookingService(
+      new CalendarBookingService({
+        queryBusyAvailability: mock(async () => ({
+          ok: true as const,
+          value: busyResponse(true),
+        })),
+        submitCommand,
+      } as unknown as SyncServiceClient),
+    );
+
+    await bookingService.createReservation(slug, {
+      slotStart: "2026-09-07T10:00:00.000Z",
+      guestName: "Ada Lovelace",
+      guestEmail: "ada@example.com",
+      guestTimeZone: "Europe/London",
+      durationMinutes: 30,
+    });
+
+    expect(submitCommand).toHaveBeenCalledTimes(1);
+    const [, request] = submitCommand.mock.calls[0] ?? [];
+    expect(request.input.createConference).toBe(false);
+    expect(request.input.content.conference).toBeNull();
   });
 
   it("clamps a requested window that extends past the host horizon", async () => {

--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -27,7 +27,7 @@ import {
 } from "@core/types/booking.contracts";
 import {
   type CalendarConference,
-  conferenceForProvider,
+  conferenceForDestination,
 } from "@core/types/calendar.contracts";
 import { DateTimeSchema, type EventId } from "@core/types/domain-primitives";
 import {
@@ -336,9 +336,10 @@ const destinationConference = async (
         (candidate) => candidate.id === destination.connectionId,
       )
     : undefined;
-  return conferenceForProvider(
+  return conferenceForDestination(
     connection?.provider ?? "google",
     destination.createsGoogleMeet !== false,
+    connection?.capabilities,
   );
 };
 

--- a/packages/backend/src/common/services/sync-service/calendar-list.translation.test.ts
+++ b/packages/backend/src/common/services/sync-service/calendar-list.translation.test.ts
@@ -147,13 +147,18 @@ describe("syncCalendarToBrowser", () => {
     expect(result.capabilities).toEqual({
       ...baseCapabilities,
       canInviteAttendees: canWrite,
+      conferenceKinds: ["meet"],
     });
   });
 
   it("maps a microsoft connection's provider through to the calendar", () => {
     const calendar = providerCalendar();
-    const result = syncCalendarToBrowser(calendar, { provider: "microsoft" });
+    const result = syncCalendarToBrowser(calendar, {
+      provider: "microsoft",
+      capabilities: ["readEvents", "writeEvents", "createTeamsMeeting"],
+    });
     expect(result.provider).toBe("microsoft");
+    expect(result.conference).toBe("teams");
   });
 
   it("derives canInviteAttendees from sync write capability for a writable calendar", () => {
@@ -202,12 +207,35 @@ describe("syncCalendarToBrowser", () => {
         .conference,
     ).toBe("none");
     expect(
-      syncCalendarToBrowser(providerCalendar(), { provider: "microsoft" })
-        .conference,
+      syncCalendarToBrowser(providerCalendar(), {
+        provider: "microsoft",
+        capabilities: ["readEvents", "writeEvents", "createTeamsMeeting"],
+      }).conference,
     ).toBe("teams");
+    expect(
+      syncCalendarToBrowser(providerCalendar(), {
+        provider: "microsoft",
+        capabilities: ["readEvents", "writeEvents"],
+      }).conference,
+    ).toBe("none");
     expect(
       syncCalendarToBrowser(providerCalendar(), { provider: "apple" })
         .conference,
     ).toBe("none");
+  });
+
+  it("exposes conferenceKinds on calendar capabilities", () => {
+    expect(
+      syncCalendarToBrowser(providerCalendar(), {
+        provider: "microsoft",
+        capabilities: ["readEvents", "writeEvents", "createTeamsMeeting"],
+      }).capabilities.conferenceKinds,
+    ).toEqual(["teams"]);
+    expect(
+      syncCalendarToBrowser(providerCalendar({ createsGoogleMeet: false }), {
+        provider: "microsoft",
+        capabilities: ["readEvents", "writeEvents", "createTeamsMeeting"],
+      }).capabilities.conferenceKinds,
+    ).toEqual([]);
   });
 });

--- a/packages/backend/src/common/services/sync-service/calendar-list.translation.ts
+++ b/packages/backend/src/common/services/sync-service/calendar-list.translation.ts
@@ -2,7 +2,8 @@ import {
   type Calendar,
   type CalendarAccess,
   CalendarSchema,
-  conferenceForProvider,
+  conferenceForDestination,
+  conferenceKindsForConference,
   getCalendarCapabilities,
 } from "@core/types/calendar.contracts";
 import { HexColorSchema } from "@core/types/domain-primitives";
@@ -55,11 +56,13 @@ const syncCalendarToBrowser = (
   calendar: ProviderCalendar,
   provider: ProviderKind,
   accountEmail?: string,
+  connectionCapabilities?: ProviderConnection["capabilities"],
 ): Calendar => {
   const access = mapCalendarAccessRole(calendar.accessRole);
-  const conference = conferenceForProvider(
+  const conference = conferenceForDestination(
     provider,
     calendar.createsGoogleMeet !== false,
+    connectionCapabilities,
   );
   // Sync stores the provider colour as a loose string; the browser Calendar
   // requires a hex colour. Fall back to the default rather than 500 the whole
@@ -80,6 +83,7 @@ const syncCalendarToBrowser = (
     capabilities: {
       ...getCalendarCapabilities(access),
       canInviteAttendees: calendar.capabilities.canWriteEvents,
+      conferenceKinds: conferenceKindsForConference(conference),
     },
     isPrimary: calendar.primary,
     isVisible: true,
@@ -105,6 +109,7 @@ export const syncCalendarsToBrowser = (
       calendar,
       connection?.provider ?? "google",
       connection?.account.email ?? undefined,
+      connection?.capabilities,
     );
   });
 };

--- a/packages/core/src/types/calendar.contracts.test.ts
+++ b/packages/core/src/types/calendar.contracts.test.ts
@@ -4,6 +4,7 @@ import {
   CalendarListResponseSchema,
   CalendarSchema,
   CONFERENCE_BY_PROVIDER,
+  conferenceForDestination,
   conferenceForProvider,
   getCalendarCapabilities,
 } from "@core/types/calendar.contracts";
@@ -81,6 +82,24 @@ describe("Calendar Contracts", () => {
     });
   });
 
+  describe("conferenceForDestination", () => {
+    it("requires createTeamsMeeting for a Microsoft destination", () => {
+      expect(
+        conferenceForDestination("microsoft", true, [
+          "readEvents",
+          "writeEvents",
+          "createTeamsMeeting",
+        ]),
+      ).toBe("teams");
+      expect(
+        conferenceForDestination("microsoft", true, [
+          "readEvents",
+          "writeEvents",
+        ]),
+      ).toBe("none");
+    });
+  });
+
   describe("getCalendarCapabilities", () => {
     it("returns full capabilities for an owner", () => {
       expect(getCalendarCapabilities("owner")).toEqual({
@@ -90,6 +109,7 @@ describe("Calendar Contracts", () => {
         canManage: true,
         canWatchEvents: true,
         canInviteAttendees: true,
+        conferenceKinds: [],
       });
     });
 
@@ -101,6 +121,7 @@ describe("Calendar Contracts", () => {
         canManage: false,
         canWatchEvents: true,
         canInviteAttendees: true,
+        conferenceKinds: [],
       });
     });
 
@@ -112,6 +133,7 @@ describe("Calendar Contracts", () => {
         canManage: false,
         canWatchEvents: true,
         canInviteAttendees: false,
+        conferenceKinds: [],
       });
     });
 
@@ -123,6 +145,7 @@ describe("Calendar Contracts", () => {
         canManage: false,
         canWatchEvents: false,
         canInviteAttendees: false,
+        conferenceKinds: [],
       });
     });
 

--- a/packages/core/src/types/calendar.contracts.ts
+++ b/packages/core/src/types/calendar.contracts.ts
@@ -4,6 +4,7 @@ import {
   HexColorSchema,
   TimeZoneSchema,
 } from "@core/types/domain-primitives";
+import { type ProviderCapability } from "@core/types/sync/identity.contracts";
 
 export const CalendarProviderSchema = z.enum([
   "local",
@@ -33,6 +34,46 @@ export function conferenceForProvider(
   return CONFERENCE_BY_PROVIDER[provider];
 }
 
+export const CalendarConferenceKindSchema = z.enum(["meet", "teams"]);
+export type CalendarConferenceKind = z.infer<
+  typeof CalendarConferenceKindSchema
+>;
+
+export function conferenceKindsForConference(
+  conference: CalendarConference,
+): readonly CalendarConferenceKind[] {
+  return conference === "none" ? [] : [conference];
+}
+
+export function canCreateConferenceForDestination(
+  provider: CalendarProvider,
+  calendarCreatesConference: boolean,
+  connectionCapabilities?: readonly ProviderCapability[],
+): boolean {
+  if (!calendarCreatesConference) {
+    return false;
+  }
+  if (provider === "microsoft") {
+    return connectionCapabilities?.includes("createTeamsMeeting") ?? false;
+  }
+  return true;
+}
+
+export function conferenceForDestination(
+  provider: CalendarProvider,
+  calendarCreatesConference: boolean,
+  connectionCapabilities?: readonly ProviderCapability[],
+): CalendarConference {
+  return conferenceForProvider(
+    provider,
+    canCreateConferenceForDestination(
+      provider,
+      calendarCreatesConference,
+      connectionCapabilities,
+    ),
+  );
+}
+
 export const CalendarAccessSchema = z.enum([
   "owner",
   "writer",
@@ -48,6 +89,8 @@ export const CalendarCapabilitiesSchema = z.strictObject({
   canManage: z.boolean(),
   canWatchEvents: z.boolean(),
   canInviteAttendees: z.boolean(),
+  // Conference kinds this calendar can mint on create. Empty when none.
+  conferenceKinds: z.array(CalendarConferenceKindSchema).readonly(),
 });
 export type CalendarCapabilities = z.infer<typeof CalendarCapabilitiesSchema>;
 
@@ -118,8 +161,14 @@ export const CAPABILITIES_BY_ACCESS = {
     canWatchEvents: false,
     canInviteAttendees: false,
   },
-} as const satisfies Record<CalendarAccess, CalendarCapabilities>;
+} as const satisfies Record<
+  CalendarAccess,
+  Omit<CalendarCapabilities, "conferenceKinds">
+>;
 
 export const getCalendarCapabilities = (
   access: CalendarAccess,
-): CalendarCapabilities => CAPABILITIES_BY_ACCESS[access];
+): CalendarCapabilities => ({
+  ...CAPABILITIES_BY_ACCESS[access],
+  conferenceKinds: [],
+});

--- a/packages/core/src/types/sync/identity.contracts.test.ts
+++ b/packages/core/src/types/sync/identity.contracts.test.ts
@@ -151,6 +151,7 @@ describe("Sync identity contracts", () => {
       "changeNotifications",
       "incrementalChanges",
       "suggestContacts",
+      "createTeamsMeeting",
     ] as const)("accepts %s", (capability) => {
       expect(ProviderCapabilitySchema.safeParse(capability).success).toBe(true);
     });

--- a/packages/core/src/types/sync/identity.contracts.ts
+++ b/packages/core/src/types/sync/identity.contracts.ts
@@ -85,6 +85,10 @@ export const ProviderCapabilitySchema = z.enum([
   // suffices — partial grants are normal); its absence is an ordinary state,
   // never an error.
   "suggestContacts",
+  // The connection's mailbox can mint a Microsoft Teams meeting link when
+  // Graph reports a Teams online-meeting provider. Derived from meeting
+  // settings at connect time, not from OAuth scopes alone.
+  "createTeamsMeeting",
 ]);
 export type ProviderCapability = z.infer<typeof ProviderCapabilitySchema>;
 

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -1014,7 +1014,7 @@ describe("BookingSettingsSection", () => {
     expect(writeText).not.toHaveBeenCalled();
   });
 
-  it("labels a Google primary destination calendar with the calendar name only", async () => {
+  it("labels a Google primary destination calendar with Google Meet in the chooser", async () => {
     const primary = createMockCalendar({
       name: "host@example.com",
       accountEmail: "host@example.com",
@@ -1049,7 +1049,7 @@ describe("BookingSettingsSection", () => {
       name: "Destination calendar",
     });
     const option = within(combobox).getByRole("option");
-    expect(option.textContent).toBe("host@example.com");
+    expect(option.textContent).toBe("host@example.com (Google Meet)");
     expect(
       within(combobox).getByRole("group", { name: "host@example.com" }),
     ).toBeInTheDocument();
@@ -1147,6 +1147,55 @@ describe("BookingSettingsSection", () => {
     expect(
       screen.getByRole("combobox", { name: "Destination calendar" }),
     ).toHaveAccessibleDescription(BOOKING_APPLE_DESTINATION_HINT);
+  });
+
+  it("labels a Microsoft destination with Microsoft Teams in the chooser", async () => {
+    const microsoftCalendar = createMockCalendar({
+      name: "Work",
+      accountEmail: "host@outlook.com",
+      provider: "microsoft",
+      conference: "teams",
+      createsGoogleMeet: false,
+    });
+
+    userMetadataActions.set({
+      google: {
+        connectionState: "NOT_CONNECTED",
+        connections: [],
+      },
+      connections: [
+        createMockConnection("host@outlook.com", { provider: "microsoft" }),
+      ],
+    });
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(
+          ctx.json({
+            ...unconfiguredPage(),
+            destinationCalendarId: microsoftCalendar.id,
+            blockingCalendarIds: [microsoftCalendar.id],
+          }),
+        ),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [microsoftCalendar]);
+
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    const combobox = await screen.findByRole("combobox", {
+      name: "Destination calendar",
+    });
+    expect(within(combobox).getByRole("option").textContent).toBe(
+      "Work (Microsoft Teams)",
+    );
   });
 
   it("does not warn when the destination can mint Meet", async () => {

--- a/packages/web/src/booking/booking-conference.copy.test.ts
+++ b/packages/web/src/booking/booking-conference.copy.test.ts
@@ -26,6 +26,7 @@ const calendar = (overrides: Partial<Calendar> = {}): Calendar =>
       canManage: true,
       canWatchEvents: true,
       canInviteAttendees: true,
+      conferenceKinds: [],
     },
     isPrimary: false,
     isVisible: true,
@@ -48,8 +49,18 @@ describe("booking conference copy", () => {
     ).toBe("Personal (No video link)");
   });
 
-  it("keeps a Google destination label as the calendar name", () => {
-    expect(formatBookingDestinationOptionLabel(calendar())).toBe("Personal");
+  it("labels a Google destination with Google Meet in the chooser", () => {
+    expect(formatBookingDestinationOptionLabel(calendar())).toBe(
+      "Personal (Google Meet)",
+    );
+  });
+
+  it("labels a Microsoft destination with Microsoft Teams in the chooser", () => {
+    expect(
+      formatBookingDestinationOptionLabel(
+        calendar({ provider: "microsoft", conference: "teams" }),
+      ),
+    ).toBe("Personal (Microsoft Teams)");
   });
 
   it("shows the iCloud hint for an Apple destination without video", () => {

--- a/packages/web/src/booking/booking-conference.copy.ts
+++ b/packages/web/src/booking/booking-conference.copy.ts
@@ -21,6 +21,14 @@ export const BOOKING_CONFERENCE_INVITE_COPY: Record<
 
 export const BOOKING_DESTINATION_NO_VIDEO_SUFFIX = "No video link";
 
+export const BOOKING_DESTINATION_CONFERENCE_SUFFIX: Record<
+  Exclude<CalendarConference, "none">,
+  string
+> = {
+  meet: "Google Meet",
+  teams: "Microsoft Teams",
+};
+
 export const BOOKING_APPLE_DESTINATION_HINT =
   "Bookings on an iCloud calendar are created without a video link. Add one in the booking notes if you need it.";
 
@@ -59,10 +67,13 @@ export function formatBookingDestinationOptionLabel(
     calendar.conference,
     calendar.createsGoogleMeet,
   );
-  if (calendar.provider === "apple" && conference === "none") {
-    return `${calendar.name} (${BOOKING_DESTINATION_NO_VIDEO_SUFFIX})`;
+  if (conference === "none") {
+    if (calendar.provider === "apple") {
+      return `${calendar.name} (${BOOKING_DESTINATION_NO_VIDEO_SUFFIX})`;
+    }
+    return calendar.name;
   }
-  return calendar.name;
+  return `${calendar.name} (${BOOKING_DESTINATION_CONFERENCE_SUFFIX[conference]})`;
 }
 
 export function bookingDestinationConferenceHint(

--- a/packages/web/src/calendars/local-calendar.sentinel.ts
+++ b/packages/web/src/calendars/local-calendar.sentinel.ts
@@ -47,6 +47,7 @@ export function synthesizeLocalCalendar(id: CalendarId): Calendar {
       canManage: false,
       canWatchEvents: false,
       canInviteAttendees: false,
+      conferenceKinds: [],
     },
     isPrimary: true,
     isVisible: true,

--- a/packages/web/src/views/Forms/EventForm/EventForm.attendees.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.attendees.test.tsx
@@ -269,6 +269,7 @@ describe("EventForm attendee editor gating", () => {
         canManage: false,
         canWatchEvents: false,
         canInviteAttendees: false,
+        conferenceKinds: [],
       },
     });
     const event = createMockEvent({


### PR DESCRIPTION
Fixes #3251

## What and why

Microsoft booking destinations now derive `conference: "teams"` only when the owning connection reports the `createTeamsMeeting` capability (from Graph meeting-provider lookup in M-06b). Calendar list translation exposes `conferenceKinds` on each calendar's capabilities, public booking reads the same conference at confirm time (`createConference: true` only when conference is not `none`), and booking settings label destinations with Google Meet or Microsoft Teams. No-conference Microsoft mailboxes get honest none copy and skip conference creation.

## Verify

```
bun run verify --strict
```

Selected packages: core, web, backend
Checks run: test:core, test:web, test:backend, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)

VERDICT: PASS