### PR TITLE
feat(web): navigate the month picker by week with stable keyboard focus

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -150,6 +150,7 @@
         "@tiptap/starter-kit": "^3.29.2",
         "bson": "^7.2.0",
         "classnames": "^2.3.1",
+        "date-fns": "^2.30.0",
         "dexie": "^4.2.1",
         "dompurify": "^3.4.13",
         "fast-deep-equal": "^3.1.3",

--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -333,6 +333,30 @@ On Day view, holding Mod reveals numbered chips left to right: `1` on the view d
 
 ---
 
+## Scenario 12c: Navigate The Month Picker By Week
+
+### UX
+
+The sidebar month picker is a keyboard cursor, not a click target. `I` (or hold Mod and press the picker's digit) lands on the cursor week's first day. In Week view every arrow key moves the cursor one week row; Day view moves one day. Enter opens the cursor week (or day). `Mod+Shift+,` / `Mod+Shift+.` and the header chevrons change the month and keep a focusable day in the new month, so arrows keep working. Clicking a day does nothing; hovering or focusing the picker shows a caption with the keys, and repeated clicks surface the keyboard hint.
+
+### Steps
+
+1. Navigate to `/week` with the sidebar open and press `I`.
+2. Press ArrowDown twice, then ArrowRight once.
+3. Press `Mod+Shift+.`.
+4. Press Enter.
+5. Click any day in the picker three or four times.
+
+### Expected Results
+
+- After `I`, the first day of the highlighted week row has focus and the whole row shows the focus ring.
+- Each arrow moves the ring one row; the calendar grid does not move yet.
+- After `Mod+Shift+.`, the next month is shown and focus is still on a day in that month.
+- Enter anchors the week view on the focused row and the accent capsule matches the visible window.
+- Clicks do not navigate. The caption under the grid reads `I focuses the picker · Arrows move by week · Enter opens it`; the keyboard hint says to press `I`, then use the arrow keys and Enter.
+
+---
+
 ## Scenario 13: The Mouse Is Permanently Inert
 
 ### UX

--- a/docs/development/feature-file-map.md
+++ b/docs/development/feature-file-map.md
@@ -130,6 +130,7 @@ The flow, its entry points, and the storage contract are documented in
 
 - Shared sidebar shell: `packages/web/src/components/Sidebar/Sidebar.tsx`
 - Month picker: `packages/web/src/components/Sidebar/MonthPicker/MonthPicker.tsx`
+  (week/day cursor math in `monthPickerCursor.ts` beside it)
 - Shared account sync-status + CTA labels: `packages/web/src/components/Sidebar/CalendarList/useAccountHeaderStatus.ts`
 - Account identity/sync indicator: `packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx`, `AccountSectionHeader.tsx`
 - Sidebar actions and shortcuts overlay: `packages/web/src/components/Sidebar/SidebarActions/SidebarActions.tsx`, `packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.tsx`

--- a/docs/frontend/contextual-pointer-guidance.md
+++ b/docs/frontend/contextual-pointer-guidance.md
@@ -14,7 +14,8 @@ of a generic legend. Acceptance coverage lives in
    Event open teaches the current jump token plus Enter, or `S` if no token is
    available. An empty timed-grid click teaches the matching HHMM digits
    (`1200`, `1830`) so the same create can be typed. An empty all-day-row
-   click teaches `Shift+C`.
+   click teaches `Shift+C`. The sidebar month picker (`calendar.date-pick`)
+   teaches `I`, then the arrow keys and Enter.
 4. A primary event click also dispatches `compass:pointer-event-jump` so the
    mounted grid's event-jump owner can assign tokens and activate leaderless
    sequences. Right-clicks stay on the generic fallback so `M` still opens

--- a/e2e/accessibility/datepicker-a11y.spec.ts
+++ b/e2e/accessibility/datepicker-a11y.spec.ts
@@ -140,23 +140,22 @@ const getRenderedContrast = (locator: Locator) =>
         current = current.parentElement;
       }
 
-      const inheritedBackground = ancestors
-        .reverse()
-        .map((ancestor) => parseRgb(getComputedStyle(ancestor).backgroundColor))
-        .reduce<Rgba>(
-          (background, foreground) => blend(foreground, background),
-          { a: 1, b: 255, g: 255, r: 255 },
-        );
-      const beforeStyle = getComputedStyle(element, "::before");
-
-      if (beforeStyle.content !== "none") {
-        return blend(
-          parseRgb(beforeStyle.backgroundColor),
-          inheritedBackground,
-        );
-      }
-
-      return inheritedBackground;
+      // Paint order from the outermost ancestor down. A `::before` pseudo
+      // element counts too: the picker draws its week capsules on the week
+      // row's `::before`, and the selected day's white text sits on that
+      // accent fill, not on the sidebar panel behind it.
+      return ancestors.reverse().reduce<Rgba>(
+        (background, ancestor) => {
+          const withOwn = blend(
+            parseRgb(getComputedStyle(ancestor).backgroundColor),
+            background,
+          );
+          const beforeStyle = getComputedStyle(ancestor, "::before");
+          if (beforeStyle.content === "none") return withOwn;
+          return blend(parseRgb(beforeStyle.backgroundColor), withOwn);
+        },
+        { a: 1, b: 255, g: 255, r: 255 },
+      );
     };
 
     const style = getComputedStyle(element);

