### PR TITLE
ci(agent-loop): allow auth paths for the apple milestone

### DIFF
--- a/.github/agent-loop/allowlists/providers-a.txt
+++ b/.github/agent-loop/allowlists/providers-a.txt
@@ -2,3 +2,7 @@
 # One extended-regex per line. Comments and blank lines are ignored.
 ^packages/sync/src/providers/
 ^packages/sync/src/providers/__contract__/
+^packages/backend/src/auth/
+^packages/web/src/auth/
+^packages/web/src/api/auth\.api\.ts$
+^packages/web/src/supertokens\.ts$

--- a/.github/scripts/agent-loop-merge-guard.test.sh
+++ b/.github/scripts/agent-loop-merge-guard.test.sh
@@ -60,11 +60,12 @@ out=$(run_guard $'packages/sync/src/providers/microsoft/foo.ts\npackages/sync/sr
 assert_contains "$out" "downgrade:" "mixed diff still refuses telemetry"
 assert_not_contains "$out" "proceed" "mixed diff does not proceed"
 
+MS_A="Providers A: Apple (iCloud)"
 MS_I="Providers I: identity decoupling"
 MS_C="Providers C: closeout"
 
-# Identity and closeout re-allow the auth paths (as P0 did); closeout also re-allows sync telemetry.
-for ms in "$MS_I" "$MS_C"; do
+# Apple, identity and closeout re-allow the auth paths (as P0 did); closeout also re-allows sync telemetry.
+for ms in "$MS_A" "$MS_I" "$MS_C"; do
   out=$(run_guard $'packages/backend/src/auth/x.ts\npackages/web/src/auth/y.ts\npackages/web/src/api/auth.api.ts\npackages/web/src/supertokens.ts' "$ms")
   assert_contains "$out" "proceed" "auth paths proceed under ${ms}"
   assert_not_contains "$out" "downgrade:" "auth paths are not refused under ${ms}"
@@ -76,6 +77,9 @@ assert_not_contains "$out" "downgrade:" "telemetry is not refused under closeout
 
 out=$(run_guard "packages/sync/src/telemetry/x.ts" "$MS_I")
 assert_contains "$out" "downgrade:" "telemetry still refused under identity"
+
+out=$(run_guard "packages/sync/src/telemetry/x.ts" "$MS_A")
+assert_contains "$out" "downgrade:" "telemetry still refused under apple"
 
 out=$(run_guard "packages/core/src/config/compass.config.ts" "$MS_I")
 assert_contains "$out" "downgrade:" "core config still refused under identity"


### PR DESCRIPTION
## Why

A-03 (#3256) adds `POST /api/auth/connections/credential` under `packages/backend/src/auth/`, and A-09 (#3263) touches `packages/web/src/auth/`. #3256 just moved from `human` to `allow`, so without this the loop's PR downgrades to `agent-loop-needs-human` after the run.

## What

- `providers-a.txt`: re-allow `packages/backend/src/auth/`, `packages/web/src/auth/`, `packages/web/src/api/auth.api.ts`, `packages/web/src/supertokens.ts` (same set as `providers-p0.txt` and #3413).
- `agent-loop-merge-guard.test.sh`: the auth-path assertions now cover A, I and C; telemetry stays refused under A.

Follow-up to #3413 for #3209.

## Verification

`bun run verify --strict`
`VERDICT: PASS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)