### PR TITLE
ci(agent-loop): allow auth and telemetry paths for the identity and closeout milestones

### DIFF
--- a/.github/agent-loop/allowlists/providers-c.txt
+++ b/.github/agent-loop/allowlists/providers-c.txt
@@ -2,3 +2,8 @@
 # One extended-regex per line. Comments and blank lines are ignored.
 ^packages/sync/src/providers/
 ^packages/sync/src/providers/__contract__/
+^packages/backend/src/auth/
+^packages/web/src/auth/
+^packages/web/src/api/auth\.api\.ts$
+^packages/web/src/supertokens\.ts$
+^packages/sync/src/telemetry/

--- a/.github/agent-loop/allowlists/providers-i.txt
+++ b/.github/agent-loop/allowlists/providers-i.txt
@@ -2,3 +2,7 @@
 # One extended-regex per line. Comments and blank lines are ignored.
 ^packages/sync/src/providers/
 ^packages/sync/src/providers/__contract__/
+^packages/backend/src/auth/
+^packages/web/src/auth/
+^packages/web/src/api/auth\.api\.ts$
+^packages/web/src/supertokens\.ts$

--- a/.github/scripts/agent-loop-merge-guard.test.sh
+++ b/.github/scripts/agent-loop-merge-guard.test.sh
@@ -60,6 +60,26 @@ out=$(run_guard $'packages/sync/src/providers/microsoft/foo.ts\npackages/sync/sr
 assert_contains "$out" "downgrade:" "mixed diff still refuses telemetry"
 assert_not_contains "$out" "proceed" "mixed diff does not proceed"
 
+MS_I="Providers I: identity decoupling"
+MS_C="Providers C: closeout"
+
+# Identity and closeout re-allow the auth paths (as P0 did); closeout also re-allows sync telemetry.
+for ms in "$MS_I" "$MS_C"; do
+  out=$(run_guard $'packages/backend/src/auth/x.ts\npackages/web/src/auth/y.ts\npackages/web/src/api/auth.api.ts\npackages/web/src/supertokens.ts' "$ms")
+  assert_contains "$out" "proceed" "auth paths proceed under ${ms}"
+  assert_not_contains "$out" "downgrade:" "auth paths are not refused under ${ms}"
+done
+
+out=$(run_guard "packages/sync/src/telemetry/x.ts" "$MS_C")
+assert_contains "$out" "proceed" "telemetry proceeds under closeout"
+assert_not_contains "$out" "downgrade:" "telemetry is not refused under closeout"
+
+out=$(run_guard "packages/sync/src/telemetry/x.ts" "$MS_I")
+assert_contains "$out" "downgrade:" "telemetry still refused under identity"
+
+out=$(run_guard "packages/core/src/config/compass.config.ts" "$MS_I")
+assert_contains "$out" "downgrade:" "core config still refused under identity"
+
 # .github/ self-service: CI-speed files may merge, agent and deploy files may not.
 for allowed in \
   ".github/workflows/test-unit.yml" \


### PR DESCRIPTION
## Why

Milestones I (identity decoupling) and C (closeout) only re-allowed `packages/sync/src/providers/` in their merge-guard allowlists. Every identity WP touches `packages/backend/src/auth/` and `packages/web/src/auth/` (SuperTokens recipes, sign-in callbacks), and the closeout health-snapshot WP touches `packages/sync/src/telemetry/`. Without this, each of those loop PRs downgrades to `agent-loop-needs-human` after the agent has already burned a run.

## What

- `providers-i.txt`: re-allow `packages/backend/src/auth/`, `packages/web/src/auth/`, `packages/web/src/api/auth.api.ts`, `packages/web/src/supertokens.ts` (the same set `providers-p0.txt` used to ship WP-07 and WP-08c).
- `providers-c.txt`: the same four plus `packages/sync/src/telemetry/` for the per-provider health snapshot.
- `agent-loop-merge-guard.test.sh`: pins that auth paths proceed under I and C, telemetry proceeds only under C, and `packages/core/src/config/` stays refused under I (all provider config landed in P0-02).

Part of the milestone grooming for #3210 and #3211. The guard's gate for these paths is Copilot review, `bun run verify --strict`, and the e2e callback specs.

## Verification

`bun run verify --strict`
`VERDICT: PASS` (type-check, lint, knip). The shell test needs bash 4 and runs in the `unit` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)