### PR TITLE
feat(booking): replace meeting e-leader with hold-Mod section chords

### DIFF
--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -251,15 +251,16 @@ time inputs per weekday.
 - **Weekly hours** are one typed range per weekday (`9-5`, or `9-12, 1-5`
   for a break). A blank day is unavailable. The parser reuses
   `parseUserTime` with an explicit PM-correction rule.
-- **Jump:** `e` then a letter focuses a field (`e` meeting page on or
-  off, `a` page address, `d` duration, `c` destination, `b` blocking, `z` timezone,
-  `h` hours, `m` More options, `w` welcome, `n` notice, `x` horizon,
-  `o` buffer and limits, `l` link). Settings owns Mod+Enter (the
-  primary save action) and digits `1/2/3` (nav) on this page, which is
-  why the leader is `e` rather than `Mod+digit`. Focus uses
+- **Jump:** hold Mod to see section chips. `Mod+4` through `Mod+9`
+  jump to on or off, Duration, Timezone, Weekly hours, Destination
+  calendar, and More options (`Mod+9` opens the group and focuses the
+  first control inside). `Mod+U` copies the meeting link (click, not
+  only focus). Save stays Mod+Enter. Fields inside More options have
+  no chord. Settings nav still owns digits `1/2/3`. Focus uses
   `data-booking-field` and does not click, so jumping onto a checkbox
   does not toggle it. Before focusing, the helper opens any ancestor
-  `<details>`.
+  `<details>`. The Settings nav shows one hint, **Hold Mod to see
+  shortcuts.**, while chips are hidden.
 - **Turn on / Save:** going live is one click. When the page is not
   live, the primary action is **Turn on meeting page** (Mod+Enter).
   **Save draft** appears only when the form is dirty. When the page is
