### PR TITLE
test(e2e): wait for the slot picker before public booking tests start

### DIFF
--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -574,6 +574,21 @@ export async function preparePublicBookingPage(
   await expect(
     page.getByRole("heading", { name: "Book with Tyler Dane" }),
   ).toBeVisible({ timeout: 15000 });
+  // The h1 renders before the slots request settles, and while slots are
+  // pending the picker shows a skeleton without the "Pick a time" heading.
+  // A test that starts typing right away (Tab to the skip link, Enter) would
+  // race that request: the skip link finds no target and focus goes nowhere.
+  // Wait for the picker itself unless the test is deliberately observing the
+  // pending, failed, or unavailable state.
+  if (
+    options.bookable !== false &&
+    !options.slotFailGate &&
+    !options.holdFirstSlots
+  ) {
+    await expect(
+      page.getByRole("heading", { name: "Pick a time" }),
+    ).toBeVisible();
+  }
 
   return captured;
 }


### PR DESCRIPTION
Fixes: no issue. Third fix from the CI audit (#3407, #3408).

## What and why

`preparePublicBookingPage` returned as soon as the "Book with Tyler Dane" h1 was visible, while the stubbed slots request was often still pending. While slots are pending the picker renders a skeleton and the "Pick a time" heading does not exist yet. A test that starts typing right away raced that: "walks the picker with the keyboard via the skip link" pressed Tab, Enter on the skip link before the heading was mounted, the skip link's click handler found no target and returned without `preventDefault`, and focus went nowhere. The heading then mounted unfocused and `toBeFocused()` timed out.

In the audit's scan of 705 CI shard-job logs from the newest 200 e2e runs, this test was 5 of the 8 passes that needed a Playwright retry, on 5 different branches. No other test recurred.

The harness now waits for the "Pick a time" heading, which two web unit tests pin as rendering only once slots have loaded, unless the caller passed `slotFailGate`, `holdFirstSlots`, or `bookable: false` and is deliberately observing the pending, failed, or unavailable state. No test file changes; the flaky test's assertions are untouched and now start from a settled page.

Product note, not changed here: a keyboard user who activates "Skip to open times" while slots are still loading gets nothing. That behavior is deliberate and tested on the web side, so it is recorded in `docs/CI-CD/ci-audit-2026-09.md` under "Looked at, not changed" rather than altered in a CI PR.

## Verify

```
Selected packages: web
Checks run: test:web, type-check, lint, knip
Checks skipped: (none)
Failed: test:a11y, test:e2e
VERDICT: FAIL
```

All 10 local e2e failures are the known macOS false failures: 9 wait on `getByRole('dialog', { name: 'Settings' })`, which the Settings shortcut never opens on Mac (`booking-a11y` settings section x3, `host-settings` x5, `public-booking-v15` settings discard), and `account-page-jump` holds Mod as Control per its own comment, which is Meta on macOS. The same 10 failed identically on an unmodified checkout earlier today. The other 121 e2e tests passed locally, including the formerly flaky skip-link walk and every other test that uses the changed harness (`public-booking`, `public-booking-v15`, `booking-a11y` public sections). Web unit tests (817), type-check, lint, and knip pass. CI on Linux is the arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)