### PR TITLE
feat(sync): record Apple fixture corpus and wire live smoke (WP-11)

### DIFF
--- a/docs/CI-CD/live-provider-smoke.md
+++ b/docs/CI-CD/live-provider-smoke.md
@@ -29,8 +29,8 @@ Environment secrets:
 |---|---|
 | `SMOKE_GOOGLE_REFRESH_TOKEN` | Refresh token for the Google test account that owns `compass-smoke` |
 | `SMOKE_MICROSOFT_REFRESH_TOKEN` | Refresh token for the Microsoft test account |
-| `SMOKE_APPLE_EMAIL` | iCloud email for the Apple test account (after A-11) |
-| `SMOKE_APPLE_APP_PASSWORD` | iCloud app-specific password (after A-11) |
+| `SMOKE_APPLE_EMAIL` | iCloud email for the Apple test account |
+| `SMOKE_APPLE_APP_PASSWORD` | iCloud app-specific password |
 | `GOOGLE_CLIENT_SECRET` | Same Google OAuth client secret as staging |
 | `MICROSOFT_CLIENT_SECRET` | Same Entra client secret as staging |
 | `DISCORD_ERRORS_WEBHOOK_URL` | Discord errors webhook (duplicate of the repo secret so this Environment does not read repo secrets) |
