### PR TITLE
feat(sync): Apple credential connect route (backend and sync)

### DIFF
--- a/packages/backend/src/__tests__/helpers/mock.setup.ts
+++ b/packages/backend/src/__tests__/helpers/mock.setup.ts
@@ -5,6 +5,7 @@ import {
   type SessionContainerInterface,
   type VerifySessionOptions,
 } from "supertokens-node/lib/build/recipe/session/types";
+import { Status } from "@core/errors/status.codes";
 import {
   type LoggerFactoryFn,
   registerLoggerFactory,
@@ -62,7 +63,7 @@ function createTestVerifySession(): ReturnType<
   typeof import("supertokens-node/recipe/session/framework/express").verifySession
 > {
   return (_options?: VerifySessionOptions) => {
-    return (req: SessionRequest, _res: Response, next?: NextFunction) => {
+    return (req: SessionRequest, res: Response, next?: NextFunction) => {
       try {
         const cookies = (req.headers.cookie?.split(";") ?? [])?.reduce(
           (items, item) => {
@@ -74,6 +75,10 @@ function createTestVerifySession(): ReturnType<
         );
 
         const sessionString = cookies["session"];
+        if (typeof sessionString !== "string") {
+          res.status(Status.UNAUTHORIZED).json({ message: "Session required" });
+          return;
+        }
         const now = new Date();
         const tId = randomUUID();
         const sessionHandle = randomUUID();

--- a/packages/backend/src/auth/auth.routes.config.ts
+++ b/packages/backend/src/auth/auth.routes.config.ts
@@ -1,8 +1,22 @@
 import type express from "express";
+import rateLimit from "express-rate-limit";
 import { verifySession } from "@backend/auth/session/session.middleware";
 import { CommonRoutesConfig } from "@backend/common/common.routes.config";
 import authController from "./controllers/auth.controller";
 import authMiddleware from "./middleware/auth.middleware";
+
+export const credentialConnectLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) => {
+    const session = (
+      req as express.Request & { session?: { getUserId(): string } }
+    ).session;
+    return session?.getUserId() ?? req.ip ?? "anonymous";
+  },
+});
 
 /**
  * Routes with the verifyIsDev middleware are
@@ -33,6 +47,13 @@ export class AuthRoutes extends CommonRoutesConfig {
       .all(requireSession)
       .post((req, res) => {
         authController.beginConnection(req, res);
+      });
+
+    this.app
+      .route(`/api/auth/connections/credential`)
+      .all(requireSession)
+      .post(credentialConnectLimiter, (req, res) => {
+        authController.connectCredential(req, res);
       });
 
     this.app

--- a/packages/backend/src/auth/controllers/auth.controller.db.test.ts
+++ b/packages/backend/src/auth/controllers/auth.controller.db.test.ts
@@ -1,4 +1,5 @@
 import { Status } from "@core/errors/status.codes";
+import { encryptCredentialConnectPayload } from "@core/security/internal-credential-envelope";
 import { BaseDriver } from "@backend/__tests__/drivers/base.driver";
 import { UtilDriver } from "@backend/__tests__/drivers/util.driver";
 import {
@@ -8,6 +9,7 @@ import {
 } from "@backend/__tests__/helpers/mock.db.setup";
 import { restoreFileMocks } from "@backend/__tests__/helpers/mock.setup";
 import { CONFIG } from "@backend/common/constants/config.constants";
+import { INVALID_APPLE_CREDENTIAL_MESSAGE } from "@backend/common/services/sync-service/sync-credential-connect";
 import * as syncServiceFactory from "@backend/common/services/sync-service/sync-service.factory";
 import {
   afterAll,
@@ -26,6 +28,7 @@ describe("auth.controller connections API", () => {
   const baseDriver = new BaseDriver();
   const originalMicrosoftId = CONFIG.MICROSOFT_CLIENT_ID;
   const originalMicrosoftSecret = CONFIG.MICROSOFT_CLIENT_SECRET;
+  const originalCredentialKey = CONFIG.SYNC_CREDENTIAL_ENCRYPTION_KEY;
 
   beforeAll(() => setupTestDb(import.meta.url));
   beforeEach(cleanupCollections);
@@ -34,11 +37,34 @@ describe("auth.controller connections API", () => {
   afterEach(() => {
     CONFIG.MICROSOFT_CLIENT_ID = originalMicrosoftId;
     CONFIG.MICROSOFT_CLIENT_SECRET = originalMicrosoftSecret;
+    CONFIG.SYNC_CREDENTIAL_ENCRYPTION_KEY = originalCredentialKey;
     restoreFileMocks();
   });
 
   const sessionFor = (userId: string) =>
     baseDriver.setSessionPlugin({ userId });
+
+  const appleEnvelope = (
+    tenantId: string,
+    principalId: string,
+    username: string,
+    secret: string,
+  ) =>
+    encryptCredentialConnectPayload(
+      CONFIG.SYNC_INTERNAL_AUTH_TOKEN,
+      { username, secret },
+      { tenantId, principalId, provider: "apple" },
+    );
+
+  const postCredential = (userId: string, username: string, secret: string) =>
+    baseDriver
+      .getServer()
+      .post("/api/auth/connections/credential")
+      .use(sessionFor(userId))
+      .send({
+        provider: "apple",
+        envelope: appleEnvelope(userId, userId, username, secret),
+      });
 
   it("returns the same redirect body from the new begin route and the Google alias", async () => {
     const { user } = await UtilDriver.setupTestUser();
@@ -89,5 +115,141 @@ describe("auth.controller connections API", () => {
     expect(response.body.code).toBe("PROVIDER_NOT_CONFIGURED");
     expect(response.body.message).toContain("Microsoft");
     expect(beginConnection).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 without a session on credential connect", async () => {
+    const response = await baseDriver
+      .getServer()
+      .post("/api/auth/connections/credential")
+      .send({
+        provider: "apple",
+        envelope: {
+          iv: "aGVsbG8=",
+          ciphertext: "Y2lwaGVydGV4dA==",
+          authTag: "dGFn",
+        },
+      })
+      .expect(Status.UNAUTHORIZED);
+
+    expect(response.body.message).toBeDefined();
+  });
+
+  it("connects Apple credentials through sync on the happy path", async () => {
+    CONFIG.SYNC_CREDENTIAL_ENCRYPTION_KEY = "test-credential-key";
+    const { user } = await UtilDriver.setupTestUser();
+    const connectionId = "507f1f77bcf86cd799439011";
+    spyOn(syncServiceFactory, "getSyncServiceClient").mockReturnValue({
+      createCredentialConnection: async () => ({
+        ok: true,
+        value: { connectionId },
+        correlationId: "corr-credential",
+      }),
+    } as never);
+
+    const response = await postCredential(
+      user._id.toString(),
+      "user@icloud.com",
+      "app-specific-password",
+    ).expect(Status.OK);
+
+    expect(response.body).toEqual({
+      kind: "connected",
+      connectionId,
+    });
+  });
+
+  it("maps sync invalidCredential to 400 with the exact user-facing copy", async () => {
+    CONFIG.SYNC_CREDENTIAL_ENCRYPTION_KEY = "test-credential-key";
+    const { user } = await UtilDriver.setupTestUser();
+    spyOn(syncServiceFactory, "getSyncServiceClient").mockReturnValue({
+      createCredentialConnection: async () => ({
+        ok: false,
+        error: {
+          kind: "unauthorized",
+          status: 401,
+          correlationId: "corr-invalid",
+        },
+      }),
+    } as never);
+
+    const response = await postCredential(
+      user._id.toString(),
+      "user@icloud.com",
+      "wrong-password",
+    ).expect(Status.BAD_REQUEST);
+
+    expect(response.body.message).toBe(INVALID_APPLE_CREDENTIAL_MESSAGE);
+    expect(response.body.code).toBe("INVALID_CREDENTIAL");
+  });
+
+  it("returns 503 when sync throttles credential validation", async () => {
+    CONFIG.SYNC_CREDENTIAL_ENCRYPTION_KEY = "test-credential-key";
+    const { user } = await UtilDriver.setupTestUser();
+    spyOn(syncServiceFactory, "getSyncServiceClient").mockReturnValue({
+      createCredentialConnection: async () => ({
+        ok: false,
+        error: {
+          kind: "unavailable",
+          status: 503,
+          correlationId: "corr-throttle",
+        },
+      }),
+    } as never);
+
+    const response = await postCredential(
+      user._id.toString(),
+      "user@icloud.com",
+      "app-specific-password",
+    ).expect(Status.SERVICE_UNAVAILABLE);
+
+    expect(response.body.message).toBe(INVALID_APPLE_CREDENTIAL_MESSAGE);
+  });
+
+  it("returns 409 when Apple connect is not configured", async () => {
+    CONFIG.SYNC_CREDENTIAL_ENCRYPTION_KEY = undefined;
+    const { user } = await UtilDriver.setupTestUser();
+    const createCredentialConnection = spyOn(
+      syncServiceFactory,
+      "getSyncServiceClient",
+    );
+
+    const response = await postCredential(
+      user._id.toString(),
+      "user@icloud.com",
+      "app-specific-password",
+    ).expect(Status.CONFLICT);
+
+    expect(response.body.code).toBe("PROVIDER_NOT_CONFIGURED");
+    expect(createCredentialConnection).not.toHaveBeenCalled();
+  });
+
+  it("rate-limits credential connect to five attempts per fifteen minutes", async () => {
+    CONFIG.SYNC_CREDENTIAL_ENCRYPTION_KEY = "test-credential-key";
+    const { user } = await UtilDriver.setupTestUser();
+    spyOn(syncServiceFactory, "getSyncServiceClient").mockReturnValue({
+      createCredentialConnection: async () => ({
+        ok: false,
+        error: {
+          kind: "unauthorized",
+          status: 401,
+          correlationId: "corr-rate-limit",
+        },
+      }),
+    } as never);
+
+    for (let i = 0; i < 5; i += 1) {
+      await postCredential(
+        user._id.toString(),
+        "user@icloud.com",
+        `wrong-password-${i}`,
+      ).expect(Status.BAD_REQUEST);
+    }
+
+    const throttled = await postCredential(
+      user._id.toString(),
+      "user@icloud.com",
+      "wrong-password-final",
+    );
+    expect(throttled.status).toBe(429);
   });
 });

--- a/packages/backend/src/auth/controllers/auth.controller.ts
+++ b/packages/backend/src/auth/controllers/auth.controller.ts
@@ -4,6 +4,7 @@ import { Logger } from "@core/logger/winston.logger";
 import {
   type ConnectionBeginRequest,
   ConnectionBeginRequestSchema,
+  ConnectionCredentialRequestSchema,
   toConnectionBeginRedirect,
 } from "@core/types/sync/connection.contracts";
 import {
@@ -14,7 +15,10 @@ import {
 import { zObjectId } from "@core/types/type.utils";
 import compassAuthService from "@backend/auth/services/compass/compass.auth.service";
 import { CONFIG } from "@backend/common/constants/config.constants";
-import { isOAuthConnectConfigured } from "@backend/common/constants/config.util";
+import {
+  isAppleConnectConfigured,
+  isOAuthConnectConfigured,
+} from "@backend/common/constants/config.util";
 import {
   AuthError,
   authErrorCopy,
@@ -22,6 +26,7 @@ import {
 import { error } from "@backend/common/errors/handlers/error.handler";
 import { assertCloudMutationsAllowed } from "@backend/common/services/sync-service/cloud-mutation-mode";
 import { beginSyncConnection } from "@backend/common/services/sync-service/sync-connection-begin";
+import { connectSyncCredential } from "@backend/common/services/sync-service/sync-credential-connect";
 import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
 import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
 import { unwrapSyncResult } from "@backend/common/services/sync-service/unwrap-sync-result";
@@ -54,6 +59,17 @@ const assertProviderCanBegin = (provider: ProviderKind): void => {
     {
       ...AuthError.ProviderNotConfigured,
       description: authErrorCopy.notConfigured(provider),
+    },
+    "Connect Failed",
+  );
+};
+
+const assertAppleCanConnect = (): void => {
+  if (isAppleConnectConfigured(CONFIG)) return;
+  throw error(
+    {
+      ...AuthError.ProviderNotConfigured,
+      description: authErrorCopy.notConfigured("apple"),
     },
     "Connect Failed",
   );
@@ -125,6 +141,26 @@ class AuthController {
     res: Res_Promise,
   ): void => {
     this.beginConnection(req, res, "google");
+  };
+
+  connectCredential = (req: SReqBody<unknown>, res: Res_Promise): void => {
+    if (rejectIfMaintenance(res)) return;
+
+    const request = ConnectionCredentialRequestSchema.parse(req.body ?? {});
+
+    try {
+      assertAppleCanConnect();
+    } catch (err) {
+      res.promise(Promise.reject(err));
+      return;
+    }
+
+    const client = getSyncServiceClient();
+    const userId = zObjectId.parse(req.session?.getUserId()).toString();
+
+    res.promise(
+      connectSyncCredential(client, toSyncPrincipal(userId), request),
+    );
   };
 
   disconnectConnection = (req: SessionRequest, res: Res_Promise): void => {

--- a/packages/backend/src/common/services/sync-service/sync-credential-connect.ts
+++ b/packages/backend/src/common/services/sync-service/sync-credential-connect.ts
@@ -1,0 +1,71 @@
+import { Status } from "@core/errors/status.codes";
+import { Logger } from "@core/logger/winston.logger";
+import {
+  type ConnectionBeginConnectedResponse,
+  type ConnectionCredentialRequest,
+  ConnectionCredentialRequestSchema,
+} from "@core/types/sync/connection.contracts";
+import { AuthError } from "@backend/common/errors/auth/auth.errors";
+import { error } from "@backend/common/errors/handlers/error.handler";
+import { throwSyncProxyFailure } from "./sync-proxy-error";
+import {
+  type SyncPrincipal,
+  type SyncServiceClient,
+} from "./sync-service.client";
+
+const logger = Logger("app:sync-credential-connect");
+
+export const INVALID_APPLE_CREDENTIAL_MESSAGE =
+  "That email or app-specific password was not accepted";
+
+/**
+ * Forward a sealed Apple credential envelope to Sync and return the connected
+ * connection id. Maps Sync invalidCredential (401) to a 400 with stable copy;
+ * throttling and other operational failures surface as 503.
+ */
+export async function connectSyncCredential(
+  client: Pick<SyncServiceClient, "createCredentialConnection">,
+  principal: SyncPrincipal,
+  request: ConnectionCredentialRequest,
+): Promise<ConnectionBeginConnectedResponse> {
+  const parsed = ConnectionCredentialRequestSchema.parse(request);
+  const result = await client.createCredentialConnection(principal, parsed);
+  if (result.ok) {
+    return {
+      kind: "connected",
+      connectionId: result.value.connectionId,
+    };
+  }
+
+  const { kind, status, correlationId, detail } = result.error;
+  if (status === 401) {
+    throw error(
+      {
+        description: INVALID_APPLE_CREDENTIAL_MESSAGE,
+        status: Status.BAD_REQUEST,
+        isOperational: true,
+        code: "INVALID_CREDENTIAL",
+      },
+      "Connect Failed",
+    );
+  }
+  if (kind === "timeout" || kind === "unavailable") {
+    logger.warn(
+      `Sync credential connect failed (${kind}) [correlationId=${correlationId}]` +
+        (detail ? ` ${detail}` : ""),
+    );
+    throw error(
+      {
+        ...AuthError.SyncConnectionUnavailable,
+        description: INVALID_APPLE_CREDENTIAL_MESSAGE,
+      },
+      "Connect Failed",
+    );
+  }
+
+  logger.warn(
+    `Sync credential connect failed (${kind}) [correlationId=${correlationId}]` +
+      (detail ? ` ${detail}` : ""),
+  );
+  throwSyncProxyFailure(kind, "Failed to connect calendar account", detail);
+}

--- a/packages/backend/src/common/services/sync-service/sync-service.client.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.ts
@@ -25,6 +25,9 @@ import {
   type ConnectionBeginRequest,
   type ConnectionBeginResponse,
   ConnectionBeginResponseSchema,
+  type ConnectionCredentialRequest,
+  type ConnectionCredentialResponse,
+  ConnectionCredentialResponseSchema,
   type ConnectionListResponse,
   ConnectionListResponseSchema,
   type ConnectionRefreshResponse,
@@ -55,6 +58,7 @@ const CHANGES_PATH = "/internal/changes";
 const CHANGES_ALL_PATH = "/internal/changes/all";
 const CONNECTIONS_PATH = "/internal/connections";
 const CONNECTIONS_BEGIN_PATH = "/internal/connections/begin";
+const CONNECTIONS_CREDENTIAL_PATH = "/internal/connections/credential";
 const CONNECTIONS_REFRESH_PATH = "/internal/connections/refresh";
 const CONNECTIONS_FOREGROUND_REFRESH_PATH =
   "/internal/connections/foreground-refresh";
@@ -261,6 +265,21 @@ export class SyncServiceClient {
       principal,
       body: request,
       schema: ConnectionBeginResponseSchema,
+      correlationId,
+    });
+  }
+
+  createCredentialConnection(
+    principal: SyncPrincipal,
+    request: ConnectionCredentialRequest,
+    correlationId?: string,
+  ): Promise<SyncClientResult<ConnectionCredentialResponse>> {
+    return this.#request({
+      method: "POST",
+      path: CONNECTIONS_CREDENTIAL_PATH,
+      principal,
+      body: request,
+      schema: ConnectionCredentialResponseSchema,
       correlationId,
     });
   }

--- a/packages/backend/src/user/controllers/user.controller.db.test.ts
+++ b/packages/backend/src/user/controllers/user.controller.db.test.ts
@@ -103,7 +103,7 @@ describe("UserController", () => {
     it("should not delete anyone when there is no session", async () => {
       const { user } = await UtilDriver.setupTestUser();
 
-      await userDriver.deleteAccount(undefined, Status.INTERNAL_SERVER);
+      await userDriver.deleteAccount(undefined, Status.UNAUTHORIZED);
 
       expect(await mongoService.user.findOne({ _id: user._id })).not.toBeNull();
     });

--- a/packages/core/src/security/internal-credential-envelope.test.ts
+++ b/packages/core/src/security/internal-credential-envelope.test.ts
@@ -1,5 +1,7 @@
 import {
+  decryptCredentialConnectPayload,
   decryptInternalCredential,
+  encryptCredentialConnectPayload,
   encryptInternalCredential,
 } from "./internal-credential-envelope";
 import { describe, expect, it } from "bun:test";
@@ -63,6 +65,52 @@ describe("internal credential envelope", () => {
       decryptInternalCredential("shared-secret", envelope, {
         ...context,
         grantedScopes: ["https://www.googleapis.com/auth/calendar.readonly"],
+      }),
+    ).toThrow();
+  });
+
+  it("round-trips a credential connect payload without exposing the secret", () => {
+    const connectContext = {
+      tenantId: context.tenantId,
+      principalId: context.principalId,
+      provider: "apple" as const,
+    };
+    const payload = {
+      username: "user@icloud.com",
+      secret: "app-specific-password",
+    };
+    const envelope = encryptCredentialConnectPayload(
+      "shared-secret",
+      payload,
+      connectContext,
+    );
+
+    expect(JSON.stringify(envelope)).not.toContain(payload.secret);
+    expect(
+      decryptCredentialConnectPayload(
+        "shared-secret",
+        envelope,
+        connectContext,
+      ),
+    ).toEqual(payload);
+  });
+
+  it("rejects a credential connect envelope replayed for another principal", () => {
+    const envelope = encryptCredentialConnectPayload(
+      "shared-secret",
+      { username: "user@icloud.com", secret: "app-specific-password" },
+      {
+        tenantId: context.tenantId,
+        principalId: context.principalId,
+        provider: "apple",
+      },
+    );
+
+    expect(() =>
+      decryptCredentialConnectPayload("shared-secret", envelope, {
+        tenantId: context.tenantId,
+        principalId: "64b7f9c2e1a2b3c4d5e6f7a9",
+        provider: "apple",
       }),
     ).toThrow();
   });

--- a/packages/core/src/security/internal-credential-envelope.ts
+++ b/packages/core/src/security/internal-credential-envelope.ts
@@ -1,8 +1,11 @@
 import {
+  type CredentialConnectPayload,
+  CredentialConnectPayloadSchema,
   type EncryptedCredentialEnvelope,
   EncryptedCredentialEnvelopeSchema,
   type ProviderAccountFacts,
 } from "@core/types/sync/connection.contracts";
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
 import {
   createCipheriv,
   createDecipheriv,
@@ -11,7 +14,9 @@ import {
 } from "node:crypto";
 
 const ALGORITHM = "aes-256-gcm";
-const ROUTE = "POST /internal/connections/adopt-google-authorization";
+const ADOPT_GOOGLE_ROUTE =
+  "POST /internal/connections/adopt-google-authorization";
+const CREDENTIAL_CONNECT_ROUTE = "POST /internal/connections/credential";
 
 function encryptionKey(secret: string): Buffer {
   return createHash("sha256")
@@ -27,35 +32,48 @@ export type GoogleConnectionCredentialContext = {
   grantedScopes: readonly string[];
 };
 
-// Bind every non-secret authorization fact to the credential. Any attempt to
-// replay it under another principal or substitute an account/scope set fails
-// AES-GCM authentication before Sync can persist a connection.
+export type CredentialConnectEnvelopeContext = {
+  tenantId: string;
+  principalId: string;
+  provider: ProviderKind;
+};
+
 function additionalAuthenticatedData(
-  context: GoogleConnectionCredentialContext,
+  route: string,
+  context: GoogleConnectionCredentialContext | CredentialConnectEnvelopeContext,
 ): Buffer {
+  if ("account" in context) {
+    return Buffer.from(
+      JSON.stringify({
+        version: 1,
+        route,
+        tenantId: context.tenantId,
+        principalId: context.principalId,
+        account: context.account,
+        grantedScopes: [...context.grantedScopes].sort(),
+      }),
+    );
+  }
   return Buffer.from(
     JSON.stringify({
       version: 1,
-      route: ROUTE,
+      route,
       tenantId: context.tenantId,
       principalId: context.principalId,
-      account: context.account,
-      grantedScopes: [...context.grantedScopes].sort(),
+      provider: context.provider,
     }),
   );
 }
 
-// Encrypt a credential before it crosses the Compass API → Sync service hop.
-// The shared internal secret provides confidentiality and authentication even
-// when the service mesh itself is configured with an http:// URL.
-export function encryptInternalCredential(
+function encryptInternalPayload(
   secret: string,
   credential: string,
-  context: GoogleConnectionCredentialContext,
+  route: string,
+  context: GoogleConnectionCredentialContext | CredentialConnectEnvelopeContext,
 ): EncryptedCredentialEnvelope {
   const iv = randomBytes(12);
   const cipher = createCipheriv(ALGORITHM, encryptionKey(secret), iv);
-  cipher.setAAD(additionalAuthenticatedData(context));
+  cipher.setAAD(additionalAuthenticatedData(route, context));
   const ciphertext = Buffer.concat([
     cipher.update(credential, "utf8"),
     cipher.final(),
@@ -67,10 +85,11 @@ export function encryptInternalCredential(
   };
 }
 
-export function decryptInternalCredential(
+function decryptInternalPayload(
   secret: string,
   envelope: EncryptedCredentialEnvelope,
-  context: GoogleConnectionCredentialContext,
+  route: string,
+  context: GoogleConnectionCredentialContext | CredentialConnectEnvelopeContext,
 ): string {
   const parsed = EncryptedCredentialEnvelopeSchema.parse(envelope);
   const decipher = createDecipheriv(
@@ -78,10 +97,62 @@ export function decryptInternalCredential(
     encryptionKey(secret),
     Buffer.from(parsed.iv, "base64"),
   );
-  decipher.setAAD(additionalAuthenticatedData(context));
+  decipher.setAAD(additionalAuthenticatedData(route, context));
   decipher.setAuthTag(Buffer.from(parsed.authTag, "base64"));
   return Buffer.concat([
     decipher.update(Buffer.from(parsed.ciphertext, "base64")),
     decipher.final(),
   ]).toString("utf8");
+}
+
+// Encrypt a credential before it crosses the Compass API → Sync service hop.
+// The shared internal secret provides confidentiality and authentication even
+// when the service mesh itself is configured with an http:// URL.
+export function encryptInternalCredential(
+  secret: string,
+  credential: string,
+  context: GoogleConnectionCredentialContext,
+): EncryptedCredentialEnvelope {
+  return encryptInternalPayload(
+    secret,
+    credential,
+    ADOPT_GOOGLE_ROUTE,
+    context,
+  );
+}
+
+export function decryptInternalCredential(
+  secret: string,
+  envelope: EncryptedCredentialEnvelope,
+  context: GoogleConnectionCredentialContext,
+): string {
+  return decryptInternalPayload(secret, envelope, ADOPT_GOOGLE_ROUTE, context);
+}
+
+export function encryptCredentialConnectPayload(
+  secret: string,
+  payload: CredentialConnectPayload,
+  context: CredentialConnectEnvelopeContext,
+): EncryptedCredentialEnvelope {
+  const parsed = CredentialConnectPayloadSchema.parse(payload);
+  return encryptInternalPayload(
+    secret,
+    JSON.stringify(parsed),
+    CREDENTIAL_CONNECT_ROUTE,
+    context,
+  );
+}
+
+export function decryptCredentialConnectPayload(
+  secret: string,
+  envelope: EncryptedCredentialEnvelope,
+  context: CredentialConnectEnvelopeContext,
+): CredentialConnectPayload {
+  const plaintext = decryptInternalPayload(
+    secret,
+    envelope,
+    CREDENTIAL_CONNECT_ROUTE,
+    context,
+  );
+  return CredentialConnectPayloadSchema.parse(JSON.parse(plaintext));
 }

--- a/packages/core/src/types/sync/connection.contracts.test.ts
+++ b/packages/core/src/types/sync/connection.contracts.test.ts
@@ -5,6 +5,8 @@ import {
   ConnectionBeginFeaturesSchema,
   ConnectionBeginRequestSchema,
   ConnectionBeginResponseSchema,
+  ConnectionCredentialRequestSchema,
+  ConnectionCredentialResponseSchema,
   ConnectionListResponseSchema,
   ConnectionStateSchema,
   GoogleConnectionAdoptionRequestSchema,
@@ -278,6 +280,54 @@ describe("Sync connection contracts", () => {
         kind: "redirect",
         authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       });
+    });
+  });
+
+  describe("ConnectionCredentialRequestSchema", () => {
+    it("accepts an Apple credential envelope", () => {
+      expect(
+        ConnectionCredentialRequestSchema.safeParse({
+          provider: "apple",
+          envelope: {
+            iv: "aGVsbG8=",
+            ciphertext: "Y2lwaGVydGV4dA==",
+            authTag: "dGFn",
+          },
+        }).success,
+      ).toBe(true);
+    });
+
+    it("rejects other providers and unknown fields", () => {
+      expect(
+        ConnectionCredentialRequestSchema.safeParse({
+          provider: "google",
+          envelope: {
+            iv: "aGVsbG8=",
+            ciphertext: "Y2lwaGVydGV4dA==",
+            authTag: "dGFn",
+          },
+        }).success,
+      ).toBe(false);
+      expect(
+        ConnectionCredentialRequestSchema.safeParse({
+          provider: "apple",
+          envelope: {
+            iv: "aGVsbG8=",
+            ciphertext: "Y2lwaGVydGV4dA==",
+            authTag: "dGFn",
+          },
+          principalId: objectId(),
+        }).success,
+      ).toBe(false);
+    });
+  });
+
+  describe("ConnectionCredentialResponseSchema", () => {
+    it("accepts a connection id", () => {
+      const connectionId = objectId();
+      expect(
+        ConnectionCredentialResponseSchema.parse({ connectionId }),
+      ).toEqual({ connectionId });
     });
   });
 

--- a/packages/core/src/types/sync/connection.contracts.ts
+++ b/packages/core/src/types/sync/connection.contracts.ts
@@ -236,6 +236,34 @@ export type ConnectionBeginConnectedResponse = z.infer<
   typeof ConnectionBeginConnectedResponseSchema
 >;
 
+// Plaintext payload the browser submits before the Compass API seals it for
+// the Sync hop. Never sent on the wire outside the encrypted envelope.
+export const CredentialConnectPayloadSchema = z.strictObject({
+  username: z.string().trim().email().max(320),
+  secret: z.string().min(1).max(256),
+});
+export type CredentialConnectPayload = z.infer<
+  typeof CredentialConnectPayloadSchema
+>;
+
+// Session-authed Compass API and Sync-internal credential connect body. The
+// principal always comes from the signed session / internal auth, never the
+// body.
+export const ConnectionCredentialRequestSchema = z.strictObject({
+  provider: z.literal("apple"),
+  envelope: EncryptedCredentialEnvelopeSchema,
+});
+export type ConnectionCredentialRequest = z.infer<
+  typeof ConnectionCredentialRequestSchema
+>;
+
+export const ConnectionCredentialResponseSchema = z.strictObject({
+  connectionId: ConnectionIdSchema,
+});
+export type ConnectionCredentialResponse = z.infer<
+  typeof ConnectionCredentialResponseSchema
+>;
+
 export const ConnectionBeginLegacyRedirectResponseSchema = z.strictObject({
   authorizationUrl: z.string().url(),
 });

--- a/packages/sync/src/providers/apple/apple-capabilities.ts
+++ b/packages/sync/src/providers/apple/apple-capabilities.ts
@@ -1,0 +1,9 @@
+import { type ProviderCapability } from "@core/types/sync/identity.contracts";
+
+export const APPLE_PROVIDER_CAPABILITIES: readonly ProviderCapability[] = [
+  "readEvents",
+  "writeEvents",
+  "readBusy",
+  "inviteAttendees",
+  "incrementalChanges",
+];

--- a/packages/sync/src/server/connection.routes.db.test.ts
+++ b/packages/sync/src/server/connection.routes.db.test.ts
@@ -1,6 +1,10 @@
 import { faker } from "@faker-js/faker";
 import { NodeEnv } from "@core/constants/core.constants";
-import { encryptInternalCredential } from "@core/security/internal-credential-envelope";
+import { decryptCredentialAtRest } from "@core/security/credential-at-rest";
+import {
+  encryptCredentialConnectPayload,
+  encryptInternalCredential,
+} from "@core/security/internal-credential-envelope";
 import {
   type ConnectionId,
   type PrincipalId,
@@ -29,7 +33,13 @@ import {
   verifyOAuthState,
 } from "@sync/oauth/oauth-state";
 import {
+  type CredentialValidationInput,
+  type PasswordCredentialAuthAdapter,
+} from "@sync/providers/apple/apple-auth.adapter";
+import { APPLE_PROVIDER_CAPABILITIES } from "@sync/providers/apple/apple-capabilities";
+import {
   type ProviderAuthAdapter,
+  ProviderAuthError,
   type ProviderAuthorization,
   type RefreshedCredential,
 } from "@sync/providers/provider-auth.port";
@@ -43,6 +53,7 @@ import {
   BEGIN_PATH,
   CALENDARS_PATH,
   CONNECTIONS_PATH,
+  CREDENTIAL_PATH,
   EVENTS_FULL_PATH,
   FOREGROUND_REFRESH_PATH,
   OAUTH_CALLBACK_PATH,
@@ -64,6 +75,7 @@ import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-
 import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
+import { readFileSync, statSync } from "node:fs";
 import { type AddressInfo } from "node:net";
 
 const uri = process.env["SYNC_MONGO_URI"] as string;
@@ -135,6 +147,51 @@ class FakeAuthAdapter implements ProviderAuthAdapter {
     this.revoked.push(input.token);
   }
 }
+
+class FakeAppleAuthAdapter implements PasswordCredentialAuthAdapter {
+  validateCalls: CredentialValidationInput[] = [];
+  validateError?: unknown;
+
+  buildAuthorizationUrl(): string {
+    throw new Error("unused");
+  }
+  exchangeAuthorizationCode(): Promise<never> {
+    throw new Error("unused");
+  }
+  refreshAccessToken(): Promise<RefreshedCredential> {
+    throw new Error("unused");
+  }
+  async revoke(): Promise<void> {}
+  async validateCredential(input: CredentialValidationInput): Promise<void> {
+    this.validateCalls.push(input);
+    if (this.validateError) throw this.validateError;
+  }
+}
+
+const registryWithApple = (authAdapter: PasswordCredentialAuthAdapter) => {
+  const config = testConfig({ EXECUTION: "active" });
+  const google = buildProviderRegistry(config, {
+    google: { auth: new FakeAuthAdapter() },
+  }).get("google");
+  return new ProviderRegistry(
+    new Map([
+      [
+        "apple",
+        {
+          ...google,
+          adapters: {
+            ...google.adapters,
+            auth: authAdapter,
+          },
+          capabilities: APPLE_PROVIDER_CAPABILITIES,
+          capabilitiesFromScopes: () => [...APPLE_PROVIDER_CAPABILITIES],
+          callbackPath: "/sync/apple",
+          notificationsCallbackPath: "/sync/notifications/apple",
+        },
+      ],
+    ]),
+  );
+};
 
 const seedConnection = (
   repo: ProviderConnectionRepository,
@@ -1856,5 +1913,195 @@ describe("POST /internal/connections/refresh", () => {
       inFlight: 0,
       resources: 1,
     });
+  });
+});
+
+describe("POST /internal/connections/credential", () => {
+  let mongo: SyncMongoService;
+  let connections: ProviderConnectionRepository;
+  let credentials: CredentialRepository;
+  let service: SyncService;
+  let base: string;
+  let appleAuth: FakeAppleAuthAdapter;
+
+  const startService = async () => {
+    service = createSyncService(testConfig({ EXECUTION: "active" }), {
+      mongo,
+      registry: registryWithApple(appleAuth),
+    });
+    await new Promise<void>((resolve) => service.httpServer.listen(0, resolve));
+    const { port } = service.httpServer.address() as AddressInfo;
+    base = `http://127.0.0.1:${port}`;
+  };
+
+  const connect = async (
+    tenantId: string,
+    principalId: string,
+    username: string,
+    secret: string,
+  ) =>
+    fetch(`${base}${CREDENTIAL_PATH}`, {
+      method: "POST",
+      headers: {
+        ...signedHeaders(tenantId, principalId),
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        provider: "apple",
+        envelope: encryptCredentialConnectPayload(
+          SECRET,
+          { username, secret },
+          { tenantId, principalId, provider: "apple" },
+        ),
+      }),
+    });
+
+  beforeEach(() => {
+    mongo = storage.mongo();
+    connections = new ProviderConnectionRepository(mongo.db);
+    credentials = new CredentialRepository(mongo.db);
+    appleAuth = new FakeAppleAuthAdapter();
+  });
+
+  afterEach(async () => {
+    await service?.stop();
+  });
+
+  it("creates a connection, stores an encrypted password, and enqueues calendarListSync", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    const secret = "app-specific-password-xyz";
+    await startService();
+
+    const logSizeBefore = statSync("logs/app.log").size;
+    const res = await connect(tenantId, principalId, "User@iCloud.com", secret);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { connectionId: string };
+    expect(body.connectionId).toMatch(/^[a-f0-9]{24}$/);
+    expect(appleAuth.validateCalls).toEqual([
+      { username: "User@iCloud.com", secret },
+    ]);
+
+    const [connection] = await connections.listByPrincipal(
+      tenantId as TenantId,
+      principalId as PrincipalId,
+    );
+    expect(connection?.provider).toBe("apple");
+    expect(connection?.account.providerAccountId).toBe("user@icloud.com");
+    expect(connection?.capabilities).toEqual([...APPLE_PROVIDER_CAPABILITIES]);
+
+    const stored = await credentials.findByConnection(body.connectionId);
+    expect(stored?.credentialKind).toBe("password");
+    const raw = await mongo.db
+      .collection(SYNC_COLLECTIONS.credentials)
+      .findOne({ _id: body.connectionId });
+    expect(JSON.stringify(raw)).not.toContain(secret);
+    if (stored?.credentialKind === "password") {
+      expect(
+        decryptCredentialAtRest(TEST_CREDENTIAL_ENCRYPTION_KEY, {
+          ciphertext: stored.secretCiphertext,
+          iv: stored.secretIv,
+          tag: stored.secretTag,
+          keyVersion: stored.keyVersion,
+        }),
+      ).toBe(secret);
+    }
+
+    const job = await mongo.db.collection(SYNC_COLLECTIONS.jobs).findOne({
+      coalescingKey: `calendarListSync:${body.connectionId}`,
+    });
+    expect(job?.kind).toBe("calendarListSync");
+
+    const logTail = readFileSync("logs/app.log")
+      .subarray(logSizeBefore)
+      .toString("utf8");
+    expect(logTail).not.toContain(secret);
+  });
+
+  it("coalesces calendarListSync when reconnecting the same username", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    await startService();
+
+    const first = await connect(
+      tenantId,
+      principalId,
+      "user@icloud.com",
+      "first-password",
+    );
+    const firstBody = (await first.json()) as { connectionId: string };
+    const second = await connect(
+      tenantId,
+      principalId,
+      "user@icloud.com",
+      "second-password",
+    );
+    const secondBody = (await second.json()) as { connectionId: string };
+
+    expect(secondBody.connectionId).toBe(firstBody.connectionId);
+    const jobs = await mongo.db
+      .collection(SYNC_COLLECTIONS.jobs)
+      .find({ coalescingKey: `calendarListSync:${firstBody.connectionId}` })
+      .toArray();
+    expect(jobs).toHaveLength(1);
+
+    const stored = await credentials.findByConnection(firstBody.connectionId);
+    if (stored?.credentialKind === "password") {
+      expect(
+        decryptCredentialAtRest(TEST_CREDENTIAL_ENCRYPTION_KEY, {
+          ciphertext: stored.secretCiphertext,
+          iv: stored.secretIv,
+          tag: stored.secretTag,
+          keyVersion: stored.keyVersion,
+        }),
+      ).toBe("second-password");
+    }
+  });
+
+  it("returns 401 invalidCredential when validation fails", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    appleAuth.validateError = new ProviderAuthError(
+      "authorizationRevoked",
+      "Apple rejected the app-specific password",
+    );
+    await startService();
+
+    const res = await connect(
+      tenantId,
+      principalId,
+      "user@icloud.com",
+      "wrong-password",
+    );
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "invalidCredential" });
+    expect(
+      await connections.listByPrincipal(
+        tenantId as TenantId,
+        principalId as PrincipalId,
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("returns 503 when validation is throttled", async () => {
+    const tenantId = objectId();
+    const principalId = objectId();
+    appleAuth.validateError = new ProviderAuthError(
+      "refreshFailed",
+      "Apple CalDAV throttled credential validation",
+    );
+    await startService();
+
+    const res = await connect(
+      tenantId,
+      principalId,
+      "user@icloud.com",
+      "app-password",
+    );
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: "provider_throttled" });
   });
 });

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -6,7 +6,10 @@ import {
 } from "express";
 import { Status } from "@core/errors/status.codes";
 import { Logger } from "@core/logger/winston.logger";
