### PR TITLE
feat(sync): register Microsoft in ProviderRegistry (WP-09)

### DIFF
--- a/packages/sync/src/config/sync.config.ts
+++ b/packages/sync/src/config/sync.config.ts
@@ -94,7 +94,7 @@ export const SyncConfigSchema = z
     // the Google adapter refuses to construct when either is absent.
     GOOGLE_CLIENT_ID: z.string().trim().min(1).optional(),
     GOOGLE_CLIENT_SECRET: z.string().trim().min(1).optional(),
-    // Microsoft OAuth client. Read-only in this WP; registration is M-09.
+    // Microsoft OAuth client. Both must be set for ProviderRegistry registration.
     MICROSOFT_CLIENT_ID: z.string().trim().min(1).optional(),
     MICROSOFT_CLIENT_SECRET: z.string().trim().min(1).optional(),
     // AES-256-GCM key for password credentials at rest (Apple). Read-only in

--- a/packages/sync/src/providers/microsoft/build-provider-resolvers.ts
+++ b/packages/sync/src/providers/microsoft/build-provider-resolvers.ts
@@ -1,0 +1,43 @@
+import { type SyncConfig } from "@sync/config/sync.config";
+import { MicrosoftAuthAdapter } from "@sync/providers/microsoft/microsoft-auth.adapter";
+import { MicrosoftCalendarAdapter } from "@sync/providers/microsoft/microsoft-calendar.adapter";
+import { MicrosoftEventReaderAdapter } from "@sync/providers/microsoft/microsoft-event-reader.adapter";
+import { MicrosoftEventWriter } from "@sync/providers/microsoft/microsoft-event-writer.adapter";
+import { MicrosoftNotificationAdapter } from "@sync/providers/microsoft/microsoft-notifications.adapter";
+import { MicrosoftPeopleAdapter } from "@sync/providers/microsoft/microsoft-people.adapter";
+import {
+  type ProviderAdapters,
+  ProviderNotConfiguredError,
+} from "@sync/providers/provider-adapters";
+
+function microsoftConfigured(config: SyncConfig): boolean {
+  return Boolean(config.MICROSOFT_CLIENT_ID && config.MICROSOFT_CLIENT_SECRET);
+}
+
+export function microsoftAdapters(
+  config: SyncConfig,
+  override?: Partial<ProviderAdapters>,
+): ProviderAdapters {
+  // Tests inject partial overrides (auth/writer only) without real OAuth config.
+  if (!microsoftConfigured(config) && override?.auth === undefined) {
+    throw new ProviderNotConfiguredError("microsoft");
+  }
+  return {
+    auth:
+      override?.auth ??
+      new MicrosoftAuthAdapter(
+        config.MICROSOFT_CLIENT_ID!,
+        config.MICROSOFT_CLIENT_SECRET!,
+      ),
+    calendars: override?.calendars ?? new MicrosoftCalendarAdapter(),
+    reader: override?.reader ?? new MicrosoftEventReaderAdapter(),
+    writer: override?.writer ?? new MicrosoftEventWriter(),
+    notifications:
+      override?.notifications ?? new MicrosoftNotificationAdapter(),
+    contacts: override?.contacts ?? new MicrosoftPeopleAdapter(),
+  };
+}
+
+export function microsoftProviderConfigured(config: SyncConfig): boolean {
+  return microsoftConfigured(config);
+}

--- a/packages/sync/src/providers/provider-registry.test.ts
+++ b/packages/sync/src/providers/provider-registry.test.ts
@@ -6,6 +6,8 @@ import {
   buildProviderRegistry,
   GOOGLE_CALLBACK_PATH,
   GOOGLE_NOTIFICATIONS_PATH,
+  MICROSOFT_CALLBACK_PATH,
+  MICROSOFT_NOTIFICATIONS_PATH,
 } from "@sync/providers/provider-registry";
 import { describe, expect, it } from "bun:test";
 
