### PR TITLE
fix(backend): align booking freshness with google reconcile lag

### DIFF
--- a/packages/backend/src/booking/services/calendar-booking.port.ts
+++ b/packages/backend/src/booking/services/calendar-booking.port.ts
@@ -5,7 +5,12 @@ import {
 } from "@core/types/domain-primitives";
 import { type BusyAvailabilityResponse } from "@core/types/sync/availability.contracts";
 
-export const BOOKING_CONFIRMATION_MAX_AGE_MS = 5 * 60 * 1000;
+// Google reconcile treats a resource as stale after 15 minutes and sweeps
+// every 10 minutes, so lastSuccessAt on a quiet calendar can be ~25 minutes
+// old while the connection is still healthy. Holiday and other unwatchable
+// calendars only advance on that sweep. A 5-minute booking maxAge marked
+// those hosts unbookable for most of the day.
+export const BOOKING_CONFIRMATION_MAX_AGE_MS = 30 * 60 * 1000;
 
 export interface BookingEventGuest {
   email: string;

--- a/packages/backend/src/booking/services/calendar-booking.service.test.ts
+++ b/packages/backend/src/booking/services/calendar-booking.service.test.ts
@@ -33,7 +33,15 @@ describe("CalendarBookingService", () => {
     mock.restore();
   });
 
-  it("queries busy availability with booking_confirmation purpose and short maxAge", async () => {
+  it("covers Google reconcile lag so quiet calendars stay bookable", () => {
+    const reconcileStaleAfterMs = 15 * 60_000;
+    const reconcileSweepIntervalMs = 10 * 60_000;
+    expect(BOOKING_CONFIRMATION_MAX_AGE_MS).toBeGreaterThanOrEqual(
+      reconcileStaleAfterMs + reconcileSweepIntervalMs,
+    );
+  });
+
+  it("queries busy availability with booking_confirmation purpose and reconcile-sized maxAge", async () => {
     const queryBusyAvailability = mock(async () => ({
       ok: true as const,
       value: busyResponse,

--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -484,6 +484,13 @@ export class PublicBookingService {
     );
 
     if (!availability.bookable) {
+      logger.warn("Public booking slots unbookable", {
+        complete: availability.complete,
+        issueReasons: availability.issues.map((issue) => issue.reason),
+        connectionStates: availability.connections.map(
+          (connection) => connection.state,
+        ),
+      });
       return BookingSlotsResponseSchema.parse({
         slots: [],
         bookable: false,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Staging public booking (`/book/lanceessert2`) loaded the host page but returned `{"slots":[],"bookable":false}`, which the guest UI shows as "Booking temporarily unavailable." Slot listing and confirm both ask Sync whether blocking calendars are fresh enough using a 5-minute `maxAge`. Google reconcile only treats a quiet resource as stale after 15 minutes and sweeps every 10 minutes, so `lastSuccessAt` on a healthy calendar (especially unwatchable holiday calendars in the default blocking set) is routinely 15–25 minutes old. Booking then fail-closed and hid every slot.

Raise `BOOKING_CONFIRMATION_MAX_AGE_MS` to 30 minutes so it covers that reconcile lag. Guest responses still omit busy payloads; logs now record issue reasons when slots are unbookable.

## Verify

`VERDICT: PASS`
Checks run: `test:backend:fast`, `type-check`, `lint`, `knip`. Also ran `calendar-booking.service.test.ts` and `public-booking.service.db.test.ts` (72 pass).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-782fb34d-75a7-48cb-a480-48db06025faa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-782fb34d-75a7-48cb-a480-48db06025faa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

