### PR TITLE
ci: quiet skip-flooded workflows and recalibrate the script budget

### DIFF
--- a/.github/perf/assert-budget.ts
+++ b/.github/perf/assert-budget.ts
@@ -29,11 +29,15 @@
  *
  * Recalibrated 2026-09-04: main measured 990,400 bytes, 400 over the old
  * 990 KB budget, after a day of booking and billing merges. The 1,000 KB
- * script budget leaves ~10 KB of headroom - deliberately less than the
- * ~170 KB gz editor stack (TipTap/react-datepicker/react-select), so a
- * static re-import of the event form still fails the gate. Script transfer
- * is near-deterministic (runs vary by tens of bytes), so it can sit this
- * tight; the paint metrics vary by runner and get much wider headroom.
+ * script budget left ~10 KB of headroom.
+ *
+ * Recalibrated 2026-09-07: main measured 1,034,338 bytes after react-toastify
+ * 9 → 11 (boot-path CompassProvider) and the multi-provider UI. The 1,060 KB
+ * script budget leaves ~25 KB of headroom, still far under the ~170 KB gz
+ * editor stack (TipTap/react-datepicker/react-select), so a static re-import
+ * of the event form still fails the gate. Script transfer is
+ * near-deterministic (runs vary by tens of bytes), so it can sit this tight;
+ * the paint metrics vary by runner and get much wider headroom.
  */
 import { mkdirSync } from "node:fs";
 
