### PR TITLE
feat(backend): emit posthog events from the stripe webhook

### DIFF
--- a/docs/features/billing.md
+++ b/docs/features/billing.md
@@ -205,12 +205,21 @@ must subscribe to Checkout and Subscriptions snapshot events, not Accounts v2:
 
 - `checkout.session.completed` (subscription Checkout and setup-mode card
   updates both arrive on this event; setup-mode has `mode: "setup"`)
+- `checkout.session.expired` (analytics only: the user reached Stripe and
+  left; nothing is written to `billing.*`)
 - `customer.subscription.created`
 - `customer.subscription.updated`
 - `customer.subscription.deleted`
 
 `staging-selfhosted` must not get those secrets — it is the live regression
 that self-host stays writable.
+
+The webhook also emits server-side PostHog events keyed by the Compass user id
+(the same distinct id the web app identifies with): `checkout_completed` after
+a subscription-mode Checkout lands, and `checkout_expired` when one lapses
+unpaid. They are best-effort; a PostHog failure never fails the webhook. The
+browser's `trial_converted` only fires on the success redirect, so these are
+the events the billing funnel should trust.
 
 Sales tax is enabled in code: the Checkout Session passes
 `automatic_tax`, `customer_update.address`, and `billing_address_collection`

--- a/packages/backend/src/billing/billing.analytics.test.ts
+++ b/packages/backend/src/billing/billing.analytics.test.ts
@@ -1,0 +1,71 @@
+import { mockEnv } from "@backend/__tests__/helpers/mock.setup";
+import { billingAnalytics } from "@backend/billing/billing.analytics";
+import { afterEach, describe, expect, it } from "bun:test";
+
+describe("billingAnalytics.capture", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it("is a no-op without POSTHOG_KEY", async () => {
+    using _env = mockEnv({ POSTHOG_KEY: undefined });
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      return { ok: true, status: 200 } as Response;
+    }) as typeof fetch;
+
+    await expect(
+      billingAnalytics.capture({ event: "checkout_expired", userId: "u1" }),
+    ).resolves.toBe(false);
+    expect(calls).toBe(0);
+  });
+
+  it("posts the event keyed by the Compass user id with the environment", async () => {
+    using _env = mockEnv({
+      POSTHOG_KEY: "phc_test",
+      POSTHOG_HOST: "https://ph.example.test",
+    });
+    const bodies: unknown[] = [];
+    globalThis.fetch = (async (input, init) => {
+      bodies.push({ url: String(input), body: JSON.parse(String(init?.body)) });
+      return { ok: true, status: 200 } as Response;
+    }) as typeof fetch;
+
+    await expect(
+      billingAnalytics.capture({
+        event: "checkout_completed",
+        userId: "u1",
+        properties: { trial: true },
+      }),
+    ).resolves.toBe(true);
+
+    expect(bodies).toEqual([
+      {
+        url: "https://ph.example.test/i/v0/e/",
+        body: {
+          api_key: "phc_test",
+          distinct_id: "u1",
+          event: "checkout_completed",
+          properties: {
+            environment: "test",
+            trial: true,
+            $lib: "compass-backend",
+          },
+        },
+      },
+    ]);
+  });
+
+  it("never throws when PostHog rejects the capture", async () => {
+    using _env = mockEnv({ POSTHOG_KEY: "phc_test" });
+    globalThis.fetch = (async () => {
+      throw new Error("network down");
+    }) as typeof fetch;
+
+    await expect(
+      billingAnalytics.capture({ event: "checkout_expired", userId: "u1" }),
+    ).resolves.toBe(false);
+  });
+});

