### PR TITLE
fix(sync): per-provider health snapshot and provider closeout docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A keyboard calendar that makes scheduling a breeze.
 
 - The **first-class shortcuts** make updating your calendar a joy.
 - The **minimal UI** will help you focus on what matters: your events.
-- The **Google Calendar two-way sync** will ensure you don't miss anything.
+- The **Google, Outlook, and iCloud Calendar two-way sync** will ensure you don't miss anything.
 
 ### You'll get less done
 
@@ -22,19 +22,18 @@ Cool things you can do with in Compass
 - Move your focus to perfect spot (no more TABing endlessly)
 - Find the perfect slot for an event with your keyboard: `SHIFT` + `↑` `↓` `←` `→`
 - Do everything from the cmd palette
-- Google Calendar sync
+- Google, Outlook, and iCloud Calendar sync
 - Add/remove event attendees and RSVP to invites, with optional Google-contact suggestions
 - Public booking pages at `/book/:username` (month grid plus day times, one duration per host, guest timezone override, confirmation permalink, guest cancel and reschedule links)
 
 Things you can't do in Compass (yet):
 
-- Add meeting links (except Google Meet on confirmed booking events)
+- Add meeting links (except Google Meet or Microsoft Teams on confirmed booking events)
 - Multiple booking event types or a standalone booking product
-- See your Outlook events
 
 Calendar hosts (Google, Microsoft, Apple) are specified in
 [docs/features/calendar-providers.md](./docs/features/calendar-providers.md).
-Outlook and iCloud stay non-goals until those milestones land.
+Connect Google Calendar, Outlook, or iCloud Calendar to import and sync events.
 
 ## Tech stack
 

--- a/docs/features/calendar-providers.md
+++ b/docs/features/calendar-providers.md
@@ -14,10 +14,9 @@ created where the host supports them, and per-connection health is honest.
 
 ## Status
 
-P0 foundation is in the tree. Google is the registered adapter. Microsoft and
-Apple adapters live under `packages/sync/src/providers/<kind>/` and register in
-M-09 / A-08. Work is tracked across six GitHub milestones, each with a tracking
-issue:
+Google, Microsoft, and Apple adapters register in `buildProviderRegistry`
+when their config is present. Work is tracked across six GitHub milestones,
+each with a tracking issue:
 
 | Milestone | Purpose |
 |---|---|
@@ -265,9 +264,6 @@ Each alias names the release that removes it.
   wires. `revokedConnectionServerMessages` emits both. Event mutations still
   return HTTP 410 `GOOGLE_REVOKED`. Milestone C removes `GOOGLE_REVOKED` after
   every client reads `CONNECTION_REVOKED`.
-- **Health snapshot fleet label.** `health-snapshot.service.ts` hard-codes
-  `provider: "google"` for the whole fleet. Milestone C splits the snapshot per
-  provider.
 - **`metadata.google` overlap.** `UserMetadata.connections[]` is the
   provider-neutral list; `metadata.google` (and `metadata.google.connections`)
   stays until WP-08c clients read `connections[]`. Drop the overlap in

--- a/docs/frontend/frontend-runtime-flow.md
+++ b/docs/frontend/frontend-runtime-flow.md
@@ -199,7 +199,8 @@ whatever the DOM did.
 `calendar_connected` has two sources, distinguished by a `source` property:
 `signup_google` from `GoogleAuthCallback` (a new user whose Google grant
 included the calendar scopes) and `connect_redirect` from
