### PR TITLE
feat(web): per-connection health copy for every state and reason

### DIFF
--- a/packages/backend/src/common/services/sync-service/connection-state.translation.test.ts
+++ b/packages/backend/src/common/services/sync-service/connection-state.translation.test.ts
@@ -144,4 +144,14 @@ describe("toGoogleSyncConnectionSummary", () => {
       false,
     );
   });
+
+  it("preserves consentRequired stateReason on the web-facing summary", () => {
+    const summary = toGoogleSyncConnectionSummary(
+      connection("actionRequired", "consentRequired", {
+        provider: "microsoft",
+      }),
+    );
+    expect(summary.stateReason).toBe("consentRequired");
+    expect(summary.connectionState).toBe("ATTENTION");
+  });
 });

--- a/packages/web/src/auth/providers/connect.util.ts
+++ b/packages/web/src/auth/providers/connect.util.ts
@@ -4,6 +4,15 @@ import {
   providerDisplayName,
 } from "@core/types/sync/identity.contracts";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
+import {
+  attentionFallbackCopy,
+  connectionHealthCopy,
+  credentialKindForConnection,
+  nameAccountInCopy,
+  OAUTH_RECONNECT_COPY,
+  pickAggregateSidebarStatus,
+  type SidebarStatusEntry,
+} from "@web/auth/providers/connection-health-copy.util";
 import { CONSENT_REQUIRED_COPY } from "@web/auth/providers/provider-copy.util";
 import {
   isAccountReconnectRequired,
@@ -18,7 +27,7 @@ import {
 
 const RECONNECT_STATUS: SyncStatus = {
   variant: "error",
-  text: "Calendar needs reconnecting",
+  text: OAUTH_RECONNECT_COPY,
 };
 
 const CONSENT_REQUIRED_STATUS: SyncStatus = {
@@ -36,10 +45,13 @@ const connectionNeedsAdminConsent = (
 // multiple accounts connected, "Calendar needs reconnecting" doesn't say
 // which one, and the user has to open Settings just to find out. Named only
 // in getSidebarSyncStatus's own reconnect returns, below.
-const reconnectStatusFor = (accountEmail?: string | null): SyncStatus =>
-  accountEmail
-    ? { variant: "error", text: `${accountEmail} needs reconnecting` }
-    : RECONNECT_STATUS;
+const reconnectStatusFor = (
+  accountEmail?: string | null,
+  copy: string = OAUTH_RECONNECT_COPY,
+): SyncStatus => ({
+  variant: "error",
+  text: nameAccountInCopy(copy, accountEmail),
+});
 
 /** Sync disconnected / product reconnect / session override after a live 410. */
 export const connectionHasReconnectRequired = (
@@ -236,17 +248,28 @@ const delayedSettingsStatus = (
   connection: GoogleSyncConnectionSummary,
   nowMs: number,
 ): SyncStatus => {
-  const lastBit = lastUpdatedSuffix(connection.lastSyncedAt, nowMs);
-  if (connection.stateReason === "providerErrors") {
-    return {
-      variant: "warning",
-      text: `Couldn't update your calendar.${lastBit} Try Refresh, or reconnect if this continues.`,
-    };
-  }
-  return {
-    variant: "warning",
-    text: `Calendar updates are taking longer than usual.${lastBit} Try Refresh, or reconnect if this continues.`,
-  };
+  const text =
+    connectionHealthCopy({
+      state: connection.state,
+      stateReason: connection.stateReason,
+      credentialKind: credentialKindForConnection(connection),
+      surface: "settings",
+      lastUpdatedSuffix: lastUpdatedSuffix(connection.lastSyncedAt, nowMs),
+    }) ?? attentionFallbackCopy();
+  return { variant: "warning", text };
+};
+
+const reauthSettingsStatus = (
+  connection: GoogleSyncConnectionSummary,
+): SyncStatus => {
+  const text =
+    connectionHealthCopy({
+      state: connection.state,
+      stateReason: connection.stateReason,
+      credentialKind: credentialKindForConnection(connection),
+      surface: "settings",
+    }) ?? OAUTH_RECONNECT_COPY;
+  return { variant: "error", text };
 };
 
 const catchingUpSettingsStatus = (
@@ -284,6 +307,9 @@ export const getGoogleSyncStatus = (
   }
 
   if (connectionNeedsReconnect(state, connection)) {
+    if (connection?.stateReason && connection.state !== "disconnected") {
+      return reauthSettingsStatus(connection);
+    }
     return RECONNECT_STATUS;
   }
 
@@ -335,7 +361,7 @@ export const getGoogleSyncStatus = (
       }
       return {
         variant: "warning",
-        text: "Calendar updates are taking longer than usual. Try Refresh, or reconnect if this continues.",
+        text: attentionFallbackCopy(),
       };
     case "RECONNECT_REQUIRED":
       return RECONNECT_STATUS;
@@ -438,7 +464,16 @@ export const getSidebarSyncStatus = ({
   }
 
   if (connectionNeedsReconnect(state, connection)) {
-    return reconnectStatusFor(connection?.accountEmail);
+    const copy =
+      connection != null
+        ? (connectionHealthCopy({
+            state: connection.state,
+            stateReason: connection.stateReason,
+            credentialKind: credentialKindForConnection(connection),
+            surface: "settings",
+          }) ?? OAUTH_RECONNECT_COPY)
+        : OAUTH_RECONNECT_COPY;
+    return reconnectStatusFor(connection?.accountEmail, copy);
   }
 
   if (
@@ -469,17 +504,27 @@ export const getSidebarSyncStatus = ({
         }
         return null;
       }
-      case "delayed":
-        return {
-          variant: "warning",
-          text:
-            connection.stateReason === "providerErrors"
-              ? "Couldn't update your calendar"
-              : "Calendar updates are delayed",
-        };
+      case "delayed": {
+        const text =
+          connectionHealthCopy({
+            state: connection.state,
+            stateReason: connection.stateReason,
+            credentialKind: credentialKindForConnection(connection),
+            surface: "sidebarShort",
+          }) ?? "Calendar updates are delayed";
+        return { variant: "warning", text };
+      }
       case "actionRequired":
-      case "disconnected":
-        return reconnectStatusFor(connection.accountEmail);
+      case "disconnected": {
+        const copy =
+          connectionHealthCopy({
+            state: connection.state,
+            stateReason: connection.stateReason,
+            credentialKind: credentialKindForConnection(connection),
+            surface: "settings",
+          }) ?? OAUTH_RECONNECT_COPY;
+        return reconnectStatusFor(connection.accountEmail, copy);
+      }
       case "connecting":
       case "importing":
         return connection.lastHealthyAt
@@ -494,4 +539,40 @@ export const getSidebarSyncStatus = ({
     refreshGaveUp,
   });
   return status?.variant === "healthy" ? null : status;
+};
+
+/** Collapse every account into one sidebar line; name the account when they disagree. */
+export const getAggregateSidebarSyncStatus = ({
+  connections,
+  isConnecting,
+  state,
+  nowMs = Date.now(),
+  refreshGaveUp = false,
+  refreshInFlight = false,
+}: {
+  connections: readonly GoogleSyncConnectionSummary[];
+  isConnecting: boolean;
+  state: GoogleUiState;
+  nowMs?: number;
+  refreshGaveUp?: boolean;
+  refreshInFlight?: boolean;
+}): SyncStatus | null => {
+  const entries: SidebarStatusEntry[] = [];
+  for (const connection of connections) {
+    const status = getSidebarSyncStatus({
+      connection,
+      isConnecting,
+      state: connection.connectionState ?? state,
+      nowMs,
+      refreshGaveUp,
+      refreshInFlight,
+    });
+    if (status) {
+      entries.push({ connection, status });
+    }
+  }
+  if (entries.length === 0) {
+    return null;
+  }
+  return pickAggregateSidebarStatus(entries);
 };

--- a/packages/web/src/auth/providers/connection-health-copy.util.test.ts
+++ b/packages/web/src/auth/providers/connection-health-copy.util.test.ts
@@ -1,0 +1,254 @@
+import { type ConnectionStateReason } from "@core/types/sync/connection.contracts";
+import {
+  attentionFallbackCopy,
+  connectionHealthCopy,
+  connectionHealthNextAction,
+  credentialKindForConnection,
+  nameAccountInCopy,
+  OAUTH_RECONNECT_COPY,
+  pickAggregateSidebarStatus,
+} from "./connection-health-copy.util";
+import { CONSENT_REQUIRED_COPY } from "./provider-copy.util";
+import { describe, expect, it } from "bun:test";
+
+const REASONS: ConnectionStateReason[] = [
+  "authorizationRevoked",
+  "authorizationExpired",
+  "insufficientScopes",
+  "consentRequired",
+  "workOverdue",
+  "providerErrors",
+];
+
+describe("connectionHealthCopy", () => {
+  for (const stateReason of REASONS) {
+    it(`returns whole oauth settings copy for reason ${stateReason}`, () => {
+      const copy = connectionHealthCopy({
+        state: "actionRequired",
+        stateReason,
+        credentialKind: "oauthRedirect",
+        surface: "settings",
+      });
+      expect(copy).toBeTruthy();
+      expect(copy).not.toContain("—");
+    });
+  }
+
+  for (const stateReason of [
+    "authorizationRevoked",
+    "authorizationExpired",
+    "insufficientScopes",
+  ] as const) {
+    it(`returns whole password settings copy for reason ${stateReason}`, () => {
+      const copy = connectionHealthCopy({
+        state: "actionRequired",
+        stateReason,
+        credentialKind: "credentialForm",
+        surface: "settings",
+      });
+      expect(copy).toBeTruthy();
+      expect(copy).not.toMatch(/reconnect google/i);
+      expect(copy).toMatch(/app-specific password/i);
+    });
+  }
+
+  it("keeps Google oauth reconnect copy byte-identical", () => {
+    for (const stateReason of [
+      "authorizationRevoked",
+      "authorizationExpired",
+      "insufficientScopes",
+    ] as const) {
+      expect(
+        connectionHealthCopy({
+          state: "actionRequired",
+          stateReason,
+          credentialKind: "oauthRedirect",
+          surface: "settings",
+        }),
+      ).toBe(OAUTH_RECONNECT_COPY);
+    }
+  });
+
+  it("renders consentRequired copy whole", () => {
+    expect(
+      connectionHealthCopy({
+        state: "actionRequired",
+        stateReason: "consentRequired",
+        credentialKind: "oauthRedirect",
+        surface: "settings",
+      }),
+    ).toBe(CONSENT_REQUIRED_COPY);
+  });
+
+  it("renders delayed workOverdue settings copy whole", () => {
+    expect(
+      connectionHealthCopy({
+        state: "delayed",
+        stateReason: "workOverdue",
+        credentialKind: "oauthRedirect",
+        surface: "settings",
+        lastUpdatedSuffix: " Last updated 15 minutes ago.",
+      }),
+    ).toBe(
+      "Calendar updates are taking longer than usual. Last updated 15 minutes ago. Try Refresh, or reconnect if this continues.",
+    );
+  });
+
+  it("renders delayed providerErrors settings copy whole", () => {
+    expect(
+      connectionHealthCopy({
+        state: "delayed",
+        stateReason: "providerErrors",
+        credentialKind: "oauthRedirect",
+        surface: "settings",
+        lastUpdatedSuffix: " Last updated 15 minutes ago.",
+      }),
+    ).toBe(
+      "Couldn't update your calendar. Last updated 15 minutes ago. Try Refresh, or reconnect if this continues.",
+    );
+  });
+
+  it("renders delayed workOverdue sidebar copy whole", () => {
+    expect(
+      connectionHealthCopy({
+        state: "delayed",
+        stateReason: "workOverdue",
+        credentialKind: "oauthRedirect",
+        surface: "sidebarShort",
+      }),
+    ).toBe("Calendar updates are delayed");
+  });
+
+  it("renders delayed providerErrors sidebar copy whole", () => {
+    expect(
+      connectionHealthCopy({
+        state: "delayed",
+        stateReason: "providerErrors",
+        credentialKind: "credentialForm",
+        surface: "sidebarShort",
+      }),
+    ).toBe("Couldn't update your calendar");
+  });
+});
+
+describe("connectionHealthNextAction", () => {
+  for (const stateReason of REASONS) {
+    it(`returns a next action for oauth reason ${stateReason}`, () => {
+      expect(
+        connectionHealthNextAction(
+          "actionRequired",
+          stateReason,
+          "oauthRedirect",
+        ),
+      ).not.toBeNull();
+    });
+  }
+
+  for (const stateReason of [
+    "authorizationRevoked",
+    "authorizationExpired",
+    "insufficientScopes",
+  ] as const) {
+    it(`returns updatePassword for password reason ${stateReason}`, () => {
+      expect(
+        connectionHealthNextAction(
+          "actionRequired",
+          stateReason,
+          "credentialForm",
+        ),
+      ).toBe("updatePassword");
+    });
+  }
+
+  it("returns learnMore for consentRequired", () => {
+    expect(
+      connectionHealthNextAction(
+        "actionRequired",
+        "consentRequired",
+        "oauthRedirect",
+      ),
+    ).toBe("learnMore");
+  });
+
+  it("returns refresh for delayed work", () => {
+    expect(
+      connectionHealthNextAction("delayed", "workOverdue", "oauthRedirect"),
+    ).toBe("refresh");
+  });
+});
+
+describe("credentialKindForConnection", () => {
+  it("derives credentialForm for Apple connections", () => {
+    expect(credentialKindForConnection({ provider: "apple" })).toBe(
+      "credentialForm",
+    );
+  });
+
+  it("derives oauthRedirect for Google connections", () => {
+    expect(credentialKindForConnection({ provider: "google" })).toBe(
+      "oauthRedirect",
+    );
+  });
+});
+
+describe("nameAccountInCopy", () => {
+  it("names the account for generic reconnect copy", () => {
+    expect(nameAccountInCopy(OAUTH_RECONNECT_COPY, "a@example.com")).toBe(
+      "a@example.com needs reconnecting",
+    );
+  });
+
+  it("leaves specific copy unchanged", () => {
+    expect(nameAccountInCopy(CONSENT_REQUIRED_COPY, "a@example.com")).toBe(
+      CONSENT_REQUIRED_COPY,
+    );
+  });
+});
+
+describe("pickAggregateSidebarStatus", () => {
+  it("names the account when two connections disagree", () => {
+    const status = pickAggregateSidebarStatus([
+      {
+        connection: {
+          id: "c1",
+          provider: "google",
+          state: "delayed",
+          stateReason: "workOverdue",
+          lastSyncedAt: null,
+          lastHealthyAt: null,
+          accountEmail: "work@example.com",
+          connectionState: "ATTENTION",
+          canSuggestContacts: false,
+        },
+        status: { variant: "warning", text: "Calendar updates are delayed" },
+      },
+      {
+        connection: {
+          id: "c2",
+          provider: "microsoft",
+          state: "actionRequired",
+          stateReason: "authorizationRevoked",
+          lastSyncedAt: null,
+          lastHealthyAt: null,
+          accountEmail: "home@example.com",
+          connectionState: "RECONNECT_REQUIRED",
+          canSuggestContacts: false,
+        },
+        status: { variant: "error", text: OAUTH_RECONNECT_COPY },
+      },
+    ]);
+
+    expect(status).toEqual({
+      variant: "error",
+      text: "home@example.com needs reconnecting",
+    });
+  });
+});
+
+describe("attentionFallbackCopy", () => {
+  it("returns the ATTENTION fallback whole", () => {
+    expect(attentionFallbackCopy()).toBe(
+      "Calendar updates are taking longer than usual. Try Refresh, or reconnect if this continues.",
+    );
+  });
+});

--- a/packages/web/src/auth/providers/connection-health-copy.util.ts
+++ b/packages/web/src/auth/providers/connection-health-copy.util.ts
@@ -1,0 +1,239 @@
+import {
+  type ConnectionState,
+  type ConnectionStateReason,
+} from "@core/types/sync/connection.contracts";
+import {
+  type GoogleConnectionState,
+  type SyncConnectionSummary,
+} from "@core/types/user.types";
+import {
+  type ConnectFlowKind,
+  connectFlowKind,
+} from "@web/auth/providers/provider-connect-flow.util";
+import { CONSENT_REQUIRED_COPY } from "@web/auth/providers/provider-copy.util";
+import {
+  type SyncStatus,
+  type SyncStatusVariant,
+} from "@web/calendars/sync-status.types";
+
+export const MICROSOFT_SELF_HOSTING_DOC_URL =
+  "https://github.com/KeepSoftwareSimple/compass-calendar/blob/main/docs/self-hosting/microsoft-calendar.md";
+
+const REAUTH_REASONS: ReadonlySet<ConnectionStateReason> = new Set([
+  "authorizationRevoked",
+  "authorizationExpired",
+  "insufficientScopes",
+]);
+
+const REFRESH_REASONS: ReadonlySet<ConnectionStateReason> = new Set([
+  "workOverdue",
+  "providerErrors",
+]);
+
+/** OAuth reconnect copy stays byte-identical for Google. */
+export const OAUTH_RECONNECT_COPY = "Calendar needs reconnecting";
+
+const PASSWORD_REAUTH_COPY: Record<
+  Extract<
+    ConnectionStateReason,
+    "authorizationRevoked" | "authorizationExpired" | "insufficientScopes"
+  >,
+  string
+> = {
+  authorizationRevoked:
+    "App-specific password was rejected. Update your password in Settings.",
+  authorizationExpired:
+    "App-specific password no longer works. Update it in Settings.",
+  insufficientScopes:
+    "Compass needs additional calendar access. Update your app-specific password in Settings.",
+};
+
+const ATTENTION_FALLBACK_COPY =
+  "Calendar updates are taking longer than usual. Try Refresh, or reconnect if this continues.";
+
+const DELAYED_WORK_OVERDUE_SETTINGS =
+  "Calendar updates are taking longer than usual.";
+const DELAYED_PROVIDER_ERRORS_SETTINGS = "Couldn't update your calendar.";
+const DELAYED_WORK_OVERDUE_SIDEBAR = "Calendar updates are delayed";
+const DELAYED_PROVIDER_ERRORS_SIDEBAR = "Couldn't update your calendar";
+
+export type HealthCopySurface = "settings" | "sidebarShort";
+
+export type HealthCopyContext = {
+  state: ConnectionState | string;
+  stateReason: ConnectionStateReason | string | null;
+  credentialKind: ConnectFlowKind;
+  surface: HealthCopySurface;
+  lastUpdatedSuffix?: string;
+};
+
+export type HealthNextAction =
+  | "reconnect"
+  | "refresh"
+  | "updatePassword"
+  | "learnMore"
+  | null;
+
+export function credentialKindForConnection(
+  connection: Pick<SyncConnectionSummary, "provider"> | null | undefined,
+): ConnectFlowKind {
+  return connectFlowKind(connection?.provider ?? "google");
+}
+
+export function isReauthReason(
+  reason: ConnectionStateReason | string | null | undefined,
+): reason is Extract<
+  ConnectionStateReason,
+  "authorizationRevoked" | "authorizationExpired" | "insufficientScopes"
+> {
+  return reason != null && REAUTH_REASONS.has(reason as ConnectionStateReason);
+}
+
+export function isRefreshReason(
+  reason: ConnectionStateReason | string | null | undefined,
+): reason is Extract<ConnectionStateReason, "workOverdue" | "providerErrors"> {
+  return reason != null && REFRESH_REASONS.has(reason as ConnectionStateReason);
+}
+
+/** Full user-facing status string for a state + reason + credential kind. */
+export function connectionHealthCopy(ctx: HealthCopyContext): string | null {
+  const {
+    state,
+    stateReason,
+    credentialKind,
+    surface,
+    lastUpdatedSuffix = "",
+  } = ctx;
+
+  if (stateReason === "consentRequired") {
+    return CONSENT_REQUIRED_COPY;
+  }
+
+  if (state === "delayed" || stateReason === "workOverdue") {
+    const base =
+      stateReason === "providerErrors"
+        ? surface === "sidebarShort"
+          ? DELAYED_PROVIDER_ERRORS_SIDEBAR
+          : DELAYED_PROVIDER_ERRORS_SETTINGS
+        : surface === "sidebarShort"
+          ? DELAYED_WORK_OVERDUE_SIDEBAR
+          : DELAYED_WORK_OVERDUE_SETTINGS;
+    if (surface === "sidebarShort") return base;
+    return `${base}${lastUpdatedSuffix} Try Refresh, or reconnect if this continues.`;
+  }
+
+  if (stateReason === "providerErrors") {
+    const base =
+      surface === "sidebarShort"
+        ? DELAYED_PROVIDER_ERRORS_SIDEBAR
+        : DELAYED_PROVIDER_ERRORS_SETTINGS;
+    if (surface === "sidebarShort") return base;
+    return `${base}${lastUpdatedSuffix} Try Refresh, or reconnect if this continues.`;
+  }
+
+  if (
+    state === "actionRequired" ||
+    state === "disconnected" ||
+    isReauthReason(stateReason)
+  ) {
+    if (credentialKind === "credentialForm" && isReauthReason(stateReason)) {
+      return PASSWORD_REAUTH_COPY[stateReason];
+    }
+    return OAUTH_RECONNECT_COPY;
+  }
+
+  if (state === "actionRequired" && stateReason === "consentRequired") {
+    return CONSENT_REQUIRED_COPY;
+  }
+
+  if (state === "actionRequired" && isRefreshReason(stateReason)) {
+    const base =
+      stateReason === "providerErrors"
+        ? DELAYED_PROVIDER_ERRORS_SETTINGS
+        : DELAYED_WORK_OVERDUE_SETTINGS;
+    return `${base}${lastUpdatedSuffix} Try Refresh, or reconnect if this continues.`;
+  }
+
+  return null;
+}
+
+export function connectionHealthNextAction(
+  state: ConnectionState | string,
+  stateReason: ConnectionStateReason | string | null,
+  credentialKind: ConnectFlowKind,
+): HealthNextAction {
+  if (stateReason === "consentRequired") return "learnMore";
+  if (isRefreshReason(stateReason) || state === "delayed") return "refresh";
+  if (credentialKind === "credentialForm" && isReauthReason(stateReason)) {
+    return "updatePassword";
+  }
+  if (
+    state === "actionRequired" ||
+    state === "disconnected" ||
+    isReauthReason(stateReason)
+  ) {
+    return "reconnect";
+  }
+  return null;
+}
+
+export function attentionFallbackCopy(): string {
+  return ATTENTION_FALLBACK_COPY;
+}
+
+export function nameAccountInCopy(
+  copy: string,
+  accountEmail: string | null | undefined,
+  genericReconnectCopy: string = OAUTH_RECONNECT_COPY,
+): string {
+  const named = accountEmail?.trim();
+  if (!named) return copy;
+  if (copy === genericReconnectCopy) {
+    return `${named} needs reconnecting`;
+  }
+  return copy;
+}
+
+const CONNECTION_STATE_PRECEDENCE: readonly GoogleConnectionState[] = [
+  "RECONNECT_REQUIRED",
+  "ATTENTION",
+  "IMPORTING",
+  "HEALTHY",
+];
+
+function connectionPrecedenceRank(
+  connectionState: GoogleConnectionState,
+): number {
+  const index = CONNECTION_STATE_PRECEDENCE.indexOf(connectionState);
+  return index === -1 ? CONNECTION_STATE_PRECEDENCE.length : index;
+}
+
+export type SidebarStatusEntry = {
+  connection: SyncConnectionSummary;
+  status: { variant: SyncStatusVariant; text: string };
+};
+
+/** Pick one sidebar line when multiple accounts need attention. Names the account when messages disagree. */
+export function pickAggregateSidebarStatus(
+  entries: readonly SidebarStatusEntry[],
+): SyncStatus | null {
+  if (entries.length === 0) return null;
+  if (entries.length === 1) return entries[0]!.status;
+
+  const sorted = [...entries].sort(
+    (left, right) =>
+      connectionPrecedenceRank(left.connection.connectionState) -
+      connectionPrecedenceRank(right.connection.connectionState),
+  );
+  const top = sorted[0]!;
+  const distinctTexts = new Set(sorted.map((entry) => entry.status.text));
+
+  if (distinctTexts.size > 1 || sorted.length > 1) {
+    return {
+      variant: top.status.variant,
+      text: nameAccountInCopy(top.status.text, top.connection.accountEmail),
+    };
+  }
+
+  return top.status;
+}

--- a/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.test.tsx
+++ b/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.test.tsx
@@ -65,9 +65,8 @@ describe("CalendarConnectionBanner", () => {
     );
   });
 
-  it("renders the consentRequired copy whole with a reconnect action", async () => {
+  it("renders the consentRequired copy whole with a learn-more action", async () => {
     const onAction = mock();
-    const user = userEvent.setup();
     render(
       <HotkeysProvider>
         <CalendarConnectionBanner
@@ -81,8 +80,10 @@ describe("CalendarConnectionBanner", () => {
     expect(screen.getByRole("alert")).toHaveTextContent(
       "Your organization's admin has to approve Compass before this account can connect.",
     );
-    await user.click(screen.getByRole("button", { name: "Reconnect" }));
-    expect(onAction).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByRole("button", { name: "Learn more" }),
+    ).toBeInTheDocument();
+    expect(onAction).not.toHaveBeenCalled();
   });
 
   it("shows a G keycap and reconnects when G is pressed", () => {

--- a/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.tsx
+++ b/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.tsx
@@ -4,6 +4,7 @@ import {
   type CalendarConnectionBannerKind,
   calendarReconnectBannerMessage,
 } from "@web/auth/providers/connect.util";
+import { MICROSOFT_SELF_HOSTING_DOC_URL } from "@web/auth/providers/connection-health-copy.util";
 import { CONSENT_REQUIRED_COPY } from "@web/auth/providers/provider-copy.util";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import {
@@ -51,7 +52,7 @@ export const CalendarConnectionBanner: FC<CalendarConnectionBannerProps> = ({
       : kind === "consentRequired"
         ? {
             message: CONSENT_REQUIRED_COPY,
-            action: "Reconnect",
+            action: "Learn more",
           }
         : STATIC_COPY[kind];
   const isError =
@@ -59,11 +60,21 @@ export const CalendarConnectionBanner: FC<CalendarConnectionBannerProps> = ({
     kind === "consentRequired" ||
     kind === "importFailed";
   const pointerAction =
-    kind === "reconnect" || kind === "consentRequired"
-      ? POINTER_ACTIONS.reconnectGoogle
-      : undefined;
+    kind === "reconnect" ? POINTER_ACTIONS.reconnectGoogle : undefined;
 
   useNoticeActionShortcut(CONNECTION_BANNER_SHORTCUT_KEY, onAction);
+
+  const handleAction = () => {
+    if (kind === "consentRequired") {
+      window.open(
+        MICROSOFT_SELF_HOSTING_DOC_URL,
+        "_blank",
+        "noopener,noreferrer",
+      );
+      return;
+    }
+    onAction();
+  };
 
   return (
     <div
@@ -78,7 +89,7 @@ export const CalendarConnectionBanner: FC<CalendarConnectionBannerProps> = ({
       <p>{message}</p>
       <button
         className="c-focus-ring inline-flex shrink-0 items-center gap-2 rounded-xs px-2 py-1 font-medium text-text hover:bg-surface-overlay"
-        onClick={onAction}
+        onClick={handleAction}
         type="button"
         {...pointerShortcutAttributes(CONNECTION_BANNER_SHORTCUT_KEY)}
         {...(pointerAction

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -11,6 +11,7 @@ import {
   googleSyncSupportMailto,
   SSE_DEGRADED_STATUS,
 } from "@web/auth/providers/connect.util";
+import { MICROSOFT_SELF_HOSTING_DOC_URL } from "@web/auth/providers/connection-health-copy.util";
 import { connectionProviderKind } from "@web/auth/providers/connection-provider.util";
 import { CALENDAR_HOST_EXPLAINER } from "@web/auth/providers/provider-copy.util";
 import { useGoogleSyncRefreshSnapshot } from "@web/auth/providers/sync.refresh";
@@ -511,6 +512,18 @@ const AccountRow: FC<AccountRowProps> = ({
               href={googleSyncSupportMailto}
             >
               Email support
+            </a>
+          </p>
+        ) : null}
+        {connection.stateReason === "consentRequired" ? (
+          <p className="text-text-muted text-xs">
+            <a
+              className="underline hover:text-text"
+              href={MICROSOFT_SELF_HOSTING_DOC_URL}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Admin consent setup guide
             </a>
           </p>
         ) : null}

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
@@ -6,6 +6,7 @@ import { seedPendingEventMutations } from "@web/__tests__/utils/event-query-test
 import { createMockConnection } from "@web/__tests__/utils/factories/calendar.factory";
 import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
 import { type GoogleUiState } from "@web/auth/providers/connect.types";
+import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import {
   initialFirstEventPromptState,
   useFirstEventPromptStore,
@@ -97,6 +98,17 @@ afterAll(() => {
   isSseDegradedMocked = false;
 });
 
+const seedSidebarConnections = (
+  connections: GoogleSyncConnectionSummary[],
+  connectionState: GoogleUiState = "HEALTHY",
+) => {
+  const aggregate =
+    connectionState === "checking" ? ("HEALTHY" as const) : connectionState;
+  userMetadataActions.set({
+    google: { connectionState: aggregate, connections },
+    connections,
+  });
+};
 const statusBarModuleUrl = new URL(
   `./SidebarStatusBar.tsx?test=${Math.random().toString(36).slice(2)}`,
   import.meta.url,
@@ -143,6 +155,7 @@ describe("SidebarStatusBar", () => {
     googleState = "HEALTHY";
     isConnecting = false;
     connection = null;
+    userMetadataActions.clear();
     isSseDegraded = false;
     draftActions.discard();
     useEventJumpStore.setState(initialEventJumpState, true);
@@ -207,6 +220,7 @@ describe("SidebarStatusBar", () => {
       lastHealthyAt: null,
       connectionState: "IMPORTING",
     });
+    seedSidebarConnections([connection], googleState);
     const { wrapper } = createStoreWrapper();
 
     render(<SidebarStatusBar />, { wrapper });
@@ -224,6 +238,7 @@ describe("SidebarStatusBar", () => {
       lastHealthyAt: new Date().toISOString(),
       connectionState: "IMPORTING",
     });
+    seedSidebarConnections([connection], googleState);
     const { wrapper } = createStoreWrapper();
 
     render(<SidebarStatusBar />, { wrapper });
@@ -240,6 +255,7 @@ describe("SidebarStatusBar", () => {
       lastHealthyAt: new Date(Date.now() - 15 * 60_000).toISOString(),
       connectionState: "IMPORTING",
     });
+    seedSidebarConnections([connection], googleState);
     const { wrapper } = createStoreWrapper();
 
     render(<SidebarStatusBar />, { wrapper });
@@ -253,6 +269,28 @@ describe("SidebarStatusBar", () => {
     );
   });
 
+  it("names the worse account when two connections disagree", () => {
+    googleState = "RECONNECT_REQUIRED";
+    const delayed = createMockConnection("work@example.com", {
+      state: "delayed",
+      stateReason: "workOverdue",
+      connectionState: "ATTENTION",
+    });
+    const reconnect = createMockConnection("home@example.com", {
+      state: "actionRequired",
+      stateReason: "authorizationRevoked",
+      connectionState: "RECONNECT_REQUIRED",
+    });
+    seedSidebarConnections([delayed, reconnect], googleState);
+    const { wrapper } = createStoreWrapper();
+
+    render(<SidebarStatusBar />, { wrapper });
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "home@example.com needs reconnecting",
+    );
+  });
+
   it("shows Calendar updates are delayed for delayed workOverdue", () => {
     googleState = "ATTENTION";
     connection = createMockConnection("ahab@pequod.com", {
@@ -262,6 +300,7 @@ describe("SidebarStatusBar", () => {
       lastHealthyAt: null,
       connectionState: "ATTENTION",
     });
+    seedSidebarConnections([connection], googleState);
     const { wrapper } = createStoreWrapper();
 
     render(<SidebarStatusBar />, { wrapper });
@@ -280,6 +319,7 @@ describe("SidebarStatusBar", () => {
       stateReason: "workOverdue",
       connectionState: "ATTENTION",
     });
+    seedSidebarConnections([connection], googleState);
     const { wrapper } = createStoreWrapper();
 
     render(<SidebarStatusBar />, { wrapper });
@@ -303,6 +343,7 @@ describe("SidebarStatusBar", () => {
       lastHealthyAt: null,
       connectionState: "IMPORTING",
     });
+    seedSidebarConnections([connection], googleState);
     const { queryClient, wrapper } = createStoreWrapper();
     seedPendingEventMutations(queryClient, ["event-1"]);
 
@@ -341,6 +382,7 @@ describe("SidebarStatusBar", () => {
       stateReason: "workOverdue",
       connectionState: "ATTENTION",
     });
+    seedSidebarConnections([connection], googleState);
     const { wrapper } = createStoreWrapper();
 
     render(<SidebarStatusBar />, { wrapper });

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.tsx
@@ -1,10 +1,14 @@
 import { type FC } from "react";
 import {
-  getSidebarSyncStatus,
+  getAggregateSidebarSyncStatus,
   SSE_DEGRADED_STATUS,
 } from "@web/auth/providers/connect.util";
 import { useGoogleSyncRefreshSnapshot } from "@web/auth/providers/sync.refresh";
 import { useConnectGoogle } from "@web/auth/providers/useConnectProvider";
+import {
+  selectSyncConnections,
+  useUserMetadataStore,
+} from "@web/auth/state/user-metadata.store";
 import { useShortcutWriteLocked } from "@web/billing/useBillingWriteLock";
 import { SYNC_STATUS_VARIANT_CLASSNAME } from "@web/calendars/sync-status.types";
 import { useHasPendingEventMutations } from "@web/events/mutations/useEventPending";
@@ -68,11 +72,12 @@ export const SidebarStatusBar: FC = () => {
   // collapse to the aggregate "IMPORTING" state, and only the connection's
   // own lastHealthyAt tells getSidebarSyncStatus the account was already
   // established and should stay quiet.
-  const { connection, isConnecting, state } = useConnectGoogle();
+  const { isConnecting, state } = useConnectGoogle();
+  const connections = useUserMetadataStore(selectSyncConnections);
   const refreshSnapshot = useGoogleSyncRefreshSnapshot();
   const sseDegraded = useSseDegraded();
-  const syncStatus = getSidebarSyncStatus({
-    connection,
+  const syncStatus = getAggregateSidebarSyncStatus({
+    connections,
     isConnecting,
     state,
     refreshGaveUp: refreshSnapshot.gaveUp,


### PR DESCRIPTION
Fixes #3278

## What and why

Providers C closeout WP-02: every `ConnectionStateReason` now has user-facing copy and a next action keyed by reason and credential kind (OAuth redirect vs password form). Google OAuth strings stay byte-identical. `consentRequired` shows admin-consent copy with a doc link instead of refresh advice. Password credentials tell users to update their app-specific password, never to reconnect Google. `SidebarStatusBar` reads all connections and names the account when statuses disagree.

Spec: `docs/features/calendar-providers.md`

## Health copy table

Settings / sidebar strings by `stateReason` and credential kind (`oauthRedirect` = Google/Microsoft OAuth, `credentialForm` = Apple password):

| stateReason | credentialKind | Settings copy | Sidebar short copy | Next action |
|---|---|---|---|---|
| authorizationRevoked | oauthRedirect | Calendar needs reconnecting | `{email} needs reconnecting` when named | Reconnect |
| authorizationRevoked | credentialForm | App-specific password was rejected. Update your password in Settings. | same (named when multi-account) | Update password |
| authorizationExpired | oauthRedirect | Calendar needs reconnecting | `{email} needs reconnecting` when named | Reconnect |
| authorizationExpired | credentialForm | App-specific password no longer works. Update it in Settings. | same | Update password |
| insufficientScopes | oauthRedirect | Calendar needs reconnecting | `{email} needs reconnecting` when named | Reconnect |
| insufficientScopes | credentialForm | Compass needs additional calendar access. Update your app-specific password in Settings. | same | Update password |
| consentRequired | oauthRedirect | Your organization's admin has to approve Compass before this account can connect. | same | Learn more (links Microsoft admin-consent guide) |
| workOverdue | either | Calendar updates are taking longer than usual. `{last updated}` Try Refresh, or reconnect if this continues. | Calendar updates are delayed | Refresh |
| providerErrors | either | Couldn't update your calendar. `{last updated}` Try Refresh, or reconnect if this continues. | Couldn't update your calendar | Refresh |

Backend: `stateReason` passes through `toGoogleSyncConnectionSummary` untouched (including `consentRequired` → `ATTENTION` collapse with reason preserved).

## Verify

```
bun run verify --strict
```

Selected packages: web, backend
Checks run: test:web, test:backend:fast, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)

VERDICT: PASS
