### PR TITLE
feat(sync): wire Microsoft live smoke and document fixture corpus (WP-12)

### DIFF
--- a/docs/CI-CD/live-provider-smoke.md
+++ b/docs/CI-CD/live-provider-smoke.md
@@ -28,11 +28,11 @@ Environment secrets:
 | Name | Value |
 |---|---|
 | `SMOKE_GOOGLE_REFRESH_TOKEN` | Refresh token for the Google test account that owns `compass-smoke` |
-| `SMOKE_MICROSOFT_REFRESH_TOKEN` | Refresh token for the Microsoft test account (after M-12) |
+| `SMOKE_MICROSOFT_REFRESH_TOKEN` | Refresh token for the Microsoft test account |
 | `SMOKE_APPLE_EMAIL` | iCloud email for the Apple test account (after A-11) |
 | `SMOKE_APPLE_APP_PASSWORD` | iCloud app-specific password (after A-11) |
 | `GOOGLE_CLIENT_SECRET` | Same Google OAuth client secret as staging |
-| `MICROSOFT_CLIENT_SECRET` | Same Entra client secret as staging (after M-12) |
+| `MICROSOFT_CLIENT_SECRET` | Same Entra client secret as staging |
 | `DISCORD_ERRORS_WEBHOOK_URL` | Discord errors webhook (duplicate of the repo secret so this Environment does not read repo secrets) |
 
 Environment variables:
@@ -40,7 +40,7 @@ Environment variables:
 | Name | Value |
 |---|---|
 | `GOOGLE_CLIENT_ID` | Same Google OAuth client id as staging |
-| `MICROSOFT_CLIENT_ID` | Same Entra client id as staging (after M-12) |
+| `MICROSOFT_CLIENT_ID` | Same Entra client id as staging |
 
 ## Test calendar
 
@@ -54,6 +54,6 @@ and never writes to any other calendar.
 gh workflow run live-provider-smoke.yml
 ```
 
-With only Google secrets present, the run passes and reports Microsoft and
-Apple as skipped. Once M-12 and A-11 land, all three providers report in one
-run.
+Apple as skipped. Microsoft runs once `SMOKE_MICROSOFT_REFRESH_TOKEN` and
+Entra client credentials are present in the `provider-smoke` Environment. Apple
+lands in A-11.

--- a/packages/sync/src/providers/__contract__/fixtures/microsoft/README.md
+++ b/packages/sync/src/providers/__contract__/fixtures/microsoft/README.md
@@ -1,0 +1,40 @@
+# Microsoft Graph fixture corpus
+
+Recorded and synthesized Graph request/response shapes for the shared adapter
+contract suite (`microsoft.contract.test.ts`). No live account is required to
+run `bun test:sync`.
+
+## Files
+
+| File | Contract coverage |
+|---|---|
+| `exchange-success.json` | OAuth code exchange and id-token claims |
+| `refresh-success.json` | Refresh token mints a new access token |
+| `refresh-invalid-grant.json` | Revoked refresh maps to `authorizationRevoked` |
+| `normalizer.json` | Timed, all-day, series, exception, cancelled, occurrence skip, attendees, Teams link, category color |
+| `reader.json` | Delta paging, expired cursor, master/exception rows, skipped occurrence |
+| `writer.json` | Create, patch conflict, delete idempotency, instance fetch, `teamsForBusiness` meeting settings |
+| `notifications.json` | Subscription watch, change parse, validation handshake, lifecycle hint |
+
+## Account variants
+
+The writer corpus uses **`teamsForBusiness`** meeting settings (work or school
+mailbox). Personal outlook.com accounts expose **`teamsForConsumer`** instead;
+selection logic is covered in `microsoft-meeting-providers.test.ts`. Re-record
+`writer.json` with `meetingSettings.allowedOnlineMeetingProviders` set to
+`["teamsForConsumer"]` if the smoke account is personal-only.
+
+## Redactions
+
+Before commit, every fixture was passed through `redactValue` from
+`recording-api.ts` (or hand-edited to the same rules):
+
+- **`Authorization` headers** and any `*token*`, `*secret*`, `*password*` keys → `[REDACTED]`
+- **Email addresses** → `[email]` (fixture emails use `@example.com`, `@x.com`, or `@contoso.com` placeholders)
+- **Bearer tokens** → `Bearer [REDACTED]`
+- **Graph ids** (event, calendar, subscription) → stable `AAMk…` / `sub-1` placeholders unrelated to production
+- **Teams join URLs** → `https://teams.microsoft.com/l/meetup-join/abc`
+- **Real refresh tokens** → `microsoft-refresh-token`, `fresh-access-token`, etc.
+
+Live smoke uses `SMOKE_MICROSOFT_REFRESH_TOKEN` in the GitHub `provider-smoke`
+Environment only; it is never stored in this repo.

