### PR TITLE
feat(sync): add Microsoft Graph change-notification adapter (WP-07)

### DIFF
--- a/.agents/handoffs/3247.md
+++ b/.agents/handoffs/3247.md
@@ -1,0 +1,35 @@
+# Handoff: #3247
+
+task_id: 3247
+status: verifying
+branch: cursor/agent-loop-outlook-provider-a7c5
+
+## Summary
+
+Implemented Microsoft Graph change-notification subscriptions via
+`MicrosoftNotificationAdapter` with injectable `MicrosoftSubscriptionsApi`.
+Extended `ProviderNotification` with an optional `lifecycle` field and routed
+lifecycle callbacks to `subscriptionMaintain` instead of incremental pulls.
+
+## Deliverables
+
+- `microsoft-notifications.adapter.ts`: watch, stopChannel, parseNotification
+- `microsoft-notifications.adapter.test.ts`: payload, TTL clamp, validation,
+  batch, lifecycle, tampered token, error mapping
+- `fixtures/microsoft/notifications.json`: contract corpus
+- `microsoft-contract.factory.ts`: `microsoftRecordedNotifications`
+- `microsoft.contract.test.ts`: notification contract cases
+- `provider-notifications.port.ts`: lifecycle + batch parse result
+- `notification.routes.ts`: batch expansion and lifecycle routing
+- `notification.routes.db.test.ts`: lifecycle enqueues subscriptionMaintain
+
+## Verify
+
+```
+bun test:sync
+bun run type-check
+bun lint
+bun knip
+```
+
+VERDICT: PASS

--- a/packages/sync/src/providers/__contract__/fixtures/microsoft/notifications.json
+++ b/packages/sync/src/providers/__contract__/fixtures/microsoft/notifications.json
@@ -1,0 +1,74 @@
+{
+  "watch": {
+    "id": "sub-1",
+    "resource": "/me/calendars/AAMkAGI2TG93AAA=/events",
+    "expirationDateTime": "2026-01-02T00:00:00.000Z"
+  },
+  "valid": {
+    "headers": {},
+    "body": {
+      "value": [
+        {
+          "subscriptionId": "chan-1",
+          "clientState": "chan-token",
+          "resource": "/me/calendars/AAMkAGI2TG93AAA=/events",
+          "changeType": "updated"
+        }
+      ]
+    },
+    "query": {}
+  },
+  "tampered": {
+    "headers": {},
+    "body": {
+      "value": [
+        {
+          "subscriptionId": "chan-1",
+          "clientState": "wrong-token",
+          "resource": "/me/calendars/AAMkAGI2TG93AAA=/events",
+          "changeType": "updated"
+        }
+      ]
+    },
+    "query": {}
+  },
+  "validation": {
+    "headers": {},
+    "body": {},
+    "query": { "validationToken": "echo-me" }
+  },
+  "batch": {
+    "headers": {},
+    "body": {
+      "value": [
+        {
+          "subscriptionId": "chan-1",
+          "clientState": "chan-token",
+          "resource": "/me/calendars/cal-a/events",
+          "changeType": "created"
+        },
+        {
+          "subscriptionId": "chan-2",
+          "clientState": "chan-token-2",
+          "resource": "/me/calendars/cal-b/events",
+          "changeType": "deleted"
+        }
+      ]
+    },
+    "query": {}
+  },
+  "lifecycle": {
+    "headers": {},
+    "body": {
+      "value": [
+        {
+          "subscriptionId": "chan-1",
+          "clientState": "chan-token",
+          "resource": "/me/calendars/AAMkAGI2TG93AAA=/events",
+          "lifecycleEvent": "reauthorizationRequired"
+        }
+      ]
+    },
+    "query": {}
+  }
+}

--- a/packages/sync/src/providers/__contract__/microsoft-contract.factory.ts
+++ b/packages/sync/src/providers/__contract__/microsoft-contract.factory.ts
@@ -9,6 +9,12 @@ import {
   type MicrosoftEventWriteApi,
   MicrosoftEventWriter,
 } from "@sync/providers/microsoft/microsoft-event-writer.adapter";
+import {
+  type GraphSubscription,
+  MicrosoftNotificationAdapter,
+  type MicrosoftSubscriptionCreateBody,
+  type MicrosoftSubscriptionsApi,
+} from "@sync/providers/microsoft/microsoft-notifications.adapter";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -36,6 +42,22 @@ interface WriterCorpus {
     readonly defaultOnlineMeetingProvider?: string;
     readonly allowedOnlineMeetingProviders?: readonly string[];
   };