-`google-connect-status.util.ts` (the sync service's add-account round trip).
+`packages/web/src/auth/providers/connect-status.util.ts` (the sync service's
+add-account round trip).
 Only the second used to fire, so the activation metric missed the path most new
 users actually take.
 

--- a/docs/self-hosting/README.md
+++ b/docs/self-hosting/README.md
@@ -26,6 +26,8 @@ flowchart TD
     supertokens[SuperTokens Core<br/>signup, login]
     postgres[(Postgres<br/>auth data)]
     google[Google Calendar]
+    microsoft[Microsoft Outlook]
+    apple[iCloud Calendar]
 
     browser -->|loads Compass| caddy
     caddy -->|web traffic| web
@@ -37,10 +39,14 @@ flowchart TD
     backend --> supertokens
     sync -->|Docker volume, own database| mongo
     sync <-->|OAuth, push notifications| google
+    sync <-->|OAuth, push notifications| microsoft
+    sync <-->|CalDAV, polling| apple
     supertokens -->|Docker volume| postgres
 ```
 
-Compass Sync owns Google Calendar sync end to end (OAuth, webhooks, and incremental pulls) in its own isolated database on the same bundled MongoDB — the backend never reads Google credentials directly. Sign-in with Google is the one exception: it stays a direct backend↔Google exchange, separate from calendar sync.
+Compass Sync owns calendar sync end to end (OAuth or app-specific password, webhooks or polling, and incremental pulls) in its own isolated database on the same bundled MongoDB. The backend never reads provider credentials directly. Sign-in with Google, Microsoft, or Apple stays a direct backend exchange, separate from calendar connect.
+
+Google and Microsoft use push notifications for near-real-time updates. Apple has no push channel, so Sync polls iCloud on a dedicated reconcile sweep (see [Calendar providers](../features/calendar-providers.md#apple-polling-cadence)).
 
 ## Start here
 

--- a/docs/self-hosting/server-guide.md
+++ b/docs/self-hosting/server-guide.md
@@ -269,9 +269,12 @@ backend:
     - https://compass.example.com
 sync:
   callbackBaseUrl: https://compass.example.com
+  credentialEncryptionKey: <32-byte-base64>
 ```
 
-`sync.callbackBaseUrl` is what makes Google Calendar connect and push notifications work — it defaults to `http://localhost:3010` (installer default, fine for local-only setups), which Google can never reach. Skip this if you don't plan to connect Google Calendar.
+`sync.callbackBaseUrl` is what makes Google Calendar and Microsoft Outlook connect and push notifications work. It defaults to `http://localhost:3010` (installer default, fine for local-only setups), which external providers can never reach. Skip this if you do not plan to connect a calendar host.
+
+`sync.credentialEncryptionKey` encrypts OAuth refresh tokens and Apple app-specific passwords at rest. The self-host installer generates it on a fresh install. For key rotation procedure, see [CLI key rotation](../development/cli.md#key-rotation-procedure-only).
 
 ### Apply config changes
 

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -266,7 +266,13 @@ async function start(): Promise<void> {
     if (posthog) {
       service.shutdown.register("posthog", () => posthog.shutdown());
     }
-    const health = buildHealthSnapshotSweep(service.identity, mongo, posthog);
+    const registry = buildProviderRegistry(config);
+    const health = buildHealthSnapshotSweep(
+      service.identity,
+      mongo,
+      posthog,
+      registry,
+    );
     service.shutdown.register("health", () => health.stop());
     health.start();
 
@@ -353,21 +359,22 @@ function buildPostHogClient(config: SyncConfig): PostHogCaptureClient | null {
 // memory: a restart re-arming the hour is fine for a condition that persisted
 // for nine days, and it keeps a diagnostic counter out of the storage schema.
 const PUSH_SILENCE_ALERT_AFTER_SAMPLES = 12;
-let pushSilenceStreak = 0;
+const pushSilenceStreaks = new Map<string, number>();
 
 function buildHealthSnapshotSweep(
   identity: ReturnType<typeof buildServiceIdentity>,
   mongo: SyncMongoService,
   client: PostHogCaptureClient | null,
+  registry: ProviderRegistry,
 ): SweepScheduler {
   return new SweepScheduler(
     {
       // SweepScheduler always passes `before`; health ignore it and use now.
       sweep: async () => {
         // A single Atlas/DNS blip must not skip the whole 5-minute gauge.
-        const snapshot = await withTransientMongoRetry(() =>
+        const snapshots = await withTransientMongoRetry(() =>
           emitHealthSnapshot({
-            deps: { mongo, identity },
+            deps: { mongo, identity, registry },
             client,
           }),
         );
@@ -386,19 +393,30 @@ function buildHealthSnapshotSweep(
         // sit idle. Firing on the first sample would have cried wolf on the
         // very deploy that FIXED this. Requiring an hour of consecutive
         // samples costs nothing against a nine-day outage.
-        const { neverNotified, healthy, renewSoon } = snapshot.subscriptions;
-        const live = healthy + renewSoon;
-        if (live > 0 && neverNotified >= live) {
-          pushSilenceStreak += 1;
-          if (pushSilenceStreak === PUSH_SILENCE_ALERT_AFTER_SAMPLES) {
-            logger.error(
-              `Sync push delivery looks broken: all ${live} live subscription(s) have gone without a single notification for over an hour. Check that the reverse proxy routes /sync/* to this service.`,
-            );
+        for (const snapshot of snapshots) {
+          if (
+            !registry
+              .get(snapshot.provider)
+              .capabilities.includes("changeNotifications")
+          ) {
+            continue;
           }
-        } else {
-          pushSilenceStreak = 0;
+          const { neverNotified, healthy, renewSoon } = snapshot.subscriptions;
+          const live = healthy + renewSoon;
+          const streakKey = snapshot.provider;
+          if (live > 0 && neverNotified >= live) {
+            const streak = (pushSilenceStreaks.get(streakKey) ?? 0) + 1;
+            pushSilenceStreaks.set(streakKey, streak);
+            if (streak === PUSH_SILENCE_ALERT_AFTER_SAMPLES) {
+              logger.error(
+                `Sync push delivery looks broken for ${snapshot.provider}: all ${live} live subscription(s) have gone without a single notification for over an hour. Check that the reverse proxy routes /sync/* to this service.`,
+              );
+            }
+          } else {
+            pushSilenceStreaks.set(streakKey, 0);
+          }
         }
-        return 1;
+        return snapshots.length;
       },
     },
     {

--- a/packages/sync/src/telemetry/health-snapshot.service.db.test.ts
+++ b/packages/sync/src/telemetry/health-snapshot.service.db.test.ts
@@ -3,16 +3,23 @@ import { NodeEnv } from "@core/constants/core.constants";
 import {
   type ConnectionId,
   type PrincipalId,
+  type ProviderCapability,
+  type ProviderKind,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
+import {
+  type ProviderRegistration,
+  ProviderRegistry,
+} from "@sync/providers/provider-registry";
 import { assertNoSafetyCanary } from "@sync/safety/safety-canary";
 import { buildServiceIdentity } from "@sync/service-identity";
 import { JobRepository } from "@sync/storage/repositories/job.repository";
 import { ProviderConnectionRepository } from "@sync/storage/repositories/provider-connection.repository";
 import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 import {
-  computeHealthSnapshot,
+  computeHealthSnapshotForProvider,
+  computeHealthSnapshots,
   emitHealthSnapshot,
   HEALTH_SUBSCRIPTION_RENEW_BEFORE_MS,
 } from "@sync/telemetry/health-snapshot.service";
@@ -22,11 +29,53 @@ import { beforeEach, describe, expect, it } from "bun:test";
 const objectId = () => faker.database.mongodbObjectId();
 const NOW = new Date("2026-07-25T02:00:00.000Z");
 
+function fakeRegistration(
+  capabilities: readonly ProviderCapability[],
+): ProviderRegistration {
+  return {
+    adapters: {} as ProviderRegistration["adapters"],
+    scopes: { forFeatures: () => [] },
+    capabilities,
+    callbackPath: "/sync/test",
+    notificationsCallbackPath: "/sync/notifications/test",
+    capabilitiesFromScopes: () => [...capabilities],
+  };
+}
+
+function fakeRegistry(
+  entries: Partial<Record<ProviderKind, readonly ProviderCapability[]>>,
+): ProviderRegistry {
+  const registrations = new Map<ProviderKind, ProviderRegistration>();
+  for (const kind of Object.keys(entries) as ProviderKind[]) {
+    const capabilities = entries[kind];
+    if (capabilities) {
+      registrations.set(kind, fakeRegistration(capabilities));
+    }
+  }
+  return new ProviderRegistry(registrations);
+}
+
 describe("computeHealthSnapshot", () => {
   const storage = setupSyncStorage(import.meta.url);
   let connections: ProviderConnectionRepository;
   let resources: SyncResourceRepository;
   let jobs: JobRepository;
+
+  const registry = fakeRegistry({
+    google: [
+      "readEvents",
+      "writeEvents",
+      "changeNotifications",
+      "incrementalChanges",
+    ],
+    microsoft: [
+      "readEvents",
+      "writeEvents",
+      "changeNotifications",
+      "incrementalChanges",
+    ],
+    apple: ["readEvents", "writeEvents", "incrementalChanges"],
+  });
 
   beforeEach(() => {
     connections = new ProviderConnectionRepository(storage.db());
@@ -42,16 +91,18 @@ describe("computeHealthSnapshot", () => {
   const deps = () => ({
     mongo: storage.mongo(),
     identity,
+    registry,
     now: () => NOW,
   });
 
   const seedConnection = (
+    provider: ProviderKind,
     state: "healthy" | "delayed" | "actionRequired" | "disconnected",
   ) =>
     connections.upsertByProviderAccount({
       tenantId: objectId() as TenantId,
       principalId: objectId() as PrincipalId,
-      provider: "google",
+      provider,
       account: {
         providerAccountId: objectId(),
         email: "h@example.com",
@@ -62,15 +113,19 @@ describe("computeHealthSnapshot", () => {
       stateReason: state === "actionRequired" ? "authorizationRevoked" : null,
     });
 
-  it("aggregates connection states, jobs, subscriptions, and freshness", async () => {
-    await seedConnection("healthy");
-    await seedConnection("healthy");
-    await seedConnection("delayed");
-    await seedConnection("disconnected");
+  it("aggregates connection states, jobs, subscriptions, and freshness per provider", async () => {
+    await seedConnection("google", "healthy");
+    await seedConnection("google", "healthy");
+    await seedConnection("google", "delayed");
+    await seedConnection("google", "disconnected");
+    await seedConnection("microsoft", "healthy");
+    await seedConnection("apple", "healthy");
+    await seedConnection("apple", "healthy");
 
     const tenantId = objectId() as TenantId;
     const principalId = objectId() as PrincipalId;
-    const connectionId = objectId() as ConnectionId;
+    const googleConnection = await seedConnection("google", "healthy");
+    const connectionId = googleConnection._id as ConnectionId;
     const healthySub = await resources.ensure({
       tenantId,
       principalId,
@@ -109,6 +164,22 @@ describe("computeHealthSnapshot", () => {
       new Date(NOW.getTime() - 60_000),
     );
 
+    const appleConnection = await seedConnection("apple", "healthy");
+    const appleResource = await resources.ensure({
+      tenantId,
+      principalId,
+      connectionId: appleConnection._id as ConnectionId,
+      resourceKind: "events",
+      calendarId: objectId() as never,
+    });
+    await resources.advanceCursor(
+      tenantId,
+      principalId,
+      appleResource._id,
+      "cursor",
+      new Date(NOW.getTime() - 45_000),
+    );
+
     await jobs.enqueue({
       tenantId,
       principalId,
@@ -121,27 +192,52 @@ describe("computeHealthSnapshot", () => {
       coalescingKey: `pull:${objectId()}`,
     });
 
-    const snapshot = await computeHealthSnapshot(deps());
+    const snapshots = await computeHealthSnapshots(deps());
+    expect(snapshots).toHaveLength(3);
 
-    expect(snapshot.service).toBe("compass-sync");
-    expect(snapshot.provider).toBe("google");
-    expect(snapshot.connections.healthy).toBe(2);
-    expect(snapshot.connections.delayed).toBe(1);
-    expect(snapshot.connections.disconnected).toBe(1);
-    expect(snapshot.jobs.pending).toBe(1);
-    expect(snapshot.jobs.oldestDueAgeMs).toBe(15_000);
-    expect(snapshot.subscriptions.healthy).toBe(1);
-    expect(snapshot.subscriptions.missing).toBe(1);
+    const google = snapshots.find((row) => row.provider === "google");
+    const microsoft = snapshots.find((row) => row.provider === "microsoft");
+    const apple = snapshots.find((row) => row.provider === "apple");
+
+    expect(google?.service).toBe("compass-sync");
+    expect(google?.connections.healthy).toBe(3);
+    expect(google?.connections.delayed).toBe(1);
+    expect(google?.connections.disconnected).toBe(1);
+    expect(google?.jobs.pending).toBe(1);
+    expect(google?.jobs.oldestDueAgeMs).toBe(15_000);
+    expect(google?.subscriptions.healthy).toBe(1);
+    expect(google?.subscriptions.missing).toBe(1);
     // The subscribed resource in this fixture has never received a push, so it
     // counts as never notified — the signal that push delivery is broken.
-    expect(snapshot.subscriptions.neverNotified).toBe(1);
-    expect(snapshot.freshness.sampleSize).toBe(2);
-    expect(snapshot.freshness.p50Ms).toBeGreaterThan(0);
-    expect(snapshot.freshness.percentOver30s).toBeGreaterThan(0);
-    expect(snapshot.computedAt).toBe(NOW.toISOString());
+    expect(google?.subscriptions.neverNotified).toBe(1);
+    expect(google?.freshness.sampleSize).toBe(2);
+    expect(google?.freshness.p50Ms).toBeGreaterThan(0);
+    expect(google?.freshness.percentOver30s).toBeGreaterThan(0);
+    expect(google?.computedAt).toBe(NOW.toISOString());
 
-    // R-SEC-04 / S44: aggregates must never carry content or credential shapes.
-    assertNoSafetyCanary(snapshot);
+    expect(microsoft?.connections.healthy).toBe(1);
+    expect(microsoft?.jobs.pending).toBe(0);
+    expect(microsoft?.subscriptions).toEqual({
+      healthy: 0,
+      renewSoon: 0,
+      expired: 0,
+      missing: 0,
+      neverNotified: 0,
+    });
+
+    expect(apple?.connections.healthy).toBe(3);
+    expect(apple?.subscriptions).toEqual({
+      healthy: 0,
+      renewSoon: 0,
+      expired: 0,
+      missing: 0,
+      neverNotified: 0,
+    });
+    expect(apple?.freshness.sampleSize).toBe(1);
+
+    for (const snapshot of snapshots) {
+      assertNoSafetyCanary(snapshot);
+    }
   });
 
   // The gauge used to read changeNotifiedAt, which the serving pull CLEARS
@@ -151,7 +247,8 @@ describe("computeHealthSnapshot", () => {
   it("does not count a resource whose push was received and then served", async () => {
     const tenantId = objectId() as TenantId;
     const principalId = objectId() as PrincipalId;
-    const connectionId = objectId() as ConnectionId;
+    const googleConnection = await seedConnection("google", "healthy");
+    const connectionId = googleConnection._id as ConnectionId;
     const resource = await resources.ensure({
       tenantId,
       principalId,
@@ -191,11 +288,11 @@ describe("computeHealthSnapshot", () => {
     expect(stored?.changeNotifiedAt).toBeNull();
     expect(stored?.pushLastReceivedAt).toEqual(notifiedAt);
 
-    const snapshot = await computeHealthSnapshot(deps());
+    const snapshot = await computeHealthSnapshotForProvider(deps(), "google");
     expect(snapshot.subscriptions.neverNotified).toBe(0);
   });
 
-  it("emits through PostHog when a client is configured", async () => {
+  it("emits one PostHog event per registered provider", async () => {
     const captured: Array<{
       event: string;
       properties: Record<string, unknown>;
@@ -207,17 +304,23 @@ describe("computeHealthSnapshot", () => {
       shutdown: async () => {},
     };
 
-    const snapshot = await emitHealthSnapshot({ deps: deps(), client });
+    const snapshots = await emitHealthSnapshot({ deps: deps(), client });
 
-    expect(captured).toHaveLength(1);
+    expect(snapshots).toHaveLength(3);
+    expect(captured).toHaveLength(3);
+    expect(captured.map((row) => row.properties["provider"]).sort()).toEqual([
+      "apple",
+      "google",
+      "microsoft",
+    ]);
     expect(captured[0]?.event).toBe("sync_health_snapshot");
     expect(captured[0]?.properties["service"]).toBe("compass-sync");
-    expect(snapshot.connections.healthy).toBe(0);
     assertNoSafetyCanary(captured[0]?.properties);
   });
 
   it("still computes when PostHog is not configured", async () => {
-    const snapshot = await emitHealthSnapshot({ deps: deps(), client: null });
-    expect(snapshot.service).toBe("compass-sync");
+    const snapshots = await emitHealthSnapshot({ deps: deps(), client: null });
+    expect(snapshots).toHaveLength(3);
+    expect(snapshots.every((row) => row.service === "compass-sync")).toBe(true);
   });
 });

--- a/packages/sync/src/telemetry/health-snapshot.service.ts
+++ b/packages/sync/src/telemetry/health-snapshot.service.ts
@@ -5,6 +5,11 @@ import {
   type SyncHealthSnapshot,
   SyncHealthSnapshotSchema,
 } from "@core/types/sync/health.contracts";
+import {
+  type ConnectionId,
+  type ProviderKind,
+} from "@core/types/sync/identity.contracts";
+import { type ProviderRegistry } from "@sync/providers/provider-registry";
 import { type StructuredServiceIdentity } from "@sync/service-identity";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
@@ -20,32 +25,47 @@ const FRESHNESS_SLO_MS = 30_000;
 // Cap the in-process freshness sample so a huge deployment stays bounded.
 const FRESHNESS_SAMPLE_LIMIT = 5_000;
 
+const ZERO_SUBSCRIPTION_COUNTS: SyncHealthSnapshot["subscriptions"] = {
+  healthy: 0,
+  renewSoon: 0,
+  expired: 0,
+  missing: 0,
+  neverNotified: 0,
+};
+
 export interface HealthSnapshotDeps {
   mongo: SyncMongoService;
   identity: StructuredServiceIdentity;
+  registry: ProviderRegistry;
   now?: () => Date;
 }
 
 // Build one sanitized aggregate snapshot from Sync storage. Pure relative to
 // PostHog — callers decide whether to emit.
-export async function computeHealthSnapshot(
+export async function computeHealthSnapshotForProvider(
   deps: HealthSnapshotDeps,
+  provider: ProviderKind,
 ): Promise<SyncHealthSnapshot> {
   const started = Date.now();
   const now = deps.now?.() ?? new Date();
   const db = deps.mongo.db;
+  const hasChangeNotifications = deps.registry
+    .get(provider)
+    .capabilities.includes("changeNotifications");
 
   const [connections, jobs, subscriptions, freshness] = await Promise.all([
-    countConnectionsByState(db),
-    summarizeJobs(db, now),
-    summarizeSubscriptions(db, now),
-    summarizeFreshness(db, now),
+    countConnectionsByState(db, provider),
+    summarizeJobs(db, now, provider),
+    hasChangeNotifications
+      ? summarizeSubscriptions(db, now, provider)
+      : Promise.resolve({ ...ZERO_SUBSCRIPTION_COUNTS }),
+    summarizeFreshness(db, now, provider),
   ]);
 
   return SyncHealthSnapshotSchema.parse({
     environment: deps.identity.environment,
     execution: deps.identity.execution,
-    provider: "google",
+    provider,
     service: "compass-sync",
     connections,
     jobs,
@@ -56,18 +76,41 @@ export async function computeHealthSnapshot(
   });
 }
 
+export async function computeHealthSnapshots(
+  deps: HealthSnapshotDeps,
+): Promise<SyncHealthSnapshot[]> {
+  return Promise.all(
+    deps.registry
+      .kinds()
+      .map((provider) => computeHealthSnapshotForProvider(deps, provider)),
+  );
+}
+
 export async function emitHealthSnapshot(input: {
   deps: HealthSnapshotDeps;
   client: PostHogCaptureClient | null;
-}): Promise<SyncHealthSnapshot> {
-  const snapshot = await computeHealthSnapshot(input.deps);
-  await captureSafely(input.client, {
-    event: SYNC_HEALTH_SNAPSHOT_EVENT,
-    // One service-level distinct id — never a user id (R-SEC-04).
-    distinctId: "compass-sync",
-    properties: snapshot as unknown as Record<string, unknown>,
-  });
-  return snapshot;
+}): Promise<SyncHealthSnapshot[]> {
+  const snapshots = await computeHealthSnapshots(input.deps);
+  for (const snapshot of snapshots) {
+    await captureSafely(input.client, {
+      event: SYNC_HEALTH_SNAPSHOT_EVENT,
+      // One service-level distinct id — never a user id (R-SEC-04).
+      distinctId: "compass-sync",
+      properties: snapshot as unknown as Record<string, unknown>,
+    });
+  }
+  return snapshots;
+}
+
+async function connectionIdsForProvider(
+  db: Db,
+  provider: ProviderKind,
+): Promise<ConnectionId[]> {
+  const rows = await db
+    .collection(SYNC_COLLECTIONS.providerConnections)
+    .find({ provider }, { projection: { _id: 1 } })
+    .toArray();
+  return rows.map((row) => String(row._id) as ConnectionId);
 }
 
 // The counters below read collections directly instead of going through the
@@ -77,10 +120,12 @@ export async function emitHealthSnapshot(input: {
 // hydrated records.
 async function countConnectionsByState(
   db: Db,
+  provider: ProviderKind,
 ): Promise<SyncHealthSnapshot["connections"]> {
   const rows = await db
     .collection(SYNC_COLLECTIONS.providerConnections)
     .aggregate<{ _id: string; count: number }>([
+      { $match: { provider } },
       { $group: { _id: "$state", count: { $sum: 1 } } },
     ])
     .toArray();
@@ -105,14 +150,22 @@ async function countConnectionsByState(
 async function summarizeJobs(
   db: Db,
   now: Date,
+  provider: ProviderKind,
 ): Promise<SyncHealthSnapshot["jobs"]> {
+  const connectionIds = await connectionIdsForProvider(db, provider);
+  if (connectionIds.length === 0) {
+    return { pending: 0, claimed: 0, failed: 0, oldestDueAgeMs: null };
+  }
+
+  const connectionFilter = { connectionId: { $in: connectionIds } };
   const collection = db.collection(SYNC_COLLECTIONS.jobs);
   const [pending, claimed, failed, oldestDue] = await Promise.all([
-    collection.countDocuments({ state: "pending" }),
-    collection.countDocuments({ state: "claimed" }),
-    collection.countDocuments({ state: "failed" }),
+    collection.countDocuments({ ...connectionFilter, state: "pending" }),
+    collection.countDocuments({ ...connectionFilter, state: "claimed" }),
+    collection.countDocuments({ ...connectionFilter, state: "failed" }),
     collection.findOne(
       {
+        ...connectionFilter,
         $or: [
           { state: "pending", runAfter: { $lte: now } },
           { state: "claimed", leaseExpiresAt: { $lt: now } },
@@ -133,12 +186,21 @@ async function summarizeJobs(
 async function summarizeSubscriptions(
   db: Db,
   now: Date,
+  provider: ProviderKind,
 ): Promise<SyncHealthSnapshot["subscriptions"]> {
+  const connectionIds = await connectionIdsForProvider(db, provider);
+  if (connectionIds.length === 0) {
+    return { ...ZERO_SUBSCRIPTION_COUNTS };
+  }
+
   const renewBefore = new Date(
     now.getTime() + HEALTH_SUBSCRIPTION_RENEW_BEFORE_MS,
   );
   const collection = db.collection(SYNC_COLLECTIONS.syncResources);
-  const eventsFilter = { resourceKind: "events" as const };
+  const eventsFilter = {
+    resourceKind: "events" as const,
+    connectionId: { $in: connectionIds },
+  };
 
   const [healthy, renewSoon, expired, missing, neverNotified] =
     await Promise.all([
@@ -180,11 +242,29 @@ async function summarizeSubscriptions(
 async function summarizeFreshness(
   db: Db,
   now: Date,
+  provider: ProviderKind,
 ): Promise<SyncHealthSnapshot["freshness"]> {
+  const connectionIds = await connectionIdsForProvider(db, provider);
+  if (connectionIds.length === 0) {
+    return {
+      sampleSize: 0,
+      p50Ms: null,
+      p95Ms: null,
+      p99Ms: null,
+      percentOver30s: null,
+    };
+  }
+
   const rows = await db
     .collection(SYNC_COLLECTIONS.syncResources)
     .aggregate<{ lastSuccessAt: Date | null }>([
-      { $match: { resourceKind: "events", lastSuccessAt: { $ne: null } } },
+      {
+        $match: {
+          resourceKind: "events",
+          lastSuccessAt: { $ne: null },
+          connectionId: { $in: connectionIds },
+        },
+      },
       { $project: { lastSuccessAt: 1 } },
       { $sample: { size: FRESHNESS_SAMPLE_LIMIT } },
     ])


### PR DESCRIPTION
Fixes #3279

## What and why

Providers C WP-03 closes out cross-provider documentation and splits the sync health snapshot by registered provider kind. README and self-hosting docs now describe Google, Outlook, and iCloud consistently. The health snapshot service emits one `sync_health_snapshot` row per registered kind with provider-scoped aggregates; poll-only kinds report zero subscription counts via a `changeNotifications` capability check so Apple resources no longer pollute the push-delivery alert.

## Verify

```
Summary
Selected packages: sync
Checks run: test:sync, type-check, lint, knip
Checks skipped: (none)

✓ All checks passed
VERDICT: PASS
```