### PR TITLE
docs(providers): document apple and microsoft setup

### DIFF
--- a/docs/self-hosting/apple-calendar.md
+++ b/docs/self-hosting/apple-calendar.md
@@ -1,10 +1,54 @@
 # Connect iCloud Calendar
 
-Stub. A-12 fills in the iCloud CalDAV connect flow.
+## Connect an iCloud calendar
 
-Until then, these are the Compass config keys. Add the matching GitHub
+Calendar sync uses CalDAV and an app-specific password. A self-hoster does
+not need Apple Developer Program membership for calendar sync.
+
+1. Enable two-factor authentication on the Apple Account used for testing.
+2. Sign in at [Apple Account](https://account.apple.com), open **Sign-In and
+   Security > App-Specific Passwords**, and generate a password named
+   `compass-staging`.
+3. In Compass, connect iCloud with the account email and that app-specific
+   password. Use the generated password rather than the main account password.
+4. Verify the connection becomes healthy and the expected calendars appear.
+
+See [Apple's app-specific password instructions](https://support.apple.com/en-us/102654).
+Revoking the password prevents further sync. Changing the main Apple Account
+password also revokes app-specific passwords. Generate a replacement and
+reconnect when Compass reports expired authorization.
+
+For staging, create a disposable `compass-smoke` calendar and recurring
+events with exceptions. If another test account is available, also share a
+second calendar read-only. Verify edits in both directions, a recurring
+exception, a booking without a video link, and the reconnect prompt after
+revoking the test password. Record actual results and dates; configuration
+alone does not establish a successful soak.
+
+The provider smoke workflow uses `SMOKE_APPLE_EMAIL` and
+`SMOKE_APPLE_APP_PASSWORD` secrets in the `provider-smoke` environment.
+
+## Sign in with Apple
+
+Apple sign-in is separate from calendar access. To configure it:
+
+1. Enroll in the Apple Developer Program and create a primary App ID with
+   the Sign in with Apple capability.
+2. In **Certificates, Identifiers & Profiles**, register a Services ID for
+   the website and enable Sign in with Apple on it.
+3. Associate the Services ID with the primary App ID. Configure the website
+   domains and backend return URLs below, then save the configuration.
+4. Create a key with Sign in with Apple enabled for that primary App ID.
+   Download its `.p8` file and retain it privately. Record the Key ID and
+   the developer account's Team ID.
+5. Set all four Compass values below and rebuild/deploy the affected services.
+   Check `/api/config` reports `providers.apple.signIn: true`.
+
+Follow Apple's [web configuration guide](https://developer.apple.com/help/account/capabilities/configure-sign-in-with-apple-for-the-web).
+
+These are the Compass config keys. Add the matching GitHub
 Environment variables and secrets on `staging-cloud`, `staging-selfhosted`,
-and `production` before I-03 need them.
+and `production` for each deployment that supports Apple sign-in.
 
 Sign in with Apple (identity only; it does not grant calendar access):
 

--- a/docs/self-hosting/microsoft-calendar.md
+++ b/docs/self-hosting/microsoft-calendar.md
@@ -1,10 +1,39 @@
 # Connect Microsoft Calendar
 
-Stub. M-14 fills in the Outlook / Microsoft 365 connect flow.
+## Register the application
 
-Until then, these are the Compass config keys. Add the matching GitHub
+In the Microsoft Entra admin center, open **App registrations > New
+registration**. Choose accounts in any organizational directory and personal
+Microsoft accounts. Compass uses delegated access; do not add application
+permissions.
+
+Register the calendar callback as a Web redirect URI for each deployment:
+
+- `http://localhost:3010/sync/microsoft`
+- `https://staging.compasscalendar.com/sync/microsoft`
+- `https://compasscalendar.com/sync/microsoft`
+
+For a self-hosted instance, replace the origin with your sync service's public
+origin. Also register the web sign-in callback, `/auth/microsoft/callback`,
+on each frontend origin used for Microsoft sign-in. Local ports must match
+the URLs printed by your development environment.
+
+Under Microsoft Graph delegated permissions, add `offline_access`,
+`User.Read`, `Calendars.ReadWrite`, and `People.Read`. Under **Certificates &
+secrets**, create a client secret and record its expiry in your private
+operations records. Store the secret value, not its identifier.
+
+For work-tenant consent, complete publisher verification through your
+Microsoft AI Cloud Partner Program account and associate the verified
+publisher with the app. Tenant policies can still require administrator
+consent. See Microsoft's [registration guide](https://learn.microsoft.com/en-us/graph/auth-register-app-v2)
+and [publisher verification requirements](https://learn.microsoft.com/en-us/entra/identity-platform/publisher-verification-overview).
+
+## Configure Compass
+
+These are the Compass config keys. Add the matching GitHub
 Environment variables and secrets on `staging-cloud`, `staging-selfhosted`,
-and `production` before M-09 / I-03 need them.
+and `production` for each deployment that supports Microsoft.
 
 ```yaml
 microsoft:
@@ -23,3 +52,18 @@ GitHub Environment:
 
 The web bundle bakes `MICROSOFT_CLIENT_ID` at build time (same as Google).
 Rebuild the web image after changing it.
+
+## Verify and troubleshoot
+
+After deploying configuration, check `/api/config`: Microsoft `signIn` and
+`connect` should be enabled. Test both a personal Outlook account and a work
+account, each with a disposable `compass-smoke` calendar. Connect on staging,
+verify healthy state, edit in both directions, reload, and make a booking.
+Record the date and observed results before calling the staging soak complete.
+
+For `consentRequired`, reconnect and review the requested permissions. If
+the tenant requires administrator consent, its administrator must approve
+the delegated permissions. For redirect mismatch errors, compare the full
+registered URI, including scheme, port, and path, with the callback sent by
+Compass. For invalid-client errors, check the secret value and expiry and
+restart the services after updating configuration.


### PR DESCRIPTION
Related to #3211, #3239, #3253, #3274, #3276, and #3414. These issues remain open because external registration and staging soak acceptance are not complete.

## What and why

Replace the Apple and Microsoft self-hosting stubs with registration, delegated permissions, callback configuration, credential setup, publisher verification, and troubleshooting instructions. Separate Apple calendar access from Apple sign-in and document the staging acceptance flows without claiming they passed.

## Verify

`VERDICT: PASS`

`bun run verify --strict`: type-check, lint, knip. `git diff --check` passed. Provider portal instructions checked against linked Microsoft and Apple documentation.
