### PR TITLE
ci: make required checks faster and stop painting main red

### DIFF
--- a/.github/perf/assert-budget.ts
+++ b/.github/perf/assert-budget.ts
@@ -29,11 +29,16 @@
  *
  * Recalibrated 2026-09-04: main measured 990,400 bytes, 400 over the old
  * 990 KB budget, after a day of booking and billing merges. The 1,000 KB
- * script budget leaves ~10 KB of headroom - deliberately less than the
- * ~170 KB gz editor stack (TipTap/react-datepicker/react-select), so a
- * static re-import of the event form still fails the gate. Script transfer
- * is near-deterministic (runs vary by tens of bytes), so it can sit this
- * tight; the paint metrics vary by runner and get much wider headroom.
+ * script budget leaves ~10 KB of headroom.
+ *
+ * Recalibrated 2026-09-07: main measured 1,034,338 bytes on every web
+ * push after react-toastify 9 → 11 (boot-path CompassProvider) and the
+ * multi-provider UI. The 1,060 KB budget leaves ~25 KB of headroom,
+ * still far under the ~170 KB gz editor stack (TipTap/react-datepicker/
+ * react-select), so a static re-import of the event form still fails
+ * the gate. Script transfer is near-deterministic (runs vary by tens of
+ * bytes), so it can sit this tight; the paint metrics vary by runner
+ * and get much wider headroom.
  */
 import { mkdirSync } from "node:fs";
 
