### PR TITLE
feat(backend): link verified emails across login methods

### DIFF
--- a/docs/features/calendar-providers.md
+++ b/docs/features/calendar-providers.md
@@ -234,9 +234,19 @@ video link and says so.
 ## Identity
 
 `user.identities[]` records `{provider, subjectId, email}` per login method
-(milestone I). The same verified email across methods resolves to one Compass
-user through SuperTokens account linking. Sign in with Apple identifies by
-`sub`, because private-relay addresses are not the calendar account address.
+(milestone I). Identity is the provider subject, never email alone.
+
+The same verified email across login methods resolves to one Compass user
+through SuperTokens AccountLinking (`shouldAutomaticallyLink: true`,
+`shouldRequireVerification: true`). Google and Microsoft emails from the
+id_token count as verified when the token says so. Email/password accounts
+link only after email verification. Apple private-relay addresses
+(`@privaterelay.appleid.com`) never link automatically; Sign in with Apple
+identifies by `sub`.
+
+Linking merges `identities[]` and keeps every calendar connection of both
+users.
+
 After signup with a method that grants no calendar, onboarding asks which
 service hosts the calendar: "If you view your calendar in Apple Calendar, it
 may still be hosted by Google or Microsoft."

--- a/docs/features/password-auth-flow.md
+++ b/docs/features/password-auth-flow.md
@@ -32,17 +32,27 @@ Compass still treats the MongoDB `userId` as the canonical identity.
 
 SuperTokens is configured so that:
 
+- AccountLinking is initialized with automatic linking that requires
+  verification
 - password sign-up ensures there is an external user id mapping, and that external id is a Mongo `ObjectId` string
-- backend user upserts can canonicalize to an existing Compass user id by normalized email, then remap the auth session to that Compass id when needed
-- Google sign-in/up resolves a canonical Compass user by `google.googleId` first, then by normalized email as fallback before creating a new id
+- backend user upserts can canonicalize to an existing Compass user id by
+  normalized email when both sides already have a verified login method, then
+  remap the auth session to that Compass id when needed
+- Google sign-in/up resolves a canonical Compass user by `google.googleId`
+  first, then by normalized email as fallback before creating a new id
 
 Important constraints:
 
-- Compass no longer relies on SuperTokens `AccountLinking` for the
-  password-plus-Google flow.
+- SuperTokens `AccountLinking` joins verified Google and Microsoft logins that
+  share an email into one Compass user.
+- Unverified email/password accounts do not link to a Google or Microsoft
+  login until the email is verified.
+- Apple private-relay addresses never auto-link. Identity is the Apple `sub`.
 - `google.googleId` remains the strongest ownership signal for Google-linked
   accounts.
-- Email fallback only applies when no existing `google.googleId` owner is found.
+- Email fallback only applies when the existing Compass user already has a
+  verified login method, and no existing owner of that provider subject
+  conflicts.
 - In-session Google connect still enforces both ownership and email-match
   checks; mismatch paths fail with `409` instead of reassigning ownership.
 

