### PR TITLE
refactor(sync): share contact suggestion ranking across people adapters

### DIFF
--- a/packages/sync/src/providers/google/google-people.adapter.ts
+++ b/packages/sync/src/providers/google/google-people.adapter.ts
@@ -11,6 +11,10 @@ import {
 } from "@sync/providers/google/google-error";
 import { GOOGLE_REQUEST_TIMEOUT_MS } from "@sync/providers/google/google-http.constants";
 import {
+  rankContactSuggestions,
+  toContactSuggestion,
+} from "@sync/providers/provider-contact-suggestions";
+import {
   type ContactsPort,
   ContactsSearchError,
   type ContactsSearchInput,
@@ -133,7 +137,7 @@ export class GooglePeopleAdapter implements ContactsPort {
     const candidates = pages.flatMap((page) =>
       page.results.flatMap((match) => toSuggestions(match)),
     );
-    return rankSuggestions(candidates, input.query).slice(
+    return rankContactSuggestions(candidates, input.query).slice(
       0,
       CONTACT_SUGGESTION_MAX_RESULTS,
     );
@@ -142,66 +146,24 @@ export class GooglePeopleAdapter implements ContactsPort {
 
 // Map one matched person to suggestion candidates — one per usable email
 // address, primary first, each carrying the person's primary display name.
-// Anything unusable (no email, over the contract's bounds) is dropped, not
-// erred: a malformed contact must not break the whole suggestion list.
 function toSuggestions(match: GooglePeoplePersonMatch): ContactSuggestion[] {
   const person = match.person;
   if (!person) return [];
 
   const names = person.names ?? [];
-  const rawName = (
+  const displayName =
     names.find((name) => name.metadata?.primary)?.displayName ??
     names[0]?.displayName ??
-    ""
-  ).trim();
-  const displayName =
-    rawName.length > 0 && rawName.length <= 256 ? rawName : null;
+    null;
 
   const addresses = [...(person.emailAddresses ?? [])].sort(
     (a, b) =>
       Number(b.metadata?.primary ?? false) -
       Number(a.metadata?.primary ?? false),
   );
-  const suggestions: ContactSuggestion[] = [];
-  for (const address of addresses) {
-    const email = (address.value ?? "").trim();
-    if (email.length === 0 || email.length > 320) continue;
-    suggestions.push({ email, displayName });
-  }
-  return suggestions;
-}
-
-// Rank by how directly the suggestion matches the typed prefix: email or name
-// prefix match first, then substring match, then the provider's own relevance
-// order. The sort is stable, so equal ranks keep source order (saved contacts
-// ahead of other contacts). De-duplicates by case-insensitive email, keeping
-// the best-ranked (first) occurrence.
-function rankSuggestions(
-  candidates: readonly ContactSuggestion[],
-  query: string,
-): ContactSuggestion[] {
-  const needle = query.trim().toLowerCase();
-  const rank = (suggestion: ContactSuggestion): number => {
-    const email = suggestion.email.toLowerCase();
-    const name = suggestion.displayName?.toLowerCase() ?? "";
-    if (email.startsWith(needle) || name.startsWith(needle)) return 0;
-    if (email.includes(needle) || name.includes(needle)) return 1;
-    return 2;
-  };
-
-  const ranked = candidates
-    .map((suggestion, index) => ({ suggestion, index, rank: rank(suggestion) }))
-    .sort((a, b) => a.rank - b.rank || a.index - b.index);
-
-  const seen = new Set<string>();
-  const unique: ContactSuggestion[] = [];
-  for (const { suggestion } of ranked) {
-    const key = suggestion.email.toLowerCase();
-    if (seen.has(key)) continue;
-    seen.add(key);
-    unique.push(suggestion);
-  }
-  return unique;
+  return addresses
+    .map((address) => toContactSuggestion(address.value, displayName))
+    .filter((suggestion) => suggestion !== null);
 }
 
 // Google's quota refusals worth backing off on, as opposed to backendError /

--- a/packages/sync/src/providers/microsoft/microsoft-people.adapter.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-people.adapter.ts
@@ -11,6 +11,10 @@ import {
   MICROSOFT_REQUEST_TIMEOUT_MS,
 } from "@sync/providers/microsoft/microsoft-http.constants";
 import {
+  rankContactSuggestions,
+  toContactSuggestion,
+} from "@sync/providers/provider-contact-suggestions";
+import {
   type ContactsPort,
   ContactsSearchError,
   type ContactsSearchInput,
@@ -72,7 +76,7 @@ export class MicrosoftPeopleAdapter implements ContactsPort {
     }
 
     const candidates = page.value.flatMap((person) => toSuggestions(person));
-    return rankSuggestions(candidates, input.query).slice(
+    return rankContactSuggestions(candidates, input.query).slice(
       0,
       CONTACT_SUGGESTION_MAX_RESULTS,
     );
@@ -123,49 +127,15 @@ class FetchMicrosoftPeopleApi implements MicrosoftPeopleApi {
   }
 }
 
+// Graph returns each person's addresses with a relevance score; take them
+// most-relevant first so equal-ranking candidates keep Graph's own ordering.
 function toSuggestions(person: GraphPersonMatch): ContactSuggestion[] {
-  const rawName = (person.displayName ?? "").trim();
-  const displayName =
-    rawName.length > 0 && rawName.length <= 256 ? rawName : null;
-
   const addresses = [...(person.scoredEmailAddresses ?? [])].sort(
     (a, b) => (b.relevanceScore ?? 0) - (a.relevanceScore ?? 0),
   );
-  const suggestions: ContactSuggestion[] = [];
-  for (const entry of addresses) {
-    const email = (entry.address ?? "").trim();
-    if (email.length === 0 || email.length > 320) continue;
-    suggestions.push({ email, displayName });
-  }
-  return suggestions;
-}
-
-function rankSuggestions(
-  candidates: readonly ContactSuggestion[],
-  query: string,
-): ContactSuggestion[] {
-  const needle = query.trim().toLowerCase();
-  const rank = (suggestion: ContactSuggestion): number => {
-    const email = suggestion.email.toLowerCase();
-    const name = suggestion.displayName?.toLowerCase() ?? "";
-    if (email.startsWith(needle) || name.startsWith(needle)) return 0;
-    if (email.includes(needle) || name.includes(needle)) return 1;
-    return 2;
-  };
-
-  const ranked = candidates
-    .map((suggestion, index) => ({ suggestion, index, rank: rank(suggestion) }))
-    .sort((a, b) => a.rank - b.rank || a.index - b.index);
-
-  const seen = new Set<string>();
-  const unique: ContactSuggestion[] = [];
-  for (const { suggestion } of ranked) {
-    const key = suggestion.email.toLowerCase();
-    if (seen.has(key)) continue;
-    seen.add(key);
-    unique.push(suggestion);
-  }
-  return unique;
+  return addresses
+    .map((entry) => toContactSuggestion(entry.address, person.displayName))
+    .filter((suggestion) => suggestion !== null);
 }
 
 function toContactsSearchError(error: unknown): ContactsSearchError {

--- a/packages/sync/src/providers/provider-contact-suggestions.test.ts
+++ b/packages/sync/src/providers/provider-contact-suggestions.test.ts
@@ -1,0 +1,87 @@
+import { type ContactSuggestion } from "@core/types/contact.contracts";
+import {
+  rankContactSuggestions,
+  toContactSuggestion,
+} from "@sync/providers/provider-contact-suggestions";
+import { describe, expect, it } from "bun:test";
+
+const suggestion = (
+  email: string,
+  displayName: string | null = null,
+): ContactSuggestion => ({ email, displayName });
+
+describe("toContactSuggestion", () => {
+  it("trims the address and the name", () => {
+    expect(toContactSuggestion("  ada@example.com  ", "  Ada  ")).toEqual(
+      suggestion("ada@example.com", "Ada"),
+    );
+  });
+
+  it("drops the candidate when the address is missing or empty", () => {
+    expect(toContactSuggestion(null, "Ada")).toBeNull();
+    expect(toContactSuggestion(undefined, "Ada")).toBeNull();
+    expect(toContactSuggestion("   ", "Ada")).toBeNull();
+  });
+
+  it("drops the candidate when the address is past the contract bound", () => {
+    expect(toContactSuggestion(`${"a".repeat(321)}`, null)).toBeNull();
+    expect(toContactSuggestion(`${"a".repeat(320)}`, null)).not.toBeNull();
+  });
+
+  it("keeps the address but drops an unusable name", () => {
+    expect(toContactSuggestion("ada@example.com", "  ")).toEqual(
+      suggestion("ada@example.com"),
+    );
+    expect(toContactSuggestion("ada@example.com", "n".repeat(257))).toEqual(
+      suggestion("ada@example.com"),
+    );
+    expect(toContactSuggestion("ada@example.com", null)).toEqual(
+      suggestion("ada@example.com"),
+    );
+  });
+});
+
+describe("rankContactSuggestions", () => {
+  it("puts prefix matches ahead of substring matches, then the rest", () => {
+    const ranked = rankContactSuggestions(
+      [
+        suggestion("someone@other.com"),
+        suggestion("team@example.com", "Not Ada"),
+        suggestion("ada@example.com"),
+      ],
+      "ada",
+    );
+    expect(ranked.map((entry) => entry.email)).toEqual([
+      "ada@example.com",
+      "team@example.com",
+      "someone@other.com",
+    ]);
+  });
+
+  it("matches a name prefix as well as an address prefix", () => {
+    const ranked = rankContactSuggestions(
+      [suggestion("zz@example.com"), suggestion("gh@example.com", "Ada L")],
+      "ada",
+    );
+    expect(ranked[0]?.email).toBe("gh@example.com");
+  });
+
+  it("keeps source order among equally ranked candidates", () => {
+    const ranked = rankContactSuggestions(
+      [suggestion("saved@example.com"), suggestion("other@example.com")],
+      "zzz",
+    );
+    expect(ranked.map((entry) => entry.email)).toEqual([
+      "saved@example.com",
+      "other@example.com",
+    ]);
+  });
+
+  it("de-duplicates by case-insensitive address, keeping the best ranked", () => {
+    const ranked = rankContactSuggestions(
+      [suggestion("Team@Example.com", "Team"), suggestion("team@example.com")],
+      "team",
+    );
+    expect(ranked).toEqual([suggestion("Team@Example.com", "Team")]);
+  });
+});

--- a/packages/sync/src/providers/provider-contact-suggestions.ts
+++ b/packages/sync/src/providers/provider-contact-suggestions.ts
@@ -1,0 +1,64 @@
+import {
+  type ContactSuggestion,
+  ContactSuggestionSchema,
+} from "@core/types/contact.contracts";
+
+// Provider-neutral suggestion assembly, shared by every ContactsPort adapter.
+// Only the shape of a provider's match is provider-specific; turning a raw
+// address into a candidate and ordering the merged list are the same work
+// whether the names came from Google People or Microsoft Graph.
+
+// The contract owns the bounds a suggestion must satisfy, so read them off the
+// schema instead of restating 320/256 in each adapter, where they drift.
+const EmailSchema = ContactSuggestionSchema.shape.email;
+const DisplayNameSchema = ContactSuggestionSchema.shape.displayName;
+
+// Build one candidate from a provider-supplied address and name. Both are
+// trimmed and bounds-checked against the contract: an unusable email drops the
+// candidate entirely (a malformed contact must not break the whole suggestion
+// list), while an unusable name only drops the name, keeping the address.
+export function toContactSuggestion(
+  email: string | null | undefined,
+  displayName: string | null | undefined,
+): ContactSuggestion | null {
+  const parsedEmail = EmailSchema.safeParse(email ?? "");
+  if (!parsedEmail.success) return null;
+  const parsedName = DisplayNameSchema.safeParse(displayName ?? null);
+  return {
+    email: parsedEmail.data,
+    displayName: parsedName.success ? parsedName.data : null,
+  };
+}
+
+// Rank by how directly the suggestion matches the typed prefix: email or name
+// prefix match first, then substring match, then the provider's own relevance
+// order. The sort is stable, so equal ranks keep source order (for Google,
+// saved contacts ahead of other contacts). De-duplicates by case-insensitive
+// email, keeping the best-ranked (first) occurrence.
+export function rankContactSuggestions(
+  candidates: readonly ContactSuggestion[],
+  query: string,
+): ContactSuggestion[] {
+  const needle = query.trim().toLowerCase();
+  const rank = (suggestion: ContactSuggestion): number => {
+    const email = suggestion.email.toLowerCase();
+    const name = suggestion.displayName?.toLowerCase() ?? "";
+    if (email.startsWith(needle) || name.startsWith(needle)) return 0;
+    if (email.includes(needle) || name.includes(needle)) return 1;
+    return 2;
+  };
+
+  const ranked = candidates
+    .map((suggestion, index) => ({ suggestion, index, rank: rank(suggestion) }))
+    .sort((a, b) => a.rank - b.rank || a.index - b.index);
+
+  const seen = new Set<string>();
+  const unique: ContactSuggestion[] = [];
+  for (const { suggestion } of ranked) {
+    const key = suggestion.email.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(suggestion);
+  }
+  return unique;
+}


### PR DESCRIPTION
## What and why

Technical-debt cleanup found while reviewing merged changes from the last 7 days. The Microsoft Graph people adapter (#3398, merged yesterday) copied `rankSuggestions` verbatim out of the Google adapter, leaving 27 byte-identical lines in two files, and both adapters restated the `ContactSuggestion` contract's `320` / `256` bounds as inline magic numbers.

This extracts `rankContactSuggestions` and `toContactSuggestion` into a shared `provider-contact-suggestions` module next to the existing `provider-contacts.port`. The bounds are now read off `ContactSuggestionSchema` rather than hand-written, so they cannot drift from the contract, and each adapter keeps only the part that is genuinely provider-specific: how to pull names and addresses out of its own match shape (Google's primary-flagged fields, Graph's relevance scores).

No behavior change. The extracted helper preserves the existing semantics exactly, including the asymmetry that an unusable email drops the candidate entirely while an unusable name only drops the name and keeps the address. The new unit test pins that asymmetry and the ranking/dedupe rules directly; both adapters' existing tests stay as regression cover and pass unchanged.

## Verify

`VERDICT: PASS` — checks run: `test:sync:fast`, `type-check`, `lint`, `knip` (selected package: sync).

Note for anyone reproducing locally: `bun run verify` reports `FAIL` on Bun 1.3.11 because `packages/sync/src/providers/microsoft/windows-zones.test.ts` asserts against `Intl.supportedValuesOf("timeZone")`, whose enumeration depends on the runtime's ICU build. That test fails identically on unmodified `main` in the same container and passes on the pinned `bun@1.3.14`, which is what the verdict above was run on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TrTV84fx55cJbbqxUXThdG

---
_Generated by [Claude Code](https://claude.ai/code/session_01TrTV84fx55cJbbqxUXThdG)_