### PR TITLE
feat(booking): rename host-facing copy from booking to meeting

### DIFF
--- a/docs/architecture/glossary.md
+++ b/docs/architecture/glossary.md
@@ -155,9 +155,9 @@ Browsers connect with `GET /api/events/stream`.
 ## Booking
 
 **Booking page**:
-The one v1 scheduling page owned by a Compass user. Settings configure
-it; guests open it at `/meet/:username`. Old `/book/:username` links
-redirect client-side.
+The one v1 scheduling page owned by a Compass user, shown to users as
+Meeting page. Settings configure it; guests open it at `/meet/:username`.
+Old `/book/:username` links redirect client-side.
 _Avoid_: event type (v1 has one duration per user, not Calendly-style
 multiple event types)
 

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -222,7 +222,7 @@ One booking-page record per user.
 | Welcome text | Optional host-authored line (max 500 characters) shown under the public name. |
 | Scheduling window | Minimum notice default **4 hours**, capped at **1440 hours** (the 60-day horizon in hours). Maximum horizon default **60 days**. Buffer default off, capped at **1440 minutes** (one working day). The 60-day cap matches Sync's busy-query bound (`BUSY_QUERY_MAX_WINDOW_MS` in `packages/core/src/types/sync/availability.contracts.ts`). |
 | Buffer | Off by default. When on, **30 minutes between appointments**, applied to both sides of a booked slot so two meetings cannot sit adjacent. |
-| Max bookings per day | Off by default. When on, default **4**. Counts confirmed booking reservations that day in the host timezone, not every calendar event. |
+| Max meetings per day | Off by default. When on, default **4**. Counts confirmed booking reservations that day in the host timezone, not every calendar event. |
 | Guest permissions | Maps to Google `guestsCanInviteOthers`. Default **on**. This is not Compass UI. `guestsCanModify` stays off. |
 
 **Slot grid:** 15-minute starts in the host timezone, filtered so a slot
@@ -231,15 +231,15 @@ blocks.
 
 ### Host Settings controls
 
-The Settings **Booking** page is keyboard-first. It is split into a
+The Settings **Meeting** page is keyboard-first. It is split into a
 status header, an Essentials group, and a collapsed **More options**
 group. It is not a native timezone `<select>` plus a checkbox and two
 time inputs per weekday.
 
-- **Status:** a live page shows "Your booking page is live" and the
-  public link with Copy and **Open booking page**. A page that is not
-  live shows "Your booking page is not live yet".
-- **Essentials:** Page address, duration, booking timezone, weekly hours, and
+- **Status:** a live page shows "Your meeting page is live" and the
+  meeting link with Copy and **Open meeting page**. A page that is not
+  live shows "Your meeting page is not live yet".
+- **Essentials:** Page address, duration, meeting timezone, weekly hours, and
   destination calendar. These fit without scrolling at 1440x900.
 - **More options:** an uncontrolled native `<details>` that starts
   collapsed. It holds blocking calendars, welcome text, notice and
@@ -251,7 +251,7 @@ time inputs per weekday.
 - **Weekly hours** are one typed range per weekday (`9-5`, or `9-12, 1-5`
   for a break). A blank day is unavailable. The parser reuses
   `parseUserTime` with an explicit PM-correction rule.
