### PR TITLE
fix(web): match welcome Google and email button widths

### DIFF
--- a/e2e/onboarding/welcome-cta-width.spec.ts
+++ b/e2e/onboarding/welcome-cta-width.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test";
+
+test.use({ storageState: { cookies: [], origins: [] } });
+test.use({ viewport: { width: 1600, height: 900 } });
+
+test("keeps Google and email signup buttons the same width", async ({
+  page,
+}) => {
+  await page.route("**/api/config", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ google: { isConfigured: true } }),
+    });
+  });
+
+  await page.goto("/week", { waitUntil: "domcontentloaded" });
+
+  const welcomeDialog = page.getByRole("dialog", {
+    name: "Welcome to Compass Calendar",
+  });
+  await expect(welcomeDialog).toBeVisible();
+  await welcomeDialog
+    .getByRole("button", { name: "Get started for free" })
+    .click();
+  await welcomeDialog.getByRole("button", { name: "Next" }).click();
+
+  const google = welcomeDialog.getByRole("button", {
+    name: "Continue with Google",
+  });
+  const email = welcomeDialog.getByRole("button", {
+    name: "Sign up with email",
+  });
+  await expect(google).toBeVisible();
+  await expect(email).toBeVisible();
+
+  const googleBox = await google.boundingBox();
+  const emailBox = await email.boundingBox();
+  expect(googleBox).not.toBeNull();
+  expect(emailBox).not.toBeNull();
+  expect(googleBox?.width).toBe(emailBox?.width);
+});

