### PR TITLE
feat(web): first-run meeting address screen

### DIFF
--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -71,10 +71,13 @@ Reserved slugs (never allocated): `week`, `day`, `life`, `auth`, `api`,
 
 Compass users have `name` and `email`, not a username
 (`packages/core/src/types/user.types.ts`). When the host opens Booking
-Settings, the setup response includes a `suggestedSlug` derived from their
-account so the address is visible before the page is first enabled. The
-host may replace it on any save; a draft keeps its chosen address even
-while disabled.
+Settings for the first time, a guided screen shows the suggested address
+from `suggestedSlug` under the `.../meet/` prefix. **Continue**
+(Mod+Enter) saves a draft (`PUT` with `enabled: false` and the seeded
+defaults) so "That address is already taken" shows on that screen.
+Reopening Settings later lands on the normal page with the switch off.
+The host may replace the address later under More options; a draft keeps
+its chosen address even while disabled.
 
 When no slug is stored yet and the host enables without choosing one,
 allocate `bookingSlug` once:
@@ -240,13 +243,19 @@ time inputs per weekday.
   live. When on, it shows "Live at" and the meeting link with Copy and
   **Open meeting page**. When off, it shows "Off. Turn it on to share
   your link." and the address the page will use.
-- **Essentials:** Page address, duration, meeting timezone, weekly hours, and
+- **Essentials:** duration, meeting timezone, weekly hours, and
   destination calendar. These fit without scrolling at 1440x900.
 - **More options:** an uncontrolled native `<details>` that starts
