### PR TITLE
feat(booking): serve public pages at /meet with /book redirect

### DIFF
--- a/.github/scripts/agent-loop-staging-smoke.sh
+++ b/.github/scripts/agent-loop-staging-smoke.sh
@@ -38,6 +38,8 @@ check_url() {
 check_url "/"
 check_url "/book/"
 check_url "/book/tylerdeane"
+check_url "/meet/"
+check_url "/meet/tylerdeane"
 
 if [ "$failures" -gt 0 ]; then
   echo "staging smoke failed (${failures} URL(s))" >&2

--- a/docs/CI-CD/agent-loop-routine.md
+++ b/docs/CI-CD/agent-loop-routine.md
@@ -157,9 +157,9 @@ Override per run with env `AGENT_LOOP_MAX_FILES` and
 
 ## Staging smoke
 
-`GET https://staging.compasscalendar.com`, `/book/`, and
-`/book/tylerdeane` must not return 5xx. 404 is success (page disabled or
-not yet shipped). The smoke script never logs in.
+`GET https://staging.compasscalendar.com`, `/book/`, `/book/tylerdeane`,
+`/meet/`, and `/meet/tylerdeane` must not return 5xx. 404 is success
+(page disabled or not yet shipped). The smoke script never logs in.
 
 Authenticated Settings is out of unattended smoke.
 The `qa-test-staging` skill remains the signed-in sweep when a human is present

--- a/docs/architecture/glossary.md
+++ b/docs/architecture/glossary.md
@@ -156,13 +156,14 @@ Browsers connect with `GET /api/events/stream`.
 
 **Booking page**:
 The one v1 scheduling page owned by a Compass user. Settings configure
-it; guests open it at `/book/:username`.
+it; guests open it at `/meet/:username`. Old `/book/:username` links
+redirect client-side.
 _Avoid_: event type (v1 has one duration per user, not Calendly-style
 multiple event types)
 
 **Booking slug**:
 The immutable-in-v1 public username segment in
-`/book/:username`. Allocated from the host's display name. Not a
+`/meet/:username`. Allocated from the host's display name. Not a
 SuperTokens username and not the Google email.
 _Avoid_: username, handle (until slug editing ships)
 

--- a/docs/development/feature-file-map.md
+++ b/docs/development/feature-file-map.md
@@ -56,8 +56,8 @@ RSVP](../features/attendees.md).
 
 Product spec: [Compass Calendar Booking (v1)](../features/booking.md).
 
-- Public URL: `/book/:username`, confirmation `/book/confirmed/:id`,
-  cancel `/book/cancel/:id` (guest routes outside the calendar shell)
+- Public URL: `/meet/:username`, confirmation `/meet/confirmed/:id`,
+  cancel `/meet/cancel/:id` (guest routes outside the calendar shell)
 - Shared contracts: `packages/core/src/types/booking.contracts.ts`
 - Slot engine: `packages/core/src/booking/compute-booking-slots.ts`
 - Backend admin: `packages/backend/src/booking/controllers/booking.controller.ts`,

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -29,21 +29,26 @@ extraction path; they are not a second service in v1.
 
 ## Public URL
 
-`https://compasscalendar.com/book/:username`
+`https://compasscalendar.com/meet/:username`
 
-Example: `https://compasscalendar.com/book/tyler-dane`
+Example: `https://compasscalendar.com/meet/tyler-dane`
 
 The username is a `bookingSlug` on the host's booking page. Hosts choose it
 in Settings before or after enabling. Interior hyphens are allowed (for
 example `tyler-dane`). Changing the address overwrites the stored slug;
-old links stop working and there are no redirects.
+old slug links stop working and there are no slug redirects.
 
-The guest's selection lives in `/book/:slug` search params
+Old `/book/:username`, `/book/cancel/:id`, `/book/reschedule/:id`, and
+`/book/confirmed/:id` links still work through client-side redirect
+routes that keep the search params (`?token=` rides on cancel and
+reschedule links). API paths stay `/api/booking/*`.
+
+The guest's selection lives in `/meet/:slug` search params
 (`?month=&date=&slot=&tz=`): Back returns from the details step to the
 picker, refresh keeps the selection, and the link is shareable. Invalid
 params drop to defaults; they never error.
 
-Confirmation permalink: `/book/confirmed/:reservationId?token=…`.
+Confirmation permalink: `/meet/confirmed/:reservationId?token=…`.
 The cancel (and post-confirm edit) capability is that unguessable token,
 not the reservation id. Just-confirmed navigation writes `?token=` into
 the permalink so a reload, bookmark, or self-sent link keeps cancel and
@@ -54,13 +59,13 @@ a cancel link in the invite: that URL is omitted from the event
 description when guests can invite others, which is the default.
 Reschedule copy stays history-only (v1.3).
 
-Cancel: `/book/cancel/:reservationId?token=…`.
+Cancel: `/meet/cancel/:reservationId?token=…`.
 
-Reschedule: `/book/reschedule/:reservationId?token=…`.
+Reschedule: `/meet/reschedule/:reservationId?token=…`.
 
 Reserved slugs (never allocated): `week`, `day`, `life`, `auth`, `api`,
-`cleanup`, `book`, `cancel`, `confirmed`, `reschedule`, `p`, `settings`,
-`admin`, `login`, `logout`, `signup`, `invite`, `calendar`.
+`cleanup`, `book`, `meet`, `cancel`, `confirmed`, `reschedule`, `p`,
+`settings`, `admin`, `login`, `logout`, `signup`, `invite`, `calendar`.
 
 ### Slug allocation
 

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -478,8 +478,8 @@ export async function preparePublicBookingPage(
           slotStart: body.slotStart,
           slotEnd: postedSlotEnd,
           guestTimeZone: body.guestTimeZone,
-          cancelUrl: `https://compasscalendar.com/book/cancel/${reservationId}?token=abc`,
-          rescheduleUrl: `https://compasscalendar.com/book/reschedule/${reservationId}?token=abc`,
+          cancelUrl: `https://compasscalendar.com/meet/cancel/${reservationId}?token=abc`,
+          rescheduleUrl: `https://compasscalendar.com/meet/reschedule/${reservationId}?token=abc`,
         }),
       );
     }
@@ -598,7 +598,7 @@ export async function preparePublicBookingPage(
     return route.fulfill(jsonResponse({}));
   });
 