@@ -60,11 +62,48 @@ describe("ProviderRegistry", () => {
         baseConfig({
           GOOGLE_CLIENT_ID: "id",
           GOOGLE_CLIENT_SECRET: "secret",
+        }),
+      ).kinds(),
+    ).toEqual(["google"]);
+    expect(
+      buildProviderRegistry(
+        baseConfig({
           MICROSOFT_CLIENT_ID: "ms-id",
           MICROSOFT_CLIENT_SECRET: "ms-secret",
         }),
       ).kinds(),
-    ).toEqual(["google"]);
+    ).toEqual(["microsoft"]);
+    expect(
+      buildProviderRegistry(
+        baseConfig({
+          GOOGLE_CLIENT_ID: "id",
+          GOOGLE_CLIENT_SECRET: "secret",
+          MICROSOFT_CLIENT_ID: "ms-id",
+          MICROSOFT_CLIENT_SECRET: "ms-secret",
+        }),
+      ).kinds(),
+    ).toEqual(["google", "microsoft"]);
+  });
+
+  it("registers microsoft only when both client id and secret are present", () => {
+    expect(
+      buildProviderRegistry(baseConfig({ MICROSOFT_CLIENT_ID: "ms-id" })).has(
+        "microsoft",
+      ),
+    ).toBe(false);
+    expect(
+      buildProviderRegistry(
+        baseConfig({ MICROSOFT_CLIENT_SECRET: "ms-secret" }),
+      ).has("microsoft"),
+    ).toBe(false);
+    expect(
+      buildProviderRegistry(
+        baseConfig({
+          MICROSOFT_CLIENT_ID: "ms-id",
+          MICROSOFT_CLIENT_SECRET: "ms-secret",
+        }),
+      ).has("microsoft"),
+    ).toBe(true);
   });
 
   it("returns capabilities per kind", () => {
@@ -101,6 +140,45 @@ describe("ProviderRegistry", () => {
       "https://www.googleapis.com/auth/contacts.other.readonly",
     ]);
     expect(google.scopes.forFeatures([])).toEqual([]);
+  });
+
+  it("returns microsoft capabilities and paths when configured", () => {
+    const registry = buildProviderRegistry(
+      baseConfig({
+        MICROSOFT_CLIENT_ID: "ms-id",
+        MICROSOFT_CLIENT_SECRET: "ms-secret",
+      }),
+    );
+    const microsoft = registry.get("microsoft");
+    expect(microsoft.callbackPath).toBe(MICROSOFT_CALLBACK_PATH);
+    expect(microsoft.notificationsCallbackPath).toBe(
+      MICROSOFT_NOTIFICATIONS_PATH,
+    );
+    expect(registry.callbackUrlFor("https://example.test", "microsoft")).toBe(
+      "https://example.test/sync/notifications/microsoft",
+    );
+    expect(microsoft.capabilities).toEqual(
+      expect.arrayContaining([
+        "readEvents",
+        "writeEvents",
+        "readBusy",
+        "inviteAttendees",
+        "changeNotifications",
+        "incrementalChanges",
+        "suggestContacts",
+      ]),
+    );
+    expect(microsoft.capabilitiesFromScopes(["Calendars.ReadWrite"])).toContain(
+      "changeNotifications",
+    );
+    expect(
+      microsoft.capabilitiesFromScopes(["Calendars.ReadWrite"]),
+    ).not.toContain("suggestContacts");
+    expect(
+      microsoft.capabilitiesFromScopes(["Calendars.ReadWrite", "People.Read"]),
+    ).toContain("suggestContacts");
+    expect(microsoft.scopes.forFeatures(["contacts"])).toEqual(["People.Read"]);
+    expect(microsoft.scopes.forFeatures([])).toEqual([]);
   });
 
   it("registers google from a test auth override without yaml credentials", () => {

--- a/packages/sync/src/providers/provider-registry.ts
+++ b/packages/sync/src/providers/provider-registry.ts
@@ -14,6 +14,15 @@ import {
   googleCapabilitiesFromScopes,
 } from "@sync/providers/google/google-capabilities";
 import {
+  microsoftAdapters,
+  microsoftProviderConfigured,
+} from "@sync/providers/microsoft/build-provider-resolvers";
+import {
+  MICROSOFT_PROVIDER_CAPABILITIES,
+  microsoftCapabilitiesFromScopes,
+  microsoftScopesForFeatures,
+} from "@sync/providers/microsoft/microsoft-scopes";
+import {
   type ProviderAdapters,
   ProviderNotConfiguredError,
   type ResolveProviderAdapters,
@@ -64,6 +73,8 @@ export class ProviderRegistry {
 
 export const GOOGLE_CALLBACK_PATH = "/sync/google";
 export const GOOGLE_NOTIFICATIONS_PATH = "/sync/notifications/google";
+export const MICROSOFT_CALLBACK_PATH = "/sync/microsoft";
+export const MICROSOFT_NOTIFICATIONS_PATH = "/sync/notifications/microsoft";
 export const OAUTH_CALLBACK_PARAM_PATH = "/sync/:provider";
 export const NOTIFICATIONS_PARAM_PATH = "/sync/notifications/:provider";
 
@@ -72,8 +83,6 @@ export function buildProviderRegistry(
   overrides: ProviderAdapterOverrides = {},
 ): ProviderRegistry {
   const registrations = new Map<ProviderKind, ProviderRegistration>();
-  // Microsoft and Apple registration lands in M-09 / A-08. Config for those
-  // kinds is read into SyncConfig in this WP but does not register them yet.
   const googleOverride = overrides.google;
   if (googleProviderConfigured(config) || googleOverride?.auth !== undefined) {
     registrations.set("google", {
@@ -85,6 +94,21 @@ export function buildProviderRegistry(
       capabilitiesFromScopes: googleCapabilitiesFromScopes,
     });
   }
+  const microsoftOverride = overrides.microsoft;
+  if (
+    microsoftProviderConfigured(config) ||
+    microsoftOverride?.auth !== undefined
+  ) {
+    registrations.set("microsoft", {
+      adapters: microsoftAdapters(config, microsoftOverride),
+      scopes: { forFeatures: microsoftScopesForFeatures },
+      capabilities: MICROSOFT_PROVIDER_CAPABILITIES,
+      callbackPath: MICROSOFT_CALLBACK_PATH,
+      notificationsCallbackPath: MICROSOFT_NOTIFICATIONS_PATH,
+      capabilitiesFromScopes: microsoftCapabilitiesFromScopes,
+    });
+  }
+  // Apple registration lands in A-08.
   return new ProviderRegistry(registrations);
 }
 


### PR DESCRIPTION
Fixes #3249

## What and why

Microsoft Graph adapters (auth, calendar discovery, event reader/writer, change notifications, people) were implemented in prior WPs but not registered in `ProviderRegistry`. This wires the full adapter set when both `MICROSOFT_CLIENT_ID` and `MICROSOFT_CLIENT_SECRET` are configured, with callback path `/sync/microsoft`, notification ingress at `/sync/notifications/microsoft`, and capabilities derived from M-01 scopes (`changeNotifications`, `incrementalChanges`, scope-dependent `suggestContacts`).

Spec: [`docs/features/calendar-providers.md`](https://github.com/KeepSoftwareSimple/compass-calendar/blob/main/docs/features/calendar-providers.md)

Founder end-to-end proof (connect → calendarListSync → initialImport → subscription watched → outlook.com edit → Compass render → Compass edit → outlook.com) requires Entra secrets and is documented on #3249 for recording on #3239.

## Verify

```
Selected packages: sync
Checks run: test:sync:fast, type-check, lint, knip
Checks skipped: (none)

✓ All checks passed
VERDICT: PASS
```

Also run locally: `bun test:sync`, `bun test:backend`.