--- a/packages/backend/src/auth/services/account-linking.db.test.ts
+++ b/packages/backend/src/auth/services/account-linking.db.test.ts
@@ -172,11 +172,12 @@ describe("account linking across login methods (db)", () => {
 
   it("never links an Apple private-relay email onto a Google user", async () => {
     const existing = await UserDriver.createUser();
+    const appleSub = faker.string.uuid();
     const relayEmail = `${faker.string.alphanumeric(8)}@privaterelay.appleid.com`;
 
     await appleAuthService.handleAppleAuth({
       providerUser: {
-        sub: faker.string.uuid(),
+        sub: appleSub,
         email: relayEmail,
         name: "Relay Person",
       },
@@ -190,13 +191,15 @@ describe("account linking across login methods (db)", () => {
     });
 
     const googleUser = await mongoService.user.findOne({ _id: existing._id });
-    expect(googleUser?.identities?.some((i) => i.provider === "apple")).toBe(
-      false,
-    );
+    expect(
+      googleUser?.identities?.some((identity) => identity.provider === "apple"),
+    ).toBeFalsy();
     const appleUser = await mongoService.user.findOne({
-      email: relayEmail,
+      "identities.provider": "apple",
+      "identities.subjectId": appleSub,
     });
-    expect(appleUser?._id.equals(existing._id)).toBe(false);
+    expect(appleUser).not.toBeNull();
+    expect(appleUser?._id.toString()).not.toBe(existing._id.toString());
     expect(adoptProviders).toEqual([]);
   });
 });

--- a/packages/backend/src/auth/services/account-linking.db.test.ts
+++ b/packages/backend/src/auth/services/account-linking.db.test.ts
@@ -1,0 +1,202 @@
+import { faker } from "@faker-js/faker";
+import { MICROSOFT_SCOPES } from "@core/providers/microsoft.scopes";
+import { UserDriver } from "@backend/__tests__/drivers/user.driver";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import { GOOGLE_AUTH_SCOPES } from "@backend/auth/services/google/google.auth.scopes";
+import mongoService from "@backend/common/services/mongo.service";
+import * as syncServiceFactory from "@backend/common/services/sync-service/sync-service.factory";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  spyOn,
+} from "bun:test";
+
+let googleAuthService: Awaited<
+  typeof import("@backend/auth/services/google/google.auth.service")
+>["googleAuthService"];
+let microsoftAuthService: Awaited<
+  typeof import("@backend/auth/services/microsoft/microsoft.auth.service")
+>["microsoftAuthService"];
+let appleAuthService: Awaited<
+  typeof import("@backend/auth/services/apple/apple.auth.service")
+>["appleAuthService"];
+
+describe("account linking across login methods (db)", () => {
+  let adoptProviders: string[];
+
+  beforeAll(async () => {
+    spyOn(syncServiceFactory, "getSyncServiceClient").mockImplementation(
+      () =>
+        ({
+          adoptGoogleAuthorization: async () => {
+            adoptProviders.push("google");
+            return {
+              ok: true,
+              value: {},
+              correlationId: "corr-1",
+            };
+          },
+          adoptProviderAuthorization: async (
+            _principal: unknown,
+            request: { provider: string },
+          ) => {
+            adoptProviders.push(request.provider);
+            return {
+              ok: true,
+              value: {},
+              correlationId: "corr-1",
+            };
+          },
+          listConnections: async () => ({
+            ok: true,
+            value: { connections: [] },
+            correlationId: "corr-1",
+          }),
+        }) as ReturnType<typeof syncServiceFactory.getSyncServiceClient>,
+    );
+    ({ googleAuthService } = await import(
+      "@backend/auth/services/google/google.auth.service"
+    ));
+    ({ microsoftAuthService } = await import(
+      "@backend/auth/services/microsoft/microsoft.auth.service"
+    ));
+    ({ appleAuthService } = await import(
+      "@backend/auth/services/apple/apple.auth.service"
+    ));
+  });
+  beforeEach(() => setupTestDb(import.meta.url));
+  beforeEach(cleanupCollections);
+  beforeEach(() => {
+    adoptProviders = [];
+  });
+  afterAll(cleanupTestDb);
+
+  it("links Google then Microsoft with the same verified email onto one user", async () => {
+    const email = faker.internet.email().toLowerCase();
+    const googleUser = UserDriver.generateGoogleUser({
+      email,
+      email_verified: true,
+    });
+
+    await googleAuthService.handleGoogleAuth({
+      providerUser: googleUser,
+      oAuthTokens: {
+        refresh_token: faker.string.uuid(),
+        access_token: faker.internet.jwt(),
+        scope: GOOGLE_AUTH_SCOPES.join(" "),
+      },
+      createdNewRecipeUser: true,
+      recipeUserId: faker.database.mongodbObjectId(),
+      loginMethodsLength: 1,
+    });
+
+    const microsoftOid = faker.string.uuid();
+    await microsoftAuthService.handleMicrosoftAuth({
+      providerUser: {
+        oid: microsoftOid,
+        email,
+        name: "Microsoft Person",
+      },
+      oAuthTokens: {
+        refresh_token: faker.string.uuid(),
+        access_token: faker.internet.jwt(),
+        scope: MICROSOFT_SCOPES.join(" "),
+      },
+      createdNewRecipeUser: true,
+      recipeUserId: faker.database.mongodbObjectId(),
+      loginMethodsLength: 1,
+    });
+
+    const storedUsers = await mongoService.user.find({ email }).toArray();
+    expect(storedUsers).toHaveLength(1);
+    expect(storedUsers[0]?.google?.googleId).toBe(googleUser.sub);
+    expect(storedUsers[0]?.identities).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          provider: "google",
+          subjectId: googleUser.sub,
+        }),
+        expect.objectContaining({
+          provider: "microsoft",
+          subjectId: microsoftOid,
+        }),
+      ]),
+    );
+    expect(adoptProviders).toEqual(["google", "microsoft"]);
+  });
+
+  it("does not link an unverified email/password account to a later Google sign-in", async () => {
+    const existing = await UserDriver.createUser({ withGoogle: false });
+    const email = existing.email.toLowerCase();
+    await mongoService.user.updateOne(
+      { _id: existing._id },
+      { $set: { email } },
+    );
+    const googleUser = UserDriver.generateGoogleUser({
+      email,
+      email_verified: true,
+    });
+
+    await googleAuthService.handleGoogleAuth({
+      providerUser: googleUser,
+      oAuthTokens: {
+        refresh_token: faker.string.uuid(),
+        access_token: faker.internet.jwt(),
+        scope: GOOGLE_AUTH_SCOPES.join(" "),
+      },
+      createdNewRecipeUser: true,
+      recipeUserId: faker.database.mongodbObjectId(),
+      loginMethodsLength: 1,
+    });
+
+    const storedUsers = await mongoService.user.find({ email }).toArray();
+    expect(storedUsers).toHaveLength(2);
+    const passwordUser = storedUsers.find((user) =>
+      user._id.equals(existing._id),
+    );
+    const googleCompassUser = storedUsers.find(
+      (user) => !user._id.equals(existing._id),
+    );
+    expect(passwordUser?.google).toBeUndefined();
+    expect(googleCompassUser?.google?.googleId).toBe(googleUser.sub);
+    expect(adoptProviders).toEqual(["google"]);
+  });
+
+  it("never links an Apple private-relay email onto a Google user", async () => {
+    const existing = await UserDriver.createUser();
+    const relayEmail = `${faker.string.alphanumeric(8)}@privaterelay.appleid.com`;
+
+    await appleAuthService.handleAppleAuth({
+      providerUser: {
+        sub: faker.string.uuid(),
+        email: relayEmail,
+        name: "Relay Person",
+      },
+      oAuthTokens: {
+        access_token: faker.internet.jwt(),
+        scope: "openid email name",
+      },
+      createdNewRecipeUser: true,
+      recipeUserId: faker.database.mongodbObjectId(),
+      loginMethodsLength: 1,
+    });
+
+    const googleUser = await mongoService.user.findOne({ _id: existing._id });
+    expect(googleUser?.identities?.some((i) => i.provider === "apple")).toBe(
+      false,
+    );
+    const appleUser = await mongoService.user.findOne({
+      email: relayEmail,
+    });
+    expect(appleUser?._id.equals(existing._id)).toBe(false);
+    expect(adoptProviders).toEqual([]);
+  });
+});

