### PR TITLE
refactor(sync): unify recurring-series transitions

### DIFF
--- a/packages/sync/src/domain/cloud-command.service.ts
+++ b/packages/sync/src/domain/cloud-command.service.ts
@@ -1,4 +1,3 @@
-import { type DateTime } from "@core/types/domain-primitives";
 import { type EditableRecurrence } from "@core/types/event.contracts";
 import { type SyncEventRecurrence } from "@core/types/sync/event.contracts";
 import { type ProviderCalendarId } from "@core/types/sync/identity.contracts";
@@ -13,8 +12,6 @@ import {
 import {
   isFollowingSplitAtSeriesStart,
   occurrenceScheduleAt,
-  stripRuleBounds,
-  truncateRulesBefore,
 } from "@sync/domain/occurrence-projection";
 import {
   executeProviderCreate,
@@ -31,12 +28,13 @@ import {
 } from "@sync/domain/provider-command.service";
 import { reprojectOccurrences } from "@sync/domain/reproject";
 import {
+  buildRemainderMaster,
   deleteExceptions,
   deleteFollowingExceptions,
   exceptionInstant,
-  isCancelledException,
-  remainderMasterId,
+  partitionEditAllExceptions,
   reprojectMaster,
+  truncatedSeriesMaster,
 } from "@sync/domain/series-exception";
 import {
   ProviderNotConfiguredError,
@@ -602,10 +600,10 @@ async function updateCloudSeries(
     command.principalId,
     master._id,
   );
-  const kept = convertsToSingle ? [] : exceptions.filter(isCancelledException);
-  const discarded = convertsToSingle
-    ? exceptions
-    : exceptions.filter((exception) => !isCancelledException(exception));
+  const { kept, discarded } = partitionEditAllExceptions(
+    exceptions,
+    convertsToSingle,
+  );
 
   await deleteExceptions(deps, command, discarded);
   const updated = applyCloudUpdate(master, command, now());
@@ -644,9 +642,6 @@ async function deleteCloudSeries(
   );
   return confirmCloud(deps, command);
 }
-
-// deleteExceptions / isCancelledException / exceptionInstant now live in
-// series-exception.ts, shared with the provider-linked executors below.
 
 // Cancel one occurrence of a cloud series (scope "this"): upsert a cancelled
 // exception tombstone at the target instant, reproject the master to exclude
@@ -713,9 +708,6 @@ async function updateCloudOccurrence(
   return confirmCloud(deps, command);
 }
 
-// reprojectMaster now lives in series-exception.ts, shared with the
-// provider-linked executors below.
-
 // Delete one occurrence of a cloud series and every occurrence after it (scope
 // "thisAndFollowing"): truncate the master's rule to end before the split point,
 // drop the exceptions at or after it, and reproject the shortened master. A
@@ -738,22 +730,12 @@ async function deleteCloudSeriesFollowing(
   }
 
   await deleteFollowingExceptions(deps, command, master._id, splitAt);
-  const truncated: EventRecord = {
-    ...master,
-    recurrence: {
-      kind: "seriesMaster",
-      rules: truncateRulesBefore(master.recurrence.rules, splitAt),
-    },
-    updatedAt: now(),
-  };
+  const truncated = truncatedSeriesMaster(master, splitAt, now());
   const applied = await deps.events.replaceExisting(truncated);
   if (!applied) return command;
   await reprojectMaster(deps, command, truncated, now);
   return confirmCloud(deps, command);
 }
-
-// deleteFollowingExceptions now lives in series-exception.ts, shared
-// with the provider-linked executors below.
 
 // Edit one occurrence of a cloud series and every occurrence after it (scope
 // "thisAndFollowing") by SPLITTING the series: truncate the original master to
@@ -789,14 +771,7 @@ async function updateCloudSeriesFollowing(
   }
 
   await deleteFollowingExceptions(deps, command, master._id, splitAt);
-  const truncated: EventRecord = {
-    ...master,
-    recurrence: {
-      kind: "seriesMaster",
-      rules: truncateRulesBefore(master.recurrence.rules, splitAt),
-    },
-    updatedAt: now(),
-  };
+  const truncated = truncatedSeriesMaster(master, splitAt, now());
   const applied = await deps.events.replaceExisting(truncated);
   if (!applied) return command;
   await reprojectMaster(deps, command, truncated, now);
@@ -806,47 +781,6 @@ async function updateCloudSeriesFollowing(
   await reprojectOccurrences(deps.occurrences, remainder, now);
   return confirmCloud(deps, command);
 }
-
-// Build the remainder series of a thisAndFollowing split: a fresh master at the
-// edit's schedule, carrying the edited content and recurrence, with a
-// deterministic id so a retry converges on one series. "preserve" continues the
-// original cadence (bounds stripped, so it runs open-ended from the split).
-function buildRemainderMaster(
-  master: EventRecord,
-  command: CommandRecord,
-  now: Date,
-): EventRecord {
-  if (command.input.kind !== "update") {
-    throw new Error("buildRemainderMaster requires an update command");
-  }
-  if (master.recurrence.kind !== "seriesMaster") {
-    throw new Error("buildRemainderMaster requires a series master");
-  }
-  const { input } = command;
-  const recurrence: SyncEventRecurrence =
-    input.recurrence.kind === "series"
-      ? { kind: "seriesMaster", rules: input.recurrence.rules }
-      : input.recurrence.kind === "single"
-        ? { kind: "single" }
-        : {
-            kind: "seriesMaster",
-            rules: stripRuleBounds(master.recurrence.rules),
-          };
-  return {
-    ...master,
-    _id: remainderMasterId(master._id, command.input.recurrenceId as DateTime),
-    clientEventId: null,
-    content: mergeUpdateContent(master.content, input.content),
-    schedule: input.schedule,
-    recurrence,
-    createdAt: now,
-    updatedAt: now,
-    confirmedAt: now,
-  };
-}
-
-// remainderMasterId now lives in series-exception.ts, shared with the
-// provider-linked split executors below.
 
 // Confirm a cloud command with no provider identity — local persistence is the
 // only durability it needs. updateOutcome only misses if the command vanished

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -27,7 +27,6 @@ import {
   occurrenceScheduleAfterSeriesEdit,
   occurrenceScheduleAt,
   scheduleStartAt,
-  stripRuleBounds,
   truncateRulesBefore,
 } from "@sync/domain/occurrence-projection";
 import {
@@ -37,11 +36,12 @@ import {
 } from "@sync/domain/provider-write-ladder";
 import { reprojectOccurrences } from "@sync/domain/reproject";
 import {
+  buildRemainderMaster,
   deleteFollowingExceptions,
   exceptionInstant,
-  isCancelledException,
-  remainderMasterId,
+  partitionEditAllExceptions,
   reprojectMaster,
+  truncatedSeriesMaster,
 } from "@sync/domain/series-exception";
 import { type ProviderEvent } from "@sync/providers/provider-event.port";
 import {
@@ -747,10 +747,10 @@ async function commitProviderSeriesUpdate(
     command.principalId,
     master._id,
   );
-  const kept = convertsToSingle ? [] : exceptions.filter(isCancelledException);
-  const discarded = convertsToSingle
-    ? exceptions
-    : exceptions.filter((exception) => !isCancelledException(exception));
+  const { kept, discarded } = partitionEditAllExceptions(
+    exceptions,
+    convertsToSingle,
+  );
 
   // Align or remove discarded overrides at Google first, then clear local
   // copies. Kept cancelled tombstones are not touched at the provider.
@@ -1253,7 +1253,7 @@ export async function executeProviderSeriesFollowingDelete(
       deps,
       command,
       master,
-      truncatedRules,
+      splitAt,
       current.providerVersion,
       now,
     );
@@ -1279,7 +1279,7 @@ export async function executeProviderSeriesFollowingDelete(
     deps,
     command,
     master,
-    truncatedRules,
+    splitAt,
     result.providerVersion,
     now,
   );
@@ -1289,17 +1289,15 @@ async function commitProviderSeriesFollowingDelete(
   deps: ProviderMutationDeps,
   command: CommandRecord,
   master: EventRecord,
-  truncatedRules: readonly string[],
+  splitAt: Date,
   providerVersion: string,
   now: () => Date,
 ): Promise<CommandRecord> {
   const truncated: EventRecord = {
-    ...master,
-    recurrence: { kind: "seriesMaster", rules: truncatedRules },
+    ...truncatedSeriesMaster(master, splitAt, now()),
     providerVersion: providerVersion as ProviderEventVersion,
     providerUpdatedAt: null,
     deliveryState: "confirmed",
-    updatedAt: now(),
   };
   const applied = await deps.events.replaceExisting(truncated);
   if (!applied) return command;
@@ -1434,40 +1432,31 @@ export async function executeProviderSeriesFollowingUpdate(
   }
 
   const truncated: EventRecord = {
-    ...master,
-    recurrence: { kind: "seriesMaster", rules: truncatedRules },
+    ...truncatedSeriesMaster(master, splitAt, now()),
     providerVersion: originalVersion as ProviderEventVersion,
     providerUpdatedAt: null,
     deliveryState: "confirmed",
-    updatedAt: now(),
   };
   const appliedTruncate = await deps.events.replaceExisting(truncated);
   if (!appliedTruncate) return command;
   await reprojectMaster(deps, command, truncated, now);
 
-  // "preserve" continues the original (pre-truncation) cadence, open-ended
-  // from the split — mirroring buildRemainderMaster's own "preserve" case,
-  // NOT intendedSeriesRecurrence's (which would re-write the already-bounded
-  // rules the master just got truncated to).
+  // Remainder comes from the original (pre-truncation) master. "preserve"
+  // must not use intendedSeriesRecurrence, which would re-write the already
+  // bounded rules the original just got truncated to.
+  const remainderDraft = buildRemainderMaster(master, command, now());
   const remainderRecurrence: ProviderWriteRecurrence =
-    input.recurrence.kind === "series"
-      ? { kind: "series", rules: input.recurrence.rules }
-      : input.recurrence.kind === "single"
-        ? { kind: "single" }
-        : { kind: "series", rules: stripRuleBounds(master.recurrence.rules) };
-  const remainderId = remainderMasterId(
-    master._id,
-    input.recurrenceId as DateTime,
-  );
-  const remainderContent = mergeUpdateContent(master.content, input.content);
+    remainderDraft.recurrence.kind === "seriesMaster"
+      ? { kind: "series", rules: remainderDraft.recurrence.rules }
+      : { kind: "single" };
 
   const createResultAttempt = await runProviderWrite(() =>
     deps.writer.createEvent({
       accessToken,
       calendarId: calendar.providerCalendarId,
-      providerEventId: remainderId,
-      content: remainderContent,
-      schedule: input.schedule,
+      providerEventId: remainderDraft._id,
+      content: remainderDraft.content,
+      schedule: remainderDraft.schedule,
       recurrence: remainderRecurrence,
       invitation: input.invitation,
     }),
@@ -1484,22 +1473,11 @@ export async function executeProviderSeriesFollowingUpdate(
   const createResult = createResultAttempt.value;
 
   const remainder: EventRecord = {
-    ...master,
-    _id: remainderId,
-    clientEventId: null,
+    ...remainderDraft,
     providerEventId: createResult.providerEventId as ProviderEventId,
     providerVersion: createResult.providerVersion as ProviderEventVersion,
     providerUpdatedAt: null,
     deliveryState: "confirmed",
-    content: remainderContent,
-    schedule: input.schedule,
-    recurrence:
-      remainderRecurrence.kind === "series"
-        ? { kind: "seriesMaster", rules: remainderRecurrence.rules }
-        : { kind: "single" },
-    createdAt: now(),
-    updatedAt: now(),
-    confirmedAt: now(),
   };
   await deps.events.put(remainder);
   await reprojectOccurrences(deps.occurrences, remainder, now);
@@ -1851,9 +1829,6 @@ function storedSeriesRecurrence(
   if (recurrence.kind === "single") return { kind: "single" };
   return master.recurrence;
 }
-
-// isCancelledException / exceptionInstant now come from series-exception.ts,
-// shared with the cloud path.
 
 // Whether the provider's current event already carries this command's intended
 // edit — the signal that a prior attempt landed and this is a safe replay.

--- a/packages/sync/src/domain/series-exception.ts
+++ b/packages/sync/src/domain/series-exception.ts
@@ -1,10 +1,21 @@
 import { type DateTime, type EventId } from "@core/types/domain-primitives";
+import { type SyncEventRecurrence } from "@core/types/sync/event.contracts";
+import { mergeUpdateContent } from "@sync/domain/merge-update-content";
+import {
+  stripRuleBounds,
+  truncateRulesBefore,
+} from "@sync/domain/occurrence-projection";
 import { reprojectOccurrences } from "@sync/domain/reproject";
 import { type CommandRecord } from "@sync/storage/contracts/command.contracts";
 import { type EventRecord } from "@sync/storage/contracts/event.contracts";
 import { type EventRepository } from "@sync/storage/repositories/event.repository";
 import { type EventOccurrenceRepository } from "@sync/storage/repositories/event-occurrence.repository";
 import { createHash } from "node:crypto";
+
+type SeriesMasterRecurrence = Extract<
+  SyncEventRecurrence,
+  { kind: "seriesMaster" }
+>;
 
 // Whether a series exception is a cancelled tombstone (a per-instance deletion)
 // rather than a content override. Shared by the cloud and provider command
@@ -110,4 +121,79 @@ export function remainderMasterId(
     .update(`${seriesId}:${splitAt}`)
     .digest("hex")
     .slice(0, 24) as EventId;
+}
+
+// Split an edit-all's exceptions into kept cancelled tombstones versus
+// discarded content/time overrides. Converting the series to a single event
+// drops every exception, cancellations included.
+export function partitionEditAllExceptions(
+  exceptions: readonly EventRecord[],
+  convertsToSingle: boolean,
+): { kept: EventRecord[]; discarded: EventRecord[] } {
+  if (convertsToSingle) {
+    return { kept: [], discarded: [...exceptions] };
+  }
+  return {
+    kept: exceptions.filter(isCancelledException),
+    discarded: exceptions.filter((event) => !isCancelledException(event)),
+  };
+}
+
+// Local truncated master for a this-and-following split: same identity,
+// rules bounded strictly before the split instant. Callers overlay
+// provider version fields after a write.
+export function truncatedSeriesMaster(
+  master: EventRecord,
+  splitAt: Date,
+  now: Date,
+): EventRecord & { recurrence: SeriesMasterRecurrence } {
+  if (master.recurrence.kind !== "seriesMaster") {
+    throw new Error("truncatedSeriesMaster requires a series master");
+  }
+  return {
+    ...master,
+    recurrence: {
+      kind: "seriesMaster",
+      rules: truncateRulesBefore(master.recurrence.rules, splitAt),
+    },
+    updatedAt: now,
+  };
+}
+
+// Remainder series of a this-and-following edit: a fresh master at the
+// edit's schedule, carrying the edited content and recurrence, with a
+// deterministic id so a retry converges on one series. "preserve" continues
+// the original cadence (bounds stripped, so it runs open-ended from the split).
+export function buildRemainderMaster(
+  master: EventRecord,
+  command: CommandRecord,
+  now: Date,
+): EventRecord {
+  if (command.input.kind !== "update") {
+    throw new Error("buildRemainderMaster requires an update command");
+  }
+  if (master.recurrence.kind !== "seriesMaster") {
+    throw new Error("buildRemainderMaster requires a series master");
+  }
+  const { input } = command;
+  const recurrence: SyncEventRecurrence =
+    input.recurrence.kind === "series"
+      ? { kind: "seriesMaster", rules: input.recurrence.rules }
+      : input.recurrence.kind === "single"
+        ? { kind: "single" }
+        : {
+            kind: "seriesMaster",
+            rules: stripRuleBounds(master.recurrence.rules),
+          };
+  return {
+    ...master,
+    _id: remainderMasterId(master._id, command.input.recurrenceId as DateTime),
+    clientEventId: null,
+    content: mergeUpdateContent(master.content, input.content),
+    schedule: input.schedule,
+    recurrence,
+    createdAt: now,
+    updatedAt: now,
+    confirmedAt: now,
+  };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3456

## What and why

Cloud-only and provider-linked recurring-series commands used to copy the same local transitions: partition cancelled vs overridden exceptions on edit-all, truncate the original master at a this-and-following split, and build the remainder master. Those three record transforms now live in `series-exception.ts`. Both command services call them; provider token, fetch, patch, create, and failure mapping stay in `provider-command.service.ts`. Crash-safe ordering, deterministic remainder ids, and recurrence semantics are unchanged.

## Verify

`VERDICT: PASS`

Checks run by `bun run verify --strict`: test:sync:fast, type-check, lint, knip.

Also ran (verify's fast tier skips Mongo db tests for these domain paths):

- `bun run test:sync -- packages/sync/src/domain/provider-command.service.db.test.ts packages/sync/src/domain/cloud-command.service.db.test.ts packages/sync/src/domain/occurrence-projection.test.ts` — 169 pass, 0 fail
- `bun run test:sync` — 1513 pass, 7 skip, 0 fail

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca4712d6-affb-48b9-acfc-4ca1e9712054?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca4712d6-affb-48b9-acfc-4ca1e9712054&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