+}
+
+interface NotificationsCorpus {
+  readonly watch: GraphSubscription;
+}
+
+class CorpusSubscriptionsApi implements MicrosoftSubscriptionsApi {
+  constructor(private readonly corpus: NotificationsCorpus) {}
+
+  async createSubscription(
+    _body: MicrosoftSubscriptionCreateBody,
+  ): Promise<GraphSubscription> {
+    return this.corpus.watch;
+  }
+
+  async deleteSubscription(_subscriptionId: string): Promise<void> {}
 }
 
 class CorpusEventListApi implements MicrosoftEventListApi {
@@ -177,4 +199,18 @@ export function microsoftRecordedWriter(
 ): MicrosoftEventWriter {
   const writer = loadJson<WriterCorpus>(corpusDir, "writer");
   return new MicrosoftEventWriter(() => new CorpusEventWriteApi(writer));
+}
+
+/** Replay `fixtures/microsoft/notifications.json` through the notification adapter. */
+export function microsoftRecordedNotifications(
+  corpusDir: string,
+): MicrosoftNotificationAdapter {
+  const notifications = loadJson<NotificationsCorpus>(
+    corpusDir,
+    "notifications",
+  );
+  return new MicrosoftNotificationAdapter(
+    () => new CorpusSubscriptionsApi(notifications),
+    () => new Date("2026-01-01T00:00:00Z"),
+  );
 }

--- a/packages/sync/src/providers/__contract__/microsoft.contract.test.ts
+++ b/packages/sync/src/providers/__contract__/microsoft.contract.test.ts
@@ -15,6 +15,7 @@ import refreshSuccessFixture from "@sync/providers/__contract__/fixtures/microso
 import {
   defaultMicrosoftReaderCorpus,
   microsoftReaderMasterCategories,
+  microsoftRecordedNotifications,
   microsoftRecordedReader,
   microsoftRecordedWriter,
 } from "@sync/providers/__contract__/microsoft-contract.factory";
@@ -33,6 +34,7 @@ import {
   type GraphEvent,
   normalizeMicrosoftEvent,
 } from "@sync/providers/microsoft/microsoft-event.normalizer";
+import { parseMicrosoftNotification } from "@sync/providers/microsoft/microsoft-notifications.adapter";
 import { ProviderAuthError } from "@sync/providers/provider-auth.port";
 import { ProviderEventError } from "@sync/providers/provider-event.port";
 import {
@@ -450,6 +452,89 @@ describe("microsoft writer contract", () => {
     });
     expect(instance).not.toBeNull();
     expect(instance?.providerEventId.length).toBeGreaterThan(0);
+  });
+});
+
+describe("microsoft notifications contract", () => {
+  const notifications = microsoftRecordedNotifications(
+    defaultCorpusDir("microsoft"),
+  );
+
+  it("watch returns a channel", async () => {
+    const channel = await notifications.watch({
+      accessToken: "contract-access-token",
+      calendarId: "AAMkAGI2TG93AAA=",
+      channelId: "chan-1",
+      token: "chan-token",
+      callbackUrl: "https://sync.example.com/sync/notifications/microsoft",
+    });
+    expect(channel.channelId).toBe("sub-1");
+    expect(channel.resourceId.length).toBeGreaterThan(0);
+    expect(channel.expiresAt).toBeInstanceOf(Date);
+  });
+
+  it("parseNotification accepts a valid callback, rejects tampered, and handles validation", () => {
+    const valid = notifications.parseNotification({
+      headers: {},
+      body: {
+        value: [
+          {
+            subscriptionId: "chan-1",
+            clientState: "chan-token",
+            resource: "/me/calendars/AAMkAGI2TG93AAA=/events",
+            changeType: "updated",
+          },
+        ],
+      },
+      query: {},
+    });
+    expect(valid).not.toBeNull();
+    if (valid && "kind" in valid && valid.kind === "validation") {
+      throw new Error(
+        "valid Microsoft callback must not be a validation handshake",
+      );
+    }
+    expect(valid && "channelId" in valid ? valid.channelId : null).toBe(
+      "chan-1",
+    );
+
+    const tampered = notifications.parseNotification({
+      headers: {},
+      body: { value: [{ resource: "/me/calendars/AAMkAGI2TG93AAA=/events" }] },
+      query: {},
+    });
+    expect(tampered).toBeNull();
+
+    const validation = notifications.parseNotification({
+      headers: {},
+      body: {},
+      query: { validationToken: "echo-me" },
+    });
+    expect(validation).toEqual({ kind: "validation", body: "echo-me" });
+  });
+
+  it("parses lifecycle notifications with a maintenance hint", () => {
+    const parsed = parseMicrosoftNotification({
+      headers: {},
+      body: {
+        value: [
+          {
+            subscriptionId: "chan-1",
+            clientState: "chan-token",
+            resource: "/me/calendars/AAMkAGI2TG93AAA=/events",
+            lifecycleEvent: "subscriptionRemoved",
+          },
+        ],
+      },
+      query: {},
+    });
+    expect(parsed).toEqual({
+      channelId: "chan-1",
+      resourceId: "/me/calendars/AAMkAGI2TG93AAA=/events",
+      token: "chan-token",
+      state: "changed",
+      lifecycle: "subscriptionRemoved",
+    });
   });
 });
 

