### PR TITLE
test(e2e): microsoft connect, consent banner, and attendee coverage

### DIFF
--- a/e2e/accessibility/connect-onboarding-a11y.spec.ts
+++ b/e2e/accessibility/connect-onboarding-a11y.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { prepareSignedInMicrosoftPage } from "../attendees/attendee-harness";
 import { prepareSignedInBookingSettingsPage } from "../booking/booking-harness";
 import { expectNoAxeViolations } from "../utils/axe-assertion";
 
@@ -49,5 +50,26 @@ test("the add-account chooser with Google and Microsoft has no automatically det
   await expectNoAxeViolations(page, {
     checkpoint: "settings add-account chooser",
     include: "[role='menu']",
+  });
+});
+
+test("the Microsoft admin-consent banner has no automatically detectable accessibility violations", async ({
+  page,
+}) => {
+  await prepareSignedInMicrosoftPage(page, {
+    events: [],
+    stateReason: "consentRequired",
+  });
+
+  const banner = page
+    .getByRole("alert")
+    .getByText(
+      "Your organization's admin has to approve Compass before this account can connect.",
+    );
+  await expect(banner).toBeVisible();
+
+  await expectNoAxeViolations(page, {
+    checkpoint: "microsoft consent required banner",
+    include: "[role='alert']",
   });
 });

--- a/e2e/attendees/attendee-editor.spec.ts
+++ b/e2e/attendees/attendee-editor.spec.ts
@@ -5,8 +5,11 @@ import {
   clickSave,
   dispatchClick,
   getGuestCombobox,
+  MICROSOFT_ACCOUNT_EMAIL,
+  MICROSOFT_CALENDAR_ID,
   openEventForm,
   prepareSignedInGooglePage,
+  prepareSignedInMicrosoftPage,
 } from "./attendee-harness";
 
 // Attendee editor end-to-end (WP-04/WP-09): adding guests on an organized,
@@ -195,4 +198,57 @@ test("an invalid email never becomes a chip", async ({ page }) => {
     page.getByRole("button", { name: "Remove not-an-email" }),
   ).toHaveCount(0);
   expect(captured.replaceRequests).toHaveLength(0);
+});
+
+test("adding a guest on a Microsoft calendar puts the replaced guest set on the wire", async ({
+  page,
+}) => {
+  const captured = await prepareSignedInMicrosoftPage(page, {
+    events: [
+      buildEventFixture({
+        id: "evt-ms-guests-1",
+        title: "Planning Review",
+        calendarId: MICROSOFT_CALENDAR_ID,
+        attendees: [
+          {
+            email: MICROSOFT_ACCOUNT_EMAIL,
+            displayName: null,
+            responseStatus: "accepted",
+          },
+          {
+            email: "bob@example.com",
+            displayName: "Bob B",
+            responseStatus: "accepted",
+          },
+        ],
+      }),
+    ],
+  });
+
+  await openEventForm(page, "Planning Review");
+
+  await expect(page.getByText("2 guests (2 yes, 0 awaiting)")).toBeVisible();
+
+  const combobox = getGuestCombobox(page);
+  await combobox.fill("dana@example.com");
+  await page.keyboard.press("Enter");
+  await expect(
+    page.getByRole("button", { name: "Remove dana@example.com" }),
+  ).toBeVisible();
+
+  await clickSave(page);
+  await expect(page.getByText("Send invitation emails?")).toBeVisible();
+  await dispatchClick(page.getByRole("button", { name: "Send", exact: true }));
+
+  await expect.poll(() => captured.replaceRequests.length).toBe(1);
+  const { eventId, body } = captured.replaceRequests[0];
+  expect(eventId).toBe("evt-ms-guests-1");
+  const content = body.content as Record<string, unknown>;
+  expect(content.attendees).toEqual([
+    { email: MICROSOFT_ACCOUNT_EMAIL, displayName: null },
+    { email: "bob@example.com", displayName: "Bob B" },
+    { email: "dana@example.com", displayName: null },
+  ]);
+  expect(body.invitation).toBe("all");
+  await expect(page.getByRole("form").getByPlaceholder("Title")).toBeHidden();
 });

