### PR TITLE
fix(web): read provider-neutral auth and metadata contracts

### DIFF
--- a/e2e/calendars/account-page-jump.spec.ts
+++ b/e2e/calendars/account-page-jump.spec.ts
@@ -108,17 +108,23 @@ const setupTwoAccountWeek = async (page: Page) => {
     }
     if (pathname.endsWith("/api/user/metadata")) {
       return json({
+        connections: [
+          connection("conn-work", WORK_EMAIL),
+          connection("conn-personal", PERSONAL_EMAIL),
+        ],
         google: {
           connectionState: "HEALTHY",
-          connections: [
-            connection("conn-work", WORK_EMAIL),
-            connection("conn-personal", PERSONAL_EMAIL),
-          ],
         },
       });
     }
     if (pathname.endsWith("/api/config")) {
-      return json({ google: { isConfigured: true } });
+      return json({
+        providers: {
+          google: { signIn: true, connect: true },
+          microsoft: { signIn: false, connect: false },
+          apple: { signIn: false, connect: false },
+        },
+      });
     }
     if (pathname.endsWith("/api/calendars/availability")) {
       return json({ busyPeriods: [] });

--- a/e2e/calendars/calendar-experience.spec.ts
+++ b/e2e/calendars/calendar-experience.spec.ts
@@ -252,10 +252,19 @@ async function setupCalendarExperiencePage(
       });
     }
     if (pathname.endsWith("/api/user/metadata")) {
-      return json({ google: { connectionState: "HEALTHY" } });
+      return json({
+        connections: [],
+        google: { connectionState: "HEALTHY" },
+      });
     }
     if (pathname.endsWith("/api/config")) {
-      return json({ google: { isConfigured: true } });
+      return json({
+        providers: {
+          google: { signIn: true, connect: true },
+          microsoft: { signIn: false, connect: false },
+          apple: { signIn: false, connect: false },
+        },
+      });
     }
     if (pathname.endsWith("/api/calendars/availability")) {
       return json({ busyPeriods: [] });

--- a/packages/web/src/api/auth.api.ts
+++ b/packages/web/src/api/auth.api.ts
@@ -31,8 +31,8 @@ const AuthApi = {
     request: ConnectionBeginRequest = {},
   ): Promise<{ authorizationUrl: string }> {
     const response = await BaseApi.post<ConnectionBeginResponse>(
-      `/auth/google/connect/begin`,
-      request,
+      `/auth/connections/begin`,
+      { ...request, provider: "google" },
     );
 
     const parsed = ConnectionBeginResponseSchema.parse(response.data);
@@ -63,14 +63,14 @@ const AuthApi = {
   // their Compass sign-in, are unaffected.
   async disconnectGoogleConnection(connectionId: string): Promise<void> {
     await BaseApi.delete(
-      `/auth/google/connect/${encodeURIComponent(connectionId)}`,
+      `/auth/connections/${encodeURIComponent(connectionId)}`,
     );
   },
 
   // Enqueue Sync catch-up pulls for the signed-in user's calendars.
   async refreshGoogleSync(): Promise<ConnectionRefreshResponse> {
     const response = await BaseApi.post<ConnectionRefreshResponse>(
-      `/auth/google/sync/refresh`,
+      `/auth/connections/refresh`,
       {},
     );
 

--- a/packages/web/src/api/util/api.util.test.ts
+++ b/packages/web/src/api/util/api.util.test.ts
@@ -323,6 +323,26 @@ describe("handleErrorResponse", () => {
     expect(onGoogleRevoked).toHaveBeenCalledWith({ calendarId: "cal-123" });
   });
 
+  it.each([
+    Status.UNAUTHORIZED,
+    Status.GONE,
+  ])("delegates connection revocation for status %s and rethrows the API error", async (status) => {
+    const onGoogleRevoked = mock();
+    const error = createApiError(
+      {
+        data: { code: "CONNECTION_REVOKED" },
+        status,
+      },
+      { body: { calendarId: "cal-456" } },
+    );
+
+    await expect(handleErrorResponse(error, { onGoogleRevoked })).rejects.toBe(
+      error,
+    );
+
+    expect(onGoogleRevoked).toHaveBeenCalledWith({ calendarId: "cal-456" });
+  });
+
   it("does not delegate unrelated API errors", async () => {
     const onGoogleRevoked = mock();
     const error = createApiError(

--- a/packages/web/src/api/util/api.util.ts
+++ b/packages/web/src/api/util/api.util.ts
@@ -202,7 +202,8 @@ export const handleErrorResponse = async (
     // "GOOGLE_REVOKED" here is the HTTP error envelope code the backend sends
     // on this response (independent of the syncStatusChanged SSE code of the
     // same name, B10).
-    getApiErrorCode(error) === "GOOGLE_REVOKED"
+    (getApiErrorCode(error) === "GOOGLE_REVOKED" ||
+      getApiErrorCode(error) === "CONNECTION_REVOKED")
   ) {
     if (!onGoogleRevoked) {
       throw new Error("Calendar revocation handler is not configured");

--- a/packages/web/src/auth/compass/user/util/user-metadata.util.ts
+++ b/packages/web/src/auth/compass/user/util/user-metadata.util.ts
@@ -8,6 +8,7 @@ import {
 } from "@web/auth/google/state/google.reconnect.state";
 import {
   findPrimaryGoogleSyncConnectionFromMetadata,
+  findSyncConnectionsFromMetadata,
   userMetadataActions,
 } from "@web/auth/state/user-metadata.store";
 import {
@@ -30,7 +31,7 @@ let metadataFetchEpoch = 0;
  * metadata payload, whether it arrived from REST refresh or SSE.
  */
 export const applyUserMetadataSideEffects = (metadata: UserMetadata): void => {
-  const connections = metadata.google?.connections ?? [];
+  const connections = findSyncConnectionsFromMetadata(metadata);
   syncReconnectRequiredFromConnections(connections);
 
   const needsReconnect =

--- a/packages/web/src/auth/providers/useIsProviderAvailable.test.tsx
+++ b/packages/web/src/auth/providers/useIsProviderAvailable.test.tsx
@@ -4,17 +4,18 @@ import { describe, expect, it, mock } from "bun:test";
 
 const getConfig = mock();
 
+const providerConfig = {
+  providers: {
+    google: { signIn: true, connect: true },
+    microsoft: { signIn: false, connect: true },
+    apple: { signIn: false, connect: false },
+  },
+};
+
 describe("useIsProviderAvailable", () => {
   it("reads connect flags from providers on the same config fetch", async () => {
     getConfig.mockClear();
-    getConfig.mockResolvedValue({
-      google: { isConfigured: true },
-      providers: {
-        google: { signIn: true, connect: true },
-        microsoft: { signIn: false, connect: true },
-        apple: { signIn: false, connect: false },
-      },
-    });
+    getConfig.mockResolvedValue(providerConfig);
     const { resetProviderAvailabilityForTests, useIsProviderAvailable } =
       createProviderAvailability({
         getConfig,
@@ -36,7 +37,11 @@ describe("useIsProviderAvailable", () => {
   it("gates google sign-in on the baked client id even when the backend is configured", async () => {
     getConfig.mockClear();
     getConfig.mockResolvedValue({
-      google: { isConfigured: true },
+      providers: {
+        google: { signIn: true, connect: true },
+        microsoft: { signIn: false, connect: false },
+        apple: { signIn: false, connect: false },
+      },
     });
     const { resetProviderAvailabilityForTests, useIsProviderAvailable } =
       createProviderAvailability({
@@ -58,7 +63,11 @@ describe("useIsProviderAvailable", () => {
   it("lets google connect succeed without a baked client id", async () => {
     getConfig.mockClear();
     getConfig.mockResolvedValue({
-      google: { isConfigured: true },
+      providers: {
+        google: { signIn: true, connect: true },
+        microsoft: { signIn: false, connect: false },
+        apple: { signIn: false, connect: false },
+      },
     });
     const { resetProviderAvailabilityForTests, useIsProviderAvailable } =
       createProviderAvailability({

--- a/packages/web/src/components/Sidebar/MonthPicker/monthPickerLocale.ts
+++ b/packages/web/src/components/Sidebar/MonthPicker/monthPickerLocale.ts
@@ -1,5 +1,5 @@
 import { type Locale } from "date-fns";
-import { enUS } from "date-fns/locale";
+import enUS from "date-fns/locale/en-US";
 
 type WeekStartsOn = NonNullable<NonNullable<Locale["options"]>["weekStartsOn"]>;
 


### PR DESCRIPTION
Fixes #3417

## What and why

The web client and e2e mocks still called the one-release Google auth aliases and read legacy `google.connections` / `google.isConfigured` shapes. This switches `AuthApi` to the provider-neutral `/auth/connections/*` routes, accepts `CONNECTION_REVOKED` alongside `GOOGLE_REVOKED` in the HTTP error envelope, reads connections through `findSyncConnectionsFromMetadata`, and updates e2e calendar mocks plus provider availability tests to use neutral `connections[]` and `providers.*` payloads. Google behavior stays byte-identical via the same backend handlers.

Also fixes a `date-fns/locale` import that broke `MonthPicker` tests under Bun from the monorepo root (unblocks `bun run verify --strict` on this VM).

Spec: `docs/features/calendar-providers.md`

## Verify

```
Selected packages: web
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)

✓ All checks passed
VERDICT: PASS
```