### PR TITLE
feat(web): one-click turn on for the booking page

### DIFF
--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -215,26 +215,48 @@ blocks.
 
 ### Host Settings controls
 
-The Settings **Booking** page is keyboard-first. It is not a native
-timezone `<select>` plus a checkbox and two time inputs per weekday.
+The Settings **Booking** page is keyboard-first. It is split into a
+status header, an Essentials group, and a collapsed **More options**
+group. It is not a native timezone `<select>` plus a checkbox and two
+time inputs per weekday.
 
+- **Status:** a live page shows "Your booking page is live" and the
+  public link with Copy and **Open booking page**. A page that is not
+  live shows "Your booking page is not live yet".
+- **Essentials:** Duration, booking timezone, weekly hours, and
+  destination calendar. These fit without scrolling at 1440x900.
+- **More options:** an uncontrolled native `<details>` that starts
+  collapsed. It holds blocking calendars, welcome text, notice and
+  horizon, and buffer and limits. Jumping to a field inside it, or an
+  invalid field in the group, opens it. Do not control the `open` prop
+  from React: the jump-key code opens the element imperatively.
 - **Timezone** uses the same searchable combobox as time travel. The
   trigger is one tab stop and still renders a stored non-canonical alias.
 - **Weekly hours** are one typed range per weekday (`9-5`, or `9-12, 1-5`
   for a break). A blank day is unavailable. The parser reuses
   `parseUserTime` with an explicit PM-correction rule.
-- **Jump:** `e` then a letter focuses a field (`e` enable, `d` duration,
-  `c` destination, `b` blocking, `z` timezone, `h` hours, `w` welcome,
-  `n` notice, `x` horizon, `o` buffer and limits, `l` link). Settings
-  owns Mod+Enter (save) and digits `1/2/3` (nav) on this page, which is
+- **Jump:** `e` then a letter focuses a field (`e` booking page on or
+  off, `d` duration, `c` destination, `b` blocking, `z` timezone,
+  `h` hours, `m` More options, `w` welcome, `n` notice, `x` horizon,
+  `o` buffer and limits, `l` link). Settings owns Mod+Enter (the
+  primary save action) and digits `1/2/3` (nav) on this page, which is
   why the leader is `e` rather than `Mod+digit`. Focus uses
   `data-booking-field` and does not click, so jumping onto a checkbox
-  does not toggle it.
-- **Save:** a successful save that returns a booking URL copies it. A
-  page that has never been enabled has no slug yet, so the toast says to
-  enable booking instead. Safari can drop a copy that follows the save
-  round trip; the toast then names `e` then `l`, and the Copy button
-  stays.
+  does not toggle it. Before focusing, the helper opens any ancestor
+  `<details>`.
+- **Turn on / Save:** going live is one click. When the page is not
+  live, the primary action is **Turn on booking page** (Mod+Enter).
+  **Save draft** appears only when the form is dirty. When the page is
+  live, the primary action is **Save changes** and the secondary action
+  is **Turn off booking page**. The Enable booking page checkbox is
+  gone. Validation and server errors render beside the save bar and
+  focus the offending field.
+- **Toasts:** turning on copies the link (`Your booking page is live.
+  Link copied.`, or `Live. Press e then l to copy your link.` if the
+  clipboard fails). Save changes copies the link with today's Saved
+  copy. Turn off says `Booking page turned off.` Save draft says
+  `Saved. Turn on your booking page to share the link.` Safari can drop
+  a copy that follows the save round trip; the Copy button stays.
 - **Open booking page** sits next to Copy and opens the public URL in a
   new tab. There is no authenticated preview iframe.
 - **Discard:** Escape on a dirty Booking form opens **Discard unsaved

--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 import {
   buildBookableSlot,
+  dispatchClick,
   dispatchFill,
   formatSlotButtonLabel,
   preparePublicBookingCancelPage,
@@ -341,9 +342,9 @@ test.describe("settings booking section", () => {
       weeklyAvailability: [],
     });
     const settingsDialog = page.getByRole("dialog", { name: "Settings" });
-    await settingsDialog
-      .getByRole("button", { name: "Turn on booking page" })
-      .click();
+    await dispatchClick(
+      settingsDialog.getByRole("button", { name: "Turn on booking page" }),
+    );
     await expect(
       settingsDialog.getByRole("alert").filter({
         hasText: "Add weekly hours before turning on your booking page.",

--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -324,10 +324,33 @@ test.describe("settings booking section", () => {
   }) => {
     await prepareSignedInBookingSettingsPage(page);
     const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+    await settingsDialog.getByText("More options", { exact: true }).click();
     await dispatchFill(settingsDialog.getByLabel("Maximum horizon (days)"), "");
     await expect(settingsDialog.getByText("Enter 1 to 60 days.")).toBeVisible();
     await expectNoAxeViolations(page, {
       checkpoint: "settings booking error",
+      include: "[role='dialog']",
+    });
+  });
+
+  test("inline save errors have no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await prepareSignedInBookingSettingsPage(page, {
+      enabled: false,
+      weeklyAvailability: [],
+    });
+    const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+    await settingsDialog
+      .getByRole("button", { name: "Turn on booking page" })
+      .click();
+    await expect(
+      settingsDialog.getByRole("alert").filter({
+        hasText: "Add weekly hours before turning on your booking page.",
+      }),
+    ).toBeVisible();
+    await expectNoAxeViolations(page, {
+      checkpoint: "settings booking inline save error",
       include: "[role='dialog']",
     });
   });

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -1,4 +1,5 @@
 import { expect, type Page } from "@playwright/test";
+import { DEFAULT_WEEKLY_AVAILABILITY } from "@core/types/booking.contracts";
 
 /** ObjectId-shaped id for stubbed Google calendar in host settings e2e. */
 export const BOOKING_CALENDAR_ID = "64b7f0a1c2d3e4f5a6b7c8d9";