--- a/e2e/attendees/attendee-harness.ts
+++ b/e2e/attendees/attendee-harness.ts
@@ -1,7 +1,8 @@
 import { expect, type Page } from "@playwright/test";
 
 /**
- * Signed-in Google-calendar harness for the attendee e2e specs.
+ * Signed-in calendar harness for the attendee e2e specs (Google by default,
+ * Microsoft via `prepareSignedInMicrosoftPage`).
  *
  * The Playwright web server runs the anonymous local-mode app (no backend on
  * port 3000), so these specs simulate the signed-in state the same way
@@ -14,8 +15,11 @@ import { expect, type Page } from "@playwright/test";
  */
 
 export const ACCOUNT_EMAIL = "user@example.com";
+export const MICROSOFT_ACCOUNT_EMAIL = "user@outlook.com";
 /** ObjectId-shaped (CalendarIdSchema) id for the stubbed Google calendar. */
 export const GOOGLE_CALENDAR_ID = "64b7f0a1c2d3e4f5a6b7c8d9";
+/** ObjectId-shaped id for the stubbed Microsoft calendar. */
+export const MICROSOFT_CALENDAR_ID = "64b7f0a1c2d3e4f5a6b7c8da";
 
 const googleCalendar = {
   id: GOOGLE_CALENDAR_ID,
@@ -41,18 +45,49 @@ const googleCalendar = {
   accountEmail: ACCOUNT_EMAIL,
 };
 
+const microsoftCalendar = {
+  id: MICROSOFT_CALENDAR_ID,
+  name: "Calendar",
+  description: "",
+  timeZone: "Etc/UTC",
+  foregroundColor: "#ffffff",
+  backgroundColor: "#0078D4",
+  provider: "microsoft",
+  access: "owner",
+  capabilities: {
+    canReadAvailability: true,
+    canReadDetails: true,
+    canWrite: true,
+    canManage: true,
+    canWatchEvents: true,
+    canInviteAttendees: true,
+    conferenceKinds: ["teams"],
+  },
+  isPrimary: true,
+  isVisible: true,
+  isActive: true,
+  accountEmail: MICROSOFT_ACCOUNT_EMAIL,
+};
+
 /** A GoogleSyncConnectionSummary shape for the stubbed GET /api/user/metadata. */
 const connectionSummary = (
   accountEmail: string,
   canSuggestContacts: boolean,
+  provider: "google" | "microsoft" = "google",
+  stateReason: string | null = null,
 ) => ({
-  id: "e2e-connection-1",
-  state: "healthy",
-  stateReason: null,
+  id:
+    provider === "microsoft" ? "e2e-microsoft-connection" : "e2e-connection-1",
+  provider,
+  state: stateReason === "consentRequired" ? "actionRequired" : "healthy",
+  stateReason,
   lastSyncedAt: null,
   lastHealthyAt: null,
   accountEmail,
-  connectionState: "HEALTHY",
+  connectionState:
+    stateReason === "consentRequired"
+      ? ("RECONNECT_REQUIRED" as const)
+      : ("HEALTHY" as const),
   canSuggestContacts,
 });
 
@@ -89,6 +124,7 @@ export interface EventFixture {
 export const buildEventFixture = (options: {
   id: string;
   title: string;
+  calendarId?: string;
   attendees?: AttendeeFixture[];
   organizer?: { email: string; displayName: string | null } | null;
   recurrence?: EventFixture["recurrence"];
@@ -96,10 +132,15 @@ export const buildEventFixture = (options: {
   const start = new Date();
   start.setMinutes(0, 0, 0);
   const end = new Date(start.getTime() + 60 * 60 * 1000);
+  const calendarId = options.calendarId ?? GOOGLE_CALENDAR_ID;
+  const defaultOrganizerEmail =
+    calendarId === MICROSOFT_CALENDAR_ID
+      ? MICROSOFT_ACCOUNT_EMAIL
+      : ACCOUNT_EMAIL;
 
   return {
     id: options.id,
-    calendarId: GOOGLE_CALENDAR_ID,
+    calendarId,
     content: {
       kind: "details",
       title: options.title,
@@ -107,7 +148,7 @@ export const buildEventFixture = (options: {
       location: null,
       organizer:
         options.organizer === undefined
-          ? { email: ACCOUNT_EMAIL, displayName: null }
+          ? { email: defaultOrganizerEmail, displayName: null }
           : options.organizer,
       attendees: options.attendees ?? [],
     },
@@ -142,6 +183,9 @@ export interface SignedInPageOptions {
    * field queries the stubbed suggestions endpoint.
    */
   canSuggestContacts?: boolean;
+  provider?: "google" | "microsoft";
+  /** Sync `stateReason` on the stubbed connection (e.g. consentRequired). */
+  stateReason?: string | null;
 }
 
 export const prepareSignedInGooglePage = async (
@@ -154,6 +198,24 @@ export const prepareSignedInGooglePage = async (
     suggestionQueries: [],
   };
   const suggestions = options.suggestions ?? [];
+  const provider = options.provider ?? "google";
+  const accountEmail =
+    provider === "microsoft" ? MICROSOFT_ACCOUNT_EMAIL : ACCOUNT_EMAIL;
+  const calendar =
+    provider === "microsoft" ? microsoftCalendar : googleCalendar;
+  const summary = connectionSummary(
+    accountEmail,
+    Boolean(options.canSuggestContacts),
+    provider,
+    options.stateReason ?? null,
+  );
+  const metadata = {
+    connections: [summary],
+    google: {
+      connectionState: summary.connectionState,
+      connections: [summary],
+    },
+  };
 
   await page.addInitScript((accountEmail) => {
     (
@@ -166,7 +228,8 @@ export const prepareSignedInGooglePage = async (
       "compass.auth",
       JSON.stringify({ hasAuthenticated: true, lastKnownEmail: accountEmail }),
     );
-  }, ACCOUNT_EMAIL);
+    localStorage.setItem("compass.onboarding.has-seen-welcome", "true");
+  }, accountEmail);
 
   const json = (body: unknown) => ({
     status: 200,
@@ -180,7 +243,7 @@ export const prepareSignedInGooglePage = async (
     const path = url.pathname;
 
     if (path.endsWith("/api/calendars")) {
-      return route.fulfill(json({ calendars: [googleCalendar] }));
+      return route.fulfill(json({ calendars: [calendar] }));
     }
 
     if (path.endsWith("/api/event") && request.method() === "GET") {
@@ -238,7 +301,7 @@ export const prepareSignedInGooglePage = async (
       );
       if (stored && typeof body.responseStatus === "string") {
         stored.content.attendees = stored.content.attendees.map((entry) =>
-          entry.email.toLowerCase() === ACCOUNT_EMAIL
+          entry.email.toLowerCase() === accountEmail.toLowerCase()
             ? {
                 ...entry,
                 responseStatus:
@@ -261,20 +324,23 @@ export const prepareSignedInGooglePage = async (
       // sync refresh, periodic invalidation), and each response overwrites
       // the zustand store — a one-time bridge injection before this route
       // even existed would get clobbered back to false by the next fetch.
-      return route.fulfill(
-        json({
-          google: {
-            connectionState: "HEALTHY",
-            connections: options.canSuggestContacts
-              ? [connectionSummary(ACCOUNT_EMAIL, true)]
-              : [],
-          },
-        }),
-      );
+      return route.fulfill(json(metadata));
     }
 
     if (path.endsWith("/api/config")) {
-      return route.fulfill(json({ google: { isConfigured: true } }));
+      return route.fulfill(
+        json({
+          google: { isConfigured: true },
+          providers: {
+            google: { signIn: true, connect: true },
+            microsoft: {
+              signIn: false,
+              connect: provider === "microsoft",
+            },
+            apple: { signIn: false, connect: false },
+          },
+        }),
+      );
     }
 
     return route.fulfill(json({}));
@@ -312,7 +378,11 @@ export const prepareSignedInGooglePage = async (
     ).__COMPASS_E2E_HOOKS__?.setAuthenticated(true);
   });
 
-  if (options.canSuggestContacts) {
+  if (
+    options.canSuggestContacts ||
+    options.stateReason ||
+    provider === "microsoft"
+  ) {
     // The stubbed GET /api/user/metadata above already answers with the
     // capability set on every fetch (including refetches), so the initial
     // paint only needs a nudge: force one metadata refetch through the
@@ -325,28 +395,26 @@ export const prepareSignedInGooglePage = async (
       ).__COMPASS_E2E_STORE__;
       return Boolean(bridge?.userMetadata);
     });
-    await page.evaluate(
-      (metadata) => {
-        const bridge = (
-          window as Window & {
-            __COMPASS_E2E_STORE__?: {
-              userMetadata?: { set: (metadata: unknown) => void };
-            };
-          }
-        ).__COMPASS_E2E_STORE__;
-        bridge?.userMetadata?.set(metadata);
-      },
-      {
-        google: {
-          connectionState: "HEALTHY",
-          connections: [connectionSummary(ACCOUNT_EMAIL, true)],
-        },
-      },
-    );
+    await page.evaluate((nextMetadata) => {
+      const bridge = (
+        window as Window & {
+          __COMPASS_E2E_STORE__?: {
+            userMetadata?: { set: (metadata: unknown) => void };
+          };
+        }
+      ).__COMPASS_E2E_STORE__;
+      bridge?.userMetadata?.set(nextMetadata);
+    }, metadata);
   }
 
   return captured;
 };
+
+export const prepareSignedInMicrosoftPage = (
+  page: Page,
+  options: SignedInPageOptions,
+): Promise<CapturedApiRequests> =>
+  prepareSignedInGooglePage(page, { ...options, provider: "microsoft" });
 
 /**
  * Dispatches a real DOM click instead of Playwright's `.click()`. Buttons

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -16,6 +16,27 @@ export const HOST_ACCOUNT_EMAIL = "host@example.com";
 export const APPLE_ACCOUNT_EMAIL = "host@icloud.com";
 export const MICROSOFT_ACCOUNT_EMAIL = "host@outlook.com";
 
+/** Stub SyncConnectionSummary for a Microsoft account. */
+export const microsoftConnectionSummary = (overrides?: {
+  stateReason?: string | null;
+  connectionState?:
+    | "NOT_CONNECTED"
+    | "RECONNECT_REQUIRED"
+    | "IMPORTING"
+    | "HEALTHY"
+    | "ATTENTION";
+}) => ({
+  id: "e2e-microsoft-connection",
+  provider: "microsoft" as const,
+  state: "healthy",
+  stateReason: overrides?.stateReason ?? null,
+  lastSyncedAt: null,
+  lastHealthyAt: null,
+  accountEmail: MICROSOFT_ACCOUNT_EMAIL,
+  connectionState: overrides?.connectionState ?? ("HEALTHY" as const),
+  canSuggestContacts: false,
+});
+
 /** Stub calendar list entry for an Apple booking destination. */
 export const appleBookingCalendar = {
   id: APPLE_BOOKING_CALENDAR_ID,

--- a/e2e/calendars/calendar-experience.spec.ts
+++ b/e2e/calendars/calendar-experience.spec.ts
@@ -27,12 +27,15 @@ const objectId = (seed: string) => seed.repeat(24);
 const CALENDAR_A_ID = objectId("a");
 const CALENDAR_B_ID = objectId("b");
 const CALENDAR_LOCAL_ID = objectId("c");
+const CALENDAR_MS_ID = objectId("d");
 const EVENT_A_ID = objectId("1");
 const EVENT_B_ID = objectId("2");
 
 const CALENDAR_A_NAME = "Acme Work";
 const CALENDAR_B_NAME = "Design Team";
 const LOCAL_CALENDAR_NAME = "Local";
+const CALENDAR_MS_NAME = "Focus";
+const MICROSOFT_ACCOUNT_EMAIL = "user@outlook.com";
 
 const EVENT_A_TITLE = "Team sync";
 const EVENT_B_TITLE = "Reader event";
@@ -65,10 +68,11 @@ function calendar(overrides: {
   name: string;
   timeZone: string | null;
   backgroundColor: string;
-  provider: "local" | "google";
+  provider: "local" | "google" | "microsoft";
   access: "owner" | "reader";
   isPrimary: boolean;
   isVisible: boolean;
+  accountEmail?: string;
 }) {
   const base = CAPABILITIES[overrides.access];
   return {
@@ -78,9 +82,13 @@ function calendar(overrides: {
     capabilities: {
       ...base,
       conferenceKinds:
-        overrides.provider === "google" && overrides.access === "owner"
-          ? ["meet"]
-          : [],
+        overrides.access !== "owner"
+          ? []
+          : overrides.provider === "google"
+            ? ["meet"]
+            : overrides.provider === "microsoft"
+              ? ["teams"]
+              : [],
     },
     isActive: true,
   };
@@ -149,7 +157,37 @@ const DEFAULT_EVENTS: FixtureEvent[] = [
   buildEvent(EVENT_B_ID, CALENDAR_B_ID, EVENT_B_TITLE, 13),
 ];
 
-function buildCalendars() {
+type FixtureCalendar = ReturnType<typeof calendar>;
+
+function microsoftCalendar(): FixtureCalendar {
+  return calendar({
+    id: CALENDAR_MS_ID,
+    name: CALENDAR_MS_NAME,
+    timeZone: TIME_ZONE,
+    backgroundColor: "#0078D4",
+    provider: "microsoft",
+    access: "owner",
+    isPrimary: true,
+    isVisible: true,
+    accountEmail: MICROSOFT_ACCOUNT_EMAIL,
+  });
+}
+
+function microsoftConnectionSummary() {
+  return {
+    id: "e2e-microsoft-connection",
+    provider: "microsoft" as const,
+    state: "healthy",
+    stateReason: null,
+    lastSyncedAt: null,
+    lastHealthyAt: null,
+    accountEmail: MICROSOFT_ACCOUNT_EMAIL,
+    connectionState: "HEALTHY" as const,
+    canSuggestContacts: false,
+  };
+}
+
+function buildCalendars(extra: FixtureCalendar[] = []) {
   // Server isVisible is ignored by the web (S39 A2 overlays localStorage).
   return [
     calendar({
@@ -182,6 +220,7 @@ function buildCalendars() {
       isPrimary: false,
       isVisible: true,
     }),
+    ...extra,
   ];
 }
 
@@ -206,10 +245,24 @@ type CompassE2EWindow = Window & {
 async function setupCalendarExperiencePage(
   page: Page,
   events: FixtureEvent[] = DEFAULT_EVENTS,
+  options: {
+    extraCalendars?: FixtureCalendar[];
+    metadata?: Record<string, unknown>;
+    microsoftConnect?: boolean;
+  } = {},
 ): Promise<CalendarExperienceHarness> {
   const harness: CalendarExperienceHarness = {
     mutationRequests: [],
   };
+  const extraCalendars = options.extraCalendars ?? [];
+  const hasMicrosoft = extraCalendars.some(
+    (entry) => entry.provider === "microsoft",
+  );
+  const metadata = options.metadata ?? {
+    connections: [],
+    google: { connectionState: "HEALTHY" },
+  };
+  const microsoftConnect = Boolean(options.microsoftConnect || hasMicrosoft);
 
   await page.addInitScript(() => {
     (window as CompassE2EWindow).__COMPASS_E2E_TEST__ = true;
@@ -252,16 +305,13 @@ async function setupCalendarExperiencePage(
       });
     }
     if (pathname.endsWith("/api/user/metadata")) {
-      return json({
-        connections: [],
-        google: { connectionState: "HEALTHY" },
-      });
+      return json(metadata);
     }
     if (pathname.endsWith("/api/config")) {
       return json({
         providers: {
           google: { signIn: true, connect: true },
-          microsoft: { signIn: false, connect: false },
+          microsoft: { signIn: false, connect: microsoftConnect },
           apple: { signIn: false, connect: false },
         },
       });
@@ -270,7 +320,7 @@ async function setupCalendarExperiencePage(
       return json({ busyPeriods: [] });
     }
     if (pathname.endsWith("/api/calendars") && method === "GET") {
-      return json({ calendars: buildCalendars() });
+      return json({ calendars: buildCalendars(extraCalendars) });
     }
     if (pathname.endsWith("/api/event") && method === "GET") {
       return json({ events });
@@ -554,4 +604,36 @@ test("a read-only event's context menu offers view and duplicate but not delete"
   await expect(menu.getByRole("menuitem", { name: "View" })).toBeVisible();
   await expect(menu.getByRole("menuitem", { name: "Duplicate" })).toBeVisible();
   await expect(menu.getByRole("menuitem", { name: "Delete" })).toHaveCount(0);
+});
+
+test("sidebar lists a Microsoft calendar under its account heading", async ({
+  page,
+}) => {
+  const summary = microsoftConnectionSummary();
+  await setupCalendarExperiencePage(page, DEFAULT_EVENTS, {
+    extraCalendars: [microsoftCalendar()],
+    metadata: {
+      connections: [summary],
+      google: { connectionState: "HEALTHY", connections: [summary] },
+    },
+  });
+  await ensureSidebarOpen(page);
+
+  const microsoftSection = page.getByRole("region", {
+    name: `Calendars for ${MICROSOFT_ACCOUNT_EMAIL}`,
+  });
+  await expect(
+    microsoftSection.getByRole("heading", { name: MICROSOFT_ACCOUNT_EMAIL }),
+  ).toBeVisible();
+  await expect(
+    microsoftSection.getByText("primary", { exact: true }),
+  ).toBeVisible();
+  await expect(
+    microsoftSection.getByText(CALENDAR_MS_NAME, { exact: true }),
+  ).toHaveCount(0);
+  await expect(
+    microsoftSection.getByRole("button", {
+      name: /^(Show|Hide) primary calendar$/,
+    }),
+  ).toBeVisible();
 });

--- a/e2e/calendars/microsoft-surfaces.spec.ts
+++ b/e2e/calendars/microsoft-surfaces.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from "@playwright/test";
+import { prepareSignedInMicrosoftPage } from "../attendees/attendee-harness";
+import { prepareSignedInBookingSettingsPage } from "../booking/booking-harness";
+
+const CONSENT_REQUIRED_COPY =
+  "Your organization's admin has to approve Compass before this account can connect.";
+
+const MICROSOFT_AUTHORIZE_URL =
+  "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=test";
+
+test.use({ viewport: { width: 1600, height: 900 } });
+
+test("shows a Microsoft connected toast from the connect-status query", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    (
+      window as Window & { __COMPASS_E2E_TEST__?: boolean }
+    ).__COMPASS_E2E_TEST__ = true;
+  });
+
+  await page.route("**/api/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: "{}",
+    });
+  });
+
+  await page.goto("/week?provider=microsoft&status=connected", {
+    waitUntil: "domcontentloaded",
+  });
+
+  await expect(page.getByText("Microsoft connected.")).toBeVisible();
+});
+
+test("shows the admin-consent banner for a Microsoft connection", async ({
+  page,
+}) => {
+  await prepareSignedInMicrosoftPage(page, {
+    events: [],
+    stateReason: "consentRequired",
+  });
+
+  await expect(
+    page.getByRole("alert").getByText(CONSENT_REQUIRED_COPY),
+  ).toBeVisible();
+});
+
+test("Add account starts Microsoft OAuth from the chooser", async ({
+  page,
+}) => {
+  await prepareSignedInBookingSettingsPage(page, { microsoftConnect: true });
+
+  let beginBody: Record<string, unknown> | undefined;
+  await page.route("**/api/auth/connections/begin", async (route) => {
+    if (route.request().method() !== "POST") {
+      return route.fallback();
+    }
+    beginBody = route.request().postDataJSON() as Record<string, unknown>;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        kind: "redirect",
+        authorizationUrl: MICROSOFT_AUTHORIZE_URL,
+      }),
+    });
+  });
+
+  const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+  await settingsDialog.getByRole("button", { name: "Accounts" }).click();
+  const addAccount = settingsDialog.getByRole("button", {
+    name: "Add account",
+  });
+  await expect(addAccount).toBeVisible();
+  await addAccount.click();
+  await expect(settingsDialog.getByRole("menu")).toBeVisible();
+
+  await Promise.all([
+    page.waitForURL(
+      /login\.microsoftonline\.com\/common\/oauth2\/v2\.0\/authorize/,
+    ),
+    settingsDialog.getByRole("menuitem", { name: "Microsoft" }).click(),
+  ]);
+
+  expect(beginBody).toMatchObject({ provider: "microsoft" });
+});


### PR DESCRIPTION
Fixes #3252

## What and why

Providers M WP-13: extend Playwright harnesses with Microsoft calendar and connection fixtures, then cover the Microsoft surfaces that already exist in product code. New specs assert the connect-status toast (`Microsoft connected.`), the admin-consent banner, Add account → Microsoft OAuth, a Microsoft calendar in the sidebar, guest edits on a Microsoft calendar, and an axe scan of the consent banner. Booking Teams copy and chooser/onboarding a11y were already covered.

## Verify

`VERDICT: PASS`

Checks run: `test:web`, `type-check`, `lint`, `knip`, `test:a11y`, `test:e2e`

New Microsoft specs passed 5 consecutive local Playwright runs with no flake. An unrelated `app-a11y` contrast failure on the first `verify --strict` did not reproduce on retry.