### PR TITLE
feat(web): page address field in booking Essentials (WP-06)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "compass",

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -230,8 +230,12 @@ time inputs per weekday.
 - **Status:** a live page shows "Your booking page is live" and the
   public link with Copy and **Open booking page**. A page that is not
   live shows "Your booking page is not live yet".
-- **Essentials:** Duration, booking timezone, weekly hours, and
+- **Essentials:** Page address, duration, booking timezone, weekly hours, and
   destination calendar. These fit without scrolling at 1440x900.
+- **Page address:** shows `<origin>/book/` as a visible prefix with an
+  editable slug. An unconfigured page shows the server's `suggestedSlug`.
+  Changing a saved address warns that old links stop working. A taken address
+  (`SLUG_TAKEN`) renders inline beside the save bar and focuses the field.
 - **More options:** an uncontrolled native `<details>` that starts
   collapsed. It holds blocking calendars, welcome text, notice and
   horizon, and buffer and limits. Jumping to a field inside it, or an
@@ -243,7 +247,7 @@ time inputs per weekday.
   for a break). A blank day is unavailable. The parser reuses
   `parseUserTime` with an explicit PM-correction rule.
 - **Jump:** `e` then a letter focuses a field (`e` booking page on or
-  off, `d` duration, `c` destination, `b` blocking, `z` timezone,
+  off, `a` address, `d` duration, `c` destination, `b` blocking, `z` timezone,
   `h` hours, `m` More options, `w` welcome, `n` notice, `x` horizon,
   `o` buffer and limits, `l` link). Settings owns Mod+Enter (the
   primary save action) and digits `1/2/3` (nav) on this page, which is

--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -356,6 +356,50 @@ test.describe("settings booking section", () => {
     });
   });
 
