### PR TITLE
feat(web): Connect iCloud credential form (WP-09)

### DIFF
--- a/e2e/accessibility/apple-connect-a11y.spec.ts
+++ b/e2e/accessibility/apple-connect-a11y.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "@playwright/test";
+import { expectNoAxeViolations } from "../utils/axe-assertion";
+import { prepareCalendarPage } from "../utils/event-test-utils";
+
+type CompassE2EStoreWindow = Window & {
+  __COMPASS_E2E_STORE__?: {
+    connectApple?: {
+      open: (initialEmail?: string) => void;
+    };
+  };
+};
+
+test("the Connect Apple Calendar form is accessible when open", async ({
+  page,
+}) => {
+  await page.route("**/*", async (route) => {
+    const url = new URL(route.request().url());
+    const { pathname } = url;
+
+    if (pathname.endsWith("/api/config")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          providers: {
+            google: { signIn: true, connect: true },
+            microsoft: { signIn: false, connect: false },
+            apple: { signIn: false, connect: true },
+          },
+        }),
+      });
+    }
+
+    return route.continue();
+  });
+
+  await prepareCalendarPage(page);
+  await page.waitForFunction(
+    () =>
+      (window as CompassE2EStoreWindow).__COMPASS_E2E_STORE__?.connectApple !=
+      null,
+  );
+  await page.evaluate(() => {
+    (
+      window as CompassE2EStoreWindow
+    ).__COMPASS_E2E_STORE__?.connectApple?.open();
+  });
+
+  await expect(
+    page.getByRole("dialog", { name: "Connect Apple Calendar" }),
+  ).toBeVisible();
+
+  await expectNoAxeViolations(page, {
+    checkpoint: "connect apple calendar form",
+  });
+});