-- **Jump:** `e` then a letter focuses a field (`e` booking page on or
+- **Jump:** `e` then a letter focuses a field (`e` meeting page on or
   off, `a` page address, `d` duration, `c` destination, `b` blocking, `z` timezone,
   `h` hours, `m` More options, `w` welcome, `n` notice, `x` horizon,
   `o` buffer and limits, `l` link). Settings owns Mod+Enter (the
@@ -261,19 +261,19 @@ time inputs per weekday.
   does not toggle it. Before focusing, the helper opens any ancestor
   `<details>`.
 - **Turn on / Save:** going live is one click. When the page is not
-  live, the primary action is **Turn on booking page** (Mod+Enter).
+  live, the primary action is **Turn on meeting page** (Mod+Enter).
   **Save draft** appears only when the form is dirty. When the page is
   live, the primary action is **Save changes** and the secondary action
-  is **Turn off booking page**. The Enable booking page checkbox is
+  is **Turn off meeting page**. The Enable meeting page checkbox is
   gone. Validation and server errors render beside the save bar and
   focus the offending field.
-- **Toasts:** turning on copies the link (`Your booking page is live.
+- **Toasts:** turning on copies the link (`Your meeting page is live.
   Link copied.`, or `Live. Press e then l to copy your link.` if the
   clipboard fails). Save changes copies the link with today's Saved
-  copy. Turn off says `Booking page turned off.` Save draft says
-  `Saved. Turn on your booking page to share the link.` Safari can drop
+  copy. Turn off says `Meeting page turned off.` Save draft says
+  `Saved. Turn on your meeting page to share the link.` Safari can drop
   a copy that follows the save round trip; the Copy button stays.
-- **Open booking page** sits next to Copy and opens the public URL in a
+- **Open meeting page** sits next to Copy and opens the public URL in a
   new tab. There is no authenticated preview iframe.
 - **Discard:** Escape on a dirty Booking form opens **Discard unsaved
   changes?** instead of closing Settings. Cancel (Escape) keeps the
@@ -398,7 +398,7 @@ Unauthenticated:
 - `GET /api/booking/pages/:slug` — public page (host display name,
   duration, timezone, enabled, optional welcome text). `404` when
   missing or disabled. A host who cannot write is `409` with
-  `This page is not accepting bookings.` (no billing, plan, or payment
+  `This page is not accepting meetings.` (no billing, plan, or payment
   wording).
 - `GET /api/booking/pages/:slug/slots?start=&end=&timeZone=` — bookable
   instants for that window, computed in the **host** timezone. `timeZone`

--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -343,11 +343,11 @@ test.describe("settings booking section", () => {
     });
     const settingsDialog = page.getByRole("dialog", { name: "Settings" });
     await dispatchClick(
-      settingsDialog.getByRole("button", { name: "Turn on booking page" }),
+      settingsDialog.getByRole("button", { name: "Turn on meeting page" }),
     );
     await expect(
       settingsDialog.getByRole("alert").filter({
-        hasText: "Add weekly hours before turning on your booking page.",
+        hasText: "Add weekly hours before turning on your meeting page.",
       }),
     ).toBeVisible();
     await expectNoAxeViolations(page, {
@@ -429,7 +429,7 @@ test.describe("settings booking section", () => {
     });
     const settingsDialog = page.getByRole("dialog", { name: "Settings" });
     await expect(
-      settingsDialog.getByText("Your booking page is not live yet"),
+      settingsDialog.getByText("Your meeting page is not live yet"),
     ).toBeVisible();
     await expectNoAxeViolations(page, {
       checkpoint: "settings booking not live",

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -1190,7 +1190,7 @@ export async function prepareSignedInBookingSettingsPage(
   } else {
     await expect(
       settingsDialog.getByRole("button", {
-        name: enabled ? "Save changes" : "Turn on booking page",
+        name: enabled ? "Save changes" : "Turn on meeting page",
       }),
     ).toBeVisible({ timeout: 15000 });
   }

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -29,11 +29,11 @@ test("settings booking page shows a copyable public link after save", async ({
   );
 
   await expect.poll(() => captured.putBodies.length).toBe(1);
-  await expect(settingsDialog.getByLabel("Public booking link")).toHaveValue(
+  await expect(settingsDialog.getByLabel("Meeting link")).toHaveValue(
     bookingUrl,
   );
   await expect(
-    settingsDialog.getByRole("link", { name: "Open booking page" }),
+    settingsDialog.getByRole("link", { name: "Open meeting page" }),
   ).toHaveAttribute("href", bookingUrl);
   expect(captured.putBodies[0]).toMatchObject({ durationMinutes: 30 });
 
@@ -100,7 +100,7 @@ test("saves welcome text", async ({ page }) => {
     welcomeText: "30 minutes to talk through Compass.",
   });
   await expect(
-    settingsDialog.getByRole("link", { name: "Open booking page" }),
+    settingsDialog.getByRole("link", { name: "Open meeting page" }),
   ).toHaveAttribute("href", bookingUrl);
 });
 
@@ -116,7 +116,7 @@ test("keyboard hint sits above the public link and the last control stays above 
   const hint = settingsDialog
     .locator("p")
     .filter({ hasText: "then a letter to jump to a field" });
-  const publicLink = settingsDialog.getByLabel("Public booking link");
+  const publicLink = settingsDialog.getByLabel("Meeting link");
   const lastControl = settingsDialog.getByRole("checkbox", {
     name: "Guest can invite others",
   });
@@ -179,7 +179,7 @@ test("turns on a not-live page in one click", async ({ page }) => {
 
   const settingsDialog = page.getByRole("dialog", { name: "Settings" });
   await dispatchClick(
-    settingsDialog.getByRole("button", { name: "Turn on booking page" }),
+    settingsDialog.getByRole("button", { name: "Turn on meeting page" }),
   );
 
   await expect.poll(() => captured.putBodies.length).toBe(1);
@@ -194,7 +194,7 @@ test("turns a not-live unconfigured page on in one click", async ({ page }) => {
 
   const settingsDialog = page.getByRole("dialog", { name: "Settings" });
   await expect(
-    settingsDialog.getByText("Your booking page is not live yet"),
+    settingsDialog.getByText("Your meeting page is not live yet"),
   ).toBeVisible();
   await expect(settingsDialog.getByLabel("Page address")).toHaveValue(
     "hostuser",
@@ -204,7 +204,7 @@ test("turns a not-live unconfigured page on in one click", async ({ page }) => {
   ).toBeVisible();
 
   await dispatchClick(
-    settingsDialog.getByRole("button", { name: "Turn on booking page" }),
+    settingsDialog.getByRole("button", { name: "Turn on meeting page" }),
   );
 
   await expect.poll(() => captured.putBodies.length).toBe(1);
@@ -214,16 +214,16 @@ test("turns a not-live unconfigured page on in one click", async ({ page }) => {
   });
 
   await expect(
-    settingsDialog.getByText("Your booking page is live"),
+    settingsDialog.getByText("Your meeting page is live"),
   ).toBeVisible();
-  await expect(settingsDialog.getByLabel("Public booking link")).toHaveValue(
+  await expect(settingsDialog.getByLabel("Meeting link")).toHaveValue(
     "https://compasscalendar.com/meet/hostuser",
   );
   await expect(
-    settingsDialog.getByRole("button", { name: "Copy booking link" }),
+    settingsDialog.getByRole("button", { name: "Copy meeting link" }),
   ).toBeVisible();
   await expect(
-    settingsDialog.getByRole("link", { name: "Open booking page" }),
+    settingsDialog.getByRole("link", { name: "Open meeting page" }),
   ).toHaveAttribute("href", "https://compasscalendar.com/meet/hostuser");
 });
 
@@ -235,12 +235,12 @@ test("blocks turn on with empty hours", async ({ page }) => {
 
   const settingsDialog = page.getByRole("dialog", { name: "Settings" });
   await dispatchClick(
-    settingsDialog.getByRole("button", { name: "Turn on booking page" }),
+    settingsDialog.getByRole("button", { name: "Turn on meeting page" }),
   );
 
   await expect(
     settingsDialog.getByRole("alert").filter({
-      hasText: "Add weekly hours before turning on your booking page.",
+      hasText: "Add weekly hours before turning on your meeting page.",
     }),
   ).toBeVisible();
   expect(captured.putBodies.length).toBe(0);

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -29,9 +29,9 @@ test("settings booking page shows a copyable public link after save", async ({
   );
 
   await expect.poll(() => captured.putBodies.length).toBe(1);
-  await expect(settingsDialog.getByLabel("Meeting link")).toHaveValue(
-    bookingUrl,
-  );
+  await expect(
+    settingsDialog.getByRole("textbox", { name: "Meeting link" }),
+  ).toHaveValue(bookingUrl);
   await expect(
     settingsDialog.getByRole("link", { name: "Open meeting page" }),
   ).toHaveAttribute("href", bookingUrl);
@@ -116,7 +116,9 @@ test("keyboard hint sits above the public link and the last control stays above 
   const hint = settingsDialog
     .locator("p")
     .filter({ hasText: "then a letter to jump to a field" });
-  const publicLink = settingsDialog.getByLabel("Meeting link");
+  const publicLink = settingsDialog.getByRole("textbox", {
+    name: "Meeting link",
+  });
   const lastControl = settingsDialog.getByRole("checkbox", {
     name: "Guest can invite others",
   });
@@ -216,9 +218,9 @@ test("turns a not-live unconfigured page on in one click", async ({ page }) => {
   await expect(
     settingsDialog.getByText("Your meeting page is live"),
   ).toBeVisible();
-  await expect(settingsDialog.getByLabel("Meeting link")).toHaveValue(
-    "https://compasscalendar.com/meet/hostuser",
-  );
+  await expect(
+    settingsDialog.getByRole("textbox", { name: "Meeting link" }),
+  ).toHaveValue("https://compasscalendar.com/meet/hostuser");
   await expect(
     settingsDialog.getByRole("button", { name: "Copy meeting link" }),
   ).toBeVisible();

--- a/packages/backend/src/booking/booking.error.test.ts
+++ b/packages/backend/src/booking/booking.error.test.ts
@@ -22,7 +22,7 @@ describe("toBookingErrorResponse", () => {
     const { status, body } = toBookingErrorResponse(
       bookingError(
         "AVAILABILITY_REQUIRED",
-        "Add weekly hours before turning on your booking page",
+        "Add weekly hours before turning on your meeting page",
       ),
     );
     expect(status).toBe(Status.BAD_REQUEST);
@@ -33,7 +33,7 @@ describe("toBookingErrorResponse", () => {
     const next = toBookingErrorResponse(
       bookingError(
         "CALENDAR_NOT_CONNECTED",
-        "Connect a healthy calendar account before enabling booking",
+        "Connect a healthy calendar account before enabling your meeting page",
       ),
     );
     const alias = toBookingErrorResponse(

--- a/packages/backend/src/booking/services/booking-page.service.ts
+++ b/packages/backend/src/booking/services/booking-page.service.ts
@@ -58,7 +58,7 @@ const assertTimeZoneForEnable = (rawInput: unknown): void => {
   if (typeof timeZone !== "string" || timeZone.trim() === "") {
     throw bookingError(
       "TIMEZONE_REQUIRED",
-      "Choose a booking timezone before enabling",
+      "Choose a meeting timezone before enabling",
     );
   }
 };
@@ -99,7 +99,7 @@ const assertHealthyWritableDestinationForEnable = async (
   if (healthyConnectionIds.size === 0) {
     throw bookingError(
       "CALENDAR_NOT_CONNECTED",
-      "Connect a healthy calendar account before enabling booking",
+      "Connect a healthy calendar account before enabling your meeting page",
     );
   }
 
@@ -213,7 +213,7 @@ class BookingPageService {
     if (input.enabled && input.weeklyAvailability.length === 0) {
       throw bookingError(
         "AVAILABILITY_REQUIRED",
-        "Add weekly hours before turning on your booking page",
+        "Add weekly hours before turning on your meeting page",
       );
     }
 
@@ -269,7 +269,7 @@ class BookingPageService {
 
     throw bookingError(
       "INVALID_INPUT",
-      "Could not persist booking page due to slug collision",
+      "Could not persist meeting page due to slug collision",
     );
   }
 }

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -465,7 +465,7 @@ describe("PublicBookingService", () => {
 
     expect(error).toMatchObject({
       bookingCode: "SLOT_UNAVAILABLE",
-      message: "This page is not accepting bookings.",
+      message: "This page is not accepting meetings.",
     });
     expect(JSON.stringify(error)).not.toMatch(
       /billing|plan|payment|paid|subscription/i,
@@ -507,7 +507,7 @@ describe("PublicBookingService", () => {
 
     expect(error).toMatchObject({
       bookingCode: "SLOT_UNAVAILABLE",
-      message: "This page is not accepting bookings.",
+      message: "This page is not accepting meetings.",
     });
     expect(JSON.stringify(error)).not.toMatch(
       /billing|plan|payment|paid|subscription/i,

--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -60,7 +60,7 @@ import { getSyncServiceClient } from "@backend/common/services/sync-service/sync
 const logger = Logger("app:booking.public");
 
 const GUEST_PAGE_NOT_ACCEPTING_BOOKINGS =
-  "This page is not accepting bookings.";
+  "This page is not accepting meetings.";
 
 const isBillingRequiredError = (error: unknown): boolean =>
   error instanceof BaseError && error.code === "BILLING_REQUIRED";
@@ -158,7 +158,7 @@ const resolveEnabledPage = async (
 ): Promise<BookingPageRecord & { bookingSlug: string }> => {
   const record = await bookingPageRepository.findBySlug(slug);
   if (!record?.bookingSlug || !record.enabled) {
-    throw bookingError("PAGE_NOT_FOUND", "Booking page not found");
+    throw bookingError("PAGE_NOT_FOUND", "Meeting page not found");
   }
   return { ...record, bookingSlug: record.bookingSlug };
 };
@@ -170,7 +170,7 @@ const getHostDisplayName = async (userId: ObjectId): Promise<string> => {
   );
   const name = user?.name?.trim();
   if (!name) {
-    throw bookingError("PAGE_NOT_FOUND", "Booking page not found");
+    throw bookingError("PAGE_NOT_FOUND", "Meeting page not found");
   }
   return name;
 };
@@ -556,7 +556,7 @@ export class PublicBookingService {
     if (!availability.bookable) {
       throw bookingError(
         "SLOT_UNAVAILABLE",
-        "Booking is temporarily unavailable",
+        "Meeting is temporarily unavailable",
       );
     }
 

--- a/packages/web/src/auth/providers/provider-copy.util.test.ts
+++ b/packages/web/src/auth/providers/provider-copy.util.test.ts
@@ -85,16 +85,16 @@ describe("provider copy", () => {
 
   it("keeps Google booking-connect copy byte-identical", () => {
     expect(bookingConnectPromptCopy(["google"])).toBe(
-      "Connect a Google account to enable your booking page. Guests book through a public link and Compass creates events on your calendar.",
+      "Connect a Google account to enable your meeting page. Guests book through a public link and Compass creates events on your calendar.",
     );
     expect(bookingConnectPromptCopy(["microsoft"])).toBe(
-      "Connect a Microsoft account to enable your booking page. Guests book through a public link and Compass creates events on your calendar.",
+      "Connect a Microsoft account to enable your meeting page. Guests book through a public link and Compass creates events on your calendar.",
     );
     expect(bookingConnectPromptCopy(["google", "microsoft"])).toBe(
-      "Connect a calendar account to enable your booking page. Guests book through a public link and Compass creates events on your calendar.",
+      "Connect a calendar account to enable your meeting page. Guests book through a public link and Compass creates events on your calendar.",
     );
     expect(bookingConnectPromptCopy([])).toBe(
-      "Connect a Google account to enable your booking page. Guests book through a public link and Compass creates events on your calendar.",
+      "Connect a Google account to enable your meeting page. Guests book through a public link and Compass creates events on your calendar.",
     );
   });
 

--- a/packages/web/src/auth/providers/provider-copy.util.ts
+++ b/packages/web/src/auth/providers/provider-copy.util.ts
@@ -77,11 +77,11 @@ export function emptyCalendarsCopy(
 
 const BOOKING_CONNECT_PROMPT: Record<ProviderKind, string> = {
   google:
-    "Connect a Google account to enable your booking page. Guests book through a public link and Compass creates events on your calendar.",
+    "Connect a Google account to enable your meeting page. Guests book through a public link and Compass creates events on your calendar.",
   microsoft:
-    "Connect a Microsoft account to enable your booking page. Guests book through a public link and Compass creates events on your calendar.",
+    "Connect a Microsoft account to enable your meeting page. Guests book through a public link and Compass creates events on your calendar.",
   apple:
-    "Connect an Apple account to enable your booking page. Guests book through a public link and Compass creates events on your calendar.",
+    "Connect an Apple account to enable your meeting page. Guests book through a public link and Compass creates events on your calendar.",
 };
 
 export function bookingConnectPromptCopy(
@@ -90,7 +90,7 @@ export function bookingConnectPromptCopy(
   if (connectable.length <= 1) {
     return BOOKING_CONNECT_PROMPT[connectable[0] ?? "google"];
   }
-  return "Connect a calendar account to enable your booking page. Guests book through a public link and Compass creates events on your calendar.";
+  return "Connect a calendar account to enable your meeting page. Guests book through a public link and Compass creates events on your calendar.";
 }
 
 export function defaultCalendarGroupLabel(

--- a/packages/web/src/booking/BookingBlockingCalendarsField.tsx
+++ b/packages/web/src/booking/BookingBlockingCalendarsField.tsx
@@ -67,7 +67,7 @@ export function BookingBlockingCalendarsField({
         </>
       )}
       <p className="text-text-muted text-xs">
-        Pending, maybe, and declined invites do not hold booking times. Accepted
+        Pending, maybe, and declined invites do not hold meeting times. Accepted
         invites and events the host organizes do.
       </p>
     </fieldset>

--- a/packages/web/src/booking/BookingCopyLink.test.tsx
+++ b/packages/web/src/booking/BookingCopyLink.test.tsx
@@ -48,7 +48,7 @@ describe("BookingCopyLink", () => {
     const bookingUrl = "https://compasscalendar.com/meet/hostuser";
     render(<BookingCopyLink bookingUrl={bookingUrl} />);
 
-    fireEvent.click(screen.getByLabelText("Copy booking link"));
+    fireEvent.click(screen.getByLabelText("Copy meeting link"));
 
     await waitFor(() => {
       expect(mockWriteText).toHaveBeenCalledWith(bookingUrl);
@@ -62,7 +62,7 @@ describe("BookingCopyLink", () => {
     const bookingUrl = "https://compasscalendar.com/meet/hostuser";
     render(<BookingCopyLink bookingUrl={bookingUrl} />);
 
-    const openLink = screen.getByRole("link", { name: "Open booking page" });
+    const openLink = screen.getByRole("link", { name: "Open meeting page" });
     expect(openLink).toHaveAttribute("href", bookingUrl);
     expect(openLink).toHaveAttribute("target", "_blank");
     expect(openLink).toHaveAttribute("rel", "noreferrer");
@@ -74,9 +74,9 @@ describe("BookingCopyLink", () => {
       <BookingCopyLink bookingUrl="https://compasscalendar.com/meet/hostuser" />,
     );
 
-    await user.hover(screen.getByRole("button", { name: "Copy booking link" }));
+    await user.hover(screen.getByRole("button", { name: "Copy meeting link" }));
     expect((await screen.findByRole("tooltip")).textContent).toBe(
-      "Copy booking link",
+      "Copy meeting link",
     );
   });
 
@@ -86,9 +86,9 @@ describe("BookingCopyLink", () => {
       <BookingCopyLink bookingUrl="https://compasscalendar.com/meet/hostuser" />,
     );
 
-    await user.hover(screen.getByRole("link", { name: "Open booking page" }));
+    await user.hover(screen.getByRole("link", { name: "Open meeting page" }));
     expect((await screen.findByRole("tooltip")).textContent).toBe(
-      "Open booking page",
+      "Open meeting page",
     );
   });
 });

--- a/packages/web/src/booking/BookingCopyLink.tsx
+++ b/packages/web/src/booking/BookingCopyLink.tsx
@@ -21,33 +21,33 @@ export function BookingCopyLink({ bookingUrl }: BookingCopyLinkProps) {
     showStatusToast(
       "booking-link-copied",
       didCopy
-        ? "Booking link copied"
+        ? "Meeting link copied"
         : "Could not copy. Select the link to copy it.",
     );
   });
 
   return (
     <div>
-      <p className="mb-1 text-sm text-text">Public booking link</p>
+      <p className="mb-1 text-sm text-text">Meeting link</p>
       <div className="flex items-center gap-1">
         <input
-          aria-label="Public booking link"
+          aria-label="Meeting link"
           className="c-focus-ring min-w-0 flex-1 rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text"
           readOnly
           value={bookingUrl}
         />
-        <TooltipWrapper description={copied ? "Copied" : "Copy booking link"}>
+        <TooltipWrapper description={copied ? "Copied" : "Copy meeting link"}>
           <IconButton
-            aria-label="Copy booking link"
+            aria-label="Copy meeting link"
             onClick={copy}
             size="small"
           >
             {copied ? <Check size={ICON_SIZE} /> : <Copy size={ICON_SIZE} />}
           </IconButton>
         </TooltipWrapper>
-        <TooltipWrapper description="Open booking page">
+        <TooltipWrapper description="Open meeting page">
           <a
-            aria-label="Open booking page"
+            aria-label="Open meeting page"
             className={iconButtonClassName("small")}
             href={bookingUrl}
             rel="noreferrer"

--- a/packages/web/src/booking/BookingLimitsFieldset.tsx
+++ b/packages/web/src/booking/BookingLimitsFieldset.tsx
@@ -52,7 +52,7 @@ export function BookingLimitsFieldset({
           })
         }
       >
-        Max bookings per day ({DEFAULT_MAX_BOOKINGS_PER_DAY})
+        Max meetings per day ({DEFAULT_MAX_BOOKINGS_PER_DAY})
       </BookingCheckboxRow>
 
       <BookingCheckboxRow

--- a/packages/web/src/booking/BookingSaveBar.tsx
+++ b/packages/web/src/booking/BookingSaveBar.tsx
@@ -5,10 +5,10 @@ import {
 } from "@web/components/OverlayPanel/OverlayPanel";
 import { settingsShortcutAttrs } from "@web/settings/useSettingsShortcuts";
 
-export const BOOKING_TURN_ON_LABEL = "Turn on booking page";
+export const BOOKING_TURN_ON_LABEL = "Turn on meeting page";
 export const BOOKING_SAVE_DRAFT_LABEL = "Save draft";
 export const BOOKING_SAVE_CHANGES_LABEL = "Save changes";
-export const BOOKING_TURN_OFF_LABEL = "Turn off booking page";
+export const BOOKING_TURN_OFF_LABEL = "Turn off meeting page";
 
 export const BOOKING_SETTINGS_SAVE_BAR_CLASS_NAME =
   "sticky -bottom-8 z-10 border-border border-t bg-surface-panel pt-3 pb-8";

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -194,7 +194,7 @@ describe("BookingSettingsSection", () => {
     );
 
     expect(
-      screen.getByText(/Connect a Google account to enable your booking page/),
+      screen.getByText(/Connect a Google account to enable your meeting page/),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: CONNECT_CALENDAR_LABEL.google }),
@@ -270,7 +270,7 @@ describe("BookingSettingsSection", () => {
     expect(await screen.findByLabelText("Duration")).toBeInTheDocument();
     expect(
       screen.queryByText(
-        /Connect a Google account to enable your booking page/,
+        /Connect a Google account to enable your meeting page/,
       ),
     ).not.toBeInTheDocument();
   });
@@ -351,10 +351,10 @@ describe("BookingSettingsSection", () => {
       });
     });
 
-    expect(await screen.findByLabelText("Public booking link")).toHaveValue(
+    expect(await screen.findByLabelText("Meeting link")).toHaveValue(
       bookingUrl,
     );
-    const openLink = screen.getByRole("link", { name: "Open booking page" });
+    const openLink = screen.getByRole("link", { name: "Open meeting page" });
     expect(openLink).toHaveAttribute("href", bookingUrl);
     expect(openLink).toHaveAttribute("target", "_blank");
   });
@@ -402,7 +402,7 @@ describe("BookingSettingsSection", () => {
     const hint = await screen.findByText(
       getPartsPlainText(BOOKING_SETTINGS_HINT_PARTS),
     );
-    const publicLink = screen.getByLabelText("Public booking link");
+    const publicLink = screen.getByLabelText("Meeting link");
     const save = screen.getByRole("button", {
       name: BOOKING_SAVE_CHANGES_LABEL,
     });
@@ -590,7 +590,7 @@ describe("BookingSettingsSection", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Pending, maybe, and declined invites do not hold booking times. Accepted invites and events the host organizes do.",
+        "Pending, maybe, and declined invites do not hold meeting times. Accepted invites and events the host organizes do.",
       ),
     ).toBeInTheDocument();
 
@@ -643,9 +643,9 @@ describe("BookingSettingsSection", () => {
     );
 
     const trigger = await screen.findByRole("button", {
-      name: /^Booking timezone:/,
+      name: /^Meeting timezone:/,
     });
-    expect(trigger).toHaveAccessibleName("Booking timezone: Chicago (CDT)");
+    expect(trigger).toHaveAccessibleName("Meeting timezone: Chicago (CDT)");
   });
 
   it("keeps a configured page's stored timezone even when it is UTC", async () => {
@@ -686,9 +686,9 @@ describe("BookingSettingsSection", () => {
     );
 
     const trigger = await screen.findByRole("button", {
-      name: /^Booking timezone:/,
+      name: /^Meeting timezone:/,
     });
-    expect(trigger).toHaveAccessibleName("Booking timezone: UTC (UTC)");
+    expect(trigger).toHaveAccessibleName("Meeting timezone: UTC (UTC)");
   });
 
   it("shows the suggested address before the page is live and is not dirty", async () => {
@@ -1214,7 +1214,7 @@ describe("BookingSettingsSection", () => {
     await user.keyboard("z");
 
     expect(document.activeElement).toBe(
-      screen.getByRole("button", { name: /^Booking timezone:/ }),
+      screen.getByRole("button", { name: /^Meeting timezone:/ }),
     );
   });
 
@@ -1239,10 +1239,10 @@ describe("BookingSettingsSection", () => {
     await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
 
     await user.click(
-      screen.getByRole("button", { name: /^Booking timezone:/ }),
+      screen.getByRole("button", { name: /^Meeting timezone:/ }),
     );
     const search = await screen.findByRole("combobox", {
-      name: "Search booking timezones",
+      name: "Search meeting timezones",
     });
     await waitFor(() => expect(search).toHaveFocus());
 
@@ -1255,7 +1255,7 @@ describe("BookingSettingsSection", () => {
 
     expect(search).toHaveFocus();
     expect(
-      screen.getByRole("combobox", { name: "Search booking timezones" }),
+      screen.getByRole("combobox", { name: "Search meeting timezones" }),
     ).toBeInTheDocument();
   });
 
@@ -1832,7 +1832,7 @@ describe("BookingSettingsSection", () => {
     );
 
     expect(screen.getByRole("alert")).toHaveTextContent(
-      "Choose a destination calendar before enabling booking.",
+      "Choose a destination calendar before enabling your meeting page.",
     );
   });
 
@@ -1874,7 +1874,7 @@ describe("BookingSettingsSection", () => {
 
     const hoursAlert = screen.getByRole("alert");
     expect(hoursAlert).toHaveTextContent(
-      "Add weekly hours before turning on your booking page.",
+      "Add weekly hours before turning on your meeting page.",
     );
     expect(findStickyAncestor(hoursAlert)).not.toBeNull();
     expect(putCount).toBe(0);
@@ -1942,7 +1942,7 @@ describe("BookingSettingsSection", () => {
           ctx.json({
             code: "CALENDAR_NOT_CONNECTED",
             message:
-              "Connect a healthy calendar account before enabling booking",
+              "Connect a healthy calendar account before enabling your meeting page",
           }),
         ),
       ),
@@ -1968,7 +1968,7 @@ describe("BookingSettingsSection", () => {
     ).toBeInTheDocument();
     await waitFor(() => {
       expect(mocks.error).toHaveBeenCalledWith(
-        "Could not save booking settings. Please try again.",
+        "Could not save meeting settings. Please try again.",
         expect.any(Object),
       );
     });
@@ -2205,7 +2205,7 @@ describe("BookingSettingsSection", () => {
     });
     expect(writeText).toHaveBeenCalledWith(bookingUrl);
     expect(mocks.toast).toHaveBeenCalledWith(
-      "Your booking page is live. Link copied.",
+      "Your meeting page is live. Link copied.",
       expect.any(Object),
     );
   });

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -414,7 +414,7 @@ export function BookingSettingsSection({
   }
 
   if (isSeedingForm) {
-    return <p className="text-sm text-text-muted">Loading booking settings…</p>;
+    return <p className="text-sm text-text-muted">Loading meeting settings…</p>;
   }
 
   const savedPage = isSavedBookingPage(serverPage) ? serverPage : null;
@@ -498,8 +498,8 @@ export function BookingSettingsSection({
             showStatusToast(
               "booking-link-copied",
               wasLive
-                ? "Booking page turned off."
-                : "Saved. Turn on your booking page to share the link.",
+                ? "Meeting page turned off."
+                : "Saved. Turn on your meeting page to share the link.",
             );
             return;
           }
@@ -513,11 +513,11 @@ export function BookingSettingsSection({
             page.bookingUrl,
             wasLive
               ? {
-                  onCopy: "Saved. Booking link copied.",
+                  onCopy: "Saved. Meeting link copied.",
                   onFail: "Saved. Press e then l to copy your link.",
                 }
               : {
-                  onCopy: "Your booking page is live. Link copied.",
+                  onCopy: "Your meeting page is live. Link copied.",
                   onFail: "Live. Press e then l to copy your link.",
                 },
           );

--- a/packages/web/src/booking/BookingStatusHeader.tsx
+++ b/packages/web/src/booking/BookingStatusHeader.tsx
@@ -16,7 +16,7 @@ export function BookingStatusHeader({
     return (
       <div className="flex flex-col gap-2">
         <p className="font-medium text-sm text-text">
-          Your booking page is live
+          Your meeting page is live
         </p>
         {bookingUrl ? (
           <div {...bookingFieldAttrs("link")}>
@@ -30,7 +30,7 @@ export function BookingStatusHeader({
   return (
     <div className="flex flex-col gap-1">
       <p className="font-medium text-sm text-text">
-        Your booking page is not live yet
+        Your meeting page is not live yet
       </p>
       {addressPreview ? (
         <p className="text-sm text-text-muted">

--- a/packages/web/src/booking/BookingTimezoneField.tsx
+++ b/packages/web/src/booking/BookingTimezoneField.tsx
@@ -15,7 +15,7 @@ interface BookingTimezoneFieldProps {
 }
 
 /**
- * The booking page's timezone, picked through the same searchable combobox as
+ * The meeting page's timezone, picked through the same searchable combobox as
  * time travel and the default-timezone dialog. It was a native <select> over
  * the whole IANA catalog: ~420 options in raw id order, where the browser's
  * type-ahead matches the rendered city text, so typing "America" or "US" found
@@ -40,13 +40,13 @@ export function BookingTimezoneField({
         className="mb-1 flex items-center gap-1 text-sm text-text"
         id="booking-timezone-label"
       >
-        Booking timezone
+        Meeting timezone
         {shortcutKeys ? <ShortcutKeys keys={[...shortcutKeys]} /> : null}
       </p>
       <button
         aria-expanded={isOpen}
         aria-haspopup="listbox"
-        aria-label={`Booking timezone: ${label}`}
+        aria-label={`Meeting timezone: ${label}`}
         className="c-focus-ring w-full rounded border border-border bg-surface-overlay px-2 py-1 text-left text-sm text-text hover:bg-surface-panel disabled:pointer-events-none disabled:opacity-60"
         disabled={disabled}
         id="booking-timezone"
@@ -63,7 +63,7 @@ export function BookingTimezoneField({
           initialFocusRef={searchRef}
           onDismiss={() => setIsOpen(false)}
           restoreFocus={() => triggerRef.current?.focus()}
-          title="Booking timezone"
+          title="Meeting timezone"
           variant="modal"
           widthClassName="w-[480px]"
         >
@@ -73,7 +73,7 @@ export function BookingTimezoneField({
               if (nextTimeZone) onChange(nextTimeZone as TimeZone);
               setIsOpen(false);
             }}
-            searchLabel="Search booking timezones"
+            searchLabel="Search meeting timezones"
             value={timeZone}
           />
         </OverlayPanel>

--- a/packages/web/src/booking/booking-conference.copy.ts
+++ b/packages/web/src/booking/booking-conference.copy.ts
@@ -30,7 +30,7 @@ export const BOOKING_DESTINATION_CONFERENCE_SUFFIX: Record<
 };
 
 export const BOOKING_APPLE_DESTINATION_HINT =
-  "Bookings on an iCloud calendar are created without a video link. Add one in the booking notes if you need it.";
+  "Meetings on an iCloud calendar are created without a video link. Add one in the meeting notes if you need it.";
 
 export const BOOKING_NO_CONFERENCE_WARNING: Record<CalendarProvider, string> = {
   local:

--- a/packages/web/src/booking/booking-sequence.fields.ts
+++ b/packages/web/src/booking/booking-sequence.fields.ts
@@ -12,19 +12,19 @@
  * than the event form's Mod+digit jump.
  */
 export const BOOKING_SEQUENCE_FIELDS = [
-  { key: "e", field: "enabled", label: "Booking page on or off" },
+  { key: "e", field: "enabled", label: "Meeting page on or off" },
   { key: "a", field: "address", label: "Page address" },
   { key: "d", field: "duration", label: "Duration" },
   { key: "c", field: "destination", label: "Destination calendar" },
   { key: "b", field: "blocking", label: "Blocking calendars" },
-  { key: "z", field: "timezone", label: "Booking timezone" },
+  { key: "z", field: "timezone", label: "Meeting timezone" },
   { key: "h", field: "hours", label: "Weekly hours" },
   { key: "m", field: "more", label: "More options" },
   { key: "w", field: "welcome", label: "Welcome text" },
   { key: "n", field: "notice", label: "Minimum notice" },
   { key: "x", field: "horizon", label: "Maximum horizon" },
   { key: "o", field: "options", label: "Buffer and limits" },
-  { key: "l", field: "link", label: "Booking link" },
+  { key: "l", field: "link", label: "Meeting link" },
 ] as const satisfies readonly {
   key: string;
   field: string;

--- a/packages/web/src/booking/booking.query.ts
+++ b/packages/web/src/booking/booking.query.ts
@@ -41,9 +41,9 @@ export const BOOKING_SAVE_ERROR_COPY: Record<string, string> = {
     "One of your blocking calendars can't be checked for busy times. Uncheck it and save again.",
   DESTINATION_NOT_WRITABLE:
     "The destination calendar can't accept new events. Choose a different calendar and save again.",
-  TIMEZONE_REQUIRED: "Choose a booking timezone before enabling booking.",
+  TIMEZONE_REQUIRED: "Choose a meeting timezone before enabling.",
   AVAILABILITY_REQUIRED:
-    "Add weekly hours before turning on your booking page.",
+    "Add weekly hours before turning on your meeting page.",
   SLUG_TAKEN: "That address is already taken. Try another.",
   INVALID_INPUT:
     "Some settings couldn't be saved. Check the highlighted fields and try again.",
@@ -76,7 +76,7 @@ function handleBookingSaveError(
   if (error instanceof ZodError) {
     // A client-side schema rejection means a form field slipped past its
     // inline validation - point at the fields, not at the server.
-    showErrorToast("Check the booking fields and try again.");
+    showErrorToast("Check the meeting fields and try again.");
     return;
   }
   if (isApiError(error)) {
@@ -97,7 +97,7 @@ function handleBookingSaveError(
       return;
     }
   }
-  showErrorToast("Could not save booking settings. Please try again.");
+  showErrorToast("Could not save meeting settings. Please try again.");
 }
 
 export function useSaveBookingPageMutation() {

--- a/packages/web/src/booking/booking.util.ts
+++ b/packages/web/src/booking/booking.util.ts
@@ -223,7 +223,8 @@ export function validateBookingForm({
   if (enabling && !canEnableBookingPage(form, writableCalendars)) {
     return {
       field: "destination",
-      message: "Choose a destination calendar before enabling booking.",
+      message:
+        "Choose a destination calendar before enabling your meeting page.",
     };
   }
   if (enabling && form.blockingCalendarIds.length === 0) {
@@ -235,7 +236,7 @@ export function validateBookingForm({
   if (enabling && form.weeklyAvailability.length === 0) {
     return {
       field: "hours",
-      message: "Add weekly hours before turning on your booking page.",
+      message: "Add weekly hours before turning on your meeting page.",
     };
   }
   return null;

--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -160,17 +160,17 @@ describe("CommandPalette", () => {
     expect(screen.queryByText("Manage Billing")).toBeNull();
   });
 
-  it("shows Booking settings when signed in", () => {
+  it("shows Meeting settings when signed in", () => {
     authenticated = true;
     renderPalette();
 
-    expect(rowLabel("Booking settings")).toBeInTheDocument();
+    expect(rowLabel("Meeting settings")).toBeInTheDocument();
   });
 
-  it("hides Booking settings when signed out", () => {
+  it("hides Meeting settings when signed out", () => {
     renderPalette();
 
-    expect(screen.queryByText("Booking settings")).toBeNull();
+    expect(screen.queryByText("Meeting settings")).toBeNull();
   });
 
   it("badges create actions as Premium when billing is read-only", () => {

--- a/packages/web/src/components/CommandPalette/hooks/useShowBookingCmdItems.test.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useShowBookingCmdItems.test.ts
@@ -53,7 +53,7 @@ describe("useShowBookingCmdItems", () => {
   it("opens Settings on Booking from the command palette item", () => {
     const { result } = renderHook(() => useShowBookingCmdItems());
 
-    expect(result.current[0].label).toBe("Booking settings");
+    expect(result.current[0].label).toBe("Meeting settings");
     expect(result.current[0].icon).toBe(CalendarIcon);
     expect(result.current[0].keywords).toContain("availability");
     expect(result.current[0].keywords).toContain("meeting link");

--- a/packages/web/src/components/CommandPalette/hooks/useShowBookingCmdItems.ts
+++ b/packages/web/src/components/CommandPalette/hooks/useShowBookingCmdItems.ts
@@ -17,7 +17,7 @@ export const useShowBookingCmdItems = (
   return [
     {
       id: "show-booking",
-      label: "Booking settings",
+      label: "Meeting settings",
       icon: CalendarIcon,
       keywords: [
         "booking",

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -673,13 +673,13 @@ describe("SettingsModal", () => {
   it("shows Booking for a signed-in user", () => {
     renderSettings({ authenticated: true });
 
-    expect(screen.getByRole("button", { name: "Booking" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Meeting" })).toBeInTheDocument();
   });
 
   it("hides Booking for a signed-out session", () => {
     renderSettings({ authenticated: false });
 
-    expect(screen.queryByRole("button", { name: "Booking" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Meeting" })).toBeNull();
   });
 
   it.each([
@@ -964,7 +964,7 @@ describe("SettingsModal", () => {
     renderSettings({ authenticated: true, page: "booking" });
 
     expect(
-      await screen.findByText("Loading booking settings\u2026"),
+      await screen.findByText("Loading meeting settings\u2026"),
     ).toBeInTheDocument();
   });
 

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -245,7 +245,7 @@ export const SettingsModal: FC = () => {
               type="button"
               {...settingsShortcutAttrs("nav-booking")}
             >
-              Booking
+              Meeting
               {areHintsVisible ? <ShortcutKeys keys="3" /> : null}
             </button>
           ) : null}

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -451,7 +451,7 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
   {
     id: "other-booking-jump",
     keys: ["e", "letter"],
-    label: "Jump to a booking settings field",
+    label: "Jump to a meeting settings field",
     section: "other",
   },
   {

--- a/packages/web/src/timezone/TimezoneCombobox.test.tsx
+++ b/packages/web/src/timezone/TimezoneCombobox.test.tsx
@@ -105,7 +105,7 @@ describe("BookingTimezoneField", () => {
     );
 
     await user.click(
-      screen.getByRole("button", { name: /^Booking timezone:/ }),
+      screen.getByRole("button", { name: /^Meeting timezone:/ }),
     );
     await user.type(screen.getByRole("combobox"), "berlin");
     await user.keyboard("{Enter}");
@@ -122,7 +122,7 @@ describe("BookingTimezoneField", () => {
     );
 
     expect(
-      screen.getByRole("button", { name: /^Booking timezone: Pacific/ }),
+      screen.getByRole("button", { name: /^Meeting timezone: Pacific/ }),
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3503

## What and why

Hosts now read **meeting** instead of **booking** in Settings, the command palette, toasts, and backend enable-guard errors. Nav tab is Meeting, header is "Your meeting page is live", timezone is Meeting timezone, palette item is Meeting settings. Machine names, ids, query keys, analytics events, and guest-facing page copy stay unchanged (guest UI is WP-03).

Spec: `docs/features/booking.md` Host Settings controls.

## Verify

`VERDICT: PASS`

Checks run: test:web, test:backend, type-check, lint, knip, test:a11y, test:e2e

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad52e327-6e23-450a-a5cb-22a43d90c4f6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad52e327-6e23-450a-a5cb-22a43d90c4f6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

