### PR TITLE
feat(sync): store customizations for provider-managed event updates

### DIFF
--- a/packages/sync/src/domain/event-instance-assembly.test.ts
+++ b/packages/sync/src/domain/event-instance-assembly.test.ts
@@ -180,6 +180,20 @@ describe("assembleEventInstances", () => {
     expect(instance && "providerManaged" in instance).toBe(false);
   });
 
+  it("overlays customizations.title onto assembled instance content", () => {
+    const event = makeEvent({
+      content: { ...baseContent, title: "Provider title" },
+      customizations: { title: "Compass title" },
+    });
+    const occurrence = makeOccurrence({ eventId: event._id });
+
+    const [instance] = assembleEventInstances([occurrence], byId(event));
+
+    expect(instance?.content.title).toBe("Compass title");
+    expect(instance?.content.description).toBe(baseContent.description);
+    expect(instance?.content.location).toBe(baseContent.location);
+  });
+
   it("maps a single event to one single row carrying full content", () => {
     const event = makeEvent({ recurrence: { kind: "single" } });
     const occurrence = makeOccurrence({ eventId: event._id });

--- a/packages/sync/src/domain/event-instance-assembly.ts
+++ b/packages/sync/src/domain/event-instance-assembly.ts
@@ -44,7 +44,7 @@ export function assembleEventInstances(
     const event = eventsById.get(occurrence.eventId);
     if (!event) continue;
 
-    const content = toInstanceContent(event.content);
+    const content = toInstanceContent(event);
     const timestamps = {
       createdAt: event.createdAt.toISOString(),
       updatedAt: event.updatedAt.toISOString(),
@@ -120,7 +120,7 @@ export function assembleEventInstances(
       SyncEventInstanceSchema.parse({
         eventId: master._id,
         calendarId: master.calendarId,
-        content: toInstanceContent(master.content),
+        content: toInstanceContent(master),
         schedule: master.schedule,
         recurrence: { kind: "series", rules: master.recurrence.rules },
         createdAt: master.createdAt.toISOString(),
@@ -148,14 +148,20 @@ const toProviderManaged = (event: EventRecord): { providerManaged?: true } => {
     : {};
 };
 
-const toInstanceContent = (content: EventRecord["content"]) => ({
-  title: content.title,
-  description: content.description,
-  location: content.location,
-  organizer: content.organizer,
-  attendees: content.attendees,
-  conference: content.conference,
-  // Heal rows that persisted write-command `color: null`.
-  ...withColor(content.color ?? undefined),
-  ...withColorHex(content.colorHex),
-});
+const toInstanceContent = (event: EventRecord) => {
+  const { content, customizations } = event;
+  return {
+    title: customizations?.title ?? content.title,
+    description: customizations?.description ?? content.description,
+    location:
+      customizations?.location !== undefined
+        ? customizations.location
+        : content.location,
+    organizer: content.organizer,
+    attendees: content.attendees,
+    conference: content.conference,
+    // Heal rows that persisted write-command `color: null`.
+    ...withColor(content.color ?? undefined),
+    ...withColorHex(content.colorHex),
+  };
+};

--- a/packages/sync/src/domain/provider-command.service.db.test.ts
+++ b/packages/sync/src/domain/provider-command.service.db.test.ts
@@ -775,6 +775,221 @@ describe("executeProviderUpdate", () => {
   });
 });
 
+describe("executeProviderUpdate on provider-managed events", () => {
+  const schedule = {
+    kind: "timed" as const,
+    start: "2026-07-14T09:00:00-06:00",
+    end: "2026-07-14T10:00:00-06:00",
+    timeZone: "America/Denver",
+  };
+  const content = (title: string, extras: Record<string, unknown> = {}) => ({
+    title,
+    description: "",
+    location: null,
+    organizer: null,
+    attendees: [],
+    conference: null,
+    ...extras,
+  });
+  const providerEvent = (
+    title: string,
+    version: string,
+    extras: Partial<ProviderEvent> = {},
+  ): ProviderEvent => ({
+    kind: "event",
+    providerEventId: "g-evt-1",
+    providerVersion: version,
+    providerUpdatedAt: null,
+    content: content(title),
+    schedule,
+    busy: true,
+    recurrence: { kind: "single" },
+    providerManaged: true,
+    ...extras,
+  });
+
+  const seedManaged = async (
+    inputOverrides: {
+      commandTitle?: string;
+      commandSchedule?: typeof schedule;
+      commandContent?: Record<string, unknown>;
+      eventCustomizations?: EventRecord["customizations"];
+    } = {},
+  ) => {
+    const ids = newCommandIds();
+    const calendar = await seedCommandCalendar(calendars, ids);
+    const event = await seedLinkedEvent(events, {
+      ids,
+      calendarId: calendar._id,
+      content: content("Provider title"),
+      schedule,
+      recurrence: { kind: "single" },
+      now: now(),
+    });
+    if (inputOverrides.eventCustomizations !== undefined) {
+      await events.replaceExisting({
+        ...event,
+        customizations: inputOverrides.eventCustomizations,
+      });
+    }
+    const commandTitle = inputOverrides.commandTitle ?? "Compass title";
+    const { record: command } = await commands.submit({
+      tenantId: ids.tenantId,
+      principalId: ids.principalId,
+      idempotencyKey: ids.idempotencyKey,
+      eventId: event._id,
+      input: {
+        kind: "update",
+        invitation: "none",
+        content: {
+          ...content(commandTitle),
+          ...inputOverrides.commandContent,
+        },
+        schedule: inputOverrides.commandSchedule ?? schedule,
+        recurrence: { kind: "preserve" },
+        scope: "all",
+      } as unknown as SyncCommandInput,
+      expectedVersion: "etag-1" as never,
+    });
+    const storedEvent = await events.findById(
+      ids.tenantId,
+      ids.principalId,
+      event._id,
+    );
+    if (!storedEvent) throw new Error("seed failed");
+    return {
+      tenantId: ids.tenantId,
+      principalId: ids.principalId,
+      calendar,
+      event: storedEvent,
+      command,
+    };
+  };
+
+  it("stores a title customization without calling patchEvent", async () => {
+    const { tenantId, principalId, calendar, event, command } =
+      await seedManaged();
+    const writer = new FakeProviderEventWriter();
+    writer.fetched = providerEvent("Provider title", "etag-1");
+
+    const result = await executeProviderUpdate(
+      {
+        commands,
+        events,
+        occurrences,
+        resources,
+        writer,
+        custody: tokenSource(),
+      },
+      command,
+      event,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("confirmed");
+    expect(writer.patchCalls).toHaveLength(0);
+    const stored = await events.findById(tenantId, principalId, event._id);
+    expect(stored?.content.title).toBe("Provider title");
+    expect(stored?.customizations).toEqual({ title: "Compass title" });
+  });
+
+  it("patches color with providerManaged and confirms at the returned version", async () => {
+    const { tenantId, principalId, calendar, event, command } =
+      await seedManaged({
+        commandContent: { color: "coral" },
+      });
+    const writer = new FakeProviderEventWriter();
+    writer.fetched = providerEvent("Provider title", "etag-1");
+
+    const result = await executeProviderUpdate(
+      {
+        commands,
+        events,
+        occurrences,
+        resources,
+        writer,
+        custody: tokenSource(),
+      },
+      command,
+      event,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("confirmed");
+    expect(writer.patchCalls).toHaveLength(1);
+    expect(writer.patchCalls[0].providerManaged).toBe(true);
+    const stored = await events.findById(tenantId, principalId, event._id);
+    expect(stored?.content.color).toBe("coral");
+    expect(stored?.providerVersion).toBe("etag-2");
+  });
+
+  it("fails schedule edits as unsupportedCapability without patching", async () => {
+    const movedSchedule = {
+      ...schedule,
+      start: "2026-07-14T10:00:00-06:00",
+      end: "2026-07-14T11:00:00-06:00",
+    };
+    const { calendar, event, command } = await seedManaged({
+      commandSchedule: movedSchedule,
+    });
+    const writer = new FakeProviderEventWriter();
+    writer.fetched = providerEvent("Provider title", "etag-1");
+
+    const result = await executeProviderUpdate(
+      {
+        commands,
+        events,
+        occurrences,
+        resources,
+        writer,
+        custody: tokenSource(),
+      },
+      command,
+      event,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("failed");
+    expect(
+      result.outcome.state === "failed" && result.outcome.failureReason,
+    ).toBe("unsupportedCapability");
+    expect(writer.patchCalls).toHaveLength(0);
+  });
+
+  it("clears customizations when the title matches the provider again", async () => {
+    const { tenantId, principalId, calendar, event, command } =
+      await seedManaged({
+        commandTitle: "Provider title",
+        eventCustomizations: { title: "Old overlay" },
+      });
+    const writer = new FakeProviderEventWriter();
+    writer.fetched = providerEvent("Provider title", "etag-1");
+
+    const result = await executeProviderUpdate(
+      {
+        commands,
+        events,
+        occurrences,
+        resources,
+        writer,
+        custody: tokenSource(),
+      },
+      command,
+      event,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("confirmed");
+    expect(writer.patchCalls).toHaveLength(0);
+    const stored = await events.findById(tenantId, principalId, event._id);
+    expect(stored?.customizations).toBeNull();
+  });
+});
+
 describe("executeProviderDelete", () => {
   const schedule = {
     kind: "timed" as const,

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -460,6 +460,22 @@ export async function executeProviderUpdate(
   // fallback) — except a single→series conversion, which writes real rules.
   const intendedRecurrence = intendedSeriesRecurrence(input.recurrence, event);
 
+  if (current.providerManaged) {
+    return executeProviderManagedUpdate(
+      deps,
+      command,
+      event,
+      current,
+      content,
+      input,
+      intendedRecurrence,
+      intendedAttendees,
+      location,
+      connectionId,
+      now,
+    );
+  }
+
   // Replay: the provider already holds this edit, so confirm at its version
   // rather than writing again.
   if (
@@ -521,6 +537,10 @@ async function commitProviderUpdate(
   content: SyncEventContent,
   providerVersion: string,
   now: () => Date,
+  commitOptions?: {
+    schedule?: EventSchedule;
+    customizations?: EventRecord["customizations"];
+  },
 ): Promise<CommandRecord> {
   if (command.input.kind !== "update") {
     throw new Error("commitProviderUpdate requires an update command");
@@ -529,13 +549,16 @@ async function commitProviderUpdate(
   const updated: EventRecord = {
     ...event,
     content,
-    schedule: input.schedule,
+    schedule: commitOptions?.schedule ?? input.schedule,
     recurrence: storedSeriesRecurrence(input.recurrence, event),
     providerVersion: providerVersion as ProviderEventVersion,
     providerUpdatedAt: null,
     deliveryState: "confirmed",
     updatedAt: now(),
   };
+  if (commitOptions && "customizations" in commitOptions) {
+    updated.customizations = commitOptions.customizations;
+  }
   const applied = await deps.events.replaceExisting(updated);
   if (!applied) return command;
   await reprojectOccurrences(deps.occurrences, updated, now);
@@ -554,6 +577,178 @@ async function commitProviderUpdate(
   return confirmed ?? command;
 }
 
+// Provider-managed events keep syncing from the provider; Compass overlays
+// title, description, and location as customizations and writes only color and
+// guest-list changes the provider accepts.
+async function executeProviderManagedUpdate(
+  deps: ProviderMutationDeps,
+  command: CommandRecord,
+  event: EventRecord,
+  current: ProviderEvent,
+  mergedContent: SyncEventContent,
+  input: Extract<CommandRecord["input"], { kind: "update" }>,
+  intendedRecurrence: ProviderWriteRecurrence,
+  intendedAttendees: readonly Attendee[] | undefined,
+  location: {
+    accessToken: string;
+    calendarId: string;
+    providerEventId: string;
+  },
+  connectionId: ConnectionId,
+  now: () => Date,
+): Promise<CommandRecord> {
+  if (
+    !deepEqual(input.schedule, current.schedule) ||
+    intendedRecurrence.kind !== "single"
+  ) {
+    return failCommand(deps, command, "unsupportedCapability", connectionId);
+  }
+
+  const customizations = computeEventCustomizations(
+    current.content,
+    mergedContent,
+  );
+  const storedContent = managedStoredContent(
+    current.content,
+    mergedContent,
+    intendedAttendees,
+  );
+  const commitOptions = {
+    schedule: current.schedule,
+    customizations,
+  };
+
+  if (
+    matchesManagedIntendedEdit(
+      current,
+      event,
+      mergedContent,
+      customizations,
+      intendedAttendees,
+    )
+  ) {
+    return commitProviderUpdate(
+      deps,
+      command,
+      event,
+      storedContent,
+      current.providerVersion,
+      now,
+      commitOptions,
+    );
+  }
+
+  if (!managedProviderSideChange(current, mergedContent, intendedAttendees)) {
+    return commitProviderUpdate(
+      deps,
+      command,
+      event,
+      storedContent,
+      current.providerVersion,
+      now,
+      commitOptions,
+    );
+  }
+
+  const patchResult = await runProviderWrite(() =>
+    deps.writer.patchEvent({
+      ...location,
+      expectedVersion: command.expectedVersion,
+      providerManaged: true,
+      content: mergedContent,
+      schedule: current.schedule,
+      recurrence: { kind: "single" },
+      invitation: input.invitation,
+      ...(intendedAttendees ? { attendees: intendedAttendees } : {}),
+    }),
+  );
+  if (!patchResult.ok) {
+    if (patchResult.stop.kind === "pending") return command;
+    return failCommand(deps, command, patchResult.stop.reason, connectionId);
+  }
+
+  return commitProviderUpdate(
+    deps,
+    command,
+    event,
+    storedContent,
+    patchResult.value.providerVersion,
+    now,
+    commitOptions,
+  );
+}
+
+function computeEventCustomizations(
+  providerContent: SyncEventContent,
+  intended: SyncEventContent,
+): EventRecord["customizations"] {
+  const customizations: {
+    title?: string;
+    description?: string;
+    location?: string | null;
+  } = {};
+  if (intended.title !== providerContent.title) {
+    customizations.title = intended.title;
+  }
+  if (intended.description !== providerContent.description) {
+    customizations.description = intended.description;
+  }
+  if (intended.location !== providerContent.location) {
+    customizations.location = intended.location;
+  }
+  return Object.keys(customizations).length === 0 ? null : customizations;
+}
+
+function managedStoredContent(
+  providerContent: SyncEventContent,
+  intended: SyncEventContent,
+  intendedAttendees: readonly Attendee[] | undefined,
+): SyncEventContent {
+  let stored = omitNullColor(
+    mergeUpdateContent(providerContent, {
+      ...providerContent,
+      color: intended.color,
+    }),
+  );
+  if (intendedAttendees) {
+    stored = { ...stored, attendees: intendedAttendees };
+  }
+  return stored;
+}
+
+function customizationsEqual(
+  left: EventRecord["customizations"],
+  right: EventRecord["customizations"],
+): boolean {
+  const normalize = (value: EventRecord["customizations"]) =>
+    value === undefined || value === null ? null : value;
+  return deepEqual(normalize(left), normalize(right));
+}
+
+function managedProviderSideChange(
+  current: ProviderEvent,
+  content: SyncEventContent,
+  intendedAttendees: readonly Attendee[] | undefined,
+): boolean {
+  const intendedColor = content.color === null ? undefined : content.color;
+  const currentColor =
+    current.content.color === null ? undefined : current.content.color;
+  if (intendedColor !== currentColor) return true;
+  if (intendedAttendees === undefined) return false;
+  return !attendeesMatchIntent(current.content.attendees, intendedAttendees);
+}
+
+function matchesManagedIntendedEdit(
+  current: ProviderEvent,
+  event: EventRecord,
+  mergedContent: SyncEventContent,
+  customizations: EventRecord["customizations"],
+  intendedAttendees: readonly Attendee[] | undefined,
+): boolean {
+  if (!customizationsEqual(event.customizations, customizations)) return false;
+  return !managedProviderSideChange(current, mergedContent, intendedAttendees);
+}
+
 // Apply a Compass-initiated scope-"all" edit to a provider-linked recurring
 // series — Google's "edit all events in the series". The master is patched with
 // the new content, schedule, AND recurrence rules, and its per-instance
@@ -561,6 +756,10 @@ async function commitProviderUpdate(
 // local commit is series-aware: it discards override exceptions but preserves
 // cancelled tombstones (a deletion must survive an edit) and reprojects the
 // master excluding their instants.
+//
+// Provider-managed events are single-only today (Google Gmail events), so this
+// path is unreachable for them; managed customizations live in the single-event
+// update path instead.
 //
 // Replay safety mirrors the single-event path: fetch the provider's current
 // master first; if it already carries this edit (content, schedule, and rules),
@@ -878,6 +1077,10 @@ async function commitProviderSeriesUpdate(
 // provider-linked series: resolve the instance's own provider identity, then
 // patch IT (never the master) — mirrors executeProviderUpdate's replay-safe
 // fetch-then-compare, but against the resolved instance's location.
+//
+// Provider-managed events are single-only today, so this occurrence path is
+// unreachable for them; managed customizations live in the single-event update
+// path instead.
 export async function executeProviderOccurrenceUpdate(
   deps: ProviderMutationDeps,
   command: CommandRecord,

--- a/packages/sync/src/domain/provider-page-applier.db.test.ts
+++ b/packages/sync/src/domain/provider-page-applier.db.test.ts
@@ -364,4 +364,55 @@ describe("ProviderPageApplier", () => {
     // One single-occurrence event each.
     expect(occCount).toBe(250);
   });
+
+  it("keeps customizations when a pull changes the provider schedule", async () => {
+    const calendar = await seedCalendar();
+    const run = applier(calendar);
+    const providerEventId = "managed-schedule";
+
+    await run.applyPage([
+      { ...single(providerEventId), providerManaged: true },
+    ]);
+    const existing = await events.findByProviderIdentity(
+      calendar.tenantId,
+      calendar.principalId,
+      {
+        connectionId: calendar.connectionId,
+        calendarId: calendar._id,
+        providerEventId,
+      },
+    );
+    if (!existing) throw new Error("seed failed");
+    await events.replaceExisting({
+      ...existing,
+      customizations: { title: "My overlay" },
+    });
+
+    const movedSchedule = {
+      kind: "timed" as const,
+      start: "2026-07-14T10:00:00-06:00",
+      end: "2026-07-14T11:00:00-06:00",
+      timeZone: "America/Denver",
+    };
+    await run.applyPage([
+      {
+        ...single(providerEventId),
+        providerManaged: true,
+        schedule: movedSchedule,
+        providerVersion: "etag-moved",
+      },
+    ]);
+
+    const updated = await events.findByProviderIdentity(
+      calendar.tenantId,
+      calendar.principalId,
+      {
+        connectionId: calendar.connectionId,
+        calendarId: calendar._id,
+        providerEventId,
+      },
+    );
+    expect(updated?.schedule).toEqual(movedSchedule);
+    expect(updated?.customizations).toEqual({ title: "My overlay" });
+  });
 });

--- a/packages/sync/src/providers/apple/apple-event-writer.adapter.ts
+++ b/packages/sync/src/providers/apple/apple-event-writer.adapter.ts
@@ -128,6 +128,8 @@ export class AppleEventWriter implements ProviderEventWriter {
   }
 
   async patchEvent(input: ProviderPatchInput): Promise<ProviderWriteResult> {
+    // providerManaged is a Google-only hint today; Apple readers never set the
+    // fact, so this adapter ignores it and sends the full body as before.
     const api = this.#makeApi(input.accessToken);
     const calendarUrl = resolveCalendarUrl(input.calendarId);
     const parsedInstance = parseAppleInstanceId(input.providerEventId);

--- a/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
@@ -372,6 +372,38 @@ describe("GoogleEventWriter", () => {
     expect(api.calls.patch[0].requestBody).not.toHaveProperty("attendees");
   });
 
+  it("sends only colorId and attendees for a provider-managed patch", async () => {
+    const api = new FakeEventsApi();
+    const { writer } = writerWith(api);
+
+    await writer.patchEvent({
+      ...basePatch,
+      providerManaged: true,
+      content: content({ color: "coral" }),
+      attendees: [
+        {
+          email: "guest@example.com",
+          displayName: null,
+          responseStatus: "needsAction",
+        },
+      ],
+    });
+
+    const body = api.calls.patch.at(-1)?.requestBody;
+    expect(body).toEqual({
+      colorId: expect.any(String),
+      attendees: [
+        { email: "guest@example.com", responseStatus: "needsAction" },
+      ],
+    });
+    expect(body).not.toHaveProperty("summary");
+    expect(body).not.toHaveProperty("description");
+    expect(body).not.toHaveProperty("location");
+    expect(body).not.toHaveProperty("start");
+    expect(body).not.toHaveProperty("end");
+    expect(body).not.toHaveProperty("recurrence");
+  });
+
   it("adds Meet createRequest and guestsCanInviteOthers on booking create only", async () => {
     const api = new FakeEventsApi();
     const { writer } = writerWith(api);

--- a/packages/sync/src/providers/google/google-event-writer.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.ts
@@ -236,6 +236,7 @@ export class GoogleEventWriter implements ProviderEventWriter {
           input.schedule,
           input.recurrence,
           input.attendees,
+          input.providerManaged,
         ),
         sendUpdates: toSendUpdates(input.invitation),
         ifMatch,
@@ -349,7 +350,14 @@ function toGoogleBody(
   schedule: EventSchedule,
   recurrence: ProviderWriteRecurrence,
   attendees?: readonly Attendee[],
+  providerManaged?: true,
 ): gSchema$Event {
+  if (providerManaged) {
+    return {
+      ...googleColorIdFields(content.color),
+      ...attendeesField(attendees),
+    };
+  }
   return {
     summary: content.title,
     description: content.description,

--- a/packages/sync/src/providers/microsoft/microsoft-event-writer.adapter.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-event-writer.adapter.ts
@@ -166,6 +166,8 @@ export class MicrosoftEventWriter implements ProviderEventWriter {
   }
 
   async patchEvent(input: ProviderPatchInput): Promise<ProviderWriteResult> {
+    // providerManaged is a Google-only hint today; Microsoft readers never set
+    // the fact, so this adapter ignores it and sends the full body as before.
     const api = this.#makeApi(input.accessToken);
     try {
       const patched = await api.patch({

--- a/packages/sync/src/providers/provider-event-writer.port.ts
+++ b/packages/sync/src/providers/provider-event-writer.port.ts
@@ -58,6 +58,9 @@ export interface ProviderPatchInput extends ProviderWriteBody {
   readonly accessToken: string;
   readonly calendarId: string;
   readonly providerEventId: string;
+  // When true, the writer must send only the fields its provider accepts on
+  // a provider-managed event (Google: color and attendees; others ignore).
+  readonly providerManaged?: true;
   // The version to condition the write on. Non-null sends an If-Match
   // precondition, so a stale caller loses to a concurrent change instead of
   // overwriting it. Null writes unconditionally (no known prior version).

--- a/packages/sync/src/storage/contracts/event.contracts.ts
+++ b/packages/sync/src/storage/contracts/event.contracts.ts
@@ -42,6 +42,16 @@ export const EventRecordSchema = z.strictObject({
   providerUpdatedAt: z.date().nullable(),
   deliveryState: ProviderDeliveryStateSchema.nullable(),
   providerMetadata: z.record(z.string(), z.string()).nullable(),
+  // Compass overlays for provider-managed events: served over the provider's
+  // title, description, and location while schedule follows the provider.
+  customizations: z
+    .strictObject({
+      title: z.string().optional(),
+      description: z.string().optional(),
+      location: z.string().nullable().optional(),
+    })
+    .nullable()
+    .optional(),
   content: SyncEventContentSchema,
   schedule: EventScheduleSchema,
   recurrence: SyncEventRecurrenceSchema,

--- a/packages/sync/src/storage/repositories/event.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/event.repository.db.test.ts
@@ -328,6 +328,79 @@ describe("EventRepository", () => {
     expect(read?.content.title).toBe("Changed");
   });
 
+  it("leaves existing customizations untouched on upsertByProviderIdentity", async () => {
+    const identity = {
+      connectionId: objectId(),
+      calendarId: objectId(),
+      providerEventId: "evt-custom",
+    };
+    const first = await repo.upsertByProviderIdentity(
+      linkedUpsert({
+        ...identity,
+        customizations: { title: "My title" },
+      }),
+    );
+    expect(first.customizations).toEqual({ title: "My title" });
+
+    const second = await repo.upsertByProviderIdentity(
+      linkedUpsert({
+        ...identity,
+        providerVersion: "etag-2",
+        content: { ...baseContent, title: "Provider title" },
+      }),
+    );
+    expect(second._id).toBe(first._id);
+    expect(second.customizations).toEqual({ title: "My title" });
+  });
+
+  it("preserves customizations on the iCalUID-preserving upsert path", async () => {
+    const identity = {
+      connectionId: objectId(),
+      calendarId: objectId(),
+      providerEventId: "evt-custom-uid",
+    };
+    const first = await repo.upsertByProviderIdentity(
+      linkedUpsert({
+        ...identity,
+        customizations: { description: "My notes" },
+        providerMetadata: { iCalUID: "kept@google.com" },
+      }),
+      { preserveIcalUidWhenAbsent: true },
+    );
+    expect(first.customizations).toEqual({ description: "My notes" });
+
+    const second = await repo.upsertByProviderIdentity(
+      linkedUpsert({
+        ...identity,
+        providerVersion: "etag-2",
+        providerMetadata: null,
+      }),
+      { preserveIcalUidWhenAbsent: true },
+    );
+    expect(second.customizations).toEqual({ description: "My notes" });
+  });
+
+  it("writes customizations through replaceExisting", async () => {
+    const record = compassRecord({
+      customizations: { title: "Overlay" },
+    });
+    await repo.put(record);
+    const updated = {
+      ...record,
+      customizations: { title: "Updated overlay", location: "Room 2" },
+    };
+    expect(await repo.replaceExisting(updated)).toBe(true);
+    const read = await repo.findById(
+      record.tenantId,
+      record.principalId,
+      record._id,
+    );
+    expect(read?.customizations).toEqual({
+      title: "Updated overlay",
+      location: "Room 2",
+    });
+  });
+
   it("finds only the owner's exceptions of one series", async () => {
     const tenantId = objectId();
     const principalId = objectId();


### PR DESCRIPTION
Fixes #3515

## What and why

Provider-managed events (for example Google Gmail-created events) refuse full patches. This work package adds Compass `customizations` on event records and routes managed updates through a dedicated sync path: title, description, and location edits are stored locally and served over the provider's values; color and guest-list replaces still go to the provider via a `providerManaged` patch hint; schedule and recurrence changes fail as `unsupportedCapability` before any provider call. Incremental pulls that change the provider schedule leave existing customizations intact.

Tracking: [Provider-managed events #3512](https://github.com/KeepSoftwareSimple/compass-calendar/issues/3512)

## Verify

```
bun test:sync
bun run type-check
bun run lint
bun run verify --strict
```

VERDICT: PASS