### PR TITLE
feat(web): group weekly hours into day-pill rows

### DIFF
--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -218,7 +218,7 @@ One booking-page record per user.
 | Duration | `15` / `30` / `45` / `60` minutes. Default `30`. Custom minutes later. |
 | Destination calendar | Writable calendar (`canWriteEvents`) on a healthy connection. Receives the created event. |
 | Blocking calendars | Calendars whose busy intervals occupy slots. Any calendar the host can read availability for, including `freeBusyReader`. Default: every imported calendar on the destination account. |
-| General availability | Weekly intervals in the **host booking timezone**. Empty weekday = unavailable. Default Mon-Fri 09:00-17:00. Turning on requires at least one window (`AVAILABILITY_REQUIRED`). Default timezone: the timezone currently in the host's calendar view when they first enable booking, not UTC. An unconfigured admin GET uses the host's primary calendar timezone. |
+| General availability | Weekly intervals in the **host booking timezone**. Empty weekday = unavailable. Default Mon-Fri 09:00-17:00, shown as one grouped hours row. Turning on requires at least one window (`AVAILABILITY_REQUIRED`). Default timezone: the timezone currently in the host's calendar view when they first enable booking, not UTC. An unconfigured admin GET uses the host's primary calendar timezone. |
 | Welcome text | Optional host-authored line (max 500 characters) shown under the public name. |
 | Scheduling window | Minimum notice default **4 hours**, capped at **1440 hours** (the 60-day horizon in hours). Maximum horizon default **60 days**. Buffer default off, capped at **1440 minutes** (one working day). The 60-day cap matches Sync's busy-query bound (`BUSY_QUERY_MAX_WINDOW_MS` in `packages/core/src/types/sync/availability.contracts.ts`). |
 | Buffer | Off by default. When on, **30 minutes between appointments**, applied to both sides of a booked slot so two meetings cannot sit adjacent. |
@@ -249,9 +249,12 @@ time inputs per weekday.
   from React: the jump-key code opens the element imperatively.
 - **Timezone** uses the same searchable combobox as time travel. The
   trigger is one tab stop and still renders a stored non-canonical alias.
-- **Weekly hours** are one typed range per weekday (`9-5`, or `9-12, 1-5`
-  for a break). A blank day is unavailable. The parser reuses
-  `parseUserTime` with an explicit PM-correction rule.
+- **Weekly hours** are grouped rows of day pills plus one typed range
+  (`9-5`, or `9-12, 1-5` for a break). The default is one row, Mon-Fri,
+  9am-5pm. **Add hours** starts a row with the days that are still
+  unassigned. A weekday belongs to at most one row. Days in no row are
+  unavailable. The parser reuses `parseUserTime` with an explicit
+  PM-correction rule.
 - **Jump:** hold Mod to see section chips. `Mod+4` through `Mod+9`
   jump to on or off, Duration, Timezone, Weekly hours, Destination
   calendar, and More options (`Mod+9` opens the group and focuses the

--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -342,9 +342,13 @@ test.describe("settings booking section", () => {
   }) => {
     await prepareSignedInBookingSettingsPage(page, {
       enabled: false,
-      weeklyAvailability: [],
     });
     const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+    const hours = settingsDialog.getByRole("textbox", { name: /Hours for/ });
+    await dispatchFill(hours, "");
+    await hours.evaluate((el) => {
+      el.dispatchEvent(new Event("blur", { bubbles: true }));
+    });
     await dispatchClick(
       settingsDialog.getByRole("switch", { name: "Meeting page" }),
     );
@@ -355,6 +359,27 @@ test.describe("settings booking section", () => {
     ).toBeVisible();
     await expectNoAxeViolations(page, {
       checkpoint: "settings booking inline save error",
+      include: "[role='dialog']",
+    });
+  });
+
+  test("hours row errors have no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await prepareSignedInBookingSettingsPage(page);
+    const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+    await dispatchClick(
+      settingsDialog.getByRole("button", { name: "Add hours" }),
+    );
+    const hoursInputs = settingsDialog.getByRole("textbox", { name: /Hours/ });
+    await expect(hoursInputs).toHaveCount(2);
+    await dispatchFill(hoursInputs.nth(0), "whenever");
+    await hoursInputs.nth(0).evaluate((el) => {
+      el.dispatchEvent(new Event("blur", { bubbles: true }));
+    });
+    await expect(settingsDialog.getByRole("alert")).toBeVisible();
+    await expectNoAxeViolations(page, {
+      checkpoint: "settings booking hours row error",
       include: "[role='dialog']",
     });
   });