@@ -961,6 +962,12 @@ export interface HostBookingSettingsStubOptions {
   slug?: string;
   bookingUrl?: string;
   microsoftConnect?: boolean;
+  enabled?: boolean;
+  weeklyAvailability?: Array<{
+    weekday: 1 | 2 | 3 | 4 | 5 | 6 | 7;
+    start: string;
+    end: string;
+  }>;
 }
 
 export interface CapturedHostBookingRequests {
@@ -974,6 +981,9 @@ export async function prepareSignedInBookingSettingsPage(
   const slug = options.slug ?? "hostuser";
   const bookingUrl =
     options.bookingUrl ?? `https://compasscalendar.com/book/${slug}`;
+  const enabled = options.enabled ?? true;
+  const weeklyAvailability =
+    options.weeklyAvailability ?? DEFAULT_WEEKLY_AVAILABILITY;
   const captured: CapturedHostBookingRequests = { putBodies: [] };
 
   await page.addInitScript((accountEmail) => {
@@ -987,12 +997,12 @@ export async function prepareSignedInBookingSettingsPage(
   }, HOST_ACCOUNT_EMAIL);
 
   const bookingPagePayload = {
-    enabled: false,
+    enabled,
     durationMinutes: 45,
     destinationCalendarId: BOOKING_CALENDAR_ID,
     blockingCalendarIds: [BOOKING_CALENDAR_ID],
     timeZone: "America/New_York",
-    weeklyAvailability: [],
+    weeklyAvailability,
     welcomeText: null,
     minNoticeHours: 4,
     maxHorizonDays: 60,
@@ -1158,7 +1168,9 @@ export async function prepareSignedInBookingSettingsPage(
       ?.click();
   });
   await expect(
-    settingsDialog.getByRole("button", { name: "Save booking settings" }),
+    settingsDialog.getByRole("button", {
+      name: enabled ? "Save changes" : "Turn on booking page",
+    }),
   ).toBeVisible({ timeout: 15000 });
 
   return captured;

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Locator, test } from "@playwright/test";
 import {
   BOOKING_CALENDAR_ID,
   COMPASS_CALENDAR_ID,
@@ -8,6 +8,10 @@ import {
 } from "./booking-harness";
 
 test.use({ viewport: { width: 1600, height: 900 } });
+
+const openMoreOptions = async (settingsDialog: Locator) => {
+  await settingsDialog.getByText("More options", { exact: true }).click();
+};
 
 test("settings booking page shows a copyable public link after save", async ({
   page,
@@ -20,7 +24,7 @@ test("settings booking page shows a copyable public link after save", async ({
   const settingsDialog = page.getByRole("dialog", { name: "Settings" });
   await settingsDialog.getByLabel("Duration").selectOption("30");
   await dispatchClick(
-    settingsDialog.getByRole("button", { name: "Save booking settings" }),
+    settingsDialog.getByRole("button", { name: "Save changes" }),
   );
 
   await expect.poll(() => captured.putBodies.length).toBe(1);
@@ -32,12 +36,9 @@ test("settings booking page shows a copyable public link after save", async ({
   ).toHaveAttribute("href", bookingUrl);
   expect(captured.putBodies[0]).toMatchObject({ durationMinutes: 30 });
 
-  // A second save has to reach the network too. Seeding the form from the
-  // saved-page response used to smuggle response-only keys into the strict
-  // PUT schema, so every save after the first died before the request.
   await settingsDialog.getByLabel("Duration").selectOption("15");
   await dispatchClick(
-    settingsDialog.getByRole("button", { name: "Save booking settings" }),
+    settingsDialog.getByRole("button", { name: "Save changes" }),
   );
 
   await expect.poll(() => captured.putBodies.length).toBe(2);
@@ -50,6 +51,7 @@ test("clearing the horizon field shows an inline error and blocks save", async (
   const captured = await prepareSignedInBookingSettingsPage(page);
 
   const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+  await openMoreOptions(settingsDialog);
   const horizon = settingsDialog.getByLabel("Maximum horizon (days)");
   await dispatchFill(horizon, "");
 
@@ -57,7 +59,7 @@ test("clearing the horizon field shows an inline error and blocks save", async (
   await expect(horizon).toHaveAttribute("aria-invalid", "true");
 
   await dispatchClick(
-    settingsDialog.getByRole("button", { name: "Save booking settings" }),
+    settingsDialog.getByRole("button", { name: "Save changes" }),
   );
   await expect(
     settingsDialog.getByText(
@@ -69,7 +71,7 @@ test("clearing the horizon field shows an inline error and blocks save", async (
   await dispatchFill(horizon, "30");
   await expect(settingsDialog.getByText("Enter 1 to 60 days.")).toHaveCount(0);
   await dispatchClick(
-    settingsDialog.getByRole("button", { name: "Save booking settings" }),
+    settingsDialog.getByRole("button", { name: "Save changes" }),
   );
 
   await expect.poll(() => captured.putBodies.length).toBe(1);
@@ -83,12 +85,13 @@ test("saves welcome text", async ({ page }) => {
   });
 
   const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+  await openMoreOptions(settingsDialog);
   await dispatchFill(
     settingsDialog.getByLabel("Welcome text"),
     "30 minutes to talk through Compass.",
   );
   await dispatchClick(
-    settingsDialog.getByRole("button", { name: "Save booking settings" }),
+    settingsDialog.getByRole("button", { name: "Save changes" }),
   );
 
   await expect.poll(() => captured.putBodies.length).toBe(1);
@@ -108,6 +111,7 @@ test("keyboard hint sits above the public link and the last control stays above 
   });
 
   const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+  await openMoreOptions(settingsDialog);
   const hint = settingsDialog
     .locator("p")
     .filter({ hasText: "then a letter to jump to a field" });
@@ -116,7 +120,7 @@ test("keyboard hint sits above the public link and the last control stays above 
     name: "Guest can invite others",
   });
   const save = settingsDialog.getByRole("button", {
-    name: "Save booking settings",
+    name: "Save changes",
   });
 
   await expect(hint).toBeVisible();
@@ -145,15 +149,12 @@ test("saves with Compass checked as a blocking calendar", async ({ page }) => {
   const captured = await prepareSignedInBookingSettingsPage(page);
 
   const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+  await openMoreOptions(settingsDialog);
   const compass = settingsDialog.getByRole("checkbox", { name: "Compass" });
   await expect(compass).toBeVisible();
-  // Calendars query replaces the synthetic local Compass id. Wait for Work
-  // (the stubbed Google calendar) so Compass is the fixture, not a placeholder.
   await expect(
     settingsDialog.getByRole("checkbox", { name: "Work" }),
   ).toBeVisible();
-  // Placeholder defaults check Compass first; the saved-page seed then
-  // unchecks it. Wait for that before checking it for the PUT.
   await expect.poll(async () => compass.isChecked()).toBe(false);
   await compass.evaluate((el) => {
     (el as HTMLInputElement).click();
@@ -161,11 +162,65 @@ test("saves with Compass checked as a blocking calendar", async ({ page }) => {
   await expect(compass).toBeChecked();
 
   await dispatchClick(
-    settingsDialog.getByRole("button", { name: "Save booking settings" }),
+    settingsDialog.getByRole("button", { name: "Save changes" }),
   );
 
   await expect.poll(() => captured.putBodies.length).toBe(1);
   expect(captured.putBodies[0]?.blockingCalendarIds).toEqual(
     expect.arrayContaining([BOOKING_CALENDAR_ID, COMPASS_CALENDAR_ID]),
+  );
+});
+
+test("turns on a not-live page in one click", async ({ page }) => {
+  const captured = await prepareSignedInBookingSettingsPage(page, {
+    enabled: false,
+  });
+
+  const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+  await dispatchClick(
+    settingsDialog.getByRole("button", { name: "Turn on booking page" }),
+  );
+
+  await expect.poll(() => captured.putBodies.length).toBe(1);
+  expect(captured.putBodies[0]).toMatchObject({ enabled: true });
+});
+
+test("blocks turn on with empty hours", async ({ page }) => {
+  const captured = await prepareSignedInBookingSettingsPage(page, {
+    enabled: false,
+    weeklyAvailability: [],
+  });
+
+  const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+  await dispatchClick(
+    settingsDialog.getByRole("button", { name: "Turn on booking page" }),
+  );
+
+  await expect(
+    settingsDialog.getByRole("alert").filter({
+      hasText: "Add weekly hours before turning on your booking page.",
+    }),
+  ).toBeVisible();
+  expect(captured.putBodies.length).toBe(0);
+});
+
+test("essentials fit without scrolling at 1440x900", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await prepareSignedInBookingSettingsPage(page);
+
+  const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+  const summary = settingsDialog.getByText("More options", { exact: true });
+  await expect(summary).toBeVisible();
+
+  await settingsDialog.evaluate((el) => {
+    el.scrollTop = 0;
+  });
+
+  const dialogBox = await settingsDialog.boundingBox();
+  const summaryBox = await summary.boundingBox();
+  expect(dialogBox).not.toBeNull();
+  expect(summaryBox).not.toBeNull();
+  expect(summaryBox!.y + summaryBox!.height).toBeLessThanOrEqual(
+    dialogBox!.y + dialogBox!.height,
   );
 });

--- a/packages/web/src/booking/BookingBlockingCalendarsField.tsx
+++ b/packages/web/src/booking/BookingBlockingCalendarsField.tsx
@@ -11,7 +11,7 @@ import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 
 interface BookingBlockingCalendarsFieldProps {
   availabilityCalendars: Calendar[];
-  blockingCalendarIds: CalendarId[];
+  blockingCalendarIds: readonly CalendarId[];
   connections: SyncConnectionSummary[];
   onToggle: (calendarId: CalendarId, checked: boolean) => void;
   showShortcuts: boolean;

--- a/packages/web/src/booking/BookingBlockingCalendarsField.tsx
+++ b/packages/web/src/booking/BookingBlockingCalendarsField.tsx
@@ -1,0 +1,75 @@
+import { type Calendar } from "@core/types/calendar.contracts";
+import { type CalendarId } from "@core/types/domain-primitives";
+import { type SyncConnectionSummary } from "@core/types/user.types";
+import { BookingCheckboxRow } from "@web/booking/BookingCheckboxRow";
+import {
+  bookingFieldAttrs,
+  bookingJumpKeys,
+} from "@web/booking/booking-sequence.fields";
+import { groupCalendarsByAccount } from "@web/calendars/calendar.util";
+import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
+
+interface BookingBlockingCalendarsFieldProps {
+  availabilityCalendars: Calendar[];
+  blockingCalendarIds: CalendarId[];
+  connections: SyncConnectionSummary[];
+  onToggle: (calendarId: CalendarId, checked: boolean) => void;
+  showShortcuts: boolean;
+}
+
+export function BookingBlockingCalendarsField({
+  availabilityCalendars,
+  blockingCalendarIds,
+  connections,
+  onToggle,
+  showShortcuts,
+}: BookingBlockingCalendarsFieldProps) {
+  const blockingSet = new Set(blockingCalendarIds);
+  const { groups, ungrouped } = groupCalendarsByAccount(
+    availabilityCalendars,
+    connections,
+  );
+
+  const renderBlockingCalendar = (calendar: Calendar) => (
+    <BookingCheckboxRow
+      checked={blockingSet.has(calendar.id)}
+      key={calendar.id}
+      onChange={(checked) => onToggle(calendar.id, checked)}
+    >
+      {calendar.name}
+    </BookingCheckboxRow>
+  );
+
+  return (
+    <fieldset
+      className="flex flex-col gap-2"
+      {...bookingFieldAttrs("blocking")}
+    >
+      <legend className="mb-1 flex items-center gap-1 text-sm text-text">
+        Blocking calendars
+        {showShortcuts ? (
+          <ShortcutKeys keys={bookingJumpKeys("blocking")} />
+        ) : null}
+      </legend>
+      {availabilityCalendars.length === 0 ? (
+        <p className="text-sm text-text-muted">No calendars available.</p>
+      ) : (
+        <>
+          {groups
+            .filter((group) => group.calendars.length > 0)
+            .map((group) => (
+              <div className="flex flex-col gap-1" key={group.accountEmail}>
+                <p className="text-text-muted text-xs">{group.accountEmail}</p>
+                {group.calendars.map(renderBlockingCalendar)}
+              </div>
+            ))}
+          {ungrouped.map(renderBlockingCalendar)}
+        </>
+      )}
+      <p className="text-text-muted text-xs">
+        Pending, maybe, and declined invites do not hold booking times. Accepted
+        invites and events the host organizes do.
+      </p>
+    </fieldset>
+  );
+}

--- a/packages/web/src/booking/BookingLimitsFieldset.tsx
+++ b/packages/web/src/booking/BookingLimitsFieldset.tsx
@@ -1,0 +1,72 @@
+import { type AdminPutBookingPageInput } from "@core/types/booking.contracts";
+import { BookingCheckboxRow } from "@web/booking/BookingCheckboxRow";
+import {
+  bookingFieldAttrs,
+  bookingJumpKeys,
+} from "@web/booking/booking-sequence.fields";
+import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
+
+const DEFAULT_BUFFER_MINUTES = 30;
+const DEFAULT_MAX_BOOKINGS_PER_DAY = 4;
+
+interface BookingLimitsFieldsetProps {
+  bufferMinutes: AdminPutBookingPageInput["bufferMinutes"];
+  guestsCanInviteOthers: boolean;
+  maxBookingsPerDay: AdminPutBookingPageInput["maxBookingsPerDay"];
+  onChange: (patch: Partial<AdminPutBookingPageInput>) => void;
+  showShortcuts: boolean;
+}
+
+export function BookingLimitsFieldset({
+  bufferMinutes,
+  guestsCanInviteOthers,
+  maxBookingsPerDay,
+  onChange,
+  showShortcuts,
+}: BookingLimitsFieldsetProps) {
+  return (
+    <fieldset className="flex flex-col gap-2" {...bookingFieldAttrs("options")}>
+      <legend className="mb-1 flex items-center gap-1 text-sm text-text">
+        Buffer and limits
+        {showShortcuts ? (
+          <ShortcutKeys keys={bookingJumpKeys("options")} />
+        ) : null}
+      </legend>
+
+      <BookingCheckboxRow
+        checked={bufferMinutes !== null}
+        onChange={(checked) =>
+          onChange({
+            bufferMinutes: checked ? DEFAULT_BUFFER_MINUTES : null,
+          })
+        }
+      >
+        Buffer between appointments ({DEFAULT_BUFFER_MINUTES} minutes)
+      </BookingCheckboxRow>
+
+      <BookingCheckboxRow
+        checked={maxBookingsPerDay !== null}
+        onChange={(checked) =>
+          onChange({
+            maxBookingsPerDay: checked ? DEFAULT_MAX_BOOKINGS_PER_DAY : null,
+          })
+        }
+      >
+        Max bookings per day ({DEFAULT_MAX_BOOKINGS_PER_DAY})
+      </BookingCheckboxRow>
+
+      <BookingCheckboxRow
+        checked={guestsCanInviteOthers}
+        onChange={(nextGuestsCanInviteOthers) =>
+          onChange({ guestsCanInviteOthers: nextGuestsCanInviteOthers })
+        }
+      >
+        Guest can invite others
+      </BookingCheckboxRow>
+      <p className="text-text-muted text-xs">
+        When this is on, Compass cannot put the cancel link in the calendar
+        description. Guests keep it from the confirmation page.
+      </p>
+    </fieldset>
+  );
+}

--- a/packages/web/src/booking/BookingMoreOptions.tsx
+++ b/packages/web/src/booking/BookingMoreOptions.tsx
@@ -1,0 +1,43 @@
+import { type ReactNode, useEffect, useRef } from "react";
+import {
+  bookingFieldAttrs,
+  bookingJumpKeys,
+} from "@web/booking/booking-sequence.fields";
+import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
+
+export const BOOKING_MORE_OPTIONS_LABEL = "More options";
+
+interface BookingMoreOptionsProps {
+  children: ReactNode;
+  forceOpen?: boolean;
+  showShortcuts?: boolean;
+}
+
+export function BookingMoreOptions({
+  children,
+  forceOpen = false,
+  showShortcuts = false,
+}: BookingMoreOptionsProps) {
+  const detailsRef = useRef<HTMLDetailsElement>(null);
+
+  useEffect(() => {
+    if (forceOpen && detailsRef.current) {
+      detailsRef.current.open = true;
+    }
+  }, [forceOpen]);
+
+  return (
+    <details className="flex flex-col gap-4" ref={detailsRef}>
+      <summary
+        className="c-focus-ring cursor-pointer list-inside text-sm font-medium text-text"
+        {...bookingFieldAttrs("more")}
+      >
+        {BOOKING_MORE_OPTIONS_LABEL}
+        {showShortcuts ? (
+          <ShortcutKeys className="ml-1" keys={bookingJumpKeys("more")} />
+        ) : null}
+      </summary>
+      <div className="mt-3 flex flex-col gap-4">{children}</div>
+    </details>
+  );
+}

--- a/packages/web/src/booking/BookingMoreOptions.tsx
+++ b/packages/web/src/booking/BookingMoreOptions.tsx
@@ -29,7 +29,7 @@ export function BookingMoreOptions({
   return (
     <details className="flex flex-col gap-4" ref={detailsRef}>
       <summary
-        className="c-focus-ring cursor-pointer list-inside text-sm font-medium text-text"
+        className="c-focus-ring cursor-pointer list-inside font-medium text-sm text-text"
         {...bookingFieldAttrs("more")}
       >
         {BOOKING_MORE_OPTIONS_LABEL}

--- a/packages/web/src/booking/BookingSaveBar.tsx
+++ b/packages/web/src/booking/BookingSaveBar.tsx
@@ -1,0 +1,82 @@
+import { bookingFieldAttrs } from "@web/booking/booking-sequence.fields";
+import {
+  OverlayPanelActionButton,
+  OverlayPanelActions,
+} from "@web/components/OverlayPanel/OverlayPanel";
+import { settingsShortcutAttrs } from "@web/settings/useSettingsShortcuts";
+
+export const BOOKING_TURN_ON_LABEL = "Turn on booking page";
+export const BOOKING_SAVE_DRAFT_LABEL = "Save draft";
+export const BOOKING_SAVE_CHANGES_LABEL = "Save changes";
+export const BOOKING_TURN_OFF_LABEL = "Turn off booking page";
+
+export const BOOKING_SETTINGS_SAVE_BAR_CLASS_NAME =
+  "sticky -bottom-8 z-10 border-border border-t bg-surface-panel pt-3 pb-8";
+
+interface BookingSaveBarProps {
+  error: string | null;
+  isDirty: boolean;
+  isLive: boolean;
+  isPending: boolean;
+  onSubmit: (enabled: boolean) => void;
+}
+
+export function BookingSaveBar({
+  error,
+  isDirty,
+  isLive,
+  isPending,
+  onSubmit,
+}: BookingSaveBarProps) {
+  const primaryLabel = isLive
+    ? BOOKING_SAVE_CHANGES_LABEL
+    : BOOKING_TURN_ON_LABEL;
+  const pendingLabel = isPending ? "Saving…" : primaryLabel;
+
+  return (
+    <div className={BOOKING_SETTINGS_SAVE_BAR_CLASS_NAME}>
+      {error ? (
+        <p className="mb-2 text-error text-sm" role="alert">
+          {error}
+        </p>
+      ) : null}
+      {/* Default align=end keeps the always-on chip Save off the hours column. */}
+      <OverlayPanelActions>
+        {isLive ? (
+          <OverlayPanelActionButton
+            className="whitespace-nowrap"
+            disabled={isPending}
+            onClick={() => onSubmit(false)}
+            variant="secondary"
+            {...bookingFieldAttrs("enabled")}
+          >
+            {BOOKING_TURN_OFF_LABEL}
+          </OverlayPanelActionButton>
+        ) : isDirty ? (
+          <OverlayPanelActionButton
+            className="whitespace-nowrap"
+            disabled={isPending}
+            onClick={() => onSubmit(false)}
+            variant="secondary"
+          >
+            {BOOKING_SAVE_DRAFT_LABEL}
+          </OverlayPanelActionButton>
+        ) : null}
+        <OverlayPanelActionButton
+          aria-busy={isPending || undefined}
+          aria-keyshortcuts="Meta+Enter Control+Enter"
+          className="whitespace-nowrap"
+          disabled={isPending}
+          onClick={() => onSubmit(true)}
+          shortcut={["Mod", "Enter"]}
+          showShortcut
+          variant="primary"
+          {...settingsShortcutAttrs("save-booking")}
+          {...(isLive ? {} : bookingFieldAttrs("enabled"))}
+        >
+          {pendingLabel}
+        </OverlayPanelActionButton>
+      </OverlayPanelActions>
+    </div>
+  );
+}

--- a/packages/web/src/booking/BookingSaveBar.tsx
+++ b/packages/web/src/booking/BookingSaveBar.tsx
@@ -36,7 +36,7 @@ export function BookingSaveBar({
   return (
     <div className={BOOKING_SETTINGS_SAVE_BAR_CLASS_NAME}>
       {error ? (
-        <p className="mb-2 text-error text-sm" role="alert">
+        <p className="mb-2 font-medium text-sm text-text" role="alert">
           {error}
         </p>
       ) : null}

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -1370,9 +1370,11 @@ describe("BookingSettingsSection", () => {
       screen.getByRole("button", { name: BOOKING_TURN_ON_LABEL }),
     );
 
-    expect(screen.getByRole("alert")).toHaveTextContent(
+    const hoursAlert = screen.getByRole("alert");
+    expect(hoursAlert).toHaveTextContent(
       "Add weekly hours before turning on your booking page.",
     );
+    expect(findStickyAncestor(hoursAlert)).not.toBeNull();
     expect(putCount).toBe(0);
     expect(document.activeElement).toBe(screen.getByLabelText("Monday"));
   });

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -16,10 +16,18 @@ import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
 import { CONNECT_CALENDAR_LABEL } from "@web/auth/providers/provider-copy.util";
 import { setProviderAvailabilityForTests } from "@web/auth/providers/useIsProviderAvailable";
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
+import { BOOKING_MORE_OPTIONS_LABEL } from "@web/booking/BookingMoreOptions";
+import {
+  BOOKING_SAVE_CHANGES_LABEL,
+  BOOKING_SAVE_DRAFT_LABEL,
+  BOOKING_TURN_OFF_LABEL,
+  BOOKING_TURN_ON_LABEL,
+} from "@web/booking/BookingSaveBar";
 import {
   BOOKING_SETTINGS_HINT_PARTS,
   BookingSettingsSection,
 } from "@web/booking/BookingSettingsSection";
+import { BOOKING_SAVE_ERROR_COPY } from "@web/booking/booking.query";
 import { BOOKING_APPLE_DESTINATION_HINT } from "@web/booking/booking-conference.copy";
 import {
   BOOKING_FIELD_BY_KEY,
@@ -235,7 +243,7 @@ describe("BookingSettingsSection", () => {
             destinationCalendarId: writableCalendar.id,
             blockingCalendarIds: [writableCalendar.id],
             timeZone: "America/New_York",
-            weeklyAvailability: [],
+            weeklyAvailability: DEFAULT_WEEKLY_AVAILABILITY,
             minNoticeHours: 4,
             maxHorizonDays: 60,
             bufferMinutes: null,
@@ -271,7 +279,7 @@ describe("BookingSettingsSection", () => {
     );
 
     const save = await screen.findByRole("button", {
-      name: "Save booking settings",
+      name: BOOKING_TURN_ON_LABEL,
     });
     const stickyBar = findStickyAncestor(save);
     expect(stickyBar).not.toBeNull();
@@ -282,11 +290,14 @@ describe("BookingSettingsSection", () => {
 
     await user.selectOptions(screen.getByLabelText("Duration"), "30");
     await user.click(
-      screen.getByRole("button", { name: "Save booking settings" }),
+      screen.getByRole("button", { name: BOOKING_TURN_ON_LABEL }),
     );
 
     await waitFor(() => {
-      expect(savedBody).toMatchObject({ durationMinutes: 30 });
+      expect(savedBody).toMatchObject({
+        durationMinutes: 30,
+        enabled: true,
+      });
     });
 
     expect(await screen.findByLabelText("Public booking link")).toHaveValue(
@@ -341,7 +352,9 @@ describe("BookingSettingsSection", () => {
       getPartsPlainText(BOOKING_SETTINGS_HINT_PARTS),
     );
     const publicLink = screen.getByLabelText("Public booking link");
-    const save = screen.getByRole("button", { name: /Save booking settings/ });
+    const save = screen.getByRole("button", {
+      name: BOOKING_SAVE_CHANGES_LABEL,
+    });
     const lastControl = screen.getByRole("checkbox", {
       name: "Guest can invite others",
     });
@@ -415,7 +428,7 @@ describe("BookingSettingsSection", () => {
       destinationCalendarId: writableCalendar.id,
       blockingCalendarIds: [writableCalendar.id],
       timeZone: "America/New_York",
-      weeklyAvailability: [],
+      weeklyAvailability: DEFAULT_WEEKLY_AVAILABILITY,
       minNoticeHours: 4,
       maxHorizonDays: 60,
       bufferMinutes: null,
@@ -445,11 +458,11 @@ describe("BookingSettingsSection", () => {
       { wrapper },
     );
 
-    await screen.findByRole("button", { name: "Save booking settings" });
+    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
 
     await user.selectOptions(screen.getByLabelText("Duration"), "30");
     await user.click(
-      screen.getByRole("button", { name: "Save booking settings" }),
+      screen.getByRole("button", { name: BOOKING_SAVE_DRAFT_LABEL }),
     );
     await waitFor(() => {
       expect(savedBodies).toHaveLength(1);
@@ -457,7 +470,7 @@ describe("BookingSettingsSection", () => {
 
     await user.selectOptions(screen.getByLabelText("Duration"), "15");
     await user.click(
-      screen.getByRole("button", { name: "Save booking settings" }),
+      screen.getByRole("button", { name: BOOKING_SAVE_DRAFT_LABEL }),
     );
 
     await waitFor(() => {
@@ -530,7 +543,7 @@ describe("BookingSettingsSection", () => {
     ).toBeInTheDocument();
 
     await user.click(
-      screen.getByRole("button", { name: "Save booking settings" }),
+      screen.getByRole("button", { name: BOOKING_TURN_ON_LABEL }),
     );
     await waitFor(() => {
       expect(savedBody).toMatchObject({ guestsCanInviteOthers: true });
@@ -646,7 +659,7 @@ describe("BookingSettingsSection", () => {
       </HotkeysProvider>,
       { wrapper },
     );
-    await screen.findByRole("button", { name: "Save booking settings" });
+    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
     expect(isAppLocked()).toBe(true);
 
     await user.keyboard("e");
@@ -674,7 +687,7 @@ describe("BookingSettingsSection", () => {
       </HotkeysProvider>,
       { wrapper },
     );
-    await screen.findByRole("button", { name: "Save booking settings" });
+    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
 
     await user.keyboard("e");
     await user.keyboard("w");
@@ -701,7 +714,7 @@ describe("BookingSettingsSection", () => {
       </HotkeysProvider>,
       { wrapper },
     );
-    await screen.findByRole("button", { name: "Save booking settings" });
+    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
 
     await user.keyboard("e");
     await user.keyboard("z");
@@ -729,7 +742,7 @@ describe("BookingSettingsSection", () => {
       </HotkeysProvider>,
       { wrapper },
     );
-    await screen.findByRole("button", { name: "Save booking settings" });
+    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
 
     await user.click(
       screen.getByRole("button", { name: /^Booking timezone:/ }),
@@ -770,7 +783,7 @@ describe("BookingSettingsSection", () => {
       </HotkeysProvider>,
       { wrapper },
     );
-    await screen.findByRole("button", { name: "Save booking settings" });
+    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
 
     // "9-5, then 11-2" is not real input, but any typed letter would be: a
     // bare `e` must reach the field, not swallow the next keystroke.
@@ -806,12 +819,12 @@ describe("BookingSettingsSection", () => {
       </HotkeysProvider>,
       { wrapper },
     );
-    await screen.findByRole("button", { name: "Save booking settings" });
+    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
 
     await user.type(screen.getByLabelText("Monday"), "whenever");
     await user.tab();
     await user.click(
-      screen.getByRole("button", { name: "Save booking settings" }),
+      screen.getByRole("button", { name: BOOKING_TURN_ON_LABEL }),
     );
 
     expect(putCount).toBe(0);
@@ -844,7 +857,7 @@ describe("BookingSettingsSection", () => {
       </HotkeysProvider>,
       { wrapper },
     );
-    await screen.findByRole("button", { name: "Save booking settings" });
+    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
 
     await user.type(
       screen.getByLabelText("Welcome text"),
@@ -852,7 +865,7 @@ describe("BookingSettingsSection", () => {
     );
 
     await user.click(
-      screen.getByRole("button", { name: "Save booking settings" }),
+      screen.getByRole("button", { name: BOOKING_TURN_ON_LABEL }),
     );
 
     await waitFor(() => {
@@ -922,7 +935,7 @@ describe("BookingSettingsSection", () => {
     );
 
     const save = await screen.findByRole("button", {
-      name: "Save booking settings",
+      name: BOOKING_TURN_ON_LABEL,
     });
     expect(save).toHaveAttribute(
       "aria-keyshortcuts",
@@ -970,10 +983,10 @@ describe("BookingSettingsSection", () => {
       </HotkeysProvider>,
       { wrapper },
     );
-    await screen.findByRole("button", { name: "Save booking settings" });
+    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
 
     await user.click(
-      screen.getByRole("button", { name: "Save booking settings" }),
+      screen.getByRole("button", { name: BOOKING_TURN_ON_LABEL }),
     );
 
     await waitFor(() => {
@@ -1009,10 +1022,11 @@ describe("BookingSettingsSection", () => {
       </HotkeysProvider>,
       { wrapper },
     );
-    await screen.findByRole("button", { name: "Save booking settings" });
+    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
 
+    await user.selectOptions(screen.getByLabelText("Duration"), "45");
     await user.click(
-      screen.getByRole("button", { name: "Save booking settings" }),
+      screen.getByRole("button", { name: BOOKING_SAVE_DRAFT_LABEL }),
     );
 
     await waitFor(() => {
@@ -1310,8 +1324,10 @@ describe("BookingSettingsSection", () => {
       { wrapper },
     );
 
-    await screen.findByLabelText("Enable booking page");
-    await user.click(screen.getByLabelText("Enable booking page"));
+    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
+    await user.click(
+      screen.getByRole("button", { name: BOOKING_TURN_ON_LABEL }),
+    );
 
     expect(screen.getByRole("alert")).toHaveTextContent(
       "Choose a destination calendar before enabling booking.",
@@ -1349,16 +1365,16 @@ describe("BookingSettingsSection", () => {
       { wrapper },
     );
 
-    await screen.findByLabelText("Enable booking page");
-    await user.click(screen.getByLabelText("Enable booking page"));
+    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
     await user.click(
-      screen.getByRole("button", { name: "Save booking settings" }),
+      screen.getByRole("button", { name: BOOKING_TURN_ON_LABEL }),
     );
 
     expect(screen.getByRole("alert")).toHaveTextContent(
       "Add weekly hours before turning on your booking page.",
     );
     expect(putCount).toBe(0);
+    expect(document.activeElement).toBe(screen.getByLabelText("Monday"));
   });
 
   it("renders Monday through Friday as 9-5 on a fresh unconfigured page", async () => {
@@ -1405,7 +1421,7 @@ describe("BookingSettingsSection", () => {
             destinationCalendarId: writableCalendar.id,
             blockingCalendarIds: [writableCalendar.id],
             timeZone: "UTC",
-            weeklyAvailability: [],
+            weeklyAvailability: DEFAULT_WEEKLY_AVAILABILITY,
             minNoticeHours: 4,
             maxHorizonDays: 60,
             bufferMinutes: null,
@@ -1436,13 +1452,13 @@ describe("BookingSettingsSection", () => {
       { wrapper },
     );
 
-    await screen.findByRole("button", { name: "Save booking settings" });
+    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
     await user.click(
-      screen.getByRole("button", { name: "Save booking settings" }),
+      screen.getByRole("button", { name: BOOKING_TURN_ON_LABEL }),
     );
 
     expect(
-      screen.getByRole("button", { name: "Save booking settings" }),
+      screen.getByRole("button", { name: BOOKING_TURN_ON_LABEL }),
     ).toBeInTheDocument();
     await waitFor(() => {
       expect(mocks.error).toHaveBeenCalledWith(
@@ -1471,7 +1487,7 @@ describe("BookingSettingsSection", () => {
             destinationCalendarId: writableCalendar.id,
             blockingCalendarIds: [writableCalendar.id],
             timeZone: "UTC",
-            weeklyAvailability: [],
+            weeklyAvailability: DEFAULT_WEEKLY_AVAILABILITY,
             minNoticeHours: 4,
             maxHorizonDays: 60,
             bufferMinutes: null,
@@ -1501,19 +1517,19 @@ describe("BookingSettingsSection", () => {
       { wrapper },
     );
 
-    await screen.findByRole("button", { name: "Save booking settings" });
+    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
     await user.click(
-      screen.getByRole("button", { name: "Save booking settings" }),
+      screen.getByRole("button", { name: BOOKING_TURN_ON_LABEL }),
     );
 
     await waitFor(() => {
-      expect(mocks.error).toHaveBeenCalledWith(
+      expect(screen.getByRole("alert")).toHaveTextContent(
         "One of your blocking calendars can't be checked for busy times. Uncheck it and save again.",
-        expect.any(Object),
       );
     });
-    expect(String(mocks.error.mock.calls[0]?.[0])).not.toMatch(
-      /Request failed for/,
+    expect(mocks.error).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(
+      screen.getByRole("checkbox", { name: "Work" }),
     );
   });
 
@@ -1549,7 +1565,7 @@ describe("BookingSettingsSection", () => {
     expect(horizon).toHaveAttribute("aria-invalid", "true");
 
     await user.click(
-      screen.getByRole("button", { name: "Save booking settings" }),
+      screen.getByRole("button", { name: BOOKING_TURN_ON_LABEL }),
     );
     expect(
       screen.getByText("Fix the highlighted number fields before saving."),
@@ -1560,7 +1576,7 @@ describe("BookingSettingsSection", () => {
     expect(screen.queryByText("Enter 1 to 60 days.")).not.toBeInTheDocument();
 
     await user.click(
-      screen.getByRole("button", { name: "Save booking settings" }),
+      screen.getByRole("button", { name: BOOKING_TURN_ON_LABEL }),
     );
     await waitFor(() => {
       expect(savedBody).toMatchObject({ maxHorizonDays: 30 });
@@ -1600,7 +1616,7 @@ describe("BookingSettingsSection", () => {
     expect(notice).toHaveAttribute("aria-invalid", "true");
 
     await user.click(
-      screen.getByRole("button", { name: "Save booking settings" }),
+      screen.getByRole("button", { name: BOOKING_TURN_ON_LABEL }),
     );
     expect(
       screen.getByText("Fix the highlighted number fields before saving."),
@@ -1614,11 +1630,248 @@ describe("BookingSettingsSection", () => {
     ).not.toBeInTheDocument();
 
     await user.click(
-      screen.getByRole("button", { name: "Save booking settings" }),
+      screen.getByRole("button", { name: BOOKING_TURN_ON_LABEL }),
     );
     await waitFor(() => {
       expect(savedBody).toMatchObject({ minNoticeHours: 4 });
     });
+  });
+
+  it("turns on a not-live page and toasts the live copy", async () => {
+    const user = userEvent.setup({ delay: null });
+    const { port, mocks } = createTestToastPort();
+    registerToastPort(port);
+    const writeText = mock(() => Promise.resolve());
+    setClipboard({ writeText });
+    let savedBody: unknown;
+    const bookingUrl = "https://compasscalendar.com/book/hostuser";
+
+    userMetadataActions.set(healthyGoogleMetadata);
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+      rest.put(bookingPageUrl, async (req, res, ctx) => {
+        savedBody = await req.json();
+        return res(
+          ctx.json({
+            ...(savedBody as object),
+            id: createObjectIdString(),
+            slug: "hostuser",
+            hostUserId: createObjectIdString(),
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            bookingUrl,
+          }),
+        );
+      }),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL }),
+    );
+
+    await waitFor(() => {
+      expect(savedBody).toMatchObject({ enabled: true });
+    });
+    expect(writeText).toHaveBeenCalledWith(bookingUrl);
+    expect(mocks.toast).toHaveBeenCalledWith(
+      "Your booking page is live. Link copied.",
+      expect.any(Object),
+    );
+  });
+
+  it("turns off a live page", async () => {
+    const user = userEvent.setup({ delay: null });
+    let savedBody: unknown;
+    const bookingUrl = "https://compasscalendar.com/book/hostuser";
+
+    userMetadataActions.set(healthyGoogleMetadata);
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(
+          ctx.json({
+            id: createObjectIdString(),
+            slug: "hostuser",
+            hostUserId: createObjectIdString(),
+            enabled: true,
+            durationMinutes: 30,
+            destinationCalendarId: writableCalendar.id,
+            blockingCalendarIds: [writableCalendar.id],
+            timeZone: "UTC",
+            weeklyAvailability: DEFAULT_WEEKLY_AVAILABILITY,
+            minNoticeHours: 4,
+            maxHorizonDays: 60,
+            bufferMinutes: null,
+            maxBookingsPerDay: null,
+            guestsCanInviteOthers: true,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            bookingUrl,
+          }),
+        ),
+      ),
+      rest.put(bookingPageUrl, async (req, res, ctx) => {
+        savedBody = await req.json();
+        return res(ctx.json({ ...(savedBody as object), bookingUrl }));
+      }),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: BOOKING_TURN_OFF_LABEL }),
+    );
+
+    await waitFor(() => {
+      expect(savedBody).toMatchObject({ enabled: false });
+    });
+  });
+
+  it("shows Save draft only when the form is dirty and not live", async () => {
+    const user = userEvent.setup({ delay: null });
+    userMetadataActions.set(healthyGoogleMetadata);
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
+    expect(
+      screen.queryByRole("button", { name: BOOKING_SAVE_DRAFT_LABEL }),
+    ).not.toBeInTheDocument();
+
+    await user.selectOptions(screen.getByLabelText("Duration"), "45");
+    expect(
+      screen.getByRole("button", { name: BOOKING_SAVE_DRAFT_LABEL }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps More options closed by default and opens it on e then w", async () => {
+    const user = userEvent.setup({ delay: null });
+    userMetadataActions.set(healthyGoogleMetadata);
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    const summary = await screen.findByText(BOOKING_MORE_OPTIONS_LABEL);
+    const details = summary.closest("details");
+    expect(details).not.toBeNull();
+    expect(details).not.toHaveAttribute("open");
+
+    await user.keyboard("e");
+    await user.keyboard("w");
+
+    expect(details).toHaveAttribute("open");
+    expect(document.activeElement).toBe(screen.getByLabelText("Welcome text"));
+  });
+
+  it("opens More options when a field inside the collapsed group becomes invalid", async () => {
+    const user = userEvent.setup({ delay: null });
+    userMetadataActions.set(healthyGoogleMetadata);
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    const summary = await screen.findByText(BOOKING_MORE_OPTIONS_LABEL);
+    const details = summary.closest("details");
+    expect(details).not.toHaveAttribute("open");
+
+    await user.clear(screen.getByLabelText("Maximum horizon (days)"));
+    expect(details).toHaveAttribute("open");
+  });
+
+  it("renders DESTINATION_NOT_WRITABLE inline, focuses destination, and does not toast", async () => {
+    const user = userEvent.setup({ delay: null });
+    const { port, mocks } = createTestToastPort();
+    registerToastPort(port);
+
+    userMetadataActions.set(healthyGoogleMetadata);
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+      rest.put(bookingPageUrl, (_req, res, ctx) =>
+        res(
+          ctx.status(400),
+          ctx.json({
+            code: "DESTINATION_NOT_WRITABLE",
+            message: "Calendar is not writable",
+          }),
+        ),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        BOOKING_SAVE_ERROR_COPY.DESTINATION_NOT_WRITABLE,
+      );
+    });
+    expect(mocks.error).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(
+      screen.getByRole("combobox", { name: "Destination calendar" }),
+    );
   });
 });
 
@@ -1685,5 +1938,22 @@ describe("focusBookingField", () => {
 
   it("reports false when the field is not rendered", () => {
     expect(focusBookingField("link")).toBe(false);
+  });
+
+  it("opens an ancestor details element before focusing", () => {
+    const details = document.createElement("details");
+    const summary = document.createElement("summary");
+    summary.textContent = "More options";
+    const wrapper = document.createElement("div");
+    wrapper.setAttribute("data-booking-field", "welcome");
+    const textarea = document.createElement("textarea");
+    wrapper.append(textarea);
+    details.append(summary, wrapper);
+    document.body.append(details);
+
+    expect(details.open).toBe(false);
+    expect(focusBookingField("welcome")).toBe(true);
+    expect(details.open).toBe(true);
+    expect(document.activeElement).toBe(textarea);
   });
 });

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -199,7 +199,8 @@ export function BookingSettingsSection({
   const access = useAppAccess();
   const isReadOnly = access.kind === "server" && access.isReadOnly;
   const effectiveTimeZone = useEffectiveTimeZone();
-  const { data: calendars = [] } = useCalendarsQuery();
+  const { data: calendars = [], isPending: calendarsPending } =
+    useCalendarsQuery();
   const accountEmailOrder = useConnectedAccountEmails();
   const writableCalendars = useMemo(
     () =>
@@ -277,6 +278,10 @@ export function BookingSettingsSection({
   );
   useEffect(() => {
     if (!serverPage || seededPageRef.current === serverPage) return;
+    // Calendars often resolve after the booking page. Seeding against an
+    // empty list writes a placeholder destination and the identity guard
+    // then refuses to correct it, so Turn on / Save changes fail validation.
+    if (calendarsPending) return;
     seededPageRef.current = serverPage;
     const seeded = buildInitialForm(
       serverPage,
@@ -288,7 +293,13 @@ export function BookingSettingsSection({
     setMinNoticeText(String(seeded.minNoticeHours));
     setHorizonText(String(seeded.maxHorizonDays));
     baselineFormRef.current = seeded;
-  }, [availabilityCalendars, effectiveTimeZone, serverPage, writableCalendars]);
+  }, [
+    availabilityCalendars,
+    calendarsPending,
+    effectiveTimeZone,
+    serverPage,
+    writableCalendars,
+  ]);
 
   const isDirty =
     (baselineFormRef.current !== null &&
@@ -318,7 +329,11 @@ export function BookingSettingsSection({
     return <BookingConnectGooglePrompt />;
   }
 
-  if (isPending) {
+  if (
+    isPending ||
+    calendarsPending ||
+    (serverPage != null && seededPageRef.current !== serverPage)
+  ) {
     return <p className="text-sm text-text-muted">Loading booking settings…</p>;
   }
 

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -22,27 +22,34 @@ import {
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
 import { useAppAccess } from "@web/billing/useAppAccess";
-import { BookingCheckboxRow } from "@web/booking/BookingCheckboxRow";
+import { BookingBlockingCalendarsField } from "@web/booking/BookingBlockingCalendarsField";
 import { BookingConnectGooglePrompt } from "@web/booking/BookingConnectGooglePrompt";
-import { BookingCopyLink } from "@web/booking/BookingCopyLink";
 import { BookingFieldLabel } from "@web/booking/BookingFieldLabel";
+import { BookingLimitsFieldset } from "@web/booking/BookingLimitsFieldset";
+import { BookingMoreOptions } from "@web/booking/BookingMoreOptions";
 import { BookingNumberField } from "@web/booking/BookingNumberField";
+import { BookingSaveBar } from "@web/booking/BookingSaveBar";
+import { BookingStatusHeader } from "@web/booking/BookingStatusHeader";
 import { BookingTimezoneField } from "@web/booking/BookingTimezoneField";
 import { BookingWeeklyHoursEditor } from "@web/booking/BookingWeeklyHoursEditor";
 import {
+  bookingSaveErrorInline,
   useBookingPageQuery,
   useSaveBookingPageMutation,
 } from "@web/booking/booking.query";
 import {
   BOOKING_PLACEHOLDER_CALENDAR_ID,
-  canEnableBookingPage,
   defaultBlockingCalendarIdsForDestination,
   getAvailabilityReadableCalendars,
   isBookingSettingsFormDirty,
   isPlaceholderDestinationCalendar,
   isUnconfiguredBookingPage,
+  isWelcomeTextTooLong,
   resolveWritableCalendars,
   toBookingPageInput,
+  validateBookingForm,
+  WELCOME_TEXT_MAX_LENGTH,
+  WELCOME_TEXT_TOO_LONG_MESSAGE,
 } from "@web/booking/booking.util";
 import {
   bookingDestinationConferenceHint,
@@ -52,6 +59,7 @@ import {
 import {
   BOOKING_FIELD_BY_KEY,
   BOOKING_SEQUENCE_FIELDS,
+  type BookingSequenceField,
   bookingFieldAttrs,
   bookingJumpKeys,
   focusBookingField,
@@ -64,12 +72,6 @@ import {
 import { useConnectedAccountEmails } from "@web/calendars/useDefaultTargetCalendar";
 import { copyText } from "@web/common/utils/clipboard/clipboard.util";
 import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
-import {
-  OverlayPanelActionButton,
-  OverlayPanelActions,
-} from "@web/components/OverlayPanel/OverlayPanel";
-import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
-import { settingsShortcutAttrs } from "@web/settings/useSettingsShortcuts";
 import { EditSequenceMenu } from "@web/shortcuts/edit-sequence/EditSequenceMenu";
 import { ShortcutTipParts } from "@web/shortcuts/tips/ShortcutTipParts";
 import { type ShortcutTipPart } from "@web/shortcuts/tips/shortcut-tips.data";
@@ -79,12 +81,6 @@ import { DiscardUnsavedChangesDialog } from "@web/views/Forms/EventForm/DiscardU
 
 const DURATION_OPTIONS: BookingDurationMinutes[] = [15, 30, 45, 60];
 
-// OverlayPanel is the scrollport and uses p-8. sticky bottom-0 would pin to
-// that padding box and leave a 32px unpainted strip; -bottom-8 + pb-8 drop
-// the painted bar into the padding without shrinking the scroll range.
-const BOOKING_SETTINGS_SAVE_BAR_CLASS_NAME =
-  "sticky -bottom-8 z-10 border-border border-t bg-surface-panel pt-3 pb-8";
-
 export const BOOKING_SETTINGS_HINT_PARTS: readonly ShortcutTipPart[] = [
   "Press ",
   { keys: ["Mod", "E"] },
@@ -93,22 +89,14 @@ export const BOOKING_SETTINGS_HINT_PARTS: readonly ShortcutTipPart[] = [
   " saves.",
 ];
 
-// Named so the value the checkbox writes and the value its label promises can
-// only ever be the same number.
-const DEFAULT_BUFFER_MINUTES = 30;
-const DEFAULT_MAX_BOOKINGS_PER_DAY = 4;
+const MORE_OPTIONS_FIELDS = new Set<BookingSequenceField>([
+  "blocking",
+  "welcome",
+  "notice",
+  "horizon",
+  "options",
+]);
 
-// Same reasoning: the textarea's hard cap, the two guards, and the message
-// that quotes the number all have to agree, so they read it from one place.
-const WELCOME_TEXT_MAX_LENGTH = 500;
-const WELCOME_TEXT_TOO_LONG_MESSAGE = `Welcome text must be ${WELCOME_TEXT_MAX_LENGTH} characters or fewer.`;
-
-const isWelcomeTextTooLong = (
-  welcomeText: string | null | undefined,
-): boolean => (welcomeText?.length ?? 0) > WELCOME_TEXT_MAX_LENGTH;
-
-// The duration and destination pickers are the same control; keeping one class
-// string stops a style fix landing on only one of them.
 const BOOKING_SELECT_CLASS_NAME =
   "c-focus-ring w-full rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text hover:bg-surface-panel";
 
@@ -116,10 +104,6 @@ const isSavedBookingPage = (
   page: AdminPutBookingPageInput | AdminGetBookingPageResponse,
 ): page is AdminGetBookingPageResponse => "bookingUrl" in page;
 
-// Clearing a number input yields "", and Number("") is 0 - which the strict
-// PUT schema rejects after the save click with no field pointer. Hold the raw
-// text and only write parsed values into the form, so an empty field becomes
-// an inline error instead of a dead Save button mystery.
 const parseBookingCount = (
   raw: string,
   { min, max }: { min: number; max: number },
@@ -134,7 +118,6 @@ const parseBookingCount = (
   return value;
 };
 
-// Bounds mirror AdminPutBookingPageInputSchema.
 const MIN_NOTICE_BOUNDS = { min: 0, max: BOOKING_MAX_MIN_NOTICE_HOURS };
 const HORIZON_BOUNDS = { min: 1, max: BOOKING_MAX_HORIZON_DAYS };
 
@@ -176,16 +159,11 @@ const buildInitialForm = (
           availabilityCalendars,
         );
 
-  // Unconfigured pages seed from the calendar-view zone (the same
-  // default-timezone the rest of the app uses). A configured page's stored
-  // zone stays, including UTC.
   const timeZone =
     page && !isUnconfiguredBookingPage(page)
       ? base.timeZone
       : effectiveTimeZone;
 
-  // toBookingPageInput, not a spread: `base` may be the saved-page response,
-  // whose response-only keys would make the strict PUT schema throw on save.
   return {
     ...toBookingPageInput(base),
     destinationCalendarId,
@@ -248,7 +226,10 @@ export function BookingSettingsSection({
       availabilityCalendars,
     ),
   );
-  const [enableError, setEnableError] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<{
+    message: string;
+    field?: BookingSequenceField;
+  } | null>(null);
   const [areHoursValid, setAreHoursValid] = useState(true);
   const [minNoticeText, setMinNoticeText] = useState(() =>
     String(form.minNoticeHours),
@@ -343,11 +324,7 @@ export function BookingSettingsSection({
 
   const savedPage =
     serverPage && isSavedBookingPage(serverPage) ? serverPage : null;
-  const blockingSet = new Set(form.blockingCalendarIds);
-  const { groups, ungrouped } = groupCalendarsByAccount(
-    availabilityCalendars,
-    connections,
-  );
+  const isLive = savedPage?.enabled === true;
   const { groups: writableGroups, ungrouped: writableUngrouped } =
     groupCalendarsByAccount(writableCalendars, connections);
   const destinationCalendar = writableCalendars.find(
@@ -366,7 +343,7 @@ export function BookingSettingsSection({
   const destinationMeetWarningId = "booking-destination-meet-warning";
   const updateForm = (patch: Partial<AdminPutBookingPageInput>) => {
     setForm((current) => ({ ...current, ...patch }));
-    setEnableError(null);
+    setSaveError(null);
   };
 
   const handleDestinationChange = (destinationCalendarId: CalendarId) => {
@@ -378,7 +355,7 @@ export function BookingSettingsSection({
         availabilityCalendars,
       ),
     }));
-    setEnableError(null);
+    setSaveError(null);
   };
 
   const toggleBlockingCalendar = (calendarId: CalendarId, checked: boolean) => {
@@ -391,76 +368,78 @@ export function BookingSettingsSection({
         blockingCalendarIds: [...next],
       };
     });
+    setSaveError(null);
   };
 
-  const renderBlockingCalendar = (calendar: Calendar) => (
-    <BookingCheckboxRow
-      checked={blockingSet.has(calendar.id)}
-      key={calendar.id}
-      onChange={(checked) => toggleBlockingCalendar(calendar.id, checked)}
-    >
-      {calendar.name}
-    </BookingCheckboxRow>
-  );
-
-  const handleEnableChange = (enabled: boolean) => {
-    if (enabled && !canEnableBookingPage(form, writableCalendars)) {
-      setEnableError("Choose a destination calendar before enabling booking.");
-      return;
-    }
-    updateForm({ enabled });
-  };
-
-  const handleSave = () => {
-    if (!areHoursValid) {
-      setEnableError("Fix the weekly hours that could not be read.");
-      return;
-    }
-    if (isWelcomeTextTooLong(form.welcomeText)) {
-      setEnableError(WELCOME_TEXT_TOO_LONG_MESSAGE);
-      return;
-    }
-    if (minNoticeInvalid || horizonInvalid) {
-      setEnableError("Fix the highlighted number fields before saving.");
-      return;
-    }
-    if (form.enabled && !canEnableBookingPage(form, writableCalendars)) {
-      setEnableError("Choose a destination calendar before enabling booking.");
-      return;
-    }
-    if (form.enabled && form.blockingCalendarIds.length === 0) {
-      setEnableError("Select at least one blocking calendar.");
-      return;
-    }
-    if (form.enabled && form.weeklyAvailability.length === 0) {
-      setEnableError("Add weekly hours before turning on your booking page.");
-      return;
-    }
-    setEnableError(null);
-    // Auto-copy lives here, not in the mutation: the mutation owns the query
-    // cache, and putting clipboard UX there would also bury the no-link case.
-    saveMutation.mutate(form, {
-      onSuccess: (page) => {
-        if (!("bookingUrl" in page)) {
-          // No slug is allocated until the page is enabled, so there is no
-          // link to copy yet - say so rather than claiming one was copied.
-          showStatusToast(
-            "booking-link-copied",
-            "Saved. Enable booking to get your link.",
-          );
-          return;
-        }
-        void copyText(page.bookingUrl).then((didCopy) => {
-          showStatusToast(
-            "booking-link-copied",
-            didCopy
-              ? "Saved. Booking link copied."
-              : "Saved. Press e then l to copy your link.",
-          );
-        });
-      },
+  const submit = (enabled: boolean) => {
+    const error = validateBookingForm({
+      areHoursValid,
+      enabling: enabled,
+      form,
+      horizonInvalid,
+      minNoticeInvalid,
+      writableCalendars,
     });
+    if (error) {
+      setSaveError(error);
+      if (error.field) focusBookingField(error.field);
+      return;
+    }
+    setSaveError(null);
+    const wasLive = isLive;
+    saveMutation.mutate(
+      { ...form, enabled },
+      {
+        onError: (mutationError) => {
+          const inline = bookingSaveErrorInline(mutationError);
+          if (inline) {
+            setSaveError(inline);
+            if (inline.field) focusBookingField(inline.field);
+          }
+        },
+        onSuccess: (page) => {
+          if (enabled && !wasLive) {
+            if (!("bookingUrl" in page)) return;
+            void copyText(page.bookingUrl).then((didCopy) => {
+              showStatusToast(
+                "booking-link-copied",
+                didCopy
+                  ? "Your booking page is live. Link copied."
+                  : "Live. Press e then l to copy your link.",
+              );
+            });
+            return;
+          }
+          if (!enabled && wasLive) {
+            showStatusToast("booking-link-copied", "Booking page turned off.");
+            return;
+          }
+          if (!enabled) {
+            showStatusToast(
+              "booking-link-copied",
+              "Saved. Turn on your booking page to share the link.",
+            );
+            return;
+          }
+          if (!("bookingUrl" in page)) return;
+          void copyText(page.bookingUrl).then((didCopy) => {
+            showStatusToast(
+              "booking-link-copied",
+              didCopy
+                ? "Saved. Booking link copied."
+                : "Saved. Press e then l to copy your link.",
+            );
+          });
+        },
+      },
+    );
   };
+
+  const forceOpenMoreOptions =
+    isWelcomeTextTooLong(form.welcomeText) ||
+    minNoticeInvalid ||
+    horizonInvalid ||
+    (saveError?.field != null && MORE_OPTIONS_FIELDS.has(saveError.field));
 
   return (
     <>
@@ -473,60 +452,63 @@ export function BookingSettingsSection({
           <ShortcutTipParts parts={BOOKING_SETTINGS_HINT_PARTS} />
         </p>
 
-        {savedPage ? (
-          <div {...bookingFieldAttrs("link")}>
-            <BookingCopyLink bookingUrl={savedPage.bookingUrl} />
+        <BookingStatusHeader
+          addressPreview={null}
+          bookingUrl={savedPage?.bookingUrl ?? null}
+          isLive={isLive}
+        />
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <BookingFieldLabel
+              field="duration"
+              htmlFor="booking-duration"
+              showShortcuts={showShortcuts}
+            >
+              Duration
+            </BookingFieldLabel>
+            <select
+              {...bookingFieldAttrs("duration")}
+              className={BOOKING_SELECT_CLASS_NAME}
+              id="booking-duration"
+              onChange={(event) =>
+                updateForm({
+                  durationMinutes: Number(
+                    event.target.value,
+                  ) as BookingDurationMinutes,
+                })
+              }
+              value={form.durationMinutes}
+            >
+              {DURATION_OPTIONS.map((minutes) => (
+                <option key={minutes} value={minutes}>
+                  {minutes} minutes
+                </option>
+              ))}
+            </select>
           </div>
-        ) : null}
 
-        <label
-          className="flex items-center gap-2 text-sm text-text"
-          {...bookingFieldAttrs("enabled")}
-        >
-          <input
-            checked={form.enabled}
-            className="c-all-day-checkbox"
-            onChange={(event) => handleEnableChange(event.target.checked)}
-            type="checkbox"
-          />
-          Enable booking page
-          {showShortcuts ? (
-            <ShortcutKeys keys={bookingJumpKeys("enabled")} />
-          ) : null}
-        </label>
-        {enableError ? (
-          <p className="text-error text-sm" role="alert">
-            {enableError}
-          </p>
-        ) : null}
+          <div {...bookingFieldAttrs("timezone")}>
+            <BookingTimezoneField
+              onChange={(timeZone) => updateForm({ timeZone })}
+              shortcutKeys={
+                showShortcuts ? bookingJumpKeys("timezone") : undefined
+              }
+              timeZone={form.timeZone}
+            />
+          </div>
+        </div>
 
-        <div>
-          <BookingFieldLabel
-            field="duration"
-            htmlFor="booking-duration"
-            showShortcuts={showShortcuts}
-          >
-            Duration
-          </BookingFieldLabel>
-          <select
-            {...bookingFieldAttrs("duration")}
-            className={BOOKING_SELECT_CLASS_NAME}
-            id="booking-duration"
-            onChange={(event) =>
-              updateForm({
-                durationMinutes: Number(
-                  event.target.value,
-                ) as BookingDurationMinutes,
-              })
+        <div className="flex flex-col gap-1" {...bookingFieldAttrs("hours")}>
+          <BookingWeeklyHoursEditor
+            onChange={(weeklyAvailability) =>
+              updateForm({ weeklyAvailability })
             }
-            value={form.durationMinutes}
-          >
-            {DURATION_OPTIONS.map((minutes) => (
-              <option key={minutes} value={minutes}>
-                {minutes} minutes
-              </option>
-            ))}
-          </select>
+            onDraftDirtyChange={setHoursDraftDirty}
+            onValidityChange={setAreHoursValid}
+            shortcutKeys={showShortcuts ? bookingJumpKeys("hours") : undefined}
+            value={form.weeklyAvailability}
+          />
         </div>
 
         <div>
@@ -588,198 +570,106 @@ export function BookingSettingsSection({
           ) : null}
         </div>
 
-        <fieldset
-          className="flex flex-col gap-2"
-          {...bookingFieldAttrs("blocking")}
+        <BookingMoreOptions
+          forceOpen={forceOpenMoreOptions}
+          showShortcuts={showShortcuts}
         >
-          <legend className="mb-1 flex items-center gap-1 text-sm text-text">
-            Blocking calendars
-            {showShortcuts ? (
-              <ShortcutKeys keys={bookingJumpKeys("blocking")} />
-            ) : null}
-          </legend>
-          {availabilityCalendars.length === 0 ? (
-            <p className="text-sm text-text-muted">No calendars available.</p>
-          ) : (
-            <>
-              {groups
-                .filter((group) => group.calendars.length > 0)
-                .map((group) => (
-                  <div className="flex flex-col gap-1" key={group.accountEmail}>
-                    <p className="text-text-muted text-xs">
-                      {group.accountEmail}
-                    </p>
-                    {group.calendars.map(renderBlockingCalendar)}
-                  </div>
-                ))}
-              {ungrouped.map(renderBlockingCalendar)}
-            </>
-          )}
-          <p className="text-text-muted text-xs">
-            Pending, maybe, and declined invites do not hold booking times.
-            Accepted invites and events the host organizes do.
-          </p>
-        </fieldset>
-
-        <div {...bookingFieldAttrs("timezone")}>
-          <BookingTimezoneField
-            onChange={(timeZone) => updateForm({ timeZone })}
-            shortcutKeys={
-              showShortcuts ? bookingJumpKeys("timezone") : undefined
-            }
-            timeZone={form.timeZone}
-          />
-        </div>
-
-        <div className="flex flex-col gap-4" {...bookingFieldAttrs("hours")}>
-          <BookingWeeklyHoursEditor
-            onChange={(weeklyAvailability) =>
-              updateForm({ weeklyAvailability })
-            }
-            onDraftDirtyChange={setHoursDraftDirty}
-            onValidityChange={setAreHoursValid}
-            shortcutKeys={showShortcuts ? bookingJumpKeys("hours") : undefined}
-            value={form.weeklyAvailability}
-          />
-        </div>
-
-        <div>
-          <BookingFieldLabel
-            field="welcome"
-            htmlFor="booking-welcome"
+          <BookingBlockingCalendarsField
+            availabilityCalendars={availabilityCalendars}
+            blockingCalendarIds={form.blockingCalendarIds}
+            connections={connections}
+            onToggle={toggleBlockingCalendar}
             showShortcuts={showShortcuts}
-          >
-            Welcome text
-          </BookingFieldLabel>
-          <textarea
-            {...bookingFieldAttrs("welcome")}
-            aria-invalid={
-              isWelcomeTextTooLong(form.welcomeText) ? true : undefined
-            }
-            className="c-focus-ring min-h-20 w-full rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text aria-invalid:border-error"
-            id="booking-welcome"
-            maxLength={WELCOME_TEXT_MAX_LENGTH}
-            onChange={(event) =>
-              updateForm({
-                welcomeText:
-                  event.target.value.trim() === "" ? null : event.target.value,
-              })
-            }
-            value={form.welcomeText ?? ""}
           />
-          {isWelcomeTextTooLong(form.welcomeText) ? (
-            <p className="text-error text-xs" role="alert">
-              {WELCOME_TEXT_TOO_LONG_MESSAGE}
-            </p>
-          ) : null}
-        </div>
 
-        <div className="grid grid-cols-2 gap-3">
-          <BookingNumberField
-            field="notice"
-            id="booking-min-notice"
-            invalid={minNoticeInvalid}
-            invalidMessage={`Enter 0 to ${BOOKING_MAX_MIN_NOTICE_HOURS} hours.`}
-            label="Minimum notice (hours)"
-            max={BOOKING_MAX_MIN_NOTICE_HOURS}
-            min={0}
-            onChange={(raw) => {
-              setMinNoticeText(raw);
-              const parsed = parseBookingCount(raw, MIN_NOTICE_BOUNDS);
-              if (parsed !== null) {
-                updateForm({ minNoticeHours: parsed });
-              }
-            }}
-            showShortcuts={showShortcuts}
-            value={minNoticeText}
-          />
-          <BookingNumberField
-            field="horizon"
-            id="booking-max-horizon"
-            invalid={horizonInvalid}
-            invalidMessage={`Enter 1 to ${BOOKING_MAX_HORIZON_DAYS} days.`}
-            label="Maximum horizon (days)"
-            max={BOOKING_MAX_HORIZON_DAYS}
-            min={1}
-            onChange={(raw) => {
-              setHorizonText(raw);
-              const parsed = parseBookingCount(raw, HORIZON_BOUNDS);
-              if (parsed !== null) {
-                updateForm({ maxHorizonDays: parsed });
-              }
-            }}
-            showShortcuts={showShortcuts}
-            value={horizonText}
-          />
-        </div>
-
-        <fieldset
-          className="flex flex-col gap-2"
-          {...bookingFieldAttrs("options")}
-        >
-          <legend className="mb-1 flex items-center gap-1 text-sm text-text">
-            Buffer and limits
-            {showShortcuts ? (
-              <ShortcutKeys keys={bookingJumpKeys("options")} />
-            ) : null}
-          </legend>
-
-          <BookingCheckboxRow
-            checked={form.bufferMinutes !== null}
-            onChange={(checked) =>
-              updateForm({
-                bufferMinutes: checked ? DEFAULT_BUFFER_MINUTES : null,
-              })
-            }
-          >
-            Buffer between appointments ({DEFAULT_BUFFER_MINUTES} minutes)
-          </BookingCheckboxRow>
-
-          <BookingCheckboxRow
-            checked={form.maxBookingsPerDay !== null}
-            onChange={(checked) =>
-              updateForm({
-                maxBookingsPerDay: checked
-                  ? DEFAULT_MAX_BOOKINGS_PER_DAY
-                  : null,
-              })
-            }
-          >
-            Max bookings per day ({DEFAULT_MAX_BOOKINGS_PER_DAY})
-          </BookingCheckboxRow>
-
-          <BookingCheckboxRow
-            checked={form.guestsCanInviteOthers}
-            onChange={(guestsCanInviteOthers) =>
-              updateForm({ guestsCanInviteOthers })
-            }
-          >
-            Guest can invite others
-          </BookingCheckboxRow>
-          <p className="text-text-muted text-xs">
-            When this is on, Compass cannot put the cancel link in the calendar
-            description. Guests keep it from the confirmation page.
-          </p>
-        </fieldset>
-
-        <div className={BOOKING_SETTINGS_SAVE_BAR_CLASS_NAME}>
-          {/* Default align=end keeps the always-on chip Save off the hours column. */}
-          <OverlayPanelActions>
-            <OverlayPanelActionButton
-              aria-busy={saveMutation.isPending || undefined}
-              aria-keyshortcuts="Meta+Enter Control+Enter"
-              className="whitespace-nowrap"
-              disabled={saveMutation.isPending}
-              onClick={handleSave}
-              shortcut={["Mod", "Enter"]}
-              showShortcut
-              variant="primary"
-              {...settingsShortcutAttrs("save-booking")}
+          <div>
+            <BookingFieldLabel
+              field="welcome"
+              htmlFor="booking-welcome"
+              showShortcuts={showShortcuts}
             >
-              {saveMutation.isPending ? "Saving…" : "Save booking settings"}
-            </OverlayPanelActionButton>
-          </OverlayPanelActions>
-        </div>
+              Welcome text
+            </BookingFieldLabel>
+            <textarea
+              {...bookingFieldAttrs("welcome")}
+              aria-invalid={
+                isWelcomeTextTooLong(form.welcomeText) ? true : undefined
+              }
+              className="c-focus-ring min-h-20 w-full rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text aria-invalid:border-error"
+              id="booking-welcome"
+              maxLength={WELCOME_TEXT_MAX_LENGTH}
+              onChange={(event) =>
+                updateForm({
+                  welcomeText:
+                    event.target.value.trim() === ""
+                      ? null
+                      : event.target.value,
+                })
+              }
+              value={form.welcomeText ?? ""}
+            />
+            {isWelcomeTextTooLong(form.welcomeText) ? (
+              <p className="text-error text-xs" role="alert">
+                {WELCOME_TEXT_TOO_LONG_MESSAGE}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <BookingNumberField
+              field="notice"
+              id="booking-min-notice"
+              invalid={minNoticeInvalid}
+              invalidMessage={`Enter 0 to ${BOOKING_MAX_MIN_NOTICE_HOURS} hours.`}
+              label="Minimum notice (hours)"
+              max={BOOKING_MAX_MIN_NOTICE_HOURS}
+              min={0}
+              onChange={(raw) => {
+                setMinNoticeText(raw);
+                const parsed = parseBookingCount(raw, MIN_NOTICE_BOUNDS);
+                if (parsed !== null) {
+                  updateForm({ minNoticeHours: parsed });
+                }
+              }}
+              showShortcuts={showShortcuts}
+              value={minNoticeText}
+            />
+            <BookingNumberField
+              field="horizon"
+              id="booking-max-horizon"
+              invalid={horizonInvalid}
+              invalidMessage={`Enter 1 to ${BOOKING_MAX_HORIZON_DAYS} days.`}
+              label="Maximum horizon (days)"
+              max={BOOKING_MAX_HORIZON_DAYS}
+              min={1}
+              onChange={(raw) => {
+                setHorizonText(raw);
+                const parsed = parseBookingCount(raw, HORIZON_BOUNDS);
+                if (parsed !== null) {
+                  updateForm({ maxHorizonDays: parsed });
+                }
+              }}
+              showShortcuts={showShortcuts}
+              value={horizonText}
+            />
+          </div>
+
+          <BookingLimitsFieldset
+            bufferMinutes={form.bufferMinutes}
+            guestsCanInviteOthers={form.guestsCanInviteOthers}
+            maxBookingsPerDay={form.maxBookingsPerDay}
+            onChange={updateForm}
+            showShortcuts={showShortcuts}
+          />
+        </BookingMoreOptions>
+
+        <BookingSaveBar
+          error={saveError?.message ?? null}
+          isDirty={isDirty}
+          isLive={isLive}
+          isPending={saveMutation.isPending}
+          onSubmit={submit}
+        />
 
         <EditSequenceMenu
           getAnchor={() => sectionRef.current}

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -69,6 +69,7 @@ import {
   compareCalendars,
   groupCalendarsByAccount,
 } from "@web/calendars/calendar.util";
+import { getLocalCalendarSentinelId } from "@web/calendars/local-calendar.sentinel";
 import { useConnectedAccountEmails } from "@web/calendars/useDefaultTargetCalendar";
 import { copyText } from "@web/common/utils/clipboard/clipboard.util";
 import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
@@ -144,9 +145,10 @@ const buildInitialForm = (
 
   const destinationCalendarId =
     !isPlaceholderDestinationCalendar(base.destinationCalendarId) &&
-    writableCalendars.some(
+    (writableCalendars.some(
       (calendar) => calendar.id === base.destinationCalendarId,
-    )
+    ) ||
+      writableCalendars.length === 0)
       ? base.destinationCalendarId
       : (writableCalendars[0]?.id ?? BOOKING_PLACEHOLDER_CALENDAR_ID);
 
@@ -199,8 +201,13 @@ export function BookingSettingsSection({
   const access = useAppAccess();
   const isReadOnly = access.kind === "server" && access.isReadOnly;
   const effectiveTimeZone = useEffectiveTimeZone();
-  const { data: calendars = [], isPending: calendarsPending } =
-    useCalendarsQuery();
+  const {
+    data: calendars = [],
+    isPending: calendarsPending,
+    refetch: refetchCalendars,
+  } = useCalendarsQuery();
+  const [hostCalendarsRefetchDone, setHostCalendarsRefetchDone] =
+    useState(false);
   const accountEmailOrder = useConnectedAccountEmails();
   const writableCalendars = useMemo(
     () =>
@@ -216,6 +223,37 @@ export function BookingSettingsSection({
       ),
     [accountEmailOrder, calendars],
   );
+  const waitingForHostCalendars =
+    hasHealthyConnection &&
+    writableCalendars.length === 0 &&
+    calendars.length === 1 &&
+    calendars[0]?.id === getLocalCalendarSentinelId() &&
+    !hostCalendarsRefetchDone;
+
+  useEffect(() => {
+    if (!hasHealthyConnection || hostCalendarsRefetchDone) return;
+    if (writableCalendars.length > 0) {
+      setHostCalendarsRefetchDone(true);
+      return;
+    }
+    if (
+      calendars.length !== 1 ||
+      calendars[0]?.id !== getLocalCalendarSentinelId()
+    ) {
+      setHostCalendarsRefetchDone(true);
+      return;
+    }
+    void refetchCalendars().finally(() => {
+      setHostCalendarsRefetchDone(true);
+    });
+  }, [
+    calendars,
+    hasHealthyConnection,
+    hostCalendarsRefetchDone,
+    refetchCalendars,
+    writableCalendars.length,
+  ]);
+
   const { data: serverPage, isPending } =
     useBookingPageQuery(hasHealthyConnection);
   const saveMutation = useSaveBookingPageMutation();
@@ -278,10 +316,11 @@ export function BookingSettingsSection({
   );
   useEffect(() => {
     if (!serverPage || seededPageRef.current === serverPage) return;
-    // Calendars often resolve after the booking page. Seeding against an
-    // empty list writes a placeholder destination and the identity guard
-    // then refuses to correct it, so Turn on / Save changes fail validation.
-    if (calendarsPending) return;
+    // The week-view cache can still be the anonymous local calendar after
+    // e2e (or a fresh login) flips authenticated. Seeding against that empty
+    // writable list sticks a placeholder destination that the identity guard
+    // will not correct.
+    if (calendarsPending || waitingForHostCalendars) return;
     seededPageRef.current = serverPage;
     const seeded = buildInitialForm(
       serverPage,
@@ -298,6 +337,7 @@ export function BookingSettingsSection({
     calendarsPending,
     effectiveTimeZone,
     serverPage,
+    waitingForHostCalendars,
     writableCalendars,
   ]);
 
@@ -332,6 +372,7 @@ export function BookingSettingsSection({
   if (
     isPending ||
     calendarsPending ||
+    waitingForHostCalendars ||
     (serverPage != null && seededPageRef.current !== serverPage)
   ) {
     return <p className="text-sm text-text-muted">Loading booking settings…</p>;

--- a/packages/web/src/booking/BookingStatusHeader.tsx
+++ b/packages/web/src/booking/BookingStatusHeader.tsx
@@ -1,0 +1,42 @@
+import { BookingCopyLink } from "@web/booking/BookingCopyLink";
+import { bookingFieldAttrs } from "@web/booking/booking-sequence.fields";
+
+interface BookingStatusHeaderProps {
+  isLive: boolean;
+  bookingUrl: string | null;
+  addressPreview: string | null;
+}
+
+export function BookingStatusHeader({
+  isLive,
+  bookingUrl,
+  addressPreview,
+}: BookingStatusHeaderProps) {
+  if (isLive) {
+    return (
+      <div className="flex flex-col gap-2">
+        <p className="text-sm font-medium text-text">
+          Your booking page is live
+        </p>
+        {bookingUrl ? (
+          <div {...bookingFieldAttrs("link")}>
+            <BookingCopyLink bookingUrl={bookingUrl} />
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <p className="text-sm font-medium text-text">
+        Your booking page is not live yet
+      </p>
+      {addressPreview ? (
+        <p className="text-sm text-text-muted">
+          It will be at {addressPreview}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/web/src/booking/BookingStatusHeader.tsx
+++ b/packages/web/src/booking/BookingStatusHeader.tsx
@@ -15,7 +15,7 @@ export function BookingStatusHeader({
   if (isLive) {
     return (
       <div className="flex flex-col gap-2">
-        <p className="text-sm font-medium text-text">
+        <p className="font-medium text-sm text-text">
           Your booking page is live
         </p>
         {bookingUrl ? (
@@ -29,7 +29,7 @@ export function BookingStatusHeader({
 
   return (
     <div className="flex flex-col gap-1">
-      <p className="text-sm font-medium text-text">
+      <p className="font-medium text-sm text-text">
         Your booking page is not live yet
       </p>
       {addressPreview ? (

--- a/packages/web/src/booking/booking-sequence.fields.ts
+++ b/packages/web/src/booking/booking-sequence.fields.ts
@@ -12,12 +12,13 @@
  * than the event form's Mod+digit jump.
  */
 export const BOOKING_SEQUENCE_FIELDS = [
-  { key: "e", field: "enabled", label: "Enable booking" },
+  { key: "e", field: "enabled", label: "Booking page on or off" },
   { key: "d", field: "duration", label: "Duration" },
   { key: "c", field: "destination", label: "Destination calendar" },
   { key: "b", field: "blocking", label: "Blocking calendars" },
   { key: "z", field: "timezone", label: "Booking timezone" },
   { key: "h", field: "hours", label: "Weekly hours" },
+  { key: "m", field: "more", label: "More options" },
   { key: "w", field: "welcome", label: "Welcome text" },
   { key: "n", field: "notice", label: "Minimum notice" },
   { key: "x", field: "horizon", label: "Maximum horizon" },
@@ -53,7 +54,7 @@ export const bookingJumpKeys = (field: BookingSequenceField): string[] => [
 ];
 
 const FOCUSABLE =
-  'input, select, textarea, button, [role="combobox"], [tabindex]:not([tabindex="-1"])';
+  'input, select, textarea, button, summary, [role="combobox"], [tabindex]:not([tabindex="-1"])';
 
 /**
  * Focus a booking field by data attribute rather than a selector map.
@@ -66,6 +67,12 @@ export function focusBookingField(field: BookingSequenceField): boolean {
     `[${BOOKING_FIELD_ATTR}="${field}"]`,
   );
   if (!anchor) return false;
+
+  let enclosing: HTMLElement | null = anchor.closest("details");
+  while (enclosing instanceof HTMLDetailsElement) {
+    enclosing.open = true;
+    enclosing = enclosing.parentElement?.closest("details") ?? null;
+  }
 
   const target = anchor.matches(FOCUSABLE)
     ? anchor

--- a/packages/web/src/booking/booking.query.ts
+++ b/packages/web/src/booking/booking.query.ts
@@ -14,6 +14,7 @@ import { BookingApi } from "@web/api/booking.api";
 import { getApiErrorCode, isApiError } from "@web/api/util/api.util";
 import { billingQueryKeys } from "@web/billing/billing.query";
 import { billingPreviewActions } from "@web/billing/billing-preview.store";
+import { type BookingSequenceField } from "@web/booking/booking-sequence.fields";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 
 export const bookingQueryKeys = {
@@ -35,7 +36,7 @@ export function useBookingPageQuery(enabled: boolean) {
   });
 }
 
-const BOOKING_SAVE_ERROR_COPY: Record<string, string> = {
+export const BOOKING_SAVE_ERROR_COPY: Record<string, string> = {
   BLOCKING_CALENDAR_INVALID:
     "One of your blocking calendars can't be checked for busy times. Uncheck it and save again.",
   DESTINATION_NOT_WRITABLE:
@@ -46,6 +47,25 @@ const BOOKING_SAVE_ERROR_COPY: Record<string, string> = {
   INVALID_INPUT:
     "Some settings couldn't be saved. Check the highlighted fields and try again.",
 };
+
+const INLINE_SAVE_ERROR_FIELDS: Record<string, BookingSequenceField> = {
+  TIMEZONE_REQUIRED: "timezone",
+  DESTINATION_NOT_WRITABLE: "destination",
+  BLOCKING_CALENDAR_INVALID: "blocking",
+  AVAILABILITY_REQUIRED: "hours",
+};
+
+export function bookingSaveErrorInline(
+  error: unknown,
+): { message: string; field?: BookingSequenceField } | null {
+  if (!isApiError(error)) return null;
+  const code = getApiErrorCode(error);
+  if (!code) return null;
+  const field = INLINE_SAVE_ERROR_FIELDS[code];
+  const message = BOOKING_SAVE_ERROR_COPY[code];
+  if (!field || !message) return null;
+  return { field, message };
+}
 
 function handleBookingSaveError(
   error: unknown,
@@ -64,6 +84,9 @@ function handleBookingSaveError(
       void queryClient.invalidateQueries({
         queryKey: billingQueryKeys.status,
       });
+      return;
+    }
+    if (bookingSaveErrorInline(error)) {
       return;
     }
     const copy = code ? BOOKING_SAVE_ERROR_COPY[code] : undefined;

--- a/packages/web/src/booking/booking.util.ts
+++ b/packages/web/src/booking/booking.util.ts
@@ -6,6 +6,7 @@ import {
 } from "@core/types/booking.contracts";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
+import { type BookingSequenceField } from "@web/booking/booking-sequence.fields";
 import {
   getLocalCalendar,
   getWritableCalendars,
@@ -148,4 +149,73 @@ export function isUnconfiguredBookingPage(
   page: AdminGetBookingPageResult,
 ): boolean {
   return "isConfigured" in page && page.isConfigured === false;
+}
+
+export const WELCOME_TEXT_MAX_LENGTH = 500;
+export const WELCOME_TEXT_TOO_LONG_MESSAGE = `Welcome text must be ${WELCOME_TEXT_MAX_LENGTH} characters or fewer.`;
+
+export const isWelcomeTextTooLong = (
+  welcomeText: string | null | undefined,
+): boolean => (welcomeText?.length ?? 0) > WELCOME_TEXT_MAX_LENGTH;
+
+export type BookingFormValidationError = {
+  message: string;
+  field?: BookingSequenceField;
+};
+
+export function validateBookingForm({
+  areHoursValid,
+  enabling,
+  form,
+  horizonInvalid,
+  minNoticeInvalid,
+  writableCalendars,
+}: {
+  areHoursValid: boolean;
+  enabling: boolean;
+  form: AdminPutBookingPageInput;
+  horizonInvalid: boolean;
+  minNoticeInvalid: boolean;
+  writableCalendars: Calendar[];
+}): BookingFormValidationError | null {
+  if (!areHoursValid) {
+    return {
+      field: "hours",
+      message: "Fix the weekly hours that could not be read.",
+    };
+  }
+  if (isWelcomeTextTooLong(form.welcomeText)) {
+    return { field: "welcome", message: WELCOME_TEXT_TOO_LONG_MESSAGE };
+  }
+  if (minNoticeInvalid) {
+    return {
+      field: "notice",
+      message: "Fix the highlighted number fields before saving.",
+    };
+  }
+  if (horizonInvalid) {
+    return {
+      field: "horizon",
+      message: "Fix the highlighted number fields before saving.",
+    };
+  }
+  if (enabling && !canEnableBookingPage(form, writableCalendars)) {
+    return {
+      field: "destination",
+      message: "Choose a destination calendar before enabling booking.",
+    };
+  }
+  if (enabling && form.blockingCalendarIds.length === 0) {
+    return {
+      field: "blocking",
+      message: "Select at least one blocking calendar.",
+    };
+  }
+  if (enabling && form.weeklyAvailability.length === 0) {
+    return {
+      field: "hours",
+      message: "Add weekly hours before turning on your booking page.",
+    };
+  }
+  return null;
 }

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -16,6 +16,7 @@ import {
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import { UpgradeConfirmationProvider } from "@web/billing/UpgradeConfirmation/UpgradeConfirmationProvider";
 import { type AppAccess } from "@web/billing/useAppAccess";
+import { BOOKING_TURN_ON_LABEL } from "@web/booking/BookingSaveBar";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import {
@@ -976,7 +977,7 @@ describe("SettingsModal", () => {
       page: "booking",
     });
 
-    await screen.findByRole("button", { name: "Save booking settings" });
+    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
     const monday = screen.getByLabelText("Monday");
     await user.clear(monday);
     await user.type(monday, "9");
@@ -1000,7 +1001,7 @@ describe("SettingsModal", () => {
       page: "booking",
     });
 
-    await screen.findByRole("button", { name: "Save booking settings" });
+    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
     await user.selectOptions(screen.getByLabelText("Duration"), "45");
     await user.keyboard("{Escape}");
 
@@ -1022,7 +1023,7 @@ describe("SettingsModal", () => {
       page: "booking",
     });
 
-    await screen.findByRole("button", { name: "Save booking settings" });
+    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
     await user.selectOptions(screen.getByLabelText("Duration"), "45");
     await user.keyboard("{Escape}");
     await user.click(screen.getByRole("button", { name: "Discard" }));
@@ -1041,7 +1042,7 @@ describe("SettingsModal", () => {
       page: "booking",
     });
 
-    await screen.findByRole("button", { name: "Save booking settings" });
+    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
     await user.selectOptions(screen.getByLabelText("Duration"), "45");
     await user.keyboard("{Escape}");
     await user.click(screen.getByRole("button", { name: "Cancel" }));
@@ -1064,7 +1065,7 @@ describe("SettingsModal", () => {
       page: "booking",
     });
 
-    await screen.findByRole("button", { name: "Save booking settings" });
+    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
     await user.keyboard("{Escape}");
 
     expect(
@@ -1084,7 +1085,7 @@ describe("SettingsModal", () => {
       page: "booking",
     });
 
-    await screen.findByRole("button", { name: "Save booking settings" });
+    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
     await user.keyboard("e");
     await user.keyboard("{Escape}");
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3483

## What and why

Settings > Booking is split into a status header, Essentials, and a collapsed More options group. Going live is one click: **Turn on booking page** replaces the enable checkbox. Validation and mapped server errors render beside the save bar and focus the field. Spec: [booking.md](https://github.com/KeepSoftwareSimple/compass-calendar/blob/main/docs/features/booking.md). Tracking: #3478.

## Evidence

- Rebased onto `main` after WP-03 (#3490) merged. This PR is web, e2e, and docs only.
- Hours editor still displays `9am-5pm` rather than `9-5` (same display helper as WP-03).
- `addressPreview` is `null` until WP-06 (#3484).
- More options stays an uncontrolled native `<details>`; `forceOpen` and `focusBookingField` set `open` on the element.
- After login the calendars query can still hold the anonymous sentinel calendar. Booking settings refetches that cache once before seeding so a placeholder destination cannot block Turn on / Save changes.
- Save-bar alerts use `text-text` rather than `text-error`: `--error` on `--surface-panel` is 3.35:1 and fails WCAG 2.2 AA / axe.

## Verify

`VERDICT: PASS`
Selected packages: web
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a3e396e-ae10-485f-8c9e-74670598e85c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a3e396e-ae10-485f-8c9e-74670598e85c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

