### PR TITLE
feat(backend): store user identities and look up by provider subject

### DIFF
--- a/docs/development/cli.md
+++ b/docs/development/cli.md
@@ -16,6 +16,7 @@ Primary file:
 | --- | --- | --- |
 | `bun run cli purge-user --email <address> [--apply] [--out report.json]` | `packages/scripts/src/commands/purge-user.ts` | Deletes one user's API, Sync, and SuperTokens data. Defaults to dry-run. |
 | `bun run cli backfill-billing [--apply] [--batch-size 500] [--cutoff ISO]` | `packages/scripts/src/commands/backfill-billing.ts` | Places existing accounts without billing status into awaiting_checkout. Defaults to dry-run. |
+| `bun run cli backfill-identities [--apply] [--batch-size 500]` | `packages/scripts/src/commands/backfill-identities.ts` | Copies `google.googleId` into `identities[]` for users that still only have the legacy Google slot. Defaults to dry-run. Staging and production runs are a founder task. |
 | `bun run cli purge-corrupt-sync-events [--apply]` | `packages/scripts/src/commands/purge-corrupt-sync-events.ts` | Deletes invalid Sync event documents. Defaults to dry-run. |
 | `bun run cli refresh-connection-states [--apply]` | `packages/scripts/src/commands/refresh-connection-states.ts` | Re-derives Sync connection state. Defaults to dry-run. |
 | `bun run cli encrypt-credentials [--apply] [--batch-size 200]` | `packages/scripts/src/commands/encrypt-credentials.ts` | Encrypts legacy plaintext OAuth refresh tokens in Sync credentials. Defaults to dry-run. |

--- a/packages/backend/src/__tests__/drivers/user.driver.ts
+++ b/packages/backend/src/__tests__/drivers/user.driver.ts
@@ -57,9 +57,12 @@ export class UserDriver {
 
     // Simulate "user never connected Google" by removing all Google data
     if (!withGoogle) {
-      await mongoService.user.updateOne({ _id }, { $unset: { google: "" } });
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars -- intentionally omit google from returned user
-      const { google: _google, ...rest } = user;
+      await mongoService.user.updateOne(
+        { _id },
+        { $unset: { google: "", identities: "" } },
+      );
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars -- intentionally omit google/identities from returned user
+      const { google: _google, identities: _identities, ...rest } = user;
       return { ...rest, _id };
     }
 

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -6,6 +6,7 @@ import { createBackendHttpServer } from "@backend/servers/express/express.server
 import { foregroundSyncRefresh } from "@backend/servers/sse/foreground-sync-refresh";
 import { syncChangeFeedBridge } from "@backend/servers/sse/sync-change-feed.bridge";
 import userService from "@backend/user/services/user.service";
+import { ensureUserIndexes } from "@backend/user/user-indexes";
 import { logger } from "./init"; //must be first import
 import { stopPostHogLogs } from "./logging/posthog-logs";
 import { type Server } from "node:http";
@@ -21,6 +22,7 @@ async function start() {
     await mongoService.start();
     await ensureBillingIndexes();
     await ensureBookingIndexes();
+    await ensureUserIndexes();
 
     await new Promise((resolve) =>
       httpServer.listen(CONFIG.PORT, () => {

--- a/packages/backend/src/auth/services/google/util/google.auth.util.test.ts
+++ b/packages/backend/src/auth/services/google/util/google.auth.util.test.ts
@@ -4,6 +4,7 @@ import { ObjectId } from "mongodb";
 import * as userQueries from "@backend/user/queries/user.queries";
 import {
   determineGoogleAuthMode,
+  determineThirdPartyAuthMode,
   parseReconnectGoogleParams,
 } from "./google.auth.util";
 import { describe, expect, it, spyOn } from "bun:test";
@@ -22,7 +23,8 @@ describe("determineGoogleAuthMode", () => {
     });
 
     expect(userQueries.findCanonicalCompassUser).toHaveBeenCalledWith({
-      googleUserId,
+      provider: "google",
+      subjectId: googleUserId,
       email: null,
     });
   });
@@ -54,8 +56,30 @@ describe("determineGoogleAuthMode", () => {
     });
 
     expect(userQueries.findCanonicalCompassUser).toHaveBeenCalledWith({
-      googleUserId,
+      provider: "google",
+      subjectId: googleUserId,
       email: " Existing@Example.com ",
+    });
+  });
+});
+
+describe("determineThirdPartyAuthMode", () => {
+  it("looks up by provider subject and returns the same SIGNUP / SIGNIN outcomes", async () => {
+    const subjectId = faker.string.uuid();
+    spyOn(userQueries, "findCanonicalCompassUser").mockResolvedValue(null);
+
+    await expect(
+      determineThirdPartyAuthMode("microsoft", subjectId, null, true),
+    ).resolves.toEqual({
+      authMode: "SIGNUP",
+      compassUserId: null,
+      createdNewRecipeUser: true,
+    });
+
+    expect(userQueries.findCanonicalCompassUser).toHaveBeenCalledWith({
+      provider: "microsoft",
+      subjectId,
+      email: null,
     });
   });
 });