--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 import {
   buildBookableSlot,
+  dispatchBlur,
   dispatchClick,
   dispatchFill,
   formatSlotButtonLabel,
@@ -346,9 +347,7 @@ test.describe("settings booking section", () => {
     const settingsDialog = page.getByRole("dialog", { name: "Settings" });
     const hours = settingsDialog.getByRole("textbox", { name: /Hours for/ });
     await dispatchFill(hours, "");
-    await hours.evaluate((el) => {
-      el.dispatchEvent(new Event("blur", { bubbles: true }));
-    });
+    await dispatchBlur(hours);
     await dispatchClick(
       settingsDialog.getByRole("switch", { name: "Meeting page" }),
     );
@@ -374,9 +373,7 @@ test.describe("settings booking section", () => {
     const hoursInputs = settingsDialog.getByRole("textbox", { name: /Hours/ });
     await expect(hoursInputs).toHaveCount(2);
     await dispatchFill(hoursInputs.nth(0), "whenever");
-    await hoursInputs.nth(0).evaluate((el) => {
-      el.dispatchEvent(new Event("blur", { bubbles: true }));
-    });
+    await dispatchBlur(hoursInputs.nth(0));
     await expect(settingsDialog.getByRole("alert")).toBeVisible();
     await expectNoAxeViolations(page, {
       checkpoint: "settings booking hours row error",

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -1227,6 +1227,19 @@ export const dispatchFill = async (
   }, value);
 };
 
+/**
+ * React maps `onBlur` to bubbling `focusout`. A native `blur` event does not
+ * reach that listener, so hours-row commit (and similar) would never run.
+ */
+export const dispatchBlur = async (
+  locator: import("@playwright/test").Locator,
+) => {
+  await locator.waitFor({ state: "attached", timeout: 10000 });
+  await locator.evaluate((el) => {
+    el.dispatchEvent(new Event("focusout", { bubbles: true }));
+  });
+};
+
 export function formatSlotButtonLabel(
   slotStart: string,
   timeZone = "UTC",

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -222,10 +222,14 @@ test("turns a not-live unconfigured page on in one click", async ({ page }) => {
 test("blocks turn on with empty hours", async ({ page }) => {
   const captured = await prepareSignedInBookingSettingsPage(page, {
     enabled: false,
-    weeklyAvailability: [],
   });
 
   const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+  const hours = settingsDialog.getByRole("textbox", { name: /Hours for/ });
+  await dispatchFill(hours, "");
+  await hours.evaluate((el) => {
+    el.dispatchEvent(new Event("blur", { bubbles: true }));
+  });
   await dispatchClick(
     settingsDialog.getByRole("switch", { name: "Meeting page" }),
   );

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -3,6 +3,7 @@ import { DEFAULT_WEEKLY_AVAILABILITY } from "@core/types/booking.contracts";
 import {
   BOOKING_CALENDAR_ID,
   COMPASS_CALENDAR_ID,
+  dispatchBlur,
   dispatchClick,
   dispatchFill,
   prepareSignedInBookingSettingsPage,
@@ -227,9 +228,7 @@ test("blocks turn on with empty hours", async ({ page }) => {
   const settingsDialog = page.getByRole("dialog", { name: "Settings" });
   const hours = settingsDialog.getByRole("textbox", { name: /Hours for/ });
   await dispatchFill(hours, "");
-  await hours.evaluate((el) => {
-    el.dispatchEvent(new Event("blur", { bubbles: true }));
-  });
+  await dispatchBlur(hours);
   await dispatchClick(
     settingsDialog.getByRole("switch", { name: "Meeting page" }),
   );

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -1000,12 +1000,12 @@ describe("BookingSettingsSection", () => {
 
     // "9-5, then 11-2" is not real input, but any typed letter would be: a
     // bare `e` must reach the field, not swallow the next keystroke.
-    const monday = screen.getByLabelText("Monday");
-    await user.click(monday);
+    const hours = screen.getByRole("textbox", { name: /^Hours/ });
+    await user.click(hours);
     await user.keyboard("eh");
 
-    expect(monday).toHaveValue("eh");
-    expect(document.activeElement).toBe(monday);
+    expect(hours).toHaveValue("eh");
+    expect(document.activeElement).toBe(hours);
   });
 
   it("blocks the save while a weekly-hours row cannot be read", async () => {
@@ -1034,7 +1034,10 @@ describe("BookingSettingsSection", () => {
     );
     await screen.findByRole("switch", { name: "Meeting page" });
 
-    await user.type(screen.getByLabelText("Monday"), "whenever");
+    await user.type(
+      screen.getByRole("textbox", { name: /Hours for/ }),
+      "whenever",
+    );
     await user.tab();
     await user.click(screen.getByRole("switch", { name: "Meeting page" }));
 
@@ -1557,12 +1560,7 @@ describe("BookingSettingsSection", () => {
 
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(
-          ctx.json({
-            ...unconfiguredPage(),
-            weeklyAvailability: [],
-          }),
-        ),
+        res(ctx.json(unconfiguredPage())),
       ),
       rest.put(bookingPageUrl, (_req, res, ctx) => {
         putCount += 1;
@@ -1581,6 +1579,9 @@ describe("BookingSettingsSection", () => {
     );
 
     await screen.findByRole("switch", { name: "Meeting page" });
+    const hours = screen.getByRole("textbox", { name: /Hours for/ });
+    await user.clear(hours);
+    await user.tab();
     await user.click(screen.getByRole("switch", { name: "Meeting page" }));
 
     const hoursAlert = screen.getByRole("alert");
@@ -1614,13 +1615,36 @@ describe("BookingSettingsSection", () => {
       { wrapper },
     );
 
-    expect(await screen.findByLabelText("Monday")).toHaveValue("9am-5pm");
-    expect(screen.getByLabelText("Tuesday")).toHaveValue("9am-5pm");
-    expect(screen.getByLabelText("Wednesday")).toHaveValue("9am-5pm");
-    expect(screen.getByLabelText("Thursday")).toHaveValue("9am-5pm");
-    expect(screen.getByLabelText("Friday")).toHaveValue("9am-5pm");
-    expect(screen.getByLabelText("Saturday")).toHaveValue("");
-    expect(screen.getByLabelText("Sunday")).toHaveValue("");
+    expect(
+      await screen.findByRole("button", { name: "Monday" }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Tuesday" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Wednesday" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Thursday" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Friday" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Saturday" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(screen.getByRole("button", { name: "Sunday" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(screen.getByRole("textbox", { name: /Hours for/ })).toHaveValue(
+      "9am-5pm",
+    );
   });
 
   it("shows an error on PUT 403 without crashing Settings", async () => {

--- a/packages/web/src/booking/BookingWeeklyHoursEditor.test.tsx
+++ b/packages/web/src/booking/BookingWeeklyHoursEditor.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { render, screen, within } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   DEFAULT_WEEKLY_AVAILABILITY,
@@ -129,6 +129,21 @@ describe("BookingWeeklyHoursEditor", () => {
     expect(
       screen.queryByRole("button", { name: "Remove" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("commits the input's current value on focusout even if React state lags", () => {
+    const onChange = renderEditor();
+    const input = hoursInput();
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    setter?.call(input, "");
+    act(() => {
+      input.dispatchEvent(new Event("focusout", { bubbles: true }));
+    });
+
+    expect(lastCall(onChange)).toEqual([]);
   });
 
   it("keeps an unreadable range, shows the alert, and reports invalid", async () => {

--- a/packages/web/src/booking/BookingWeeklyHoursEditor.test.tsx
+++ b/packages/web/src/booking/BookingWeeklyHoursEditor.test.tsx
@@ -1,7 +1,10 @@
 import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { type WeeklyAvailability } from "@core/types/booking.contracts";
+import {
+  DEFAULT_WEEKLY_AVAILABILITY,
+  type WeeklyAvailability,
+} from "@core/types/booking.contracts";
 import { BookingWeeklyHoursEditor } from "@web/booking/BookingWeeklyHoursEditor";
 import { afterEach, describe, expect, it, mock } from "bun:test";
 
@@ -9,7 +12,9 @@ afterEach(() => {
   document.body.replaceChildren();
 });
 
-const renderEditor = (value: WeeklyAvailability = []) => {
+const renderEditor = (
+  value: WeeklyAvailability = DEFAULT_WEEKLY_AVAILABILITY,
+) => {
   const onChange = mock((_next: WeeklyAvailability) => {});
   render(<BookingWeeklyHoursEditor onChange={onChange} value={value} />);
   return onChange;
@@ -18,113 +23,152 @@ const renderEditor = (value: WeeklyAvailability = []) => {
 const lastCall = (onChange: ReturnType<typeof renderEditor>) =>
   onChange.mock.calls[onChange.mock.calls.length - 1]?.[0];
 
+const hoursInput = () => screen.getByRole("textbox", { name: /Hours/ });
+
+const dayPill = (name: string) => screen.getByRole("button", { name });
+
 describe("BookingWeeklyHoursEditor", () => {
-  it("turns a typed range into availability on blur", async () => {
+  it("shows one Mon-Fri row at 9am-5pm by default", () => {
+    renderEditor();
+
+    expect(screen.getAllByRole("textbox", { name: /Hours/ })).toHaveLength(1);
+    expect(hoursInput()).toHaveValue("9am-5pm");
+    for (const name of [
+      "Monday",
+      "Tuesday",
+      "Wednesday",
+      "Thursday",
+      "Friday",
+    ]) {
+      expect(dayPill(name)).toHaveAttribute("aria-pressed", "true");
+    }
+    expect(dayPill("Saturday")).toHaveAttribute("aria-pressed", "false");
+    expect(dayPill("Sunday")).toHaveAttribute("aria-pressed", "false");
+    expect(
+      screen.getByText("Unavailable: Saturday, Sunday"),
+    ).toBeInTheDocument();
+  });
+
+  it("emits two intervals for each pressed day after typing a break", async () => {
     const user = userEvent.setup({ delay: null });
     const onChange = renderEditor();
 
-    await user.type(screen.getByLabelText("Monday"), "9-5");
+    await user.clear(hoursInput());
+    await user.type(hoursInput(), "9-12, 1-5");
     await user.tab();
 
     expect(lastCall(onChange)).toEqual([
-      { weekday: 1, start: "09:00", end: "17:00" },
-    ]);
-  });
-
-  it("normalizes the row so the user sees what was understood", async () => {
-    const user = userEvent.setup({ delay: null });
-    renderEditor();
-
-    await user.type(screen.getByLabelText("Tuesday"), "930-5:30p");
-    await user.tab();
-
-    expect(screen.getByLabelText("Tuesday")).toHaveValue("9:30am-5:30pm");
-  });
-
-  it("treats a blank day as unavailable", async () => {
-    const user = userEvent.setup({ delay: null });
-    const onChange = renderEditor([
-      { weekday: 3, start: "09:00", end: "17:00" },
-    ]);
-
-    await user.clear(screen.getByLabelText("Wednesday"));
-    await user.tab();
-
-    expect(lastCall(onChange)).toEqual([]);
-    expect(screen.getAllByText("Unavailable").length).toBeGreaterThan(0);
-  });
-
-  it("keeps both intervals on a day with a break", () => {
-    // The old editor read the day with .find and destroyed the second
-    // interval on the next save.
-    renderEditor([
+      { weekday: 1, start: "09:00", end: "12:00" },
+      { weekday: 1, start: "13:00", end: "17:00" },
+      { weekday: 2, start: "09:00", end: "12:00" },
+      { weekday: 2, start: "13:00", end: "17:00" },
+      { weekday: 3, start: "09:00", end: "12:00" },
+      { weekday: 3, start: "13:00", end: "17:00" },
       { weekday: 4, start: "09:00", end: "12:00" },
       { weekday: 4, start: "13:00", end: "17:00" },
+      { weekday: 5, start: "09:00", end: "12:00" },
+      { weekday: 5, start: "13:00", end: "17:00" },
     ]);
-
-    expect(screen.getByLabelText("Thursday")).toHaveValue("9am-12pm, 1pm-5pm");
+    expect(hoursInput()).toHaveValue("9am-12pm, 1pm-5pm");
   });
 
-  it("reports an unreadable row without discarding what was typed", async () => {
+  it("adds Saturday intervals from a second row", async () => {
+    const user = userEvent.setup({ delay: null });
+    const onChange = renderEditor();
+
+    await user.click(screen.getByRole("button", { name: "Add hours" }));
+    const groups = screen.getAllByRole("group", { name: "Days" });
+    expect(groups).toHaveLength(2);
+    const secondInput = screen.getAllByRole("textbox", { name: /Hours/ })[1]!;
+    await user.type(secondInput, "10-2");
+    await user.tab();
+
+    expect(lastCall(onChange)).toEqual(
+      expect.arrayContaining([
+        { weekday: 6, start: "10:00", end: "14:00" },
+        { weekday: 1, start: "09:00", end: "17:00" },
+      ]),
+    );
+  });
+
+  it("moves Monday onto the second row", async () => {
+    const user = userEvent.setup({ delay: null });
+    const onChange = renderEditor();
+
+    await user.click(screen.getByRole("button", { name: "Add hours" }));
+    const groups = screen.getAllByRole("group", { name: "Days" });
+    await user.click(
+      within(groups[1]!).getByRole("button", { name: "Monday" }),
+    );
+
+    expect(
+      within(groups[0]!).getByRole("button", { name: "Monday" }),
+    ).toHaveAttribute("aria-pressed", "false");
+    expect(
+      within(groups[1]!).getByRole("button", { name: "Monday" }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(lastCall(onChange)?.filter((entry) => entry.weekday === 1)).toEqual(
+      [],
+    );
+  });
+
+  it("leaves a removed row's days unavailable", async () => {
+    const user = userEvent.setup({ delay: null });
+    const onChange = renderEditor();
+
+    await user.click(screen.getByRole("button", { name: "Add hours" }));
+    const secondInput = screen.getAllByRole("textbox", { name: /Hours/ })[1]!;
+    await user.type(secondInput, "10-2");
+    await user.tab();
+    await user.click(screen.getAllByRole("button", { name: "Remove" })[1]!);
+
+    expect(lastCall(onChange)?.some((entry) => entry.weekday === 6)).toBe(
+      false,
+    );
+    expect(screen.getByText(/Unavailable:.*Saturday/)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Remove" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps an unreadable range, shows the alert, and reports invalid", async () => {
     const user = userEvent.setup({ delay: null });
     const onValidityChange = mock((_valid: boolean) => {});
     render(
       <BookingWeeklyHoursEditor
         onChange={() => {}}
         onValidityChange={onValidityChange}
-        value={[]}
+        value={DEFAULT_WEEKLY_AVAILABILITY}
       />,
     );
 
-    await user.type(screen.getByLabelText("Friday"), "whenever");
+    await user.clear(hoursInput());
+    await user.type(hoursInput(), "whenever");
     await user.tab();
 
     expect(screen.getByRole("alert")).toHaveTextContent(
       'Could not read "whenever". Try 9-5.',
     );
-    expect(screen.getByLabelText("Friday")).toHaveValue("whenever");
+    expect(hoursInput()).toHaveValue("whenever");
     expect(onValidityChange).toHaveBeenLastCalledWith(false);
   });
 
-  it("applies Monday to the weekdays and leaves the weekend alone", async () => {
+  it("costs two tab stops per row plus Remove", async () => {
     const user = userEvent.setup({ delay: null });
-    const onChange = renderEditor();
-
-    await user.type(screen.getByLabelText("Monday"), "9-5");
-    await user.click(
-      screen.getByRole("button", { name: "Apply Monday to weekdays" }),
-    );
-
-    expect(lastCall(onChange)).toEqual([
-      { weekday: 1, start: "09:00", end: "17:00" },
-      { weekday: 2, start: "09:00", end: "17:00" },
-      { weekday: 3, start: "09:00", end: "17:00" },
-      { weekday: 4, start: "09:00", end: "17:00" },
-      { weekday: 5, start: "09:00", end: "17:00" },
-    ]);
-    expect(screen.getByLabelText("Saturday")).toHaveValue("");
-  });
-
-  it("clears every day", async () => {
-    const user = userEvent.setup({ delay: null });
-    const onChange = renderEditor([
-      { weekday: 1, start: "09:00", end: "17:00" },
-      { weekday: 6, start: "10:00", end: "12:00" },
-    ]);
-
-    await user.click(screen.getByRole("button", { name: "Clear all" }));
-
-    expect(lastCall(onChange)).toEqual([]);
-    expect(screen.getByLabelText("Monday")).toHaveValue("");
-  });
-
-  it("costs 9 tab stops, not the 21 the time inputs did", () => {
     renderEditor();
+    await user.click(screen.getByRole("button", { name: "Add hours" }));
 
-    // 7 day inputs + the two bulk buttons.
-    const inputs = screen.getAllByRole("textbox");
-    const buttons = screen.getAllByRole("button");
-    expect(inputs).toHaveLength(7);
-    expect(buttons).toHaveLength(2);
+    const groups = screen.getAllByRole("group", { name: "Days" });
+    const inputs = screen.getAllByRole("textbox", { name: /Hours/ });
+    const remove = screen.getAllByRole("button", { name: "Remove" });
+    expect(groups).toHaveLength(2);
+    expect(inputs).toHaveLength(2);
+    expect(remove).toHaveLength(2);
+
+    const firstGroupButtons = within(groups[0]!).getAllByRole("button");
+    const tabStops = firstGroupButtons.filter(
+      (button) => button.tabIndex === 0,
+    );
+    expect(tabStops).toHaveLength(1);
   });
 });

--- a/packages/web/src/booking/BookingWeeklyHoursEditor.tsx
+++ b/packages/web/src/booking/BookingWeeklyHoursEditor.tsx
@@ -1,18 +1,25 @@
-import { useEffect, useRef, useState } from "react";
+import { type KeyboardEvent, useEffect, useId, useRef, useState } from "react";
+import { type WeeklyAvailability } from "@core/types/booking.contracts";
 import {
-  type WeeklyAvailability,
-  type WeeklyAvailabilityInterval,
-} from "@core/types/booking.contracts";
-import { ISO_WEEKDAYS, weekdayLabel } from "@web/booking/booking.util";
+  ISO_WEEKDAYS,
+  type IsoWeekday,
+  weekdayLabel,
+  weekdayShortLabel,
+} from "@web/booking/booking.util";
 import {
   formatHoursRanges,
   parseHoursRanges,
 } from "@web/booking/weekly-hours.parse";
+import {
+  availabilityFromRows,
+  claimWeekday,
+  type HoursRow,
+  hoursInputLabel,
+  rowsFromAvailability,
+  textForRow,
+  unassignedWeekdays,
+} from "@web/booking/weekly-hours.rows";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
-
-type Weekday = WeeklyAvailabilityInterval["weekday"];
-
-const WEEKDAYS: readonly Weekday[] = [1, 2, 3, 4, 5];
 
 interface BookingWeeklyHoursEditorProps {
   value: WeeklyAvailability;
@@ -26,23 +33,29 @@ interface BookingWeeklyHoursEditorProps {
   shortcutKeys?: readonly string[];
 }
 
-const textForWeekday = (value: WeeklyAvailability, weekday: Weekday): string =>
-  formatHoursRanges(value.filter((entry) => entry.weekday === weekday));
+interface EditorRow extends HoursRow {
+  id: number;
+}
 
-const textsFromAvailability = (
+const emptyRow = (): HoursRow => ({
+  weekdays: new Set<IsoWeekday>(),
+  text: "",
+});
+
+const toEditorRows = (
   value: WeeklyAvailability,
-): Record<Weekday, string> =>
-  Object.fromEntries(
-    ISO_WEEKDAYS.map((weekday) => [weekday, textForWeekday(value, weekday)]),
-  ) as Record<Weekday, string>;
+  nextId: () => number,
+): EditorRow[] => {
+  const grouped = rowsFromAvailability(value);
+  const source = grouped.length > 0 ? grouped : [emptyRow()];
+  return source.map((row) => ({ ...row, id: nextId() }));
+};
+
+const pillClassName =
+  "c-focus-ring min-h-8 min-w-8 rounded border border-border px-1.5 text-xs text-text hover:bg-surface-panel aria-pressed:border-accent aria-pressed:bg-accent aria-pressed:text-on-accent";
 
 /**
- * One typed range per day - "9-5", or "9-12, 1-5", or blank for unavailable.
- *
- * This replaced a checkbox plus two native <input type="time"> per day: 21 tab
- * stops, each time input itself a multi-segment widget. Blankness is now the
- * unavailable state, so the checkboxes are gone, and the parser is the same
- * one behind the event form's time field.
+ * Grouped day-pill rows: one typed range shared by the days in that row.
  */
 export function BookingWeeklyHoursEditor({
   value,
@@ -52,94 +65,114 @@ export function BookingWeeklyHoursEditor({
   onDraftDirtyChange,
   shortcutKeys,
 }: BookingWeeklyHoursEditorProps) {
-  // Raw text per row so a half-typed value is never yanked out from under the
-  // user; it only becomes availability once it parses.
-  const [texts, setTexts] = useState<Record<Weekday, string>>(() =>
-    textsFromAvailability(value),
+  const hintId = useId();
+  const idRef = useRef(1);
+  const allocId = () => {
+    const id = idRef.current;
+    idRef.current += 1;
+    return id;
+  };
+  const [rows, setRows] = useState<EditorRow[]>(() =>
+    toEditorRows(value, allocId),
   );
-  const [errors, setErrors] = useState<Partial<Record<Weekday, string>>>({});
+  const [errors, setErrors] = useState<ReadonlyMap<number, string>>(new Map());
   const [announcement, setAnnouncement] = useState("");
-  // What we last handed upward. Anything else arriving in `value` came from
-  // outside - the server response seeding the form - so the rows resync,
-  // without yanking a half-typed value out from under the user.
+  const [rover, setRover] = useState<Record<number, IsoWeekday>>({});
   const emittedRef = useRef<WeeklyAvailability>(value);
   const draftDirtyRef = useRef(false);
 
   useEffect(() => {
     if (value === emittedRef.current) return;
     emittedRef.current = value;
-    setTexts(textsFromAvailability(value));
-    setErrors({});
+    setRows(
+      toEditorRows(value, () => {
+        const id = idRef.current;
+        idRef.current += 1;
+        return id;
+      }),
+    );
+    setErrors(new Map());
   }, [value]);
 
   useEffect(() => {
-    onValidityChange?.(Object.keys(errors).length === 0);
+    onValidityChange?.(errors.size === 0);
   }, [errors, onValidityChange]);
 
   useEffect(() => {
     if (!onDraftDirtyChange) return;
-    const dirty = ISO_WEEKDAYS.some(
-      (weekday) => (texts[weekday] ?? "") !== textForWeekday(value, weekday),
-    );
+    const dirty = rows.some((row) => row.text !== textForRow(value, row));
     if (draftDirtyRef.current === dirty) return;
     draftDirtyRef.current = dirty;
     onDraftDirtyChange(dirty);
-  }, [onDraftDirtyChange, texts, value]);
+  }, [onDraftDirtyChange, rows, value]);
 
-  const commit = (nextTexts: Record<Weekday, string>) => {
-    const nextErrors: Partial<Record<Weekday, string>> = {};
-    const intervals: WeeklyAvailabilityInterval[] = [];
-
-    for (const weekday of ISO_WEEKDAYS) {
-      const result = parseHoursRanges(nextTexts[weekday] ?? "");
-      if (!result.ok) {
-        nextErrors[weekday] = result.error;
-        continue;
-      }
-      for (const range of result.ranges) {
-        intervals.push({ weekday, start: range.start, end: range.end });
-      }
+  const commitRows = (nextRows: EditorRow[], liveAnnouncement?: string) => {
+    const result = availabilityFromRows(nextRows);
+    setRows(nextRows);
+    if (!result.ok) {
+      setErrors(result.errors);
+      if (liveAnnouncement) setAnnouncement(liveAnnouncement);
+      return;
     }
-
-    setErrors(nextErrors);
-    emittedRef.current = intervals;
-    onChange(intervals);
+    setErrors(new Map());
+    emittedRef.current = result.value;
+    onChange(result.value);
+    if (liveAnnouncement) setAnnouncement(liveAnnouncement);
   };
 
-  const setText = (weekday: Weekday, text: string) => {
-    setTexts((current) => ({ ...current, [weekday]: text }));
-  };
-
-  const commitRow = (weekday: Weekday) => {
-    const result = parseHoursRanges(texts[weekday] ?? "");
-    const nextTexts = result.ok
-      ? { ...texts, [weekday]: formatHoursRanges(result.ranges) }
-      : texts;
-    setTexts(nextTexts);
-    commit(nextTexts);
-  };
-
-  const applyToWeekdays = () => {
-    const source = texts[1] ?? "";
-    const nextTexts = { ...texts };
-    for (const weekday of WEEKDAYS) nextTexts[weekday] = source;
-    setTexts(nextTexts);
-    commit(nextTexts);
-    setAnnouncement(
-      source.trim() === ""
-        ? "Cleared Monday through Friday"
-        : `Set Monday through Friday to ${source}`,
+  const setRowText = (id: number, text: string) => {
+    setRows((current) =>
+      current.map((row) => (row.id === id ? { ...row, text } : row)),
     );
   };
 
-  const clearAll = () => {
-    const nextTexts = Object.fromEntries(
-      ISO_WEEKDAYS.map((weekday) => [weekday, ""]),
-    ) as Record<Weekday, string>;
-    setTexts(nextTexts);
-    commit(nextTexts);
-    setAnnouncement("Cleared every day");
+  const commitText = (id: number) => {
+    const current = rows.find((row) => row.id === id);
+    if (!current) return;
+    const parsed = parseHoursRanges(current.text);
+    const snapped = parsed.ok ? formatHoursRanges(parsed.ranges) : current.text;
+    const nextRows = rows.map((row) =>
+      row.id === id ? { ...row, text: snapped } : row,
+    );
+    commitRows(nextRows);
   };
+
+  const toggleDay = (rowIndex: number, weekday: IsoWeekday) => {
+    const next = claimWeekday(rows, rowIndex, weekday).map((row, index) => ({
+      ...row,
+      id: rows[index]?.id ?? allocId(),
+    }));
+    const pressed = next[rowIndex]?.weekdays.has(weekday) === true;
+    commitRows(
+      next,
+      pressed
+        ? `Added ${weekdayLabel(weekday)}`
+        : `Removed ${weekdayLabel(weekday)}`,
+    );
+  };
+
+  const addRow = () => {
+    const seeded = new Set(unassignedWeekdays(rows));
+    const next: EditorRow[] = [
+      ...rows,
+      { id: allocId(), weekdays: seeded, text: "" },
+    ];
+    commitRows(next, "Added hours row");
+  };
+
+  const removeRow = (id: number) => {
+    if (rows.length < 2) return;
+    commitRows(
+      rows.filter((row) => row.id !== id),
+      "Removed hours row",
+    );
+  };
+
+  const unavailable = unassignedWeekdays(rows);
+  const unavailableCopy =
+    unavailable.length > 0
+      ? `Unavailable: ${unavailable.map(weekdayLabel).join(", ")}`
+      : null;
 
   return (
     <fieldset className="flex flex-col gap-2" disabled={disabled}>
@@ -147,66 +180,138 @@ export function BookingWeeklyHoursEditor({
         Weekly hours
         {shortcutKeys ? <ShortcutKeys keys={[...shortcutKeys]} /> : null}
       </legend>
-      <p className="text-text-muted text-xs" id="booking-hours-hint">
-        Type a range like 9-5, or 9-12, 1-5 for a break. Leave a day blank to be
-        unavailable.
+      <p className="text-text-muted text-xs" id={hintId}>
+        Type a range like 9-5, or 9-12, 1-5 for a break.
       </p>
+      {unavailableCopy ? (
+        <p className="text-sm text-text-muted">{unavailableCopy}</p>
+      ) : null}
 
       <span aria-live="polite" className="sr-only" role="status">
         {announcement}
       </span>
 
-      {ISO_WEEKDAYS.map((weekday) => (
-        <div className="flex flex-col gap-1" key={weekday}>
-          <div className="flex items-center gap-2">
-            <label
-              className="w-28 shrink-0 text-sm text-text"
-              htmlFor={`booking-hours-${weekday}`}
-            >
-              {weekdayLabel(weekday)}
-            </label>
-            <input
-              aria-describedby="booking-hours-hint"
-              aria-invalid={errors[weekday] ? true : undefined}
-              className="c-focus-ring w-40 rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text"
-              id={`booking-hours-${weekday}`}
-              onBlur={() => commitRow(weekday)}
-              onChange={(event) => setText(weekday, event.target.value)}
-              onKeyDown={(event) => {
-                if (event.key === "Enter") commitRow(weekday);
-              }}
-              placeholder="9-5"
-              type="text"
-              value={texts[weekday] ?? ""}
-            />
-            {(texts[weekday] ?? "").trim() === "" && !errors[weekday] ? (
-              <span className="text-sm text-text-muted">Unavailable</span>
+      {rows.map((row, rowIndex) => {
+        const error = errors.get(rowIndex);
+        const errorId = error ? `booking-hours-row-${row.id}-error` : undefined;
+        const tabStop = roverDay(row, rover[row.id]);
+        return (
+          <div className="flex flex-col gap-1" key={row.id}>
+            <div className="flex flex-wrap items-center gap-2">
+              <fieldset
+                className="flex flex-wrap gap-1"
+                onKeyDown={(event) =>
+                  handleDayGroupKeyDown(event, tabStop, (weekday) => {
+                    setRover((current) => ({ ...current, [row.id]: weekday }));
+                    const pill = event.currentTarget.querySelector<HTMLElement>(
+                      `[aria-label="${weekdayLabel(weekday)}"]`,
+                    );
+                    pill?.focus();
+                  })
+                }
+              >
+                <legend className="sr-only">Days</legend>
+                {ISO_WEEKDAYS.map((weekday) => (
+                  <button
+                    aria-label={weekdayLabel(weekday)}
+                    aria-pressed={row.weekdays.has(weekday)}
+                    className={pillClassName}
+                    key={weekday}
+                    onClick={() => toggleDay(rowIndex, weekday)}
+                    onFocus={() =>
+                      setRover((current) => ({ ...current, [row.id]: weekday }))
+                    }
+                    tabIndex={weekday === tabStop ? 0 : -1}
+                    type="button"
+                  >
+                    {weekdayShortLabel(weekday)}
+                  </button>
+                ))}
+              </fieldset>
+              <input
+                aria-describedby={errorId ? `${hintId} ${errorId}` : hintId}
+                aria-invalid={error ? true : undefined}
+                aria-label={hoursInputLabel(row)}
+                className="c-focus-ring min-w-40 flex-1 rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text"
+                id={`booking-hours-row-${row.id}`}
+                onBlur={() => commitText(row.id)}
+                onChange={(event) => setRowText(row.id, event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    commitText(row.id);
+                  }
+                }}
+                placeholder="9-5"
+                type="text"
+                value={row.text}
+              />
+              {rows.length > 1 ? (
+                <button
+                  className="c-focus-ring rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text hover:bg-surface-panel"
+                  onClick={() => removeRow(row.id)}
+                  type="button"
+                >
+                  Remove
+                </button>
+              ) : null}
+            </div>
+            {error ? (
+              <p className="text-error text-xs" id={errorId} role="alert">
+                {error}
+              </p>
             ) : null}
           </div>
-          {errors[weekday] ? (
-            <p className="pl-30 text-error text-xs" role="alert">
-              {errors[weekday]}
-            </p>
-          ) : null}
-        </div>
-      ))}
+        );
+      })}
 
-      <div className="mt-1 flex gap-2">
-        <button
-          className="c-focus-ring rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text hover:bg-surface-panel"
-          onClick={applyToWeekdays}
-          type="button"
-        >
-          Apply Monday to weekdays
-        </button>
-        <button
-          className="c-focus-ring rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text hover:bg-surface-panel"
-          onClick={clearAll}
-          type="button"
-        >
-          Clear all
-        </button>
-      </div>
+      <button
+        className="c-focus-ring self-start rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text hover:bg-surface-panel"
+        onClick={addRow}
+        type="button"
+      >
+        Add hours
+      </button>
     </fieldset>
   );
 }
+
+const roverDay = (
+  row: HoursRow,
+  focused: IsoWeekday | undefined,
+): IsoWeekday => {
+  if (focused != null && ISO_WEEKDAYS.includes(focused)) return focused;
+  return (
+    ISO_WEEKDAYS.find((weekday) => row.weekdays.has(weekday)) ?? ISO_WEEKDAYS[0]
+  );
+};
+
+const handleDayGroupKeyDown = (
+  event: KeyboardEvent<HTMLFieldSetElement>,
+  current: IsoWeekday,
+  move: (weekday: IsoWeekday) => void,
+) => {
+  const index = ISO_WEEKDAYS.indexOf(current);
+  if (index < 0) return;
+  let nextIndex: number | null = null;
+  switch (event.key) {
+    case "ArrowRight":
+      nextIndex = Math.min(index + 1, ISO_WEEKDAYS.length - 1);
+      break;
+    case "ArrowLeft":
+      nextIndex = Math.max(index - 1, 0);
+      break;
+    case "Home":
+      nextIndex = 0;
+      break;
+    case "End":
+      nextIndex = ISO_WEEKDAYS.length - 1;
+      break;
+    default:
+      return;
+  }
+  const next = ISO_WEEKDAYS[nextIndex];
+  if (next == null || next === current) return;
+  event.preventDefault();
+  move(next);
+};

--- a/packages/web/src/booking/BookingWeeklyHoursEditor.tsx
+++ b/packages/web/src/booking/BookingWeeklyHoursEditor.tsx
@@ -126,11 +126,9 @@ export function BookingWeeklyHoursEditor({
     );
   };
 
-  const commitText = (id: number) => {
-    const current = rows.find((row) => row.id === id);
-    if (!current) return;
-    const parsed = parseHoursRanges(current.text);
-    const snapped = parsed.ok ? formatHoursRanges(parsed.ranges) : current.text;
+  const commitText = (id: number, rawText: string) => {
+    const parsed = parseHoursRanges(rawText);
+    const snapped = parsed.ok ? formatHoursRanges(parsed.ranges) : rawText;
     const nextRows = rows.map((row) =>
       row.id === id ? { ...row, text: snapped } : row,
     );
@@ -234,12 +232,14 @@ export function BookingWeeklyHoursEditor({
                 aria-label={hoursInputLabel(row)}
                 className="c-focus-ring min-w-40 flex-1 rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text"
                 id={`booking-hours-row-${row.id}`}
-                onBlur={() => commitText(row.id)}
+                onBlur={(event) =>
+                  commitText(row.id, event.currentTarget.value)
+                }
                 onChange={(event) => setRowText(row.id, event.target.value)}
                 onKeyDown={(event) => {
                   if (event.key === "Enter") {
                     event.preventDefault();
-                    commitText(row.id);
+                    commitText(row.id, event.currentTarget.value);
                   }
                 }}
                 placeholder="9-5"

--- a/packages/web/src/booking/BookingWeeklyHoursEditor.tsx
+++ b/packages/web/src/booking/BookingWeeklyHoursEditor.tsx
@@ -257,7 +257,11 @@ export function BookingWeeklyHoursEditor({
               ) : null}
             </div>
             {error ? (
-              <p className="text-error text-xs" id={errorId} role="alert">
+              <p
+                className="font-medium text-sm text-text"
+                id={errorId}
+                role="alert"
+              >
                 {error}
               </p>
             ) : null}

--- a/packages/web/src/booking/booking.util.ts
+++ b/packages/web/src/booking/booking.util.ts
@@ -81,6 +81,22 @@ export function weekdayLabel(weekday: WeeklyAvailabilityInterval["weekday"]) {
 
 export const ISO_WEEKDAYS = [1, 2, 3, 4, 5, 6, 7] as const;
 
+export type IsoWeekday = (typeof ISO_WEEKDAYS)[number];
+
+const WEEKDAY_SHORT_LABELS: Record<IsoWeekday, string> = {
+  1: "Mon",
+  2: "Tue",
+  3: "Wed",
+  4: "Thu",
+  5: "Fri",
+  6: "Sat",
+  7: "Sun",
+};
+
+export function weekdayShortLabel(weekday: IsoWeekday) {
+  return WEEKDAY_SHORT_LABELS[weekday];
+}
+
 /**
  * The PUT body, and only the PUT body.
  *

--- a/packages/web/src/booking/weekly-hours.rows.test.ts
+++ b/packages/web/src/booking/weekly-hours.rows.test.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_WEEKLY_AVAILABILITY } from "@core/types/booking.contracts";
-import { ISO_WEEKDAYS } from "@web/booking/booking.util";
+import { type IsoWeekday } from "@web/booking/booking.util";
 import {
   availabilityFromRows,
   claimWeekday,
@@ -100,8 +100,8 @@ describe("availabilityFromRows", () => {
 describe("claimWeekday", () => {
   test("removes the day from its previous row", () => {
     const rows = [
-      { weekdays: new Set(ISO_WEEKDAYS.slice(0, 5)), text: "9am-5pm" },
-      { weekdays: new Set(), text: "" },
+      { weekdays: new Set<IsoWeekday>([1, 2, 3, 4, 5]), text: "9am-5pm" },
+      { weekdays: new Set<IsoWeekday>(), text: "" },
     ];
     const next = claimWeekday(rows, 1, 1);
     expect(next[0]!.weekdays.has(1)).toBe(false);

--- a/packages/web/src/booking/weekly-hours.rows.test.ts
+++ b/packages/web/src/booking/weekly-hours.rows.test.ts
@@ -1,0 +1,122 @@
+import { DEFAULT_WEEKLY_AVAILABILITY } from "@core/types/booking.contracts";
+import { ISO_WEEKDAYS } from "@web/booking/booking.util";
+import {
+  availabilityFromRows,
+  claimWeekday,
+  rowsFromAvailability,
+  textForRow,
+} from "@web/booking/weekly-hours.rows";
+import { describe, expect, test } from "bun:test";
+
+describe("rowsFromAvailability", () => {
+  test("groups Mon-Fri 09:00-17:00 into one row", () => {
+    const rows = rowsFromAvailability(DEFAULT_WEEKLY_AVAILABILITY);
+    expect(rows).toHaveLength(1);
+    expect([...rows[0]!.weekdays].sort()).toEqual([1, 2, 3, 4, 5]);
+    expect(rows[0]!.text).toBe("9am-5pm");
+  });
+
+  test("groups matching weekday hours even when stored order is scrambled", () => {
+    const rows = rowsFromAvailability([
+      { weekday: 6, start: "10:00", end: "14:00" },
+      { weekday: 3, start: "13:00", end: "17:00" },
+      { weekday: 1, start: "13:00", end: "17:00" },
+      { weekday: 5, start: "09:00", end: "12:00" },
+      { weekday: 2, start: "09:00", end: "12:00" },
+      { weekday: 4, start: "13:00", end: "17:00" },
+      { weekday: 1, start: "09:00", end: "12:00" },
+      { weekday: 5, start: "13:00", end: "17:00" },
+      { weekday: 2, start: "13:00", end: "17:00" },
+      { weekday: 3, start: "09:00", end: "12:00" },
+      { weekday: 4, start: "09:00", end: "12:00" },
+    ]);
+
+    expect(rows).toHaveLength(2);
+    expect([...rows[0]!.weekdays].sort()).toEqual([1, 2, 3, 4, 5]);
+    expect(rows[0]!.text).toBe("9am-12pm, 1pm-5pm");
+    expect([...rows[1]!.weekdays]).toEqual([6]);
+    expect(rows[1]!.text).toBe("10am-2pm");
+  });
+});
+
+describe("availabilityFromRows", () => {
+  test("round-trips a Mon-Fri 9-5 row", () => {
+    const rows = rowsFromAvailability(DEFAULT_WEEKLY_AVAILABILITY);
+    const result = availabilityFromRows(rows);
+    expect(result).toEqual({
+      ok: true,
+      value: [...DEFAULT_WEEKLY_AVAILABILITY],
+    });
+  });
+
+  test("round-trips two grouped rows", () => {
+    const stored = [
+      { weekday: 1 as const, start: "09:00", end: "12:00" },
+      { weekday: 1 as const, start: "13:00", end: "17:00" },
+      { weekday: 2 as const, start: "09:00", end: "12:00" },
+      { weekday: 2 as const, start: "13:00", end: "17:00" },
+      { weekday: 3 as const, start: "09:00", end: "12:00" },
+      { weekday: 3 as const, start: "13:00", end: "17:00" },
+      { weekday: 4 as const, start: "09:00", end: "12:00" },
+      { weekday: 4 as const, start: "13:00", end: "17:00" },
+      { weekday: 5 as const, start: "09:00", end: "12:00" },
+      { weekday: 5 as const, start: "13:00", end: "17:00" },
+      { weekday: 6 as const, start: "10:00", end: "14:00" },
+    ];
+    const result = availabilityFromRows(rowsFromAvailability(stored));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual(stored);
+    }
+  });
+
+  test("blank text with days emits nothing and is valid", () => {
+    const result = availabilityFromRows([
+      { weekdays: new Set([1, 2, 3]), text: "" },
+    ]);
+    expect(result).toEqual({ ok: true, value: [] });
+  });
+
+  test("text with no days errors", () => {
+    const result = availabilityFromRows([{ weekdays: new Set(), text: "9-5" }]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.get(0)).toBe("Choose at least one day.");
+    }
+  });
+
+  test("first row wins when a weekday appears twice", () => {
+    const result = availabilityFromRows([
+      { weekdays: new Set([1]), text: "9-5" },
+      { weekdays: new Set([1]), text: "10-2" },
+    ]);
+    expect(result).toEqual({
+      ok: true,
+      value: [{ weekday: 1, start: "09:00", end: "17:00" }],
+    });
+  });
+});
+
+describe("claimWeekday", () => {
+  test("removes the day from its previous row", () => {
+    const rows = [
+      { weekdays: new Set(ISO_WEEKDAYS.slice(0, 5)), text: "9am-5pm" },
+      { weekdays: new Set(), text: "" },
+    ];
+    const next = claimWeekday(rows, 1, 1);
+    expect(next[0]!.weekdays.has(1)).toBe(false);
+    expect(next[1]!.weekdays.has(1)).toBe(true);
+    expect([...next[0]!.weekdays].sort()).toEqual([2, 3, 4, 5]);
+  });
+});
+
+describe("textForRow", () => {
+  test("reads the first weekday's formatted hours", () => {
+    expect(
+      textForRow(DEFAULT_WEEKLY_AVAILABILITY, {
+        weekdays: new Set([3, 1, 5]),
+        text: "typed",
+      }),
+    ).toBe("9am-5pm");
+  });
+});

--- a/packages/web/src/booking/weekly-hours.rows.ts
+++ b/packages/web/src/booking/weekly-hours.rows.ts
@@ -1,0 +1,135 @@
+import {
+  type WeeklyAvailability,
+  type WeeklyAvailabilityInterval,
+} from "@core/types/booking.contracts";
+import {
+  ISO_WEEKDAYS,
+  type IsoWeekday,
+  weekdayLabel,
+} from "@web/booking/booking.util";
+import {
+  formatHoursRanges,
+  parseHoursRanges,
+} from "@web/booking/weekly-hours.parse";
+
+export interface HoursRow {
+  weekdays: ReadonlySet<IsoWeekday>;
+  text: string;
+}
+
+export type RowsResult =
+  | { ok: true; value: WeeklyAvailability }
+  | { ok: false; errors: ReadonlyMap<number, string> };
+
+const intervalsForDay = (
+  value: WeeklyAvailability,
+  weekday: IsoWeekday,
+): WeeklyAvailabilityInterval[] =>
+  value
+    .filter((entry) => entry.weekday === weekday)
+    .slice()
+    .sort((a, b) => a.start.localeCompare(b.start));
+
+/** Group stored intervals into rows that share the same formatted hours text. */
+export function rowsFromAvailability(value: WeeklyAvailability): HoursRow[] {
+  const groups = new Map<string, Set<IsoWeekday>>();
+  const order: string[] = [];
+
+  for (const weekday of ISO_WEEKDAYS) {
+    const text = formatHoursRanges(intervalsForDay(value, weekday));
+    if (text === "") continue;
+    const existing = groups.get(text);
+    if (existing) {
+      existing.add(weekday);
+      continue;
+    }
+    groups.set(text, new Set([weekday]));
+    order.push(text);
+  }
+
+  return order.map((text) => ({
+    weekdays: groups.get(text) ?? new Set<IsoWeekday>(),
+    text,
+  }));
+}
+
+export function availabilityFromRows(rows: readonly HoursRow[]): RowsResult {
+  const errors = new Map<number, string>();
+  const claimed = new Set<IsoWeekday>();
+  const intervals: WeeklyAvailabilityInterval[] = [];
+
+  rows.forEach((row, index) => {
+    const hasDays = row.weekdays.size > 0;
+    const trimmed = row.text.trim();
+    if (!hasDays && trimmed === "") return;
+    if (!hasDays) {
+      errors.set(index, "Choose at least one day.");
+      return;
+    }
+
+    const parsed = parseHoursRanges(row.text);
+    if (!parsed.ok) {
+      errors.set(index, parsed.error);
+      return;
+    }
+
+    for (const weekday of ISO_WEEKDAYS) {
+      if (!row.weekdays.has(weekday) || claimed.has(weekday)) continue;
+      claimed.add(weekday);
+      for (const range of parsed.ranges) {
+        intervals.push({
+          weekday,
+          start: range.start,
+          end: range.end,
+        });
+      }
+    }
+  });
+
+  if (errors.size > 0) return { ok: false, errors };
+  intervals.sort(
+    (left, right) =>
+      left.weekday - right.weekday || left.start.localeCompare(right.start),
+  );
+  return { ok: true, value: intervals };
+}
+
+/** Toggle `weekday` on `rowIndex`, removing it from every other row. */
+export function claimWeekday(
+  rows: readonly HoursRow[],
+  rowIndex: number,
+  weekday: IsoWeekday,
+): HoursRow[] {
+  return rows.map((row, index) => {
+    const weekdays = new Set(row.weekdays);
+    if (index === rowIndex) {
+      if (weekdays.has(weekday)) weekdays.delete(weekday);
+      else weekdays.add(weekday);
+    } else {
+      weekdays.delete(weekday);
+    }
+    return { weekdays, text: row.text };
+  });
+}
+
+/** Formatted hours for the row's first weekday, or blank when it has none. */
+export function textForRow(value: WeeklyAvailability, row: HoursRow): string {
+  const first = ISO_WEEKDAYS.find((weekday) => row.weekdays.has(weekday));
+  if (first == null) return "";
+  return formatHoursRanges(intervalsForDay(value, first));
+}
+
+export function hoursInputLabel(row: HoursRow): string {
+  const names = ISO_WEEKDAYS.filter((weekday) => row.weekdays.has(weekday)).map(
+    weekdayLabel,
+  );
+  return names.length > 0 ? `Hours for ${names.join(", ")}` : "Hours";
+}
+
+export function unassignedWeekdays(rows: readonly HoursRow[]): IsoWeekday[] {
+  const assigned = new Set<IsoWeekday>();
+  for (const row of rows) {
+    for (const weekday of row.weekdays) assigned.add(weekday);
+  }
+  return ISO_WEEKDAYS.filter((weekday) => !assigned.has(weekday));
+}

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -989,7 +989,7 @@ describe("SettingsModal", () => {
     });
 
     await screen.findByRole("switch", { name: "Meeting page" });
-    const monday = screen.getByLabelText("Monday");
+    const monday = screen.getByRole("textbox", { name: /Hours for/ });
     await user.clear(monday);
     await user.type(monday, "9");
     await user.keyboard("{Escape}");
@@ -1000,7 +1000,7 @@ describe("SettingsModal", () => {
     expect(
       screen.getByRole("dialog", { name: "Settings" }),
     ).toBeInTheDocument();
-    expect(screen.getByLabelText("Monday")).toHaveValue("9");
+    expect(screen.getByRole("textbox", { name: /Hours for/ })).toHaveValue("9");
   });
 
   it("asks before discarding unsaved booking edits on Escape", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3507

## What and why

Weekly hours in Booking Settings are grouped rows: seven day pills plus one typed range (`9-5`, or `9-12, 1-5` for a break). Default is one row, Mon-Fri, 9am-5pm. **Add hours** seeds still-unassigned days. A weekday belongs to at most one row. Days in no row are unavailable. Apply Monday to weekdays and Clear all are gone. Stored availability shape and parser are unchanged.

Hours commit reads the input on `focusout` (React's `onBlur`). Row parse errors use the same `font-medium text-sm text-text` treatment as other Settings alerts so they meet contrast on the dialog surface.

Spec: `docs/features/booking.md`. Tracking: #3501.

## Verify

`bun run verify --strict` selected web: test:web, type-check, lint, knip, test:a11y, test:e2e.

Local: test:web, type-check, lint, knip, and test:e2e passed. test:a11y failed once on `e2e/accessibility/app-a11y.spec.ts` "the event action row is accessible" (`bg-accent-secondary` contrast 4.39 vs 4.5). That spec is outside this diff. A rerun of that spec passed. CI e2e-shard 1 (`e2e/accessibility` + `e2e/allday`) passed, as did the booking shard.

Focused local Playwright: empty hours, inline save-error a11y, and hours-row-error a11y all passed.

VERDICT: PASS (CI required checks green; local a11y flake was outside the diff)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad52e327-6e23-450a-a5cb-22a43d90c4f6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad52e327-6e23-450a-a5cb-22a43d90c4f6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

