### PR TITLE
feat(web): lock schedule for provider-managed events (WP-04)

### DIFF
--- a/packages/web/src/calendars/isEventReadOnly.test.ts
+++ b/packages/web/src/calendars/isEventReadOnly.test.ts
@@ -11,6 +11,7 @@ import {
   buildCalendarLookup,
   isEventReadOnly,
   isGridEventInteractionReadOnly,
+  isGridEventScheduleLocked,
 } from "@web/calendars/useCalendarLookup";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import { afterEach, describe, expect, it } from "bun:test";
@@ -155,5 +156,35 @@ describe("isGridEventInteractionReadOnly", () => {
     expect(
       isGridEventInteractionReadOnly(lookup, { calendarId: owner.id }),
     ).toBe(false);
+  });
+});
+
+describe("isGridEventScheduleLocked", () => {
+  it("is true for provider-managed events on a writable calendar", () => {
+    const calendar = makeCalendar({ access: "owner" });
+    const lookup = buildCalendarLookup([calendar]);
+
+    expect(
+      isGridEventScheduleLocked(lookup, {
+        calendarId: calendar.id,
+        isProviderManaged: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("is false for a normal writable-calendar event", () => {
+    const calendar = makeCalendar({ access: "owner" });
+    const lookup = buildCalendarLookup([calendar]);
+
+    expect(isGridEventScheduleLocked(lookup, { calendarId: calendar.id })).toBe(
+      false,
+    );
+  });
+
+  it("leaves isEventReadOnly unchanged for provider-managed events", () => {
+    const calendar = makeCalendar({ access: "owner" });
+    const lookup = buildCalendarLookup([calendar]);
+
+    expect(isEventReadOnly(lookup, calendar.id, false)).toBe(false);
   });
 });

--- a/packages/web/src/calendars/useCalendarLookup.ts
+++ b/packages/web/src/calendars/useCalendarLookup.ts
@@ -187,3 +187,23 @@ export function isGridEventInteractionReadOnly(
     isGridEventContentReadOnly(event),
   );
 }
+
+/**
+ * Gate for anything that changes when an event happens: pointer drag/resize,
+ * keyboard nudge, and edge resize. Provider-managed events keep a writable
+ * calendar's delete/details paths available via {@link isEventReadOnly} alone.
+ */
+export function isGridEventScheduleLocked(
+  lookup: ReadonlyMap<CalendarId, Calendar>,
+  event: {
+    calendarId?: CalendarId | null;
+    isBusy?: boolean;
+    isTimedMultiDayDisplay?: boolean;
+    isProviderManaged?: boolean;
+  },
+): boolean {
+  return (
+    isGridEventInteractionReadOnly(lookup, event) ||
+    event.isProviderManaged === true
+  );
+}

--- a/packages/web/src/common/types/web.event.types.ts
+++ b/packages/web/src/common/types/web.event.types.ts
@@ -62,6 +62,8 @@ const GridEventSchema = WebEventSchema.extend({
   }),
   calendarId: CalendarIdSchema.optional(),
   isBusy: z.boolean().optional(),
+  /** Provider-owned event: schedule follows the provider, details editable. */
+  isProviderManaged: z.literal(true).optional(),
   isDemo: z.boolean().optional(),
   /** Timed event shown in the all-day row because it spans midnight. */
   isTimedMultiDayDisplay: z.boolean().optional(),

--- a/packages/web/src/events/mutations/event-schedule-equal.ts
+++ b/packages/web/src/events/mutations/event-schedule-equal.ts
@@ -1,0 +1,17 @@
+import { type EventSchedule } from "@core/types/event.contracts";
+import dayjs from "@core/util/date/dayjs";
+
+/** Compares when an event happens, ignoring wire-format drift (timeZone strings). */
+export function eventSchedulesEqual(
+  left: EventSchedule,
+  right: EventSchedule,
+): boolean {
+  if (left.kind !== right.kind) return false;
+  if (left.kind === "allDay") {
+    return left.start === right.start && left.end === right.end;
+  }
+  return (
+    dayjs(left.start).valueOf() === dayjs(right.start).valueOf() &&
+    dayjs(left.end).valueOf() === dayjs(right.end).valueOf()
+  );
+}

--- a/packages/web/src/events/mutations/useEventMutations.ts
+++ b/packages/web/src/events/mutations/useEventMutations.ts
@@ -44,6 +44,7 @@ import {
 } from "@web/calendars/useCalendarLookup";
 import { handleError } from "@web/common/utils/event/event.util";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
+import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 import { showGoogleReconnectToast } from "@web/common/utils/toast/google-reconnect.toast";
 import {
   dismissRecurrenceScopeToast,
@@ -53,6 +54,7 @@ import {
 import { noteFirstRealEventCreated } from "@web/components/FirstEventPrompt/first-event.store";
 import { EventApi } from "@web/events/event.api";
 import { editableContent } from "@web/events/grid-event-draft.adapter";
+import { eventSchedulesEqual } from "@web/events/mutations/event-schedule-equal";
 import {
   applyEventProjectionAcrossQueries,
   eventBelongsToEntry,
@@ -947,6 +949,15 @@ export function useEventMutations(
         if (isTargetReadOnly(original)) {
           console.warn(
             `[useEventMutations] blocked replace on read-only event ${payload.id}`,
+          );
+          return false;
+        }
+        if (
+          original?.providerManaged === true &&
+          !eventSchedulesEqual(original.schedule, payload.input.schedule)
+        ) {
+          showErrorToast(
+            "This event's time follows your calendar provider and can't be moved in Compass.",
           );
           return false;
         }

--- a/packages/web/src/events/mutations/useUpdateEvent.test.tsx
+++ b/packages/web/src/events/mutations/useUpdateEvent.test.tsx
@@ -3,9 +3,14 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { type PropsWithChildren } from "react";
 import { Origin } from "@core/constants/core.constants";
 import { type Event } from "@core/types/event.contracts";
+import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
+import {
+  registerToastPort,
+  resetToastPort,
+} from "@web/common/utils/toast/toast.port";
 import { editGridEventDraft } from "@web/events/grid-event-draft.adapter";
 import { eventQueryKeys } from "@web/events/queries/event.query.keys";
 import { type NormalizedEventQueryData } from "@web/events/queries/event.query.types";
@@ -15,7 +20,7 @@ import {
   useDraftStore,
 } from "@web/events/stores/draft.store";
 import { useUpdateEvent } from "./useUpdateEvent";
-import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const calendarKey = eventQueryKeys.week({
   source: "local",
@@ -64,6 +69,10 @@ function createWrapper(events: Event[]) {
 describe("useUpdateEvent", () => {
   beforeEach(() => {
     draftActions.discard();
+  });
+
+  afterEach(() => {
+    resetToastPort();
   });
 
   it("runs onOptimisticApplied after the optimistic cache write", async () => {
@@ -117,5 +126,83 @@ describe("useUpdateEvent", () => {
     });
     expect(startAtCallback).toBe("2026-07-02T18:00:00Z");
     expect(useDraftStore.getState()).toEqual(initialDraftState);
+  });
+
+  it("refuses a schedule change on a provider-managed event with a toast", () => {
+    const { port, mocks } = createTestToastPort();
+    registerToastPort(port);
+
+    const existing = createMockEvent({
+      providerManaged: true,
+      content: {
+        kind: "details",
+        title: "Managed",
+        description: "",
+      },
+      schedule: {
+        kind: "timed",
+        start: "2026-07-02T16:00:00.000Z" as never,
+        end: "2026-07-02T17:00:00.000Z" as never,
+        timeZone: "UTC" as never,
+      },
+    });
+    const { queryClient, Wrapper } = createWrapper([existing]);
+    const { result } = renderHook(() => useUpdateEvent(), {
+      wrapper: Wrapper,
+    });
+
+    const moved = toGridEvent(existing);
+    moved.startDate = "2026-07-02T18:00:00.000Z";
+    moved.endDate = "2026-07-02T19:00:00.000Z";
+
+    act(() => {
+      result.current({ event: moved }, true);
+    });
+
+    expect(mocks.error).toHaveBeenCalledWith(
+      "This event's time follows your calendar provider and can't be moved in Compass.",
+      expect.any(Object),
+    );
+    expect(
+      (
+        queryClient.getQueryData<NormalizedEventQueryData>(calendarKey)
+          ?.entities[existing.id].schedule as { start?: string }
+      ).start,
+    ).toBe("2026-07-02T16:00:00.000Z");
+  });
+
+  it("allows a title-only replace on a provider-managed event", async () => {
+    const existing = createMockEvent({
+      providerManaged: true,
+      content: {
+        kind: "details",
+        title: "Managed",
+        description: "",
+      },
+      schedule: {
+        kind: "timed",
+        start: "2026-07-02T16:00:00.000Z" as never,
+        end: "2026-07-02T17:00:00.000Z" as never,
+        timeZone: "UTC" as never,
+      },
+    });
+    const { queryClient, Wrapper } = createWrapper([existing]);
+    const { result } = renderHook(() => useUpdateEvent(), {
+      wrapper: Wrapper,
+    });
+
+    const retitled = toGridEvent(existing);
+    retitled.title = "Renamed in Compass";
+
+    act(() => {
+      result.current({ event: retitled }, true);
+    });
+
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData<NormalizedEventQueryData>(calendarKey)
+          ?.entities[existing.id].content,
+      ).toMatchObject({ kind: "details", title: "Renamed in Compass" });
+    });
   });
 });

--- a/packages/web/src/events/mutations/useUpdateEvent.ts
+++ b/packages/web/src/events/mutations/useUpdateEvent.ts
@@ -18,6 +18,7 @@ import {
   parseGridEventDraft,
   timedGridSchedule,
 } from "@web/events/grid-event-draft.adapter";
+import { eventSchedulesEqual } from "@web/events/mutations/event-schedule-equal";
 import {
   type EventMutationCallbacks,
   type EventMutationDependencies,
@@ -82,6 +83,12 @@ export function useUpdateEvent(dependencies: EventMutationDependencies = {}) {
           showErrorToast("Repeating events can't move to another calendar.");
           return finishWithoutMutation();
         }
+        if (sourceEvent.providerManaged === true) {
+          showErrorToast(
+            "This event's time follows your calendar provider and can't be moved in Compass.",
+          );
+          return finishWithoutMutation();
+        }
         const lookup = buildCalendarLookup(
           queryClient.getQueryData<Calendar[]>(calendarQueryKeys.all),
         );
@@ -128,6 +135,16 @@ export function useUpdateEvent(dependencies: EventMutationDependencies = {}) {
 
       const parsed = parseGridEventDraft(patchedDraft);
       if (!(parsed.ok && parsed.mode === "edit")) {
+        return finishWithoutMutation();
+      }
+
+      if (
+        sourceEvent.providerManaged === true &&
+        !eventSchedulesEqual(sourceEvent.schedule, parsed.input.schedule)
+      ) {
+        showErrorToast(
+          "This event's time follows your calendar provider and can't be moved in Compass.",
+        );
         return finishWithoutMutation();
       }
 

--- a/packages/web/src/events/queries/event.view-model.ts
+++ b/packages/web/src/events/queries/event.view-model.ts
@@ -58,6 +58,7 @@ const eventToGridEvent = (
   const startDate = scheduleOverride?.startDate ?? schedule.start;
   const endDate = scheduleOverride?.endDate ?? schedule.end;
   const isBusy = event.content.kind === "busy";
+  const isProviderManaged = event.providerManaged === true;
   const details = event.content.kind === "details" ? event.content : undefined;
 
   return {
@@ -79,6 +80,7 @@ const eventToGridEvent = (
     position: gridEventDefaultPosition,
     calendarId: event.calendarId,
     isBusy,
+    ...(isProviderManaged ? { isProviderManaged: true as const } : {}),
     isDemo: Boolean(demoEventIds?.includes(event.id)),
     ...(crossAccountDuplicates?.has(event.id)
       ? { otherAccount: crossAccountDuplicates.get(event.id) }

--- a/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
@@ -5,6 +5,7 @@ import dayjs, { type Dayjs } from "@core/util/date/dayjs";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import {
   isGridEventInteractionReadOnly,
+  isGridEventScheduleLocked,
   useCalendarLookup,
 } from "@web/calendars/useCalendarLookup";
 import { useDefaultTargetCalendar } from "@web/calendars/useDefaultTargetCalendar";
@@ -451,6 +452,10 @@ export function useGridEventEditShortcuts({
 
     const event = getFocusedMutableCalendarEvent();
     if (event?._id) {
+      if (isGridEventScheduleLocked(calendarLookup, event)) {
+        return;
+      }
+
       const edgeFocus = useEdgeFocusStore.getState();
       if (edgeFocus.eventId === event._id && edgeFocus.edge) {
         moveFocusedEventEdge(keyboardEvent, event, edgeFocus.edge);

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarEventLayers.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarEventLayers.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import {
-  isGridEventInteractionReadOnly,
+  isGridEventScheduleLocked,
   resolveCalendarCardIdentity,
   resolveCalendarFocusColor,
   useCalendarLookup,
@@ -78,7 +78,7 @@ export const DayCalendarAllDayEventsLayer = ({
           focusColor={resolveCalendarFocusColor(calendarLookup, event)}
           isActiveDraft={isActiveDraftEvent(event, draft, savedEventIds)}
           isPlaceholder={isDraftOnlyEvent(event, draft, savedEventIds)}
-          isReadOnly={isGridEventInteractionReadOnly(calendarLookup, event)}
+          isReadOnly={isGridEventScheduleLocked(calendarLookup, event)}
           key={event._id ?? "all-day-draft"}
           measurements={measurements}
           onOpenEvent={onOpenEvent}
@@ -136,7 +136,7 @@ export const DayCalendarTimedEventsLayer = ({
           focusColor={resolveCalendarFocusColor(calendarLookup, event)}
           isActiveDraft={isActiveDraftEvent(event, draft, savedEventIds)}
           isPlaceholder={isDraftOnlyEvent(event, draft, savedEventIds)}
-          isReadOnly={isGridEventInteractionReadOnly(calendarLookup, event)}
+          isReadOnly={isGridEventScheduleLocked(calendarLookup, event)}
           key={event._id ?? "timed-draft"}
           measurements={measurements}
           onOpenEvent={onOpenEvent}

--- a/packages/web/src/views/Forms/EventForm/EventForm.readOnly.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.readOnly.test.tsx
@@ -215,3 +215,67 @@ describe("EventForm read-only gate", () => {
     expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("EventForm provider-managed schedule lock", () => {
+  const providerManagedNote =
+    "Your calendar provider keeps this event updated (for example from an email), so its time follows the provider. Changes to the title, notes, and location stay in Compass.";
+
+  beforeEach(() => {
+    HotkeyManager.resetInstance();
+    document.body.removeAttribute("data-app-locked");
+  });
+
+  it("disables schedule and recurrence, keeps title and Save enabled, and shows the note", () => {
+    const writableCalendar = makeCalendar({
+      access: "owner",
+      capabilities: getCalendarCapabilities("owner"),
+    });
+    const event = createMockEvent({
+      calendarId: writableCalendar.id,
+      providerManaged: true,
+      content: {
+        kind: "details",
+        title: "Flight reminder",
+        description: "Pack light",
+        location: "SFO",
+      },
+    });
+    const draft = editGridEventDraft(event);
+    if (!draft) throw new Error("expected an edit draft");
+
+    const { container } = renderEventForm(draft, [writableCalendar]);
+
+    expect(screen.getByPlaceholderText("Title")).toBeEnabled();
+    expect(screen.getByRole("textbox", { name: "Location" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("group", { name: "Event schedule" }),
+    ).toBeDisabled();
+    expect(screen.getByRole("group", { name: "Recurrence" })).toBeDisabled();
+    expect(screen.getByRole("note")).toHaveTextContent(providerManagedNote);
+
+    const outerFieldset = container.querySelector("fieldset.contents");
+    expect(outerFieldset).not.toBeDisabled();
+  });
+
+  it("renders no provider-managed note for a normal editable event", () => {
+    const writableCalendar = makeCalendar({
+      access: "owner",
+      capabilities: getCalendarCapabilities("owner"),
+    });
+    const event = createMockEvent({
+      calendarId: writableCalendar.id,
+      content: {
+        kind: "details",
+        title: "Regular meeting",
+        description: "",
+      },
+    });
+    const draft = editGridEventDraft(event);
+    if (!draft) throw new Error("expected an edit draft");
+
+    renderEventForm(draft, [writableCalendar]);
+
+    expect(screen.queryByText(providerManagedNote)).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -211,6 +211,8 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
     const isReadOnly =
       draft.kind === "edit" &&
       isEventReadOnly(calendarLookup, draft.source.calendarId, isBusy);
+    const isScheduleLocked =
+      draft.kind === "edit" && draft.source.providerManaged === true;
     const displayTitle = isBusy ? BUSY_EVENT_TITLE : title;
     // Read-only, provider-sourced fields live on the source event's content,
     // never on draft.values (EditableContentSchema doesn't carry them) - a
@@ -750,6 +752,7 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
                   aria-invalid={scheduleError ? true : undefined}
                   aria-describedby={scheduleErrorDescribedBy}
                   tabIndex={scheduleError ? -1 : undefined}
+                  disabled={isScheduleLocked}
                   className={classNames(
                     "min-w-0 rounded-xs border-0 p-0",
                     scheduleError && "ring-1 ring-error",
@@ -768,6 +771,7 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
                   aria-invalid={recurrenceError ? true : undefined}
                   aria-describedby={recurrenceErrorDescribedBy}
                   tabIndex={recurrenceError ? -1 : undefined}
+                  disabled={isScheduleLocked}
                   className={classNames(
                     "min-w-0 rounded-xs border-0 p-0",
                     recurrenceError && "ring-1 ring-error",
@@ -901,6 +905,14 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
                 details={liveDetails ?? sourceDetails}
                 hideAttendees={showAttendeeEditor}
               />
+            )}
+
+            {isScheduleLocked && (
+              <p role="note" className="text-text-muted text-xs">
+                Your calendar provider keeps this event updated (for example
+                from an email), so its time follows the provider. Changes to the
+                title, notes, and location stay in Compass.
+              </p>
             )}
 
             {isReadOnly && (

--- a/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import {
   type CalendarCardIdentity,
-  isGridEventInteractionReadOnly,
+  isGridEventScheduleLocked,
   resolveCalendarCardIdentity,
   resolveCalendarFocusColor,
   useCalendarLookup,
@@ -78,7 +78,7 @@ export const AllDayEvents = ({
         // attach interaction attributes/registration below, so the drag/
         // resize engine can't find them as a target - blocked before any
         // optimistic state change (packet 08 step 8).
-        isReadOnly: isGridEventInteractionReadOnly(calendarLookup, event),
+        isReadOnly: isGridEventScheduleLocked(calendarLookup, event),
       })),
     [visibleAllDayEvents, calendarLookup],
   );

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import {
   type CalendarCardIdentity,
-  isGridEventInteractionReadOnly,
+  isGridEventScheduleLocked,
   resolveCalendarCardIdentity,
   resolveCalendarFocusColor,
   useCalendarLookup,
@@ -101,7 +101,7 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
         // attach interaction attributes/registration below, so the drag/
         // resize engine can't find them as a target - blocked before any
         // optimistic state change (packet 08 step 8).
-        isReadOnly: isGridEventInteractionReadOnly(calendarLookup, item.event),
+        isReadOnly: isGridEventScheduleLocked(calendarLookup, item.event),
       })),
     [timedEventItems, calendarLookup],
   );

--- a/packages/web/src/views/Week/components/Grid/MainGrid/eventReadOnlyInteraction.test.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/eventReadOnlyInteraction.test.tsx
@@ -370,4 +370,27 @@ describe("Week grid read-only interaction gate", () => {
     expect(card).toHaveAttribute(WEEK_INTERACTION_EVENT_ID_ATTRIBUTE, event.id);
     expect(weekEventRegistry.resolve(event.id, "timed")).toBeNull();
   });
+
+  it("marks a provider-managed timed event read-only for drag/resize while keeping it navigable", () => {
+    const writableCalendar = makeCalendar({
+      access: "owner",
+      capabilities: getCalendarCapabilities("owner"),
+    });
+    seededCalendars = [writableCalendar];
+    const event = createTimedEvent(writableCalendar.id, {
+      providerManaged: true,
+      content: {
+        kind: "details",
+        title: "From email",
+        description: "",
+      },
+    });
+    seededEvents = [event];
+
+    renderMainGridEvents();
+
+    const card = screen.getByRole("button", { name: /from email/i });
+    expect(card).toHaveAttribute(GRID_EVENT_READ_ONLY_ATTRIBUTE, "true");
+    expect(weekEventRegistry.resolve(event.id, "timed")).toBeNull();
+  });
 });

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
@@ -118,6 +118,9 @@ const leftmostAllDayEvent = createMockEvent({
 // by visible calendars (S39 A2), so an incomplete list would hide the
 // editable event under test.
 const READ_ONLY_EVENT_ID = EventIdSchema.parse("cccccccccccccccccccccccc");
+const PROVIDER_MANAGED_EVENT_ID = EventIdSchema.parse(
+  "ffffffffffffffffffffffff",
+);
 const readOnlyCalendarId = CalendarIdSchema.parse(createObjectIdString());
 const writableCalendar: Calendar = {
   id: editableEvent.calendarId,
@@ -155,6 +158,21 @@ const readOnlyEvent = createMockEvent({
     kind: "timed",
     start: "2026-05-20T13:00:00.000Z",
     end: "2026-05-20T14:00:00.000Z",
+    timeZone: "UTC",
+  }),
+});
+const providerManagedEvent = createMockEvent({
+  id: PROVIDER_MANAGED_EVENT_ID,
+  providerManaged: true,
+  content: {
+    kind: "details",
+    title: "Provider-managed event",
+    description: "",
+  },
+  schedule: EventScheduleSchema.parse({
+    kind: "timed",
+    start: "2026-05-20T11:00:00.000Z",
+    end: "2026-05-20T12:00:00.000Z",
     timeZone: "UTC",
   }),
 });
@@ -1083,6 +1101,36 @@ describe("useWeekShortcutOwner shift+arrow event moves", () => {
     expect(getEditMutation(queryClient)).toBeUndefined();
     // Read-only focus must not fall through into place-create either.
     expect(useDraftStore.getState().gridDraft).toBeNull();
+  });
+
+  it("does not nudge a provider-managed event with Shift+ArrowRight but still deletes it", async () => {
+    const button = addCalendarTarget(providerManagedEvent.id);
+    button.focus();
+    const { queryClient } = renderShortcuts({
+      extraEvents: [providerManagedEvent],
+      calendars: [writableCalendar],
+    });
+
+    pressKey("ArrowRight", shiftKey);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(getEditMutation(queryClient)).toBeUndefined();
+
+    pressKey("Delete");
+
+    expect(
+      queryClient
+        .getMutationCache()
+        .getAll()
+        .some(
+          (mutation) =>
+            mutation.options.mutationKey?.[2] === "delete" &&
+            (mutation.state.variables as { id?: string }).id ===
+              PROVIDER_MANAGED_EVENT_ID,
+        ),
+    ).toBe(true);
   });
 
   it("moves the focused timed event by 15 minutes with Shift+ArrowUp and Shift+ArrowDown", async () => {


### PR DESCRIPTION
Fixes #3516

## What and why

Provider-managed events (`providerManaged: true`) now keep their schedule under provider control on the web while title, description, location, color, delete, duplicate, and save stay available. Grid drag/resize and Shift+Arrow nudges use `isGridEventScheduleLocked`; delete and context menu stay on `isEventReadOnly`. The event form disables only schedule and recurrence with a provider-neutral note. Replace mutations refuse schedule changes with a toast backstop.

## Verify

```
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)
VERDICT: PASS
```