-import { decryptInternalCredential } from "@core/security/internal-credential-envelope";
+import {
+  decryptCredentialConnectPayload,
+  decryptInternalCredential,
+} from "@core/security/internal-credential-envelope";
 import {
   BusyAvailabilityRequestSchema,
   type BusyAvailabilityResponse,
@@ -14,6 +17,8 @@ import {
 } from "@core/types/sync/availability.contracts";
 import {
   ConnectionBeginFeaturesSchema,
+  ConnectionCredentialRequestSchema,
+  ConnectionCredentialResponseSchema,
   type ConnectionListResponse,
   ConnectionRefreshResponseSchema,
   ForegroundRefreshRequestSchema,
@@ -32,6 +37,7 @@ import {
   type ConnectionId,
   ConnectionIdSchema,
   type PrincipalId,
+  ProviderAccountIdSchema,
   type ProviderKind,
   ProviderKindSchema,
   type TenantId,
@@ -56,6 +62,8 @@ import {
   HORIZON_PAST_MONTHS,
 } from "@sync/domain/horizon";
 import { signOAuthState, verifyOAuthState } from "@sync/oauth/oauth-state";
+import { isPasswordCredentialAuthAdapter } from "@sync/providers/apple/apple-auth.adapter";
+import { APPLE_PROVIDER_CAPABILITIES } from "@sync/providers/apple/apple-capabilities";
 import { isMicrosoftConsentRequired } from "@sync/providers/microsoft/microsoft-consent";
 import {
   type ProviderAuthAdapter,
@@ -99,6 +107,7 @@ export const FOREGROUND_REFRESH_PATH =
   "/internal/connections/foreground-refresh";
 export const ADOPT_GOOGLE_AUTHORIZATION_PATH =
   "/internal/connections/adopt-google-authorization";
+export const CREDENTIAL_PATH = "/internal/connections/credential";
 // Where the provider redirects the browser after consent; `begin` builds the
 // redirect_uri from it and the public callback route below mounts on it.
 // Legacy alias: Google OAuth callback path (also registered under
@@ -622,9 +631,6 @@ export function registerConnectionRoutes(
     },
   );
 
-  // The regular Compass Google sign-in flow already exchanged consent with
-  // Google. Adopt that server-side authorization into Sync so sign-up creates
-  // the same connection and initial import as the dedicated Connect flow.
   app.post(
     ADOPT_GOOGLE_AUTHORIZATION_PATH,
     internalRateLimit,
@@ -669,6 +675,99 @@ export function registerConnectionRoutes(
       } catch (error) {
         logger.error(
           "Failed to adopt Google authorization",
+          redactedCause(error),
+        );
+        respondInternalError(res);
+      }
+    },
+  );
+
+  app.post(
+    CREDENTIAL_PATH,
+    internalRateLimit,
+    deps.authMiddleware,
+    async (req, res) => {
+      const auth = requireAuth(req, res);
+      if (!auth) return;
+      if (!ensureConnected(deps.mongo, res)) return;
+      if (deps.execution === "passive") {
+        res.status(Status.CONFLICT).json({ error: "provider_work_disabled" });
+        return;
+      }
+
+      const parsed = ConnectionCredentialRequestSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(Status.BAD_REQUEST).json({ error: "invalid_request" });
+        return;
+      }
+      const { provider, envelope } = parsed.data;
+      if (!deps.registry.has(provider) || !deps.credentialAtRestKey) {
+        res.status(Status.CONFLICT).json({ error: "provider_work_disabled" });
+        return;
+      }
+
+      const registration = deps.registry.get(provider);
+      const authAdapter = registration.adapters.auth;
+      if (!isPasswordCredentialAuthAdapter(authAdapter)) {
+        res.status(Status.CONFLICT).json({ error: "provider_work_disabled" });
+        return;
+      }
+
+      let username: string;
+      let secret: string;
+      try {
+        const payload = decryptCredentialConnectPayload(
+          deps.credentialEncryptionSecret,
+          envelope,
+          {
+            tenantId: auth.tenantId,
+            principalId: auth.principalId,
+            provider,
+          },
+        );
+        username = payload.username;
+        secret = payload.secret;
+      } catch {
+        res.status(Status.BAD_REQUEST).json({ error: "invalid_request" });
+        return;
+      }
+
+      try {
+        await authAdapter.validateCredential({ username, secret });
+      } catch (error) {
+        if (error instanceof ProviderAuthError) {
+          if (error.reason === "authorizationRevoked") {
+            res
+              .status(Status.UNAUTHORIZED)
+              .json({ error: "invalidCredential" });
+            return;
+          }
+          if (error.reason === "refreshFailed") {
+            res
+              .status(Status.SERVICE_UNAVAILABLE)
+              .json({ error: "provider_throttled" });
+            return;
+          }
+        }
+        logger.error("Credential validation failed", redactedCause(error));
+        respondInternalError(res);
+        return;
+      }
+
+      try {
+        const connectionId = await linkCredentialConnection(deps, {
+          tenantId: auth.tenantId,
+          principalId: auth.principalId,
+          provider,
+          username,
+          secret,
+        });
+        res
+          .status(Status.OK)
+          .json(ConnectionCredentialResponseSchema.parse({ connectionId }));
+      } catch (error) {
+        logger.error(
+          "Failed to link credential connection",
           redactedCause(error),
         );
         respondInternalError(res);
@@ -910,6 +1009,70 @@ function redirectAfterConnect(
   url.searchParams.set("provider", provider);
   url.searchParams.set("status", status);
   res.redirect(url.toString());
+}
+
+async function linkCredentialConnection(
+  deps: ConnectionApiDeps,
+  input: {
+    tenantId: TenantId;
+    principalId: PrincipalId;
+    provider: ProviderKind;
+    username: string;
+    secret: string;
+  },
+): Promise<ConnectionId> {
+  const repos = syncRepositories(deps.mongo);
+  const normalizedUsername = input.username.trim().toLowerCase();
+  const derived: DerivedConnectionState = { state: "importing", reason: null };
+
+  const connection = await repos.connections.upsertByProviderAccount({
+    tenantId: input.tenantId,
+    principalId: input.principalId,
+    provider: input.provider,
+    account: {
+      providerAccountId: ProviderAccountIdSchema.parse(normalizedUsername),
+      email: normalizedUsername,
+      displayName: null,
+    },
+    capabilities: [...APPLE_PROVIDER_CAPABILITIES],
+    state: derived.state,
+    stateReason: derived.reason,
+  });
+
+  try {
+    const custody = new CredentialCustody(
+      repos.credentials,
+      resolveAuthForConnectionApi(deps),
+      undefined,
+      undefined,
+      deps.credentialAtRestKey,
+    );
+    await custody.storePassword(
+      connection._id,
+      input.provider,
+      normalizedUsername,
+      input.secret,
+    );
+  } catch (error) {
+    await repos.connections
+      .markDisconnected(input.tenantId, input.principalId, connection._id)
+      .catch(() => undefined);
+    throw error;
+  }
+
+  await repos.jobs.enqueue(
+    calendarListSyncJob(
+      {
+        tenantId: input.tenantId,
+        principalId: input.principalId,
+        connectionId: connection._id,
+      },
+      new Date(),
+      JOB_PRIORITY.user,
+    ),
+  );
+
+  return connection._id;
 }
 
 // Link an authorized account: upsert its connection (create or reconnect by the


### PR DESCRIPTION
Fixes #3256

## What and why

Adds end-to-end Apple (iCloud) credential connect for WP-03: the Compass API accepts a sealed `{provider: "apple", envelope}` body, forwards it to Sync, validates the app-specific password, stores it encrypted at rest, and enqueues `calendarListSync` (coalesced on reconnect). Wrong credentials map to 400 with stable copy; Sync throttling maps to 503. The route is rate-limited to five attempts per fifteen minutes per signed-in user.

Spec: `docs/features/calendar-providers.md`

## Verify

```
bun test:backend
bun test:sync
bun run type-check
bun lint
bun knip
bun run verify --strict
```

VERDICT: PASS