@@ -61,7 +66,7 @@ const DESKTOP_BUDGETS = [
   {
     metric: "scriptBytes",
     label: "Script transfer size",
-    max: 1_000_000,
+    max: 1_060_000,
     unit: "bytes",
     level: "error",
   },

--- a/.github/scripts/detect-code-changes.sh
+++ b/.github/scripts/detect-code-changes.sh
@@ -5,20 +5,46 @@ event_name=${1:?usage: detect-code-changes.sh <event-name> <repository> [pull-re
 repository=${2:?usage: detect-code-changes.sh <event-name> <repository> [pull-request-number]}
 pull_request_number=${3:-}
 
-# code: anything outside docs, so the Unit legs and static checks run.
+# code: anything outside docs, so static checks run.
 # e2e:  anything the Playwright suite can observe. The suite boots the web
 #       dev server (packages/web, which imports only packages/core) against
 #       stubbed routes; packages/backend, packages/sync, and packages/scripts
 #       are never loaded, so a PR that touches only those skips the e2e
-#       shards. merge_group and push runs always run everything, so nothing
-#       reaches main untested.
+#       shards.
+# core/web/backend/sync/scripts: unit-leg filters. packages/core, the root
+#       lockfile, root package.json, or a root tsconfig run every leg.
+#       Otherwise only the packages the PR touched run. e2e/ and
+#       playwright.config.ts also run scripts (the shard-list contract).
+# merge_group and push runs always run everything, so nothing reaches
+# main untested.
 set_outputs() {
-  printf 'code=%s\ne2e=%s\n' "$1" "$2" >>"$GITHUB_OUTPUT"
-  printf 'Non-docs changes: %s\nE2E-reachable changes: %s\n' "$1" "$2"
+  local code=$1 e2e=$2 core=$3 web=$4 backend=$5 sync=$6 scripts=$7
+  {
+    printf 'code=%s\n' "$code"
+    printf 'e2e=%s\n' "$e2e"
+    printf 'core=%s\n' "$core"
+    printf 'web=%s\n' "$web"
+    printf 'backend=%s\n' "$backend"
+    printf 'sync=%s\n' "$sync"
+    printf 'scripts=%s\n' "$scripts"
+  } >>"$GITHUB_OUTPUT"
+  printf 'Non-docs changes: %s\n' "$code"
+  printf 'E2E-reachable changes: %s\n' "$e2e"
+  printf 'Unit legs: core=%s web=%s backend=%s sync=%s scripts=%s\n' \
+    "$core" "$web" "$backend" "$sync" "$scripts"
+}
+
+all_true() {
+  set_outputs true true true true true true true
+}
+
+matches_any() {
+  local pattern=$1
+  printf '%s\n' "$code_files" | grep -E "$pattern" >/dev/null
 }
 
 if [ "$event_name" != "pull_request" ]; then
-  set_outputs true true
+  all_true
   exit 0
 fi
 
@@ -28,7 +54,7 @@ if ! files=$(gh api --paginate \
   "repos/${repository}/pulls/${pull_request_number}/files" \
   --jq '.[].filename'); then
   echo "Could not read pull request files; running checks." >&2
-  set_outputs true true
+  all_true
   exit 0
 fi
 
@@ -41,12 +67,37 @@ e2e_files=$(printf '%s\n' "$code_files" |
 
 # An empty response is unverified, so run the checks.
 if [ -z "$files" ]; then
-  set_outputs true true
+  all_true
   exit 0
 fi
 
 code=false
 e2e=false
+core=false
+web=false
+backend=false
+sync=false
+scripts=false
 [ -n "$code_files" ] && code=true
 [ -n "$e2e_files" ] && e2e=true
-set_outputs "$code" "$e2e"
+
+if [ -n "$code_files" ]; then
+  if matches_any '^(packages/core/|package.json$|bun.lock$|tsconfig[^/]*$)'; then
+    core=true
+    web=true
+    backend=true
+    sync=true
+    scripts=true
+  else
+    matches_any '^packages/web/' && web=true
+    matches_any '^packages/backend/' && backend=true
+    matches_any '^packages/sync/' && sync=true
+    if matches_any '^packages/scripts/' ||
+      matches_any '^e2e/' ||
+      matches_any '^playwright.config.ts$'; then
+      scripts=true
+    fi
+  fi
+fi
+
+set_outputs "$code" "$e2e" "$core" "$web" "$backend" "$sync" "$scripts"

--- a/.github/scripts/detect-code-changes.test.sh
+++ b/.github/scripts/detect-code-changes.test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Local assertions for detect-code-changes.sh package routing.
+# Run: bash .github/scripts/detect-code-changes.test.sh
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+cd "$ROOT"
+
+PASS=0
+FAIL=0
+assert_eq() {
+  local got=$1
+  local want=$2
+  local name=$3
+  got=${got%"${got##*[![:space:]]}"}
+  want=${want%"${want##*[![:space:]]}"}
+  if [ "$got" = "$want" ]; then
+    echo "ok ${name}"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL ${name}: got '${got}' want '${want}'" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+STUB_DIR=$(mktemp -d)
+OUTPUT=$(mktemp)
+trap 'rm -rf "$STUB_DIR"; rm -f "$OUTPUT"' EXIT
+
+cat >"${STUB_DIR}/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s' "${DETECT_CODE_CHANGES_TEST_FILES:-}"
+STUB
+chmod +x "${STUB_DIR}/gh"
+
+run_detector() {
+  local event=$1
+  local files=${2-}
+  : >"$OUTPUT"
+  DETECT_CODE_CHANGES_TEST_FILES=$files \
+    GITHUB_OUTPUT=$OUTPUT \
+    PATH="${STUB_DIR}:${PATH}" \
+    bash "${ROOT}/.github/scripts/detect-code-changes.sh" \
+    "$event" "example/compass" "42" >/dev/null
+  cat "$OUTPUT"
+}
+
+ALL_ON=$'code=true\ne2e=true\ncore=true\nweb=true\nbackend=true\nsync=true\nscripts=true\n'
+ALL_OFF=$'code=false\ne2e=false\ncore=false\nweb=false\nbackend=false\nsync=false\nscripts=false\n'
+
+assert_eq "$(run_detector merge_group)" "$ALL_ON" "merge_group runs every leg"
+assert_eq "$(run_detector push)" "$ALL_ON" "push runs every leg"
+assert_eq "$(run_detector pull_request $'.gitignore\ndocs/testing.md\nREADME.md')" \
+  "$ALL_OFF" "docs-only skips every leg"
+
+assert_eq "$(run_detector pull_request 'packages/backend/src/app.ts')" \
+  $'code=true\ne2e=false\ncore=false\nweb=false\nbackend=true\nsync=false\nscripts=false\n' \
+  "backend-only runs the backend leg"
+
+assert_eq "$(run_detector pull_request 'packages/web/src/app.tsx')" \
+  $'code=true\ne2e=true\ncore=false\nweb=true\nbackend=false\nsync=false\nscripts=false\n' \
+  "web-only runs the web leg"
+
+assert_eq "$(run_detector pull_request 'packages/core/src/types.ts')" \
+  "$ALL_ON" "core runs every leg"
+
+assert_eq "$(run_detector pull_request 'bun.lock')" \
+  "$ALL_ON" "lockfile runs every leg"
+
+assert_eq "$(run_detector pull_request $'packages/web/src/app.tsx\npackages/backend/src/app.ts')" \
+  $'code=true\ne2e=true\ncore=false\nweb=true\nbackend=true\nsync=false\nscripts=false\n' \
+  "web plus backend runs those two legs"
+
+assert_eq "$(run_detector pull_request 'e2e/timed/event-smoke.spec.ts')" \
+  $'code=true\ne2e=true\ncore=false\nweb=false\nbackend=false\nsync=false\nscripts=true\n' \
+  "e2e specs run the scripts shard-list contract"
+
+assert_eq "$(run_detector pull_request '.github/workflows/test-unit.yml')" \
+  $'code=true\ne2e=true\ncore=false\nweb=false\nbackend=false\nsync=false\nscripts=false\n' \
+  "workflow-only skips unit legs"
+
+echo
+echo "passed=${PASS} failed=${FAIL}"
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi

--- a/.github/workflows/agent-loop.yml
+++ b/.github/workflows/agent-loop.yml
@@ -26,12 +26,19 @@ on:
         required: false
         type: string
   schedule:
-    - cron: "*/15 * * * *"
+    # Hourly watchdog. Launch-on-merge and post-deploy-on-release already
+    # fill the fleet; */15 created ~96 skip-flooded runs a day.
+    - cron: "0 * * * *"
   workflow_run:
     workflows: ["Release on main"]
     types: [completed]
   pull_request:
-    types: [labeled, synchronize, opened, reopened, ready_for_review, closed]
+    # Label/unlabel/close only. synchronize/opened/ready_for_review on
+    # unlabeled PRs was ~147 Agent loop runs/day, almost all skipped.
+    # Merge-guard needs the label; auto-merge then waits on checks
+    # without a re-run on every agent push. The hourly job re-runs
+    # merge-guard on labeled PRs.
+    types: [labeled, unlabeled, closed]
 
 permissions:
   contents: read

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -5,9 +5,12 @@ name: Agent review
 # the in-session "Reviewer" role, which had the implementer's own context.
 #
 # Kill switch: repo variable AGENT_REVIEW_ENABLED (string "true"; default off).
+# synchronize is omitted on purpose: a skipped run on every PR push drowned
+# the Actions tab while the kill switch is off, and a ready review does not
+# need to re-fire on each subsequent push.
 on:
   pull_request:
-    types: [opened, ready_for_review, synchronize]
+    types: [opened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -35,6 +35,11 @@ jobs:
     timeout-minutes: 2
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      core: ${{ steps.filter.outputs.core }}
+      web: ${{ steps.filter.outputs.web }}
+      backend: ${{ steps.filter.outputs.backend }}
+      sync: ${{ steps.filter.outputs.sync }}
+      scripts: ${{ steps.filter.outputs.scripts }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v7
@@ -119,13 +124,16 @@ jobs:
           bash -n .github/scripts/*.sh
           bash .github/scripts/agent-loop-next.test.sh
           bash .github/scripts/agent-loop-merge-guard.test.sh
+          bash .github/scripts/detect-code-changes.test.sh
 
   # A skipped MATRIX job collapses to one check run, so the `unit` rollup
   # below would see `skipped` for a docs-only PR only if every leg started.
   # Let the legs start and skip every step instead: each reports in a few
-  # seconds, for free. `unit-leg (web, 1)` and `unit-leg (web, 2)` each cover
-  # half the suite as two sequential shards (`WEB_TEST_SHARDS=4` with index
-  # `1,2` / `3,4`) so RSS stays under 7 GB.
+  # seconds, for free. Per-package outputs skip unrelated legs the same
+  # way: a backend-only PR still starts `unit-leg (web, 1)` but skips
+  # checkout through tests. `unit-leg (web, 1)` and `unit-leg (web, 2)`
+  # each cover half the suite as two sequential shards (`WEB_TEST_SHARDS=4`
+  # with index `1,2` / `3,4`) so RSS stays under 7 GB.
   unit-leg:
     needs: changes
     runs-on: ubuntu-latest
@@ -152,17 +160,17 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        if: needs.changes.outputs.code == 'true'
+        if: needs.changes.outputs.code == 'true' && needs.changes.outputs[matrix.project] == 'true'
         uses: actions/checkout@v7
 
       - name: Install Bun
-        if: needs.changes.outputs.code == 'true'
+        if: needs.changes.outputs.code == 'true' && needs.changes.outputs[matrix.project] == 'true'
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
 
       - name: Cache Bun dependencies
-        if: needs.changes.outputs.code == 'true'
+        if: needs.changes.outputs.code == 'true' && needs.changes.outputs[matrix.project] == 'true'
         uses: actions/cache@v6
         with:
           path: ~/.bun/install/cache
@@ -171,21 +179,21 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Install Dependencies
-        if: needs.changes.outputs.code == 'true'
+        if: needs.changes.outputs.code == 'true' && needs.changes.outputs[matrix.project] == 'true'
         run: |
           bun install --frozen-lockfile
 
       # backend and scripts boot an in-memory MongoDB; cache the downloaded
       # mongod binary so each run doesn't re-fetch it.
       - name: Cache MongoDB binaries
-        if: needs.changes.outputs.code == 'true' && (matrix.project == 'backend' || matrix.project == 'scripts' || matrix.project == 'sync')
+        if: needs.changes.outputs.code == 'true' && needs.changes.outputs[matrix.project] == 'true' && (matrix.project == 'backend' || matrix.project == 'scripts' || matrix.project == 'sync')
         uses: actions/cache@v6
         with:
           path: ~/.cache/mongodb-binaries
           key: ${{ runner.os }}-mongodb-memory-server
 
       - name: Run web tests
-        if: needs.changes.outputs.code == 'true' && (matrix.project == 'web')
+        if: needs.changes.outputs.code == 'true' && needs.changes.outputs[matrix.project] == 'true' && (matrix.project == 'web')
         timeout-minutes: 5
         env:
           TZ: Etc/UTC
@@ -206,7 +214,7 @@ jobs:
       # which now kills a wedged run at 4 minutes and names the likely cause
       # instead of letting this timeout fire with no output.
       - name: Run ${{ matrix.project }} tests
-        if: needs.changes.outputs.code == 'true' && (matrix.project != 'web')
+        if: needs.changes.outputs.code == 'true' && needs.changes.outputs[matrix.project] == 'true' && (matrix.project != 'web')
         timeout-minutes: 5
         env:
           TZ: Etc/UTC

--- a/docs/CI-CD/agent-loop-routine.md
+++ b/docs/CI-CD/agent-loop-routine.md
@@ -18,16 +18,16 @@ ROUTINE: agent-loop
 PURPOSE: Walk milestone issues from GitHub to merged-on-staging
   without a human in the loop, except the one-time setup listed below.
 OWNER: compass-maintainers
-TRIGGER: workflow_dispatch | */15 cron | Release on main completed | pull_request labeled agent-automerge
+TRIGGER: workflow_dispatch | hourly cron | Release on main completed | pull_request labeled/unlabeled/closed agent-automerge
 INPUT: GitHub issue in the first AGENT_LOOP_MILESTONES entry that has an eligible WP
 SKILL/PROMPT: .github/prompts/<milestone-slug>.md or .github/prompts/agent-loop.md
 OUTPUT: draft PR marked ready after bun run verify, Fixes #<n>, labeled agent-automerge; GitHub auto-merges; next WP launched on merge; staging smoke after release
 IDEMPOTENCY: up to AGENT_LOOP_CONCURRENCY in-flight agents with non-overlapping partitions; agent-loop-running; skip issues with an open Fixes PR
-RETRY: HTTP 429 waits for credits and retries on the 15-minute watchdog; dispatch a
+RETRY: HTTP 429 waits for credits and retries on the hourly watchdog; dispatch a
   fresh run for all other retryable investigation (do not "Re-run jobs" on a failed snapshot)
 APPROVAL: agent-automerge + merge-guard (size, paths, main not red) + GitHub auto-merge on required checks
 STOP: repo var AGENT_LOOP_ENABLED or BOOKING_LOOP_ENABLED (must be string "true"; default off)
-HEARTBEAT: */15 cron watchdog when idle; Discord on merge-guard / smoke failure
+HEARTBEAT: hourly cron watchdog when idle; Discord on merge-guard / smoke failure
 VERIFIER: .github/scripts/agent-loop-merge-guard.sh (not the LLM)
 STAGING: https://staging.compasscalendar.com (unauthenticated smoke only)
 NEVER: enter credentials; merge PRs that touch .github/ or auth/billing paths
@@ -120,7 +120,7 @@ both channels are configured).
    Agents API when `CURSOR_API_KEY` is set; otherwise comment
    `agent-loop: pickup`. Never both. HTTP 429 records the provider's retry
    time, labels the issue `agent-loop-waiting-for-credits`, and exits
-   successfully so the 15-minute watchdog can resume it. Other launch
+   successfully so the hourly watchdog can resume it. Other launch
    failures are `agent-loop-needs-human` stops. The prompt file is
    `.github/prompts/<milestone-slug>.md` when that file exists, else
    `.github/prompts/agent-loop.md`.
@@ -142,7 +142,7 @@ both channels are configured).
    launch them. `Fixes #<n>` closes the merged issue. A failing smoke
    stops launches.
 6. **Release on main** deploys staging (code paths only; docs-only merges
-   skip deploy). The 15-minute cron is the watchdog for docs-only WPs.
+   skip deploy). The hourly cron is the watchdog for docs-only WPs.
 7. **Post-deploy** (`workflow_run`): smokes the new release, annotates
    the issue, and tops the fleet up to N; on failure it labels the issue
    `agent-loop-needs-human` and does not launch.

--- a/docs/CI-CD/ci-audit-2026-09.md
+++ b/docs/CI-CD/ci-audit-2026-09.md
@@ -365,3 +365,20 @@ were kept because each covers a distinct page state.
   during that window gets nothing. The e2e harness fix removes the flake;
   the product behavior is unchanged and noted here for a UX pass.
 - Unit web legs: a third leg would shave under 20s. Not worth a runner.
+
+## Follow-up (2026-09-07)
+
+Required Unit and E2E stayed green. Performance budget was red on every
+`main` web push from 2026-09-04 (1,034,338 byte script transfer vs a
+1,000 KB budget). Agent loop was ~147 runs/day vs ~49 Unit, almost all
+skipped `pull_request` events plus a `*/15` cron.
+
+Changes in the follow-up PR:
+
+- Recalibrate desktop script transfer to 1,060 KB from the 2026-09-07
+  main actual, still under the ~170 KB editor-stack tripwire.
+- Agent loop: `pull_request` types `labeled` / `unlabeled` / `closed`
+  only; cron hourly.
+- Agent review: drop `synchronize`.
+- Unit legs skip by package on pull requests (same detector as the e2e
+  skip). `merge_group` and `push` still run every leg.

--- a/docs/CI-CD/workflows.md
+++ b/docs/CI-CD/workflows.md
@@ -7,11 +7,11 @@ Compass uses GitHub Actions for continuous integration, Docker Hub for image dis
 | Unit (`test-unit.yml`) | Push / PR / merge_group to `main` | Runs `static` (lint, knip, type-check) and unit tests |
 | E2E (`test-e2e.yml`) | Push / PR / merge_group to `main` | Playwright e2e in four shards behind one required `e2e` gate (PRs that touch only docs, or only `packages/backend`, `packages/sync`, `packages/scripts`, skip the shards; merge queue and `main` always run them) |
 | CodeQL | Push / PR to `main` | Static security analysis |
-| Performance budget | Push to `main` (web/core/lock/budget), nightly schedule, `workflow_dispatch`; PR only when `.github/perf/**` or the workflow file changes | Lighthouse budget (not a required merge check) |
+| Performance budget | Push to `main` (web/core/lock/budget), nightly schedule, `workflow_dispatch`; PR only when `.github/perf/**` or the workflow file changes | Lighthouse budget (not a required merge check). Desktop script transfer is 1,060 KB as of 2026-09-07. |
 | Error autofix (`error-autofix.yml`) | `posthog[bot]` issue / `workflow_dispatch` | Governed Routine: triage or fix PostHog error issues |
 | Error autofix post-deploy (`error-autofix-postdeploy.yml`) | `Release on main` completed | Notifies Discord/GitHub of autofix release outcome |
-| Agent review (`agent-review.yml`) | PR opened / ready / synchronize, non-draft; repo var `AGENT_REVIEW_ENABLED` | Independent read-only diff review posted as a PR comment (not a required check) |
-| Agent loop (`agent-loop.yml`) | `workflow_dispatch` / `*/15` cron / `Release on main` / `agent-automerge` PRs | Governed Routine: next milestone WP → merge → staging smoke |
+| Agent review (`agent-review.yml`) | PR opened / ready_for_review, non-draft; repo var `AGENT_REVIEW_ENABLED` | Independent read-only diff review posted as a PR comment (not a required check). Does not re-run on every push. |
+| Agent loop (`agent-loop.yml`) | `workflow_dispatch` / hourly cron / `Release on main` / `agent-automerge` label or close | Governed Routine: next milestone WP → merge → staging smoke |
 | Release on main | Push to `main` | Auto-increments patch version, publishes Docker images, then deploys staging |
 | Publish Docker images | Reusable workflow / manual dispatch / manual `v*.*.*` tag push | Builds and pushes Docker images only |
 | Deploy staging | Reusable workflow / manual dispatch | Pulls published images on staging, restarts the stack, then runs deploy health checks |
@@ -38,7 +38,11 @@ Source: [`.github/workflows/test-unit.yml`](../../.github/workflows/test-unit.ym
 `static` (lint, knip, and type-check as separate steps) and each `unit-leg`
 carry a 10-minute job timeout. A rollup `unit` job requires every leg, so
 the ruleset needs only `static`, `unit`, and `e2e`; legs can change without
-touching branch protection. Unit test-run steps are separately capped
+touching branch protection. On pull requests, `detect-code-changes.sh`
+runs only the packages the diff can affect (`packages/core`, the root
+lockfile, root `package.json`, or a root `tsconfig*` still run every
+leg). `merge_group` and `push` to `main` still run every leg. `static`
+still runs for any non-docs change. Unit test-run steps are separately capped
 at 5 minutes each, leaving headroom for checkout, setup-bun, cache, and
 install. These bound a hung job to a fixed, small window instead of
 GitHub's 360-minute default. GitHub Actions has no native way to give

--- a/packages/scripts/src/testing/detect-code-changes.test.ts
+++ b/packages/scripts/src/testing/detect-code-changes.test.ts
@@ -61,6 +61,47 @@ printf '%s' "$DETECT_CODE_CHANGES_TEST_FILES"
   return details;
 }
 
+function routingOutput(flags: {
+  code: boolean;
+  e2e: boolean;
+  core: boolean;
+  web: boolean;
+  backend: boolean;
+  sync: boolean;
+  scripts: boolean;
+}) {
+  return [
+    `code=${flags.code}`,
+    `e2e=${flags.e2e}`,
+    `core=${flags.core}`,
+    `web=${flags.web}`,
+    `backend=${flags.backend}`,
+    `sync=${flags.sync}`,
+    `scripts=${flags.scripts}`,
+    "",
+  ].join("\n");
+}
+
+const ALL_ON = routingOutput({
+  code: true,
+  e2e: true,
+  core: true,
+  web: true,
+  backend: true,
+  sync: true,
+  scripts: true,
+});
+
+const ALL_OFF = routingOutput({
+  code: false,
+  e2e: false,
+  core: false,
+  web: false,
+  backend: false,
+  sync: false,
+  scripts: false,
+});
+
 describe("detect-code-changes", () => {
   it("is the single detector used by both required-check workflows", () => {
     for (const workflowPath of [
@@ -74,7 +115,7 @@ describe("detect-code-changes", () => {
     }
   });
 
-  it("gates the e2e shards on the e2e output and the unit legs on code", () => {
+  it("gates the e2e shards on the e2e output and the unit legs on per-package outputs", () => {
     const unit = readFileSync(".github/workflows/test-unit.yml", "utf8");
     const e2e = readFileSync(".github/workflows/test-e2e.yml", "utf8");
 
@@ -82,6 +123,10 @@ describe("detect-code-changes", () => {
     expect(e2e).toContain("if: needs.changes.outputs.e2e == 'true'");
     expect(e2e).not.toContain("needs.changes.outputs.code");
     expect(unit).toContain("code: ${{ steps.filter.outputs.code }}");
+    expect(unit).toContain("core: ${{ steps.filter.outputs.core }}");
+    expect(unit).toContain("web: ${{ steps.filter.outputs.web }}");
+    expect(unit).toContain("needs.changes.outputs[matrix.project] == 'true'");
+    expect(unit).toContain("detect-code-changes.test.sh");
     expect(unit).not.toContain("outputs.e2e");
   });
 
@@ -116,7 +161,7 @@ describe("detect-code-changes", () => {
       const result = runDetector(eventName);
 
       expect(result.status, result.stderr).toBe(0);
-      expect(result.output).toBe("code=true\ne2e=true\n");
+      expect(result.output).toBe(ALL_ON);
       expect(result.command).toBe("");
     }
   });
@@ -128,7 +173,7 @@ describe("detect-code-changes", () => {
     );
 
     expect(result.status, result.stderr).toBe(0);
-    expect(result.output).toBe("code=false\ne2e=false\n");
+    expect(result.output).toBe(ALL_OFF);
   });
 
   it("skips only e2e for backend, sync, and scripts pull requests", () => {
@@ -138,7 +183,17 @@ describe("detect-code-changes", () => {
     );
 
     expect(result.status, result.stderr).toBe(0);
-    expect(result.output).toBe("code=true\ne2e=false\n");
+    expect(result.output).toBe(
+      routingOutput({
+        code: true,
+        e2e: false,
+        core: false,
+        web: false,
+        backend: true,
+        sync: true,
+        scripts: true,
+      }),
+    );
   });
 
   it("runs e2e when a backend pull request also touches anything else", () => {
@@ -156,7 +211,7 @@ describe("detect-code-changes", () => {
       );
 
       expect(result.status, result.stderr).toBe(0);
-      expect(result.output, other).toBe("code=true\ne2e=true\n");
+      expect(result.output, other).toMatch(/^code=true\ne2e=true\n/);
     }
   });
 
@@ -167,7 +222,17 @@ describe("detect-code-changes", () => {
     );
 
     expect(result.status, result.stderr).toBe(0);
-    expect(result.output).toBe("code=true\ne2e=true\n");
+    expect(result.output).toBe(
+      routingOutput({
+        code: true,
+        e2e: true,
+        core: false,
+        web: true,
+        backend: false,
+        sync: false,
+        scripts: false,
+      }),
+    );
     expect(result.command).toContain(
       "api --paginate repos/example/compass/pulls/42/files --jq .[].filename",
     );
@@ -181,7 +246,19 @@ describe("detect-code-changes", () => {
       const result = runDetector("pull_request", files, ghStatus);
 
       expect(result.status, result.stderr).toBe(0);
-      expect(result.output).toBe("code=true\ne2e=true\n");
+      expect(result.output).toBe(ALL_ON);
     }
+  });
+
+  it("keeps the bash routing contract green", () => {
+    const result = spawnSync(
+      "bash",
+      [".github/scripts/detect-code-changes.test.sh"],
+      { cwd: process.cwd(), encoding: "utf8" },
+    );
+
+    expect(result.status, result.stderr + result.stdout).toBe(0);
+    expect(result.stdout).toContain("backend-only runs the backend leg");
+    expect(result.stdout).toContain("workflow-only skips unit legs");
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Performance budget has failed every `main` web push since 2026-09-04 (script transfer 1,034,338 bytes vs a 1,000 KB budget). Agent loop was ~147 runs/day vs ~49 Unit, almost all skipped `pull_request` events plus a 15-minute cron. Required Unit and E2E were already green.

This PR:

- Recalibrates desktop script transfer to 1,060 KB from the 2026-09-07 main actual. The ~170 KB editor-stack tripwire still holds.
- Runs Agent loop hourly and only on `labeled` / `unlabeled` / `closed`. Drops Agent review `synchronize`.
- Skips unrelated unit legs on pull requests (same detector as the e2e shard skip). `merge_group` and `push` still run every leg.
- Leftover GitHub workflow records `e2e.yml` and `pr-body.yml` are already `disabled_manually`.

`.github/workflows/agent-loop.yml` and `agent-review.yml` are merge-guard no-auto-merge paths, so this is not an `agent-automerge` candidate.

## Verify

```
VERDICT: PASS
Selected packages: scripts
Checks run: test:scripts:fast, type-check, lint, knip
Checks skipped: (none)
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-532055da-b018-44e4-87c8-b0cbbea9f71a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-532055da-b018-44e4-87c8-b0cbbea9f71a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

