### PR TITLE
refactor(web): derive EventForm schedule state from the draft

### DIFF
--- a/packages/web/src/events/grid-event-draft.adapter.ts
+++ b/packages/web/src/events/grid-event-draft.adapter.ts
@@ -470,39 +470,6 @@ export function patchGridDraftRecurrence(
   return { ...draft, values: { ...draft.values, recurrence } };
 }
 
-export function patchGridDraftScheduleDates(
-  current: GridEventDraft,
-  patch: { startDate?: string; endDate?: string },
-): GridEventDraft {
-  const { schedule } = current.values;
-  const nextSchedule: GridScheduleDraft =
-    schedule.kind === "allDay"
-      ? {
-          kind: "allDay",
-          start: patch.startDate
-            ? dayjs(patch.startDate).toDate()
-            : schedule.start,
-          end: patch.endDate ? dayjs(patch.endDate).toDate() : schedule.end,
-        }
-      : {
-          kind: "timed",
-          start: patch.startDate
-            ? dayjs(patch.startDate).toDate()
-            : schedule.start,
-          end: patch.endDate ? dayjs(patch.endDate).toDate() : schedule.end,
-          timeZone: schedule.timeZone,
-        };
-
-  if (current.kind === "create") {
-    return {
-      ...current,
-      values: { ...current.values, schedule: nextSchedule },
-    };
-  }
-
-  return { ...current, values: { ...current.values, schedule: nextSchedule } };
-}
-
 export function patchGridDraftFields(
   current: GridEventDraft,
   patch: Partial<

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/DatePickers/DatePickers.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/DatePickers/DatePickers.tsx
@@ -6,7 +6,8 @@ import { dateIsValid } from "@web/common/utils/datetime/web.date.util";
 import { shouldAdjustComplimentDate } from "@web/common/utils/datetime/web.datetime.util";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import { DatePicker } from "@web/components/DatePicker/DatePicker";
-import { type SetEventFormSchedule } from "@web/views/Forms/EventForm/types";
+import { type GridEventDraft } from "@web/events/event-draft.types";
+import { type OnEventFormScheduleChange } from "@web/views/Forms/EventForm/types";
 
 const stopPropagation = (e: React.MouseEvent<HTMLDivElement>) => {
   e.stopPropagation();
@@ -24,30 +25,26 @@ const dateFieldClassName =
 
 interface Props {
   displayEndDate: Date;
+  draft: GridEventDraft;
   isEndDatePickerOpen: boolean;
   isStartDatePickerOpen: boolean;
   selectedEndDate: Date;
   selectedStartDate: Date;
-  onSetScheduleField: SetEventFormSchedule;
-  setDisplayEndDate: (value: Date) => void;
-  setSelectedEndDate: (value: Date) => void;
-  setSelectedStartDate: (value: Date) => void;
+  onScheduleChange: OnEventFormScheduleChange;
   setIsStartDatePickerOpen: (arg0: boolean) => void;
   setIsEndDatePickerOpen: (arg0: boolean) => void;
 }
 
 export const DatePickers: FC<Props> = ({
   displayEndDate,
+  draft,
   isEndDatePickerOpen,
   isStartDatePickerOpen,
   selectedEndDate,
   selectedStartDate,
-  onSetScheduleField,
-  setDisplayEndDate,
+  onScheduleChange,
   setIsEndDatePickerOpen,
   setIsStartDatePickerOpen,
-  setSelectedEndDate,
-  setSelectedStartDate,
 }) => {
   const closeEndDatePicker = () => {
     setIsEndDatePickerOpen(false);
@@ -146,9 +143,18 @@ export const DatePickers: FC<Props> = ({
     return dayjs(date).format(dayjs.DateFormat.YEAR_MONTH_DAY_FORMAT);
   };
 
+  const toAllDayDate = (date: Date) => dayjs(formatDate(date)).toDate();
+
+  const currentAllDayBounds = () => {
+    const { schedule } = draft.values;
+    if (schedule.kind === "allDay") {
+      return { start: schedule.start, end: schedule.end };
+    }
+    return { start: selectedStartDate, end: selectedEndDate };
+  };
+
   const onSelectStartDate = (start: Date) => {
     setIsStartDatePickerOpen(false);
-    setSelectedStartDate(start);
 
     const { shouldAdjust: shouldAdjustEnd, compliment } =
       shouldAdjustComplimentDate("start", {
@@ -161,18 +167,17 @@ export const DatePickers: FC<Props> = ({
       // the event form should show a start of "2025-12-25" and an end of "2025-12-25",
       // and the backend should store the start as "2025-12-25" and the end as "2025-12-26".
       // Adding one day to the end here helps us achieve that requirement.
-      const endDisplay = dayjs(compliment).add(1, "day").toDate();
-      setDisplayEndDate(endDisplay);
-
-      setSelectedEndDate(compliment);
-
-      onSetScheduleField({
-        startDate: formatDate(start),
-        endDate: formatDate(compliment),
+      onScheduleChange({
+        kind: "allDay",
+        start: toAllDayDate(start),
+        end: toAllDayDate(compliment),
       });
     } else {
-      const newStartDate = formatDate(start);
-      onSetScheduleField({ startDate: newStartDate });
+      onScheduleChange({
+        kind: "allDay",
+        start: toAllDayDate(start),
+        end: currentAllDayBounds().end,
+      });
     }
   };
 
@@ -185,16 +190,16 @@ export const DatePickers: FC<Props> = ({
     });
 
     if (shouldAdjust) {
-      setSelectedStartDate(compliment);
-      setSelectedEndDate(compliment);
-      setDisplayEndDate(compliment);
-      onSetScheduleField({
-        startDate: formatDate(compliment),
-        endDate: formatDate(compliment),
+      onScheduleChange({
+        kind: "allDay",
+        start: toAllDayDate(compliment),
+        end: toAllDayDate(compliment),
       });
     } else {
-      onSetScheduleField({
-        endDate: formatDate(dayjs(end).add(1, "day").toDate()),
+      onScheduleChange({
+        kind: "allDay",
+        start: currentAllDayBounds().start,
+        end: toAllDayDate(dayjs(end).add(1, "day").toDate()),
       });
     }
   };

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/DateTimeSection.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/DateTimeSection.tsx
@@ -4,7 +4,7 @@ import { Categories_Event } from "@web/common/types/web.event.types";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import { DatePickers } from "@web/views/Forms/EventForm/DateControlsSection/DateTimeSection/DatePickers/DatePickers";
 import { TimePickers } from "@web/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers";
-import { type SetEventFormSchedule } from "@web/views/Forms/EventForm/types";
+import { type OnEventFormScheduleChange } from "@web/views/Forms/EventForm/types";
 
 export interface Props {
   category: Categories_Event;
@@ -13,17 +13,11 @@ export interface Props {
   endTime: SelectOption<string>;
   isEndDatePickerOpen: boolean;
   isStartDatePickerOpen: boolean;
-  onSetScheduleField: SetEventFormSchedule;
+  onScheduleChange: OnEventFormScheduleChange;
   selectedEndDate: Date;
   selectedStartDate: Date;
-  setDisplayEndDate: (value: Date) => void;
-  setDraft: (draft: GridEventDraft) => void;
-  setEndTime: (value: SelectOption<string>) => void;
   setIsEndDatePickerOpen: (arg0: boolean) => void;
   setIsStartDatePickerOpen: (arg0: boolean) => void;
-  setSelectedEndDate: (value: Date) => void;
-  setSelectedStartDate: (value: Date) => void;
-  setStartTime: (value: SelectOption<string>) => void;
   startTime: SelectOption<string>;
 }
 
@@ -35,15 +29,9 @@ export const DateTimeSection: FC<Props> = ({
   isStartDatePickerOpen,
   selectedEndDate,
   selectedStartDate,
-  onSetScheduleField,
-  setDisplayEndDate,
+  onScheduleChange,
   setIsStartDatePickerOpen,
   setIsEndDatePickerOpen,
-  setStartTime,
-  setEndTime,
-  setSelectedEndDate,
-  setSelectedStartDate,
-  setDraft,
   startTime,
   endTime,
 }) => {
@@ -52,14 +40,12 @@ export const DateTimeSection: FC<Props> = ({
       {category === Categories_Event.ALLDAY && (
         <DatePickers
           displayEndDate={displayEndDate}
+          draft={draft}
           isEndDatePickerOpen={isEndDatePickerOpen}
           isStartDatePickerOpen={isStartDatePickerOpen}
           selectedEndDate={selectedEndDate}
           selectedStartDate={selectedStartDate}
-          onSetScheduleField={onSetScheduleField}
-          setDisplayEndDate={setDisplayEndDate}
-          setSelectedEndDate={setSelectedEndDate}
-          setSelectedStartDate={setSelectedStartDate}
+          onScheduleChange={onScheduleChange}
           setIsEndDatePickerOpen={setIsEndDatePickerOpen}
           setIsStartDatePickerOpen={setIsStartDatePickerOpen}
         />
@@ -67,11 +53,8 @@ export const DateTimeSection: FC<Props> = ({
 
       {category === Categories_Event.TIMED && (
         <TimePickers
-          draft={draft}
           endTime={endTime}
-          setStartTime={setStartTime}
-          setEndTime={setEndTime}
-          setDraft={setDraft}
+          onScheduleChange={onScheduleChange}
           startTime={startTime}
           selectedEndDate={selectedEndDate}
           selectedStartDate={selectedStartDate}

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.test.tsx
@@ -1,11 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
-import dayjs from "@core/util/date/dayjs";
-import { getTimeOptionByValue } from "@web/common/utils/datetime/web.date.util";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import {
   createGridEventDraft,
+  replaceGridDraftSchedule,
   scheduleDatesFromDraft,
   timedGridSchedule,
 } from "@web/events/grid-event-draft.adapter";
@@ -16,11 +15,10 @@ import { describe, expect, it } from "bun:test";
 const START_DATE = new Date("2026-04-24T14:00:00.000Z");
 const END_DATE = new Date("2026-04-24T15:00:00.000Z");
 
-// The selected dates come from getFormDates over the draft's schedule, which
-// is how EventForm builds them (createDateTimeState). That mapping matters
-// here: for a same-day draft getFormDates returns the *start* instant as the
-// end date, so the two dates only diverge once a draft crosses midnight.
-// startTime/endTime stay component state, as they are in EventForm.
+// The selected dates and times come from getFormDates over the draft's
+// schedule, which is how EventForm builds them. That mapping matters here:
+// for a same-day draft getFormDates returns the *start* instant as the end
+// date, so the two dates only diverge once a draft crosses midnight.
 function Harness({
   start = START_DATE,
   end = END_DATE,
@@ -31,10 +29,6 @@ function Harness({
   const [draft, setDraft] = useState<GridEventDraft>(
     createGridEventDraft(timedGridSchedule(start, end)),
   );
-  const [startTime, setStartTime] = useState(
-    getTimeOptionByValue(dayjs(start)),
-  );
-  const [endTime, setEndTime] = useState(getTimeOptionByValue(dayjs(end)));
 
   const { startDate, endDate } = scheduleDatesFromDraft(draft);
   const formDates = getFormDates(startDate, endDate);
@@ -42,14 +36,13 @@ function Harness({
   return (
     <>
       <TimePickers
-        draft={draft}
-        endTime={endTime}
+        endTime={formDates.endTime}
+        onScheduleChange={(schedule) => {
+          setDraft((current) => replaceGridDraftSchedule(current, schedule));
+        }}
         selectedEndDate={formDates.endDate}
         selectedStartDate={formDates.startDate}
-        setDraft={setDraft}
-        setEndTime={setEndTime}
-        setStartTime={setStartTime}
-        startTime={startTime}
+        startTime={formDates.startTime}
       />
       <p>{`draft: ${startDate} / ${endDate}`}</p>
     </>

--- a/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.tsx
+++ b/packages/web/src/views/Forms/EventForm/DateControlsSection/DateTimeSection/TimePicker/TimePickers.tsx
@@ -8,8 +8,7 @@ import {
   tryMapToBackend,
 } from "@web/common/utils/datetime/web.date.util";
 import { shouldAdjustComplimentTime } from "@web/common/utils/datetime/web.datetime.util";
-import { type GridEventDraft } from "@web/events/event-draft.types";
-import { replaceGridDraftSchedule } from "@web/events/grid-event-draft.adapter";
+import { type OnEventFormScheduleChange } from "@web/views/Forms/EventForm/types";
 import { TimePicker } from "./TimePicker";
 
 export const END_TIME_ORDER_ERROR = "End time must be after start time";
@@ -17,24 +16,18 @@ export const END_TIME_ORDER_ERROR = "End time must be after start time";
 const timeOptions = getTimeOptions();
 
 interface Props {
-  draft: GridEventDraft;
   endTime: SelectOption<string>;
+  onScheduleChange: OnEventFormScheduleChange;
   selectedEndDate: Date;
   selectedStartDate: Date;
-  setDraft: (draft: GridEventDraft) => void;
-  setEndTime: (value: SelectOption<string>) => void;
-  setStartTime: (value: SelectOption<string>) => void;
   startTime: SelectOption<string>;
 }
 
 export const TimePickers: FC<Props> = ({
-  draft,
   endTime,
+  onScheduleChange,
   selectedEndDate,
   selectedStartDate,
-  setDraft,
-  setEndTime,
-  setStartTime,
   startTime,
 }) => {
   const [isStartMenuOpen, setIsStartMenuOpen] = useState(false);
@@ -128,19 +121,15 @@ export const TimePickers: FC<Props> = ({
     }
 
     setTimeError(null);
-    (changed === "start" ? setStartTime : setEndTime)(option);
-    (changed === "start" ? setEndTime : setStartTime)(corrected);
 
     // TS guard: isAllDay: false above always yields "timed".
     if (mapped.schedule.kind === "timed") {
-      setDraft(
-        replaceGridDraftSchedule(draft, {
-          kind: "timed",
-          start: dayjs(mapped.schedule.start).toDate(),
-          end: dayjs(mapped.schedule.end).toDate(),
-          timeZone: mapped.schedule.timeZone,
-        }),
-      );
+      onScheduleChange({
+        kind: "timed",
+        start: dayjs(mapped.schedule.start).toDate(),
+        end: dayjs(mapped.schedule.end).toDate(),
+        timeZone: mapped.schedule.timeZone,
+      });
     }
     closeMenu(changed);
   };

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -9,7 +9,6 @@ import {
   type SetStateAction,
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState,
 } from "react";
@@ -25,7 +24,6 @@ import {
 import { useDefaultTargetCalendar } from "@web/calendars/useDefaultTargetCalendar";
 import { ID_EVENT_FORM } from "@web/common/constants/web.constants";
 import { useEventPalette } from "@web/common/styles/theme.util";
-import { type SelectOption } from "@web/common/types/component.types";
 import { Categories_Event } from "@web/common/types/web.event.types";
 import {
   getTimeOptionByValue,
@@ -47,8 +45,8 @@ import {
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import {
   patchGridDraftFields,
-  patchGridDraftScheduleDates,
   replaceGridDraftSchedule,
+  scheduleDatesFromDraft,
 } from "@web/events/grid-event-draft.adapter";
 import { BUSY_EVENT_TITLE } from "@web/events/queries/event.view-model";
 import { useEventById } from "@web/events/queries/useEventById";
@@ -78,7 +76,7 @@ import { RsvpControl } from "@web/views/Forms/EventForm/RsvpControl";
 import { SaveSection } from "@web/views/Forms/EventForm/SaveSection/SaveSection";
 import {
   type GridEventFormProps,
-  type SetEventFormSchedule,
+  type OnEventFormScheduleChange,
 } from "@web/views/Forms/EventForm/types";
 import { EventFormShell } from "@web/views/Forms/EventFormShell";
 import { useEscapeToCloseForm } from "@web/views/Forms/hooks/useEscapeToCloseForm";
@@ -142,48 +140,6 @@ const FormCard = ({ children }: { children: ReactNode }) => (
 const mapsUrlForLocation = (location: string) =>
   `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(location)}`;
 
-interface EventFormDateTimeState {
-  displayEndDate: Date;
-  endTime: SelectOption<string>;
-  selectedEndDate: Date;
-  selectedStartDate: Date;
-  sourceEndDate: string;
-  sourceStartDate: string;
-  startTime: SelectOption<string>;
-}
-
-const createDateTimeState = (
-  sourceStartDate: string,
-  sourceEndDate: string,
-): EventFormDateTimeState => {
-  const dt = getFormDates(sourceStartDate, sourceEndDate);
-
-  return {
-    displayEndDate: dayjs(dt.displayEndDate).toDate(),
-    endTime: dt.endTime,
-    selectedEndDate: dt.endDate,
-    selectedStartDate: dt.startDate,
-    sourceEndDate,
-    sourceStartDate,
-    startTime: dt.startTime,
-  };
-};
-
-const resolveDateTimeState = (
-  state: EventFormDateTimeState,
-  sourceStartDate: string,
-  sourceEndDate: string,
-) => {
-  if (
-    state.sourceStartDate === sourceStartDate &&
-    state.sourceEndDate === sourceEndDate
-  ) {
-    return state;
-  }
-
-  return createDateTimeState(sourceStartDate, sourceEndDate);
-};
-
 const handleEventFormDelete = ({
   isDraft,
   onClose,
@@ -202,22 +158,6 @@ const handleEventFormDelete = ({
 };
 
 const DEFAULT_TIMED_START_HOUR = 9; // fallback when the grid can't be measured
-
-const scheduleDateStrings = (draft: GridEventDraft) => {
-  const { schedule } = draft.values;
-
-  if (schedule.kind === "allDay") {
-    return {
-      startDate: dayjs(schedule.start).toYearMonthDayString(),
-      endDate: dayjs(schedule.end).toYearMonthDayString(),
-    };
-  }
-
-  return {
-    startDate: dayjs(schedule.start).format(),
-    endDate: dayjs(schedule.end).format(),
-  };
-};
 
 export const EventForm: React.FC<GridEventFormProps> = memo(
   ({
@@ -362,78 +302,18 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
           );
     const latestDraftRef = useRef(draft);
     const { startDate: eventStartDate, endDate: eventEndDate } =
-      scheduleDateStrings(draft);
+      scheduleDatesFromDraft(draft);
+    const formDates = getFormDates(eventStartDate, eventEndDate);
+    const selectedStartDate = formDates.startDate;
+    const selectedEndDate = formDates.endDate;
+    const displayEndDate = dayjs(formDates.displayEndDate).toDate();
+    const { startTime, endTime } = formDates;
 
     /********
      * State
      ********/
     const [isEndDatePickerOpen, setIsEndDatePickerOpen] = useState(false);
     const [isStartDatePickerOpen, setIsStartDatePickerOpen] = useState(false);
-    const [dateTimeState, setDateTimeState] = useState<EventFormDateTimeState>(
-      () => createDateTimeState(eventStartDate, eventEndDate),
-    );
-
-    const currentDateTimeState = useMemo(
-      () => resolveDateTimeState(dateTimeState, eventStartDate, eventEndDate),
-      [dateTimeState, eventEndDate, eventStartDate],
-    );
-    const {
-      displayEndDate,
-      endTime,
-      selectedEndDate,
-      selectedStartDate,
-      startTime,
-    } = currentDateTimeState;
-
-    const updateDateTimeState = useCallback(
-      (
-        field: Partial<
-          Omit<EventFormDateTimeState, "sourceStartDate" | "sourceEndDate">
-        >,
-      ) => {
-        setDateTimeState((state) => {
-          const resolvedState = resolveDateTimeState(
-            state,
-            eventStartDate,
-            eventEndDate,
-          );
-          const nextState = { ...resolvedState, ...field };
-
-          if (fastDeepEqual(nextState, state)) {
-            return state;
-          }
-
-          if (fastDeepEqual(nextState, resolvedState)) {
-            return resolvedState;
-          }
-
-          return nextState;
-        });
-      },
-      [eventEndDate, eventStartDate],
-    );
-
-    const setStartTime = useCallback(
-      (value: SelectOption<string>) =>
-        updateDateTimeState({ startTime: value }),
-      [updateDateTimeState],
-    );
-    const setEndTime = useCallback(
-      (value: SelectOption<string>) => updateDateTimeState({ endTime: value }),
-      [updateDateTimeState],
-    );
-    const setSelectedStartDate = useCallback(
-      (value: Date) => updateDateTimeState({ selectedStartDate: value }),
-      [updateDateTimeState],
-    );
-    const setSelectedEndDate = useCallback(
-      (value: Date) => updateDateTimeState({ selectedEndDate: value }),
-      [updateDateTimeState],
-    );
-    const setDisplayEndDate = useCallback(
-      (value: Date) => updateDateTimeState({ displayEndDate: value }),
-      [updateDateTimeState],
-    );
 
     const setLatestDraft = useCallback(
       (nextDraft: SetStateAction<GridEventDraft | null>) => {
@@ -481,11 +361,11 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
       [setLatestDraft],
     );
 
-    const onSetScheduleField: SetEventFormSchedule = useCallback(
-      (patch) => {
+    const onScheduleChange: OnEventFormScheduleChange = useCallback(
+      (schedule) => {
         setLatestDraft((current) => {
           if (!current) return current;
-          return patchGridDraftScheduleDates(current, patch);
+          return replaceGridDraftSchedule(current, schedule);
         });
       },
       [setLatestDraft],
@@ -627,13 +507,11 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
 
         if (schedule.kind !== "allDay") return;
 
-        setLatestDraft(
-          replaceGridDraftSchedule(currentDraft, {
-            kind: "allDay",
-            start: dayjs(schedule.start).toDate(),
-            end: dayjs(schedule.end).toDate(),
-          }),
-        );
+        onScheduleChange({
+          kind: "allDay",
+          start: dayjs(schedule.start).toDate(),
+          end: dayjs(schedule.end).toDate(),
+        });
         return;
       }
 
@@ -655,21 +533,12 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
 
       if (schedule.kind !== "timed") return;
 
-      updateDateTimeState({
-        displayEndDate: timedStart.toDate(),
-        endTime: nextEndTime,
-        selectedEndDate: timedEnd.toDate(),
-        selectedStartDate: timedStart.toDate(),
-        startTime: nextStartTime,
+      onScheduleChange({
+        kind: "timed",
+        start: dayjs(schedule.start).toDate(),
+        end: dayjs(schedule.end).toDate(),
+        timeZone: schedule.timeZone,
       });
-      setLatestDraft(
-        replaceGridDraftSchedule(currentDraft, {
-          kind: "timed",
-          start: dayjs(schedule.start).toDate(),
-          end: dayjs(schedule.end).toDate(),
-          timeZone: schedule.timeZone,
-        }),
-      );
     };
 
     const dateTimeSectionProps = {
@@ -679,18 +548,12 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
       endTime,
       isEndDatePickerOpen,
       isStartDatePickerOpen,
-      onSetScheduleField,
+      onScheduleChange,
       selectedEndDate,
       selectedStartDate,
-      setEndTime,
-      setSelectedEndDate,
-      setSelectedStartDate,
-      setStartTime,
       startTime,
-      setDisplayEndDate,
       setIsEndDatePickerOpen,
       setIsStartDatePickerOpen,
-      setDraft: setLatestDraft,
     };
 
     const recurrenceSectionProps = {

--- a/packages/web/src/views/Forms/EventForm/types.ts
+++ b/packages/web/src/views/Forms/EventForm/types.ts
@@ -1,5 +1,8 @@
 import { type Dispatch, type SetStateAction } from "react";
-import { type GridEventDraft } from "@web/events/event-draft.types";
+import {
+  type GridEventDraft,
+  type GridScheduleDraft,
+} from "@web/events/event-draft.types";
 
 // EventForm's props: the grid draft forms (Day + Week) both converge on the
 // canonical GridEventDraft.
@@ -15,7 +18,4 @@ export interface GridEventFormProps {
   setDraft: Dispatch<SetStateAction<GridEventDraft | null>>;
 }
 
-export type SetEventFormSchedule = (patch: {
-  startDate?: string;
-  endDate?: string;
-}) => void;
+export type OnEventFormScheduleChange = (schedule: GridScheduleDraft) => void;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3458

## What and why

`EventForm` kept a second date/time model (`EventFormDateTimeState`) next to `draft.values.schedule`, then reconciled the two. Date and time controls now derive selected dates, display end date, and time options from the draft during render. Accepted changes go through one `onScheduleChange` path that writes the next `GridScheduleDraft`. Picker-open and rejected-time UI state stay local. The unused `patchGridDraftScheduleDates` helper is gone.

## Verify

`VERDICT: PASS`

Checks run: `test:web`, `type-check`, `lint`, `knip`, `test:a11y`, `test:e2e`. Focused EventForm/time-picker/adapter tests: 98 pass. Playwright e2e: 149 pass. Playwright a11y: 37 pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca4712d6-affb-48b9-acfc-4ca1e9712054?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca4712d6-affb-48b9-acfc-4ca1e9712054&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