-  await page.goto(`/book/${slug}`, { waitUntil: "domcontentloaded" });
+  await page.goto(`/meet/${slug}`, { waitUntil: "domcontentloaded" });
   if (options.notFound || options.enabled === false) {
     await expect(
       page.getByRole("heading", { name: "Booking page not found" }),
@@ -716,7 +716,7 @@ export async function preparePublicBookingConfirmedPage(
   const search = options.token
     ? `?token=${encodeURIComponent(options.token)}`
     : "";
-  await page.goto(`/book/confirmed/${reservationId}${search}`, {
+  await page.goto(`/meet/confirmed/${reservationId}${search}`, {
     waitUntil: "domcontentloaded",
   });
 
@@ -803,7 +803,7 @@ export async function preparePublicBookingCancelPage(
   });
 
   const search = token ? `?token=${encodeURIComponent(token)}` : "";
-  await page.goto(`/book/cancel/${reservationId}${search}`, {
+  await page.goto(`/meet/cancel/${reservationId}${search}`, {
     waitUntil: "domcontentloaded",
   });
 
@@ -963,7 +963,7 @@ export async function preparePublicBookingReschedulePage(
   });
 
   const search = token ? `?token=${encodeURIComponent(token)}` : "";
-  await page.goto(`/book/reschedule/${reservationId}${search}`, {
+  await page.goto(`/meet/reschedule/${reservationId}${search}`, {
     waitUntil: "domcontentloaded",
   });
 
@@ -996,7 +996,7 @@ export async function prepareSignedInBookingSettingsPage(
 ): Promise<CapturedHostBookingRequests> {
   const slug = options.slug ?? "hostuser";
   const bookingUrl =
-    options.bookingUrl ?? `https://compasscalendar.com/book/${slug}`;
+    options.bookingUrl ?? `https://compasscalendar.com/meet/${slug}`;
   const configured = options.configured ?? true;
   const healthyConnection = options.healthyConnection ?? true;
   const enabled = options.enabled ?? configured;
@@ -1105,7 +1105,7 @@ export async function prepareSignedInBookingSettingsPage(
         ...savedPageFields,
         ...body,
         slug: nextSlug,
-        bookingUrl: `https://compasscalendar.com/book/${nextSlug}`,
+        bookingUrl: `https://compasscalendar.com/meet/${nextSlug}`,
       };
       return route.fulfill(jsonResponse(getPayload));
     }

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -17,7 +17,7 @@ const openMoreOptions = async (settingsDialog: Locator) => {
 test("settings booking page shows a copyable public link after save", async ({
   page,
 }) => {
-  const bookingUrl = "https://compasscalendar.com/book/hostuser";
+  const bookingUrl = "https://compasscalendar.com/meet/hostuser";
   const captured = await prepareSignedInBookingSettingsPage(page, {
     bookingUrl,
   });
@@ -80,7 +80,7 @@ test("clearing the horizon field shows an inline error and blocks save", async (
 });
 
 test("saves welcome text", async ({ page }) => {
-  const bookingUrl = "https://compasscalendar.com/book/hostuser";
+  const bookingUrl = "https://compasscalendar.com/meet/hostuser";
   const captured = await prepareSignedInBookingSettingsPage(page, {
     bookingUrl,
   });
@@ -108,7 +108,7 @@ test("keyboard hint sits above the public link and the last control stays above 
   page,
 }) => {
   await prepareSignedInBookingSettingsPage(page, {
-    bookingUrl: "https://compasscalendar.com/book/hostuser",
+    bookingUrl: "https://compasscalendar.com/meet/hostuser",
   });
 
   const settingsDialog = page.getByRole("dialog", { name: "Settings" });
@@ -200,7 +200,7 @@ test("turns a not-live unconfigured page on in one click", async ({ page }) => {
     "hostuser",
   );
   await expect(
-    settingsDialog.getByText(/It will be at .*\/book\/hostuser/),
+    settingsDialog.getByText(/It will be at .*\/meet\/hostuser/),
   ).toBeVisible();
 
   await dispatchClick(
@@ -217,14 +217,14 @@ test("turns a not-live unconfigured page on in one click", async ({ page }) => {
     settingsDialog.getByText("Your booking page is live"),
   ).toBeVisible();
   await expect(settingsDialog.getByLabel("Public booking link")).toHaveValue(
-    "https://compasscalendar.com/book/hostuser",
+    "https://compasscalendar.com/meet/hostuser",
   );
   await expect(
     settingsDialog.getByRole("button", { name: "Copy booking link" }),
   ).toBeVisible();
   await expect(
     settingsDialog.getByRole("link", { name: "Open booking page" }),
-  ).toHaveAttribute("href", "https://compasscalendar.com/book/hostuser");
+  ).toHaveAttribute("href", "https://compasscalendar.com/meet/hostuser");
 });
 
 test("blocks turn on with empty hours", async ({ page }) => {

--- a/e2e/booking/public-booking-reschedule.spec.ts
+++ b/e2e/booking/public-booking-reschedule.spec.ts
@@ -44,7 +44,7 @@ test.describe("public booking reschedule", () => {
       .getByRole("link", { name: "Reschedule this booking" })
       .getAttribute("href");
     expect(rescheduleHref).toContain(
-      "/book/reschedule/000000000000000000000099?token=abc",
+      "/meet/reschedule/000000000000000000000099?token=abc",
     );
     // Create returns an absolute compasscalendar.com URL; follow its path on
     // the Playwright origin instead of leaving the stubbed app.
@@ -52,7 +52,7 @@ test.describe("public booking reschedule", () => {
     await page.goto(`${rescheduleUrl.pathname}${rescheduleUrl.search}`);
 
     await expect(page).toHaveURL(
-      /\/book\/reschedule\/000000000000000000000099\?token=abc/,
+      /\/meet\/reschedule\/000000000000000000000099\?token=abc/,
     );
     await expect(
       page.getByRole("heading", {

--- a/e2e/booking/public-booking-v15.spec.ts
+++ b/e2e/booking/public-booking-v15.spec.ts
@@ -37,7 +37,7 @@ test.describe("booking v1.5 escape and self-service", () => {
     await expect(
       page.getByRole("heading", { name: "Your details" }),
     ).toHaveCount(0);
-    await expect(page).toHaveURL(/\/book\/tylerdane/);
+    await expect(page).toHaveURL(/\/meet\/tylerdane/);
   });
 
   test("closes the timezone overlay on Escape without leaving Your details", async ({
@@ -93,7 +93,7 @@ test.describe("booking v1.5 escape and self-service", () => {
     await expect(
       page.getByRole("heading", { name: "Pick a time" }),
     ).toBeVisible();
-    await expect(page).toHaveURL(/\/book\/tylerdane/);
+    await expect(page).toHaveURL(/\/meet\/tylerdane/);
   });
 
   test("does not leave the month grid on Escape", async ({ page }) => {
@@ -134,7 +134,7 @@ test.describe("booking v1.5 escape and self-service", () => {
       page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
     ).toBeVisible();
     await expect(page).toHaveURL(
-      /\/book\/confirmed\/000000000000000000000099\?token=abc$/,
+      /\/meet\/confirmed\/000000000000000000000099\?token=abc$/,
     );
     await expect(
       page.getByRole("button", { name: "Edit details" }),
@@ -155,7 +155,7 @@ test.describe("booking v1.5 escape and self-service", () => {
       page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
     ).toBeFocused();
     await expect(page).toHaveURL(
-      /\/book\/confirmed\/000000000000000000000099\?token=abc$/,
+      /\/meet\/confirmed\/000000000000000000000099\?token=abc$/,
     );
     await expect(page.getByText("Ada Lovelace")).toBeVisible();
     await expect(page.getByText("bring coffee")).toBeVisible();
@@ -215,7 +215,7 @@ test.describe("booking v1.5 escape and self-service", () => {
     await expect(page.getByText("Ada Lovelace")).toBeVisible();
     await expect(page.getByText("Grace Hopper")).toHaveCount(0);
     await expect(page).toHaveURL(
-      /\/book\/confirmed\/000000000000000000000099\?token=abc$/,
+      /\/meet\/confirmed\/000000000000000000000099\?token=abc$/,
     );
   });
 });

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -11,6 +11,21 @@ import {
 } from "./booking-harness";
 
 test.describe("public booking page", () => {
+  test("legacy /book path redirects to /meet and keeps the query string", async ({
+    page,
+  }) => {
+    await page.goto("/book/tylerdane?token=abc", {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(page).toHaveURL(/\/meet\/tylerdane/);
+    expect(new URL(page.url()).searchParams.get("token")).toBe("abc");
+
+    await page.goto("/book/cancel/000000000000000000000099?token=abc", {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(page).toHaveURL(/\/meet\/cancel\/000000000000000000000099/);
+    expect(new URL(page.url()).searchParams.get("token")).toBe("abc");
+  });
   test("renders Teams copy for a Microsoft destination on the public page and confirmation", async ({
     page,
   }) => {
@@ -195,7 +210,7 @@ test.describe("public booking page", () => {
     ).toBeVisible();
     await expect(
       page.getByRole("link", {
-        name: "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+        name: "https://compasscalendar.com/meet/cancel/000000000000000000000099?token=abc",
       }),
     ).toHaveCount(0);
     expect(captured.reservationPosts).toHaveLength(1);
@@ -225,7 +240,7 @@ test.describe("public booking page", () => {
 
     await page.keyboard.press("Escape");
 
-    await expect(page).toHaveURL(/\/book\/tylerdane(?:\?|$)/);
+    await expect(page).toHaveURL(/\/meet\/tylerdane(?:\?|$)/);
     await expect(
       page.getByRole("heading", { name: "Book with Tyler Dane" }),
     ).toBeFocused();
@@ -278,7 +293,7 @@ test.describe("public booking page", () => {
       page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
     ).toBeFocused();
     await expect(page).toHaveURL(
-      /\/book\/confirmed\/000000000000000000000099\?token=abc$/,
+      /\/meet\/confirmed\/000000000000000000000099\?token=abc$/,
     );
     await expect(
       page.getByRole("button", { name: "Copy cancel link" }),
@@ -293,7 +308,7 @@ test.describe("public booking page", () => {
     await expect(page.getByText("Duration")).toBeVisible();
     await expect(page.getByText("30 minutes")).toBeVisible();
     await expect(page).toHaveURL(
-      /\/book\/confirmed\/000000000000000000000099\?token=abc$/,
+      /\/meet\/confirmed\/000000000000000000000099\?token=abc$/,
     );
     await expect(
       page.getByRole("button", { name: "Copy cancel link" }),
@@ -349,7 +364,7 @@ test.describe("public booking page", () => {
       page.getByRole("link", { name: "Cancel this booking" }),
     ).toHaveAttribute(
       "href",
-      "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+      "https://compasscalendar.com/meet/cancel/000000000000000000000099?token=abc",
     );
     await page.getByRole("button", { name: "Copy cancel link" }).click();
     await expect(page.getByRole("button", { name: "Copied" })).toBeVisible();
@@ -357,7 +372,7 @@ test.describe("public booking page", () => {
     await expect
       .poll(async () => page.evaluate(() => navigator.clipboard.readText()))
       .toBe(
-        "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+        "https://compasscalendar.com/meet/cancel/000000000000000000000099?token=abc",
       );
   });
 

--- a/packages/backend/src/booking/booking-page.mapper.ts
+++ b/packages/backend/src/booking/booking-page.mapper.ts
@@ -10,7 +10,7 @@ import { type BookingPageRecord } from "@backend/booking/booking-page.record";
 import { CONFIG } from "@backend/common/constants/config.constants";
 
 export const buildBookingUrl = (slug: string): string =>
-  new URL(`/book/${slug}`, CONFIG.FRONTEND_URL).href;
+  new URL(`/meet/${slug}`, CONFIG.FRONTEND_URL).href;
 
 export const mapBookingPageRecordToWire = (
   record: BookingPageRecord & { bookingSlug: string },

--- a/packages/backend/src/booking/services/booking-page.service.db.test.ts
+++ b/packages/backend/src/booking/services/booking-page.service.db.test.ts
@@ -376,6 +376,7 @@ describe("BookingPageService", () => {
 
     const enabled = await bookingPageService.putAdminPage(userId, input);
     expect("slug" in enabled && enabled.slug).toBe("guarduser");
+    expect("bookingUrl" in enabled && enabled.bookingUrl).toContain("/meet/");
 
     const updated = await bookingPageService.putAdminPage(userId, {
       ...input,

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -357,7 +357,8 @@ describe("PublicBookingService", () => {
     expect(response.reservationId).toBeTruthy();
     expect(response.cancelUrl).toContain("token=");
     expect(response.rescheduleUrl).toContain("token=");
-    expect(response.rescheduleUrl).toContain("/book/reschedule/");
+    expect(response.cancelUrl).toContain("/meet/cancel/");
+    expect(response.rescheduleUrl).toContain("/meet/reschedule/");
   });
 
   it("confirms at the pinned duration and calls createBookingEvent once", async () => {

--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -138,7 +138,7 @@ const buildGuestActionUrl = (
   token: string,
 ): string =>
   new URL(
-    `/book/${action}/${reservationId}?token=${encodeURIComponent(token)}`,
+    `/meet/${action}/${reservationId}?token=${encodeURIComponent(token)}`,
     CONFIG.FRONTEND_URL,
   ).href;
 

--- a/packages/core/src/types/booking.contracts.test.ts
+++ b/packages/core/src/types/booking.contracts.test.ts
@@ -89,8 +89,8 @@ describe("BookingSlugSchema", () => {
     expect(BookingSlugSchema.safeParse("").success).toBe(false);
   });
 
-  it("rejects reserved slug week", () => {
-    expect(BookingSlugSchema.safeParse("week").success).toBe(false);
+  it("rejects reserved slug meet", () => {
+    expect(BookingSlugSchema.safeParse("meet").success).toBe(false);
   });
 
   it("rejects every reserved word", () => {
@@ -102,6 +102,7 @@ describe("BookingSlugSchema", () => {
       "api",
       "cleanup",
       "book",
+      "meet",
       "cancel",
       "reschedule",
       "confirmed",
@@ -428,7 +429,7 @@ describe("HTTP booking contracts", () => {
     expect(
       AdminGetBookingPageResponseSchema.safeParse({
         ...admin,
-        bookingUrl: "https://compasscalendar.com/book/tylerdane",
+        bookingUrl: "https://compasscalendar.com/meet/tylerdane",
       }).success,
     ).toBe(true);
   });
@@ -617,9 +618,9 @@ describe("HTTP booking contracts", () => {
       slotEnd: "2026-09-01T15:30:00.000Z",
       guestTimeZone: "Europe/London",
       cancelUrl:
-        "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+        "https://compasscalendar.com/meet/cancel/000000000000000000000099?token=abc",
       rescheduleUrl:
-        "https://compasscalendar.com/book/reschedule/000000000000000000000099?token=abc",
+        "https://compasscalendar.com/meet/reschedule/000000000000000000000099?token=abc",
     };
     expect(
       CreateBookingReservationResponseSchema.safeParse(created).success,

--- a/packages/core/src/types/booking.contracts.ts
+++ b/packages/core/src/types/booking.contracts.ts
@@ -19,6 +19,7 @@ export const BOOKING_RESERVED_SLUGS = [
   "api",
   "cleanup",
   "book",
+  "meet",
   "cancel",
   "reschedule",
   "confirmed",

--- a/packages/web/src/booking/BookingAddressField.tsx
+++ b/packages/web/src/booking/BookingAddressField.tsx
@@ -12,7 +12,7 @@ export function bookingAddressPrefix(bookingUrl: string | null): string {
   const origin = bookingUrl
     ? new URL(bookingUrl).origin
     : window.location.origin;
-  return `${origin}/book/`;
+  return `${origin}/meet/`;
 }
 
 interface BookingAddressFieldProps {

--- a/packages/web/src/booking/BookingCopyLink.test.tsx
+++ b/packages/web/src/booking/BookingCopyLink.test.tsx
@@ -45,7 +45,7 @@ describe("BookingCopyLink", () => {
   });
 
   it("copies the booking link", async () => {
-    const bookingUrl = "https://compasscalendar.com/book/hostuser";
+    const bookingUrl = "https://compasscalendar.com/meet/hostuser";
     render(<BookingCopyLink bookingUrl={bookingUrl} />);
 
     fireEvent.click(screen.getByLabelText("Copy booking link"));
@@ -59,7 +59,7 @@ describe("BookingCopyLink", () => {
   });
 
   it("opens the public booking page in a new tab", () => {
-    const bookingUrl = "https://compasscalendar.com/book/hostuser";
+    const bookingUrl = "https://compasscalendar.com/meet/hostuser";
     render(<BookingCopyLink bookingUrl={bookingUrl} />);
 
     const openLink = screen.getByRole("link", { name: "Open booking page" });
@@ -71,7 +71,7 @@ describe("BookingCopyLink", () => {
   it("explains the copy icon in a tooltip", async () => {
     const user = userEvent.setup({ delay: null });
     render(
-      <BookingCopyLink bookingUrl="https://compasscalendar.com/book/hostuser" />,
+      <BookingCopyLink bookingUrl="https://compasscalendar.com/meet/hostuser" />,
     );
 
     await user.hover(screen.getByRole("button", { name: "Copy booking link" }));
@@ -83,7 +83,7 @@ describe("BookingCopyLink", () => {
   it("explains the open-page icon in a tooltip", async () => {
     const user = userEvent.setup({ delay: null });
     render(
-      <BookingCopyLink bookingUrl="https://compasscalendar.com/book/hostuser" />,
+      <BookingCopyLink bookingUrl="https://compasscalendar.com/meet/hostuser" />,
     );
 
     await user.hover(screen.getByRole("link", { name: "Open booking page" }));

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -278,7 +278,7 @@ describe("BookingSettingsSection", () => {
   it("saves 30-minute duration and shows the copyable booking link", async () => {
     const user = userEvent.setup({ delay: null });
     const slug = "hostuser";
-    const bookingUrl = `https://compasscalendar.com/book/${slug}`;
+    const bookingUrl = `https://compasscalendar.com/meet/${slug}`;
     let savedBody: unknown;
 
     userMetadataActions.set(healthyGoogleMetadata);
@@ -361,7 +361,7 @@ describe("BookingSettingsSection", () => {
 
   it("renders the keyboard hint above the public link, outside the sticky save bar", async () => {
     userMetadataActions.set(healthyGoogleMetadata);
-    const bookingUrl = "https://compasscalendar.com/book/hostuser";
+    const bookingUrl = "https://compasscalendar.com/meet/hostuser";
 
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
@@ -462,7 +462,7 @@ describe("BookingSettingsSection", () => {
   it("saves again after the first save, sending only PUT input keys", async () => {
     const user = userEvent.setup({ delay: null });
     const slug = "hostuser";
-    const bookingUrl = `https://compasscalendar.com/book/${slug}`;
+    const bookingUrl = `https://compasscalendar.com/meet/${slug}`;
     const savedBodies: Record<string, unknown>[] = [];
 
     userMetadataActions.set(healthyGoogleMetadata);
@@ -564,7 +564,7 @@ describe("BookingSettingsSection", () => {
             hostUserId: createObjectIdString(),
             createdAt: new Date().toISOString(),
             updatedAt: new Date().toISOString(),
-            bookingUrl: "https://compasscalendar.com/book/hostuser",
+            bookingUrl: "https://compasscalendar.com/meet/hostuser",
           }),
         );
       }),
@@ -877,7 +877,7 @@ describe("BookingSettingsSection", () => {
 
     view.unmount();
 
-    const bookingUrl = "https://compasscalendar.com/book/hostuser";
+    const bookingUrl = "https://compasscalendar.com/meet/hostuser";
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
         res(
@@ -972,7 +972,7 @@ describe("BookingSettingsSection", () => {
 
   it("fires booking_settings_opened for a live connected page", async () => {
     userMetadataActions.set(healthyGoogleMetadata);
-    const bookingUrl = "https://compasscalendar.com/book/hostuser";
+    const bookingUrl = "https://compasscalendar.com/meet/hostuser";
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
         res(
@@ -1019,7 +1019,7 @@ describe("BookingSettingsSection", () => {
     const user = userEvent.setup({ delay: null });
     userMetadataActions.set(healthyGoogleMetadata);
     const slug = "hostuser";
-    const bookingUrl = `https://compasscalendar.com/book/${slug}`;
+    const bookingUrl = `https://compasscalendar.com/meet/${slug}`;
     const writeText = mock(() => Promise.resolve());
     setClipboard({ writeText });
 
@@ -1068,7 +1068,7 @@ describe("BookingSettingsSection", () => {
   it("fires booking_page_enabled with first_time false when a saved page turns on", async () => {
     const user = userEvent.setup({ delay: null });
     userMetadataActions.set(healthyGoogleMetadata);
-    const bookingUrl = "https://compasscalendar.com/book/hostuser";
+    const bookingUrl = "https://compasscalendar.com/meet/hostuser";
     const writeText = mock(() => Promise.resolve());
     setClipboard({ writeText });
 
@@ -1446,7 +1446,7 @@ describe("BookingSettingsSection", () => {
     const user = userEvent.setup({ delay: null });
     userMetadataActions.set(healthyGoogleMetadata);
     const slug = "hostuser";
-    const bookingUrl = `https://compasscalendar.com/book/${slug}`;
+    const bookingUrl = `https://compasscalendar.com/meet/${slug}`;
     const writeText = mock(() => Promise.resolve());
     setClipboard({ writeText });
 
@@ -2164,7 +2164,7 @@ describe("BookingSettingsSection", () => {
     const writeText = mock(() => Promise.resolve());
     setClipboard({ writeText });
     let savedBody: unknown;
-    const bookingUrl = "https://compasscalendar.com/book/hostuser";
+    const bookingUrl = "https://compasscalendar.com/meet/hostuser";
 
     userMetadataActions.set(healthyGoogleMetadata);
     server.use(
@@ -2213,7 +2213,7 @@ describe("BookingSettingsSection", () => {
   it("turns off a live page", async () => {
     const user = userEvent.setup({ delay: null });
     let savedBody: unknown;
-    const bookingUrl = "https://compasscalendar.com/book/hostuser";
+    const bookingUrl = "https://compasscalendar.com/meet/hostuser";
 
     userMetadataActions.set(healthyGoogleMetadata);
     server.use(

--- a/packages/web/src/booking/PublicBookingCancelPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingCancelPage.test.tsx
@@ -15,7 +15,7 @@ import { routeTree } from "@web/routers/router.routes";
 import { describe, expect, it } from "bun:test";
 
 const reservationId = "000000000000000000000099";
-const cancelPath = `/book/cancel/${reservationId}?token=abc`;
+const cancelPath = `/meet/cancel/${reservationId}?token=abc`;
 const slotStart = "2026-09-15T15:00:00.000Z";
 
 function reservationGetHandler(overrides: Record<string, unknown> = {}) {
@@ -181,7 +181,7 @@ describe("PublicBookingCancelPage", () => {
       ),
     );
 
-    renderCancelRoute(`/book/cancel/${reservationId}`);
+    renderCancelRoute(`/meet/cancel/${reservationId}`);
 
     expect(
       await screen.findByRole("heading", { name: "Booking not found" }),
@@ -257,7 +257,7 @@ describe("PublicBookingCancelPage", () => {
       }),
     ).toBeInTheDocument();
     expect(router.state.location.pathname).toBe(
-      `/book/confirmed/${reservationId}`,
+      `/meet/confirmed/${reservationId}`,
     );
     expect(router.state.location.search).toEqual({ token: "abc" });
     expect(
@@ -303,7 +303,7 @@ describe("PublicBookingCancelPage", () => {
       screen.getByRole("heading", { name: "Cancel this booking?" }),
     ).toBeInTheDocument();
     expect(router.state.location.pathname).toBe(
-      `/book/cancel/${reservationId}`,
+      `/meet/cancel/${reservationId}`,
     );
     expect(cancelPosts).toBe(1);
 
@@ -316,7 +316,7 @@ describe("PublicBookingCancelPage", () => {
 
   it("does not navigate on Escape from the not-found heading", async () => {
     const user = userEvent.setup({ delay: null });
-    const { router } = renderCancelRoute(`/book/cancel/${reservationId}`);
+    const { router } = renderCancelRoute(`/meet/cancel/${reservationId}`);
 
     const heading = await screen.findByRole("heading", {
       name: "Booking not found",
@@ -330,7 +330,7 @@ describe("PublicBookingCancelPage", () => {
       screen.getByRole("heading", { name: "Booking not found" }),
     ).toBeInTheDocument();
     expect(router.state.location.pathname).toBe(
-      `/book/cancel/${reservationId}`,
+      `/meet/cancel/${reservationId}`,
     );
   });
 
@@ -422,7 +422,7 @@ describe("PublicBookingCancelPage", () => {
     const rebook = await screen.findByRole("link", {
       name: "Book another time",
     });
-    expect(rebook).toHaveAttribute("href", "/book/tylerdane");
+    expect(rebook).toHaveAttribute("href", "/meet/tylerdane");
     expect(rebook.getAttribute("href")).not.toContain("token");
   });
 
@@ -435,7 +435,7 @@ describe("PublicBookingCancelPage", () => {
       await screen.findByRole("heading", { name: "Booking canceled" }),
     ).toBeInTheDocument();
     const rebook = screen.getByRole("link", { name: "Book another time" });
-    expect(rebook).toHaveAttribute("href", "/book/tylerdane");
+    expect(rebook).toHaveAttribute("href", "/meet/tylerdane");
     expect(rebook.getAttribute("href")).not.toContain("token");
     expect(rebook.getAttribute("href")).not.toContain(reservationId);
   });

--- a/packages/web/src/booking/PublicBookingCancelPage.tsx
+++ b/packages/web/src/booking/PublicBookingCancelPage.tsx
@@ -65,8 +65,8 @@ const resolveCancelPageView = (
 };
 
 export function PublicBookingCancelPage() {
-  const { reservationId } = useParams({ from: "/book/cancel/$reservationId" });
-  const search = useSearch({ from: "/book/cancel/$reservationId" });
+  const { reservationId } = useParams({ from: ROOT_ROUTES.BOOK_CANCEL });
+  const search = useSearch({ from: ROOT_ROUTES.BOOK_CANCEL });
   const navigate = useNavigate();
   const token = search.token ?? "";
   const canLoad = Boolean(reservationId && token);
@@ -153,7 +153,7 @@ export function PublicBookingCancelPage() {
         ) : null}
         {showRebook && bookingSlug ? (
           <a
-            href={`/book/${bookingSlug}`}
+            href={`/meet/${bookingSlug}`}
             className="c-focus-ring mt-4 inline-block text-accent text-sm underline"
           >
             Book another time

--- a/packages/web/src/booking/PublicBookingConfirmationView.test.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmationView.test.tsx
@@ -10,9 +10,9 @@ import { describe, expect, it, mock } from "bun:test";
 const slotStart = "2026-09-15T15:00:00.000Z";
 const timeZone = "UTC";
 const cancelUrl =
-  "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc";
+  "https://compasscalendar.com/meet/cancel/000000000000000000000099?token=abc";
 const rescheduleUrl =
-  "https://compasscalendar.com/book/reschedule/000000000000000000000099?token=abc";
+  "https://compasscalendar.com/meet/reschedule/000000000000000000000099?token=abc";
 
 describe("PublicBookingConfirmationView", () => {
   it("shows the slot summary instead of a raw cancel URL", () => {

--- a/packages/web/src/booking/PublicBookingConfirmedPage.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmedPage.tsx
@@ -71,10 +71,10 @@ function rescheduleUrlFromHistory(state: unknown): string | undefined {
 
 export function PublicBookingConfirmedPage() {
   const { reservationId } = useParams({
-    from: "/book/confirmed/$reservationId",
+    from: ROOT_ROUTES.BOOK_CONFIRMED,
   });
   const { token: searchToken } = useSearch({
-    from: "/book/confirmed/$reservationId",
+    from: ROOT_ROUTES.BOOK_CONFIRMED,
   });
   const historyCancelUrl = useRouterState({
     select: (routerState) => cancelUrlFromHistory(routerState.location.state),

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -298,7 +298,7 @@ describe("PublicBookingPage", () => {
   });
 
   it("shows a generic not-found state for an unknown slug", async () => {
-    renderBookingRoute("/book/unknown-host");
+    renderBookingRoute("/meet/unknown-host");
 
     expect(
       await screen.findByRole("heading", { name: "Booking page not found" }),
@@ -314,7 +314,7 @@ describe("PublicBookingPage", () => {
 
   it("fires booking_page_viewed once for an enabled page", async () => {
     server.use(pageHandler(), slotsInWindow([currentSlot]));
-    renderBookingRoute("/book/tylerdane");
+    renderBookingRoute("/meet/tylerdane");
 
     expect(
       await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
@@ -336,7 +336,7 @@ describe("PublicBookingPage", () => {
           ),
       ),
     );
-    renderBookingRoute("/book/tylerdane");
+    renderBookingRoute("/meet/tylerdane");
 
     expect(
       await screen.findByRole("heading", { name: "Booking page not found" }),
@@ -350,7 +350,7 @@ describe("PublicBookingPage", () => {
   it("skips the month grid to the slot list", async () => {
     const user = userEvent.setup({ delay: null });
     server.use(pageHandler(), slotsInWindow([currentSlot]));
-    renderBookingRoute("/book/tylerdane");
+    renderBookingRoute("/meet/tylerdane");
 
     expect(
       await screen.findByRole("heading", { name: "Pick a time" }),
@@ -396,7 +396,7 @@ describe("PublicBookingPage", () => {
       slotsInWindow([currentSlot]),
     );
 
-    renderBookingRoute("/book/tylerdane");
+    renderBookingRoute("/meet/tylerdane");
 
     expect(
       await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
@@ -420,7 +420,7 @@ describe("PublicBookingPage", () => {
       slotsInWindow([currentSlot]),
     );
 
-    renderBookingRoute("/book/tylerdane");
+    renderBookingRoute("/meet/tylerdane");
 
     expect(
       await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
@@ -442,7 +442,7 @@ describe("PublicBookingPage", () => {
       slotsInWindow([currentSlot]),
     );
 
-    renderBookingRoute("/book/tylerdane");
+    renderBookingRoute("/meet/tylerdane");
 
     expect(
       await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
@@ -472,16 +472,16 @@ describe("PublicBookingPage", () => {
               slotEnd: currentSlot.slotEnd,
               guestTimeZone: "UTC",
               cancelUrl:
-                "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+                "https://compasscalendar.com/meet/cancel/000000000000000000000099?token=abc",
               rescheduleUrl:
-                "https://compasscalendar.com/book/reschedule/000000000000000000000099?token=abc",
+                "https://compasscalendar.com/meet/reschedule/000000000000000000000099?token=abc",
             }),
           );
         },
       ),
     );
 
-    renderBookingRoute("/book/tylerdane");
+    renderBookingRoute("/meet/tylerdane");
 
     expect(
       await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
@@ -610,16 +610,16 @@ describe("PublicBookingPage", () => {
               slotEnd: slot.slotEnd,
               guestTimeZone: overrideZone,
               cancelUrl:
-                "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+                "https://compasscalendar.com/meet/cancel/000000000000000000000099?token=abc",
               rescheduleUrl:
-                "https://compasscalendar.com/book/reschedule/000000000000000000000099?token=abc",
+                "https://compasscalendar.com/meet/reschedule/000000000000000000000099?token=abc",
             }),
           );
         },
       ),
     );
 
-    renderBookingRoute("/book/tzhost");
+    renderBookingRoute("/meet/tzhost");
 
     expect(
       await screen.findByText(/Times shown in your timezone/),
@@ -722,7 +722,7 @@ describe("PublicBookingPage", () => {
       ),
     );
 
-    renderBookingRoute("/book/tzpersist");
+    renderBookingRoute("/meet/tzpersist");
 
     await screen.findByRole("button", {
       name: slotButtonName(currentSlot.slotStart, guestTimeZone),
@@ -790,7 +790,7 @@ describe("PublicBookingPage", () => {
       ),
     );
 
-    renderBookingRoute("/book/tylerdane");
+    renderBookingRoute("/meet/tylerdane");
 
     expect(
       await screen.findByRole("heading", {
@@ -815,7 +815,7 @@ describe("PublicBookingPage", () => {
       ),
     );
 
-    renderBookingRoute("/book/tylerdane");
+    renderBookingRoute("/meet/tylerdane");
 
     await screen.findByRole("heading", { name: "Book with Tyler Dane" });
     await user.click(
@@ -874,7 +874,7 @@ describe("PublicBookingPage", () => {
       ),
     );
 
-    renderBookingRoute("/book/tylerdane");
+    renderBookingRoute("/meet/tylerdane");
 
     await screen.findByRole("heading", { name: "Book with Tyler Dane" });
     expect(screen.queryByText(/Keyboard shortcuts/i)).not.toBeInTheDocument();
@@ -914,7 +914,7 @@ describe("PublicBookingPage", () => {
       ),
     );
 
-    renderBookingRoute("/book/tylerdane");
+    renderBookingRoute("/meet/tylerdane");
 
     await waitFor(() => {
       expect(events).toContain("page-start");
@@ -942,7 +942,7 @@ describe("PublicBookingPage", () => {
       }),
     );
 
-    renderBookingRoute("/book/tylerdane");
+    renderBookingRoute("/meet/tylerdane");
 
     await screen.findByRole("heading", { name: "Book with Tyler Dane" });
     expect(
@@ -1007,7 +1007,7 @@ describe("PublicBookingPage", () => {
       ),
     );
 
-    renderBookingRoute("/book/tylerdane");
+    renderBookingRoute("/meet/tylerdane");
 
     expect(
       await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
@@ -1031,7 +1031,7 @@ describe("PublicBookingPage", () => {
     const user = userEvent.setup({ delay: null });
     server.use(pageHandler(), slotsInWindow([currentSlot, nextMonthSlot]));
 
-    renderBookingRoute("/book/tylerdane");
+    renderBookingRoute("/meet/tylerdane");
 
     expect(
       await screen.findByRole("button", {
@@ -1072,7 +1072,7 @@ describe("PublicBookingPage", () => {
     const user = userEvent.setup({ delay: null });
     server.use(pageHandler(), slotsInWindow([nextMonthSlot]));
 
-    renderBookingRoute("/book/tylerdane");
+    renderBookingRoute("/meet/tylerdane");
 
     await screen.findByRole("heading", { name: "Book with Tyler Dane" });
     expect(
@@ -1113,7 +1113,7 @@ describe("PublicBookingPage", () => {
     const user = userEvent.setup({ delay: null });
     server.use(pageHandler(), slotsInWindow([]));
 
-    renderBookingRoute("/book/tylerdane");
+    renderBookingRoute("/meet/tylerdane");
 
     await screen.findByRole("heading", { name: "Book with Tyler Dane" });
     expect(
@@ -1147,7 +1147,7 @@ describe("PublicBookingPage", () => {
     const user = userEvent.setup({ delay: null });
     server.use(pageHandler(), slotsInWindow([currentSlot, laterCurrentSlot]));
 
-    renderBookingRoute("/book/tylerdane");
+    renderBookingRoute("/meet/tylerdane");
 
     await user.click(
       await screen.findByRole("button", {
@@ -1220,16 +1220,16 @@ describe("PublicBookingPage", () => {
               slotEnd: currentSlot.slotEnd,
               guestTimeZone: "UTC",
               cancelUrl:
-                "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+                "https://compasscalendar.com/meet/cancel/000000000000000000000099?token=abc",
               rescheduleUrl:
-                "https://compasscalendar.com/book/reschedule/000000000000000000000099?token=abc",
+                "https://compasscalendar.com/meet/reschedule/000000000000000000000099?token=abc",
             }),
           );
         },
       ),
     );
 
-    renderBookingRoute("/book/tylerdane");
+    renderBookingRoute("/meet/tylerdane");
 
     await user.click(
       await screen.findByRole("button", {
@@ -1276,7 +1276,7 @@ describe("PublicBookingPage", () => {
       ),
     );
 
-    renderBookingRoute("/book/tylerdane");
+    renderBookingRoute("/meet/tylerdane");
 
     expect(
       await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
@@ -1323,7 +1323,7 @@ describe("PublicBookingPage", () => {
       ),
     );
 
-    renderBookingRoute("/book/retryhost");
+    renderBookingRoute("/meet/retryhost");
 
     expect(
       await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
@@ -1383,7 +1383,7 @@ describe("PublicBookingPage", () => {
       ),
     );
 
-    renderBookingRoute("/book/tylerdane");
+    renderBookingRoute("/meet/tylerdane");
 
     expect(
       await screen.findByRole("heading", { name: "Pick a time" }),
@@ -1421,7 +1421,7 @@ describe("PublicBookingPage", () => {
   it("returns to the picker on Escape from Your details", async () => {
     const user = userEvent.setup({ delay: null });
     server.use(pageHandler(), slotsInWindow([currentSlot]));
-    renderBookingRoute("/book/tylerdane");
+    renderBookingRoute("/meet/tylerdane");
 
     await user.click(
       await screen.findByRole("button", {
@@ -1446,7 +1446,7 @@ describe("PublicBookingPage", () => {
   it("moves focus from a slot to the selected day on Escape", async () => {
     const user = userEvent.setup({ delay: null });
     server.use(pageHandler(), slotsInWindow([currentSlot]));
-    renderBookingRoute("/book/tylerdane");
+    renderBookingRoute("/meet/tylerdane");
 
     await screen.findByRole("heading", { name: "Pick a time" });
     const dateKey = formatBookingDateKey(currentSlot.slotStart, guestTimeZone);
@@ -1467,7 +1467,7 @@ describe("PublicBookingPage", () => {
   it("closes the timezone panel on Escape without leaving Your details", async () => {
     const user = userEvent.setup({ delay: null });
     server.use(pageHandler(), slotsInWindow([currentSlot]));
-    renderBookingRoute("/book/tylerdane");
+    renderBookingRoute("/meet/tylerdane");
 
     await user.click(
       await screen.findByRole("button", {
@@ -1498,7 +1498,7 @@ describe("PublicBookingPage", () => {
   it("does not navigate away when Escape is pressed on the month grid", async () => {
     const user = userEvent.setup({ delay: null });
     server.use(pageHandler(), slotsInWindow([currentSlot]));
-    const { router } = renderBookingRoute("/book/tylerdane");
+    const { router } = renderBookingRoute("/meet/tylerdane");
 
     await screen.findByRole("heading", { name: "Pick a time" });
     const dateKey = formatBookingDateKey(currentSlot.slotStart, guestTimeZone);
@@ -1523,7 +1523,7 @@ describe("PublicBookingPage", () => {
 describe("PublicBookingConfirmedPage", () => {
   it("shows booking details from the public GET", async () => {
     server.use(reservationGetHandler());
-    renderBookingRoute("/book/confirmed/000000000000000000000099");
+    renderBookingRoute("/meet/confirmed/000000000000000000000099");
 
     expect(
       await screen.findByRole("heading", {
@@ -1556,7 +1556,7 @@ describe("PublicBookingConfirmedPage", () => {
 
   it("offers cancel and edit on a cold permalink with a token", async () => {
     server.use(reservationGetHandler());
-    renderBookingRoute("/book/confirmed/000000000000000000000099?token=abc");
+    renderBookingRoute("/meet/confirmed/000000000000000000000099?token=abc");
 
     expect(
       await screen.findByRole("heading", {
@@ -1576,13 +1576,13 @@ describe("PublicBookingConfirmedPage", () => {
       screen.getByRole("link", { name: "Cancel this booking" }),
     ).toHaveAttribute(
       "href",
-      `${window.location.origin}/book/cancel/000000000000000000000099?token=abc`,
+      `${window.location.origin}/meet/cancel/000000000000000000000099?token=abc`,
     );
     expect(
       screen.getByRole("link", { name: "Reschedule this booking" }),
     ).toHaveAttribute(
       "href",
-      `${window.location.origin}/book/reschedule/000000000000000000000099?token=abc`,
+      `${window.location.origin}/meet/reschedule/000000000000000000000099?token=abc`,
     );
     expect(
       screen.getByText("A Google Meet invite is on its way to your email."),
@@ -1594,7 +1594,7 @@ describe("PublicBookingConfirmedPage", () => {
 
   it("promises a calendar invite when the reservation cannot mint Meet", async () => {
     server.use(reservationGetHandler({ createsGoogleMeet: false }));
-    renderBookingRoute("/book/confirmed/000000000000000000000099");
+    renderBookingRoute("/meet/confirmed/000000000000000000000099");
 
     expect(
       await screen.findByRole("heading", {
@@ -1620,7 +1620,7 @@ describe("PublicBookingConfirmedPage", () => {
       reservationGetHandler(),
     );
     const { router } = renderBookingRoute(
-      "/book/confirmed/000000000000000000000099",
+      "/meet/confirmed/000000000000000000000099",
     );
 
     await screen.findByRole("heading", {
@@ -1634,14 +1634,14 @@ describe("PublicBookingConfirmedPage", () => {
     await waitFor(() => {
       expect(heading).toHaveFocus();
     });
-    expect(router.state.location.pathname).toBe("/book/tylerdane");
+    expect(router.state.location.pathname).toBe("/meet/tylerdane");
   });
 
   it("does not navigate on Escape when the confirmation has no slug", async () => {
     const user = userEvent.setup({ delay: null });
     server.use(reservationGetHandler({ status: "cancelled" }));
     const { router } = renderBookingRoute(
-      "/book/confirmed/000000000000000000000099",
+      "/meet/confirmed/000000000000000000000099",
     );
 
     const heading = await screen.findByRole("heading", {
@@ -1651,7 +1651,7 @@ describe("PublicBookingConfirmedPage", () => {
 
     expect(heading).toHaveFocus();
     expect(router.state.location.pathname).toBe(
-      "/book/confirmed/000000000000000000000099",
+      "/meet/confirmed/000000000000000000000099",
     );
   });
 
@@ -1664,7 +1664,7 @@ describe("PublicBookingConfirmedPage", () => {
       ),
     );
     const { router } = renderBookingRoute(
-      "/book/confirmed/000000000000000000000099",
+      "/meet/confirmed/000000000000000000000099",
     );
 
     const heading = await screen.findByRole("heading", {
@@ -1674,13 +1674,13 @@ describe("PublicBookingConfirmedPage", () => {
 
     expect(heading).toHaveFocus();
     expect(router.state.location.pathname).toBe(
-      "/book/confirmed/000000000000000000000099",
+      "/meet/confirmed/000000000000000000000099",
     );
   });
 
   it("shows a calm state for a cancelled reservation", async () => {
     server.use(reservationGetHandler({ status: "cancelled" }));
-    renderBookingRoute("/book/confirmed/000000000000000000000099");
+    renderBookingRoute("/meet/confirmed/000000000000000000000099");
 
     expect(
       await screen.findByRole("heading", {
@@ -1705,7 +1705,7 @@ describe("PublicBookingConfirmedPage", () => {
         (_req, res, ctx) => res(ctx.status(Status.NOT_FOUND), ctx.json({})),
       ),
     );
-    renderBookingRoute("/book/confirmed/000000000000000000000099");
+    renderBookingRoute("/meet/confirmed/000000000000000000000099");
 
     expect(
       await screen.findByRole("heading", { name: "Booking not found" }),
@@ -1720,7 +1720,7 @@ describe("PublicBookingConfirmedPage", () => {
           res(ctx.status(Status.INTERNAL_SERVER), ctx.json({})),
       ),
     );
-    renderBookingRoute("/book/confirmed/000000000000000000000099");
+    renderBookingRoute("/meet/confirmed/000000000000000000000099");
 
     expect(
       await screen.findByRole("heading", { name: "Could not load booking" }),
@@ -1754,15 +1754,15 @@ describe("PublicBookingConfirmedPage", () => {
               slotEnd: currentSlot.slotEnd,
               guestTimeZone: "UTC",
               cancelUrl:
-                "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+                "https://compasscalendar.com/meet/cancel/000000000000000000000099?token=abc",
               rescheduleUrl:
-                "https://compasscalendar.com/book/reschedule/000000000000000000000099?token=abc",
+                "https://compasscalendar.com/meet/reschedule/000000000000000000000099?token=abc",
             }),
           ),
       ),
     );
 
-    renderBookingRoute("/book/tylerdane");
+    renderBookingRoute("/meet/tylerdane");
     await user.click(
       await screen.findByRole("button", {
         name: slotButtonName(currentSlot.slotStart),
@@ -1775,17 +1775,17 @@ describe("PublicBookingConfirmedPage", () => {
       await screen.findByRole("link", { name: "Cancel this booking" }),
     ).toHaveAttribute(
       "href",
-      "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+      "https://compasscalendar.com/meet/cancel/000000000000000000000099?token=abc",
     );
     expect(
       screen.getByRole("link", { name: "Reschedule this booking" }),
     ).toHaveAttribute(
       "href",
-      "https://compasscalendar.com/book/reschedule/000000000000000000000099?token=abc",
+      "https://compasscalendar.com/meet/reschedule/000000000000000000000099?token=abc",
     );
     expect(
       screen.queryByRole("link", {
-        name: "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+        name: "https://compasscalendar.com/meet/cancel/000000000000000000000099?token=abc",
       }),
     ).not.toBeInTheDocument();
     expect(screen.queryByText(/token=abc/)).not.toBeInTheDocument();
@@ -1794,7 +1794,7 @@ describe("PublicBookingConfirmedPage", () => {
     );
 
     expect(written).toEqual([
-      "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+      "https://compasscalendar.com/meet/cancel/000000000000000000000099?token=abc",
     ]);
     expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
     expect(screen.getByRole("status")).toHaveTextContent("Copied");
@@ -1822,9 +1822,9 @@ describe("PublicBookingConfirmedPage", () => {
               slotEnd: currentSlot.slotEnd,
               guestTimeZone: "UTC",
               cancelUrl:
-                "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+                "https://compasscalendar.com/meet/cancel/000000000000000000000099?token=abc",
               rescheduleUrl:
-                "https://compasscalendar.com/book/reschedule/000000000000000000000099?token=abc",
+                "https://compasscalendar.com/meet/reschedule/000000000000000000000099?token=abc",
             }),
           ),
       ),
@@ -1850,7 +1850,7 @@ describe("PublicBookingConfirmedPage", () => {
       ),
     );
 
-    renderBookingRoute("/book/tylerdane");
+    renderBookingRoute("/meet/tylerdane");
     await user.click(
       await screen.findByRole("button", {
         name: slotButtonName(currentSlot.slotStart),
@@ -1918,15 +1918,15 @@ describe("PublicBookingConfirmedPage", () => {
               slotEnd: currentSlot.slotEnd,
               guestTimeZone: "UTC",
               cancelUrl:
-                "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+                "https://compasscalendar.com/meet/cancel/000000000000000000000099?token=abc",
               rescheduleUrl:
-                "https://compasscalendar.com/book/reschedule/000000000000000000000099?token=abc",
+                "https://compasscalendar.com/meet/reschedule/000000000000000000000099?token=abc",
             }),
           ),
       ),
     );
 
-    const { router } = renderBookingRoute("/book/tylerdane");
+    const { router } = renderBookingRoute("/meet/tylerdane");
     await user.click(
       await screen.findByRole("button", {
         name: slotButtonName(currentSlot.slotStart),
@@ -1947,7 +1947,7 @@ describe("PublicBookingConfirmedPage", () => {
       }),
     ).toBeInTheDocument();
     expect(router.state.location.pathname).toBe(
-      "/book/confirmed/000000000000000000000099",
+      "/meet/confirmed/000000000000000000000099",
     );
   });
 });

--- a/packages/web/src/booking/PublicBookingPage.tsx
+++ b/packages/web/src/booking/PublicBookingPage.tsx
@@ -28,9 +28,10 @@ import {
   useBookingHeadingFocus,
 } from "@web/booking/use-booking-heading-focus";
 import { usePublicBookingFlow } from "@web/booking/use-public-booking-flow";
+import { ROOT_ROUTES } from "@web/common/constants/routes";
 
 export function PublicBookingPage() {
-  const { username } = useParams({ from: "/book/$username" });
+  const { username } = useParams({ from: ROOT_ROUTES.BOOK });
   const flow = usePublicBookingFlow();
   const { pageQuery, slotsQuery } = flow;
   const focusHostHeadingRef = useRef(isPublicBookingPageHeadingFocusPending());

--- a/packages/web/src/booking/PublicBookingReschedulePage.test.tsx
+++ b/packages/web/src/booking/PublicBookingReschedulePage.test.tsx
@@ -16,7 +16,7 @@ import { routeTree } from "@web/routers/router.routes";
 import { describe, expect, it } from "bun:test";
 
 const reservationId = "000000000000000000000099";
-const reschedulePath = `/book/reschedule/${reservationId}?token=abc`;
+const reschedulePath = `/meet/reschedule/${reservationId}?token=abc`;
 const slotStart = (() => {
   const start = new Date(Date.now() + 48 * 60 * 60 * 1000);
   start.setUTCMinutes(0, 0, 0);
@@ -146,12 +146,12 @@ describe("PublicBookingReschedulePage", () => {
     });
     await waitFor(() => {
       expect(router.state.location.pathname).toBe(
-        `/book/confirmed/${reservationId}`,
+        `/meet/confirmed/${reservationId}`,
       );
     });
     expect(router.state.location.state).toMatchObject({
-      cancelUrl: `${window.location.origin}/book/cancel/${reservationId}?token=abc`,
-      rescheduleUrl: `${window.location.origin}/book/reschedule/${reservationId}?token=abc`,
+      cancelUrl: `${window.location.origin}/meet/cancel/${reservationId}?token=abc`,
+      rescheduleUrl: `${window.location.origin}/meet/reschedule/${reservationId}?token=abc`,
     });
   });
 
@@ -214,7 +214,7 @@ describe("PublicBookingReschedulePage", () => {
       }),
     );
 
-    renderRescheduleRoute(`/book/reschedule/${reservationId}`);
+    renderRescheduleRoute(`/meet/reschedule/${reservationId}`);
 
     expect(
       await screen.findByRole("heading", { name: "Booking not found" }),
@@ -258,7 +258,7 @@ describe("PublicBookingReschedulePage", () => {
       }),
     ).toBeInTheDocument();
     expect(router.state.location.pathname).toBe(
-      `/book/reschedule/${reservationId}`,
+      `/meet/reschedule/${reservationId}`,
     );
   });
 

--- a/packages/web/src/booking/public-booking-search.test.ts
+++ b/packages/web/src/booking/public-booking-search.test.ts
@@ -94,19 +94,19 @@ describe("tokenFromGuestActionUrl", () => {
   it("reads token from an absolute cancel URL", () => {
     expect(
       tokenFromGuestActionUrl(
-        "https://compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+        "https://compasscalendar.com/meet/cancel/000000000000000000000099?token=abc",
       ),
     ).toBe("abc");
   });
 
   it("reads token from a relative URL", () => {
-    expect(tokenFromGuestActionUrl("/book/cancel/99?token=secret")).toBe(
+    expect(tokenFromGuestActionUrl("/meet/cancel/99?token=secret")).toBe(
       "secret",
     );
   });
 
   it("returns empty when token is missing or the URL is unusable", () => {
-    expect(tokenFromGuestActionUrl("/book/cancel/99")).toBe("");
+    expect(tokenFromGuestActionUrl("/meet/cancel/99")).toBe("");
     expect(tokenFromGuestActionUrl("://bad")).toBe("");
   });
 });
@@ -120,7 +120,7 @@ describe("publicCancelUrlForReservation", () => {
         "https://staging.compasscalendar.com",
       ),
     ).toBe(
-      "https://staging.compasscalendar.com/book/cancel/000000000000000000000099?token=abc",
+      "https://staging.compasscalendar.com/meet/cancel/000000000000000000000099?token=abc",
     );
   });
 });
@@ -134,7 +134,7 @@ describe("publicRescheduleUrlForReservation", () => {
         "https://staging.compasscalendar.com",
       ),
     ).toBe(
-      "https://staging.compasscalendar.com/book/reschedule/000000000000000000000099?token=abc",
+      "https://staging.compasscalendar.com/meet/reschedule/000000000000000000000099?token=abc",
     );
   });
 });

--- a/packages/web/src/booking/public-booking-search.ts
+++ b/packages/web/src/booking/public-booking-search.ts
@@ -122,7 +122,7 @@ function publicGuestActionUrlForReservation(
   token: string,
   origin: string,
 ): string {
-  const url = new URL(`/book/${action}/${reservationId}`, origin);
+  const url = new URL(`/meet/${action}/${reservationId}`, origin);
   url.searchParams.set("token", token);
   return url.toString();
 }

--- a/packages/web/src/booking/use-booking-heading-focus.ts
+++ b/packages/web/src/booking/use-booking-heading-focus.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef } from "react";
 
 let pendingPublicBookingPageHeadingFocus = false;
 
-/** Arm host-page h1 focus for the next `/book/:slug` mount (confirmation Escape). */
+/** Arm host-page h1 focus for the next `/meet/:slug` mount (confirmation Escape). */
 export function requestPublicBookingPageHeadingFocus() {
   pendingPublicBookingPageHeadingFocus = true;
 }

--- a/packages/web/src/booking/use-public-booking-flow.ts
+++ b/packages/web/src/booking/use-public-booking-flow.ts
@@ -48,10 +48,10 @@ const SLOT_CONFLICT_ALERT =
  * selection, and the link is shareable. The page component only renders.
  */
 export function usePublicBookingFlow() {
-  const { username } = useParams({ from: "/book/$username" });
+  const { username } = useParams({ from: ROOT_ROUTES.BOOK });
   const slug = username ?? "";
   const navigate = useNavigate();
-  const search: PublicBookingSearch = useSearch({ from: "/book/$username" });
+  const search: PublicBookingSearch = useSearch({ from: ROOT_ROUTES.BOOK });
   const queryClient = useQueryClient();
 
   const browserTimeZone = useMemo(getBrowserTimeZone, []);

--- a/packages/web/src/booking/use-public-booking-reschedule-flow.ts
+++ b/packages/web/src/booking/use-public-booking-reschedule-flow.ts
@@ -35,10 +35,10 @@ const SLOT_CONFLICT_ALERT =
 
 export function usePublicBookingRescheduleFlow() {
   const { reservationId } = useParams({
-    from: "/book/reschedule/$reservationId",
+    from: ROOT_ROUTES.BOOK_RESCHEDULE,
   });
   const search: PublicBookingRescheduleSearch = useSearch({
-    from: "/book/reschedule/$reservationId",
+    from: ROOT_ROUTES.BOOK_RESCHEDULE,
   });
   const navigate = useNavigate();
   const queryClient = useQueryClient();

--- a/packages/web/src/common/constants/routes.ts
+++ b/packages/web/src/common/constants/routes.ts
@@ -1,9 +1,9 @@
 export const ROOT_ROUTES = {
   API: "/api",
-  BOOK: "/book/$username",
-  BOOK_CANCEL: "/book/cancel/$reservationId",
-  BOOK_RESCHEDULE: "/book/reschedule/$reservationId",
-  BOOK_CONFIRMED: "/book/confirmed/$reservationId",
+  BOOK: "/meet/$username",
+  BOOK_CANCEL: "/meet/cancel/$reservationId",
+  BOOK_RESCHEDULE: "/meet/reschedule/$reservationId",
+  BOOK_CONFIRMED: "/meet/confirmed/$reservationId",
   CLEANUP: "/cleanup",
   GOOGLE_AUTH_CALLBACK: "/auth/google/callback",
   PROVIDER_AUTH_CALLBACK: "/auth/$provider/callback",
@@ -15,6 +15,11 @@ export const ROOT_ROUTES = {
   DAY: "/day",
   DAY_DATE: "/day/$dateString",
 } as const;
+
+export const LEGACY_BOOK = "/book/$username";
+export const LEGACY_BOOK_CANCEL = "/book/cancel/$reservationId";
+export const LEGACY_BOOK_RESCHEDULE = "/book/reschedule/$reservationId";
+export const LEGACY_BOOK_CONFIRMED = "/book/confirmed/$reservationId";
 
 export const DEFAULT_CALENDAR_ROUTE = ROOT_ROUTES.WEEK;
 

--- a/packages/web/src/routers/index.test.tsx
+++ b/packages/web/src/routers/index.test.tsx
@@ -6,6 +6,7 @@ import {
   calendarShellRoute,
   lifeRoute,
   providerAuthCallbackRoute,
+  publicBookCancelRoute,
   publicBookConfirmedRoute,
   publicBookRescheduleRoute,
   publicBookRoute,
@@ -23,24 +24,57 @@ describe("routeTree", () => {
     expect(lifeRoute.parentRoute).toBe(calendarShellRoute);
   });
 
-  it("registers /book/$username as a public route outside the calendar shell", () => {
-    expect(publicBookRoute.fullPath).toBe("/book/$username");
+  it("registers /meet/$username as a public route outside the calendar shell", () => {
+    expect(publicBookRoute.fullPath).toBe("/meet/$username");
     expect(publicBookRoute.options.beforeLoad).toBeUndefined();
     expect(publicBookRoute.parentRoute).toBe(rootRoute);
   });
 
-  it("registers /book/confirmed/$reservationId as a public route", () => {
+  it("registers /meet/confirmed/$reservationId as a public route", () => {
     expect(publicBookConfirmedRoute.fullPath).toBe(
-      "/book/confirmed/$reservationId",
+      "/meet/confirmed/$reservationId",
     );
     expect(publicBookConfirmedRoute.parentRoute).toBe(rootRoute);
   });
 
-  it("registers /book/reschedule/$reservationId as a public route", () => {
+  it("registers /meet/reschedule/$reservationId as a public route", () => {
     expect(publicBookRescheduleRoute.fullPath).toBe(
-      "/book/reschedule/$reservationId",
+      "/meet/reschedule/$reservationId",
     );
     expect(publicBookRescheduleRoute.parentRoute).toBe(rootRoute);
+  });
+
+  it("registers /meet/cancel/$reservationId as a public route", () => {
+    expect(publicBookCancelRoute.fullPath).toBe("/meet/cancel/$reservationId");
+    expect(publicBookCancelRoute.parentRoute).toBe(rootRoute);
+  });
+
+  it("redirects legacy /book paths to /meet and keeps search params", async () => {
+    const hostRouter = createRouter({
+      routeTree,
+      history: createMemoryHistory({
+        initialEntries: ["/book/x?token=abc"],
+      }),
+    });
+    await hostRouter.load();
+    expect(hostRouter.state.location.pathname).toBe("/meet/x");
+    expect(hostRouter.state.location.search).toEqual(
+      expect.objectContaining({ token: "abc" }),
+    );
+
+    const cancelRouter = createRouter({
+      routeTree,
+      history: createMemoryHistory({
+        initialEntries: ["/book/cancel/000000000000000000000099?token=abc"],
+      }),
+    });
+    await cancelRouter.load();
+    expect(cancelRouter.state.location.pathname).toBe(
+      "/meet/cancel/000000000000000000000099",
+    );
+    expect(cancelRouter.state.location.search).toEqual(
+      expect.objectContaining({ token: "abc" }),
+    );
   });
 
   it("gates the authenticated layout behind loadAuthenticated inside the calendar shell", () => {

--- a/packages/web/src/routers/router.routes.tsx
+++ b/packages/web/src/routers/router.routes.tsx
@@ -2,6 +2,7 @@ import {
   createRootRoute,
   createRoute,
   lazyRouteComponent,
+  redirect,
 } from "@tanstack/react-router";
 import { APPLE_AUTH_CALLBACK_PATH } from "@web/auth/apple/authorization/apple-authorization.constants";
 import {
@@ -13,7 +14,13 @@ import {
   IS_BOOKING_ENABLED,
   IS_DEV,
 } from "@web/common/constants/env.constants";
-import { ROOT_ROUTES } from "@web/common/constants/routes";
+import {
+  LEGACY_BOOK,
+  LEGACY_BOOK_CANCEL,
+  LEGACY_BOOK_CONFIRMED,
+  LEGACY_BOOK_RESCHEDULE,
+  ROOT_ROUTES,
+} from "@web/common/constants/routes";
 import { validateAuthSearch } from "@web/components/AuthModal/hooks/useAuthModal";
 import {
   loadAuthenticated,
@@ -82,6 +89,54 @@ export const publicBookConfirmedRoute = createRoute({
     () => import("@web/booking/PublicBookingConfirmedPage"),
     "PublicBookingConfirmedPage",
   ),
+});
+
+export const legacyBookRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: LEGACY_BOOK,
+  beforeLoad: ({ params, search }) => {
+    throw redirect({
+      to: ROOT_ROUTES.BOOK,
+      params,
+      search,
+    });
+  },
+});
+
+export const legacyBookCancelRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: LEGACY_BOOK_CANCEL,
+  beforeLoad: ({ params, search }) => {
+    throw redirect({
+      to: ROOT_ROUTES.BOOK_CANCEL,
+      params,
+      search,
+    });
+  },
+});
+
+export const legacyBookRescheduleRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: LEGACY_BOOK_RESCHEDULE,
+  beforeLoad: ({ params, search }) => {
+    throw redirect({
+      to: ROOT_ROUTES.BOOK_RESCHEDULE,
+      params,
+      search,
+    });
+  },
+});
+
+export const legacyBookConfirmedRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: LEGACY_BOOK_CONFIRMED,
+  beforeLoad: ({ params, search }) => {
+    throw redirect({
+      to: ROOT_ROUTES.BOOK_CONFIRMED,
+      params,
+      search,
+    });
+  },
 });
 
 export const lifeRoute = createRoute({
@@ -201,6 +256,10 @@ export const routeTree = rootRoute.addChildren([
         publicBookCancelRoute,
         publicBookRescheduleRoute,
         publicBookRoute,
+        legacyBookConfirmedRoute,
+        legacyBookCancelRoute,
+        legacyBookRescheduleRoute,
+        legacyBookRoute,
       ]
     : []),
   appleAuthCallbackRoute,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3502

## What and why

Public meeting links now read `/meet/:slug` (plus cancel, reschedule, and confirmed). Legacy `/book/...` URLs redirect client-side and keep search params such as `?token=`. `meet` is a reserved slug. API paths stay `/api/booking/*`. Spec: [docs/features/booking.md](https://github.com/KeepSoftwareSimple/compass-calendar/blob/main/docs/features/booking.md). Tracking: #3501.

## Verify

`VERDICT: PASS`

Checks run: `test:core`, `test:web`, `test:backend`, `type-check`, `lint`, `knip`, `test:a11y`, `test:e2e`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad52e327-6e23-450a-a5cb-22a43d90c4f6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad52e327-6e23-450a-a5cb-22a43d90c4f6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