@@ -61,7 +65,7 @@ const DESKTOP_BUDGETS = [
   {
     metric: "scriptBytes",
     label: "Script transfer size",
-    max: 1_000_000,
+    max: 1_060_000,
     unit: "bytes",
     level: "error",
   },

--- a/.github/scripts/detect-code-changes.sh
+++ b/.github/scripts/detect-code-changes.sh
@@ -5,20 +5,40 @@ event_name=${1:?usage: detect-code-changes.sh <event-name> <repository> [pull-re
 repository=${2:?usage: detect-code-changes.sh <event-name> <repository> [pull-request-number]}
 pull_request_number=${3:-}
 
-# code: anything outside docs, so the Unit legs and static checks run.
+# code: anything outside docs, so static (lint, knip, type-check) runs.
 # e2e:  anything the Playwright suite can observe. The suite boots the web
 #       dev server (packages/web, which imports only packages/core) against
 #       stubbed routes; packages/backend, packages/sync, and packages/scripts
 #       are never loaded, so a PR that touches only those skips the e2e
-#       shards. merge_group and push runs always run everything, so nothing
-#       reaches main untested.
-set_outputs() {
-  printf 'code=%s\ne2e=%s\n' "$1" "$2" >>"$GITHUB_OUTPUT"
-  printf 'Non-docs changes: %s\nE2E-reachable changes: %s\n' "$1" "$2"
+#       shards.
+# core/web/backend/sync/scripts: unit-leg filters. packages/core, root
+#       package.json, bun.lock, or root tsconfig* turn every leg on.
+#       Otherwise only the packages the PR touched run. merge_group and
+#       push always run everything, so nothing reaches main untested.
+write_outputs() {
+  {
+    printf 'code=%s\n' "$1"
+    printf 'e2e=%s\n' "$2"
+    printf 'core=%s\n' "$3"
+    printf 'web=%s\n' "$4"
+    printf 'backend=%s\n' "$5"
+    printf 'sync=%s\n' "$6"
+    printf 'scripts=%s\n' "$7"
+  } >>"$GITHUB_OUTPUT"
+  printf 'Non-docs changes: %s\nE2E-reachable changes: %s\nUnit packages: core=%s web=%s backend=%s sync=%s scripts=%s\n' \
+    "$1" "$2" "$3" "$4" "$5" "$6" "$7"
+}
+
+all_on() {
+  write_outputs true true true true true true true
+}
+
+all_off() {
+  write_outputs false false false false false false false
 }
 
 if [ "$event_name" != "pull_request" ]; then
-  set_outputs true true
+  all_on
   exit 0
 fi
 
@@ -28,7 +48,7 @@ if ! files=$(gh api --paginate \
   "repos/${repository}/pulls/${pull_request_number}/files" \
   --jq '.[].filename'); then
   echo "Could not read pull request files; running checks." >&2
-  set_outputs true true
+  all_on
   exit 0
 fi
 
@@ -41,12 +61,43 @@ e2e_files=$(printf '%s\n' "$code_files" |
 
 # An empty response is unverified, so run the checks.
 if [ -z "$files" ]; then
-  set_outputs true true
+  all_on
   exit 0
 fi
 
-code=false
+if [ -z "$code_files" ]; then
+  all_off
+  exit 0
+fi
+
+code=true
 e2e=false
-[ -n "$code_files" ] && code=true
 [ -n "$e2e_files" ] && e2e=true
-set_outputs "$code" "$e2e"
+
+all_units_files=$(printf '%s\n' "$code_files" |
+  grep -E '^(packages/core(/|$)|package\.json$|bun\.lock$|tsconfig[^/]*\.json$)' || true)
+web_files=$(printf '%s\n' "$code_files" | grep -E '^packages/web(/|$)' || true)
+backend_files=$(printf '%s\n' "$code_files" | grep -E '^packages/backend(/|$)' || true)
+sync_files=$(printf '%s\n' "$code_files" | grep -E '^packages/sync(/|$)' || true)
+scripts_files=$(printf '%s\n' "$code_files" | grep -E '^packages/scripts(/|$)' || true)
+
+core=false
+web=false
+backend=false
+sync=false
+scripts=false
+
+if [ -n "$all_units_files" ]; then
+  core=true
+  web=true
+  backend=true
+  sync=true
+  scripts=true
+else
+  [ -n "$web_files" ] && web=true
+  [ -n "$backend_files" ] && backend=true
+  [ -n "$sync_files" ] && sync=true
+  [ -n "$scripts_files" ] && scripts=true
+fi
+
+write_outputs "$code" "$e2e" "$core" "$web" "$backend" "$sync" "$scripts"

--- a/.github/scripts/detect-code-changes.test.sh
+++ b/.github/scripts/detect-code-changes.test.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Local assertions for detect-code-changes.sh package routing.
+# Run: bash .github/scripts/detect-code-changes.test.sh
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+cd "$ROOT"
+
+PASS=0
+FAIL=0
+
+STUB_DIR=$(mktemp -d)
+OUTPUT=$(mktemp)
+trap 'rm -rf "$STUB_DIR" "$OUTPUT" "${OUTPUT}.want"' EXIT
+
+cat >"${STUB_DIR}/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s' "${DETECT_CODE_CHANGES_TEST_FILES:-}"
+STUB
+chmod +x "${STUB_DIR}/gh"
+
+run_detector() {
+  local event=$1
+  local files=${2-}
+  : >"$OUTPUT"
+  DETECT_CODE_CHANGES_TEST_FILES=$files \
+    GITHUB_OUTPUT=$OUTPUT \
+    PATH="${STUB_DIR}:${PATH}" \
+    bash .github/scripts/detect-code-changes.sh "$event" example/compass 42 >/dev/null
+}
+
+assert_output() {
+  local want=$1
+  local name=$2
+  local want_file="${OUTPUT}.want"
+  printf '%s' "$want" >"$want_file"
+  if cmp -s "$OUTPUT" "$want_file"; then
+    echo "ok ${name}"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL ${name}:" >&2
+    diff -u "$want_file" "$OUTPUT" >&2 || true
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+ALL_ON=$'code=true\ne2e=true\ncore=true\nweb=true\nbackend=true\nsync=true\nscripts=true\n'
+ALL_OFF=$'code=false\ne2e=false\ncore=false\nweb=false\nbackend=false\nsync=false\nscripts=false\n'
+
+run_detector push
+assert_output "$ALL_ON" "push runs every check"
+run_detector merge_group
+assert_output "$ALL_ON" "merge_group runs every check"
+run_detector pull_request $'.gitignore\ndocs/testing.md\nREADME.md'
+assert_output "$ALL_OFF" "docs-only PR skips every check"
+run_detector pull_request 'packages/backend/src/app.ts'
+assert_output $'code=true\ne2e=false\ncore=false\nweb=false\nbackend=true\nsync=false\nscripts=false\n' \
+  "backend-only PR skips e2e and other unit legs"
+run_detector pull_request 'packages/web/src/app.tsx'
+assert_output $'code=true\ne2e=true\ncore=false\nweb=true\nbackend=false\nsync=false\nscripts=false\n' \
+  "web-only PR runs web and e2e"
+run_detector pull_request 'packages/core/src/types.ts'
+assert_output "$ALL_ON" "core PR runs every unit leg"
+run_detector pull_request 'bun.lock'
+assert_output "$ALL_ON" "lockfile PR runs every unit leg"
+run_detector pull_request 'tsconfig.json'
+assert_output "$ALL_ON" "root tsconfig PR runs every unit leg"
+run_detector pull_request 'packages/web/tsconfig.json'
+assert_output $'code=true\ne2e=true\ncore=false\nweb=true\nbackend=false\nsync=false\nscripts=false\n' \
+  "nested tsconfig does not turn every leg on"
+
+echo
+echo "${PASS} passed, ${FAIL} failed"
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi

--- a/.github/workflows/agent-loop.yml
+++ b/.github/workflows/agent-loop.yml
@@ -26,12 +26,18 @@ on:
         required: false
         type: string
   schedule:
-    - cron: "*/15 * * * *"
+    # Hourly watchdog. Launch-on-merge and post-deploy-on-release fill the
+    # fleet; */15 was ~96 skip-runs/day on top of every PR synchronize.
+    - cron: "0 * * * *"
   workflow_run:
     workflows: ["Release on main"]
     types: [completed]
   pull_request:
-    types: [labeled, synchronize, opened, reopened, ready_for_review, closed]
+    # Label and close only. synchronize/opened/ready_for_review on every PR
+    # created a skipped run even with no agent-automerge label. Auto-merge,
+    # once enabled, does not need a re-run on each push; the hourly job
+    # re-runs merge-guard on labeled PRs.
+    types: [labeled, unlabeled, closed]
 
 permissions:
   contents: read

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -7,7 +7,9 @@ name: Agent review
 # Kill switch: repo variable AGENT_REVIEW_ENABLED (string "true"; default off).
 on:
   pull_request:
-    types: [opened, ready_for_review, synchronize]
+    # opened / ready_for_review only. synchronize on every push created a
+    # skipped run while AGENT_REVIEW_ENABLED is off.
+    types: [opened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -35,6 +35,11 @@ jobs:
     timeout-minutes: 2
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      core: ${{ steps.filter.outputs.core }}
+      web: ${{ steps.filter.outputs.web }}
+      backend: ${{ steps.filter.outputs.backend }}
+      sync: ${{ steps.filter.outputs.sync }}
+      scripts: ${{ steps.filter.outputs.scripts }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v7
@@ -119,13 +124,16 @@ jobs:
           bash -n .github/scripts/*.sh
           bash .github/scripts/agent-loop-next.test.sh
           bash .github/scripts/agent-loop-merge-guard.test.sh
+          bash .github/scripts/detect-code-changes.test.sh
 
   # A skipped MATRIX job collapses to one check run, so the `unit` rollup
   # below would see `skipped` for a docs-only PR only if every leg started.
   # Let the legs start and skip every step instead: each reports in a few
-  # seconds, for free. `unit-leg (web, 1)` and `unit-leg (web, 2)` each cover
-  # half the suite as two sequential shards (`WEB_TEST_SHARDS=4` with index
-  # `1,2` / `3,4`) so RSS stays under 7 GB.
+  # seconds, for free. Per-package outputs skip unrelated legs the same way
+  # (a backend-only PR must not pay two web runners). `unit-leg (web, 1)`
+  # and `unit-leg (web, 2)` each cover half the suite as two sequential
+  # shards (`WEB_TEST_SHARDS=4` with index `1,2` / `3,4`) so RSS stays
+  # under 7 GB.
   unit-leg:
     needs: changes
     runs-on: ubuntu-latest
@@ -152,17 +160,17 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        if: needs.changes.outputs.code == 'true'
+        if: ${{ needs.changes.outputs.code == 'true' && needs.changes.outputs[matrix.project] == 'true' }}
         uses: actions/checkout@v7
 
       - name: Install Bun
-        if: needs.changes.outputs.code == 'true'
+        if: ${{ needs.changes.outputs.code == 'true' && needs.changes.outputs[matrix.project] == 'true' }}
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
 
       - name: Cache Bun dependencies
-        if: needs.changes.outputs.code == 'true'
+        if: ${{ needs.changes.outputs.code == 'true' && needs.changes.outputs[matrix.project] == 'true' }}
         uses: actions/cache@v6
         with:
           path: ~/.bun/install/cache
@@ -171,21 +179,21 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Install Dependencies
-        if: needs.changes.outputs.code == 'true'
+        if: ${{ needs.changes.outputs.code == 'true' && needs.changes.outputs[matrix.project] == 'true' }}
         run: |
           bun install --frozen-lockfile
 
       # backend and scripts boot an in-memory MongoDB; cache the downloaded
       # mongod binary so each run doesn't re-fetch it.
       - name: Cache MongoDB binaries
-        if: needs.changes.outputs.code == 'true' && (matrix.project == 'backend' || matrix.project == 'scripts' || matrix.project == 'sync')
+        if: ${{ needs.changes.outputs.code == 'true' && needs.changes.outputs[matrix.project] == 'true' && (matrix.project == 'backend' || matrix.project == 'scripts' || matrix.project == 'sync') }}
         uses: actions/cache@v6
         with:
           path: ~/.cache/mongodb-binaries
           key: ${{ runner.os }}-mongodb-memory-server
 
       - name: Run web tests
-        if: needs.changes.outputs.code == 'true' && (matrix.project == 'web')
+        if: ${{ needs.changes.outputs.code == 'true' && needs.changes.outputs[matrix.project] == 'true' && matrix.project == 'web' }}
         timeout-minutes: 5
         env:
           TZ: Etc/UTC
@@ -206,7 +214,7 @@ jobs:
       # which now kills a wedged run at 4 minutes and names the likely cause
       # instead of letting this timeout fire with no output.
       - name: Run ${{ matrix.project }} tests
-        if: needs.changes.outputs.code == 'true' && (matrix.project != 'web')
+        if: ${{ needs.changes.outputs.code == 'true' && needs.changes.outputs[matrix.project] == 'true' && matrix.project != 'web' }}
         timeout-minutes: 5
         env:
           TZ: Etc/UTC

--- a/docs/CI-CD/agent-loop-routine.md
+++ b/docs/CI-CD/agent-loop-routine.md
@@ -18,16 +18,16 @@ ROUTINE: agent-loop
 PURPOSE: Walk milestone issues from GitHub to merged-on-staging
   without a human in the loop, except the one-time setup listed below.
 OWNER: compass-maintainers
-TRIGGER: workflow_dispatch | */15 cron | Release on main completed | pull_request labeled agent-automerge
+TRIGGER: workflow_dispatch | hourly cron | Release on main completed | pull_request labeled/unlabeled/closed (agent-automerge)
 INPUT: GitHub issue in the first AGENT_LOOP_MILESTONES entry that has an eligible WP
 SKILL/PROMPT: .github/prompts/<milestone-slug>.md or .github/prompts/agent-loop.md
 OUTPUT: draft PR marked ready after bun run verify, Fixes #<n>, labeled agent-automerge; GitHub auto-merges; next WP launched on merge; staging smoke after release
 IDEMPOTENCY: up to AGENT_LOOP_CONCURRENCY in-flight agents with non-overlapping partitions; agent-loop-running; skip issues with an open Fixes PR
-RETRY: HTTP 429 waits for credits and retries on the 15-minute watchdog; dispatch a
+RETRY: HTTP 429 waits for credits and retries on the hourly watchdog; dispatch a
   fresh run for all other retryable investigation (do not "Re-run jobs" on a failed snapshot)
 APPROVAL: agent-automerge + merge-guard (size, paths, main not red) + GitHub auto-merge on required checks
 STOP: repo var AGENT_LOOP_ENABLED or BOOKING_LOOP_ENABLED (must be string "true"; default off)
-HEARTBEAT: */15 cron watchdog when idle; Discord on merge-guard / smoke failure
+HEARTBEAT: hourly cron watchdog when idle; Discord on merge-guard / smoke failure
 VERIFIER: .github/scripts/agent-loop-merge-guard.sh (not the LLM)
 STAGING: https://staging.compasscalendar.com (unauthenticated smoke only)
 NEVER: enter credentials; merge PRs that touch .github/ or auth/billing paths
@@ -120,7 +120,7 @@ both channels are configured).
    Agents API when `CURSOR_API_KEY` is set; otherwise comment
    `agent-loop: pickup`. Never both. HTTP 429 records the provider's retry
    time, labels the issue `agent-loop-waiting-for-credits`, and exits
-   successfully so the 15-minute watchdog can resume it. Other launch
+   successfully so the hourly watchdog can resume it. Other launch
    failures are `agent-loop-needs-human` stops. The prompt file is
    `.github/prompts/<milestone-slug>.md` when that file exists, else
    `.github/prompts/agent-loop.md`.
@@ -142,7 +142,7 @@ both channels are configured).
    launch them. `Fixes #<n>` closes the merged issue. A failing smoke
    stops launches.
 6. **Release on main** deploys staging (code paths only; docs-only merges
-   skip deploy). The 15-minute cron is the watchdog for docs-only WPs.
+   skip deploy). The hourly cron is the watchdog for docs-only WPs.
 7. **Post-deploy** (`workflow_run`): smokes the new release, annotates
    the issue, and tops the fleet up to N; on failure it labels the issue
    `agent-loop-needs-human` and does not launch.

--- a/docs/CI-CD/ci-audit-2026-09.md
+++ b/docs/CI-CD/ci-audit-2026-09.md
@@ -365,3 +365,22 @@ were kept because each covers a distinct page state.
   during that window gets nothing. The e2e harness fix removes the flake;
   the product behavior is unchanged and noted here for a UX pass.
 - Unit web legs: a third leg would shave under 20s. Not worth a runner.
+
+## After (2026-09-07): reliability follow-up
+
+Required Unit and E2E checks were already green. The remaining pain was a
+permanently red Performance budget on `main` (desktop script transfer
+1,034,338 bytes vs a 1,000,000 budget since 2026-09-04) and Agent loop /
+Agent review skip-flooding the Actions tab (~147 Agent loop runs in 24h
+vs ~49 Unit). Follow-up:
+
+1. Recalibrate desktop `scriptBytes` to 1,060,000 from the 2026-09-07
+   main actual, still under the ~170 KB editor-stack tripwire.
+2. Agent loop `pull_request` types are now `labeled` / `unlabeled` /
+   `closed` only; cron is hourly instead of `*/15`.
+3. Agent review no longer runs on `synchronize`.
+4. Unit legs skip packages the PR did not touch, with
+   `detect-code-changes.sh` emitting `core` / `web` / `backend` / `sync`
+   / `scripts`. Merge queue and `main` still run every leg.
+5. Leftover GitHub workflow records for deleted `e2e.yml` and
+   `pr-body.yml` are disabled so `gh run list --workflow=E2E` is unique.

--- a/docs/CI-CD/workflows.md
+++ b/docs/CI-CD/workflows.md
@@ -4,14 +4,14 @@ Compass uses GitHub Actions for continuous integration, Docker Hub for image dis
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| Unit (`test-unit.yml`) | Push / PR / merge_group to `main` | Runs `static` (lint, knip, type-check) and unit tests |
+| Unit (`test-unit.yml`) | Push / PR / merge_group to `main` | Runs `static` (lint, knip, type-check) and unit tests. PRs run only the packages they touched (`packages/core`, root `package.json` / `bun.lock` / `tsconfig*` still turn every leg on). Merge queue and `main` always run every leg. |
 | E2E (`test-e2e.yml`) | Push / PR / merge_group to `main` | Playwright e2e in four shards behind one required `e2e` gate (PRs that touch only docs, or only `packages/backend`, `packages/sync`, `packages/scripts`, skip the shards; merge queue and `main` always run them) |
 | CodeQL | Push / PR to `main` | Static security analysis |
-| Performance budget | Push to `main` (web/core/lock/budget), nightly schedule, `workflow_dispatch`; PR only when `.github/perf/**` or the workflow file changes | Lighthouse budget (not a required merge check) |
+| Performance budget | Push to `main` (web/core/lock/budget), nightly schedule, `workflow_dispatch`; PR only when `.github/perf/**` or the workflow file changes | Lighthouse budget (not a required merge check). Desktop script transfer is calibrated to 1,060 KB as of 2026-09-07 (main measured 1,034,338 bytes). |
 | Error autofix (`error-autofix.yml`) | `posthog[bot]` issue / `workflow_dispatch` | Governed Routine: triage or fix PostHog error issues |
 | Error autofix post-deploy (`error-autofix-postdeploy.yml`) | `Release on main` completed | Notifies Discord/GitHub of autofix release outcome |
-| Agent review (`agent-review.yml`) | PR opened / ready / synchronize, non-draft; repo var `AGENT_REVIEW_ENABLED` | Independent read-only diff review posted as a PR comment (not a required check) |
-| Agent loop (`agent-loop.yml`) | `workflow_dispatch` / `*/15` cron / `Release on main` / `agent-automerge` PRs | Governed Routine: next milestone WP → merge → staging smoke |
+| Agent review (`agent-review.yml`) | PR opened / ready_for_review, non-draft; repo var `AGENT_REVIEW_ENABLED` | Independent read-only diff review posted as a PR comment (not a required check). Does not re-run on every synchronize. |
+| Agent loop (`agent-loop.yml`) | `workflow_dispatch` / hourly cron / `Release on main` / `agent-automerge` label or close | Governed Routine: next milestone WP → merge → staging smoke |
 | Release on main | Push to `main` | Auto-increments patch version, publishes Docker images, then deploys staging |
 | Publish Docker images | Reusable workflow / manual dispatch / manual `v*.*.*` tag push | Builds and pushes Docker images only |
 | Deploy staging | Reusable workflow / manual dispatch | Pulls published images on staging, restarts the stack, then runs deploy health checks |
@@ -53,6 +53,13 @@ processes of about 96 files (a single 191-file process exceeds the 7 GB
 runner). Local `bun test:web` still runs every shard sequentially.
 `WEB_TEST_SHARDS=2 WEB_TEST_SHARD_INDEX=2 bun test:web` still runs only
 the second half.
+
+On pull requests, `detect-code-changes.sh` also emits per-package outputs
+(`core`, `web`, `backend`, `sync`, `scripts`). A backend-only PR still
+runs `static` and the backend leg, and skips the web runners. Changes
+under `packages/core`, or to root `package.json`, `bun.lock`, or
+`tsconfig*.json`, turn every leg on. `merge_group` and push to `main`
+always run every leg.
 
 **Known flakiness**: a job can occasionally hang for several minutes on
 runner/network flakiness unrelated to the diff, while the identical job on

--- a/packages/scripts/src/testing/detect-code-changes.test.ts
+++ b/packages/scripts/src/testing/detect-code-changes.test.ts
@@ -61,6 +61,53 @@ printf '%s' "$DETECT_CODE_CHANGES_TEST_FILES"
   return details;
 }
 
+const ALL_ON = [
+  "code=true",
+  "e2e=true",
+  "core=true",
+  "web=true",
+  "backend=true",
+  "sync=true",
+  "scripts=true",
+  "",
+].join("\n");
+
+const ALL_OFF = [
+  "code=false",
+  "e2e=false",
+  "core=false",
+  "web=false",
+  "backend=false",
+  "sync=false",
+  "scripts=false",
+  "",
+].join("\n");
+
+function flags(values: {
+  code?: boolean;
+  e2e?: boolean;
+  core?: boolean;
+  web?: boolean;
+  backend?: boolean;
+  sync?: boolean;
+  scripts?: boolean;
+}) {
+  const resolved = {
+    code: false,
+    e2e: false,
+    core: false,
+    web: false,
+    backend: false,
+    sync: false,
+    scripts: false,
+    ...values,
+  };
+  return (["code", "e2e", "core", "web", "backend", "sync", "scripts"] as const)
+    .map((key) => `${key}=${resolved[key]}`)
+    .concat("")
+    .join("\n");
+}
+
 describe("detect-code-changes", () => {
   it("is the single detector used by both required-check workflows", () => {
     for (const workflowPath of [
@@ -74,7 +121,7 @@ describe("detect-code-changes", () => {
     }
   });
 
-  it("gates the e2e shards on the e2e output and the unit legs on code", () => {
+  it("gates the e2e shards on the e2e output and the unit legs on package outputs", () => {
     const unit = readFileSync(".github/workflows/test-unit.yml", "utf8");
     const e2e = readFileSync(".github/workflows/test-e2e.yml", "utf8");
 
@@ -82,6 +129,9 @@ describe("detect-code-changes", () => {
     expect(e2e).toContain("if: needs.changes.outputs.e2e == 'true'");
     expect(e2e).not.toContain("needs.changes.outputs.code");
     expect(unit).toContain("code: ${{ steps.filter.outputs.code }}");
+    expect(unit).toContain("web: ${{ steps.filter.outputs.web }}");
+    expect(unit).toContain("needs.changes.outputs[matrix.project]");
+    expect(unit).toContain("bash .github/scripts/detect-code-changes.test.sh");
     expect(unit).not.toContain("outputs.e2e");
   });
 
@@ -116,7 +166,7 @@ describe("detect-code-changes", () => {
       const result = runDetector(eventName);
 
       expect(result.status, result.stderr).toBe(0);
-      expect(result.output).toBe("code=true\ne2e=true\n");
+      expect(result.output).toBe(ALL_ON);
       expect(result.command).toBe("");
     }
   });
@@ -128,17 +178,19 @@ describe("detect-code-changes", () => {
     );
 
     expect(result.status, result.stderr).toBe(0);
-    expect(result.output).toBe("code=false\ne2e=false\n");
+    expect(result.output).toBe(ALL_OFF);
   });
 
-  it("skips only e2e for backend, sync, and scripts pull requests", () => {
+  it("skips e2e and unrelated unit legs for backend, sync, and scripts pull requests", () => {
     const result = runDetector(
       "pull_request",
       "packages/backend/src/app.ts\npackages/sync/src/jobs.ts\npackages/scripts/src/cli.ts\ndocs/sync.md",
     );
 
     expect(result.status, result.stderr).toBe(0);
-    expect(result.output).toBe("code=true\ne2e=false\n");
+    expect(result.output).toBe(
+      flags({ code: true, backend: true, sync: true, scripts: true }),
+    );
   });
 
   it("runs e2e when a backend pull request also touches anything else", () => {
@@ -156,21 +208,36 @@ describe("detect-code-changes", () => {
       );
 
       expect(result.status, result.stderr).toBe(0);
-      expect(result.output, other).toBe("code=true\ne2e=true\n");
+      expect(result.output, other).toMatch(/^code=true\ne2e=true\n/);
     }
   });
 
-  it("runs checks for pull requests containing code", () => {
+  it("runs only the web unit legs for a web-only pull request", () => {
     const result = runDetector(
       "pull_request",
       "docs/testing.md\npackages/web/src/app.tsx",
     );
 
     expect(result.status, result.stderr).toBe(0);
-    expect(result.output).toBe("code=true\ne2e=true\n");
+    expect(result.output).toBe(flags({ code: true, e2e: true, web: true }));
     expect(result.command).toContain(
       "api --paginate repos/example/compass/pulls/42/files --jq .[].filename",
     );
+  });
+
+  it("runs every unit leg when core, the lockfile, or a root tsconfig changes", () => {
+    for (const file of [
+      "packages/core/src/types.ts",
+      "package.json",
+      "bun.lock",
+      "tsconfig.json",
+      "tsconfig.typecheck.json",
+    ]) {
+      const result = runDetector("pull_request", file);
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.output, file).toBe(ALL_ON);
+    }
   });
 
   it("runs checks when the pull request file list cannot be verified", () => {
@@ -181,7 +248,7 @@ describe("detect-code-changes", () => {
       const result = runDetector("pull_request", files, ghStatus);
 
       expect(result.status, result.stderr).toBe(0);
-      expect(result.output).toBe("code=true\ne2e=true\n");
+      expect(result.output).toBe(ALL_ON);
     }
   });
 });


### PR DESCRIPTION
Fixes #

## What and why

Required Unit and E2E checks were already green. CI looked broken because Performance budget has failed every `main` run since 2026-09-04 (script transfer 1.034 MB vs 1.000 MB), and Agent loop was flooding Actions (~147 runs/day vs ~49 Unit). This recalibrates the desktop script budget to 1,060 KB from the 2026-09-07 main actual, stops Agent loop/review from firing on every PR synchronize, and skips unrelated unit legs on PRs. Merge queue and `main` still run every package.

## Verify

`bun run verify` selected scripts + type-check, lint, knip. lint, type-check, knip, and `detect-code-changes` tests passed. `test:scripts:fast` hit three pre-existing macOS bash 3.2 failures in untouched `agent-loop-next` tests (`mapfile` / empty array under `set -u`); those scripts require bash 4+ and run on ubuntu-latest in CI.