### PR TITLE
feat(backend): add Sign in with Apple as a login method

### DIFF
--- a/docs/self-hosting/apple-calendar.md
+++ b/docs/self-hosting/apple-calendar.md
@@ -20,6 +20,32 @@ apple:
 All four values are required together. The web bundle bakes the Services ID
 at build time.
 
+In Apple Developer, the Services ID Return URL must be a POST to the
+backend, not the SPA:
+
+```
+POST {BACKEND_URL}/api/auth/apple/callback
+```
+
+Apple posts the authorization result (`response_mode=form_post`). Compass
+reads `code` and `state` from that form body, then 302-redirects the browser
+to:
+
+```
+{FRONTEND_URL}/auth/apple/callback?code=...&state=...
+```
+
+A missing or mismatched `state` is rejected (HTTP 400). Do not register the
+SPA path as the Return URL. Apple will not GET that URL.
+
+Apple may send a private relay address (`@privaterelay.appleid.com`) instead
+of the user's real email. Compass keys the Apple identity by the id_token
+`sub`, not by that email, so a later sign-in with a different relay still
+resolves to the same user.
+
+Apple includes the user's name only on the first authorization. Compass
+stores that name when it is present. Later sign-ins omit it.
+
 iCloud calendar connect uses an app-specific password. Compass stores it
 encrypted at rest with a 32-byte base64 key:
 

--- a/e2e/oauth/apple-auth-callback.spec.ts
+++ b/e2e/oauth/apple-auth-callback.spec.ts
@@ -1,0 +1,110 @@
+import { expect, type Page, test } from "@playwright/test";
+
+const CALLBACK_PATH = "/auth/apple/callback";
+const INTENT_STORAGE_PREFIX = "compass.appleAuthorizationIntent";
+
+const getIntentStorageKey = (state: string) =>
+  `${INTENT_STORAGE_PREFIX}.${state}`;
+
+const getCallbackUrl = (state: string) =>
+  `${CALLBACK_PATH}?state=${encodeURIComponent(state)}&code=auth-code`;
+
+const prepareAppleAuthCallbackPage = async (page: Page) => {
+  const loginOrSignupRequests: unknown[] = [];
+
+  await page.addInitScript(() => {
+    (
+      window as Window & { __COMPASS_E2E_TEST__?: boolean }
+    ).__COMPASS_E2E_TEST__ = true;
+    window.alert = () => undefined;
+    window.confirm = () => true;
+    window.prompt = () => null;
+  });
+
+  await page.route("**/api/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+
+    if (url.pathname.endsWith("/api/signinup")) {
+      loginOrSignupRequests.push(request.postDataJSON());
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          user: { emails: ["hidden@privaterelay.appleid.com"] },
+        }),
+      });
+    }
+
+    if (url.pathname.endsWith("/api/user/metadata")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({}),
+      });
+    }
+
+    if (url.pathname.endsWith("/api/config")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          google: { isConfigured: true },
+          apple: { signIn: true, calendar: false },
+        }),
+      });
+    }
+
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({}),
+    });
+  });
+
+  return { loginOrSignupRequests };
+};
+
+test("finishes a saved Apple Sign in callback without connecting a calendar", async ({
+  page,
+}) => {
+  const state = "apple-sign-in-state";
+  const apiMocks = await prepareAppleAuthCallbackPage(page);
+
+  await page.goto("/week");
+  await page.evaluate(
+    ({ key, value }) => {
+      sessionStorage.setItem(key, JSON.stringify(value));
+    },
+    {
+      key: getIntentStorageKey(state),
+      value: {
+        intent: "signIn",
+        returnPath: "/week",
+        createdAt: Date.now(),
+      },
+    },
+  );
+
+  await page.goto(getCallbackUrl(state));
+
+  await expect(
+    page.locator('[role="status"][aria-live="polite"]'),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/\/week$/);
+  expect(apiMocks.loginOrSignupRequests).toHaveLength(1);
+  expect(apiMocks.loginOrSignupRequests[0]).toEqual(
+    expect.objectContaining({
+      thirdPartyId: "apple",
+    }),
+  );
+  expect(JSON.stringify(apiMocks.loginOrSignupRequests[0])).not.toContain(
+    "calendar",
+  );
+  expect(
+    await page.evaluate(
+      (key) => sessionStorage.getItem(key),
+      getIntentStorageKey(state),
+    ),
+  ).toBeNull();
+});

--- a/packages/backend/src/auth/auth.routes.config.ts
+++ b/packages/backend/src/auth/auth.routes.config.ts
@@ -1,5 +1,7 @@
 import type express from "express";
+import { urlencoded } from "express";
 import rateLimit from "express-rate-limit";
+import { APPLE_SIGNIN_FORM_POST_PATH } from "@backend/auth/services/apple/apple.auth.callback";
 import { verifySession } from "@backend/auth/session/session.middleware";
 import { CommonRoutesConfig } from "@backend/common/common.routes.config";
 import authController from "./controllers/auth.controller";
@@ -16,6 +18,14 @@ export const credentialConnectLimiter = rateLimit({
     ).session;
     return session?.getUserId() ?? req.ip ?? "anonymous";
   },