-  collapsed. It holds blocking calendars, welcome text, notice and
-  horizon, and buffer and limits. Jumping to a field inside it, or an
-  invalid field in the group, opens it. Do not control the `open` prop
-  from React: the jump-key code opens the element imperatively.
+  collapsed. It holds page address (with "Links using your old address
+  will stop working." when the slug changes), blocking calendars,
+  welcome text, notice and horizon, and buffer and limits. Jumping to a
+  field inside it, or an invalid field in the group, opens it. Do not
+  control the `open` prop from React: the jump-key code opens the
+  element imperatively.
+- **First run:** before any draft exists, the Meeting tab is only the
+  address screen: heading "Your meeting page", one sentence, the address
+  field, the helper, and **Continue**. There is no switch, duration, or
+  hours editor until Continue saves the draft.
 - **Timezone** uses the same searchable combobox as time travel. The
   trigger is one tab stop and still renders a stored non-canonical alias.
 - **Weekly hours** are grouped rows of day pills plus one typed range

--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -386,6 +386,7 @@ test.describe("settings booking section", () => {
   }) => {
     await prepareSignedInBookingSettingsPage(page);
     const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+    await settingsDialog.getByText("More options", { exact: true }).click();
     const address = settingsDialog.getByLabel("Page address");
     await address.click();
     await dispatchFill(address, "ab");
@@ -406,6 +407,7 @@ test.describe("settings booking section", () => {
   }) => {
     await prepareSignedInBookingSettingsPage(page);
     const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+    await settingsDialog.getByText("More options", { exact: true }).click();
     await dispatchFill(
       settingsDialog.getByLabel("Page address"),
       "new-address",
@@ -449,7 +451,6 @@ test.describe("settings booking section", () => {
     page,
   }) => {
     await prepareSignedInBookingSettingsPage(page, {
-      configured: false,
       enabled: false,
     });
     const settingsDialog = page.getByRole("dialog", { name: "Settings" });
@@ -474,6 +475,58 @@ test.describe("settings booking section", () => {
     await expect(settingsDialog.getByLabel("Welcome text")).toBeVisible();
     await expectNoAxeViolations(page, {
       checkpoint: "settings booking more options",
+      include: "[role='dialog']",
+    });
+  });
+
+  test("first-run address setup has no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await prepareSignedInBookingSettingsPage(page, {
+      configured: false,
+      enabled: false,
+    });
+    const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+    await expect(
+      settingsDialog.getByRole("heading", { name: "Your meeting page" }),
+    ).toBeVisible();
+    await expectNoAxeViolations(page, {
+      checkpoint: "settings booking first-run address",
+      include: "[role='dialog']",
+    });
+  });
+
+  test("first-run taken-address error has no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await prepareSignedInBookingSettingsPage(page, {
+      configured: false,
+      enabled: false,
+    });
+    await page.route("**/api/booking/page", async (route) => {
+      if (route.request().method() === "PUT") {
+        return route.fulfill({
+          status: 409,
+          contentType: "application/json",
+          body: JSON.stringify({
+            code: "SLUG_TAKEN",
+            message: "taken",
+          }),
+        });
+      }
+      return route.fallback();
+    });
+    const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+    await dispatchClick(
+      settingsDialog.getByRole("button", { name: /Continue/ }),
+    );
+    await expect(
+      settingsDialog.getByRole("alert").filter({
+        hasText: "That address is already taken",
+      }),
+    ).toBeVisible();
+    await expectNoAxeViolations(page, {
+      checkpoint: "settings booking first-run slug taken",
       include: "[role='dialog']",
     });
   });

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -1187,6 +1187,10 @@ export async function prepareSignedInBookingSettingsPage(
     await expect(
       settingsDialog.getByRole("button", { name: "Connect Google Calendar" }),
     ).toBeVisible({ timeout: 15000 });
+  } else if (!configured) {
+    await expect(
+      settingsDialog.getByRole("heading", { name: "Your meeting page" }),
+    ).toBeVisible({ timeout: 15000 });
   } else {
     await expect(
       settingsDialog.getByRole("switch", { name: "Meeting page" }),

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -189,21 +189,33 @@ test("turns a not-live unconfigured page on in one click", async ({ page }) => {
 
   const settingsDialog = page.getByRole("dialog", { name: "Settings" });
   await expect(
-    settingsDialog.getByText("Off. Turn it on to share your link."),
+    settingsDialog.getByRole("heading", { name: "Your meeting page" }),
   ).toBeVisible();
   await expect(settingsDialog.getByLabel("Page address")).toHaveValue(
     "hostuser",
   );
-  await expect(
-    settingsDialog.getByText(/It will be at .*\/meet\/hostuser/),
-  ).toBeVisible();
 
-  await dispatchClick(
-    settingsDialog.getByRole("switch", { name: "Meeting page" }),
-  );
+  await dispatchClick(settingsDialog.getByRole("button", { name: /Continue/ }));
 
   await expect.poll(() => captured.putBodies.length).toBe(1);
   expect(captured.putBodies[0]).toMatchObject({
+    enabled: false,
+    slug: "hostuser",
+    weeklyAvailability: DEFAULT_WEEKLY_AVAILABILITY,
+  });
+
+  const meetingSwitch = settingsDialog.getByRole("switch", {
+    name: "Meeting page",
+  });
+  await expect(meetingSwitch).toHaveAttribute("aria-checked", "false");
+  await expect(
+    settingsDialog.getByText("Off. Turn it on to share your link."),
+  ).toBeVisible();
+
+  await dispatchClick(meetingSwitch);
+
+  await expect.poll(() => captured.putBodies.length).toBe(2);
+  expect(captured.putBodies[1]).toMatchObject({
     enabled: true,
     weeklyAvailability: DEFAULT_WEEKLY_AVAILABILITY,
   });
@@ -248,6 +260,7 @@ test("changes the page address and PUTs slug", async ({ page }) => {
   const captured = await prepareSignedInBookingSettingsPage(page);
 
   const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+  await openMoreOptions(settingsDialog);
   await dispatchFill(settingsDialog.getByLabel("Page address"), "new-address");
   await dispatchClick(
     settingsDialog.getByRole("button", { name: "Save changes" }),

--- a/packages/web/src/__tests__/__mocks__/server/mock.handlers.ts
+++ b/packages/web/src/__tests__/__mocks__/server/mock.handlers.ts
@@ -111,6 +111,9 @@ export const globalHandlers = [
     return res(
       ctx.status(Status.OK),
       ctx.json({
+        id: "000000000000000000000001",
+        slug: "hostuser",
+        hostUserId: "000000000000000000000002",
         enabled: false,
         durationMinutes: 30,
         destinationCalendarId: "000000000000000000000001",
@@ -123,8 +126,9 @@ export const globalHandlers = [
         bufferMinutes: null,
         maxBookingsPerDay: null,
         guestsCanInviteOthers: true,
-        isConfigured: false,
-        suggestedSlug: "hostuser",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        bookingUrl: "https://compasscalendar.com/meet/hostuser",
       }),
     );
   }),

--- a/packages/web/src/booking/BookingAddressSetup.tsx
+++ b/packages/web/src/booking/BookingAddressSetup.tsx
@@ -1,0 +1,69 @@
+import { BookingAddressField } from "@web/booking/BookingAddressField";
+import {
+  OverlayPanelActionButton,
+  OverlayPanelActions,
+} from "@web/components/OverlayPanel/OverlayPanel";
+import { settingsShortcutAttrs } from "@web/settings/useSettingsShortcuts";
+
+const SETUP_HEADING = "Your meeting page";
+const SETUP_SENTENCE =
+  "Pick the address people will use to book time with you. You can change it later.";
+
+interface BookingAddressSetupProps {
+  slug: string;
+  bookingUrl: string | null;
+  error: string | null;
+  forceInvalid?: boolean;
+  isPending: boolean;
+  onChange: (slug: string) => void;
+  onContinue: () => void;
+}
+
+/**
+ * First-run Meeting settings: pick an address, then Continue saves a draft.
+ */
+export function BookingAddressSetup({
+  slug,
+  bookingUrl,
+  error,
+  forceInvalid = false,
+  isPending,
+  onChange,
+  onContinue,
+}: BookingAddressSetupProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2">
+        <h2 className="font-medium text-lg text-text">{SETUP_HEADING}</h2>
+        <p className="text-sm text-text">{SETUP_SENTENCE}</p>
+      </div>
+      <BookingAddressField
+        bookingUrl={bookingUrl}
+        forceInvalid={forceInvalid}
+        onChange={onChange}
+        savedSlug={null}
+        showShortcuts={false}
+        slug={slug}
+      />
+      {error ? (
+        <p className="font-medium text-sm text-text" role="alert">
+          {error}
+        </p>
+      ) : null}
+      <OverlayPanelActions>
+        <OverlayPanelActionButton
+          aria-busy={isPending || undefined}
+          aria-keyshortcuts="Meta+Enter Control+Enter"
+          disabled={isPending}
+          onClick={onContinue}
+          shortcut={["Mod", "Enter"]}
+          showShortcut
+          variant="primary"
+          {...settingsShortcutAttrs("save-booking")}
+        >
+          Continue
+        </OverlayPanelActionButton>
+      </OverlayPanelActions>
+    </div>
+  );
+}

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -18,10 +18,7 @@ import {
   setProviderAvailabilityForTests,
 } from "@web/auth/providers/useIsProviderAvailable";
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
-import {
-  BOOKING_ADDRESS_CHANGE_WARNING,
-  bookingAddressPrefix,
-} from "@web/booking/BookingAddressField";
+import { BOOKING_ADDRESS_CHANGE_WARNING } from "@web/booking/BookingAddressField";
 import { BOOKING_CONNECT_EMPTY_ENV_COPY } from "@web/booking/BookingConnectPrompt";
 import { BOOKING_MORE_OPTIONS_LABEL } from "@web/booking/BookingMoreOptions";
 import { BOOKING_SAVE_CHANGES_LABEL } from "@web/booking/BookingSaveBar";
@@ -108,6 +105,26 @@ const unconfiguredPage = () => ({
   guestsCanInviteOthers: true,
   isConfigured: false,
   suggestedSlug: "hostuser",
+});
+
+const savedOffPage = () => ({
+  enabled: false,
+  durationMinutes: 30,
+  destinationCalendarId: writableCalendar.id,
+  blockingCalendarIds: [writableCalendar.id],
+  timeZone: "UTC",
+  weeklyAvailability: DEFAULT_WEEKLY_AVAILABILITY,
+  minNoticeHours: 4,
+  maxHorizonDays: 60,
+  bufferMinutes: null,
+  maxBookingsPerDay: null,
+  guestsCanInviteOthers: true,
+  id: createObjectIdString(),
+  slug: "hostuser",
+  hostUserId: createObjectIdString(),
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  bookingUrl: "https://compasscalendar.com/meet/hostuser",
 });
 
 const healthyGoogleMetadata = {
@@ -225,7 +242,7 @@ describe("BookingSettingsSection", () => {
       rest.get(bookingPageUrl, (_req, res, ctx) =>
         res(
           ctx.json({
-            ...unconfiguredPage(),
+            ...savedOffPage(),
             destinationCalendarId: writableCalendar.id,
             blockingCalendarIds: [writableCalendar.id],
           }),
@@ -270,19 +287,9 @@ describe("BookingSettingsSection", () => {
       rest.get(bookingPageUrl, (_req, res, ctx) =>
         res(
           ctx.json({
-            enabled: false,
+            ...savedOffPage(),
             durationMinutes: 45,
-            destinationCalendarId: writableCalendar.id,
-            blockingCalendarIds: [writableCalendar.id],
             timeZone: "America/New_York",
-            weeklyAvailability: DEFAULT_WEEKLY_AVAILABILITY,
-            minNoticeHours: 4,
-            maxHorizonDays: 60,
-            bufferMinutes: null,
-            maxBookingsPerDay: null,
-            guestsCanInviteOthers: true,
-            isConfigured: false,
-            suggestedSlug: "hostuser",
           }),
         ),
       ),
@@ -429,7 +436,7 @@ describe("BookingSettingsSection", () => {
 
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
+        res(ctx.json(savedOffPage())),
       ),
       rest.put(bookingPageUrl, async (req, res, ctx) => {
         savedBody = await req.json();
@@ -505,6 +512,20 @@ describe("BookingSettingsSection", () => {
           }),
         ),
       ),
+      rest.put(bookingPageUrl, async (req, res, ctx) => {
+        const body = (await req.json()) as Record<string, unknown>;
+        return res(
+          ctx.json({
+            ...body,
+            id: createObjectIdString(),
+            slug: body.slug,
+            hostUserId: createObjectIdString(),
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            bookingUrl: `https://compasscalendar.com/meet/${body.slug}`,
+          }),
+        );
+      }),
     );
 
     const { wrapper, queryClient } = createStoreWrapper();
@@ -516,6 +537,10 @@ describe("BookingSettingsSection", () => {
       </HotkeysProvider>,
       { wrapper },
     );
+
+    await userEvent
+      .setup({ delay: null })
+      .click(await screen.findByRole("button", { name: "Continue" }));
 
     const trigger = await screen.findByRole("button", {
       name: /^Meeting timezone:/,
@@ -566,7 +591,7 @@ describe("BookingSettingsSection", () => {
     expect(trigger).toHaveAccessibleName("Meeting timezone: UTC (UTC)");
   });
 
-  it("shows the suggested address before the page is live and is not dirty", async () => {
+  it("shows the first-run address screen on an unconfigured page", async () => {
     userMetadataActions.set(healthyGoogleMetadata);
 
     server.use(
@@ -584,14 +609,203 @@ describe("BookingSettingsSection", () => {
       { wrapper },
     );
 
-    const address = await screen.findByLabelText("Page address");
-    expect(address).toHaveValue("hostuser");
     expect(
-      screen.getByText(`It will be at ${bookingAddressPrefix(null)}hostuser`),
+      await screen.findByRole("heading", { name: "Your meeting page" }),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Save draft" }),
+      screen.getByText(
+        "Pick the address people will use to book time with you. You can change it later.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Page address")).toHaveValue("hostuser");
+    expect(
+      screen.getByRole("button", { name: "Continue" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("Duration")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("textbox", { name: /Hours/ }),
     ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("switch", { name: "Meeting page" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("Continue PUTs a disabled draft with the typed slug and does not toast", async () => {
+    const user = userEvent.setup({ delay: null });
+    const { port, mocks } = createTestToastPort();
+    registerToastPort(port);
+    let savedBody: unknown;
+    userMetadataActions.set(healthyGoogleMetadata);
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+      rest.put(bookingPageUrl, async (req, res, ctx) => {
+        savedBody = await req.json();
+        return res(
+          ctx.json({
+            ...(savedBody as object),
+            id: createObjectIdString(),
+            slug: (savedBody as { slug: string }).slug,
+            hostUserId: createObjectIdString(),
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            bookingUrl: `https://compasscalendar.com/meet/${(savedBody as { slug: string }).slug}`,
+          }),
+        );
+      }),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    const address = await screen.findByLabelText("Page address");
+    await user.clear(address);
+    await user.type(address, "my-page");
+    await user.click(screen.getByRole("button", { name: /^Continue/ }));
+
+    await waitFor(() => {
+      expect(savedBody).toMatchObject({
+        enabled: false,
+        slug: "my-page",
+        durationMinutes: 30,
+        weeklyAvailability: DEFAULT_WEEKLY_AVAILABILITY,
+      });
+    });
+    expect(mocks.toast).not.toHaveBeenCalled();
+    expect(mocks.success).not.toHaveBeenCalled();
+    const meetingSwitch = await screen.findByRole("switch", {
+      name: "Meeting page",
+    });
+    expect(meetingSwitch).toHaveAttribute("aria-checked", "false");
+    expect(meetingSwitch).toHaveFocus();
+    expect(
+      screen.getByText("Off. Turn it on to share your link."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Your meeting page" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the setup screen and shows SLUG_TAKEN under the field", async () => {
+    const user = userEvent.setup({ delay: null });
+    userMetadataActions.set(healthyGoogleMetadata);
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+      rest.put(bookingPageUrl, (_req, res, ctx) =>
+        res(
+          ctx.status(409),
+          ctx.json({ code: "SLUG_TAKEN", message: "taken" }),
+        ),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    await user.click(await screen.findByRole("button", { name: /^Continue/ }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Your meeting page" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      BOOKING_SAVE_ERROR_COPY.SLUG_TAKEN,
+    );
+    expect(
+      screen.queryByRole("switch", { name: "Meeting page" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("blocks Continue on an invalid slug with the parse message", async () => {
+    const user = userEvent.setup({ delay: null });
+    let putCount = 0;
+    userMetadataActions.set(healthyGoogleMetadata);
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+      rest.put(bookingPageUrl, (_req, res, ctx) => {
+        putCount += 1;
+        return res(ctx.status(500));
+      }),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection showShortcuts={false} />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    const address = await screen.findByLabelText("Page address");
+    await user.clear(address);
+    await user.type(address, "ab");
+    await user.click(screen.getByRole("button", { name: /^Continue/ }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Use 3 to 32 lowercase letters, digits, or hyphens",
+    );
+    expect(putCount).toBe(0);
+  });
+
+  it("Continue runs on Mod+Enter from the setup screen", async () => {
+    let savedBody: unknown;
+    userMetadataActions.set(healthyGoogleMetadata);
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+      rest.put(bookingPageUrl, async (req, res, ctx) => {
+        savedBody = await req.json();
+        return res(
+          ctx.json({
+            ...(savedBody as object),
+            id: createObjectIdString(),
+            slug: "hostuser",
+            hostUserId: createObjectIdString(),
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            bookingUrl: "https://compasscalendar.com/meet/hostuser",
+          }),
+        );
+      }),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsWithShortcuts />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    const address = await screen.findByLabelText("Page address");
+    dispatchModKey(address, "Enter");
+
+    await waitFor(() => {
+      expect(savedBody).toMatchObject({ enabled: false, slug: "hostuser" });
+    });
   });
 
   it("PUTs slug when the host edits the page address", async () => {
@@ -601,7 +815,7 @@ describe("BookingSettingsSection", () => {
 
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
+        res(ctx.json(savedOffPage())),
       ),
       rest.put(bookingPageUrl, async (req, res, ctx) => {
         savedBody = await req.json();
@@ -625,6 +839,9 @@ describe("BookingSettingsSection", () => {
     );
 
     const address = await screen.findByLabelText("Page address");
+    expect(
+      screen.queryByRole("heading", { name: "Your meeting page" }),
+    ).not.toBeInTheDocument();
     await user.clear(address);
     await user.type(address, "tyler-dane");
     await user.click(
@@ -643,7 +860,7 @@ describe("BookingSettingsSection", () => {
 
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
+        res(ctx.json(savedOffPage())),
       ),
       rest.put(bookingPageUrl, (_req, res, ctx) => {
         putCount += 1;
@@ -683,7 +900,7 @@ describe("BookingSettingsSection", () => {
 
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
+        res(ctx.json(savedOffPage())),
       ),
       rest.put(bookingPageUrl, (_req, res, ctx) =>
         res(
@@ -862,7 +1079,7 @@ describe("BookingSettingsSection", () => {
     });
   });
 
-  it("fires booking_page_enabled with first_time true and copies from save", async () => {
+  it("fires booking_page_enabled after Continue, then turn on, with first_time false", async () => {
     const user = userEvent.setup({ delay: null });
     userMetadataActions.set(healthyGoogleMetadata);
     const slug = "hostuser";
@@ -898,13 +1115,14 @@ describe("BookingSettingsSection", () => {
       { wrapper },
     );
 
+    await user.click(await screen.findByRole("button", { name: "Continue" }));
     await user.click(
       await screen.findByRole("switch", { name: "Meeting page" }),
     );
 
     await waitFor(() => {
       expect(mockTrack).toHaveBeenCalledWith("booking_page_enabled", {
-        first_time: true,
+        first_time: false,
       });
     });
     expect(mockTrack).toHaveBeenCalledWith("booking_link_copied", {
@@ -984,7 +1202,7 @@ describe("BookingSettingsSection", () => {
 
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json({ ...unconfiguredPage(), weeklyAvailability: [] })),
+        res(ctx.json({ ...savedOffPage(), weeklyAvailability: [] })),
       ),
     );
 
@@ -1015,7 +1233,7 @@ describe("BookingSettingsSection", () => {
 
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
+        res(ctx.json(savedOffPage())),
       ),
       rest.put(bookingPageUrl, async (req, res, ctx) => {
         putCount += 1;
@@ -1054,7 +1272,7 @@ describe("BookingSettingsSection", () => {
 
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
+        res(ctx.json(savedOffPage())),
       ),
       rest.put(bookingPageUrl, async (req, res, ctx) => {
         savedBody = await req.json();
@@ -1095,7 +1313,7 @@ describe("BookingSettingsSection", () => {
 
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
+        res(ctx.json(savedOffPage())),
       ),
       rest.put(bookingPageUrl, async (req, res, ctx) => {
         putCount += 1;
@@ -1132,7 +1350,7 @@ describe("BookingSettingsSection", () => {
 
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
+        res(ctx.json(savedOffPage())),
       ),
     );
 
@@ -1169,7 +1387,7 @@ describe("BookingSettingsSection", () => {
 
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
+        res(ctx.json(savedOffPage())),
       ),
       rest.put(bookingPageUrl, async (req, res, ctx) =>
         res(
@@ -1212,7 +1430,7 @@ describe("BookingSettingsSection", () => {
 
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
+        res(ctx.json(savedOffPage())),
       ),
       // Saving while disabled allocates no slug, so the response carries no
       // bookingUrl and there is nothing to copy.
@@ -1263,7 +1481,7 @@ describe("BookingSettingsSection", () => {
       rest.get(bookingPageUrl, (_req, res, ctx) =>
         res(
           ctx.json({
-            ...unconfiguredPage(),
+            ...savedOffPage(),
             destinationCalendarId: primary.id,
             blockingCalendarIds: [primary.id],
           }),
@@ -1304,7 +1522,7 @@ describe("BookingSettingsSection", () => {
       rest.get(bookingPageUrl, (_req, res, ctx) =>
         res(
           ctx.json({
-            ...unconfiguredPage(),
+            ...savedOffPage(),
             destinationCalendarId: noMeet.id,
             blockingCalendarIds: [noMeet.id],
           }),
@@ -1353,7 +1571,7 @@ describe("BookingSettingsSection", () => {
       rest.get(bookingPageUrl, (_req, res, ctx) =>
         res(
           ctx.json({
-            ...unconfiguredPage(),
+            ...savedOffPage(),
             destinationCalendarId: appleCalendar.id,
             blockingCalendarIds: [appleCalendar.id],
           }),
@@ -1408,7 +1626,7 @@ describe("BookingSettingsSection", () => {
       rest.get(bookingPageUrl, (_req, res, ctx) =>
         res(
           ctx.json({
-            ...unconfiguredPage(),
+            ...savedOffPage(),
             destinationCalendarId: microsoftCalendar.id,
             blockingCalendarIds: [microsoftCalendar.id],
           }),
@@ -1441,7 +1659,7 @@ describe("BookingSettingsSection", () => {
       rest.get(bookingPageUrl, (_req, res, ctx) =>
         res(
           ctx.json({
-            ...unconfiguredPage(),
+            ...savedOffPage(),
             destinationCalendarId: writableCalendar.id,
             blockingCalendarIds: [writableCalendar.id],
           }),
@@ -1477,7 +1695,7 @@ describe("BookingSettingsSection", () => {
       rest.get(bookingPageUrl, (_req, res, ctx) =>
         res(
           ctx.json({
-            ...unconfiguredPage(),
+            ...savedOffPage(),
             destinationCalendarId: "000000000000000000000001",
             blockingCalendarIds: ["000000000000000000000001"],
           }),
@@ -1513,19 +1731,10 @@ describe("BookingSettingsSection", () => {
       rest.get(bookingPageUrl, (_req, res, ctx) =>
         res(
           ctx.json({
-            enabled: false,
-            durationMinutes: 30,
+            ...savedOffPage(),
             destinationCalendarId: "000000000000000000000001",
             blockingCalendarIds: ["000000000000000000000001"],
-            timeZone: "UTC",
             weeklyAvailability: [],
-            minNoticeHours: 4,
-            maxHorizonDays: 60,
-            bufferMinutes: null,
-            maxBookingsPerDay: null,
-            guestsCanInviteOthers: true,
-            isConfigured: false,
-            suggestedSlug: "hostuser",
           }),
         ),
       ),
@@ -1560,7 +1769,7 @@ describe("BookingSettingsSection", () => {
 
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
+        res(ctx.json(savedOffPage())),
       ),
       rest.put(bookingPageUrl, (_req, res, ctx) => {
         putCount += 1;
@@ -1601,7 +1810,7 @@ describe("BookingSettingsSection", () => {
 
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
+        res(ctx.json(savedOffPage())),
       ),
     );
 
@@ -1658,19 +1867,7 @@ describe("BookingSettingsSection", () => {
       rest.get(bookingPageUrl, (_req, res, ctx) =>
         res(
           ctx.json({
-            enabled: false,
-            durationMinutes: 30,
-            destinationCalendarId: writableCalendar.id,
-            blockingCalendarIds: [writableCalendar.id],
-            timeZone: "UTC",
-            weeklyAvailability: DEFAULT_WEEKLY_AVAILABILITY,
-            minNoticeHours: 4,
-            maxHorizonDays: 60,
-            bufferMinutes: null,
-            maxBookingsPerDay: null,
-            guestsCanInviteOthers: true,
-            isConfigured: false,
-            suggestedSlug: "hostuser",
+            ...savedOffPage(),
           }),
         ),
       ),
@@ -1724,19 +1921,7 @@ describe("BookingSettingsSection", () => {
       rest.get(bookingPageUrl, (_req, res, ctx) =>
         res(
           ctx.json({
-            enabled: false,
-            durationMinutes: 30,
-            destinationCalendarId: writableCalendar.id,
-            blockingCalendarIds: [writableCalendar.id],
-            timeZone: "UTC",
-            weeklyAvailability: DEFAULT_WEEKLY_AVAILABILITY,
-            minNoticeHours: 4,
-            maxHorizonDays: 60,
-            bufferMinutes: null,
-            maxBookingsPerDay: null,
-            guestsCanInviteOthers: true,
-            isConfigured: false,
-            suggestedSlug: "hostuser",
+            ...savedOffPage(),
           }),
         ),
       ),
@@ -1782,7 +1967,7 @@ describe("BookingSettingsSection", () => {
     userMetadataActions.set(healthyGoogleMetadata);
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
+        res(ctx.json(savedOffPage())),
       ),
       rest.put(bookingPageUrl, async (req, res, ctx) => {
         savedBody = await req.json();
@@ -1834,7 +2019,7 @@ describe("BookingSettingsSection", () => {
     userMetadataActions.set(healthyGoogleMetadata);
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
+        res(ctx.json(savedOffPage())),
       ),
       rest.put(bookingPageUrl, async (req, res, ctx) => {
         savedBody = await req.json();
@@ -1895,7 +2080,7 @@ describe("BookingSettingsSection", () => {
     userMetadataActions.set(healthyGoogleMetadata);
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
+        res(ctx.json(savedOffPage())),
       ),
       rest.put(bookingPageUrl, async (req, res, ctx) => {
         savedBody = await req.json();
@@ -2014,7 +2199,7 @@ describe("BookingSettingsSection", () => {
     userMetadataActions.set(healthyGoogleMetadata);
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
+        res(ctx.json(savedOffPage())),
       ),
       rest.put(bookingPageUrl, async (req, res, ctx) => {
         savedBody = await req.json();
@@ -2070,7 +2255,7 @@ describe("BookingSettingsSection", () => {
 
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
+        res(ctx.json(savedOffPage())),
       ),
       rest.put(bookingPageUrl, (_req, res, ctx) =>
         res(
@@ -2111,7 +2296,7 @@ describe("BookingSettingsSection", () => {
     userMetadataActions.set(healthyGoogleMetadata);
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
+        res(ctx.json(savedOffPage())),
       ),
     );
 
@@ -2140,7 +2325,7 @@ describe("BookingSettingsSection", () => {
     userMetadataActions.set(healthyGoogleMetadata);
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
+        res(ctx.json(savedOffPage())),
       ),
     );
 
@@ -2164,7 +2349,7 @@ describe("BookingSettingsSection", () => {
     userMetadataActions.set(healthyGoogleMetadata);
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
+        res(ctx.json(savedOffPage())),
       ),
     );
 
@@ -2193,7 +2378,7 @@ describe("BookingSettingsSection", () => {
     userMetadataActions.set(healthyGoogleMetadata);
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
-        res(ctx.json(unconfiguredPage())),
+        res(ctx.json(savedOffPage())),
       ),
       rest.put(bookingPageUrl, (_req, res, ctx) =>
         res(

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -29,6 +29,7 @@ import {
   BookingAddressField,
   bookingAddressPrefix,
 } from "@web/booking/BookingAddressField";
+import { BookingAddressSetup } from "@web/booking/BookingAddressSetup";
 import { BookingBlockingCalendarsField } from "@web/booking/BookingBlockingCalendarsField";
 import { BookingConnectPrompt } from "@web/booking/BookingConnectPrompt";
 import { BookingFieldLabel } from "@web/booking/BookingFieldLabel";
@@ -45,6 +46,7 @@ import {
   useSaveBookingPageMutation,
 } from "@web/booking/booking.query";
 import {
+  bookingSlugParseMessage,
   defaultBlockingCalendarIdsForDestination,
   getAvailabilityReadableCalendars,
   isBookingSettingsFormDirty,
@@ -84,6 +86,7 @@ import { DiscardUnsavedChangesDialog } from "@web/views/Forms/EventForm/DiscardU
 const DURATION_OPTIONS: BookingDurationMinutes[] = [15, 30, 45, 60];
 
 const MORE_OPTIONS_FIELDS = new Set<BookingField>([
+  "address",
   "blocking",
   "welcome",
   "notice",
@@ -273,6 +276,7 @@ export function BookingSettingsSection({
   );
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
   const [hoursDraftDirty, setHoursDraftDirty] = useState(false);
+  const focusSwitchAfterSetupRef = useRef(false);
   // The settings fieldset is disabled while a save is in flight, so focusing
   // from onError is a no-op. Wait until the mutation settles and the field
   // is enabled again.
@@ -280,6 +284,13 @@ export function BookingSettingsSection({
     if (saveMutation.isPending || saveError?.field == null) return;
     focusBookingField(saveError.field);
   }, [saveError, saveMutation.isPending]);
+  useLayoutEffect(() => {
+    if (!focusSwitchAfterSetupRef.current) return;
+    if (serverPage && isUnconfiguredBookingPage(serverPage)) return;
+    if (focusBookingField("enabled")) {
+      focusSwitchAfterSetupRef.current = false;
+    }
+  });
   const sectionRef = useRef<HTMLFieldSetElement>(null);
   const baselineFormRef = useRef<AdminPutBookingPageInput | null>(null);
 
@@ -381,6 +392,8 @@ export function BookingSettingsSection({
     return <p className="text-sm text-text-muted">Loading meeting settings…</p>;
   }
 
+  const isSetup = serverPage != null && isUnconfiguredBookingPage(serverPage);
+
   const savedPage = isSavedBookingPage(serverPage) ? serverPage : null;
   const isLive = savedPage?.enabled === true;
   const savedSlug =
@@ -435,7 +448,7 @@ export function BookingSettingsSection({
     setSaveError(null);
   };
 
-  const submit = (enabled: boolean) => {
+  const submit = (enabled: boolean, options?: { silent?: boolean }) => {
     const error = validateBookingForm({
       areHoursValid,
       enabling: enabled,
@@ -450,21 +463,26 @@ export function BookingSettingsSection({
     }
     setSaveError(null);
     const wasLive = isLive;
+    const silent = options?.silent === true;
+    if (silent) focusSwitchAfterSetupRef.current = true;
     saveMutation.mutate(
       { ...form, enabled },
       {
         onError: (mutationError) => {
+          if (silent) focusSwitchAfterSetupRef.current = false;
           const inline = bookingSaveErrorInline(mutationError);
           if (inline) setSaveError(inline);
         },
         onSuccess: (page) => {
           if (!enabled) {
-            showStatusToast(
-              "booking-link-copied",
-              wasLive
-                ? "Meeting page turned off."
-                : "Saved. Turn on your meeting page to share the link.",
-            );
+            if (!silent) {
+              showStatusToast(
+                "booking-link-copied",
+                wasLive
+                  ? "Meeting page turned off."
+                  : "Saved. Turn on your meeting page to share the link.",
+              );
+            }
             return;
           }
           if (!wasLive) {
@@ -496,6 +514,26 @@ export function BookingSettingsSection({
     horizonInvalid ||
     (saveError?.field != null && MORE_OPTIONS_FIELDS.has(saveError.field));
 
+  if (isSetup) {
+    const parseMessage = bookingSlugParseMessage(form.slug);
+    const setupError =
+      saveError?.field === "address" &&
+      (parseMessage == null || saveError.message !== parseMessage)
+        ? saveError.message
+        : null;
+    return (
+      <BookingAddressSetup
+        bookingUrl={null}
+        error={setupError}
+        forceInvalid={saveError?.field === "address"}
+        isPending={saveMutation.isPending}
+        onChange={(nextSlug) => updateForm({ slug: nextSlug })}
+        onContinue={() => submit(false, { silent: true })}
+        slug={form.slug ?? ""}
+      />
+    );
+  }
+
   return (
     <>
       <fieldset
@@ -510,15 +548,6 @@ export function BookingSettingsSection({
           isPending={saveMutation.isPending}
           onToggle={(next) => submit(next)}
           showShortcuts={showShortcuts}
-        />
-
-        <BookingAddressField
-          bookingUrl={savedPage?.bookingUrl ?? null}
-          forceInvalid={saveError?.field === "address"}
-          onChange={(nextSlug) => updateForm({ slug: nextSlug })}
-          savedSlug={savedSlug}
-          showShortcuts={showShortcuts}
-          slug={form.slug ?? ""}
         />
 
         <div className="grid grid-cols-2 gap-3">
@@ -637,6 +666,15 @@ export function BookingSettingsSection({
           forceOpen={forceOpenMoreOptions}
           showShortcuts={showShortcuts}
         >
+          <BookingAddressField
+            bookingUrl={savedPage?.bookingUrl ?? null}
+            forceInvalid={saveError?.field === "address"}
+            onChange={(nextSlug) => updateForm({ slug: nextSlug })}
+            savedSlug={savedSlug}
+            showShortcuts={showShortcuts}
+            slug={form.slug ?? ""}
+          />
+
           <BookingBlockingCalendarsField
             availabilityCalendars={availabilityCalendars}
             blockingCalendarIds={form.blockingCalendarIds}

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -1166,7 +1166,7 @@ describe("SettingsModal", () => {
     await user.keyboard(`{${modKey}>}9{/${modKey}}`);
 
     expect(details).toHaveAttribute("open");
-    expect(screen.getByRole("checkbox", { name: "Work" })).toHaveFocus();
+    expect(screen.getByLabelText("Page address")).toHaveFocus();
   });
 
   it("copies the meeting link with Mod+U", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3508

## What and why

A host opening the Meeting tab for the first time sees only their address: heading "Your meeting page", one sentence, the suggested slug under `.../meet/`, the helper, and **Continue** (Mod+Enter). Continue saves a disabled draft so a taken address is caught there. After that, the switch is off and **Page address** lives under More options.

Spec: `docs/features/booking.md`. Tracking: #3501. Depends on #3506 and #3502.

## Verify

`bun run verify --strict`

Selected packages: web
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)

VERDICT: PASS
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad52e327-6e23-450a-a5cb-22a43d90c4f6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad52e327-6e23-450a-a5cb-22a43d90c4f6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