--- a/packages/sync/src/providers/microsoft/microsoft-notifications.adapter.test.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-notifications.adapter.test.ts
@@ -1,0 +1,428 @@
+import { verifyNotification } from "@sync/notifications/notification-verification";
+import {
+  MicrosoftNotificationAdapter as Adapter,
+  type GraphSubscription,
+  type MicrosoftSubscriptionCreateBody,
+  type MicrosoftSubscriptionsApi,
+  parseMicrosoftNotification,
+} from "@sync/providers/microsoft/microsoft-notifications.adapter";
+import { type ProviderNotificationError } from "@sync/providers/provider-notifications.port";
+import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";
+
+const msError = (status: number, code?: string) =>
+  Object.assign(new Error(`microsoft error ${status}`), {
+    response: {
+      status,
+      data: code ? { error: { code, message: code } } : undefined,
+    },
+    config: { headers: { Authorization: "Bearer super-secret-token" } },
+  });
+
+type CreateBehavior = GraphSubscription | Error;
+type DeleteBehavior = Error | undefined;
+
+class FakeSubscriptionsApi implements MicrosoftSubscriptionsApi {
+  createCalls: MicrosoftSubscriptionCreateBody[] = [];
+  deleteCalls: string[] = [];
+
+  constructor(
+    private readonly behavior: {
+      create?: CreateBehavior;
+      delete?: DeleteBehavior;
+    } = {},
+  ) {}
+
+  async createSubscription(
+    body: MicrosoftSubscriptionCreateBody,
+  ): Promise<GraphSubscription> {
+    this.createCalls.push(body);
+    if (this.behavior.create instanceof Error) throw this.behavior.create;
+    return (
+      this.behavior.create ?? {
+        id: "sub-1",
+        resource: body.resource,
+        expirationDateTime: "2026-01-02T00:00:00.000Z",
+      }
+    );
+  }
+
+  async deleteSubscription(subscriptionId: string): Promise<void> {
+    this.deleteCalls.push(subscriptionId);
+    if (this.behavior.delete) throw this.behavior.delete;
+  }
+}
+
+const adapterWith = (
+  api: MicrosoftSubscriptionsApi,
+  now = () => new Date("2026-01-01T00:00:00Z"),
+) => {
+  const tokens: string[] = [];
+  const adapter = new Adapter((accessToken) => {
+    tokens.push(accessToken);
+    return api;
+  }, now);
+  return { adapter, tokens };
+};
+
+const watchInput = {
+  accessToken: "at",
+  calendarId: "AAMkAGI2TG93AAA=",
+  channelId: "chan-1",
+  token: "chan-token",
+  callbackUrl: "https://sync.example.com/sync/notifications/microsoft",
+};
+
+describe("MicrosoftNotificationAdapter watch/stop", () => {
+  it("opens a subscription with the Graph payload and returns provider expiry", async () => {
+    const api = new FakeSubscriptionsApi({
+      create: {
+        id: "sub-1",
+        resource: "/me/calendars/AAMkAGI2TG93AAA=/events",
+        expirationDateTime: "2026-01-02T00:00:00.000Z",
+      },
+    });
+    const { adapter, tokens } = adapterWith(api);
+
+    const channel = await adapter.watch(watchInput);
+
+    expect(tokens).toEqual(["at"]);
+    expect(api.createCalls[0]).toEqual({
+      changeType: "created,updated,deleted",
+      notificationUrl: "https://sync.example.com/sync/notifications/microsoft",
+      lifecycleNotificationUrl:
+        "https://sync.example.com/sync/notifications/microsoft",
+      resource: "/me/calendars/AAMkAGI2TG93AAA=/events",
+      clientState: "chan-token",
+      expirationDateTime: "2026-01-03T00:00:00.000Z",
+    });
+    expect(channel).toEqual({
+      channelId: "sub-1",
+      resourceId: "/me/calendars/AAMkAGI2TG93AAA=/events",
+      expiresAt: new Date("2026-01-02T00:00:00.000Z"),
+    });
+  });
+
+  it("clamps ttl to Graph's 4230 minute maximum", async () => {
+    const api = new FakeSubscriptionsApi();
+    const { adapter } = adapterWith(api);
+
+    await adapter.watch({
+      ...watchInput,
+      ttlMs: 5000 * 60 * 60 * 1000,
+    });
+
+    expect(api.createCalls[0]?.expirationDateTime).toBe(
+      "2026-01-03T22:30:00.000Z",
+    );
+  });
+
+  it("requests a caller-supplied ttl but lets the provider expiry win", async () => {
+    const api = new FakeSubscriptionsApi({
+      create: {
+        id: "sub-1",
+        resource: "/me/calendars/AAMkAGI2TG93AAA=/events",
+        expirationDateTime: "2026-01-01T12:00:00.000Z",
+      },
+    });
+    const { adapter } = adapterWith(api);
+
+    const channel = await adapter.watch({
+      ...watchInput,
+      ttlMs: 3600_000,
+    });
+
+    expect(api.createCalls[0]?.expirationDateTime).toBe(
+      "2026-01-01T01:00:00.000Z",
+    );
+    expect(channel.expiresAt).toEqual(new Date("2026-01-01T12:00:00.000Z"));
+  });
+
+  it("falls back to the requested expiry when the provider omits one", async () => {
+    const api = new FakeSubscriptionsApi({
+      create: {
+        id: "sub-1",
+        resource: "/me/calendars/AAMkAGI2TG93AAA=/events",
+        expirationDateTime: "",
+      },
+    });
+    const { adapter } = adapterWith(api);
+
+    const channel = await adapter.watch({
+      ...watchInput,
+      ttlMs: 3600_000,
+    });
+
+    expect(channel.expiresAt).toEqual(new Date("2026-01-01T01:00:00.000Z"));
+  });
+
+  it("refuses calendar-list watches as unsupported", async () => {
+    const api = new FakeSubscriptionsApi();
+    const { adapter } = adapterWith(api);
+
+    const error = (await adapter
+      .watch({
+        accessToken: "at",
+        channelId: "chan-list",
+        token: "chan-token",
+        callbackUrl: "https://sync.example.com/sync/notifications/microsoft",
+      })
+      .catch((e) => e)) as ProviderNotificationError;
+
+    expect(error.reason).toBe("watchUnsupported");
+    expect(api.createCalls).toHaveLength(0);
+  });
+
+  it("fails when the provider returns no subscription id", async () => {
+    const api = new FakeSubscriptionsApi({
+      create: {
+        id: "",
+        resource: "/me/calendars/AAMkAGI2TG93AAA=/events",
+        expirationDateTime: "2026-01-02T00:00:00.000Z",
+      },
+    });
+    const { adapter } = adapterWith(api);
+
+    const error = (await adapter
+      .watch(watchInput)
+      .catch((e) => e)) as ProviderNotificationError;
+
+    expect(error.reason).toBe("watchFailed");
+  });
+
+  it("classifies ExtensionError as watchUnsupported", async () => {
+    const api = new FakeSubscriptionsApi({
+      create: msError(400, "ExtensionError"),
+    });
+    const { adapter } = adapterWith(api);
+
+    const error = (await adapter
+      .watch(watchInput)
+      .catch((e) => e)) as ProviderNotificationError;
+
+    expect(error.reason).toBe("watchUnsupported");
+  });
+
+  it("classifies other 4xx responses as watchFailed", async () => {
+    const api = new FakeSubscriptionsApi({ create: msError(403, "Forbidden") });
+    const { adapter } = adapterWith(api);
+
+    const error = (await adapter
+      .watch(watchInput)
+      .catch((e) => e)) as ProviderNotificationError;
+
+    expect(error.reason).toBe("watchFailed");
+  });
+
+  it("classifies 429 and 5xx as transient", async () => {
+    for (const status of [429, 500, 503]) {
+      const api = new FakeSubscriptionsApi({ create: msError(status) });
+      const { adapter } = adapterWith(api);
+
+      const error = (await adapter
+        .watch(watchInput)
+        .catch((e) => e)) as ProviderNotificationError;
+
+      expect(error.reason).toBe("transient");
+    }
+  });
+
+  it("classifies a revoked credential and never leaks the bearer token", async () => {
+    const api = new FakeSubscriptionsApi({ create: msError(401) });
+    const { adapter } = adapterWith(api);
+
+    const error = (await adapter
+      .watch(watchInput)
+      .catch((e) => e)) as ProviderNotificationError;
+
+    expect(error.reason).toBe("authorizationRevoked");
+    expect(JSON.stringify(error.cause ?? {})).not.toContain(
+      "super-secret-token",
+    );
+  });
+
+  it("stops a subscription by id", async () => {
+    const api = new FakeSubscriptionsApi();
+    const { adapter } = adapterWith(api);
+
+    await adapter.stopChannel({
+      accessToken: "at",
+      channelId: "sub-1",
+      resourceId: "/me/calendars/AAMkAGI2TG93AAA=/events",
+    });
+
+    expect(api.deleteCalls).toEqual(["sub-1"]);
+  });
+
+  it("treats stopping an already-gone subscription as success", async () => {
+    const api = new FakeSubscriptionsApi({ delete: msError(404) });
+    const { adapter } = adapterWith(api);
+
+    await adapter.stopChannel({
+      accessToken: "at",
+      channelId: "sub-1",
+      resourceId: "/me/calendars/AAMkAGI2TG93AAA=/events",
+    });
+    expect(api.deleteCalls).toHaveLength(1);
+  });
+
+  it("surfaces an unexpected stop failure as transient", async () => {
+    const api = new FakeSubscriptionsApi({ delete: msError(500) });
+    const { adapter } = adapterWith(api);
+
+    const error = (await adapter
+      .stopChannel({
+        accessToken: "at",
+        channelId: "sub-1",
+        resourceId: "/me/calendars/AAMkAGI2TG93AAA=/events",
+      })
+      .catch((e) => e)) as ProviderNotificationError;
+
+    expect(error.reason).toBe("transient");
+  });
+});
+
+describe("parseMicrosoftNotification", () => {
+  it("normalizes a change callback from the Graph body", () => {
+    const notification = parseMicrosoftNotification({
+      headers: {},
+      body: {
+        value: [
+          {
+            subscriptionId: "chan-1",
+            clientState: "chan-token",
+            resource: "/me/calendars/AAMkAGI2TG93AAA=/events",
+            changeType: "updated",
+          },
+        ],
+      },
+      query: {},
+    });
+
+    expect(notification).toEqual({
+      channelId: "chan-1",
+      resourceId: "/me/calendars/AAMkAGI2TG93AAA=/events",
+      token: "chan-token",
+      state: "changed",
+    });
+  });
+
+  it("returns a batch when Graph sends two notifications", () => {
+    const parsed = parseMicrosoftNotification({
+      headers: {},
+      body: {
+        value: [
+          {
+            subscriptionId: "chan-1",
+            clientState: "chan-token",
+            resource: "/me/calendars/cal-a/events",
+            changeType: "created",
+          },
+          {
+            subscriptionId: "chan-2",
+            clientState: "chan-token-2",
+            resource: "/me/calendars/cal-b/events",
+            changeType: "deleted",
+          },
+        ],
+      },
+      query: {},
+    });
+
+    expect(parsed).toEqual({
+      kind: "batch",
+      notifications: [
+        {
+          channelId: "chan-1",
+          resourceId: "/me/calendars/cal-a/events",
+          token: "chan-token",
+          state: "changed",
+        },
+        {
+          channelId: "chan-2",
+          resourceId: "/me/calendars/cal-b/events",
+          token: "chan-token-2",
+          state: "changed",
+        },
+      ],
+    });
+  });
+
+  it("maps lifecycle notifications with a maintenance hint", () => {
+    const notification = parseMicrosoftNotification({
+      headers: {},
+      body: {
+        value: [
+          {
+            subscriptionId: "chan-1",
+            clientState: "chan-token",
+            resource: "/me/calendars/AAMkAGI2TG93AAA=/events",
+            lifecycleEvent: "reauthorizationRequired",
+          },
+        ],
+      },
+      query: {},
+    });
+
+    expect(notification).toEqual({
+      channelId: "chan-1",
+      resourceId: "/me/calendars/AAMkAGI2TG93AAA=/events",
+      token: "chan-token",
+      state: "changed",
+      lifecycle: "reauthorizationRequired",
+    });
+  });
+
+  it("returns the validation handshake from validationToken query param", () => {
+    const parsed = parseMicrosoftNotification({
+      headers: {},
+      body: {},
+      query: { validationToken: "echo-me" },
+    });
+
+    expect(parsed).toEqual({ kind: "validation", body: "echo-me" });
+  });
+
+  it("rejects a tampered clientState downstream in verifyNotification", () => {
+    const notification = parseMicrosoftNotification({
+      headers: {},
+      body: {
+        value: [
+          {
+            subscriptionId: "chan-1",
+            clientState: "wrong-token",
+            resource: "/me/calendars/AAMkAGI2TG93AAA=/events",
+            changeType: "updated",
+          },
+        ],
+      },
+      query: {},
+    });
+
+    expect(notification).not.toBeNull();
+    if (!notification || !("channelId" in notification)) {
+      throw new Error("expected a single notification");
+    }
+
+    const resource = {
+      subscriptionId: "chan-1",
+      subscriptionResourceId: "/me/calendars/AAMkAGI2TG93AAA=/events",
+      subscriptionToken: "chan-token",
+      subscriptionExpiresAt: new Date("2026-02-01T00:00:00.000Z"),
+    } as SyncResourceRecord;
+
+    expect(verifyNotification(notification, resource).status).toBe("rejected");
+  });
+
+  it("returns null when the body is not recognizable", () => {
+    expect(
+      parseMicrosoftNotification({ headers: {}, body: {}, query: {} }),
+    ).toBeNull();
+    expect(
+      parseMicrosoftNotification({
+        headers: {},
+        body: { value: [{ resource: "only-resource" }] },
+        query: {},
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/sync/src/providers/microsoft/microsoft-notifications.adapter.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-notifications.adapter.ts
@@ -1,0 +1,329 @@
+import {
+  isMicrosoftTransient,
+  microsoftErrorCode,
+  microsoftFailureCause,
+  microsoftStatus,
+} from "@sync/providers/microsoft/microsoft-error";
+import {
+  MICROSOFT_GRAPH_BASE_URL,
+  MICROSOFT_REQUEST_TIMEOUT_MS,
+} from "@sync/providers/microsoft/microsoft-http.constants";
+import {
+  type NotificationChannel,
+  type NotificationParseResult,
+  type NotificationRequest,
+  type ProviderNotification,
+  type ProviderNotificationAdapter,
+  ProviderNotificationError,
+  type ProviderNotificationLifecycle,
+} from "@sync/providers/provider-notifications.port";
+
+export interface GraphSubscription {
+  readonly id: string;
+  readonly resource: string;
+  readonly expirationDateTime: string;
+}
+
+export interface MicrosoftSubscriptionCreateBody {
+  readonly changeType: string;
+  readonly notificationUrl: string;
+  readonly lifecycleNotificationUrl: string;
+  readonly resource: string;
+  readonly expirationDateTime: string;
+  readonly clientState: string;
+}
+
+export interface MicrosoftSubscriptionsApi {
+  createSubscription(
+    body: MicrosoftSubscriptionCreateBody,
+  ): Promise<GraphSubscription>;
+  deleteSubscription(subscriptionId: string): Promise<void>;
+}
+
+export type MicrosoftSubscriptionsApiFactory = (
+  accessToken: string,
+) => MicrosoftSubscriptionsApi;
+
+const DEFAULT_TTL_MS = 48 * 60 * 60 * 1000;
+const MAX_TTL_MS = 4230 * 60 * 1000;
+
+const defaultApiFactory: MicrosoftSubscriptionsApiFactory = (accessToken) =>
+  new FetchMicrosoftSubscriptionsApi(accessToken);
+
+export class MicrosoftNotificationAdapter
+  implements ProviderNotificationAdapter
+{
+  #makeApi: MicrosoftSubscriptionsApiFactory;
+  #now: () => Date;
+
+  constructor(
+    makeApi: MicrosoftSubscriptionsApiFactory = defaultApiFactory,
+    now: () => Date = () => new Date(),
+  ) {
+    this.#makeApi = makeApi;
+    this.#now = now;
+  }
+
+  async watch(input: {
+    accessToken: string;
+    calendarId?: string;
+    channelId: string;
+    token: string;
+    callbackUrl: string;
+    ttlMs?: number;
+  }): Promise<NotificationChannel> {
+    if (input.calendarId === undefined) {
+      throw new ProviderNotificationError(
+        "watchUnsupported",
+        "Microsoft Graph does not support watching calendar list changes",
+      );
+    }
+
+    const api = this.#makeApi(input.accessToken);
+    const expirationDateTime = this.#expirationIso(input.ttlMs);
+    const resource = `/me/calendars/${input.calendarId}/events`;
+
+    let subscription: GraphSubscription;
+    try {
+      subscription = await api.createSubscription({
+        changeType: "created,updated,deleted",
+        notificationUrl: input.callbackUrl,
+        lifecycleNotificationUrl: input.callbackUrl,
+        resource,
+        expirationDateTime,
+        clientState: input.token,
+      });
+    } catch (error) {
+      throw classifyWatchError(error);
+    }
+
+    if (!subscription.id || !subscription.resource) {
+      throw new ProviderNotificationError(
+        "watchFailed",
+        "Microsoft returned a subscription without an id or resource",
+      );
+    }
+
+    return {
+      channelId: subscription.id,
+      resourceId: subscription.resource,
+      expiresAt: parseExpiration(
+        subscription.expirationDateTime,
+        expirationDateTime,
+      ),
+    };
+  }
+
+  async stopChannel(input: {
+    accessToken: string;
+    channelId: string;
+    resourceId: string;
+  }): Promise<void> {
+    void input.resourceId;
+    const api = this.#makeApi(input.accessToken);
+    try {
+      await api.deleteSubscription(input.channelId);
+    } catch (error) {
+      const status = microsoftStatus(error);
+      if (status === 404) return;
+      throw classifyWatchError(error);
+    }
+  }
+
+  parseNotification(request: NotificationRequest): NotificationParseResult {
+    return parseMicrosoftNotification(request);
+  }
+
+  #expirationIso(ttlMs?: number): string {
+    const ttl = Math.min(ttlMs ?? DEFAULT_TTL_MS, MAX_TTL_MS);
+    return new Date(this.#now().getTime() + ttl).toISOString();
+  }
+}
+
+class FetchMicrosoftSubscriptionsApi implements MicrosoftSubscriptionsApi {
+  constructor(private readonly accessToken: string) {}
+
+  async createSubscription(
+    body: MicrosoftSubscriptionCreateBody,
+  ): Promise<GraphSubscription> {
+    const response = await fetch(`${MICROSOFT_GRAPH_BASE_URL}/subscriptions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(MICROSOFT_REQUEST_TIMEOUT_MS),
+    });
+
+    const data = (await response.json()) as GraphSubscription & {
+      error?: { code?: string; message?: string };
+    };
+
+    if (!response.ok) {
+      throw Object.assign(
+        new Error(
+          data.error?.message ?? "microsoft_subscription_create_failed",
+        ),
+        { response: { status: response.status, data } },
+      );
+    }
+
+    return data;
+  }
+
+  async deleteSubscription(subscriptionId: string): Promise<void> {
+    const response = await fetch(
+      `${MICROSOFT_GRAPH_BASE_URL}/subscriptions/${encodeURIComponent(subscriptionId)}`,
+      {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${this.accessToken}` },
+        signal: AbortSignal.timeout(MICROSOFT_REQUEST_TIMEOUT_MS),
+      },
+    );
+
+    if (response.ok) return;
+
+    const data = (await response.json().catch(() => ({}))) as {
+      error?: { code?: string; message?: string };
+    };
+    throw Object.assign(
+      new Error(data.error?.message ?? "microsoft_subscription_delete_failed"),
+      { response: { status: response.status, data } },
+    );
+  }
+}
+
+interface GraphNotificationItem {
+  readonly subscriptionId?: string;
+  readonly clientState?: string;
+  readonly resource?: string;
+  readonly changeType?: string;
+  readonly lifecycleEvent?: string;
+}
+
+export function parseMicrosoftNotification(
+  request: NotificationRequest,
+): NotificationParseResult {
+  const validationToken = readValidationToken(request.query);
+  if (validationToken !== null) {
+    return { kind: "validation", body: validationToken };
+  }
+
+  const items = readNotificationItems(request.body);
+  if (items.length === 0) return null;
+
+  const notifications = items
+    .map(mapGraphNotificationItem)
+    .filter((item): item is ProviderNotification => item !== null);
+
+  if (notifications.length === 0) return null;
+  if (notifications.length === 1) return notifications[0]!;
+  return { kind: "batch", notifications };
+}
+
+function readValidationToken(query: Record<string, unknown>): string | null {
+  const token = query["validationToken"];
+  if (typeof token !== "string" || token.length === 0) return null;
+  return token;
+}
+
+function readNotificationItems(body: unknown): GraphNotificationItem[] {
+  if (typeof body !== "object" || body === null) return [];
+  const value = (body as { value?: unknown }).value;
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (item): item is GraphNotificationItem =>
+      typeof item === "object" && item !== null,
+  );
+}
+
+function mapGraphNotificationItem(
+  item: GraphNotificationItem,
+): ProviderNotification | null {
+  const channelId = item.subscriptionId;
+  const resourceId = item.resource;
+  if (!channelId || !resourceId) return null;
+
+  const lifecycle = mapLifecycleEvent(item.lifecycleEvent);
+  return {
+    channelId,
+    resourceId,
+    token: item.clientState ?? null,
+    state: "changed",
+    ...(lifecycle ? { lifecycle } : {}),
+  };
+}
+
+function mapLifecycleEvent(
+  lifecycleEvent: string | undefined,
+): ProviderNotificationLifecycle | undefined {
+  if (lifecycleEvent === "reauthorizationRequired") {
+    return "reauthorizationRequired";
+  }
+  if (lifecycleEvent === "subscriptionRemoved") return "subscriptionRemoved";
+  if (lifecycleEvent === "missed") return "missed";
+  return undefined;
+}
+
+function parseExpiration(
+  expirationDateTime: string | null | undefined,
+  fallbackIso: string,
+): Date {
+  if (!expirationDateTime) return new Date(fallbackIso);
+  const parsed = Date.parse(expirationDateTime);
+  return Number.isFinite(parsed) ? new Date(parsed) : new Date(fallbackIso);
+}
+
+function classifyWatchError(error: unknown): ProviderNotificationError {
+  if (error instanceof ProviderNotificationError) return error;
+
+  const cause = microsoftFailureCause(error);
+  const status = microsoftStatus(error);
+  const code = microsoftErrorCode(error);
+  const detail = cause?.message;
+
+  if (status === 401) {
+    return new ProviderNotificationError(
+      "authorizationRevoked",
+      detail ?? "Microsoft rejected the credential",
+      { cause },
+    );
+  }
+  if (isWatchUnsupported(error, status, code)) {
+    return new ProviderNotificationError(
+      "watchUnsupported",
+      detail ?? "Microsoft does not support watching this resource",
+      { cause },
+    );
+  }
+  if (isMicrosoftTransient(error, status)) {
+    return new ProviderNotificationError(
+      "transient",
+      detail
+        ? `Microsoft watch temporarily unavailable (${detail})`
+        : "Microsoft watch temporarily unavailable",
+      { cause },
+    );
+  }
+  return new ProviderNotificationError(
+    "watchFailed",
+    detail
+      ? `Microsoft refused to open the channel (${detail})`
+      : "Microsoft refused to open the channel",
+    { cause },
+  );
+}
+
+function isWatchUnsupported(
+  error: unknown,
+  status: number | undefined,
+  code: string | undefined,
+): boolean {
+  if (status !== 400) return false;
+  if (code === "ExtensionError") return true;
+  const data = (
+    error as { response?: { data?: { error?: { code?: string } } } }
+  )?.response?.data?.error?.code;
+  return data === "ExtensionError";
+}

--- a/packages/sync/src/providers/provider-notifications.port.ts
+++ b/packages/sync/src/providers/provider-notifications.port.ts
@@ -17,17 +17,28 @@ export interface NotificationChannel {
 // the caller should act on.
 export type NotificationState = "initialSync" | "changed";
 
+export type ProviderNotificationLifecycle =
+  | "reauthorizationRequired"
+  | "subscriptionRemoved"
+  | "missed";
+
 export interface ProviderNotification {
   readonly channelId: string;
   readonly resourceId: string;
   // The secret the provider echoes back; compared to the stored token.
   readonly token: string | null;
   readonly state: NotificationState;
+  // Graph lifecycle callbacks enqueue subscription maintenance instead of a pull.
+  readonly lifecycle?: ProviderNotificationLifecycle;
 }
 
 export type NotificationParseResult =
   | ProviderNotification
   | { readonly kind: "validation"; readonly body: string }
+  | {
+      readonly kind: "batch";
+      readonly notifications: readonly ProviderNotification[];
+    }
   | null;
 
 export interface NotificationRequest {

--- a/packages/sync/src/server/notification.routes.db.test.ts
+++ b/packages/sync/src/server/notification.routes.db.test.ts
@@ -9,6 +9,7 @@ import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { createSyncService, type SyncService } from "@sync/app";
 import { type SyncConfig } from "@sync/config/sync.config";
 import { parseGoogleNotification } from "@sync/providers/google/google-notifications.adapter";
+import { parseMicrosoftNotification } from "@sync/providers/microsoft/microsoft-notifications.adapter";
 import { type ProviderNotificationAdapter } from "@sync/providers/provider-notifications.port";
 import {
   buildProviderRegistry,
@@ -440,5 +441,36 @@ describe("POST /sync/notifications/google", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/plain");
     expect(await res.text()).toBe("validation-token");
+  });
+
+  it("enqueues subscriptionMaintain for a lifecycle notification", async () => {
+    const { _id: resourceId } = await seedSubscription();
+    const lifecycleAdapter: ProviderNotificationAdapter = {
+      watch: async () => {
+        throw new Error("unused in route test");
+      },
+      stopChannel: async () => {},
+      parseNotification: (request) => parseMicrosoftNotification(request),
+    };
+    await startService(testConfig(), registryWithMicrosoft(lifecycleAdapter));
+
+    const res = await fetch(`${base}/sync/notifications/microsoft`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        value: [
+          {
+            subscriptionId: CHANNEL,
+            clientState: TOKEN,
+            resource: RESOURCE,
+            lifecycleEvent: "reauthorizationRequired",
+          },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await jobCount(`subscriptionMaintain:${resourceId}`)).toBe(1);
+    expect(await jobCount(`incrementalPull:${resourceId}`)).toBe(0);
   });
 });

--- a/packages/sync/src/server/notification.routes.ts
+++ b/packages/sync/src/server/notification.routes.ts
@@ -74,12 +74,20 @@ export function registerNotificationRoutes(
         res.status(Status.OK).type("text/plain").send(parsed.body);
         return;
       }
-      if (!("channelId" in parsed)) {
+
+      const notifications = expandNotifications(parsed);
+      if (notifications.length === 0) {
         res.status(Status.BAD_REQUEST).end();
         return;
       }
 
-      await processNotification(deps, parsed, res);
+      for (const notification of notifications) {
+        const ok = await processNotification(deps, notification, res);
+        if (!ok) return;
+      }
+      if (!res.headersSent) {
+        res.status(Status.OK).end();
+      }
     };
 
   app.post(
@@ -108,15 +116,25 @@ function isValidationHandshake(
   );
 }
 
+function expandNotifications(
+  parsed: NotificationParseResult,
+): readonly ProviderNotification[] {
+  if (parsed === null) return [];
+  if ("kind" in parsed) {
+    if (parsed.kind === "validation") return [];
+    return parsed.notifications;
+  }
+  return [parsed];
+}
+
 async function processNotification(
   deps: NotificationApiDeps,
   notification: ProviderNotification,
   res: Response,
-): Promise<void> {
+): Promise<boolean> {
   // A passive service has no subscriptions to match; accept and drop.
   if (deps.execution === "passive" || !deps.mongo.isConnected) {
-    res.status(Status.OK).end();
-    return;
+    return true;
   }
 
   try {
@@ -134,31 +152,38 @@ async function processNotification(
     }
 
     if (verdict.status === "process" && resource) {
-      if (resource.resourceKind === "calendarList") {
-        await resources.clearSyncCursor(
+      if (notification.lifecycle) {
+        await new JobRepository(deps.mongo.db).enqueue(
+          resourceJob(resource, "subscriptionMaintain", now),
+        );
+      } else {
+        if (resource.resourceKind === "calendarList") {
+          await resources.clearSyncCursor(
+            resource.tenantId,
+            resource.principalId,
+            resource._id,
+          );
+        }
+        await resources.markChangeNotified(
           resource.tenantId,
           resource.principalId,
           resource._id,
+          now,
         );
+        const job =
+          resource.resourceKind === "calendarList"
+            ? calendarListSyncJob(resource, now)
+            : resourceJob(resource, "incrementalPull", now);
+        await new JobRepository(deps.mongo.db).enqueue(job);
       }
-      await resources.markChangeNotified(
-        resource.tenantId,
-        resource.principalId,
-        resource._id,
-        now,
-      );
-      const job =
-        resource.resourceKind === "calendarList"
-          ? calendarListSyncJob(resource, now)
-          : resourceJob(resource, "incrementalPull", now);
-      await new JobRepository(deps.mongo.db).enqueue(job);
     }
-    res.status(Status.OK).end();
+    return true;
   } catch (error) {
     logger.error(
       `Failed to process notification for channel ${notification.channelId}`,
       redactedCause(error),
     );
     res.status(Status.INTERNAL_SERVER).end();
+    return false;
   }
 }


### PR DESCRIPTION
Fixes #3247

## What and why

Implements `ProviderNotificationAdapter` for Microsoft Graph subscriptions (WP-07). The adapter creates and deletes `/subscriptions` for calendar event changes, parses validation handshakes and change/lifecycle payloads, and classifies Graph errors into the shared notification error reasons. Lifecycle notifications route to `subscriptionMaintain` instead of incremental pulls; batch payloads are expanded in the notification route.

Spec: `docs/features/calendar-providers.md`

## Verify

```
bun test:sync
bun run type-check
bun lint
bun knip
```

VERDICT: PASS