### PR TITLE
refactor(booking): remove duplication left by the v1.6 booking work

### DIFF
--- a/packages/core/src/types/booking.contracts.ts
+++ b/packages/core/src/types/booking.contracts.ts
@@ -515,6 +515,17 @@ export type AdminGetBookingPageResult =
   | AdminGetBookingPageResponse
   | AdminGetBookingPageSetupResponse;
 
+/**
+ * `bookingUrl` is the discriminator between the two admin answers: only a
+ * saved, addressable page carries a public link. One predicate keeps the API
+ * parser and every UI consumer narrowing the union the same way. It accepts
+ * `unknown` so the response parser can use it before validation.
+ */
+export const isSavedBookingPage = (
+  page: unknown,
+): page is AdminGetBookingPageResponse =>
+  typeof page === "object" && page !== null && "bookingUrl" in page;
+
 const slugifyBookingCandidate = (value: string): string =>
   value.toLowerCase().replace(/[^a-z0-9]/g, "");
 

--- a/packages/web/src/api/booking.api.ts
+++ b/packages/web/src/api/booking.api.ts
@@ -1,34 +1,28 @@
 import {
-  type AdminGetBookingPageResponse,
   AdminGetBookingPageResponseSchema,
   type AdminGetBookingPageResult,
   AdminGetBookingPageSetupResponseSchema,
   type AdminPutBookingPageInput,
+  isSavedBookingPage,
 } from "@core/types/booking.contracts";
 import { BaseApi } from "@web/api/base/base.api";
 
-const isAdminGetBookingPageResponse = (
-  page: unknown,
-): page is AdminGetBookingPageResponse =>
-  typeof page === "object" && page !== null && "bookingUrl" in page;
+const parseBookingPage = (data: unknown): AdminGetBookingPageResult =>
+  isSavedBookingPage(data)
+    ? AdminGetBookingPageResponseSchema.parse(data)
+    : AdminGetBookingPageSetupResponseSchema.parse(data);
 
 const BookingApi = {
   async getPage(): Promise<AdminGetBookingPageResult> {
     const response = await BaseApi.get<unknown>(`/booking/page`);
-    if (isAdminGetBookingPageResponse(response.data)) {
-      return AdminGetBookingPageResponseSchema.parse(response.data);
-    }
-    return AdminGetBookingPageSetupResponseSchema.parse(response.data);
+    return parseBookingPage(response.data);
   },
 
   async putPage(
     input: AdminPutBookingPageInput,
   ): Promise<AdminGetBookingPageResult> {
     const response = await BaseApi.put<unknown>(`/booking/page`, input);
-    if (isAdminGetBookingPageResponse(response.data)) {
-      return AdminGetBookingPageResponseSchema.parse(response.data);
-    }
-    return AdminGetBookingPageSetupResponseSchema.parse(response.data);
+    return parseBookingPage(response.data);
   },
 };
 

--- a/packages/web/src/booking/BookingAddressField.tsx
+++ b/packages/web/src/booking/BookingAddressField.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { BookingSlugSchema } from "@core/types/booking.contracts";
 import { BookingFieldLabel } from "@web/booking/BookingFieldLabel";
+import { bookingSlugParseMessage } from "@web/booking/booking.util";
 import { bookingFieldAttrs } from "@web/booking/booking-sequence.fields";
 
 export const BOOKING_ADDRESS_HELPER =
