### PR TITLE
fix(web): reuse sign-in provider pills for booking connect prompts

### DIFF
--- a/packages/web/src/auth/providers/ConnectProviderChooser.test.tsx
+++ b/packages/web/src/auth/providers/ConnectProviderChooser.test.tsx
@@ -8,8 +8,10 @@ import * as realConnectProvider from "@web/auth/providers/useConnectProvider";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
 let available: ProviderKind[] = ["google"];
+let connectingKind: ProviderKind | null = null;
 const mockConnectGoogle = mock();
 const mockConnectMicrosoft = mock();
+const mockConnectApple = mock();
 
 mockModuleForFile(
   "@web/auth/providers/useAvailableConnectProviders",
@@ -20,7 +22,7 @@ mockModuleForFile(
 const connectByKind: Record<ProviderKind, ReturnType<typeof mock>> = {
   google: mockConnectGoogle,
   microsoft: mockConnectMicrosoft,
-  apple: mock(),
+  apple: mockConnectApple,
 };
 
 const labelByKind: Record<ProviderKind, string> = {
@@ -36,7 +38,7 @@ mockModuleForFile(
     useConnectProvider: (kind: ProviderKind) => ({
       state: "NOT_CONNECTED",
       isAvailable: true,
-      isConnecting: false,
+      isConnecting: connectingKind === kind,
       isRefreshing: false,
       commandAction: {
         label: labelByKind[kind],
@@ -58,8 +60,10 @@ const { ConnectProviderChooser } = (await import(
 describe("ConnectProviderChooser", () => {
   beforeEach(() => {
     available = ["google"];
+    connectingKind = null;
     mockConnectGoogle.mockClear();
     mockConnectMicrosoft.mockClear();
+    mockConnectApple.mockClear();
   });
 
   afterEach(() => {
@@ -108,5 +112,68 @@ describe("ConnectProviderChooser", () => {
     expect(mockConnectMicrosoft).toHaveBeenCalledTimes(1);
     expect(mockConnectGoogle).not.toHaveBeenCalled();
     expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  describe("prompt variant", () => {
+    beforeEach(() => {
+      available = ["google", "microsoft", "apple"];
+    });
+
+    it("renders branded connect pills with calendar labels", () => {
+      render(
+        <ConnectProviderChooser
+          idleLabel="Connect Google Calendar"
+          variant="prompt"
+        />,
+      );
+
+      expect(
+        screen.getByRole("button", { name: "Connect Google Calendar" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Connect Microsoft Calendar" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Connect Apple Calendar" }),
+      ).toBeInTheDocument();
+    });
+
+    it("routes Microsoft connect from the prompt pills", async () => {
+      const user = userEvent.setup();
+      render(
+        <ConnectProviderChooser
+          idleLabel="Connect Google Calendar"
+          variant="prompt"
+        />,
+      );
+
+      await user.click(
+        screen.getByRole("button", { name: "Connect Microsoft Calendar" }),
+      );
+
+      expect(mockConnectMicrosoft).toHaveBeenCalledTimes(1);
+      expect(mockConnectGoogle).not.toHaveBeenCalled();
+    });
+
+    it("shows opening copy on the connecting pill and disables all pills", () => {
+      connectingKind = "microsoft";
+      render(
+        <ConnectProviderChooser
+          idleLabel="Connect Google Calendar"
+          variant="prompt"
+        />,
+      );
+
+      const busyButton = screen.getByRole("button", {
+        name: "Opening Microsoft…",
+      });
+      expect(busyButton).toHaveAttribute("aria-busy", "true");
+      expect(
+        screen.getByRole("button", { name: "Connect Google Calendar" }),
+      ).toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: "Connect Apple Calendar" }),
+      ).toBeDisabled();
+    });
   });
 });

--- a/packages/web/src/auth/providers/ConnectProviderChooser.tsx
+++ b/packages/web/src/auth/providers/ConnectProviderChooser.tsx
@@ -13,15 +13,13 @@ import {
   providerDisplayName,
 } from "@core/types/sync/identity.contracts";
 import { openingProviderLabel } from "@web/auth/providers/connection-provider.util";
-import { BOOKING_CONNECT_BUTTON_LABEL } from "@web/auth/providers/provider-copy.util";
+import { CONNECT_CALENDAR_LABEL } from "@web/auth/providers/provider-copy.util";
 import { useAvailableConnectProviders } from "@web/auth/providers/useAvailableConnectProviders";
 import { useConnectProvider } from "@web/auth/providers/useConnectProvider";
 import { focusOnPointerEnter } from "@web/common/utils/focus-on-pointer-enter";
 import { MicrosoftLogo } from "@web/components/AuthModal/components/MicrosoftButton";
-import {
-  OverlayPanelActionButton,
-  OverlayPanelActions,
-} from "@web/components/OverlayPanel/OverlayPanel";
+import { SignInProviderButtons } from "@web/components/AuthModal/components/SignInProviderButtons";
+import { OverlayPanelActionButton } from "@web/components/OverlayPanel/OverlayPanel";
 
 const PROVIDER_MENU_ICON: Partial<Record<ProviderKind, typeof MicrosoftLogo>> =
   {
@@ -137,21 +135,14 @@ export const ConnectProviderChooser: FC<ConnectProviderChooserProps> = ({
 
   if (variant === "prompt") {
     return (
-      <OverlayPanelActions align="start">
-        {available.map((kind) => (
-          <OverlayPanelActionButton
-            aria-busy={byKind[kind].isConnecting || undefined}
-            disabled={isConnecting}
-            key={kind}
-            onClick={() => runConnect(kind)}
-            variant="primary"
-          >
-            {byKind[kind].isConnecting
-              ? openingProviderLabel(kind)
-              : BOOKING_CONNECT_BUTTON_LABEL[kind]}
-          </OverlayPanelActionButton>
-        ))}
-      </OverlayPanelActions>
+      <SignInProviderButtons
+        available={available}
+        busyLabel={openingProviderLabel}
+        labels={CONNECT_CALENDAR_LABEL}
+        loadingKind={connectingKind ?? null}
+        onSignIn={runConnect}
+        shortcutKeys={null}
+      />
     );
   }
 

--- a/packages/web/src/auth/providers/provider-copy.util.ts
+++ b/packages/web/src/auth/providers/provider-copy.util.ts
@@ -93,12 +93,6 @@ export function bookingConnectPromptCopy(
   return "Connect a calendar account to enable your booking page. Guests book through a public link and Compass creates events on your calendar.";
 }
 
-export const BOOKING_CONNECT_BUTTON_LABEL: Record<ProviderKind, string> = {
-  google: "Connect Google",
-  microsoft: CONNECT_CALENDAR_LABEL.microsoft,
-  apple: CONNECT_CALENDAR_LABEL.apple,
-};
-
 export function defaultCalendarGroupLabel(
   accountEmail: string,
   kind: ProviderKind,

--- a/packages/web/src/booking/BookingConnectGooglePrompt.tsx
+++ b/packages/web/src/booking/BookingConnectGooglePrompt.tsx
@@ -1,5 +1,8 @@
 import { ConnectProviderChooser } from "@web/auth/providers/ConnectProviderChooser";
-import { bookingConnectPromptCopy } from "@web/auth/providers/provider-copy.util";
+import {
+  bookingConnectPromptCopy,
+  CONNECT_CALENDAR_LABEL,
+} from "@web/auth/providers/provider-copy.util";
 import { useAvailableConnectProviders } from "@web/auth/providers/useAvailableConnectProviders";
 
 export function BookingConnectGooglePrompt() {
@@ -11,7 +14,10 @@ export function BookingConnectGooglePrompt() {
         {bookingConnectPromptCopy(connectable)}
       </p>
       {connectable.length > 0 ? (
-        <ConnectProviderChooser idleLabel="Connect Google" variant="prompt" />
+        <ConnectProviderChooser
+          idleLabel={CONNECT_CALENDAR_LABEL.google}
+          variant="prompt"
+        />
       ) : (
         <p className="text-sm text-text-muted">
           Google sign-in is not configured in this environment.

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -12,6 +12,10 @@ import {
   createMockConnection,
 } from "@web/__tests__/utils/factories/calendar.factory";
 import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
+import {
+  resetProviderAvailabilityForTests,
+  setProviderAvailabilityForTests,
+} from "@web/auth/providers/useIsProviderAvailable";
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import {
   BOOKING_SETTINGS_HINT_PARTS,
@@ -142,6 +146,7 @@ function dispatchModKey(target: HTMLElement, key: string) {
 
 describe("BookingSettingsSection", () => {
   it("shows connect Google prompt when Google is not healthy", () => {
+    setProviderAvailabilityForTests("google", "available", "connect");
     userMetadataActions.set({
       google: {
         connectionState: "NOT_CONNECTED",
@@ -160,7 +165,11 @@ describe("BookingSettingsSection", () => {
     expect(
       screen.getByText(/Connect a Google account to enable your booking page/),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Connect Google Calendar" }),
+    ).toBeInTheDocument();
     expect(screen.queryByLabelText("Duration")).not.toBeInTheDocument();
+    resetProviderAvailabilityForTests();
   });
 
   it("shows booking settings when a healthy non-google connection exists", async () => {

--- a/packages/web/src/components/AuthModal/components/AppleButton.tsx
+++ b/packages/web/src/components/AuthModal/components/AppleButton.tsx
@@ -21,18 +21,21 @@ export const AppleButton = ({
   label = "Continue with Apple",
   shortcutKey,
   style,
+  busy,
 }: {
   onClick: () => void;
   disabled?: boolean;
   label?: string;
   shortcutKey?: string;
   style?: React.CSSProperties;
+  busy?: boolean;
 }) => {
   return (
     <button
       type="button"
       onClick={onClick}
       disabled={disabled}
+      aria-busy={busy || undefined}
       aria-label={label}
       className={classNames(
         "inline-flex h-10 items-center justify-center gap-2.5 whitespace-nowrap rounded-full border border-[#1f1f1f] bg-[#000] px-3 font-medium text-[#fff] text-sm transition-[background-color,box-shadow,transform] duration-200",

--- a/packages/web/src/components/AuthModal/components/GoogleButton.tsx
+++ b/packages/web/src/components/AuthModal/components/GoogleButton.tsx
@@ -40,18 +40,21 @@ export const GoogleButton = ({
   label = "Sign in with Google",
   shortcutKey,
   style,
+  busy,
 }: {
   onClick: () => void;
   disabled?: boolean;
   label?: string;
   shortcutKey?: string;
   style?: React.CSSProperties;
+  busy?: boolean;
 }) => {
   return (
     <button
       type="button"
       onClick={onClick}
       disabled={disabled}
+      aria-busy={busy || undefined}
       aria-label={label}
       className={classNames(
         "inline-flex h-10 items-center justify-center gap-2.5 whitespace-nowrap rounded-full border border-[#1f1f1f] bg-[#fff] px-3 font-medium text-[#1f1f1f] text-sm transition-[background-color,box-shadow,transform] duration-200",

--- a/packages/web/src/components/AuthModal/components/MicrosoftButton.tsx
+++ b/packages/web/src/components/AuthModal/components/MicrosoftButton.tsx
@@ -28,18 +28,21 @@ export const MicrosoftButton = ({
   label = "Connect Microsoft",
   shortcutKey,
   style,
+  busy,
 }: {
   onClick: () => void;
   disabled?: boolean;
   label?: string;
   shortcutKey?: string;
   style?: React.CSSProperties;
+  busy?: boolean;
 }) => {
   return (
     <button
       type="button"
       onClick={onClick}
       disabled={disabled}
+      aria-busy={busy || undefined}
       aria-label={label}
       className={classNames(
         "inline-flex h-10 items-center justify-center gap-2.5 whitespace-nowrap rounded-full border border-[#1f1f1f] bg-[#fff] px-3 font-medium text-[#1f1f1f] text-sm transition-[background-color,box-shadow,transform] duration-200",

--- a/packages/web/src/components/AuthModal/components/SignInProviderButtons.test.tsx
+++ b/packages/web/src/components/AuthModal/components/SignInProviderButtons.test.tsx
@@ -1,7 +1,14 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
 import { SignInProviderButtons } from "@web/components/AuthModal/components/SignInProviderButtons";
 import { describe, expect, it, mock } from "bun:test";
+
+const customLabels: Record<ProviderKind, string> = {
+  google: "Connect Google Calendar",
+  microsoft: "Connect Microsoft Calendar",
+  apple: "Connect Apple Calendar",
+};
 
 describe("SignInProviderButtons", () => {
   it("renders all three provider buttons with whole-string labels", () => {
@@ -28,6 +35,67 @@ describe("SignInProviderButtons", () => {
     expect(
       screen.queryByText("Signs you up and connects your Outlook calendar."),
     ).not.toBeInTheDocument();
+  });
+
+  it("renders custom labels as accessible names", () => {
+    render(
+      <SignInProviderButtons
+        available={["google", "microsoft", "apple"]}
+        labels={customLabels}
+        loadingKind={null}
+        onSignIn={mock()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Connect Google Calendar" }),
+    ).toHaveTextContent("Connect Google Calendar");
+    expect(
+      screen.getByRole("button", { name: "Connect Microsoft Calendar" }),
+    ).toHaveTextContent("Connect Microsoft Calendar");
+    expect(
+      screen.getByRole("button", { name: "Connect Apple Calendar" }),
+    ).toHaveTextContent("Connect Apple Calendar");
+  });
+
+  it("hides shortcut chips when shortcutKeys is null", () => {
+    render(
+      <SignInProviderButtons
+        available={["google", "microsoft", "apple"]}
+        loadingKind={null}
+        onSignIn={mock()}
+        shortcutKeys={null}
+      />,
+    );
+
+    expect(screen.queryByText("G")).toBeNull();
+    expect(screen.queryByText("M")).toBeNull();
+    expect(screen.queryByText("A")).toBeNull();
+  });
+
+  it("shows busyLabel and aria-busy on the loading button and disables the rest", () => {
+    render(
+      <SignInProviderButtons
+        available={["google", "microsoft", "apple"]}
+        busyLabel={(kind) => `Opening ${kind}…`}
+        labels={customLabels}
+        loadingKind="microsoft"
+        onSignIn={mock()}
+        shortcutKeys={null}
+      />,
+    );
+
+    const busyButton = screen.getByRole("button", {
+      name: "Opening microsoft…",
+    });
+    expect(busyButton).toHaveAttribute("aria-busy", "true");
+    expect(busyButton).toHaveTextContent("Opening microsoft…");
+    expect(
+      screen.getByRole("button", { name: "Connect Google Calendar" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Connect Apple Calendar" }),
+    ).toBeDisabled();
   });
 
   it("calls onSignIn with the clicked provider kind", async () => {

--- a/packages/web/src/components/AuthModal/components/SignInProviderButtons.tsx
+++ b/packages/web/src/components/AuthModal/components/SignInProviderButtons.tsx
@@ -13,6 +13,9 @@ type SignInProviderButtonsProps = {
   loadingKind: ProviderKind | null;
   onSignIn: (kind: ProviderKind) => void;
   fullWidth?: boolean;
+  labels?: Record<ProviderKind, string>;
+  shortcutKeys?: Record<ProviderKind, string> | null;
+  busyLabel?: (kind: ProviderKind) => string;
 };
 
 const SIGN_IN_BUTTONS = {
@@ -25,17 +28,32 @@ const renderProviderButton = (
   kind: ProviderKind,
   props: Omit<SignInProviderButtonsProps, "available"> & {
     style?: CSSProperties;
+    resolvedLabels: Record<ProviderKind, string>;
+    resolvedShortcutKeys: Record<ProviderKind, string> | null;
   },
 ) => {
-  const { loadingKind, onSignIn, style } = props;
+  const {
+    loadingKind,
+    onSignIn,
+    style,
+    busyLabel,
+    resolvedLabels,
+    resolvedShortcutKeys,
+  } = props;
   const Button = SIGN_IN_BUTTONS[kind];
+  const isBusy = loadingKind === kind;
+  const label = isBusy && busyLabel ? busyLabel(kind) : resolvedLabels[kind];
+  const shortcutKey =
+    resolvedShortcutKeys === null ? undefined : resolvedShortcutKeys[kind];
+
   return (
     <Button
       key={kind}
+      busy={isBusy || undefined}
       disabled={loadingKind != null}
-      label={CONTINUE_WITH_LABEL[kind]}
+      label={label}
       onClick={() => onSignIn(kind)}
-      shortcutKey={SIGN_IN_SHORTCUT_KEY[kind]}
+      shortcutKey={shortcutKey}
       style={style}
     />
   );
@@ -46,22 +64,33 @@ export const SignInProviderButtons: FC<SignInProviderButtonsProps> = ({
   loadingKind,
   onSignIn,
   fullWidth = true,
+  labels,
+  shortcutKeys,
+  busyLabel,
 }) => {
   if (available.length === 0) {
     return null;
   }
 
+  const resolvedLabels = labels ?? CONTINUE_WITH_LABEL;
+  const resolvedShortcutKeys =
+    shortcutKeys === undefined ? SIGN_IN_SHORTCUT_KEY : shortcutKeys;
   const buttonStyle = fullWidth ? { width: "100%" } : undefined;
 
-  return (
-    <>
-      {available.map((kind) =>
-        renderProviderButton(kind, {
-          loadingKind,
-          onSignIn,
-          style: buttonStyle,
-        }),
-      )}
-    </>
+  const buttons = available.map((kind) =>
+    renderProviderButton(kind, {
+      loadingKind,
+      onSignIn,
+      style: buttonStyle,
+      busyLabel,
+      resolvedLabels,
+      resolvedShortcutKeys,
+    }),
   );
+
+  if (fullWidth) {
+    return <div className="flex w-full flex-col gap-3">{buttons}</div>;
+  }
+
+  return <>{buttons}</>;
 };

--- a/packages/web/src/components/ConnectCalendarPrompt/ConnectCalendarPrompt.test.tsx
+++ b/packages/web/src/components/ConnectCalendarPrompt/ConnectCalendarPrompt.test.tsx
@@ -40,7 +40,7 @@ const connectByKind: Record<ProviderKind, ReturnType<typeof mock>> = {
 };
 
 const buttonLabelByKind: Record<ProviderKind, string> = {
-  google: "Connect Google",
+  google: "Connect Google Calendar",
   microsoft: "Connect Microsoft Calendar",
   apple: "Connect Apple Calendar",
 };

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -639,7 +639,7 @@ describe("WelcomeModal", () => {
       ).toBeNull();
       expect(screen.queryByText("You'll pick your calendar next.")).toBeNull();
       expect(
-        screen.queryByRole("button", { name: "Connect Microsoft" }),
+        screen.queryByRole("button", { name: "Connect Microsoft Calendar" }),
       ).toBeNull();
     });
 
@@ -708,10 +708,10 @@ describe("WelcomeModal", () => {
         screen.getByRole("heading", { name: "Connect the calendar you use" }),
       ).toBeTruthy();
       expect(
-        screen.getByRole("button", { name: "Connect Microsoft" }),
+        screen.getByRole("button", { name: "Connect Microsoft Calendar" }),
       ).toBeTruthy();
       await user.click(
-        screen.getByRole("button", { name: "Connect Microsoft" }),
+        screen.getByRole("button", { name: "Connect Microsoft Calendar" }),
       );
       expect(mockOpenModal).toHaveBeenCalledWith("signUp");
     });

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -3,13 +3,15 @@ import { useContext, useEffect, useId, useRef, useState } from "react";
 import { type ProviderKind } from "@core/types/sync/identity.contracts";
 import { SessionContext } from "@web/auth/compass/session/session.context";
 import { track } from "@web/auth/posthog/track";
-import { CONNECT_THE_CALENDAR_YOU_USE } from "@web/auth/providers/provider-copy.util";
+import {
+  CONNECT_CALENDAR_LABEL,
+  CONNECT_THE_CALENDAR_YOU_USE,
+} from "@web/auth/providers/provider-copy.util";
 import { signInProviderForShortcutLetter } from "@web/auth/providers/sign-in-provider.util";
 import { useIsProviderAvailable } from "@web/auth/providers/useIsProviderAvailable";
 import { useSignInProviders } from "@web/auth/providers/useSignInProviders";
 import { MODAL_DISMISS_MS } from "@web/common/constants/motion.constants";
 import { useDismissTransition } from "@web/common/hooks/useDismissTransition";
-import { MicrosoftButton } from "@web/components/AuthModal/components/MicrosoftButton";
 import { SignInProviderButtons } from "@web/components/AuthModal/components/SignInProviderButtons";
 import { useAuthModal } from "@web/components/AuthModal/hooks/useAuthModal";
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
@@ -387,12 +389,11 @@ export function WelcomeModal() {
               ) : null}
               {showMicrosoftConnectCta ? (
                 <>
-                  <MicrosoftButton
-                    onClick={() => handOffToAuth("sign_up")}
-                    disabled={isLoading}
-                    label="Connect Microsoft"
-                    shortcutKey="M"
-                    style={{ width: "100%" }}
+                  <SignInProviderButtons
+                    available={["microsoft"]}
+                    labels={CONNECT_CALENDAR_LABEL}
+                    loadingKind={isLoading ? "microsoft" : null}
+                    onSignIn={() => handOffToAuth("sign_up")}
                   />
                   <p className="text-center text-text-muted text-xs">
                     Create an account, then connect Microsoft from Settings.


### PR DESCRIPTION
Fixes #3479

## What and why

Booking v1.6 WP-01: Settings > Booking and the signed-in connect prompt now render the same branded Google, Microsoft, and Apple pills as sign-in/sign-up, stacked full width, instead of three accent OverlayPanelActionButtons side by side. Labels come from CONNECT_CALENDAR_LABEL ("Connect Google Calendar", etc.).

SignInProviderButtons gained optional labels, shortcutKeys, and busyLabel props plus a built-in full-width stack wrapper. The prompt variant of ConnectProviderChooser delegates to it; BOOKING_CONNECT_BUTTON_LABEL was removed.

## Verify

Selected packages: web
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)

All checks passed
VERDICT: PASS