### PR TITLE
feat(web): name the key in the locked-shortcut upgrade toast and attribute conversions

### DIFF
--- a/packages/web/src/auth/posthog/track.test.ts
+++ b/packages/web/src/auth/posthog/track.test.ts
@@ -136,7 +136,7 @@ describe("shortcut telemetry", () => {
     document.body.appendChild(input);
     input.focus();
 
-    recordShortcutUnavailableAttempt("edge-focus", "app_locked", {
+    recordShortcutUnavailableAttempt("edge-focus", "billing_locked", {
       hotkey: "Tab",
       event: {
         altKey: false,
@@ -154,7 +154,7 @@ describe("shortcut telemetry", () => {
       feature_area: "event_editing",
       is_repeat: true,
       outcome: "unavailable",
-      reason_code: "app_locked",
+      reason_code: "billing_locked",
       shortcut_key: "Tab",
       source: "keyboard",
       view: "week_view",
@@ -166,7 +166,7 @@ describe("shortcut telemetry", () => {
 
   it("names the lock context unknown when no reason is registered", () => {
     window.history.pushState({}, "", "/day");
-    recordShortcutUnavailableAttempt("nudge", "app_locked", {
+    recordShortcutUnavailableAttempt("nudge", "overlay_open", {
       hotkey: { key: "ArrowLeft", shift: true },
       event: {
         altKey: false,
@@ -181,6 +181,7 @@ describe("shortcut telemetry", () => {
       "shortcut_unavailable_attempt",
       expect.objectContaining({
         context: "unknown",
+        reason_code: "overlay_open",
         shortcut_key: "Shift+ArrowLeft",
         view: "day_view",
         was_modifier_held: true,

--- a/packages/web/src/auth/posthog/track.ts
+++ b/packages/web/src/auth/posthog/track.ts
@@ -33,6 +33,7 @@ export type ProductEvent =
   | "trial_celebration_shown"
   | "billing_gate_shown"
   | "billing_gate_cta_clicked"
+  | "billing_gate_shortcut_converted"
   | "billing_cancel_scheduled"
   | "billing_resumed"
   | "billing_card_update_completed"

--- a/packages/web/src/billing/BillingGateModal.test.tsx
+++ b/packages/web/src/billing/BillingGateModal.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
 import { HotkeyManager, HotkeysProvider } from "@tanstack/react-hotkeys";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { SessionContext } from "@web/auth/compass/session/session.context";
 import * as Track from "@web/auth/posthog/track";
@@ -16,6 +16,7 @@ import {
   useCheckoutCelebrationStore,
 } from "@web/billing/checkout-celebration.store";
 import {
+  checkoutPanelActions,
   initialCheckoutPanelState,
   useCheckoutPanelStore,
 } from "@web/billing/checkout-panel.store";
@@ -166,7 +167,11 @@ describe("BillingGateModal", () => {
     await user.click(screen.getByRole("button", { name: "Complete checkout" }));
 
     expect(useCheckoutCelebrationStore.getState().isCelebrating).toBe(true);
-    expect(track).toHaveBeenCalledWith("trial_converted");
+    expect(track).toHaveBeenCalledWith("trial_converted", { source: "gate" });
+    expect(track).not.toHaveBeenCalledWith(
+      "billing_gate_shortcut_converted",
+      expect.anything(),
+    );
     await waitFor(() => {
       expect(invalidate).toHaveBeenCalledWith({
         queryKey: ["billing", "status"],
@@ -174,6 +179,36 @@ describe("BillingGateModal", () => {
     });
     track.mockRestore();
     invalidate.mockRestore();
+  });
+
+  it("attributes a conversion to the shortcut toast that opened Checkout", async () => {
+    const track = spyOn(Track, "track");
+    const user = userEvent.setup();
+    renderGate();
+    act(() => {
+      checkoutPanelActions.open({
+        kind: "shortcut_prompt",
+        featureArea: "event_creation",
+        actionId: "calendar.create_timed_event",
+      });
+    });
+
+    await user.click(
+      await screen.findByRole("button", { name: "Complete checkout" }),
+    );
+
+    const attribution = {
+      source: "shortcut_prompt",
+      feature_area: "event_creation",
+      action_id: "calendar.create_timed_event",
+    };
+    expect(track).toHaveBeenCalledWith("trial_converted", attribution);
+    expect(track).toHaveBeenCalledWith(
+      "billing_gate_shortcut_converted",
+      attribution,
+    );
+    expect(useCheckoutPanelStore.getState().source).toBeNull();
+    track.mockRestore();
   });
 
   it("enters the read-only look-around with L", async () => {

--- a/packages/web/src/billing/BillingGateModal.tsx
+++ b/packages/web/src/billing/BillingGateModal.tsx
@@ -96,7 +96,17 @@ export const BillingGateModal: FC<BillingGateModalProps> = ({ status }) => {
   );
 
   const onCheckoutComplete = useCallback(() => {
-    track("trial_converted");
+    // Read before close() clears it.
+    const source = useCheckoutPanelStore.getState().source;
+    const attribution = {
+      source: source?.kind ?? "gate",
+      ...(source?.featureArea ? { feature_area: source.featureArea } : {}),
+      ...(source?.actionId ? { action_id: source.actionId } : {}),
+    };
+    track("trial_converted", attribution);
+    if (source?.kind === "shortcut_prompt") {
+      track("billing_gate_shortcut_converted", attribution);
+    }
     checkoutCelebrationActions.celebrate();
     checkoutPanelActions.close();
     startBillingStatusPoll(queryClient, () => {});

--- a/packages/web/src/billing/BillingReadOnlyBanner.tsx
+++ b/packages/web/src/billing/BillingReadOnlyBanner.tsx
@@ -20,7 +20,7 @@ export const BillingReadOnlyBanner: FC = () => {
       onCta={() => {
         track("billing_gate_cta_clicked", { cta: "banner_checkout" });
         billingPreviewActions.exit();
-        checkoutPanelActions.open();
+        checkoutPanelActions.open({ kind: "banner" });
       }}
       pointerAction={POINTER_ACTIONS.startTrial}
       shortcutKey={START_TRIAL_SHORTCUT_KEY}

--- a/packages/web/src/billing/ShortcutProBadge.tsx
+++ b/packages/web/src/billing/ShortcutProBadge.tsx
@@ -1,4 +1,4 @@
-export const SHORTCUT_PRO_BADGE_LABEL = "Pro";
+export const SHORTCUT_PRO_BADGE_LABEL = "Premium";
 export const SHORTCUT_PRO_TOOLTIP = "Included with Premium";
 
 /**

--- a/packages/web/src/billing/ShortcutUpgradeToast.test.tsx
+++ b/packages/web/src/billing/ShortcutUpgradeToast.test.tsx
@@ -15,6 +15,7 @@ import {
 } from "@web/billing/checkout-panel.store";
 import { ShortcutUpgradeToast } from "@web/billing/ShortcutUpgradeToast";
 import { registerToastPort } from "@web/common/utils/toast/toast.port";
+import { getShortcutHint } from "@web/shortcuts/tips/shortcut-tips.data";
 import { afterEach, describe, expect, it, spyOn } from "bun:test";
 
 describe("ShortcutUpgradeToast", () => {
@@ -37,6 +38,10 @@ describe("ShortcutUpgradeToast", () => {
           toastId="shortcut-upgrade-toast"
           title="Unlock event editing shortcuts with Premium. Upgrade in 30 seconds."
           ctaLabel="Start trial"
+          checkoutSource={{
+            kind: "shortcut_prompt",
+            featureArea: "event_editing",
+          }}
         />
       </HotkeysProvider>,
     );
@@ -61,7 +66,54 @@ describe("ShortcutUpgradeToast", () => {
       true,
     );
     expect(useBillingPreviewStore.getState().isPreviewing).toBe(false);
+    expect(useCheckoutPanelStore.getState().source).toEqual({
+      kind: "shortcut_prompt",
+      featureArea: "event_editing",
+    });
     expect(mocks.dismiss).toHaveBeenCalledWith("shortcut-upgrade-toast");
+    track.mockRestore();
+  });
+
+  it("names the exact key that was pressed and hands its action to Checkout", async () => {
+    registerToastPort(port);
+    const track = spyOn(Track, "track");
+    const user = userEvent.setup();
+    render(
+      <HotkeysProvider>
+        <ShortcutUpgradeToast
+          toastId="shortcut-upgrade-toast"
+          parts={getShortcutHint("nudge").parts}
+          title="Premium unlocks it, so you can reschedule in seconds without touching the mouse."
+          ctaLabel="Start trial"
+          checkoutSource={{
+            kind: "shortcut_prompt",
+            featureArea: "event_editing",
+            actionId: "event.move",
+          }}
+        />
+      </HotkeysProvider>,
+    );
+
+    expect(
+      screen.getByText("Shift and an arrow moves the event"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Premium unlocks it, so you can reschedule in seconds without touching the mouse.",
+      ),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Start trial" }));
+
+    expect(track).toHaveBeenCalledWith("billing_gate_cta_clicked", {
+      cta: "shortcut_prompt",
+      action_id: "event.move",
+    });
+    expect(useCheckoutPanelStore.getState().source).toEqual({
+      kind: "shortcut_prompt",
+      featureArea: "event_editing",
+      actionId: "event.move",
+    });
     track.mockRestore();
   });
 });

--- a/packages/web/src/billing/ShortcutUpgradeToast.tsx
+++ b/packages/web/src/billing/ShortcutUpgradeToast.tsx
@@ -1,29 +1,50 @@
 import { type Id } from "react-toastify";
 import { track } from "@web/auth/posthog/track";
 import { billingPreviewActions } from "@web/billing/billing-preview.store";
-import { checkoutPanelActions } from "@web/billing/checkout-panel.store";
+import {
+  type CheckoutPanelSource,
+  checkoutPanelActions,
+} from "@web/billing/checkout-panel.store";
 import { ToastActionButton } from "@web/common/utils/toast/ToastActionButton";
 import { ToastNotice } from "@web/common/utils/toast/ToastNotice";
 import { getToast } from "@web/common/utils/toast/toast.port";
+import { ShortcutTipParts } from "@web/shortcuts/tips/ShortcutTipParts";
+import { type ShortcutTipPart } from "@web/shortcuts/tips/shortcut-tips.data";
 
 export function ShortcutUpgradeToast({
   toastId,
+  parts,
   title,
   ctaLabel,
+  checkoutSource,
 }: {
   toastId: Id;
+  /** The exact key the user pressed, as keycap chips. Absent for callers
+   * that only know the feature area (command palette, edit sequence). */
+  parts?: readonly ShortcutTipPart[];
   title: string;
   ctaLabel: string;
+  checkoutSource: CheckoutPanelSource;
 }) {
   const handleUpgrade = () => {
-    track("billing_gate_cta_clicked", { cta: "shortcut_prompt" });
+    track("billing_gate_cta_clicked", {
+      cta: "shortcut_prompt",
+      ...(checkoutSource.actionId
+        ? { action_id: checkoutSource.actionId }
+        : {}),
+    });
     getToast().dismiss(toastId);
     billingPreviewActions.exit();
-    checkoutPanelActions.open();
+    checkoutPanelActions.open(checkoutSource);
   };
 
   return (
     <ToastNotice>
+      {parts && (
+        <p className="font-medium text-sm text-text">
+          <ShortcutTipParts parts={parts} />
+        </p>
+      )}
       <p className="text-sm text-text">{title}</p>
       <ToastActionButton onClick={handleUpgrade}>{ctaLabel}</ToastActionButton>
     </ToastNotice>

--- a/packages/web/src/billing/checkout-panel.store.test.ts
+++ b/packages/web/src/billing/checkout-panel.store.test.ts
@@ -1,0 +1,35 @@
+import {
+  checkoutPanelActions,
+  initialCheckoutPanelState,
+  useCheckoutPanelStore,
+} from "@web/billing/checkout-panel.store";
+import { afterEach, describe, expect, it } from "bun:test";
+
+describe("checkoutPanelActions", () => {
+  afterEach(() => {
+    useCheckoutPanelStore.setState(initialCheckoutPanelState, true);
+  });
+
+  it("opens from the gate with no source", () => {
+    checkoutPanelActions.open();
+
+    expect(useCheckoutPanelStore.getState()).toEqual({
+      isOpen: true,
+      source: null,
+    });
+  });
+
+  it("keeps the opener's source until Checkout closes", () => {
+    const source = {
+      kind: "shortcut_prompt" as const,
+      featureArea: "event_creation" as const,
+      actionId: "calendar.create_timed_event",
+    };
+
+    checkoutPanelActions.open(source);
+    expect(useCheckoutPanelStore.getState()).toEqual({ isOpen: true, source });
+
+    checkoutPanelActions.close();
+    expect(useCheckoutPanelStore.getState()).toEqual(initialCheckoutPanelState);
+  });
+});

--- a/packages/web/src/billing/checkout-panel.store.ts
+++ b/packages/web/src/billing/checkout-panel.store.ts
@@ -1,11 +1,21 @@
 import { create } from "zustand";
+import { type ShortcutFeatureArea } from "@web/shortcuts/tips/shortcut-tips.data";
+
+/** Where Checkout was opened from. `null` is the billing gate itself. */
+export type CheckoutPanelSource = {
+  kind: "shortcut_prompt" | "banner";
+  featureArea?: ShortcutFeatureArea;
+  actionId?: string;
+};
 
 export type CheckoutPanelState = {
   isOpen: boolean;
+  source: CheckoutPanelSource | null;
 };
 
 export const initialCheckoutPanelState: CheckoutPanelState = {
   isOpen: false,
+  source: null,
 };
 
 /** In-memory: a reload puts the trial ask back in front of the user. */
@@ -14,11 +24,12 @@ export const useCheckoutPanelStore = create<CheckoutPanelState>()(() => ({
 }));
 
 export const checkoutPanelActions = {
-  open: () => {
-    useCheckoutPanelStore.setState({ isOpen: true });
+  /** `source` survives until close so completion can attribute the conversion. */
+  open: (source: CheckoutPanelSource | null = null) => {
+    useCheckoutPanelStore.setState({ isOpen: true, source });
   },
   close: () => {
-    useCheckoutPanelStore.setState({ isOpen: false });
+    useCheckoutPanelStore.setState({ isOpen: false, source: null });
   },
 };
 

--- a/packages/web/src/billing/prompt-shortcut-upgrade.test.ts
+++ b/packages/web/src/billing/prompt-shortcut-upgrade.test.ts
@@ -14,6 +14,7 @@ import {
 } from "@web/billing/prompt-shortcut-upgrade";
 import { registerToastPort } from "@web/common/utils/toast/toast.port";
 import { setAppLockReason } from "@web/shortcuts/app-lock";
+import { getShortcutHint } from "@web/shortcuts/tips/shortcut-tips.data";
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 
 const trackModule = await import("@web/auth/posthog/track");
@@ -88,6 +89,58 @@ describe("promptShortcutUpgrade", () => {
       expect(mocks.toast).toHaveBeenCalledTimes(1);
     });
     setAppLockReason("billingGate", false);
+  });
+
+  it("names the pressed key and its pitch when the caller knows the shortcut", async () => {
+    setBillingWriteLock({ locked: true, status: "awaiting_checkout" });
+
+    promptShortcutUpgrade({
+      featureArea: "event_creation",
+      actionId: "calendar.create_timed_event",
+      hintId: "create-event",
+      source: "keyboard",
+    });
+
+    await waitFor(() => {
+      expect(mocks.toast).toHaveBeenCalledTimes(1);
+    });
+    const [[element]] = mocks.toast.mock.calls as unknown as [
+      [{ props: Record<string, unknown> }],
+    ];
+    expect(element.props).toMatchObject({
+      parts: getShortcutHint("create-event").parts,
+      title:
+        "Premium unlocks it, so you can block time the moment you think of it.",
+      ctaLabel: "Start trial",
+      checkoutSource: {
+        kind: "shortcut_prompt",
+        featureArea: "event_creation",
+        actionId: "calendar.create_timed_event",
+      },
+    });
+  });
+
+  it("falls back to feature-area copy without a key line when no shortcut is known", async () => {
+    setBillingWriteLock({ locked: true, status: "expired" });
+
+    promptShortcutUpgrade({
+      featureArea: "event_creation",
+      actionId: "calendar.create_timed_event",
+      source: "command_palette",
+    });
+
+    await waitFor(() => {
+      expect(mocks.toast).toHaveBeenCalledTimes(1);
+    });
+    const [[element]] = mocks.toast.mock.calls as unknown as [
+      [{ props: Record<string, unknown> }],
+    ];
+    expect(element.props.parts).toBeUndefined();
+    expect(element.props).toMatchObject({
+      title:
+        "Unlock event creation shortcuts with Premium. Upgrade in 30 seconds.",
+      ctaLabel: "Subscribe",
+    });
   });
 
   it("deduplicates tracking for a rapid repeat of the same shortcut", async () => {

--- a/packages/web/src/billing/prompt-shortcut-upgrade.ts
+++ b/packages/web/src/billing/prompt-shortcut-upgrade.ts
@@ -5,9 +5,15 @@ import {
   getBillingWriteLockStatus,
   isBillingWriteLocked,
 } from "@web/billing/billing-write-lock";
+import { type CheckoutPanelSource } from "@web/billing/checkout-panel.store";
 import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
 import { hasAppLockReason } from "@web/shortcuts/app-lock";
-import { type ShortcutFeatureArea } from "@web/shortcuts/tips/shortcut-tips.data";
+import {
+  getShortcutHint,
+  type ShortcutFeatureArea,
+  type ShortcutHintId,
+  type ShortcutTipPart,
+} from "@web/shortcuts/tips/shortcut-tips.data";
 
 export const SHORTCUT_UPGRADE_TOAST_ID: Id = "shortcut-upgrade-toast";
 
@@ -18,18 +24,40 @@ export type ShortcutUpgradePromptSource = "keyboard" | "command_palette";
 export type ShortcutUpgradePromptInput = {
   featureArea: ShortcutFeatureArea;
   actionId?: string;
+  /** Names the exact key in the toast. Omit when only the feature area is
+   * known (command palette, edit sequence). */
+  hintId?: ShortcutHintId;
   source: ShortcutUpgradePromptSource;
+};
+
+type ShortcutUpgradeCopy = {
+  parts?: readonly ShortcutTipPart[];
+  title: string;
+  cta: string;
 };
 
 let lastPresentationKey = "";
 let lastPresentationAt = 0;
 
-const promptCopy = (
-  featureArea: ShortcutFeatureArea,
-): { title: string; cta: string } => {
+/** One sentence per hinted shortcut: what Premium unlocks, in the user's
+ * terms. Shortcuts without a pitch fall back to the feature-area copy. */
+const UPGRADE_PITCH: Partial<Record<ShortcutHintId, string>> = {
+  "create-event":
+    "Premium unlocks it, so you can block time the moment you think of it.",
+  "edge-focus":
+    "Premium unlocks it, so you can resize events to the minute without dragging.",
+  nudge:
+    "Premium unlocks it, so you can reschedule in seconds without touching the mouse.",
+};
+
+const promptCopy = (input: ShortcutUpgradePromptInput): ShortcutUpgradeCopy => {
   const status = getBillingWriteLockStatus();
   const cta = status === "awaiting_checkout" ? "Start trial" : "Subscribe";
-  if (featureArea === "event_creation") {
+  const pitch = input.hintId ? UPGRADE_PITCH[input.hintId] : undefined;
+  if (input.hintId && pitch) {
+    return { parts: getShortcutHint(input.hintId).parts, title: pitch, cta };
+  }
+  if (input.featureArea === "event_creation") {
     return {
       title:
         "Unlock event creation shortcuts with Premium. Upgrade in 30 seconds.",
@@ -58,7 +86,7 @@ export function promptShortcutUpgrade(
     enterBillingLookAround();
   }
 
-  const copy = promptCopy(input.featureArea);
+  const copy = promptCopy(input);
   const presentationKey = `${input.featureArea}:${input.actionId ?? ""}:${input.source}`;
   if (
     presentationKey !== lastPresentationKey ||
@@ -77,7 +105,11 @@ export function promptShortcutUpgrade(
     });
   }
 
-  showUpgradeToast(copy.title, copy.cta);
+  showUpgradeToast(copy, {
+    kind: "shortcut_prompt",
+    featureArea: input.featureArea,
+    ...(input.actionId ? { actionId: input.actionId } : {}),
+  });
 }
 
 /**
@@ -94,15 +126,20 @@ function enterBillingLookAround(): void {
   );
 }
 
-function showUpgradeToast(title: string, ctaLabel: string): void {
+function showUpgradeToast(
+  copy: ShortcutUpgradeCopy,
+  checkoutSource: CheckoutPanelSource,
+): void {
   void import("@web/billing/ShortcutUpgradeToast").then(
     ({ ShortcutUpgradeToast }) => {
       showStatusToast(
         SHORTCUT_UPGRADE_TOAST_ID,
         createElement(ShortcutUpgradeToast, {
           toastId: SHORTCUT_UPGRADE_TOAST_ID,
-          title,
-          ctaLabel,
+          parts: copy.parts,
+          title: copy.title,
+          ctaLabel: copy.cta,
+          checkoutSource,
         }),
       );
     },

--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -173,7 +173,7 @@ describe("CommandPalette", () => {
     expect(screen.queryByText("Booking settings")).toBeNull();
   });
 
-  it("badges create actions as Pro when billing is read-only", () => {
+  it("badges create actions as Premium when billing is read-only", () => {
     authenticated = true;
     access = {
       kind: "server",
@@ -184,7 +184,7 @@ describe("CommandPalette", () => {
     renderPalette();
 
     const row = rowLabel("Create event").closest("button") as HTMLElement;
-    expect(within(row).getByText("Pro")).toBeInTheDocument();
+    expect(within(row).getByText("Premium")).toBeInTheDocument();
   });
 
   it("renders all sections with items and focuses the input on mount", () => {

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -307,7 +307,7 @@ export const CommandPalette = ({
   const eventItems = writeLocked
     ? eventCommandPaletteItems.map((item) => ({
         ...item,
-        badge: "Pro",
+        badge: "Premium",
         onClick: () =>
           promptShortcutUpgrade({
             featureArea: "event_creation",

--- a/packages/web/src/components/Shortcuts/ShortcutList.test.tsx
+++ b/packages/web/src/components/Shortcuts/ShortcutList.test.tsx
@@ -92,7 +92,7 @@ describe("ShortcutList", () => {
       />,
     );
 
-    expect(screen.getByText("Pro")).toBeInTheDocument();
+    expect(screen.getByText("Premium")).toBeInTheDocument();
     expect(screen.getByText("Premium shortcut.")).toBeInTheDocument();
     await user.hover(screen.getByText("Create timed event"));
     expect(

--- a/packages/web/src/shortcuts/tips/shortcut-telemetry.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-telemetry.ts
@@ -169,16 +169,23 @@ export type ShortcutUnavailableAttempt = {
   >;
 };
 
-/** A registered shortcut reached the app handler but an app-level lock owned
- * the keyboard. `context` names the lock owner(s) (settingsModal,
- * commandPalette, billingGate...) so we can tell "pressed Tab inside a modal
- * form" apart from "wanted to create an event behind the billing gate".
+/** Why a registered shortcut could not run: the account cannot write
+ * (`billing_locked`, with or without the gate on screen) or some other
+ * overlay owned the keyboard (`overlay_open`). */
+export type ShortcutUnavailableReason = "billing_locked" | "overlay_open";
+
+/** A registered shortcut reached the app handler but could not run.
+ * `reason_code` isolates the billing case; `context` names the lock owner(s)
+ * (settingsModal, commandPalette, billingGate...) so we can tell "pressed Tab
+ * inside a modal form" apart from "wanted to create an event behind the
+ * billing gate". In look-around mode no lock is held, so `context` reads
+ * "unknown" and `reason_code` carries the signal.
  * Only the static registration string, lock names, view name, modifier
  * flags, and the focused element's tag are captured. No typed value, DOM
  * content, or raw key value is captured. */
 export function recordShortcutUnavailableAttempt(
   hintId: ShortcutHintId,
-  reasonCode: "app_locked",
+  reasonCode: ShortcutUnavailableReason,
   attempt: ShortcutUnavailableAttempt,
 ): void {
   const hint = getShortcutHint(hintId);

--- a/packages/web/src/shortcuts/useAppShortcut.test.ts
+++ b/packages/web/src/shortcuts/useAppShortcut.test.ts
@@ -1,6 +1,7 @@
 import { HotkeyManager, resolveModifier } from "@tanstack/react-hotkeys";
 import { renderHook, waitFor } from "@testing-library/react";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
+import * as Track from "@web/auth/posthog/track";
 import {
   resetBillingWriteLockForTests,
   setBillingWriteLock,
@@ -12,7 +13,7 @@ import {
   useAppShortcutUp,
   WRITE_CREATE_SHORTCUT,
 } from "@web/shortcuts/useAppShortcut";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
 
 function dispatchKeyEvent(
   key: string,
@@ -268,5 +269,109 @@ describe("useAppShortcut", () => {
     });
     expect(mocks.toast).not.toHaveBeenCalled();
     setAppLockReason("settingsModal", false);
+  });
+
+  describe("unavailable-attempt telemetry", () => {
+    const attempts = (track: { mock: { calls: unknown[][] } }) =>
+      track.mock.calls.filter(
+        ([name]) => name === "shortcut_unavailable_attempt",
+      );
+
+    it("records overlay_open when a non-billing overlay owns the keyboard", async () => {
+      const track = spyOn(Track, "track");
+      setAppLockReason("settingsModal", true);
+
+      renderHook(() =>
+        useAppShortcut("C", mockHandler, {
+          ...WRITE_CREATE_SHORTCUT,
+          telemetryHintId: "create-event",
+        }),
+      );
+      dispatchKeyEvent("c", "keydown");
+
+      await waitFor(() => {
+        expect(attempts(track)).toHaveLength(1);
+      });
+      expect(track).toHaveBeenCalledWith(
+        "shortcut_unavailable_attempt",
+        expect.objectContaining({
+          action_id: "calendar.create_timed_event",
+          context: "settingsModal",
+          reason_code: "overlay_open",
+        }),
+      );
+      setAppLockReason("settingsModal", false);
+      track.mockRestore();
+    });
+
+    it("records billing_locked while the billing gate is up", async () => {
+      const track = spyOn(Track, "track");
+      setBillingWriteLock({ locked: true, status: "awaiting_checkout" });
+      setAppLockReason("billingGate", true);
+
+      renderHook(() =>
+        useAppShortcut("C", mockHandler, {
+          ...WRITE_CREATE_SHORTCUT,
+          telemetryHintId: "create-event",
+        }),
+      );
+      dispatchKeyEvent("c", "keydown");
+
+      await waitFor(() => {
+        expect(attempts(track)).toHaveLength(1);
+      });
+      expect(track).toHaveBeenCalledWith(
+        "shortcut_unavailable_attempt",
+        expect.objectContaining({ reason_code: "billing_locked" }),
+      );
+      setAppLockReason("billingGate", false);
+      track.mockRestore();
+    });
+
+    it("records billing_locked in look-around, where no lock is held", async () => {
+      const track = spyOn(Track, "track");
+      setBillingWriteLock({ locked: true, status: "awaiting_checkout" });
+
+      renderHook(() =>
+        useAppShortcut("C", mockHandler, {
+          ...WRITE_CREATE_SHORTCUT,
+          telemetryHintId: "create-event",
+        }),
+      );
+      dispatchKeyEvent("c", "keydown");
+
+      await waitFor(() => {
+        expect(attempts(track)).toHaveLength(1);
+        expect(mocks.toast).toHaveBeenCalled();
+      });
+      expect(track).toHaveBeenCalledWith(
+        "shortcut_unavailable_attempt",
+        expect.objectContaining({
+          context: "unknown",
+          reason_code: "billing_locked",
+        }),
+      );
+      track.mockRestore();
+    });
+
+    it("ignores practice presses while the onboarding game owns the keys", async () => {
+      const track = spyOn(Track, "track");
+      setAppLockReason("shortcutShowcase", true);
+
+      renderHook(() =>
+        useAppShortcut("C", mockHandler, {
+          ...WRITE_CREATE_SHORTCUT,
+          telemetryHintId: "create-event",
+        }),
+      );
+      dispatchKeyEvent("c", "keydown");
+
+      await waitFor(() => {
+        expect(mockHandler).not.toHaveBeenCalled();
+      });
+      expect(attempts(track)).toHaveLength(0);
+      setAppLockReason("shortcutShowcase", false);
+      track.mockRestore();
+    });
   });
 });

--- a/packages/web/src/shortcuts/useAppShortcut.ts
+++ b/packages/web/src/shortcuts/useAppShortcut.ts
@@ -59,6 +59,7 @@ function promptLockedWriteShortcut(
   promptShortcutUpgrade({
     featureArea: upgradeFeatureArea ?? hint?.featureArea ?? "event_editing",
     actionId: hint?.actionId,
+    hintId: telemetryHintId,
     source: "keyboard",
   });
 }
@@ -88,11 +89,14 @@ export function useAppShortcut(
     hotkey,
     (event) => {
       if (!ignoreAppLock && isAppLocked()) {
-        if (telemetryHintId) {
-          recordShortcutUnavailableAttempt(telemetryHintId, "app_locked", {
-            hotkey,
-            event,
-          });
+        // The onboarding game owns these keys on purpose; its practice
+        // presses are not attempts at an unavailable feature.
+        if (telemetryHintId && !hasAppLockReason("shortcutShowcase")) {
+          recordShortcutUnavailableAttempt(
+            telemetryHintId,
+            hasAppLockReason("billingGate") ? "billing_locked" : "overlay_open",
+            { hotkey, event },
+          );
         }
         if (
           requiresWrite &&
@@ -105,6 +109,12 @@ export function useAppShortcut(
       }
 
       if (requiresWrite && isBillingWriteLocked()) {
+        if (telemetryHintId) {
+          recordShortcutUnavailableAttempt(telemetryHintId, "billing_locked", {
+            hotkey,
+            event,
+          });
+        }
         promptLockedWriteShortcut(telemetryHintId, upgradeFeatureArea);
         return;
       }


### PR DESCRIPTION
Fixes #3465

## What and why

A PostHog signal flagged 20+ `shortcut_unavailable_attempt` events per hour behind the billing gate. Production data shows the gate was open for only ~6 of ~131 blocked keypresses; ~87 were the onboarding shortcut game (it holds the `shortcutShowcase` app lock and handles its own keys without stopping propagation), so the metric was two thirds noise and `reason_code` was a single hard-typed literal. There is no free/Pro tier, so "locked shortcut" means "write shortcut while read-only", and the existing upgrade toast from #3166 was the surface to improve. This PR:

- **Toast names the key.** `promptShortcutUpgrade` accepts `hintId`; the toast renders the hint's keycap parts through `ShortcutTipParts` (platform-aware chips, sr-only sentence) above a one-sentence Premium pitch for C, Tab, and Shift+Arrow. Command palette and edit-sequence callers keep the generic copy.
- **Conversion attribution.** `checkoutPanelActions.open(source)` remembers the opener; embedded Checkout completion emits `trial_converted` with `source` (`gate | shortcut_prompt | banner`) plus `feature_area` / `action_id`, and `billing_gate_shortcut_converted` when the toast opened Checkout. `billing_gate_cta_clicked {cta: shortcut_prompt}` also carries `action_id`.
- **Telemetry hygiene.** `shortcut_unavailable_attempt.reason_code` is now `billing_locked | overlay_open`, nothing fires while the onboarding game owns the keys, and the look-around path (no app lock) now emits `billing_locked` so unpaid attempts are countable.
- Plan badge copy unified to "Premium" (sidebar chip, command palette).

Kept the hard gate; soft-gate default and `telemetryHintId` for `Shift+C` and the other `requiresWrite` rows are follow-ups on #3465.

## Verify

`VERDICT: FAIL` locally (`bun run verify --strict`, selected package web). Checks run: test:web, type-check, lint, knip all passed. Failed: test:a11y, test:e2e.

The local failures are the documented macOS environment issues, not this diff: `booking-a11y` settings section (Control+Comma binding), booking slot click timeouts, and run contention. The one non-environmental a11y failure (`app-a11y.spec.ts` event action row color contrast) passes in isolation on this branch and on `origin/main` `packages/web/src`. No e2e spec exercises billing, the upgrade toast, or the badge text, and e2e runs anonymous with billing failing open. CI on Linux is the gate.

## Sensitive paths

Touches `packages/web/src/auth/posthog/track.ts` (+test) and `packages/web/src/billing/*`, both on `NO_AUTOMERGE_PATH_PATTERNS` with no allowlist, so this is labeled `agent-loop-needs-human` instead of `agent-automerge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)