+  test("page address validation error has no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await prepareSignedInBookingSettingsPage(page, {
+      enabled: false,
+      isConfigured: false,
+      suggestedSlug: "hostuser",
+    });
+    const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+    const address = settingsDialog.getByLabel("Page address");
+    await dispatchFill(address, "ab");
+    await address.blur();
+    await expect(
+      settingsDialog.getByText(
+        "Use 3 to 32 lowercase letters, digits, or hyphens",
+      ),
+    ).toBeVisible();
+    await expectNoAxeViolations(page, {
+      checkpoint: "settings booking address error",
+      include: "[role='dialog']",
+    });
+  });
+
+  test("page address change warning has no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await prepareSignedInBookingSettingsPage(page, {
+      enabled: true,
+      slug: "hostuser",
+      bookingUrl: "https://compasscalendar.com/book/hostuser",
+    });
+    const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+    await dispatchFill(settingsDialog.getByLabel("Page address"), "new-slug");
+    await expect(
+      settingsDialog.getByText(
+        "Links using your old address will stop working.",
+      ),
+    ).toBeVisible();
+    await expectNoAxeViolations(page, {
+      checkpoint: "settings booking address warning",
+      include: "[role='dialog']",
+    });
+  });
+
   test("discard confirmation has no automatically detectable accessibility violations", async ({
     page,
   }) => {

--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -366,12 +366,12 @@ test.describe("settings booking section", () => {
     });
     const settingsDialog = page.getByRole("dialog", { name: "Settings" });
     const address = settingsDialog.getByLabel("Page address");
-    await dispatchFill(address, "ab");
+    await address.fill("ab");
     await address.blur();
     await expect(
-      settingsDialog.getByText(
-        "Use 3 to 32 lowercase letters, digits, or hyphens",
-      ),
+      settingsDialog.getByRole("alert").filter({
+        hasText: "Use 3 to 32 lowercase letters, digits, or hyphens",
+      }),
     ).toBeVisible();
     await expectNoAxeViolations(page, {
       checkpoint: "settings booking address error",

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -963,6 +963,8 @@ export interface HostBookingSettingsStubOptions {
   bookingUrl?: string;
   microsoftConnect?: boolean;
   enabled?: boolean;
+  isConfigured?: boolean;
+  suggestedSlug?: string;
   weeklyAvailability?: Array<{
     weekday: 1 | 2 | 3 | 4 | 5 | 6 | 7;
     start: string;
@@ -982,6 +984,8 @@ export async function prepareSignedInBookingSettingsPage(
   const bookingUrl =
     options.bookingUrl ?? `https://compasscalendar.com/book/${slug}`;
   const enabled = options.enabled ?? true;
+  const isConfigured = options.isConfigured ?? true;
+  const suggestedSlug = options.suggestedSlug ?? slug;
   const weeklyAvailability =
     options.weeklyAvailability ?? DEFAULT_WEEKLY_AVAILABILITY;
   const captured: CapturedHostBookingRequests = { putBodies: [] };
@@ -1011,14 +1015,19 @@ export async function prepareSignedInBookingSettingsPage(
     guestsCanInviteOthers: true,
   };
 
-  const savedPageFields = {
-    id: "000000000000000000000001",
-    slug,
-    hostUserId: "000000000000000000000002",
-    createdAt: new Date(0).toISOString(),
-    updatedAt: new Date(0).toISOString(),
-    bookingUrl,
-  };
+  const savedPageFields = isConfigured
+    ? {
+        id: "000000000000000000000001",
+        slug,
+        hostUserId: "000000000000000000000002",
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+        bookingUrl,
+      }
+    : {
+        isConfigured: false,
+        suggestedSlug,
+      };
 
   await page.route("**/api/**", async (route) => {
     const request = route.request();
@@ -1048,10 +1057,31 @@ export async function prepareSignedInBookingSettingsPage(
     if (path.endsWith("/api/booking/page") && request.method() === "PUT") {
       const body = request.postDataJSON() as Record<string, unknown>;
       captured.putBodies.push(body);
+      const nextSlug = typeof body.slug === "string" ? body.slug : slug;
+      const nextBookingUrl = `https://compasscalendar.com/book/${nextSlug}`;
+      const putResponseFields = isConfigured
+        ? {
+            id: "000000000000000000000001",
+            slug: nextSlug,
+            hostUserId: "000000000000000000000002",
+            createdAt: new Date(0).toISOString(),
+            updatedAt: new Date(0).toISOString(),
+            bookingUrl: nextBookingUrl,
+          }
+        : {
+            isConfigured: true,
+            suggestedSlug: nextSlug,
+            id: "000000000000000000000001",
+            slug: nextSlug,
+            hostUserId: "000000000000000000000002",
+            createdAt: new Date(0).toISOString(),
+            updatedAt: new Date(0).toISOString(),
+            bookingUrl: nextBookingUrl,
+          };
       return route.fulfill(
         jsonResponse({
           ...bookingPagePayload,
-          ...savedPageFields,
+          ...putResponseFields,
           ...body,
         }),
       );

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -13,6 +13,24 @@ const openMoreOptions = async (settingsDialog: Locator) => {
   await settingsDialog.getByText("More options", { exact: true }).click();
 };
 
+test("changes the page address and PUTs slug", async ({ page }) => {
+  const captured = await prepareSignedInBookingSettingsPage(page, {
+    enabled: false,
+    isConfigured: false,
+    suggestedSlug: "hostuser",
+  });
+
+  const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+  const address = settingsDialog.getByLabel("Page address");
+  await dispatchFill(address, "my-booking-page");
+  await dispatchClick(
+    settingsDialog.getByRole("button", { name: "Turn on booking page" }),
+  );
+
+  await expect.poll(() => captured.putBodies.length).toBe(1);
+  expect(captured.putBodies[0]).toMatchObject({ slug: "my-booking-page" });
+});
+
 test("settings booking page shows a copyable public link after save", async ({
   page,
 }) => {

--- a/packages/web/src/booking/BookingAddressField.tsx
+++ b/packages/web/src/booking/BookingAddressField.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { BookingSlugSchema } from "@core/types/booking.contracts";
+import { BookingFieldLabel } from "@web/booking/BookingFieldLabel";
+import { bookingFieldAttrs } from "@web/booking/booking-sequence.fields";
+
+export const BOOKING_ADDRESS_HELPER =
+  "3 to 32 lowercase letters, digits, or hyphens.";
+
+export const BOOKING_ADDRESS_CHANGE_WARNING =
+  "Links using your old address will stop working.";
+
+export function bookingAddressPrefix(bookingUrl: string | null): string {
+  if (bookingUrl) {
+    return `${new URL(bookingUrl).origin}/book/`;
+  }
+  return `${window.location.origin}/book/`;
+}
+
+interface BookingAddressFieldProps {
+  value: string;
+  onChange: (slug: string) => void;
+  bookingUrl: string | null;
+  savedSlug: string | undefined;
+  showShortcuts: boolean;
+  highlightInvalid?: boolean;
+}
+
+export function BookingAddressField({
+  value,
+  onChange,
+  bookingUrl,
+  savedSlug,
+  showShortcuts,
+  highlightInvalid = false,
+}: BookingAddressFieldProps) {
+  const [blurred, setBlurred] = useState(false);
+  const prefix = bookingAddressPrefix(bookingUrl);
+  const parseResult = BookingSlugSchema.safeParse(value);
+  const showInlineError = (blurred || highlightInvalid) && !parseResult.success;
+  const errorMessage = !parseResult.success
+    ? (parseResult.error.issues[0]?.message ?? BOOKING_ADDRESS_HELPER)
+    : null;
+  const errorId = "booking-address-error";
+  const showWarning = savedSlug !== undefined && value !== savedSlug;
+
+  return (
+    <div>
+      <BookingFieldLabel
+        field="address"
+        htmlFor="booking-address"
+        showShortcuts={showShortcuts}
+      >
+        Page address
+      </BookingFieldLabel>
+      <div className="flex overflow-hidden rounded border border-border bg-surface-overlay text-sm text-text">
+        <span className="shrink-0 border-border border-r bg-surface-panel px-2 py-1 text-text-muted">
+          {prefix}
+        </span>
+        <input
+          {...bookingFieldAttrs("address")}
+          aria-describedby={showInlineError ? errorId : undefined}
+          aria-invalid={showInlineError || undefined}
+          autoCapitalize="none"
+          className="c-focus-ring min-w-0 flex-1 bg-transparent px-2 py-1 aria-invalid:text-error"
+          id="booking-address"
+          onBlur={() => setBlurred(true)}
+          onChange={(event) => onChange(event.target.value.toLowerCase())}
+          spellCheck={false}
+          value={value}
+        />
+      </div>
+      <p className="mt-1 text-text-muted text-xs">{BOOKING_ADDRESS_HELPER}</p>
+      {showInlineError && errorMessage ? (
+        <p className="text-error text-xs" id={errorId} role="alert">
+          {errorMessage}
+        </p>
+      ) : null}
+      {showWarning ? (
+        <p className="mt-1 text-sm text-warning" role="status">
+          {BOOKING_ADDRESS_CHANGE_WARNING}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/web/src/booking/BookingAddressField.tsx
+++ b/packages/web/src/booking/BookingAddressField.tsx
@@ -52,7 +52,9 @@ export function BookingAddressField({
       >
         Page address
       </BookingFieldLabel>
-      <div className="flex overflow-hidden rounded border border-border bg-surface-overlay text-sm text-text">
+      <div
+        className={`flex overflow-hidden rounded border bg-surface-overlay text-sm text-text ${showInlineError ? "border-error" : "border-border"}`}
+      >
         <span className="shrink-0 border-border border-r bg-surface-panel px-2 py-1 text-text-muted">
           {prefix}
         </span>
@@ -61,7 +63,7 @@ export function BookingAddressField({
           aria-describedby={showInlineError ? errorId : undefined}
           aria-invalid={showInlineError || undefined}
           autoCapitalize="none"
-          className="c-focus-ring min-w-0 flex-1 bg-transparent px-2 py-1 aria-invalid:text-error"
+          className="c-focus-ring min-w-0 flex-1 bg-transparent px-2 py-1"
           id="booking-address"
           onBlur={() => setBlurred(true)}
           onChange={(event) => onChange(event.target.value.toLowerCase())}
@@ -71,12 +73,19 @@ export function BookingAddressField({
       </div>
       <p className="mt-1 text-text-muted text-xs">{BOOKING_ADDRESS_HELPER}</p>
       {showInlineError && errorMessage ? (
-        <p className="text-error text-xs" id={errorId} role="alert">
+        <p
+          className="rounded border border-error/40 bg-surface-panel px-2 py-1 text-sm text-text"
+          id={errorId}
+          role="alert"
+        >
           {errorMessage}
         </p>
       ) : null}
       {showWarning ? (
-        <p className="mt-1 text-sm text-warning" role="status">
+        <p
+          className="mt-1 rounded border border-warning/40 bg-warning/10 px-2 py-1 text-sm text-text"
+          role="status"
+        >
           {BOOKING_ADDRESS_CHANGE_WARNING}
         </p>
       ) : null}

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -239,17 +239,9 @@ describe("BookingSettingsSection", () => {
       rest.get(bookingPageUrl, (_req, res, ctx) =>
         res(
           ctx.json({
-            enabled: false,
+            ...unconfiguredPage(),
             durationMinutes: 45,
-            destinationCalendarId: writableCalendar.id,
-            blockingCalendarIds: [writableCalendar.id],
             timeZone: "America/New_York",
-            weeklyAvailability: DEFAULT_WEEKLY_AVAILABILITY,
-            minNoticeHours: 4,
-            maxHorizonDays: 60,
-            bufferMinutes: null,
-            maxBookingsPerDay: null,
-            guestsCanInviteOthers: true,
           }),
         ),
       ),
@@ -617,7 +609,6 @@ describe("BookingSettingsSection", () => {
             bufferMinutes: null,
             maxBookingsPerDay: null,
             guestsCanInviteOthers: true,
-            // Saved, never enabled. UTC here is a deliberate choice.
             isConfigured: true,
             suggestedSlug: "hostuser",
           }),
@@ -1308,17 +1299,10 @@ describe("BookingSettingsSection", () => {
       rest.get(bookingPageUrl, (_req, res, ctx) =>
         res(
           ctx.json({
-            enabled: false,
-            durationMinutes: 30,
+            ...unconfiguredPage(),
             destinationCalendarId: "000000000000000000000001",
             blockingCalendarIds: ["000000000000000000000001"],
-            timeZone: "UTC",
             weeklyAvailability: [],
-            minNoticeHours: 4,
-            maxHorizonDays: 60,
-            bufferMinutes: null,
-            maxBookingsPerDay: null,
-            guestsCanInviteOthers: true,
           }),
         ),
       ),
@@ -1428,17 +1412,7 @@ describe("BookingSettingsSection", () => {
       rest.get(bookingPageUrl, (_req, res, ctx) =>
         res(
           ctx.json({
-            enabled: false,
-            durationMinutes: 30,
-            destinationCalendarId: writableCalendar.id,
-            blockingCalendarIds: [writableCalendar.id],
-            timeZone: "UTC",
-            weeklyAvailability: DEFAULT_WEEKLY_AVAILABILITY,
-            minNoticeHours: 4,
-            maxHorizonDays: 60,
-            bufferMinutes: null,
-            maxBookingsPerDay: null,
-            guestsCanInviteOthers: true,
+            ...unconfiguredPage(),
           }),
         ),
       ),
@@ -1492,21 +1466,7 @@ describe("BookingSettingsSection", () => {
 
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(
-          ctx.json({
-            enabled: false,
-            durationMinutes: 30,
-            destinationCalendarId: writableCalendar.id,
-            blockingCalendarIds: [writableCalendar.id],
-            timeZone: "UTC",
-            weeklyAvailability: DEFAULT_WEEKLY_AVAILABILITY,
-            minNoticeHours: 4,
-            maxHorizonDays: 60,
-            bufferMinutes: null,
-            maxBookingsPerDay: null,
-            guestsCanInviteOthers: true,
-          }),
-        ),
+        res(ctx.json(unconfiguredPage())),
       ),
       rest.put(bookingPageUrl, (_req, res, ctx) =>
         res(

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -1853,6 +1853,265 @@ describe("BookingSettingsSection", () => {
     expect(details).toHaveAttribute("open");
   });
 
+  it("shows suggested address on an unconfigured page and is not dirty", async () => {
+    userMetadataActions.set(healthyGoogleMetadata);
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
+    expect(screen.getByLabelText("Page address")).toHaveValue("hostuser");
+    expect(
+      screen.getByText(/It will be at .*\/book\/hostuser/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: BOOKING_SAVE_DRAFT_LABEL }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("PUTs slug when the page address is edited", async () => {
+    const user = userEvent.setup({ delay: null });
+    let savedBody: unknown;
+    userMetadataActions.set(healthyGoogleMetadata);
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+      rest.put(bookingPageUrl, async (req, res, ctx) => {
+        savedBody = await req.json();
+        return res(
+          ctx.json({
+            ...(savedBody as object),
+            id: createObjectIdString(),
+            slug: (savedBody as { slug: string }).slug,
+            hostUserId: createObjectIdString(),
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            bookingUrl: `https://compasscalendar.com/book/${(savedBody as { slug: string }).slug}`,
+          }),
+        );
+      }),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    const address = await screen.findByLabelText("Page address");
+    await user.clear(address);
+    await user.type(address, "my-page");
+    await user.click(
+      screen.getByRole("button", { name: BOOKING_TURN_ON_LABEL }),
+    );
+
+    await waitFor(() => {
+      expect(savedBody).toMatchObject({ slug: "my-page" });
+    });
+  });
+
+  it("blocks save for an invalid page address and focuses the field", async () => {
+    const user = userEvent.setup({ delay: null });
+    let putCount = 0;
+    userMetadataActions.set(healthyGoogleMetadata);
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+      rest.put(bookingPageUrl, (_req, res, ctx) => {
+        putCount += 1;
+        return res(ctx.status(500));
+      }),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    const address = await screen.findByLabelText("Page address");
+    await user.clear(address);
+    await user.type(address, "ab");
+    await user.tab();
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Use 3 to 32 lowercase letters, digits, or hyphens",
+    );
+    expect(address).toHaveAttribute("aria-invalid", "true");
+
+    await user.click(
+      screen.getByRole("button", { name: BOOKING_TURN_ON_LABEL }),
+    );
+    expect(putCount).toBe(0);
+    expect(document.activeElement).toBe(address);
+  });
+
+  it("renders SLUG_TAKEN inline beside the save bar, focuses the field, and does not toast", async () => {
+    const user = userEvent.setup({ delay: null });
+    const { port, mocks } = createTestToastPort();
+    registerToastPort(port);
+    userMetadataActions.set(healthyGoogleMetadata);
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+      rest.put(bookingPageUrl, (_req, res, ctx) =>
+        res(
+          ctx.status(409),
+          ctx.json({
+            code: "SLUG_TAKEN",
+            message: "That address is already taken",
+          }),
+        ),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    const address = await screen.findByLabelText("Page address");
+    await user.clear(address);
+    await user.type(address, "taken-slug");
+    await user.click(
+      screen.getByRole("button", { name: BOOKING_TURN_ON_LABEL }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        BOOKING_SAVE_ERROR_COPY.SLUG_TAKEN,
+      );
+    });
+    expect(mocks.error).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(address);
+  });
+
+  it("shows the address-change warning only when a saved slug is changed", async () => {
+    const user = userEvent.setup({ delay: null });
+    const bookingUrl = "https://compasscalendar.com/book/hostuser";
+    userMetadataActions.set(healthyGoogleMetadata);
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(
+          ctx.json({
+            id: createObjectIdString(),
+            slug: "hostuser",
+            hostUserId: createObjectIdString(),
+            enabled: true,
+            durationMinutes: 30,
+            destinationCalendarId: writableCalendar.id,
+            blockingCalendarIds: [writableCalendar.id],
+            timeZone: "UTC",
+            weeklyAvailability: DEFAULT_WEEKLY_AVAILABILITY,
+            minNoticeHours: 4,
+            maxHorizonDays: 60,
+            bufferMinutes: null,
+            maxBookingsPerDay: null,
+            guestsCanInviteOthers: true,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            bookingUrl,
+          }),
+        ),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    const address = await screen.findByLabelText("Page address");
+    expect(
+      screen.queryByText("Links using your old address will stop working."),
+    ).not.toBeInTheDocument();
+
+    await user.clear(address);
+    await user.type(address, "new-slug");
+    expect(
+      screen.getByText("Links using your old address will stop working."),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show the address-change warning on an unconfigured page", async () => {
+    const user = userEvent.setup({ delay: null });
+    userMetadataActions.set(healthyGoogleMetadata);
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    const address = await screen.findByLabelText("Page address");
+    await user.clear(address);
+    await user.type(address, "other-slug");
+    expect(
+      screen.queryByText("Links using your old address will stop working."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("jumps to the page address with e then a", async () => {
+    const user = userEvent.setup({ delay: null });
+    userMetadataActions.set(healthyGoogleMetadata);
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
+
+    await user.keyboard("e");
+    await user.keyboard("a");
+
+    expect(document.activeElement).toBe(screen.getByLabelText("Page address"));
+  });
+
   it("renders DESTINATION_NOT_WRITABLE inline, focuses destination, and does not toast", async () => {
     const user = userEvent.setup({ delay: null });
     const { port, mocks } = createTestToastPort();

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -22,6 +22,10 @@ import {
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
 import { useAppAccess } from "@web/billing/useAppAccess";
+import {
+  BookingAddressField,
+  bookingAddressPrefix,
+} from "@web/booking/BookingAddressField";
 import { BookingBlockingCalendarsField } from "@web/booking/BookingBlockingCalendarsField";
 import { BookingConnectGooglePrompt } from "@web/booking/BookingConnectGooglePrompt";
 import { BookingFieldLabel } from "@web/booking/BookingFieldLabel";
@@ -45,6 +49,7 @@ import {
   isPlaceholderDestinationCalendar,
   isUnconfiguredBookingPage,
   isWelcomeTextTooLong,
+  resolveBookingFormSlug,
   resolveWritableCalendars,
   toBookingPageInput,
   validateBookingForm,
@@ -168,6 +173,7 @@ const buildInitialForm = (
 
   return {
     ...toBookingPageInput(base),
+    slug: resolveBookingFormSlug(page),
     destinationCalendarId,
     blockingCalendarIds,
     timeZone: TimeZoneSchema.parse(timeZone || effectiveTimeZone),
@@ -381,6 +387,10 @@ export function BookingSettingsSection({
   const savedPage =
     serverPage && isSavedBookingPage(serverPage) ? serverPage : null;
   const isLive = savedPage?.enabled === true;
+  const addressPreview =
+    form.slug !== undefined
+      ? `${bookingAddressPrefix(savedPage?.bookingUrl ?? null)}${form.slug}`
+      : null;
   const { groups: writableGroups, ungrouped: writableUngrouped } =
     groupCalendarsByAccount(writableCalendars, connections);
   const destinationCalendar = writableCalendars.find(
@@ -509,10 +519,21 @@ export function BookingSettingsSection({
         </p>
 
         <BookingStatusHeader
-          addressPreview={null}
+          addressPreview={addressPreview}
           bookingUrl={savedPage?.bookingUrl ?? null}
           isLive={isLive}
         />
+
+        {form.slug !== undefined ? (
+          <BookingAddressField
+            bookingUrl={savedPage?.bookingUrl ?? null}
+            highlightInvalid={saveError?.field === "address"}
+            onChange={(slug) => updateForm({ slug })}
+            savedSlug={savedPage?.slug}
+            showShortcuts={showShortcuts}
+            value={form.slug}
+          />
+        ) : null}
 
         <div className="grid grid-cols-2 gap-3">
           <div>

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -510,7 +510,7 @@ export function BookingSettingsSection({
   return (
     <>
       <fieldset
-        className="flex flex-col gap-4"
+        className="flex flex-col gap-3"
         disabled={isReadOnly || saveMutation.isPending}
         ref={sectionRef}
       >

--- a/packages/web/src/booking/booking-sequence.fields.ts
+++ b/packages/web/src/booking/booking-sequence.fields.ts
@@ -13,6 +13,7 @@
  */
 export const BOOKING_SEQUENCE_FIELDS = [
   { key: "e", field: "enabled", label: "Booking page on or off" },
+  { key: "a", field: "address", label: "Page address" },
   { key: "d", field: "duration", label: "Duration" },
   { key: "c", field: "destination", label: "Destination calendar" },
   { key: "b", field: "blocking", label: "Blocking calendars" },

--- a/packages/web/src/booking/booking.query.ts
+++ b/packages/web/src/booking/booking.query.ts
@@ -44,6 +44,7 @@ export const BOOKING_SAVE_ERROR_COPY: Record<string, string> = {
   TIMEZONE_REQUIRED: "Choose a booking timezone before enabling booking.",
   AVAILABILITY_REQUIRED:
     "Add weekly hours before turning on your booking page.",
+  SLUG_TAKEN: "That address is already taken. Try another.",
   INVALID_INPUT:
     "Some settings couldn't be saved. Check the highlighted fields and try again.",
 };
@@ -53,6 +54,7 @@ const INLINE_SAVE_ERROR_FIELDS: Record<string, BookingSequenceField> = {
   DESTINATION_NOT_WRITABLE: "destination",
   BLOCKING_CALENDAR_INVALID: "blocking",
   AVAILABILITY_REQUIRED: "hours",
+  SLUG_TAKEN: "address",
 };
 
 export function bookingSaveErrorInline(

--- a/packages/web/src/booking/booking.util.ts
+++ b/packages/web/src/booking/booking.util.ts
@@ -1,6 +1,7 @@
 import {
   type AdminGetBookingPageResult,
   type AdminPutBookingPageInput,
+  BookingSlugSchema,
   pickAdminPutBookingPageInput,
   type WeeklyAvailabilityInterval,
 } from "@core/types/booking.contracts";
@@ -163,6 +164,28 @@ export type BookingFormValidationError = {
   field?: BookingSequenceField;
 };
 
+export function bookingSlugValidationError(
+  slug: string | undefined,
+): BookingFormValidationError | null {
+  const result = BookingSlugSchema.safeParse(slug ?? "");
+  if (result.success) {
+    return null;
+  }
+  return {
+    field: "address",
+    message: result.error.issues[0]?.message ?? "Enter a valid page address.",
+  };
+}
+
+export function resolveBookingFormSlug(
+  page: AdminGetBookingPageResult | undefined,
+): string | undefined {
+  if (!page) {
+    return undefined;
+  }
+  return "bookingUrl" in page ? page.slug : page.suggestedSlug;
+}
+
 export function validateBookingForm({
   areHoursValid,
   enabling,
@@ -178,6 +201,10 @@ export function validateBookingForm({
   minNoticeInvalid: boolean;
   writableCalendars: Calendar[];
 }): BookingFormValidationError | null {
+  const slugError = bookingSlugValidationError(form.slug);
+  if (slugError) {
+    return slugError;
+  }
   if (!areHoursValid) {
     return {
       field: "hours",


### PR DESCRIPTION
Fixes #3484

## What and why

Adds the editable **Page address** field as the first Essentials control on Settings > Booking. Hosts see `<origin>/book/` plus a slug seeded from `suggestedSlug` or their saved slug, with inline validation, a rename warning when a live slug changes, and inline `SLUG_TAKEN` handling beside the save bar. Jump key `e` then `a` focuses the field; docs and e2e/a11y coverage are updated.

## Verify

```
Selected packages: web
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)

VERDICT: PASS
```