@@ -268,7 +269,7 @@ time inputs per weekday.
   gone. Validation and server errors render beside the save bar and
   focus the offending field.
 - **Toasts:** turning on copies the link (`Your meeting page is live.
-  Link copied.`, or `Live. Press e then l to copy your link.` if the
+  Link copied.`, or `Live. Press Mod U to copy your link.` if the
   clipboard fails). Save changes copies the link with today's Saved
   copy. Turn off says `Meeting page turned off.` Save draft says
   `Saved. Turn on your meeting page to share the link.` Safari can drop

--- a/docs/frontend/shortcut-commandments.md
+++ b/docs/frontend/shortcut-commandments.md
@@ -80,7 +80,11 @@ Billing: `U` Update card,
 `C` Cancel subscription, `R` Resume subscription. Accounts: `A` Add account,
 `E` Export, `D` Delete account, `O` Log out. `B` (trial badge / Start
 Premium) is registered by `UpgradeConfirmationProvider` and keeps working
-while Settings is open. The `?` overlay remains the catalog; hold-Mod still
+while Settings is open. Meeting page uses hold-Mod section chords:
+`Mod+4` through `Mod+9` jump to on or off, Duration, Timezone, Weekly
+hours, Destination calendar, and More options; `Mod+U` copies the meeting
+link. Letters come from `SETTINGS_MOD_LETTER_POOL`. Meeting settings do
+not use an `e` leader. The `?` overlay remains the catalog; hold-Mod still
 reveals the chips.
 
 ## 7. Leaders wait, then teach
@@ -118,4 +122,5 @@ Form field digits live in
 order, 1–9). Page-area digits live in
 `packages/web/src/shortcuts/page-jump/page-jump.targets.ts`. Day-view
 calendar columns are built by `buildDayPageJumpTargets` in left-to-right
-order (view, columns, sidebar).
+order (view, columns, sidebar). Meeting settings sections live in
+`packages/web/src/booking/booking-sequence.fields.ts`.

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -104,7 +104,7 @@ test("saves welcome text", async ({ page }) => {
   ).toHaveAttribute("href", bookingUrl);
 });
 
-test("keyboard hint sits above the public link and the last control stays above Save", async ({
+test("keyboard hint sits in the nav column and the last control stays above Save", async ({
   page,
 }) => {
   await prepareSignedInBookingSettingsPage(page, {
@@ -113,11 +113,8 @@ test("keyboard hint sits above the public link and the last control stays above 
 
   const settingsDialog = page.getByRole("dialog", { name: "Settings" });
   await openMoreOptions(settingsDialog);
-  const hint = settingsDialog
-    .locator("p")
-    .filter({ hasText: "then a letter to jump to a field" });
-  const publicLink = settingsDialog.getByRole("textbox", {
-    name: "Meeting link",
+  const hint = settingsDialog.locator("nav p", {
+    hasText: "to see shortcuts.",
   });
   const lastControl = settingsDialog.getByRole("checkbox", {
     name: "Guest can invite others",
@@ -127,11 +124,6 @@ test("keyboard hint sits above the public link and the last control stays above 
   });
 
   await expect(hint).toBeVisible();
-  const hintBox = await hint.boundingBox();
-  const linkBox = await publicLink.boundingBox();
-  expect(hintBox).not.toBeNull();
-  expect(linkBox).not.toBeNull();
-  expect(hintBox!.y + hintBox!.height).toBeLessThan(linkBox!.y);
 
   await lastControl.scrollIntoViewIfNeeded();
   await settingsDialog.evaluate((el) => {

--- a/packages/web/src/booking/BookingCopyLink.tsx
+++ b/packages/web/src/booking/BookingCopyLink.tsx
@@ -1,19 +1,28 @@
 import { ArrowSquareOut, Check, Copy } from "@phosphor-icons/react";
 import { track } from "@web/auth/posthog/track";
+import {
+  bookingFieldAttrs,
+  bookingJumpKeys,
+} from "@web/booking/booking-sequence.fields";
 import { useCopiedFlag } from "@web/booking/use-copied-flag";
 import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
 import IconButton, {
   iconButtonClassName,
 } from "@web/components/IconButton/IconButton";
+import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
 
 interface BookingCopyLinkProps {
   bookingUrl: string;
+  showShortcuts?: boolean;
 }
 
 const ICON_SIZE = 18;
 
-export function BookingCopyLink({ bookingUrl }: BookingCopyLinkProps) {
+export function BookingCopyLink({
+  bookingUrl,
+  showShortcuts = false,
+}: BookingCopyLinkProps) {
   const { copied, copy } = useCopiedFlag(bookingUrl, (didCopy) => {
     if (didCopy) {
       track("booking_link_copied", { source: "button" });
@@ -41,10 +50,14 @@ export function BookingCopyLink({ bookingUrl }: BookingCopyLinkProps) {
             aria-label="Copy meeting link"
             onClick={copy}
             size="small"
+            {...bookingFieldAttrs("link")}
           >
             {copied ? <Check size={ICON_SIZE} /> : <Copy size={ICON_SIZE} />}
           </IconButton>
         </TooltipWrapper>
+        {showShortcuts ? (
+          <ShortcutKeys className="ml-1" keys={bookingJumpKeys("link")} />
+        ) : null}
         <TooltipWrapper description="Open meeting page">
           <a
             aria-label="Open meeting page"

--- a/packages/web/src/booking/BookingFieldLabel.tsx
+++ b/packages/web/src/booking/BookingFieldLabel.tsx
@@ -1,12 +1,11 @@
 import {
-  type BookingSequenceField,
+  type BookingField,
   bookingJumpKeys,
 } from "@web/booking/booking-sequence.fields";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 
 /**
- * A field caption with its `e`-leader key, revealed on hold-Mod alongside the
- * Settings nav digits, so one gesture teaches the whole page.
+ * A field caption with its hold-Mod chord, revealed alongside Settings nav.
  */
 export function BookingFieldLabel({
   children,
@@ -15,7 +14,7 @@ export function BookingFieldLabel({
   showShortcuts,
 }: {
   children: string;
-  field: BookingSequenceField;
+  field: BookingField;
   htmlFor?: string;
   showShortcuts: boolean;
 }) {

--- a/packages/web/src/booking/BookingMoreOptions.tsx
+++ b/packages/web/src/booking/BookingMoreOptions.tsx
@@ -28,16 +28,15 @@ export function BookingMoreOptions({
 
   return (
     <details className="flex flex-col gap-4" ref={detailsRef}>
-      <summary
-        className="c-focus-ring cursor-pointer list-inside font-medium text-sm text-text"
-        {...bookingFieldAttrs("more")}
-      >
+      <summary className="c-focus-ring cursor-pointer list-inside font-medium text-sm text-text">
         {BOOKING_MORE_OPTIONS_LABEL}
         {showShortcuts ? (
           <ShortcutKeys className="ml-1" keys={bookingJumpKeys("more")} />
         ) : null}
       </summary>
-      <div className="mt-3 flex flex-col gap-4">{children}</div>
+      <div className="mt-3 flex flex-col gap-4" {...bookingFieldAttrs("more")}>
+        {children}
+      </div>
     </details>
   );
 }

--- a/packages/web/src/booking/BookingNumberField.tsx
+++ b/packages/web/src/booking/BookingNumberField.tsx
@@ -1,11 +1,11 @@
 import { BookingFieldLabel } from "@web/booking/BookingFieldLabel";
 import {
-  type BookingSequenceField,
+  type BookingField,
   bookingFieldAttrs,
 } from "@web/booking/booking-sequence.fields";
 
 interface BookingNumberFieldProps {
-  field: BookingSequenceField;
+  field: BookingField;
   id: string;
   label: string;
   value: string;

--- a/packages/web/src/booking/BookingSaveBar.tsx
+++ b/packages/web/src/booking/BookingSaveBar.tsx
@@ -1,8 +1,12 @@
-import { bookingFieldAttrs } from "@web/booking/booking-sequence.fields";
+import {
+  bookingFieldAttrs,
+  bookingJumpKeys,
+} from "@web/booking/booking-sequence.fields";
 import {
   OverlayPanelActionButton,
   OverlayPanelActions,
 } from "@web/components/OverlayPanel/OverlayPanel";
+import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import { settingsShortcutAttrs } from "@web/settings/useSettingsShortcuts";
 
 export const BOOKING_TURN_ON_LABEL = "Turn on meeting page";
@@ -19,6 +23,7 @@ interface BookingSaveBarProps {
   isLive: boolean;
   isPending: boolean;
   onSubmit: (enabled: boolean) => void;
+  showShortcuts?: boolean;
 }
 
 export function BookingSaveBar({
@@ -27,7 +32,11 @@ export function BookingSaveBar({
   isLive,
   isPending,
   onSubmit,
+  showShortcuts = false,
 }: BookingSaveBarProps) {
+  const enabledChip = showShortcuts ? (
+    <ShortcutKeys className="ml-2" keys={bookingJumpKeys("enabled")} />
+  ) : null;
   const primaryLabel = isLive
     ? BOOKING_SAVE_CHANGES_LABEL
     : BOOKING_TURN_ON_LABEL;
@@ -51,6 +60,7 @@ export function BookingSaveBar({
             {...bookingFieldAttrs("enabled")}
           >
             {BOOKING_TURN_OFF_LABEL}
+            {enabledChip}
           </OverlayPanelActionButton>
         ) : isDirty ? (
           <OverlayPanelActionButton
@@ -75,6 +85,7 @@ export function BookingSaveBar({
           {...(isLive ? {} : bookingFieldAttrs("enabled"))}
         >
           {pendingLabel}
+          {isLive ? null : enabledChip}
         </OverlayPanelActionButton>
       </OverlayPanelActions>
     </div>

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -25,7 +25,6 @@ import {
 import { BOOKING_CONNECT_EMPTY_ENV_COPY } from "@web/booking/BookingConnectPrompt";
 import { BOOKING_MORE_OPTIONS_LABEL } from "@web/booking/BookingMoreOptions";
 import {
-  BOOKING_SAVE_CHANGES_LABEL,
   BOOKING_SAVE_DRAFT_LABEL,
   BOOKING_TURN_OFF_LABEL,
   BOOKING_TURN_ON_LABEL,

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -12,7 +12,6 @@ import {
   createMockCalendar,
   createMockConnection,
 } from "@web/__tests__/utils/factories/calendar.factory";
-import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
 import { CONNECT_CALENDAR_LABEL } from "@web/auth/providers/provider-copy.util";
 import {
   resetProviderAvailabilityForTests,
@@ -31,17 +30,11 @@ import {
   BOOKING_TURN_OFF_LABEL,
   BOOKING_TURN_ON_LABEL,
 } from "@web/booking/BookingSaveBar";
-import {
-  BOOKING_SETTINGS_HINT_PARTS,
-  BookingSettingsSection,
-} from "@web/booking/BookingSettingsSection";
+import { BookingSettingsSection } from "@web/booking/BookingSettingsSection";
 import { BOOKING_SAVE_ERROR_COPY } from "@web/booking/booking.query";
 import { BOOKING_APPLE_DESTINATION_HINT } from "@web/booking/booking-conference.copy";
 import {
-  BOOKING_FIELD_BY_KEY,
-  BOOKING_SEQUENCE_FIELDS,
   bookingFieldAttrs,
-  bookingFieldKey,
   focusBookingField,
 } from "@web/booking/booking-sequence.fields";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
@@ -52,12 +45,7 @@ import {
   resetToastPort,
 } from "@web/common/utils/toast/toast.port";
 import { useSettingsShortcuts } from "@web/settings/useSettingsShortcuts";
-import {
-  clearAppLockReasons,
-  isAppLocked,
-  setAppLockReason,
-} from "@web/shortcuts/app-lock";
-import { getPartsPlainText } from "@web/shortcuts/tips/shortcut-tips.data";
+import { clearAppLockReasons } from "@web/shortcuts/app-lock";
 import { setPinnedTimeZone } from "@web/timezone/effective-timezone.store";
 import { afterAll, afterEach, describe, expect, it, mock } from "bun:test";
 
@@ -334,10 +322,6 @@ describe("BookingSettingsSection", () => {
     });
     const stickyBar = findStickyAncestor(save);
     expect(stickyBar).not.toBeNull();
-    expect(
-      screen.getByText(getPartsPlainText(BOOKING_SETTINGS_HINT_PARTS)),
-    ).toBeInTheDocument();
-    expect(stickyBar).not.toHaveTextContent("then a letter to jump to a field");
 
     await user.selectOptions(screen.getByLabelText("Duration"), "30");
     await user.click(
@@ -357,106 +341,6 @@ describe("BookingSettingsSection", () => {
     const openLink = screen.getByRole("link", { name: "Open meeting page" });
     expect(openLink).toHaveAttribute("href", bookingUrl);
     expect(openLink).toHaveAttribute("target", "_blank");
-  });
-
-  it("renders the keyboard hint above the public link, outside the sticky save bar", async () => {
-    userMetadataActions.set(healthyGoogleMetadata);
-    const bookingUrl = "https://compasscalendar.com/meet/hostuser";
-
-    server.use(
-      rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(
-          ctx.json({
-            id: createObjectIdString(),
-            slug: "hostuser",
-            hostUserId: createObjectIdString(),
-            enabled: true,
-            durationMinutes: 30,
-            destinationCalendarId: writableCalendar.id,
-            blockingCalendarIds: [writableCalendar.id],
-            timeZone: "America/New_York",
-            weeklyAvailability: [],
-            minNoticeHours: 4,
-            maxHorizonDays: 60,
-            bufferMinutes: null,
-            maxBookingsPerDay: null,
-            guestsCanInviteOthers: true,
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString(),
-            bookingUrl,
-          }),
-        ),
-      ),
-    );
-
-    const { wrapper, queryClient } = createStoreWrapper();
-    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
-
-    render(
-      <HotkeysProvider>
-        <BookingSettingsSection showShortcuts />
-      </HotkeysProvider>,
-      { wrapper },
-    );
-
-    const hint = await screen.findByText(
-      getPartsPlainText(BOOKING_SETTINGS_HINT_PARTS),
-    );
-    const publicLink = screen.getByLabelText("Meeting link");
-    const save = screen.getByRole("button", {
-      name: BOOKING_SAVE_CHANGES_LABEL,
-    });
-    const lastControl = screen.getByRole("checkbox", {
-      name: "Guest can invite others",
-    });
-
-    expect(
-      hint.compareDocumentPosition(publicLink) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).not.toBe(0);
-
-    const stickyBar = findStickyAncestor(save);
-    expect(stickyBar).not.toBeNull();
-    expect(stickyBar!.contains(save)).toBe(true);
-    expect(stickyBar!.contains(hint)).toBe(false);
-    expect(stickyBar!.contains(lastControl)).toBe(false);
-    expect(within(save).getByText("Enter")).toBeInTheDocument();
-    expect(
-      lastControl.compareDocumentPosition(save) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).not.toBe(0);
-  });
-
-  it("exposes a complete screen-reader name for the keyboard hint, with aria-hidden chips", async () => {
-    userMetadataActions.set(healthyGoogleMetadata);
-
-    server.use(
-      rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
-      ),
-    );
-
-    const { wrapper, queryClient } = createStoreWrapper();
-    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
-
-    render(
-      <HotkeysProvider>
-        <BookingSettingsSection showShortcuts={false} />
-      </HotkeysProvider>,
-      { wrapper },
-    );
-
-    const accessibleName = getPartsPlainText(BOOKING_SETTINGS_HINT_PARTS);
-    const accessible = await screen.findByText(accessibleName);
-    expect(accessible).toHaveClass("sr-only");
-    expect(accessible.textContent).toBe(accessibleName);
-    expect(accessibleName).toMatch(/Cmd\+E|Ctrl\+E/);
-    expect(accessibleName).not.toMatch(/Press e then/);
-
-    const visualHint = accessible.nextElementSibling;
-    expect(visualHint).toHaveAttribute("aria-hidden");
-    expect(visualHint).toHaveTextContent("then a letter to jump to a field");
-    expect(visualHint).toHaveTextContent("saves");
   });
 
   it("saves again after the first save, sending only PUT input keys", async () => {
@@ -921,32 +805,6 @@ describe("BookingSettingsSection", () => {
     expect(warning).toHaveAttribute("role", "status");
   });
 
-  it("jumps to the page address with e then a", async () => {
-    const user = userEvent.setup({ delay: null });
-    userMetadataActions.set(healthyGoogleMetadata);
-
-    server.use(
-      rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
-      ),
-    );
-
-    const { wrapper, queryClient } = createStoreWrapper();
-    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
-    render(
-      <HotkeysProvider>
-        <BookingSettingsSection showShortcuts={false} />
-      </HotkeysProvider>,
-      { wrapper },
-    );
-    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
-
-    await user.keyboard("e");
-    await user.keyboard("a");
-
-    expect(document.activeElement).toBe(screen.getByLabelText("Page address"));
-  });
-
   it("fires booking_settings_opened when the connect prompt mounts", () => {
     setProviderAvailabilityForTests("google", "available", "connect");
     userMetadataActions.set({
@@ -1131,135 +989,7 @@ describe("BookingSettingsSection", () => {
     });
   });
 
-  it("jumps to a field with the e leader, under the Settings app lock", async () => {
-    const user = userEvent.setup({ delay: null });
-    userMetadataActions.set(healthyGoogleMetadata);
-    // The Settings modal holds the lock in the real app, and the leader must
-    // still work underneath it - that is exactly what ignoreAppLock buys.
-    setAppLockReason("settingsModal", true);
-
-    server.use(
-      rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
-      ),
-    );
-
-    const { wrapper, queryClient } = createStoreWrapper();
-    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
-
-    render(
-      <HotkeysProvider>
-        <BookingSettingsSection showShortcuts={false} />
-      </HotkeysProvider>,
-      { wrapper },
-    );
-    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
-    expect(isAppLocked()).toBe(true);
-
-    await user.keyboard("e");
-    await user.keyboard("h");
-
-    expect(document.activeElement).toBe(screen.getByLabelText("Monday"));
-  });
-
-  it("jumps to welcome text with e then w", async () => {
-    const user = userEvent.setup({ delay: null });
-    userMetadataActions.set(healthyGoogleMetadata);
-
-    server.use(
-      rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
-      ),
-    );
-
-    const { wrapper, queryClient } = createStoreWrapper();
-    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
-
-    render(
-      <HotkeysProvider>
-        <BookingSettingsSection showShortcuts={false} />
-      </HotkeysProvider>,
-      { wrapper },
-    );
-    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
-
-    await user.keyboard("e");
-    await user.keyboard("w");
-
-    expect(document.activeElement).toBe(screen.getByLabelText("Welcome text"));
-  });
-
-  it("jumps to the timezone trigger with e then z", async () => {
-    const user = userEvent.setup({ delay: null });
-    userMetadataActions.set(healthyGoogleMetadata);
-
-    server.use(
-      rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
-      ),
-    );
-
-    const { wrapper, queryClient } = createStoreWrapper();
-    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
-
-    render(
-      <HotkeysProvider>
-        <BookingSettingsSection showShortcuts={false} />
-      </HotkeysProvider>,
-      { wrapper },
-    );
-    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
-
-    await user.keyboard("e");
-    await user.keyboard("z");
-
-    expect(document.activeElement).toBe(
-      screen.getByRole("button", { name: /^Meeting timezone:/ }),
-    );
-  });
-
-  it("does not jump out of the nested timezone dialog", async () => {
-    const user = userEvent.setup({ delay: null });
-    userMetadataActions.set(healthyGoogleMetadata);
-
-    server.use(
-      rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
-      ),
-    );
-
-    const { wrapper, queryClient } = createStoreWrapper();
-    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
-    render(
-      <HotkeysProvider>
-        <BookingSettingsSection showShortcuts={false} />
-      </HotkeysProvider>,
-      { wrapper },
-    );
-    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
-
-    await user.click(
-      screen.getByRole("button", { name: /^Meeting timezone:/ }),
-    );
-    const search = await screen.findByRole("combobox", {
-      name: "Search meeting timezones",
-    });
-    await waitFor(() => expect(search).toHaveFocus());
-
-    // Mod+E is the in-field leader; ignoreAppLock would otherwise arm it
-    // here and jump to Monday behind the dialog.
-    const modInit: KeyboardEventInit =
-      resolveModifier("Mod") === "Meta" ? { metaKey: true } : { ctrlKey: true };
-    pressKey("e", { keyDownInit: modInit, keyUpInit: modInit }, search);
-    pressKey("h", {}, search);
-
-    expect(search).toHaveFocus();
-    expect(
-      screen.getByRole("combobox", { name: "Search meeting timezones" }),
-    ).toBeInTheDocument();
-  });
-
-  it("does not arm the leader while the caret is in a field", async () => {
+  it("types a bare e in a weekly-hours field", async () => {
     const user = userEvent.setup({ delay: null });
     userMetadataActions.set(healthyGoogleMetadata);
 
@@ -1438,8 +1168,7 @@ describe("BookingSettingsSection", () => {
     expect(within(save).getByText("Enter")).toBeInTheDocument();
 
     const durationLabel = screen.getByText("Duration");
-    expect(within(durationLabel).queryByText("D")).not.toBeInTheDocument();
-    expect(within(durationLabel).queryByText("E")).not.toBeInTheDocument();
+    expect(within(durationLabel).queryByText("5")).not.toBeInTheDocument();
   });
 
   it("copies the booking link after a save that returns one", async () => {
@@ -2293,8 +2022,7 @@ describe("BookingSettingsSection", () => {
     ).toBeInTheDocument();
   });
 
-  it("keeps More options closed by default and opens it on e then w", async () => {
-    const user = userEvent.setup({ delay: null });
+  it("keeps More options closed by default", async () => {
     userMetadataActions.set(healthyGoogleMetadata);
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
@@ -2315,12 +2043,6 @@ describe("BookingSettingsSection", () => {
     const details = summary.closest("details");
     expect(details).not.toBeNull();
     expect(details).not.toHaveAttribute("open");
-
-    await user.keyboard("e");
-    await user.keyboard("w");
-
-    expect(details).toHaveAttribute("open");
-    expect(document.activeElement).toBe(screen.getByLabelText("Welcome text"));
   });
 
   it("opens More options when a field inside the collapsed group becomes invalid", async () => {
@@ -2394,28 +2116,6 @@ describe("BookingSettingsSection", () => {
         screen.getByRole("combobox", { name: "Destination calendar" }),
       );
     });
-  });
-});
-
-describe("BOOKING_SEQUENCE_FIELDS", () => {
-  it("assigns every field a unique key", () => {
-    const keys = BOOKING_SEQUENCE_FIELDS.map((entry) => entry.key);
-    expect(new Set(keys).size).toBe(keys.length);
-  });
-
-  it("leaves Settings' own booking-page keys alone", () => {
-    // Save is Mod+Enter; `s` stays free so it can type in hours and welcome.
-    // Digits are Settings nav.
-    const keys = BOOKING_SEQUENCE_FIELDS.map((entry) => entry.key);
-    expect(keys).not.toContain("s");
-    for (const key of keys) expect(key).not.toMatch(/^\d$/);
-  });
-
-  it("maps every key back to its field", () => {
-    for (const { key, field } of BOOKING_SEQUENCE_FIELDS) {
-      expect(BOOKING_FIELD_BY_KEY[key]).toBe(field);
-      expect(bookingFieldKey(field)).toBe(key);
-    }
   });
 });
 

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -63,9 +63,7 @@ import {
   resolveBookingConference,
 } from "@web/booking/booking-conference.copy";
 import {
-  BOOKING_FIELD_BY_KEY,
-  BOOKING_SEQUENCE_FIELDS,
-  type BookingSequenceField,
+  type BookingField,
   bookingFieldAttrs,
   bookingJumpKeys,
   focusBookingField,
@@ -80,24 +78,12 @@ import { getLocalCalendarSentinelId } from "@web/calendars/local-calendar.sentin
 import { useConnectedAccountEmails } from "@web/calendars/useDefaultTargetCalendar";
 import { copyText } from "@web/common/utils/clipboard/clipboard.util";
 import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
-import { EditSequenceMenu } from "@web/shortcuts/edit-sequence/EditSequenceMenu";
-import { ShortcutTipParts } from "@web/shortcuts/tips/ShortcutTipParts";
-import { type ShortcutTipPart } from "@web/shortcuts/tips/shortcut-tips.data";
-import { useEditSequenceShortcut } from "@web/shortcuts/useEditSequenceShortcut";
 import { useEffectiveTimeZone } from "@web/timezone/effective-timezone.store";
 import { DiscardUnsavedChangesDialog } from "@web/views/Forms/EventForm/DiscardUnsavedChangesDialog";
 
 const DURATION_OPTIONS: BookingDurationMinutes[] = [15, 30, 45, 60];
 
-export const BOOKING_SETTINGS_HINT_PARTS: readonly ShortcutTipPart[] = [
-  "Press ",
-  { keys: ["Mod", "E"] },
-  " then a letter to jump to a field. ",
-  { keys: ["Mod", "Enter"] },
-  " saves.",
-];
-
-const MORE_OPTIONS_FIELDS = new Set<BookingSequenceField>([
+const MORE_OPTIONS_FIELDS = new Set<BookingField>([
   "blocking",
   "welcome",
   "notice",
@@ -276,7 +262,7 @@ export function BookingSettingsSection({
   );
   const [saveError, setSaveError] = useState<{
     message: string;
-    field?: BookingSequenceField;
+    field?: BookingField;
   } | null>(null);
   const [areHoursValid, setAreHoursValid] = useState(true);
   const [minNoticeText, setMinNoticeText] = useState(() =>
@@ -301,28 +287,6 @@ export function BookingSettingsSection({
     parseBookingCount(minNoticeText, MIN_NOTICE_BOUNDS) === null;
   const horizonInvalid =
     parseBookingCount(horizonText, HORIZON_BOUNDS) === null;
-
-  // ignoreAppLock because the Settings modal itself holds the lock, the same
-  // reason useSettingsShortcuts sets it. Scoped to "booking" so the which-key
-  // menu cannot appear over the grid, and so the grid's still-mounted listener
-  // cannot disarm this sequence on the follow key.
-  //
-  // Stand down when focus is in a nested dialog (the timezone OverlayPanel):
-  // that panel also holds app-lock, and ignoreAppLock would otherwise arm
-  // Mod+E inside it and jump to a field behind the dialog.
-  useEditSequenceShortcut({
-    canArm: () => {
-      const active = document.activeElement;
-      if (!(active instanceof HTMLElement)) return true;
-      const closestDialog = active.closest("[role='dialog']");
-      const settingsDialog = sectionRef.current?.closest("[role='dialog']");
-      return closestDialog == null || closestDialog === settingsDialog;
-    },
-    fieldByKey: BOOKING_FIELD_BY_KEY,
-    ignoreAppLock: true,
-    onSequence: focusBookingField,
-    scope: "booking",
-  });
 
   // Re-seed only when the server actually answers with a different page.
   // Keying the effect on writableCalendars/effectiveTimeZone as well meant a
@@ -514,11 +478,11 @@ export function BookingSettingsSection({
             wasLive
               ? {
                   onCopy: "Saved. Meeting link copied.",
-                  onFail: "Saved. Press e then l to copy your link.",
+                  onFail: "Saved. Press Mod U to copy your link.",
                 }
               : {
                   onCopy: "Your meeting page is live. Link copied.",
-                  onFail: "Live. Press e then l to copy your link.",
+                  onFail: "Live. Press Mod U to copy your link.",
                 },
           );
         },
@@ -539,14 +503,11 @@ export function BookingSettingsSection({
         disabled={isReadOnly || saveMutation.isPending}
         ref={sectionRef}
       >
-        <p className="text-text-muted text-xs">
-          <ShortcutTipParts parts={BOOKING_SETTINGS_HINT_PARTS} />
-        </p>
-
         <BookingStatusHeader
           addressPreview={addressPreview}
           bookingUrl={savedPage?.bookingUrl ?? null}
           isLive={isLive}
+          showShortcuts={showShortcuts}
         />
 
         <BookingAddressField
@@ -769,13 +730,7 @@ export function BookingSettingsSection({
           isLive={isLive}
           isPending={saveMutation.isPending}
           onSubmit={submit}
-        />
-
-        <EditSequenceMenu
-          getAnchor={() => sectionRef.current}
-          options={BOOKING_SEQUENCE_FIELDS}
-          prompt="Jump to which field?"
-          scope="booking"
+          showShortcuts={showShortcuts}
         />
       </fieldset>
       <DiscardUnsavedChangesDialog

--- a/packages/web/src/booking/BookingStatusHeader.tsx
+++ b/packages/web/src/booking/BookingStatusHeader.tsx
@@ -1,16 +1,17 @@
 import { BookingCopyLink } from "@web/booking/BookingCopyLink";
-import { bookingFieldAttrs } from "@web/booking/booking-sequence.fields";
 
 interface BookingStatusHeaderProps {
   isLive: boolean;
   bookingUrl: string | null;
   addressPreview: string | null;
+  showShortcuts?: boolean;
 }
 
 export function BookingStatusHeader({
   isLive,
   bookingUrl,
   addressPreview,
+  showShortcuts = false,
 }: BookingStatusHeaderProps) {
   if (isLive) {
     return (
@@ -19,9 +20,10 @@ export function BookingStatusHeader({
           Your meeting page is live
         </p>
         {bookingUrl ? (
-          <div {...bookingFieldAttrs("link")}>
-            <BookingCopyLink bookingUrl={bookingUrl} />
-          </div>
+          <BookingCopyLink
+            bookingUrl={bookingUrl}
+            showShortcuts={showShortcuts}
+          />
         ) : null}
       </div>
     );

--- a/packages/web/src/booking/booking-sequence.fields.test.ts
+++ b/packages/web/src/booking/booking-sequence.fields.test.ts
@@ -59,8 +59,9 @@ describe("BOOKING_SECTION_CHORDS", () => {
       /^[a-z]$/.test(chord.key),
     ).map((chord) => chord.key);
     expect(letters.length).toBeGreaterThan(0);
+    const pool: readonly string[] = SETTINGS_MOD_LETTER_POOL;
     for (const letter of letters) {
-      expect(SETTINGS_MOD_LETTER_POOL).toContain(letter);
+      expect(pool).toContain(letter);
       expect(EXCLUDED_LETTERS.has(letter)).toBe(false);
     }
   });

--- a/packages/web/src/booking/booking-sequence.fields.test.ts
+++ b/packages/web/src/booking/booking-sequence.fields.test.ts
@@ -1,0 +1,136 @@
+import {
+  BOOKING_FIELDS,
+  BOOKING_SECTION_CHORDS,
+  bookingChordForEvent,
+  dispatchBookingChord,
+  SETTINGS_MOD_LETTER_POOL,
+} from "@web/booking/booking-sequence.fields";
+import { afterEach, describe, expect, test } from "bun:test";
+
+const EXCLUDED_LETTERS = new Set([
+  "a",
+  "c",
+  "v",
+  "x",
+  "z",
+  "f",
+  "g",
+  "h",
+  "m",
+  "q",
+  "n",
+  "t",
+  "w",
+  "l",
+  "r",
+  "p",
+  "s",
+  "d",
+  "k",
+  "e",
+  ",",
+]);
+
+const chordFor = (field: (typeof BOOKING_SECTION_CHORDS)[number]["field"]) => {
+  const chord = BOOKING_SECTION_CHORDS.find((entry) => entry.field === field);
+  if (!chord) throw new Error(`missing chord for ${field}`);
+  return chord;
+};
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe("BOOKING_SECTION_CHORDS", () => {
+  test("each chord has a unique key", () => {
+    const keys = BOOKING_SECTION_CHORDS.map((chord) => chord.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  test("digit chords are only 4 through 9", () => {
+    const digits = BOOKING_SECTION_CHORDS.filter((chord) =>
+      /^\d$/.test(chord.key),
+    ).map((chord) => Number(chord.key));
+    expect(digits).toEqual([4, 5, 6, 7, 8, 9]);
+  });
+
+  test("letter chords come from SETTINGS_MOD_LETTER_POOL and skip excluded letters", () => {
+    const letters = BOOKING_SECTION_CHORDS.filter((chord) =>
+      /^[a-z]$/.test(chord.key),
+    ).map((chord) => chord.key);
+    expect(letters.length).toBeGreaterThan(0);
+    for (const letter of letters) {
+      expect(SETTINGS_MOD_LETTER_POOL).toContain(letter);
+      expect(EXCLUDED_LETTERS.has(letter)).toBe(false);
+    }
+  });
+
+  test("BOOKING_FIELDS keeps a unique id for every save-error anchor", () => {
+    expect(new Set(BOOKING_FIELDS).size).toBe(BOOKING_FIELDS.length);
+  });
+});
+
+describe("bookingChordForEvent", () => {
+  test("Digit4 maps to enabled", () => {
+    expect(bookingChordForEvent({ code: "Digit4", key: "4" })?.field).toBe(
+      "enabled",
+    );
+  });
+
+  test("KeyU and lowercase u map to link", () => {
+    expect(bookingChordForEvent({ code: "KeyU", key: "u" })?.field).toBe(
+      "link",
+    );
+    expect(bookingChordForEvent({ code: "KeyU", key: "U" })?.field).toBe(
+      "link",
+    );
+  });
+
+  test("unmapped digits and letters return null", () => {
+    expect(bookingChordForEvent({ code: "Digit1", key: "1" })).toBeNull();
+    expect(bookingChordForEvent({ code: "KeyA", key: "a" })).toBeNull();
+  });
+});
+
+describe("dispatchBookingChord", () => {
+  test("focuses the matching field", () => {
+    const input = document.createElement("input");
+    input.setAttribute("data-booking-field", "duration");
+    document.body.append(input);
+
+    expect(dispatchBookingChord(chordFor("duration"))).toBe(true);
+    expect(document.activeElement).toBe(input);
+  });
+
+  test("clicks the link button", () => {
+    const button = document.createElement("button");
+    button.setAttribute("data-booking-field", "link");
+    let clicked = false;
+    button.addEventListener("click", () => {
+      clicked = true;
+    });
+    document.body.append(button);
+
+    expect(dispatchBookingChord(chordFor("link"))).toBe(true);
+    expect(document.activeElement).toBe(button);
+    expect(clicked).toBe(true);
+  });
+
+  test("consumes the chord when a foreign dialog is open", () => {
+    const dialog = document.createElement("div");
+    dialog.setAttribute("role", "dialog");
+    const inner = document.createElement("input");
+    dialog.append(inner);
+    const target = document.createElement("input");
+    target.setAttribute("data-booking-field", "duration");
+    document.body.append(dialog, target);
+    inner.focus();
+
+    expect(dispatchBookingChord(chordFor("duration"))).toBe(true);
+    expect(document.activeElement).toBe(inner);
+  });
+
+  test("returns false when the field is missing", () => {
+    expect(dispatchBookingChord(chordFor("duration"))).toBe(false);
+  });
+});

--- a/packages/web/src/booking/booking-sequence.fields.ts
+++ b/packages/web/src/booking/booking-sequence.fields.ts
@@ -1,61 +1,85 @@
+import {
+  PICK_KEY_LABELS,
+  physicalDigitIndex,
+} from "@web/shortcuts/digit-pick.util";
+import { normalizedKeyboardKey } from "@web/shortcuts/is-bare-letter-key";
+
 /**
- * The one source of truth for the booking form's `e`-leader sequences: the
- * dispatch map, the which-key menu, the hold-Mod chips beside each label, and
- * the shortcuts-legend row all derive from this list, so behavior and
- * documentation cannot drift apart.
+ * Hold-Mod chords for Meeting settings sections. Nav already owns 1/2/3.
+ * Save stays Mod+Enter on Settings. Fields inside More options have no chord.
  *
- * Data-only on purpose, mirroring edit-sequence.fields.ts.
- *
- * `s` is deliberately absent so it can type in hours and welcome fields.
- * Save is Mod+Enter, owned by Settings. Digits are unavailable too - Settings
- * nav owns 1/2/3 - which is why this surface reuses the letter leader rather
- * than the event form's Mod+digit jump.
+ * Letter pool exclusions: editing (A C V X Z), find (F G), OS level (H M Q),
+ * browser owned (N T W L), risky (R P S D), app owned (K palette, E edit
+ * leader, comma settings).
  */
-export const BOOKING_SEQUENCE_FIELDS = [
-  { key: "e", field: "enabled", label: "Meeting page on or off" },
-  { key: "a", field: "address", label: "Page address" },
-  { key: "d", field: "duration", label: "Duration" },
-  { key: "c", field: "destination", label: "Destination calendar" },
-  { key: "b", field: "blocking", label: "Blocking calendars" },
-  { key: "z", field: "timezone", label: "Meeting timezone" },
-  { key: "h", field: "hours", label: "Weekly hours" },
-  { key: "m", field: "more", label: "More options" },
-  { key: "w", field: "welcome", label: "Welcome text" },
-  { key: "n", field: "notice", label: "Minimum notice" },
-  { key: "x", field: "horizon", label: "Maximum horizon" },
-  { key: "o", field: "options", label: "Buffer and limits" },
-  { key: "l", field: "link", label: "Meeting link" },
-] as const satisfies readonly {
-  key: string;
-  field: string;
-  label: string;
-}[];
+export const SETTINGS_MOD_LETTER_POOL = ["u", "i", "j", "y", "b", "o"] as const;
 
-export type BookingSequenceField =
-  (typeof BOOKING_SEQUENCE_FIELDS)[number]["field"];
+export const BOOKING_SECTION_CHORDS = [
+  { key: "4", field: "enabled", label: "Meeting page on or off" },
+  { key: "5", field: "duration", label: "Duration" },
+  { key: "6", field: "timezone", label: "Timezone" },
+  { key: "7", field: "hours", label: "Weekly hours" },
+  { key: "8", field: "destination", label: "Destination calendar" },
+  { key: "9", field: "more", label: "More options" },
+  { key: "u", field: "link", label: "Copy link", activate: true },
+] as const;
 
-/** Second key -> booking field, for dispatch. */
-export const BOOKING_FIELD_BY_KEY = Object.fromEntries(
-  BOOKING_SEQUENCE_FIELDS.map(({ key, field }) => [key, field]),
-) as Record<string, BookingSequenceField>;
+export type BookingSectionChord = (typeof BOOKING_SECTION_CHORDS)[number];
+
+/** Every `data-booking-field` anchor, including More-options fields with no chord. */
+export const BOOKING_FIELDS = [
+  "enabled",
+  "address",
+  "duration",
+  "destination",
+  "blocking",
+  "timezone",
+  "hours",
+  "more",
+  "welcome",
+  "notice",
+  "horizon",
+  "options",
+  "link",
+] as const;
+
+export type BookingField = (typeof BOOKING_FIELDS)[number];
 
 export const BOOKING_FIELD_ATTR = "data-booking-field";
 
-export const bookingFieldAttrs = (field: BookingSequenceField) =>
+export const bookingFieldAttrs = (field: BookingField) =>
   ({ [BOOKING_FIELD_ATTR]: field }) as const;
 
-/** The key a given field answers to, for rendering a chip beside its label. */
-export const bookingFieldKey = (field: BookingSequenceField): string =>
-  BOOKING_SEQUENCE_FIELDS.find((entry) => entry.field === field)?.key ?? "";
+const chordForField = (field: BookingField): BookingSectionChord | undefined =>
+  BOOKING_SECTION_CHORDS.find((entry) => entry.field === field);
 
-/** Hold-Mod chips for a field: leader then the field's letter. */
-export const bookingJumpKeys = (field: BookingSequenceField): string[] => [
-  "e",
-  bookingFieldKey(field),
-];
+/** Hold-Mod chip for a section, or nothing when the field has no chord. */
+export const bookingJumpKeys = (field: BookingField): string[] => {
+  const chord = chordForField(field);
+  return chord ? [chord.key] : [];
+};
+
+export function bookingChordForEvent(
+  event: Pick<KeyboardEvent, "code" | "key">,
+): BookingSectionChord | null {
+  const digit = physicalDigitIndex(event);
+  const key =
+    digit !== null
+      ? (PICK_KEY_LABELS[digit] ?? null)
+      : normalizedKeyboardKey(event);
+  if (!key) return null;
+  return BOOKING_SECTION_CHORDS.find((chord) => chord.key === key) ?? null;
+}
 
 const FOCUSABLE =
   'input, select, textarea, button, summary, [role="combobox"], [tabindex]:not([tabindex="-1"])';
+
+const enclosingDialog = (node: Element | null): HTMLElement | null =>
+  node instanceof HTMLElement ? node.closest("[role='dialog']") : null;
+
+const isDisabledAnchor = (anchor: HTMLElement): boolean =>
+  anchor.hasAttribute("disabled") ||
+  ("disabled" in anchor && Boolean(anchor.disabled));
 
 /**
  * Focus a booking field by data attribute rather than a selector map.
@@ -63,7 +87,7 @@ const FOCUSABLE =
  * Focus, never click: several of these targets are checkboxes, and the
  * Settings idiom's focus-then-click would toggle them on the way past.
  */
-export function focusBookingField(field: BookingSequenceField): boolean {
+export function focusBookingField(field: BookingField): boolean {
   const anchor = document.querySelector<HTMLElement>(
     `[${BOOKING_FIELD_ATTR}="${field}"]`,
   );
@@ -82,4 +106,26 @@ export function focusBookingField(field: BookingSequenceField): boolean {
 
   target.focus();
   return true;
+}
+
+export function dispatchBookingChord(chord: BookingSectionChord): boolean {
+  const anchor = document.querySelector<HTMLElement>(
+    `[${BOOKING_FIELD_ATTR}="${chord.field}"]`,
+  );
+  if (!anchor) return false;
+  if (isDisabledAnchor(anchor)) return false;
+
+  const activeDialog = enclosingDialog(document.activeElement);
+  const anchorDialog = enclosingDialog(anchor);
+  if (activeDialog && activeDialog !== anchorDialog) {
+    return true;
+  }
+
+  if ("activate" in chord && chord.activate) {
+    anchor.focus({ preventScroll: true });
+    anchor.click();
+    return true;
+  }
+
+  return focusBookingField(chord.field);
 }

--- a/packages/web/src/booking/booking.query.ts
+++ b/packages/web/src/booking/booking.query.ts
@@ -14,7 +14,7 @@ import { BookingApi } from "@web/api/booking.api";
 import { getApiErrorCode, isApiError } from "@web/api/util/api.util";
 import { billingQueryKeys } from "@web/billing/billing.query";
 import { billingPreviewActions } from "@web/billing/billing-preview.store";
-import { type BookingSequenceField } from "@web/booking/booking-sequence.fields";
+import { type BookingField } from "@web/booking/booking-sequence.fields";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 
 export const bookingQueryKeys = {
@@ -49,7 +49,7 @@ export const BOOKING_SAVE_ERROR_COPY: Record<string, string> = {
     "Some settings couldn't be saved. Check the highlighted fields and try again.",
 };
 
-const INLINE_SAVE_ERROR_FIELDS: Record<string, BookingSequenceField> = {
+const INLINE_SAVE_ERROR_FIELDS: Record<string, BookingField> = {
   TIMEZONE_REQUIRED: "timezone",
   DESTINATION_NOT_WRITABLE: "destination",
   BLOCKING_CALENDAR_INVALID: "blocking",
@@ -59,7 +59,7 @@ const INLINE_SAVE_ERROR_FIELDS: Record<string, BookingSequenceField> = {
 
 export function bookingSaveErrorInline(
   error: unknown,
-): { message: string; field?: BookingSequenceField } | null {
+): { message: string; field?: BookingField } | null {
   if (!isApiError(error)) return null;
   const code = getApiErrorCode(error);
   if (!code) return null;

--- a/packages/web/src/booking/booking.util.ts
+++ b/packages/web/src/booking/booking.util.ts
@@ -8,7 +8,7 @@ import {
 } from "@core/types/booking.contracts";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
-import { type BookingSequenceField } from "@web/booking/booking-sequence.fields";
+import { type BookingField } from "@web/booking/booking-sequence.fields";
 import { getLocalCalendar } from "@web/calendars/calendar.util";
 
 export function getAvailabilityReadableCalendars(
@@ -177,7 +177,7 @@ export function bookingSlugParseMessage(
 
 export type BookingFormValidationError = {
   message: string;
-  field?: BookingSequenceField;
+  field?: BookingField;
 };
 
 export function validateBookingForm({

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -10,6 +10,7 @@ import { server } from "@web/__tests__/__mocks__/server/mock.server";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
 import { createMockCalendar } from "@web/__tests__/utils/factories/calendar.factory";
+import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
 import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
 import { AuthApi } from "@web/api/auth.api";
 import {
@@ -1226,7 +1227,11 @@ describe("SettingsModal", () => {
       expect(
         within(linkRow).getByText("U", { exact: true }),
       ).toBeInTheDocument();
-      await user.keyboard(`u{/${modKey}}`);
+      const modInit: KeyboardEventInit =
+        resolveModifier("Mod") === "Meta"
+          ? { metaKey: true, code: "KeyU" }
+          : { ctrlKey: true, code: "KeyU" };
+      pressKey("u", { keyDownInit: modInit, keyUpInit: modInit });
 
       await waitFor(() => {
         expect(writeText).toHaveBeenCalledWith(bookingUrl);

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -1,9 +1,12 @@
 import { HotkeysProvider, resolveModifier } from "@tanstack/react-hotkeys";
 import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { rest } from "msw";
+import { DEFAULT_WEEKLY_AVAILABILITY } from "@core/types/booking.contracts";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import dayjs from "@core/util/date/dayjs";
+import { server } from "@web/__tests__/__mocks__/server/mock.server";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
 import { createMockCalendar } from "@web/__tests__/utils/factories/calendar.factory";
@@ -16,14 +19,17 @@ import {
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import { UpgradeConfirmationProvider } from "@web/billing/UpgradeConfirmation/UpgradeConfirmationProvider";
 import { type AppAccess } from "@web/billing/useAppAccess";
+import { BOOKING_MORE_OPTIONS_LABEL } from "@web/booking/BookingMoreOptions";
 import { BOOKING_TURN_ON_LABEL } from "@web/booking/BookingSaveBar";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
+import { ENV_WEB } from "@web/common/constants/env.constants";
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import {
   ACCOUNT_DISCONNECTED_TOAST_ID,
   GOOGLE_REVOKED_TOAST_ID,
 } from "@web/common/constants/toast.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import {
   registerToastPort,
   resetToastPort,
@@ -34,6 +40,7 @@ import {
   settingsActions,
   useSettingsStore,
 } from "@web/settings/settings.store";
+import { getPartsPlainText } from "@web/shortcuts/tips/shortcut-tips.data";
 import * as realUsessedegraded from "@web/sse/hooks/useSseDegraded";
 import {
   afterAll,
@@ -129,7 +136,7 @@ const settingsModalUrl = new URL(
   `./SettingsModal.tsx?test=${Math.random().toString(36).slice(2)}`,
   import.meta.url,
 );
-const { SettingsModal } = (await import(
+const { SettingsModal, SETTINGS_HOLD_MOD_HINT_PARTS } = (await import(
   settingsModalUrl.href
 )) as typeof import("./SettingsModal");
 
@@ -686,7 +693,7 @@ describe("SettingsModal", () => {
     "accounts",
     "billing",
     "booking",
-  ] as const)("tells the host to click a page on the %s screen", (page) => {
+  ] as const)("tells the host to hold Mod on the %s screen", (page) => {
     access = {
       kind: "server",
       status: "active",
@@ -697,7 +704,7 @@ describe("SettingsModal", () => {
 
     expect(
       within(screen.getByRole("dialog", { name: "Settings" })).getByText(
-        "Click a page or press its number.",
+        getPartsPlainText(SETTINGS_HOLD_MOD_HINT_PARTS),
       ),
     ).toBeInTheDocument();
   });
@@ -898,6 +905,9 @@ describe("SettingsModal", () => {
       within(screen.getByRole("button", { name: "Accounts" })).queryByText("1"),
     ).toBeNull();
 
+    const hint = getPartsPlainText(SETTINGS_HOLD_MOD_HINT_PARTS);
+    expect(screen.getByText(hint)).toBeInTheDocument();
+
     const modKey = resolveModifier("Mod") === "Meta" ? "Meta" : "Control";
     await user.keyboard(`{${modKey}>}`);
     expect(
@@ -906,11 +916,13 @@ describe("SettingsModal", () => {
     expect(
       within(screen.getByRole("button", { name: "Billing" })).getByText("2"),
     ).toBeInTheDocument();
+    expect(screen.queryByText(hint)).toBeNull();
 
     await user.keyboard(`{/${modKey}}`);
     expect(
       within(screen.getByRole("button", { name: "Accounts" })).queryByText("1"),
     ).toBeNull();
+    expect(screen.getByText(hint)).toBeInTheDocument();
   });
 
   it("opens the upgrade confirmation with B while Settings is open", async () => {
@@ -1076,7 +1088,7 @@ describe("SettingsModal", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("disarms the e leader on Escape without closing Booking Settings", async () => {
+  it("reveals meeting section chips 4 through 9 while Mod is held", async () => {
     const user = userEvent.setup({ delay: null });
     const calendar = createMockCalendar({ name: "Work" });
     renderSettings({
@@ -1086,17 +1098,175 @@ describe("SettingsModal", () => {
     });
 
     await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
-    await user.keyboard("e");
-    await user.keyboard("{Escape}");
+    const modKey = resolveModifier("Mod") === "Meta" ? "Meta" : "Control";
+    await user.keyboard(`{${modKey}>}`);
 
+    const settings = screen.getByRole("dialog", { name: "Settings" });
     expect(
-      screen.queryByRole("dialog", { name: "Discard unsaved changes?" }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.getByRole("dialog", { name: "Settings" }),
+      within(
+        screen.getByRole("button", { name: BOOKING_TURN_ON_LABEL }),
+      ).getByText("4", { exact: true }),
     ).toBeInTheDocument();
+    expect(
+      within(screen.getByText("Duration")).getByText("5", { exact: true }),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByText("Meeting timezone")).getByText("6", {
+        exact: true,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByText("Weekly hours")).getByText("7", { exact: true }),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByText("Destination calendar")).getByText("8", {
+        exact: true,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByText(BOOKING_MORE_OPTIONS_LABEL)).getByText("9", {
+        exact: true,
+      }),
+    ).toBeInTheDocument();
+    expect(within(settings).queryByText("U", { exact: true })).toBeNull();
 
-    await user.keyboard("h");
-    expect(document.activeElement).not.toBe(screen.getByLabelText("Monday"));
+    await user.keyboard(`{/${modKey}}`);
+  });
+
+  it("jumps to Duration with Mod+5", async () => {
+    const user = userEvent.setup({ delay: null });
+    const calendar = createMockCalendar({ name: "Work" });
+    renderSettings({
+      authenticated: true,
+      calendars: [calendar],
+      page: "booking",
+    });
+
+    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
+    const modKey = resolveModifier("Mod") === "Meta" ? "Meta" : "Control";
+    await user.keyboard(`{${modKey}>}5{/${modKey}}`);
+
+    expect(screen.getByLabelText("Duration")).toHaveFocus();
+  });
+
+  it("opens More options with Mod+9 and focuses the first control", async () => {
+    const user = userEvent.setup({ delay: null });
+    const calendar = createMockCalendar({ name: "Work" });
+    renderSettings({
+      authenticated: true,
+      calendars: [calendar],
+      page: "booking",
+    });
+
+    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
+    const summary = screen.getByText(BOOKING_MORE_OPTIONS_LABEL);
+    const details = summary.closest("details");
+    expect(details).not.toHaveAttribute("open");
+
+    const modKey = resolveModifier("Mod") === "Meta" ? "Meta" : "Control";
+    await user.keyboard(`{${modKey}>}9{/${modKey}}`);
+
+    expect(details).toHaveAttribute("open");
+    expect(screen.getByRole("checkbox", { name: "Work" })).toHaveFocus();
+  });
+
+  it("copies the meeting link with Mod+U", async () => {
+    const user = userEvent.setup({ delay: null });
+    const calendar = createMockCalendar({ name: "Work" });
+    const bookingUrl = "https://compasscalendar.com/meet/hostuser";
+    const writeText = mock(() => Promise.resolve());
+    const originalClipboard = navigator.clipboard;
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    const { port, mocks } = createTestToastPort();
+    registerToastPort(port);
+
+    server.use(
+      rest.get(`${ENV_WEB.API_BASEURL}/booking/page`, (_req, res, ctx) =>
+        res(
+          ctx.json({
+            id: createObjectIdString(),
+            slug: "hostuser",
+            hostUserId: createObjectIdString(),
+            enabled: true,
+            durationMinutes: 30,
+            destinationCalendarId: calendar.id,
+            blockingCalendarIds: [calendar.id],
+            timeZone: "America/New_York",
+            weeklyAvailability: DEFAULT_WEEKLY_AVAILABILITY,
+            minNoticeHours: 4,
+            maxHorizonDays: 60,
+            bufferMinutes: null,
+            maxBookingsPerDay: null,
+            guestsCanInviteOthers: true,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            bookingUrl,
+          }),
+        ),
+      ),
+    );
+
+    try {
+      renderSettings({
+        authenticated: true,
+        calendars: [calendar],
+        page: "booking",
+      });
+
+      await screen.findByRole("button", { name: "Copy meeting link" });
+      const modKey = resolveModifier("Mod") === "Meta" ? "Meta" : "Control";
+      await user.keyboard(`{${modKey}>}`);
+      expect(
+        within(
+          screen.getByRole("textbox", { name: "Meeting link" }).parentElement
+            as HTMLElement,
+        ).getByText("U", { exact: true }),
+      ).toBeInTheDocument();
+      await user.keyboard(`u{/${modKey}}`);
+
+      await waitFor(() => {
+        expect(writeText).toHaveBeenCalledWith(bookingUrl);
+      });
+      expect(mocks.toast).toHaveBeenCalledWith(
+        "Meeting link copied",
+        expect.any(Object),
+      );
+    } finally {
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: originalClipboard,
+      });
+      resetToastPort();
+    }
+  });
+
+  it("does not jump behind an open timezone panel with Mod+5", async () => {
+    const user = userEvent.setup({ delay: null });
+    const calendar = createMockCalendar({ name: "Work" });
+    renderSettings({
+      authenticated: true,
+      calendars: [calendar],
+      page: "booking",
+    });
+
+    await screen.findByRole("button", { name: BOOKING_TURN_ON_LABEL });
+    await user.click(
+      screen.getByRole("button", { name: /^Meeting timezone:/ }),
+    );
+    const search = await screen.findByRole("combobox", {
+      name: "Search meeting timezones",
+    });
+    await waitFor(() => expect(search).toHaveFocus());
+
+    const modKey = resolveModifier("Mod") === "Meta" ? "Meta" : "Control";
+    await user.keyboard(`{${modKey}>}5{/${modKey}}`);
+
+    expect(search).toHaveFocus();
+    expect(
+      screen.getByRole("combobox", { name: "Search meeting timezones" }),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -1174,11 +1174,10 @@ describe("SettingsModal", () => {
     const user = userEvent.setup({ delay: null });
     const calendar = createMockCalendar({ name: "Work" });
     const bookingUrl = "https://compasscalendar.com/meet/hostuser";
-    const writeText = mock(() => Promise.resolve());
     const originalClipboard = navigator.clipboard;
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
-      value: { writeText },
+      value: { writeText: mock(() => Promise.resolve()) },
     });
     const { port, mocks } = createTestToastPort();
     registerToastPort(port);
@@ -1221,12 +1220,11 @@ describe("SettingsModal", () => {
       await user.keyboard(`{${modKey}>}u{/${modKey}}`);
 
       await waitFor(() => {
-        expect(writeText).toHaveBeenCalledWith(bookingUrl);
+        expect(mocks.toast).toHaveBeenCalledWith(
+          "Meeting link copied",
+          expect.any(Object),
+        );
       });
-      expect(mocks.toast).toHaveBeenCalledWith(
-        "Meeting link copied",
-        expect.any(Object),
-      );
 
       await user.keyboard(`{${modKey}>}`);
       const linkRow = screen.getByRole("textbox", {

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -10,7 +10,6 @@ import { server } from "@web/__tests__/__mocks__/server/mock.server";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
 import { createMockCalendar } from "@web/__tests__/utils/factories/calendar.factory";
-import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
 import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
 import { AuthApi } from "@web/api/auth.api";
 import {
@@ -1219,19 +1218,7 @@ describe("SettingsModal", () => {
 
       await screen.findByRole("button", { name: "Copy meeting link" });
       const modKey = resolveModifier("Mod") === "Meta" ? "Meta" : "Control";
-      await user.keyboard(`{${modKey}>}`);
-      const linkRow = screen.getByRole("textbox", {
-        name: "Meeting link",
-      }).parentElement;
-      if (!linkRow) throw new Error("missing meeting link row");
-      expect(
-        within(linkRow).getByText("U", { exact: true }),
-      ).toBeInTheDocument();
-      const modInit: KeyboardEventInit =
-        resolveModifier("Mod") === "Meta"
-          ? { metaKey: true, code: "KeyU" }
-          : { ctrlKey: true, code: "KeyU" };
-      pressKey("u", { keyDownInit: modInit, keyUpInit: modInit });
+      await user.keyboard(`{${modKey}>}u{/${modKey}}`);
 
       await waitFor(() => {
         expect(writeText).toHaveBeenCalledWith(bookingUrl);
@@ -1240,6 +1227,16 @@ describe("SettingsModal", () => {
         "Meeting link copied",
         expect.any(Object),
       );
+
+      await user.keyboard(`{${modKey}>}`);
+      const linkRow = screen.getByRole("textbox", {
+        name: "Meeting link",
+      }).parentElement;
+      if (!linkRow) throw new Error("missing meeting link row");
+      expect(
+        within(linkRow).getByText("U", { exact: true }),
+      ).toBeInTheDocument();
+      await user.keyboard(`{/${modKey}}`);
     } finally {
       Object.defineProperty(navigator, "clipboard", {
         configurable: true,

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -1219,11 +1219,12 @@ describe("SettingsModal", () => {
       await screen.findByRole("button", { name: "Copy meeting link" });
       const modKey = resolveModifier("Mod") === "Meta" ? "Meta" : "Control";
       await user.keyboard(`{${modKey}>}`);
+      const linkRow = screen.getByRole("textbox", {
+        name: "Meeting link",
+      }).parentElement;
+      if (!linkRow) throw new Error("missing meeting link row");
       expect(
-        within(
-          screen.getByRole("textbox", { name: "Meeting link" }).parentElement
-            as HTMLElement,
-        ).getByText("U", { exact: true }),
+        within(linkRow).getByText("U", { exact: true }),
       ).toBeInTheDocument();
       await user.keyboard(`u{/${modKey}}`);
 

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -66,13 +66,19 @@ import {
   useSettingsShortcuts,
 } from "@web/settings/useSettingsShortcuts";
 import { useAppLockReason } from "@web/shortcuts/app-lock";
+import { ShortcutTipParts } from "@web/shortcuts/tips/ShortcutTipParts";
+import { type ShortcutTipPart } from "@web/shortcuts/tips/shortcut-tips.data";
 import { useSseDegraded } from "@web/sse/hooks/useSseDegraded";
 import { DefaultTimezonePicker } from "@web/timezone/DefaultTimezonePicker";
 
 const OUTLINE_BUTTON_CLASSNAME =
   "c-focus-ring shrink-0 rounded border border-border bg-surface-overlay px-2 py-1 text-xs text-text transition-colors hover:bg-surface-panel disabled:pointer-events-none disabled:opacity-60";
 
-const SETTINGS_NAV_HINT = "Click a page or press its number.";
+export const SETTINGS_HOLD_MOD_HINT_PARTS: readonly ShortcutTipPart[] = [
+  "Hold ",
+  { keys: ["Mod"] },
+  " to see shortcuts.",
+];
 
 const navButtonClassName = (current: boolean) =>
   current
@@ -157,8 +163,7 @@ export const SettingsModal: FC = () => {
       setConfirmingId(null);
       return;
     }
-    // Booking form is dirty: ask before dropping the modal. The e-leader
-    // capture-phase Escape never reaches here.
+    // Booking form is dirty: ask before dropping the modal.
     if (bookingDismissGuardRef.current?.()) return;
     dismissToPalette();
   };
@@ -249,9 +254,11 @@ export const SettingsModal: FC = () => {
               {areHintsVisible ? <ShortcutKeys keys="3" /> : null}
             </button>
           ) : null}
-          <p className="mt-2 px-2 text-text-muted text-xs">
-            {SETTINGS_NAV_HINT}
-          </p>
+          {!areHintsVisible ? (
+            <p className="mt-2 px-2 text-text-muted text-xs">
+              <ShortcutTipParts parts={SETTINGS_HOLD_MOD_HINT_PARTS} />
+            </p>
+          ) : null}
         </nav>
         <div className="flex min-w-0 flex-1 flex-col gap-4">
           {page === "billing" ? (

--- a/packages/web/src/settings/useSettingsShortcuts.ts
+++ b/packages/web/src/settings/useSettingsShortcuts.ts
@@ -1,4 +1,8 @@
 import { useEffect } from "react";
+import {
+  bookingChordForEvent,
+  dispatchBookingChord,
+} from "@web/booking/booking-sequence.fields";
 import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
 import { type SettingsPage } from "@web/settings/settings.store";
 import { physicalDigitIndex } from "@web/shortcuts/digit-pick.util";
@@ -93,8 +97,12 @@ export function useSettingsShortcuts({
     ignoreAppLock: true,
     onModChord: (event) => {
       const id = shortcutIdForEvent(event, page, hasBilling, hasBooking);
-      if (!id) return false;
-      return clickSettingsShortcut(id);
+      if (id) return clickSettingsShortcut(id);
+      if (page === "booking") {
+        const chord = bookingChordForEvent(event);
+        return chord ? dispatchBookingChord(chord) : false;
+      }
+      return false;
     },
   });
 

--- a/packages/web/src/shortcuts/edit-sequence/EditSequenceMenu.test.tsx
+++ b/packages/web/src/shortcuts/edit-sequence/EditSequenceMenu.test.tsx
@@ -77,31 +77,4 @@ describe("EditSequenceMenu", () => {
 
     expect(document.querySelector("[data-edit-sequence-menu]")).not.toBeNull();
   });
-
-  it("stays hidden when a different scope is armed", () => {
-    editSequenceActions.arm("booking");
-    editSequenceActions.showMenu();
-    render(<EditSequenceMenu getAnchor={() => null} />);
-
-    expect(document.querySelector("[data-edit-sequence-menu]")).toBeNull();
-  });
-
-  it("renders the supplied rows for its own scope", () => {
-    editSequenceActions.arm("booking");
-    editSequenceActions.showMenu();
-    render(
-      <EditSequenceMenu
-        getAnchor={() => null}
-        options={[{ key: "h", label: "Weekly hours" }]}
-        prompt="Jump to which field?"
-        scope="booking"
-      />,
-    );
-
-    const menu = document.querySelector("[data-edit-sequence-menu]");
-    expect(menu?.textContent).toContain("Weekly hours");
-    expect(menu?.textContent).not.toContain("Title");
-    expect(menu?.textContent).toContain("Jump to which field?");
-    expect(menu?.textContent).not.toContain("Edit which field?");
-  });
 });

--- a/packages/web/src/shortcuts/edit-sequence/EditSequenceMenu.tsx
+++ b/packages/web/src/shortcuts/edit-sequence/EditSequenceMenu.tsx
@@ -11,9 +11,7 @@ import { Z_INDEX_TOOLTIP } from "@web/common/constants/web.constants";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
 import { EDIT_SEQUENCE_LETTER_FIELDS } from "@web/shortcuts/edit-sequence/edit-sequence.fields";
 import {
-  type EditSequenceScope,
   selectEditSequenceMenuVisible,
-  selectEditSequenceScope,
   useEditSequenceStore,
 } from "@web/shortcuts/edit-sequence/edit-sequence.store";
 
@@ -64,20 +62,11 @@ const isOffscreen = (element: HTMLElement) => {
  */
 export function EditSequenceMenu({
   getAnchor,
-  options = EDIT_SEQUENCE_LETTER_FIELDS,
-  prompt = "Edit which field?",
-  scope = "event",
 }: {
   getAnchor: () => HTMLElement | null;
-  /** Defaults to the event form's letter rows. */
-  options?: readonly EditSequenceMenuOption[];
-  prompt?: string;
-  /** Render only while this surface owns the armed sequence. */
-  scope?: EditSequenceScope;
 }) {
   const menuVisible = useEditSequenceStore(selectEditSequenceMenuVisible);
-  const armedScope = useEditSequenceStore(selectEditSequenceScope);
-  const isVisible = menuVisible && armedScope === scope;
+  const isVisible = menuVisible;
   // Read through a ref: the owners rebuild `getAnchor` every render, so using
   // it as an effect dependency would re-seat the reference constantly.
   const getAnchorRef = useRef(getAnchor);
@@ -126,11 +115,15 @@ export function EditSequenceMenu({
         className="rounded border border-border bg-surface-raised p-2 shadow-[0_4px_6px_var(--color-shadow-default)]"
         role="status"
       >
-        <span className="sr-only">{srText(prompt, options)}</span>
+        <span className="sr-only">
+          {srText("Edit which field?", EDIT_SEQUENCE_LETTER_FIELDS)}
+        </span>
         <div aria-hidden className="flex flex-col gap-1">
-          <span className="px-0.5 text-text-muted text-xs">{prompt}</span>
+          <span className="px-0.5 text-text-muted text-xs">
+            Edit which field?
+          </span>
           <div className="grid grid-cols-2 gap-x-2 gap-y-1">
-            {options.map((option) => (
+            {EDIT_SEQUENCE_LETTER_FIELDS.map((option) => (
               <span
                 key={option.key}
                 className="flex items-center gap-1.5 text-text text-xs"

--- a/packages/web/src/shortcuts/edit-sequence/edit-sequence.store.ts
+++ b/packages/web/src/shortcuts/edit-sequence/edit-sequence.store.ts
@@ -3,11 +3,9 @@ import { devtools } from "zustand/middleware";
 import { IS_DEV } from "@web/common/constants/env.constants";
 
 /**
- * Which surface armed the leader. One store rather than one per surface, so a
- * sequence armed in the booking form cannot leave a menu pinned over the grid;
- * the menu renders only for its own scope.
+ * Which surface armed the leader. Booking settings no longer use this store.
  */
-export type EditSequenceScope = "event" | "booking";
+export type EditSequenceScope = "event";
 
 export type EditSequenceState = {
   /** True from the leader keypress until a second key, Escape, or a cancel. */

--- a/packages/web/src/shortcuts/edit-sequence/edit-sequence.store.ts
+++ b/packages/web/src/shortcuts/edit-sequence/edit-sequence.store.ts
@@ -48,6 +48,3 @@ export const editSequenceActions = {
 
 export const selectEditSequenceMenuVisible = (state: EditSequenceState) =>
   state.isMenuVisible;
-
-export const selectEditSequenceScope = (state: EditSequenceState) =>
-  state.scope;

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -445,13 +445,13 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
   },
   // One summary row rather than ten, following the collapsed Mod+E / Mod 0-9
   // rows above. Ungated for the same reason as the edit sequences: the legend
-  // is a reference, not a live-focus readout. The which-key menu carries the
-  // per-field detail in the moment, which matters here because the legend
+  // is a reference, not a live-focus readout. Hold-Mod chips carry the
+  // per-section detail in the moment, which matters here because the legend
   // overlay is unreachable while the Settings modal holds app-lock.
   {
     id: "other-booking-jump",
-    keys: ["e", "letter"],
-    label: "Jump to a meeting settings field",
+    keys: ["Mod", "4-9"],
+    label: "Jump to a meeting settings section",
     section: "other",
   },
   {

--- a/packages/web/src/shortcuts/useEditSequenceShortcut.test.tsx
+++ b/packages/web/src/shortcuts/useEditSequenceShortcut.test.tsx
@@ -337,32 +337,6 @@ describe("useEditSequenceShortcut", () => {
 
       expect(onSequence).toHaveBeenCalledWith("duration");
     });
-
-    it("does not let the event-scope hook disarm a booking sequence under app lock", () => {
-      // The grid listener stays mounted while Settings is open. Both hooks
-      // must live in one render: a second renderHook unmounts the first.
-      // Use a reason SettingsModal does not own: the test wrapper mounts it
-      // closed, which would clear `settingsModal` and let the event hook arm.
-      const onEvent = mock(() => {});
-      const onBooking = mock((_field: string) => {});
-      setAppLockReason("test-lock", true);
-
-      renderHook(() => {
-        useEditSequenceShortcut({ onSequence: onEvent });
-        useEditSequenceShortcut({
-          fieldByKey: { d: "duration" },
-          ignoreAppLock: true,
-          onSequence: onBooking,
-          scope: "booking",
-        });
-      });
-
-      pressKey("e");
-      pressKey("d");
-
-      expect(onBooking).toHaveBeenCalledWith("duration");
-      expect(onEvent).not.toHaveBeenCalled();
-    });
   });
 
   it("ignores KeyboardEvents with no key instead of throwing", () => {

--- a/packages/web/src/shortcuts/useEditSequenceShortcut.ts
+++ b/packages/web/src/shortcuts/useEditSequenceShortcut.ts
@@ -137,9 +137,8 @@ export function useEditSequenceShortcut<
       if (event.defaultPrevented) return;
 
       if (isEditSequenceArmed()) {
-        // Two surfaces share this store (grid event form and booking settings).
-        // The grid listener stays mounted under Settings; without a scope
-        // check it would disarm the booking sequence on the follow key.
+        // The grid listener stays mounted under Settings. Ignore a foreign
+        // scope so a leftover arm from another surface cannot steal keys.
         if (useEditSequenceStore.getState().scope !== scope) {
           return;
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3505

## What and why

Meeting settings no longer uses an `e` leader or which-key menu. Settings shows one hint, Hold Mod to see shortcuts, in the nav column. Holding Mod reveals section chips: Mod+4 through 9 jump to on/off, Duration, Timezone, Weekly hours, Destination calendar, and More options. Mod+U copies the meeting link. Save stays Mod+Enter. Spec: `docs/features/booking.md`. Locked on #3501.

## Verify

`VERDICT: PASS`

Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad52e327-6e23-450a-a5cb-22a43d90c4f6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad52e327-6e23-450a-a5cb-22a43d90c4f6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

