### PR TITLE
refactor(backend): narrow the Stripe billing seam

### DIFF
--- a/packages/backend/src/billing/controllers/billing.webhook.controller.ts
+++ b/packages/backend/src/billing/controllers/billing.webhook.controller.ts
@@ -2,13 +2,20 @@ import { type Request, type Response } from "express";
 import { Status } from "@core/errors/status.codes";
 import { Logger } from "@core/logger/winston.logger";
 import { processStripeEvent } from "@backend/billing/services/billing.webhook.service";
-import { getStripeClient } from "@backend/billing/services/stripe.client";
+import {
+  type StripeBillingGateway,
+  stripeBillingGateway,
+} from "@backend/billing/services/stripe.client";
 import { CONFIG } from "@backend/common/constants/config.constants";
 import { isStripeConfigured } from "@backend/common/constants/config.util";
 
 const logger = Logger("app:billing.webhook");
 
-class BillingWebhookController {
+export class BillingWebhookController {
+  constructor(
+    private readonly stripe: StripeBillingGateway = stripeBillingGateway,
+  ) {}
+
   handleStripe = async (req: Request, res: Response) => {
     if (!isStripeConfigured(CONFIG) || !CONFIG.STRIPE_WEBHOOK_SECRET) {
       res.status(Status.NOT_FOUND).json({ error: "Stripe is not configured" });
@@ -35,12 +42,12 @@ class BillingWebhookController {
       // Must be the async variant: under Bun the SDK selects
       // SubtleCryptoProvider, whose synchronous HMAC path throws
       // unconditionally, so constructEvent() rejects every signature.
-      const event = await getStripeClient().webhooks.constructEventAsync(
+      const event = await this.stripe.constructWebhookEvent(
         req.body,
         signature,
         CONFIG.STRIPE_WEBHOOK_SECRET,
       );
-      await processStripeEvent(event);
+      await processStripeEvent(event, this.stripe);
       res.status(Status.OK).json({ received: true });
     } catch (e) {
       const message = e instanceof Error ? e.message : "Webhook error";

--- a/packages/backend/src/billing/services/billing.webhook.service.db.test.ts
+++ b/packages/backend/src/billing/services/billing.webhook.service.db.test.ts
@@ -13,8 +13,9 @@ import billingWebhookController from "@backend/billing/controllers/billing.webho
 import { processStripeEvent } from "@backend/billing/services/billing.webhook.service";
 import {
   STRIPE_API_VERSION,
-  setStripeClientForTests,
+  stripeBillingGateway,
 } from "@backend/billing/services/stripe.client";
+import { stubBillingGateway } from "@backend/billing/services/stripe-billing-gateway.test-helpers";
 import mongoService from "@backend/common/services/mongo.service";
 import {
   afterAll,
@@ -25,6 +26,7 @@ import {
   expect,
   it,
   mock,
+  spyOn,
 } from "bun:test";
 
 const stripeConfigured = {
@@ -69,7 +71,7 @@ describe("Stripe webhook", () => {
   });
   beforeEach(cleanupCollections);
   afterEach(() => {
-    setStripeClientForTests(undefined);
+    mock.restore();
   });
   afterAll(cleanupTestDb);
 
@@ -89,15 +91,11 @@ describe("Stripe webhook", () => {
 
   it("returns 400 for a bad signature", async () => {
     using _env = mockEnv(stripeConfigured);
-    setStripeClientForTests({
-      webhooks: {
-        constructEventAsync: () => {
-          throw new Error(
-            "No signatures found matching the expected signature",
-          );
-        },
+    spyOn(stripeBillingGateway, "constructWebhookEvent").mockImplementation(
+      () => {
+        throw new Error("No signatures found matching the expected signature");
       },
-    } as unknown as Stripe);
+    );
 
     const { res, json } = jsonRes();
     await billingWebhookController.handleStripe(
@@ -117,13 +115,13 @@ describe("Stripe webhook", () => {
   });
 
   /**
-   * The other webhook tests stub the Stripe client wholesale, so the SDK's
-   * own signature verification never runs. These two use the real
-   * `webhooks` object and stub only the API call, which is the difference
-   * between testing our dispatch and testing that Stripe events can get in
-   * at all. Under Bun the SDK picks an async-only crypto provider, so a
-   * synchronous constructEvent() fails here no matter how valid the
-   * signature is.
+   * The other webhook tests stub the Compass billing gateway, so the SDK's
+   * own signature verification never runs. These two use the production
+   * `constructWebhookEvent` adapter and stub only the API call, which is the
+   * difference between testing our dispatch and testing that Stripe events
+   * can get in at all. Under Bun the SDK picks an async-only crypto
+   * provider, so a synchronous constructEvent() fails here no matter how
+   * valid the signature is.
    */
   const realStripe = () =>
     new Stripe(stripeConfigured.STRIPE_SECRET_KEY, {
@@ -163,16 +161,13 @@ describe("Stripe webhook", () => {
     using _env = mockEnv(stripeConfigured);
     const userId = await seedAwaitingUser("signed@example.com");
     const stripe = realStripe();
-    setStripeClientForTests({
-      webhooks: stripe.webhooks,
-      subscriptions: {
-        retrieve: mock(() =>
-          Promise.resolve(
-            subscription({ metadata: { compassUserId: userId.toString() } }),
-          ),
+    spyOn(stripeBillingGateway, "retrieveSubscription").mockImplementation(
+      mock(() =>
+        Promise.resolve(
+          subscription({ metadata: { compassUserId: userId.toString() } }),
         ),
-      },
-    } as unknown as Stripe);
+      ),
+    );
 
     const payload = checkoutPayload(userId.toString());
     const signature = await stripe.webhooks.generateTestHeaderStringAsync({
@@ -203,16 +198,13 @@ describe("Stripe webhook", () => {
     using _env = mockEnv(stripeConfigured);
     const userId = await seedAwaitingUser("http-signed@example.com");
     const stripe = realStripe();
-    setStripeClientForTests({
-      webhooks: stripe.webhooks,
-      subscriptions: {
-        retrieve: mock(() =>
-          Promise.resolve(
-            subscription({ metadata: { compassUserId: userId.toString() } }),
-          ),
+    spyOn(stripeBillingGateway, "retrieveSubscription").mockImplementation(
+      mock(() =>
+        Promise.resolve(
+          subscription({ metadata: { compassUserId: userId.toString() } }),
         ),
-      },
-    } as unknown as Stripe);
+      ),
+    );
 
     // Pretty-printed so JSON.parse + stringify would change the bytes and
     // fail HMAC. The Express stack must hand the original payload through.
@@ -252,10 +244,9 @@ describe("Stripe webhook", () => {
     using _env = mockEnv(stripeConfigured);
     const userId = await seedAwaitingUser("tampered@example.com");
     const stripe = realStripe();
-    setStripeClientForTests({
-      webhooks: stripe.webhooks,
-      subscriptions: { retrieve: mock() },
-    } as unknown as Stripe);
+    spyOn(stripeBillingGateway, "retrieveSubscription").mockImplementation(
+      mock(),
+    );
 
     const payload = checkoutPayload(userId.toString());
     const signature = await stripe.webhooks.generateTestHeaderStringAsync({
@@ -293,31 +284,32 @@ describe("Stripe webhook", () => {
       billing: { subscriptionStatus: "awaiting_checkout" },
     });
 
-    setStripeClientForTests({
-      subscriptions: {
-        retrieve: mock(() =>
-          Promise.resolve(
-            subscription({
-              metadata: { compassUserId: userId.toString() },
-            }),
-          ),
+    const stripe = stubBillingGateway({
+      retrieveSubscription: mock(() =>
+        Promise.resolve(
+          subscription({
+            metadata: { compassUserId: userId.toString() },
+          }),
         ),
-      },
-    } as unknown as Stripe);
+      ),
+    });
 
-    await processStripeEvent({
-      id: "evt_checkout_1",
-      type: "checkout.session.completed",
-      created: 1_775_000_100,
-      data: {
-        object: {
-          id: "cs_1",
-          client_reference_id: userId.toString(),
-          customer: "cus_1",
-          subscription: "sub_1",
+    await processStripeEvent(
+      {
+        id: "evt_checkout_1",
+        type: "checkout.session.completed",
+        created: 1_775_000_100,
+        data: {
+          object: {
+            id: "cs_1",
+            client_reference_id: userId.toString(),
+            customer: "cus_1",
+            subscription: "sub_1",
+          },
         },
-      },
-    } as unknown as Stripe.Event);
+      } as unknown as Stripe.Event,
+      stripe,
+    );
 
     const stored = await mongoService.user.findOne({ _id: userId });
     expect(stored?.billing?.subscriptionStatus).toBe("trialing");
@@ -339,9 +331,7 @@ describe("Stripe webhook", () => {
     });
 
     const retrieve = mock(() => Promise.resolve(subscription()));
-    setStripeClientForTests({
-      subscriptions: { retrieve },
-    } as unknown as Stripe);
+    const stripe = stubBillingGateway({ retrieveSubscription: retrieve });
 
     const event = {
       id: "evt_dup_1",
@@ -355,8 +345,8 @@ describe("Stripe webhook", () => {
       { $set: { "billing.stripeSubscriptionId": "sub_1" } },
     );
 
-    await processStripeEvent(event);
-    await processStripeEvent(event);
+    await processStripeEvent(event, stripe);
+    await processStripeEvent(event, stripe);
 
     expect(retrieve).toHaveBeenCalledTimes(1);
     expect(await mongoService.billingEvent.countDocuments()).toBe(1);
@@ -381,20 +371,21 @@ describe("Stripe webhook", () => {
       },
     });
 
-    setStripeClientForTests({
-      subscriptions: {
-        retrieve: mock(() =>
-          Promise.resolve(subscription({ status: "canceled" })),
-        ),
-      },
-    } as unknown as Stripe);
+    const stripe = stubBillingGateway({
+      retrieveSubscription: mock(() =>
+        Promise.resolve(subscription({ status: "canceled" })),
+      ),
+    });
 
-    await processStripeEvent({
-      id: "evt_stale_1",
-      type: "customer.subscription.updated",
-      created: Math.floor(newer.getTime() / 1000) - 90,
-      data: { object: { id: "sub_1" } },
-    } as unknown as Stripe.Event);
+    await processStripeEvent(
+      {
+        id: "evt_stale_1",
+        type: "customer.subscription.updated",
+        created: Math.floor(newer.getTime() / 1000) - 90,
+        data: { object: { id: "sub_1" } },
+      } as unknown as Stripe.Event,
+      stripe,
+    );
 
     const stored = await mongoService.user.findOne({ _id: userId });
     expect(stored?.billing?.subscriptionStatus).toBe("active");
@@ -419,20 +410,21 @@ describe("Stripe webhook", () => {
       },
     });
 
-    setStripeClientForTests({
-      subscriptions: {
-        retrieve: mock(() =>
-          Promise.resolve(subscription({ status: "canceled" })),
-        ),
-      },
-    } as unknown as Stripe);
+    const stripe = stubBillingGateway({
+      retrieveSubscription: mock(() =>
+        Promise.resolve(subscription({ status: "canceled" })),
+      ),
+    });
 
-    await processStripeEvent({
-      id: "evt_same_second_1",
-      type: "customer.subscription.deleted",
-      created: Math.floor(created.getTime() / 1000),
-      data: { object: { id: "sub_1" } },
-    } as unknown as Stripe.Event);
+    await processStripeEvent(
+      {
+        id: "evt_same_second_1",
+        type: "customer.subscription.deleted",
+        created: Math.floor(created.getTime() / 1000),
+        data: { object: { id: "sub_1" } },
+      } as unknown as Stripe.Event,
+      stripe,
+    );
 
     const stored = await mongoService.user.findOne({ _id: userId });
     expect(stored?.billing?.subscriptionStatus).toBe("canceled");
@@ -454,11 +446,11 @@ describe("Stripe webhook", () => {
       },
     });
 
-    setStripeClientForTests({
-      subscriptions: {
-        retrieve: mock(() => Promise.reject(new Error("stripe unavailable"))),
-      },
-    } as unknown as Stripe);
+    const stripe = stubBillingGateway({
+      retrieveSubscription: mock(() =>
+        Promise.reject(new Error("stripe unavailable")),
+      ),
+    });
 
     const event = {
       id: "evt_throw_1",
@@ -467,7 +459,7 @@ describe("Stripe webhook", () => {
       data: { object: { id: "sub_1" } },
     } as unknown as Stripe.Event;
 
-    await expect(processStripeEvent(event)).rejects.toThrow(
+    await expect(processStripeEvent(event, stripe)).rejects.toThrow(
       "stripe unavailable",
     );
 
@@ -481,10 +473,10 @@ describe("Stripe webhook", () => {
     expect(stored?.billing?.subscriptionStatus).toBe("awaiting_checkout");
 
     // A retry after Stripe recovers is reprocessed rather than deduped away.
-    setStripeClientForTests({
-      subscriptions: { retrieve: mock(() => Promise.resolve(subscription())) },
-    } as unknown as Stripe);
-    await processStripeEvent(event);
+    const recovered = stubBillingGateway({
+      retrieveSubscription: mock(() => Promise.resolve(subscription())),
+    });
+    await processStripeEvent(event, recovered);
 
     const retried = await mongoService.user.findOne({ _id: userId });
     expect(retried?.billing?.subscriptionStatus).toBe("trialing");
@@ -508,16 +500,17 @@ describe("Stripe webhook", () => {
     });
 
     const retrieve = mock(() => Promise.resolve(subscription()));
-    setStripeClientForTests({
-      subscriptions: { retrieve },
-    } as unknown as Stripe);
+    const stripe = stubBillingGateway({ retrieveSubscription: retrieve });
 
-    await processStripeEvent({
-      id: "evt_invoice_paid_1",
-      type: "invoice.paid",
-      created: 1_775_000_100,
-      data: { object: { id: "in_1", subscription: "sub_1" } },
-    } as unknown as Stripe.Event);
+    await processStripeEvent(
+      {
+        id: "evt_invoice_paid_1",
+        type: "invoice.paid",
+        created: 1_775_000_100,
+        data: { object: { id: "in_1", subscription: "sub_1" } },
+      } as unknown as Stripe.Event,
+      stripe,
+    );
 
     expect(retrieve).not.toHaveBeenCalled();
     const stored = await mongoService.user.findOne({ _id: userId });
@@ -597,13 +590,13 @@ describe("Stripe webhook", () => {
       const sessionsRetrieve = mock(() =>
         Promise.resolve(retrievedSetupSession(userId.toString())),
       );
-      setStripeClientForTests({
-        checkout: { sessions: { retrieve: sessionsRetrieve } },
-        customers: { update: customersUpdate },
-        subscriptions: { update: subscriptionsUpdate },
-      } as unknown as Stripe);
+      const stripe = stubBillingGateway({
+        retrieveCheckoutSession: sessionsRetrieve,
+        updateCustomer: customersUpdate,
+        updateSubscription: subscriptionsUpdate,
+      });
 
-      await processStripeEvent(setupEvent(userId.toString()));
+      await processStripeEvent(setupEvent(userId.toString()), stripe);
 
       expect(sessionsRetrieve.mock.calls[0]?.[0]).toBe("cs_setup_1");
       expect(sessionsRetrieve.mock.calls[0]?.[1]).toEqual({
@@ -627,19 +620,18 @@ describe("Stripe webhook", () => {
       const userId = await seedCustomer();
       const customersUpdate = mock(() => Promise.resolve({ id: "cus_setup" }));
       const subscriptionsUpdate = mock();
-      setStripeClientForTests({
-        checkout: {
-          sessions: {
-            retrieve: mock(() =>
-              Promise.resolve(retrievedSetupSession(userId.toString())),
-            ),
-          },
-        },
-        customers: { update: customersUpdate },
-        subscriptions: { update: subscriptionsUpdate },
-      } as unknown as Stripe);
+      const stripe = stubBillingGateway({
+        retrieveCheckoutSession: mock(() =>
+          Promise.resolve(retrievedSetupSession(userId.toString())),
+        ),
+        updateCustomer: customersUpdate,
+        updateSubscription: subscriptionsUpdate,
+      });
 
-      await processStripeEvent(setupEvent(userId.toString(), "evt_setup_2"));
+      await processStripeEvent(
+        setupEvent(userId.toString(), "evt_setup_2"),
+        stripe,
+      );
 
       expect(customersUpdate).toHaveBeenCalled();
       expect(subscriptionsUpdate).not.toHaveBeenCalled();
@@ -663,25 +655,28 @@ describe("Stripe webhook", () => {
           subscription({ metadata: { compassUserId: userId.toString() } }),
         ),
       );
-      setStripeClientForTests({
-        checkout: { sessions: { retrieve: sessionsRetrieve } },
-        subscriptions: { retrieve },
-      } as unknown as Stripe);
+      const stripe = stubBillingGateway({
+        retrieveCheckoutSession: sessionsRetrieve,
+        retrieveSubscription: retrieve,
+      });
 
-      await processStripeEvent({
-        id: "evt_sub_mode_1",
-        type: "checkout.session.completed",
-        created: 1_775_000_100,
-        data: {
-          object: {
-            id: "cs_sub_1",
-            mode: "subscription",
-            client_reference_id: userId.toString(),
-            customer: "cus_1",
-            subscription: "sub_1",
+      await processStripeEvent(
+        {
+          id: "evt_sub_mode_1",
+          type: "checkout.session.completed",
+          created: 1_775_000_100,
+          data: {
+            object: {
+              id: "cs_sub_1",
+              mode: "subscription",
+              client_reference_id: userId.toString(),
+              customer: "cus_1",
+              subscription: "sub_1",
+            },
           },
-        },
-      } as unknown as Stripe.Event);
+        } as unknown as Stripe.Event,
+        stripe,
+      );
 
       expect(sessionsRetrieve).not.toHaveBeenCalled();
       expect(retrieve).toHaveBeenCalled();
@@ -692,18 +687,14 @@ describe("Stripe webhook", () => {
     it("leaves no billingEvent row when Stripe fails, so the retry reprocesses", async () => {
       using _env = mockEnv(stripeConfigured);
       const userId = await seedCustomer({ stripeSubscriptionId: "sub_setup" });
-      setStripeClientForTests({
-        checkout: {
-          sessions: {
-            retrieve: mock(() =>
-              Promise.reject(new Error("stripe unavailable")),
-            ),
-          },
-        },
-      } as unknown as Stripe);
+      const stripe = stubBillingGateway({
+        retrieveCheckoutSession: mock(() =>
+          Promise.reject(new Error("stripe unavailable")),
+        ),
+      });
 
       const event = setupEvent(userId.toString(), "evt_setup_fail");
-      await expect(processStripeEvent(event)).rejects.toThrow(
+      await expect(processStripeEvent(event, stripe)).rejects.toThrow(
         "stripe unavailable",
       );
       expect(
@@ -725,18 +716,15 @@ describe("Stripe webhook", () => {
           }),
         ),
       );
-      setStripeClientForTests({
-        webhooks: stripe.webhooks,
-        checkout: {
-          sessions: {
-            retrieve: mock(() =>
-              Promise.resolve(retrievedSetupSession(userId.toString())),
-            ),
-          },
-        },
-        customers: { update: customersUpdate },
-        subscriptions: { update: subscriptionsUpdate },
-      } as unknown as Stripe);
+      spyOn(stripeBillingGateway, "retrieveCheckoutSession").mockImplementation(
+        mock(() => Promise.resolve(retrievedSetupSession(userId.toString()))),
+      );
+      spyOn(stripeBillingGateway, "updateCustomer").mockImplementation(
+        customersUpdate,
+      );
+      spyOn(stripeBillingGateway, "updateSubscription").mockImplementation(
+        subscriptionsUpdate,
+      );
 
       const payload = JSON.stringify({
         id: "evt_setup_signed",

--- a/packages/backend/src/billing/services/billing.webhook.service.ts
+++ b/packages/backend/src/billing/services/billing.webhook.service.ts
@@ -4,7 +4,10 @@ import {
   STRIPE_TO_COMPASS_STATUS,
   type StripeSubscriptionStatus,
 } from "@backend/billing/billing.constants";
-import { getStripeClient } from "@backend/billing/services/stripe.client";
+import {
+  type StripeBillingGateway,
+  stripeBillingGateway,
+} from "@backend/billing/services/stripe.client";
 import mongoService from "@backend/common/services/mongo.service";
 
 const logger = Logger("app:billing.webhook");
@@ -136,11 +139,11 @@ async function findUserIdForSubscription(
 }
 
 async function handleSetupCheckoutSession(
-  stripe: Stripe,
+  stripe: StripeBillingGateway,
   session: Stripe.Checkout.Session,
   eventCreatedAt: Date,
 ): Promise<void> {
-  const retrieved = await stripe.checkout.sessions.retrieve(session.id, {
+  const retrieved = await stripe.retrieveCheckoutSession(session.id, {
     expand: ["setup_intent"],
   });
   const setupIntent = retrieved.setup_intent;
@@ -179,23 +182,25 @@ async function handleSetupCheckoutSession(
     return;
   }
 
-  await stripe.customers.update(resolvedCustomerId, {
+  await stripe.updateCustomer(resolvedCustomerId, {
     invoice_settings: { default_payment_method: paymentMethodId },
   });
 
   const subscriptionId = user?.billing?.stripeSubscriptionId;
   if (!subscriptionId) return;
 
-  const subscription = await stripe.subscriptions.update(subscriptionId, {
+  const subscription = await stripe.updateSubscription(subscriptionId, {
     default_payment_method: paymentMethodId,
   });
   await applySubscription(userId, subscription, eventCreatedAt);
 }
 
-async function handleEvent(event: Stripe.Event): Promise<void> {
+async function handleEvent(
+  event: Stripe.Event,
+  stripe: StripeBillingGateway,
+): Promise<void> {
   if (!HANDLED_TYPES.has(event.type)) return;
 
-  const stripe = getStripeClient();
   const eventCreatedAt = toDate(event.created) ?? new Date();
 
   if (event.type === "checkout.session.completed") {
@@ -209,7 +214,7 @@ async function handleEvent(event: Stripe.Event): Promise<void> {
       logger.warn("checkout.session.completed had no subscription id");
       return;
     }
-    const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+    const subscription = await stripe.retrieveSubscription(subscriptionId);
     const userId = await findUserIdForSubscription(
       subscription,
       session.client_reference_id,
@@ -229,7 +234,7 @@ async function handleEvent(event: Stripe.Event): Promise<void> {
     logger.warn(`${event.type} had no subscription id`);
     return;
   }
-  const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+  const subscription = await stripe.retrieveSubscription(subscriptionId);
   const userId = await findUserIdForSubscription(subscription);
   if (!userId) {
     logger.warn(
@@ -240,7 +245,10 @@ async function handleEvent(event: Stripe.Event): Promise<void> {
   await applySubscription(userId, subscription, eventCreatedAt);
 }
 
-export async function processStripeEvent(event: Stripe.Event): Promise<void> {
+export async function processStripeEvent(
+  event: Stripe.Event,
+  stripe: StripeBillingGateway = stripeBillingGateway,
+): Promise<void> {
   try {
     await mongoService.billingEvent.insertOne({
       _id: event.id,
@@ -254,7 +262,7 @@ export async function processStripeEvent(event: Stripe.Event): Promise<void> {
   }
 
   try {
-    await handleEvent(event);
+    await handleEvent(event, stripe);
   } catch (error) {
     await mongoService.billingEvent.deleteOne({ _id: event.id });
     throw error;

--- a/packages/backend/src/billing/services/stripe-billing-gateway.test-helpers.ts
+++ b/packages/backend/src/billing/services/stripe-billing-gateway.test-helpers.ts
@@ -1,0 +1,27 @@
+import { type StripeBillingGateway } from "@backend/billing/services/stripe.client";
+
+function unused<K extends keyof StripeBillingGateway>(
+  name: K,
+): StripeBillingGateway[K] {
+  return ((..._args: never[]) => {
+    throw new Error(`StripeBillingGateway.${name} is not stubbed`);
+  }) as StripeBillingGateway[K];
+}
+
+export function stubBillingGateway(
+  overrides: Partial<StripeBillingGateway>,
+): StripeBillingGateway {
+  return {
+    createCustomer: unused("createCustomer"),
+    deleteCustomer: unused("deleteCustomer"),
+    retrieveCustomer: unused("retrieveCustomer"),
+    updateCustomer: unused("updateCustomer"),
+    createCheckoutSession: unused("createCheckoutSession"),
+    retrieveCheckoutSession: unused("retrieveCheckoutSession"),
+    updateSubscription: unused("updateSubscription"),
+    retrieveSubscription: unused("retrieveSubscription"),
+    listInvoices: unused("listInvoices"),
+    constructWebhookEvent: unused("constructWebhookEvent"),
+    ...overrides,
+  };
+}

--- a/packages/backend/src/billing/services/stripe.client.ts
+++ b/packages/backend/src/billing/services/stripe.client.ts
@@ -21,10 +21,8 @@ const _stripeStatusIsTotal: AssertEqual<
 void _stripeStatusIsTotal;
 
 let client: Stripe | undefined;
-let clientOverride: Stripe | undefined;
 
-export function getStripeClient(): Stripe {
-  if (clientOverride) return clientOverride;
+function getStripe(): Stripe {
   if (!isStripeConfigured(CONFIG) || !CONFIG.STRIPE_SECRET_KEY) {
     throw new Error("Stripe is not configured");
   }
@@ -36,7 +34,72 @@ export function getStripeClient(): Stripe {
   return client;
 }
 
-export function setStripeClientForTests(next: Stripe | undefined): void {
-  clientOverride = next;
-  client = undefined;
+// Compass-owned Stripe surface. Only the operations billing actually calls;
+// production delegates to the same SDK methods, tests stub just those.
+export interface StripeBillingGateway {
+  createCustomer(
+    params: Stripe.CustomerCreateParams,
+    options?: Stripe.RequestOptions,
+  ): Promise<{ id: string }>;
+  deleteCustomer(id: string, options?: Stripe.RequestOptions): Promise<void>;
+  retrieveCustomer(
+    id: string,
+    params?: Stripe.CustomerRetrieveParams,
+  ): Promise<Stripe.Customer | Stripe.DeletedCustomer>;
+  updateCustomer(
+    id: string,
+    params: Stripe.CustomerUpdateParams,
+  ): Promise<Stripe.Customer>;
+  createCheckoutSession(
+    params: Stripe.Checkout.SessionCreateParams,
+    options?: Stripe.RequestOptions,
+  ): Promise<{ client_secret?: string | null }>;
+  retrieveCheckoutSession(
+    id: string,
+    params?: Stripe.Checkout.SessionRetrieveParams,
+  ): Promise<Stripe.Checkout.Session>;
+  updateSubscription(
+    id: string,
+    params: Stripe.SubscriptionUpdateParams,
+    options?: Stripe.RequestOptions,
+  ): Promise<Stripe.Subscription>;
+  retrieveSubscription(
+    id: string,
+    params?: Stripe.SubscriptionRetrieveParams,
+  ): Promise<Stripe.Subscription>;
+  listInvoices(
+    params?: Stripe.InvoiceListParams,
+  ): Promise<{ data: Stripe.Invoice[] }>;
+  constructWebhookEvent(
+    payload: string | Buffer,
+    header: string,
+    secret: string,
+  ): Promise<Stripe.Event>;
 }
+
+function createStripeBillingGateway(): StripeBillingGateway {
+  return {
+    createCustomer: (params, options) =>
+      getStripe().customers.create(params, options),
+    deleteCustomer: async (id, options) => {
+      await getStripe().customers.del(id, options);
+    },
+    retrieveCustomer: (id, params) =>
+      getStripe().customers.retrieve(id, params),
+    updateCustomer: (id, params) => getStripe().customers.update(id, params),
+    createCheckoutSession: (params, options) =>
+      getStripe().checkout.sessions.create(params, options),
+    retrieveCheckoutSession: (id, params) =>
+      getStripe().checkout.sessions.retrieve(id, params),
+    updateSubscription: (id, params, options) =>
+      getStripe().subscriptions.update(id, params, options),
+    retrieveSubscription: (id, params) =>
+      getStripe().subscriptions.retrieve(id, params),
+    listInvoices: (params) => getStripe().invoices.list(params),
+    constructWebhookEvent: (payload, header, secret) =>
+      getStripe().webhooks.constructEventAsync(payload, header, secret),
+  };
+}
+
+export const stripeBillingGateway: StripeBillingGateway =
+  createStripeBillingGateway();

--- a/packages/backend/src/billing/services/stripe.service.db.test.ts
+++ b/packages/backend/src/billing/services/stripe.service.db.test.ts
@@ -10,7 +10,6 @@ import { stubBillingGateway } from "@backend/billing/services/stripe-billing-gat
 import mongoService from "@backend/common/services/mongo.service";
 import {
   afterAll,
-  afterEach,
   beforeAll,
   beforeEach,
   describe,

--- a/packages/backend/src/billing/services/stripe.service.db.test.ts
+++ b/packages/backend/src/billing/services/stripe.service.db.test.ts
@@ -5,8 +5,8 @@ import {
   setupTestDb,
 } from "@backend/__tests__/helpers/mock.db.setup";
 import { mockEnv } from "@backend/__tests__/helpers/mock.setup";
-import { setStripeClientForTests } from "@backend/billing/services/stripe.client";
-import stripeService from "@backend/billing/services/stripe.service";
+import { StripeService } from "@backend/billing/services/stripe.service";
+import { stubBillingGateway } from "@backend/billing/services/stripe-billing-gateway.test-helpers";
 import mongoService from "@backend/common/services/mongo.service";
 import {
   afterAll,
@@ -32,9 +32,6 @@ describe("StripeService", () => {
     await setupTestDb(import.meta.url);
   });
   beforeEach(cleanupCollections);
-  afterEach(() => {
-    setStripeClientForTests(undefined);
-  });
   afterAll(cleanupTestDb);
 
   it("creates a Checkout session in subscription mode with a trial", async () => {
@@ -54,10 +51,12 @@ describe("StripeService", () => {
       Promise.resolve({ client_secret: "cs_test_1" }),
     );
 
-    setStripeClientForTests({
-      customers: { create: customersCreate },
-      checkout: { sessions: { create: sessionsCreate } },
-    } as unknown as Stripe);
+    const stripeService = new StripeService(
+      stubBillingGateway({
+        createCustomer: customersCreate,
+        createCheckoutSession: sessionsCreate,
+      }),
+    );
 
     const result = await stripeService.createCheckoutSession(userId.toString());
 
@@ -130,10 +129,12 @@ describe("StripeService", () => {
     const sessionsCreate = mock(() =>
       Promise.resolve({ client_secret: "cs_test_2" }),
     );
-    setStripeClientForTests({
-      customers: { create: customersCreate },
-      checkout: { sessions: { create: sessionsCreate } },
-    } as unknown as Stripe);
+    const stripeService = new StripeService(
+      stubBillingGateway({
+        createCustomer: customersCreate,
+        createCheckoutSession: sessionsCreate,
+      }),
+    );
 
     await stripeService.createCheckoutSession(userId.toString());
 
@@ -162,7 +163,11 @@ describe("StripeService", () => {
     const del = mock(() =>
       Promise.resolve({ id: "cus_delete", deleted: true }),
     );
-    setStripeClientForTests({ customers: { del } } as unknown as Stripe);
+    const stripeService = new StripeService(
+      stubBillingGateway({
+        deleteCustomer: del,
+      }),
+    );
 
     await stripeService.deleteCustomerForAccount(userId.toString());
 
@@ -191,9 +196,11 @@ describe("StripeService", () => {
       type: "invalid_request_error",
       statusCode: 404,
     });
-    setStripeClientForTests({
-      customers: { del: mock(() => Promise.reject(missing)) },
-    } as unknown as Stripe);
+    const stripeService = new StripeService(
+      stubBillingGateway({
+        deleteCustomer: mock(() => Promise.reject(missing)),
+      }),
+    );
 
     await expect(
       stripeService.deleteCustomerForAccount(userId.toString()),
@@ -220,9 +227,11 @@ describe("StripeService", () => {
     const sessionsCreate = mock(() =>
       Promise.resolve({ client_secret: "cs_test_stale" }),
     );
-    setStripeClientForTests({
-      checkout: { sessions: { create: sessionsCreate } },
-    } as unknown as Stripe);
+    const stripeService = new StripeService(
+      stubBillingGateway({
+        createCheckoutSession: sessionsCreate,
+      }),
+    );
 
     const result = await stripeService.createCheckoutSession(userId.toString());
 
@@ -253,10 +262,12 @@ describe("StripeService", () => {
     const sessionsCreate = mock(() =>
       Promise.resolve({ client_secret: "cs_test_3" }),
     );
-    setStripeClientForTests({
-      customers: { create: mock() },
-      checkout: { sessions: { create: sessionsCreate } },
-    } as unknown as Stripe);
+    const stripeService = new StripeService(
+      stubBillingGateway({
+        createCustomer: mock(),
+        createCheckoutSession: sessionsCreate,
+      }),
+    );
 
     await stripeService.createCheckoutSession(userId.toString());
 
@@ -271,9 +282,11 @@ describe("StripeService", () => {
     const sessionsCreate = mock(() =>
       Promise.resolve({ client_secret: "cs_should_not_create" }),
     );
-    setStripeClientForTests({
-      checkout: { sessions: { create: sessionsCreate } },
-    } as unknown as Stripe);
+    const stripeService = new StripeService(
+      stubBillingGateway({
+        createCheckoutSession: sessionsCreate,
+      }),
+    );
 
     for (const status of ["trialing", "active", "past_due"] as const) {
       const userId = mongoService.objectId();
@@ -321,16 +334,12 @@ describe("StripeService", () => {
       type: "invalid_request_error",
       statusCode: 400,
     });
-    setStripeClientForTests({
-      customers: {
-        create: mock(() => Promise.resolve({ id: "cus_1" })),
-      },
-      checkout: {
-        sessions: {
-          create: mock(() => Promise.reject(stripeError)),
-        },
-      },
-    } as unknown as Stripe);
+    const stripeService = new StripeService(
+      stubBillingGateway({
+        createCustomer: mock(() => Promise.resolve({ id: "cus_1" })),
+        createCheckoutSession: mock(() => Promise.reject(stripeError)),
+      }),
+    );
 
     await expect(
       stripeService.createCheckoutSession(userId.toString()),
@@ -387,9 +396,11 @@ describe("StripeService", () => {
       const userId = await seedTrialingUser();
 
       const update = mock(() => Promise.resolve(stripeSubscription("active")));
-      setStripeClientForTests({
-        subscriptions: { update },
-      } as unknown as Stripe);
+      const stripeService = new StripeService(
+        stubBillingGateway({
+          updateSubscription: update,
+        }),
+      );
 
       const result = await stripeService.endTrialNow(userId.toString());
 
@@ -418,11 +429,13 @@ describe("StripeService", () => {
       using _env = mockEnv(stripeConfigured);
       const userId = await seedTrialingUser();
 
-      setStripeClientForTests({
-        subscriptions: {
-          update: mock(() => Promise.resolve(stripeSubscription("past_due"))),
-        },
-      } as unknown as Stripe);
+      const stripeService = new StripeService(
+        stubBillingGateway({
+          updateSubscription: mock(() =>
+            Promise.resolve(stripeSubscription("past_due")),
+          ),
+        }),
+      );
 
       const result = await stripeService.endTrialNow(userId.toString());
 
@@ -435,9 +448,11 @@ describe("StripeService", () => {
       const userId = await seedTrialingUser({ cancelAtPeriodEnd: true });
 
       const update = mock(() => Promise.resolve(stripeSubscription("active")));
-      setStripeClientForTests({
-        subscriptions: { update },
-      } as unknown as Stripe);
+      const stripeService = new StripeService(
+        stubBillingGateway({
+          updateSubscription: update,
+        }),
+      );
 
       const result = await stripeService.endTrialNow(userId.toString());
 
@@ -455,9 +470,11 @@ describe("StripeService", () => {
       const userId = await seedTrialingUser({ subscriptionStatus: "active" });
 
       const update = mock(() => Promise.resolve(stripeSubscription("active")));
-      setStripeClientForTests({
-        subscriptions: { update },
-      } as unknown as Stripe);
+      const stripeService = new StripeService(
+        stubBillingGateway({
+          updateSubscription: update,
+        }),
+      );
 
       await expect(
         stripeService.endTrialNow(userId.toString()),
@@ -474,6 +491,7 @@ describe("StripeService", () => {
       const userId = await seedTrialingUser({
         stripeSubscriptionId: undefined,
       });
+      const stripeService = new StripeService(stubBillingGateway({}));
 
       await expect(
         stripeService.endTrialNow(userId.toString()),
@@ -489,9 +507,11 @@ describe("StripeService", () => {
         type: "invalid_request_error",
         statusCode: 400,
       });
-      setStripeClientForTests({
-        subscriptions: { update: mock(() => Promise.reject(stripeError)) },
-      } as unknown as Stripe);
+      const stripeService = new StripeService(
+        stubBillingGateway({
+          updateSubscription: mock(() => Promise.reject(stripeError)),
+        }),
+      );
 
       await expect(
         stripeService.endTrialNow(userId.toString()),
@@ -581,11 +601,13 @@ describe("StripeService", () => {
           ],
         }),
       );
-      setStripeClientForTests({
-        subscriptions: { retrieve },
-        customers: { retrieve: customersRetrieve },
-        invoices: { list: invoicesList },
-      } as unknown as Stripe);
+      const stripeService = new StripeService(
+        stubBillingGateway({
+          retrieveCustomer: customersRetrieve,
+          retrieveSubscription: retrieve,
+          listInvoices: invoicesList,
+        }),
+      );
 
       const result = await stripeService.getSubscriptionSummary(
         userId.toString(),
@@ -640,11 +662,13 @@ describe("StripeService", () => {
           invoice_settings: { default_payment_method: cardPaymentMethod },
         }),
       );
-      setStripeClientForTests({
-        subscriptions: { retrieve },
-        customers: { retrieve: customersRetrieve },
-        invoices: { list: mock(() => Promise.resolve({ data: [] })) },
-      } as unknown as Stripe);
+      const stripeService = new StripeService(
+        stubBillingGateway({
+          retrieveCustomer: customersRetrieve,
+          retrieveSubscription: retrieve,
+          listInvoices: mock(() => Promise.resolve({ data: [] })),
+        }),
+      );
 
       const result = await stripeService.getSubscriptionSummary(
         userId.toString(),
@@ -671,10 +695,12 @@ describe("StripeService", () => {
 
       const retrieve = mock(() => Promise.reject(new Error("no stripe")));
       const invoicesList = mock(() => Promise.reject(new Error("no stripe")));
-      setStripeClientForTests({
-        subscriptions: { retrieve },
-        invoices: { list: invoicesList },
-      } as unknown as Stripe);
+      const stripeService = new StripeService(
+        stubBillingGateway({
+          retrieveSubscription: retrieve,
+          listInvoices: invoicesList,
+        }),
+      );
 
       const result = await stripeService.getSubscriptionSummary(
         userId.toString(),
@@ -734,9 +760,11 @@ describe("StripeService", () => {
       using _env = mockEnv(stripeConfigured);
       const userId = await seedSubscriber();
       const update = mock(() => Promise.resolve(updatedSubscription(true)));
-      setStripeClientForTests({
-        subscriptions: { update },
-      } as unknown as Stripe);
+      const stripeService = new StripeService(
+        stubBillingGateway({
+          updateSubscription: update,
+        }),
+      );
 
       const result = await stripeService.setCancelAtPeriodEnd(
         userId.toString(),
@@ -755,9 +783,11 @@ describe("StripeService", () => {
       using _env = mockEnv(stripeConfigured);
       const userId = await seedSubscriber({ cancelAtPeriodEnd: true });
       const update = mock(() => Promise.resolve(updatedSubscription(false)));
-      setStripeClientForTests({
-        subscriptions: { update },
-      } as unknown as Stripe);
+      const stripeService = new StripeService(
+        stubBillingGateway({
+          updateSubscription: update,
+        }),
+      );
 
       const result = await stripeService.setCancelAtPeriodEnd(
         userId.toString(),
@@ -780,9 +810,11 @@ describe("StripeService", () => {
       using _env = mockEnv(stripeConfigured);
       const userId = await seedSubscriber({ subscriptionStatus: status });
       const update = mock(() => Promise.resolve(updatedSubscription(true)));
-      setStripeClientForTests({
-        subscriptions: { update },
-      } as unknown as Stripe);
+      const stripeService = new StripeService(
+        stubBillingGateway({
+          updateSubscription: update,
+        }),
+      );
 
       await expect(
         stripeService.setCancelAtPeriodEnd(userId.toString(), true),
@@ -799,6 +831,7 @@ describe("StripeService", () => {
       const userId = await seedSubscriber({
         stripeSubscriptionId: undefined,
       });
+      const stripeService = new StripeService(stubBillingGateway({}));
 
       await expect(
         stripeService.setCancelAtPeriodEnd(userId.toString(), true),
@@ -830,9 +863,11 @@ describe("StripeService", () => {
       const sessionsCreate = mock(() =>
         Promise.resolve({ client_secret: "seti_secret_1" }),
       );
-      setStripeClientForTests({
-        checkout: { sessions: { create: sessionsCreate } },
-      } as unknown as Stripe);
+      const stripeService = new StripeService(
+        stubBillingGateway({
+          createCheckoutSession: sessionsCreate,
+        }),
+      );
 
       const result = await stripeService.createPaymentMethodSession(
         userId.toString(),
@@ -867,9 +902,11 @@ describe("StripeService", () => {
       const sessionsCreate = mock(() =>
         Promise.resolve({ client_secret: "seti_secret_1" }),
       );
-      setStripeClientForTests({
-        checkout: { sessions: { create: sessionsCreate } },
-      } as unknown as Stripe);
+      const stripeService = new StripeService(
+        stubBillingGateway({
+          createCheckoutSession: sessionsCreate,
+        }),
+      );
 
       await expect(
         stripeService.createPaymentMethodSession(userId.toString()),

--- a/packages/backend/src/billing/services/stripe.service.ts
+++ b/packages/backend/src/billing/services/stripe.service.ts
@@ -15,7 +15,10 @@ import {
 } from "@backend/billing/billing.errors";
 import billingService from "@backend/billing/services/billing.service";
 import { applySubscription } from "@backend/billing/services/billing.webhook.service";
-import { getStripeClient } from "@backend/billing/services/stripe.client";
+import {
+  type StripeBillingGateway,
+  stripeBillingGateway,
+} from "@backend/billing/services/stripe.client";
 import { CONFIG } from "@backend/common/constants/config.constants";
 import { isStripeConfigured } from "@backend/common/constants/config.util";
 import mongoService from "@backend/common/services/mongo.service";
@@ -23,7 +26,11 @@ import mongoService from "@backend/common/services/mongo.service";
 /** Bump when Checkout Session create params change so Stripe does not replay a failed create. */
 const CHECKOUT_IDEMPOTENCY_PREFIX = "compass-checkout-v3-";
 
-class StripeService {
+export class StripeService {
+  constructor(
+    private readonly stripe: StripeBillingGateway = stripeBillingGateway,
+  ) {}
+
   /**
    * Account deletion is deliberately stronger than cancelling a plan: deleting
    * the Stripe customer immediately ends every subscription and removes saved
@@ -45,9 +52,8 @@ class StripeService {
       );
     }
 
-    const stripe = getStripeClient();
     try {
-      await stripe.customers.del(customerId, {
+      await this.stripe.deleteCustomer(customerId, {
         idempotencyKey: `compass-account-delete-${userId}`,
       });
     } catch (error) {
@@ -87,13 +93,12 @@ class StripeService {
       );
     }
 
-    const stripe = getStripeClient();
     let customerId = user.billing?.stripeCustomerId;
     const grantTrial = !user.billing?.stripeSubscriptionId;
 
     if (!customerId) {
-      const customer = await stripe.customers
-        .create(
+      const customer = await this.stripe
+        .createCustomer(
           {
             email: user.email,
             metadata: { compassUserId: userId },
@@ -116,8 +121,8 @@ class StripeService {
       );
     }
 
-    const session = await stripe.checkout.sessions
-      .create(
+    const session = await this.stripe
+      .createCheckoutSession(
         {
           mode: "subscription",
           customer: customerId,
@@ -194,9 +199,8 @@ class StripeService {
       throw new BillingHttpError(Status.CONFLICT, "No active trial to end.");
     }
 
-    const stripe = getStripeClient();
-    const subscription = await stripe.subscriptions
-      .update(
+    const subscription = await this.stripe
+      .updateSubscription(
         subscriptionId,
         {
           trial_end: "now",
@@ -240,9 +244,10 @@ class StripeService {
       throw new Error("Stripe is not configured");
     }
 
-    const stripe = getStripeClient();
-    const subscription = await stripe.subscriptions
-      .retrieve(subscriptionId, { expand: ["default_payment_method"] })
+    const subscription = await this.stripe
+      .retrieveSubscription(subscriptionId, {
+        expand: ["default_payment_method"],
+      })
       .catch(wrapStripeFailure);
 
     let paymentMethod = cardFromPaymentMethod(
@@ -251,8 +256,8 @@ class StripeService {
     const customerId =
       customerIdOf(subscription.customer) ?? billing?.stripeCustomerId;
     if (!paymentMethod && customerId) {
-      const customer = await stripe.customers
-        .retrieve(customerId, {
+      const customer = await this.stripe
+        .retrieveCustomer(customerId, {
           expand: ["invoice_settings.default_payment_method"],
         })
         .catch(wrapStripeFailure);
@@ -265,8 +270,8 @@ class StripeService {
 
     const invoices = customerId
       ? (
-          await stripe.invoices
-            .list({ customer: customerId, limit: 12 })
+          await this.stripe
+            .listInvoices({ customer: customerId, limit: 12 })
             .catch(wrapStripeFailure)
         ).data.flatMap((invoice) => {
           const mapped = mapInvoice(invoice);
@@ -308,9 +313,8 @@ class StripeService {
       );
     }
 
-    const stripe = getStripeClient();
-    const subscription = await stripe.subscriptions
-      .update(subscriptionId, { cancel_at_period_end: cancel })
+    const subscription = await this.stripe
+      .updateSubscription(subscriptionId, { cancel_at_period_end: cancel })
       .catch(wrapStripeFailure);
 
     await applySubscription(userId, subscription, new Date());
@@ -336,9 +340,8 @@ class StripeService {
       throw new BillingHttpError(Status.CONFLICT, "No billing account yet.");
     }
 
-    const stripe = getStripeClient();
-    const session = await stripe.checkout.sessions
-      .create({
+    const session = await this.stripe
+      .createCheckoutSession({
         mode: "setup",
         customer: customerId,
         payment_method_types: ["card"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3457

## What and why

Billing talked to Stripe through a process-global `clientOverride` and tests stuffed nested SDK namespaces behind `as unknown as Stripe`. Compass now owns a flat `StripeBillingGateway` in `stripe.client.ts` (same API version, same SDK methods). `StripeService`, webhook processing, and the webhook controller take that gateway through a constructor or default-argument seam. Tests stub only the operations they use.

Sensitive path: this diff matches `billing` and `stripe` in `NO_AUTOMERGE_PATH_PATTERNS` (`.github/scripts/agent-loop-merge-guard.sh`). There is no simplification-loop allowlist for those prefixes, so merge-guard cannot auto-merge it. Do not add `agent-automerge`.

agent-loop-needs-human

- Decision: squash-merge this PR by hand, or add a milestone allowlist for `billing`/`stripe` (that allowlist itself lives under `.github/agent-loop/`, which is also a no-automerge path).
- Recommended option: human squash-merge of this PR. The change is a test/production seam only: same Stripe API version, same SDK methods, same request params and webhook behavior. An allowlist PR would still need a human because it touches `.github/agent-loop/`.
- Cost of waiting: blocks #3458 (EventForm schedule state) and #3459 (notification state). Milestone 21 cannot advance until this lands on `main`.

## Verify

`VERDICT: PASS`

Checks run: `test:backend`, `type-check`, `lint`, `knip`. Focused billing suite: 45 pass, 0 fail. Full backend: 685 pass, 1 skip, 0 fail.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca4712d6-affb-48b9-acfc-4ca1e9712054?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca4712d6-affb-48b9-acfc-4ca1e9712054&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