--- a/packages/backend/src/billing/billing.analytics.ts
+++ b/packages/backend/src/billing/billing.analytics.ts
@@ -1,0 +1,49 @@
+import {
+  captureSafely,
+  createPostHogCaptureClient,
+  DEFAULT_POSTHOG_HOST,
+  type PostHogCaptureClient,
+} from "@core/logger/posthog-capture";
+import { CONFIG } from "@backend/common/constants/config.constants";
+
+/**
+ * Server-side billing events. The web app's `trial_converted` fires only when
+ * the browser lands on the Checkout success redirect, so a user who pays and
+ * closes the tab is invisible there. These come from the Stripe webhook and
+ * are the source of truth for the PostHog billing funnel.
+ */
+export type BillingServerEvent = "checkout_completed" | "checkout_expired";
+
+// The HTTP client is stateless, so build it per call: CONFIG is read at
+// call time and tests can toggle POSTHOG_KEY through mockEnv.
+function getClient(): PostHogCaptureClient | null {
+  const apiKey = CONFIG.POSTHOG_KEY;
+  if (!apiKey) return null;
+  return createPostHogCaptureClient({
+    apiKey,
+    host: CONFIG.POSTHOG_HOST ?? DEFAULT_POSTHOG_HOST,
+    lib: "compass-backend",
+  });
+}
+
+export const billingAnalytics = {
+  /**
+   * Best-effort capture keyed by the Compass user id, which is the same
+   * distinct id the web app passes to `posthog.identify`, so server and
+   * browser events land on one person. Never throws.
+   */
+  capture(input: {
+    event: BillingServerEvent;
+    userId: string;
+    properties?: Record<string, boolean | number | string>;
+  }): Promise<boolean> {
+    return captureSafely(getClient(), {
+      event: input.event,
+      distinctId: input.userId,
+      properties: {
+        environment: CONFIG.NODE_ENV,
+        ...input.properties,
+      },
+    });
+  },
+};

--- a/packages/backend/src/billing/services/billing.webhook.service.db.test.ts
+++ b/packages/backend/src/billing/services/billing.webhook.service.db.test.ts
@@ -8,6 +8,7 @@ import {
   setupTestDb,
 } from "@backend/__tests__/helpers/mock.db.setup";
 import { mockEnv } from "@backend/__tests__/helpers/mock.setup";
+import { billingAnalytics } from "@backend/billing/billing.analytics";
 import { STRIPE_WEBHOOK_PATH } from "@backend/billing/billing.constants";
 import billingWebhookController from "@backend/billing/controllers/billing.webhook.controller";
 import { processStripeEvent } from "@backend/billing/services/billing.webhook.service";
