### PR TITLE
fix(ci): enable autofix auto-merge with a token that has contents:write

### DIFF
--- a/.github/scripts/agent-loop-merge-guard.sh
+++ b/.github/scripts/agent-loop-merge-guard.sh
@@ -253,8 +253,12 @@ check_and_merge() {
   # The ruleset merge queue owns the strategy (SQUASH) and the repo deletes
   # branches on merge; passing --squash or --delete-branch here is rejected
   # ("Cannot use --delete-branch when merge queue enabled", 2026-09-04).
-  if ! gh pr merge "$pr_number" --repo "$REPO" --auto; then
-    notify "Agent-loop PR #${pr_number} passed verification but \`gh pr merge --auto\` failed: https://github.com/${REPO}/pull/${pr_number}"
+  # Carry gh's own error into the notice so a token or queue problem is
+  # readable from Discord instead of needing a job-log dig.
+  local merge_error
+  if ! merge_error=$(gh pr merge "$pr_number" --repo "$REPO" --auto 2>&1); then
+    printf '%s\n' "$merge_error" >&2
+    notify "Agent-loop PR #${pr_number} passed verification but \`gh pr merge --auto\` failed (${merge_error%%$'\n'*}): https://github.com/${REPO}/pull/${pr_number}"
     return 0
   fi
   printf 'enabled auto-merge on agent PR #%s; the merge queue squash-merges when required checks pass\n' "$pr_number"

--- a/.github/scripts/autofix-merge-guard.sh
+++ b/.github/scripts/autofix-merge-guard.sh
@@ -102,8 +102,12 @@ main() {
   fi
 
   # Merge queue owns the strategy and the repo deletes branches on merge.
-  if ! gh pr merge "$pr_number" --repo "$REPO" --auto; then
-    notify "Autofix PR #${pr_number} (issue #${ISSUE_NUMBER}) passed the merge guard but \`gh pr merge --auto\` failed — needs a human to enable merge manually — https://github.com/${REPO}/pull/${pr_number}"
+  # Carry gh's own error into the notice: without it the 2026-09-06 token
+  # permission failure read as a generic "failed" and took a log dig to find.
+  local merge_error
+  if ! merge_error=$(gh pr merge "$pr_number" --repo "$REPO" --auto 2>&1); then
+    printf '%s\n' "$merge_error" >&2
+    notify "Autofix PR #${pr_number} (issue #${ISSUE_NUMBER}) passed the merge guard but \`gh pr merge --auto\` failed (${merge_error%%$'\n'*}); needs a human to enable merge manually: https://github.com/${REPO}/pull/${pr_number}"
     return 0
   fi
   # Do not watch CI here: this job runs under a cancel-in-progress:false

--- a/.github/workflows/error-autofix.yml
+++ b/.github/workflows/error-autofix.yml
@@ -110,9 +110,13 @@ jobs:
 
       # Uses a PAT, not GITHUB_TOKEN: the merge push must fire
       # release-on-main.yml (see comment above), which GITHUB_TOKEN-authored
-      # events do not do.
+      # events do not do. Prefers the agent-loop token: enabling auto-merge
+      # (enablePullRequestAutoMerge) needs contents:write as well as
+      # pull_requests:write, and AUTOFIX_GITHUB_TOKEN lacked it, failing every
+      # gate with "Resource not accessible by personal access token"
+      # (2026-09-06, PR #3450).
       - name: Deterministic merge guard + enable auto-merge
         env:
-          GH_TOKEN: ${{ secrets.AUTOFIX_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AGENT_LOOP_GITHUB_TOKEN || secrets.AUTOFIX_GITHUB_TOKEN }}
           DISCORD_ERRORS_WEBHOOK_URL: ${{ secrets.DISCORD_ERRORS_WEBHOOK_URL }}
         run: .github/scripts/autofix-merge-guard.sh "${{ github.event.issue.number || inputs.issue_number }}"

--- a/docs/CI-CD/agent-loop-routine.md
+++ b/docs/CI-CD/agent-loop-routine.md
@@ -79,9 +79,14 @@ required; the loop pulls its work from the issue queue.
      Alias notes: an Automation still listening for `booking-loop: pickup`
      needs its trigger updated.
 4. A PAT with `contents:write` + `pull_requests:write` stored as
-   `AGENT_LOOP_GITHUB_TOKEN`, or reuse `BOOKING_LOOP_GITHUB_TOKEN` /
-   `AUTOFIX_GITHUB_TOKEN`. Required so squash-merge commits trigger
-   `release-on-main` (the default `GITHUB_TOKEN` does not).
+   `AGENT_LOOP_GITHUB_TOKEN` (`BOOKING_LOOP_GITHUB_TOKEN` is still read as
+   an alias). Both scopes are required: `gh pr merge --auto` calls the
+   `enablePullRequestAutoMerge` mutation, which a PAT without
+   `contents:write` rejects with "Resource not accessible by personal
+   access token". The PAT is also what makes squash-merge commits trigger
+   `release-on-main` (the default `GITHUB_TOKEN` does not). The error
+   autofix gate uses this same token first and falls back to
+   `AUTOFIX_GITHUB_TOKEN` only when it is unset.
 5. Labels `agent-automerge`, `agent-loop-running`,
    `agent-loop-waiting-for-credits`, `agent-loop-needs-human` on this
    repo (`gh label create` if missing). Alias notes: the `booking-*`

--- a/packages/scripts/src/testing/agent-loop-routine.test.ts
+++ b/packages/scripts/src/testing/agent-loop-routine.test.ts
@@ -19,7 +19,9 @@ describe("agent-loop Routine contract", () => {
       ".github/scripts/agent-loop-merge-guard.sh",
       "utf8",
     );
-    expect(guard).toMatch(/gh pr merge "\$pr_number" --repo "\$REPO" --auto;/);
+    expect(guard).toMatch(
+      /gh pr merge "\$pr_number" --repo "\$REPO" --auto 2>&1\)/,
+    );
     // The merge queue rejects an explicit strategy or branch deletion.
     expect(guard).not.toMatch(/gh pr merge[^\n]*(--squash|--delete-branch)/);
     expect(guard).not.toContain("gh pr checks");

--- a/packages/scripts/src/testing/error-autofix-routine.test.ts
+++ b/packages/scripts/src/testing/error-autofix-routine.test.ts
@@ -23,6 +23,25 @@ describe("error-autofix Routine contract", () => {
     expect(guard).toMatch(/^MAX_LINES=250$/m);
   });
 
+  it("enables auto-merge with a token that has contents:write", () => {
+    // AUTOFIX_GITHUB_TOKEN alone failed every gate with "Resource not
+    // accessible by personal access token (enablePullRequestAutoMerge)"
+    // (2026-09-06, PR #3450); the agent-loop PAT carries both scopes.
+    const workflow = readFileSync(
+      ".github/workflows/error-autofix.yml",
+      "utf8",
+    );
+    expect(workflow).toContain(
+      "GH_TOKEN: ${{ secrets.AGENT_LOOP_GITHUB_TOKEN || secrets.AUTOFIX_GITHUB_TOKEN }}",
+    );
+    const guard = readFileSync(
+      ".github/scripts/autofix-merge-guard.sh",
+      "utf8",
+    );
+    // The notice carries gh's own error so a token failure reads from Discord.
+    expect(guard).toMatch(/merge_error=\$\(gh pr merge[^\n]*--auto 2>&1\)/);
+  });
+
   it("still blocks the sensitive paths from auto-merging", () => {
     const guard = readFileSync(
       ".github/scripts/autofix-merge-guard.sh",


### PR DESCRIPTION
## What and why

Every error-autofix `gate-and-merge` run since `AUTOFIX_MODE=merge` was enabled has failed at the last step. The Discord notice only said `gh pr merge --auto` failed; the job log shows the real error:

```
GraphQL: Resource not accessible by personal access token (enablePullRequestAutoMerge)
```

The gate used `AUTOFIX_GITHUB_TOKEN` alone. Enabling auto-merge needs `contents:write` as well as `pull_requests:write`, and that token does not carry it. The agent-loop guard runs the identical call with `AGENT_LOOP_GITHUB_TOKEN` and succeeds (it enabled auto-merge on #3451 the same day #3450 failed). No autofix-labeled PR has ever merged, so this is not a regression from the merge queue; the token never worked for this.

## Changes

- `error-autofix.yml`: the gate now uses `AGENT_LOOP_GITHUB_TOKEN || AUTOFIX_GITHUB_TOKEN`, matching the agent-loop guard's chain.
- Both merge guards capture `gh pr merge --auto` stderr and put its first line in the Discord notice, and echo it to the job log. Discord escaping already goes through `jq`, so raw `gh` output is safe.
- `agent-loop-routine.md` no longer suggests reusing `AUTOFIX_GITHUB_TOKEN` for the loop and spells out why both scopes are required.
- Contract tests pin the token chain and the error capture; the existing regex that pinned `--auto;` is widened to accept the `2>&1)` capture.

## Verification

- `bun run verify --strict`: `VERDICT: PASS` (selects no packages for `.github` + docs changes).
- `bun test packages/scripts/src/testing/error-autofix-routine.test.ts packages/scripts/src/testing/agent-loop-routine.test.ts`: 14 pass.
- `bun run lint`: passed.
- `agent-loop-merge-guard.test.sh` needs bash 4 (`mapfile`), which this Mac lacks; the `static` CI job runs it on Linux.
- `bun run type-check:tests` reports a pre-existing error in `packages/sync/src/telemetry/posthog-capture.test.ts`, untouched by this branch.

## Merge note

Touches `error-autofix.yml` and the two guard scripts, which both guards refuse to auto-merge, so this one needs a human merge. #3450 itself is `CLEAN` and mergeable; `gh pr merge 3450 --auto` from a user with write access unblocks it independently of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
