### PR TITLE
fix(sync): classify google write 400 as unsupportedCapability

### DIFF
--- a/packages/sync/src/domain/provider-write-ladder.test.ts
+++ b/packages/sync/src/domain/provider-write-ladder.test.ts
@@ -1,3 +1,8 @@
+import {
+  type LoggerInstance,
+  registerLoggerFactory,
+  resetLoggerFactory,
+} from "@core/logger/logger.factory";
 import { type ConnectionId } from "@core/types/sync/identity.contracts";
 import {
   type AccessTokenSource,
@@ -6,7 +11,7 @@ import {
 } from "@sync/domain/provider-write-ladder";
 import { ProviderAuthError } from "@sync/providers/provider-auth.port";
 import { ProviderWriteError } from "@sync/providers/provider-event-writer.port";
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, mock } from "bun:test";
 
 const connectionId = "507f1f77bcf86cd799439011" as ConnectionId;
 
@@ -53,6 +58,10 @@ describe("resolveAccessToken", () => {
 });
 
 describe("runProviderWrite", () => {
+  afterEach(() => {
+    resetLoggerFactory();
+  });
+
   it("returns the value on success", async () => {
     await expect(runProviderWrite(async () => 42)).resolves.toEqual({
       ok: true,
@@ -85,5 +94,37 @@ describe("runProviderWrite", () => {
         throw new Error("boom");
       }),
     ).rejects.toThrow("boom");
+  });
+
+  it("logs one warn containing the cause message when a write fails", async () => {
+    const warn = mock(() => {});
+    registerLoggerFactory(
+      () =>
+        ({
+          warn,
+          error: mock(),
+          info: mock(),
+          debug: mock(),
+        }) as LoggerInstance,
+    );
+
+    await expect(
+      runProviderWrite(async () => {
+        throw new ProviderWriteError(
+          "unsupportedCapability",
+          "Google declined to change this event",
+          { cause: new Error("google error 400 (HTTP 400, reason invalid)") },
+        );
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      stop: { kind: "failed", reason: "unsupportedCapability" },
+    });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [message] = warn.mock.calls[0] ?? [];
+    expect(message).toContain("Google declined to change this event");
+    expect(message).toContain("HTTP 400");
+    expect(message).toContain("reason invalid");
   });
 });

--- a/packages/sync/src/domain/provider-write-ladder.ts
+++ b/packages/sync/src/domain/provider-write-ladder.ts
@@ -1,3 +1,4 @@
+import { LoggerFactory } from "@core/logger/logger.factory";
 import { type SyncCommandFailureReason } from "@core/types/sync/command.contracts";
 import { type ConnectionId } from "@core/types/sync/identity.contracts";
 import { ProviderAuthError } from "@sync/providers/provider-auth.port";
@@ -58,6 +59,11 @@ export async function runProviderWrite<T>(
       if (error.reason === "transient") {
         return { ok: false, stop: { kind: "pending" } };
       }
+      const causeMessage =
+        error.cause instanceof Error ? error.cause.message : undefined;
+      LoggerFactory("sync:provider-write").warn(
+        causeMessage ? `${error.message} ${causeMessage}` : error.message,
+      );
       return { ok: false, stop: { kind: "failed", reason: error.reason } };
     }
     throw error;

--- a/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
@@ -252,6 +252,23 @@ describe("GoogleEventWriter", () => {
     );
   });
 
+  it("maps a 400 on create to unsupportedCapability with Google's status and reason", async () => {
+    const api = new FakeEventsApi({ insert: gError(400, "invalid") });
+    const { writer } = writerWith(api);
+
+    const error = (await writer
+      .createEvent(baseCreate)
+      .catch((e) => e)) as ProviderWriteError;
+
+    expect(error).toBeInstanceOf(ProviderWriteError);
+    expect(error.reason).toBe("unsupportedCapability");
+    expect((error.cause as Error)?.message).toContain("HTTP 400");
+    expect((error.cause as Error)?.message).toContain("invalid");
+    expect(JSON.stringify(error.cause ?? {})).not.toContain(
+      "super-secret-token",
+    );
+  });
+
   it("emits intended attendees on create, omitting a null displayName", async () => {
     const api = new FakeEventsApi();
     const { writer } = writerWith(api);
@@ -532,6 +549,23 @@ describe("GoogleEventWriter", () => {
     expect(error.reason).toBe("readOnlyCalendar");
   });
 
+  it("maps a 400 on patch to unsupportedCapability with Google's status and reason", async () => {
+    const api = new FakeEventsApi({ patch: gError(400, "invalid") });
+    const { writer } = writerWith(api);
+
+    const error = (await writer
+      .patchEvent(basePatch)
+      .catch((e) => e)) as ProviderWriteError;
+
+    expect(error).toBeInstanceOf(ProviderWriteError);
+    expect(error.reason).toBe("unsupportedCapability");
+    expect((error.cause as Error)?.message).toContain("HTTP 400");
+    expect((error.cause as Error)?.message).toContain("invalid");
+    expect(JSON.stringify(error.cause ?? {})).not.toContain(
+      "super-secret-token",
+    );
+  });
+
   it("maps a quota 403 to transient (retryable)", async () => {
     const api = new FakeEventsApi({ patch: gError(403, "rateLimitExceeded") });
     const { writer } = writerWith(api);
@@ -631,6 +665,7 @@ describe("GoogleEventWriter", () => {
 
     expect(error).toBeInstanceOf(ProviderWriteError);
     expect(error.reason).toBe("unsupportedCapability");
+    expect((error.cause as Error)?.message).toContain("HTTP 400");
   });
 
   it("still surfaces a precondition failure on delete", async () => {

--- a/packages/sync/src/providers/google/google-event-writer.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.ts
@@ -10,7 +10,10 @@ import {
 import { type SyncEventContent } from "@core/types/sync/event.contracts";
 import dayjs from "@core/util/date/dayjs";
 import { googleColorIdFields } from "@sync/providers/google/google-color.map";
-import { googleStatus } from "@sync/providers/google/google-error";
+import {
+  googleFailureCause,
+  googleStatus,
+} from "@sync/providers/google/google-error";
 import {
   mapConference,
   normalizeGoogleEvent,
@@ -39,7 +42,6 @@ import {
   isNotFoundStatus,
   type ProviderWriteErrorPolicy,
 } from "@sync/providers/provider-write-error";
-import { redactedCause } from "@sync/safety/redact-error";
 
 // The Google event calls the writer makes. Depending on this narrow interface
 // (not the concrete googleapis client) lets tests script results and errors
@@ -205,6 +207,12 @@ export class GoogleEventWriter implements ProviderEventWriter {
           throw classifyWriteError(getError);
         }
       }
+      if (googleStatus(error) === 400) {
+        throw googleUnsupportedCapability(
+          error,
+          "Google declined to change this event",
+        );
+      }
       throw classifyWriteError(error);
     }
   }
@@ -243,6 +251,12 @@ export class GoogleEventWriter implements ProviderEventWriter {
       });
       return toResult(patched);
     } catch (error) {
+      if (googleStatus(error) === 400) {
+        throw googleUnsupportedCapability(
+          error,
+          "Google declined to change this event",
+        );
+      }
       throw classifyWriteError(error);
     }
   }
@@ -267,10 +281,9 @@ export class GoogleEventWriter implements ProviderEventWriter {
       // never resolve; a typed capability refusal maps to an honest,
       // non-retryable error instead.
       if (googleStatus(error) === 400) {
-        throw new ProviderWriteError(
-          "unsupportedCapability",
+        throw googleUnsupportedCapability(
+          error,
           "Google declined to delete this event",
-          { cause: redactedCause(error) },
         );
       }
       throw classifyWriteError(error);
@@ -574,10 +587,19 @@ const RETRYABLE_403_REASONS = new Set([
 
 const GOOGLE_WRITE_ERROR_POLICY: ProviderWriteErrorPolicy = {
   status: googleStatus,
-  cause: redactedCause,
+  cause: googleFailureCause,
   credentialRejectedMessage: "Google rejected the credential",
   writeRejectedMessage: "Google rejected the write",
 };
+
+function googleUnsupportedCapability(
+  error: unknown,
+  message: string,
+): ProviderWriteError {
+  return new ProviderWriteError("unsupportedCapability", message, {
+    cause: googleFailureCause(error),
+  });
+}
 
 function classifyWriteError(error: unknown): ProviderWriteError {
   // An already-classified error (e.g. a missing-identity result) must not be
@@ -589,7 +611,7 @@ function classifyWriteError(error: unknown): ProviderWriteError {
   // leftover throw is a permanent rejection, not a blip.
   if (error instanceof ProviderEventError) {
     return new ProviderWriteError("permanentProviderError", error.message, {
-      cause: redactedCause(error),
+      cause: googleFailureCause(error),
     });
   }
   // A quota 403 is retryable. Every other 403 falls through to the shared
@@ -598,7 +620,7 @@ function classifyWriteError(error: unknown): ProviderWriteError {
     return new ProviderWriteError(
       "transient",
       "Google rate limited the write",
-      { cause: redactedCause(error) },
+      { cause: googleFailureCause(error) },
     );
   }
   return classifyProviderWriteError(error, GOOGLE_WRITE_ERROR_POLICY);

--- a/packages/web/src/common/utils/event/event.util.test.ts
+++ b/packages/web/src/common/utils/event/event.util.test.ts
@@ -190,9 +190,10 @@ describe("handleError", () => {
   });
 
   it("shows curated copy for a mutation failure the user can act on, not the catch-all", () => {
-    // A deterministic provider refusal (Google declining a birthday-occurrence
-    // delete) used to show "Something went wrong behind the scenes. Please try
-    // again later." — an invitation to retry something that can never work.
+    // A deterministic provider refusal (Google declining a patch of an
+    // email-created event) used to show "Something went wrong behind the
+    // scenes. Please try again later." — an invitation to retry something
+    // that can never work.
     const error = createServerError(Status.FORBIDDEN);
     error.response = {
       status: Status.FORBIDDEN,
@@ -208,9 +209,8 @@ describe("handleError", () => {
     expect(mockCaptureException).not.toHaveBeenCalled();
     expect(mocks.error).toHaveBeenCalledTimes(1);
     const [message] = mocks.error.mock.calls[0] ?? [];
-    expect(message).toContain("This calendar doesn't allow this change");
-    expect(message).not.toBe(
-      "Something went wrong behind the scenes. Please try again later.",
+    expect(message).toBe(
+      "Google doesn't allow this change for this event (for example events created from an email, birthdays, or holidays). Delete it or manage it in your calendar.",
     );
   });
 

--- a/packages/web/src/common/utils/event/event.util.ts
+++ b/packages/web/src/common/utils/event/event.util.ts
@@ -217,14 +217,15 @@ const CATCHALL_TOAST_MESSAGE =
 // Curated copy for backend-authored mutation failures the user can act on.
 // Codes without an entry fall back to the catch-all — backend messages are
 // written for the API contract, not for a toast, so they are never shown
-// verbatim. UNSUPPORTED_OPERATION exists because a Google birthday-event
-// occurrence delete used to surface as the catch-all with nothing telling
-// the user why it would never work.
+// verbatim. UNSUPPORTED_OPERATION exists because a provider declining a
+// patch or delete (events created from an email, birthdays, holidays) used
+// to surface as the catch-all with nothing telling the user why it would
+// never work.
 const MUTATION_ERROR_TOAST_MESSAGES: Partial<
   Record<EventMutationError["code"], string>
 > = {
   UNSUPPORTED_OPERATION:
-    "This calendar doesn't allow this change for this event (like birthdays or holidays). Try deleting the entire series, or manage it in your calendar.",
+    "Google doesn't allow this change for this event (for example events created from an email, birthdays, or holidays). Delete it or manage it in your calendar.",
   CALENDAR_READ_ONLY:
     "This calendar is read-only, so its events can't be changed from Compass.",
   RECURRENCE_CONFLICT:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3513

## What and why

A Google 400 on event patch or create was a retryable `permanentProviderError` (502) with no HTTP status or reason in logs, so email-created events showed "Something went wrong behind the scenes." Patch and create 400s now map to `unsupportedCapability` (backend `UNSUPPORTED_OPERATION` 403, not retryable), the write-error cause carries Google's status and reason, a failed write logs that cause, and the web toast names events created from an email.

Tracking: #3512 (Provider-managed events milestone).

## Verify

```
Selected packages: sync, web
Checks run: test:sync:fast, test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)

✓ All checks passed
VERDICT: PASS
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cae7677f-02d1-4c32-9b4a-4340bc6d5671?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cae7677f-02d1-4c32-9b4a-4340bc6d5671&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

