### PR TITLE
feat(sync): carry providerManaged read fact from provider read to web event (WP-02)

### DIFF
--- a/packages/backend/src/common/services/sync-service/event-list.translation.test.ts
+++ b/packages/backend/src/common/services/sync-service/event-list.translation.test.ts
@@ -74,6 +74,20 @@ describe("syncEventInstanceToBrowser", () => {
     expect("icalUid" in event).toBe(false);
   });
 
+  it("carries providerManaged through to the browser event", () => {
+    const event = syncEventInstanceToBrowser(
+      baseInstance({ providerManaged: true }),
+    );
+
+    expect(event.providerManaged).toBe(true);
+  });
+
+  it("leaves providerManaged absent when sync reported none", () => {
+    const event = syncEventInstanceToBrowser(baseInstance());
+
+    expect("providerManaged" in event).toBe(false);
+  });
+
   it("maps a series master row keeping the real eventId and rules", () => {
     const instance = baseInstance({
       recurrence: { kind: "series", rules: ["RRULE:FREQ=WEEKLY"] },

--- a/packages/backend/src/common/services/sync-service/event-list.translation.ts
+++ b/packages/backend/src/common/services/sync-service/event-list.translation.ts
@@ -32,6 +32,9 @@ export const syncEventInstanceToBrowser = (
     // Absent stays absent: the browser contract treats a missing key as "the
     // provider reported no correlation key", not as an empty one.
     ...(instance.icalUid ? { icalUid: instance.icalUid } : {}),
+    ...(instance.providerManaged
+      ? { providerManaged: instance.providerManaged }
+      : {}),
   };
 
   switch (instance.recurrence.kind) {

--- a/packages/core/src/types/event.contracts.test.ts
+++ b/packages/core/src/types/event.contracts.test.ts
@@ -298,6 +298,24 @@ describe("Event Contracts", () => {
 
       expect(EventSchema.safeParse(event).success).toBe(false);
     });
+
+    it("accepts providerManaged: true", () => {
+      expect(
+        EventSchema.safeParse(baseEvent({ providerManaged: true })).success,
+      ).toBe(true);
+    });
+
+    it("rejects providerManaged: false", () => {
+      expect(
+        EventSchema.safeParse(baseEvent({ providerManaged: false })).success,
+      ).toBe(false);
+    });
+
+    it('rejects providerManaged: "true"', () => {
+      expect(
+        EventSchema.safeParse(baseEvent({ providerManaged: "true" })).success,
+      ).toBe(false);
+    });
   });
 
   describe("BusyPeriodSchema", () => {

--- a/packages/core/src/types/event.contracts.ts
+++ b/packages/core/src/types/event.contracts.ts
@@ -111,6 +111,9 @@ export const EventSchema = z.strictObject({
   // meeting. Absent for events the provider reported none for, and for
   // locally created events.
   icalUid: z.string().optional(),
+  // The provider owns this event's details and schedule. Omitted rather than
+  // nulled so events imported before it was recorded stay contract-valid.
+  providerManaged: z.literal(true).optional(),
 });
 export type Event = z.infer<typeof EventSchema>;
 

--- a/packages/core/src/types/sync/event.contracts.test.ts
+++ b/packages/core/src/types/sync/event.contracts.test.ts
@@ -398,6 +398,21 @@ describe("Sync event contracts", () => {
       const instance = baseInstance({ calendarId: "not-an-id" });
       expect(SyncEventInstanceSchema.safeParse(instance).success).toBe(false);
     });
+
+    it("accepts providerManaged: true", () => {
+      const instance = baseInstance({ providerManaged: true });
+      expect(SyncEventInstanceSchema.safeParse(instance).success).toBe(true);
+    });
+
+    it("rejects providerManaged: false", () => {
+      const instance = baseInstance({ providerManaged: false });
+      expect(SyncEventInstanceSchema.safeParse(instance).success).toBe(false);
+    });
+
+    it('rejects providerManaged: "true"', () => {
+      const instance = baseInstance({ providerManaged: "true" });
+      expect(SyncEventInstanceSchema.safeParse(instance).success).toBe(false);
+    });
   });
 
   describe("EventInstanceListQuerySchema", () => {

--- a/packages/core/src/types/sync/event.contracts.ts
+++ b/packages/core/src/types/sync/event.contracts.ts
@@ -232,6 +232,9 @@ export const SyncEventInstanceSchema = z.strictObject({
   // metadata bag so consumers get a plain scalar. Copies of one meeting on
   // different accounts share it. Absent when the provider reported none.
   icalUid: z.string().optional(),
+  // The provider owns this event's details and schedule. Omitted rather than
+  // nulled so events imported before it was recorded stay contract-valid.
+  providerManaged: z.literal(true).optional(),
 });
 export type SyncEventInstance = z.infer<typeof SyncEventInstanceSchema>;
 

--- a/packages/sync/src/domain/event-instance-assembly.test.ts
+++ b/packages/sync/src/domain/event-instance-assembly.test.ts
@@ -123,6 +123,63 @@ describe("assembleEventInstances", () => {
     expect(instance && "icalUid" in instance).toBe(false);
   });
 
+  it("lifts providerManaged out of the metadata bag on every row shape", () => {
+    const managedMetadata = { providerManaged: "true" as const };
+    const singleEvent = makeEvent({
+      recurrence: { kind: "single" },
+      providerMetadata: managedMetadata,
+    });
+    const master = makeEvent({
+      recurrence: { kind: "seriesMaster", rules: ["RRULE:FREQ=DAILY"] },
+      providerMetadata: managedMetadata,
+    });
+    const exception = makeEvent({
+      recurrence: {
+        kind: "exception",
+        seriesId: master._id,
+        recurrenceId: "2026-07-14T15:00:00.000Z",
+        cancelled: false,
+      },
+      providerMetadata: managedMetadata,
+    });
+    const monday = makeOccurrence({
+      eventId: master._id,
+      startAt: new Date("2026-07-13T15:00:00.000Z"),
+    });
+    const movedOccurrence = makeOccurrence({
+      eventId: exception._id,
+      startAt: new Date("2026-07-14T18:00:00.000Z"),
+    });
+
+    const singleRow = assembleEventInstances(
+      [makeOccurrence({ eventId: singleEvent._id })],
+      byId(singleEvent),
+    )[0];
+    const seriesRows = assembleEventInstances(
+      [monday, movedOccurrence],
+      byId(master, exception),
+    );
+
+    expect(singleRow?.providerManaged).toBe(true);
+    for (const row of seriesRows) {
+      expect(row.providerManaged).toBe(true);
+    }
+  });
+
+  it("omits providerManaged when the metadata bag has no such entry", () => {
+    const event = makeEvent({
+      recurrence: { kind: "single" },
+      providerMetadata: null,
+    });
+
+    const [instance] = assembleEventInstances(
+      [makeOccurrence({ eventId: event._id })],
+      byId(event),
+    );
+
+    expect(instance && "providerManaged" in instance).toBe(false);
+  });
+
   it("maps a single event to one single row carrying full content", () => {
     const event = makeEvent({ recurrence: { kind: "single" } });
     const occurrence = makeOccurrence({ eventId: event._id });

--- a/packages/sync/src/domain/event-instance-assembly.ts
+++ b/packages/sync/src/domain/event-instance-assembly.ts
@@ -49,7 +49,10 @@ export function assembleEventInstances(
       createdAt: event.createdAt.toISOString(),
       updatedAt: event.updatedAt.toISOString(),
     };
-    const correlation = toIcalUid(event);
+    const correlation = {
+      ...toIcalUid(event),
+      ...toProviderManaged(event),
+    };
 
     if (event.recurrence.kind === "single") {
       instances.push(
@@ -123,6 +126,7 @@ export function assembleEventInstances(
         createdAt: master.createdAt.toISOString(),
         updatedAt: master.updatedAt.toISOString(),
         ...toIcalUid(master),
+        ...toProviderManaged(master),
       }),
     );
   }
@@ -136,6 +140,12 @@ export function assembleEventInstances(
 const toIcalUid = (event: EventRecord): { icalUid?: string } => {
   const icalUid = event.providerMetadata?.["iCalUID"];
   return icalUid ? { icalUid } : {};
+};
+
+const toProviderManaged = (event: EventRecord): { providerManaged?: true } => {
+  return event.providerMetadata?.["providerManaged"] === "true"
+    ? { providerManaged: true }
+    : {};
 };
 
 const toInstanceContent = (content: EventRecord["content"]) => ({

--- a/packages/sync/src/domain/provider-page-applier.db.test.ts
+++ b/packages/sync/src/domain/provider-page-applier.db.test.ts
@@ -111,6 +111,28 @@ describe("ProviderPageApplier", () => {
     });
   });
 
+  it("stores providerManaged in providerMetadata when the read is managed", async () => {
+    const calendar = await seedCalendar();
+    const run = applier(calendar);
+
+    await run.applyPage([
+      { ...single("managed"), providerManaged: true },
+      { ...single("normal") },
+    ]);
+
+    const byId = (providerEventId: string) =>
+      events.findByProviderIdentity(calendar.tenantId, calendar.principalId, {
+        connectionId: calendar.connectionId,
+        calendarId: calendar._id,
+        providerEventId,
+      });
+
+    expect((await byId("managed"))?.providerMetadata).toEqual({
+      providerManaged: "true",
+    });
+    expect((await byId("normal"))?.providerMetadata).toBeNull();
+  });
+
   it("projects transparent imports as non-busy while opaque siblings occupy listBusyOverlapping", async () => {
     const calendar = await seedCalendar();
     const run = applier(calendar);

--- a/packages/sync/src/domain/provider-page-applier.ts
+++ b/packages/sync/src/domain/provider-page-applier.ts
@@ -32,6 +32,7 @@ function providerMetadataFor(
   const metadata = {
     ...(read.busy ? {} : { transparency: "transparent" }),
     ...(read.icalUid ? { iCalUID: read.icalUid } : {}),
+    ...(read.providerManaged ? { providerManaged: "true" } : {}),
     ...(read.resourceHref ? { href: read.resourceHref } : {}),
   };
   return Object.keys(metadata).length > 0 ? metadata : null;

--- a/packages/sync/src/providers/apple/apple-event.normalizer.test.ts
+++ b/packages/sync/src/providers/apple/apple-event.normalizer.test.ts
@@ -88,6 +88,7 @@ END:VEVENT`),
     expect(Date.parse(event.schedule.start)).toBe(
       Date.parse("2025-01-15T09:00:00-05:00"),
     );
+    expect(event).not.toHaveProperty("providerManaged");
   });
 
   it("anchors floating times to the connection zone", () => {

--- a/packages/sync/src/providers/google/google-event.normalizer.test.ts
+++ b/packages/sync/src/providers/google/google-event.normalizer.test.ts
@@ -445,4 +445,26 @@ describe("normalizeGoogleEvent", () => {
 
     expect(read.content).not.toHaveProperty("colorHex");
   });
+
+  it("sets providerManaged for a non-default eventType", () => {
+    const read = asProviderEvent(
+      normalizeGoogleEvent(gEvent({ eventType: "fromGmail" })),
+    );
+
+    expect(read.providerManaged).toBe(true);
+  });
+
+  it("omits providerManaged for eventType default", () => {
+    const read = asProviderEvent(
+      normalizeGoogleEvent(gEvent({ eventType: "default" })),
+    );
+
+    expect(read).not.toHaveProperty("providerManaged");
+  });
+
+  it("omits providerManaged when eventType is absent", () => {
+    const read = asProviderEvent(normalizeGoogleEvent(gEvent({})));
+
+    expect(read).not.toHaveProperty("providerManaged");
+  });
 });

--- a/packages/sync/src/providers/google/google-event.normalizer.ts
+++ b/packages/sync/src/providers/google/google-event.normalizer.ts
@@ -63,6 +63,9 @@ export function normalizeGoogleEvent(
     // Absent transparency means "opaque" (busy) in Google's model.
     busy: item.transparency !== "transparent",
     ...(item.iCalUID ? { icalUid: item.iCalUID } : {}),
+    ...(item.eventType && item.eventType !== "default"
+      ? { providerManaged: true as const }
+      : {}),
     recurrence: mapRecurrence(item),
   };
 }

--- a/packages/sync/src/providers/microsoft/microsoft-event.normalizer.test.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-event.normalizer.test.ts
@@ -68,6 +68,7 @@ describe("normalizeMicrosoftEvent", () => {
     expect(read.icalUid).toBe(
       "040000008200E00074C5B7101A82E00800000000000000000000000000000000000000000000000000",
     );
+    expect(read).not.toHaveProperty("providerManaged");
   });
 
   it("normalizes an all-day free event", () => {

--- a/packages/sync/src/providers/provider-event.port.ts
+++ b/packages/sync/src/providers/provider-event.port.ts
@@ -36,6 +36,11 @@ export interface ProviderEvent {
   // the same meeting on different accounts share it, unlike providerEventId.
   // Absent when the provider reported none.
   readonly icalUid?: string;
+  // The provider owns this event's details and schedule and refuses writes to
+  // them; only presentation fields (color, attendees) may be written. Today
+  // Google sets this for any eventType other than "default"; birthday's
+  // slightly looser rules are ignored on purpose.
+  readonly providerManaged?: true;
   // CalDAV resource href for resolving sync-collection deletions.
   readonly resourceHref?: string;
   readonly recurrence: ProviderEventRecurrence;


### PR DESCRIPTION
Fixes #3514

## What and why

Provider-managed events (Google `eventType` other than `default`, e.g. Gmail-created meetings) need a neutral read fact on the web `Event` contract before WP-03/WP-04 can overlay customizations and lock the schedule. This WP adds optional `providerManaged: true` on `ProviderEvent`, `SyncEventInstanceSchema`, and `EventSchema`, sets it in the Google normalizer, stores it in `providerMetadata`, lifts it in instance assembly, and passes it through backend event-list translation. Microsoft and Apple readers leave it unset.

Tracking: #3512 (Provider-managed events milestone).

## Verify

```
Selected packages: core, sync, backend
Checks run: test:core, test:sync, test:backend:fast, type-check, lint, knip
Checks skipped: (none)

✓ All checks passed
VERDICT: PASS
```