+});
+
+export const appleSignInCallbackLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 20,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) => req.ip ?? "anonymous",
 });
 
 /**
@@ -91,6 +101,16 @@ export class AuthRoutes extends CommonRoutesConfig {
       .post((req, res) => {
         authController.refreshGoogleSync(req, res);
       });
+
+    this.app
+      .route(APPLE_SIGNIN_FORM_POST_PATH)
+      .post(
+        appleSignInCallbackLimiter,
+        urlencoded({ extended: false }),
+        (req, res) => {
+          authController.appleSignInCallback(req, res);
+        },
+      );
 
     return this.app;
   }

--- a/packages/backend/src/auth/controllers/apple-signin-callback.db.test.ts
+++ b/packages/backend/src/auth/controllers/apple-signin-callback.db.test.ts
@@ -1,0 +1,49 @@
+import { BaseDriver } from "@backend/__tests__/drivers/base.driver";
+import {
+  APPLE_SIGNIN_FORM_POST_PATH,
+  APPLE_SIGNIN_SPA_CALLBACK_PATH,
+  encodeAppleOAuthState,
+} from "@backend/auth/services/apple/apple.auth.callback";
+import { CONFIG } from "@backend/common/constants/config.constants";
+import { describe, expect, it } from "bun:test";
+
+describe("POST /api/auth/apple/callback", () => {
+  const baseDriver = new BaseDriver();
+
+  it("redirects a valid form_post to the SPA callback", async () => {
+    const state = encodeAppleOAuthState(
+      `${CONFIG.FRONTEND_URL}${APPLE_SIGNIN_SPA_CALLBACK_PATH}`,
+    );
+
+    const response = await baseDriver
+      .getServer()
+      .post(APPLE_SIGNIN_FORM_POST_PATH)
+      .type("form")
+      .send({ code: "auth-code", state });
+
+    expect(response.status).toBe(302);
+    expect(response.headers["location"]).toContain(
+      APPLE_SIGNIN_SPA_CALLBACK_PATH,
+    );
+    expect(response.headers["location"]).toContain("code=auth-code");
+    expect(response.headers["location"]).toContain(
+      `state=${encodeURIComponent(state)}`,
+    );
+  });
+
+  it("rejects a missing or mismatched state", async () => {
+    const missing = await baseDriver
+      .getServer()
+      .post(APPLE_SIGNIN_FORM_POST_PATH)
+      .type("form")
+      .send({ code: "auth-code" });
+    expect(missing.status).toBe(400);
+
+    const mismatched = await baseDriver
+      .getServer()
+      .post(APPLE_SIGNIN_FORM_POST_PATH)
+      .type("form")
+      .send({ code: "auth-code", state: "garbage" });
+    expect(mismatched.status).toBe(400);
+  });
+});

--- a/packages/backend/src/auth/controllers/auth.controller.ts
+++ b/packages/backend/src/auth/controllers/auth.controller.ts
@@ -12,6 +12,7 @@ import {
   ProviderKindSchema,
 } from "@core/types/sync/identity.contracts";
 import { zObjectId } from "@core/types/type.utils";
+import { resolveAppleFormPostRedirect } from "@backend/auth/services/apple/apple.auth.callback";
 import compassAuthService from "@backend/auth/services/compass/compass.auth.service";
 import { CONFIG } from "@backend/common/constants/config.constants";
 import {
@@ -213,6 +214,18 @@ class AuthController {
 
   refreshGoogleSync = (req: SessionRequest, res: Res_Promise): void => {
     this.refreshConnection(req, res);
+  };
+
+  appleSignInCallback = (
+    req: ReqBody<Record<string, unknown>>,
+    res: Res_Promise,
+  ): void => {
+    const result = resolveAppleFormPostRedirect(req.body ?? {});
+    if ("status" in result) {
+      res.status(result.status).json({ error: result.message });
+      return;
+    }
+    res.redirect(302, result.location);
   };
 }
 

--- a/packages/backend/src/auth/services/apple/apple.auth.callback.test.ts
+++ b/packages/backend/src/auth/services/apple/apple.auth.callback.test.ts
@@ -1,0 +1,72 @@
+import { Status } from "@core/errors/status.codes";
+import { CONFIG } from "@backend/common/constants/config.constants";
+import {
+  APPLE_SIGNIN_SPA_CALLBACK_PATH,
+  appleSpaCallbackUrl,
+  encodeAppleOAuthState,
+  resolveAppleFormPostRedirect,
+} from "./apple.auth.callback";
+import { describe, expect, it } from "bun:test";
+
+describe("resolveAppleFormPostRedirect", () => {
+  const frontendUrl = "http://localhost:9080";
+  const spa = `${frontendUrl}${APPLE_SIGNIN_SPA_CALLBACK_PATH}`;
+
+  it("redirects a valid SuperTokens state to the SPA callback", () => {
+    const state = encodeAppleOAuthState(spa);
+    const result = resolveAppleFormPostRedirect(
+      { code: "auth-code", state, user: '{"name":{"firstName":"Ada"}}' },
+      frontendUrl,
+    );
+
+    expect(result).toEqual({
+      location: appleSpaCallbackUrl(frontendUrl, {
+        code: "auth-code",
+        state,
+        user: '{"name":{"firstName":"Ada"}}',
+      }),
+    });
+  });
+
+  it("rejects a missing state", () => {
+    expect(
+      resolveAppleFormPostRedirect({ code: "auth-code" }, frontendUrl),
+    ).toEqual({
+      status: Status.BAD_REQUEST,
+      message: "Sign in with Apple is missing the OAuth state",
+    });
+  });
+
+  it("rejects a mismatched state", () => {
+    expect(
+      resolveAppleFormPostRedirect(
+        { code: "auth-code", state: "not-valid-state" },
+        frontendUrl,
+      ),
+    ).toEqual({
+      status: Status.BAD_REQUEST,
+      message: "Sign in with Apple returned a mismatched OAuth state",
+    });
+
+    const otherApp = encodeAppleOAuthState(
+      "https://evil.example/auth/apple/callback",
+    );
+    expect(
+      resolveAppleFormPostRedirect(
+        { code: "auth-code", state: otherApp },
+        frontendUrl,
+      ),
+    ).toEqual({
+      status: Status.BAD_REQUEST,
+      message: "Sign in with Apple returned a mismatched OAuth state",
+    });
+  });
+
+  it("uses CONFIG.FRONTEND_URL when the caller omits an origin", () => {
+    const state = encodeAppleOAuthState(
+      `${CONFIG.FRONTEND_URL}${APPLE_SIGNIN_SPA_CALLBACK_PATH}`,
+    );
+    const result = resolveAppleFormPostRedirect({ code: "c", state });
+    expect("location" in result).toBe(true);
+  });
+});

--- a/packages/backend/src/auth/services/apple/apple.auth.callback.ts
+++ b/packages/backend/src/auth/services/apple/apple.auth.callback.ts
@@ -1,0 +1,97 @@
+import { Status } from "@core/errors/status.codes";
+import { CONFIG } from "@backend/common/constants/config.constants";
+
+export const APPLE_SIGNIN_FORM_POST_PATH = "/api/auth/apple/callback";
+export const APPLE_SIGNIN_SPA_CALLBACK_PATH = "/auth/apple/callback";
+
+type FormPostBody = Record<string, unknown>;
+
+const formField = (body: FormPostBody, key: string): string => {
+  const value = body[key];
+  return typeof value === "string" ? value : "";
+};
+
+export function encodeAppleOAuthState(frontendRedirectURI: string): string {
+  return Buffer.from(JSON.stringify({ frontendRedirectURI }), "utf8").toString(
+    "base64",
+  );
+}
+
+export function appleSpaCallbackUrl(
+  frontendUrl: string,
+  params: { code?: string; state: string; user?: string; error?: string },
+): string {
+  const url = new URL(APPLE_SIGNIN_SPA_CALLBACK_PATH, frontendUrl);
+  url.searchParams.set("state", params.state);
+  if (params.code) {
+    url.searchParams.set("code", params.code);
+  }
+  if (params.user) {
+    url.searchParams.set("user", params.user);
+  }
+  if (params.error) {
+    url.searchParams.set("error", params.error);
+  }
+  return url.toString();
+}
+
+export function resolveAppleFormPostRedirect(
+  body: FormPostBody,
+  frontendUrl: string = CONFIG.FRONTEND_URL,
+):
+  | { location: string }
+  | { status: typeof Status.BAD_REQUEST; message: string } {
+  const state = formField(body, "state").trim();
+  if (!state) {
+    return {
+      status: Status.BAD_REQUEST,
+      message: "Sign in with Apple is missing the OAuth state",
+    };
+  }
+
+  let frontendRedirectURI: string;
+  try {
+    const decoded = Buffer.from(state, "base64").toString("utf8");
+    const parsed = JSON.parse(decoded) as { frontendRedirectURI?: unknown };
+    if (typeof parsed.frontendRedirectURI !== "string") {
+      throw new Error("missing frontendRedirectURI");
+    }
+    frontendRedirectURI = parsed.frontendRedirectURI;
+  } catch {
+    return {
+      status: Status.BAD_REQUEST,
+      message: "Sign in with Apple returned a mismatched OAuth state",
+    };
+  }
+
+  let redirectUrl: URL;
+  let expectedOrigin: string;
+  try {
+    redirectUrl = new URL(frontendRedirectURI);
+    expectedOrigin = new URL(frontendUrl).origin;
+  } catch {
+    return {
+      status: Status.BAD_REQUEST,
+      message: "Sign in with Apple returned a mismatched OAuth state",
+    };
+  }
+
+  if (
+    redirectUrl.origin !== expectedOrigin ||
+    redirectUrl.pathname !== APPLE_SIGNIN_SPA_CALLBACK_PATH
+  ) {
+    return {
+      status: Status.BAD_REQUEST,
+      message: "Sign in with Apple returned a mismatched OAuth state",
+    };
+  }
+
+  return {
+    location: appleSpaCallbackUrl(frontendUrl, {
+      state,
+      code: formField(body, "code") || undefined,
+      user: formField(body, "user") || undefined,
+      error: formField(body, "error") || undefined,
+    }),
+  };
+}

--- a/packages/backend/src/auth/services/apple/apple.auth.service.db.test.ts
+++ b/packages/backend/src/auth/services/apple/apple.auth.service.db.test.ts
@@ -112,7 +112,8 @@ describe("appleAuthService", () => {
     await appleAuthService.handleAppleAuth(success);
 
     const stored = await mongoService.user.findOne({
-      email: success.providerUser.email,
+      "identities.provider": "apple",
+      "identities.subjectId": success.providerUser.sub,
     });
     expect(stored?.name).toBe("Ada Lovelace");
     expect(stored?.identities).toEqual([

--- a/packages/backend/src/auth/services/apple/apple.auth.service.db.test.ts
+++ b/packages/backend/src/auth/services/apple/apple.auth.service.db.test.ts
@@ -1,0 +1,204 @@
+import { faker } from "@faker-js/faker";
+import { GOOGLE_SCOPE_CALENDAR_EVENTS } from "@core/providers/google.scopes";
+import { UserDriver } from "@backend/__tests__/drivers/user.driver";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import { authErrorCopy } from "@backend/common/errors/auth/auth.errors";
+import mongoService from "@backend/common/services/mongo.service";
+import * as syncServiceFactory from "@backend/common/services/sync-service/sync-service.factory";
+import { type AppleSignInSuccess } from "./apple.auth.types";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  spyOn,
+} from "bun:test";
+import { createHmac } from "node:crypto";
+
+let appleAuthService: Awaited<
+  typeof import("./apple.auth.service")
+>["appleAuthService"];
+
+const signTestIdToken = (payload: Record<string, unknown>): string => {
+  const header = Buffer.from(
+    JSON.stringify({ alg: "HS256", typ: "JWT" }),
+  ).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const signature = createHmac("sha256", "apple-test-secret")
+    .update(`${header}.${body}`)
+    .digest("base64url");
+  return `${header}.${body}.${signature}`;
+};
+
+const payloadFromIdToken = (idToken: string): Record<string, unknown> =>
+  JSON.parse(
+    Buffer.from(idToken.split(".")[1] ?? "", "base64url").toString("utf8"),
+  ) as Record<string, unknown>;
+
+describe("appleAuthService", () => {
+  let adoptCalls: unknown[];
+
+  beforeAll(async () => {
+    spyOn(syncServiceFactory, "getSyncServiceClient").mockImplementation(
+      () =>
+        ({
+          adoptProviderAuthorization: async (...args: unknown[]) => {
+            adoptCalls.push(args);
+            return {
+              ok: true,
+              value: {},
+              correlationId: "corr-1",
+            };
+          },
+          listConnections: async () => ({
+            ok: true,
+            value: { connections: [] },
+            correlationId: "corr-1",
+          }),
+        }) as ReturnType<typeof syncServiceFactory.getSyncServiceClient>,
+    );
+    ({ appleAuthService } = await import("./apple.auth.service"));
+  });
+  beforeEach(() => setupTestDb(import.meta.url));
+  beforeEach(cleanupCollections);
+  beforeEach(() => {
+    adoptCalls = [];
+  });
+  afterAll(cleanupTestDb);
+
+  const makeSuccess = (
+    overrides?: Partial<AppleSignInSuccess>,
+  ): AppleSignInSuccess => {
+    const sub = faker.string.uuid();
+    const email = `${faker.string.alphanumeric(8)}@privaterelay.appleid.com`;
+    const idToken = signTestIdToken({
+      sub,
+      email,
+      email_verified: "true",
+      user: {
+        name: { firstName: "Ada", lastName: "Lovelace" },
+      },
+    });
+    const payload = payloadFromIdToken(idToken);
+    return {
+      providerUser: {
+        sub: typeof payload["sub"] === "string" ? payload["sub"] : sub,
+        email: typeof payload["email"] === "string" ? payload["email"] : email,
+        user:
+          payload["user"] && typeof payload["user"] === "object"
+            ? (payload["user"] as AppleSignInSuccess["providerUser"]["user"])
+            : undefined,
+      },
+      oAuthTokens: {
+        access_token: faker.internet.jwt(),
+        scope: "openid email name",
+      },
+      createdNewRecipeUser: true,
+      recipeUserId: faker.database.mongodbObjectId(),
+      loginMethodsLength: 1,
+      ...overrides,
+    };
+  };
+
+  it("stores the name and an apple identity keyed by sub on first sign-in", async () => {
+    const success = makeSuccess();
+
+    await appleAuthService.handleAppleAuth(success);
+
+    const stored = await mongoService.user.findOne({
+      email: success.providerUser.email,
+    });
+    expect(stored?.name).toBe("Ada Lovelace");
+    expect(stored?.identities).toEqual([
+      expect.objectContaining({
+        provider: "apple",
+        subjectId: success.providerUser.sub,
+        email: success.providerUser.email,
+        displayName: "Ada Lovelace",
+      }),
+    ]);
+    expect(stored?.google).toBeUndefined();
+    expect(adoptCalls).toHaveLength(0);
+  });
+
+  it("resolves a second sign-in with a different relay email to the same user", async () => {
+    const first = makeSuccess();
+    await appleAuthService.handleAppleAuth(first);
+
+    const nextRelay = `${faker.string.alphanumeric(8)}@privaterelay.appleid.com`;
+    await appleAuthService.handleAppleAuth({
+      ...first,
+      createdNewRecipeUser: false,
+      recipeUserId: faker.database.mongodbObjectId(),
+      providerUser: {
+        ...first.providerUser,
+        email: nextRelay,
+        user: undefined,
+        name: undefined,
+      },
+    });
+
+    const storedUsers = await mongoService.user
+      .find({
+        "identities.provider": "apple",
+        "identities.subjectId": first.providerUser.sub,
+      })
+      .toArray();
+    expect(storedUsers).toHaveLength(1);
+    expect(storedUsers[0]?.name).toBe("Ada Lovelace");
+    expect(storedUsers[0]?.identities).toEqual([
+      expect.objectContaining({
+        provider: "apple",
+        subjectId: first.providerUser.sub,
+      }),
+    ]);
+    expect(adoptCalls).toHaveLength(0);
+  });
+
+  it("fails closed when the email already belongs to a Google user", async () => {
+    const existing = await UserDriver.createUser();
+    const normalizedEmail = existing.email.toLowerCase();
+    await mongoService.user.updateOne(
+      { _id: existing._id },
+      { $set: { email: normalizedEmail } },
+    );
+    const success = makeSuccess({
+      providerUser: {
+        sub: faker.string.uuid(),
+        email: normalizedEmail,
+        name: "Apple Person",
+      },
+    });
+
+    await expect(
+      appleAuthService.handleAppleAuth(success),
+    ).rejects.toMatchObject({
+      result: authErrorCopy.signInWhileAuthenticated("apple"),
+      code: "GOOGLE_SIGNIN_WHILE_AUTHENTICATED",
+    });
+
+    const stored = await mongoService.user.findOne({ _id: existing._id });
+    expect(stored?.identities?.some((i) => i.provider === "apple")).toBe(false);
+    expect(adoptCalls).toHaveLength(0);
+  });
+
+  it("adopts a calendar connection when the grant includes a calendar scope", async () => {
+    const success = makeSuccess({
+      oAuthTokens: {
+        access_token: faker.internet.jwt(),
+        refresh_token: faker.internet.jwt(),
+        scope: `openid email ${GOOGLE_SCOPE_CALENDAR_EVENTS}`,
+      },
+    });
+
+    await appleAuthService.handleAppleAuth(success);
+
+    expect(adoptCalls).toHaveLength(1);
+  });
+});

--- a/packages/backend/src/auth/services/apple/apple.auth.service.ts
+++ b/packages/backend/src/auth/services/apple/apple.auth.service.ts
@@ -1,4 +1,8 @@
 import { LoggerFactory } from "@core/logger/logger.factory";
+import {
+  type ProviderAccountFacts,
+  ProviderAccountFactsSchema,
+} from "@core/types/sync/connection.contracts";
 import { StringV4Schema, zObjectId } from "@core/types/type.utils";
 import { type Schema_UserIdentity } from "@core/types/user.types";
 import {
@@ -62,6 +66,17 @@ export function appleDisplayName(
   const last = providerUser.user?.name?.lastName?.trim() ?? "";
   const combined = `${first} ${last}`.trim();
   return combined || undefined;
+}
+
+function appleAccount(
+  providerUser: AppleIdTokenPayload,
+  email: string,
+): ProviderAccountFacts {
+  return ProviderAccountFactsSchema.parse({
+    providerAccountId: appleSubjectId(providerUser),
+    email,
+    displayName: appleDisplayName(providerUser) ?? null,
+  });
 }
 
 function appleIdentity(
@@ -130,11 +145,7 @@ async function adoptIfCalendarGranted(
     toSyncPrincipal(compassUserId),
     {
       provider: "apple",
-      account: {
-        providerAccountId: appleSubjectId(providerUser),
-        email,
-        displayName: appleDisplayName(providerUser) ?? null,
-      },
+      account: appleAccount(providerUser, email),
       refreshToken,
       grantedScopes,
     },

--- a/packages/backend/src/auth/services/apple/apple.auth.service.ts
+++ b/packages/backend/src/auth/services/apple/apple.auth.service.ts
@@ -1,0 +1,264 @@
+import { LoggerFactory } from "@core/logger/logger.factory";
+import { StringV4Schema, zObjectId } from "@core/types/type.utils";
+import { type Schema_UserIdentity } from "@core/types/user.types";
+import {
+  grantedScopesIncludeCalendarAccess,
+  parseGrantedScopes,
+} from "@backend/auth/services/calendar-grant.util";
+import { determineThirdPartyAuthMode } from "@backend/auth/services/google/util/google.auth.util";
+import { CONFIG } from "@backend/common/constants/config.constants";
+import {
+  AuthError,
+  authErrorCopy,
+} from "@backend/common/errors/auth/auth.errors";
+import { error } from "@backend/common/errors/handlers/error.handler";
+import { normalizeEmail } from "@backend/common/helpers/email.util";
+import { adoptProviderAuthorization } from "@backend/common/services/sync-service/sync-connection-adoption";
+import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
+import * as syncServiceFactory from "@backend/common/services/sync-service/sync-service.factory";
+import { findCompassUserBy } from "@backend/user/queries/user.queries";
+import userService from "@backend/user/services/user.service";
+import {
+  type AppleIdTokenPayload,
+  type AppleSignInSuccess,
+  type AuthDecision,
+} from "./apple.auth.types";
+import { createHmac } from "node:crypto";
+
+let logger: ReturnType<typeof LoggerFactory> | undefined;
+const getLogger = () => (logger ??= LoggerFactory("app:auth.apple.service"));
+const AUTH_TRACE_ID_LENGTH = 16;
+
+function getTraceId(value: string | null | undefined): string | undefined {
+  const normalizedValue = value?.trim();
+
+  if (!normalizedValue) {
+    return undefined;
+  }
+
+  return createHmac("sha256", CONFIG.TOKEN_COMPASS_SYNC)
+    .update(normalizedValue)
+    .digest("hex")
+    .slice(0, AUTH_TRACE_ID_LENGTH);
+}
+
+export function appleSubjectId(providerUser: AppleIdTokenPayload): string {
+  return typeof providerUser.sub === "string" ? providerUser.sub.trim() : "";
+}
+
+export function appleEmail(providerUser: AppleIdTokenPayload): string {
+  return typeof providerUser.email === "string"
+    ? providerUser.email.trim()
+    : "";
+}
+
+export function appleDisplayName(
+  providerUser: AppleIdTokenPayload,
+): string | undefined {
+  if (typeof providerUser.name === "string" && providerUser.name.trim()) {
+    return providerUser.name.trim();
+  }
+  const first = providerUser.user?.name?.firstName?.trim() ?? "";
+  const last = providerUser.user?.name?.lastName?.trim() ?? "";
+  const combined = `${first} ${last}`.trim();
+  return combined || undefined;
+}
+
+function appleIdentity(
+  providerUser: AppleIdTokenPayload,
+  email: string,
+): Schema_UserIdentity {
+  const identity: Schema_UserIdentity = {
+    provider: "apple",
+    subjectId: appleSubjectId(providerUser),
+    email,
+    linkedAt: new Date(),
+  };
+  const displayName = appleDisplayName(providerUser);
+  if (displayName) {
+    identity.displayName = displayName;
+  }
+  return identity;
+}
+
+function getAppleAuthDecisionTrace({
+  createdNewRecipeUser,
+  decision,
+  subjectId,
+  loginMethodsLength,
+  providerEmail,
+}: {
+  createdNewRecipeUser: boolean;
+  decision: AuthDecision;
+  subjectId: string;
+  loginMethodsLength: number;
+  providerEmail: string | null | undefined;
+}) {
+  const providerEmailTraceId = providerEmail
+    ? getTraceId(normalizeEmail(providerEmail))
+    : undefined;
+  const appleUserTraceId = getTraceId(subjectId);
+  const compassUserTraceId = getTraceId(decision.compassUserId);
+
+  return {
+    event: "apple_auth_decision",
+    authMode: decision.authMode,
+    createdNewRecipeUser,
+    hasCompassUserId: Boolean(decision.compassUserId),
+    hasAppleUserId: Boolean(subjectId),
+    hasProviderEmail: Boolean(providerEmail),
+    loginMethodsLength,
+    ...(compassUserTraceId ? { compassUserTraceId } : {}),
+    ...(appleUserTraceId ? { appleUserTraceId } : {}),
+    ...(providerEmailTraceId ? { providerEmailTraceId } : {}),
+  };
+}
+
+async function adoptIfCalendarGranted(
+  compassUserId: string,
+  providerUser: AppleIdTokenPayload,
+  email: string,
+  refreshToken: string | undefined,
+  grantedScopes: readonly string[],
+): Promise<void> {
+  if (!grantedScopesIncludeCalendarAccess(grantedScopes) || !refreshToken) {
+    return;
+  }
+
+  await adoptProviderAuthorization(
+    syncServiceFactory.getSyncServiceClient(),
+    toSyncPrincipal(compassUserId),
+    {
+      provider: "apple",
+      account: {
+        providerAccountId: appleSubjectId(providerUser),
+        email,
+        displayName: appleDisplayName(providerUser) ?? null,
+      },
+      refreshToken,
+      grantedScopes,
+    },
+  );
+}
+
+async function appleSignup(
+  providerUser: AppleIdTokenPayload,
+  email: string,
+  userId: string,
+) {
+  const existingByEmail = await findCompassUserBy(
+    "email",
+    normalizeEmail(email),
+  );
+  if (existingByEmail) {
+    throw error(
+      AuthError.GoogleSignInWhileAuthenticated,
+      authErrorCopy.signInWhileAuthenticated("apple"),
+    );
+  }
+
+  const cUser = await userService.upsertUserFromAuth({
+    userId,
+    email,
+    name: appleDisplayName(providerUser),
+    identities: [appleIdentity(providerUser, email)],
+  });
+
+  return { cUserId: cUser.user.userId };
+}
+
+async function handleAppleAuth(
+  success: AppleSignInSuccess,
+  options?: { hasExistingSession?: boolean },
+): Promise<void> {
+  const {
+    providerUser,
+    oAuthTokens,
+    createdNewRecipeUser,
+    recipeUserId,
+    loginMethodsLength,
+  } = success;
+
+  const subjectId = appleSubjectId(providerUser);
+  if (!subjectId) {
+    throw new Error("Apple user ID (sub) is required");
+  }
+  const email = appleEmail(providerUser);
+  if (!email) {
+    throw new Error("Apple email is required");
+  }
+  StringV4Schema.parse(subjectId, {
+    error: () => "Invalid Apple user ID",
+  });
+  const scopes = parseGrantedScopes(oAuthTokens.scope);
+
+  // Look up by Apple subject only. Relay addresses change and must not
+  // attach this login to an existing Google or password user (I-06).
+  const decision = await determineThirdPartyAuthMode(
+    "apple",
+    subjectId,
+    null,
+    createdNewRecipeUser,
+  );
+
+  getLogger().info(
+    "apple_auth_decision",
+    getAppleAuthDecisionTrace({
+      createdNewRecipeUser,
+      decision,
+      subjectId,
+      loginMethodsLength,
+      providerEmail: email,
+    }),
+  );
+
+  switch (decision.authMode) {
+    case "SIGNUP": {
+      if (options?.hasExistingSession) {
+        throw error(
+          AuthError.GoogleSignInWhileAuthenticated,
+          authErrorCopy.signInWhileAuthenticated("apple"),
+        );
+      }
+
+      const persisted = await appleSignup(providerUser, email, recipeUserId);
+      await adoptIfCalendarGranted(
+        persisted.cUserId,
+        providerUser,
+        email,
+        oAuthTokens.refresh_token,
+        scopes,
+      );
+      return;
+    }
+
+    case "SIGNIN": {
+      const compassUserId = decision.compassUserId;
+      if (!compassUserId) {
+        throw new Error("Compass user ID expected for Apple sign-in");
+      }
+      zObjectId.parse(compassUserId);
+
+      await userService.upsertUserFromAuth({
+        userId: compassUserId,
+        email,
+        name: appleDisplayName(providerUser),
+        identities: [appleIdentity(providerUser, email)],
+      });
+
+      await adoptIfCalendarGranted(
+        compassUserId,
+        providerUser,
+        email,
+        oAuthTokens.refresh_token,
+        scopes,
+      );
+      return;
+    }
+  }
+}
+
+export const appleAuthService = {
+  appleSignup,
+  handleAppleAuth,
+};

--- a/packages/backend/src/auth/services/apple/apple.auth.types.ts
+++ b/packages/backend/src/auth/services/apple/apple.auth.types.ts
@@ -1,0 +1,29 @@
+export type {
+  AuthDecision,
+  AuthMode,
+} from "@backend/auth/services/google/google.auth.types";
+
+export type AppleIdTokenPayload = {
+  sub?: string;
+  email?: string;
+  email_verified?: boolean | string;
+  name?: string;
+  user?: {
+    name?: {
+      firstName?: string;
+      lastName?: string;
+    };
+  };
+};
+
+export type AppleSignInSuccess = {
+  providerUser: AppleIdTokenPayload;
+  oAuthTokens: {
+    refresh_token?: string;
+    access_token?: string;
+    scope?: string;
+  };
+  createdNewRecipeUser: boolean;
+  recipeUserId: string;
+  loginMethodsLength: number;
+};

--- a/packages/backend/src/auth/services/calendar-grant.util.test.ts
+++ b/packages/backend/src/auth/services/calendar-grant.util.test.ts
@@ -1,0 +1,42 @@
+import {
+  GOOGLE_SCOPE_CALENDAR_EVENTS,
+  GOOGLE_SCOPE_USERINFO_EMAIL,
+} from "@core/providers/google.scopes";
+import { MICROSOFT_SCOPE_CALENDARS_READWRITE } from "@core/providers/microsoft.scopes";
+import {
+  grantedScopesIncludeCalendarAccess,
+  parseGrantedScopes,
+} from "./calendar-grant.util";
+import { describe, expect, it } from "bun:test";
+
+describe("grantedScopesIncludeCalendarAccess", () => {
+  it("is true when a Google or Microsoft calendar scope is present", () => {
+    expect(
+      grantedScopesIncludeCalendarAccess([
+        GOOGLE_SCOPE_USERINFO_EMAIL,
+        GOOGLE_SCOPE_CALENDAR_EVENTS,
+      ]),
+    ).toBe(true);
+    expect(
+      grantedScopesIncludeCalendarAccess([MICROSOFT_SCOPE_CALENDARS_READWRITE]),
+    ).toBe(true);
+  });
+
+  it("is false for Sign in with Apple style grants", () => {
+    expect(
+      grantedScopesIncludeCalendarAccess(["openid", "email", "name"]),
+    ).toBe(false);
+    expect(grantedScopesIncludeCalendarAccess([])).toBe(false);
+  });
+});
+
+describe("parseGrantedScopes", () => {
+  it("splits a space-delimited scope string", () => {
+    expect(parseGrantedScopes("openid email name")).toEqual([
+      "openid",
+      "email",
+      "name",
+    ]);
+    expect(parseGrantedScopes(undefined)).toEqual([]);
+  });
+});

--- a/packages/backend/src/auth/services/calendar-grant.util.ts
+++ b/packages/backend/src/auth/services/calendar-grant.util.ts
@@ -1,0 +1,22 @@
+import {
+  GOOGLE_SCOPE_CALENDAR_EVENTS,
+  GOOGLE_SCOPE_CALENDAR_READONLY,
+} from "@core/providers/google.scopes";
+import { MICROSOFT_SCOPE_CALENDARS_READWRITE } from "@core/providers/microsoft.scopes";
+
+const CALENDAR_SCOPES = new Set<string>([
+  GOOGLE_SCOPE_CALENDAR_EVENTS,
+  GOOGLE_SCOPE_CALENDAR_READONLY,
+  MICROSOFT_SCOPE_CALENDARS_READWRITE,
+]);
+
+/** Sign-in adopts a calendar connection only when the grant includes a calendar scope. */
+export function grantedScopesIncludeCalendarAccess(
+  scopes: readonly string[],
+): boolean {
+  return scopes.some((scope) => CALENDAR_SCOPES.has(scope));
+}
+
+export function parseGrantedScopes(scope: string | null | undefined): string[] {
+  return (scope ?? "").split(/\s+/).filter(Boolean);
+}

