### PR TITLE
feat(web): connect-calendar prompt for signed-in users with no connections (WP-04)

### DIFF
--- a/e2e/accessibility/connect-onboarding-a11y.spec.ts
+++ b/e2e/accessibility/connect-onboarding-a11y.spec.ts
@@ -5,6 +5,94 @@ import { expectNoAxeViolations } from "../utils/axe-assertion";
 test.use({ storageState: { cookies: [], origins: [] } });
 test.use({ viewport: { width: 1600, height: 900 } });
 
+function jsonResponse(body: unknown) {
+  return {
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  };
+}
+
+async function prepareSignedInZeroConnectionsPage(
+  page: import("@playwright/test").Page,
+) {
+  await page.addInitScript(() => {
+    (
+      window as Window & { __COMPASS_E2E_TEST__?: boolean }
+    ).__COMPASS_E2E_TEST__ = true;
+    localStorage.setItem(
+      "compass.auth",
+      JSON.stringify({
+        hasAuthenticated: true,
+        lastKnownEmail: "host@example.com",
+      }),
+    );
+    localStorage.setItem("compass.onboarding.has-seen-welcome", "true");
+    localStorage.setItem(
+      "compass.onboarding.has-seen-shortcut-showcase",
+      "true",
+    );
+  });
+
+  await page.route("**/api/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname;
+
+    if (path.endsWith("/api/calendars")) {
+      return route.fulfill(jsonResponse({ calendars: [] }));
+    }
+
+    if (path.endsWith("/api/event") && request.method() === "GET") {
+      return route.fulfill(jsonResponse({ events: [] }));
+    }
+
+    if (path.endsWith("/api/user/metadata")) {
+      return route.fulfill(
+        jsonResponse({
+          google: { connectionState: "NOT_CONNECTED", connections: [] },
+          connections: [],
+        }),
+      );
+    }
+
+    if (path.endsWith("/api/config")) {
+      return route.fulfill(
+        jsonResponse({
+          google: { isConfigured: true },
+          providers: {
+            google: { signIn: true, connect: true },
+            microsoft: { signIn: true, connect: true },
+            apple: { signIn: false, connect: true },
+          },
+        }),
+      );
+    }
+
+    return route.fulfill(jsonResponse({}));
+  });
+
+  await page.goto("/week", { waitUntil: "domcontentloaded" });
+  await page.waitForFunction(
+    () =>
+      (
+        window as Window & {
+          __COMPASS_E2E_HOOKS__?: { setAuthenticated: (v: boolean) => void };
+        }
+      ).__COMPASS_E2E_HOOKS__ !== undefined,
+  );
+  await page.evaluate(() => {
+    (
+      window as Window & {
+        __COMPASS_E2E_HOOKS__?: { setAuthenticated: (v: boolean) => void };
+      }
+    ).__COMPASS_E2E_HOOKS__?.setAuthenticated(true);
+  });
+  await expect(
+    page.getByRole("dialog", { name: "Connect the calendar you use" }),
+  ).toBeVisible({ timeout: 15000 });
+}
+
 test("the connect-calendar onboarding step has no automatically detectable accessibility violations", async ({
   page,
 }) => {
@@ -27,6 +115,17 @@ test("the connect-calendar onboarding step has no automatically detectable acces
   await expectNoAxeViolations(page, {
     checkpoint: "connect calendar onboarding",
     include: '[role="dialog"][aria-label="Welcome to Compass Calendar"]',
+  });
+});
+
+test("the signed-in connect-calendar prompt has no automatically detectable accessibility violations", async ({
+  page,
+}) => {
+  await prepareSignedInZeroConnectionsPage(page);
+
+  await expectNoAxeViolations(page, {
+    checkpoint: "signed-in connect calendar prompt",
+    include: '[role="dialog"][aria-label="Connect the calendar you use"]',
   });
 });
 

--- a/packages/web/src/__tests__/utils/state/reset-stores.ts
+++ b/packages/web/src/__tests__/utils/state/reset-stores.ts
@@ -26,6 +26,7 @@ import { resetCalendarVisibilityStoreForTests } from "@web/calendars/calendar-vi
 import { resetCollapsedAccountsStoreForTests } from "@web/calendars/collapsed-accounts.store";
 import { resetDefaultCalendarStoreForTests } from "@web/calendars/default-calendar.store";
 import { resetRecentCommandsStoreForTests } from "@web/components/CommandPalette/recent-commands.store";
+import { resetConnectCalendarPromptStoreForTests } from "@web/components/ConnectCalendarPrompt/connect-calendar.store";
 import { useFeedbackStore } from "@web/components/Feedback/feedback.store";
 import {
   initialFirstEventPromptState,
@@ -107,6 +108,7 @@ const storeResets: StoreReset[] = [
   () => useFeedbackStore.setState(useFeedbackStore.getInitialState(), true),
   () => useShortcutShowcaseStore.setState(initialShortcutShowcaseState, true),
   () => useFirstEventPromptStore.setState(initialFirstEventPromptState, true),
+  resetConnectCalendarPromptStoreForTests,
   () =>
     useWelcomeGuideStore.setState(useWelcomeGuideStore.getInitialState(), true),
   () => useThemeStore.setState(useThemeStore.getInitialState(), true),

--- a/packages/web/src/auth/posthog/track.ts
+++ b/packages/web/src/auth/posthog/track.ts
@@ -28,6 +28,7 @@ export type ProductEvent =
   | "first_event_prompt_shown"
   | "first_event_prompt_completed"
   | "first_event_prompt_dismissed"
+  | "connect_calendar_prompt_dismissed"
   | "trial_converted"
   | "trial_celebration_shown"
   | "billing_gate_shown"

--- a/packages/web/src/common/constants/storage.constants.ts
+++ b/packages/web/src/common/constants/storage.constants.ts
@@ -16,6 +16,8 @@ type StorageKey =
   // "completed" | "dismissed": the first-event prompt's terminal state.
   // Absent means it is still live (or never shown).
   | "compass.onboarding.first-event-done"
+  // Set when a signed-in user dismisses the connect-calendar onboarding step.
+  | "compass.onboarding.has-dismissed-connect-calendar-prompt"
   | "compass.shortcuts.tips-muted"
   // Demonstrated sidebar shortcut-tip ids (JSON). Device-local; an unknown
   // id is skipped on read, not an error.
@@ -65,6 +67,7 @@ export const STORAGE_KEYS: Record<
   | "SHORTCUT_SHOWCASE_STEP"
   | "HAS_PENDING_SHOWCASE_OFFER"
   | "FIRST_EVENT_DONE"
+  | "HAS_DISMISSED_CONNECT_CALENDAR_PROMPT"
   | "SHORTCUT_TIPS_MUTED"
   | "SHORTCUT_TIPS_DEMONSTRATED"
   | "SHORTCUT_PERSONALIZATION"
@@ -97,6 +100,8 @@ export const STORAGE_KEYS: Record<
   SHORTCUT_SHOWCASE_STEP: "compass.onboarding.shortcut-showcase-step",
   HAS_PENDING_SHOWCASE_OFFER: "compass.onboarding.has-pending-showcase-offer",
   FIRST_EVENT_DONE: "compass.onboarding.first-event-done",
+  HAS_DISMISSED_CONNECT_CALENDAR_PROMPT:
+    "compass.onboarding.has-dismissed-connect-calendar-prompt",
   SHORTCUT_TIPS_MUTED: "compass.shortcuts.tips-muted",
   SHORTCUT_TIPS_DEMONSTRATED: "compass.shortcuts.tips-demonstrated",
   SHORTCUT_PERSONALIZATION: "compass.shortcuts.personalization",

--- a/packages/web/src/components/ConnectCalendarPrompt/ConnectCalendarPrompt.test.tsx
+++ b/packages/web/src/components/ConnectCalendarPrompt/ConnectCalendarPrompt.test.tsx
@@ -1,0 +1,210 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+import { createMockConnection } from "@web/__tests__/utils/factories/calendar.factory";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
+import { SessionContext } from "@web/auth/compass/session/session.context";
+import {
+  CALENDAR_HOST_EXPLAINER,
+  CONNECT_THE_CALENDAR_YOU_USE,
+} from "@web/auth/providers/provider-copy.util";
+import * as realAvailableProviders from "@web/auth/providers/useAvailableConnectProviders";
+import * as realConnectProvider from "@web/auth/providers/useConnectProvider";
+import { userMetadataActions } from "@web/auth/state/user-metadata.store";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import { AuthModalContext } from "@web/components/AuthModal/hooks/useAuthModal";
+import { CONNECT_CALENDAR_LATER_LABEL } from "@web/components/ConnectCalendarPrompt/ConnectCalendarPrompt";
+import {
+  initialConnectCalendarPromptState,
+  useConnectCalendarPromptStore,
+} from "@web/components/ConnectCalendarPrompt/connect-calendar.store";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+let available: ProviderKind[] = ["google", "microsoft", "apple"];
+const mockConnectGoogle = mock();
+const mockConnectMicrosoft = mock();
+const mockConnectApple = mock();
+
+mockModuleForFile(
+  "@web/auth/providers/useAvailableConnectProviders",
+  realAvailableProviders,
+  { useAvailableConnectProviders: () => available },
+);
+
+const connectByKind: Record<ProviderKind, ReturnType<typeof mock>> = {
+  google: mockConnectGoogle,
+  microsoft: mockConnectMicrosoft,
+  apple: mockConnectApple,
+};
+
+const buttonLabelByKind: Record<ProviderKind, string> = {
+  google: "Connect Google",
+  microsoft: "Connect Microsoft Calendar",
+  apple: "Connect Apple Calendar",
+};
+
+mockModuleForFile(
+  "@web/auth/providers/useConnectProvider",
+  realConnectProvider,
+  {
+    useConnectProvider: (kind: ProviderKind) => ({
+      state: "NOT_CONNECTED",
+      isAvailable: true,
+      isConnecting: false,
+      isRefreshing: false,
+      commandAction: null,
+      connect: connectByKind[kind],
+    }),
+  },
+);
+
+const gateModuleUrl = new URL(
+  `./ConnectCalendarPromptGate.tsx?test=${Math.random().toString(36).slice(2)}`,
+  import.meta.url,
+);
+const { ConnectCalendarPromptGate: GateUnderTest } = (await import(
+  gateModuleUrl.href
+)) as typeof import("./ConnectCalendarPromptGate");
+
+const emptyMetadata = {
+  google: { connectionState: "NOT_CONNECTED" as const, connections: [] },
+  connections: [],
+};
+
+const oneConnection = createMockConnection("user@example.com");
+const oneConnectionMetadata = {
+  google: {
+    connectionState: "HEALTHY" as const,
+    connections: [oneConnection],
+  },
+  connections: [oneConnection],
+};
+
+const renderGate = (options?: { authenticated?: boolean }) => {
+  const authenticated = options?.authenticated ?? true;
+
+  return render(
+    <SessionContext.Provider
+      value={{ authenticated, setAuthenticated: mock() }}
+    >
+      <AuthModalContext.Provider
+        value={{
+          isOpen: false,
+          currentView: "login",
+          openModal: mock(),
+          closeModal: mock(),
+          setView: mock(),
+        }}
+      >
+        <GateUnderTest />
+      </AuthModalContext.Provider>
+    </SessionContext.Provider>,
+  );
+};
+
+describe("ConnectCalendarPromptGate", () => {
+  beforeEach(() => {
+    available = ["google", "microsoft", "apple"];
+    mockConnectGoogle.mockClear();
+    mockConnectMicrosoft.mockClear();
+    mockConnectApple.mockClear();
+    useConnectCalendarPromptStore.setState({
+      ...initialConnectCalendarPromptState,
+      isDismissed: false,
+    });
+    persistentBrowserStore.set(
+      STORAGE_KEYS.HAS_DISMISSED_CONNECT_CALENDAR_PROMPT,
+      "",
+    );
+    userMetadataActions.set(emptyMetadata);
+  });
+
+  afterEach(() => {
+    userMetadataActions.clear();
+  });
+
+  it("renders for a signed-in user with zero connections", () => {
+    renderGate();
+
+    expect(
+      screen.getByRole("dialog", { name: CONNECT_THE_CALENDAR_YOU_USE }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(CONNECT_THE_CALENDAR_YOU_USE)).toBeInTheDocument();
+    expect(screen.getByText(CALENDAR_HOST_EXPLAINER)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: CONNECT_CALENDAR_LATER_LABEL }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render when the user already has a connection", () => {
+    userMetadataActions.set(oneConnectionMetadata);
+    renderGate();
+
+    expect(
+      screen.queryByRole("dialog", { name: CONNECT_THE_CALENDAR_YOU_USE }),
+    ).toBeNull();
+  });
+
+  it("does not render for an anonymous user", () => {
+    renderGate({ authenticated: false });
+    expect(
+      screen.queryByRole("dialog", { name: CONNECT_THE_CALENDAR_YOU_USE }),
+    ).toBeNull();
+  });
+
+  it("does not render after dismissal", () => {
+    persistentBrowserStore.set(
+      STORAGE_KEYS.HAS_DISMISSED_CONNECT_CALENDAR_PROMPT,
+      "true",
+    );
+    useConnectCalendarPromptStore.setState({ isDismissed: true });
+    renderGate();
+
+    expect(
+      screen.queryByRole("dialog", { name: CONNECT_THE_CALENDAR_YOU_USE }),
+    ).toBeNull();
+  });
+
+  it("routes each provider button to its connect flow", async () => {
+    const user = userEvent.setup();
+    renderGate();
+
+    await user.click(
+      screen.getByRole("button", { name: buttonLabelByKind.google }),
+    );
+    expect(mockConnectGoogle).toHaveBeenCalledTimes(1);
+
+    await user.click(
+      screen.getByRole("button", { name: buttonLabelByKind.microsoft }),
+    );
+    expect(mockConnectMicrosoft).toHaveBeenCalledTimes(1);
+
+    await user.click(
+      screen.getByRole("button", { name: buttonLabelByKind.apple }),
+    );
+    expect(mockConnectApple).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists dismissal from I'll do this later", async () => {
+    const user = userEvent.setup();
+    renderGate();
+
+    await user.click(
+      screen.getByRole("button", { name: CONNECT_CALENDAR_LATER_LABEL }),
+    );
+
+    await waitFor(
+      () => {
+        expect(
+          persistentBrowserStore.get(
+            STORAGE_KEYS.HAS_DISMISSED_CONNECT_CALENDAR_PROMPT,
+          ),
+        ).toBe("true");
+      },
+      { timeout: 1000 },
+    );
+    expect(useConnectCalendarPromptStore.getState().isDismissed).toBe(true);
+  });
+});

--- a/packages/web/src/components/ConnectCalendarPrompt/ConnectCalendarPrompt.tsx
+++ b/packages/web/src/components/ConnectCalendarPrompt/ConnectCalendarPrompt.tsx
@@ -1,0 +1,52 @@
+import { type FC, useRef } from "react";
+import { ConnectProviderChooser } from "@web/auth/providers/ConnectProviderChooser";
+import {
+  CALENDAR_HOST_EXPLAINER,
+  CONNECT_THE_CALENDAR_YOU_USE,
+} from "@web/auth/providers/provider-copy.util";
+import { MODAL_DISMISS_MS } from "@web/common/constants/motion.constants";
+import { useDismissTransition } from "@web/common/hooks/useDismissTransition";
+import { connectCalendarPromptActions } from "@web/components/ConnectCalendarPrompt/connect-calendar.store";
+import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
+import { pointerPassAttributes } from "@web/shortcuts/keyboard-only/pointer-action";
+
+export const CONNECT_CALENDAR_LATER_LABEL = "I'll do this later";
+
+export const ConnectCalendarPrompt: FC = () => {
+  const { closing, beginDismiss } = useDismissTransition(MODAL_DISMISS_MS);
+  const skipFocusRestoreRef = useRef(false);
+
+  const dismiss = () => beginDismiss(connectCalendarPromptActions.dismiss);
+
+  return (
+    <OverlayPanel
+      align="start"
+      ariaLabel={CONNECT_THE_CALENDAR_YOU_USE}
+      backdropClassName="overflow-y-auto py-8"
+      closing={closing}
+      onDismiss={dismiss}
+      skipFocusRestoreRef={skipFocusRestoreRef}
+      widthClassName="w-120"
+    >
+      <div className="flex w-full flex-col gap-6" {...pointerPassAttributes}>
+        <div className="flex w-full flex-col gap-2">
+          <h2 className="font-bold text-2xl text-text leading-snug">
+            {CONNECT_THE_CALENDAR_YOU_USE}
+          </h2>
+          <p className="text-sm text-text-muted">{CALENDAR_HOST_EXPLAINER}</p>
+        </div>
+        <ConnectProviderChooser
+          idleLabel={CONNECT_THE_CALENDAR_YOU_USE}
+          variant="prompt"
+        />
+        <button
+          className="c-focus-ring self-center rounded-md px-2 py-1 text-text-muted text-xs hover:bg-surface-overlay hover:text-text"
+          onClick={dismiss}
+          type="button"
+        >
+          {CONNECT_CALENDAR_LATER_LABEL}
+        </button>
+      </div>
+    </OverlayPanel>
+  );
+};

--- a/packages/web/src/components/ConnectCalendarPrompt/ConnectCalendarPromptGate.tsx
+++ b/packages/web/src/components/ConnectCalendarPrompt/ConnectCalendarPromptGate.tsx
@@ -1,0 +1,54 @@
+import { type FC, useContext } from "react";
+import { SessionContext } from "@web/auth/compass/session/session.context";
+import {
+  selectConnectAppleOpen,
+  useConnectAppleStore,
+} from "@web/auth/providers/connect-apple.store";
+import { useAvailableConnectProviders } from "@web/auth/providers/useAvailableConnectProviders";
+import {
+  selectSyncConnections,
+  selectUserMetadataStatus,
+  useUserMetadataStore,
+} from "@web/auth/state/user-metadata.store";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import { AuthModalContext } from "@web/components/AuthModal/hooks/useAuthModal";
+import { ConnectCalendarPrompt } from "@web/components/ConnectCalendarPrompt/ConnectCalendarPrompt";
+import {
+  selectConnectCalendarPromptDismissed,
+  useConnectCalendarPromptStore,
+} from "@web/components/ConnectCalendarPrompt/connect-calendar.store";
+import {
+  selectIsAboutOpen,
+  selectIsSettingsOpen,
+  useSettingsStore,
+} from "@web/settings/settings.store";
+
+export const ConnectCalendarPromptGate: FC = () => {
+  const { authenticated } = useContext(SessionContext);
+  const { isOpen: isAuthModalOpen } = useContext(AuthModalContext);
+  const connections = useUserMetadataStore(selectSyncConnections);
+  const metadataStatus = useUserMetadataStore(selectUserMetadataStatus);
+  const isDismissed = useConnectCalendarPromptStore(
+    selectConnectCalendarPromptDismissed,
+  );
+  const availableProviders = useAvailableConnectProviders();
+  const isSettingsOpen = useSettingsStore(selectIsSettingsOpen);
+  const isAboutOpen = useSettingsStore(selectIsAboutOpen);
+  const isAppleFormOpen = useConnectAppleStore(selectConnectAppleOpen);
+
+  const isLive =
+    authenticated &&
+    metadataStatus === "loaded" &&
+    connections.length === 0 &&
+    !isDismissed &&
+    availableProviders.length > 0 &&
+    persistentBrowserStore.isAvailable() &&
+    !isAuthModalOpen &&
+    !isSettingsOpen &&
+    !isAboutOpen &&
+    !isAppleFormOpen;
+
+  if (!isLive) return null;
+
+  return <ConnectCalendarPrompt />;
+};

--- a/packages/web/src/components/ConnectCalendarPrompt/connect-calendar.storage.ts
+++ b/packages/web/src/components/ConnectCalendarPrompt/connect-calendar.storage.ts
@@ -1,0 +1,18 @@
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+
+export function getConnectCalendarPromptDismissed(): boolean {
+  if (!persistentBrowserStore.isAvailable()) return false;
+  return (
+    persistentBrowserStore.get(
+      STORAGE_KEYS.HAS_DISMISSED_CONNECT_CALENDAR_PROMPT,
+    ) === "true"
+  );
+}
+
+export function markConnectCalendarPromptDismissed(): void {
+  persistentBrowserStore.set(
+    STORAGE_KEYS.HAS_DISMISSED_CONNECT_CALENDAR_PROMPT,
+    "true",
+  );
+}

--- a/packages/web/src/components/ConnectCalendarPrompt/connect-calendar.store.ts
+++ b/packages/web/src/components/ConnectCalendarPrompt/connect-calendar.store.ts
@@ -1,0 +1,39 @@
+import { create } from "zustand";
+import { track } from "@web/auth/posthog/track";
+import {
+  getConnectCalendarPromptDismissed,
+  markConnectCalendarPromptDismissed,
+} from "@web/components/ConnectCalendarPrompt/connect-calendar.storage";
+
+export type ConnectCalendarPromptState = {
+  isDismissed: boolean;
+};
+
+export const initialConnectCalendarPromptState: ConnectCalendarPromptState = {
+  isDismissed: getConnectCalendarPromptDismissed(),
+};
+
+export const useConnectCalendarPromptStore = create<ConnectCalendarPromptState>(
+  () => ({
+    ...initialConnectCalendarPromptState,
+  }),
+);
+
+export const connectCalendarPromptActions = {
+  dismiss: () => {
+    track("connect_calendar_prompt_dismissed");
+    markConnectCalendarPromptDismissed();
+    useConnectCalendarPromptStore.setState({ isDismissed: true });
+  },
+};
+
+export const resetConnectCalendarPromptStoreForTests = (): void => {
+  useConnectCalendarPromptStore.setState(
+    initialConnectCalendarPromptState,
+    true,
+  );
+};
+
+export const selectConnectCalendarPromptDismissed = (
+  state: ConnectCalendarPromptState,
+): boolean => state.isDismissed;

--- a/packages/web/src/components/RootShell/RootShell.tsx
+++ b/packages/web/src/components/RootShell/RootShell.tsx
@@ -19,6 +19,7 @@ import { usePlanChangeToasts } from "@web/billing/usePlanChangeToasts";
 import { isMobileOS } from "@web/common/utils/device/device.util";
 import { AuthModal } from "@web/components/AuthModal/AuthModal";
 import { AuthModalProvider } from "@web/components/AuthModal/AuthModalProvider";
+import { ConnectCalendarPromptGate } from "@web/components/ConnectCalendarPrompt/ConnectCalendarPromptGate";
 import { FirstEventPrompt } from "@web/components/FirstEventPrompt/FirstEventPrompt";
 import { PointerHint } from "@web/components/PointerHint/PointerHint";
 import { ShowcasePlayLink } from "@web/components/ShortcutShowcase/play-link";
@@ -100,6 +101,7 @@ export function RootShell() {
       <UpcomingEventNotifier />
       <AuthModal />
       <ConnectAppleForm />
+      {gateStatus === null && <ConnectCalendarPromptGate />}
       {gateStatus !== null && <BillingGateModal status={gateStatus} />}
       <CheckoutCelebrationModal />
       {showCalendarOnboarding && <WelcomeModal />}


### PR DESCRIPTION
Fixes #3268

## What and why

After signup with a login method that grants no calendar (email/password today, Apple after I-03), signed-in users with zero connections now see a dismissible "Connect the calendar you use" step. It reuses `ConnectProviderChooser` (prompt variant) for Google/Microsoft redirect and Apple credential form flows, shows the spec host-explainer copy, and persists dismissal via local storage. The sidebar connect prompt remains available after "I'll do this later."

Spec: [`docs/features/calendar-providers.md`](https://github.com/KeepSoftwareSimple/compass-calendar/blob/main/docs/features/calendar-providers.md)

## Verify

```
bun run verify --strict
bun test:web
```

VERDICT: PASS

Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e