### PR TITLE
feat(web): make settings nav read as clickable pages

### DIFF
--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -681,6 +681,26 @@ describe("SettingsModal", () => {
     expect(screen.queryByRole("button", { name: "Booking" })).toBeNull();
   });
 
+  it.each([
+    "accounts",
+    "billing",
+    "booking",
+  ] as const)("tells the host to click a page on the %s screen", (page) => {
+    access = {
+      kind: "server",
+      status: "active",
+      isReadOnly: false,
+      trialEndsAt: null,
+    };
+    renderSettings({ authenticated: true, page });
+
+    expect(
+      within(screen.getByRole("dialog", { name: "Settings" })).getByText(
+        "Click a page or press its number.",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("says nothing about a plan on an install without billing", () => {
     renderSettings({ authenticated: true });
 

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -72,9 +72,11 @@ import { DefaultTimezonePicker } from "@web/timezone/DefaultTimezonePicker";
 const OUTLINE_BUTTON_CLASSNAME =
   "c-focus-ring shrink-0 rounded border border-border bg-surface-overlay px-2 py-1 text-xs text-text transition-colors hover:bg-surface-panel disabled:pointer-events-none disabled:opacity-60";
 
+const SETTINGS_NAV_HINT = "Click a page or press its number.";
+
 const navButtonClassName = (current: boolean) =>
   current
-    ? "c-focus-ring flex w-full items-center justify-between rounded bg-surface-overlay px-2 py-1 text-left text-sm text-text"
+    ? "c-focus-ring flex w-full items-center justify-between rounded border-l-2 border-accent bg-surface-overlay px-2 py-1 text-left text-sm font-medium text-text"
     : "c-focus-ring flex w-full items-center justify-between rounded px-2 py-1 text-left text-sm text-text-muted transition-colors hover:bg-surface-overlay hover:text-text";
 
 /**
@@ -247,6 +249,9 @@ export const SettingsModal: FC = () => {
               {areHintsVisible ? <ShortcutKeys keys="3" /> : null}
             </button>
           ) : null}
+          <p className="mt-2 px-2 text-text-muted text-xs">
+            {SETTINGS_NAV_HINT}
+          </p>
         </nav>
         <div className="flex min-w-0 flex-1 flex-col gap-4">
           {page === "billing" ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3480

## What and why

Settings nav (Accounts / Billing / Booking) now reads as clickable pages: the current page uses a left accent border and medium weight, and a muted line under the nav says `Click a page or press its number.` Digit shortcuts and hint-visibility are unchanged. Tracking: #3478.

## Verify

`VERDICT: PASS`

Checks run: `test:web`, `type-check`, `lint`, `knip`, `test:a11y`, `test:e2e`

## Evidence

`navButtonClassName(true)` adds `font-medium border-l-2 border-accent` and keeps `aria-current="true"`. The hint sits inside `<nav>` after the page buttons.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a3e396e-ae10-485f-8c9e-74670598e85c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a3e396e-ae10-485f-8c9e-74670598e85c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