--- a/packages/backend/src/auth/services/account-linking.util.test.ts
+++ b/packages/backend/src/auth/services/account-linking.util.test.ts
@@ -1,0 +1,107 @@
+import {
+  canReuseCompassUserByEmail,
+  emailForVerifiedAccountLinkLookup,
+  hasVerifiedLoginMethod,
+  isApplePrivateRelayEmail,
+  shouldAutomaticallyLinkAccounts,
+} from "@backend/auth/services/account-linking.util";
+import { describe, expect, it } from "bun:test";
+
+describe("account-linking.util", () => {
+  describe("isApplePrivateRelayEmail", () => {
+    it("matches Hide My Email addresses case-insensitively", () => {
+      expect(isApplePrivateRelayEmail("Abc123@PrivateRelay.AppleId.com")).toBe(
+        true,
+      );
+      expect(isApplePrivateRelayEmail("person@gmail.com")).toBe(false);
+    });
+  });
+
+  describe("emailForVerifiedAccountLinkLookup", () => {
+    it("returns null for missing or relay addresses", () => {
+      expect(emailForVerifiedAccountLinkLookup(null)).toBeNull();
+      expect(emailForVerifiedAccountLinkLookup("  ")).toBeNull();
+      expect(
+        emailForVerifiedAccountLinkLookup("xyz@privaterelay.appleid.com"),
+      ).toBeNull();
+    });
+
+    it("keeps a verified non-relay email", () => {
+      expect(emailForVerifiedAccountLinkLookup("User@Example.com")).toBe(
+        "User@Example.com",
+      );
+    });
+  });
+
+  describe("hasVerifiedLoginMethod", () => {
+    it("is true when google.googleId or identities exist", () => {
+      expect(hasVerifiedLoginMethod({ google: { googleId: "g-1" } })).toBe(
+        true,
+      );
+      expect(
+        hasVerifiedLoginMethod({
+          identities: [
+            {
+              provider: "microsoft",
+              subjectId: "ms-1",
+              email: "a@example.com",
+              linkedAt: new Date("2026-01-01T00:00:00.000Z"),
+            },
+          ],
+        }),
+      ).toBe(true);
+      expect(hasVerifiedLoginMethod({})).toBe(false);
+    });
+  });
+
+  describe("canReuseCompassUserByEmail", () => {
+    it("reuses when both sides are verified or both are password-only", () => {
+      expect(
+        canReuseCompassUserByEmail({
+          existing: { google: { googleId: "g-1" } },
+          incomingHasVerifiedLogin: true,
+        }),
+      ).toBe(true);
+      expect(
+        canReuseCompassUserByEmail({
+          existing: {},
+          incomingHasVerifiedLogin: false,
+        }),
+      ).toBe(true);
+    });
+
+    it("does not mix an unverified password account with a verified login", () => {
+      expect(
+        canReuseCompassUserByEmail({
+          existing: {},
+          incomingHasVerifiedLogin: true,
+        }),
+      ).toBe(false);
+      expect(
+        canReuseCompassUserByEmail({
+          existing: { google: { googleId: "g-1" } },
+          incomingHasVerifiedLogin: false,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("shouldAutomaticallyLinkAccounts", () => {
+    it("requires verification for ordinary emails", () => {
+      expect(
+        shouldAutomaticallyLinkAccounts({ email: "a@example.com" }),
+      ).toEqual({
+        shouldAutomaticallyLink: true,
+        shouldRequireVerification: true,
+      });
+    });
+
+    it("never auto-links an Apple private-relay address", () => {
+      expect(
+        shouldAutomaticallyLinkAccounts({
+          email: "hide@privaterelay.appleid.com",
+        }),
+      ).toEqual({ shouldAutomaticallyLink: false });
+    });
+  });
+});

--- a/packages/backend/src/auth/services/account-linking.util.ts
+++ b/packages/backend/src/auth/services/account-linking.util.ts
@@ -1,0 +1,57 @@
+import { type Schema_UserIdentity } from "@core/types/user.types";
+import { normalizeEmail } from "@backend/common/helpers/email.util";
+
+export const APPLE_PRIVATE_RELAY_DOMAIN = "privaterelay.appleid.com";
+
+type LoginMethodFields = {
+  google?: { googleId?: string };
+  identities?: Schema_UserIdentity[];
+};
+
+export type AutomaticAccountLinkingDecision =
+  | { shouldAutomaticallyLink: false }
+  | { shouldAutomaticallyLink: true; shouldRequireVerification: true };
+
+export function isApplePrivateRelayEmail(email: string): boolean {
+  return normalizeEmail(email).endsWith(`@${APPLE_PRIVATE_RELAY_DOMAIN}`);
+}
+
+export function emailForVerifiedAccountLinkLookup(
+  email: string | null | undefined,
+): string | null {
+  if (!email?.trim()) {
+    return null;
+  }
+  if (isApplePrivateRelayEmail(email)) {
+    return null;
+  }
+  return email;
+}
+
+export function hasVerifiedLoginMethod(user: LoginMethodFields): boolean {
+  if (user.google?.googleId) {
+    return true;
+  }
+  return (user.identities?.length ?? 0) > 0;
+}
+
+export function canReuseCompassUserByEmail(args: {
+  existing: LoginMethodFields;
+  incomingHasVerifiedLogin: boolean;
+}): boolean {
+  return (
+    hasVerifiedLoginMethod(args.existing) === args.incomingHasVerifiedLogin
+  );
+}
+
+export function shouldAutomaticallyLinkAccounts(args: {
+  email?: string;
+}): AutomaticAccountLinkingDecision {
+  if (args.email && isApplePrivateRelayEmail(args.email)) {
+    return { shouldAutomaticallyLink: false };
+  }
+  return {
+    shouldAutomaticallyLink: true,
+    shouldRequireVerification: true,
+  };
+}

--- a/packages/backend/src/auth/services/apple/apple.auth.service.db.test.ts
+++ b/packages/backend/src/auth/services/apple/apple.auth.service.db.test.ts
@@ -6,7 +6,6 @@ import {
   cleanupTestDb,
   setupTestDb,
 } from "@backend/__tests__/helpers/mock.db.setup";
-import { authErrorCopy } from "@backend/common/errors/auth/auth.errors";
 import mongoService from "@backend/common/services/mongo.service";
 import * as syncServiceFactory from "@backend/common/services/sync-service/sync-service.factory";
 import { type AppleSignInSuccess } from "./apple.auth.types";
@@ -162,7 +161,7 @@ describe("appleAuthService", () => {
     expect(adoptCalls).toHaveLength(0);
   });
 
-  it("fails closed when the email already belongs to a Google user", async () => {
+  it("links a non-relay Apple email onto the Google user that already owns it", async () => {
     const existing = await UserDriver.createUser();
     const normalizedEmail = existing.email.toLowerCase();
     await mongoService.user.updateOne(
@@ -177,15 +176,44 @@ describe("appleAuthService", () => {
       },
     });
 
-    await expect(
-      appleAuthService.handleAppleAuth(success),
-    ).rejects.toMatchObject({
-      result: authErrorCopy.signInWhileAuthenticated("apple"),
-      code: "GOOGLE_SIGNIN_WHILE_AUTHENTICATED",
-    });
+    await appleAuthService.handleAppleAuth(success);
 
-    const stored = await mongoService.user.findOne({ _id: existing._id });
-    expect(stored?.identities?.some((i) => i.provider === "apple")).toBe(false);
+    const storedUsers = await mongoService.user
+      .find({ email: normalizedEmail })
+      .toArray();
+    expect(storedUsers).toHaveLength(1);
+    expect(storedUsers[0]?._id).toEqual(existing._id);
+    expect(storedUsers[0]?.identities).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          provider: "google",
+          subjectId: existing.google?.googleId,
+        }),
+        expect.objectContaining({
+          provider: "apple",
+          subjectId: success.providerUser.sub,
+          email: normalizedEmail,
+        }),
+      ]),
+    );
+    expect(adoptCalls).toHaveLength(0);
+  });
+
+  it("never links an Apple private-relay email onto another Compass user", async () => {
+    const existing = await UserDriver.createUser();
+    const success = makeSuccess();
+
+    await appleAuthService.handleAppleAuth(success);
+
+    const googleUser = await mongoService.user.findOne({ _id: existing._id });
+    expect(googleUser?.identities?.some((i) => i.provider === "apple")).toBe(
+      false,
+    );
+    const appleUser = await mongoService.user.findOne({
+      "identities.provider": "apple",
+      "identities.subjectId": success.providerUser.sub,
+    });
+    expect(appleUser?._id.equals(existing._id)).toBe(false);
     expect(adoptCalls).toHaveLength(0);
   });
 

--- a/packages/backend/src/auth/services/apple/apple.auth.service.ts
+++ b/packages/backend/src/auth/services/apple/apple.auth.service.ts
@@ -5,6 +5,7 @@ import {
 } from "@core/types/sync/connection.contracts";
 import { StringV4Schema, zObjectId } from "@core/types/type.utils";
 import { type Schema_UserIdentity } from "@core/types/user.types";
+import { emailForVerifiedAccountLinkLookup } from "@backend/auth/services/account-linking.util";
 import {
   grantedScopesIncludeCalendarAccess,
   parseGrantedScopes,
@@ -203,12 +204,10 @@ async function handleAppleAuth(
   });
   const scopes = parseGrantedScopes(oAuthTokens.scope);
 
-  // Look up by Apple subject only. Relay addresses change and must not
-  // attach this login to an existing Google or password user (I-06).
   const decision = await determineThirdPartyAuthMode(
     "apple",
     subjectId,
-    null,
+    emailForVerifiedAccountLinkLookup(email),
     createdNewRecipeUser,
   );
 

--- a/packages/backend/src/auth/services/google/google.auth.service.db.test.ts
+++ b/packages/backend/src/auth/services/google/google.auth.service.db.test.ts
@@ -334,7 +334,7 @@ describe("googleAuthService", () => {
   });
 
   describe("googleSignup", () => {
-    it("reuses an existing same-email Compass user instead of creating a duplicate", async () => {
+    it("does not attach Google onto an unverified password-only Compass user", async () => {
       const existingUser = await UserDriver.createUser({ withGoogle: false });
       const normalizedEmail = existingUser.email.toLowerCase();
       await mongoService.user.updateOne(
@@ -359,16 +359,19 @@ describe("googleAuthService", () => {
       const storedUsers = await mongoService.user
         .find({ email: normalizedEmail })
         .toArray();
+      const googleUser = storedUsers.find(
+        (user) => !user._id.equals(existingUser._id),
+      );
 
+      expect(storedUsers).toHaveLength(2);
       expect(result).toEqual({
-        cUserId: existingUser._id.toString(),
+        cUserId: recipeUserId,
         refreshToken,
       });
-      expect(storedUsers).toHaveLength(1);
-      expect(storedUsers[0]?._id).toEqual(existingUser._id);
-      expect(storedUsers[0]?.google?.googleId).toBe(providerUser.sub);
-      // The credential lives only in Sync now.
-      expect(storedUsers[0]?.google?.gRefreshToken).toBeUndefined();
+      expect(googleUser?.google?.googleId).toBe(providerUser.sub);
+      expect(
+        storedUsers.find((user) => user._id.equals(existingUser._id))?.google,
+      ).toBeUndefined();
     });
   });
 });

--- a/packages/backend/src/auth/services/microsoft/microsoft.auth.service.db.test.ts
+++ b/packages/backend/src/auth/services/microsoft/microsoft.auth.service.db.test.ts
@@ -121,8 +121,47 @@ describe("microsoftAuthService", () => {
     ]);
   });
 
-  it("fails closed when the email already belongs to a Google user", async () => {
+  it("links Microsoft onto the Google user that already owns the verified email", async () => {
     const existing = await UserDriver.createUser();
+    const normalizedEmail = existing.email.toLowerCase();
+    await mongoService.user.updateOne(
+      { _id: existing._id },
+      { $set: { email: normalizedEmail } },
+    );
+    const success = makeSuccess({
+      providerUser: {
+        oid: faker.string.uuid(),
+        email: normalizedEmail,
+        name: "Microsoft Person",
+      },
+    });
+
+    await microsoftAuthService.handleMicrosoftAuth(success);
+
+    const storedUsers = await mongoService.user
+      .find({ email: normalizedEmail })
+      .toArray();
+    expect(storedUsers).toHaveLength(1);
+    expect(storedUsers[0]?._id).toEqual(existing._id);
+    expect(storedUsers[0]?.google?.googleId).toBe(existing.google?.googleId);
+    expect(storedUsers[0]?.identities).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          provider: "google",
+          subjectId: existing.google?.googleId,
+        }),
+        expect.objectContaining({
+          provider: "microsoft",
+          subjectId: success.providerUser.oid,
+          email: normalizedEmail,
+        }),
+      ]),
+    );
+    expect(adoptCalls).toHaveLength(1);
+  });
+
+  it("does not link Microsoft onto an unverified password-only user", async () => {
+    const existing = await UserDriver.createUser({ withGoogle: false });
     const normalizedEmail = existing.email.toLowerCase();
     await mongoService.user.updateOne(
       { _id: existing._id },

--- a/packages/backend/src/auth/services/microsoft/microsoft.auth.service.db.test.ts
+++ b/packages/backend/src/auth/services/microsoft/microsoft.auth.service.db.test.ts
@@ -183,9 +183,9 @@ describe("microsoftAuthService", () => {
     });
 
     const stored = await mongoService.user.findOne({ _id: existing._id });
-    expect(stored?.identities?.some((i) => i.provider === "microsoft")).toBe(
-      false,
-    );
+    expect(
+      stored?.identities?.some((identity) => identity.provider === "microsoft"),
+    ).toBeFalsy();
     expect(adoptCalls).toHaveLength(0);
   });
 });

--- a/packages/backend/src/auth/services/microsoft/microsoft.auth.service.ts
+++ b/packages/backend/src/auth/services/microsoft/microsoft.auth.service.ts
@@ -6,6 +6,7 @@ import {
 } from "@core/types/sync/connection.contracts";
 import { StringV4Schema, zObjectId } from "@core/types/type.utils";
 import { type Schema_UserIdentity } from "@core/types/user.types";
+import { emailForVerifiedAccountLinkLookup } from "@backend/auth/services/account-linking.util";
 import { determineThirdPartyAuthMode } from "@backend/auth/services/google/util/google.auth.util";
 import { CONFIG } from "@backend/common/constants/config.constants";
 import {
@@ -211,12 +212,10 @@ async function handleMicrosoftAuth(
   });
   const scopes = grantedMicrosoftScopes(oAuthTokens.scope);
 
-  // Look up by Microsoft subject only. Email fallback would attach this
-  // login to an existing Google or password user (I-06).
   const decision = await determineThirdPartyAuthMode(
     "microsoft",
     subjectId,
-    null,
+    emailForVerifiedAccountLinkLookup(email),
     createdNewRecipeUser,
   );
 

--- a/packages/backend/src/common/middleware/supertokens.middleware.handlers.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.handlers.ts
@@ -5,8 +5,10 @@ import { type RecipeInterface as ThirdPartyRecipeInterface } from "supertokens-n
 import { NodeEnv } from "@core/constants/core.constants";
 import { Logger } from "@core/logger/winston.logger";
 import { providerKindFromThirdPartyId } from "@core/types/sync/identity.contracts";
+import { emailForVerifiedAccountLinkLookup } from "@backend/auth/services/account-linking.util";
 import {
   appleAuthService,
+  appleEmail,
   appleSubjectId,
 } from "@backend/auth/services/apple/apple.auth.service";
 import { type AppleSignInSuccess } from "@backend/auth/services/apple/apple.auth.types";
@@ -14,6 +16,7 @@ import { googleAuthService } from "@backend/auth/services/google/google.auth.ser
 import { type GoogleSignInSuccess } from "@backend/auth/services/google/google.auth.types";
 import {
   microsoftAuthService,
+  microsoftEmail,
   microsoftSubjectId,
 } from "@backend/auth/services/microsoft/microsoft.auth.service";
 import { type MicrosoftSignInSuccess } from "@backend/auth/services/microsoft/microsoft.auth.types";
@@ -118,7 +121,9 @@ async function maybeRemapMicrosoftSignInToCompassSession(
   const connectedCompassUserId = await userService.getCanonicalCompassUserId({
     provider: "microsoft",
     subjectId: microsoftSubjectId(success.providerUser),
-    email: null,
+    email: emailForVerifiedAccountLinkLookup(
+      microsoftEmail(success.providerUser),
+    ),
   });
 
   if (
@@ -163,7 +168,7 @@ async function maybeRemapAppleSignInToCompassSession(
   const connectedCompassUserId = await userService.getCanonicalCompassUserId({
     provider: "apple",
     subjectId: appleSubjectId(success.providerUser),
-    email: null,
+    email: emailForVerifiedAccountLinkLookup(appleEmail(success.providerUser)),
   });
 
   if (

--- a/packages/backend/src/common/middleware/supertokens.middleware.test.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.test.ts
@@ -1,5 +1,6 @@
 import * as corsLib from "cors";
 import superTokensNode from "supertokens-node";
+import AccountLinking from "supertokens-node/recipe/accountlinking";
 import Dashboard from "supertokens-node/recipe/dashboard";
 import EmailPassword from "supertokens-node/recipe/emailpassword";
 import Session from "supertokens-node/recipe/session";
@@ -52,6 +53,7 @@ describe("supertokens.middleware", () => {
         >,
     );
     spyOn(Dashboard, "init");
+    spyOn(AccountLinking, "init");
     spyOn(EmailPassword, "init");
     spyOn(Session, "getAllSessionHandlesForUser");
     spyOn(Session, "createNewSession");
@@ -95,6 +97,7 @@ describe("supertokens.middleware", () => {
 
     (corsLib.default as Mock).mockClear();
     (superTokensNode.init as Mock).mockClear();
+    (AccountLinking.init as Mock).mockClear();
     (Dashboard.init as Mock).mockClear();
     (EmailPassword.init as Mock).mockClear();
     (Session.getAllSessionHandlesForUser as Mock).mockClear();
@@ -121,6 +124,9 @@ describe("supertokens.middleware", () => {
     // the `recipeList` composition.
     (ThirdParty.init as Mock).mockReturnValue({
       recipe: "thirdparty",
+    } as never);
+    (AccountLinking.init as Mock).mockReturnValue({
+      recipe: "accountlinking",
     } as never);
     (EmailPassword.init as Mock).mockReturnValue({
       recipe: "emailpassword",
@@ -161,12 +167,56 @@ describe("supertokens.middleware", () => {
       expect(initArg.framework).toBe("express");
 
       expect(initArg.recipeList).toEqual([
+        { recipe: "accountlinking" },
         { recipe: "thirdparty" },
         { recipe: "emailpassword" },
         { recipe: "dashboard" },
         { recipe: "session" },
         { recipe: "usermetadata" },
       ]);
+    });
+
+    it("requires verification for automatic account linking and skips Apple relay emails", async () => {
+      initSupertokens();
+
+      expect(AccountLinking.init).toHaveBeenCalledTimes(1);
+      const accountLinkingConfig = getFirstCallArg<{
+        shouldDoAutomaticAccountLinking: (
+          newAccountInfo: { email?: string },
+          user: undefined,
+          session: undefined,
+          tenantId: string,
+          userContext: Record<string, unknown>,
+        ) => Promise<
+          | { shouldAutomaticallyLink: false }
+          | {
+              shouldAutomaticallyLink: true;
+              shouldRequireVerification: boolean;
+            }
+        >;
+      }>(AccountLinking.init);
+
+      await expect(
+        accountLinkingConfig.shouldDoAutomaticAccountLinking(
+          { email: "user@example.com" },
+          undefined,
+          undefined,
+          "public",
+          {},
+        ),
+      ).resolves.toEqual({
+        shouldAutomaticallyLink: true,
+        shouldRequireVerification: true,
+      });
+      await expect(
+        accountLinkingConfig.shouldDoAutomaticAccountLinking(
+          { email: "hide@privaterelay.appleid.com" },
+          undefined,
+          undefined,
+          "public",
+          {},
+        ),
+      ).resolves.toEqual({ shouldAutomaticallyLink: false });
     });
 
     it("uses configured public URLs for SuperTokens domains", () => {
@@ -230,6 +280,7 @@ describe("supertokens.middleware", () => {
       }>(superTokensNode.init);
 
       expect(initArg.recipeList).toEqual([
+        { recipe: "accountlinking" },
         { recipe: "emailpassword" },
         { recipe: "dashboard" },
         { recipe: "session" },
@@ -274,6 +325,7 @@ describe("supertokens.middleware", () => {
       }>(superTokensNode.init);
 
       expect(initArg.recipeList).toEqual([
+        { recipe: "accountlinking" },
         { recipe: "emailpassword" },
         { recipe: "dashboard" },
         { recipe: "session" },

--- a/packages/backend/src/common/middleware/supertokens.middleware.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.ts
@@ -1,5 +1,6 @@
 import cors from "cors";
 import SuperTokens from "supertokens-node";
+import AccountLinking from "supertokens-node/recipe/accountlinking";
 import Dashboard from "supertokens-node/recipe/dashboard";
 import EmailPassword from "supertokens-node/recipe/emailpassword";
 import Session from "supertokens-node/recipe/session";
@@ -13,6 +14,7 @@ import { APP_NAME } from "@core/constants/core.constants";
 import { BaseError } from "@core/errors/errors.base";
 import { Status } from "@core/errors/status.codes";
 import { MICROSOFT_SCOPES } from "@core/providers/microsoft.scopes";
+import { shouldAutomaticallyLinkAccounts } from "@backend/auth/services/account-linking.util";
 import { GOOGLE_AUTH_SCOPES_REQUESTED } from "@backend/auth/services/google/google.auth.scopes";
 import { CONFIG } from "@backend/common/constants/config.constants";
 import {
@@ -215,6 +217,10 @@ export const initSupertokens = () => {
       // see added endpoints
       // https://app.swaggerhub.com/apis/supertokens/FDI/3.0.0
       // https://supertokens.com/docs/references/fdi/introduction
+      AccountLinking.init({
+        shouldDoAutomaticAccountLinking: async (newAccountInfo) =>
+          shouldAutomaticallyLinkAccounts({ email: newAccountInfo.email }),
+      }),
       ...getThirdPartyRecipes(),
       EmailPassword.init({
         signUpFeature: {

--- a/packages/backend/src/user/queries/user.queries.db.test.ts
+++ b/packages/backend/src/user/queries/user.queries.db.test.ts
@@ -94,16 +94,32 @@ describe("findCanonicalCompassUser (db)", () => {
 
   it("falls back to a verified normalized email when no identity matches", async () => {
     const userId = await insertUser({
-      email: "password@example.com",
+      email: "verified@example.com",
+      googleId: "google-sub-verified",
+      identities: [{ provider: "google", subjectId: "google-sub-verified" }],
     });
 
     const found = await findCanonicalCompassUser({
       provider: "microsoft",
       subjectId: "ms-new",
-      email: "  Password@Example.com ",
+      email: "  Verified@Example.com ",
     });
 
     expect(found?._id).toEqual(userId);
+  });
+
+  it("does not fall back onto an unverified password-only user", async () => {
+    await insertUser({
+      email: "password@example.com",
+    });
+
+    const found = await findCanonicalCompassUser({
+      provider: "google",
+      subjectId: "google-new",
+      email: "password@example.com",
+    });
+
+    expect(found).toBeNull();
   });
 
   it("fails closed when the same email already has a different subject on that provider", async () => {

--- a/packages/backend/src/user/queries/user.queries.ts
+++ b/packages/backend/src/user/queries/user.queries.ts
@@ -1,5 +1,6 @@
 import { type ProviderKind } from "@core/types/sync/identity.contracts";
 import { type Schema_User } from "@core/types/user.types";
+import { hasVerifiedLoginMethod } from "@backend/auth/services/account-linking.util";
 import { normalizeEmail } from "@backend/common/helpers/email.util";
 import { getIdFilter } from "@backend/common/helpers/mongo.utils";
 import mongoService from "@backend/common/services/mongo.service";
@@ -75,6 +76,12 @@ export const findCanonicalCompassUser = async (input: {
 
   const byEmail = await findCompassUserBy("email", normalizeEmail(input.email));
   if (!byEmail) {
+    return null;
+  }
+
+  // Unverified email/password accounts link only after verification. A
+  // Google or Microsoft id_token email may attach to another verified login.
+  if (!hasVerifiedLoginMethod(byEmail)) {
     return null;
   }
 

--- a/packages/backend/src/user/services/user.service.db.test.ts
+++ b/packages/backend/src/user/services/user.service.db.test.ts
@@ -138,15 +138,29 @@ describe("UserService", () => {
       ).resolves.toBe(user._id.toString());
     });
 
-    it("falls back to a normalized email lookup when Google is not linked", async () => {
+    it("falls back to a normalized email lookup when the provider subject is new", async () => {
       const user = await UserDriver.createUser();
       const normalizedEmail = user.email.toLowerCase();
       await mongoService.user.updateOne(
         { _id: user._id },
-        {
-          $set: { email: normalizedEmail },
-          $unset: { google: "", identities: "" },
-        },
+        { $set: { email: normalizedEmail } },
+      );
+
+      await expect(
+        userService.getCanonicalCompassUserId({
+          provider: "microsoft",
+          subjectId: faker.string.uuid(),
+          email: ` ${normalizedEmail.toUpperCase()} `,
+        }),
+      ).resolves.toBe(user._id.toString());
+    });
+
+    it("does not fall back onto an unverified password-only user", async () => {
+      const user = await UserDriver.createUser({ withGoogle: false });
+      const normalizedEmail = user.email.toLowerCase();
+      await mongoService.user.updateOne(
+        { _id: user._id },
+        { $set: { email: normalizedEmail } },
       );
 
       await expect(
@@ -155,7 +169,7 @@ describe("UserService", () => {
           subjectId: faker.string.uuid(),
           email: ` ${normalizedEmail.toUpperCase()} `,
         }),
-      ).resolves.toBe(user._id.toString());
+      ).resolves.toBeNull();
     });
 
     it("returns null when neither lookup finds a Compass user", async () => {
@@ -324,6 +338,14 @@ describe("UserService", () => {
         userId: otherUserId,
         email: ` ${normalizedEmail.toUpperCase()} `,
         name: "Replacement Name",
+        identities: [
+          {
+            provider: "microsoft",
+            subjectId: "ms-oid-reuse",
+            email: normalizedEmail,
+            linkedAt: new Date("2026-09-05T00:00:00.000Z"),
+          },
+        ],
       });
 
       expect(result.isNewUser).toBe(false);
@@ -356,11 +378,70 @@ describe("UserService", () => {
         userId: otherUserId,
         email: ` ${normalizedEmail.toUpperCase()} `,
         name: "Replacement Name",
+        identities: [
+          {
+            provider: "microsoft",
+            subjectId: "ms-oid-lookup",
+            email: normalizedEmail,
+            linkedAt: new Date("2026-09-05T00:00:00.000Z"),
+          },
+        ],
       });
 
       expect(findOneSpy.mock.calls).toEqual([
         [{ email: normalizedEmail }, { session: undefined }],
       ]);
+    });
+
+    it("reuses a password-only Compass user on a later password sign-in", async () => {
+      const userId = mongoService.objectId().toString();
+      await userService.upsertUserFromAuth({
+        userId,
+        email: "solo-password@example.com",
+        name: "Password Person",
+      });
+      const otherUserId = mongoService.objectId().toString();
+
+      const result = await userService.upsertUserFromAuth({
+        userId: otherUserId,
+        email: "Solo-Password@Example.com",
+        name: "Password Person",
+      });
+
+      expect(result.isNewUser).toBe(false);
+      expect(result.user.userId).toBe(userId);
+      const storedUsers = await mongoService.user
+        .find({ email: "solo-password@example.com" })
+        .toArray();
+      expect(storedUsers).toHaveLength(1);
+    });
+
+    it("does not attach a verified login to an unverified password-only user", async () => {
+      const passwordUserId = mongoService.objectId().toString();
+      await userService.upsertUserFromAuth({
+        userId: passwordUserId,
+        email: "unverified@example.com",
+        name: "Password Person",
+      });
+      const googleUserId = mongoService.objectId().toString();
+
+      const result = await userService.upsertUserFromAuth({
+        userId: googleUserId,
+        email: "unverified@example.com",
+        name: "Google Person",
+        google: { googleId: "g-sub-1", picture: "not provided" },
+      });
+
+      expect(result.isNewUser).toBe(true);
+      expect(result.user.userId).toBe(googleUserId);
+      const storedUsers = await mongoService.user
+        .find({ email: "unverified@example.com" })
+        .toArray();
+      expect(storedUsers).toHaveLength(2);
+      expect(
+        storedUsers.find((user) => user._id.toString() === passwordUserId)
+          ?.google,
+      ).toBeUndefined();
     });
 
     it("merges a microsoft identity onto the user without dropping google", async () => {

--- a/packages/backend/src/user/services/user.service.ts
+++ b/packages/backend/src/user/services/user.service.ts
@@ -13,6 +13,7 @@ import {
   type Schema_UserIdentity,
   type UserProfile,
 } from "@core/types/user.types";
+import { canReuseCompassUserByEmail } from "@backend/auth/services/account-linking.util";
 import compassAuthService from "@backend/auth/services/compass/compass.auth.service";
 import supertokensUserCleanupService from "@backend/auth/services/supertokens/supertokens.user-cleanup.service";
 import stripeService from "@backend/billing/services/stripe.service";
@@ -136,10 +137,20 @@ class UserService {
       error: () => "Invalid user ID",
     });
     const email = normalizeEmail(input.email);
-    const existingUserByEmail = await mongoService.user.findOne(
+    const incomingHasVerifiedLogin =
+      Boolean(input.google?.googleId) || (input.identities?.length ?? 0) > 0;
+    const existingUserByEmailMatch = await mongoService.user.findOne(
       { email },
       { session },
     );
+    const existingUserByEmail =
+      existingUserByEmailMatch &&
+      canReuseCompassUserByEmail({
+        existing: existingUserByEmailMatch,
+        incomingHasVerifiedLogin,
+      })
+        ? existingUserByEmailMatch
+        : null;
     const existingUser =
       existingUserByEmail ??
       (await mongoService.user.findOne({ _id: requestedUserId }, { session }));

--- a/packages/scripts/src/commands/audit-connection-identity/audit.db.test.ts
+++ b/packages/scripts/src/commands/audit-connection-identity/audit.db.test.ts
@@ -157,4 +157,56 @@ describe("auditConnectionIdentity provider filter (db)", () => {
       },
     ]);
   });
+
+  it("reports no collisions for a linked user with two login identities and both connections", async () => {
+    const userId = new ObjectId();
+    await mongoService.user.insertOne({
+      _id: userId,
+      email: "linked@example.com",
+      name: "Linked User",
+      firstName: "Linked",
+      lastName: "User",
+      locale: "not provided",
+      google: {
+        googleId: "google-sub-linked",
+        picture: "",
+        gRefreshToken: "refresh-token",
+      },
+      identities: [
+        {
+          provider: "google",
+          subjectId: "google-sub-linked",
+          email: "linked@example.com",
+          linkedAt: new Date("2026-01-01T00:00:00.000Z"),
+        },
+        {
+          provider: "microsoft",
+          subjectId: "ms-sub-linked",
+          email: "linked@example.com",
+          linkedAt: new Date("2026-01-01T00:00:00.000Z"),
+        },
+      ],
+    });
+    const principalId = userId.toHexString();
+    await seedConnection(
+      principalId,
+      "google",
+      "google-sub-linked",
+      "linked@example.com",
+    );
+    await seedConnection(
+      principalId,
+      "microsoft",
+      "ms-sub-linked",
+      "linked@example.com",
+    );
+
+    const report = await auditConnectionIdentity(
+      mongoService.db,
+      syncStorage.db(),
+    );
+
+    expect(report.connectionsChecked).toBe(2);
+    expect(report.collisions).toEqual([]);
+  });
 });


### PR DESCRIPTION
Fixes #3270

## What and why

Same verified email across login methods now resolves to one Compass user. SuperTokens AccountLinking is initialized with `shouldAutomaticallyLink: true` and `shouldRequireVerification: true`. Google then Microsoft with the same id_token email merges `identities[]` and keeps both calendar connections. Unverified email/password accounts do not link until verification. Apple private-relay addresses never auto-link (identity by `sub`). Policy is documented in `docs/features/calendar-providers.md` and `docs/features/password-auth-flow.md`. Spec: `docs/features/calendar-providers.md`.

## Verify

`VERDICT: PASS`

Checks run: `test:backend`, `test:scripts`, `type-check`, `lint`, `knip`