--- a/packages/backend/src/common/middleware/supertokens.middleware.handlers.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.handlers.ts
@@ -5,6 +5,11 @@ import { type RecipeInterface as ThirdPartyRecipeInterface } from "supertokens-n
 import { NodeEnv } from "@core/constants/core.constants";
 import { Logger } from "@core/logger/winston.logger";
 import { providerKindFromThirdPartyId } from "@core/types/sync/identity.contracts";
+import {
+  appleAuthService,
+  appleSubjectId,
+} from "@backend/auth/services/apple/apple.auth.service";
+import { type AppleSignInSuccess } from "@backend/auth/services/apple/apple.auth.types";
 import { googleAuthService } from "@backend/auth/services/google/google.auth.service";
 import { type GoogleSignInSuccess } from "@backend/auth/services/google/google.auth.types";
 import {
@@ -14,15 +19,19 @@ import {
 import { type MicrosoftSignInSuccess } from "@backend/auth/services/microsoft/microsoft.auth.types";
 import { CONFIG } from "@backend/common/constants/config.constants";
 import {
+  appleFormUserJsonFromInput,
   buildResetPasswordLink,
+  createAppleSignInSuccess,
   createGoogleSignInSuccess,
   createMicrosoftSignInSuccess,
   ensureExternalUserIdMapping,
   getFormFieldValue,
   maybeReplaceEmailPasswordSession,
+  withAppleFirstAuthorizationName,
 } from "@backend/common/middleware/supertokens.middleware.util";
 import userService from "@backend/user/services/user.service";
 import {
+  type CreateAppleSignInResponse,
   type CreateGoogleSignInResponse,
   type CreateMicrosoftSignInResponse,
   type CreateNewRecipeUserFn,
@@ -143,6 +152,51 @@ async function maybeRemapMicrosoftSignInToCompassSession(
   };
 }
 
+async function maybeRemapAppleSignInToCompassSession(
+  input: ThirdPartySignInUpInput,
+  response: Awaited<ReturnType<ThirdPartySignInUpPostFn>>,
+  success: AppleSignInSuccess,
+): Promise<{
+  response: Awaited<ReturnType<ThirdPartySignInUpPostFn>>;
+  success: AppleSignInSuccess;
+}> {
+  const connectedCompassUserId = await userService.getCanonicalCompassUserId({
+    provider: "apple",
+    subjectId: appleSubjectId(success.providerUser),
+    email: null,
+  });
+
+  if (
+    input.session ||
+    !connectedCompassUserId ||
+    response.status !== "OK" ||
+    response.session.getUserId() === connectedCompassUserId
+  ) {
+    return { response, success };
+  }
+
+  const session = await replaceSessionWithCompassUser(
+    input,
+    response.session,
+    connectedCompassUserId,
+  );
+
+  const responseWithCompassSession = { ...response, session };
+  const successAfterSessionRemap = createAppleSignInSuccess(
+    responseWithCompassSession as CreateAppleSignInResponse,
+  );
+  if (!successAfterSessionRemap) {
+    throw new Error(
+      "Missing Apple sign-in success after Compass session replacement",
+    );
+  }
+
+  return {
+    response: responseWithCompassSession,
+    success: successAfterSessionRemap,
+  };
+}
+
 export async function createThirdPartyUser(
   input: Parameters<CreateThirdPartyUserFn>[0],
   originalCreateThirdPartyUser: CreateThirdPartyUserFn,
@@ -183,6 +237,30 @@ export async function handleThirdPartySignInUp(
     await microsoftAuthService.handleMicrosoftAuth(remapped.success, {
       hasExistingSession: Boolean(input.session),
     });
+    return remapped.response;
+  }
+
+  if (kind === "apple") {
+    const success = createAppleSignInSuccess(
+      response as CreateAppleSignInResponse,
+    );
+    if (!success) {
+      return response;
+    }
+    const remapped = await maybeRemapAppleSignInToCompassSession(
+      input,
+      response,
+      success,
+    );
+    await appleAuthService.handleAppleAuth(
+      withAppleFirstAuthorizationName(
+        remapped.success,
+        appleFormUserJsonFromInput(input),
+      ),
+      {
+        hasExistingSession: Boolean(input.session),
+      },
+    );
     return remapped.response;
   }
 

--- a/packages/backend/src/common/middleware/supertokens.middleware.test.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.test.ts
@@ -6,6 +6,7 @@ import Session from "supertokens-node/recipe/session";
 import ThirdParty from "supertokens-node/recipe/thirdparty";
 import UserMetadata from "supertokens-node/recipe/usermetadata";
 import { APP_NAME } from "@core/constants/core.constants";
+import { appleAuthService } from "@backend/auth/services/apple/apple.auth.service";
 import { googleAuthService } from "@backend/auth/services/google/google.auth.service";
 import { microsoftAuthService } from "@backend/auth/services/microsoft/microsoft.auth.service";
 import { CONFIG } from "@backend/common/constants/config.constants";
@@ -16,6 +17,7 @@ import {
 import * as supertokensMiddlewareUtil from "@backend/common/middleware/supertokens.middleware.util";
 import {
   buildResetPasswordLink,
+  createAppleSignInSuccess,
   createGoogleSignInSuccess,
   createMicrosoftSignInSuccess,
   ensureExternalUserIdMapping,
@@ -61,6 +63,7 @@ describe("supertokens.middleware", () => {
     spyOn(microsoftAuthService, "handleMicrosoftAuth").mockResolvedValue(
       undefined,
     );
+    spyOn(appleAuthService, "handleAppleAuth").mockResolvedValue(undefined);
     spyOn(userService, "getCanonicalCompassUserId").mockResolvedValue(null);
     spyOn(userService, "upsertUserFromAuth").mockResolvedValue({
       user: { userId: "compass-user-id" },
@@ -77,6 +80,10 @@ describe("supertokens.middleware", () => {
     spyOn(
       supertokensMiddlewareUtil,
       "createMicrosoftSignInSuccess",
+    ).mockImplementation((payload) => payload as never);
+    spyOn(
+      supertokensMiddlewareUtil,
+      "createAppleSignInSuccess",
     ).mockImplementation((payload) => payload as never);
     spyOn(
       supertokensMiddlewareUtil,
@@ -98,6 +105,7 @@ describe("supertokens.middleware", () => {
     (UserMetadata.init as Mock).mockClear();
     (googleAuthService.handleGoogleAuth as Mock).mockClear();
     (microsoftAuthService.handleMicrosoftAuth as Mock).mockClear();
+    (appleAuthService.handleAppleAuth as Mock).mockClear();
     (userService.getCanonicalCompassUserId as Mock).mockClear();
     (userService.upsertUserFromAuth as Mock).mockClear();
     (supertokensMiddlewareUtil.buildResetPasswordLink as Mock).mockClear();
@@ -105,6 +113,7 @@ describe("supertokens.middleware", () => {
     (
       supertokensMiddlewareUtil.createMicrosoftSignInSuccess as Mock
     ).mockClear();
+    (supertokensMiddlewareUtil.createAppleSignInSuccess as Mock).mockClear();
     (supertokensMiddlewareUtil.ensureExternalUserIdMapping as Mock).mockClear();
     (supertokensMiddlewareUtil.getFormFieldValue as Mock).mockClear();
 
@@ -184,15 +193,23 @@ describe("supertokens.middleware", () => {
       }
     });
 
-    it("omits ThirdParty when Google and Microsoft are not configured", () => {
+    it("omits ThirdParty when Google, Microsoft, and Apple are not configured", () => {
       const originalGoogleId = CONFIG.GOOGLE_CLIENT_ID;
       const originalGoogleSecret = CONFIG.GOOGLE_CLIENT_SECRET;
       const originalMicrosoftId = CONFIG.MICROSOFT_CLIENT_ID;
       const originalMicrosoftSecret = CONFIG.MICROSOFT_CLIENT_SECRET;
+      const originalAppleId = CONFIG.APPLE_SIGNIN_SERVICES_ID;
+      const originalAppleTeam = CONFIG.APPLE_SIGNIN_TEAM_ID;
+      const originalAppleKey = CONFIG.APPLE_SIGNIN_KEY_ID;
+      const originalApplePrivate = CONFIG.APPLE_SIGNIN_PRIVATE_KEY;
       CONFIG.GOOGLE_CLIENT_ID = undefined;
       CONFIG.GOOGLE_CLIENT_SECRET = undefined;
       CONFIG.MICROSOFT_CLIENT_ID = undefined;
       CONFIG.MICROSOFT_CLIENT_SECRET = undefined;
+      CONFIG.APPLE_SIGNIN_SERVICES_ID = undefined;
+      CONFIG.APPLE_SIGNIN_TEAM_ID = undefined;
+      CONFIG.APPLE_SIGNIN_KEY_ID = undefined;
+      CONFIG.APPLE_SIGNIN_PRIVATE_KEY = undefined;
 
       try {
         initSupertokens();
@@ -201,6 +218,10 @@ describe("supertokens.middleware", () => {
         CONFIG.GOOGLE_CLIENT_SECRET = originalGoogleSecret;
         CONFIG.MICROSOFT_CLIENT_ID = originalMicrosoftId;
         CONFIG.MICROSOFT_CLIENT_SECRET = originalMicrosoftSecret;
+        CONFIG.APPLE_SIGNIN_SERVICES_ID = originalAppleId;
+        CONFIG.APPLE_SIGNIN_TEAM_ID = originalAppleTeam;
+        CONFIG.APPLE_SIGNIN_KEY_ID = originalAppleKey;
+        CONFIG.APPLE_SIGNIN_PRIVATE_KEY = originalApplePrivate;
       }
 
       expect(ThirdParty.init).not.toHaveBeenCalled();
@@ -221,10 +242,18 @@ describe("supertokens.middleware", () => {
       const originalGoogleSecret = CONFIG.GOOGLE_CLIENT_SECRET;
       const originalMicrosoftId = CONFIG.MICROSOFT_CLIENT_ID;
       const originalMicrosoftSecret = CONFIG.MICROSOFT_CLIENT_SECRET;
+      const originalAppleId = CONFIG.APPLE_SIGNIN_SERVICES_ID;
+      const originalAppleTeam = CONFIG.APPLE_SIGNIN_TEAM_ID;
+      const originalAppleKey = CONFIG.APPLE_SIGNIN_KEY_ID;
+      const originalApplePrivate = CONFIG.APPLE_SIGNIN_PRIVATE_KEY;
       CONFIG.GOOGLE_CLIENT_ID = undefined;
       CONFIG.GOOGLE_CLIENT_SECRET = undefined;
       CONFIG.MICROSOFT_CLIENT_ID = undefined;
       CONFIG.MICROSOFT_CLIENT_SECRET = undefined;
+      CONFIG.APPLE_SIGNIN_SERVICES_ID = undefined;
+      CONFIG.APPLE_SIGNIN_TEAM_ID = undefined;
+      CONFIG.APPLE_SIGNIN_KEY_ID = undefined;
+      CONFIG.APPLE_SIGNIN_PRIVATE_KEY = undefined;
 
       try {
         initSupertokens();
@@ -233,6 +262,10 @@ describe("supertokens.middleware", () => {
         CONFIG.GOOGLE_CLIENT_SECRET = originalGoogleSecret;
         CONFIG.MICROSOFT_CLIENT_ID = originalMicrosoftId;
         CONFIG.MICROSOFT_CLIENT_SECRET = originalMicrosoftSecret;
+        CONFIG.APPLE_SIGNIN_SERVICES_ID = originalAppleId;
+        CONFIG.APPLE_SIGNIN_TEAM_ID = originalAppleTeam;
+        CONFIG.APPLE_SIGNIN_KEY_ID = originalAppleKey;
+        CONFIG.APPLE_SIGNIN_PRIVATE_KEY = originalApplePrivate;
       }
 
       expect(ThirdParty.init).not.toHaveBeenCalled();
@@ -271,6 +304,44 @@ describe("supertokens.middleware", () => {
         (provider) => provider.config.thirdPartyId,
       );
       expect(ids).toContain("active-directory");
+    });
+
+    it("includes the Apple provider when Sign in with Apple is configured", () => {
+      const originalAppleId = CONFIG.APPLE_SIGNIN_SERVICES_ID;
+      const originalAppleTeam = CONFIG.APPLE_SIGNIN_TEAM_ID;
+      const originalAppleKey = CONFIG.APPLE_SIGNIN_KEY_ID;
+      const originalApplePrivate = CONFIG.APPLE_SIGNIN_PRIVATE_KEY;
+      CONFIG.APPLE_SIGNIN_SERVICES_ID = "com.example.siwa";
+      CONFIG.APPLE_SIGNIN_TEAM_ID = "TEAMID12";
+      CONFIG.APPLE_SIGNIN_KEY_ID = "KEYID123";
+      CONFIG.APPLE_SIGNIN_PRIVATE_KEY = "dummy-private-key";
+
+      try {
+        initSupertokens();
+      } finally {
+        CONFIG.APPLE_SIGNIN_SERVICES_ID = originalAppleId;
+        CONFIG.APPLE_SIGNIN_TEAM_ID = originalAppleTeam;
+        CONFIG.APPLE_SIGNIN_KEY_ID = originalAppleKey;
+        CONFIG.APPLE_SIGNIN_PRIVATE_KEY = originalApplePrivate;
+      }
+
+      expect(ThirdParty.init).toHaveBeenCalledTimes(1);
+      const thirdPartyConfig = getFirstCallArg<{
+        signInAndUpFeature: {
+          providers: Array<{
+            config: {
+              thirdPartyId: string;
+              clients: Array<{ additionalConfig?: { keyId?: string } }>;
+            };
+          }>;
+        };
+      }>(ThirdParty.init);
+      const apple = thirdPartyConfig.signInAndUpFeature.providers.find(
+        (provider) => provider.config.thirdPartyId === "apple",
+      );
+      expect(apple?.config.clients[0]?.additionalConfig?.keyId).toBe(
+        "KEYID123",
+      );
     });
 
     it("wires EmailPassword name validation", async () => {
@@ -585,6 +656,42 @@ describe("supertokens.middleware", () => {
         { hasExistingSession: false },
       );
       expect(googleAuthService.handleGoogleAuth).not.toHaveBeenCalled();
+    });
+
+    it("calls appleAuthService.handleAppleAuth for apple", async () => {
+      const responsePayload = { status: "OK" };
+      const successPayload = { providerUser: { sub: "apple-sub" } };
+
+      (createAppleSignInSuccess as Mock).mockReturnValue(successPayload);
+
+      initSupertokens();
+
+      const thirdPartyConfig = getFirstCallArg<{
+        override: {
+          apis: (originalImplementation: {
+            signInUpPOST?: (input: unknown) => Promise<unknown>;
+          }) => {
+            signInUpPOST: (input: unknown) => Promise<unknown>;
+          };
+        };
+      }>(ThirdParty.init);
+
+      const originalImplementation = {
+        signInUpPOST: mock().mockResolvedValue(responsePayload),
+      };
+
+      const overridden = thirdPartyConfig.override.apis(originalImplementation);
+
+      await overridden.signInUpPOST({
+        provider: { id: "apple" },
+      });
+
+      expect(appleAuthService.handleAppleAuth).toHaveBeenCalledWith(
+        successPayload,
+        { hasExistingSession: false },
+      );
+      expect(googleAuthService.handleGoogleAuth).not.toHaveBeenCalled();
+      expect(microsoftAuthService.handleMicrosoftAuth).not.toHaveBeenCalled();
     });
 
     it("replaces the EmailPassword sign-up session with the canonical Compass user", async () => {

--- a/packages/backend/src/common/middleware/supertokens.middleware.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.ts
@@ -16,6 +16,7 @@ import { MICROSOFT_SCOPES } from "@core/providers/microsoft.scopes";
 import { GOOGLE_AUTH_SCOPES_REQUESTED } from "@backend/auth/services/google/google.auth.scopes";
 import { CONFIG } from "@backend/common/constants/config.constants";
 import {
+  isAppleSignInConfigured,
   isGoogleConfigured,
   isMicrosoftConfigured,
 } from "@backend/common/constants/config.util";
@@ -61,6 +62,29 @@ const createMicrosoftProvider = (
         scope: [...MICROSOFT_SCOPES],
         additionalConfig: {
           directoryId: "common",
+        },
+      },
+    ],
+  },
+});
+
+const createAppleProvider = (
+  clientId: string,
+  keyId: string,
+  teamId: string,
+  privateKey: string,
+): ProviderInput => ({
+  config: {
+    thirdPartyId: "apple",
+    clients: [
+      {
+        clientType: "web",
+        clientId,
+        scope: ["openid", "email", "name"],
+        additionalConfig: {
+          keyId,
+          teamId,
+          privateKey,
         },
       },
     ],
@@ -125,6 +149,27 @@ const getThirdPartyRecipes = (): ReturnType<typeof ThirdParty.init>[] => {
   ) {
     providers.push(
       createMicrosoftProvider(microsoftClientId, microsoftClientSecret),
+    );
+  }
+
+  const appleClientId = CONFIG.APPLE_SIGNIN_SERVICES_ID;
+  const appleKeyId = CONFIG.APPLE_SIGNIN_KEY_ID;
+  const appleTeamId = CONFIG.APPLE_SIGNIN_TEAM_ID;
+  const applePrivateKey = CONFIG.APPLE_SIGNIN_PRIVATE_KEY;
+  if (
+    appleClientId &&
+    appleKeyId &&
+    appleTeamId &&
+    applePrivateKey &&
+    isAppleSignInConfigured(CONFIG)
+  ) {
+    providers.push(
+      createAppleProvider(
+        appleClientId,
+        appleKeyId,
+        appleTeamId,
+        applePrivateKey,
+      ),
     );
   }
 

--- a/packages/backend/src/common/middleware/supertokens.middleware.types.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.types.ts
@@ -40,6 +40,20 @@ type MicrosoftThirdPartySignInUpSuccess = ThirdPartySignInUpSuccess & {
   session?: SessionContainerInterface;
 };
 
+type AppleThirdPartySignInUpSuccess = ThirdPartySignInUpSuccess & {
+  rawUserInfoFromProvider: {
+    fromIdTokenPayload?: Record<string, unknown>;
+    fromUserInfoAPI?: Record<string, unknown>;
+  };
+  oAuthTokens: {
+    refresh_token?: string;
+    access_token?: string;
+    scope?: string;
+  };
+  user: { id: string; loginMethods: unknown[] };
+  session?: SessionContainerInterface;
+};
+
 export type ThirdPartySignInUpInput = Parameters<ThirdPartySignInUpPostFn>[0];
 export type CreateGoogleSignInResponse =
   | { status: Exclude<ThirdPartySignInUpResponse["status"], "OK"> }
@@ -47,6 +61,9 @@ export type CreateGoogleSignInResponse =
 export type CreateMicrosoftSignInResponse =
   | { status: Exclude<ThirdPartySignInUpResponse["status"], "OK"> }
   | MicrosoftThirdPartySignInUpSuccess;
+export type CreateAppleSignInResponse =
+  | { status: Exclude<ThirdPartySignInUpResponse["status"], "OK"> }
+  | AppleThirdPartySignInUpSuccess;
 export type CreateThirdPartyUserFn =
   ThirdPartyRecipeInterface["manuallyCreateOrUpdateUser"];
 export type AuthFormField = { id: string; value: unknown };

--- a/packages/backend/src/common/middleware/supertokens.middleware.util.test.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.util.test.ts
@@ -3,11 +3,13 @@ import { registerUserIdMappingStore } from "@backend/auth/ports/supertokens.regi
 import { createInMemoryUserIdMappingStore } from "@backend/auth/ports/supertokens.stores";
 import {
   buildResetPasswordLink,
+  createAppleSignInSuccess,
   createGoogleSignInSuccess,
   createMicrosoftSignInSuccess,
   ensureExternalUserIdMapping,
   getFormFieldValue,
   maybeReplaceEmailPasswordSession,
+  withAppleFirstAuthorizationName,
 } from "@backend/common/middleware/supertokens.middleware.util";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
@@ -168,6 +170,94 @@ describe("supertokens.middleware.util", () => {
         recipeUserId,
         loginMethodsLength: 1,
         providerUser: { oid, email, name: "Microsoft Person" },
+      });
+    });
+  });
+
+  describe("createAppleSignInSuccess", () => {
+    it("reads sub, email, and first-authorization name from the id token payload", () => {
+      const recipeUserId = faker.database.mongodbObjectId();
+      const sub = faker.string.uuid();
+      const email = `${faker.string.alphanumeric(8)}@privaterelay.appleid.com`;
+
+      const success = createAppleSignInSuccess({
+        status: "OK",
+        createdNewRecipeUser: true,
+        rawUserInfoFromProvider: {
+          fromIdTokenPayload: {
+            sub,
+            email,
+            user: { name: { firstName: "Ada", lastName: "Lovelace" } },
+          },
+        },
+        oAuthTokens: {
+          access_token: faker.internet.jwt(),
+          scope: "openid email name",
+        },
+        user: {
+          id: recipeUserId,
+          loginMethods: [{}],
+        },
+      } as Parameters<typeof createAppleSignInSuccess>[0]);
+
+      expect(success).toMatchObject({
+        createdNewRecipeUser: true,
+        recipeUserId,
+        loginMethodsLength: 1,
+        providerUser: {
+          sub,
+          email,
+          user: { name: { firstName: "Ada", lastName: "Lovelace" } },
+        },
+      });
+    });
+
+    it("reads the first-authorization name from fromUserInfoAPI when the id token omits it", () => {
+      const recipeUserId = faker.database.mongodbObjectId();
+      const sub = faker.string.uuid();
+
+      const success = createAppleSignInSuccess({
+        status: "OK",
+        createdNewRecipeUser: true,
+        rawUserInfoFromProvider: {
+          fromIdTokenPayload: { sub, email: "a@privaterelay.appleid.com" },
+          fromUserInfoAPI: {
+            name: { firstName: "Ada", lastName: "Lovelace" },
+          },
+        },
+        oAuthTokens: { access_token: faker.internet.jwt() },
+        user: { id: recipeUserId, loginMethods: [{}] },
+      } as Parameters<typeof createAppleSignInSuccess>[0]);
+
+      expect(success?.providerUser.user).toEqual({
+        name: { firstName: "Ada", lastName: "Lovelace" },
+      });
+    });
+  });
+
+  describe("withAppleFirstAuthorizationName", () => {
+    it("attaches Apple's form_post user JSON when the id token has no name", () => {
+      const recipeUserId = faker.database.mongodbObjectId();
+      const success = createAppleSignInSuccess({
+        status: "OK",
+        createdNewRecipeUser: true,
+        rawUserInfoFromProvider: {
+          fromIdTokenPayload: {
+            sub: faker.string.uuid(),
+            email: "a@privaterelay.appleid.com",
+          },
+        },
+        oAuthTokens: { access_token: faker.internet.jwt() },
+        user: { id: recipeUserId, loginMethods: [{}] },
+      } as Parameters<typeof createAppleSignInSuccess>[0]);
+
+      expect(success).not.toBeNull();
+      const merged = withAppleFirstAuthorizationName(
+        success!,
+        JSON.stringify({ name: { firstName: "Ada", lastName: "Lovelace" } }),
+      );
+      expect(merged.providerUser.user).toEqual({
+        name: { firstName: "Ada", lastName: "Lovelace" },
       });
     });
   });

--- a/packages/backend/src/common/middleware/supertokens.middleware.util.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.util.ts
@@ -1,14 +1,17 @@
 import { ObjectId } from "mongodb";
 import { type SessionContainerInterface } from "supertokens-node/recipe/session/types";
 import { getUserIdMappingStore } from "@backend/auth/ports/supertokens.registry";
+import { type AppleSignInSuccess } from "@backend/auth/services/apple/apple.auth.types";
 import { type GoogleSignInSuccess } from "@backend/auth/services/google/google.auth.types";
 import { type MicrosoftSignInSuccess } from "@backend/auth/services/microsoft/microsoft.auth.types";
 import {
   type AuthFormField,
+  type CreateAppleSignInResponse,
   type CreateGoogleSignInResponse,
   type CreateMicrosoftSignInResponse,
   type EmailPasswordAuthInput,
   type EmailPasswordAuthResponse,
+  type ThirdPartySignInUpInput,
 } from "./supertokens.middleware.types";
 
 export function getFormFieldValue(
@@ -98,6 +101,94 @@ export function createMicrosoftSignInSuccess(
           ? payload["preferred_username"]
           : undefined,
       name: typeof payload["name"] === "string" ? payload["name"] : undefined,
+    },
+    oAuthTokens: response.oAuthTokens,
+    createdNewRecipeUser: response.createdNewRecipeUser,
+    recipeUserId: response.session?.getUserId() ?? response.user.id,
+    loginMethodsLength: response.user.loginMethods.length,
+  };
+}
+
+function appleUserFromPayload(
+  payload: Record<string, unknown>,
+): AppleSignInSuccess["providerUser"]["user"] {
+  const raw = payload["user"] ?? payload;
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const name =
+    "name" in raw && raw.name && typeof raw.name === "object"
+      ? (raw.name as { firstName?: unknown; lastName?: unknown })
+      : undefined;
+  const firstName =
+    typeof name?.firstName === "string" ? name.firstName : undefined;
+  const lastName =
+    typeof name?.lastName === "string" ? name.lastName : undefined;
+  if (!firstName && !lastName) {
+    return undefined;
+  }
+  return { name: { firstName, lastName } };
+}
+
+export function appleUserFromFormField(
+  raw: string | undefined,
+): AppleSignInSuccess["providerUser"]["user"] {
+  if (!raw?.trim()) {
+    return undefined;
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") {
+      return undefined;
+    }
+    return appleUserFromPayload(parsed as Record<string, unknown>);
+  } catch {
+    return undefined;
+  }
+}
+
+export function withAppleFirstAuthorizationName(
+  success: AppleSignInSuccess,
+  formUserJson?: string,
+): AppleSignInSuccess {
+  if (success.providerUser.name?.trim() || success.providerUser.user) {
+    return success;
+  }
+  const user = appleUserFromFormField(formUserJson);
+  if (!user) {
+    return success;
+  }
+  return {
+    ...success,
+    providerUser: { ...success.providerUser, user },
+  };
+}
+
+export function appleFormUserJsonFromInput(
+  input: ThirdPartySignInUpInput,
+): string | undefined {
+  if (!("redirectURIInfo" in input) || input.redirectURIInfo == null) {
+    return undefined;
+  }
+  const user = input.redirectURIInfo.redirectURIQueryParams?.user;
+  return typeof user === "string" ? user : undefined;
+}
+
+export function createAppleSignInSuccess(
+  response: CreateAppleSignInResponse,
+): AppleSignInSuccess | null {
+  if (response.status !== "OK") return null;
+
+  const payload = response.rawUserInfoFromProvider.fromIdTokenPayload ?? {};
+  const fromApi = response.rawUserInfoFromProvider.fromUserInfoAPI ?? {};
+
+  return {
+    providerUser: {
+      sub: typeof payload["sub"] === "string" ? payload["sub"] : undefined,
+      email:
+        typeof payload["email"] === "string" ? payload["email"] : undefined,
+      name: typeof payload["name"] === "string" ? payload["name"] : undefined,
+      user: appleUserFromPayload(payload) ?? appleUserFromPayload(fromApi),
     },
     oAuthTokens: response.oAuthTokens,
     createdNewRecipeUser: response.createdNewRecipeUser,

--- a/packages/core/src/types/auth.types.ts
+++ b/packages/core/src/types/auth.types.ts
@@ -14,7 +14,7 @@ export interface UserInfo_Google {
 }
 
 export const GoogleAuthCodeRequestSchema = z.object({
-  thirdPartyId: z.literal("google"),
+  thirdPartyId: z.enum(["google", "apple"]),
   clientType: z.literal("web"),
   redirectURIInfo: z.object({
     redirectURIOnProviderDashboard: z.string().nonempty(),
@@ -22,6 +22,7 @@ export const GoogleAuthCodeRequestSchema = z.object({
       code: z.string().nonempty(),
       scope: z.string().optional(),
       state: z.string().optional(),
+      user: z.string().optional(),
     }),
     pkceCodeVerifier: z.string().optional(),
   }),

--- a/packages/web/src/auth/apple/authorization/apple-authorization.constants.ts
+++ b/packages/web/src/auth/apple/authorization/apple-authorization.constants.ts
@@ -1,0 +1,10 @@
+import { ROOT_ROUTES } from "@web/common/constants/routes";
+
+export const APPLE_AUTH_CALLBACK_PATH = ROOT_ROUTES.APPLE_AUTH_CALLBACK;
+/** Backend form_post Return URL registered with the Apple Services ID. */
+export const APPLE_SIGNIN_FORM_POST_PATH = "/api/auth/apple/callback";
+export const APPLE_AUTH_INTENT_STORAGE_PREFIX =
+  "compass.appleAuthorizationIntent";
+export const APPLE_AUTH_INTENT_MAX_AGE_MS = 10 * 60 * 1000;
+export const APPLE_AUTHORIZATION_ERROR_MESSAGE =
+  "We couldn't sign you in with Apple. Please try again.";

--- a/packages/web/src/auth/apple/authorization/apple-authorization.storage.ts
+++ b/packages/web/src/auth/apple/authorization/apple-authorization.storage.ts
@@ -1,0 +1,70 @@
+import { z } from "zod/v4";
+import { sessionBrowserStore } from "@web/common/storage/browser-key-value.store";
+import {
+  APPLE_AUTH_INTENT_MAX_AGE_MS,
+  APPLE_AUTH_INTENT_STORAGE_PREFIX,
+} from "./apple-authorization.constants";
+
+export const AppleAuthorizationIntentSchema = z.object({
+  intent: z.literal("signIn"),
+  returnPath: z
+    .string()
+    .startsWith("/")
+    .refine((path) => !path.startsWith("//")),
+  createdAt: z.number(),
+});
+
+export type AppleAuthorizationIntent = z.infer<
+  typeof AppleAuthorizationIntentSchema
+>;
+
+const getStorageKey = (state: string) =>
+  `${APPLE_AUTH_INTENT_STORAGE_PREFIX}.${state}`;
+
+export function writeAppleAuthorizationIntent(
+  state: string,
+  intent: AppleAuthorizationIntent,
+): void {
+  sessionBrowserStore.set(getStorageKey(state), JSON.stringify(intent));
+}
+
+export function readAppleAuthorizationIntent(
+  state: string,
+): AppleAuthorizationIntent | null {
+  const key = getStorageKey(state);
+  const stored = sessionBrowserStore.get(key);
+
+  if (!stored) {
+    return null;
+  }
+
+  let storedIntent: unknown;
+
+  try {
+    storedIntent = JSON.parse(stored);
+  } catch {
+    sessionBrowserStore.remove(key);
+    return null;
+  }
+
+  const parsed = AppleAuthorizationIntentSchema.safeParse(storedIntent);
+
+  if (!parsed.success) {
+    sessionBrowserStore.remove(key);
+    return null;
+  }
+
+  const isExpired =
+    Date.now() - parsed.data.createdAt > APPLE_AUTH_INTENT_MAX_AGE_MS;
+
+  if (isExpired) {
+    sessionBrowserStore.remove(key);
+    return null;
+  }
+
+  return parsed.data;
+}
+
+export function clearAppleAuthorizationIntent(state: string): void {
+  sessionBrowserStore.remove(getStorageKey(state));
+}

--- a/packages/web/src/auth/apple/authorization/apple-authorization.util.test.ts
+++ b/packages/web/src/auth/apple/authorization/apple-authorization.util.test.ts
@@ -1,0 +1,44 @@
+import { ENV_WEB } from "@web/common/constants/env.constants";
+import { APPLE_SIGNIN_FORM_POST_PATH } from "./apple-authorization.constants";
+import {
+  buildAppleAuthCodePayload,
+  buildAppleSignInRedirectUri,
+} from "./apple-authorization.util";
+import { describe, expect, it } from "bun:test";
+
+describe("buildAppleAuthCodePayload", () => {
+  it("posts the code to SuperTokens with Apple's backend form_post redirect", () => {
+    expect(buildAppleSignInRedirectUri()).toBe(
+      `${ENV_WEB.BACKEND_BASEURL}${APPLE_SIGNIN_FORM_POST_PATH}`,
+    );
+    expect(
+      buildAppleAuthCodePayload({
+        code: "auth-code",
+        state: "oauth-state",
+        user: '{"name":{"firstName":"Ada"}}',
+      }),
+    ).toEqual({
+      thirdPartyId: "apple",
+      clientType: "web",
+      redirectURIInfo: {
+        redirectURIOnProviderDashboard: buildAppleSignInRedirectUri(),
+        redirectURIQueryParams: {
+          code: "auth-code",
+          state: "oauth-state",
+          user: '{"name":{"firstName":"Ada"}}',
+        },
+      },
+    });
+  });
+
+  it("omits optional form fields when Apple did not send them", () => {
+    expect(buildAppleAuthCodePayload({ code: "auth-code" })).toEqual({
+      thirdPartyId: "apple",
+      clientType: "web",
+      redirectURIInfo: {
+        redirectURIOnProviderDashboard: buildAppleSignInRedirectUri(),
+        redirectURIQueryParams: { code: "auth-code" },
+      },
+    });
+  });
+});

--- a/packages/web/src/auth/apple/authorization/apple-authorization.util.ts
+++ b/packages/web/src/auth/apple/authorization/apple-authorization.util.ts
@@ -1,0 +1,34 @@
+import { type GoogleAuthCodeRequest } from "@core/types/auth.types";
+import { ENV_WEB } from "@web/common/constants/env.constants";
+import { APPLE_SIGNIN_FORM_POST_PATH } from "./apple-authorization.constants";
+
+export function buildAppleSignInRedirectUri(
+  backendOrigin = ENV_WEB.BACKEND_BASEURL,
+) {
+  return `${backendOrigin}${APPLE_SIGNIN_FORM_POST_PATH}`;
+}
+
+export function buildAppleAuthCodePayload({
+  code,
+  state,
+  user,
+  redirectUri = buildAppleSignInRedirectUri(),
+}: {
+  code: string;
+  state?: string;
+  user?: string;
+  redirectUri?: string;
+}): GoogleAuthCodeRequest {
+  return {
+    thirdPartyId: "apple",
+    clientType: "web",
+    redirectURIInfo: {
+      redirectURIOnProviderDashboard: redirectUri,
+      redirectURIQueryParams: {
+        code,
+        ...(state ? { state } : {}),
+        ...(user ? { user } : {}),
+      },
+    },
+  };
+}

--- a/packages/web/src/common/constants/routes.ts
+++ b/packages/web/src/common/constants/routes.ts
@@ -6,6 +6,7 @@ export const ROOT_ROUTES = {
   BOOK_CONFIRMED: "/book/confirmed/$reservationId",
   CLEANUP: "/cleanup",
   GOOGLE_AUTH_CALLBACK: "/auth/google/callback",
+  APPLE_AUTH_CALLBACK: "/auth/apple/callback",
   LIFE: "/life",
   ROOT: "/",
   WEEK: "/week",

--- a/packages/web/src/routers/router.routes.tsx
+++ b/packages/web/src/routers/router.routes.tsx
@@ -3,6 +3,7 @@ import {
   createRoute,
   lazyRouteComponent,
 } from "@tanstack/react-router";
+import { APPLE_AUTH_CALLBACK_PATH } from "@web/auth/apple/authorization/apple-authorization.constants";
 import {
   validateBookingCancelSearch,
   validateBookingRescheduleSearch,
@@ -171,6 +172,15 @@ export const googleAuthCallbackRoute = createRoute({
   ),
 });
 
+export const appleAuthCallbackRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: APPLE_AUTH_CALLBACK_PATH,
+  component: lazyRouteComponent(
+    () => import("@web/views/AppleAuthCallback/AppleAuthCallback"),
+    "AppleAuthCallbackView",
+  ),
+});
+
 const authenticatedRoute = authenticatedLayoutRoute.addChildren([
   dayRoute.addChildren([dayDateRoute, dayIndexRoute]),
   weekRoute.addChildren([weekDateRoute, weekIndexRoute]),
@@ -194,4 +204,5 @@ export const routeTree = rootRoute.addChildren([
       ]
     : []),
   googleAuthCallbackRoute,
+  appleAuthCallbackRoute,
 ]);

--- a/packages/web/src/views/AppleAuthCallback/AppleAuthCallback.test.ts
+++ b/packages/web/src/views/AppleAuthCallback/AppleAuthCallback.test.ts
@@ -1,0 +1,97 @@
+import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
+import { AuthApi } from "@web/api/auth.api";
+import {
+  readAppleAuthorizationIntent,
+  writeAppleAuthorizationIntent,
+} from "@web/auth/apple/authorization/apple-authorization.storage";
+import { registerToastPort } from "@web/common/utils/toast/toast.port";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+
+const mockLoginOrSignup = mock();
+const realLoginOrSignup = AuthApi.loginOrSignup;
+AuthApi.loginOrSignup = mockLoginOrSignup as typeof AuthApi.loginOrSignup;
+
+afterAll(() => {
+  AuthApi.loginOrSignup = realLoginOrSignup;
+});
+
+const { port, mocks } = createTestToastPort();
+
+const { completeAppleAuthCallback } =
+  require("./AppleAuthCallback") as typeof import("./AppleAuthCallback");
+
+const callbackSearch = (state: string) =>
+  `?state=${encodeURIComponent(state)}&code=auth-code`;
+
+const writeIntent = (state: string, returnPath = "/week") => {
+  writeAppleAuthorizationIntent(state, {
+    intent: "signIn",
+    returnPath,
+    createdAt: Date.now(),
+  });
+};
+
+describe("completeAppleAuthCallback", () => {
+  const completeAuthentication = mock();
+  const navigate = mock();
+
+  beforeEach(() => {
+    mocks.error.mockClear();
+    registerToastPort(port);
+    sessionStorage.clear();
+    mockLoginOrSignup.mockClear();
+    completeAuthentication.mockClear();
+    navigate.mockClear();
+    mockLoginOrSignup.mockResolvedValue({
+      createdNewRecipeUser: true,
+      user: { emails: ["hidden@privaterelay.appleid.com"] },
+    });
+  });
+
+  it("finishes a saved Apple sign-in intent without requiring calendar scopes", async () => {
+    writeIntent("sign-in-state", "/week");
+
+    await completeAppleAuthCallback({
+      completeAuthentication,
+      navigate,
+      search: callbackSearch("sign-in-state"),
+    });
+
+    expect(mockLoginOrSignup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        thirdPartyId: "apple",
+        redirectURIInfo: expect.objectContaining({
+          redirectURIOnProviderDashboard: expect.stringMatching(
+            /\/api\/auth\/apple\/callback$/,
+          ),
+          redirectURIQueryParams: expect.objectContaining({
+            code: "auth-code",
+            state: "sign-in-state",
+          }),
+        }),
+      }),
+    );
+    expect(completeAuthentication).toHaveBeenCalledWith({
+      email: "hidden@privaterelay.appleid.com",
+    });
+    expect(mocks.error).not.toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledWith("/week", { replace: true });
+    expect(readAppleAuthorizationIntent("sign-in-state")).toBeNull();
+  });
+
+  it("rejects an Apple callback without a saved intent", async () => {
+    await completeAppleAuthCallback({
+      completeAuthentication,
+      navigate,
+      search: callbackSearch("unknown-state"),
+    });
+
+    expect(mockLoginOrSignup).not.toHaveBeenCalled();
+    expect(completeAuthentication).not.toHaveBeenCalled();
+    expect(mocks.error).toHaveBeenCalledWith(
+      "We couldn't sign you in with Apple. Please try again.",
+      expect.any(Object),
+    );
+    expect(navigate).toHaveBeenCalledWith("/week", { replace: true });
+  });
+});

--- a/packages/web/src/views/AppleAuthCallback/AppleAuthCallback.tsx
+++ b/packages/web/src/views/AppleAuthCallback/AppleAuthCallback.tsx
@@ -1,0 +1,115 @@
+import { useLocation, useRouter } from "@tanstack/react-router";
+import { useEffect, useRef } from "react";
+import { AuthApi } from "@web/api/auth.api";
+import { APPLE_AUTHORIZATION_ERROR_MESSAGE } from "@web/auth/apple/authorization/apple-authorization.constants";
+import {
+  clearAppleAuthorizationIntent,
+  readAppleAuthorizationIntent,
+} from "@web/auth/apple/authorization/apple-authorization.storage";
+import { buildAppleAuthCodePayload } from "@web/auth/apple/authorization/apple-authorization.util";
+import { useCompleteAuthentication } from "@web/auth/compass/hooks/useCompleteAuthentication";
+import { track } from "@web/auth/posthog/track";
+import { DEFAULT_CALENDAR_ROUTE } from "@web/common/constants/routes";
+import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
+import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
+
+type CompleteAuthentication = ReturnType<typeof useCompleteAuthentication>;
+
+type CompleteAppleAuthCallbackOptions = {
+  completeAuthentication: CompleteAuthentication;
+  navigate: (path: string, opts: { replace: true }) => void;
+  search: string;
+};
+
+export async function completeAppleAuthCallback({
+  completeAuthentication,
+  navigate,
+  search,
+}: CompleteAppleAuthCallbackOptions): Promise<void> {
+  const params = new URLSearchParams(search);
+  const state = params.get("state");
+
+  if (!state) {
+    showErrorToast(APPLE_AUTHORIZATION_ERROR_MESSAGE);
+    navigate(DEFAULT_CALENDAR_ROUTE, { replace: true });
+    return;
+  }
+
+  const savedIntent = readAppleAuthorizationIntent(state);
+  clearAppleAuthorizationIntent(state);
+  const returnPath = savedIntent?.returnPath ?? DEFAULT_CALENDAR_ROUTE;
+
+  if (!savedIntent || params.get("error")) {
+    showErrorToast(APPLE_AUTHORIZATION_ERROR_MESSAGE);
+    navigate(returnPath, { replace: true });
+    return;
+  }
+
+  const code = params.get("code");
+
+  if (!code) {
+    showErrorToast(APPLE_AUTHORIZATION_ERROR_MESSAGE);
+    navigate(returnPath, { replace: true });
+    return;
+  }
+
+  try {
+    const result = await AuthApi.loginOrSignup(
+      buildAppleAuthCodePayload({
+        code,
+        state,
+        user: params.get("user") ?? undefined,
+      }),
+    );
+    await completeAuthentication({
+      email: result.user.emails?.[0],
+    });
+
+    if (result.createdNewRecipeUser) {
+      track("signup_completed", { method: "apple" });
+    } else {
+      track("login_completed", { method: "apple" });
+    }
+
+    navigate(returnPath, { replace: true });
+  } catch {
+    showErrorToast(APPLE_AUTHORIZATION_ERROR_MESSAGE);
+    navigate(returnPath, { replace: true });
+  }
+}
+
+export function AppleAuthCallbackView() {
+  const didRun = useRef(false);
+  const location = useLocation();
+  const router = useRouter();
+  const completeAuthentication = useCompleteAuthentication();
+
+  useEffect(() => {
+    if (didRun.current) {
+      return;
+    }
+
+    didRun.current = true;
+
+    void completeAppleAuthCallback({
+      completeAuthentication,
+      navigate: (path) => router.history.replace(path),
+      search: location.searchStr,
+    });
+  }, [completeAuthentication, location.searchStr, router]);
+
+  return (
+    <OverlayPanel
+      title="Just finishing up …"
+      message="Returning you to Compass."
+      role="status"
+      variant="status"
+      icon={
+        <div
+          className="h-10 w-10 animate-spin rounded-full border-2 border-border border-t-text"
+          aria-hidden="true"
+        />
+      }
+    />
+  );
+}


### PR DESCRIPTION
Fixes #3267

## What and why

Sign in with Apple is a login method that never connects a calendar ([spec](https://github.com/KeepSoftwareSimple/compass-calendar/blob/main/docs/features/calendar-providers.md)). This WP adds SuperTokens' built-in `apple` provider when `isAppleSignInConfigured`, keys the identity by id_token `sub` (relay emails can change), persists Apple's first-authorization name, and skips I-02a calendar adoption unless the grant includes a calendar scope. Apple `form_post`s to rate-limited `POST /api/auth/apple/callback`, which 302s to the SPA `/auth/apple/callback`. Docs cover the Return URL, relay email, and name-on-first-sign-in.

## Verify

`VERDICT: PASS`

Checks run: `test:core`, `test:web`, `test:backend`, `type-check`, `lint`, `knip`, `test:a11y`, `test:e2e`