@@ -13,17 +13,6 @@ export function bookingAddressPrefix(bookingUrl: string | null): string {
     ? new URL(bookingUrl).origin
     : window.location.origin;
   return `${origin}/book/`;
-}
-
-function bookingSlugParseMessage(slug: string | undefined): string | null {
-  const parsed = BookingSlugSchema.safeParse(slug);
-  if (parsed.success) {
-    return null;
-  }
-  return (
-    parsed.error.issues[0]?.message ??
-    "Use 3 to 32 lowercase letters, digits, or hyphens"
-  );
 }
 
 interface BookingAddressFieldProps {

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -7,7 +7,6 @@ import {
   useState,
 } from "react";
 import {
-  type AdminGetBookingPageResponse,
   type AdminGetBookingPageResult,
   type AdminPutBookingPageInput,
   BOOKING_MAX_HORIZON_DAYS,
@@ -15,6 +14,7 @@ import {
   BOOKING_PLACEHOLDER_CALENDAR_ID,
   type BookingDurationMinutes,
   buildDefaultAdminPutInput,
+  isSavedBookingPage,
 } from "@core/types/booking.contracts";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId, TimeZoneSchema } from "@core/types/domain-primitives";
@@ -108,9 +108,18 @@ const MORE_OPTIONS_FIELDS = new Set<BookingSequenceField>([
 const BOOKING_SELECT_CLASS_NAME =
   "c-focus-ring w-full rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text hover:bg-surface-panel";
 
-const isSavedBookingPage = (
-  page: AdminPutBookingPageInput | AdminGetBookingPageResponse,
-): page is AdminGetBookingPageResponse => "bookingUrl" in page;
+/** Copy the public link, then report whichever of the two outcomes happened. */
+const copyBookingLinkThenToast = (
+  bookingUrl: string,
+  copy: { onCopy: string; onFail: string },
+) => {
+  void copyText(bookingUrl).then((didCopy) => {
+    if (didCopy) {
+      track("booking_link_copied", { source: "save" });
+    }
+    showStatusToast("booking-link-copied", didCopy ? copy.onCopy : copy.onFail);
+  });
+};
 
 const parseBookingCount = (
   raw: string,
@@ -348,6 +357,15 @@ export function BookingSettingsSection({
     writableCalendars,
   ]);
 
+  // Not ready until the calendars settle and the effect above has consumed
+  // this server page. The analytics effect and the render guard must read the
+  // same value, or "settings opened" fires against a form the host cannot see.
+  const isSeedingForm =
+    isPending ||
+    calendarsPending ||
+    waitingForHostCalendars ||
+    (serverPage != null && seededPageRef.current !== serverPage);
+
   const isDirty =
     (baselineFormRef.current !== null &&
       isBookingSettingsFormDirty({
@@ -383,46 +401,23 @@ export function BookingSettingsSection({
       });
       return;
     }
-    if (
-      isPending ||
-      calendarsPending ||
-      waitingForHostCalendars ||
-      (serverPage != null && seededPageRef.current !== serverPage)
-    ) {
-      return;
-    }
+    if (isSeedingForm) return;
     settingsOpenedRef.current = true;
-    const isLive =
-      serverPage != null &&
-      "bookingUrl" in serverPage &&
-      serverPage.enabled === true;
     track("booking_settings_opened", {
       has_connection: true,
-      is_live: isLive,
+      is_live: isSavedBookingPage(serverPage) && serverPage.enabled === true,
     });
-  }, [
-    calendarsPending,
-    hasHealthyConnection,
-    isPending,
-    serverPage,
-    waitingForHostCalendars,
-  ]);
+  }, [hasHealthyConnection, isSeedingForm, serverPage]);
 
   if (!hasHealthyConnection) {
     return <BookingConnectPrompt />;
   }
 
-  if (
-    isPending ||
-    calendarsPending ||
-    waitingForHostCalendars ||
-    (serverPage != null && seededPageRef.current !== serverPage)
-  ) {
+  if (isSeedingForm) {
     return <p className="text-sm text-text-muted">Loading booking settings…</p>;
   }
 
-  const savedPage =
-    serverPage && isSavedBookingPage(serverPage) ? serverPage : null;
+  const savedPage = isSavedBookingPage(serverPage) ? serverPage : null;
   const isLive = savedPage?.enabled === true;
   const savedSlug =
     serverPage && !isUnconfiguredBookingPage(serverPage)
@@ -499,47 +494,33 @@ export function BookingSettingsSection({
           if (inline) setSaveError(inline);
         },
         onSuccess: (page) => {
-          if (enabled && !wasLive) {
-            track("booking_page_enabled", {
-              first_time: savedPage == null,
-            });
-            if (!("bookingUrl" in page)) return;
-            void copyText(page.bookingUrl).then((didCopy) => {
-              if (didCopy) {
-                track("booking_link_copied", { source: "save" });
-              }
-              showStatusToast(
-                "booking-link-copied",
-                didCopy
-                  ? "Your booking page is live. Link copied."
-                  : "Live. Press e then l to copy your link.",
-              );
-            });
-            return;
-          }
-          if (!enabled && wasLive) {
-            showStatusToast("booking-link-copied", "Booking page turned off.");
-            return;
-          }
           if (!enabled) {
             showStatusToast(
               "booking-link-copied",
-              "Saved. Turn on your booking page to share the link.",
+              wasLive
+                ? "Booking page turned off."
+                : "Saved. Turn on your booking page to share the link.",
             );
             return;
           }
-          if (!("bookingUrl" in page)) return;
-          void copyText(page.bookingUrl).then((didCopy) => {
-            if (didCopy) {
-              track("booking_link_copied", { source: "save" });
-            }
-            showStatusToast(
-              "booking-link-copied",
-              didCopy
-                ? "Saved. Booking link copied."
-                : "Saved. Press e then l to copy your link.",
-            );
-          });
+          if (!wasLive) {
+            track("booking_page_enabled", {
+              first_time: savedPage == null,
+            });
+          }
+          if (!isSavedBookingPage(page)) return;
+          copyBookingLinkThenToast(
+            page.bookingUrl,
+            wasLive
+              ? {
+                  onCopy: "Saved. Booking link copied.",
+                  onFail: "Saved. Press e then l to copy your link.",
+                }
+              : {
+                  onCopy: "Your booking page is live. Link copied.",
+                  onFail: "Live. Press e then l to copy your link.",
+                },
+          );
         },
       },
     );

--- a/packages/web/src/booking/booking.util.ts
+++ b/packages/web/src/booking/booking.util.ts
@@ -157,6 +157,24 @@ export const isWelcomeTextTooLong = (
   welcomeText: string | null | undefined,
 ): boolean => (welcomeText?.length ?? 0) > WELCOME_TEXT_MAX_LENGTH;
 
+const BOOKING_SLUG_FALLBACK_MESSAGE =
+  "Use 3 to 32 lowercase letters, digits, or hyphens";
+
+/**
+ * The first schema complaint about a slug, or null when it parses. The address
+ * field shows this on blur and the save path reuses it, so the inline hint and
+ * the save error can never disagree.
+ */
+export function bookingSlugParseMessage(
+  slug: string | undefined,
+): string | null {
+  const parsed = BookingSlugSchema.safeParse(slug);
+  if (parsed.success) {
+    return null;
+  }
+  return parsed.error.issues[0]?.message ?? BOOKING_SLUG_FALLBACK_MESSAGE;
+}
+
 export type BookingFormValidationError = {
   message: string;
   field?: BookingSequenceField;
@@ -177,14 +195,9 @@ export function validateBookingForm({
   minNoticeInvalid: boolean;
   writableCalendars: Calendar[];
 }): BookingFormValidationError | null {
-  const slugError = BookingSlugSchema.safeParse(form.slug);
-  if (!slugError.success) {
-    return {
-      field: "address",
-      message:
-        slugError.error.issues[0]?.message ??
-        "Use 3 to 32 lowercase letters, digits, or hyphens",
-    };
+  const slugMessage = bookingSlugParseMessage(form.slug);
+  if (slugMessage) {
+    return { field: "address", message: slugMessage };
   }
   if (!areHoursValid) {
     return {


### PR DESCRIPTION
## What and why

Nightly technical-debt sweep over the last 7 days of merged work. The v1.6 booking work packages (#3487, #3490, #3492, #3493, #3495) were the week's largest churn by a wide margin, and they left four repetitions behind in the host settings surface. #3497 already took one pass at this; these are the four it did not reach. All four are behavior-preserving.

- **The union discriminator was open-coded five times.** `"bookingUrl" in page` is what separates a saved, addressable booking page from a setup response, and it appeared behind two near-identical local predicates (`booking.api.ts`, `BookingSettingsSection.tsx`) plus three raw inline checks. One `isSavedBookingPage` now lives in `booking.contracts.ts`, the contract that owns the union, so the response parser and every UI consumer narrow the same way.
- **The slug parse message was implemented twice**, once for the address field's inline hint and once for the save path, each with its own copy of the hardcoded fallback string. A shared `bookingSlugParseMessage` in `booking.util.ts` means the inline hint and the save error can no longer disagree.
- **The four-clause "form is not seeded yet" condition was duplicated** between the analytics effect and the render guard, which is exactly the drift that would fire `booking_settings_opened` against a form the host cannot see yet. It is now derived once as `isSeedingForm` and both read it. The event still fires once, with the same payload; it now fires on the render where the form actually appears rather than the one before it.
- **The save `onSuccess` handler ran the same copy-link-then-toast sequence down two branches** that differed only in their two strings. Collapsed to one `copyBookingLinkThenToast` helper plus the copy each branch supplies. Every toast string is preserved verbatim and `booking_link_copied` / `booking_page_enabled` fire on exactly the same paths as before.

Net 100 lines removed, 88 added, no contract or behavior change.

## Verify

**CI is green: all 18 check runs pass on `743af47`**, including `static`, all six `unit-leg` jobs, and all four `e2e-shard` jobs (shard 1 `e2e/accessibility`, shard 2 `e2e/booking`).

Local `bun run verify --strict` returned `VERDICT: FAIL`, but only from sandbox speed, which CI has now confirmed:

```
Selected packages: core, web
Checks run: test:core, test:web, type-check, lint, knip
Checks skipped: (none)
Failed: test:a11y, test:e2e
VERDICT: FAIL
```

Locally passing: `test:core` (743 pass, 0 fail), `test:web` (826 pass, 0 fail, including all of `BookingSettingsSection.test.tsx`), `type-check`, `lint`, `knip`.

The two Playwright checks failed only under the sandbox's speed. Every failure there was a 30s timeout on `page.goto`, `page.waitForLoadState`, or the axe `frame.evaluate`, never an assertion, and never in a file this diff can reach:

- `test:a11y`: 35 passed, 8 failed, 12.9 minutes. Failures all in `app-a11y.spec.ts`, `apple-connect-a11y.spec.ts` and `datepicker-a11y.spec.ts`. `booking-a11y.spec.ts` passed in full.
- `e2e/booking`: 52 passed, 2 failed, 10.0 minutes. Both failures in the public guest flow, which reads through `public-booking.query.ts`, not `booking.api.ts`. `host-settings.spec.ts` passed in full.

The same suites finish in about 3 minutes on CI runners and are green there. No timeout was widened and no test was skipped or weakened.

**Not labelled `agent-automerge`, and left for human review.** The debt-sweep routine's auto-merge gate refers to a path denylist in `.github/scripts/autofix-merge-guard.sh` that no longer exists: both merge guards now state that path prefixes are not a merge gate. With the gate the routine was told to apply gone, this is left for a human to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hQMQQLgZknXP9eoFm4qzt
