### PR TITLE
feat(web): sign-in buttons per configured provider and callback e2e

### DIFF
--- a/e2e/auth/sign-in-providers.spec.ts
+++ b/e2e/auth/sign-in-providers.spec.ts
@@ -1,0 +1,117 @@
+import { expect, type Page, test } from "@playwright/test";
+
+type ProviderFlags = {
+  signIn: boolean;
+  connect: boolean;
+};
+
+type ProviderConfig = {
+  google: ProviderFlags;
+  microsoft: ProviderFlags;
+  apple: ProviderFlags;
+};
+
+const signInOnly = (signIn: boolean): ProviderFlags => ({
+  signIn,
+  connect: false,
+});
+
+const prepareSignInProvidersPage = async (
+  page: Page,
+  providers?: ProviderConfig,
+) => {
+  await page.addInitScript(() => {
+    (
+      window as Window & { __COMPASS_E2E_TEST__?: boolean }
+    ).__COMPASS_E2E_TEST__ = true;
+  });
+
+  await page.route("**/api/**", async (route) => {
+    const url = new URL(route.request().url());
+
+    if (url.pathname.endsWith("/api/config")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          google: { isConfigured: true },
+          ...(providers ? { providers } : {}),
+        }),
+      });
+    }
+
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({}),
+    });
+  });
+};
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe("sign-in provider buttons", () => {
+  test("renders all three configured providers on the auth modal", async ({
+    page,
+  }) => {
+    await prepareSignInProvidersPage(page, {
+      google: signInOnly(true),
+      microsoft: signInOnly(true),
+      apple: signInOnly(true),
+    });
+
+    await page.goto("/week?auth=login", { waitUntil: "domcontentloaded" });
+    await expect(
+      page.getByRole("dialog", { name: "Hey, welcome back" }),
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole("button", { name: "Continue with Google" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Continue with Microsoft" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Continue with Apple" }),
+    ).toBeVisible();
+  });
+
+  test("renders only Google when it is the sole configured provider", async ({
+    page,
+  }) => {
+    await prepareSignInProvidersPage(page);
+
+    await page.goto("/week?auth=login", { waitUntil: "domcontentloaded" });
+
+    await expect(
+      page.getByRole("button", { name: "Continue with Google" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Continue with Microsoft" }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: "Continue with Apple" }),
+    ).toHaveCount(0);
+  });
+
+  test("starts Microsoft sign-in with the M shortcut", async ({ page }) => {
+    await prepareSignInProvidersPage(page, {
+      google: signInOnly(true),
+      microsoft: signInOnly(true),
+      apple: signInOnly(false),
+    });
+
+    await page.goto("/week?auth=login", { waitUntil: "domcontentloaded" });
+    await expect(
+      page.getByRole("button", { name: "Continue with Microsoft" }),
+    ).toBeVisible();
+    await page.getByRole("heading", { name: "Hey, welcome back" }).click();
+
+    await Promise.all([
+      page.waitForURL(
+        /login\.microsoftonline\.com\/common\/oauth2\/v2\.0\/authorize/,
+      ),
+      page.keyboard.press("m"),
+    ]);
+  });
+});

--- a/e2e/compass.playwright.yaml
+++ b/e2e/compass.playwright.yaml
@@ -24,6 +24,10 @@ google:
   clientId: test-client-id
   clientSecret: unused-e2e-build
 
+microsoft:
+  clientId: test-microsoft-client-id
+  clientSecret: unused-e2e-build
+
 posthog:
   key: test-posthog-key
   host: https://app.posthog.com

--- a/packages/web/src/auth/providers/authorization/useStartProviderAuthorization.ts
+++ b/packages/web/src/auth/providers/authorization/useStartProviderAuthorization.ts
@@ -1,9 +1,25 @@
 import { type ProviderKind } from "@core/types/sync/identity.contracts";
 import { useStartProviderAuthorizationImpl } from "./useStartProviderAuthorization.impl";
 
+export type UseStartProviderAuthorization =
+  typeof useStartProviderAuthorizationImpl;
+
+let useStartProviderAuthorizationHook: UseStartProviderAuthorization =
+  useStartProviderAuthorizationImpl;
+
+export function registerUseStartProviderAuthorizationForTests(
+  hook: UseStartProviderAuthorization,
+): void {
+  useStartProviderAuthorizationHook = hook;
+}
+
+export function resetUseStartProviderAuthorizationForTests(): void {
+  useStartProviderAuthorizationHook = useStartProviderAuthorizationImpl;
+}
+
 export function useStartProviderAuthorization(
   provider: ProviderKind,
   options: Parameters<typeof useStartProviderAuthorizationImpl>[1],
 ): ReturnType<typeof useStartProviderAuthorizationImpl> {
-  return useStartProviderAuthorizationImpl(provider, options);
+  return useStartProviderAuthorizationHook(provider, options);
 }

--- a/packages/web/src/auth/providers/provider-copy.util.ts
+++ b/packages/web/src/auth/providers/provider-copy.util.ts
@@ -122,6 +122,12 @@ export function reconnectPointerHint(kind: ProviderKind): string {
   return `Press G to reconnect ${calendarProductName(kind)}.`;
 }
 
+export const SIGN_IN_WELCOME_SUBLINE: Record<ProviderKind, string> = {
+  google: "Signs you up and connects your Google Calendar.",
+  microsoft: "Signs you up and connects your Outlook calendar.",
+  apple: "You'll pick your calendar next.",
+};
+
 export function relabelConnectCommand(
   commandAction: GoogleUiConfig["commandAction"],
   kind: ProviderKind,

--- a/packages/web/src/auth/providers/sign-in-provider.util.test.ts
+++ b/packages/web/src/auth/providers/sign-in-provider.util.test.ts
@@ -1,0 +1,27 @@
+import {
+  CONTINUE_WITH_LABEL,
+  signInProviderForShortcutLetter,
+} from "./sign-in-provider.util";
+import { describe, expect, it } from "bun:test";
+
+describe("signInProviderForShortcutLetter", () => {
+  it("maps shortcut letters to configured providers", () => {
+    const available = ["google", "microsoft", "apple"] as const;
+    expect(signInProviderForShortcutLetter("g", available)).toBe("google");
+    expect(signInProviderForShortcutLetter("M", available)).toBe("microsoft");
+    expect(signInProviderForShortcutLetter("a", available)).toBe("apple");
+    expect(signInProviderForShortcutLetter("x", available)).toBeUndefined();
+  });
+
+  it("ignores providers that are not available", () => {
+    expect(signInProviderForShortcutLetter("m", ["google"])).toBeUndefined();
+  });
+});
+
+describe("CONTINUE_WITH_LABEL", () => {
+  it("uses whole-string provider labels", () => {
+    expect(CONTINUE_WITH_LABEL.google).toBe("Continue with Google");
+    expect(CONTINUE_WITH_LABEL.microsoft).toBe("Continue with Microsoft");
+    expect(CONTINUE_WITH_LABEL.apple).toBe("Continue with Apple");
+  });
+});

--- a/packages/web/src/auth/providers/sign-in-provider.util.ts
+++ b/packages/web/src/auth/providers/sign-in-provider.util.ts
@@ -1,0 +1,27 @@
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+
+export const CONTINUE_WITH_LABEL: Record<ProviderKind, string> = {
+  google: "Continue with Google",
+  microsoft: "Continue with Microsoft",
+  apple: "Continue with Apple",
+};
+
+export const SIGN_IN_SHORTCUT_KEY: Record<ProviderKind, string> = {
+  google: "G",
+  microsoft: "M",
+  apple: "A",
+};
+
+const SIGN_IN_SHORTCUT_LETTER: Record<ProviderKind, string> = {
+  google: "g",
+  microsoft: "m",
+  apple: "a",
+};
+
+export function signInProviderForShortcutLetter(
+  letter: string,
+  available: readonly ProviderKind[],
+): ProviderKind | undefined {
+  const normalized = letter.toLowerCase();
+  return available.find((kind) => SIGN_IN_SHORTCUT_LETTER[kind] === normalized);
+}

--- a/packages/web/src/auth/providers/useAvailableSignInProviders.ts
+++ b/packages/web/src/auth/providers/useAvailableSignInProviders.ts
@@ -1,0 +1,16 @@
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+import { ALL_PROVIDER_KINDS } from "@web/auth/providers/connection-provider.util";
+import { useIsProviderAvailable } from "@web/auth/providers/useIsProviderAvailable";
+
+/** Provider kinds whose sign-in flow is configured on this deployment. */
+export const useAvailableSignInProviders = (): ProviderKind[] => {
+  const google = useIsProviderAvailable("google", "signIn");
+  const microsoft = useIsProviderAvailable("microsoft", "signIn");
+  const apple = useIsProviderAvailable("apple", "signIn");
+  const ready: Record<ProviderKind, boolean> = {
+    google,
+    microsoft,
+    apple,
+  };
+  return ALL_PROVIDER_KINDS.filter((kind) => ready[kind]);
+};

--- a/packages/web/src/auth/providers/useSignInProviders.ts
+++ b/packages/web/src/auth/providers/useSignInProviders.ts
@@ -1,0 +1,62 @@
+import { useCallback, useMemo } from "react";
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+import { useStartGoogleAuthorization } from "@web/auth/google/authorization/useStartGoogleAuthorization";
+import { useStartProviderAuthorization } from "@web/auth/providers/authorization/useStartProviderAuthorization";
+import { useAvailableSignInProviders } from "@web/auth/providers/useAvailableSignInProviders";
+
+type GoogleSignInOptions = {
+  onStart?: () => void;
+  prompt?: "consent" | "none" | "select_account";
+};
+
+type UseSignInProvidersOptions = {
+  google?: GoogleSignInOptions;
+};
+
+export function useSignInProviders(options: UseSignInProvidersOptions = {}) {
+  const available = useAvailableSignInProviders();
+  const {
+    loading: isGoogleLoading,
+    startGoogleAuthorization: startGoogleSignIn,
+  } = useStartGoogleAuthorization({
+    intent: "signIn",
+    onStart: options.google?.onStart,
+    prompt: options.google?.prompt,
+  });
+  const microsoftAuth = useStartProviderAuthorization("microsoft", {
+    intent: "signIn",
+  });
+  const appleAuth = useStartProviderAuthorization("apple", {
+    intent: "signIn",
+  });
+
+  const byKind = useMemo(
+    () => ({
+      google: {
+        loading: isGoogleLoading,
+        startAuthorization: startGoogleSignIn,
+      },
+      microsoft: microsoftAuth,
+      apple: appleAuth,
+    }),
+    [appleAuth, isGoogleLoading, microsoftAuth, startGoogleSignIn],
+  );
+
+  const loadingKind = available.find((kind) => byKind[kind].loading) ?? null;
+  const isLoading = loadingKind != null;
+
+  const startSignIn = useCallback(
+    (kind: ProviderKind) => {
+      byKind[kind].startAuthorization();
+    },
+    [byKind],
+  );
+
+  return {
+    available,
+    byKind,
+    isLoading,
+    loadingKind,
+    startSignIn,
+  };
+}

--- a/packages/web/src/common/utils/draft/draft.util.test.ts
+++ b/packages/web/src/common/utils/draft/draft.util.test.ts
@@ -99,6 +99,23 @@ describe("shortcut draft creation", () => {
     expectSameTime(gridDraft?.values.schedule.end, "2026-05-21T00:00:00.000Z");
   });
 
+  it("keeps a late-evening timed draft on the selected day when minutes round past the hour", async () => {
+    // 23:50 -> roundToNext(50, 15) is 60, and minute(60) at 23:00 is the next
+    // day. The selected column must still own the draft.
+    setSystemTime(new Date("2026-05-20T23:50:00.000Z"));
+
+    await createTimedDraft(dayjs("2026-06-01T00:00:00.000Z"), "createShortcut");
+
+    const { gridDraft, status } = useDraftStore.getState();
+
+    expect(status?.eventType).toBe(Categories_Event.TIMED);
+    expectSameTime(
+      gridDraft?.values.schedule.start,
+      "2026-06-01T23:45:00.000Z",
+    );
+    expectSameTime(gridDraft?.values.schedule.end, "2026-06-02T00:00:00.000Z");
+  });
+
   it("stores a provided calendarId on timed shortcut drafts", async () => {
     setSystemTime(new Date("2026-05-20T10:07:00.000Z"));
     const calendarId = CalendarIdSchema.parse(createObjectIdString());

--- a/packages/web/src/common/utils/draft/draft.util.ts
+++ b/packages/web/src/common/utils/draft/draft.util.ts
@@ -107,13 +107,22 @@ export const getDraftTimes = (targetDay: Dayjs) => {
   const currentMinute = now.minute();
   const nextMinuteInterval = roundToNext(currentMinute, GRID_TIME_STEP);
 
-  const _start = targetDay
+  let start = targetDay
     .startOf("day")
     .hour(now.hour())
     .minute(nextMinuteInterval)
     .second(0);
-  const startDate = _start.format();
-  const endDate = timedDraftEnd(_start).format();
+  // minute(60) overflows into the next hour, and at 23:xx that is the next
+  // day. Keep the draft on the selected column, on the last grid slot.
+  if (!start.isSame(targetDay, "day")) {
+    start = targetDay
+      .startOf("day")
+      .hour(23)
+      .minute(60 - GRID_TIME_STEP)
+      .second(0);
+  }
+  const startDate = start.format();
+  const endDate = timedDraftEnd(start).format();
 
   return { startDate, endDate };
 };

--- a/packages/web/src/components/AuthModal/AuthModal.test.tsx
+++ b/packages/web/src/components/AuthModal/AuthModal.test.tsx
@@ -21,8 +21,13 @@ import { registerUseCompleteAuthenticationForTests } from "@web/auth/compass/hoo
 import { markGoogleAuthNeedsConsentRetry } from "@web/auth/google/authorization/google-authorization.storage";
 import { registerUseStartGoogleAuthorizationForTests } from "@web/auth/google/authorization/useStartGoogleAuthorization";
 import {
-  resetGoogleAvailabilityForTests,
+  registerUseStartProviderAuthorizationForTests,
+  resetUseStartProviderAuthorizationForTests,
+} from "@web/auth/providers/authorization/useStartProviderAuthorization";
+import {
+  resetProviderAvailabilityForTests,
   setGoogleAvailabilityForTests,
+  setProviderAvailabilityForTests,
 } from "@web/auth/providers/useIsProviderAvailable";
 import { AuthModal } from "./AuthModal";
 import { AuthModalProvider } from "./AuthModalProvider";
@@ -143,14 +148,29 @@ function installAuthModalTestSeams() {
   mockEmailPassword = createTestEmailPasswordPort();
 
   registerUseStartGoogleAuthorizationForTests(mockUseStartGoogleAuthorization);
+  resetUseStartProviderAuthorizationForTests();
   registerUseCompleteAuthenticationForTests(() => mockCompleteAuthentication);
   registerEmailPasswordPort(mockEmailPassword);
-  resetGoogleAvailabilityForTests();
+  resetProviderAvailabilityForTests();
   setGoogleAvailabilityForTests("available");
   mockUseSession.mockReset().mockReturnValue({
     authenticated: false,
     userId: undefined,
   });
+}
+
+function setSignInAvailability(options: {
+  google?: "available" | "unavailable";
+  microsoft?: "available" | "unavailable";
+  apple?: "available" | "unavailable";
+}) {
+  resetProviderAvailabilityForTests();
+  setProviderAvailabilityForTests("google", options.google ?? "unavailable");
+  setProviderAvailabilityForTests(
+    "microsoft",
+    options.microsoft ?? "unavailable",
+  );
+  setProviderAvailabilityForTests("apple", options.apple ?? "unavailable");
 }
 
 describe("AuthModal", () => {
@@ -786,9 +806,9 @@ describe("AuthModal", () => {
       expect(mockGoogleLogin).toHaveBeenCalled();
     });
 
-    it("hides Google sign in when backend Google support is unavailable", async () => {
+    it("hides provider sign in when no providers are configured", async () => {
       const user = userEvent.setup();
-      setGoogleAvailabilityForTests("unavailable");
+      setSignInAvailability({});
       await renderWithProviders(<ModalTrigger />);
 
       await user.click(screen.getByRole("button", { name: /open modal/i }));
@@ -796,6 +816,12 @@ describe("AuthModal", () => {
 
       expect(
         screen.queryByRole("button", { name: /continue with google/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /continue with microsoft/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /continue with apple/i }),
       ).not.toBeInTheDocument();
     });
 
@@ -819,6 +845,72 @@ describe("AuthModal", () => {
           screen.getByRole("button", { name: /continue with google/i }),
         ).toHaveTextContent(/continue with google/i);
       });
+    });
+  });
+
+  describe("Provider sign-in buttons", () => {
+    it("renders all three configured provider buttons", async () => {
+      const user = userEvent.setup();
+      setSignInAvailability({
+        google: "available",
+        microsoft: "available",
+        apple: "available",
+      });
+      await renderWithProviders(<ModalTrigger />);
+
+      await user.click(screen.getByRole("button", { name: /open modal/i }));
+      await waitForAuthModal();
+
+      expect(
+        screen.getByRole("button", { name: "Continue with Google" }),
+      ).toHaveTextContent("Continue with Google");
+      expect(
+        screen.getByRole("button", { name: "Continue with Microsoft" }),
+      ).toHaveTextContent("Continue with Microsoft");
+      expect(
+        screen.getByRole("button", { name: "Continue with Apple" }),
+      ).toHaveTextContent("Continue with Apple");
+    });
+
+    it("renders only Google when it is the sole configured provider", async () => {
+      const user = userEvent.setup();
+      setSignInAvailability({ google: "available" });
+      await renderWithProviders(<ModalTrigger />);
+
+      await user.click(screen.getByRole("button", { name: /open modal/i }));
+      await waitForAuthModal();
+
+      expect(
+        screen.getByRole("button", { name: "Continue with Google" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Continue with Microsoft" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Continue with Apple" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("starts Microsoft auth with M when focus is not in a field", async () => {
+      const mockMicrosoftStart = mock();
+      registerUseStartProviderAuthorizationForTests((provider) => ({
+        loading: false,
+        startAuthorization:
+          provider === "microsoft" ? mockMicrosoftStart : mock(),
+      }));
+      const user = userEvent.setup();
+      setSignInAvailability({
+        google: "available",
+        microsoft: "available",
+      });
+      await renderWithProviders(<ModalTrigger />);
+      await user.click(screen.getByRole("button", { name: /open modal/i }));
+      await waitForAuthModal();
+
+      screen.getByRole("dialog").focus();
+      await user.keyboard("m");
+
+      expect(mockMicrosoftStart).toHaveBeenCalled();
     });
   });
 

--- a/packages/web/src/components/AuthModal/AuthModal.tsx
+++ b/packages/web/src/components/AuthModal/AuthModal.tsx
@@ -8,15 +8,16 @@ import {
   useRef,
   useState,
 } from "react";
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
 import { consumeGoogleAuthNeedsConsentRetry } from "@web/auth/google/authorization/google-authorization.storage";
-import { useStartGoogleAuthorization } from "@web/auth/google/authorization/useStartGoogleAuthorization";
-import { useIsProviderAvailable } from "@web/auth/providers/useIsProviderAvailable";
+import { signInProviderForShortcutLetter } from "@web/auth/providers/sign-in-provider.util";
+import { useSignInProviders } from "@web/auth/providers/useSignInProviders";
 import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
 import {
   dismissErrorToast,
   SESSION_EXPIRED_TOAST_ID,
 } from "@web/common/utils/toast/error-toast.util";
-import { GoogleButton } from "@web/components/AuthModal/components/GoogleButton";
+import { SignInProviderButtons } from "@web/components/AuthModal/components/SignInProviderButtons";
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 import { useAppLockReason } from "@web/shortcuts/app-lock";
@@ -59,16 +60,14 @@ export const AuthModal: FC = () => {
   // signup that failed after Google-side consent but before Compass finished
   // linking would otherwise fail the exact same way on every retry, forever.
   const [needsConsentRetry] = useState(consumeGoogleAuthNeedsConsentRetry);
-  const googleAuth = useStartGoogleAuthorization({
-    intent: "signIn",
-    onStart: handleGoogleAuthStart,
-    prompt: needsConsentRetry ? "consent" : undefined,
-  });
-  const {
-    loading: isGoogleAuthLoading,
-    startGoogleAuthorization: startGoogleSignIn,
-  } = googleAuth;
-  const isGoogleAvailable = useIsProviderAvailable("google", "signIn");
+  const { available, isLoading, loadingKind, startSignIn } = useSignInProviders(
+    {
+      google: {
+        onStart: handleGoogleAuthStart,
+        prompt: needsConsentRetry ? "consent" : undefined,
+      },
+    },
+  );
   const isLoginView =
     currentView === "login" || currentView === "loginAfterReset";
   const search = useSearch({ from: "__root__" });
@@ -116,10 +115,13 @@ export const AuthModal: FC = () => {
     [currentView, setView],
   );
 
-  const handleGoogleSignIn = useCallback(() => {
-    void startGoogleSignIn();
-    closeModal();
-  }, [closeModal, startGoogleSignIn]);
+  const handleProviderSignIn = useCallback(
+    (kind: ProviderKind) => {
+      startSignIn(kind);
+      closeModal();
+    },
+    [closeModal, startSignIn],
+  );
 
   const navigateToForgotPassword = useCallback(() => {
     setView("forgotPassword");
@@ -142,9 +144,10 @@ export const AuthModal: FC = () => {
       if (event.metaKey || event.ctrlKey || event.altKey) return;
       if (isEditableKeyboardTarget(event)) return;
       const key = keyboardKey(event).toLowerCase();
-      if (key === "g" && isGoogleAvailable) {
+      const providerKind = signInProviderForShortcutLetter(key, available);
+      if (providerKind) {
         event.preventDefault();
-        handleGoogleSignIn();
+        handleProviderSignIn(providerKind);
         return;
       }
       if (key === "u" && isLoginView) {
@@ -161,9 +164,9 @@ export const AuthModal: FC = () => {
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
   }, [
+    available,
     currentView,
-    handleGoogleSignIn,
-    isGoogleAvailable,
+    handleProviderSignIn,
     isLoginView,
     isOpen,
     setView,
@@ -174,7 +177,8 @@ export const AuthModal: FC = () => {
     return null;
   }
 
-  const showGoogleAuth = currentView !== "resetPassword" && isGoogleAvailable;
+  const showProviderSignIn =
+    currentView !== "resetPassword" && available.length > 0;
   const showSubmitError =
     submitError !== null && (isLoginView || currentView === "signUp");
   const trimmedName = signUpName.trim();
@@ -255,19 +259,17 @@ export const AuthModal: FC = () => {
           </p>
         ) : null}
         {/* Google Sign In - at bottom */}
-        {showGoogleAuth ? (
+        {showProviderSignIn ? (
           <>
             <div className="flex items-center gap-3">
               <div className="h-px flex-1 bg-border" />
               <span className="text-sm text-text-muted">or</span>
               <div className="h-px flex-1 bg-border" />
             </div>
-            <GoogleButton
-              onClick={handleGoogleSignIn}
-              disabled={isGoogleAuthLoading}
-              label="Continue with Google"
-              shortcutKey="G"
-              style={{ width: "100%" }}
+            <SignInProviderButtons
+              available={available}
+              loadingKind={isLoading ? loadingKind : null}
+              onSignIn={handleProviderSignIn}
             />
           </>
         ) : null}

--- a/packages/web/src/components/AuthModal/components/AppleButton.tsx
+++ b/packages/web/src/components/AuthModal/components/AppleButton.tsx
@@ -1,0 +1,56 @@
+import classNames from "classnames";
+import type React from "react";
+import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
+
+const AppleLogo = ({ size = 18 }: { size?: number }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+  >
+    <path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
+  </svg>
+);
+
+export const AppleButton = ({
+  onClick,
+  disabled,
+  label = "Continue with Apple",
+  shortcutKey,
+  style,
+}: {
+  onClick: () => void;
+  disabled?: boolean;
+  label?: string;
+  shortcutKey?: string;
+  style?: React.CSSProperties;
+}) => {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={label}
+      className={classNames(
+        "inline-flex h-10 items-center justify-center gap-2.5 whitespace-nowrap rounded-full border border-[#1f1f1f] bg-[#000] px-3 font-medium text-[#fff] text-sm transition-[background-color,box-shadow,transform] duration-200",
+        disabled
+          ? "cursor-not-allowed opacity-60"
+          : "c-button-elevated cursor-pointer hover:bg-[#1a1a1a]",
+      )}
+      style={{
+        fontFamily:
+          "-apple-system, BlinkMacSystemFont, 'SF Pro Text', sans-serif",
+        ...style,
+      }}
+    >
+      <AppleLogo size={18} />
+      <span>{label}</span>
+      {shortcutKey ? (
+        <ShortcutHint className="shrink-0">{shortcutKey}</ShortcutHint>
+      ) : null}
+    </button>
+  );
+};

--- a/packages/web/src/components/AuthModal/components/MicrosoftButton.tsx
+++ b/packages/web/src/components/AuthModal/components/MicrosoftButton.tsx
@@ -1,0 +1,58 @@
+import classNames from "classnames";
+import type React from "react";
+import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
+
+const MicrosoftLogo = ({ size = 18 }: { size?: number }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 21 21"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+  >
+    <rect x="1" y="1" width="9" height="9" fill="#F25022" />
+    <rect x="11" y="1" width="9" height="9" fill="#7FBA00" />
+    <rect x="1" y="11" width="9" height="9" fill="#00A4EF" />
+    <rect x="11" y="11" width="9" height="9" fill="#FFB900" />
+  </svg>
+);
+
+export const MicrosoftButton = ({
+  onClick,
+  disabled,
+  label = "Continue with Microsoft",
+  shortcutKey,
+  style,
+}: {
+  onClick: () => void;
+  disabled?: boolean;
+  label?: string;
+  shortcutKey?: string;
+  style?: React.CSSProperties;
+}) => {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={label}
+      className={classNames(
+        "inline-flex h-10 items-center justify-center gap-2.5 whitespace-nowrap rounded-full border border-[#1f1f1f] bg-[#fff] px-3 font-medium text-[#1f1f1f] text-sm transition-[background-color,box-shadow,transform] duration-200",
+        disabled
+          ? "cursor-not-allowed opacity-60"
+          : "c-button-elevated cursor-pointer hover:bg-[#f8f8f8]",
+      )}
+      style={{
+        fontFamily: "'Segoe UI', sans-serif",
+        ...style,
+      }}
+    >
+      <MicrosoftLogo size={18} />
+      <span>{label}</span>
+      {shortcutKey ? (
+        <ShortcutHint className="shrink-0">{shortcutKey}</ShortcutHint>
+      ) : null}
+    </button>
+  );
+};

--- a/packages/web/src/components/AuthModal/components/SignInProviderButtons.test.tsx
+++ b/packages/web/src/components/AuthModal/components/SignInProviderButtons.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SignInProviderButtons } from "@web/components/AuthModal/components/SignInProviderButtons";
+import { describe, expect, it, mock } from "bun:test";
+
+describe("SignInProviderButtons", () => {
+  it("renders all three provider buttons with whole-string labels", () => {
+    render(
+      <SignInProviderButtons
+        available={["google", "microsoft", "apple"]}
+        loadingKind={null}
+        onSignIn={mock()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Continue with Google" }),
+    ).toHaveTextContent("Continue with Google");
+    expect(
+      screen.getByRole("button", { name: "Continue with Microsoft" }),
+    ).toHaveTextContent("Continue with Microsoft");
+    expect(
+      screen.getByRole("button", { name: "Continue with Apple" }),
+    ).toHaveTextContent("Continue with Apple");
+  });
+
+  it("renders welcome sublines for each provider", () => {
+    render(
+      <SignInProviderButtons
+        available={["google", "microsoft", "apple"]}
+        loadingKind={null}
+        onSignIn={mock()}
+        variant="welcome"
+      />,
+    );
+
+    expect(
+      screen.getByText("Signs you up and connects your Google Calendar."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Signs you up and connects your Outlook calendar."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("You'll pick your calendar next."),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onSignIn with the clicked provider kind", async () => {
+    const user = userEvent.setup();
+    const onSignIn = mock();
+    render(
+      <SignInProviderButtons
+        available={["google", "microsoft"]}
+        loadingKind={null}
+        onSignIn={onSignIn}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Continue with Microsoft" }),
+    );
+
+    expect(onSignIn).toHaveBeenCalledWith("microsoft");
+  });
+});

--- a/packages/web/src/components/AuthModal/components/SignInProviderButtons.tsx
+++ b/packages/web/src/components/AuthModal/components/SignInProviderButtons.tsx
@@ -1,0 +1,89 @@
+import { type CSSProperties, type FC } from "react";
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+import { SIGN_IN_WELCOME_SUBLINE } from "@web/auth/providers/provider-copy.util";
+import {
+  CONTINUE_WITH_LABEL,
+  SIGN_IN_SHORTCUT_KEY,
+} from "@web/auth/providers/sign-in-provider.util";
+import { AppleButton } from "@web/components/AuthModal/components/AppleButton";
+import { GoogleButton } from "@web/components/AuthModal/components/GoogleButton";
+import { MicrosoftButton } from "@web/components/AuthModal/components/MicrosoftButton";
+
+type SignInProviderButtonsProps = {
+  available: readonly ProviderKind[];
+  loadingKind: ProviderKind | null;
+  onSignIn: (kind: ProviderKind) => void;
+  variant?: "auth" | "welcome";
+  fullWidth?: boolean;
+};
+
+const SIGN_IN_BUTTONS = {
+  google: GoogleButton,
+  microsoft: MicrosoftButton,
+  apple: AppleButton,
+} as const;
+
+const renderProviderButton = (
+  kind: ProviderKind,
+  props: Omit<SignInProviderButtonsProps, "available" | "variant"> & {
+    style?: CSSProperties;
+  },
+) => {
+  const { loadingKind, onSignIn, style } = props;
+  const Button = SIGN_IN_BUTTONS[kind];
+  return (
+    <Button
+      key={kind}
+      disabled={loadingKind != null}
+      label={CONTINUE_WITH_LABEL[kind]}
+      onClick={() => onSignIn(kind)}
+      shortcutKey={SIGN_IN_SHORTCUT_KEY[kind]}
+      style={style}
+    />
+  );
+};
+
+export const SignInProviderButtons: FC<SignInProviderButtonsProps> = ({
+  available,
+  loadingKind,
+  onSignIn,
+  variant = "auth",
+  fullWidth = true,
+}) => {
+  if (available.length === 0) {
+    return null;
+  }
+
+  const buttonStyle = fullWidth ? { width: "100%" } : undefined;
+
+  if (variant === "welcome") {
+    return (
+      <>
+        {available.map((kind) => (
+          <div key={kind} className="flex w-full flex-col items-center gap-3">
+            {renderProviderButton(kind, {
+              loadingKind,
+              onSignIn,
+              style: buttonStyle,
+            })}
+            <p className="text-center text-text-muted text-xs">
+              {SIGN_IN_WELCOME_SUBLINE[kind]}
+            </p>
+          </div>
+        ))}
+      </>
+    );
+  }
+
+  return (
+    <>
+      {available.map((kind) =>
+        renderProviderButton(kind, {
+          loadingKind,
+          onSignIn,
+          style: buttonStyle,
+        }),
+      )}
+    </>
+  );
+};

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -13,8 +13,12 @@ import {
   resetUseStartGoogleAuthorizationForTests,
 } from "@web/auth/google/authorization/useStartGoogleAuthorization";
 import {
-  resetGoogleAvailabilityForTests,
-  setGoogleAvailabilityForTests,
+  registerUseStartProviderAuthorizationForTests,
+  resetUseStartProviderAuthorizationForTests,
+} from "@web/auth/providers/authorization/useStartProviderAuthorization";
+import {
+  resetProviderAvailabilityForTests,
+  setProviderAvailabilityForTests,
 } from "@web/auth/providers/useIsProviderAvailable";
 import {
   afterAll,
@@ -79,6 +83,20 @@ const goToChooseScreen = async (user: ReturnType<typeof userEvent.setup>) => {
     screen.getByRole("button", { name: "Explore without an account" }),
   ).toBeTruthy();
 };
+
+function setSignInAvailability(options: {
+  google?: "available" | "unavailable";
+  microsoft?: "available" | "unavailable";
+  apple?: "available" | "unavailable";
+}) {
+  resetProviderAvailabilityForTests();
+  setProviderAvailabilityForTests("google", options.google ?? "unavailable");
+  setProviderAvailabilityForTests(
+    "microsoft",
+    options.microsoft ?? "unavailable",
+  );
+  setProviderAvailabilityForTests("apple", options.apple ?? "unavailable");
+}
 
 describe("WelcomeModal", () => {
   beforeEach(() => {
@@ -501,27 +519,40 @@ describe("WelcomeModal", () => {
     ).not.toHaveFocus();
   });
 
-  describe("with Google available", () => {
+  describe("with sign-in providers configured", () => {
     const startGoogleAuthorization = mock();
+    const startMicrosoftAuthorization = mock();
+    const startAppleAuthorization = mock();
 
     beforeEach(() => {
       startGoogleAuthorization.mockClear();
+      startMicrosoftAuthorization.mockClear();
+      startAppleAuthorization.mockClear();
       registerUseStartGoogleAuthorizationForTests(() => ({
         loading: false,
         startGoogleAuthorization,
       }));
-      resetGoogleAvailabilityForTests();
-      setGoogleAvailabilityForTests("available");
+      registerUseStartProviderAuthorizationForTests((provider) => ({
+        loading: false,
+        startAuthorization:
+          provider === "microsoft"
+            ? startMicrosoftAuthorization
+            : provider === "apple"
+              ? startAppleAuthorization
+              : mock(),
+      }));
+      setSignInAvailability({ google: "available" });
     });
 
     afterEach(() => {
-      // Unmount before restoring the seams. resetGoogleAvailabilityForTests
+      // Unmount before restoring the seams. resetProviderAvailabilityForTests
       // emits synchronously, so a still-mounted modal would re-render against
       // the real hook after the mock had already rendered without one, and
       // React would throw "Should have a queue" on the hook-count change.
       cleanup();
       resetUseStartGoogleAuthorizationForTests();
-      resetGoogleAvailabilityForTests();
+      resetUseStartProviderAuthorizationForTests();
+      resetProviderAvailabilityForTests();
     });
 
     it("leads with the Google round trip that also connects the calendar", async () => {
@@ -570,6 +601,79 @@ describe("WelcomeModal", () => {
       await user.keyboard("g");
 
       expect(startGoogleAuthorization).toHaveBeenCalled();
+    });
+
+    it("renders all three configured provider buttons with whole-string labels", async () => {
+      setSignInAvailability({
+        google: "available",
+        microsoft: "available",
+        apple: "available",
+      });
+      const user = userEvent.setup();
+      render(<WelcomeModal />);
+      await goToChooseScreen(user);
+
+      expect(
+        screen.getByRole("button", { name: "Continue with Google" }),
+      ).toHaveTextContent("Continue with Google");
+      expect(
+        screen.getByRole("button", { name: "Continue with Microsoft" }),
+      ).toHaveTextContent("Continue with Microsoft");
+      expect(
+        screen.getByRole("button", { name: "Continue with Apple" }),
+      ).toHaveTextContent("Continue with Apple");
+      expect(
+        screen.getByText("Signs you up and connects your Google Calendar."),
+      ).toBeTruthy();
+      expect(
+        screen.getByText("Signs you up and connects your Outlook calendar."),
+      ).toBeTruthy();
+      expect(screen.getByText("You'll pick your calendar next.")).toBeTruthy();
+    });
+
+    it("renders only Google when it is the sole configured provider", async () => {
+      const user = userEvent.setup();
+      render(<WelcomeModal />);
+      await goToChooseScreen(user);
+
+      expect(
+        screen.getByRole("button", { name: "Continue with Google" }),
+      ).toBeTruthy();
+      expect(
+        screen.queryByRole("button", { name: "Continue with Microsoft" }),
+      ).toBeNull();
+      expect(
+        screen.queryByRole("button", { name: "Continue with Apple" }),
+      ).toBeNull();
+    });
+
+    it("shows Sign up without email when no providers are configured", async () => {
+      setSignInAvailability({});
+      const user = userEvent.setup();
+      render(<WelcomeModal />);
+      await goToChooseScreen(user);
+
+      expect(
+        screen.queryByRole("button", { name: "Continue with Google" }),
+      ).toBeNull();
+      expect(screen.getByRole("button", { name: "Sign up" })).toBeTruthy();
+      expect(
+        screen.queryByRole("button", { name: "Sign up with email" }),
+      ).toBeNull();
+    });
+
+    it("starts Microsoft auth with the M shortcut", async () => {
+      setSignInAvailability({
+        google: "available",
+        microsoft: "available",
+      });
+      const user = userEvent.setup();
+      render(<WelcomeModal />);
+      await goToChooseScreen(user);
+
+      await user.keyboard("m");
+
+      expect(startMicrosoftAuthorization).toHaveBeenCalled();
     });
   });
 });

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -1,12 +1,13 @@
 import classNames from "classnames";
 import { useContext, useEffect, useId, useRef, useState } from "react";
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
 import { SessionContext } from "@web/auth/compass/session/session.context";
-import { useStartGoogleAuthorization } from "@web/auth/google/authorization/useStartGoogleAuthorization";
 import { track } from "@web/auth/posthog/track";
-import { useIsProviderAvailable } from "@web/auth/providers/useIsProviderAvailable";
+import { signInProviderForShortcutLetter } from "@web/auth/providers/sign-in-provider.util";
+import { useSignInProviders } from "@web/auth/providers/useSignInProviders";
 import { MODAL_DISMISS_MS } from "@web/common/constants/motion.constants";
 import { useDismissTransition } from "@web/common/hooks/useDismissTransition";
-import { GoogleButton } from "@web/components/AuthModal/components/GoogleButton";
+import { SignInProviderButtons } from "@web/components/AuthModal/components/SignInProviderButtons";
 import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
 import { hasPlayDeepLink } from "@web/components/ShortcutShowcase/play-link";
@@ -54,9 +55,9 @@ function WelcomeSteps({ step }: { step: WelcomeStep }) {
 export function WelcomeModal() {
   const { authenticated } = useContext(SessionContext);
   const { openModal, isOpen: isAuthModalOpen } = useAuthModal();
-  const isGoogleAvailable = useIsProviderAvailable("google", "signIn");
-  const { loading: isGoogleAuthLoading, startGoogleAuthorization } =
-    useStartGoogleAuthorization({ intent: "signIn" });
+  const { available, isLoading, loadingKind, startSignIn } =
+    useSignInProviders();
+  const hasSignInProviders = available.length > 0;
   // A ?play= deep link goes straight to the practice game. This initializer
   // runs before ShowcasePlayLink's consume effect can mark welcome seen, so
   // the param itself has to keep this modal closed.
@@ -77,7 +78,7 @@ export function WelcomeModal() {
   // cannot start the practice on top of a login that has not committed yet.
   const [hidingForAuth, setHidingForAuth] = useState(false);
   const hidingForAuthRef = useRef(false);
-  const googleHandoffRef = useRef(false);
+  const providerHandoffRef = useRef(false);
   // Each screen has one primary button, and Enter is its native activation.
   // On the last screen that is email signup rather than Google: Enter on an
   // OAuth redirect would fling a first-time visitor off-site.
@@ -101,9 +102,9 @@ export function WelcomeModal() {
   }, [isAuthModalOpen]);
 
   useEffect(() => {
-    if (isGoogleAuthLoading) return;
-    googleHandoffRef.current = false;
-  }, [isGoogleAuthLoading]);
+    if (isLoading) return;
+    providerHandoffRef.current = false;
+  }, [isLoading]);
 
   const shownRef = useRef(false);
   useEffect(() => {
@@ -139,7 +140,7 @@ export function WelcomeModal() {
   // not one of them: a login during that fade must still cancel the pending
   // practice start, so only the step and explore actions check it.
   const isHandingOff = () =>
-    hidingForAuthRef.current || googleHandoffRef.current || isGoogleAuthLoading;
+    hidingForAuthRef.current || providerHandoffRef.current || isLoading;
 
   const advance = () => {
     if (closing || isHandingOff()) return;
@@ -191,21 +192,18 @@ export function WelcomeModal() {
     openModal(cta === "log_in" ? "login" : "signUp");
   };
 
-  // The shortest path to the thing that makes Compass worth keeping: one
-  // round trip that signs the user up and grants calendar access together,
-  // because the Google scopes Compass asks for include the calendar.
-  const handOffToGoogle = () => {
-    // Stay mounted: Google is a redirect, and a GIS error must not hide
-    // welcome for the rest of the session. Ignore Explore while it loads.
+  const handOffToProvider = (kind: ProviderKind) => {
+    // Stay mounted: OAuth is a redirect, and a provider-side error must not
+    // hide welcome for the rest of the session. Ignore Explore while it loads.
     skipFocusRestoreRef.current = true;
     startShowcaseAfterDismissRef.current = false;
-    googleHandoffRef.current = true;
+    providerHandoffRef.current = true;
     cancelDismiss();
     markWelcomeSeen();
     shortcutShowcaseActions.deferUntilSignup();
-    track("welcome_modal_dismissed", { cta: "sign_up_google" });
-    track("signup_started", { source: "welcome_modal_google" });
-    void startGoogleAuthorization();
+    track("welcome_modal_dismissed", { cta: `sign_up_${kind}` });
+    track("signup_started", { source: `welcome_modal_${kind}` });
+    startSignIn(kind);
   };
 
   const handleShortcutKey = (e: React.KeyboardEvent) => {
@@ -224,9 +222,10 @@ export function WelcomeModal() {
       return;
     }
     if (step !== 3) return;
-    if (key === "g" && isGoogleAvailable) {
+    const providerKind = signInProviderForShortcutLetter(key, available);
+    if (providerKind) {
       e.preventDefault();
-      handOffToGoogle();
+      handOffToProvider(providerKind);
     } else if (key === "u") {
       e.preventDefault();
       handOffToAuth("sign_up");
@@ -368,27 +367,21 @@ export function WelcomeModal() {
                 calendar access at once, leads; everything else is a fallback
                 from it. */}
             <div className="flex w-full flex-col items-center gap-3">
-              {isGoogleAvailable && (
-                <>
-                  <GoogleButton
-                    onClick={handOffToGoogle}
-                    disabled={isGoogleAuthLoading}
-                    label="Continue with Google"
-                    shortcutKey="G"
-                    style={{ width: "100%" }}
-                  />
-                  <p className="text-center text-text-muted text-xs">
-                    Signs you up and connects your Google Calendar.
-                  </p>
-                </>
-              )}
+              {hasSignInProviders ? (
+                <SignInProviderButtons
+                  available={available}
+                  loadingKind={isLoading ? loadingKind : null}
+                  onSignIn={handOffToProvider}
+                  variant="welcome"
+                />
+              ) : null}
               <button
                 type="button"
                 ref={primaryRef}
                 onClick={() => handOffToAuth("sign_up")}
                 className={PRIMARY_CTA_CLASS}
               >
-                {isGoogleAvailable ? "Sign up with email" : "Sign up"}
+                {hasSignInProviders ? "Sign up with email" : "Sign up"}
                 <ShortcutHint className="ml-2">U</ShortcutHint>
               </button>
               <button


### PR DESCRIPTION
Fixes #3269

## What and why

Providers I WP-05 adds sign-in buttons for every provider with `providers.<kind>.signIn` enabled, in Google → Microsoft → Apple order, with shared `SignInProviderButtons` used by both `AuthModal` and `WelcomeModal`. Keyboard shortcuts `g`, `m`, and `a` stay in lockstep via `signInProviderForShortcutLetter`. Welcome step 3 shows provider-aware sublines from `SIGN_IN_WELCOME_SUBLINE`. Google sign-in behavior stays on `useStartGoogleAuthorization` (consent retry unchanged).

Merged `main` after #3428: Continue with Microsoft starts OAuth when sign-in is configured; the welcome Connect Microsoft path remains when only connect is available. `e2e/auth` is assigned to e2e shard 2.

Also clamps late-evening shortcut drafts to the last grid slot of the selected day so `minute(60)` at 23:xx does not create the event on the next column.

## Verify

```
VERDICT: PASS
```

Checks run: `test:web`, `type-check`, `lint`, `knip`, `test:a11y`, `test:e2e` (via `bun run verify --strict`).