### PR TITLE
fix(web): polish welcome signup flow

### DIFF
--- a/packages/backend/src/config/config.route.test.ts
+++ b/packages/backend/src/config/config.route.test.ts
@@ -1,3 +1,4 @@
+import { NodeEnv } from "@core/constants/core.constants";
 import { Status } from "@core/errors/status.codes";
 import { BaseDriver } from "@backend/__tests__/drivers/base.driver";
 import { CONFIG } from "@backend/common/constants/config.constants";
@@ -118,6 +119,60 @@ describe("GET /api/config", () => {
     } finally {
       CONFIG.GOOGLE_CLIENT_ID = originals.googleId;
       CONFIG.GOOGLE_CLIENT_SECRET = originals.googleSecret;
+      CONFIG.MICROSOFT_CLIENT_ID = originals.microsoftId;
+      CONFIG.MICROSOFT_CLIENT_SECRET = originals.microsoftSecret;
+    }
+  });
+
+  it("hides Microsoft in production even when credentials are configured", async () => {
+    const originals = {
+      nodeEnv: CONFIG.NODE_ENV,
+      microsoftId: CONFIG.MICROSOFT_CLIENT_ID,
+      microsoftSecret: CONFIG.MICROSOFT_CLIENT_SECRET,
+    };
+    CONFIG.NODE_ENV = NodeEnv.Production;
+    CONFIG.MICROSOFT_CLIENT_ID = "ms-client-id";
+    CONFIG.MICROSOFT_CLIENT_SECRET = "ms-client-secret";
+
+    try {
+      const response = await baseDriver
+        .getServer()
+        .get("/api/config")
+        .expect(Status.OK);
+
+      expect(response.body.providers.microsoft).toEqual({
+        signIn: false,
+        connect: false,
+      });
+    } finally {
+      CONFIG.NODE_ENV = originals.nodeEnv;
+      CONFIG.MICROSOFT_CLIENT_ID = originals.microsoftId;
+      CONFIG.MICROSOFT_CLIENT_SECRET = originals.microsoftSecret;
+    }
+  });
+
+  it("offers Microsoft in staging when credentials are configured", async () => {
+    const originals = {
+      nodeEnv: CONFIG.NODE_ENV,
+      microsoftId: CONFIG.MICROSOFT_CLIENT_ID,
+      microsoftSecret: CONFIG.MICROSOFT_CLIENT_SECRET,
+    };
+    CONFIG.NODE_ENV = NodeEnv.Staging;
+    CONFIG.MICROSOFT_CLIENT_ID = "ms-client-id";
+    CONFIG.MICROSOFT_CLIENT_SECRET = "ms-client-secret";
+
+    try {
+      const response = await baseDriver
+        .getServer()
+        .get("/api/config")
+        .expect(Status.OK);
+
+      expect(response.body.providers.microsoft).toEqual({
+        signIn: true,
+        connect: true,
+      });
+    } finally {
+      CONFIG.NODE_ENV = originals.nodeEnv;
       CONFIG.MICROSOFT_CLIENT_ID = originals.microsoftId;
       CONFIG.MICROSOFT_CLIENT_SECRET = originals.microsoftSecret;
     }

--- a/packages/backend/src/config/controllers/config.controller.ts
+++ b/packages/backend/src/config/controllers/config.controller.ts
@@ -1,6 +1,7 @@
 import { type Request, type Response } from "express";
 import { BILLING_PLAN } from "@core/constants/billing.constants";
 import { type AppConfig, AppConfigSchema } from "@core/types/config.types";
+import { isMicrosoftOffered } from "@core/util/env.util";
 import { CONFIG } from "@backend/common/constants/config.constants";
 import {
   isAppleConnectConfigured,
@@ -15,7 +16,8 @@ import { getCloudMutationMode } from "@backend/common/services/sync-service/clou
 class ConfigController {
   get = (_req: Request<never, AppConfig, never, never>, res: Response) => {
     const google = isGoogleConfigured(CONFIG);
-    const microsoft = isMicrosoftConfigured(CONFIG);
+    const microsoft =
+      isMicrosoftConfigured(CONFIG) && isMicrosoftOffered(CONFIG.NODE_ENV);
     const appleSignIn = isAppleSignInConfigured(CONFIG);
     const appleConnect = isAppleConnectConfigured(CONFIG);
     const stripe = isStripeConfigured(CONFIG);

--- a/packages/core/src/util/env.util.test.ts
+++ b/packages/core/src/util/env.util.test.ts
@@ -1,5 +1,10 @@
 import { NodeEnv } from "@core/constants/core.constants";
-import { isBookingEnabled, isDev } from "@core/util/env.util";
+import {
+  isBookingEnabled,
+  isDev,
+  isMicrosoftOffered,
+  isNonProduction,
+} from "@core/util/env.util";
 import { describe, expect, it } from "bun:test";
 
 describe("isDev", () => {
@@ -21,5 +26,27 @@ describe("isBookingEnabled", () => {
   it("is off in production", () => {
     expect(isBookingEnabled(NodeEnv.Production)).toBe(false);
     expect(isBookingEnabled("production")).toBe(false);
+  });
+});
+
+describe("isNonProduction", () => {
+  it("is false only for production", () => {
+    expect(isNonProduction(NodeEnv.Development)).toBe(true);
+    expect(isNonProduction(NodeEnv.Staging)).toBe(true);
+    expect(isNonProduction(NodeEnv.Test)).toBe(true);
+    expect(isNonProduction(NodeEnv.Production)).toBe(false);
+  });
+});
+
+describe("isMicrosoftOffered", () => {
+  it("is on in development, staging, and tests", () => {
+    expect(isMicrosoftOffered(NodeEnv.Development)).toBe(true);
+    expect(isMicrosoftOffered(NodeEnv.Staging)).toBe(true);
+    expect(isMicrosoftOffered(NodeEnv.Test)).toBe(true);
+  });
+
+  it("is off in production while publisher verification is pending", () => {
+    expect(isMicrosoftOffered(NodeEnv.Production)).toBe(false);
+    expect(isMicrosoftOffered("production")).toBe(false);
   });
 });

--- a/packages/core/src/util/env.util.ts
+++ b/packages/core/src/util/env.util.ts
@@ -3,6 +3,17 @@ import { NodeEnv } from "@core/constants/core.constants";
 export const isDev = (nodeEnv: NodeEnv | string) =>
   nodeEnv === NodeEnv.Development;
 
+/** True when `nodeEnv` is not production. */
+export const isNonProduction = (nodeEnv: NodeEnv | string) =>
+  nodeEnv !== NodeEnv.Production;
+
 /** Booking v1 is on in development, staging, and tests. Not production. */
 export const isBookingEnabled = (nodeEnv: NodeEnv | string) =>
-  nodeEnv !== NodeEnv.Production;
+  isNonProduction(nodeEnv);
+
+/**
+ * Microsoft sign-in and connect stay off in production until publisher
+ * verification lands. Staging, local, and tests can still offer it.
+ */
+export const isMicrosoftOffered = (nodeEnv: NodeEnv | string) =>
+  isNonProduction(nodeEnv);

--- a/packages/web/src/auth/providers/provider-copy.util.ts
+++ b/packages/web/src/auth/providers/provider-copy.util.ts
@@ -133,12 +133,6 @@ export function reconnectPointerHint(kind: ProviderKind): string {
   return `Press G to reconnect ${calendarProductName(kind)}.`;
 }
 
-export const SIGN_IN_WELCOME_SUBLINE: Record<ProviderKind, string> = {
-  google: "Signs you up and connects your Google Calendar.",
-  microsoft: "Signs you up and connects your Outlook calendar.",
-  apple: "You'll pick your calendar next.",
-};
-
 export function relabelConnectCommand(
   commandAction: GoogleUiConfig["commandAction"],
   kind: ProviderKind,

--- a/packages/web/src/common/constants/social.constants.ts
+++ b/packages/web/src/common/constants/social.constants.ts
@@ -14,6 +14,6 @@ export const SOCIAL_LINKS: SocialLink[] = [
   {
     id: "github",
     label: "GitHub",
-    href: "https://www.github.com/SwitchbackTech/compass-calendar",
+    href: "https://github.com/KeepSoftwareSimple/compass-calendar",
   },
 ];

--- a/packages/web/src/components/AuthModal/AuthModal.test.tsx
+++ b/packages/web/src/components/AuthModal/AuthModal.test.tsx
@@ -913,13 +913,16 @@ describe("AuthModal", () => {
   });
 
   describe("Privacy and Terms Links", () => {
-    it("renders privacy and terms links", async () => {
+    it("renders pricing, privacy, and terms links", async () => {
       const user = userEvent.setup();
       await renderWithProviders(<ModalTrigger />);
 
       await user.click(screen.getByRole("button", { name: /open modal/i }));
 
       await waitFor(() => {
+        expect(
+          screen.getByRole("link", { name: /pricing/i }),
+        ).toBeInTheDocument();
         expect(
           screen.getByRole("link", { name: /terms/i }),
         ).toBeInTheDocument();
@@ -929,6 +932,19 @@ describe("AuthModal", () => {
       });
     });
 
+    it("shows an Esc hint to leave the form", async () => {
+      const user = userEvent.setup();
+      await renderWithProviders(<ModalTrigger />);
+
+      await user.click(screen.getByRole("button", { name: /open modal/i }));
+      await waitForAuthModal();
+
+      expect(screen.getByRole("button", { name: /back/i })).toBeInTheDocument();
+      expect(
+        within(screen.getByRole("button", { name: /back/i })).getByText("Esc"),
+      ).toBeInTheDocument();
+    });
+
     it("links open in new tab", async () => {
       const user = userEvent.setup();
       await renderWithProviders(<ModalTrigger />);
@@ -936,6 +952,9 @@ describe("AuthModal", () => {
       await user.click(screen.getByRole("button", { name: /open modal/i }));
 
       await waitFor(() => {
+        const pricingLink = screen.getByRole("link", {
+          name: /pricing/i,
+        });
         const termsLink = screen.getByRole("link", {
           name: /terms/i,
         });
@@ -943,10 +962,16 @@ describe("AuthModal", () => {
           name: /privacy/i,
         });
 
+        expect(pricingLink).toHaveAttribute("target", "_blank");
         expect(termsLink).toHaveAttribute("target", "_blank");
         expect(privacyLink).toHaveAttribute("target", "_blank");
+        expect(pricingLink).toHaveAttribute("rel", "noopener noreferrer");
         expect(termsLink).toHaveAttribute("rel", "noopener noreferrer");
         expect(privacyLink).toHaveAttribute("rel", "noopener noreferrer");
+        expect(pricingLink).toHaveAttribute(
+          "href",
+          "https://compasscalendar.com/pricing",
+        );
       });
     });
   });

--- a/packages/web/src/components/AuthModal/AuthModal.tsx
+++ b/packages/web/src/components/AuthModal/AuthModal.tsx
@@ -90,6 +90,7 @@ export const AuthModal: FC = () => {
   const prevViewRef = useRef(currentView);
   // OverlayPanel would otherwise seat the view-switch chip (first focusable).
   const emailInputRef = useRef<HTMLInputElement>(null);
+  const pricingLinkRef = useRef<HTMLAnchorElement>(null);
 
   useEffect(() => {
     if (prevViewRef.current !== "signUp" && currentView === "signUp") {
@@ -138,12 +139,18 @@ export const AuthModal: FC = () => {
   const showAuthSwitch = isLoginView || currentView === "signUp";
 
   useEffect(() => {
-    if (!isOpen || !showAuthSwitch) return;
+    if (!isOpen) return;
 
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.metaKey || event.ctrlKey || event.altKey) return;
       if (isEditableKeyboardTarget(event)) return;
       const key = keyboardKey(event).toLowerCase();
+      if (key === "p") {
+        event.preventDefault();
+        pricingLinkRef.current?.click();
+        return;
+      }
+      if (!showAuthSwitch) return;
       const providerKind = signInProviderForShortcutLetter(key, available);
       if (providerKind) {
         event.preventDefault();
@@ -279,8 +286,28 @@ export const AuthModal: FC = () => {
             anytime.
           </p>
         ) : null}
-        {/* Privacy & Terms links */}
+        <div className="flex w-full justify-center">
+          <button
+            type="button"
+            onClick={closeModal}
+            className="c-focus-ring inline-flex items-center rounded-md px-2 py-1 text-text-muted text-xs hover:bg-surface-overlay hover:text-text"
+          >
+            Back
+            <ShortcutHint className="ml-2">Esc</ShortcutHint>
+          </button>
+        </div>
         <div className="flex items-center justify-center text-center text-text-muted text-xs">
+          <a
+            ref={pricingLinkRef}
+            href="https://compasscalendar.com/pricing"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-text hover:underline"
+          >
+            Pricing
+            <ShortcutHint>P</ShortcutHint>
+          </a>
+          <DotIcon size={26} />
           <a
             href="https://www.compasscalendar.com/terms"
             target="_blank"

--- a/packages/web/src/components/AuthModal/components/SignInProviderButtons.test.tsx
+++ b/packages/web/src/components/AuthModal/components/SignInProviderButtons.test.tsx
@@ -22,27 +22,12 @@ describe("SignInProviderButtons", () => {
     expect(
       screen.getByRole("button", { name: "Continue with Apple" }),
     ).toHaveTextContent("Continue with Apple");
-  });
-
-  it("renders welcome sublines for each provider", () => {
-    render(
-      <SignInProviderButtons
-        available={["google", "microsoft", "apple"]}
-        loadingKind={null}
-        onSignIn={mock()}
-        variant="welcome"
-      />,
-    );
-
     expect(
-      screen.getByText("Signs you up and connects your Google Calendar."),
-    ).toBeInTheDocument();
+      screen.queryByText("Signs you up and connects your Google Calendar."),
+    ).not.toBeInTheDocument();
     expect(
-      screen.getByText("Signs you up and connects your Outlook calendar."),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("You'll pick your calendar next."),
-    ).toBeInTheDocument();
+      screen.queryByText("Signs you up and connects your Outlook calendar."),
+    ).not.toBeInTheDocument();
   });
 
   it("calls onSignIn with the clicked provider kind", async () => {

--- a/packages/web/src/components/AuthModal/components/SignInProviderButtons.tsx
+++ b/packages/web/src/components/AuthModal/components/SignInProviderButtons.tsx
@@ -1,6 +1,5 @@
 import { type CSSProperties, type FC } from "react";
 import { type ProviderKind } from "@core/types/sync/identity.contracts";
-import { SIGN_IN_WELCOME_SUBLINE } from "@web/auth/providers/provider-copy.util";
 import {
   CONTINUE_WITH_LABEL,
   SIGN_IN_SHORTCUT_KEY,
@@ -13,7 +12,6 @@ type SignInProviderButtonsProps = {
   available: readonly ProviderKind[];
   loadingKind: ProviderKind | null;
   onSignIn: (kind: ProviderKind) => void;
-  variant?: "auth" | "welcome";
   fullWidth?: boolean;
 };
 
@@ -25,7 +23,7 @@ const SIGN_IN_BUTTONS = {
 
 const renderProviderButton = (
   kind: ProviderKind,
-  props: Omit<SignInProviderButtonsProps, "available" | "variant"> & {
+  props: Omit<SignInProviderButtonsProps, "available"> & {
     style?: CSSProperties;
   },
 ) => {
@@ -47,7 +45,6 @@ export const SignInProviderButtons: FC<SignInProviderButtonsProps> = ({
   available,
   loadingKind,
   onSignIn,
-  variant = "auth",
   fullWidth = true,
 }) => {
   if (available.length === 0) {
@@ -55,25 +52,6 @@ export const SignInProviderButtons: FC<SignInProviderButtonsProps> = ({
   }
 
   const buttonStyle = fullWidth ? { width: "100%" } : undefined;
-
-  if (variant === "welcome") {
-    return (
-      <>
-        {available.map((kind) => (
-          <div key={kind} className="flex w-full flex-col items-center gap-3">
-            {renderProviderButton(kind, {
-              loadingKind,
-              onSignIn,
-              style: buttonStyle,
-            })}
-            <p className="text-center text-text-muted text-xs">
-              {SIGN_IN_WELCOME_SUBLINE[kind]}
-            </p>
-          </div>
-        ))}
-      </>
-    );
-  }
 
   return (
     <>

--- a/packages/web/src/components/WelcomeModal/WelcomeGuideBody.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeGuideBody.test.tsx
@@ -115,26 +115,37 @@ describe("WelcomeGuideBody", () => {
     expect(screen.getByText(/and \? opens the full legend/)).toBeTruthy();
   });
 
-  it("opens footer links with digits 6 through 0", () => {
+  it("opens footer links with digits 6 through 0, and P for Pricing", () => {
     renderWelcomeGuide();
 
     const x = captureLinkClick("X (Twitter)");
     const linkedin = captureLinkClick("LinkedIn");
     const github = captureLinkClick("GitHub");
+    const pricing = captureLinkClick("Pricing");
     const privacy = captureLinkClick("Privacy");
     const terms = captureLinkClick("Terms");
 
     pressWindowKey({ key: "6", code: "Digit6" });
     pressWindowKey({ key: "7", code: "Digit7" });
     pressWindowKey({ key: "8", code: "Digit8" });
+    pressWindowKey({ key: "p", code: "KeyP" });
     pressWindowKey({ key: "9", code: "Digit9" });
     pressWindowKey({ key: "0", code: "Digit0" });
 
     expect(x).toHaveBeenCalledTimes(1);
     expect(linkedin).toHaveBeenCalledTimes(1);
     expect(github).toHaveBeenCalledTimes(1);
+    expect(pricing).toHaveBeenCalledTimes(1);
     expect(privacy).toHaveBeenCalledTimes(1);
     expect(terms).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("link", { name: "GitHub" })).toHaveAttribute(
+      "href",
+      "https://github.com/KeepSoftwareSimple/compass-calendar",
+    );
+    expect(screen.getByRole("link", { name: "Pricing" })).toHaveAttribute(
+      "href",
+      "https://compasscalendar.com/pricing",
+    );
   });
 
   it("flashes the matching FAQ key after a blocked click, then clears", async () => {

--- a/packages/web/src/components/WelcomeModal/WelcomeLinks.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeLinks.tsx
@@ -16,7 +16,14 @@ const SOCIAL_ICONS = {
   github: GithubLogoIcon,
 } as const;
 
-const LEGAL_LINKS = [
+const PRICING_LINK = {
+  shortcut: "P",
+  letter: "p",
+  label: "Pricing",
+  href: "https://compasscalendar.com/pricing",
+} as const;
+
+const DIGIT_LEGAL_LINKS = [
   {
     digit: "9",
     label: "Privacy",
@@ -31,6 +38,7 @@ const LEGAL_LINKS = [
 
 function JumpAnchor({
   jumpIndex,
+  letter,
   digit,
   href,
   label,
@@ -38,7 +46,8 @@ function JumpAnchor({
   className,
   children,
 }: {
-  jumpIndex: number;
+  jumpIndex?: number;
+  letter?: string;
   digit: string;
   href: string;
   label?: string;
@@ -53,7 +62,10 @@ function JumpAnchor({
       rel="noopener noreferrer"
       aria-label={label}
       className={className}
-      data-welcome-jump={String(jumpIndex)}
+      data-welcome-jump={
+        jumpIndex !== undefined ? String(jumpIndex) : undefined
+      }
+      data-welcome-letter={letter}
       {...pointerShortcutAttributes(digit)}
     >
       {children}
@@ -91,7 +103,16 @@ export function WelcomeLinks({ flashedKey }: { flashedKey: string | null }) {
         })}
       </div>
       <div className="flex items-center gap-4 text-text-muted text-xs">
-        {LEGAL_LINKS.map(({ digit, label, href }, index) => (
+        <JumpAnchor
+          letter={PRICING_LINK.letter}
+          digit={PRICING_LINK.shortcut}
+          href={PRICING_LINK.href}
+          flashedKey={flashedKey}
+          className="c-focus-ring inline-flex items-center gap-1 underline-offset-4 hover:text-text hover:underline"
+        >
+          {PRICING_LINK.label}
+        </JumpAnchor>
+        {DIGIT_LEGAL_LINKS.map(({ digit, label, href }, index) => (
           <JumpAnchor
             key={label}
             jumpIndex={SOCIAL_LINKS.length + index}

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -131,6 +131,10 @@ describe("WelcomeModal", () => {
 
     expect(mockOpenModal).toHaveBeenCalledWith("login");
     expect(localStorage.getItem(STORAGE_KEYS.HAS_SEEN_WELCOME)).toBe("true");
+    // Stay mounted until auth actually opens so the calendar does not flash.
+    expect(
+      screen.getByRole("dialog", { name: "Welcome to Compass Calendar" }),
+    ).toBeTruthy();
 
     // The welcome screen hides while the auth modal is open
     authModalState.isOpen = true;
@@ -232,12 +236,19 @@ describe("WelcomeModal", () => {
     expect(
       screen.getByRole("heading", { name: "Connect the calendar you use" }),
     ).toBeTruthy();
+    expect(screen.getByText("Pick how you want to start.")).toBeTruthy();
     expect(
-      screen.getByText(
+      screen.queryByText(
         "If you view your calendar in Apple Calendar, it may still be hosted by Google or Microsoft.",
       ),
-    ).toBeTruthy();
+    ).toBeNull();
+    expect(screen.queryByText(/You can sign up later/)).toBeNull();
     expect(screen.getByRole("link", { name: "Terms" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Pricing" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "GitHub" })).toHaveAttribute(
+      "href",
+      "https://github.com/KeepSoftwareSimple/compass-calendar",
+    );
     expect(screen.getByRole("button", { name: "Sign up" })).toHaveFocus();
 
     await user.keyboard("{Escape}");
@@ -426,8 +437,8 @@ describe("WelcomeModal", () => {
     await user.keyboard("i");
     expect(mockOpenModal).toHaveBeenCalledWith("login");
     expect(
-      screen.queryByRole("dialog", { name: "Welcome to Compass Calendar" }),
-    ).toBeNull();
+      screen.getByRole("dialog", { name: "Welcome to Compass Calendar" }),
+    ).toBeTruthy();
 
     await user.keyboard("s");
     await act(async () => {
@@ -562,8 +573,8 @@ describe("WelcomeModal", () => {
         screen.getByRole("button", { name: "Continue with Google" }),
       ).toBeTruthy();
       expect(
-        screen.getByText(/Signs you up and connects your Google Calendar/),
-      ).toBeTruthy();
+        screen.queryByText(/Signs you up and connects your Google Calendar/),
+      ).toBeNull();
       expect(
         within(
           screen.getByRole("button", { name: "Continue with Google" }),
@@ -621,12 +632,12 @@ describe("WelcomeModal", () => {
         screen.getByRole("button", { name: "Continue with Apple" }),
       ).toHaveTextContent("Continue with Apple");
       expect(
-        screen.getByText("Signs you up and connects your Google Calendar."),
-      ).toBeTruthy();
+        screen.queryByText("Signs you up and connects your Google Calendar."),
+      ).toBeNull();
       expect(
-        screen.getByText("Signs you up and connects your Outlook calendar."),
-      ).toBeTruthy();
-      expect(screen.getByText("You'll pick your calendar next.")).toBeTruthy();
+        screen.queryByText("Signs you up and connects your Outlook calendar."),
+      ).toBeNull();
+      expect(screen.queryByText("You'll pick your calendar next.")).toBeNull();
       expect(
         screen.queryByRole("button", { name: "Connect Microsoft" }),
       ).toBeNull();
@@ -688,7 +699,7 @@ describe("WelcomeModal", () => {
       resetProviderAvailabilityForTests();
     });
 
-    it("offers a Connect Microsoft button and the host explainer", async () => {
+    it("offers a Connect Microsoft button when sign-in is not available", async () => {
       const user = userEvent.setup();
       render(<WelcomeModal />);
       await goToChooseScreen(user);

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -89,8 +89,7 @@ export function WelcomeModal() {
   const startShowcaseAfterDismissRef = useRef(false);
   // openModal() only schedules a URL update. Keep this overlay up until
   // Auth actually opens so the calendar does not flash through the gap.
-  // hidingForAuth still blocks Explore and shortcuts during that wait.
-  const [hidingForAuth, setHidingForAuth] = useState(false);
+  // hidingForAuthRef still blocks Explore and shortcuts during that wait.
   const hidingForAuthRef = useRef(false);
   const providerHandoffRef = useRef(false);
   // Each screen has one primary button, and Enter is its native activation.
@@ -111,7 +110,6 @@ export function WelcomeModal() {
   useEffect(() => {
     if (isAuthModalOpen) return;
     hidingForAuthRef.current = false;
-    setHidingForAuth(false);
   }, [isAuthModalOpen]);
 
   useEffect(() => {
@@ -190,7 +188,6 @@ export function WelcomeModal() {
     skipFocusRestoreRef.current = true;
     startShowcaseAfterDismissRef.current = false;
     hidingForAuthRef.current = true;
-    setHidingForAuth(true);
     cancelDismiss();
   };
 

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -3,10 +3,7 @@ import { useContext, useEffect, useId, useRef, useState } from "react";
 import { type ProviderKind } from "@core/types/sync/identity.contracts";
 import { SessionContext } from "@web/auth/compass/session/session.context";
 import { track } from "@web/auth/posthog/track";
-import {
-  CALENDAR_HOST_EXPLAINER,
-  CONNECT_THE_CALENDAR_YOU_USE,
-} from "@web/auth/providers/provider-copy.util";
+import { CONNECT_THE_CALENDAR_YOU_USE } from "@web/auth/providers/provider-copy.util";
 import { signInProviderForShortcutLetter } from "@web/auth/providers/sign-in-provider.util";
 import { useIsProviderAvailable } from "@web/auth/providers/useIsProviderAvailable";
 import { useSignInProviders } from "@web/auth/providers/useSignInProviders";
@@ -90,8 +87,9 @@ export function WelcomeModal() {
   // handoff during the fade must cancel that so the takeover does not cover
   // the auth form.
   const startShowcaseAfterDismissRef = useRef(false);
-  // openModal() only schedules a URL update. Hide immediately so Explore
-  // cannot start the practice on top of a login that has not committed yet.
+  // openModal() only schedules a URL update. Keep this overlay up until
+  // Auth actually opens so the calendar does not flash through the gap.
+  // hidingForAuth still blocks Explore and shortcuts during that wait.
   const [hidingForAuth, setHidingForAuth] = useState(false);
   const hidingForAuthRef = useRef(false);
   const providerHandoffRef = useRef(false);
@@ -108,8 +106,7 @@ export function WelcomeModal() {
   // The auth modal's openness lives in the URL (?auth=), so the welcome
   // screen simply hides while it is open and reappears when the browser
   // back button (or Escape) removes the param again.
-  const visible =
-    isOpen && !isAuthModalOpen && !authenticated && !hidingForAuth;
+  const visible = isOpen && !isAuthModalOpen && !authenticated;
 
   useEffect(() => {
     if (isAuthModalOpen) return;
@@ -377,12 +374,7 @@ export function WelcomeModal() {
               <h2 className="font-bold text-2xl text-text leading-snug">
                 {CONNECT_THE_CALENDAR_YOU_USE}
               </h2>
-              <p className="text-text-muted">
-                Pick how you want to start. You can sign up later.
-              </p>
-              <p className="text-text-muted text-xs">
-                {CALENDAR_HOST_EXPLAINER}
-              </p>
+              <p className="text-text-muted">Pick how you want to start.</p>
             </div>
             {/* Connecting a calendar is the moment Compass starts being
                 useful, so the Google round trip, which signs up and grants
@@ -394,7 +386,6 @@ export function WelcomeModal() {
                   available={available}
                   loadingKind={isLoading ? loadingKind : null}
                   onSignIn={handOffToProvider}
-                  variant="welcome"
                 />
               ) : null}
               {showMicrosoftConnectCta ? (

--- a/packages/web/src/components/WelcomeModal/useWelcomeJumpShortcuts.ts
+++ b/packages/web/src/components/WelcomeModal/useWelcomeJumpShortcuts.ts
@@ -1,9 +1,14 @@
 import { useEffect } from "react";
 import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
 import { physicalDigitIndex } from "@web/shortcuts/digit-pick.util";
+import {
+  isBareLetterKey,
+  keyboardKey,
+} from "@web/shortcuts/is-bare-letter-key";
 import { FAQ_ITEMS } from "./faq";
 
 export const WELCOME_JUMP_ATTR = "data-welcome-jump";
+export const WELCOME_LETTER_ATTR = "data-welcome-letter";
 
 /**
  * Press a number (with or without Mod) to toggle that FAQ or open a footer
@@ -11,7 +16,8 @@ export const WELCOME_JUMP_ATTR = "data-welcome-jump";
  *
  * 1–5 toggle FAQ items when `toggleFaqAt` is given (omit it on a screen with
  * no FAQ). 6–0 activate matching `[data-welcome-jump]` links, and no-op when
- * none is mounted.
+ * none is mounted. Bare letters activate matching `[data-welcome-letter]`
+ * links (Pricing / P).
  */
 export function useWelcomeJumpShortcuts(toggleFaqAt?: (index: number) => void) {
   useEffect(() => {
@@ -19,23 +25,34 @@ export function useWelcomeJumpShortcuts(toggleFaqAt?: (index: number) => void) {
       if (isEditableKeyboardTarget(event)) return;
 
       const index = physicalDigitIndex(event);
-      if (index === null) return;
+      if (index !== null) {
+        if (index < FAQ_ITEMS.length) {
+          if (!toggleFaqAt) return;
+          event.preventDefault();
+          toggleFaqAt(index);
+          return;
+        }
 
-      if (index < FAQ_ITEMS.length) {
-        if (!toggleFaqAt) return;
+        const footerIndex = index - FAQ_ITEMS.length;
+        const el = document.querySelector<HTMLElement>(
+          `[${WELCOME_JUMP_ATTR}="${footerIndex}"]`,
+        );
+        if (!el) return;
+
         event.preventDefault();
-        toggleFaqAt(index);
+        el.click();
         return;
       }
 
-      const footerIndex = index - FAQ_ITEMS.length;
-      const el = document.querySelector<HTMLElement>(
-        `[${WELCOME_JUMP_ATTR}="${footerIndex}"]`,
+      const letter = keyboardKey(event).toLowerCase();
+      if (!isBareLetterKey(event, letter)) return;
+      const letterEl = document.querySelector<HTMLElement>(
+        `[${WELCOME_LETTER_ATTR}="${letter}"]`,
       );
-      if (!el) return;
+      if (!letterEl) return;
 
       event.preventDefault();
-      el.click();
+      letterEl.click();
     };
 
     window.addEventListener("keydown", onKeyDown);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

The welcome-to-signup handoff unmounted the overlay before `?auth=` committed, so the calendar flashed, then the form appeared. This keeps welcome mounted until the auth modal is actually open, drops the extra Google/Microsoft/Apple Calendar copy, adds an Esc hint on the sign-in and sign-up forms, puts Pricing (`P`) in the footer, points GitHub at `https://github.com/KeepSoftwareSimple/compass-calendar`, and stops advertising Microsoft in production while publisher verification is pending (`/api/config` reports it unavailable when `runtime.nodeEnv` is production).

This diff deletes unused signup sublines from `packages/web/src/auth/providers/provider-copy.util.ts`, which matches `NO_AUTOMERGE_PATH_PATTERNS`. Needs a human review before merge.

## Verify

`VERDICT: PASS`

Checks: `test:core`, `test:web`, `test:backend:fast`, `type-check`, `lint`, `knip`, `test:a11y`, `test:e2e` (`bun run verify --strict`, exit 0).

![Welcome step 3 with shorter copy and Pricing P](https://cursor.com/artifacts/c/art-6954bcab-d2cc-4ca8-9091-9d4a7e73e3a3)
![Signup form with Back Esc and Pricing P](https://cursor.com/artifacts/c/art-88538de9-272f-4cbf-a272-03fd22b6408c)
<a href="https://cursor.com/agents/bc-6c530633-e94c-4316-a361-d5bad0a96f51/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwelcome_signup_click_no_flash.mp4"><img src="https://cursor.com/artifacts/c/art-0bb300ea-d0fa-4154-9cb7-743be17238a4" alt="welcome_signup_click_no_flash.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c530633-e94c-4316-a361-d5bad0a96f51?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c530633-e94c-4316-a361-d5bad0a96f51&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

