### PR TITLE
docs: document provider-managed events and add acceptance scenario (WP-05)

### DIFF
--- a/docs/acceptance/events.md
+++ b/docs/acceptance/events.md
@@ -335,7 +335,51 @@ action is unavailable.
 
 ---
 
-## Scenario 13: Busy Private Events Show No Details
+## Scenario 13: Provider-Managed Event Keeps Provider Schedule, Compass Overlays Details
+
+### UX
+
+Some events stay owned by the calendar provider and keep receiving updates
+from it (today: Google events auto-created from forwarded email when "Events
+from Gmail" is on). Compass lets you rename and annotate them, but their time
+follows the provider. Drag, resize, and Shift+Arrow nudges are refused; Delete
+still works.
+
+### Steps
+
+1. Forward a flight or hotel confirmation email to a Gmail account that has
+   "Events from Gmail" enabled in Google Calendar settings. Wait for the event
+   to sync into Compass (see `google-sync.md`).
+2. Open the synced event in Compass (`M` or left-click).
+3. Note which fields are editable and read the schedule note.
+4. Change the title and save.
+5. Change the event color and save.
+6. Try to drag the event to a new time slot.
+7. Focus the event on the grid and press Shift+ArrowRight.
+8. Delete the event.
+
+### Expected Results
+
+- The form keeps the title, location, description, and color controls enabled
+  and shows a Save button.
+- Schedule and recurrence controls are disabled.
+- A note reads: "Your calendar provider keeps this event updated (for example
+  from an email), so its time follows the provider. Changes to the title,
+  notes, and location stay in Compass."
+- After a title-only save, the new title appears in Compass and the sync log
+  shows no `patchEvent` call for that update (the overlay is stored locally in
+  Sync).
+- After a color change, the sync log shows a `patchEvent` that writes only
+  provider-allowed fields (for Google: `colorId`).
+- Dragging the event does not move it; no drag preview appears.
+- Shift+ArrowRight does not nudge the event; no schedule-change toast appears
+  unless you change the time from the form (then the toast reads: "This
+  event's time follows your calendar provider and can't be moved in Compass.").
+- Delete removes the event from Compass and the provider.
+
+---
+
+## Scenario 14: Busy Private Events Show No Details
 
 ### UX
 

--- a/docs/architecture/event-domain-model.md
+++ b/docs/architecture/event-domain-model.md
@@ -83,7 +83,20 @@ Important event fields:
 - `recurrence`: discriminated union: `single` (standalone event), `series`
   (recurring base, carries `rules`), or `occurrence` (references its parent
   via `seriesId`)
+- `providerManaged`: optional, present only when `true` (same convention as
+  `icalUid`). Marks events the provider owns and keeps updating (today: Google
+  events whose `eventType` is not `"default"`, such as Gmail-created flights).
+  Omitted on events imported before the field existed and on locally created
+  events.
 - `createdAt`, `updatedAt`
+
+Sync persists Compass overlays for provider-managed events in a separate
+`customizations` record field (`packages/sync/src/storage/contracts/event.contracts.ts`):
+optional `title`, `description`, and `location` served over the provider's
+values while schedule follows the provider. The wire contract exposes
+`providerManaged` on `SyncEventInstanceSchema`; customizations stay on the sync
+record and are applied when instances are assembled
+(`packages/sync/src/domain/event-instance-assembly.ts`).
 
 The backend record shape (`packages/backend/src/event/event.record.ts`) mirrors
 this with Mongo-native types (`ObjectId`, `Date`) plus a single nullable
@@ -142,6 +155,10 @@ Do not assume every incoming `id` is already a durable Mongo id.
 - Every persisted event must have a stable Compass `id`.
 - Occurrences reference their series via `recurrence.seriesId`.
 - Series events carry `recurrence.rules`.
+- The schedule of a provider-managed event is never customized; start and end
+  always follow the provider.
+- A customization set back to the provider's exact value for that field is
+  cleared, so later provider updates to that field show through.
 - Local storage schemas can evolve, but migrations must preserve existing user data.
 
 ## Before Changing The Domain

--- a/docs/backend/backend-error-handling.md
+++ b/docs/backend/backend-error-handling.md
@@ -10,6 +10,10 @@ Compass uses typed operational errors plus a centralized Express error handler.
   (`code` / `message` / `retryable`). Unknown/programmer errors are
   **non-retryable 500** — only true Sync/provider failures stay retryable
   `PROVIDER_FAILURE`.
+- When a provider refuses a patch with HTTP 400 because the operation is not
+  supported for that event (for example editing title on a Gmail-created event),
+  Sync reports `unsupportedCapability` and the backend answers
+  `UNSUPPORTED_OPERATION` 403 (non-retryable), not `PROVIDER_FAILURE` 502.
 - Sync proxy failures on calendar/auth reads use `throwSyncProxyFailure` /
   `unwrapSyncResult` (503/502), never `GenericError.NotSure`.
 

--- a/docs/features/calendar-providers.md
+++ b/docs/features/calendar-providers.md
@@ -61,6 +61,7 @@ each with a tracking issue:
 | Conference link on create | Google Meet | Microsoft Teams when the mailbox allows it | none |
 | Event colors | 11 slots plus labels | categories read as hex; no write in v1 | calendar color only |
 | Attendees and invitations | yes | yes | yes, server-side scheduling |
+| Provider-managed events | yes (`eventType !== "default"`) | no equivalent | no equivalent |
 | Contact suggestions | People API | `/me/people` | none |
 | Booking destination | yes | yes | yes, without a video link |
 
@@ -275,6 +276,13 @@ Each alias names the release that removes it.
   milestone C.
 - Microsoft category colors are read but never written back.
 - Apple freshness depends on polling and is bounded by iCloud rate limits.
+- **Provider-managed events.** Google is the only provider that sets
+  `providerManaged` today: its reader marks any event whose `eventType` is not
+  `"default"` (for example `fromGmail` events created from forwarded
+  confirmations when "Events from Gmail" is on). Microsoft and Apple readers
+  leave `providerManaged` unset; their writers ignore the hint. On patch, the
+  writer receives `providerManaged: true` on the input and sends only the body
+  fields that provider accepts (Google: `colorId` and attendees).
 
 ## Microsoft Graph event reads
 


### PR DESCRIPTION
Fixes #3517

## What and why

Closes the provider-managed events milestone documentation work package. Updates the event domain model, calendar providers spec, backend error handling doc, and acceptance scenarios so they match the code shipped in WP-01 through WP-04. User-facing strings in the acceptance doc were grepped against the web and sync code before writing.

## Verify

```
VERDICT: PASS
```

Checks run: `type-check`, `lint`, `knip` (docs-only diff; verify selected scripts contract subset from repo root with `--strict`).