--- a/packages/backend/src/auth/services/google/util/google.auth.util.ts
+++ b/packages/backend/src/auth/services/google/util/google.auth.util.ts
@@ -1,4 +1,5 @@
 import { type Credentials, type TokenPayload } from "google-auth-library";
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
 import { StringV4Schema, zObjectId } from "@core/types/type.utils";
 import { findCanonicalCompassUser } from "@backend/user/queries/user.queries";
 import {
@@ -6,12 +7,17 @@ import {
   type ParsedReconnectGoogleParams,
 } from "../google.auth.types";
 
-export async function determineGoogleAuthMode(
-  googleUserId: string,
+export async function determineThirdPartyAuthMode(
+  provider: ProviderKind,
+  subjectId: string,
   email: string | null | undefined,
   createdNewRecipeUser: boolean,
 ): Promise<AuthDecision> {
-  const user = await findCanonicalCompassUser({ googleUserId, email });
+  const user = await findCanonicalCompassUser({
+    provider,
+    subjectId,
+    email,
+  });
 
   if (!user) {
     return {
@@ -26,6 +32,19 @@ export async function determineGoogleAuthMode(
     compassUserId: user._id.toString(),
     createdNewRecipeUser,
   };
+}
+
+export async function determineGoogleAuthMode(
+  googleUserId: string,
+  email: string | null | undefined,
+  createdNewRecipeUser: boolean,
+): Promise<AuthDecision> {
+  return determineThirdPartyAuthMode(
+    "google",
+    googleUserId,
+    email,
+    createdNewRecipeUser,
+  );
 }
 
 export function parseReconnectGoogleParams(

--- a/packages/backend/src/common/middleware/supertokens.middleware.handlers.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.handlers.ts
@@ -54,8 +54,9 @@ async function maybeRemapGoogleSignInToCompassSession(
   success: GoogleSignInSuccess;
 }> {
   const connectedCompassUserId = await userService.getCanonicalCompassUserId({
+    provider: "google",
+    subjectId: success.providerUser.sub,
     email: success.providerUser.email,
-    googleUserId: success.providerUser.sub,
   });
 
   if (

--- a/packages/backend/src/user/queries/user.queries.db.test.ts
+++ b/packages/backend/src/user/queries/user.queries.db.test.ts
@@ -1,0 +1,133 @@
+import { ObjectId } from "mongodb";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import mongoService from "@backend/common/services/mongo.service";
+import {
+  findCanonicalCompassUser,
+  identitiesProviderSubjectFilter,
+} from "@backend/user/queries/user.queries";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
+
+const insertUser = async (overrides: {
+  email: string;
+  googleId?: string;
+  identities?: Array<{
+    provider: "google" | "microsoft" | "apple";
+    subjectId: string;
+    email?: string;
+  }>;
+}) => {
+  const _id = new ObjectId();
+  await mongoService.user.insertOne({
+    _id,
+    email: overrides.email,
+    name: "Test User",
+    firstName: "Test",
+    lastName: "User",
+    locale: "en",
+    ...(overrides.googleId
+      ? {
+          google: {
+            googleId: overrides.googleId,
+            picture: "not provided",
+          },
+        }
+      : {}),
+    ...(overrides.identities
+      ? {
+          identities: overrides.identities.map((identity) => ({
+            provider: identity.provider,
+            subjectId: identity.subjectId,
+            email: identity.email ?? overrides.email,
+            linkedAt: new Date("2026-01-01T00:00:00.000Z"),
+          })),
+        }
+      : {}),
+  });
+  return _id;
+};
+
+describe("findCanonicalCompassUser (db)", () => {
+  beforeAll(() => setupTestDb(import.meta.url));
+  beforeEach(cleanupCollections);
+  afterAll(cleanupTestDb);
+
+  it("matches identities by provider and subjectId first", async () => {
+    const userId = await insertUser({
+      email: "ms@example.com",
+      identities: [{ provider: "microsoft", subjectId: "ms-sub-1" }],
+    });
+
+    const found = await findCanonicalCompassUser({
+      provider: "microsoft",
+      subjectId: "ms-sub-1",
+      email: "other@example.com",
+    });
+
+    expect(found?._id).toEqual(userId);
+  });
+
+  it("falls back to google.googleId when identities are missing", async () => {
+    const userId = await insertUser({
+      email: "legacy@example.com",
+      googleId: "google-sub-legacy",
+    });
+
+    const found = await findCanonicalCompassUser({
+      provider: "google",
+      subjectId: "google-sub-legacy",
+      email: "other@example.com",
+    });
+
+    expect(found?._id).toEqual(userId);
+  });
+
+  it("falls back to a verified normalized email when no identity matches", async () => {
+    const userId = await insertUser({
+      email: "password@example.com",
+    });
+
+    const found = await findCanonicalCompassUser({
+      provider: "microsoft",
+      subjectId: "ms-new",
+      email: "  Password@Example.com ",
+    });
+
+    expect(found?._id).toEqual(userId);
+  });
+
+  it("fails closed when the same email already has a different subject on that provider", async () => {
+    await insertUser({
+      email: "taken@example.com",
+      googleId: "google-sub-a",
+      identities: [{ provider: "google", subjectId: "google-sub-a" }],
+    });
+
+    const found = await findCanonicalCompassUser({
+      provider: "google",
+      subjectId: "google-sub-b",
+      email: "taken@example.com",
+    });
+
+    expect(found).toBeNull();
+  });
+
+  it("repeats the partial-index predicate in the identity query", () => {
+    expect(identitiesProviderSubjectFilter("google", "sub-1")).toEqual({
+      identities: {
+        $exists: true,
+        $elemMatch: { provider: "google", subjectId: "sub-1" },
+      },
+    });
+  });
+});

--- a/packages/backend/src/user/queries/user.queries.ts
+++ b/packages/backend/src/user/queries/user.queries.ts
@@ -1,21 +1,71 @@
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+import { type Schema_User } from "@core/types/user.types";
 import { normalizeEmail } from "@backend/common/helpers/email.util";
 import { getIdFilter } from "@backend/common/helpers/mongo.utils";
 import mongoService from "@backend/common/services/mongo.service";
 
 type Ids_User = "email" | "_id" | "google.googleId";
 
-export const findCanonicalCompassUser = async (input: {
-  email?: string | null;
-  googleUserId?: string | null;
-}) => {
-  if (input.googleUserId) {
-    const connectedUser = await findCompassUserBy(
-      "google.googleId",
-      input.googleUserId,
-    );
+export const identitiesProviderSubjectFilter = (
+  provider: ProviderKind,
+  subjectId: string,
+) => ({
+  // Repeat the partial-index predicate so Atlas will consider
+  // `user_identities_provider_subject_unique`.
+  identities: {
+    $exists: true,
+    $elemMatch: { provider, subjectId },
+  },
+});
 
-    if (connectedUser) {
-      return connectedUser;
+function loginSubjectIds(
+  user: Schema_User,
+  provider: ProviderKind,
+): Set<string> {
+  const subjects = new Set<string>();
+  for (const identity of user.identities ?? []) {
+    if (identity.provider === provider) {
+      subjects.add(identity.subjectId);
+    }
+  }
+  // Legacy Google slot still counts as a google login identity until C
+  // drops `google.googleId`. It is not a Microsoft or Apple subject.
+  if (provider === "google" && user.google?.googleId) {
+    subjects.add(user.google.googleId);
+  }
+  return subjects;
+}
+
+function hasConflictingLogin(
+  user: Schema_User,
+  provider: ProviderKind,
+  subjectId: string,
+): boolean {
+  const subjects = loginSubjectIds(user, provider);
+  return subjects.size > 0 && !subjects.has(subjectId);
+}
+
+export const findCanonicalCompassUser = async (input: {
+  provider: ProviderKind;
+  subjectId?: string | null;
+  email?: string | null;
+}) => {
+  if (input.subjectId) {
+    const byIdentity = await mongoService.user.findOne(
+      identitiesProviderSubjectFilter(input.provider, input.subjectId),
+    );
+    if (byIdentity) {
+      return byIdentity;
+    }
+
+    // One-release fallback: un-backfilled Google rows still key off
+    // `google.googleId` only. A non-Google subject will not match.
+    const byLegacyGoogleId = await findCompassUserBy(
+      "google.googleId",
+      input.subjectId,
+    );
+    if (byLegacyGoogleId) {
+      return byLegacyGoogleId;
     }
   }
 
@@ -23,7 +73,21 @@ export const findCanonicalCompassUser = async (input: {
     return null;
   }
 
-  return findCompassUserBy("email", normalizeEmail(input.email));
+  const byEmail = await findCompassUserBy("email", normalizeEmail(input.email));
+  if (!byEmail) {
+    return null;
+  }
+
+  // Same email, different subject on the same provider: do not attach this
+  // login to the existing user (fail closed).
+  if (
+    input.subjectId &&
+    hasConflictingLogin(byEmail, input.provider, input.subjectId)
+  ) {
+    return null;
+  }
+
+  return byEmail;
 };
 
 export const findCompassUserBy = async (key: Ids_User, value: string) => {

--- a/packages/backend/src/user/services/user.service.db.test.ts
+++ b/packages/backend/src/user/services/user.service.db.test.ts
@@ -85,6 +85,13 @@ describe("UserService", () => {
       expect(storedUser?.google?.googleId).toBe(gUser.sub);
       // The credential lives only in Sync now.
       expect(storedUser?.google?.gRefreshToken).toBeUndefined();
+      expect(storedUser?.identities).toEqual([
+        expect.objectContaining({
+          provider: "google",
+          subjectId: gUser.sub,
+          email: gUser.email,
+        }),
+      ]);
     });
   });
 
@@ -124,7 +131,8 @@ describe("UserService", () => {
 
       await expect(
         userService.getCanonicalCompassUserId({
-          googleUserId: user.google?.googleId,
+          provider: "google",
+          subjectId: user.google?.googleId,
           email: faker.internet.email(),
         }),
       ).resolves.toBe(user._id.toString());
@@ -135,12 +143,16 @@ describe("UserService", () => {
       const normalizedEmail = user.email.toLowerCase();
       await mongoService.user.updateOne(
         { _id: user._id },
-        { $set: { email: normalizedEmail }, $unset: { google: "" } },
+        {
+          $set: { email: normalizedEmail },
+          $unset: { google: "", identities: "" },
+        },
       );
 
       await expect(
         userService.getCanonicalCompassUserId({
-          googleUserId: faker.string.uuid(),
+          provider: "google",
+          subjectId: faker.string.uuid(),
           email: ` ${normalizedEmail.toUpperCase()} `,
         }),
       ).resolves.toBe(user._id.toString());
@@ -149,7 +161,8 @@ describe("UserService", () => {
     it("returns null when neither lookup finds a Compass user", async () => {
       await expect(
         userService.getCanonicalCompassUserId({
-          googleUserId: faker.string.uuid(),
+          provider: "google",
+          subjectId: faker.string.uuid(),
           email: faker.internet.email(),
         }),
       ).resolves.toBeNull();

--- a/packages/backend/src/user/services/user.service.ts
+++ b/packages/backend/src/user/services/user.service.ts
@@ -1,7 +1,11 @@
 import { type TokenPayload } from "google-auth-library";
 import { type ClientSession, ObjectId, type WithId } from "mongodb";
 import { Logger } from "@core/logger/winston.logger";
-import { mapUserToCompass } from "@core/mappers/map.user";
+import {
+  mapUserToCompass,
+  mergeGoogleLoginIdentity,
+} from "@core/mappers/map.user";
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
 import { zObjectId } from "@core/types/type.utils";
 import { type Schema_User, type UserProfile } from "@core/types/user.types";
 import compassAuthService from "@backend/auth/services/compass/compass.auth.service";
@@ -101,8 +105,9 @@ class UserService {
   };
 
   getCanonicalCompassUserId = async (input: {
+    provider: ProviderKind;
+    subjectId?: string | null;
     email?: string | null;
-    googleUserId?: string | null;
   }): Promise<string | null> => {
     const user = await findCanonicalCompassUser(input);
     return user?._id.toString() ?? null;
@@ -142,6 +147,12 @@ class UserService {
 
     // Preserve existing Google data, but allow override from input
     const google = input.google ?? existingUser?.google;
+    const identities = mergeGoogleLoginIdentity(
+      existingUser?.identities,
+      google,
+      email,
+      name,
+    );
 
     const nextUser: Schema_User = {
       email,
@@ -152,6 +163,7 @@ class UserService {
       signedUpAt,
       lastLoggedInAt: new Date(),
       ...(google ? { google } : {}),
+      ...(identities ? { identities } : {}),
     };
 
     const { signedUpAt: nextSignedUpAt, ...updatableUser } = nextUser;

--- a/packages/backend/src/user/user-indexes.db.test.ts
+++ b/packages/backend/src/user/user-indexes.db.test.ts
@@ -1,0 +1,99 @@
+import { ObjectId } from "mongodb";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import mongoService from "@backend/common/services/mongo.service";
+import { identitiesProviderSubjectFilter } from "@backend/user/queries/user.queries";
+import {
+  ensureUserIndexes,
+  USER_IDENTITIES_PROVIDER_SUBJECT_INDEX,
+} from "@backend/user/user-indexes";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
+
+const indexNamesFromPlan = (stage: unknown, names: string[] = []): string[] => {
+  if (!stage || typeof stage !== "object") return names;
+  const record = stage as Record<string, unknown>;
+  if (typeof record.indexName === "string") names.push(record.indexName);
+  if (record.inputStage) indexNamesFromPlan(record.inputStage, names);
+  if (Array.isArray(record.inputStages)) {
+    for (const child of record.inputStages) {
+      indexNamesFromPlan(child, names);
+    }
+  }
+  return names;
+};
+
+describe("user indexes", () => {
+  beforeAll(async () => {
+    await setupTestDb(import.meta.url);
+    await ensureUserIndexes();
+  });
+
+  beforeEach(cleanupCollections);
+
+  afterAll(cleanupTestDb);
+
+  it("rejects a second user with the same identities provider and subjectId", async () => {
+    const identity = {
+      provider: "google" as const,
+      subjectId: "shared-sub",
+      email: "a@example.com",
+      linkedAt: new Date("2026-01-01T00:00:00.000Z"),
+    };
+    await mongoService.user.insertOne({
+      email: "a@example.com",
+      name: "A",
+      firstName: "A",
+      lastName: "User",
+      locale: "en",
+      identities: [identity],
+    });
+
+    await expect(
+      mongoService.user.insertOne({
+        email: "b@example.com",
+        name: "B",
+        firstName: "B",
+        lastName: "User",
+        locale: "en",
+        identities: [{ ...identity, email: "b@example.com" }],
+      }),
+    ).rejects.toMatchObject({ code: 11000 });
+  });
+
+  it("uses the identities provider+subject index when the partial predicate is present", async () => {
+    await mongoService.user.insertOne({
+      _id: new ObjectId(),
+      email: "indexed@example.com",
+      name: "Indexed",
+      firstName: "Indexed",
+      lastName: "User",
+      locale: "en",
+      identities: [
+        {
+          provider: "microsoft",
+          subjectId: "ms-sub-index",
+          email: "indexed@example.com",
+          linkedAt: new Date("2026-01-01T00:00:00.000Z"),
+        },
+      ],
+    });
+
+    const explained = await mongoService.user
+      .find(identitiesProviderSubjectFilter("microsoft", "ms-sub-index"))
+      .explain("queryPlanner");
+    const plan = (explained as { queryPlanner?: { winningPlan?: unknown } })
+      .queryPlanner?.winningPlan;
+    const used = indexNamesFromPlan(plan);
+    expect(used).toContain(USER_IDENTITIES_PROVIDER_SUBJECT_INDEX);
+  });
+});

--- a/packages/backend/src/user/user-indexes.ts
+++ b/packages/backend/src/user/user-indexes.ts
@@ -1,0 +1,15 @@
+import mongoService from "@backend/common/services/mongo.service";
+
+export const USER_IDENTITIES_PROVIDER_SUBJECT_INDEX =
+  "user_identities_provider_subject_unique";
+
+export async function ensureUserIndexes(): Promise<void> {
+  await mongoService.user.createIndex(
+    { "identities.provider": 1, "identities.subjectId": 1 },
+    {
+      name: USER_IDENTITIES_PROVIDER_SUBJECT_INDEX,
+      unique: true,
+      partialFilterExpression: { identities: { $exists: true } },
+    },
+  );
+}

--- a/packages/core/src/mappers/map.user.test.ts
+++ b/packages/core/src/mappers/map.user.test.ts
@@ -1,5 +1,5 @@
 import { BaseError } from "../errors/errors.base";
-import { mapUserToCompass } from "./map.user";
+import { mapUserToCompass, mergeGoogleLoginIdentity } from "./map.user";
 
 describe("Map to Compass", () => {
   it("adds placeholders for acceptible fields", () => {
@@ -20,10 +20,40 @@ describe("Map to Compass", () => {
     expect(cUser.firstName).toEqual("Mystery");
     expect(cUser.lastName).toEqual("Person");
     expect(cUser.google?.picture).toEqual("not provided");
+    expect(cUser.google?.googleId).toEqual(gUser.sub);
+    expect(cUser.identities).toEqual([
+      expect.objectContaining({
+        provider: "google",
+        subjectId: gUser.sub,
+        email: gUser.email,
+        picture: "not provided",
+      }),
+    ]);
   });
   it("throws error if missing email", () => {
     expect(() => {
       mapUserToCompass({});
     }).toThrow(BaseError);
+  });
+
+  it("does not duplicate an existing google identity", () => {
+    const google = { googleId: "sub-1", picture: "pic" };
+    const existing = mergeGoogleLoginIdentity(
+      undefined,
+      google,
+      "a@example.com",
+      "A",
+      new Date("2026-01-01T00:00:00.000Z"),
+    );
+
+    expect(
+      mergeGoogleLoginIdentity(
+        existing,
+        google,
+        "a@example.com",
+        "A",
+        new Date("2026-02-01T00:00:00.000Z"),
+      ),
+    ).toEqual(existing);
   });
 });

--- a/packages/core/src/mappers/map.user.ts
+++ b/packages/core/src/mappers/map.user.ts
@@ -1,7 +1,51 @@
 import { type TokenPayload } from "google-auth-library";
 import { BaseError } from "@core/errors/errors.base";
 import { Status } from "@core/errors/status.codes";
-import { type Schema_User } from "@core/types/user.types";
+import {
+  type Schema_User,
+  type Schema_UserIdentity,
+} from "@core/types/user.types";
+
+/**
+ * Dual-write the Google login slot into `identities[]` without duplicating
+ * an existing google identity. `google.googleId` remains the one-release
+ * legacy field; this is the identities copy.
+ */
+export const mergeGoogleLoginIdentity = (
+  identities: Schema_UserIdentity[] | undefined,
+  google: Schema_User["google"] | undefined,
+  email: string,
+  displayName?: string,
+  linkedAt?: Date,
+): Schema_UserIdentity[] | undefined => {
+  if (!google?.googleId) {
+    return identities;
+  }
+
+  const existing = identities ?? [];
+  if (
+    existing.some(
+      (identity) =>
+        identity.provider === "google" &&
+        identity.subjectId === google.googleId,
+    )
+  ) {
+    return existing;
+  }
+
+  const next: Schema_UserIdentity = {
+    provider: "google",
+    subjectId: google.googleId,
+    email,
+    picture: google.picture,
+    linkedAt: linkedAt ?? new Date(),
+  };
+  if (displayName) {
+    next.displayName = displayName;
+  }
+
+  return [...existing, next];
+};
 
 // Map  user object given by google signin to our schema //
 export const mapUserToCompass = (gUser: TokenPayload): Schema_User => {
@@ -14,15 +58,23 @@ export const mapUserToCompass = (gUser: TokenPayload): Schema_User => {
     );
   }
 
+  const google = {
+    googleId: gUser.sub,
+    picture: gUser.picture || "not provided",
+  };
+
   return {
     email: gUser.email,
     name: gUser.name || "Mystery Person",
     firstName: gUser.given_name || "Mystery",
     lastName: gUser.family_name || "Person",
     locale: gUser.locale || "not provided",
-    google: {
-      googleId: gUser.sub,
-      picture: gUser.picture || "not provided",
-    },
+    google,
+    identities: mergeGoogleLoginIdentity(
+      undefined,
+      google,
+      gUser.email,
+      gUser.name,
+    ),
   };
 };

--- a/packages/core/src/types/user.types.ts
+++ b/packages/core/src/types/user.types.ts
@@ -1,5 +1,19 @@
 import type SupertokensUserMetadata from "supertokens-node/recipe/usermetadata";
+import { type ProviderKind } from "./sync/identity.contracts";
 import { type WithId } from "./type.utils";
+
+/**
+ * One login method on a Compass user. Identity is `(provider, subjectId)`;
+ * `email` is display data and is never the lookup key by itself.
+ */
+export interface Schema_UserIdentity {
+  provider: ProviderKind;
+  subjectId: string;
+  email: string;
+  displayName?: string;
+  picture?: string;
+  linkedAt: Date;
+}
 
 export interface Schema_User {
   email: string;
@@ -7,6 +21,11 @@ export interface Schema_User {
   lastName: string;
   name: string;
   locale: string;
+  /**
+   * Login methods linked to this Compass user. `google.googleId` stays
+   * populated for one release while rows are dual-written and backfilled.
+   */
+  identities?: Schema_UserIdentity[];
   google?: {
     googleId: string;
     picture: string;

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -2,6 +2,7 @@ import { CliValidator } from "@scripts/cli.validator";
 import { runApplePollThrottleCommand } from "@scripts/commands/apple-poll-throttle";
 import { runAuditConnectionIdentity } from "@scripts/commands/audit-connection-identity";
 import { runBackfillBilling } from "@scripts/commands/backfill-billing";
+import { runBackfillIdentities } from "@scripts/commands/backfill-identities";
 import { runEncryptCredentials } from "@scripts/commands/encrypt-credentials";
 import { runManageFailedJobs } from "@scripts/commands/manage-failed-jobs";
 import { runPurgeUser } from "@scripts/commands/purge-user";
@@ -29,6 +30,9 @@ export default class CompassCLI {
         break;
       case cmd === "backfill-billing":
         await runBackfillBilling();
+        break;
+      case cmd === "backfill-identities":
+        await runBackfillIdentities();
         break;
       case cmd === "audit-connection-identity":
         await runAuditConnectionIdentity();
@@ -63,6 +67,14 @@ export default class CompassCLI {
       .allowUnknownOption(true)
       .description(
         "stamp awaiting_checkout on accounts with no billing status (--apply to write)",
+      );
+
+    program
+      .command("backfill-identities")
+      .helpOption(false)
+      .allowUnknownOption(true)
+      .description(
+        "copy google.googleId into identities[] for every user (--apply to write)",
       );
 
     program

--- a/packages/scripts/src/commands/audit-connection-identity/audit.db.test.ts
+++ b/packages/scripts/src/commands/audit-connection-identity/audit.db.test.ts
@@ -52,6 +52,7 @@ describe("auditConnectionIdentity provider filter (db)", () => {
                 provider: "microsoft",
                 subjectId: identities.microsoft.subjectId,
                 email: identities.microsoft.email ?? email,
+                linkedAt: new Date("2026-01-01T00:00:00.000Z"),
               },
             ],
           }

--- a/packages/scripts/src/commands/audit-connection-identity/audit.ts
+++ b/packages/scripts/src/commands/audit-connection-identity/audit.ts
@@ -1,8 +1,9 @@
-import { type Db } from "mongodb";
+import { type Db, type WithId } from "mongodb";
 import {
   type ProviderKind,
   ProviderKindSchema,
 } from "@core/types/sync/identity.contracts";
+import { type Schema_User } from "@core/types/user.types";
 import { Collections } from "@backend/common/constants/collections";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 
@@ -30,19 +31,6 @@ export type AuditConnectionIdentityOptions = {
   /** When omitted, every provider kind is audited. */
   provider?: ProviderKind;
 };
-
-interface UserLoginIdentityDoc {
-  provider: ProviderKind;
-  subjectId: string;
-  email?: string;
-}
-
-interface UserLoginDoc {
-  _id: unknown;
-  email: string;
-  google?: { googleId?: string };
-  identities?: UserLoginIdentityDoc[];
-}
 
 interface ConnectionDoc {
   _id: unknown;
@@ -91,7 +79,7 @@ function connectionQuery(providers: readonly ProviderKind[]) {
 }
 
 function indexUserLoginIdentities(
-  user: UserLoginDoc,
+  user: WithId<Schema_User>,
   providers: ReadonlySet<ProviderKind>,
   loginByKey: Map<string, { userId: string; email: string }>,
 ): void {
@@ -138,7 +126,7 @@ export async function auditConnectionIdentity(
   const loginByKey = new Map<string, { userId: string; email: string }>();
 
   const users = compassDb
-    .collection<UserLoginDoc>(Collections.USER)
+    .collection<Schema_User>(Collections.USER)
     .find(userLoginQuery(providers));
   for await (const user of users) {
     indexUserLoginIdentities(user, providerSet, loginByKey);

--- a/packages/scripts/src/commands/backfill-identities.db.test.ts
+++ b/packages/scripts/src/commands/backfill-identities.db.test.ts
@@ -1,0 +1,111 @@
+import { backfillIdentities } from "@scripts/commands/backfill-identities/backfill";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import mongoService from "@backend/common/services/mongo.service";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
+
+const NOW = new Date("2026-09-05T12:00:00.000Z");
+const SIGNED_UP = new Date("2026-01-15T00:00:00.000Z");
+
+describe("backfill-identities (db)", () => {
+  beforeAll(() => setupTestDb(import.meta.url));
+  beforeEach(cleanupCollections);
+  afterAll(cleanupTestDb);
+
+  it("dry-run reports matches without writing", async () => {
+    await mongoService.user.insertOne({
+      email: "legacy@example.com",
+      name: "Legacy",
+      firstName: "Legacy",
+      lastName: "User",
+      locale: "en",
+      signedUpAt: SIGNED_UP,
+      google: { googleId: "google-sub-1", picture: "pic.png" },
+    });
+
+    const report = await backfillIdentities(mongoService.user, {
+      dryRun: true,
+      batchSize: 500,
+      now: NOW,
+    });
+
+    expect(report.matched).toBe(1);
+    expect(report.modified).toBe(0);
+    const stored = await mongoService.user.findOne({
+      email: "legacy@example.com",
+    });
+    expect(stored?.identities).toBeUndefined();
+  });
+
+  it("copies google.googleId into identities and is idempotent", async () => {
+    await mongoService.user.insertOne({
+      email: "legacy@example.com",
+      name: "Legacy User",
+      firstName: "Legacy",
+      lastName: "User",
+      locale: "en",
+      signedUpAt: SIGNED_UP,
+      google: { googleId: "google-sub-1", picture: "pic.png" },
+    });
+    await mongoService.user.insertOne({
+      email: "already@example.com",
+      name: "Already",
+      firstName: "Already",
+      lastName: "Done",
+      locale: "en",
+      signedUpAt: SIGNED_UP,
+      google: { googleId: "google-sub-2", picture: "pic2.png" },
+      identities: [
+        {
+          provider: "google",
+          subjectId: "google-sub-2",
+          email: "already@example.com",
+          linkedAt: SIGNED_UP,
+        },
+      ],
+    });
+
+    const first = await backfillIdentities(mongoService.user, {
+      dryRun: false,
+      batchSize: 500,
+      now: NOW,
+      sleep: async () => undefined,
+    });
+    expect(first.matched).toBe(1);
+    expect(first.modified).toBe(1);
+
+    const stored = await mongoService.user.findOne({
+      email: "legacy@example.com",
+    });
+    expect(stored?.google?.googleId).toBe("google-sub-1");
+    expect(stored?.identities).toEqual([
+      {
+        provider: "google",
+        subjectId: "google-sub-1",
+        email: "legacy@example.com",
+        displayName: "Legacy User",
+        picture: "pic.png",
+        linkedAt: SIGNED_UP,
+      },
+    ]);
+
+    const second = await backfillIdentities(mongoService.user, {
+      dryRun: false,
+      batchSize: 500,
+      now: NOW,
+      sleep: async () => undefined,
+    });
+    expect(second.matched).toBe(0);
+    expect(second.modified).toBe(0);
+  });
+});

--- a/packages/scripts/src/commands/backfill-identities.ts
+++ b/packages/scripts/src/commands/backfill-identities.ts
@@ -1,0 +1,54 @@
+import { backfillIdentities } from "@scripts/commands/backfill-identities/backfill";
+import { Logger } from "@core/logger/winston.logger";
+import mongoService from "@backend/common/services/mongo.service";
+import { ensureUserIndexes } from "@backend/user/user-indexes";
+
+const logger = Logger("scripts.commands.backfill-identities");
+
+function parseArgs(argv: string[]): { dryRun: boolean; batchSize: number } {
+  const batchFlag = argv.indexOf("--batch-size");
+  const batchSize = batchFlag >= 0 ? Number(argv[batchFlag + 1]) : 500;
+  if (!Number.isFinite(batchSize) || batchSize < 1) {
+    throw new Error(
+      "backfill-identities --batch-size must be a positive number",
+    );
+  }
+
+  return { dryRun: !argv.includes("--apply"), batchSize };
+}
+
+/**
+ * Copies `google.googleId` into `identities[]` for users that still only have
+ * the legacy Google slot. Dry-run by default; pass `--apply` to write.
+ * Idempotent: a second apply changes nothing.
+ *
+ * Staging and production runs are a founder task, not this command's job.
+ *
+ * Usage:
+ *   bun run cli backfill-identities [--apply] [--batch-size 500]
+ */
+export async function runBackfillIdentities(): Promise<void> {
+  try {
+    const { dryRun, batchSize } = parseArgs(process.argv.slice(3));
+    await mongoService.start();
+    await ensureUserIndexes();
+
+    logger.info(`backfill-identities dryRun=${dryRun} batchSize=${batchSize}`);
+
+    const report = await backfillIdentities(mongoService.user, {
+      dryRun,
+      batchSize,
+    });
+
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    logger.info(
+      `backfill-identities dryRun=${report.dryRun} matched=${report.matched} modified=${report.modified}`,
+    );
+
+    await mongoService.stop();
+    process.exit(0);
+  } catch (error) {
+    logger.error(error);
+    process.exit(1);
+  }
+}

--- a/packages/scripts/src/commands/backfill-identities/backfill.ts
+++ b/packages/scripts/src/commands/backfill-identities/backfill.ts
@@ -1,0 +1,77 @@
+import { type Collection, type ObjectId } from "mongodb";
+import { mergeGoogleLoginIdentity } from "@core/mappers/map.user";
+import { type Schema_User } from "@core/types/user.types";
+
+export type BackfillIdentitiesReport = {
+  dryRun: boolean;
+  matched: number;
+  modified: number;
+};
+
+const NEEDS_GOOGLE_IDENTITY = {
+  "google.googleId": { $exists: true, $nin: [null, ""] },
+  identities: {
+    $not: { $elemMatch: { provider: "google" as const } },
+  },
+};
+
+export async function backfillIdentities(
+  users: Collection<Schema_User>,
+  options: {
+    dryRun: boolean;
+    batchSize: number;
+    now?: Date;
+    sleep?: (ms: number) => Promise<void>;
+  },
+): Promise<BackfillIdentitiesReport> {
+  const now = options.now ?? new Date();
+  const matched = await users.countDocuments(NEEDS_GOOGLE_IDENTITY);
+  if (options.dryRun || matched === 0) {
+    return { dryRun: options.dryRun, matched, modified: 0 };
+  }
+
+  let modified = 0;
+  let lastId: ObjectId | undefined;
+
+  for (;;) {
+    const batchFilter = lastId
+      ? { ...NEEDS_GOOGLE_IDENTITY, _id: { $gt: lastId } }
+      : NEEDS_GOOGLE_IDENTITY;
+    const batch = await users
+      .find(batchFilter)
+      .sort({ _id: 1 })
+      .limit(options.batchSize)
+      .toArray();
+
+    if (batch.length === 0) break;
+
+    for (const user of batch) {
+      if (!user.google?.googleId) continue;
+      const identities = mergeGoogleLoginIdentity(
+        user.identities,
+        user.google,
+        user.email,
+        user.name,
+        user.signedUpAt ?? now,
+      );
+      if (!identities) continue;
+
+      const result = await users.updateOne(
+        {
+          _id: user._id,
+          "google.googleId": user.google.googleId,
+          identities: {
+            $not: { $elemMatch: { provider: "google" } },
+          },
+        },
+        { $set: { identities } },
+      );
+      modified += result.modifiedCount;
+    }
+
+    lastId = batch[batch.length - 1]?._id;
+    if (options.sleep) await options.sleep(50);
+  }
+
+  return { dryRun: false, matched, modified };
+}


### PR DESCRIPTION
Fixes #3265

## What and why

Providers I WP-01: Compass users now carry `identities[]` (`provider`, `subjectId`, `email`, optional `displayName`/`picture`, `linkedAt`) so login is keyed by provider subject, not email alone. `findCanonicalCompassUser` matches identities first, then the one-release `google.googleId` fallback, then verified normalized email; the same email with a different subject on the same provider fails closed. `determineGoogleAuthMode` is a thin wrapper over `determineThirdPartyAuthMode("google", ...)`, so Google sign-in call sites stay equivalent. New Google users are dual-written. `backfill-identities` copies existing `google.googleId` rows into `identities[]` (dry-run default; staging/prod runs remain #3416).

Line numbers in the issue were from `a85f848`; this branch is from `c2dfe8efb`. `Schema_User` gained `identities` above `google`; lookup still lives in `user.queries.ts`; Google auth mode still lives in `google.auth.util.ts`.

## Verify

`VERDICT: PASS`

Checks run: `test:core`, `test:backend`, `test:scripts`, `type-check`, `lint`, `knip`
Checks skipped: (none)