--- a/packages/web/src/components/AuthModal/components/AppleButton.tsx
+++ b/packages/web/src/components/AuthModal/components/AppleButton.tsx
@@ -38,7 +38,7 @@ export const AppleButton = ({
       aria-busy={busy || undefined}
       aria-label={label}
       className={classNames(
-        "inline-flex h-10 items-center justify-center gap-2.5 whitespace-nowrap rounded-full border border-[#1f1f1f] bg-[#000] px-3 font-medium text-[#fff] text-sm transition-[background-color,box-shadow,transform] duration-200",
+        "inline-flex h-10 w-full items-center justify-center gap-2.5 whitespace-nowrap rounded-full border border-[#1f1f1f] bg-[#000] px-3 font-medium text-[#fff] text-sm transition-[background-color,box-shadow,transform] duration-200",
         disabled
           ? "cursor-not-allowed opacity-60"
           : "c-button-elevated cursor-pointer hover:bg-[#1a1a1a]",

--- a/packages/web/src/components/AuthModal/components/GoogleButton.tsx
+++ b/packages/web/src/components/AuthModal/components/GoogleButton.tsx
@@ -57,7 +57,7 @@ export const GoogleButton = ({
       aria-busy={busy || undefined}
       aria-label={label}
       className={classNames(
-        "inline-flex h-10 items-center justify-center gap-2.5 whitespace-nowrap rounded-full border border-[#1f1f1f] bg-[#fff] px-3 font-medium text-[#1f1f1f] text-sm transition-[background-color,box-shadow,transform] duration-200",
+        "inline-flex h-10 w-full items-center justify-center gap-2.5 whitespace-nowrap rounded-full border border-[#1f1f1f] bg-[#fff] px-3 font-medium text-[#1f1f1f] text-sm transition-[background-color,box-shadow,transform] duration-200",
         disabled
           ? "cursor-not-allowed opacity-60"
           : "c-button-elevated cursor-pointer hover:bg-[#f8f8f8]",

--- a/packages/web/src/components/AuthModal/components/MicrosoftButton.tsx
+++ b/packages/web/src/components/AuthModal/components/MicrosoftButton.tsx
@@ -45,7 +45,7 @@ export const MicrosoftButton = ({
       aria-busy={busy || undefined}
       aria-label={label}
       className={classNames(
-        "inline-flex h-10 items-center justify-center gap-2.5 whitespace-nowrap rounded-full border border-[#1f1f1f] bg-[#fff] px-3 font-medium text-[#1f1f1f] text-sm transition-[background-color,box-shadow,transform] duration-200",
+        "inline-flex h-10 w-full items-center justify-center gap-2.5 whitespace-nowrap rounded-full border border-[#1f1f1f] bg-[#fff] px-3 font-medium text-[#1f1f1f] text-sm transition-[background-color,box-shadow,transform] duration-200",
         disabled
           ? "cursor-not-allowed opacity-60"
           : "c-button-elevated cursor-pointer hover:bg-[#f8f8f8]",

--- a/packages/web/src/components/AuthModal/components/SignInProviderButtons.test.tsx
+++ b/packages/web/src/components/AuthModal/components/SignInProviderButtons.test.tsx
@@ -18,6 +18,15 @@ describe("SignInProviderButtons", () => {
       screen.getByRole("button", { name: "Continue with Google" }),
     ).toHaveTextContent("Continue with Google");
     expect(
+      screen.getByRole("button", { name: "Continue with Google" }),
+    ).toHaveClass("w-full");
+    expect(
+      screen.getByRole("button", { name: "Continue with Microsoft" }),
+    ).toHaveClass("w-full");
+    expect(
+      screen.getByRole("button", { name: "Continue with Apple" }),
+    ).toHaveClass("w-full");
+    expect(
       screen.getByRole("button", { name: "Continue with Microsoft" }),
     ).toHaveTextContent("Continue with Microsoft");
     expect(
@@ -29,6 +38,28 @@ describe("SignInProviderButtons", () => {
     expect(
       screen.queryByText("Signs you up and connects your Outlook calendar."),
     ).not.toBeInTheDocument();
+  });
+
+  it("stretches the button stack to the container width", () => {
+    const { container } = render(
+      <SignInProviderButtons
+        available={["google"]}
+        loadingKind={null}
+        onSignIn={mock()}
+      />,
+    );
+
+    expect(container.firstElementChild).toHaveClass(
+      "w-full",
+      "flex",
+      "flex-col",
+    );
+    expect(
+      screen.getByRole("button", { name: "Continue with Google" }),
+    ).toHaveClass("w-full");
+    expect(
+      screen.getByRole("button", { name: "Continue with Google" }),
+    ).toHaveStyle({ width: "100%" });
   });
 
   it("calls onSignIn with the clicked provider kind", async () => {

--- a/packages/web/src/components/AuthModal/components/SignInProviderButtons.tsx
+++ b/packages/web/src/components/AuthModal/components/SignInProviderButtons.tsx
@@ -81,7 +81,7 @@ export const SignInProviderButtons: FC<SignInProviderButtonsProps> = ({
   );
 
   if (fullWidth) {
-    return <div className="flex flex-col gap-3">{buttons}</div>;
+    return <div className="flex w-full flex-col gap-3">{buttons}</div>;
   }
 
   return <>{buttons}</>;

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -584,6 +584,9 @@ describe("WelcomeModal", () => {
       expect(
         screen.getByRole("button", { name: "Sign up with email" }),
       ).toHaveClass("w-full", "h-10", "c-button-elevated");
+      expect(
+        screen.getByRole("button", { name: "Continue with Google" }),
+      ).toHaveClass("w-full", "h-10");
     });
 
     it("starts Google auth from the button and queues the practice offer", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

On the welcome "choose how to start" screen, Continue with Google sat in a shrink-wrapped flex child while Sign up with email used `w-full`, so the two pills did not share a width. The provider stack now stretches to the same full width as the email CTA, including Microsoft and Apple when they are shown.

## Verify

VERDICT: PASS

Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e

Local measurements on the choose screen: both CTAs rendered at 416px by 40px.

![Welcome choose screen with equal-width Google and email buttons](https://cursor.com/artifacts/c/art-3004ed07-e646-41bc-9ede-0c5171318a71)

<a href="https://cursor.com/agents/bc-ce84e143-5b4a-4edb-a849-ced40cb0beb9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwelcome_google_and_email_same_width.mp4"><img src="https://cursor.com/artifacts/c/art-19356489-2afc-4444-a764-22abb827da3a" alt="welcome_google_and_email_same_width.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce84e143-5b4a-4edb-a849-ced40cb0beb9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce84e143-5b4a-4edb-a849-ced40cb0beb9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