--- a/e2e/accessibility/focus-visible.spec.ts
+++ b/e2e/accessibility/focus-visible.spec.ts
@@ -25,28 +25,33 @@ test("the 'i' shortcut moves focus to a visibly-focused sidebar day", async ({
   await expect(focused).toHaveClass(/react-datepicker__day/);
 
   // The landing element must actually paint a focus indicator, not just hold
-  // focus. The datepicker day uses an outline; other focus targets use a ring
-  // (box-shadow) — accept either so the assertion tracks "is it visible".
-  const indicator = await focused.evaluate((el) => {
+  // focus. In Week view the picker moves by week rows, so the outline sits on
+  // the focused day's week row; Day view outlines the day itself. Other focus
+  // targets use a ring (box-shadow) — accept any so the assertion tracks
+  // "is it visible".
+  const readIndicator = (el: Element) => {
     const s = getComputedStyle(el);
+    const row = el.closest(".react-datepicker__week");
+    const rowOutline = row ? getComputedStyle(row).outlineStyle : "none";
     return {
       matchesFocusVisible: el.matches(":focus-visible"),
-      outlineStyle: s.outlineStyle,
-      boxShadow: s.boxShadow,
+      painted:
+        s.outlineStyle !== "none" ||
+        s.boxShadow !== "none" ||
+        rowOutline !== "none",
     };
-  });
+  };
+  const indicator = await focused.evaluate(readIndicator);
   expect(indicator.matchesFocusVisible).toBe(true);
-  expect(
-    indicator.outlineStyle !== "none" || indicator.boxShadow !== "none",
-  ).toBe(true);
+  expect(indicator.painted).toBe(true);
 
-  // Arrow keys navigate dates from the landing spot, and the indicator
-  // follows focus to the newly selected day.
+  // Arrow keys move the cursor from the landing spot (one week row in Week
+  // view), and the indicator follows focus to the newly focused day.
+  const landedOn = await focused.getAttribute("aria-label");
   await page.keyboard.press("ArrowRight");
   const nextFocused = page.locator(".react-datepicker__day:focus");
   await expect(nextFocused).toBeVisible();
-  const stillVisible = await nextFocused.evaluate(
-    (el) => getComputedStyle(el).outlineStyle !== "none",
-  );
-  expect(stillVisible).toBe(true);
+  await expect(nextFocused).not.toHaveAttribute("aria-label", landedOn ?? "");
+  const stillVisible = await nextFocused.evaluate(readIndicator);
+  expect(stillVisible.painted).toBe(true);
 });

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -22,6 +22,7 @@
     "@tiptap/starter-kit": "^3.29.2",
     "bson": "^7.2.0",
     "classnames": "^2.3.1",
+    "date-fns": "^2.30.0",
     "dexie": "^4.2.1",
     "dompurify": "^3.4.13",
     "fast-deep-equal": "^3.1.3",

--- a/packages/web/src/components/DatePicker/DatePicker.tsx
+++ b/packages/web/src/components/DatePicker/DatePicker.tsx
@@ -28,10 +28,18 @@ export interface Props extends Omit<ReactDatePickerProps, "autoFocus"> {
   inputColor?: string;
   isOpen?: boolean;
   monthTextClassName?: string;
-  /** Sidebar-only: hover keycaps on the month chevrons. */
+  /**
+   * Sidebar-only: hover keycaps on the month chevrons, plus optional
+   * overrides so the owner can move its own cursor instead of letting
+   * react-datepicker step its internal month (MonthPicker remounts the grid
+   * on those jumps to keep a focusable day in the new month).
+   */
   monthNav?: {
     prevShortcut: readonly string[];
     nextShortcut: readonly string[];
+    onPrev?: () => void;
+    onNext?: () => void;
+    onToday?: () => void;
   };
   withUnderline?: boolean;
   view: "sidebar" | "grid";
@@ -205,9 +213,9 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
                     ariaLabel="Previous month"
                     color={headerColor}
                     isSidebarStyle={view === "sidebar"}
-                    onClick={() => {
-                      headerProps.decreaseMonth();
-                    }}
+                    onClick={
+                      monthNav?.onPrev ?? (() => headerProps.decreaseMonth())
+                    }
                     shortcut={monthNav ? [...monthNav.prevShortcut] : undefined}
                   >
                     <ChevronLeftIcon />
@@ -216,9 +224,9 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
                     ariaLabel="Next month"
                     color={headerColor}
                     isSidebarStyle={view === "sidebar"}
-                    onClick={() => {
-                      headerProps.increaseMonth();
-                    }}
+                    onClick={
+                      monthNav?.onNext ?? (() => headerProps.increaseMonth())
+                    }
                     shortcut={monthNav ? [...monthNav.nextShortcut] : undefined}
                   >
                     <ChevronRightIcon />
@@ -242,10 +250,13 @@ export const DatePicker: React.FC<Props> = (datePickerProps) => {
                           : undefined
                       }
                       style={{ color: headerColor }}
-                      onClick={() => {
-                        headerProps.changeMonth(dayjs().month());
-                        headerProps.changeYear(dayjs().year());
-                      }}
+                      onClick={
+                        monthNav?.onToday ??
+                        (() => {
+                          headerProps.changeMonth(dayjs().month());
+                          headerProps.changeYear(dayjs().year());
+                        })
+                      }
                     >
                       <CircleIcon />
                     </button>

--- a/packages/web/src/components/PointerHint/PointerHint.test.tsx
+++ b/packages/web/src/components/PointerHint/PointerHint.test.tsx
@@ -111,6 +111,20 @@ describe("PointerHint", () => {
     );
   });
 
+  it("teaches the focus key, arrows, and Enter for the month picker", () => {
+    render(<PointerHint />);
+
+    act(() => {
+      pointerConfusionActions.triggerHintForTests({
+        actionId: POINTER_ACTIONS.datePick,
+      });
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Press I to focus the calendar, then use the arrow keys and Enter to go to a date.",
+    );
+  });
+
   it("teaches Esc for the up-next dismiss target", () => {
     render(<PointerHint />);
 

--- a/packages/web/src/components/PointerHint/PointerHint.tsx
+++ b/packages/web/src/components/PointerHint/PointerHint.tsx
@@ -76,6 +76,15 @@ const pointerHintMessage = ({
     );
   }
 
+  if (attempt?.actionId === POINTER_ACTIONS.datePick) {
+    return (
+      <>
+        Press <Key>I</Key> to focus the calendar, then use the arrow keys and{" "}
+        <Key>Enter</Key> to go to a date.
+      </>
+    );
+  }
+
   if (attempt?.actionId === POINTER_ACTIONS.switchView) {
     return (
       <>

--- a/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.test.tsx
+++ b/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.test.tsx
@@ -18,8 +18,8 @@ import {
 import { MONTH_PICKER_IN_VIEW_CLASS } from "./monthPickerDayClassName";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
-const getSelectedDay = () =>
-  document.querySelector(".react-datepicker__day--selected");
+const getTabStopDay = () =>
+  document.querySelector<HTMLElement>('.react-datepicker__day[tabindex="0"]');
 
 const dayNamed = (label: string) => screen.getByLabelText(label);
 
@@ -60,25 +60,209 @@ afterEach(() => {
 });
 
 describe("MonthPicker", () => {
-  it("keeps the clicked date selected while navigation catches up", async () => {
+  it("ignores day clicks and marks the picker as a pointer-teaching target", async () => {
     const user = userEvent.setup({ skipHover: true });
     const onSelectDate = mock();
 
+    renderPicker(<MonthPicker onSelectDate={onSelectDate} {...pickerProps} />);
+
+    await user.click(dayNamed("Choose Monday, May 25th, 2026"));
+
+    expect(onSelectDate).not.toHaveBeenCalled();
+    expect(dayNamed("Choose Monday, May 25th, 2026")).not.toHaveFocus();
+    expect(
+      screen.getByRole("group", { name: "Date navigation" }),
+    ).toHaveAttribute("data-pointer-action", POINTER_ACTIONS.datePick);
+  });
+
+  it("moves a week at a time with every arrow key and opens the week with Enter", async () => {
+    const user = userEvent.setup({ skipHover: true });
+    const onSelectDate = mock();
+    renderPicker(<MonthPicker onSelectDate={onSelectDate} {...pickerProps} />);
+
+    const picker = screen.getByRole("group", { name: "Date navigation" });
+    expect(picker).toHaveAttribute("data-picker-unit", "week");
+
+    // The only tab stop is the start of the cursor week (Sunday-first view).
+    const tabStop = getTabStopDay();
+    expect(tabStop?.getAttribute("aria-label")).toBe(
+      "Choose Sunday, May 17th, 2026",
+    );
+    act(() => tabStop?.focus());
+
+    await user.keyboard("{ArrowDown}");
+    await waitFor(() => {
+      expect(dayNamed("Choose Sunday, May 24th, 2026")).toHaveFocus();
+    });
+    expect(
+      dayNamed("Choose Sunday, May 24th, 2026").closest(
+        ".react-datepicker__week",
+      ),
+    ).toHaveClass("react-datepicker__week--keyboard-selected");
+
+    await user.keyboard("{ArrowRight}");
+    await waitFor(() => {
+      expect(dayNamed("Choose Sunday, May 31st, 2026")).toHaveFocus();
+    });
+
+    await user.keyboard("{ArrowLeft}{ArrowUp}");
+    await waitFor(() => {
+      expect(dayNamed("Choose Sunday, May 17th, 2026")).toHaveFocus();
+    });
+
+    await user.keyboard("{ArrowDown}{Enter}");
+    expect(onSelectDate).toHaveBeenCalledTimes(1);
+    expect(onSelectDate.mock.calls[0]?.[0].format("YYYY-MM-DD")).toBe(
+      "2026-05-24",
+    );
+    expect(
+      dayNamed("Choose Sunday, May 24th, 2026").closest(
+        ".react-datepicker__week",
+      ),
+    ).toHaveClass("react-datepicker__week--selected");
+  });
+
+  it("anchors the cursor week on Monday when the view starts Monday", async () => {
+    const user = userEvent.setup({ skipHover: true });
+    const onSelectDate = mock();
     renderPicker(
       <MonthPicker
         onSelectDate={onSelectDate}
-        selectedDate={dayjs("2026-05-18")}
-        viewEnd={dayjs("2026-05-23")}
-        viewStart={dayjs("2026-05-17")}
+        selectedDate={dayjs("2026-05-13")}
+        viewEnd={dayjs("2026-05-17")}
+        viewStart={dayjs("2026-05-11")}
       />,
     );
 
-    await user.click(screen.getByLabelText("Choose Monday, May 25th, 2026"));
-
-    expect(onSelectDate).toHaveBeenCalledTimes(1);
-    expect(getSelectedDay()?.getAttribute("aria-label")).toBe(
-      "Choose Monday, May 25th, 2026",
+    const tabStop = getTabStopDay();
+    expect(tabStop?.getAttribute("aria-label")).toBe(
+      "Choose Monday, May 11th, 2026",
     );
+    act(() => tabStop?.focus());
+
+    await user.keyboard("{ArrowDown}{Enter}");
+    expect(onSelectDate.mock.calls[0]?.[0].format("YYYY-MM-DD")).toBe(
+      "2026-05-18",
+    );
+  });
+
+  it("steps by day for a single-day window", async () => {
+    const user = userEvent.setup({ skipHover: true });
+    const onSelectDate = mock();
+    renderPicker(
+      <MonthPicker
+        onSelectDate={onSelectDate}
+        selectedDate={dayjs("2026-05-13")}
+        viewEnd={dayjs("2026-05-13")}
+        viewStart={dayjs("2026-05-13")}
+      />,
+    );
+
+    expect(
+      screen.getByRole("group", { name: "Date navigation" }),
+    ).toHaveAttribute("data-picker-unit", "day");
+    const tabStop = getTabStopDay();
+    expect(tabStop?.getAttribute("aria-label")).toBe(
+      "Choose Wednesday, May 13th, 2026",
+    );
+    act(() => tabStop?.focus());
+
+    await user.keyboard("{ArrowRight}");
+    await waitFor(() => {
+      expect(dayNamed("Choose Thursday, May 14th, 2026")).toHaveFocus();
+    });
+
+    await user.keyboard("{Enter}");
+    expect(onSelectDate.mock.calls[0]?.[0].format("YYYY-MM-DD")).toBe(
+      "2026-05-14",
+    );
+  });
+
+  it("keeps focus on a day in the new month after a month chord", async () => {
+    renderPicker(<MonthPicker onSelectDate={mock()} {...pickerProps} />);
+
+    act(() => getTabStopDay()?.focus());
+    act(() => {
+      pressMonthChord(".");
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Jun 2026")).toBeInTheDocument();
+    });
+    const tabStop = getTabStopDay();
+    expect(tabStop?.getAttribute("aria-label")).toContain("June");
+    expect(tabStop).toHaveFocus();
+  });
+
+  it("leaves outside focus alone on a month chord but still provides a tab stop", async () => {
+    renderPicker(<MonthPicker onSelectDate={mock()} {...pickerProps} />);
+    expect(document.activeElement).toBe(document.body);
+
+    act(() => {
+      pressMonthChord(".");
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Jun 2026")).toBeInTheDocument();
+    });
+    expect(document.activeElement).toBe(document.body);
+    expect(getTabStopDay()?.getAttribute("aria-label")).toContain("June");
+  });
+
+  it("keeps focus on the chevron after a keyboard month change", async () => {
+    const user = userEvent.setup({ skipHover: true });
+    renderPicker(<MonthPicker onSelectDate={mock()} {...pickerProps} />);
+
+    const next = screen.getByRole("button", { name: "Next month" });
+    act(() => next.focus());
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(screen.getByText("Jun 2026")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: "Next month" })).toHaveFocus();
+    expect(getTabStopDay()?.getAttribute("aria-label")).toContain("June");
+  });
+
+  it("re-anchors the tab stop when chording back to the cursor's month after arrowing away", async () => {
+    const user = userEvent.setup({ skipHover: true });
+    renderPicker(<MonthPicker onSelectDate={mock()} {...pickerProps} />);
+
+    act(() => getTabStopDay()?.focus());
+    await user.keyboard("{ArrowDown}{ArrowDown}{ArrowDown}");
+    await waitFor(() => {
+      expect(screen.getByText("Jun 2026")).toBeInTheDocument();
+    });
+
+    act(() => {
+      pressMonthChord(",");
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("May 2026")).toBeInTheDocument();
+    });
+    const tabStop = getTabStopDay();
+    expect(tabStop?.getAttribute("aria-label")).toContain("May");
+    expect(tabStop).toHaveFocus();
+  });
+
+  it("teaches the focus key and the unit in its caption", () => {
+    const { rerender } = renderPicker(
+      <MonthPicker onSelectDate={mock()} {...pickerProps} />,
+    );
+    const picker = screen.getByRole("group", { name: "Date navigation" });
+    expect(picker.textContent).toContain("I");
+    expect(picker.textContent).toContain("Arrows move by week");
+
+    rerender(
+      <MonthPicker
+        onSelectDate={mock()}
+        selectedDate={dayjs("2026-05-13")}
+        viewEnd={dayjs("2026-05-13")}
+        viewStart={dayjs("2026-05-13")}
+      />,
+    );
+    expect(picker.textContent).toContain("Arrows move by day");
   });
 
   it("highlights the visible Sun-Sat window, not adjacent days", () => {
@@ -255,6 +439,20 @@ describe("MonthPicker", () => {
     expect(picker.textContent).not.toContain("Shift");
     expect(picker.textContent).not.toContain(",");
     expect(picker.textContent).not.toContain(".");
+  });
+
+  it("keeps the selected day bold across the whole cursor week", () => {
+    renderPicker(<MonthPicker onSelectDate={mock()} {...pickerProps} />);
+
+    expect(dayNamed("Choose Sunday, May 17th, 2026")).toHaveClass(
+      "!font-semibold",
+    );
+    expect(dayNamed("Choose Saturday, May 23rd, 2026")).toHaveClass(
+      "!font-semibold",
+    );
+    expect(dayNamed("Choose Sunday, May 24th, 2026")).toHaveClass(
+      "!font-light",
+    );
   });
 
   it("labels the today control with the t shortcut and pointer-teaching action", async () => {

--- a/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.tsx
+++ b/packages/web/src/components/Sidebar/MonthPicker/MonthPicker.tsx
@@ -1,10 +1,25 @@
-import { type FC, useEffect, useRef, useState } from "react";
+import {
+  type FC,
+  type MouseEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { TrialBadge } from "@web/billing/TrialBadge";
 import { ID_DATEPICKER_SIDEBAR } from "@web/common/constants/web.constants";
 import { DatePicker } from "@web/components/DatePicker/DatePicker";
+import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
+import { POINTER_ACTIONS } from "@web/shortcuts/keyboard-only/pointer-action";
 import { pageJumpAttrs } from "@web/shortcuts/page-jump/page-jump.targets";
+import {
+  type MonthPickerUnit,
+  normalizePickerCursor,
+  resolveMonthJumpCursor,
+} from "./monthPickerCursor";
 import { getMonthPickerDayClassName } from "./monthPickerDayClassName";
+import { monthPickerLocale } from "./monthPickerLocale";
 import {
   MONTH_PICKER_NEXT_KEYCAPS,
   MONTH_PICKER_PREV_KEYCAPS,
@@ -24,6 +39,18 @@ const monthPickerClassName =
 
 const headerActionsClassName = "!ml-2.5";
 
+const DAY_SELECTOR = ".react-datepicker__day";
+const TAB_STOP_DAY_SELECTOR = '.react-datepicker__day[tabindex="0"]';
+
+/** Day clicks are inert: the picker is keyboard driven and the confusion
+ * tracker turns repeated clicks into a hint (data-pointer-action below). */
+const swallowDayPointer = (event: MouseEvent<HTMLElement>) => {
+  const target = event.target;
+  if (!(target instanceof Element) || !target.closest(DAY_SELECTOR)) return;
+  event.preventDefault();
+  event.stopPropagation();
+};
+
 export const MonthPicker: FC<Props> = ({
   monthsShown,
   onSelectDate,
@@ -31,85 +58,164 @@ export const MonthPicker: FC<Props> = ({
   viewEnd,
   viewStart,
 }) => {
+  // A single-day window (Day view, or Week view squeezed to one column)
+  // steps by day with Sunday-first columns; anything wider is a week view
+  // and the cursor is a whole week row aligned to the view's start day.
+  const isSingleDayWindow = viewStart.isSame(viewEnd, "day");
+  const unit: MonthPickerUnit = isSingleDayWindow ? "day" : "week";
+  const weekStartDay = isSingleDayWindow ? 0 : viewStart.day();
+
   const selectedDateKey = selectedDate.format(
     dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT,
   );
-  const previousSelectedDateKeyRef = useRef(selectedDateKey);
-  const [focusedDate, setFocusedDate] = useState(() => selectedDate);
+  // The cursor is re-derived when the parent's date moves, and also when the
+  // window's start day changes (Shift+J/K can turn a Sunday-start window into
+  // a Monday-start one), because the week anchor depends on both.
+  const cursorSyncKey = `${selectedDateKey}|${unit}|${weekStartDay}`;
+  const previousCursorSyncKeyRef = useRef(cursorSyncKey);
+  const [focusedDate, setFocusedDate] = useState(() =>
+    normalizePickerCursor(selectedDate, unit, weekStartDay),
+  );
   const [displayedMonth, setDisplayedMonth] = useState(() =>
     selectedDate.startOf("month"),
   );
+  // Bumped on explicit month jumps so react-datepicker remounts with its
+  // internal cursor (the one tabindex=0 day) reset to `selected`. Arrow keys
+  // move that cursor themselves and never remount.
+  const [jumpGeneration, setJumpGeneration] = useState(0);
+  const fieldsetRef = useRef<HTMLFieldSetElement>(null);
+  const restoreFocusRef = useRef<{ buttonLabel: string | null } | null>(null);
+
+  const jumpToMonth = useCallback(
+    (targetMonth: Dayjs) => {
+      const active = document.activeElement;
+      const fieldset = fieldsetRef.current;
+      restoreFocusRef.current =
+        fieldset && active instanceof HTMLElement && fieldset.contains(active)
+          ? {
+              buttonLabel:
+                active.closest("button")?.getAttribute("aria-label") ?? null,
+            }
+          : null;
+
+      setDisplayedMonth(targetMonth.startOf("month"));
+      setFocusedDate((cursor) =>
+        resolveMonthJumpCursor({ cursor, targetMonth, unit, weekStartDay }),
+      );
+      setJumpGeneration((generation) => generation + 1);
+    },
+    [unit, weekStartDay],
+  );
 
   useMonthPickerShortcuts({
-    onPrevMonth: () => setDisplayedMonth((month) => month.subtract(1, "month")),
-    onNextMonth: () => setDisplayedMonth((month) => month.add(1, "month")),
+    onPrevMonth: () => jumpToMonth(displayedMonth.subtract(1, "month")),
+    onNextMonth: () => jumpToMonth(displayedMonth.add(1, "month")),
   });
 
+  // After a remount the previously focused element is gone. Put focus back on
+  // the same header button, or on the new month's tab-stop day, but only when
+  // the jump started inside the picker (chords fired from the grid stay put).
   useEffect(() => {
-    if (previousSelectedDateKeyRef.current === selectedDateKey) {
+    if (jumpGeneration === 0) return;
+    const restore = restoreFocusRef.current;
+    restoreFocusRef.current = null;
+    const fieldset = fieldsetRef.current;
+    if (!restore || !fieldset) return;
+
+    const target =
+      (restore.buttonLabel
+        ? fieldset.querySelector<HTMLElement>(
+            `button[aria-label="${restore.buttonLabel}"]`,
+          )
+        : null) ?? fieldset.querySelector<HTMLElement>(TAB_STOP_DAY_SELECTOR);
+    target?.focus({ preventScroll: true });
+  }, [jumpGeneration]);
+
+  useEffect(() => {
+    if (previousCursorSyncKeyRef.current === cursorSyncKey) {
       return;
     }
 
-    previousSelectedDateKeyRef.current = selectedDateKey;
+    previousCursorSyncKeyRef.current = cursorSyncKey;
     const nextDate = dayjs(
       selectedDateKey,
       dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT,
     );
-    setFocusedDate(nextDate);
+    setFocusedDate(normalizePickerCursor(nextDate, unit, weekStartDay));
     setDisplayedMonth(nextDate.startOf("month"));
-  }, [selectedDateKey]);
+  }, [cursorSyncKey, selectedDateKey, unit, weekStartDay]);
 
   const getDayClassName = (date: Date) =>
     getMonthPickerDayClassName({
       date: dayjs(date),
       selectedDate: focusedDate,
+      selectedEnd: unit === "week" ? focusedDate.add(6, "day") : focusedDate,
       viewEnd,
       viewStart,
     });
 
   return (
     <fieldset
+      ref={fieldsetRef}
       className={`c-month-picker ${monthPickerClassName}`}
       data-testid="Month picker"
+      data-picker-unit={unit}
+      data-pointer-action={POINTER_ACTIONS.datePick}
       aria-label="Date navigation"
+      onClickCapture={swallowDayPointer}
+      onMouseDownCapture={swallowDayPointer}
       {...pageJumpAttrs("month-picker")}
     >
-      <DatePicker
-        animationOnToggle={false}
-        calendarClassName={ID_DATEPICKER_SIDEBAR}
-        calendarStartDay={
-          viewStart.isSame(viewEnd, "day") ? 0 : viewStart.day()
-        }
-        dayClassName={getDayClassName}
-        headerActionsClassName={headerActionsClassName}
-        headerClassName="!relative !justify-start !px-0 !pb-3"
-        headerEndContent={<TrialBadge />}
-        inline
-        isOpen={true}
-        monthNav={{
-          prevShortcut: MONTH_PICKER_PREV_KEYCAPS,
-          nextShortcut: MONTH_PICKER_NEXT_KEYCAPS,
-        }}
-        monthTextClassName="text-[14px] font-medium"
-        monthsShown={monthsShown}
-        onChange={(date) => {
-          if (!date) return;
+      <div className="group relative">
+        <DatePicker
+          key={jumpGeneration}
+          animationOnToggle={false}
+          calendarClassName={ID_DATEPICKER_SIDEBAR}
+          calendarStartDay={weekStartDay}
+          dayClassName={getDayClassName}
+          headerActionsClassName={headerActionsClassName}
+          headerClassName="!relative !justify-start !px-0 !pb-3"
+          headerEndContent={<TrialBadge />}
+          inline
+          isOpen={true}
+          locale={monthPickerLocale(weekStartDay)}
+          monthNav={{
+            prevShortcut: MONTH_PICKER_PREV_KEYCAPS,
+            nextShortcut: MONTH_PICKER_NEXT_KEYCAPS,
+            onPrev: () => jumpToMonth(displayedMonth.subtract(1, "month")),
+            onNext: () => jumpToMonth(displayedMonth.add(1, "month")),
+            onToday: () => jumpToMonth(dayjs()),
+          }}
+          monthTextClassName="text-[14px] font-medium"
+          monthsShown={monthsShown}
+          onChange={(date) => {
+            if (!date) return;
 
-          const nextDate = dayjs(date);
+            const nextDate = normalizePickerCursor(
+              dayjs(date),
+              unit,
+              weekStartDay,
+            );
 
-          setFocusedDate(nextDate);
-          setDisplayedMonth(nextDate.startOf("month"));
-          onSelectDate(nextDate);
-        }}
-        onMonthChange={(date) => {
-          setDisplayedMonth(dayjs(date).startOf("month"));
-        }}
-        openToDate={displayedMonth.toDate()}
-        selected={focusedDate.toDate()}
-        shouldCloseOnSelect={false}
-        view="sidebar"
-        withTodayButton={true}
-      />
+            setFocusedDate(nextDate);
+            setDisplayedMonth(nextDate.startOf("month"));
+            onSelectDate(nextDate);
+          }}
+          onMonthChange={(date) => {
+            setDisplayedMonth(dayjs(date).startOf("month"));
+          }}
+          openToDate={displayedMonth.toDate()}
+          selected={focusedDate.toDate()}
+          shouldCloseOnSelect={false}
+          showWeekPicker={unit === "week"}
+          view="sidebar"
+          withTodayButton={true}
+        />
+        <span className="c-context-tooltip top-full bottom-auto left-1/2 mt-1.5 mb-0 flex -translate-x-1/2 items-center gap-1.5">
+          <ShortcutKeys keys="I" /> focuses the picker · Arrows move by {unit} ·
+          Enter opens it
+        </span>
+      </div>
     </fieldset>
   );
 };

--- a/packages/web/src/components/Sidebar/MonthPicker/monthPickerCursor.test.ts
+++ b/packages/web/src/components/Sidebar/MonthPicker/monthPickerCursor.test.ts
@@ -1,0 +1,71 @@
+import dayjs from "@core/util/date/dayjs";
+import {
+  normalizePickerCursor,
+  resolveMonthJumpCursor,
+  startOfPickerWeek,
+} from "./monthPickerCursor";
+import { describe, expect, it } from "bun:test";
+
+const fmt = (date: dayjs.Dayjs) => date.format("YYYY-MM-DD");
+
+describe("startOfPickerWeek", () => {
+  it("snaps to Sunday for a Sunday-start week", () => {
+    expect(fmt(startOfPickerWeek(dayjs("2026-05-20"), 0))).toBe("2026-05-17");
+    expect(fmt(startOfPickerWeek(dayjs("2026-05-17"), 0))).toBe("2026-05-17");
+  });
+
+  it("snaps to Monday for a Monday-start week, including Sundays", () => {
+    expect(fmt(startOfPickerWeek(dayjs("2026-05-20"), 1))).toBe("2026-05-18");
+    expect(fmt(startOfPickerWeek(dayjs("2026-05-17"), 1))).toBe("2026-05-11");
+  });
+});
+
+describe("normalizePickerCursor", () => {
+  it("leaves the day untouched in day mode", () => {
+    expect(fmt(normalizePickerCursor(dayjs("2026-05-20"), "day", 0))).toBe(
+      "2026-05-20",
+    );
+  });
+});
+
+describe("resolveMonthJumpCursor", () => {
+  it("keeps the day-of-month, clamped to the shorter month", () => {
+    expect(
+      fmt(
+        resolveMonthJumpCursor({
+          cursor: dayjs("2026-01-31"),
+          targetMonth: dayjs("2026-02-01"),
+          unit: "day",
+          weekStartDay: 0,
+        }),
+      ),
+    ).toBe("2026-02-28");
+  });
+
+  it("snaps to the week start in week mode", () => {
+    expect(
+      fmt(
+        resolveMonthJumpCursor({
+          cursor: dayjs("2026-05-20"),
+          targetMonth: dayjs("2026-06-01"),
+          unit: "week",
+          weekStartDay: 0,
+        }),
+      ),
+    ).toBe("2026-06-14");
+  });
+
+  it("advances a week whose start falls in the previous month", () => {
+    // June 1st 2026 is a Monday; its Sunday-start week begins May 31st.
+    expect(
+      fmt(
+        resolveMonthJumpCursor({
+          cursor: dayjs("2026-05-03"),
+          targetMonth: dayjs("2026-06-01"),
+          unit: "week",
+          weekStartDay: 0,
+        }),
+      ),
+    ).toBe("2026-06-07");
+  });
+});

--- a/packages/web/src/components/Sidebar/MonthPicker/monthPickerCursor.ts
+++ b/packages/web/src/components/Sidebar/MonthPicker/monthPickerCursor.ts
@@ -1,0 +1,48 @@
+import { type Dayjs } from "@core/util/date/dayjs";
+
+/**
+ * How the sidebar month picker's cursor moves. Week view steps whole week
+ * rows; Day view steps single days.
+ */
+export type MonthPickerUnit = "day" | "week";
+
+/** First day of the picker week that contains `date`, honoring the view's
+ * start-of-week (0 = Sunday, 1 = Monday, ...). */
+export const startOfPickerWeek = (date: Dayjs, weekStartDay: number): Dayjs =>
+  date.subtract((date.day() - weekStartDay + 7) % 7, "day").startOf("day");
+
+/** Normalize a cursor to the unit's anchor: the week start in week mode. */
+export const normalizePickerCursor = (
+  date: Dayjs,
+  unit: MonthPickerUnit,
+  weekStartDay: number,
+): Dayjs =>
+  unit === "week" ? startOfPickerWeek(date, weekStartDay) : date.startOf("day");
+
+/**
+ * Where the cursor lands after an explicit month jump (chevrons, month
+ * chords, the today button). Keeps the day-of-month, clamped to the target
+ * month's length, then snaps to the unit's anchor. In week mode the anchor
+ * must stay inside the target month: react-datepicker only shows the tab
+ * stop when the `selected` week start is rendered, and a week start in the
+ * previous month would leave the displayed month without one.
+ */
+export const resolveMonthJumpCursor = ({
+  cursor,
+  targetMonth,
+  unit,
+  weekStartDay,
+}: {
+  cursor: Dayjs;
+  targetMonth: Dayjs;
+  unit: MonthPickerUnit;
+  weekStartDay: number;
+}): Dayjs => {
+  const month = targetMonth.startOf("month");
+  const sameDay = month.date(Math.min(cursor.date(), month.daysInMonth()));
+  const anchored = normalizePickerCursor(sameDay, unit, weekStartDay);
+  if (unit === "week" && anchored.isBefore(month, "day")) {
+    return anchored.add(1, "week");
+  }
+  return anchored;
+};

--- a/packages/web/src/components/Sidebar/MonthPicker/monthPickerDayClassName.test.ts
+++ b/packages/web/src/components/Sidebar/MonthPicker/monthPickerDayClassName.test.ts
@@ -49,4 +49,19 @@ describe("getMonthPickerDayClassName", () => {
     expect(shifted).toContain(MONTH_PICKER_IN_VIEW_CLASS);
     expect(shifted).toContain("!font-semibold");
   });
+
+  it("bolds the whole cursor week when a week end is given", () => {
+    const weekClass = (date: string) =>
+      getMonthPickerDayClassName({
+        date: dayjs(date),
+        selectedDate: dayjs("2026-05-10"),
+        selectedEnd: dayjs("2026-05-16"),
+        viewEnd: dayjs("2026-05-16"),
+        viewStart: dayjs("2026-05-10"),
+      });
+
+    expect(weekClass("2026-05-10")).toContain("!font-semibold");
+    expect(weekClass("2026-05-16")).toContain("!font-semibold");
+    expect(weekClass("2026-05-17")).toContain("!font-light");
+  });
 });

--- a/packages/web/src/components/Sidebar/MonthPicker/monthPickerDayClassName.ts
+++ b/packages/web/src/components/Sidebar/MonthPicker/monthPickerDayClassName.ts
@@ -5,15 +5,18 @@ export const MONTH_PICKER_IN_VIEW_CLASS = "react-datepicker__day--in-view";
 export function getMonthPickerDayClassName({
   date,
   selectedDate,
+  selectedEnd = selectedDate,
   viewEnd,
   viewStart,
 }: {
   date: Dayjs;
   selectedDate: Dayjs;
+  /** Last day of the cursor unit (the week end in week mode). */
+  selectedEnd?: Dayjs;
   viewEnd: Dayjs;
   viewStart: Dayjs;
 }): string {
-  const isSelected = date.isSame(selectedDate, "day");
+  const isSelected = date.isBetween(selectedDate, selectedEnd, "day", "[]");
   const classes = [isSelected ? "!font-semibold" : "!font-light"];
 
   if (date.isBetween(viewStart, viewEnd, "day", "[]")) {

--- a/packages/web/src/components/Sidebar/MonthPicker/monthPickerLocale.ts
+++ b/packages/web/src/components/Sidebar/MonthPicker/monthPickerLocale.ts
@@ -1,0 +1,26 @@
+import { type Locale } from "date-fns";
+import { enUS } from "date-fns/locale";
+
+type WeekStartsOn = NonNullable<NonNullable<Locale["options"]>["weekStartsOn"]>;
+
+const localesByWeekStart = new Map<number, Locale>();
+
+/**
+ * react-datepicker 4.x passes `calendarStartDay` to its Month and Week
+ * components but not to Day, so in `showWeekPicker` mode each day decides
+ * "am I the start of my week" from the locale alone. A Monday-start view
+ * would otherwise normalize the cursor to Monday at the root while the days
+ * look for Sunday, and no day would be a tab stop. Handing the picker a
+ * locale whose `weekStartsOn` matches the view keeps both in agreement;
+ * formatting is unchanged because it is still en-US.
+ */
+export const monthPickerLocale = (weekStartDay: number): Locale => {
+  const cached = localesByWeekStart.get(weekStartDay);
+  if (cached) return cached;
+  const locale: Locale = {
+    ...enUS,
+    options: { ...enUS.options, weekStartsOn: weekStartDay as WeekStartsOn },
+  };
+  localesByWeekStart.set(weekStartDay, locale);
+  return locale;
+};

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -885,6 +885,14 @@
     outline-offset: 1px;
   }
 
+  /* Sidebar days are keyboard targets, not click targets: no hover affordance. */
+  &[data-view="sidebar"] .react-datepicker__day,
+  &[data-view="sidebar"] .react-datepicker__day:hover {
+    background-color: transparent;
+    color: inherit;
+    cursor: default;
+  }
+
   & .react-datepicker__day-names {
     display: flex;
     width: 100%;
@@ -1239,5 +1247,43 @@
     .react-datepicker__day {
     position: relative;
     z-index: 10;
+  }
+}
+
+/*
+ * Week mode: the cursor is a whole week row. react-datepicker's showWeekPicker
+ * marks every day in the week as selected, so the per-day circle above is
+ * replaced by one accent capsule on the row, and the focus ring wraps the
+ * row instead of its first day (the only tab stop).
+ */
+.c-month-picker[data-picker-unit="week"] .c-date-picker {
+  & .react-datepicker__day--selected::before {
+    content: none;
+  }
+  & .react-datepicker__day--selected,
+  & .react-datepicker__day--selected:hover {
+    color: var(--date-picker-selected-text);
+  }
+  & .react-datepicker__week--selected {
+    position: relative;
+  }
+  & .react-datepicker__week--selected::before {
+    position: absolute;
+    inset: 0 -3px;
+    border-radius: var(--radius-default);
+    background: var(--date-picker-selected-bg);
+    content: "";
+  }
+  & .react-datepicker__week--selected .react-datepicker__day {
+    position: relative;
+    z-index: 10;
+  }
+  & .react-datepicker__day:focus-visible {
+    outline: none;
+  }
+  & .react-datepicker__week:has(.react-datepicker__day:focus-visible) {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+    border-radius: var(--radius-default);
   }
 }

--- a/packages/web/src/shortcuts/keyboard-only/pointer-action.ts
+++ b/packages/web/src/shortcuts/keyboard-only/pointer-action.ts
@@ -27,6 +27,7 @@ export const POINTER_GRID_CREATE_REQUEST = "compass:pointer-grid-create";
 
 export const POINTER_ACTIONS = {
   eventOpen: "event.open",
+  datePick: "calendar.date-pick",
   goToToday: "calendar.today",
   switchView: "calendar.view",
   sidebarClose: "sidebar.close",

--- a/packages/web/src/shortcuts/shortcuts.menu.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.menu.test.ts
@@ -221,7 +221,7 @@ describe("shortcut menu sections", () => {
         }).find((section) => section.id === "focus");
 
       expect(stripMetadata(findFocus("day")?.shortcuts ?? [])).toEqual([
-        { keys: ["i"], label: "Focus sidebar" },
+        { keys: ["i"], label: "Focus month picker" },
         { keys: ["u"], label: "Focus calendar event" },
         { keys: ["h"], label: "Toggle event jump keys" },
         {
@@ -236,7 +236,7 @@ describe("shortcut menu sections", () => {
         },
       ]);
       expect(stripMetadata(findFocus("week")?.shortcuts ?? [])).toEqual([
-        { keys: ["i"], label: "Focus sidebar" },
+        { keys: ["i"], label: "Focus month picker" },
         { keys: ["u"], label: "Focus calendar event" },
         { keys: ["h"], label: "Toggle event jump keys" },
         {

--- a/packages/web/src/shortcuts/shortcuts.registry.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.test.ts
@@ -162,6 +162,26 @@ describe("shortcuts.registry", () => {
       expect(life).not.toContain("nav-month-next");
     });
 
+    it("lists the month picker step row with a per-view unit, not in life", () => {
+      const label = (view: "day" | "week") =>
+        filterShortcutsByContext({ view, isViewingCurrentPeriod: true }).find(
+          (shortcut) => shortcut.id === "nav-picker-step",
+        )?.label;
+
+      expect(label("week")).toBe(
+        "Move the month picker by a week (Enter opens it)",
+      );
+      expect(label("day")).toBe(
+        "Move the month picker by a day (Enter opens it)",
+      );
+
+      const life = filterShortcutsByContext({
+        view: "life",
+        isViewingCurrentPeriod: true,
+      }).map((shortcut) => shortcut.id);
+      expect(life).not.toContain("nav-picker-step");
+    });
+
     it("lists the page jump shortcut in day, week, and life", () => {
       for (const view of ["day", "week", "life"] as const) {
         const ids = filterShortcutsByContext({

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -97,6 +97,12 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
     section: "navigate",
   },
   {
+    id: "nav-picker-step",
+    keys: [...KEYMAP.moveFocus.keycaps],
+    label: "Move the month picker by a week (Enter opens it)",
+    section: "navigate",
+  },
+  {
     id: "nav-today",
     keys: ["t"],
     label: "Go to today",
@@ -187,7 +193,7 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
   {
     id: "focus-sidebar",
     keys: ["i"],
-    label: "Focus sidebar",
+    label: "Focus month picker",
     section: "focus",
   },
   {
@@ -482,6 +488,10 @@ interface FilterOptions {
 const LABEL_OVERRIDES: Record<string, (options: FilterOptions) => string> = {
   "nav-previous": ({ view }) => `Previous ${view}`,
   "nav-next": ({ view }) => `Next ${view}`,
+  "nav-picker-step": ({ view }) =>
+    view === "day"
+      ? "Move the month picker by a day (Enter opens it)"
+      : "Move the month picker by a week (Enter opens it)",
   "nav-today": ({ view, isViewingCurrentPeriod }) => {
     if (isViewingCurrentPeriod) return "Scroll to now";
     return view === "week" ? "Go to current week" : "Go to today";


### PR DESCRIPTION
Fixes #3403

## What and why

The sidebar month picker becomes a keyboard cursor. In Week view every arrow key moves one week row (react-datepicker's `showWeekPicker`) and Enter opens that week; Day view keeps per-day stepping. Month chords, the chevrons, and the today button now route through one `jumpToMonth` that moves the cursor into the new month, remounts the grid so a `tabindex="0"` day always exists, and restores focus to the same header button or the new month's tab-stop day. Previously those jumps only changed `openToDate`, so react-datepicker's internal cursor stayed in the old month and `i` / Mod+2 fell back to the chevron.

Day clicks are inert and teach: the fieldset carries a new `calendar.date-pick` pointer action (repeated clicks trigger the confusion-gated hint "Press I to focus the calendar, then use the arrow keys and Enter to go to a date") and a caption under the grid appears on hover or focus. In week mode the accent capsule paints the whole cursor row and the focus ring wraps the row. The legend relabels `i` to "Focus month picker" and adds a per-view row for the arrow stepping.

Library gap: react-datepicker 4.25 passes `calendarStartDay` to Month and Week but not to Day, so Monday-start views had no tab stop at all in week mode. The picker now receives an en-US locale clone whose `weekStartsOn` matches the view; `date-fns@^2.30` is added as a direct web dependency (same major react-datepicker already pins, so one installed copy).

Test-side: the contrast helper in `datepicker-a11y.spec.ts` now blends ancestor `::before` backgrounds. It previously ignored the row capsule under the white selected-week text and reported a 1.19:1 ratio that does not exist on screen.

## Verify

Local `bun run verify --strict` after rebase onto `main`:

```
Checks run: test:web, lint, knip
Failed: type-check, test:a11y, test:e2e
VERDICT: FAIL
```

Every local failure is environmental, and CI (Linux, one worker) is green on this PR: static, all unit legs, all four e2e shards.

- `type-check`: `Cannot find module 'ical.js' / 'fast-xml-parser' / 'jose'` in `packages/sync` files that arrived with the rebase; passes after `bun install` in the worktree.
- `test:a11y` (3) and `test:e2e` (9 of 10): every failing spec opens Settings with `Control+Comma`, which never opens Settings on macOS (documented in the repo's local e2e notes).
- `test:e2e` (1 of 10): `account-page-jump.spec.ts` "hold-Mod gives each calendar account its own jump key". The failure snapshot shows the Keyboard-shortcuts legend dialog already open when hold-Mod runs, which holds the app lock and suppresses hint chips. Unrelated to the picker; passes on CI.

Picker-specific checks that pass locally: `test:web` (171 targeted tests including Monday-start weeks and a chord after arrowing into another month), `type-check`, `lint`, `knip`, and the two picker Playwright specs alone with one worker (`focus-visible.spec.ts` with a real `i` keypress, `datepicker-a11y.spec.ts` per-day contrast). Browser check on the dev server confirmed the week capsule, caption, inert day click, and post-chord focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)