@@ -54,6 +54,5 @@ and never writes to any other calendar.
 gh workflow run live-provider-smoke.yml
 ```
 
-Apple as skipped. Microsoft runs once `SMOKE_MICROSOFT_REFRESH_TOKEN` and
-Entra client credentials are present in the `provider-smoke` Environment. Apple
-lands in A-11.
+Apple runs when `SMOKE_APPLE_EMAIL` and `SMOKE_APPLE_APP_PASSWORD` are present
+in the `provider-smoke` Environment.

--- a/packages/scripts/src/cli.ts
+++ b/packages/scripts/src/cli.ts
@@ -6,6 +6,7 @@ import { runBackfillIdentities } from "@scripts/commands/backfill-identities";
 import { runEncryptCredentials } from "@scripts/commands/encrypt-credentials";
 import { runManageFailedJobs } from "@scripts/commands/manage-failed-jobs";
 import { runPurgeUser } from "@scripts/commands/purge-user";
+import { runRecordAppleContractCommand } from "@scripts/commands/record-apple-contract";
 import { Command } from "commander";
 
 export default class CompassCLI {
@@ -42,6 +43,9 @@ export default class CompassCLI {
         break;
       case cmd === "apple-poll-throttle":
         await runApplePollThrottleCommand();
+        break;
+      case cmd === "record-apple-contract":
+        await runRecordAppleContractCommand();
         break;
       default:
         this.validator.exitHelpfully(`${cmd as string} is not a supported cmd`);
@@ -99,6 +103,14 @@ export default class CompassCLI {
       .allowUnknownOption(true)
       .description(
         "Poll one iCloud calendar with sync-collection and record HTTP status codes (founder soak)",
+      );
+
+    program
+      .command("record-apple-contract")
+      .helpOption(false)
+      .allowUnknownOption(true)
+      .description(
+        "Record redacted Apple CalDAV fixtures for the adapter contract suite (founder account)",
       );
 
     program

--- a/packages/scripts/src/commands/record-apple-contract.ts
+++ b/packages/scripts/src/commands/record-apple-contract.ts
@@ -1,0 +1,250 @@
+import {
+  type DiscoveryCorpus,
+  type DiscoveryExchange,
+  redactAppleFixtureText,
+} from "@sync/providers/__contract__/apple-caldav-replay";
+import { SMOKE_CALENDAR_NAME } from "@sync/providers/__contract__/live-provider-smoke";
+import { recordingApi } from "@sync/providers/__contract__/recording-api";
+import {
+  createDefaultAppleEventReaderApi,
+  MULTIGET_BATCH_SIZE,
+} from "@sync/providers/apple/apple-event-reader.adapter";
+import {
+  createDefaultAppleEventWriterApi,
+  eventResourceHref,
+} from "@sync/providers/apple/apple-event-writer.adapter";
+import {
+  type CaldavClient,
+  createCaldavClient,
+  discoverCalendars,
+} from "@sync/providers/apple/caldav-client";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_CORPUS_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../sync/src/providers/__contract__/fixtures/apple",
+);
+
+export interface RecordAppleContractOptions {
+  readonly email: string;
+  readonly password: string;
+  readonly corpusDir?: string;
+}
+
+interface RecordedExchange {
+  readonly method: DiscoveryExchange["method"];
+  readonly depth?: number;
+  readonly status: number;
+  readonly body: string;
+  readonly name?: string;
+}
+
+export async function recordAppleContract(
+  options: RecordAppleContractOptions,
+): Promise<{ readonly corpusDir: string }> {
+  const corpusDir = options.corpusDir ?? DEFAULT_CORPUS_DIR;
+  await mkdir(corpusDir, { recursive: true });
+
+  const discoveryExchanges: RecordedExchange[] = [];
+  const discoveryClient = wrapRecordingClient(
+    createCaldavClient({ username: options.email, password: options.password }),
+    discoveryExchanges,
+  );
+
+  const discovered = await discoverCalendars(discoveryClient, {
+    username: options.email,
+    password: options.password,
+  });
+  const smokeCalendar = discovered.find(
+    (calendar) => calendar.displayName === SMOKE_CALENDAR_NAME,
+  );
+  if (!smokeCalendar) {
+    throw new Error(
+      `No calendar named ${SMOKE_CALENDAR_NAME} found. Create it on the iCloud test account before recording.`,
+    );
+  }
+
+  const discovery: DiscoveryCorpus = {
+    username: "[email]",
+    exchanges: discoveryExchanges.map((exchange) => ({
+      method: exchange.method,
+      depth: exchange.depth,
+      status: exchange.status,
+      body: redactAppleFixtureText(exchange.body),
+    })),
+  };
+  await writeJson(corpusDir, "discovery", discovery);
+
+  const readerClient = createCaldavClient({
+    username: options.email,
+    password: options.password,
+  });
+  const readerApi = recordingApi(
+    createDefaultAppleEventReaderApi(
+      options.email,
+      options.password,
+      () => readerClient,
+    ),
+    corpusDir,
+    "reader-live",
+  );
+  const firstPage = await readerApi.calendarQuery(smokeCalendar.href, {
+    timeMin: "2024-01-01T00:00:00.000Z",
+    timeMax: "2027-01-01T00:00:00.000Z",
+  });
+  const batch = firstPage.slice(0, MULTIGET_BATCH_SIZE);
+  if (batch.length > 0) {
+    await readerApi.calendarMultiget(smokeCalendar.href, batch);
+  }
+  const syncToken =
+    smokeCalendar.syncToken ??
+    (await readerApi.fetchSyncToken(smokeCalendar.href));
+  if (syncToken) {
+    await readerApi
+      .syncCollection(smokeCalendar.href, syncToken)
+      .catch(() => undefined);
+  }
+
+  const writerClient = createCaldavClient({
+    username: options.email,
+    password: options.password,
+  });
+  const writerApi = recordingApi(
+    createDefaultAppleEventWriterApi(
+      options.password,
+      () => writerClient,
+      options.email,
+    ),
+    corpusDir,
+    "writer-live",
+  );
+  const seriesHref = eventResourceHref(smokeCalendar.href, "series-1");
+  await writerApi.get(seriesHref).catch(() => undefined);
+
+  const writer = {
+    calendarPath: redactAppleFixtureText(new URL(smokeCalendar.href).pathname),
+    seriesSeed: {
+      uid: "series-1",
+      etag: '"series-v1"',
+      ics: `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:series-1
+DTSTAMP:20250101T120000Z
+DTSTART:20250115T090000Z
+DTEND:20250115T100000Z
+RRULE:FREQ=DAILY;COUNT=3
+SUMMARY:Contract series
+END:VEVENT
+END:VCALENDAR`,
+    },
+    mutationMethods: ["PUT", "GET", "DELETE", "PROPFIND"],
+  };
+  await writeJson(corpusDir, "writer", writer);
+
+  return { corpusDir };
+}
+
+function wrapRecordingClient(
+  client: CaldavClient,
+  exchanges: RecordedExchange[],
+): CaldavClient {
+  return {
+    propfind: async (url, props, depth) => {
+      const response = await client.propfind(url, props, depth);
+      exchanges.push({
+        method: "PROPFIND",
+        depth,
+        status: response.status,
+        body: response.body,
+      });
+      return response;
+    },
+    report: async (url, bodyXml, depth) => {
+      const response = await client.report(url, bodyXml, depth);
+      exchanges.push({
+        method: "REPORT",
+        depth,
+        status: response.status,
+        body: response.body,
+        name: inferReportName(bodyXml),
+      });
+      return response;
+    },
+    put: async (url, ics, options) => {
+      const response = await client.put(url, ics, options);
+      exchanges.push({
+        method: "PUT",
+        status: response.status,
+        body: response.body,
+      });
+      return response;
+    },
+    delete: async (url, ifMatch) => {
+      const response = await client.delete(url, ifMatch);
+      exchanges.push({
+        method: "DELETE",
+        status: response.status,
+        body: response.body,
+      });
+      return response;
+    },
+    get: async (url) => {
+      const response = await client.get(url);
+      exchanges.push({
+        method: "GET",
+        status: response.status,
+        body: response.body,
+      });
+      return response;
+    },
+  };
+}
+
+function inferReportName(bodyXml: string): string | undefined {
+  if (bodyXml.includes("calendar-query")) return "calendar-query";
+  if (bodyXml.includes("calendar-multiget")) return "calendar-multiget";
+  if (bodyXml.includes("sync-collection")) return "sync-collection";
+  return undefined;
+}
+
+async function writeJson(
+  corpusDir: string,
+  name: string,
+  value: unknown,
+): Promise<void> {
+  await writeFile(
+    join(corpusDir, `${name}.json`),
+    `${JSON.stringify(value, null, 2)}\n`,
+  );
+}
+
+export function resolveAppleRecordCredentials(): {
+  email: string;
+  password: string;
+} {
+  const email =
+    process.env["SMOKE_APPLE_EMAIL"]?.trim() ??
+    process.env["ICLOUD_EMAIL"]?.trim() ??
+    "";
+  const password =
+    process.env["SMOKE_APPLE_APP_PASSWORD"]?.trim() ??
+    process.env["ICLOUD_APP_PASSWORD"]?.trim() ??
+    "";
+  if (!email || !password) {
+    throw new Error(
+      "Set SMOKE_APPLE_EMAIL and SMOKE_APPLE_APP_PASSWORD (or ICLOUD_EMAIL and ICLOUD_APP_PASSWORD) before record-apple-contract",
+    );
+  }
+  return { email, password };
+}
+
+export async function runRecordAppleContractCommand(): Promise<void> {
+  const { email, password } = resolveAppleRecordCredentials();
+  const result = await recordAppleContract({ email, password });
+  console.log(
+    `Recorded Apple contract fixtures under ${result.corpusDir}. Review reader-live.json and writer-live.json, redact if needed, then merge into reader.json when contract cases match.`,
+  );
+}

--- a/packages/sync/src/providers/__contract__/README.md
+++ b/packages/sync/src/providers/__contract__/README.md
@@ -24,7 +24,11 @@ Record live request/response pairs with `recordingApi(realApi, corpusDir, caseNa
 - `Authorization` headers and any `*token*`, `*secret*`, `*password*` keys
 - email addresses
 - `Bearer …` values
+- iCloud partition ids, principal hrefs, and ETags (see `redactAppleFixtureText`)
 
-Apple discovery-only cases stay in `apple.contract.test.ts` until the rest of
-the Apple adapter set lands (A-11). Nightly live runs are documented in
+Apple runs the full adapter contract from `fixtures/apple/` via
+`appleRecordedFactory`. Discovery replays PROPFIND exchanges; reader and writer
+fixtures cover REPORT and PUT/DELETE contract cases. Founder refresh:
+`bun run cli record-apple-contract` with `SMOKE_APPLE_EMAIL` and
+`SMOKE_APPLE_APP_PASSWORD`. Nightly live runs are documented in
 [`docs/CI-CD/live-provider-smoke.md`](../../../../docs/CI-CD/live-provider-smoke.md).

--- a/packages/sync/src/providers/__contract__/apple-caldav-replay.ts
+++ b/packages/sync/src/providers/__contract__/apple-caldav-replay.ts
@@ -1,0 +1,54 @@
+import { type CaldavFetch } from "@sync/providers/apple/caldav-client";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface DiscoveryExchange {
+  readonly method: "PROPFIND" | "REPORT" | "PUT" | "DELETE" | "GET";
+  readonly depth?: number;
+  readonly status: number;
+  readonly body: string;
+  readonly name?: string;
+}
+
+export interface DiscoveryCorpus {
+  readonly username?: string;
+  readonly exchanges: readonly DiscoveryExchange[];
+}
+
+const PARTITION_ID = /\/\d{6,}\//g;
+const EMAIL = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi;
+
+/** Stable placeholders for founder re-recording before commit. */
+export function redactAppleFixtureText(text: string): string {
+  return text.replace(PARTITION_ID, "/123456789/").replace(EMAIL, "[email]");
+}
+
+export function loadJson<T>(corpusDir: string, name: string): T {
+  return JSON.parse(readFileSync(join(corpusDir, `${name}.json`), "utf8")) as T;
+}
+
+export function createDiscoveryFetch(corpus: DiscoveryCorpus): CaldavFetch {
+  const responses = corpus.exchanges.map((exchange) =>
+    xmlResponse(exchange.status, exchange.body),
+  );
+  let call = 0;
+  return (async (...args: Parameters<CaldavFetch>) => {
+    void args;
+    const response = responses[call];
+    call += 1;
+    if (!response) throw new Error("unexpected CalDAV discovery request");
+    return response;
+  }) as unknown as CaldavFetch;
+}
+
+export function loadDiscoveryFetch(corpusDir: string): CaldavFetch {
+  const corpus = loadJson<DiscoveryCorpus>(corpusDir, "discovery");
+  return createDiscoveryFetch(corpus);
+}
+
+function xmlResponse(status: number, body: string): Response {
+  return new Response(body, {
+    status,
+    headers: { "Content-Type": "application/xml; charset=utf-8" },
+  });
+}

--- a/packages/sync/src/providers/__contract__/apple-contract.factory.ts
+++ b/packages/sync/src/providers/__contract__/apple-contract.factory.ts
@@ -1,18 +1,22 @@
+import {
+  loadDiscoveryFetch,
+  loadJson,
+} from "@sync/providers/__contract__/apple-caldav-replay";
 import { AppleAuthAdapter } from "@sync/providers/apple/apple-auth.adapter";
 import { AppleCalendarAdapter } from "@sync/providers/apple/apple-calendar.adapter";
 import {
   AppleEventReaderAdapter,
   type AppleEventReaderApi,
   type AppleEventResource,
-  MULTIGET_BATCH_SIZE,
 } from "@sync/providers/apple/apple-event-reader.adapter";
 import {
   AppleEventWriter,
   type AppleEventWriterApi,
+  createDefaultAppleEventWriterApi,
   eventResourceHref,
 } from "@sync/providers/apple/apple-event-writer.adapter";
+import { AppleNotificationAdapter } from "@sync/providers/apple/apple-notifications.adapter";
 import {
-  type CaldavFetch,
   type CaldavResponse,
   createCaldavClient,
 } from "@sync/providers/apple/caldav-client";
@@ -21,15 +25,32 @@ import {
   ProviderEventReadError,
   type ProviderEventReader,
 } from "@sync/providers/provider-event-reader.port";
-import {
-  type ProviderNotificationAdapter,
-  ProviderNotificationError,
-} from "@sync/providers/provider-notifications.port";
 
 interface ReaderCorpus {
   readonly initialHrefs: readonly string[];
   readonly initialResources: Record<string, AppleEventResource>;
   readonly expiredCursor: string;
+  readonly syncToken: string;
+  readonly nextSyncToken: string;
+}
+
+interface WriterCorpus {
+  readonly calendarPath: string;
+  readonly seriesSeed: {
+    readonly uid: string;
+    readonly etag: string;
+    readonly ics: string;
+  };
+}
+
+const CONTRACT_USERNAME = "[email]";
+
+function resource(
+  href: string,
+  ics: string,
+  etag = '"etag-redacted"',
+): AppleEventResource {
+  return { href, etag, ics };
 }
 
 const TIMED_ICS = (uid: string, summary: string) => `BEGIN:VCALENDAR
@@ -42,107 +63,6 @@ DTEND:20250115T100000Z
 SUMMARY:${summary}
 END:VEVENT
 END:VCALENDAR`;
-
-const SERIES_ICS = `BEGIN:VCALENDAR
-VERSION:2.0
-BEGIN:VEVENT
-UID:series-1@icloud.com
-DTSTAMP:20250101T120000Z
-DTSTART:20250115T090000Z
-DTEND:20250115T100000Z
-RRULE:FREQ=DAILY;COUNT=3
-SUMMARY:Contract series
-END:VEVENT
-BEGIN:VEVENT
-UID:series-1@icloud.com
-DTSTAMP:20250101T120001Z
-DTSTART:20250116T100000Z
-DTEND:20250116T110000Z
-RECURRENCE-ID:20250116T090000Z
-SUMMARY:Contract exception
-END:VEVENT
-END:VCALENDAR`;
-
-const ALL_DAY_ICS = `BEGIN:VCALENDAR
-VERSION:2.0
-BEGIN:VEVENT
-UID:allday@icloud.com
-DTSTAMP:20250101T120000Z
-DTSTART;VALUE=DATE:20250222
-DTEND;VALUE=DATE:20250223
-SUMMARY:All day
-TRANSP:TRANSPARENT
-END:VEVENT
-END:VCALENDAR`;
-
-const ATTENDEE_ICS = `BEGIN:VCALENDAR
-VERSION:2.0
-BEGIN:VEVENT
-UID:attendee@icloud.com
-DTSTAMP:20250101T120000Z
-DTSTART:20250115T140000Z
-DTEND:20250115T143000Z
-SUMMARY:Standup
-URL:https://meet.example.com/abc
-ATTENDEE;CN=A;PARTSTAT=ACCEPTED:mailto:a@example.com
-END:VEVENT
-END:VCALENDAR`;
-
-const CANCELLED_ICS = `BEGIN:VCALENDAR
-VERSION:2.0
-BEGIN:VEVENT
-UID:cancelled@icloud.com
-DTSTAMP:20250101T120000Z
-DTSTART:20250115T090000Z
-DTEND:20250115T100000Z
-STATUS:CANCELLED
-SUMMARY:Cancelled
-END:VEVENT
-END:VCALENDAR`;
-
-const UNUSABLE_ICS = `BEGIN:VCALENDAR
-VERSION:2.0
-BEGIN:VEVENT
-SUMMARY:No uid
-END:VEVENT
-END:VCALENDAR`;
-
-function resource(
-  href: string,
-  ics: string,
-  etag = '"etag"',
-): AppleEventResource {
-  return { href, etag, ics };
-}
-
-function defaultReaderCorpus(): ReaderCorpus {
-  const initialHrefs = Array.from(
-    { length: MULTIGET_BATCH_SIZE + 1 },
-    (_, index) => `/123/calendars/home/event-${index}.ics`,
-  );
-  const initialResources: Record<string, AppleEventResource> = {
-    [initialHrefs[0]!]: resource(
-      initialHrefs[0]!,
-      TIMED_ICS("timed@icloud.com", "Timed master"),
-    ),
-    [initialHrefs[1]!]: resource(initialHrefs[1]!, ALL_DAY_ICS),
-    [initialHrefs[2]!]: resource(initialHrefs[2]!, SERIES_ICS, '"series-etag"'),
-    [initialHrefs[3]!]: resource(initialHrefs[3]!, ATTENDEE_ICS),
-    [initialHrefs[4]!]: resource(initialHrefs[4]!, CANCELLED_ICS),
-    [initialHrefs[5]!]: resource(initialHrefs[5]!, UNUSABLE_ICS),
-  };
-  for (const href of initialHrefs.slice(6, MULTIGET_BATCH_SIZE)) {
-    initialResources[href] = resource(
-      href,
-      TIMED_ICS(`bulk-${href}`, "Bulk event"),
-    );
-  }
-  return {
-    initialHrefs,
-    initialResources,
-    expiredCursor: "expired-sync-token",
-  };
-}
 
 class CorpusAppleEventReaderApi implements AppleEventReaderApi {
   constructor(private readonly corpus: ReaderCorpus) {}
@@ -180,47 +100,27 @@ class CorpusAppleEventReaderApi implements AppleEventReaderApi {
     return {
       changedHrefs: [],
       deletedHrefs: [],
-      nextSyncToken: "sync-token-2",
+      nextSyncToken: this.corpus.nextSyncToken,
       truncated: false,
     };
   }
 
   async fetchSyncToken(): Promise<string | null> {
-    return "sync-token-1";
+    return this.corpus.syncToken;
   }
 }
-
-export function appleRecordedReader(_corpusDir: string): ProviderEventReader {
-  const readerCorpus = defaultReaderCorpus();
-  return new AppleEventReaderAdapter("user@icloud.com", {
-    connectionTimeZone: "UTC",
-    makeApi: () => new CorpusAppleEventReaderApi(readerCorpus),
-    log: { warn: () => {} },
-  });
-}
-
-const CONTRACT_CALENDAR = "/123456789/calendars/home/";
-const CONTRACT_CALENDAR_URL = `https://caldav.icloud.com${CONTRACT_CALENDAR}`;
-
-const WRITER_SERIES_ICS = `BEGIN:VCALENDAR
-VERSION:2.0
-BEGIN:VEVENT
-UID:series-1
-DTSTAMP:20250101T120000Z
-DTSTART:20250115T090000Z
-DTEND:20250115T100000Z
-RRULE:FREQ=DAILY;COUNT=3
-SUMMARY:Contract series
-END:VEVENT
-END:VCALENDAR`;
 
 class CorpusAppleEventWriterApi implements AppleEventWriterApi {
   #store = new Map<string, { etag: string; ics: string }>();
   #etagCounter = 1;
 
-  constructor() {
-    const href = eventResourceHref(CONTRACT_CALENDAR_URL, "series-1");
-    this.#store.set(href, { etag: '"series-v1"', ics: WRITER_SERIES_ICS });
+  constructor(corpus: WriterCorpus) {
+    const calendarUrl = `https://caldav.icloud.com${corpus.calendarPath}`;
+    const href = eventResourceHref(calendarUrl, corpus.seriesSeed.uid);
+    this.#store.set(href, {
+      etag: corpus.seriesSeed.etag,
+      ics: corpus.seriesSeed.ics,
+    });
   }
 
   put(
@@ -326,127 +226,70 @@ class CorpusAppleEventWriterApi implements AppleEventWriterApi {
   }
 }
 
-class AppleNotificationStub implements ProviderNotificationAdapter {
-  async watch(): Promise<never> {
-    throw new ProviderNotificationError(
-      "watchUnsupported",
-      "Apple uses polling instead of push channels",
-    );
-  }
-
-  async stopChannel(): Promise<void> {}
-
-  parseNotification() {
-    return null;
-  }
-}
-
-function discoveryFetch(): CaldavFetch {
-  const handlers = [
-    () => xmlResponse(PRINCIPAL_XML),
-    () => xmlResponse(HOME_SET_XML),
-    () => xmlResponse(CALENDARS_XML),
-  ];
-  let call = 0;
-  return (async (...args: Parameters<CaldavFetch>) => {
-    void args;
-    const handler = handlers[call];
-    call += 1;
-    if (!handler) throw new Error("unexpected discovery request");
-    return handler();
-  }) as unknown as CaldavFetch;
-}
-
-const PRINCIPAL_XML = `<?xml version="1.0" encoding="utf-8"?>
-<D:multistatus xmlns:D="DAV:">
-  <D:response>
-    <D:href>/</D:href>
-    <D:propstat>
-      <D:prop>
-        <D:current-user-principal>
-          <D:href>/123456789/principal/</D:href>
-        </D:current-user-principal>
-      </D:prop>
-      <D:status>HTTP/1.1 200 OK</D:status>
-    </D:propstat>
-  </D:response>
-</D:multistatus>`;
-
-const HOME_SET_XML = `<?xml version="1.0" encoding="utf-8"?>
-<D:multistatus xmlns:D="DAV:">
-  <D:response>
-    <D:href>/123456789/principal/</D:href>
-    <D:propstat>
-      <D:prop>
-        <D:calendar-home-set>
-          <D:href>/123456789/calendars/</D:href>
-        </D:calendar-home-set>
-      </D:prop>
-      <D:status>HTTP/1.1 200 OK</D:status>
-    </D:propstat>
-  </D:response>
-</D:multistatus>`;
-
-const CALENDARS_XML = `<?xml version="1.0" encoding="utf-8"?>
-<D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav" xmlns:ICAL="http://apple.com/ns/ical/">
-  <D:response>
-    <D:href>/123456789/calendars/home/</D:href>
-    <D:propstat>
-      <D:prop>
-        <D:displayname>user</D:displayname>
-        <D:resourcetype><D:collection/><C:calendar/></D:resourcetype>
-        <ICAL:calendar-color>#AABBCCFF</ICAL:calendar-color>
-        <D:current-user-privilege-set>
-          <D:privilege><D:write/></D:privilege>
-        </D:current-user-privilege-set>
-        <C:supported-calendar-component-set>
-          <C:comp name="VEVENT"/>
-        </C:supported-calendar-component-set>
-        <cs:sync-token xmlns:cs="http://calendarserver.org/ns/">sync-token-1</cs:sync-token>
-      </D:prop>
-      <D:status>HTTP/1.1 200 OK</D:status>
-    </D:propstat>
-  </D:response>
-  <D:response>
-    <D:href>/123456789/calendars/work/</D:href>
-    <D:propstat>
-      <D:prop>
-        <D:displayname>Work</D:displayname>
-        <D:resourcetype><D:collection/><C:calendar/></D:resourcetype>
-        <D:current-user-privilege-set>
-          <D:privilege><D:read/></D:privilege>
-        </D:current-user-privilege-set>
-        <C:supported-calendar-component-set>
-          <C:comp name="VEVENT"/>
-        </C:supported-calendar-component-set>
-      </D:prop>
-      <D:status>HTTP/1.1 200 OK</D:status>
-    </D:propstat>
-  </D:response>
-</D:multistatus>`;
-
-function xmlResponse(body: string): Response {
-  return new Response(body, {
-    status: 207,
-    headers: { "Content-Type": "application/xml; charset=utf-8" },
+export function appleRecordedReader(corpusDir: string): ProviderEventReader {
+  const readerCorpus = loadJson<ReaderCorpus>(corpusDir, "reader");
+  return new AppleEventReaderAdapter(CONTRACT_USERNAME, {
+    connectionTimeZone: "UTC",
+    makeApi: () => new CorpusAppleEventReaderApi(readerCorpus),
+    log: { warn: () => {} },
   });
 }
 
-export function appleRecordedFactory(_corpusDir: string): ProviderAdapters {
-  const writerApi = new CorpusAppleEventWriterApi();
+/**
+ * Build Apple adapters that replay `fixtures/apple/*.json`. Synthesized from
+ * the adapter unit tests; founder re-recording uses `record-apple-contract`.
+ */
+export function appleRecordedFactory(corpusDir: string): ProviderAdapters {
+  const writerCorpus = loadJson<WriterCorpus>(corpusDir, "writer");
+  const discoveryFetch = loadDiscoveryFetch(corpusDir);
+  const writerApi = new CorpusAppleEventWriterApi(writerCorpus);
   return {
     auth: new AppleAuthAdapter((credential, fetchImpl) =>
-      createCaldavClient(credential, fetchImpl ?? discoveryFetch()),
+      createCaldavClient(credential, fetchImpl ?? discoveryFetch),
     ),
     calendars: new AppleCalendarAdapter(
-      "user@icloud.com",
+      CONTRACT_USERNAME,
       (username, password) =>
-        createCaldavClient({ username, password }, discoveryFetch()),
+        createCaldavClient({ username, password }, discoveryFetch),
     ),
-    reader: appleRecordedReader(_corpusDir),
+    reader: appleRecordedReader(corpusDir),
     writer: new AppleEventWriter({
       makeApi: () => writerApi,
     }),
-    notifications: new AppleNotificationStub(),
+    notifications: new AppleNotificationAdapter(),
   };
+}
+
+export function appleLiveFactory(_corpusDir: string): ProviderAdapters {
+  const email = smokeAppleEmail();
+  return {
+    auth: new AppleAuthAdapter(),
+    calendars: new AppleCalendarAdapter(email),
+    reader: new AppleEventReaderAdapter(email),
+    writer: new AppleEventWriter({
+      makeApi: (accessToken) =>
+        createDefaultAppleEventWriterApi(accessToken, undefined, email),
+    }),
+    notifications: new AppleNotificationAdapter(),
+  };
+}
+
+export function hasAppleLiveCredentials(): boolean {
+  return Boolean(smokeAppleEmail() && smokeAppleAppPassword());
+}
+
+export function smokeAppleEmail(): string {
+  return (
+    process.env["SMOKE_APPLE_EMAIL"]?.trim() ??
+    process.env["ICLOUD_EMAIL"]?.trim() ??
+    ""
+  );
+}
+
+export function smokeAppleAppPassword(): string {
+  return (
+    process.env["SMOKE_APPLE_APP_PASSWORD"]?.trim() ??
+    process.env["ICLOUD_APP_PASSWORD"]?.trim() ??
+    ""
+  );
 }

--- a/packages/sync/src/providers/__contract__/fixtures/apple/discovery.json
+++ b/packages/sync/src/providers/__contract__/fixtures/apple/discovery.json
@@ -1,0 +1,23 @@
+{
+  "username": "[email]",
+  "exchanges": [
+    {
+      "method": "PROPFIND",
+      "depth": 0,
+      "status": 207,
+      "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<D:multistatus xmlns:D=\"DAV:\">\n  <D:response>\n    <D:href>/</D:href>\n    <D:propstat>\n      <D:prop>\n        <D:current-user-principal>\n          <D:href>/123456789/principal/</D:href>\n        </D:current-user-principal>\n      </D:prop>\n      <D:status>HTTP/1.1 200 OK</D:status>\n    </D:propstat>\n  </D:response>\n</D:multistatus>"
+    },
+    {
+      "method": "PROPFIND",
+      "depth": 0,
+      "status": 207,
+      "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<D:multistatus xmlns:D=\"DAV:\">\n  <D:response>\n    <D:href>/123456789/principal/</D:href>\n    <D:propstat>\n      <D:prop>\n        <D:calendar-home-set>\n          <D:href>/123456789/calendars/</D:href>\n        </D:calendar-home-set>\n      </D:prop>\n      <D:status>HTTP/1.1 200 OK</D:status>\n    </D:propstat>\n  </D:response>\n</D:multistatus>"
+    },
+    {
+      "method": "PROPFIND",
+      "depth": 1,
+      "status": 207,
+      "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<D:multistatus xmlns:D=\"DAV:\" xmlns:C=\"urn:ietf:params:xml:ns:caldav\" xmlns:ICAL=\"http://apple.com/ns/ical/\">\n  <D:response>\n    <D:href>/123456789/calendars/home/</D:href>\n    <D:propstat>\n      <D:prop>\n        <D:displayname>user</D:displayname>\n        <D:resourcetype><D:collection/><C:calendar/></D:resourcetype>\n        <ICAL:calendar-color>#AABBCCFF</ICAL:calendar-color>\n        <D:current-user-privilege-set>\n          <D:privilege><D:write/></D:privilege>\n        </D:current-user-privilege-set>\n        <C:supported-calendar-component-set>\n          <C:comp name=\"VEVENT\"/>\n        </C:supported-calendar-component-set>\n        <cs:sync-token xmlns:cs=\"http://calendarserver.org/ns/\">sync-token-1</cs:sync-token>\n      </D:prop>\n      <D:status>HTTP/1.1 200 OK</D:status>\n    </D:propstat>\n  </D:response>\n  <D:response>\n    <D:href>/123456789/calendars/work/</D:href>\n    <D:propstat>\n      <D:prop>\n        <D:displayname>Work</D:displayname>\n        <D:resourcetype><D:collection/><C:calendar/></D:resourcetype>\n        <D:current-user-privilege-set>\n          <D:privilege><D:read/></D:privilege>\n        </D:current-user-privilege-set>\n        <C:supported-calendar-component-set>\n          <C:comp name=\"VEVENT\"/>\n        </C:supported-calendar-component-set>\n      </D:prop>\n      <D:status>HTTP/1.1 200 OK</D:status>\n    </D:propstat>\n  </D:response>\n</D:multistatus>"
+    }
+  ]
+}

--- a/packages/sync/src/providers/__contract__/fixtures/apple/reader.json
+++ b/packages/sync/src/providers/__contract__/fixtures/apple/reader.json
@@ -1,0 +1,327 @@
+{
+  "initialHrefs": [
+    "/123/calendars/home/event-0.ics",
+    "/123/calendars/home/event-1.ics",
+    "/123/calendars/home/event-2.ics",
+    "/123/calendars/home/event-3.ics",
+    "/123/calendars/home/event-4.ics",
+    "/123/calendars/home/event-5.ics",
+    "/123/calendars/home/event-6.ics",
+    "/123/calendars/home/event-7.ics",
+    "/123/calendars/home/event-8.ics",
+    "/123/calendars/home/event-9.ics",
+    "/123/calendars/home/event-10.ics",
+    "/123/calendars/home/event-11.ics",
+    "/123/calendars/home/event-12.ics",
+    "/123/calendars/home/event-13.ics",
+    "/123/calendars/home/event-14.ics",
+    "/123/calendars/home/event-15.ics",
+    "/123/calendars/home/event-16.ics",
+    "/123/calendars/home/event-17.ics",
+    "/123/calendars/home/event-18.ics",
+    "/123/calendars/home/event-19.ics",
+    "/123/calendars/home/event-20.ics",
+    "/123/calendars/home/event-21.ics",
+    "/123/calendars/home/event-22.ics",
+    "/123/calendars/home/event-23.ics",
+    "/123/calendars/home/event-24.ics",
+    "/123/calendars/home/event-25.ics",
+    "/123/calendars/home/event-26.ics",
+    "/123/calendars/home/event-27.ics",
+    "/123/calendars/home/event-28.ics",
+    "/123/calendars/home/event-29.ics",
+    "/123/calendars/home/event-30.ics",
+    "/123/calendars/home/event-31.ics",
+    "/123/calendars/home/event-32.ics",
+    "/123/calendars/home/event-33.ics",
+    "/123/calendars/home/event-34.ics",
+    "/123/calendars/home/event-35.ics",
+    "/123/calendars/home/event-36.ics",
+    "/123/calendars/home/event-37.ics",
+    "/123/calendars/home/event-38.ics",
+    "/123/calendars/home/event-39.ics",
+    "/123/calendars/home/event-40.ics",
+    "/123/calendars/home/event-41.ics",
+    "/123/calendars/home/event-42.ics",
+    "/123/calendars/home/event-43.ics",
+    "/123/calendars/home/event-44.ics",
+    "/123/calendars/home/event-45.ics",
+    "/123/calendars/home/event-46.ics",
+    "/123/calendars/home/event-47.ics",
+    "/123/calendars/home/event-48.ics",
+    "/123/calendars/home/event-49.ics",
+    "/123/calendars/home/event-50.ics"
+  ],
+  "initialResources": {
+    "/123/calendars/home/event-0.ics": {
+      "href": "/123/calendars/home/event-0.ics",
+      "etag": "\"etag-timed\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:timed@icloud.com\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Timed master\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-1.ics": {
+      "href": "/123/calendars/home/event-1.ics",
+      "etag": "\"etag-allday\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:allday@icloud.com\nDTSTAMP:20250101T120000Z\nDTSTART;VALUE=DATE:20250222\nDTEND;VALUE=DATE:20250223\nSUMMARY:All day\nTRANSP:TRANSPARENT\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-2.ics": {
+      "href": "/123/calendars/home/event-2.ics",
+      "etag": "\"series-etag\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:series-1@icloud.com\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nRRULE:FREQ=DAILY;COUNT=3\nSUMMARY:Contract series\nEND:VEVENT\nBEGIN:VEVENT\nUID:series-1@icloud.com\nDTSTAMP:20250101T120001Z\nDTSTART:20250116T100000Z\nDTEND:20250116T110000Z\nRECURRENCE-ID:20250116T090000Z\nSUMMARY:Contract exception\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-3.ics": {
+      "href": "/123/calendars/home/event-3.ics",
+      "etag": "\"etag-attendee\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:attendee@icloud.com\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T140000Z\nDTEND:20250115T143000Z\nSUMMARY:Standup\nURL:https://meet.example.com/abc\nATTENDEE;CN=A;PARTSTAT=ACCEPTED:mailto:a@example.com\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-4.ics": {
+      "href": "/123/calendars/home/event-4.ics",
+      "etag": "\"etag-cancelled\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:cancelled@icloud.com\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSTATUS:CANCELLED\nSUMMARY:Cancelled\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-5.ics": {
+      "href": "/123/calendars/home/event-5.ics",
+      "etag": "\"etag-unusable\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nSUMMARY:No uid\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-6.ics": {
+      "href": "/123/calendars/home/event-6.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-6.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-7.ics": {
+      "href": "/123/calendars/home/event-7.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-7.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-8.ics": {
+      "href": "/123/calendars/home/event-8.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-8.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-9.ics": {
+      "href": "/123/calendars/home/event-9.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-9.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-10.ics": {
+      "href": "/123/calendars/home/event-10.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-10.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-11.ics": {
+      "href": "/123/calendars/home/event-11.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-11.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-12.ics": {
+      "href": "/123/calendars/home/event-12.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-12.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-13.ics": {
+      "href": "/123/calendars/home/event-13.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-13.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-14.ics": {
+      "href": "/123/calendars/home/event-14.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-14.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-15.ics": {
+      "href": "/123/calendars/home/event-15.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-15.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-16.ics": {
+      "href": "/123/calendars/home/event-16.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-16.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-17.ics": {
+      "href": "/123/calendars/home/event-17.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-17.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-18.ics": {
+      "href": "/123/calendars/home/event-18.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-18.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-19.ics": {
+      "href": "/123/calendars/home/event-19.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-19.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-20.ics": {
+      "href": "/123/calendars/home/event-20.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-20.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-21.ics": {
+      "href": "/123/calendars/home/event-21.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-21.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-22.ics": {
+      "href": "/123/calendars/home/event-22.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-22.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-23.ics": {
+      "href": "/123/calendars/home/event-23.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-23.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-24.ics": {
+      "href": "/123/calendars/home/event-24.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-24.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-25.ics": {
+      "href": "/123/calendars/home/event-25.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-25.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-26.ics": {
+      "href": "/123/calendars/home/event-26.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-26.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-27.ics": {
+      "href": "/123/calendars/home/event-27.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-27.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-28.ics": {
+      "href": "/123/calendars/home/event-28.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-28.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-29.ics": {
+      "href": "/123/calendars/home/event-29.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-29.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-30.ics": {
+      "href": "/123/calendars/home/event-30.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-30.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-31.ics": {
+      "href": "/123/calendars/home/event-31.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-31.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-32.ics": {
+      "href": "/123/calendars/home/event-32.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-32.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-33.ics": {
+      "href": "/123/calendars/home/event-33.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-33.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-34.ics": {
+      "href": "/123/calendars/home/event-34.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-34.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-35.ics": {
+      "href": "/123/calendars/home/event-35.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-35.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-36.ics": {
+      "href": "/123/calendars/home/event-36.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-36.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-37.ics": {
+      "href": "/123/calendars/home/event-37.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-37.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-38.ics": {
+      "href": "/123/calendars/home/event-38.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-38.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-39.ics": {
+      "href": "/123/calendars/home/event-39.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-39.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-40.ics": {
+      "href": "/123/calendars/home/event-40.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-40.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-41.ics": {
+      "href": "/123/calendars/home/event-41.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-41.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-42.ics": {
+      "href": "/123/calendars/home/event-42.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-42.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-43.ics": {
+      "href": "/123/calendars/home/event-43.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-43.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-44.ics": {
+      "href": "/123/calendars/home/event-44.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-44.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-45.ics": {
+      "href": "/123/calendars/home/event-45.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-45.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-46.ics": {
+      "href": "/123/calendars/home/event-46.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-46.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-47.ics": {
+      "href": "/123/calendars/home/event-47.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-47.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-48.ics": {
+      "href": "/123/calendars/home/event-48.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-48.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    },
+    "/123/calendars/home/event-49.ics": {
+      "href": "/123/calendars/home/event-49.ics",
+      "etag": "\"etag-bulk\"",
+      "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:bulk-/123/calendars/home/event-49.ics\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nSUMMARY:Bulk event\nEND:VEVENT\nEND:VCALENDAR"
+    }
+  },
+  "expiredCursor": "expired-sync-token",
+  "syncToken": "sync-token-1",
+  "nextSyncToken": "sync-token-2",
+  "reportExchanges": [
+    {
+      "method": "REPORT",
+      "name": "calendar-query",
+      "depth": 1
+    },
+    {
+      "method": "REPORT",
+      "name": "calendar-multiget",
+      "depth": 1
+    },
+    {
+      "method": "REPORT",
+      "name": "sync-collection",
+      "depth": 1
+    }
+  ]
+}

--- a/packages/sync/src/providers/__contract__/fixtures/apple/writer.json
+++ b/packages/sync/src/providers/__contract__/fixtures/apple/writer.json
@@ -1,0 +1,9 @@
+{
+  "calendarPath": "/123456789/calendars/home/",
+  "seriesSeed": {
+    "uid": "series-1",
+    "etag": "\"series-v1\"",
+    "ics": "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:series-1\nDTSTAMP:20250101T120000Z\nDTSTART:20250115T090000Z\nDTEND:20250115T100000Z\nRRULE:FREQ=DAILY;COUNT=3\nSUMMARY:Contract series\nEND:VEVENT\nEND:VCALENDAR"
+  },
+  "mutationMethods": ["PUT", "GET", "DELETE", "PROPFIND"]
+}

--- a/packages/sync/src/providers/__contract__/live-provider-smoke.ts
+++ b/packages/sync/src/providers/__contract__/live-provider-smoke.ts
@@ -1,5 +1,6 @@
 import { EventScheduleSchema } from "@core/types/event.contracts";
 import { SyncEventContentSchema } from "@core/types/sync/event.contracts";
+import { appleLiveFactory } from "@sync/providers/__contract__/apple-contract.factory";
 import { googleLiveFactory } from "@sync/providers/__contract__/google-contract.factory";
 import { microsoftLiveFactory } from "@sync/providers/__contract__/microsoft-contract.factory";
 import { type ProviderAdapters } from "@sync/providers/provider-adapters";
@@ -158,6 +159,148 @@ export async function runMicrosoftLiveSmoke(input: {
     if (gone !== null) {
       throw new LiveSmokeError(
         "microsoft",
+        "delete",
+        "event still present after delete",
+      );
+    }
+  } finally {
+    await adapters.writer
+      .deleteEvent({
+        accessToken,
+        calendarId,
+        providerEventId: created.providerEventId,
+        expectedVersion: null,
+        invitation: "none",
+      })
+      .catch(() => undefined);
+  }
+}
+
+export async function runAppleLiveSmoke(input: {
+  readonly runId: string;
+  readonly email: string;
+  readonly appPassword: string;
+}): Promise<void> {
+  const adapters = appleLiveFactory("");
+  const refreshed = await adapters.auth.refreshAccessToken({
+    refreshToken: input.appPassword,
+  });
+  const accessToken = refreshed.accessToken;
+  const calendarId = await findSmokeCalendar(adapters, accessToken, "apple");
+  process.env["LIVE_ACCESS_TOKEN"] = accessToken;
+  process.env["LIVE_CALENDAR_ID"] = calendarId;
+
+  await teardownStaleSmokeEvents(
+    adapters,
+    accessToken,
+    calendarId,
+    input.runId,
+  );
+
+  const eventId = randomBytes(12).toString("hex");
+  const createdAt = new Date().toISOString();
+  const description = `${SMOKE_DESCRIPTION_PREFIX} run=${input.runId} created=${createdAt}`;
+  const start = new Date(Date.now() + 2 * 60 * 60 * 1000);
+  const end = new Date(start.getTime() + 30 * 60 * 1000);
+  const schedule = EventScheduleSchema.parse({
+    kind: "timed",
+    start: start.toISOString(),
+    end: end.toISOString(),
+    timeZone: "UTC",
+  });
+  const content = SyncEventContentSchema.parse({
+    title: `compass-smoke ${input.runId}`,
+    description,
+    location: null,
+    organizer: null,
+    attendees: [],
+    conference: null,
+  });
+
+  let created: ProviderWriteResult;
+  try {
+    created = await adapters.writer.createEvent({
+      accessToken,
+      calendarId,
+      providerEventId: eventId,
+      content,
+      schedule,
+      recurrence: { kind: "single" },
+      invitation: "none",
+    });
+  } catch (error) {
+    throw new LiveSmokeError(
+      "apple",
+      "create",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+
+  try {
+    const readBack = await adapters.writer.fetchEvent({
+      accessToken,
+      calendarId,
+      providerEventId: created.providerEventId,
+    });
+    if (readBack?.kind !== "event") {
+      throw new LiveSmokeError(
+        "apple",
+        "read-back",
+        "created event was not readable",
+      );
+    }
+    if (!readBack.content.description.includes(input.runId)) {
+      throw new LiveSmokeError(
+        "apple",
+        "read-back",
+        "created event did not carry the run id",
+      );
+    }
+
+    const patched = await adapters.writer.patchEvent({
+      accessToken,
+      calendarId,
+      providerEventId: created.providerEventId,
+      expectedVersion: created.providerVersion,
+      content: { ...content, title: `compass-smoke ${input.runId} updated` },
+      schedule,
+      recurrence: { kind: "single" },
+      invitation: "none",
+    });
+    if (
+      !patched.providerVersion ||
+      patched.providerVersion === created.providerVersion
+    ) {
+      throw new LiveSmokeError(
+        "apple",
+        "update",
+        "patch did not change version",
+      );
+    }
+
+    await runExceptionCase(
+      adapters.writer,
+      accessToken,
+      calendarId,
+      input.runId,
+      "apple",
+    );
+
+    await adapters.writer.deleteEvent({
+      accessToken,
+      calendarId,
+      providerEventId: created.providerEventId,
+      expectedVersion: null,
+      invitation: "none",
+    });
+    const gone = await adapters.writer.fetchEvent({
+      accessToken,
+      calendarId,
+      providerEventId: created.providerEventId,
+    });
+    if (gone !== null) {
+      throw new LiveSmokeError(
+        "apple",
         "delete",
         "event still present after delete",
       );

--- a/packages/sync/src/providers/__contract__/live-provider.contract.test.ts
+++ b/packages/sync/src/providers/__contract__/live-provider.contract.test.ts
@@ -1,5 +1,10 @@
 import { describeProviderContract } from "@sync/providers/__contract__/adapter-contract";
 import {
+  appleLiveFactory,
+  hasAppleLiveCredentials,
+  smokeAppleAppPassword,
+} from "@sync/providers/__contract__/apple-contract.factory";
+import {
   googleLiveFactory,
   hasGoogleLiveCredentials,
 } from "@sync/providers/__contract__/google-contract.factory";
@@ -36,6 +41,16 @@ if (!liveKind) {
     skipAuthRevoked: true,
     skipWatch: true,
     skipNotifications: true,
+  });
+} else if (liveKind === "apple" && hasAppleLiveCredentials() && calendarId) {
+  describeProviderContract("apple", appleLiveFactory, {
+    calendarId,
+    accessToken: smokeAppleAppPassword(),
+    skipAuthExchange: true,
+    skipAuthRevoked: true,
+    skipWatch: true,
+    skipNotifications: true,
+    skipNormalizerRoundTrip: true,
   });
 } else {
   describe.skip(`live provider contract (${liveKind})`, () => {

--- a/packages/sync/src/providers/__contract__/live-provider.smoke.test.ts
+++ b/packages/sync/src/providers/__contract__/live-provider.smoke.test.ts
@@ -1,5 +1,11 @@
+import {
+  hasAppleLiveCredentials,
+  smokeAppleAppPassword,
+  smokeAppleEmail,
+} from "@sync/providers/__contract__/apple-contract.factory";
 import { hasGoogleLiveCredentials } from "@sync/providers/__contract__/google-contract.factory";
 import {
+  runAppleLiveSmoke,
   runGoogleLiveSmoke,
   runMicrosoftLiveSmoke,
 } from "@sync/providers/__contract__/live-provider-smoke";
@@ -33,6 +39,24 @@ if (!liveKind) {
       await runMicrosoftLiveSmoke({
         runId: process.env["GITHUB_RUN_ID"] ?? `local-${Date.now()}`,
         refreshToken,
+      });
+      expect(process.env["LIVE_CALENDAR_ID"]).toBeTruthy();
+    });
+  });
+} else if (liveKind === "apple" && hasAppleLiveCredentials()) {
+  describe("apple live provider smoke", () => {
+    it("creates, reads, updates, exceptions, and deletes only on compass-smoke", async () => {
+      const email = smokeAppleEmail();
+      const appPassword = smokeAppleAppPassword();
+      if (!email || !appPassword) {
+        throw new Error(
+          "SMOKE_APPLE_EMAIL or SMOKE_APPLE_APP_PASSWORD missing",
+        );
+      }
+      await runAppleLiveSmoke({
+        runId: process.env["GITHUB_RUN_ID"] ?? `local-${Date.now()}`,
+        email,
+        appPassword,
       });
       expect(process.env["LIVE_CALENDAR_ID"]).toBeTruthy();
     });


### PR DESCRIPTION
Fixes #3275

## What and why

Providers A WP-11 moves the Apple adapter contract off inline mocks into a redacted fixture corpus under `fixtures/apple/`. Discovery replays PROPFIND exchanges; reader and writer fixtures cover REPORT and PUT/DELETE contract cases. A founder-only `record-apple-contract` CLI re-records from the iCloud test account, and nightly live-provider smoke now runs Apple when `SMOKE_APPLE_*` secrets are present.

Spec: `docs/features/calendar-providers.md`

## Verify

```
Summary
Selected packages: sync, scripts
Checks run: test:sync:fast, test:scripts:fast, type-check, lint, knip
Checks skipped: (none)

✓ All checks passed
VERDICT: PASS
```