### PR TITLE
feat(web): reuse sign-in pills for connect prompts

### DIFF
--- a/packages/web/src/auth/providers/ConnectProviderChooser.test.tsx
+++ b/packages/web/src/auth/providers/ConnectProviderChooser.test.tsx
@@ -8,7 +8,7 @@ import * as realConnectProvider from "@web/auth/providers/useConnectProvider";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
 let available: ProviderKind[] = ["google"];
-const connectingKind: ProviderKind | null = null;
+let connectingKind: ProviderKind | null = null;
 const mockConnectGoogle = mock();
 const mockConnectMicrosoft = mock();
 const mockConnectApple = mock();

--- a/packages/web/src/auth/providers/ConnectProviderChooser.test.tsx
+++ b/packages/web/src/auth/providers/ConnectProviderChooser.test.tsx
@@ -8,8 +8,10 @@ import * as realConnectProvider from "@web/auth/providers/useConnectProvider";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
 let available: ProviderKind[] = ["google"];
+const connectingKind: ProviderKind | null = null;
 const mockConnectGoogle = mock();
 const mockConnectMicrosoft = mock();
+const mockConnectApple = mock();
 
 mockModuleForFile(
   "@web/auth/providers/useAvailableConnectProviders",
@@ -20,7 +22,7 @@ mockModuleForFile(
 const connectByKind: Record<ProviderKind, ReturnType<typeof mock>> = {
   google: mockConnectGoogle,
   microsoft: mockConnectMicrosoft,
-  apple: mock(),
+  apple: mockConnectApple,
 };
 
 const labelByKind: Record<ProviderKind, string> = {
@@ -36,7 +38,7 @@ mockModuleForFile(
     useConnectProvider: (kind: ProviderKind) => ({
       state: "NOT_CONNECTED",
       isAvailable: true,
-      isConnecting: false,
+      isConnecting: connectingKind === kind,
       isRefreshing: false,
       commandAction: {
         label: labelByKind[kind],
@@ -58,8 +60,10 @@ const { ConnectProviderChooser } = (await import(
 describe("ConnectProviderChooser", () => {
   beforeEach(() => {
     available = ["google"];
+    connectingKind = null;
     mockConnectGoogle.mockClear();
     mockConnectMicrosoft.mockClear();
+    mockConnectApple.mockClear();
   });
 
   afterEach(() => {
@@ -108,5 +112,56 @@ describe("ConnectProviderChooser", () => {
     expect(mockConnectMicrosoft).toHaveBeenCalledTimes(1);
     expect(mockConnectGoogle).not.toHaveBeenCalled();
     expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("renders branded connect pills for the prompt variant", async () => {
+    const user = userEvent.setup();
+    available = ["google", "microsoft", "apple"];
+
+    render(
+      <ConnectProviderChooser
+        idleLabel="Connect Google Calendar"
+        variant="prompt"
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Connect Google Calendar" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Connect Microsoft Calendar" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Connect Apple Calendar" }),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Connect Microsoft Calendar" }),
+    );
+    expect(mockConnectMicrosoft).toHaveBeenCalledTimes(1);
+    expect(mockConnectGoogle).not.toHaveBeenCalled();
+    expect(mockConnectApple).not.toHaveBeenCalled();
+  });
+
+  it("relabels the connecting prompt pill and disables the others", () => {
+    available = ["google", "microsoft", "apple"];
+    connectingKind = "microsoft";
+
+    render(
+      <ConnectProviderChooser
+        idleLabel="Connect Google Calendar"
+        variant="prompt"
+      />,
+    );
+
+    const busy = screen.getByRole("button", { name: "Opening Microsoft…" });
+    expect(busy).toHaveAttribute("aria-busy", "true");
+    expect(busy).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Connect Google Calendar" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Connect Apple Calendar" }),
+    ).toBeDisabled();
   });
 });

--- a/packages/web/src/auth/providers/ConnectProviderChooser.tsx
+++ b/packages/web/src/auth/providers/ConnectProviderChooser.tsx
@@ -13,15 +13,13 @@ import {
   providerDisplayName,
 } from "@core/types/sync/identity.contracts";
 import { openingProviderLabel } from "@web/auth/providers/connection-provider.util";
-import { BOOKING_CONNECT_BUTTON_LABEL } from "@web/auth/providers/provider-copy.util";
+import { CONNECT_CALENDAR_LABEL } from "@web/auth/providers/provider-copy.util";
 import { useAvailableConnectProviders } from "@web/auth/providers/useAvailableConnectProviders";
 import { useConnectProvider } from "@web/auth/providers/useConnectProvider";
 import { focusOnPointerEnter } from "@web/common/utils/focus-on-pointer-enter";
 import { MicrosoftLogo } from "@web/components/AuthModal/components/MicrosoftButton";
-import {
-  OverlayPanelActionButton,
-  OverlayPanelActions,
-} from "@web/components/OverlayPanel/OverlayPanel";
+import { SignInProviderButtons } from "@web/components/AuthModal/components/SignInProviderButtons";
+import { OverlayPanelActionButton } from "@web/components/OverlayPanel/OverlayPanel";
 
 const PROVIDER_MENU_ICON: Partial<Record<ProviderKind, typeof MicrosoftLogo>> =
   {
@@ -137,21 +135,14 @@ export const ConnectProviderChooser: FC<ConnectProviderChooserProps> = ({
 
   if (variant === "prompt") {
     return (
-      <OverlayPanelActions align="start">
-        {available.map((kind) => (
-          <OverlayPanelActionButton
-            aria-busy={byKind[kind].isConnecting || undefined}
-            disabled={isConnecting}
-            key={kind}
-            onClick={() => runConnect(kind)}
-            variant="primary"
-          >
-            {byKind[kind].isConnecting
-              ? openingProviderLabel(kind)
-              : BOOKING_CONNECT_BUTTON_LABEL[kind]}
-          </OverlayPanelActionButton>
-        ))}
-      </OverlayPanelActions>
+      <SignInProviderButtons
+        available={available}
+        busyLabel={openingProviderLabel}
+        labels={CONNECT_CALENDAR_LABEL}
+        loadingKind={connectingKind ?? null}
+        onSignIn={runConnect}
+        shortcutKeys={null}
+      />
     );
   }
 

--- a/packages/web/src/auth/providers/provider-copy.util.ts
+++ b/packages/web/src/auth/providers/provider-copy.util.ts
@@ -93,12 +93,6 @@ export function bookingConnectPromptCopy(
   return "Connect a calendar account to enable your booking page. Guests book through a public link and Compass creates events on your calendar.";
 }
 
-export const BOOKING_CONNECT_BUTTON_LABEL: Record<ProviderKind, string> = {
-  google: "Connect Google",
-  microsoft: CONNECT_CALENDAR_LABEL.microsoft,
-  apple: CONNECT_CALENDAR_LABEL.apple,
-};
-
 export function defaultCalendarGroupLabel(
   accountEmail: string,
   kind: ProviderKind,

--- a/packages/web/src/booking/BookingConnectGooglePrompt.tsx
+++ b/packages/web/src/booking/BookingConnectGooglePrompt.tsx
@@ -1,5 +1,8 @@
 import { ConnectProviderChooser } from "@web/auth/providers/ConnectProviderChooser";
-import { bookingConnectPromptCopy } from "@web/auth/providers/provider-copy.util";
+import {
+  bookingConnectPromptCopy,
+  CONNECT_CALENDAR_LABEL,
+} from "@web/auth/providers/provider-copy.util";
 import { useAvailableConnectProviders } from "@web/auth/providers/useAvailableConnectProviders";
 
 export function BookingConnectGooglePrompt() {
@@ -11,7 +14,10 @@ export function BookingConnectGooglePrompt() {
         {bookingConnectPromptCopy(connectable)}
       </p>
       {connectable.length > 0 ? (
-        <ConnectProviderChooser idleLabel="Connect Google" variant="prompt" />
+        <ConnectProviderChooser
+          idleLabel={CONNECT_CALENDAR_LABEL.google}
+          variant="prompt"
+        />
       ) : (
         <p className="text-sm text-text-muted">
           Google sign-in is not configured in this environment.

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -12,6 +12,8 @@ import {
   createMockConnection,
 } from "@web/__tests__/utils/factories/calendar.factory";
 import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
+import { CONNECT_CALENDAR_LABEL } from "@web/auth/providers/provider-copy.util";
+import { setProviderAvailabilityForTests } from "@web/auth/providers/useIsProviderAvailable";
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import {
   BOOKING_SETTINGS_HINT_PARTS,
@@ -142,6 +144,7 @@ function dispatchModKey(target: HTMLElement, key: string) {
 
 describe("BookingSettingsSection", () => {
   it("shows connect Google prompt when Google is not healthy", () => {
+    setProviderAvailabilityForTests("google", "available", "connect");
     userMetadataActions.set({
       google: {
         connectionState: "NOT_CONNECTED",
@@ -159,6 +162,9 @@ describe("BookingSettingsSection", () => {
 
     expect(
       screen.getByText(/Connect a Google account to enable your booking page/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: CONNECT_CALENDAR_LABEL.google }),
     ).toBeInTheDocument();
     expect(screen.queryByLabelText("Duration")).not.toBeInTheDocument();
   });

--- a/packages/web/src/components/AuthModal/components/AppleButton.tsx
+++ b/packages/web/src/components/AuthModal/components/AppleButton.tsx
@@ -18,12 +18,14 @@ const AppleLogo = ({ size = 18 }: { size?: number }) => (
 export const AppleButton = ({
   onClick,
   disabled,
+  busy,
   label = "Continue with Apple",
   shortcutKey,
   style,
 }: {
   onClick: () => void;
   disabled?: boolean;
+  busy?: boolean;
   label?: string;
   shortcutKey?: string;
   style?: React.CSSProperties;
@@ -33,6 +35,7 @@ export const AppleButton = ({
       type="button"
       onClick={onClick}
       disabled={disabled}
+      aria-busy={busy || undefined}
       aria-label={label}
       className={classNames(
         "inline-flex h-10 items-center justify-center gap-2.5 whitespace-nowrap rounded-full border border-[#1f1f1f] bg-[#000] px-3 font-medium text-[#fff] text-sm transition-[background-color,box-shadow,transform] duration-200",

--- a/packages/web/src/components/AuthModal/components/GoogleButton.tsx
+++ b/packages/web/src/components/AuthModal/components/GoogleButton.tsx
@@ -37,12 +37,14 @@ const GoogleGLogo = ({ size = 18 }: { size?: number }) => (
 export const GoogleButton = ({
   onClick,
   disabled,
+  busy,
   label = "Sign in with Google",
   shortcutKey,
   style,
 }: {
   onClick: () => void;
   disabled?: boolean;
+  busy?: boolean;
   label?: string;
   shortcutKey?: string;
   style?: React.CSSProperties;
@@ -52,6 +54,7 @@ export const GoogleButton = ({
       type="button"
       onClick={onClick}
       disabled={disabled}
+      aria-busy={busy || undefined}
       aria-label={label}
       className={classNames(
         "inline-flex h-10 items-center justify-center gap-2.5 whitespace-nowrap rounded-full border border-[#1f1f1f] bg-[#fff] px-3 font-medium text-[#1f1f1f] text-sm transition-[background-color,box-shadow,transform] duration-200",

--- a/packages/web/src/components/AuthModal/components/MicrosoftButton.tsx
+++ b/packages/web/src/components/AuthModal/components/MicrosoftButton.tsx
@@ -25,12 +25,14 @@ export const MicrosoftLogo = ({ size = 18 }: { size?: number }) => (
 export const MicrosoftButton = ({
   onClick,
   disabled,
+  busy,
   label = "Connect Microsoft",
   shortcutKey,
   style,
 }: {
   onClick: () => void;
   disabled?: boolean;
+  busy?: boolean;
   label?: string;
   shortcutKey?: string;
   style?: React.CSSProperties;
@@ -40,6 +42,7 @@ export const MicrosoftButton = ({
       type="button"
       onClick={onClick}
       disabled={disabled}
+      aria-busy={busy || undefined}
       aria-label={label}
       className={classNames(
         "inline-flex h-10 items-center justify-center gap-2.5 whitespace-nowrap rounded-full border border-[#1f1f1f] bg-[#fff] px-3 font-medium text-[#1f1f1f] text-sm transition-[background-color,box-shadow,transform] duration-200",

--- a/packages/web/src/components/AuthModal/components/SignInProviderButtons.test.tsx
+++ b/packages/web/src/components/AuthModal/components/SignInProviderButtons.test.tsx
@@ -1,3 +1,4 @@
+import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { SignInProviderButtons } from "@web/components/AuthModal/components/SignInProviderButtons";
@@ -46,5 +47,66 @@ describe("SignInProviderButtons", () => {
     );
 
     expect(onSignIn).toHaveBeenCalledWith("microsoft");
+  });
+
+  it("renders custom labels as the accessible names", () => {
+    render(
+      <SignInProviderButtons
+        available={["google", "microsoft", "apple"]}
+        labels={{
+          google: "Connect Google Calendar",
+          microsoft: "Connect Microsoft Calendar",
+          apple: "Connect Apple Calendar",
+        }}
+        loadingKind={null}
+        onSignIn={mock()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Connect Google Calendar" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Connect Microsoft Calendar" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Connect Apple Calendar" }),
+    ).toBeTruthy();
+  });
+
+  it("hides shortcut chips when shortcutKeys is null", () => {
+    render(
+      <SignInProviderButtons
+        available={["google", "microsoft", "apple"]}
+        loadingKind={null}
+        onSignIn={mock()}
+        shortcutKeys={null}
+      />,
+    );
+
+    expect(screen.queryByText("G")).toBeNull();
+    expect(screen.queryByText("M")).toBeNull();
+    expect(screen.queryByText("A")).toBeNull();
+  });
+
+  it("relabels the loading pill and disables the others", () => {
+    render(
+      <SignInProviderButtons
+        available={["google", "microsoft", "apple"]}
+        busyLabel={(kind) => `Opening ${kind}…`}
+        loadingKind="microsoft"
+        onSignIn={mock()}
+      />,
+    );
+
+    const busy = screen.getByRole("button", { name: "Opening microsoft…" });
+    expect(busy).toHaveAttribute("aria-busy", "true");
+    expect(busy).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Continue with Google" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Continue with Apple" }),
+    ).toBeDisabled();
   });
 });

--- a/packages/web/src/components/AuthModal/components/SignInProviderButtons.tsx
+++ b/packages/web/src/components/AuthModal/components/SignInProviderButtons.tsx
@@ -13,6 +13,9 @@ type SignInProviderButtonsProps = {
   loadingKind: ProviderKind | null;
   onSignIn: (kind: ProviderKind) => void;
   fullWidth?: boolean;
+  labels?: Record<ProviderKind, string>;
+  shortcutKeys?: Record<ProviderKind, string> | null;
+  busyLabel?: (kind: ProviderKind) => string;
 };
 
 const SIGN_IN_BUTTONS = {
@@ -27,15 +30,26 @@ const renderProviderButton = (
     style?: CSSProperties;
   },
 ) => {
-  const { loadingKind, onSignIn, style } = props;
+  const {
+    loadingKind,
+    onSignIn,
+    style,
+    labels = CONTINUE_WITH_LABEL,
+    shortcutKeys = SIGN_IN_SHORTCUT_KEY,
+    busyLabel,
+  } = props;
   const Button = SIGN_IN_BUTTONS[kind];
+  const isBusy = loadingKind === kind;
+  const label = isBusy && busyLabel ? busyLabel(kind) : labels[kind];
+  const shortcutKey = shortcutKeys == null ? undefined : shortcutKeys[kind];
   return (
     <Button
       key={kind}
+      busy={isBusy}
       disabled={loadingKind != null}
-      label={CONTINUE_WITH_LABEL[kind]}
+      label={label}
       onClick={() => onSignIn(kind)}
-      shortcutKey={SIGN_IN_SHORTCUT_KEY[kind]}
+      shortcutKey={shortcutKey}
       style={style}
     />
   );
@@ -46,22 +60,29 @@ export const SignInProviderButtons: FC<SignInProviderButtonsProps> = ({
   loadingKind,
   onSignIn,
   fullWidth = true,
+  labels,
+  shortcutKeys,
+  busyLabel,
 }) => {
   if (available.length === 0) {
     return null;
   }
 
   const buttonStyle = fullWidth ? { width: "100%" } : undefined;
-
-  return (
-    <>
-      {available.map((kind) =>
-        renderProviderButton(kind, {
-          loadingKind,
-          onSignIn,
-          style: buttonStyle,
-        }),
-      )}
-    </>
+  const buttons = available.map((kind) =>
+    renderProviderButton(kind, {
+      loadingKind,
+      onSignIn,
+      style: buttonStyle,
+      labels,
+      shortcutKeys,
+      busyLabel,
+    }),
   );
+
+  if (fullWidth) {
+    return <div className="flex flex-col gap-3">{buttons}</div>;
+  }
+
+  return <>{buttons}</>;
 };

--- a/packages/web/src/components/ConnectCalendarPrompt/ConnectCalendarPrompt.test.tsx
+++ b/packages/web/src/components/ConnectCalendarPrompt/ConnectCalendarPrompt.test.tsx
@@ -40,7 +40,7 @@ const connectByKind: Record<ProviderKind, ReturnType<typeof mock>> = {
 };
 
 const buttonLabelByKind: Record<ProviderKind, string> = {
-  google: "Connect Google",
+  google: "Connect Google Calendar",
   microsoft: "Connect Microsoft Calendar",
   apple: "Connect Apple Calendar",
 };

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -639,7 +639,7 @@ describe("WelcomeModal", () => {
       ).toBeNull();
       expect(screen.queryByText("You'll pick your calendar next.")).toBeNull();
       expect(
-        screen.queryByRole("button", { name: "Connect Microsoft" }),
+        screen.queryByRole("button", { name: "Connect Microsoft Calendar" }),
       ).toBeNull();
     });
 
@@ -708,10 +708,10 @@ describe("WelcomeModal", () => {
         screen.getByRole("heading", { name: "Connect the calendar you use" }),
       ).toBeTruthy();
       expect(
-        screen.getByRole("button", { name: "Connect Microsoft" }),
+        screen.getByRole("button", { name: "Connect Microsoft Calendar" }),
       ).toBeTruthy();
       await user.click(
-        screen.getByRole("button", { name: "Connect Microsoft" }),
+        screen.getByRole("button", { name: "Connect Microsoft Calendar" }),
       );
       expect(mockOpenModal).toHaveBeenCalledWith("signUp");
     });

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -3,13 +3,15 @@ import { useContext, useEffect, useId, useRef, useState } from "react";
 import { type ProviderKind } from "@core/types/sync/identity.contracts";
 import { SessionContext } from "@web/auth/compass/session/session.context";
 import { track } from "@web/auth/posthog/track";
-import { CONNECT_THE_CALENDAR_YOU_USE } from "@web/auth/providers/provider-copy.util";
+import {
+  CONNECT_CALENDAR_LABEL,
+  CONNECT_THE_CALENDAR_YOU_USE,
+} from "@web/auth/providers/provider-copy.util";
 import { signInProviderForShortcutLetter } from "@web/auth/providers/sign-in-provider.util";
 import { useIsProviderAvailable } from "@web/auth/providers/useIsProviderAvailable";
 import { useSignInProviders } from "@web/auth/providers/useSignInProviders";
 import { MODAL_DISMISS_MS } from "@web/common/constants/motion.constants";
 import { useDismissTransition } from "@web/common/hooks/useDismissTransition";
-import { MicrosoftButton } from "@web/components/AuthModal/components/MicrosoftButton";
 import { SignInProviderButtons } from "@web/components/AuthModal/components/SignInProviderButtons";
 import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
@@ -387,12 +389,13 @@ export function WelcomeModal() {
               ) : null}
               {showMicrosoftConnectCta ? (
                 <>
-                  <MicrosoftButton
-                    onClick={() => handOffToAuth("sign_up")}
-                    disabled={isLoading}
-                    label="Connect Microsoft"
-                    shortcutKey="M"
-                    style={{ width: "100%" }}
+                  <SignInProviderButtons
+                    available={["microsoft"]}
+                    labels={CONNECT_CALENDAR_LABEL}
+                    loadingKind={
+                      isLoading ? (loadingKind ?? "microsoft") : null
+                    }
+                    onSignIn={() => handOffToAuth("sign_up")}
                   />
                   <p className="text-center text-text-muted text-xs">
                     Create an account, then connect Microsoft from Settings.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3479

## What and why

Connect prompts on Settings > Booking and the signed-in connect overlay now render the same branded Google, Microsoft, and Apple pills as sign-in and sign-up, stacked full width, with labels from `CONNECT_CALENDAR_LABEL`. `ConnectProviderChooser` still owns connect logic, including Apple's app-password detour. Welcome's Microsoft-only connect CTA uses the same pills. Spec: [docs/features/booking.md](https://github.com/KeepSoftwareSimple/compass-calendar/blob/main/docs/features/booking.md). Tracking: #3478.

## Verify

`VERDICT: PASS`

Checks run: `test:web`, `type-check`, `lint`, `knip`, `test:a11y`, `test:e2e`

Evidence: RTL coverage for custom labels, hidden shortcut chips, busy-state `aria-busy`, prompt-variant connect pills (`Connect Google Calendar` / `Connect Microsoft Calendar` / `Connect Apple Calendar`), and the Booking Settings connect prompt. Existing chooser, WelcomeModal, and ConnectCalendarPrompt tests still pass.

## Evidence

Code already used `CONNECT_CALENDAR_LABEL` for Microsoft and Apple; Google's prompt button was the short "Connect Google". Sign-in defaults (`CONTINUE_WITH_LABEL`, shortcut chips) are unchanged. `BOOKING_CONNECT_BUTTON_LABEL` deleted.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a3e396e-ae10-485f-8c9e-74670598e85c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a3e396e-ae10-485f-8c9e-74670598e85c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

