### PR TITLE
feat(booking): rename guest-facing copy from booking to meeting

### DIFF
--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -118,16 +118,16 @@ notes), and confirm. They do not need a Compass account.
 
 ```mermaid
 flowchart TD
-  load["Open /book/:slug"]
+  load["Open /meet/:slug"]
   picker["Two-pane: month grid + day's times"]
   details["Your details"]
-  permalink["/book/confirmed/:id"]
-  cancel["/book/cancel/:id"]
-  reschedule["/book/reschedule/:id"]
+  permalink["/meet/confirmed/:id"]
+  cancel["/meet/cancel/:id"]
+  reschedule["/meet/reschedule/:id"]
   load --> picker
   picker -->|select a time| details
   details -->|Change time| picker
-  details -->|Confirm booking| permalink
+  details -->|Confirm meeting| permalink
   permalink -->|tokenized cancel URL| cancel
   permalink -->|tokenized reschedule URL| reschedule
   reschedule -->|reuse picker| picker
@@ -151,16 +151,16 @@ focus uses the accent ring. Intended Tab order on the picker:
    to the first slot. Enter or Space on a slot opens **Your details**
    and moves focus to that heading. **Skip to your details** is the
    first tab stop on that step.
-4. **Change time**, then name, email, notes, **Confirm booking**.
+4. **Change time**, then name, email, notes, **Confirm meeting**.
    **Change time** returns focus to **Pick a time**.
-5. After confirm, `/book/confirmed/:id` focuses **You are booked with
+5. After confirm, `/meet/confirmed/:id` focuses **You're meeting with
    {host}**. Unknown, cancelled, and load-error states focus their
    headings.
 6. A 409 conflict focuses the alert. Slot-load retry focuses **Pick a
    time**. Jump to next available day does the same.
-7. Cancel (`/book/cancel/:id`) focuses its heading on load and after
-   each state change. Tab then reaches **Cancel this booking**.
-8. Reschedule (`/book/reschedule/:id`) focuses **Reschedule your booking
+7. Cancel (`/meet/cancel/:id`) focuses its heading on load and after
+   each state change. Tab then reaches **Cancel this meeting**.
+8. Reschedule (`/meet/reschedule/:id`) focuses **Reschedule your meeting
    with {host}** on load and after each state change. Tab then reaches
    the picker (same month grid and slot list as the public page), then
    **Confirm**. A 409 conflict focuses the alert. Missing or invalid
@@ -182,13 +182,13 @@ holds the app lock first.
   step (picker or details) in place.
 - **Slot list:** Escape moves focus to the selected day. It does not
   change the URL.
-- **Month grid:** Escape is a no-op. It does not leave `/book/:slug`.
-- **Confirmation** (`/book/confirmed/:id`): Escape returns to
-  `/book/:bookingSlug` and focuses **Book with {host}**. Unknown,
+- **Month grid:** Escape is a no-op. It does not leave `/meet/:slug`.
+- **Confirmation** (`/meet/confirmed/:id`): Escape returns to
+  `/meet/:bookingSlug` and focuses **Meet with {host}**. Unknown,
   cancelled, and load-error states have no slug path and stay put.
 - **Edit details:** Escape returns to confirmation without PATCHing.
-- **Cancel confirm** (`/book/cancel/:id`): Escape returns to
-  `/book/confirmed/:id` with the same `?token=` and does not POST.
+- **Cancel confirm** (`/meet/cancel/:id`): Escape returns to
+  `/meet/confirmed/:id` with the same `?token=` and does not POST.
   In-flight cancel does not navigate or abort.
 
 ### Outcome

--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -85,7 +85,7 @@ test("the public booking conflict alert has no automatically detectable accessib
     .click();
   await page.getByLabel("Name").fill("Guest User");
   await page.getByLabel("Email").fill("guest@example.com");
-  await page.getByRole("button", { name: "Confirm booking" }).click();
+  await page.getByRole("button", { name: "Confirm meeting" }).click();
 
   await expect(page.getByRole("alert")).toBeVisible();
   await expectNoAxeViolations(page, { checkpoint: "public booking conflict" });
@@ -97,7 +97,7 @@ test.describe("public booking confirmation page", () => {
   }) => {
     await preparePublicBookingConfirmedPage(page);
     await expect(
-      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+      page.getByRole("heading", { name: "You're meeting with Tyler Dane" }),
     ).toBeVisible();
     await expectNoAxeViolations(page, {
       checkpoint: "booking confirmation permalink",
@@ -109,7 +109,7 @@ test.describe("public booking confirmation page", () => {
   }) => {
     await preparePublicBookingConfirmedPage(page, { token: "abc" });
     await expect(
-      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+      page.getByRole("heading", { name: "You're meeting with Tyler Dane" }),
     ).toBeVisible();
     await expect(
       page.getByRole("button", { name: "Edit details" }),
@@ -144,7 +144,7 @@ test.describe("public booking confirmation page", () => {
       reservationStatus: "cancelled",
     });
     await expect(
-      page.getByRole("heading", { name: "This booking was canceled" }),
+      page.getByRole("heading", { name: "This meeting was canceled" }),
     ).toBeVisible();
     await expectNoAxeViolations(page, {
       checkpoint: "booking confirmation cancelled",
@@ -158,7 +158,7 @@ test.describe("public booking confirmation page", () => {
       reservationNotFound: true,
     });
     await expect(
-      page.getByRole("heading", { name: "Booking not found" }),
+      page.getByRole("heading", { name: "Meeting not found" }),
     ).toBeVisible();
     await expectNoAxeViolations(page, {
       checkpoint: "booking confirmation not found",
@@ -172,7 +172,7 @@ test.describe("public booking confirmation page", () => {
       reservationGetStatus: 500,
     });
     await expect(
-      page.getByRole("heading", { name: "Could not load booking" }),
+      page.getByRole("heading", { name: "Could not load meeting" }),
     ).toBeVisible();
     await expectNoAxeViolations(page, {
       checkpoint: "booking confirmation load error",
@@ -186,7 +186,7 @@ test.describe("public booking cancel page", () => {
   }) => {
     await preparePublicBookingCancelPage(page);
     await expect(
-      page.getByRole("heading", { name: "Cancel this booking?" }),
+      page.getByRole("heading", { name: "Cancel this meeting?" }),
     ).toBeVisible();
     await expectNoAxeViolations(page, { checkpoint: "cancel confirm" });
   });
@@ -199,14 +199,14 @@ test.describe("public booking cancel page", () => {
       release = resolve;
     });
     await preparePublicBookingCancelPage(page, { holdCancel });
-    await page.getByRole("button", { name: "Cancel this booking" }).click();
+    await page.getByRole("button", { name: "Cancel this meeting" }).click();
     await expect(
       page.getByRole("button", { name: "Canceling..." }),
     ).toBeVisible();
     await expectNoAxeViolations(page, { checkpoint: "cancel in-flight" });
     release();
     await expect(
-      page.getByRole("heading", { name: "Booking canceled" }),
+      page.getByRole("heading", { name: "Meeting canceled" }),
     ).toBeVisible();
   });
 
@@ -214,9 +214,9 @@ test.describe("public booking cancel page", () => {
     page,
   }) => {
     await preparePublicBookingCancelPage(page);
-    await page.getByRole("button", { name: "Cancel this booking" }).click();
+    await page.getByRole("button", { name: "Cancel this meeting" }).click();
     await expect(
-      page.getByRole("heading", { name: "Booking canceled" }),
+      page.getByRole("heading", { name: "Meeting canceled" }),
     ).toBeVisible();
     await expectNoAxeViolations(page, { checkpoint: "cancel success" });
   });
@@ -226,7 +226,7 @@ test.describe("public booking cancel page", () => {
   }) => {
     await preparePublicBookingCancelPage(page, { token: "" });
     await expect(
-      page.getByRole("heading", { name: "Booking not found" }),
+      page.getByRole("heading", { name: "Meeting not found" }),
     ).toBeVisible();
     await expectNoAxeViolations(page, { checkpoint: "cancel not found" });
   });
@@ -235,9 +235,9 @@ test.describe("public booking cancel page", () => {
     page,
   }) => {
     await preparePublicBookingCancelPage(page, { cancelStatus: 500 });
-    await page.getByRole("button", { name: "Cancel this booking" }).click();
+    await page.getByRole("button", { name: "Cancel this meeting" }).click();
     await expect(
-      page.getByRole("heading", { name: "Could not cancel booking" }),
+      page.getByRole("heading", { name: "Could not cancel meeting" }),
     ).toBeVisible();
     await expectNoAxeViolations(page, { checkpoint: "cancel error" });
   });
@@ -250,7 +250,7 @@ test.describe("public booking reschedule page", () => {
     await preparePublicBookingReschedulePage(page);
     await expect(
       page.getByRole("heading", {
-        name: "Reschedule your booking with Tyler Dane",
+        name: "Reschedule your meeting with Tyler Dane",
       }),
     ).toBeVisible();
     await expect(
@@ -266,7 +266,7 @@ test.describe("public booking reschedule page", () => {
   }) => {
     await preparePublicBookingReschedulePage(page, { token: "" });
     await expect(
-      page.getByRole("heading", { name: "Booking not found" }),
+      page.getByRole("heading", { name: "Meeting not found" }),
     ).toBeVisible();
     await expectNoAxeViolations(page, {
       checkpoint: "booking reschedule not found",
@@ -280,7 +280,7 @@ test.describe("public booking reschedule page", () => {
       reservationStatus: "cancelled",
     });
     await expect(
-      page.getByRole("heading", { name: "This booking was canceled" }),
+      page.getByRole("heading", { name: "This meeting was canceled" }),
     ).toBeVisible();
     await expectNoAxeViolations(page, {
       checkpoint: "booking reschedule canceled",

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -601,12 +601,12 @@ export async function preparePublicBookingPage(
   await page.goto(`/meet/${slug}`, { waitUntil: "domcontentloaded" });
   if (options.notFound || options.enabled === false) {
     await expect(
-      page.getByRole("heading", { name: "Booking page not found" }),
+      page.getByRole("heading", { name: "Meeting page not found" }),
     ).toBeVisible({ timeout: 15000 });
     return captured;
   }
   await expect(
-    page.getByRole("heading", { name: "Book with Tyler Dane" }),
+    page.getByRole("heading", { name: "Meet with Tyler Dane" }),
   ).toBeVisible({ timeout: 15000 });
   // The h1 renders before the slots request settles, and while slots are
   // pending the picker shows a skeleton without the "Pick a time" heading.

--- a/e2e/booking/public-booking-cancel.spec.ts
+++ b/e2e/booking/public-booking-cancel.spec.ts
@@ -8,20 +8,20 @@ test.describe("public booking cancel page", () => {
     const captured = await preparePublicBookingCancelPage(page);
 
     await expect(
-      page.getByRole("heading", { name: "Cancel this booking?" }),
+      page.getByRole("heading", { name: "Cancel this meeting?" }),
     ).toBeVisible();
     await expect(
-      page.getByText("You are canceling a booking with Tyler Dane."),
+      page.getByText("You are canceling a meeting with Tyler Dane."),
     ).toBeVisible();
     await expect(page.getByText("When")).toBeVisible();
     await expect(page.getByText("Duration")).toBeVisible();
     await expect(page.getByText("Timezone")).toBeVisible();
     expect(captured.cancelPosts).toHaveLength(0);
 
-    await page.getByRole("button", { name: "Cancel this booking" }).click();
+    await page.getByRole("button", { name: "Cancel this meeting" }).click();
 
     await expect(
-      page.getByRole("heading", { name: "Booking canceled" }),
+      page.getByRole("heading", { name: "Meeting canceled" }),
     ).toBeFocused();
     expect(captured.cancelPosts).toHaveLength(1);
     expect(captured.cancelPosts[0]).toMatchObject({ token: "abc" });
@@ -32,12 +32,12 @@ test.describe("public booking cancel page", () => {
   }) => {
     await preparePublicBookingCancelPage(page);
 
-    const heading = page.getByRole("heading", { name: "Cancel this booking?" });
+    const heading = page.getByRole("heading", { name: "Cancel this meeting?" });
     await expect(heading).toBeFocused();
 
     await page.keyboard.press("Tab");
     await expect(
-      page.getByRole("button", { name: "Cancel this booking" }),
+      page.getByRole("button", { name: "Cancel this meeting" }),
     ).toBeFocused();
   });
 
@@ -49,10 +49,10 @@ test.describe("public booking cancel page", () => {
     });
 
     await expect(
-      page.getByRole("heading", { name: "Booking canceled" }),
+      page.getByRole("heading", { name: "Meeting canceled" }),
     ).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "Cancel this booking" }),
+      page.getByRole("button", { name: "Cancel this meeting" }),
     ).toHaveCount(0);
     expect(captured.cancelPosts).toHaveLength(0);
   });
@@ -62,13 +62,13 @@ test.describe("public booking cancel page", () => {
   }) => {
     await preparePublicBookingCancelPage(page, { cancelStatus: 500 });
 
-    await page.getByRole("button", { name: "Cancel this booking" }).click();
+    await page.getByRole("button", { name: "Cancel this meeting" }).click();
 
     await expect(
-      page.getByRole("heading", { name: "Could not cancel booking" }),
+      page.getByRole("heading", { name: "Could not cancel meeting" }),
     ).toBeFocused();
     await expect(
-      page.getByRole("heading", { name: "Booking canceled" }),
+      page.getByRole("heading", { name: "Meeting canceled" }),
     ).not.toBeVisible();
   });
 });

--- a/e2e/booking/public-booking-reschedule.spec.ts
+++ b/e2e/booking/public-booking-reschedule.spec.ts
@@ -28,20 +28,20 @@ test.describe("public booking reschedule", () => {
       .click();
     await page.getByLabel("Name").fill("Guest User");
     await page.getByLabel("Email").fill("guest@example.com");
-    await page.getByRole("button", { name: "Confirm booking" }).click();
+    await page.getByRole("button", { name: "Confirm meeting" }).click();
 
     await expect(
-      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+      page.getByRole("heading", { name: "You're meeting with Tyler Dane" }),
     ).toBeFocused();
     await expect(
       page.getByText(formatSlotWhenLabel(first.slotStart, timeZone)),
     ).toBeVisible();
     await expect(
-      page.getByRole("link", { name: "Reschedule this booking" }),
+      page.getByRole("link", { name: "Reschedule this meeting" }),
     ).toBeVisible();
 
     const rescheduleHref = await page
-      .getByRole("link", { name: "Reschedule this booking" })
+      .getByRole("link", { name: "Reschedule this meeting" })
       .getAttribute("href");
     expect(rescheduleHref).toContain(
       "/meet/reschedule/000000000000000000000099?token=abc",
@@ -56,7 +56,7 @@ test.describe("public booking reschedule", () => {
     );
     await expect(
       page.getByRole("heading", {
-        name: "Reschedule your booking with Tyler Dane",
+        name: "Reschedule your meeting with Tyler Dane",
       }),
     ).toBeFocused();
 
@@ -66,7 +66,7 @@ test.describe("public booking reschedule", () => {
     await page.getByRole("button", { name: "Confirm" }).click();
 
     await expect(
-      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+      page.getByRole("heading", { name: "You're meeting with Tyler Dane" }),
     ).toBeVisible();
     await expect(
       page.getByText(formatSlotWhenLabel(second.slotStart, timeZone)),
@@ -88,7 +88,7 @@ test.describe("public booking reschedule", () => {
 
     await expect(
       page.getByRole("heading", {
-        name: "Reschedule your booking with Tyler Dane",
+        name: "Reschedule your meeting with Tyler Dane",
       }),
     ).toBeFocused();
 
@@ -110,7 +110,7 @@ test.describe("public booking reschedule", () => {
     await page.keyboard.press("Enter");
 
     await expect(
-      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+      page.getByRole("heading", { name: "You're meeting with Tyler Dane" }),
     ).toBeVisible();
     expect(captured.reschedulePosts).toHaveLength(1);
     expect(captured.reschedulePosts[0]).toMatchObject({
@@ -128,11 +128,11 @@ test.describe("public booking reschedule", () => {
     });
 
     await expect(
-      page.getByRole("heading", { name: "Booking not found" }),
+      page.getByRole("heading", { name: "Meeting not found" }),
     ).toBeFocused();
     await expect(
       page.getByRole("heading", {
-        name: "Reschedule your booking with Tyler Dane",
+        name: "Reschedule your meeting with Tyler Dane",
       }),
     ).toHaveCount(0);
     expect(captured.reservationSlotGets).toBe(0);

--- a/e2e/booking/public-booking-v15.spec.ts
+++ b/e2e/booking/public-booking-v15.spec.ts
@@ -125,13 +125,13 @@ test.describe("booking v1.5 escape and self-service", () => {
     const captured = await preparePublicBookingCancelPage(page);
 
     await expect(
-      page.getByRole("heading", { name: "Cancel this booking?" }),
+      page.getByRole("heading", { name: "Cancel this meeting?" }),
     ).toBeFocused();
 
     await page.keyboard.press("Escape");
 
     await expect(
-      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+      page.getByRole("heading", { name: "You're meeting with Tyler Dane" }),
     ).toBeVisible();
     await expect(page).toHaveURL(
       /\/meet\/confirmed\/000000000000000000000099\?token=abc$/,
@@ -152,7 +152,7 @@ test.describe("booking v1.5 escape and self-service", () => {
     });
 
     await expect(
-      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+      page.getByRole("heading", { name: "You're meeting with Tyler Dane" }),
     ).toBeFocused();
     await expect(page).toHaveURL(
       /\/meet\/confirmed\/000000000000000000000099\?token=abc$/,
@@ -163,7 +163,7 @@ test.describe("booking v1.5 escape and self-service", () => {
       page.getByRole("button", { name: "Copy cancel link" }),
     ).toBeVisible();
     await expect(
-      page.getByRole("link", { name: "Cancel this booking" }),
+      page.getByRole("link", { name: "Cancel this meeting" }),
     ).toBeVisible();
 
     await page.getByRole("button", { name: "Edit details" }).click();
@@ -182,7 +182,7 @@ test.describe("booking v1.5 escape and self-service", () => {
     await page.getByRole("button", { name: "Save details" }).click();
 
     await expect(
-      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+      page.getByRole("heading", { name: "You're meeting with Tyler Dane" }),
     ).toBeVisible();
     await expect(page.getByText("Grace Hopper")).toBeVisible();
     await expect(page.getByText("bring tea")).toBeVisible();
@@ -210,7 +210,7 @@ test.describe("booking v1.5 escape and self-service", () => {
     await page.keyboard.press("Escape");
 
     await expect(
-      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+      page.getByRole("heading", { name: "You're meeting with Tyler Dane" }),
     ).toBeVisible();
     await expect(page.getByText("Ada Lovelace")).toBeVisible();
     await expect(page.getByText("Grace Hopper")).toHaveCount(0);

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -43,7 +43,7 @@ test.describe("public booking page", () => {
       .click();
     await page.getByLabel("Name").fill("Guest User");
     await page.getByLabel("Email").fill("guest@example.com");
-    await page.getByRole("button", { name: "Confirm booking" }).click();
+    await page.getByRole("button", { name: "Confirm meeting" }).click();
 
     await expect(
       page.getByText("A Microsoft Teams invite is on its way to your email."),
@@ -71,7 +71,7 @@ test.describe("public booking page", () => {
       .click();
     await page.getByLabel("Name").fill("Guest User");
     await page.getByLabel("Email").fill("guest@example.com");
-    await page.getByRole("button", { name: "Confirm booking" }).click();
+    await page.getByRole("button", { name: "Confirm meeting" }).click();
 
     await expect(
       page.getByText("The calendar invite is on its way to your email."),
@@ -90,7 +90,7 @@ test.describe("public booking page", () => {
     });
 
     await expect(
-      page.getByRole("heading", { name: "Book with Tyler Dane" }),
+      page.getByRole("heading", { name: "Meet with Tyler Dane" }),
     ).toBeVisible();
     await expect(page.getByText("30 minutes Google Meet")).toBeVisible();
     await expect(
@@ -110,7 +110,7 @@ test.describe("public booking page", () => {
       notFound: true,
     });
     await expect(
-      page.getByRole("heading", { name: "Booking page not found" }),
+      page.getByRole("heading", { name: "Meeting page not found" }),
     ).toBeVisible();
 
     await page.unroute("**/api/**");
@@ -194,10 +194,10 @@ test.describe("public booking page", () => {
     ).toBeVisible();
     await page.getByLabel("Name").fill("Guest User");
     await page.getByLabel("Email").fill("guest@example.com");
-    await page.getByRole("button", { name: "Confirm booking" }).click();
+    await page.getByRole("button", { name: "Confirm meeting" }).click();
 
     await expect(
-      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+      page.getByRole("heading", { name: "You're meeting with Tyler Dane" }),
     ).toBeFocused();
     await expect(page.getByText("When")).toBeVisible();
     await expect(page.getByText("Duration")).toBeVisible();
@@ -206,7 +206,7 @@ test.describe("public booking page", () => {
       page.getByText("A Google Meet invite is on its way to your email."),
     ).toBeVisible();
     await expect(
-      page.getByRole("link", { name: "Cancel this booking" }),
+      page.getByRole("link", { name: "Cancel this meeting" }),
     ).toBeVisible();
     await expect(
       page.getByRole("link", {
@@ -233,16 +233,16 @@ test.describe("public booking page", () => {
       .click();
     await page.getByLabel("Name").fill("Guest User");
     await page.getByLabel("Email").fill("guest@example.com");
-    await page.getByRole("button", { name: "Confirm booking" }).click();
+    await page.getByRole("button", { name: "Confirm meeting" }).click();
     await expect(
-      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+      page.getByRole("heading", { name: "You're meeting with Tyler Dane" }),
     ).toBeFocused();
 
     await page.keyboard.press("Escape");
 
     await expect(page).toHaveURL(/\/meet\/tylerdane(?:\?|$)/);
     await expect(
-      page.getByRole("heading", { name: "Book with Tyler Dane" }),
+      page.getByRole("heading", { name: "Meet with Tyler Dane" }),
     ).toBeFocused();
   });
 
@@ -266,10 +266,10 @@ test.describe("public booking page", () => {
       .click();
     await page.getByLabel("Name").fill("Guest User");
     await page.getByLabel("Email").fill("guest@example.com");
-    await page.getByRole("button", { name: "Confirm booking" }).click();
+    await page.getByRole("button", { name: "Confirm meeting" }).click();
 
     await expect(
-      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+      page.getByRole("heading", { name: "You're meeting with Tyler Dane" }),
     ).toBeFocused();
     expect(captured.reservationPosts).toHaveLength(1);
     expect(captured.reservationPosts[0]).toMatchObject({
@@ -287,10 +287,10 @@ test.describe("public booking page", () => {
       .click();
     await page.getByLabel("Name").fill("Guest User");
     await page.getByLabel("Email").fill("guest@example.com");
-    await page.getByRole("button", { name: "Confirm booking" }).click();
+    await page.getByRole("button", { name: "Confirm meeting" }).click();
 
     await expect(
-      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+      page.getByRole("heading", { name: "You're meeting with Tyler Dane" }),
     ).toBeFocused();
     await expect(page).toHaveURL(
       /\/meet\/confirmed\/000000000000000000000099\?token=abc$/,
@@ -302,7 +302,7 @@ test.describe("public booking page", () => {
     await page.reload({ waitUntil: "domcontentloaded" });
 
     await expect(
-      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+      page.getByRole("heading", { name: "You're meeting with Tyler Dane" }),
     ).toBeFocused();
     await expect(page.getByText("When")).toBeVisible();
     await expect(page.getByText("Duration")).toBeVisible();
@@ -314,7 +314,7 @@ test.describe("public booking page", () => {
       page.getByRole("button", { name: "Copy cancel link" }),
     ).toBeVisible();
     await expect(
-      page.getByRole("link", { name: "Cancel this booking" }),
+      page.getByRole("link", { name: "Cancel this meeting" }),
     ).toBeVisible();
     await expect(
       page.getByRole("button", { name: "Edit details" }),
@@ -326,13 +326,13 @@ test.describe("public booking page", () => {
   }) => {
     await preparePublicBookingConfirmedPage(page);
     await expect(
-      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+      page.getByRole("heading", { name: "You're meeting with Tyler Dane" }),
     ).toBeFocused();
     await expect(
       page.getByRole("button", { name: "Copy cancel link" }),
     ).toHaveCount(0);
     await expect(
-      page.getByRole("link", { name: "Cancel this booking" }),
+      page.getByRole("link", { name: "Cancel this meeting" }),
     ).toHaveCount(0);
     await expect(
       page.getByRole("button", { name: "Edit details" }),
@@ -358,10 +358,10 @@ test.describe("public booking page", () => {
       .click();
     await page.getByLabel("Name").fill("Guest User");
     await page.getByLabel("Email").fill("guest@example.com");
-    await page.getByRole("button", { name: "Confirm booking" }).click();
+    await page.getByRole("button", { name: "Confirm meeting" }).click();
 
     await expect(
-      page.getByRole("link", { name: "Cancel this booking" }),
+      page.getByRole("link", { name: "Cancel this meeting" }),
     ).toHaveAttribute(
       "href",
       "https://compasscalendar.com/meet/cancel/000000000000000000000099?token=abc",
@@ -383,7 +383,7 @@ test.describe("public booking page", () => {
       reservationStatus: "cancelled",
     });
     await expect(
-      page.getByRole("heading", { name: "This booking was canceled" }),
+      page.getByRole("heading", { name: "This meeting was canceled" }),
     ).toBeFocused();
   });
 
@@ -394,7 +394,7 @@ test.describe("public booking page", () => {
       reservationNotFound: true,
     });
     await expect(
-      page.getByRole("heading", { name: "Booking not found" }),
+      page.getByRole("heading", { name: "Meeting not found" }),
     ).toBeFocused();
   });
 
@@ -405,7 +405,7 @@ test.describe("public booking page", () => {
       reservationGetStatus: 500,
     });
     await expect(
-      page.getByRole("heading", { name: "Could not load booking" }),
+      page.getByRole("heading", { name: "Could not load meeting" }),
     ).toBeFocused();
   });
 
@@ -417,7 +417,7 @@ test.describe("public booking page", () => {
       .getByRole("button", { name: formatSlotButtonLabel(slotStart) })
       .click();
     await page.getByLabel("Name").fill("Guest User");
-    await page.getByRole("button", { name: "Confirm booking" }).click();
+    await page.getByRole("button", { name: "Confirm meeting" }).click();
 
     expect(captured.reservationPosts).toHaveLength(0);
     await expect(page.getByLabel("Email")).toBeFocused();
@@ -517,7 +517,7 @@ test.describe("public booking page", () => {
     await page.getByLabel("Name").fill("Guest User");
     await page.getByLabel("Email").fill("guest@example.com");
     await page.getByLabel("Notes (optional)").fill("Bring slides");
-    await page.getByRole("button", { name: "Confirm booking" }).click();
+    await page.getByRole("button", { name: "Confirm meeting" }).click();
 
     const alert = page.getByRole("alert");
     await expect(alert).toHaveText(
@@ -535,7 +535,7 @@ test.describe("public booking page", () => {
       }),
     ).toHaveAttribute("aria-pressed", "false");
     await expect(
-      page.getByRole("button", { name: "Confirm booking" }),
+      page.getByRole("button", { name: "Confirm meeting" }),
     ).toBeDisabled();
     await expect.poll(() => captured.slotGets).toBeGreaterThan(1);
 
@@ -546,7 +546,7 @@ test.describe("public booking page", () => {
       page.getByRole("heading", { name: "Your details" }),
     ).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "Confirm booking" }),
+      page.getByRole("button", { name: "Confirm meeting" }),
     ).toBeEnabled();
     await expect(page.getByLabel("Name")).toHaveValue("Guest User");
   });
@@ -735,7 +735,7 @@ test.describe("public booking page", () => {
       .getByRole("button", { name: formatSlotButtonLabel(slotStart) })
       .click();
     await expect(
-      page.getByRole("button", { name: "Confirm booking" }),
+      page.getByRole("button", { name: "Confirm meeting" }),
     ).toBeVisible();
   });
 
@@ -794,7 +794,7 @@ test.describe("public booking page", () => {
       .click();
     await page.getByLabel("Name").fill("Guest User");
     await page.getByLabel("Email").fill("guest@example.com");
-    await page.getByRole("button", { name: "Confirm booking" }).click();
+    await page.getByRole("button", { name: "Confirm meeting" }).click();
     const confirming = page.getByRole("button", { name: "Confirming..." });
     await expect(confirming).toHaveAttribute("aria-busy", "true");
     await expect.poll(() => captured.reservationPosts.length).toBe(1);
@@ -802,7 +802,7 @@ test.describe("public booking page", () => {
     expect(captured.reservationPosts).toHaveLength(1);
     release();
     await expect(
-      page.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+      page.getByRole("heading", { name: "You're meeting with Tyler Dane" }),
     ).toBeFocused();
     expect(captured.reservationPosts).toHaveLength(1);
   });
@@ -817,7 +817,7 @@ test.describe("public booking page", () => {
     await preparePublicBookingPage(page, { holdFirstSlots });
 
     await expect(
-      page.getByRole("heading", { name: "Book with Tyler Dane" }),
+      page.getByRole("heading", { name: "Meet with Tyler Dane" }),
     ).toBeVisible();
     await expect(page.getByRole("status")).toHaveText("Loading open times");
     await expect(
@@ -842,7 +842,7 @@ test.describe("public booking page", () => {
 
     await expect(page.getByRole("button", { name: "Retry" })).toBeVisible();
     await expect(
-      page.getByRole("heading", { name: "Book with Tyler Dane" }),
+      page.getByRole("heading", { name: "Meet with Tyler Dane" }),
     ).toBeVisible();
     slotFailGate.fail = false;
     await page.getByRole("button", { name: "Retry" }).click();

--- a/packages/web/src/api/public-booking.api.ts
+++ b/packages/web/src/api/public-booking.api.ts
@@ -27,7 +27,7 @@ import { getErrorStatus } from "@web/api/util/api.util";
 
 export class PublicBookingNotFoundError extends Error {
   constructor() {
-    super("Booking page not found");
+    super("Meeting page not found");
     this.name = "PublicBookingNotFoundError";
   }
 }

--- a/packages/web/src/booking/PublicBookingCancelPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingCancelPage.test.tsx
@@ -74,16 +74,16 @@ describe("PublicBookingCancelPage", () => {
     renderCancelRoute(cancelPath);
 
     expect(
-      await screen.findByRole("heading", { name: "Cancel this booking?" }),
+      await screen.findByRole("heading", { name: "Cancel this meeting?" }),
     ).toBeInTheDocument();
     expect(cancelPosts).toBe(0);
 
     await user.click(
-      screen.getByRole("button", { name: "Cancel this booking" }),
+      screen.getByRole("button", { name: "Cancel this meeting" }),
     );
 
     expect(
-      await screen.findByRole("heading", { name: "Booking canceled" }),
+      await screen.findByRole("heading", { name: "Meeting canceled" }),
     ).toBeInTheDocument();
     expect(cancelPosts).toBe(1);
   });
@@ -111,7 +111,7 @@ describe("PublicBookingCancelPage", () => {
     renderCancelRoute(cancelPath);
 
     await user.click(
-      await screen.findByRole("button", { name: "Cancel this booking" }),
+      await screen.findByRole("button", { name: "Cancel this meeting" }),
     );
     await user.click(
       await screen.findByRole("button", { name: "Canceling..." }),
@@ -119,7 +119,7 @@ describe("PublicBookingCancelPage", () => {
     expect(cancelPosts).toBe(1);
     release();
     expect(
-      await screen.findByRole("heading", { name: "Booking canceled" }),
+      await screen.findByRole("heading", { name: "Meeting canceled" }),
     ).toBeInTheDocument();
   });
 
@@ -130,7 +130,7 @@ describe("PublicBookingCancelPage", () => {
     renderCancelRoute(cancelPath);
 
     const heading = await screen.findByRole("heading", {
-      name: "Cancel this booking?",
+      name: "Cancel this meeting?",
     });
     await waitFor(() => {
       expect(heading).toHaveFocus();
@@ -138,7 +138,7 @@ describe("PublicBookingCancelPage", () => {
 
     await user.tab();
     expect(
-      screen.getByRole("button", { name: "Cancel this booking" }),
+      screen.getByRole("button", { name: "Cancel this meeting" }),
     ).toHaveFocus();
   });
 
@@ -157,14 +157,14 @@ describe("PublicBookingCancelPage", () => {
     renderCancelRoute(cancelPath);
 
     await user.click(
-      await screen.findByRole("button", { name: "Cancel this booking" }),
+      await screen.findByRole("button", { name: "Cancel this meeting" }),
     );
 
     expect(
-      await screen.findByRole("heading", { name: "Could not cancel booking" }),
+      await screen.findByRole("heading", { name: "Could not cancel meeting" }),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("heading", { name: "Booking canceled" }),
+      screen.queryByRole("heading", { name: "Meeting canceled" }),
     ).not.toBeInTheDocument();
   });
 
@@ -184,7 +184,7 @@ describe("PublicBookingCancelPage", () => {
     renderCancelRoute(`/meet/cancel/${reservationId}`);
 
     expect(
-      await screen.findByRole("heading", { name: "Booking not found" }),
+      await screen.findByRole("heading", { name: "Meeting not found" }),
     ).toBeInTheDocument();
     expect(cancelPosts).toBe(0);
   });
@@ -195,10 +195,10 @@ describe("PublicBookingCancelPage", () => {
     renderCancelRoute(cancelPath);
 
     expect(
-      await screen.findByRole("heading", { name: "Cancel this booking?" }),
+      await screen.findByRole("heading", { name: "Cancel this meeting?" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("You are canceling a booking with Tyler Dane."),
+      screen.getByText("You are canceling a meeting with Tyler Dane."),
     ).toBeInTheDocument();
     expect(screen.getByText("When")).toBeInTheDocument();
     expect(screen.getByText("Duration")).toBeInTheDocument();
@@ -222,10 +222,10 @@ describe("PublicBookingCancelPage", () => {
     renderCancelRoute(cancelPath);
 
     expect(
-      await screen.findByRole("heading", { name: "Booking canceled" }),
+      await screen.findByRole("heading", { name: "Meeting canceled" }),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Cancel this booking" }),
+      screen.queryByRole("button", { name: "Cancel this meeting" }),
     ).not.toBeInTheDocument();
     expect(cancelPosts).toBe(0);
   });
@@ -247,13 +247,13 @@ describe("PublicBookingCancelPage", () => {
     const { router } = renderCancelRoute(cancelPath);
 
     expect(
-      await screen.findByRole("heading", { name: "Cancel this booking?" }),
+      await screen.findByRole("heading", { name: "Cancel this meeting?" }),
     ).toBeInTheDocument();
     await user.keyboard("{Escape}");
 
     expect(
       await screen.findByRole("heading", {
-        name: "You are booked with Tyler Dane",
+        name: "You're meeting with Tyler Dane",
       }),
     ).toBeInTheDocument();
     expect(router.state.location.pathname).toBe(
@@ -292,7 +292,7 @@ describe("PublicBookingCancelPage", () => {
     const { router } = renderCancelRoute(cancelPath);
 
     await user.click(
-      await screen.findByRole("button", { name: "Cancel this booking" }),
+      await screen.findByRole("button", { name: "Cancel this meeting" }),
     );
     expect(
       await screen.findByRole("button", { name: "Canceling..." }),
@@ -300,7 +300,7 @@ describe("PublicBookingCancelPage", () => {
     await user.keyboard("{Escape}");
 
     expect(
-      screen.getByRole("heading", { name: "Cancel this booking?" }),
+      screen.getByRole("heading", { name: "Cancel this meeting?" }),
     ).toBeInTheDocument();
     expect(router.state.location.pathname).toBe(
       `/meet/cancel/${reservationId}`,
@@ -309,7 +309,7 @@ describe("PublicBookingCancelPage", () => {
 
     release();
     expect(
-      await screen.findByRole("heading", { name: "Booking canceled" }),
+      await screen.findByRole("heading", { name: "Meeting canceled" }),
     ).toBeInTheDocument();
     expect(cancelPosts).toBe(1);
   });
@@ -319,7 +319,7 @@ describe("PublicBookingCancelPage", () => {
     const { router } = renderCancelRoute(`/meet/cancel/${reservationId}`);
 
     const heading = await screen.findByRole("heading", {
-      name: "Booking not found",
+      name: "Meeting not found",
     });
     await waitFor(() => {
       expect(heading).toHaveFocus();
@@ -327,7 +327,7 @@ describe("PublicBookingCancelPage", () => {
     await user.keyboard("{Escape}");
 
     expect(
-      screen.getByRole("heading", { name: "Booking not found" }),
+      screen.getByRole("heading", { name: "Meeting not found" }),
     ).toBeInTheDocument();
     expect(router.state.location.pathname).toBe(
       `/meet/cancel/${reservationId}`,
@@ -357,23 +357,23 @@ describe("PublicBookingCancelPage", () => {
 
     renderCancelRoute(cancelPath);
     await user.click(
-      await screen.findByRole("button", { name: "Cancel this booking" }),
+      await screen.findByRole("button", { name: "Cancel this meeting" }),
     );
     expect(
-      await screen.findByRole("heading", { name: "Could not cancel booking" }),
+      await screen.findByRole("heading", { name: "Could not cancel meeting" }),
     ).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Retry" }));
     expect(
-      await screen.findByRole("heading", { name: "Cancel this booking?" }),
+      await screen.findByRole("heading", { name: "Cancel this meeting?" }),
     ).toBeInTheDocument();
     expect(screen.getByText("When")).toBeInTheDocument();
     expect(screen.getByText("Duration")).toBeInTheDocument();
     expect(screen.getByText("Timezone")).toBeInTheDocument();
     await user.click(
-      screen.getByRole("button", { name: "Cancel this booking" }),
+      screen.getByRole("button", { name: "Cancel this meeting" }),
     );
     expect(
-      await screen.findByRole("heading", { name: "Booking canceled" }),
+      await screen.findByRole("heading", { name: "Meeting canceled" }),
     ).toBeInTheDocument();
     expect(tokens).toEqual(["abc", "abc"]);
   });
@@ -394,10 +394,10 @@ describe("PublicBookingCancelPage", () => {
 
     renderCancelRoute(cancelPath);
     await user.click(
-      await screen.findByRole("button", { name: "Cancel this booking" }),
+      await screen.findByRole("button", { name: "Cancel this meeting" }),
     );
     expect(
-      await screen.findByRole("heading", { name: "Booking not found" }),
+      await screen.findByRole("heading", { name: "Meeting not found" }),
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Retry" }),
@@ -405,7 +405,7 @@ describe("PublicBookingCancelPage", () => {
     expect(cancelPosts).toBe(1);
   });
 
-  it("links Book another time after cancel when bookingSlug is present", async () => {
+  it("links Meet another time after cancel when bookingSlug is present", async () => {
     const user = userEvent.setup({ delay: null });
     server.use(
       reservationGetHandler(),
@@ -417,30 +417,30 @@ describe("PublicBookingCancelPage", () => {
 
     renderCancelRoute(cancelPath);
     await user.click(
-      await screen.findByRole("button", { name: "Cancel this booking" }),
+      await screen.findByRole("button", { name: "Cancel this meeting" }),
     );
     const rebook = await screen.findByRole("link", {
-      name: "Book another time",
+      name: "Meet another time",
     });
     expect(rebook).toHaveAttribute("href", "/meet/tylerdane");
     expect(rebook.getAttribute("href")).not.toContain("token");
   });
 
-  it("shows Book another time on an already-cancelled reservation", async () => {
+  it("shows Meet another time on an already-cancelled reservation", async () => {
     server.use(reservationGetHandler({ status: "cancelled" }));
 
     renderCancelRoute(cancelPath);
 
     expect(
-      await screen.findByRole("heading", { name: "Booking canceled" }),
+      await screen.findByRole("heading", { name: "Meeting canceled" }),
     ).toBeInTheDocument();
-    const rebook = screen.getByRole("link", { name: "Book another time" });
+    const rebook = screen.getByRole("link", { name: "Meet another time" });
     expect(rebook).toHaveAttribute("href", "/meet/tylerdane");
     expect(rebook.getAttribute("href")).not.toContain("token");
     expect(rebook.getAttribute("href")).not.toContain(reservationId);
   });
 
-  it("hides Book another time when bookingSlug is missing", async () => {
+  it("hides Meet another time when bookingSlug is missing", async () => {
     server.use(
       rest.get(
         `${ENV_WEB.API_BASEURL}/booking/reservations/${reservationId}`,
@@ -463,10 +463,10 @@ describe("PublicBookingCancelPage", () => {
     renderCancelRoute(cancelPath);
 
     expect(
-      await screen.findByRole("heading", { name: "Booking canceled" }),
+      await screen.findByRole("heading", { name: "Meeting canceled" }),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("link", { name: "Book another time" }),
+      screen.queryByRole("link", { name: "Meet another time" }),
     ).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/booking/PublicBookingCancelPage.tsx
+++ b/packages/web/src/booking/PublicBookingCancelPage.tsx
@@ -27,23 +27,23 @@ type CancelActionState =
   | "error";
 
 const BOOKING_NOT_FOUND = {
-  title: "Booking not found",
+  title: "Meeting not found",
   description: "This cancel link may be invalid or already used.",
 } as const;
 
 const BOOKING_CANCELED = {
-  title: "Booking canceled",
+  title: "Meeting canceled",
   description: "Your appointment has been canceled. You can close this page.",
 } as const;
 
 const BOOKING_CANCEL_FAILED = {
-  title: "Could not cancel booking",
+  title: "Could not cancel meeting",
   description: "Please try again or use the link from your calendar invite.",
 } as const;
 
 const BOOKING_LOADING = {
-  title: "Loading booking",
-  description: "One moment while we load this booking.",
+  title: "Loading meeting",
+  description: "One moment while we load this meeting.",
 } as const;
 
 const resolveCancelPageView = (
@@ -78,7 +78,7 @@ export function PublicBookingCancelPage() {
     `${action}:${reservationQuery.status}:${reservationQuery.data?.status ?? ""}`,
   );
   const inFlightRef = useRef(false);
-  useBookingDocumentTitle("Cancel booking");
+  useBookingDocumentTitle("Cancel meeting");
 
   const handleConfirm = async () => {
     if (!reservationId || !token || inFlightRef.current) {
@@ -156,7 +156,7 @@ export function PublicBookingCancelPage() {
             href={`/meet/${bookingSlug}`}
             className="c-focus-ring mt-4 inline-block text-accent text-sm underline"
           >
-            Book another time
+            Meet another time
           </a>
         ) : null}
       </PublicBookingStatusMessage>
@@ -173,10 +173,10 @@ export function PublicBookingCancelPage() {
           tabIndex={-1}
           className={PUBLIC_BOOKING_HEADING_CLASS}
         >
-          Cancel this booking?
+          Cancel this meeting?
         </h1>
         <p className="mt-2 text-sm text-text">
-          You are canceling a booking with {reservation.hostDisplayName}.
+          You are canceling a meeting with {reservation.hostDisplayName}.
         </p>
         <p className="mt-2 text-sm text-text-muted">
           This will remove the appointment from the host calendar.
@@ -196,7 +196,7 @@ export function PublicBookingCancelPage() {
           }}
           className="c-button c-button-primary mt-6"
         >
-          {busy ? "Canceling..." : "Cancel this booking"}
+          {busy ? "Canceling..." : "Cancel this meeting"}
         </button>
       </section>
     </PublicBookingLayout>

--- a/packages/web/src/booking/PublicBookingConfirmationView.test.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmationView.test.tsx
@@ -29,7 +29,7 @@ describe("PublicBookingConfirmationView", () => {
     );
 
     expect(
-      screen.getByRole("heading", { name: "You are booked with Tyler Dane" }),
+      screen.getByRole("heading", { name: "You're meeting with Tyler Dane" }),
     ).toBeInTheDocument();
     expect(screen.getByText("Name")).toBeInTheDocument();
     expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
@@ -43,7 +43,7 @@ describe("PublicBookingConfirmationView", () => {
     expect(screen.getByText("Timezone")).toBeInTheDocument();
     expect(screen.queryByText(cancelUrl)).not.toBeInTheDocument();
     expect(
-      screen.getByRole("link", { name: "Cancel this booking" }),
+      screen.getByRole("link", { name: "Cancel this meeting" }),
     ).toHaveAttribute("href", cancelUrl);
     expect(
       screen.getByRole("button", { name: "Copy cancel link" }),
@@ -72,17 +72,17 @@ describe("PublicBookingConfirmationView", () => {
     );
 
     const heading = screen.getByRole("heading", {
-      name: "You are booked with Tyler Dane",
+      name: "You're meeting with Tyler Dane",
     });
     expect(screen.queryByText(rescheduleUrl)).not.toBeInTheDocument();
     expect(
-      screen.getByRole("link", { name: "Reschedule this booking" }),
+      screen.getByRole("link", { name: "Reschedule this meeting" }),
     ).toHaveAttribute("href", rescheduleUrl);
     expect(
       screen.getByRole("button", { name: "Copy reschedule link" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("group", { name: "Booking actions" }),
+      screen.getByRole("group", { name: "Meeting actions" }),
     ).toBeInTheDocument();
 
     heading.focus();
@@ -92,7 +92,7 @@ describe("PublicBookingConfirmationView", () => {
     ).toHaveFocus();
     await user.tab();
     expect(
-      screen.getByRole("link", { name: "Cancel this booking" }),
+      screen.getByRole("link", { name: "Cancel this meeting" }),
     ).toHaveFocus();
     await user.tab();
     expect(
@@ -185,13 +185,13 @@ describe("PublicBookingConfirmationView", () => {
       screen.queryByRole("button", { name: "Copy reschedule link" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("link", { name: "cancel this booking" }),
+      screen.queryByRole("link", { name: "cancel this meeting" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("link", { name: "Cancel this booking" }),
+      screen.queryByRole("link", { name: "Cancel this meeting" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("link", { name: "Reschedule this booking" }),
+      screen.queryByRole("link", { name: "Reschedule this meeting" }),
     ).not.toBeInTheDocument();
     expect(
       screen.getByText("A Google Meet invite is on its way to your email."),

--- a/packages/web/src/booking/PublicBookingConfirmationView.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmationView.tsx
@@ -58,7 +58,7 @@ export function PublicBookingConfirmationView({
             tabIndex={-1}
             className={PUBLIC_BOOKING_HEADING_CLASS}
           >
-            You are booked with {hostDisplayName}
+            You're meeting with {hostDisplayName}
           </h1>
         </div>
         <PublicBookingSlotSummary
@@ -99,19 +99,19 @@ export function PublicBookingConfirmationView({
           <div
             className="flex flex-col items-start gap-3"
             role="group"
-            aria-label="Booking actions"
+            aria-label="Meeting actions"
           >
             {cancelUrl ? (
               <PublicBookingCopyGuestAction
                 copyLabel="Copy cancel link"
-                linkLabel="Cancel this booking"
+                linkLabel="Cancel this meeting"
                 url={cancelUrl}
               />
             ) : null}
             {rescheduleUrl ? (
               <PublicBookingCopyGuestAction
                 copyLabel="Copy reschedule link"
-                linkLabel="Reschedule this booking"
+                linkLabel="Reschedule this meeting"
                 url={rescheduleUrl}
               />
             ) : null}

--- a/packages/web/src/booking/PublicBookingConfirmedPage.tsx
+++ b/packages/web/src/booking/PublicBookingConfirmedPage.tsx
@@ -30,23 +30,23 @@ import { isHigherEscapeOwner } from "@web/shortcuts/escape-ownership";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
 
 const BOOKING_LOADING = {
-  title: "Loading booking",
+  title: "Loading meeting",
   description: "One moment while we load this confirmation.",
 } as const;
 
 const BOOKING_NOT_FOUND = {
-  title: "Booking not found",
+  title: "Meeting not found",
   description:
     "This confirmation link may be incorrect or no longer available.",
 } as const;
 
 const BOOKING_LOAD_FAILED = {
-  title: "Could not load booking",
+  title: "Could not load meeting",
   description: "Please refresh and try again.",
 } as const;
 
 const BOOKING_CANCELED = {
-  title: "This booking was canceled",
+  title: "This meeting was canceled",
   description:
     "The appointment is no longer on the host calendar. You can close this page.",
 } as const;
@@ -110,7 +110,7 @@ export function PublicBookingConfirmedPage() {
     usePatchPublicBookingReservationMutation(reservationId);
   const [isEditing, setIsEditing] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
-  useBookingDocumentTitle("Booking confirmed");
+  useBookingDocumentTitle("Meeting confirmed");
   const navigate = useNavigate();
 
   const view = resolveConfirmedPageView(reservationQuery);
@@ -170,7 +170,7 @@ export function PublicBookingConfirmedPage() {
               onError: (error) => {
                 setSaveError(
                   getErrorStatus(error) === 404
-                    ? "This booking could not be updated. Use the link in your invite."
+                    ? "This meeting could not be updated. Use the link in your invite."
                     : "Could not save your details. Please try again.",
                 );
               },

--- a/packages/web/src/booking/PublicBookingGuestForm.tsx
+++ b/packages/web/src/booking/PublicBookingGuestForm.tsx
@@ -171,7 +171,7 @@ export function PublicBookingGuestForm({
         aria-busy={disabled || undefined}
         className="c-button c-button-primary"
       >
-        {disabled ? "Confirming..." : "Confirm booking"}
+        {disabled ? "Confirming..." : "Confirm meeting"}
       </button>
     </form>
   );

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -304,7 +304,9 @@ describe("PublicBookingPage", () => {
       await screen.findByRole("heading", { name: "Meeting page not found" }),
     ).toHaveFocus();
     expect(
-      screen.getByText(/may be incorrect or the host has turned this meeting page off/),
+      screen.getByText(
+        /may be incorrect or the host has turned this meeting page off/,
+      ),
     ).toBeInTheDocument();
     expect(mockTrack).not.toHaveBeenCalledWith(
       "booking_page_viewed",

--- a/packages/web/src/booking/PublicBookingPage.test.tsx
+++ b/packages/web/src/booking/PublicBookingPage.test.tsx
@@ -301,10 +301,10 @@ describe("PublicBookingPage", () => {
     renderBookingRoute("/meet/unknown-host");
 
     expect(
-      await screen.findByRole("heading", { name: "Booking page not found" }),
+      await screen.findByRole("heading", { name: "Meeting page not found" }),
     ).toHaveFocus();
     expect(
-      screen.getByText(/may be incorrect or the host has turned booking off/),
+      screen.getByText(/may be incorrect or the host has turned this meeting page off/),
     ).toBeInTheDocument();
     expect(mockTrack).not.toHaveBeenCalledWith(
       "booking_page_viewed",
@@ -317,7 +317,7 @@ describe("PublicBookingPage", () => {
     renderBookingRoute("/meet/tylerdane");
 
     expect(
-      await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
+      await screen.findByRole("heading", { name: "Meet with Tyler Dane" }),
     ).toBeInTheDocument();
     expect(mockTrack).toHaveBeenCalledTimes(1);
     expect(mockTrack).toHaveBeenCalledWith("booking_page_viewed", {
@@ -339,7 +339,7 @@ describe("PublicBookingPage", () => {
     renderBookingRoute("/meet/tylerdane");
 
     expect(
-      await screen.findByRole("heading", { name: "Booking page not found" }),
+      await screen.findByRole("heading", { name: "Meeting page not found" }),
     ).toBeInTheDocument();
     expect(mockTrack).not.toHaveBeenCalledWith(
       "booking_page_viewed",
@@ -399,7 +399,7 @@ describe("PublicBookingPage", () => {
     renderBookingRoute("/meet/tylerdane");
 
     expect(
-      await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
+      await screen.findByRole("heading", { name: "Meet with Tyler Dane" }),
     ).toBeInTheDocument();
     expect(screen.getByText("30 minutes Google Meet")).toBeInTheDocument();
     expect(
@@ -423,7 +423,7 @@ describe("PublicBookingPage", () => {
     renderBookingRoute("/meet/tylerdane");
 
     expect(
-      await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
+      await screen.findByRole("heading", { name: "Meet with Tyler Dane" }),
     ).toBeInTheDocument();
     expect(screen.getByText("30 minutes Microsoft Teams")).toBeInTheDocument();
     expect(screen.queryByText(/Google Meet/)).not.toBeInTheDocument();
@@ -445,7 +445,7 @@ describe("PublicBookingPage", () => {
     renderBookingRoute("/meet/tylerdane");
 
     expect(
-      await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
+      await screen.findByRole("heading", { name: "Meet with Tyler Dane" }),
     ).toBeInTheDocument();
     expect(screen.getByText("30 minutes")).toBeInTheDocument();
     expect(screen.queryByText(/Google Meet/)).not.toBeInTheDocument();
@@ -484,7 +484,7 @@ describe("PublicBookingPage", () => {
     renderBookingRoute("/meet/tylerdane");
 
     expect(
-      await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
+      await screen.findByRole("heading", { name: "Meet with Tyler Dane" }),
     ).toBeInTheDocument();
     expect(screen.getByText("30 minutes Google Meet")).toBeInTheDocument();
     expect(screen.getByRole("main").parentElement).toHaveAttribute(
@@ -526,11 +526,11 @@ describe("PublicBookingPage", () => {
     ).not.toBeInTheDocument();
     await user.type(screen.getByLabelText("Name"), "Guest User");
     await user.type(screen.getByLabelText("Email"), "guest@example.com");
-    await user.click(screen.getByRole("button", { name: "Confirm booking" }));
+    await user.click(screen.getByRole("button", { name: "Confirm meeting" }));
 
     expect(
       await screen.findByRole("heading", {
-        name: "You are booked with Tyler Dane",
+        name: "You're meeting with Tyler Dane",
       }),
     ).toHaveFocus();
     expect(postedBody).toMatchObject({
@@ -547,7 +547,7 @@ describe("PublicBookingPage", () => {
       screen.getByRole("button", { name: "Copy reschedule link" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("link", { name: "Cancel this booking" }),
+      screen.getByRole("link", { name: "Cancel this meeting" }),
     ).toBeInTheDocument();
     expect(mockTrack).toHaveBeenCalledWith("booking_reservation_created", {
       duration_minutes: 30,
@@ -559,7 +559,7 @@ describe("PublicBookingPage", () => {
       ["booking_reservation_created", { duration_minutes: 30 }],
     ]);
     expect(
-      screen.getByRole("link", { name: "Reschedule this booking" }),
+      screen.getByRole("link", { name: "Reschedule this meeting" }),
     ).toBeInTheDocument();
   });
 
@@ -679,11 +679,11 @@ describe("PublicBookingPage", () => {
     ).toBeInTheDocument();
     await user.type(screen.getByLabelText("Name"), "Guest User");
     await user.type(screen.getByLabelText("Email"), "guest@example.com");
-    await user.click(screen.getByRole("button", { name: "Confirm booking" }));
+    await user.click(screen.getByRole("button", { name: "Confirm meeting" }));
 
     expect(
       await screen.findByRole("heading", {
-        name: "You are booked with Tyler Dane",
+        name: "You're meeting with Tyler Dane",
       }),
     ).toBeInTheDocument();
     expect(postedBody).toMatchObject({
@@ -794,7 +794,7 @@ describe("PublicBookingPage", () => {
 
     expect(
       await screen.findByRole("heading", {
-        name: "Booking temporarily unavailable",
+        name: "Meeting temporarily unavailable",
       }),
     ).toBeInTheDocument();
     expect(screen.queryByText(/week/i)).not.toBeInTheDocument();
@@ -817,7 +817,7 @@ describe("PublicBookingPage", () => {
 
     renderBookingRoute("/meet/tylerdane");
 
-    await screen.findByRole("heading", { name: "Book with Tyler Dane" });
+    await screen.findByRole("heading", { name: "Meet with Tyler Dane" });
     await user.click(
       await screen.findByRole("button", {
         name: slotButtonName(currentSlot.slotStart),
@@ -826,7 +826,7 @@ describe("PublicBookingPage", () => {
     await user.type(screen.getByLabelText("Name"), "Guest User");
     await user.type(screen.getByLabelText("Email"), "guest@example.com");
     await user.type(screen.getByLabelText("Notes (optional)"), "Bring slides");
-    await user.click(screen.getByRole("button", { name: "Confirm booking" }));
+    await user.click(screen.getByRole("button", { name: "Confirm meeting" }));
 
     const alert = await screen.findByRole("alert");
     expect(alert).toHaveTextContent(
@@ -841,7 +841,7 @@ describe("PublicBookingPage", () => {
       "Bring slides",
     );
     expect(
-      screen.getByRole("button", { name: "Confirm booking" }),
+      screen.getByRole("button", { name: "Confirm meeting" }),
     ).toBeDisabled();
     await waitFor(() => {
       expect(slotRequests).toBeGreaterThan(1);
@@ -859,7 +859,7 @@ describe("PublicBookingPage", () => {
       await screen.findByRole("heading", { name: "Your details" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Confirm booking" }),
+      screen.getByRole("button", { name: "Confirm meeting" }),
     ).toBeEnabled();
     expect(screen.getByLabelText("Name")).toHaveValue("Guest User");
   });
@@ -876,7 +876,7 @@ describe("PublicBookingPage", () => {
 
     renderBookingRoute("/meet/tylerdane");
 
-    await screen.findByRole("heading", { name: "Book with Tyler Dane" });
+    await screen.findByRole("heading", { name: "Meet with Tyler Dane" });
     expect(screen.queryByText(/Keyboard shortcuts/i)).not.toBeInTheDocument();
   });
 
@@ -924,7 +924,7 @@ describe("PublicBookingPage", () => {
     expect(events).not.toContain("slots-end");
 
     expect(
-      await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
+      await screen.findByRole("heading", { name: "Meet with Tyler Dane" }),
     ).toBeInTheDocument();
     expect(
       await screen.findByRole("heading", { name: "Pick a time" }),
@@ -944,7 +944,7 @@ describe("PublicBookingPage", () => {
 
     renderBookingRoute("/meet/tylerdane");
 
-    await screen.findByRole("heading", { name: "Book with Tyler Dane" });
+    await screen.findByRole("heading", { name: "Meet with Tyler Dane" });
     expect(
       await screen.findByRole("heading", { name: "Pick a time" }),
     ).toBeInTheDocument();
@@ -955,7 +955,7 @@ describe("PublicBookingPage", () => {
 
     await user.click(screen.getByRole("button", { name: "Next month" }));
     expect(
-      screen.getByRole("heading", { name: "Book with Tyler Dane" }),
+      screen.getByRole("heading", { name: "Meet with Tyler Dane" }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("heading", { name: "Pick a time" }),
@@ -1010,7 +1010,7 @@ describe("PublicBookingPage", () => {
     renderBookingRoute("/meet/tylerdane");
 
     expect(
-      await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
+      await screen.findByRole("heading", { name: "Meet with Tyler Dane" }),
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("heading", { name: "Could not load times" }),
@@ -1074,7 +1074,7 @@ describe("PublicBookingPage", () => {
 
     renderBookingRoute("/meet/tylerdane");
 
-    await screen.findByRole("heading", { name: "Book with Tyler Dane" });
+    await screen.findByRole("heading", { name: "Meet with Tyler Dane" });
     expect(
       await screen.findByText("No open times this month."),
     ).toBeInTheDocument();
@@ -1115,7 +1115,7 @@ describe("PublicBookingPage", () => {
 
     renderBookingRoute("/meet/tylerdane");
 
-    await screen.findByRole("heading", { name: "Book with Tyler Dane" });
+    await screen.findByRole("heading", { name: "Meet with Tyler Dane" });
     expect(
       await screen.findByText("No open times this month."),
     ).toBeInTheDocument();
@@ -1138,7 +1138,7 @@ describe("PublicBookingPage", () => {
       screen.queryByRole("heading", { name: "Your details" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Confirm booking" }),
+      screen.queryByRole("button", { name: "Confirm meeting" }),
     ).not.toBeInTheDocument();
     expect(screen.getByText("Select a time to continue.")).toBeInTheDocument();
   });
@@ -1238,7 +1238,7 @@ describe("PublicBookingPage", () => {
     );
     await user.type(screen.getByLabelText("Name"), "Guest User");
     await user.type(screen.getByLabelText("Email"), "guest@example.com");
-    const confirm = screen.getByRole("button", { name: "Confirm booking" });
+    const confirm = screen.getByRole("button", { name: "Confirm meeting" });
     await user.click(confirm);
     const confirming = await screen.findByRole("button", {
       name: "Confirming...",
@@ -1250,7 +1250,7 @@ describe("PublicBookingPage", () => {
 
     expect(
       await screen.findByRole("heading", {
-        name: "You are booked with Tyler Dane",
+        name: "You're meeting with Tyler Dane",
       }),
     ).toBeInTheDocument();
     expect(posts).toBe(1);
@@ -1279,7 +1279,7 @@ describe("PublicBookingPage", () => {
     renderBookingRoute("/meet/tylerdane");
 
     expect(
-      await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
+      await screen.findByRole("heading", { name: "Meet with Tyler Dane" }),
     ).toBeInTheDocument();
     await waitFor(() => {
       expect(screen.getByRole("status")).toHaveTextContent(
@@ -1295,7 +1295,7 @@ describe("PublicBookingPage", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("status")).toHaveTextContent("Times loaded");
     expect(
-      screen.getByRole("heading", { name: "Book with Tyler Dane" }),
+      screen.getByRole("heading", { name: "Meet with Tyler Dane" }),
     ).toBeInTheDocument();
   });
 
@@ -1326,7 +1326,7 @@ describe("PublicBookingPage", () => {
     renderBookingRoute("/meet/retryhost");
 
     expect(
-      await screen.findByRole("heading", { name: "Book with Tyler Dane" }),
+      await screen.findByRole("heading", { name: "Meet with Tyler Dane" }),
     ).toBeInTheDocument();
     expect(
       await screen.findByRole("button", { name: "Retry" }),
@@ -1348,7 +1348,7 @@ describe("PublicBookingPage", () => {
       }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", { name: "Book with Tyler Dane" }),
+      screen.getByRole("heading", { name: "Meet with Tyler Dane" }),
     ).toBeInTheDocument();
   });
 
@@ -1394,7 +1394,7 @@ describe("PublicBookingPage", () => {
 
     await user.click(screen.getByRole("button", { name: "Next month" }));
     expect(
-      screen.getByRole("heading", { name: "Book with Tyler Dane" }),
+      screen.getByRole("heading", { name: "Meet with Tyler Dane" }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("heading", {
@@ -1512,7 +1512,7 @@ describe("PublicBookingPage", () => {
     expect(day).toHaveFocus();
     expect(router.state.location.href).toBe(href);
     expect(
-      screen.getByRole("heading", { name: "Book with Tyler Dane" }),
+      screen.getByRole("heading", { name: "Meet with Tyler Dane" }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("heading", { name: "Pick a time" }),
@@ -1527,7 +1527,7 @@ describe("PublicBookingConfirmedPage", () => {
 
     expect(
       await screen.findByRole("heading", {
-        name: "You are booked with Tyler Dane",
+        name: "You're meeting with Tyler Dane",
       }),
     ).toHaveFocus();
     expect(
@@ -1560,7 +1560,7 @@ describe("PublicBookingConfirmedPage", () => {
 
     expect(
       await screen.findByRole("heading", {
-        name: "You are booked with Tyler Dane",
+        name: "You're meeting with Tyler Dane",
       }),
     ).toBeInTheDocument();
     expect(
@@ -1573,13 +1573,13 @@ describe("PublicBookingConfirmedPage", () => {
       screen.getByRole("button", { name: "Edit details" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("link", { name: "Cancel this booking" }),
+      screen.getByRole("link", { name: "Cancel this meeting" }),
     ).toHaveAttribute(
       "href",
       `${window.location.origin}/meet/cancel/000000000000000000000099?token=abc`,
     );
     expect(
-      screen.getByRole("link", { name: "Reschedule this booking" }),
+      screen.getByRole("link", { name: "Reschedule this meeting" }),
     ).toHaveAttribute(
       "href",
       `${window.location.origin}/meet/reschedule/000000000000000000000099?token=abc`,
@@ -1598,7 +1598,7 @@ describe("PublicBookingConfirmedPage", () => {
 
     expect(
       await screen.findByRole("heading", {
-        name: "You are booked with Tyler Dane",
+        name: "You're meeting with Tyler Dane",
       }),
     ).toBeInTheDocument();
     expect(
@@ -1624,12 +1624,12 @@ describe("PublicBookingConfirmedPage", () => {
     );
 
     await screen.findByRole("heading", {
-      name: "You are booked with Tyler Dane",
+      name: "You're meeting with Tyler Dane",
     });
     await user.keyboard("{Escape}");
 
     const heading = await screen.findByRole("heading", {
-      name: "Book with Tyler Dane",
+      name: "Meet with Tyler Dane",
     });
     await waitFor(() => {
       expect(heading).toHaveFocus();
@@ -1645,7 +1645,7 @@ describe("PublicBookingConfirmedPage", () => {
     );
 
     const heading = await screen.findByRole("heading", {
-      name: "This booking was canceled",
+      name: "This meeting was canceled",
     });
     await user.keyboard("{Escape}");
 
@@ -1668,7 +1668,7 @@ describe("PublicBookingConfirmedPage", () => {
     );
 
     const heading = await screen.findByRole("heading", {
-      name: "Booking not found",
+      name: "Meeting not found",
     });
     await user.keyboard("{Escape}");
 
@@ -1684,7 +1684,7 @@ describe("PublicBookingConfirmedPage", () => {
 
     expect(
       await screen.findByRole("heading", {
-        name: "This booking was canceled",
+        name: "This meeting was canceled",
       }),
     ).toHaveFocus();
     expect(
@@ -1694,7 +1694,7 @@ describe("PublicBookingConfirmedPage", () => {
       screen.queryByRole("button", { name: "Copy reschedule link" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("link", { name: "Reschedule this booking" }),
+      screen.queryByRole("link", { name: "Reschedule this meeting" }),
     ).not.toBeInTheDocument();
   });
 
@@ -1708,7 +1708,7 @@ describe("PublicBookingConfirmedPage", () => {
     renderBookingRoute("/meet/confirmed/000000000000000000000099");
 
     expect(
-      await screen.findByRole("heading", { name: "Booking not found" }),
+      await screen.findByRole("heading", { name: "Meeting not found" }),
     ).toHaveFocus();
   });
 
@@ -1723,7 +1723,7 @@ describe("PublicBookingConfirmedPage", () => {
     renderBookingRoute("/meet/confirmed/000000000000000000000099");
 
     expect(
-      await screen.findByRole("heading", { name: "Could not load booking" }),
+      await screen.findByRole("heading", { name: "Could not load meeting" }),
     ).toHaveFocus();
   });
 
@@ -1770,15 +1770,15 @@ describe("PublicBookingConfirmedPage", () => {
     );
     await user.type(screen.getByLabelText("Name"), "Guest User");
     await user.type(screen.getByLabelText("Email"), "guest@example.com");
-    await user.click(screen.getByRole("button", { name: "Confirm booking" }));
+    await user.click(screen.getByRole("button", { name: "Confirm meeting" }));
     expect(
-      await screen.findByRole("link", { name: "Cancel this booking" }),
+      await screen.findByRole("link", { name: "Cancel this meeting" }),
     ).toHaveAttribute(
       "href",
       "https://compasscalendar.com/meet/cancel/000000000000000000000099?token=abc",
     );
     expect(
-      screen.getByRole("link", { name: "Reschedule this booking" }),
+      screen.getByRole("link", { name: "Reschedule this meeting" }),
     ).toHaveAttribute(
       "href",
       "https://compasscalendar.com/meet/reschedule/000000000000000000000099?token=abc",
@@ -1859,7 +1859,7 @@ describe("PublicBookingConfirmedPage", () => {
     await user.type(screen.getByLabelText("Name"), "Ada Lovelace");
     await user.type(screen.getByLabelText("Email"), "ada@example.com");
     await user.type(screen.getByLabelText("Notes (optional)"), "bring coffee");
-    await user.click(screen.getByRole("button", { name: "Confirm booking" }));
+    await user.click(screen.getByRole("button", { name: "Confirm meeting" }));
 
     expect(
       await screen.findByRole("button", { name: "Edit details" }),
@@ -1887,7 +1887,7 @@ describe("PublicBookingConfirmedPage", () => {
 
     expect(
       await screen.findByRole("heading", {
-        name: "You are booked with Tyler Dane",
+        name: "You're meeting with Tyler Dane",
       }),
     ).toBeInTheDocument();
     expect(screen.getByText("Grace Hopper")).toBeInTheDocument();
@@ -1934,7 +1934,7 @@ describe("PublicBookingConfirmedPage", () => {
     );
     await user.type(screen.getByLabelText("Name"), "Ada Lovelace");
     await user.type(screen.getByLabelText("Email"), "ada@example.com");
-    await user.click(screen.getByRole("button", { name: "Confirm booking" }));
+    await user.click(screen.getByRole("button", { name: "Confirm meeting" }));
     await user.click(
       await screen.findByRole("button", { name: "Edit details" }),
     );
@@ -1943,7 +1943,7 @@ describe("PublicBookingConfirmedPage", () => {
 
     expect(
       await screen.findByRole("heading", {
-        name: "You are booked with Tyler Dane",
+        name: "You're meeting with Tyler Dane",
       }),
     ).toBeInTheDocument();
     expect(router.state.location.pathname).toBe(

--- a/packages/web/src/booking/PublicBookingPage.tsx
+++ b/packages/web/src/booking/PublicBookingPage.tsx
@@ -62,14 +62,14 @@ export function PublicBookingPage() {
 
   useBookingDocumentTitle(
     pageQuery.data?.enabled
-      ? `Book with ${pageQuery.data.hostDisplayName}`
+      ? `Meet with ${pageQuery.data.hostDisplayName}`
       : null,
   );
 
   if (pageQuery.isLoading) {
     return (
       <PublicBookingStatusMessage
-        title="Loading booking page"
+        title="Loading meeting page"
         description="One moment while we load available times."
       />
     );
@@ -81,8 +81,8 @@ export function PublicBookingPage() {
   ) {
     return (
       <PublicBookingStatusMessage
-        title="Booking page not found"
-        description="This link may be incorrect or the host has turned booking off."
+        title="Meeting page not found"
+        description="This link may be incorrect or the host has turned this meeting page off."
       />
     );
   }
@@ -90,7 +90,7 @@ export function PublicBookingPage() {
   if (pageQuery.isError || !pageQuery.isSuccess || !pageQuery.data) {
     return (
       <PublicBookingStatusMessage
-        title="Could not load booking page"
+        title="Could not load meeting"
         description="Please refresh and try again."
       />
     );
@@ -101,8 +101,8 @@ export function PublicBookingPage() {
   if (slotsQuery.data && !slotsQuery.data.bookable) {
     return (
       <PublicBookingStatusMessage
-        title="Booking temporarily unavailable"
-        description="The host calendar is not ready for new bookings. Please try again later."
+        title="Meeting temporarily unavailable"
+        description="The host calendar is not ready for new meetings. Please try again later."
       />
     );
   }
@@ -125,7 +125,7 @@ export function PublicBookingPage() {
           ref={headingRef}
           tabIndex={-1}
         >
-          Book with {page.hostDisplayName}
+          Meet with {page.hostDisplayName}
         </h1>
         <p className="text-sm text-text-muted">
           {formatBookingDurationWithConference(

--- a/packages/web/src/booking/PublicBookingReschedulePage.test.tsx
+++ b/packages/web/src/booking/PublicBookingReschedulePage.test.tsx
@@ -127,7 +127,7 @@ describe("PublicBookingReschedulePage", () => {
 
     expect(
       await screen.findByRole("heading", {
-        name: "Reschedule your booking with Tyler Dane",
+        name: "Reschedule your meeting with Tyler Dane",
       }),
     ).toHaveFocus();
     expect(posts).toHaveLength(0);
@@ -217,12 +217,12 @@ describe("PublicBookingReschedulePage", () => {
     renderRescheduleRoute(`/meet/reschedule/${reservationId}`);
 
     expect(
-      await screen.findByRole("heading", { name: "Booking not found" }),
+      await screen.findByRole("heading", { name: "Meeting not found" }),
     ).toHaveFocus();
     expect(slotGets).toBe(0);
     expect(
       screen.queryByRole("heading", {
-        name: "Reschedule your booking with Tyler Dane",
+        name: "Reschedule your meeting with Tyler Dane",
       }),
     ).not.toBeInTheDocument();
   });
@@ -254,7 +254,7 @@ describe("PublicBookingReschedulePage", () => {
     );
     expect(
       screen.getByRole("heading", {
-        name: "Reschedule your booking with Tyler Dane",
+        name: "Reschedule your meeting with Tyler Dane",
       }),
     ).toBeInTheDocument();
     expect(router.state.location.pathname).toBe(
@@ -276,7 +276,7 @@ describe("PublicBookingReschedulePage", () => {
 
     expect(
       await screen.findByRole("heading", {
-        name: "This booking was canceled",
+        name: "This meeting was canceled",
       }),
     ).toHaveFocus();
     expect(

--- a/packages/web/src/booking/PublicBookingReschedulePage.tsx
+++ b/packages/web/src/booking/PublicBookingReschedulePage.tsx
@@ -22,22 +22,22 @@ import { useBookingHeadingFocus } from "@web/booking/use-booking-heading-focus";
 import { usePublicBookingRescheduleFlow } from "@web/booking/use-public-booking-reschedule-flow";
 
 const BOOKING_LOADING = {
-  title: "Loading booking",
-  description: "One moment while we load this booking.",
+  title: "Loading meeting",
+  description: "One moment while we load this meeting.",
 } as const;
 
 const BOOKING_NOT_FOUND = {
-  title: "Booking not found",
+  title: "Meeting not found",
   description: "This reschedule link may be invalid or already used.",
 } as const;
 
 const BOOKING_LOAD_FAILED = {
-  title: "Could not load booking",
+  title: "Could not load meeting",
   description: "Please refresh and try again.",
 } as const;
 
 const BOOKING_CANCELED = {
-  title: "This booking was canceled",
+  title: "This meeting was canceled",
   description:
     "The appointment is no longer on the host calendar. You can close this page.",
 } as const;
@@ -58,7 +58,7 @@ export function PublicBookingReschedulePage() {
       ? hostDisplayName
       : null,
   );
-  useBookingDocumentTitle("Reschedule booking");
+  useBookingDocumentTitle("Reschedule meeting");
 
   if (reservationView.kind === "status") {
     return <PublicBookingStatusMessage {...reservationView} />;
@@ -69,7 +69,7 @@ export function PublicBookingReschedulePage() {
   if (pageQuery.isLoading) {
     return (
       <PublicBookingStatusMessage
-        title="Loading booking page"
+        title="Loading meeting page"
         description="One moment while we load available times."
       />
     );
@@ -92,8 +92,8 @@ export function PublicBookingReschedulePage() {
   if (slotsQuery.data && !slotsQuery.data.bookable) {
     return (
       <PublicBookingStatusMessage
-        title="Booking temporarily unavailable"
-        description="The host calendar is not ready for new bookings. Please try again later."
+        title="Meeting temporarily unavailable"
+        description="The host calendar is not ready for new meetings. Please try again later."
       />
     );
   }
@@ -111,7 +111,7 @@ export function PublicBookingReschedulePage() {
           ref={headingRef}
           tabIndex={-1}
         >
-          Reschedule your booking with {reservation.hostDisplayName}
+          Reschedule your meeting with {reservation.hostDisplayName}
         </h1>
         <p className="text-sm text-text-muted">Current time</p>
         <PublicBookingSlotSummary

--- a/packages/web/src/booking/use-public-booking-flow.ts
+++ b/packages/web/src/booking/use-public-booking-flow.ts
@@ -310,11 +310,11 @@ export function usePublicBookingFlow() {
       if (getErrorStatus(error) === 404) {
         // The host disabled the page mid-flow; the refetch flips the whole
         // page to its not-found state.
-        setAlertMessage("This booking page is no longer available.");
+        setAlertMessage("This meeting page is no longer available.");
         await pageQuery.refetch();
         return;
       }
-      setAlertMessage("Could not confirm this booking. Please try again.");
+      setAlertMessage("Could not confirm this meeting. Please try again.");
     } finally {
       submitInFlightRef.current = false;
     }

--- a/packages/web/src/booking/use-public-booking-reschedule-flow.ts
+++ b/packages/web/src/booking/use-public-booking-reschedule-flow.ts
@@ -300,11 +300,11 @@ export function usePublicBookingRescheduleFlow() {
         error instanceof PublicBookingNotFoundError ||
         getErrorStatus(error) === 404
       ) {
-        setAlertMessage("This booking is no longer available.");
+        setAlertMessage("This meeting is no longer available.");
         await reservationQuery.refetch();
         return;
       }
-      setAlertMessage("Could not reschedule this booking. Please try again.");
+      setAlertMessage("Could not reschedule this meeting. Please try again.");
     } finally {
       submitInFlightRef.current = false;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3504

## What and why

Guests on `/meet/:slug` and the confirmed, cancel, and reschedule pages now read **meeting** copy: heading and tab title "Meet with {host}", button "Confirm meeting", confirmation "You're meeting with {host}", actions "Cancel this meeting" and "Reschedule this meeting", and states such as "Meeting not found" and "Meeting canceled". Analytics events, ids, query keys, and `/api/booking/*` paths stay unchanged.

Spec: `docs/features/booking.md` Guest and Outcome sections.

## Verify

`VERDICT: PASS`

Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad52e327-6e23-450a-a5cb-22a43d90c4f6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad52e327-6e23-450a-a5cb-22a43d90c4f6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

