### PR TITLE
feat(web): provider-parameterized sign-in start and callback

### DIFF
--- a/e2e/oauth/google-auth-callback.spec.ts
+++ b/e2e/oauth/google-auth-callback.spec.ts
@@ -1,12 +1,9 @@
 import { expect, type Page, test } from "@playwright/test";
+import { GOOGLE_SCOPES } from "@core/providers/google.scopes";
 
 const CALLBACK_PATH = "/auth/google/callback";
 const INTENT_STORAGE_PREFIX = "compass.googleAuthorizationIntent";
-const REQUIRED_SCOPES = [
-  "https://www.googleapis.com/auth/userinfo.email",
-  "https://www.googleapis.com/auth/calendar.readonly",
-  "https://www.googleapis.com/auth/calendar.events",
-];
+const REQUIRED_SCOPES = [...GOOGLE_SCOPES];
 
 const getIntentStorageKey = (state: string) =>
   `${INTENT_STORAGE_PREFIX}.${state}`;

--- a/e2e/oauth/microsoft-auth-callback.spec.ts
+++ b/e2e/oauth/microsoft-auth-callback.spec.ts
@@ -1,0 +1,157 @@
+import { expect, type Page, test } from "@playwright/test";
+import { MICROSOFT_SCOPES } from "@core/providers/microsoft.scopes";
+
+const CALLBACK_PATH = "/auth/microsoft/callback";
+const INTENT_STORAGE_PREFIX = "compass.providerAuthorizationIntent.microsoft";
+const REQUIRED_SCOPES = [...MICROSOFT_SCOPES];
+
+const getIntentStorageKey = (state: string) =>
+  `${INTENT_STORAGE_PREFIX}.${state}`;
+
+const getCallbackUrl = (state: string, grantedScopes = REQUIRED_SCOPES) =>
+  `${CALLBACK_PATH}?state=${encodeURIComponent(
+    state,
+  )}&code=auth-code&scope=${encodeURIComponent(grantedScopes.join(" "))}`;
+
+type MetadataPayload = Record<string, unknown>;
+
+const prepareMicrosoftAuthCallbackPage = async (
+  page: Page,
+  options: { metadata?: MetadataPayload } = {},
+) => {
+  const loginOrSignupRequests: unknown[] = [];
+  const metadata = options.metadata ?? {
+    microsoft: { connectionState: "HEALTHY" },
+  };
+
+  await page.addInitScript(() => {
+    (
+      window as Window & { __COMPASS_E2E_TEST__?: boolean }
+    ).__COMPASS_E2E_TEST__ = true;
+    window.alert = () => undefined;
+    window.confirm = () => true;
+    window.prompt = () => null;
+  });
+
+  await page.route("**/api/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+
+    if (url.pathname.endsWith("/api/signinup")) {
+      loginOrSignupRequests.push(request.postDataJSON());
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          user: { emails: ["user@example.com"] },
+          createdNewRecipeUser: false,
+        }),
+      });
+    }
+
+    if (url.pathname.endsWith("/api/user/metadata")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(metadata),
+      });
+    }
+
+    if (url.pathname.endsWith("/api/config")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          providers: {
+            microsoft: { signIn: true, connect: true },
+          },
+        }),
+      });
+    }
+
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({}),
+    });
+  });
+
+  return { loginOrSignupRequests };
+};
+
+test("finishes a saved Microsoft sign-in callback", async ({ page }) => {
+  const state = "microsoft-sign-in-state";
+  const apiMocks = await prepareMicrosoftAuthCallbackPage(page);
+
+  await page.goto("/week");
+  await page.evaluate(
+    ({ key, value }) => {
+      sessionStorage.setItem(key, JSON.stringify(value));
+    },
+    {
+      key: getIntentStorageKey(state),
+      value: {
+        intent: "signIn",
+        returnPath: "/week",
+        createdAt: Date.now(),
+      },
+    },
+  );
+
+  await page.goto(getCallbackUrl(state));
+
+  await expect(
+    page.locator('[role="status"][aria-live="polite"]'),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/\/week$/);
+  expect(apiMocks.loginOrSignupRequests).toHaveLength(1);
+  expect(apiMocks.loginOrSignupRequests[0]).toEqual(
+    expect.objectContaining({
+      thirdPartyId: "active-directory",
+      redirectURIInfo: expect.objectContaining({
+        redirectURIQueryParams: expect.objectContaining({
+          code: "auth-code",
+          state,
+        }),
+      }),
+    }),
+  );
+  expect(
+    await page.evaluate(
+      (key) => sessionStorage.getItem(key),
+      getIntentStorageKey(state),
+    ),
+  ).toBeNull();
+});
+
+test("rejects a Microsoft callback that is missing required scopes", async ({
+  page,
+}) => {
+  const state = "microsoft-missing-scopes";
+  const apiMocks = await prepareMicrosoftAuthCallbackPage(page);
+
+  await page.goto("/week");
+  await page.evaluate(
+    ({ key, value }) => {
+      sessionStorage.setItem(key, JSON.stringify(value));
+    },
+    {
+      key: getIntentStorageKey(state),
+      value: {
+        intent: "signIn",
+        returnPath: "/week",
+        createdAt: Date.now(),
+      },
+    },
+  );
+
+  await page.goto(getCallbackUrl(state, [REQUIRED_SCOPES[0] ?? "openid"]));
+
+  await expect(page).toHaveURL(/\/week$/);
+  expect(apiMocks.loginOrSignupRequests).toHaveLength(0);
+  await expect(
+    page.getByText(
+      "Compass needs all the requested permissions to sync your calendar. Please allow them and try again.",
+    ),
+  ).toBeVisible();
+});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -11,7 +11,10 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true
+    "noUnusedParameters": true,
+    "paths": {
+      "@core/*": ["../packages/core/src/*"]
+    }
   },
   "include": ["./**/*.ts"]
 }

--- a/packages/web/src/api/auth.api.ts
+++ b/packages/web/src/api/auth.api.ts
@@ -13,10 +13,11 @@ import {
   type CredentialConnectPayload,
 } from "@core/types/sync/connection.contracts";
 import { BaseApi } from "@web/api/base/base.api";