@@ -315,6 +316,102 @@ describe("Stripe webhook", () => {
     expect(stored?.billing?.subscriptionStatus).toBe("trialing");
     expect(stored?.billing?.stripeCustomerId).toBe("cus_1");
     expect(stored?.billing?.stripeSubscriptionId).toBe("sub_1");
+  });
+
+  it("captures checkout_completed for the user once the subscription is applied", async () => {
+    using _env = mockEnv(stripeConfigured);
+    const capture = spyOn(billingAnalytics, "capture").mockResolvedValue(true);
+    const userId = mongoService.objectId();
+    await mongoService.user.insertOne({
+      _id: userId,
+      email: "captured@example.com",
+      name: "Captured",
+      firstName: "Captured",
+      lastName: "User",
+      locale: "en",
+      billing: { subscriptionStatus: "awaiting_checkout" },
+    });
+    const stripe = stubBillingGateway({
+      retrieveSubscription: mock(() => Promise.resolve(subscription())),
+    });
+
+    await processStripeEvent(
+      {
+        id: "evt_checkout_captured",
+        type: "checkout.session.completed",
+        created: 1_775_000_100,
+        data: {
+          object: {
+            id: "cs_captured",
+            client_reference_id: userId.toString(),
+            customer: "cus_1",
+            subscription: "sub_1",
+          },
+        },
+      } as unknown as Stripe.Event,
+      stripe,
+    );
+
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(capture).toHaveBeenCalledWith({
+      event: "checkout_completed",
+      userId: userId.toString(),
+      properties: {
+        checkout_session_id: "cs_captured",
+        subscription_status: "trialing",
+        trial: true,
+      },
+    });
+  });
+
+  it("captures checkout_expired by customer id and leaves billing untouched", async () => {
+    using _env = mockEnv(stripeConfigured);
+    const capture = spyOn(billingAnalytics, "capture").mockResolvedValue(true);
+    const userId = mongoService.objectId();
+    await mongoService.user.insertOne({
+      _id: userId,
+      email: "left@example.com",
+      name: "Left",
+      firstName: "Left",
+      lastName: "User",
+      locale: "en",
+      billing: {
+        subscriptionStatus: "awaiting_checkout",
+        stripeCustomerId: "cus_left",
+      },
+    });
+    const retrieve = mock(() => Promise.resolve(subscription()));
+    const stripe = stubBillingGateway({ retrieveSubscription: retrieve });
+
+    await processStripeEvent(
+      {
+        id: "evt_checkout_expired",
+        type: "checkout.session.expired",
+        created: 1_775_000_100,
+        data: {
+          object: {
+            id: "cs_expired",
+            mode: "subscription",
+            client_reference_id: null,
+            customer: "cus_left",
+            subscription: null,
+          },
+        },
+      } as unknown as Stripe.Event,
+      stripe,
+    );
+
+    expect(capture).toHaveBeenCalledWith({
+      event: "checkout_expired",
+      userId: userId.toString(),
+      properties: { checkout_session_id: "cs_expired" },
+    });
+    expect(retrieve).not.toHaveBeenCalled();
+    const stored = await mongoService.user.findOne({ _id: userId });
+    expect(stored?.billing).toEqual({
+      subscriptionStatus: "awaiting_checkout",
+      stripeCustomerId: "cus_left",
+    });
   });
 
   it("acks a duplicate delivery without a second write", async () => {

--- a/packages/backend/src/billing/services/billing.webhook.service.ts
+++ b/packages/backend/src/billing/services/billing.webhook.service.ts
@@ -1,5 +1,6 @@
 import type Stripe from "stripe";
 import { Logger } from "@core/logger/winston.logger";
+import { billingAnalytics } from "@backend/billing/billing.analytics";
 import {
   STRIPE_TO_COMPASS_STATUS,
   type StripeSubscriptionStatus,
@@ -14,6 +15,7 @@ const logger = Logger("app:billing.webhook");
 
 const HANDLED_TYPES = new Set<Stripe.Event.Type>([
   "checkout.session.completed",
+  "checkout.session.expired",
   "customer.subscription.created",
   "customer.subscription.updated",
   "customer.subscription.deleted",
@@ -138,6 +140,18 @@ async function findUserIdForSubscription(
   return null;
 }
 
+async function findUserIdForCheckoutSession(
+  session: Pick<Stripe.Checkout.Session, "client_reference_id" | "customer">,
+): Promise<string | null> {
+  if (session.client_reference_id) return session.client_reference_id;
+  const customerId = customerIdOf(session.customer);
+  if (!customerId) return null;
+  const byCustomer = await mongoService.user.findOne({
+    "billing.stripeCustomerId": customerId,
+  });
+  return byCustomer?._id.toString() ?? null;
+}
+
 async function handleSetupCheckoutSession(
   stripe: StripeBillingGateway,
   session: Stripe.Checkout.Session,
@@ -226,6 +240,33 @@ async function handleEvent(
       return;
     }
     await applySubscription(userId, subscription, eventCreatedAt);
+    await billingAnalytics.capture({
+      event: "checkout_completed",
+      userId,
+      properties: {
+        checkout_session_id: session.id,
+        subscription_status: subscription.status,
+        trial: subscription.status === "trialing",
+      },
+    });
+    return;
+  }
+
+  // An expired session is the "reached Stripe and left" signal. Nothing to
+  // write: billing stays awaiting_checkout and a new session can be opened.
+  if (event.type === "checkout.session.expired") {
+    const session = event.data.object as Stripe.Checkout.Session;
+    if (session.mode === "setup") return;
+    const userId = await findUserIdForCheckoutSession(session);
+    if (!userId) {
+      logger.warn(`No Compass user for expired checkout session ${session.id}`);
+      return;
+    }
+    await billingAnalytics.capture({
+      event: "checkout_expired",
+      userId,
+      properties: { checkout_session_id: session.id },
+    });
     return;
   }
 

--- a/packages/core/src/logger/posthog-capture.test.ts
+++ b/packages/core/src/logger/posthog-capture.test.ts
@@ -1,7 +1,7 @@
 import {
   captureSafely,
   createPostHogCaptureClient,
-} from "@sync/telemetry/posthog-capture";
+} from "@core/logger/posthog-capture";
 import { describe, expect, it } from "bun:test";
 
 describe("createPostHogCaptureClient", () => {
@@ -10,6 +10,7 @@ describe("createPostHogCaptureClient", () => {
     const client = createPostHogCaptureClient({
       apiKey: "phc_test",
       host: "https://us.i.posthog.com",
+      lib: "compass-sync",
       fetch: (async (input, init) => {
         calls.push({
           url: String(input),
@@ -53,6 +54,7 @@ describe("createPostHogCaptureClient", () => {
     const client = createPostHogCaptureClient({
       apiKey: "phc_test",
       host: "https://us.i.posthog.com",
+      lib: "compass-sync",
       fetch: (async () => {
         throw new Error("network down");
       }) as typeof fetch,

--- a/packages/core/src/logger/posthog-capture.ts
+++ b/packages/core/src/logger/posthog-capture.ts
@@ -1,6 +1,6 @@
 import { Logger } from "@core/logger/winston.logger";
 
-const logger = Logger("sync:posthog");
+const logger = Logger("posthog:capture");
 
 export interface PostHogCaptureClient {
   capture: (input: {
@@ -14,13 +14,15 @@ export interface PostHogCaptureClient {
 export interface PostHogCaptureOptions {
   apiKey: string;
   host: string;
+  /** Reported as `$lib` so PostHog can split events by emitting service. */
+  lib: string;
   fetch?: typeof fetch;
 }
 
 const DEFAULT_HOST = "https://us.i.posthog.com";
 
-// Thin HTTP capture client for Sync aggregate events. No-ops are handled by
-// the caller when apiKey is absent — this client always attempts delivery.
+// Thin HTTP capture client for server-side product events. No-ops are handled
+// by the caller when apiKey is absent — this client always attempts delivery.
 export function createPostHogCaptureClient(
   options: PostHogCaptureOptions,
 ): PostHogCaptureClient {
@@ -38,7 +40,7 @@ export function createPostHogCaptureClient(
           event,
           properties: {
             ...properties,
-            $lib: "compass-sync",
+            $lib: options.lib,
           },
         }),
       });
@@ -55,7 +57,7 @@ export function createPostHogCaptureClient(
 }
 
 // Best-effort capture: log and continue on failure so telemetry never takes
-// down the Sync process.
+// down the process that emits it.
 export async function captureSafely(
   client: PostHogCaptureClient | null,
   input: {

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -1,4 +1,10 @@
 import { startOtelLogs, stopOtelLogs } from "@core/logger/otel-logs";
+import {
+  captureSafely,
+  createPostHogCaptureClient,
+  DEFAULT_POSTHOG_HOST,
+  type PostHogCaptureClient,
+} from "@core/logger/posthog-capture";
 import { Logger } from "@core/logger/winston.logger";
 import { configureHttpServer } from "@core/server/http-server";
 import {
@@ -59,12 +65,6 @@ import {
 import { SyncMongoService } from "@sync/storage/sync-mongo.service";
 import { syncRepositories } from "@sync/storage/sync-repositories";
 import { emitHealthSnapshot } from "@sync/telemetry/health-snapshot.service";
-import {
-  captureSafely,
-  createPostHogCaptureClient,
-  DEFAULT_POSTHOG_HOST,
-  type PostHogCaptureClient,
-} from "@sync/telemetry/posthog-capture";
 import { randomUUID } from "node:crypto";
 import { createServer, type Server } from "node:http";
 
@@ -351,6 +351,7 @@ function buildPostHogClient(config: SyncConfig): PostHogCaptureClient | null {
   return createPostHogCaptureClient({
     apiKey: config.POSTHOG_KEY,
     host: config.POSTHOG_HOST ?? DEFAULT_POSTHOG_HOST,
+    lib: "compass-sync",
   });
 }
 

--- a/packages/sync/src/telemetry/health-snapshot.service.db.test.ts
+++ b/packages/sync/src/telemetry/health-snapshot.service.db.test.ts
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { NodeEnv } from "@core/constants/core.constants";
+import { type PostHogCaptureClient } from "@core/logger/posthog-capture";
 import {
   type ConnectionId,
   type PrincipalId,
@@ -23,7 +24,6 @@ import {
   emitHealthSnapshot,
   HEALTH_SUBSCRIPTION_RENEW_BEFORE_MS,
 } from "@sync/telemetry/health-snapshot.service";
-import { type PostHogCaptureClient } from "@core/logger/posthog-capture";
 import { beforeEach, describe, expect, it } from "bun:test";
 
 const objectId = () => faker.database.mongodbObjectId();

--- a/packages/sync/src/telemetry/health-snapshot.service.db.test.ts
+++ b/packages/sync/src/telemetry/health-snapshot.service.db.test.ts
@@ -23,7 +23,7 @@ import {
   emitHealthSnapshot,
   HEALTH_SUBSCRIPTION_RENEW_BEFORE_MS,
 } from "@sync/telemetry/health-snapshot.service";
-import { type PostHogCaptureClient } from "@sync/telemetry/posthog-capture";
+import { type PostHogCaptureClient } from "@core/logger/posthog-capture";
 import { beforeEach, describe, expect, it } from "bun:test";
 
 const objectId = () => faker.database.mongodbObjectId();

--- a/packages/sync/src/telemetry/health-snapshot.service.ts
+++ b/packages/sync/src/telemetry/health-snapshot.service.ts
@@ -16,7 +16,7 @@ import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
 import {
   captureSafely,
   type PostHogCaptureClient,
-} from "@sync/telemetry/posthog-capture";
+} from "@core/logger/posthog-capture";
 
 // Channels expiring within this window count as renewSoon (aligns with the
 // subscription maintenance sweep).

--- a/packages/sync/src/telemetry/health-snapshot.service.ts
+++ b/packages/sync/src/telemetry/health-snapshot.service.ts
@@ -1,4 +1,8 @@
 import { type Db } from "mongodb";
+import {
+  captureSafely,
+  type PostHogCaptureClient,
+} from "@core/logger/posthog-capture";
 import { ConnectionStateSchema } from "@core/types/sync/connection.contracts";
 import {
   SYNC_HEALTH_SNAPSHOT_EVENT,
@@ -13,10 +17,6 @@ import { type ProviderRegistry } from "@sync/providers/provider-registry";
 import { type StructuredServiceIdentity } from "@sync/service-identity";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import { type SyncMongoService } from "@sync/storage/sync-mongo.service";
-import {
-  captureSafely,
-  type PostHogCaptureClient,
-} from "@core/logger/posthog-capture";
 
 // Channels expiring within this window count as renewSoon (aligns with the
 // subscription maintenance sweep).


### PR DESCRIPTION
Fixes #3469

## What and why

The billing funnel in PostHog relied on the browser's `trial_converted`, which only fires when the user lands on the `?checkout=success` redirect, and abandonment on the Stripe payment page was invisible outside the Stripe Dashboard. The Stripe webhook now captures two server-side PostHog events keyed by the Compass user id (the same distinct id the web app identifies with): `checkout_completed` after a subscription-mode Checkout is applied, and `checkout_expired` when a session lapses unpaid. Capture is best-effort and never fails the webhook. `checkout.session.expired` joins the handled event set and is documented in `docs/features/billing.md`. The sync package's HTTP PostHog capture client moved to `@core/logger/posthog-capture` so backend and sync share it; `$lib` is now a constructor option.

After merge, one manual step: the live Stripe webhook endpoint (`we_1U9ZOl49d6A3QjhaDWlTmLio`) currently subscribes to four events and needs `checkout.session.expired` added in the Stripe Dashboard. The PostHog "Billing funnel" dashboard already accepts `checkout_completed` for its trial step.

## Verify

```
VERDICT: FAIL
Checks run: test:core, test:backend, type-check, lint, knip
Failed: test:sync
```

The only failure is `packages/sync/src/providers/microsoft/windows-zones.test.ts` ("maps every Windows zone to a supported IANA name"), which fails on macOS because local ICU 74.2 lists legacy canonical zone names. This branch does not touch that code; it fails identically on `origin/main` from this machine, and the Ubuntu `unit-leg (sync)` job is green on main. Tracked as #3470. The sync tests that this PR touches pass: `health-snapshot.service.db.test.ts` (4 pass), and `bun test:backend` for `billing.analytics.test.ts` and `billing.webhook.service.db.test.ts` (21 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