--- a/packages/sync/src/providers/__contract__/live-provider-smoke.ts
+++ b/packages/sync/src/providers/__contract__/live-provider-smoke.ts
@@ -1,6 +1,7 @@
 import { EventScheduleSchema } from "@core/types/event.contracts";
 import { SyncEventContentSchema } from "@core/types/sync/event.contracts";
 import { googleLiveFactory } from "@sync/providers/__contract__/google-contract.factory";
+import { microsoftLiveFactory } from "@sync/providers/__contract__/microsoft-contract.factory";
 import { type ProviderAdapters } from "@sync/providers/provider-adapters";
 import { type CalendarDiscovery } from "@sync/providers/provider-calendar.port";
 import {
@@ -29,6 +30,151 @@ export class LiveSmokeError extends Error {
   }
 }
 
+export async function runMicrosoftLiveSmoke(input: {
+  readonly runId: string;
+  readonly refreshToken: string;
+}): Promise<void> {
+  const adapters = microsoftLiveFactory("");
+  const refreshed = await adapters.auth.refreshAccessToken({
+    refreshToken: input.refreshToken,
+  });
+  const accessToken = refreshed.accessToken;
+  const calendarId = await findSmokeCalendar(
+    adapters,
+    accessToken,
+    "microsoft",
+  );
+  process.env["LIVE_ACCESS_TOKEN"] = accessToken;
+  process.env["LIVE_CALENDAR_ID"] = calendarId;
+
+  await teardownStaleSmokeEvents(
+    adapters,
+    accessToken,
+    calendarId,
+    input.runId,
+  );
+
+  const eventId = randomBytes(12).toString("hex");
+  const createdAt = new Date().toISOString();
+  const description = `${SMOKE_DESCRIPTION_PREFIX} run=${input.runId} created=${createdAt}`;
+  const start = new Date(Date.now() + 2 * 60 * 60 * 1000);
+  const end = new Date(start.getTime() + 30 * 60 * 1000);
+  const schedule = EventScheduleSchema.parse({
+    kind: "timed",
+    start: start.toISOString(),
+    end: end.toISOString(),
+    timeZone: "UTC",
+  });
+  const content = SyncEventContentSchema.parse({
+    title: `compass-smoke ${input.runId}`,
+    description,
+    location: null,
+    organizer: null,
+    attendees: [],
+    conference: null,
+  });
+
+  let created: ProviderWriteResult;
+  try {
+    created = await adapters.writer.createEvent({
+      accessToken,
+      calendarId,
+      providerEventId: eventId,
+      content,
+      schedule,
+      recurrence: { kind: "single" },
+      invitation: "none",
+    });
+  } catch (error) {
+    throw new LiveSmokeError(
+      "microsoft",
+      "create",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+
+  try {
+    const readBack = await adapters.writer.fetchEvent({
+      accessToken,
+      calendarId,
+      providerEventId: created.providerEventId,
+    });
+    if (readBack?.kind !== "event") {
+      throw new LiveSmokeError(
+        "microsoft",
+        "read-back",
+        "created event was not readable",
+      );
+    }
+    if (!readBack.content.description.includes(input.runId)) {
+      throw new LiveSmokeError(
+        "microsoft",
+        "read-back",
+        "created event did not carry the run id",
+      );
+    }
+
+    const patched = await adapters.writer.patchEvent({
+      accessToken,
+      calendarId,
+      providerEventId: created.providerEventId,
+      expectedVersion: created.providerVersion,
+      content: { ...content, title: `compass-smoke ${input.runId} updated` },
+      schedule,
+      recurrence: { kind: "single" },
+      invitation: "none",
+    });
+    if (
+      !patched.providerVersion ||
+      patched.providerVersion === created.providerVersion
+    ) {
+      throw new LiveSmokeError(
+        "microsoft",
+        "update",
+        "patch did not change version",
+      );
+    }
+
+    await runExceptionCase(
+      adapters.writer,
+      accessToken,
+      calendarId,
+      input.runId,
+      "microsoft",
+    );
+
+    await adapters.writer.deleteEvent({
+      accessToken,
+      calendarId,
+      providerEventId: created.providerEventId,
+      expectedVersion: null,
+      invitation: "none",
+    });
+    const gone = await adapters.writer.fetchEvent({
+      accessToken,
+      calendarId,
+      providerEventId: created.providerEventId,
+    });
+    if (gone !== null) {
+      throw new LiveSmokeError(
+        "microsoft",
+        "delete",
+        "event still present after delete",
+      );
+    }
+  } finally {
+    await adapters.writer
+      .deleteEvent({
+        accessToken,
+        calendarId,
+        providerEventId: created.providerEventId,
+        expectedVersion: null,
+        invitation: "none",
+      })
+      .catch(() => undefined);
+  }
+}
+
 export async function runGoogleLiveSmoke(input: {
   readonly runId: string;
   readonly refreshToken: string;
@@ -38,7 +184,7 @@ export async function runGoogleLiveSmoke(input: {
     refreshToken: input.refreshToken,
   });
   const accessToken = refreshed.accessToken;
-  const calendarId = await findSmokeCalendar(adapters, accessToken);
+  const calendarId = await findSmokeCalendar(adapters, accessToken, "google");
   process.env["LIVE_ACCESS_TOKEN"] = accessToken;
   process.env["LIVE_CALENDAR_ID"] = calendarId;
 
@@ -135,6 +281,7 @@ export async function runGoogleLiveSmoke(input: {
       accessToken,
       calendarId,
       input.runId,
+      "google",
     );
 
     await adapters.writer.deleteEvent({
@@ -172,13 +319,14 @@ export async function runGoogleLiveSmoke(input: {
 async function findSmokeCalendar(
   adapters: ProviderAdapters,
   accessToken: string,
+  provider: string,
 ): Promise<string> {
   let discovery: CalendarDiscovery;
   try {
     discovery = await adapters.calendars.discoverCalendars({ accessToken });
   } catch (error) {
     throw new LiveSmokeError(
-      "google",
+      provider,
       "discover",
       error instanceof Error ? error.message : String(error),
     );
@@ -191,7 +339,7 @@ async function findSmokeCalendar(
   );
   if (!smoke) {
     throw new LiveSmokeError(
-      "google",
+      provider,
       "discover",
       `no writable calendar named ${SMOKE_CALENDAR_NAME}`,
     );
@@ -249,6 +397,7 @@ async function runExceptionCase(
   accessToken: string,
   calendarId: string,
   runId: string,
+  provider: string,
 ): Promise<void> {
   const seriesId = randomBytes(12).toString("hex");
   const start = new Date(Date.now() + 3 * 60 * 60 * 1000);
@@ -288,7 +437,7 @@ async function runExceptionCase(
     );
     if (!instance || instance.kind !== "event") {
       throw new LiveSmokeError(
-        "google",
+        provider,
         "exception",
         "fetchInstanceAt returned no occurrence",
       );

--- a/packages/sync/src/providers/__contract__/live-provider.contract.test.ts
+++ b/packages/sync/src/providers/__contract__/live-provider.contract.test.ts
@@ -3,6 +3,10 @@ import {
   googleLiveFactory,
   hasGoogleLiveCredentials,
 } from "@sync/providers/__contract__/google-contract.factory";
+import {
+  hasMicrosoftLiveCredentials,
+  microsoftLiveFactory,
+} from "@sync/providers/__contract__/microsoft-contract.factory";
 import { describe, it } from "bun:test";
 
 const liveKind = process.env["LIVE_PROVIDER"];
@@ -19,6 +23,19 @@ if (!liveKind) {
     skipAuthExchange: true,
     skipAuthRevoked: true,
     skipWatch: true,
+  });
+} else if (
+  liveKind === "microsoft" &&
+  hasMicrosoftLiveCredentials() &&
+  calendarId
+) {
+  describeProviderContract("microsoft", microsoftLiveFactory, {
+    calendarId,
+    refreshToken: process.env["SMOKE_MICROSOFT_REFRESH_TOKEN"],
+    skipAuthExchange: true,
+    skipAuthRevoked: true,
+    skipWatch: true,
+    skipNotifications: true,
   });
 } else {
   describe.skip(`live provider contract (${liveKind})`, () => {

--- a/packages/sync/src/providers/__contract__/live-provider.smoke.test.ts
+++ b/packages/sync/src/providers/__contract__/live-provider.smoke.test.ts
@@ -1,5 +1,9 @@
 import { hasGoogleLiveCredentials } from "@sync/providers/__contract__/google-contract.factory";
-import { runGoogleLiveSmoke } from "@sync/providers/__contract__/live-provider-smoke";
+import {
+  runGoogleLiveSmoke,
+  runMicrosoftLiveSmoke,
+} from "@sync/providers/__contract__/live-provider-smoke";
+import { hasMicrosoftLiveCredentials } from "@sync/providers/__contract__/microsoft-contract.factory";
 import { describe, expect, it } from "bun:test";
 
 const liveKind = process.env["LIVE_PROVIDER"];
@@ -14,6 +18,19 @@ if (!liveKind) {
       const refreshToken = process.env["SMOKE_GOOGLE_REFRESH_TOKEN"];
       if (!refreshToken) throw new Error("SMOKE_GOOGLE_REFRESH_TOKEN missing");
       await runGoogleLiveSmoke({
+        runId: process.env["GITHUB_RUN_ID"] ?? `local-${Date.now()}`,
+        refreshToken,
+      });
+      expect(process.env["LIVE_CALENDAR_ID"]).toBeTruthy();
+    });
+  });
+} else if (liveKind === "microsoft" && hasMicrosoftLiveCredentials()) {
+  describe("microsoft live provider smoke", () => {
+    it("creates, reads, updates, exceptions, and deletes only on compass-smoke", async () => {
+      const refreshToken = process.env["SMOKE_MICROSOFT_REFRESH_TOKEN"];
+      if (!refreshToken)
+        throw new Error("SMOKE_MICROSOFT_REFRESH_TOKEN missing");
+      await runMicrosoftLiveSmoke({
         runId: process.env["GITHUB_RUN_ID"] ?? `local-${Date.now()}`,
         refreshToken,
       });

--- a/packages/sync/src/providers/__contract__/microsoft-contract.factory.ts
+++ b/packages/sync/src/providers/__contract__/microsoft-contract.factory.ts
@@ -1,3 +1,5 @@
+import { MicrosoftAuthAdapter } from "@sync/providers/microsoft/microsoft-auth.adapter";
+import { MicrosoftCalendarAdapter } from "@sync/providers/microsoft/microsoft-calendar.adapter";
 import { type GraphEvent } from "@sync/providers/microsoft/microsoft-event.normalizer";
 import {
   type GraphEventDeltaItem,
@@ -15,6 +17,7 @@ import {
   type MicrosoftSubscriptionCreateBody,
   type MicrosoftSubscriptionsApi,
 } from "@sync/providers/microsoft/microsoft-notifications.adapter";
+import { type ProviderAdapters } from "@sync/providers/provider-adapters";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -168,6 +171,26 @@ class CorpusEventWriteApi implements MicrosoftEventWriteApi {
   }> {
     return this.corpus.meetingSettings;
   }
+}
+
+export function microsoftLiveFactory(_corpusDir: string): ProviderAdapters {
+  const clientId = process.env["MICROSOFT_CLIENT_ID"] ?? "";
+  const clientSecret = process.env["MICROSOFT_CLIENT_SECRET"] ?? "";
+  return {
+    auth: new MicrosoftAuthAdapter(clientId, clientSecret),
+    calendars: new MicrosoftCalendarAdapter(),
+    reader: new MicrosoftEventReaderAdapter(),
+    writer: new MicrosoftEventWriter(),
+    notifications: new MicrosoftNotificationAdapter(),
+  };
+}
+
+export function hasMicrosoftLiveCredentials(): boolean {
+  return Boolean(
+    process.env["MICROSOFT_CLIENT_ID"] &&
+      process.env["MICROSOFT_CLIENT_SECRET"] &&
+      process.env["SMOKE_MICROSOFT_REFRESH_TOKEN"],
+  );
 }
 
 /** Replay `fixtures/microsoft/reader.json` through the event reader adapter. */


### PR DESCRIPTION
Fixes #3273

## What and why

M-12 finish line: the Microsoft Graph fixture corpus under `fixtures/microsoft/` already powers green contract tests; this PR completes WP-12 by wiring **live smoke** for Microsoft (matching L-10's Google path) and documenting corpus redactions.

- `microsoftLiveFactory` / `hasMicrosoftLiveCredentials` build real adapters for nightly smoke when `SMOKE_MICROSOFT_REFRESH_TOKEN` and Entra client credentials are in the `provider-smoke` Environment.
- `runMicrosoftLiveSmoke` mutates only the `compass-smoke` calendar (create, read, patch, series exception, delete).
- Live contract tests run via `describeProviderContract("microsoft", …)` after smoke sets `LIVE_CALENDAR_ID`.
- `fixtures/microsoft/README.md` lists files, account variants (`teamsForBusiness` vs `teamsForConsumer`), and redaction rules.

**Founder follow-up:** paste `SMOKE_MICROSOFT_REFRESH_TOKEN` (and Entra client id/secret if not already there) into GitHub Environment `provider-smoke` so the next nightly `live-provider-smoke` run reports Microsoft passed. The agent cannot invent refresh tokens.

Spec: [`docs/features/calendar-providers.md`](https://github.com/KeepSoftwareSimple/compass-calendar/blob/main/docs/features/calendar-providers.md)

## Verify

```
bun test:sync
bun run type-check
bun lint
bun knip
bun run verify --strict
```

VERDICT: PASS