### PR TITLE
refactor(sync): share provider write-error classification

### DIFF
--- a/packages/sync/src/providers/apple/apple-event-writer.adapter.ts
+++ b/packages/sync/src/providers/apple/apple-event-writer.adapter.ts
@@ -33,6 +33,10 @@ import {
   type ProviderWriteRecurrence,
   type ProviderWriteResult,
 } from "@sync/providers/provider-event-writer.port";
+import {
+  classifyProviderWriteError,
+  type ProviderWriteErrorPolicy,
+} from "@sync/providers/provider-write-error";
 import { redactedCause } from "@sync/safety/redact-error";
 
 const CALDAV_ORIGIN = "https://caldav.icloud.com";
@@ -590,49 +594,25 @@ function assertWriteStatus(response: CaldavResponse): void {
   }
 }
 
+const APPLE_WRITE_ERROR_POLICY: ProviderWriteErrorPolicy = {
+  status: responseStatus,
+  cause: redactedCause,
+  credentialRejectedMessage: "Apple rejected the credentials",
+  writeRejectedMessage: "Apple rejected the write",
+};
+
 function classifyWriteError(error: unknown): ProviderWriteError {
   if (error instanceof ProviderWriteError) return error;
-  const cause = redactedCause(error);
-  const status = responseStatus(error);
-
-  if (status === 412) {
-    return new ProviderWriteError(
-      "versionConflict",
-      "The event was modified since the expected version",
-      { cause },
-    );
-  }
-  if (status === 401) {
-    return new ProviderWriteError(
-      "authorizationRevoked",
-      "Apple rejected the credentials",
-      { cause },
-    );
-  }
-  if (status === 403) {
-    return new ProviderWriteError(
-      "readOnlyCalendar",
-      "The calendar cannot be written",
-      { cause },
-    );
-  }
-  if (status === 507) {
+  // Insufficient storage is a 5xx the shared table would read as transient,
+  // but retrying never clears it: the iCloud account is out of room.
+  if (responseStatus(error) === 507) {
     return new ProviderWriteError(
       "permanentProviderError",
       "Apple rejected the write with insufficient storage",
-      { cause },
+      { cause: redactedCause(error) },
     );
   }
-  if (status === undefined || status === 429 || status >= 500) {
-    return new ProviderWriteError("transient", "The write failed transiently", {
-      cause,
-    });
-  }
-  return new ProviderWriteError(
-    "permanentProviderError",
-    "Apple rejected the write",
-    { cause },
-  );
+  return classifyProviderWriteError(error, APPLE_WRITE_ERROR_POLICY);
 }
 
 function responseStatus(error: unknown): number | undefined {

--- a/packages/sync/src/providers/google/google-event-writer.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.ts
@@ -10,6 +10,7 @@ import {
 import { type SyncEventContent } from "@core/types/sync/event.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { googleColorIdFields } from "@sync/providers/google/google-color.map";
+import { googleStatus } from "@sync/providers/google/google-error";
 import {
   mapConference,
   normalizeGoogleEvent,
@@ -33,6 +34,11 @@ import {
   type ProviderWriteRecurrence,
   type ProviderWriteResult,
 } from "@sync/providers/provider-event-writer.port";
+import {
+  classifyProviderWriteError,
+  isNotFoundStatus,
+  type ProviderWriteErrorPolicy,
+} from "@sync/providers/provider-write-error";
 import { redactedCause } from "@sync/safety/redact-error";
 
 // The Google event calls the writer makes. Depending on this narrow interface
@@ -558,6 +564,13 @@ const RETRYABLE_403_REASONS = new Set([
   "dailyLimitExceeded",
 ]);
 
+const GOOGLE_WRITE_ERROR_POLICY: ProviderWriteErrorPolicy = {
+  status: googleStatus,
+  cause: redactedCause,
+  credentialRejectedMessage: "Google rejected the credential",
+  writeRejectedMessage: "Google rejected the write",
+};
+
 function classifyWriteError(error: unknown): ProviderWriteError {
   // An already-classified error (e.g. a missing-identity result) must not be
   // re-wrapped as transient just because it carries no HTTP status.
@@ -571,63 +584,20 @@ function classifyWriteError(error: unknown): ProviderWriteError {
       cause: redactedCause(error),
     });
   }
-
-  const status = googleStatus(error);
-  const cause = redactedCause(error);
-
-  if (status === 412) {
+  // A quota 403 is retryable. Every other 403 falls through to the shared
+  // table, which reads it as a calendar this authorization cannot write.
+  if (googleStatus(error) === 403 && hasRetryable403Reason(error)) {
     return new ProviderWriteError(
-      "versionConflict",
-      "The event was modified since the expected version",
-      { cause },
+      "transient",
+      "Google rate limited the write",
+      { cause: redactedCause(error) },
     );
   }
-  if (status === 401) {
-    return new ProviderWriteError(
-      "authorizationRevoked",
-      "Google rejected the credential",
-      { cause },
-    );
-  }
-  if (status === 403) {
-    // A quota 403 is retryable; any other 403 means the calendar is not
-    // writable with this authorization.
-    if (hasRetryable403Reason(error)) {
-      return new ProviderWriteError(
-        "transient",
-        "Google rate limited the write",
-        { cause },
-      );
-    }
-    return new ProviderWriteError(
-      "readOnlyCalendar",
-      "The calendar cannot be written",
-      { cause },
-    );
-  }
-  // No status (network failure) or 429/5xx are transient and safe to retry.
-  if (status === undefined || status === 429 || status >= 500) {
-    return new ProviderWriteError("transient", "The write failed transiently", {
-      cause,
-    });
-  }
-  return new ProviderWriteError(
-    "permanentProviderError",
-    "Google rejected the write",
-    { cause },
-  );
+  return classifyProviderWriteError(error, GOOGLE_WRITE_ERROR_POLICY);
 }
 
 function isNotFound(error: unknown): boolean {
-  const status = googleStatus(error);
-  return status === 404 || status === 410;
-}
-
-function googleStatus(error: unknown): number | undefined {
-  return (
-    (error as { response?: { status?: number } })?.response?.status ??
-    (error as { code?: number })?.code
-  );
+  return isNotFoundStatus(googleStatus(error));
 }
 
 function hasRetryable403Reason(error: unknown): boolean {

--- a/packages/sync/src/providers/microsoft/microsoft-event-writer.adapter.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-event-writer.adapter.ts
@@ -3,7 +3,6 @@ import { type Attendee } from "@core/types/event-attendance.contracts";
 import { type SyncEventContent } from "@core/types/sync/event.contracts";
 import dayjs from "@core/util/date/dayjs";
 import {
-  isMicrosoftTransient,
   microsoftFailureCause,
   microsoftStatus,
 } from "@sync/providers/microsoft/microsoft-error";
@@ -44,6 +43,11 @@ import {
   type ProviderWriteRecurrence,
   type ProviderWriteResult,
 } from "@sync/providers/provider-event-writer.port";
+import {
+  classifyProviderWriteError,
+  isNotFoundStatus,
+  type ProviderWriteErrorPolicy,
+} from "@sync/providers/provider-write-error";
 import { redactedCause } from "@sync/safety/redact-error";
 
 const GRAPH_DATETIME = "YYYY-MM-DD[T]HH:mm:ss.SSS";
@@ -405,6 +409,13 @@ function toCanonicalRecurrenceId(originalStart: string): string {
   return new Date(originalStart).toISOString();
 }
 
+const MICROSOFT_WRITE_ERROR_POLICY: ProviderWriteErrorPolicy = {
+  status: microsoftStatus,
+  cause: microsoftFailureCause,
+  credentialRejectedMessage: "Microsoft rejected the credential",
+  writeRejectedMessage: "Microsoft rejected the write",
+};
+
 function classifyWriteError(error: unknown): ProviderWriteError {
   if (error instanceof ProviderWriteError) return error;
   if (error instanceof ProviderEventError) {
@@ -412,50 +423,11 @@ function classifyWriteError(error: unknown): ProviderWriteError {
       cause: redactedCause(error),
     });
   }
-
-  const status = microsoftStatus(error);
-  const cause = microsoftFailureCause(error);
-
-  if (status === 412) {
-    return new ProviderWriteError(
-      "versionConflict",
-      "The event was modified since the expected version",
-      { cause },
-    );
-  }
-  if (status === 401) {
-    return new ProviderWriteError(
-      "authorizationRevoked",
-      "Microsoft rejected the credential",
-      { cause },
-    );
-  }
-  if (status === 403) {
-    return new ProviderWriteError(
-      "readOnlyCalendar",
-      "The calendar cannot be written",
-      { cause },
-    );
-  }
-  if (
-    status === undefined ||
-    status === 429 ||
-    isMicrosoftTransient(error, status)
-  ) {
-    return new ProviderWriteError("transient", "The write failed transiently", {
-      cause,
-    });
-  }
-  return new ProviderWriteError(
-    "permanentProviderError",
-    "Microsoft rejected the write",
-    { cause },
-  );
+  return classifyProviderWriteError(error, MICROSOFT_WRITE_ERROR_POLICY);
 }
 
 function isNotFound(error: unknown): boolean {
-  const status = microsoftStatus(error);
-  return status === 404 || status === 410;
+  return isNotFoundStatus(microsoftStatus(error));
 }
 
 class FetchMicrosoftEventWriteApi implements MicrosoftEventWriteApi {

--- a/packages/sync/src/providers/provider-write-error.test.ts
+++ b/packages/sync/src/providers/provider-write-error.test.ts
@@ -1,0 +1,72 @@
+import { ProviderWriteError } from "@sync/providers/provider-event-writer.port";
+import {
+  classifyProviderWriteError,
+  isNotFoundStatus,
+  type ProviderWriteErrorPolicy,
+} from "@sync/providers/provider-write-error";
+import { describe, expect, it } from "bun:test";
+
+const policy: ProviderWriteErrorPolicy = {
+  status: (error) => (error as { status?: number })?.status,
+  cause: (error) =>
+    new Error(`cause:${(error as { status?: number })?.status}`),
+  credentialRejectedMessage: "Testly rejected the credential",
+  writeRejectedMessage: "Testly rejected the write",
+};
+
+const classify = (status?: number): ProviderWriteError =>
+  classifyProviderWriteError(status === undefined ? {} : { status }, policy);
+
+describe("classifyProviderWriteError", () => {
+  it("maps a failed precondition to a version conflict", () => {
+    const error = classify(412);
+    expect(error.reason).toBe("versionConflict");
+    expect(error.message).toBe(
+      "The event was modified since the expected version",
+    );
+  });
+
+  it("maps 401 to a revoked authorization, named by the policy", () => {
+    const error = classify(401);
+    expect(error.reason).toBe("authorizationRevoked");
+    expect(error.message).toBe("Testly rejected the credential");
+  });
+
+  it("maps 403 to a read-only calendar", () => {
+    expect(classify(403).reason).toBe("readOnlyCalendar");
+  });
+
+  it("treats a missing status, 429 and every 5xx as transient", () => {
+    for (const status of [undefined, 429, 500, 503, 599]) {
+      expect(classify(status).reason).toBe("transient");
+    }
+  });
+
+  it("maps any other 4xx to a permanent rejection, named by the policy", () => {
+    const error = classify(400);
+    expect(error.reason).toBe("permanentProviderError");
+    expect(error.message).toBe("Testly rejected the write");
+  });
+
+  it("carries the policy's cause through", () => {
+    expect(classify(400).cause).toEqual(new Error("cause:400"));
+  });
+
+  it("returns a ProviderWriteError so instanceof narrowing still works", () => {
+    expect(classify(412)).toBeInstanceOf(ProviderWriteError);
+    expect(classify(412).name).toBe("ProviderWriteError");
+  });
+});
+
+describe("isNotFoundStatus", () => {
+  it("accepts the two statuses that mean the event is gone", () => {
+    expect(isNotFoundStatus(404)).toBe(true);
+    expect(isNotFoundStatus(410)).toBe(true);
+  });
+
+  it("rejects everything else, including a missing status", () => {
+    for (const status of [undefined, 200, 400, 403, 412, 500]) {
+      expect(isNotFoundStatus(status)).toBe(false);
+    }
+  });
+});

--- a/packages/sync/src/providers/provider-write-error.ts
+++ b/packages/sync/src/providers/provider-write-error.ts
@@ -1,0 +1,74 @@
+import { ProviderWriteError } from "@sync/providers/provider-event-writer.port";
+
+// The HTTP-status-to-reason mapping every provider writer agreed on. Google,
+// Microsoft and Apple each grew their own copy of this table as they were
+// added, so a fix to one (or a new reason) silently missed the others.
+//
+// Only four things genuinely differ per provider: how to read an HTTP status
+// off that client's thrown error, how to build the redacted `cause`, and the
+// two messages that name the provider. Anything a provider treats specially
+// (Google's retryable quota 403, Apple's 507) stays in that adapter and is
+// checked before this table, where it is visible next to the API it explains.
+export interface ProviderWriteErrorPolicy {
+  // Reads the HTTP status off the provider client's thrown error. Undefined
+  // means no response reached us, which the table reads as transient.
+  status(error: unknown): number | undefined;
+  // Builds the error's `cause`, already stripped of request-derived fields
+  // (a client config carries the bearer token).
+  cause(error: unknown): Error | undefined;
+  // Names the provider on a rejected credential, e.g. "Google rejected the
+  // credential". Kept verbatim per provider rather than composed, because
+  // Apple's reads "credentials" and these strings reach operators in logs.
+  readonly credentialRejectedMessage: string;
+  // Names the provider on an unclassified rejection, e.g. "Google rejected
+  // the write".
+  readonly writeRejectedMessage: string;
+}
+
+// 404 and 410 both mean the provider no longer holds the event. Callers treat
+// this as a settled outcome (a delete of an already-deleted event succeeded),
+// not a failure, so it is a predicate rather than a classified error.
+export function isNotFoundStatus(status: number | undefined): boolean {
+  return status === 404 || status === 410;
+}
+
+export function classifyProviderWriteError(
+  error: unknown,
+  policy: ProviderWriteErrorPolicy,
+): ProviderWriteError {
+  const status = policy.status(error);
+  const cause = policy.cause(error);
+
+  if (status === 412) {
+    return new ProviderWriteError(
+      "versionConflict",
+      "The event was modified since the expected version",
+      { cause },
+    );
+  }
+  if (status === 401) {
+    return new ProviderWriteError(
+      "authorizationRevoked",
+      policy.credentialRejectedMessage,
+      { cause },
+    );
+  }
+  if (status === 403) {
+    return new ProviderWriteError(
+      "readOnlyCalendar",
+      "The calendar cannot be written",
+      { cause },
+    );
+  }
+  // No status (a network failure) or 429/5xx are transient and safe to retry.
+  if (status === undefined || status === 429 || status >= 500) {
+    return new ProviderWriteError("transient", "The write failed transiently", {
+      cause,
+    });
+  }
+  return new ProviderWriteError(
+    "permanentProviderError",
+    policy.writeRejectedMessage,
+    { cause },
+  );
+}


### PR DESCRIPTION
## What and why

Second technical-debt item from the same sweep that produced #3401, and a bigger one.

Google, Microsoft and Apple each grew their own `classifyWriteError` as they were added over the past week, and all three converged on the same table: `412` to `versionConflict`, `401` to `authorizationRevoked`, `403` to `readOnlyCalendar`, no-status/`429`/`5xx` to `transient`, anything else to `permanentProviderError`. Three copies means a fix or a new reason applied to one silently misses the other two. `isNotFound` (`404` or `410`) was duplicated the same way, and the Google writer carried a private `googleStatus` shadowing the exported one in `google-error`.

This extracts the agreed table into `provider-write-error`, parameterized by the four things that genuinely differ per provider: how to read a status off that client's thrown error, how to build the redacted `cause`, and the two messages that carry a provider name. Note that Microsoft's transient arm was `status === undefined || status === 429 || isMicrosoftTransient(error, status)`, where `isMicrosoftTransient` is itself `undefined || 429 || >= 500` — the same rule stated twice.

Provider-specific escapes deliberately stay in their own adapters, checked before the shared table, where they sit next to the API that explains them:

- **Google** — a quota `403` is retryable, so it maps to `transient` rather than `readOnlyCalendar`.
- **Apple** — `507` insufficient storage is a `5xx` the shared table would read as transient, but retrying never clears it.

No behavior change. All 87 existing writer tests across the three adapters pass unchanged, and the new unit test pins the shared table directly, including that a missing status, `429` and every `5xx` are transient while other `4xx` are permanent.

## Verify

`VERDICT: PASS` — checks run: `test:sync:fast` (729 tests), `type-check`, `lint`, `knip` (selected package: sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TrTV84fx55cJbbqxUXThdG

---
_Generated by [Claude Code](https://claude.ai/code/session_01TrTV84fx55cJbbqxUXThdG)_