+import { type ProviderAuthCodeRequest } from "@web/auth/providers/authorization/provider-authorization.util";
 
 const AuthApi = {
   async loginOrSignup(
-    data: GoogleAuthCodeRequest,
+    data: GoogleAuthCodeRequest | ProviderAuthCodeRequest,
   ): Promise<Result_Auth_Compass> {
     const response = await BaseApi.post<Result_Auth_Compass>(
       `/signinup`,

--- a/packages/web/src/auth/google/authorization/complete-google-authorization.ts
+++ b/packages/web/src/auth/google/authorization/complete-google-authorization.ts
@@ -1,150 +1,25 @@
 import {
-  type GoogleAuthCodeRequest,
-  type GoogleConnectErrorResponse,
-  GoogleConnectErrorResponseSchema,
-} from "@core/types/auth.types";
-import { type ApiError } from "@web/api/api.types";
-import { DEFAULT_CALENDAR_ROUTE } from "@web/common/constants/routes";
-import {
-  GOOGLE_AUTH_SCOPES_REQUIRED,
-  GOOGLE_AUTHORIZATION_ERROR_MESSAGE,
-  MISSING_GOOGLE_SCOPES_ERROR_MESSAGE,
-} from "./google-authorization.constants";
-import {
-  clearGoogleAuthorizationIntent,
-  markGoogleAuthNeedsConsentRetry,
-  readGoogleAuthorizationIntent,
-} from "./google-authorization.storage";
-import {
-  buildGoogleAuthCallbackUrl,
-  buildGoogleAuthCodePayload,
-} from "./google-authorization.util";
+  type CompleteProviderAuthorizationOptions,
+  type CompleteProviderAuthorizationResult,
+  completeProviderAuthorization,
+  type ProviderAuthorizationAuthAdapter,
+} from "@web/auth/providers/authorization/complete-provider-authorization";
 
-type CompleteAuthentication = (input: {
-  email?: string;
-  onComplete?: () => void;
-}) => Promise<void>;
+export type GoogleAuthorizationAuthAdapter = ProviderAuthorizationAuthAdapter;
 
-export type GoogleAuthorizationAuthAdapter = {
-  loginOrSignup(data: GoogleAuthCodeRequest): Promise<{
-    createdNewRecipeUser: boolean;
-    user: { emails?: string[] };
-  }>;
-};
-
-export type CompleteGoogleAuthorizationOptions = {
-  authApi: GoogleAuthorizationAuthAdapter;
-  completeAuthentication: CompleteAuthentication;
-  search: string;
-};
+export type CompleteGoogleAuthorizationOptions = Omit<
+  CompleteProviderAuthorizationOptions,
+  "provider"
+>;
 
 export type CompleteGoogleAuthorizationResult =
-  | {
-      returnPath: string;
-      status: "completed";
-      isNewUser: boolean;
-    }
-  | {
-      message: string;
-      returnPath: string;
-      status: "failed";
-    };
+  CompleteProviderAuthorizationResult;
 
-const fail = (
-  message = GOOGLE_AUTHORIZATION_ERROR_MESSAGE,
-  returnPath: string = DEFAULT_CALENDAR_ROUTE,
-): CompleteGoogleAuthorizationResult => ({
-  message,
-  returnPath,
-  status: "failed",
-});
-
-const getApiError = (error: unknown): ApiError | undefined => {
-  if (typeof error !== "object" || error === null || !("response" in error)) {
-    return undefined;
-  }
-
-  return error as ApiError;
-};
-
-const parseGoogleConnectError = (
-  error: unknown,
-): GoogleConnectErrorResponse | undefined => {
-  const data = getApiError(error)?.response?.data;
-  const parsed = GoogleConnectErrorResponseSchema.safeParse(data);
-
-  return parsed.success ? parsed.data : undefined;
-};
-
-export async function completeGoogleAuthorization({
-  authApi,
-  completeAuthentication,
-  search,
-}: CompleteGoogleAuthorizationOptions): Promise<CompleteGoogleAuthorizationResult> {
-  const params = new URLSearchParams(search);
-  const state = params.get("state");
-
-  if (!state) {
-    return fail();
-  }
-
-  const savedIntent = readGoogleAuthorizationIntent(state);
-  clearGoogleAuthorizationIntent(state);
-  const returnPath = savedIntent?.returnPath ?? DEFAULT_CALENDAR_ROUTE;
-
-  if (!savedIntent || params.get("error")) {
-    return fail(GOOGLE_AUTHORIZATION_ERROR_MESSAGE, returnPath);
-  }
-
-  const code = params.get("code");
-
-  if (!code) {
-    return fail(GOOGLE_AUTHORIZATION_ERROR_MESSAGE, returnPath);
-  }
-
-  const grantedScopes = new Set((params.get("scope") ?? "").split(" "));
-  const isMissingRequiredScope = GOOGLE_AUTH_SCOPES_REQUIRED.some(
-    (scope) => !grantedScopes.has(scope),
-  );
-
-  if (isMissingRequiredScope) {
-    return fail(MISSING_GOOGLE_SCOPES_ERROR_MESSAGE, returnPath);
-  }
-
-  const payload = buildGoogleAuthCodePayload({
-    code,
-    scope: params.get("scope") ?? undefined,
-    state,
-    redirectUri: buildGoogleAuthCallbackUrl(),
+export async function completeGoogleAuthorization(
+  options: CompleteGoogleAuthorizationOptions,
+): Promise<CompleteGoogleAuthorizationResult> {
+  return completeProviderAuthorization({
+    provider: "google",
+    ...options,
   });
-
-  try {
-    const result = await authApi.loginOrSignup(payload);
-    await completeAuthentication({
-      email: result.user.emails?.[0],
-    });
-
-    return {
-      returnPath,
-      status: "completed",
-      isNewUser: result.createdNewRecipeUser,
-    };
-  } catch (error) {
-    const parsedError = parseGoogleConnectError(error);
-
-    if (parsedError?.code === "GOOGLE_REFRESH_TOKEN_MISSING") {
-      // This browser already consented once before (e.g. an earlier attempt
-      // failed after Google-side consent but before Compass finished
-      // linking) - Google silently withholds the refresh token on a repeat
-      // consent. Mark it so the NEXT attempt forces prompt=consent, or it
-      // fails the exact same way forever.
-      markGoogleAuthNeedsConsentRetry();
-    }
-
-    if (parsedError?.message) {
-      return fail(parsedError.message, returnPath);
-    }
-
-    return fail(GOOGLE_AUTHORIZATION_ERROR_MESSAGE, returnPath);
-  }
 }

--- a/packages/web/src/auth/google/authorization/google-authorization.constants.ts
+++ b/packages/web/src/auth/google/authorization/google-authorization.constants.ts
@@ -1,26 +1,4 @@
-import { ROOT_ROUTES } from "@web/common/constants/routes";
+import { GOOGLE_SCOPES } from "@core/providers/google.scopes";
 
-export const GOOGLE_AUTH_CALLBACK_PATH = ROOT_ROUTES.GOOGLE_AUTH_CALLBACK;
-export const GOOGLE_AUTH_INTENT_STORAGE_PREFIX =
-  "compass.googleAuthorizationIntent";
-export const GOOGLE_AUTH_INTENT_MAX_AGE_MS = 10 * 60 * 1000;
-
-// Sign-in fails without every scope in this list (complete-google-authorization
-// verifies the callback granted them all). It must NEVER gain a contacts scope:
-// contacts are optional (below), and requiring one would brick sign-in for
-// every user who declines it.
-export const GOOGLE_AUTH_SCOPES_REQUIRED = [
-  "https://www.googleapis.com/auth/userinfo.email",
-  "https://www.googleapis.com/auth/calendar.readonly",
-  "https://www.googleapis.com/auth/calendar.events",
-];
-
-// Contacts are requested only by the explicit contacts feature flow in Sync.
-// Keeping sign-in to the verified Calendar scopes prevents Google from
-// treating the login request as unverified.
+export const GOOGLE_AUTH_SCOPES_REQUIRED = [...GOOGLE_SCOPES];
 export const GOOGLE_AUTH_SCOPES_REQUESTED = GOOGLE_AUTH_SCOPES_REQUIRED;
-
-export const GOOGLE_AUTHORIZATION_ERROR_MESSAGE =
-  "We couldn't connect your Google account. Please try again.";
-export const MISSING_GOOGLE_SCOPES_ERROR_MESSAGE =
-  "Compass needs all the requested permissions to sync your calendar. Please allow them and try again.";

--- a/packages/web/src/auth/google/authorization/google-authorization.storage.ts
+++ b/packages/web/src/auth/google/authorization/google-authorization.storage.ts
@@ -1,91 +1,29 @@
-import { z } from "zod/v4";
-import { sessionBrowserStore } from "@web/common/storage/browser-key-value.store";
 import {
-  GOOGLE_AUTH_INTENT_MAX_AGE_MS,
-  GOOGLE_AUTH_INTENT_STORAGE_PREFIX,
-} from "./google-authorization.constants";
+  clearProviderAuthorizationIntent,
+  consumeGoogleAuthNeedsConsentRetry,
+  markGoogleAuthNeedsConsentRetry,
+  type ProviderAuthorizationIntent,
+  readProviderAuthorizationIntent,
+  writeProviderAuthorizationIntent,
+} from "@web/auth/providers/authorization/provider-authorization.storage";
 
-export const GoogleAuthorizationIntentSchema = z.object({
-  intent: z.literal("signIn"),
-  returnPath: z
-    .string()
-    .startsWith("/")
-    .refine((path) => !path.startsWith("//")),
-  createdAt: z.number(),
-});
-
-export type GoogleAuthorizationIntent = z.infer<
-  typeof GoogleAuthorizationIntentSchema
->;
-
-const getStorageKey = (state: string) =>
-  `${GOOGLE_AUTH_INTENT_STORAGE_PREFIX}.${state}`;
+export type GoogleAuthorizationIntent = ProviderAuthorizationIntent;
 
 export function writeGoogleAuthorizationIntent(
   state: string,
   intent: GoogleAuthorizationIntent,
 ): void {
-  sessionBrowserStore.set(getStorageKey(state), JSON.stringify(intent));
+  writeProviderAuthorizationIntent("google", state, intent);
 }
 
 export function readGoogleAuthorizationIntent(
   state: string,
 ): GoogleAuthorizationIntent | null {
-  const key = getStorageKey(state);
-  const stored = sessionBrowserStore.get(key);
-
-  if (!stored) {
-    return null;
-  }
-
-  let storedIntent: unknown;
-
-  try {
-    storedIntent = JSON.parse(stored);
-  } catch {
-    sessionBrowserStore.remove(key);
-    return null;
-  }
-
-  const parsed = GoogleAuthorizationIntentSchema.safeParse(storedIntent);
-
-  if (!parsed.success) {
-    sessionBrowserStore.remove(key);
-    return null;
-  }
-
-  const isExpired =
-    Date.now() - parsed.data.createdAt > GOOGLE_AUTH_INTENT_MAX_AGE_MS;
-
-  if (isExpired) {
-    sessionBrowserStore.remove(key);
-    return null;
-  }
-
-  return parsed.data;
+  return readProviderAuthorizationIntent("google", state);
 }
 
 export function clearGoogleAuthorizationIntent(state: string): void {
-  sessionBrowserStore.remove(getStorageKey(state));
+  clearProviderAuthorizationIntent("google", state);
 }
 
-// Not keyed by state (unlike the intent above): this needs to survive INTO
-// the next authorization attempt, which mints a fresh state of its own. Set
-// when Google withholds a refresh token because this browser already
-// consented once before (GOOGLE_REFRESH_TOKEN_MISSING) - the next attempt
-// must pass prompt=consent or it fails the exact same way, forever.
-const NEEDS_CONSENT_RETRY_KEY = `${GOOGLE_AUTH_INTENT_STORAGE_PREFIX}.needsConsentRetry`;
-
-export function markGoogleAuthNeedsConsentRetry(): void {
-  sessionBrowserStore.set(NEEDS_CONSENT_RETRY_KEY, "1");
-}
-
-// Read-and-clear: the flag is consumed by exactly the next attempt, not every
-// attempt afterward.
-export function consumeGoogleAuthNeedsConsentRetry(): boolean {
-  const needsRetry = sessionBrowserStore.get(NEEDS_CONSENT_RETRY_KEY) !== null;
-  if (needsRetry) {
-    sessionBrowserStore.remove(NEEDS_CONSENT_RETRY_KEY);
-  }
-  return needsRetry;
-}
+export { consumeGoogleAuthNeedsConsentRetry, markGoogleAuthNeedsConsentRetry };

--- a/packages/web/src/auth/google/authorization/google-authorization.util.ts
+++ b/packages/web/src/auth/google/authorization/google-authorization.util.ts
@@ -1,36 +1,19 @@
 import { type GoogleAuthCodeRequest } from "@core/types/auth.types";
-import { DEFAULT_CALENDAR_ROUTE } from "@web/common/constants/routes";
-import { GOOGLE_AUTH_CALLBACK_PATH } from "./google-authorization.constants";
+import {
+  buildProviderAuthCallbackUrl,
+  buildProviderAuthCodePayload,
+  getSafeProviderAuthReturnPath,
+} from "@web/auth/providers/authorization/provider-authorization.util";
 
 export function buildGoogleAuthCallbackUrl(origin = window.location.origin) {
-  return `${origin}${GOOGLE_AUTH_CALLBACK_PATH}`;
+  return buildProviderAuthCallbackUrl("google", origin);
 }
 
 export function getSafeGoogleAuthReturnPath(
   href = window.location.href,
   origin = window.location.origin,
 ): string {
-  try {
-    const url = new URL(href, origin);
-
-    if (url.origin !== origin) {
-      return DEFAULT_CALENDAR_ROUTE;
-    }
-
-    if (url.pathname === GOOGLE_AUTH_CALLBACK_PATH) {
-      return DEFAULT_CALENDAR_ROUTE;
-    }
-
-    // Drop the transient auth-modal params so the OAuth round-trip doesn't
-    // navigate back into an open login modal on top of the authenticated
-    // calendar. See the auth modal, which reopens on any `?auth=` param.
-    url.searchParams.delete("auth");
-    url.searchParams.delete("token");
-
-    return `${url.pathname}${url.search}${url.hash}`;
-  } catch {
-    return DEFAULT_CALENDAR_ROUTE;
-  }
+  return getSafeProviderAuthReturnPath("google", href, origin);
 }
 
 export function buildGoogleAuthCodePayload({
@@ -44,12 +27,11 @@ export function buildGoogleAuthCodePayload({
   state?: string;
   redirectUri?: string;
 }): GoogleAuthCodeRequest {
-  return {
-    thirdPartyId: "google",
-    clientType: "web",
-    redirectURIInfo: {
-      redirectURIOnProviderDashboard: redirectUri,
-      redirectURIQueryParams: { code, scope, state },
-    },
-  };
+  return buildProviderAuthCodePayload({
+    provider: "google",
+    code,
+    scope,
+    state,
+    redirectUri,
+  }) as GoogleAuthCodeRequest;
 }

--- a/packages/web/src/auth/google/authorization/useStartGoogleAuthorization.impl.ts
+++ b/packages/web/src/auth/google/authorization/useStartGoogleAuthorization.impl.ts
@@ -1,77 +1,15 @@
-import {
-  type UseGoogleLoginOptionsAuthCodeFlow,
-  useGoogleLogin as useGoogleLoginBase,
-} from "@react-oauth/google";
-import { useCallback, useMemo, useState } from "react";
-import { track } from "@web/auth/posthog/track";
-import { GOOGLE_AUTH_SCOPES_REQUESTED } from "./google-authorization.constants";
-import {
-  type GoogleAuthorizationIntent,
-  writeGoogleAuthorizationIntent,
-} from "./google-authorization.storage";
-import {
-  buildGoogleAuthCallbackUrl,
-  getSafeGoogleAuthReturnPath,
-} from "./google-authorization.util";
+import { useStartProviderAuthorization } from "@web/auth/providers/authorization/useStartProviderAuthorization";
 
-export const useStartGoogleAuthorizationImpl = ({
-  intent,
-  onStart,
-  onError,
-  prompt,
-}: {
-  intent: GoogleAuthorizationIntent["intent"];
-  onStart?: () => void;
-  onError?: (error: unknown) => void;
-  prompt?: "consent" | "none" | "select_account";
-}) => {
-  const [loading, setLoading] = useState(false);
-  const [state] = useState(() => crypto.randomUUID());
-  const [redirectUri] = useState(buildGoogleAuthCallbackUrl);
-
-  const loginOptions = useMemo<
-    UseGoogleLoginOptionsAuthCodeFlow & {
-      prompt?: "consent" | "none" | "select_account";
-    }
-  >(
-    () => ({
-      flow: "auth-code",
-      // Contacts are requested separately only after the user enables the
-      // contacts feature. Login asks solely for verified Calendar scopes.
-      scope: GOOGLE_AUTH_SCOPES_REQUESTED.join(" "),
-      prompt,
-      state,
-      ux_mode: "redirect",
-      redirect_uri: redirectUri,
-      onNonOAuthError(error) {
-        setLoading(false);
-        onError?.(error);
-      },
-      onError(error) {
-        setLoading(false);
-        onError?.(error);
-      },
-    }),
-    [onError, prompt, redirectUri, state],
+export const useStartGoogleAuthorizationImpl = (
+  options: Parameters<typeof useStartProviderAuthorization>[1],
+) => {
+  const { loading, startAuthorization } = useStartProviderAuthorization(
+    "google",
+    options,
   );
-
-  const startGoogleAuthorization = useGoogleLoginBase(loginOptions);
 
   return {
     loading,
-    startGoogleAuthorization: useCallback(() => {
-      onStart?.();
-      setLoading(true);
-      writeGoogleAuthorizationIntent(state, {
-        intent,
-        returnPath: getSafeGoogleAuthReturnPath(),
-        createdAt: Date.now(),
-      });
-      // PostHog loses the session at the redirect; this marks "left for
-      // Google" so abandoned round trips are distinguishable from silent
-      // failures on return.
-      track("oauth_redirect_started", { provider: "google", intent });
-      return startGoogleAuthorization();
-    }, [intent, onStart, startGoogleAuthorization, state]),
+    startGoogleAuthorization: startAuthorization,
   };
 };

--- a/packages/web/src/auth/providers/authorization/complete-provider-authorization.test.ts
+++ b/packages/web/src/auth/providers/authorization/complete-provider-authorization.test.ts
@@ -1,0 +1,136 @@
+import { GOOGLE_SCOPES } from "@core/providers/google.scopes";
+import { MICROSOFT_SCOPES } from "@core/providers/microsoft.scopes";
+import { completeProviderAuthorization } from "./complete-provider-authorization";
+import { PROVIDER_AUTH_SCOPES_REQUIRED } from "./provider-authorization.constants";
+import {
+  consumeGoogleAuthNeedsConsentRetry,
+  readProviderAuthorizationIntent,
+  writeProviderAuthorizationIntent,
+} from "./provider-authorization.storage";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const makeDeps = () => ({
+  authApi: {
+    loginOrSignup: mock(async () => ({
+      createdNewRecipeUser: false,
+      status: "OK" as const,
+      user: { emails: ["user@example.com"] },
+    })),
+  },
+  completeAuthentication: mock(async () => undefined),
+});
+
+const callbackSearch = (state: string, scope: string) =>
+  `?state=${encodeURIComponent(
+    state,
+  )}&code=auth-code&scope=${encodeURIComponent(scope)}`;
+
+describe("completeProviderAuthorization", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("completes a saved Google sign-in intent", async () => {
+    const deps = makeDeps();
+    writeProviderAuthorizationIntent("google", "state-1", {
+      intent: "signIn",
+      returnPath: "/week",
+      createdAt: Date.now(),
+    });
+
+    await expect(
+      completeProviderAuthorization({
+        provider: "google",
+        ...deps,
+        search: callbackSearch("state-1", GOOGLE_SCOPES.join(" ")),
+      }),
+    ).resolves.toEqual({
+      status: "completed",
+      returnPath: "/week",
+      isNewUser: false,
+    });
+
+    expect(deps.authApi.loginOrSignup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        thirdPartyId: "google",
+        redirectURIInfo: expect.objectContaining({
+          redirectURIQueryParams: expect.objectContaining({
+            code: "auth-code",
+            state: "state-1",
+          }),
+        }),
+      }),
+    );
+    expect(readProviderAuthorizationIntent("google", "state-1")).toBeNull();
+  });
+
+  it("completes a saved Microsoft sign-in intent", async () => {
+    const deps = makeDeps();
+    writeProviderAuthorizationIntent("microsoft", "ms-state", {
+      intent: "signIn",
+      returnPath: "/week",
+      createdAt: Date.now(),
+    });
+
+    await expect(
+      completeProviderAuthorization({
+        provider: "microsoft",
+        ...deps,
+        search: callbackSearch("ms-state", MICROSOFT_SCOPES.join(" ")),
+      }),
+    ).resolves.toEqual({
+      status: "completed",
+      returnPath: "/week",
+      isNewUser: false,
+    });
+
+    expect(deps.authApi.loginOrSignup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        thirdPartyId: "active-directory",
+      }),
+    );
+  });
+
+  it("reads required scopes from core constants", () => {
+    expect(PROVIDER_AUTH_SCOPES_REQUIRED.google).toEqual([...GOOGLE_SCOPES]);
+    expect(PROVIDER_AUTH_SCOPES_REQUIRED.microsoft).toEqual([
+      ...MICROSOFT_SCOPES,
+    ]);
+  });
+
+  it("marks the next Google attempt for a forced consent retry", async () => {
+    const deps = makeDeps();
+    deps.authApi.loginOrSignup = mock(async () => {
+      throw Object.assign(new Error("Conflict"), {
+        response: {
+          data: {
+            code: "GOOGLE_REFRESH_TOKEN_MISSING",
+            message:
+              "Google did not grant a fresh authorization. Please try again.",
+          },
+        },
+      });
+    });
+    writeProviderAuthorizationIntent("google", "state-4", {
+      intent: "signIn",
+      returnPath: "/week",
+      createdAt: Date.now(),
+    });
+
+    expect(consumeGoogleAuthNeedsConsentRetry()).toBe(false);
+
+    await expect(
+      completeProviderAuthorization({
+        provider: "google",
+        ...deps,
+        search: callbackSearch("state-4", GOOGLE_SCOPES.join(" ")),
+      }),
+    ).resolves.toEqual({
+      status: "failed",
+      message: "Google did not grant a fresh authorization. Please try again.",
+      returnPath: "/week",
+    });
+
+    expect(consumeGoogleAuthNeedsConsentRetry()).toBe(true);
+  });
+});

--- a/packages/web/src/auth/providers/authorization/complete-provider-authorization.ts
+++ b/packages/web/src/auth/providers/authorization/complete-provider-authorization.ts
@@ -1,0 +1,172 @@
+import {
+  type GoogleConnectErrorResponse,
+  GoogleConnectErrorResponseSchema,
+} from "@core/types/auth.types";
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+import { type ApiError } from "@web/api/api.types";
+import { DEFAULT_CALENDAR_ROUTE } from "@web/common/constants/routes";
+import {
+  GOOGLE_AUTHORIZATION_ERROR_MESSAGE,
+  MISSING_GOOGLE_SCOPES_ERROR_MESSAGE,
+  MISSING_PROVIDER_SCOPES_ERROR_MESSAGE,
+  PROVIDER_AUTH_SCOPES_REQUIRED,
+  PROVIDER_AUTHORIZATION_ERROR_MESSAGE,
+} from "./provider-authorization.constants";
+import {
+  clearProviderAuthorizationIntent,
+  markGoogleAuthNeedsConsentRetry,
+  readProviderAuthorizationIntent,
+} from "./provider-authorization.storage";
+import {
+  buildProviderAuthCallbackUrl,
+  buildProviderAuthCodePayload,
+  type ProviderAuthCodeRequest,
+} from "./provider-authorization.util";
+
+type CompleteAuthentication = (input: {
+  email?: string;
+  onComplete?: () => void;
+}) => Promise<void>;
+
+export type ProviderAuthorizationAuthAdapter = {
+  loginOrSignup(data: ProviderAuthCodeRequest): Promise<{
+    createdNewRecipeUser: boolean;
+    user: { emails?: string[] };
+  }>;
+};
+
+export type CompleteProviderAuthorizationOptions = {
+  provider: ProviderKind;
+  authApi: ProviderAuthorizationAuthAdapter;
+  completeAuthentication: CompleteAuthentication;
+  search: string;
+};
+
+export type CompleteProviderAuthorizationResult =
+  | {
+      returnPath: string;
+      status: "completed";
+      isNewUser: boolean;
+    }
+  | {
+      message: string;
+      returnPath: string;
+      status: "failed";
+    };
+
+const AUTHORIZATION_ERROR_MESSAGE: Record<ProviderKind, string> = {
+  google: GOOGLE_AUTHORIZATION_ERROR_MESSAGE,
+  microsoft: PROVIDER_AUTHORIZATION_ERROR_MESSAGE,
+  apple: PROVIDER_AUTHORIZATION_ERROR_MESSAGE,
+};
+
+const MISSING_SCOPES_ERROR_MESSAGE: Record<ProviderKind, string> = {
+  google: MISSING_GOOGLE_SCOPES_ERROR_MESSAGE,
+  microsoft: MISSING_PROVIDER_SCOPES_ERROR_MESSAGE,
+  apple: MISSING_PROVIDER_SCOPES_ERROR_MESSAGE,
+};
+
+const CONSENT_RETRY_ERROR_CODES_BY_PROVIDER: Partial<
+  Record<ProviderKind, ReadonlySet<string>>
+> = {
+  google: new Set(["GOOGLE_REFRESH_TOKEN_MISSING"]),
+};
+
+const fail = (
+  provider: ProviderKind,
+  returnPath: string = DEFAULT_CALENDAR_ROUTE,
+  message = AUTHORIZATION_ERROR_MESSAGE[provider],
+): CompleteProviderAuthorizationResult => ({
+  message,
+  returnPath,
+  status: "failed",
+});
+
+const getApiError = (error: unknown): ApiError | undefined => {
+  if (typeof error !== "object" || error === null || !("response" in error)) {
+    return undefined;
+  }
+
+  return error as ApiError;
+};
+
+const parseGoogleConnectError = (
+  error: unknown,
+): GoogleConnectErrorResponse | undefined => {
+  const data = getApiError(error)?.response?.data;
+  const parsed = GoogleConnectErrorResponseSchema.safeParse(data);
+
+  return parsed.success ? parsed.data : undefined;
+};
+
+export async function completeProviderAuthorization({
+  provider,
+  authApi,
+  completeAuthentication,
+  search,
+}: CompleteProviderAuthorizationOptions): Promise<CompleteProviderAuthorizationResult> {
+  const params = new URLSearchParams(search);
+  const state = params.get("state");
+
+  if (!state) {
+    return fail(provider);
+  }
+
+  const savedIntent = readProviderAuthorizationIntent(provider, state);
+  clearProviderAuthorizationIntent(provider, state);
+  const returnPath = savedIntent?.returnPath ?? DEFAULT_CALENDAR_ROUTE;
+
+  if (!savedIntent || params.get("error")) {
+    return fail(provider, returnPath);
+  }
+
+  const code = params.get("code");
+
+  if (!code) {
+    return fail(provider, returnPath);
+  }
+
+  const requiredScopes = PROVIDER_AUTH_SCOPES_REQUIRED[provider];
+  const grantedScopes = new Set((params.get("scope") ?? "").split(" "));
+  const isMissingRequiredScope = requiredScopes.some(
+    (scope) => !grantedScopes.has(scope),
+  );
+
+  if (isMissingRequiredScope) {
+    return fail(provider, returnPath, MISSING_SCOPES_ERROR_MESSAGE[provider]);
+  }
+
+  const payload = buildProviderAuthCodePayload({
+    provider,
+    code,
+    scope: params.get("scope") ?? undefined,
+    state,
+    redirectUri: buildProviderAuthCallbackUrl(provider),
+  });
+
+  try {
+    const result = await authApi.loginOrSignup(payload);
+    await completeAuthentication({
+      email: result.user.emails?.[0],
+    });
+
+    return {
+      returnPath,
+      status: "completed",
+      isNewUser: result.createdNewRecipeUser,
+    };
+  } catch (error) {
+    const parsedError = parseGoogleConnectError(error);
+    const consentRetryCodes = CONSENT_RETRY_ERROR_CODES_BY_PROVIDER[provider];
+
+    if (parsedError?.code && consentRetryCodes?.has(parsedError.code)) {
+      markGoogleAuthNeedsConsentRetry();
+    }
+
+    if (parsedError?.message) {
+      return fail(provider, returnPath, parsedError.message);
+    }
+
+    return fail(provider, returnPath);
+  }
+}

--- a/packages/web/src/auth/providers/authorization/provider-authorization.config.ts
+++ b/packages/web/src/auth/providers/authorization/provider-authorization.config.ts
@@ -1,0 +1,5 @@
+import { ENV_WEB } from "@web/common/constants/env.constants";
+
+export function getMicrosoftSignInClientId(): string {
+  return ENV_WEB.MICROSOFT_CLIENT_ID?.trim() ?? "";
+}

--- a/packages/web/src/auth/providers/authorization/provider-authorization.constants.ts
+++ b/packages/web/src/auth/providers/authorization/provider-authorization.constants.ts
@@ -1,0 +1,40 @@
+import { GOOGLE_SCOPES } from "@core/providers/google.scopes";
+import { MICROSOFT_SCOPES } from "@core/providers/microsoft.scopes";
+import {
+  type ProviderKind,
+  ProviderKindSchema,
+} from "@core/types/sync/identity.contracts";
+
+export const PROVIDER_AUTH_INTENT_STORAGE_PREFIX =
+  "compass.providerAuthorizationIntent";
+export const PROVIDER_AUTH_INTENT_MAX_AGE_MS = 10 * 60 * 1000;
+
+export const GOOGLE_AUTH_INTENT_STORAGE_PREFIX =
+  "compass.googleAuthorizationIntent";
+
+export const PROVIDER_AUTH_SCOPES_REQUIRED: Record<
+  ProviderKind,
+  readonly string[]
+> = {
+  google: GOOGLE_SCOPES,
+  microsoft: MICROSOFT_SCOPES,
+  apple: [],
+};
+
+export const PROVIDER_AUTHORIZATION_ERROR_MESSAGE =
+  "We couldn't finish signing you in. Please try again.";
+export const MISSING_PROVIDER_SCOPES_ERROR_MESSAGE =
+  "Compass needs all the requested permissions to sync your calendar. Please allow them and try again.";
+
+export const GOOGLE_AUTHORIZATION_ERROR_MESSAGE =
+  "We couldn't connect your Google account. Please try again.";
+export const MISSING_GOOGLE_SCOPES_ERROR_MESSAGE =
+  MISSING_PROVIDER_SCOPES_ERROR_MESSAGE;
+
+export function isSignInProviderKind(value: string): value is ProviderKind {
+  return ProviderKindSchema.safeParse(value).success;
+}
+
+export function providerAuthCallbackPath(kind: ProviderKind): string {
+  return `/auth/${kind}/callback`;
+}

--- a/packages/web/src/auth/providers/authorization/provider-authorization.redirect.ts
+++ b/packages/web/src/auth/providers/authorization/provider-authorization.redirect.ts
@@ -1,0 +1,3 @@
+export function assignAuthorizationRedirect(url: string): void {
+  window.location.assign(url);
+}

--- a/packages/web/src/auth/providers/authorization/provider-authorization.storage.ts
+++ b/packages/web/src/auth/providers/authorization/provider-authorization.storage.ts
@@ -1,0 +1,101 @@
+import { z } from "zod/v4";
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+import { sessionBrowserStore } from "@web/common/storage/browser-key-value.store";
+import {
+  GOOGLE_AUTH_INTENT_STORAGE_PREFIX,
+  PROVIDER_AUTH_INTENT_MAX_AGE_MS,
+  PROVIDER_AUTH_INTENT_STORAGE_PREFIX,
+} from "./provider-authorization.constants";
+
+export const ProviderAuthorizationIntentSchema = z.object({
+  intent: z.literal("signIn"),
+  returnPath: z
+    .string()
+    .startsWith("/")
+    .refine((path) => !path.startsWith("//")),
+  createdAt: z.number(),
+});
+
+export type ProviderAuthorizationIntent = z.infer<
+  typeof ProviderAuthorizationIntentSchema
+>;
+
+const INTENT_STORAGE_PREFIX_BY_KIND: Record<ProviderKind, string> = {
+  google: GOOGLE_AUTH_INTENT_STORAGE_PREFIX,
+  microsoft: `${PROVIDER_AUTH_INTENT_STORAGE_PREFIX}.microsoft`,
+  apple: `${PROVIDER_AUTH_INTENT_STORAGE_PREFIX}.apple`,
+};
+
+const getStorageKey = (provider: ProviderKind, state: string) =>
+  `${INTENT_STORAGE_PREFIX_BY_KIND[provider]}.${state}`;
+
+export function writeProviderAuthorizationIntent(
+  provider: ProviderKind,
+  state: string,
+  intent: ProviderAuthorizationIntent,
+): void {
+  sessionBrowserStore.set(
+    getStorageKey(provider, state),
+    JSON.stringify(intent),
+  );
+}
+
+export function readProviderAuthorizationIntent(
+  provider: ProviderKind,
+  state: string,
+): ProviderAuthorizationIntent | null {
+  const key = getStorageKey(provider, state);
+  const stored = sessionBrowserStore.get(key);
+
+  if (!stored) {
+    return null;
+  }
+
+  let storedIntent: unknown;
+
+  try {
+    storedIntent = JSON.parse(stored);
+  } catch {
+    sessionBrowserStore.remove(key);
+    return null;
+  }
+
+  const parsed = ProviderAuthorizationIntentSchema.safeParse(storedIntent);
+
+  if (!parsed.success) {
+    sessionBrowserStore.remove(key);
+    return null;
+  }
+
+  const isExpired =
+    Date.now() - parsed.data.createdAt > PROVIDER_AUTH_INTENT_MAX_AGE_MS;
+
+  if (isExpired) {
+    sessionBrowserStore.remove(key);
+    return null;
+  }
+
+  return parsed.data;
+}
+
+export function clearProviderAuthorizationIntent(
+  provider: ProviderKind,
+  state: string,
+): void {
+  sessionBrowserStore.remove(getStorageKey(provider, state));
+}
+
+const googleNeedsConsentRetryKey = `${GOOGLE_AUTH_INTENT_STORAGE_PREFIX}.needsConsentRetry`;
+
+export function markGoogleAuthNeedsConsentRetry(): void {
+  sessionBrowserStore.set(googleNeedsConsentRetryKey, "1");
+}
+
+export function consumeGoogleAuthNeedsConsentRetry(): boolean {
+  const needsRetry =
+    sessionBrowserStore.get(googleNeedsConsentRetryKey) !== null;
+  if (needsRetry) {
+    sessionBrowserStore.remove(googleNeedsConsentRetryKey);
+  }
+  return needsRetry;
+}

--- a/packages/web/src/auth/providers/authorization/provider-authorization.third-party.ts
+++ b/packages/web/src/auth/providers/authorization/provider-authorization.third-party.ts
@@ -1,0 +1,17 @@
+import {
+  type ProviderKind,
+  SUPERTOKENS_THIRD_PARTY_TO_KIND,
+  type SuperTokensThirdPartyId,
+} from "@core/types/sync/identity.contracts";
+
+const KIND_TO_THIRD_PARTY = Object.fromEntries(
+  Object.entries(SUPERTOKENS_THIRD_PARTY_TO_KIND).map(
+    ([thirdPartyId, kind]) => [kind, thirdPartyId],
+  ),
+) as Record<ProviderKind, SuperTokensThirdPartyId>;
+
+export function thirdPartyIdForProviderKind(
+  kind: ProviderKind,
+): SuperTokensThirdPartyId {
+  return KIND_TO_THIRD_PARTY[kind];
+}

--- a/packages/web/src/auth/providers/authorization/provider-authorization.util.test.ts
+++ b/packages/web/src/auth/providers/authorization/provider-authorization.util.test.ts
@@ -1,0 +1,33 @@
+import { MICROSOFT_SCOPES } from "@core/providers/microsoft.scopes";
+import {
+  buildMicrosoftAuthorizationUrl,
+  buildProviderAuthCallbackUrl,
+} from "./provider-authorization.util";
+import { describe, expect, it } from "bun:test";
+
+describe("buildMicrosoftAuthorizationUrl", () => {
+  it("builds the common Microsoft authorize URL", () => {
+    const url = buildMicrosoftAuthorizationUrl({
+      clientId: "microsoft-client-id",
+      redirectUri: buildProviderAuthCallbackUrl(
+        "microsoft",
+        "http://localhost:9080",
+      ),
+      scopes: MICROSOFT_SCOPES,
+      state: "microsoft-state",
+      prompt: "consent",
+    });
+
+    expect(url).toContain(
+      "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+    );
+    expect(url).toContain("client_id=microsoft-client-id");
+    expect(url).toContain(
+      encodeURIComponent("http://localhost:9080/auth/microsoft/callback"),
+    );
+    expect(url).toContain("scope=openid");
+    expect(url).toContain("Calendars.ReadWrite");
+    expect(url).toContain("state=microsoft-state");
+    expect(url).toContain("prompt=consent");
+  });
+});

--- a/packages/web/src/auth/providers/authorization/provider-authorization.util.ts
+++ b/packages/web/src/auth/providers/authorization/provider-authorization.util.ts
@@ -1,0 +1,103 @@
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+import { DEFAULT_CALENDAR_ROUTE } from "@web/common/constants/routes";
+import { providerAuthCallbackPath } from "./provider-authorization.constants";
+import { thirdPartyIdForProviderKind } from "./provider-authorization.third-party";
+
+export type ProviderAuthCodeRequest = {
+  thirdPartyId: ReturnType<typeof thirdPartyIdForProviderKind>;
+  clientType: "web";
+  redirectURIInfo: {
+    redirectURIOnProviderDashboard: string;
+    redirectURIQueryParams: {
+      code: string;
+      scope?: string;
+      state?: string;
+    };
+    pkceCodeVerifier?: string;
+  };
+};
+
+export function buildProviderAuthCallbackUrl(
+  provider: ProviderKind,
+  origin = window.location.origin,
+): string {
+  return `${origin}${providerAuthCallbackPath(provider)}`;
+}
+
+export function getSafeProviderAuthReturnPath(
+  provider: ProviderKind,
+  href = window.location.href,
+  origin = window.location.origin,
+): string {
+  try {
+    const url = new URL(href, origin);
+
+    if (url.origin !== origin) {
+      return DEFAULT_CALENDAR_ROUTE;
+    }
+
+    if (url.pathname === providerAuthCallbackPath(provider)) {
+      return DEFAULT_CALENDAR_ROUTE;
+    }
+
+    url.searchParams.delete("auth");
+    url.searchParams.delete("token");
+
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return DEFAULT_CALENDAR_ROUTE;
+  }
+}
+
+export function buildProviderAuthCodePayload({
+  provider,
+  code,
+  scope,
+  state,
+  redirectUri,
+}: {
+  provider: ProviderKind;
+  code: string;
+  scope?: string;
+  state?: string;
+  redirectUri?: string;
+}): ProviderAuthCodeRequest {
+  return {
+    thirdPartyId: thirdPartyIdForProviderKind(provider),
+    clientType: "web",
+    redirectURIInfo: {
+      redirectURIOnProviderDashboard:
+        redirectUri ?? buildProviderAuthCallbackUrl(provider),
+      redirectURIQueryParams: { code, scope, state },
+    },
+  };
+}
+
+export function buildMicrosoftAuthorizationUrl({
+  clientId,
+  redirectUri,
+  scopes,
+  state,
+  prompt,
+}: {
+  clientId: string;
+  redirectUri: string;
+  scopes: readonly string[];
+  state: string;
+  prompt?: "consent" | "none" | "select_account";
+}): string {
+  const params = new URLSearchParams({
+    client_id: clientId,
+    response_type: "code",
+    redirect_uri: redirectUri,
+    response_mode: "query",
+    scope: scopes.join(" "),
+    state,
+  });
+
+  if (prompt) {
+    params.set("prompt", prompt);
+  }
+
+  return `https://login.microsoftonline.com/common/oauth2/v2.0/authorize?${params.toString()}`;
+}

--- a/packages/web/src/auth/providers/authorization/useStartProviderAuthorization.impl.ts
+++ b/packages/web/src/auth/providers/authorization/useStartProviderAuthorization.impl.ts
@@ -1,0 +1,156 @@
+import {
+  type UseGoogleLoginOptionsAuthCodeFlow,
+  useGoogleLogin as useGoogleLoginBase,
+} from "@react-oauth/google";
+import { useCallback, useMemo, useState } from "react";
+import { GOOGLE_SCOPES } from "@core/providers/google.scopes";
+import { MICROSOFT_SCOPES } from "@core/providers/microsoft.scopes";
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+import { track } from "@web/auth/posthog/track";
+import { getMicrosoftSignInClientId } from "./provider-authorization.config";
+import { assignAuthorizationRedirect } from "./provider-authorization.redirect";
+import {
+  type ProviderAuthorizationIntent,
+  writeProviderAuthorizationIntent,
+} from "./provider-authorization.storage";
+import {
+  buildMicrosoftAuthorizationUrl,
+  buildProviderAuthCallbackUrl,
+  getSafeProviderAuthReturnPath,
+} from "./provider-authorization.util";
+
+type StartProviderAuthorizationOptions = {
+  intent: ProviderAuthorizationIntent["intent"];
+  onStart?: () => void;
+  onError?: (error: unknown) => void;
+  prompt?: "consent" | "none" | "select_account";
+};
+
+type StartProviderAuthorizationResult = {
+  loading: boolean;
+  startAuthorization: () => void;
+};
+
+type ProviderAuthorizationStrategy = (
+  options: StartProviderAuthorizationOptions,
+) => StartProviderAuthorizationResult;
+
+const useGoogleProviderAuthorizationStrategy: ProviderAuthorizationStrategy = ({
+  intent,
+  onStart,
+  onError,
+  prompt,
+}) => {
+  const [loading, setLoading] = useState(false);
+  const [state] = useState(() => crypto.randomUUID());
+  const [redirectUri] = useState(() => buildProviderAuthCallbackUrl("google"));
+
+  const loginOptions = useMemo<
+    UseGoogleLoginOptionsAuthCodeFlow & {
+      prompt?: "consent" | "none" | "select_account";
+    }
+  >(
+    () => ({
+      flow: "auth-code",
+      scope: GOOGLE_SCOPES.join(" "),
+      prompt,
+      state,
+      ux_mode: "redirect",
+      redirect_uri: redirectUri,
+      onNonOAuthError(error) {
+        setLoading(false);
+        onError?.(error);
+      },
+      onError(error) {
+        setLoading(false);
+        onError?.(error);
+      },
+    }),
+    [onError, prompt, redirectUri, state],
+  );
+
+  const startGoogleAuthorization = useGoogleLoginBase(loginOptions);
+
+  return {
+    loading,
+    startAuthorization: useCallback(() => {
+      onStart?.();
+      setLoading(true);
+      writeProviderAuthorizationIntent("google", state, {
+        intent,
+        returnPath: getSafeProviderAuthReturnPath("google"),
+        createdAt: Date.now(),
+      });
+      track("oauth_redirect_started", { provider: "google", intent });
+      return startGoogleAuthorization();
+    }, [intent, onStart, startGoogleAuthorization, state]),
+  };
+};
+
+const useMicrosoftProviderAuthorizationStrategy: ProviderAuthorizationStrategy =
+  ({ intent, onStart, onError, prompt }) => {
+    const [loading, setLoading] = useState(false);
+    const [state] = useState(() => crypto.randomUUID());
+    const [redirectUri] = useState(() =>
+      buildProviderAuthCallbackUrl("microsoft"),
+    );
+
+    return {
+      loading,
+      startAuthorization: useCallback(() => {
+        const clientId = getMicrosoftSignInClientId();
+
+        if (!clientId) {
+          onError?.(new Error("Microsoft sign-in is not configured"));
+          return;
+        }
+
+        onStart?.();
+        setLoading(true);
+        writeProviderAuthorizationIntent("microsoft", state, {
+          intent,
+          returnPath: getSafeProviderAuthReturnPath("microsoft"),
+          createdAt: Date.now(),
+        });
+        track("oauth_redirect_started", { provider: "microsoft", intent });
+
+        try {
+          assignAuthorizationRedirect(
+            buildMicrosoftAuthorizationUrl({
+              clientId,
+              redirectUri,
+              scopes: MICROSOFT_SCOPES,
+              state,
+              prompt,
+            }),
+          );
+        } catch (error) {
+          setLoading(false);
+          onError?.(error);
+        }
+      }, [intent, onError, onStart, prompt, redirectUri, state]),
+    };
+  };
+
+const useUnsupportedProviderAuthorizationStrategy: ProviderAuthorizationStrategy =
+  ({ onError }) => ({
+    loading: false,
+    startAuthorization: useCallback(() => {
+      onError?.(new Error("This sign-in method is not available yet"));
+    }, [onError]),
+  });
+
+const PROVIDER_AUTHORIZATION_STRATEGIES: Record<
+  ProviderKind,
+  ProviderAuthorizationStrategy
+> = {
+  google: useGoogleProviderAuthorizationStrategy,
+  microsoft: useMicrosoftProviderAuthorizationStrategy,
+  apple: useUnsupportedProviderAuthorizationStrategy,
+};
+
+export const useStartProviderAuthorizationImpl = (
+  provider: ProviderKind,
+  options: StartProviderAuthorizationOptions,
+): StartProviderAuthorizationResult =>
+  PROVIDER_AUTHORIZATION_STRATEGIES[provider](options);

--- a/packages/web/src/auth/providers/authorization/useStartProviderAuthorization.test.tsx
+++ b/packages/web/src/auth/providers/authorization/useStartProviderAuthorization.test.tsx
@@ -1,0 +1,100 @@
+import { act, renderHook } from "@testing-library/react";
+import { GOOGLE_SCOPES } from "@core/providers/google.scopes";
+import { readProviderAuthorizationIntent } from "./provider-authorization.storage";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const mockGoogleLogin = mock();
+const mockTrack = mock();
+const mockAssignAuthorizationRedirect = mock();
+const mockGetMicrosoftSignInClientId = mock(() => "microsoft-client-id");
+
+mock.module("@react-oauth/google", () => ({
+  useGoogleLogin: () => mockGoogleLogin,
+}));
+
+mock.module("@web/auth/posthog/track", () => ({
+  track: (...args: unknown[]) => mockTrack(...args),
+}));
+
+mock.module("./provider-authorization.redirect", () => ({
+  assignAuthorizationRedirect: (...args: unknown[]) =>
+    mockAssignAuthorizationRedirect(...args),
+}));
+
+mock.module("./provider-authorization.config", () => ({
+  getMicrosoftSignInClientId: () => mockGetMicrosoftSignInClientId(),
+}));
+
+const { useStartProviderAuthorizationImpl } =
+  require("./useStartProviderAuthorization.impl") as typeof import("./useStartProviderAuthorization.impl");
+
+describe("useStartProviderAuthorizationImpl", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    mockGoogleLogin.mockClear();
+    mockTrack.mockClear();
+    mockAssignAuthorizationRedirect.mockClear();
+    mockGetMicrosoftSignInClientId.mockClear();
+    mockGetMicrosoftSignInClientId.mockReturnValue("microsoft-client-id");
+  });
+
+  it("starts Google authorization with core scopes and analytics", () => {
+    const { result } = renderHook(() =>
+      useStartProviderAuthorizationImpl("google", { intent: "signIn" }),
+    );
+
+    act(() => {
+      result.current.startAuthorization();
+    });
+
+    expect(mockTrack).toHaveBeenCalledWith("oauth_redirect_started", {
+      provider: "google",
+      intent: "signIn",
+    });
+    expect(mockGoogleLogin).toHaveBeenCalled();
+    const intents = Object.keys(sessionStorage).filter((key) =>
+      key.includes("googleAuthorizationIntent"),
+    );
+    expect(intents).toHaveLength(1);
+    const state = intents[0]?.split(".").at(-1);
+    expect(state).toBeDefined();
+    expect(readProviderAuthorizationIntent("google", state!)).toEqual(
+      expect.objectContaining({
+        intent: "signIn",
+      }),
+    );
+    expect(GOOGLE_SCOPES.join(" ")).toContain(
+      "https://www.googleapis.com/auth/userinfo.email",
+    );
+  });
+
+  it("starts Microsoft authorization with analytics and a redirect", () => {
+    const { result } = renderHook(() =>
+      useStartProviderAuthorizationImpl("microsoft", { intent: "signIn" }),
+    );
+
+    act(() => {
+      result.current.startAuthorization();
+    });
+
+    expect(mockTrack).toHaveBeenCalledWith("oauth_redirect_started", {
+      provider: "microsoft",
+      intent: "signIn",
+    });
+    expect(mockAssignAuthorizationRedirect).toHaveBeenCalledTimes(1);
+    expect(
+      String(mockAssignAuthorizationRedirect.mock.calls[0]?.[0]),
+    ).toContain("login.microsoftonline.com/common/oauth2/v2.0/authorize");
+
+    const intents = Object.keys(sessionStorage).filter((key) =>
+      key.includes("providerAuthorizationIntent.microsoft"),
+    );
+    expect(intents).toHaveLength(1);
+    const state = intents[0]?.split(".").at(-1);
+    expect(readProviderAuthorizationIntent("microsoft", state!)).toEqual(
+      expect.objectContaining({
+        intent: "signIn",
+      }),
+    );
+  });
+});

--- a/packages/web/src/auth/providers/authorization/useStartProviderAuthorization.ts
+++ b/packages/web/src/auth/providers/authorization/useStartProviderAuthorization.ts
@@ -1,0 +1,9 @@
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+import { useStartProviderAuthorizationImpl } from "./useStartProviderAuthorization.impl";
+
+export function useStartProviderAuthorization(
+  provider: ProviderKind,
+  options: Parameters<typeof useStartProviderAuthorizationImpl>[1],
+): ReturnType<typeof useStartProviderAuthorizationImpl> {
+  return useStartProviderAuthorizationImpl(provider, options);
+}

--- a/packages/web/src/common/constants/routes.ts
+++ b/packages/web/src/common/constants/routes.ts
@@ -6,6 +6,7 @@ export const ROOT_ROUTES = {
   BOOK_CONFIRMED: "/book/confirmed/$reservationId",
   CLEANUP: "/cleanup",
   GOOGLE_AUTH_CALLBACK: "/auth/google/callback",
+  PROVIDER_AUTH_CALLBACK: "/auth/$provider/callback",
   LIFE: "/life",
   ROOT: "/",
   WEEK: "/week",

--- a/packages/web/src/routers/index.test.tsx
+++ b/packages/web/src/routers/index.test.tsx
@@ -4,6 +4,7 @@ import {
   authenticatedLayoutRoute,
   calendarShellRoute,
   lifeRoute,
+  providerAuthCallbackRoute,
   publicBookConfirmedRoute,
   publicBookRescheduleRoute,
   publicBookRoute,
@@ -44,5 +45,45 @@ describe("routeTree", () => {
   it("gates the authenticated layout behind loadAuthenticated inside the calendar shell", () => {
     expect(authenticatedLayoutRoute.options.beforeLoad).toBeDefined();
     expect(authenticatedLayoutRoute.parentRoute).toBe(calendarShellRoute);
+  });
+
+  it("registers /auth/google/callback on the provider auth callback route", async () => {
+    expect(providerAuthCallbackRoute.fullPath).toBe(
+      ROOT_ROUTES.PROVIDER_AUTH_CALLBACK,
+    );
+
+    const router = createRouter({
+      routeTree,
+      history: createMemoryHistory({
+        initialEntries: ["/auth/google/callback?state=test"],
+      }),
+    });
+
+    await router.load();
+    expect(router.state.location.pathname).toBe("/auth/google/callback");
+    const callbackMatch = router.state.matches.find((match) =>
+      match.routeId.includes("callback"),
+    );
+    expect(callbackMatch?.params).toEqual(
+      expect.objectContaining({ provider: "google" }),
+    );
+  });
+
+  it("registers /auth/microsoft/callback on the provider auth callback route", async () => {
+    const router = createRouter({
+      routeTree,
+      history: createMemoryHistory({
+        initialEntries: ["/auth/microsoft/callback?state=test"],
+      }),
+    });
+
+    await router.load();
+    expect(router.state.location.pathname).toBe("/auth/microsoft/callback");
+    const callbackMatch = router.state.matches.find((match) =>
+      match.routeId.includes("callback"),
+    );
+    expect(callbackMatch?.params).toEqual(
+      expect.objectContaining({ provider: "microsoft" }),
+    );
   });
 });

--- a/packages/web/src/routers/router.routes.tsx
+++ b/packages/web/src/routers/router.routes.tsx
@@ -162,14 +162,18 @@ export const cleanupRoute = createRoute({
   ),
 });
 
-export const googleAuthCallbackRoute = createRoute({
+export const providerAuthCallbackRoute = createRoute({
   getParentRoute: () => rootRoute,
-  path: ROOT_ROUTES.GOOGLE_AUTH_CALLBACK,
+  path: ROOT_ROUTES.PROVIDER_AUTH_CALLBACK,
   component: lazyRouteComponent(
-    () => import("@web/views/GoogleAuthCallback/GoogleAuthCallback"),
-    "GoogleAuthCallbackView",
+    () => import("@web/views/ProviderAuthCallback/ProviderAuthCallback"),
+    "ProviderAuthCallbackView",
   ),
 });
+
+/** @deprecated One-release alias; `/auth/google/callback` is handled by `providerAuthCallbackRoute`. */
+const googleAuthCallbackRoute = providerAuthCallbackRoute;
+void googleAuthCallbackRoute;
 
 const authenticatedRoute = authenticatedLayoutRoute.addChildren([
   dayRoute.addChildren([dayDateRoute, dayIndexRoute]),
@@ -193,5 +197,5 @@ export const routeTree = rootRoute.addChildren([
         publicBookRoute,
       ]
     : []),
-  googleAuthCallbackRoute,
+  providerAuthCallbackRoute,
 ]);

--- a/packages/web/src/routers/router.routes.tsx
+++ b/packages/web/src/routers/router.routes.tsx
@@ -172,9 +172,6 @@ export const providerAuthCallbackRoute = createRoute({
   ),
 });
 
-/** @deprecated One-release alias; `/auth/google/callback` is handled by `providerAuthCallbackRoute`. */
-export const googleAuthCallbackRoute = providerAuthCallbackRoute;
-
 export const appleAuthCallbackRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: APPLE_AUTH_CALLBACK_PATH,

--- a/packages/web/src/views/GoogleAuthCallback/GoogleAuthCallback.test.ts
+++ b/packages/web/src/views/GoogleAuthCallback/GoogleAuthCallback.test.ts
@@ -6,12 +6,9 @@ import {
   writeGoogleAuthorizationIntent,
 } from "@web/auth/google/authorization/google-authorization.storage";
 import { registerToastPort } from "@web/common/utils/toast/toast.port";
+import { completeProviderAuthCallback } from "@web/views/ProviderAuthCallback/ProviderAuthCallback";
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
-// Patch the one method on the real AuthApi object rather than replacing the
-// module: mock.module is process-wide and permanent, and an AuthApi carrying
-// only loginOrSignup breaks every later file that reaches for another method
-// (useConnectGoogle.scope.test.tsx spies on beginGoogleConnection).
 const mockLoginOrSignup = mock();
 const realLoginOrSignup = AuthApi.loginOrSignup;
 AuthApi.loginOrSignup = mockLoginOrSignup as typeof AuthApi.loginOrSignup;
@@ -21,9 +18,6 @@ afterAll(() => {
 });
 
 const { port, mocks } = createTestToastPort();
-
-const { completeGoogleAuthCallback } =
-  require("./GoogleAuthCallback") as typeof import("./GoogleAuthCallback");
 
 const callbackSearch = (
   state: string,
@@ -41,7 +35,7 @@ const writeIntent = (state: string, returnPath = "/week") => {
   });
 };
 
-describe("completeGoogleAuthCallback", () => {
+describe("completeProviderAuthCallback (google)", () => {
   const completeAuthentication = mock();
   const navigate = mock();
 
@@ -60,7 +54,8 @@ describe("completeGoogleAuthCallback", () => {
   it("finishes a saved Google sign-in intent and returns to the saved path", async () => {
     writeIntent("sign-in-state", "/week");
 
-    await completeGoogleAuthCallback({
+    await completeProviderAuthCallback({
+      provider: "google",
       completeAuthentication,
       navigate,
       search: callbackSearch("sign-in-state"),
@@ -88,12 +83,13 @@ describe("completeGoogleAuthCallback", () => {
   it("rejects a Google callback that is missing required calendar scopes", async () => {
     writeIntent("missing-scopes-state", "/week");
 
-    await completeGoogleAuthCallback({
+    await completeProviderAuthCallback({
+      provider: "google",
       completeAuthentication,
       navigate,
       search: callbackSearch(
         "missing-scopes-state",
-        GOOGLE_AUTH_SCOPES_REQUIRED[0],
+        GOOGLE_AUTH_SCOPES_REQUIRED[0]!,
       ),
     });
 
@@ -107,7 +103,8 @@ describe("completeGoogleAuthCallback", () => {
   });
 
   it("rejects a Google callback without a saved intent", async () => {
-    await completeGoogleAuthCallback({
+    await completeProviderAuthCallback({
+      provider: "google",
       completeAuthentication,
       navigate,
       search: callbackSearch("unknown-state"),

--- a/packages/web/src/views/ProviderAuthCallback/ProviderAuthCallback.tsx
+++ b/packages/web/src/views/ProviderAuthCallback/ProviderAuthCallback.tsx
@@ -1,27 +1,33 @@
-import { useLocation, useRouter } from "@tanstack/react-router";
+import { useLocation, useParams, useRouter } from "@tanstack/react-router";
 import { useEffect, useRef } from "react";
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
 import { AuthApi } from "@web/api/auth.api";
 import { useCompleteAuthentication } from "@web/auth/compass/hooks/useCompleteAuthentication";
-import { completeGoogleAuthorization } from "@web/auth/google/authorization/complete-google-authorization";
 import { track } from "@web/auth/posthog/track";
+import { completeProviderAuthorization } from "@web/auth/providers/authorization/complete-provider-authorization";
+import { isSignInProviderKind } from "@web/auth/providers/authorization/provider-authorization.constants";
+import { DEFAULT_CALENDAR_ROUTE } from "@web/common/constants/routes";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
 import { shortcutShowcaseActions } from "@web/components/ShortcutShowcase/showcase.store";
 
 type CompleteAuthentication = ReturnType<typeof useCompleteAuthentication>;
 
-type CompleteGoogleAuthCallbackOptions = {
+type CompleteProviderAuthCallbackOptions = {
+  provider: ProviderKind;
   completeAuthentication: CompleteAuthentication;
   navigate: (path: string, opts: { replace: true }) => void;
   search: string;
 };
 
-export async function completeGoogleAuthCallback({
+export async function completeProviderAuthCallback({
+  provider,
   completeAuthentication,
   navigate,
   search,
-}: CompleteGoogleAuthCallbackOptions): Promise<void> {
-  const result = await completeGoogleAuthorization({
+}: CompleteProviderAuthCallbackOptions): Promise<void> {
+  const result = await completeProviderAuthorization({
+    provider,
     authApi: AuthApi,
     completeAuthentication,
     search,
@@ -30,26 +36,19 @@ export async function completeGoogleAuthCallback({
   if (result.status === "failed") {
     showErrorToast(result.message);
   } else if (result.isNewUser) {
-    track("signup_completed", { method: "google" });
-    // completeGoogleAuthorization only reports "completed" once Google granted
-    // every required scope, calendar included, so signing up with Google *is*
-    // the connect. Only the sync service's redirect-after-connect used to fire
-    // this, which is why activation looked like it barely happened: the path
-    // most new users actually take never reported it.
-    track("calendar_connected", {
-      source: "signup_google",
-      provider: "google",
-    });
+    track("signup_completed", { method: provider });
+    track("calendar_connected", { source: `signup_${provider}` });
     shortcutShowcaseActions.offerAfterSignupIfPending();
   } else {
-    track("login_completed", { method: "google" });
+    track("login_completed", { method: provider });
   }
 
   navigate(result.returnPath, { replace: true });
 }
 
-export function GoogleAuthCallbackView() {
+export function ProviderAuthCallbackView() {
   const didRun = useRef(false);
+  const { provider: providerParam } = useParams({ strict: false });
   const location = useLocation();
   const router = useRouter();
   const completeAuthentication = useCompleteAuthentication();
@@ -61,12 +60,19 @@ export function GoogleAuthCallbackView() {
 
     didRun.current = true;
 
-    void completeGoogleAuthCallback({
+    if (!providerParam || !isSignInProviderKind(providerParam)) {
+      showErrorToast("We couldn't finish signing you in. Please try again.");
+      router.history.replace(DEFAULT_CALENDAR_ROUTE);
+      return;
+    }
+
+    void completeProviderAuthCallback({
+      provider: providerParam,
       completeAuthentication,
       navigate: (path) => router.history.replace(path),
       search: location.searchStr,
     });
-  }, [completeAuthentication, location.searchStr, router]);
+  }, [completeAuthentication, location.searchStr, providerParam, router]);
 
   return (
     <OverlayPanel


### PR DESCRIPTION
Fixes #3415

## What and why

Providers I WP-02b decouples web sign-in start and OAuth callback from Google-only code. A shared `useStartProviderAuthorization(provider)` hook handles Google (via `@react-oauth/google`, byte-identical scopes and `/auth/google/callback` redirect URI) and Microsoft (standard authorization-code redirect to Entra `/common`). A parameterized `ProviderAuthCallback` view at `/auth/$provider/callback` completes sign-in through `/api/signinup` using each provider's SuperTokens `thirdPartyId`. Analytics now emit `oauth_redirect_started.provider`, `signup_completed.method`, `login_completed.method`, and `calendar_connected.source` with the provider kind. Scope lists in web and e2e read from `@core/providers/*` constants.

Sign in with Apple keeps its dedicated `/auth/apple/callback` form_post SPA beside the parameterized OAuth route. Merged `origin/main` to resolve conflicts in `routes.ts` and `router.routes.tsx`.

Spec: [`docs/features/calendar-providers.md`](https://github.com/KeepSoftwareSimple/compass-calendar/blob/main/docs/features/calendar-providers.md)

## Verify

```
bun run verify --strict
Selected packages: web
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
VERDICT: PASS
```