--- a/packages/backend/src/auth/controllers/auth.controller.ts
+++ b/packages/backend/src/auth/controllers/auth.controller.ts
@@ -4,7 +4,6 @@ import { Logger } from "@core/logger/winston.logger";
 import {
   type ConnectionBeginRequest,
   ConnectionBeginRequestSchema,
-  ConnectionCredentialRequestSchema,
   toConnectionBeginRedirect,
 } from "@core/types/sync/connection.contracts";
 import {
@@ -25,6 +24,7 @@ import {
 } from "@backend/common/errors/auth/auth.errors";
 import { error } from "@backend/common/errors/handlers/error.handler";
 import { assertCloudMutationsAllowed } from "@backend/common/services/sync-service/cloud-mutation-mode";
+import { sealCredentialConnectRequest } from "@backend/common/services/sync-service/seal-credential-connect-request";
 import { beginSyncConnection } from "@backend/common/services/sync-service/sync-connection-begin";
 import { connectSyncCredential } from "@backend/common/services/sync-service/sync-credential-connect";
 import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
@@ -146,8 +146,6 @@ class AuthController {
   connectCredential = (req: SReqBody<unknown>, res: Res_Promise): void => {
     if (rejectIfMaintenance(res)) return;
 
-    const request = ConnectionCredentialRequestSchema.parse(req.body ?? {});
-
     try {
       assertAppleCanConnect();
     } catch (err) {
@@ -157,6 +155,11 @@ class AuthController {
 
     const client = getSyncServiceClient();
     const userId = zObjectId.parse(req.session?.getUserId()).toString();
+    const request = sealCredentialConnectRequest(
+      userId,
+      userId,
+      req.body ?? {},
+    );
 
     res.promise(
       connectSyncCredential(client, toSyncPrincipal(userId), request),

--- a/packages/backend/src/common/services/sync-service/seal-credential-connect-request.ts
+++ b/packages/backend/src/common/services/sync-service/seal-credential-connect-request.ts
@@ -1,0 +1,34 @@
+import { encryptCredentialConnectPayload } from "@core/security/internal-credential-envelope";
+import {
+  ConnectionCredentialBrowserRequestSchema,
+  type ConnectionCredentialRequest,
+  ConnectionCredentialRequestSchema,
+  ConnectionCredentialSubmitRequestSchema,
+} from "@core/types/sync/connection.contracts";
+import { CONFIG } from "@backend/common/constants/config.constants";
+
+export function sealCredentialConnectRequest(
+  tenantId: string,
+  principalId: string,
+  body: unknown,
+): ConnectionCredentialRequest {
+  const parsed = ConnectionCredentialSubmitRequestSchema.parse(body);
+  if ("envelope" in parsed) {
+    return ConnectionCredentialRequestSchema.parse(parsed);
+  }
+
+  const browser = ConnectionCredentialBrowserRequestSchema.parse(parsed);
+  const secret = CONFIG.SYNC_INTERNAL_AUTH_TOKEN;
+  if (!secret) {
+    throw new Error("Sync internal auth token is not configured");
+  }
+
+  return {
+    provider: "apple",
+    envelope: encryptCredentialConnectPayload(
+      secret,
+      { username: browser.username, secret: browser.secret },
+      { tenantId, principalId, provider: "apple" },
+    ),
+  };
+}

--- a/packages/core/src/types/sync/connection.contracts.test.ts
+++ b/packages/core/src/types/sync/connection.contracts.test.ts
@@ -7,6 +7,7 @@ import {
   ConnectionBeginResponseSchema,
   ConnectionCredentialRequestSchema,
   ConnectionCredentialResponseSchema,
+  ConnectionCredentialSubmitRequestSchema,
   ConnectionListResponseSchema,
   ConnectionStateSchema,
   GoogleConnectionAdoptionRequestSchema,
@@ -293,6 +294,16 @@ describe("Sync connection contracts", () => {
             ciphertext: "Y2lwaGVydGV4dA==",
             authTag: "dGFn",
           },
+        }).success,
+      ).toBe(true);
+    });
+
+    it("accepts a browser credential payload in the submit union", () => {
+      expect(
+        ConnectionCredentialSubmitRequestSchema.safeParse({
+          provider: "apple",
+          username: "user@icloud.com",
+          secret: "app-specific-password",
         }).success,
       ).toBe(true);
     });

--- a/packages/core/src/types/sync/connection.contracts.ts
+++ b/packages/core/src/types/sync/connection.contracts.ts
@@ -246,6 +246,17 @@ export type CredentialConnectPayload = z.infer<
   typeof CredentialConnectPayloadSchema
 >;
 
+// Browser-submitted credential connect body over HTTPS. The Compass API
+// seals this into an envelope before forwarding to Sync.
+export const ConnectionCredentialBrowserRequestSchema = z.strictObject({
+  provider: z.literal("apple"),
+  username: CredentialConnectPayloadSchema.shape.username,
+  secret: CredentialConnectPayloadSchema.shape.secret,
+});
+export type ConnectionCredentialBrowserRequest = z.infer<
+  typeof ConnectionCredentialBrowserRequestSchema
+>;
+
 // Session-authed Compass API and Sync-internal credential connect body. The
 // principal always comes from the signed session / internal auth, never the
 // body.
@@ -255,6 +266,14 @@ export const ConnectionCredentialRequestSchema = z.strictObject({
 });
 export type ConnectionCredentialRequest = z.infer<
   typeof ConnectionCredentialRequestSchema
+>;
+
+export const ConnectionCredentialSubmitRequestSchema = z.union([
+  ConnectionCredentialBrowserRequestSchema,
+  ConnectionCredentialRequestSchema,
+]);
+export type ConnectionCredentialSubmitRequest = z.infer<
+  typeof ConnectionCredentialSubmitRequestSchema
 >;
 
 export const ConnectionCredentialResponseSchema = z.strictObject({

--- a/packages/web/declaration.d.ts
+++ b/packages/web/declaration.d.ts
@@ -41,6 +41,11 @@ interface Window {
    * user-metadata.store.ts); keys are optional because they populate
    * independently as their modules evaluate. */
   __COMPASS_E2E_STORE__?: {
+    connectApple?: {
+      close: () => void;
+      getState: () => import("@web/auth/providers/connect-apple.store").ConnectAppleState;
+      open: (initialEmail?: string) => void;
+    };
     userMetadata?: {
       getState: () => import("@web/auth/state/user-metadata.store").UserMetadataState;
       set: (metadata: import("@core/types/user.types").UserMetadata) => void;

--- a/packages/web/src/__tests__/utils/state/reset-stores.ts
+++ b/packages/web/src/__tests__/utils/state/reset-stores.ts
@@ -5,6 +5,7 @@
  * a fresh store per render.
  */
 
+import { resetConnectAppleStoreForTests } from "@web/auth/providers/connect-apple.store";
 import {
   initialUserMetadataState,
   useUserMetadataStore,
@@ -93,6 +94,7 @@ const storeResets: StoreReset[] = [
   resetEventRepositorySourceForTests,
   // Storage itself is cleared by resetBrowserState() (test-lifecycle.ts)
   // before this runs; this just resyncs the module-singleton store to match.
+  resetConnectAppleStoreForTests,
   resetCalendarVisibilityStoreForTests,
   resetDefaultCalendarStoreForTests,
   resetEffectiveTimeZoneStoreForTests,

--- a/packages/web/src/api/auth.api.ts
+++ b/packages/web/src/api/auth.api.ts
@@ -3,11 +3,14 @@ import {
   type Result_Auth_Compass,
 } from "@core/types/auth.types";
 import {
+  type ConnectionBeginConnectedResponse,
+  ConnectionBeginConnectedResponseSchema,
   type ConnectionBeginRequest,
   type ConnectionBeginResponse,
   ConnectionBeginResponseSchema,
   type ConnectionRefreshResponse,
   ConnectionRefreshResponseSchema,
+  type CredentialConnectPayload,
 } from "@core/types/sync/connection.contracts";
 import { BaseApi } from "@web/api/base/base.api";
 
@@ -75,6 +78,17 @@ const AuthApi = {
     );
 
     return ConnectionRefreshResponseSchema.parse(response.data);
+  },
+
+  async connectAppleCredential(
+    payload: CredentialConnectPayload,
+  ): Promise<ConnectionBeginConnectedResponse> {
+    const response = await BaseApi.post(`/auth/connections/credential`, {
+      provider: "apple",
+      username: payload.username,
+      secret: payload.secret,
+    });
+    return ConnectionBeginConnectedResponseSchema.parse(response.data);
   },
 };
 

--- a/packages/web/src/auth/providers/ConnectAppleForm.test.tsx
+++ b/packages/web/src/auth/providers/ConnectAppleForm.test.tsx
@@ -1,0 +1,190 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Status } from "@core/errors/status.codes";
+import { ConnectionIdSchema } from "@core/types/sync/identity.contracts";
+import { createStoreWrapper } from "@web/__tests__/render-with-store";
+import { AuthApi } from "@web/api/auth.api";
+import { createApiError } from "@web/api/util/api.util";
+import { refreshUserMetadata } from "@web/auth/compass/user/util/user-metadata.util";
+import { ConnectAppleForm } from "@web/auth/providers/ConnectAppleForm";
+import {
+  APPLE_CREDENTIAL_INVALID_MESSAGE,
+  APPLE_CREDENTIAL_RATE_LIMIT_MESSAGE,
+} from "@web/auth/providers/connect-apple.copy";
+import {
+  connectAppleActions,
+  useConnectAppleStore,
+} from "@web/auth/providers/connect-apple.store";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
+
+mock.module("@web/auth/compass/user/util/user-metadata.util", () => ({
+  refreshUserMetadata: mock(() => Promise.resolve()),
+}));
+
+describe("ConnectAppleForm", () => {
+  beforeEach(() => {
+    connectAppleActions.open();
+  });
+
+  afterEach(() => {
+    connectAppleActions.close();
+  });
+
+  it("connects successfully and clears the password field", async () => {
+    const user = userEvent.setup();
+    const connectSpy = spyOn(
+      AuthApi,
+      "connectAppleCredential",
+    ).mockResolvedValue({
+      kind: "connected",
+      connectionId: ConnectionIdSchema.parse("64b7f9c2e1a2b3c4d5e6f7a8"),
+    });
+    const { wrapper } = createStoreWrapper();
+
+    render(<ConnectAppleForm />, { wrapper });
+
+    await user.type(screen.getByLabelText("Apple ID email"), "user@icloud.com");
+    await user.type(
+      screen.getByLabelText("App-specific password"),
+      "secret-password",
+    );
+    await user.click(screen.getByRole("button", { name: "Connect" }));
+
+    await waitFor(() => {
+      expect(connectSpy).toHaveBeenCalledWith({
+        username: "user@icloud.com",
+        secret: "secret-password",
+      });
+    });
+    expect(refreshUserMetadata).toHaveBeenCalledWith({ force: true });
+    await waitFor(() => {
+      expect(useConnectAppleStore.getState().isOpen).toBe(false);
+    });
+
+    connectSpy.mockRestore();
+  });
+
+  it("shows the backend wrong-password copy whole", async () => {
+    const user = userEvent.setup();
+    const connectSpy = spyOn(
+      AuthApi,
+      "connectAppleCredential",
+    ).mockRejectedValue(
+      createApiError(
+        { method: "POST", url: "/auth/connections/credential" },
+        {
+          config: { method: "POST", url: "/auth/connections/credential" },
+          data: {
+            code: "INVALID_CREDENTIAL",
+            message: APPLE_CREDENTIAL_INVALID_MESSAGE,
+          },
+          headers: new Headers(),
+          status: Status.BAD_REQUEST,
+          statusText: "Bad Request",
+        },
+      ),
+    );
+    const { wrapper } = createStoreWrapper();
+
+    render(<ConnectAppleForm />, { wrapper });
+
+    await user.type(screen.getByLabelText("Apple ID email"), "user@icloud.com");
+    await user.type(
+      screen.getByLabelText("App-specific password"),
+      "wrong-password",
+    );
+    await user.click(screen.getByRole("button", { name: "Connect" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      APPLE_CREDENTIAL_INVALID_MESSAGE,
+    );
+
+    connectSpy.mockRestore();
+  });
+
+  it("shows the rate-limited copy whole", async () => {
+    const user = userEvent.setup();
+    const connectSpy = spyOn(
+      AuthApi,
+      "connectAppleCredential",
+    ).mockRejectedValue(
+      createApiError(
+        { method: "POST", url: "/auth/connections/credential" },
+        {
+          config: { method: "POST", url: "/auth/connections/credential" },
+          data: { message: "Too Many Requests" },
+          headers: new Headers(),
+          status: Status.TOO_MANY_REQUESTS,
+          statusText: "Too Many Requests",
+        },
+      ),
+    );
+    const { wrapper } = createStoreWrapper();
+
+    render(<ConnectAppleForm />, { wrapper });
+
+    await user.type(screen.getByLabelText("Apple ID email"), "user@icloud.com");
+    await user.type(
+      screen.getByLabelText("App-specific password"),
+      "wrong-password",
+    );
+    await user.click(screen.getByRole("button", { name: "Connect" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      APPLE_CREDENTIAL_RATE_LIMIT_MESSAGE,
+    );
+
+    connectSpy.mockRestore();
+  });
+
+  it("pre-fills the email on reconnect open", () => {
+    connectAppleActions.open("host@icloud.com");
+    const { wrapper } = createStoreWrapper();
+
+    render(<ConnectAppleForm />, { wrapper });
+
+    expect(screen.getByLabelText("Apple ID email")).toHaveValue(
+      "host@icloud.com",
+    );
+  });
+
+  it("does not keep the password in the connect store after submit", async () => {
+    const user = userEvent.setup();
+    const connectSpy = spyOn(
+      AuthApi,
+      "connectAppleCredential",
+    ).mockResolvedValue({
+      kind: "connected",
+      connectionId: ConnectionIdSchema.parse("64b7f9c2e1a2b3c4d5e6f7a8"),
+    });
+    const { wrapper } = createStoreWrapper();
+
+    render(<ConnectAppleForm />, { wrapper });
+
+    await user.type(screen.getByLabelText("Apple ID email"), "user@icloud.com");
+    await user.type(
+      screen.getByLabelText("App-specific password"),
+      "secret-password",
+    );
+    await user.click(screen.getByRole("button", { name: "Connect" }));
+
+    await waitFor(() => {
+      expect(connectSpy).toHaveBeenCalled();
+    });
+    expect(useConnectAppleStore.getState()).toEqual({
+      isOpen: false,
+      initialEmail: "",
+    });
+    expect(screen.queryByLabelText("App-specific password")).toBeNull();
+
+    connectSpy.mockRestore();
+  });
+});

--- a/packages/web/src/auth/providers/ConnectAppleForm.tsx
+++ b/packages/web/src/auth/providers/ConnectAppleForm.tsx
@@ -1,0 +1,192 @@
+import { type FC, useEffect, useId, useRef, useState } from "react";
+import {
+  APPLE_CREDENTIAL_INSTRUCTIONS,
+  APPLE_CREDENTIAL_PRIVACY_NOTE,
+  APPLE_SELF_HOSTING_DOC_URL,
+} from "@web/auth/providers/connect-apple.copy";
+import {
+  connectAppleActions,
+  selectConnectAppleInitialEmail,
+  selectConnectAppleOpen,
+  useConnectAppleStore,
+} from "@web/auth/providers/connect-apple.store";
+import { useSubmitAppleCredential } from "@web/auth/providers/useSubmitAppleCredential";
+import { AuthInput } from "@web/components/AuthModal/components/AuthInput";
+import {
+  OverlayPanel,
+  OverlayPanelActionButton,
+  OverlayPanelActions,
+} from "@web/components/OverlayPanel/OverlayPanel";
+import { useAppLockReason } from "@web/shortcuts/app-lock";
+import { isFloatingLayerOpen } from "@web/shortcuts/floating-layer";
+import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
+import { DiscardUnsavedChangesDialog } from "@web/views/Forms/EventForm/DiscardUnsavedChangesDialog";
+
+export const ConnectAppleForm: FC = () => {
+  const isOpen = useConnectAppleStore(selectConnectAppleOpen);
+  const initialEmail = useConnectAppleStore(selectConnectAppleInitialEmail);
+  const submitCredential = useSubmitAppleCredential();
+  const emailRef = useRef<HTMLInputElement>(null);
+  const instructionsId = useId();
+  const privacyId = useId();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const [baselineEmail, setBaselineEmail] = useState("");
+  useAppLockReason("connectAppleForm", isOpen);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setEmail(initialEmail);
+    setBaselineEmail(initialEmail);
+    setPassword("");
+    setError(null);
+    setIsSubmitting(false);
+    setIsConfirmOpen(false);
+  }, [initialEmail, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    emailRef.current?.focus();
+  }, [isOpen]);
+
+  const isDirty = email.trim() !== baselineEmail.trim() || password.length > 0;
+
+  const requestClose = () => {
+    if (isSubmitting) return;
+    if (isDirty) {
+      setIsConfirmOpen(true);
+      return;
+    }
+    connectAppleActions.close();
+  };
+
+  useAppShortcut(
+    "Escape",
+    (event) => {
+      if (!isOpen || isFloatingLayerOpen()) return;
+      event.preventDefault();
+      requestClose();
+    },
+    { ignoreInputs: false },
+  );
+
+  const handleSubmit = async () => {
+    if (isSubmitting) return;
+    setError(null);
+    setIsSubmitting(true);
+    const username = email.trim();
+    const secret = password;
+    try {
+      await submitCredential(username, secret);
+      setPassword("");
+    } catch (submitError) {
+      if (submitError instanceof Error && submitError.message) {
+        setError(submitError.message);
+      }
+    } finally {
+      setIsSubmitting(false);
+      setPassword("");
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      <OverlayPanel
+        align="start"
+        ariaLabel="Connect Apple Calendar"
+        initialFocusRef={emailRef}
+        onDismiss={requestClose}
+        onModEnter={() => {
+          void handleSubmit();
+        }}
+        onShiftEscape={() => {
+          if (isSubmitting) return;
+          setIsConfirmOpen(false);
+          connectAppleActions.close();
+        }}
+        title="Connect Apple Calendar"
+        variant="modal"
+        widthClassName="w-120"
+      >
+        <div className="flex flex-col gap-4 text-sm text-text">
+          <ol
+            className="list-decimal space-y-1 pl-5 text-text-muted"
+            id={instructionsId}
+          >
+            {APPLE_CREDENTIAL_INSTRUCTIONS.map((step) => (
+              <li key={step}>{step}</li>
+            ))}
+          </ol>
+          <p>
+            <a
+              className="c-focus-ring rounded-xs text-accent underline"
+              href={APPLE_SELF_HOSTING_DOC_URL}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Self-hosting guide with screenshots
+            </a>
+          </p>
+          <p className="text-text-muted" id={privacyId}>
+            {APPLE_CREDENTIAL_PRIVACY_NOTE}
+          </p>
+          <AuthInput
+            autoComplete="email"
+            disabled={isSubmitting}
+            label="Apple ID email"
+            onChange={(event) => setEmail(event.target.value)}
+            ref={emailRef}
+            type="email"
+            value={email}
+          />
+          <AuthInput
+            aria-describedby={`${instructionsId} ${privacyId}`}
+            autoComplete="new-password"
+            disabled={isSubmitting}
+            error={error ?? undefined}
+            hasError={error != null}
+            label="App-specific password"
+            onChange={(event) => setPassword(event.target.value)}
+            type="password"
+            value={password}
+          />
+        </div>
+        <OverlayPanelActions align="end">
+          <OverlayPanelActionButton
+            disabled={isSubmitting}
+            onClick={requestClose}
+          >
+            Cancel
+          </OverlayPanelActionButton>
+          <OverlayPanelActionButton
+            aria-busy={isSubmitting || undefined}
+            disabled={
+              isSubmitting || email.trim().length === 0 || password.length === 0
+            }
+            onClick={() => {
+              void handleSubmit();
+            }}
+            shortcut={["Mod", "Enter"]}
+            showShortcut
+            variant="primary"
+          >
+            {isSubmitting ? "Connecting…" : "Connect"}
+          </OverlayPanelActionButton>
+        </OverlayPanelActions>
+      </OverlayPanel>
+      <DiscardUnsavedChangesDialog
+        isOpen={isConfirmOpen}
+        onCancel={() => setIsConfirmOpen(false)}
+        onDiscard={() => {
+          setIsConfirmOpen(false);
+          connectAppleActions.close();
+        }}
+      />
+    </>
+  );
+};

--- a/packages/web/src/auth/providers/connect-apple.copy.ts
+++ b/packages/web/src/auth/providers/connect-apple.copy.ts
@@ -1,0 +1,19 @@
+export const APPLE_CREDENTIAL_INVALID_MESSAGE =
+  "That email or app-specific password was not accepted";
+
+export const APPLE_CREDENTIAL_RATE_LIMIT_MESSAGE =
+  "Too many attempts. Try again in 15 minutes.";
+
+export const APPLE_CREDENTIAL_PRIVACY_NOTE =
+  "An app-specific password gives Compass access to your whole iCloud account. Compass uses it only for Calendar and stores it encrypted. You can revoke it any time at appleid.apple.com.";
+
+export const APPLE_CREDENTIAL_INSTRUCTIONS = [
+  "Sign in at appleid.apple.com.",
+  "Open Sign-In and Security.",
+  "Choose App-Specific Passwords.",
+  'Generate a password and name it "Compass".',
+  "Paste the generated password here.",
+] as const;
+
+export const APPLE_SELF_HOSTING_DOC_URL =
+  "https://github.com/KeepSoftwareSimple/compass-calendar/blob/main/docs/self-hosting/apple-calendar.md";

--- a/packages/web/src/auth/providers/connect-apple.store.ts
+++ b/packages/web/src/auth/providers/connect-apple.store.ts
@@ -1,0 +1,49 @@
+import { create } from "zustand";
+
+export type ConnectAppleState = {
+  isOpen: boolean;
+  initialEmail: string;
+};
+
+const initialConnectAppleState: ConnectAppleState = {
+  isOpen: false,
+  initialEmail: "",
+};
+
+export const useConnectAppleStore = create<ConnectAppleState>(
+  () => initialConnectAppleState,
+);
+
+export const connectAppleActions = {
+  open: (initialEmail = ""): void => {
+    useConnectAppleStore.setState({
+      isOpen: true,
+      initialEmail: initialEmail.trim(),
+    });
+  },
+  close: (): void => {
+    useConnectAppleStore.setState(initialConnectAppleState);
+  },
+};
+
+export const resetConnectAppleStoreForTests = (): void => {
+  useConnectAppleStore.setState(initialConnectAppleState, true);
+};
+
+if (typeof window !== "undefined") {
+  window.__COMPASS_E2E_STORE__ = {
+    ...window.__COMPASS_E2E_STORE__,
+    connectApple: {
+      close: connectAppleActions.close,
+      getState: useConnectAppleStore.getState,
+      open: connectAppleActions.open,
+    },
+  };
+}
+
+export const selectConnectAppleOpen = (state: ConnectAppleState): boolean =>
+  state.isOpen;
+
+export const selectConnectAppleInitialEmail = (
+  state: ConnectAppleState,
+): string => state.initialEmail;

--- a/packages/web/src/auth/providers/provider-connect-flow.util.ts
+++ b/packages/web/src/auth/providers/provider-connect-flow.util.ts
@@ -1,0 +1,17 @@
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+
+export type ConnectFlowKind = "oauthRedirect" | "credentialForm";
+
+const CONNECT_FLOW_BY_KIND: Record<ProviderKind, ConnectFlowKind> = {
+  google: "oauthRedirect",
+  microsoft: "oauthRedirect",
+  apple: "credentialForm",
+};
+
+export function connectFlowKind(kind: ProviderKind): ConnectFlowKind {
+  return CONNECT_FLOW_BY_KIND[kind];
+}
+
+export function usesCredentialFormConnect(kind: ProviderKind): boolean {
+  return connectFlowKind(kind) === "credentialForm";
+}

--- a/packages/web/src/auth/providers/useConnectProvider.test.tsx
+++ b/packages/web/src/auth/providers/useConnectProvider.test.tsx
@@ -3,6 +3,10 @@ import { ConnectionIdSchema } from "@core/types/sync/identity.contracts";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
 import { AuthApi } from "@web/api/auth.api";
+import {
+  connectAppleActions,
+  useConnectAppleStore,
+} from "@web/auth/providers/connect-apple.store";
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import { useConnectProvider } from "./useConnectProvider";
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
@@ -60,6 +64,69 @@ describe("useConnectProvider", () => {
     assign.mockRestore();
   });
 
+  it("opens the Apple credential form instead of navigating", async () => {
+    const assign = spyOn(window.location, "assign").mockImplementation(
+      () => {},
+    );
+    const beginSpy = spyOn(AuthApi, "beginConnection");
+
+    const { wrapper } = createStoreWrapper();
+    const { result } = renderHook(
+      () => useConnectProvider("apple", { newAccount: true }),
+      { wrapper },
+    );
+    act(() => result.current.connect());
+
+    await waitFor(() => {
+      expect(useConnectAppleStore.getState().isOpen).toBe(true);
+    });
+    expect(beginSpy).not.toHaveBeenCalled();
+    expect(assign).not.toHaveBeenCalled();
+
+    connectAppleActions.close();
+    beginSpy.mockRestore();
+    assign.mockRestore();
+  });
+
+  it("pre-fills Apple reconnect email when authorization expired", async () => {
+    userMetadataActions.set({
+      google: {
+        connectionState: "RECONNECT_REQUIRED",
+        connections: [
+          connection({
+            id: "connection-apple",
+            provider: "apple",
+            stateReason: "authorizationExpired",
+            accountEmail: "host@icloud.com",
+          }),
+        ],
+      },
+    });
+
+    const { wrapper } = createStoreWrapper();
+    const { result } = renderHook(
+      () =>
+        useConnectProvider("apple", {
+          connection: connection({
+            id: "connection-apple",
+            provider: "apple",
+            stateReason: "authorizationExpired",
+            accountEmail: "host@icloud.com",
+          }),
+        }),
+      { wrapper },
+    );
+    act(() => result.current.connect());
+
+    await waitFor(() => {
+      expect(useConnectAppleStore.getState().initialEmail).toBe(
+        "host@icloud.com",
+      );
+    });
+
+    connectAppleActions.close();
+  });
+
   it("does not navigate on a connected begin response", async () => {
     const assign = spyOn(window.location, "assign").mockImplementation(
       () => {},
@@ -67,11 +134,11 @@ describe("useConnectProvider", () => {
     const beginSpy = spyOn(AuthApi, "beginConnection").mockResolvedValue({
       kind: "connected",
       connectionId: ConnectionIdSchema.parse("64b7f9c2e1a2b3c4d5e6f7a8"),
-    } as Awaited<ReturnType<typeof AuthApi.beginConnection>>);
+    });
 
     const { wrapper } = createStoreWrapper();
     const { result } = renderHook(
-      () => useConnectProvider("apple", { newAccount: true }),
+      () => useConnectProvider("microsoft", { newAccount: true }),
       { wrapper },
     );
     act(() => result.current.connect());

--- a/packages/web/src/auth/providers/useConnectProvider.ts
+++ b/packages/web/src/auth/providers/useConnectProvider.ts
@@ -14,6 +14,8 @@ import {
   connectionHasReconnectRequired,
   getGoogleConnectionConfig,
 } from "@web/auth/providers/connect.util";
+import { connectAppleActions } from "@web/auth/providers/connect-apple.store";
+import { usesCredentialFormConnect } from "@web/auth/providers/provider-connect-flow.util";
 import {
   connectionProvider,
   relabelConnectCommand,
@@ -25,6 +27,7 @@ import {
 } from "@web/auth/providers/sync.refresh";
 import { useIsProviderAvailable } from "@web/auth/providers/useIsProviderAvailable";
 import { useGoogleUiState } from "@web/auth/providers/useProviderUiState";
+import { finishCredentialConnect } from "@web/auth/providers/useSubmitAppleCredential";
 import {
   selectSyncConnections,
   useUserMetadataStore,
@@ -111,12 +114,21 @@ export const useConnectProvider = (
       return;
     }
 
+    settingsActions.closeCmdPalette();
+
+    if (usesCredentialFormConnect(kind)) {
+      const prefillEmail =
+        syncConnection?.stateReason === "authorizationExpired"
+          ? (syncConnection.accountEmail ?? "")
+          : "";
+      connectAppleActions.open(prefillEmail);
+      return;
+    }
+
     isConnectingRef.current = true;
     setIsConnecting(true);
 
     const start = async () => {
-      settingsActions.closeCmdPalette();
-
       try {
         const beginRequest = {
           ...(options?.newAccount ||
@@ -133,6 +145,10 @@ export const useConnectProvider = (
           window.location.assign(result.authorizationUrl);
           return;
         }
+        if (result.kind === "connected") {
+          finishCredentialConnect(kind);
+          void queryClient.invalidateQueries({ queryKey: eventQueryKeys.all });
+        }
         stopConnecting();
       } catch {
         stopConnecting();
@@ -148,9 +164,12 @@ export const useConnectProvider = (
     kind,
     options?.features,
     options?.newAccount,
+    queryClient,
     state,
     stopConnecting,
+    syncConnection?.accountEmail,
     syncConnection?.id,
+    syncConnection?.stateReason,
   ]);
 
   const onRefresh = useCallback(

--- a/packages/web/src/auth/providers/useSubmitAppleCredential.ts
+++ b/packages/web/src/auth/providers/useSubmitAppleCredential.ts
@@ -1,0 +1,68 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { Status } from "@core/errors/status.codes";
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+import { AuthApi } from "@web/api/auth.api";
+import { getApiErrorMessage, getErrorStatus } from "@web/api/util/api.util";
+import { refreshUserMetadata } from "@web/auth/compass/user/util/user-metadata.util";
+import { track } from "@web/auth/posthog/track";
+import {
+  APPLE_CREDENTIAL_INVALID_MESSAGE,
+  APPLE_CREDENTIAL_RATE_LIMIT_MESSAGE,
+} from "@web/auth/providers/connect-apple.copy";
+import { connectAppleActions } from "@web/auth/providers/connect-apple.store";
+import {
+  GOOGLE_CONNECT_FAILED_TOAST_ID,
+  getToastDefaultOptions,
+} from "@web/common/constants/toast.constants";
+import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
+import { getToast } from "@web/common/utils/toast/toast.port";
+import { eventQueryKeys } from "@web/events/queries/event.query.keys";
+
+const SUCCESS_TOAST_ID = "connect-success";
+
+function connectedCopy(): string {
+  return "Apple connected.";
+}
+
+export function finishCredentialConnect(provider: ProviderKind): void {
+  track("calendar_connected", { source: "credential_form", provider });
+  getToast().success(connectedCopy(), {
+    ...getToastDefaultOptions(),
+    toastId: SUCCESS_TOAST_ID,
+  });
+  void refreshUserMetadata({ force: true });
+}
+
+export function useSubmitAppleCredential() {
+  const queryClient = useQueryClient();
+
+  return useCallback(
+    async (username: string, secret: string) => {
+      try {
+        await AuthApi.connectAppleCredential({ username, secret });
+        connectAppleActions.close();
+        finishCredentialConnect("apple");
+        await queryClient.invalidateQueries({ queryKey: eventQueryKeys.all });
+      } catch (error) {
+        const status = getErrorStatus(error);
+        if (status === Status.TOO_MANY_REQUESTS) {
+          throw new Error(APPLE_CREDENTIAL_RATE_LIMIT_MESSAGE);
+        }
+        const message = getApiErrorMessage(error);
+        if (
+          status === Status.BAD_REQUEST &&
+          message === APPLE_CREDENTIAL_INVALID_MESSAGE
+        ) {
+          throw new Error(APPLE_CREDENTIAL_INVALID_MESSAGE);
+        }
+        showErrorToast(
+          "We couldn't connect your Apple Calendar. Please try again.",
+          { toastId: GOOGLE_CONNECT_FAILED_TOAST_ID },
+        );
+        throw error;
+      }
+    },
+    [queryClient],
+  );
+}

--- a/packages/web/src/components/RootShell/RootShell.tsx
+++ b/packages/web/src/components/RootShell/RootShell.tsx
@@ -1,5 +1,6 @@
 import { Outlet, useLocation } from "@tanstack/react-router";
 import { useMemo } from "react";
+import { ConnectAppleForm } from "@web/auth/providers/ConnectAppleForm";
 import { BillingGateModal } from "@web/billing/BillingGateModal";
 import { BillingPastDueBanner } from "@web/billing/BillingPastDueBanner";
 import { BillingReadOnlyBanner } from "@web/billing/BillingReadOnlyBanner";
@@ -98,6 +99,7 @@ export function RootShell() {
       <Outlet />
       <UpcomingEventNotifier />
       <AuthModal />
+      <ConnectAppleForm />
       {gateStatus !== null && <BillingGateModal status={gateStatus} />}
       <CheckoutCelebrationModal />
       {showCalendarOnboarding && <WelcomeModal />}


### PR DESCRIPTION
Fixes #3263

## What and why

Adds the Connect iCloud credential form for Apple calendar connect when `providers.apple.connect` is true. Choosing Apple in the add-account chooser (Settings, sidebar, booking prompt) opens an email plus app-specific password form instead of an OAuth redirect. Successful connect shows the Apple connected toast and refreshes metadata and calendar queries. Reconnect for `authorizationExpired` pre-fills the account email.

The Compass API now accepts a browser credential payload over HTTPS and seals it for the Sync hop (per the contract comment on `CredentialConnectPayloadSchema`), since the internal envelope secret cannot live in the browser.

Spec: `docs/features/calendar-providers.md`

## Verify

```
bun run verify --strict
```

Selected packages: core, web, backend
Checks run: test:core, test:web, test:backend:fast, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)

VERDICT: PASS