### PR TITLE
test(e2e): close out booking v1.7 first visit, a11y, and docs

### DIFF
--- a/.github/prompts/booking-product-audit.md
+++ b/.github/prompts/booking-product-audit.md
@@ -34,12 +34,18 @@ guest, without turning Compass into Calendly.
   one-click turn on, Essentials / More options split, editable address,
   default hours, funnel events) unless you show a regression in current
   main.
+- Re-propose closed Booking v1.7 Meeting page work unless you show a
+  regression in current main: public `/meet/:slug` (legacy `/book`
+  redirects), meeting copy, hold-Mod section chords (no letter leader on
+  Meeting settings), the on/off Meeting page switch, grouped weekly hours
+  rows, the first-run address screen, or user-facing "Meeting page" copy
+  (internal `SettingsPage` stays `"booking"`).
 - Recommend flipping `isBookingEnabled` in production, Compass-sent
   email/SMS, paid booking, team/round-robin pages, a standalone booking
   brand/domain, or `guestsCanModify` unless you have concrete evidence
   it is the bottleneck **and** you label the item `deferred / human`.
 - Enter credentials or complete Google OAuth on staging. Public
-  `/book/...` needs no login.
+  `/meet/...` needs no login.
 - Retarget `BOOKING_LOOP_MILESTONE`.
 - Invent findings. If you did not read the code or exercise the path,
   say so.
@@ -65,17 +71,18 @@ from **at least one** of: source, tests, e2e, or a public staging
 page. Prefer code that a guest or host can feel over cleanup.
 
 1. **Guest path (anonymous).** Trace
-   `/book/:slug` → details → confirm → `/book/confirmed/:id` →
-   `/book/cancel/:id`. Note what v1.3 will add (`/book/reschedule/:id`)
-   so you do not duplicate it. Use
-   `https://staging.compasscalendar.com/book/...` when a known staging
+   `/meet/:slug` → details → confirm → `/meet/confirmed/:id` →
+   `/meet/cancel/:id`. Note that guest reschedule (`/meet/reschedule/:id`)
+   already shipped in v1.3 so you do not duplicate it. Use
+   `https://staging.compasscalendar.com/meet/...` when a known staging
    slug exists; otherwise reason from `e2e/booking/` and
    `packages/web/src/booking/`.
-2. **Host path.** Settings Booking page
-   (`BookingSettingsSection.tsx`): enable, duration, destination,
-   blocking calendars, weekly hours, welcome, notice, horizon, buffer,
-   max per day, guest permissions, copy/open link. Do not attempt
-   login if the signed-in profile is not already present.
+2. **Host path.** Settings Meeting page
+   (`BookingSettingsSection.tsx`): first-run address, Continue, switch,
+   duration, destination, blocking calendars, weekly hours rows, welcome,
+   notice, horizon, buffer, max per day, guest permissions, copy/open
+   link. Do not attempt login if the signed-in profile is not already
+   present.
 3. **Honesty.** Slot engine, occupancy (`occupies-booking-slot.ts`),
    fail-closed `bookable: false`, unique `(pageId, slotStart)`, rate
    limits, cancel token hashing, public JSON that must not leak
@@ -87,7 +94,7 @@ page. Prefer code that a guest or host can feel over cleanup.
    coverage around booking; `e2e/booking/`; `e2e/accessibility/booking-a11y.spec.ts`.
    A missing test is not a feature. Only call it out when a real
    behavior is unprotected.
-6. **Keyboard and copy.** Public booking and Settings Booking are
+6. **Keyboard and copy.** Public booking and Settings Meeting are
    keyboard-first. No em-dashes in user-facing strings.
 
 You may run **read-only** git and `gh` commands. You may start

--- a/docs/CI-CD/agent-loop-routine.md
+++ b/docs/CI-CD/agent-loop-routine.md
@@ -157,9 +157,10 @@ Override per run with env `AGENT_LOOP_MAX_FILES` and
 
 ## Staging smoke
 
-`GET https://staging.compasscalendar.com`, `/book/`, `/book/tylerdeane`,
-`/meet/`, and `/meet/tylerdeane` must not return 5xx. 404 is success
-(page disabled or not yet shipped). The smoke script never logs in.
+`GET https://staging.compasscalendar.com`, the legacy book homepage and
+a known slug, `/meet/`, and `/meet/tylerdeane` must not return 5xx. 404
+is success (page disabled or not yet shipped). The smoke script never
+logs in.
 
 Authenticated Settings is out of unattended smoke.
 The `qa-test-staging` skill remains the signed-in sweep when a human is present

--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -28,6 +28,7 @@ Use this guide to validate:
 - toggling event-jump chips (`H`); the mouse is permanently inert (Compass is keyboard-only)
 - toggling the sidebar (])
 - undoing / redoing with the keyboard (Cmd+Z / Cmd+Shift+Z)
+- jumping Meeting settings sections with hold-Mod (`Mod+4` through `Mod+9`, `Mod+U`)
 - confirming that shortcuts do not fire while typing in inputs
 
 Do not use this guide to validate:
@@ -481,6 +482,28 @@ With a grid event focused (form closed, not typing in an input), Cmd+C (Mac) or 
 
 ---
 
+## Scenario 18: Jump Meeting Settings With Hold-Mod
+
+### UX
+
+Settings > Meeting uses hold-Mod section chords. Settings nav still owns digits `1` / `2` / `3`. `Mod+4` through `Mod+9` jump to on or off, Duration, Timezone, Weekly hours, Destination calendar, and More options. `Mod+U` copies the meeting link. Save is Mod+Enter. Meeting settings do not use a letter leader.
+
+### Steps
+
+1. Open Settings and go to Meeting with the page already configured and live.
+2. Hold Mod until the section chips appear.
+3. Press `5`.
+4. Press `U` while Mod is still held.
+
+### Expected Results
+
+- Chips `4` through `9` and `U` appear while Mod is held. The nav hint **Hold Mod to see shortcuts.** hides while chips are visible.
+- `Mod+5` focuses Duration.
+- `Mod+U` copies the meeting link.
+- Releasing Mod hides the chips and restores the nav hint.
+
+---
+
 ## Focused Regression Checks
 
 If time is limited, run these checks before shipping shortcut-related changes:
@@ -506,3 +529,4 @@ If time is limited, run these checks before shipping shortcut-related changes:
 19. `Z` opens time travel in Day and Week view; Cmd+Z / Ctrl+Z still undoes and does not open the picker.
 20. On Day view, hold Mod then a column digit (2+) focuses that writable calendar column; Shift+Arrow / `C` seed a draft there.
 21. Cmd+C / Ctrl+C copies a focused event; Cmd+V / Ctrl+V pastes a duplicate at the original time without requiring focus. A later copy replaces the clipboard. Empty paste is a no-op. Copy/paste do not fire while typing in an input (native text clipboard). Cmd+D is unchanged.
+22. In Settings > Meeting, hold Mod to reveal chips `4`–`9` and `U`; `Mod+5` focuses Duration; `Mod+U` copies the meeting link.

--- a/docs/architecture/glossary.md
+++ b/docs/architecture/glossary.md
@@ -157,15 +157,15 @@ Browsers connect with `GET /api/events/stream`.
 **Booking page**:
 The one v1 scheduling page owned by a Compass user, shown to users as
 Meeting page. Settings configure it; guests open it at `/meet/:username`.
-Old `/book/:username` links redirect client-side.
+Old `/book` username links redirect client-side.
 _Avoid_: event type (v1 has one duration per user, not Calendly-style
 multiple event types)
 
 **Booking slug**:
-The immutable-in-v1 public username segment in
-`/meet/:username`. Allocated from the host's display name. Not a
-SuperTokens username and not the Google email.
-_Avoid_: username, handle (until slug editing ships)
+The public username segment in `/meet/:username`. Allocated from the
+host's display name; the host may edit it in Settings. Not a SuperTokens
+username and not the Google email.
+_Avoid_: username, handle
 
 **Reservation**:
 A confirmed (or cancelled) booking record owned by the Booking module.

--- a/docs/architecture/product-suite-boundaries.md
+++ b/docs/architecture/product-suite-boundaries.md
@@ -202,7 +202,7 @@ rule is maintained now.
    in Calendar. Keep Sync as-is operationally.
 2. **First Booking slice:** specified in
    [Compass Calendar Booking (v1)](../features/booking.md). Add a `booking`
-   domain module in the existing API and public `/book/` routes in Compass
+   domain module in the existing API and public `/meet/` routes in Compass
    Web. Use Calendar application interfaces. Do not extract a microservice.
 3. **First Reminders slice:** add reminder contracts/policy plus a worker
    entrypoint backed by durable, idempotent jobs.

--- a/docs/development/feature-file-map.md
+++ b/docs/development/feature-file-map.md
@@ -68,7 +68,9 @@ Product spec: [Compass Calendar Booking (v1)](../features/booking.md).
 - Occupancy: `packages/sync/src/domain/occurrence-projection.ts`,
   `packages/sync/src/domain/busy-query.service.ts`,
   `POST /internal/availability/busy`
-- Host Settings: `packages/web/src/booking/BookingSettingsSection.tsx`
+- Host Settings: `packages/web/src/booking/BookingSettingsSection.tsx`,
+  `BookingAddressSetup.tsx`, `weekly-hours.rows.ts`,
+  `packages/web/src/components/Switch/Switch.tsx`
 - Public guest UI: `packages/web/src/booking/PublicBookingPage.tsx`,
   `PublicBookingConfirmedPage.tsx`, `PublicBookingCancelPage.tsx`
 - Web API client: `packages/web/src/api/public-booking.api.ts`

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -1,4 +1,4 @@
-# Compass Calendar Booking (v1 / v1.1 / v1.3 / v1.5 / v1.6)
+# Compass Calendar Booking (v1 / v1.1 / v1.3 / v1.5 / v1.6 / v1.7)
 
 Locked product spec for public scheduling on Compass Cloud
 (`https://compasscalendar.com`). Approved 2026-08-30. v1.1 shipped
@@ -8,21 +8,24 @@ Escape paths, guest edit-details after confirm, confirmation permalink
 tokens, and the audit fixes on milestone Booking v1.5. v1.3 (guest
 reschedule) is specified here and implemented. v1.6 shipped one-click
 turn on, Essentials / More options, editable address, default hours,
-branded connect pills, and funnel analytics. The production gate stays
-off.
+branded connect pills, and funnel analytics. v1.7 shipped the Meeting
+page redesign: `/meet` URLs, meeting copy, hold-Mod section chords, the
+on/off switch, grouped weekly hours rows, and the first-run address
+screen. The production gate stays off.
 
 Compass never sends email itself. Google emails the guest when Compass
 creates the calendar event with `invitation: "all"`.
 
 ## Status
 
-v1, v1.1, v1.3, v1.5, and v1.6 are implemented in the Compass monorepo
-(public `/book/:username`, host Settings, backend APIs, guest cancel,
-guest reschedule, edit-details, one-click turn on, Essentials / More
-options, editable address, default hours, branded connect pills, and
-funnel analytics). Booking is enabled in development and staging
-(`runtime.nodeEnv` other than `production`) and disabled in production.
-Do not flip `isBookingEnabled`.
+v1, v1.1, v1.3, v1.5, v1.6, and v1.7 are implemented in the Compass
+monorepo (public `/meet/:username`, host Settings, backend APIs, guest
+cancel, guest reschedule, edit-details, one-click turn on, Essentials /
+More options, editable address, default hours, branded connect pills,
+funnel analytics, meeting copy, hold-Mod section chords, the on/off
+switch, grouped weekly hours, and the first-run address screen). Booking
+is enabled in development and staging (`runtime.nodeEnv` other than
+`production`) and disabled in production. Do not flip `isBookingEnabled`.
 A standalone Compass Booking product (separate brand, domain, or
 deployable) is **explicitly deferred**. The seams below are the
 extraction path; they are not a second service in v1.
@@ -33,15 +36,15 @@ extraction path; they are not a second service in v1.
 
 Example: `https://compasscalendar.com/meet/tyler-dane`
 
-The username is a `bookingSlug` on the host's booking page. Hosts choose it
+The username is a `bookingSlug` on the host's Meeting page. Hosts choose it
 in Settings before or after enabling. Interior hyphens are allowed (for
 example `tyler-dane`). Changing the address overwrites the stored slug;
 old slug links stop working and there are no slug redirects.
 
-Old `/book/:username`, `/book/cancel/:id`, `/book/reschedule/:id`, and
-`/book/confirmed/:id` links still work through client-side redirect
-routes that keep the search params (`?token=` rides on cancel and
-reschedule links). API paths stay `/api/booking/*`.
+Legacy `/book` username, cancel, reschedule, and confirmed links still
+work through client-side redirect routes that keep the search params
+(`?token=` rides on cancel and reschedule links). API paths stay
+`/api/booking/*`.
 
 The guest's selection lives in `/meet/:slug` search params
 (`?month=&date=&slot=&tz=`): Back returns from the details step to the
@@ -97,7 +100,7 @@ Store the slug on a booking-owned profile row keyed by Compass user id
 
 ## Product shape
 
-v1 is **one booking page per Compass user**, with one duration. Multiple
+v1 is **one Meeting page per Compass user**, with one duration. Multiple
 appointment types are a later collection, not a v1 field.
 
 ### Host
@@ -107,8 +110,8 @@ writable calendar connection. Anonymous IndexedDB users do not get a
 booking link. Password-only users see a connect-Google prompt in
 Settings, not a broken public page.
 
-Host administration lives in Settings as a Booking page
-(`SettingsPage` includes `"booking"` in
+Host administration lives in Settings as Meeting. The internal name
+remains Booking page (`SettingsPage` includes `"booking"` in
 `packages/web/src/settings/settings.store.ts`). There is no dedicated
 `/booking` host app in v1.
 
@@ -165,10 +168,9 @@ focus uses the accent ring. Intended Tab order on the picker:
    each state change. Tab then reaches **Cancel this meeting**.
 8. Reschedule (`/meet/reschedule/:id`) focuses **Reschedule your meeting
    with {host}** on load and after each state change. Tab then reaches
-   the picker (same month grid and slot list as the public page), then
-   **Confirm**. A 409 conflict focuses the alert. Missing or invalid
-   token focuses the not-found heading. This path is v1.3 and is not
-   shipped.
+  the picker (same month grid and slot list as the public page), then
+  **Confirm**. A 409 conflict focuses the alert. Missing or invalid
+  token focuses the not-found heading.
 
 The month grid stays in the DOM ahead of the slot list. The skip link
 exists so keyboard users are not forced through every day cell before
@@ -344,7 +346,7 @@ There is no host reservation inbox.
   to cancel when history state has `rescheduleUrl`. Cold permalink has
   neither reschedule secret. Cancel and edit use `?token=` on the
   confirmation URL (see Guest cancel and edit details).
-- `/book/reschedule/:id?token=` reuses the public month/slot picker. Do
+- `/meet/reschedule/:id?token=` reuses the public month/slot picker. Do
   not re-collect name, email, or notes. Confirm and reschedule both pin
   `durationMinutes` from the page the guest saw: a mismatch with the
   current page duration is `409`.
@@ -373,7 +375,7 @@ flowchart LR
   calendar[Calendar app interface]
   sync[Sync service]
 
-  guest -->|"public /book/:slug"| api
+  guest -->|"public /meet/:slug"| api
   host -->|authenticated admin| api
   api --> booking
   booking -->|"getAvailability / createEvent / updateEvent / deleteEvent"| calendar
@@ -386,7 +388,7 @@ flowchart LR
 - **Persistence:** Booking-owned Mongo collections (page config,
   reservations). Calendar collections stay Calendar/Sync-owned.
   Cross-domain references are stable ids only.
-- **Web:** same Compass Web deploy. Public `/book/$username` routes do
+- **Web:** same Compass Web deploy. Public `/meet/$username` routes do
   **not** sit under the authenticated layout and must lazy-load a small
   booking bundle so the keyboard-first calendar does not boot.
 - Native iOS/desktop later call the same Booking HTTP contracts. They do
@@ -484,7 +486,7 @@ Guest reschedule is **in scope for v1.3**, not v1 / v1.1.
 | Reservations + cancel tokens | `packages/backend/src/booking/booking-reservation.repository.ts`, `booking-cancel-token.ts` |
 | Calendar application port | `packages/backend/src/booking/services/calendar-booking.port.ts` (`updateBookingEvent`), `services/calendar-booking.service.ts` |
 | Sync busy occupancy | `packages/sync/src/domain/occurrence-projection.ts`, `busy-query.service.ts`, `booking-occupancy-facts.ts` |
-| Host Settings UI | `packages/web/src/booking/BookingSettingsSection.tsx`, `BookingStatusHeader.tsx`, `BookingMoreOptions.tsx`, `BookingSaveBar.tsx`, `BookingAddressField.tsx`, `BookingBlockingCalendarsField.tsx`, `BookingLimitsFieldset.tsx`, `packages/web/src/components/Settings/SettingsModal.tsx` |
+| Host Settings UI | `packages/web/src/booking/BookingSettingsSection.tsx`, `BookingAddressSetup.tsx`, `BookingStatusHeader.tsx`, `BookingMoreOptions.tsx`, `BookingSaveBar.tsx`, `BookingAddressField.tsx`, `BookingBlockingCalendarsField.tsx`, `BookingLimitsFieldset.tsx`, `weekly-hours.rows.ts`, `packages/web/src/components/Switch/Switch.tsx`, `packages/web/src/components/Settings/SettingsModal.tsx` |
 | Public guest UI | `packages/web/src/booking/PublicBookingPage.tsx`, `PublicBookingConfirmedPage.tsx`, `PublicBookingCancelPage.tsx`, `PublicBookingReschedulePage.tsx`, `PublicBookingCopyGuestAction.tsx`, `PublicBookingEditDetailsForm.tsx` |
 | Public web API client | `packages/web/src/api/public-booking.api.ts` |
 | E2e | `e2e/booking/`, `e2e/booking/public-booking-reschedule.spec.ts`, `e2e/accessibility/booking-a11y.spec.ts` |
@@ -492,12 +494,12 @@ Guest reschedule is **in scope for v1.3**, not v1 / v1.1.
 ### Analytics
 
 PostHog product events for the nothing-to-live funnel. No guest name, email,
-notes, or reservation id. Autocapture already runs on public `/book/*`
+notes, or reservation id. Autocapture already runs on public `/meet/*`
 routes; these are the named events in `packages/web/src/auth/posthog/track.ts`.
 
 | Event | Properties | When |
 | --- | --- | --- |
-| `booking_settings_opened` | `has_connection: boolean`, `is_live: boolean` | Settings > Booking mounts (after the page is known, or immediately on the connect prompt) |
+| `booking_settings_opened` | `has_connection: boolean`, `is_live: boolean` | Settings > Meeting mounts (after the page is known, or immediately on the connect prompt) |
 | `booking_page_enabled` | `first_time: boolean` | Turn-on save succeeds. `first_time` is true when the page had no `bookingUrl` before this save |
 | `booking_link_copied` | `source: "button" \| "save"` | Successful copy from the Copy button, or auto-copy after a successful turn-on / save |
 | `booking_page_viewed` | `duration_minutes: number` | Public page query succeeds with `enabled: true`, once per slug |
@@ -512,8 +514,8 @@ routes; these are the named events in `packages/web/src/auth/posthog/track.ts`.
   reconnects to a different replica resets its bucket. Accepted for v1
   while `isBookingEnabled` stays false in production.
 - **Cancel, edit, and reschedule tokens travel in the query string.** The
-  bearer lives in `?token=` on `/book/confirmed/:id`, `/book/cancel/:id`,
-  and `/book/reschedule/:id`, so it can appear in browser history, Referer
+  bearer lives in `?token=` on `/meet/confirmed/:id`, `/meet/cancel/:id`,
+  and `/meet/reschedule/:id`, so it can appear in browser history, Referer
   headers, and access logs. Accepted for v1: a fragment or POST landing
   page would break the confirmation permalink. Tokens stop working at
   `slotEnd`.
@@ -534,6 +536,11 @@ routes; these are the named events in `packages/web/src/auth/posthog/track.ts`.
   host edit can be overwritten. Accepted for v1.3.
 - **Confirm is fail-closed.** When Sync reports `bookable: false`, slots
   disappear and confirm returns `409`.
+- **Letter pool is hand-maintained.** `SETTINGS_MOD_LETTER_POOL` in
+  `packages/web/src/booking/booking-sequence.fields.ts` is a comment-backed
+  exclusion list, not derived from the keymap. Adding a Meeting chord
+  means checking that list by hand so it does not collide with editing,
+  find, OS, browser, or app-owned letters.
 
 ## Related docs
 

--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -4,12 +4,15 @@ import {
   dispatchBlur,
   dispatchClick,
   dispatchFill,
+  expectMeetingShortcutChips,
   formatSlotButtonLabel,
+  holdSettingsMod,
   preparePublicBookingCancelPage,
   preparePublicBookingConfirmedPage,
   preparePublicBookingPage,
   preparePublicBookingReschedulePage,
   prepareSignedInBookingSettingsPage,
+  releaseSettingsMod,
 } from "../booking/booking-harness";
 import { expectNoAxeViolations } from "../utils/axe-assertion";
 
@@ -445,6 +448,27 @@ test.describe("settings booking section", () => {
       checkpoint: "settings booking connect pills",
       include: "[role='dialog']",
     });
+  });
+
+  test("hold-Mod chips have no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await prepareSignedInBookingSettingsPage(page);
+    const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+    await expect(
+      settingsDialog.getByRole("switch", { name: "Meeting page" }),
+    ).toHaveAttribute("aria-checked", "true");
+
+    await holdSettingsMod(page);
+    try {
+      await expectMeetingShortcutChips(settingsDialog);
+      await expectNoAxeViolations(page, {
+        checkpoint: "settings booking hold-mod chips",
+        include: "[role='dialog']",
+      });
+    } finally {
+      await releaseSettingsMod(page);
+    }
   });
 
   test("not-live status has no automatically detectable accessibility violations", async ({

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -1,4 +1,4 @@
-import { expect, type Page } from "@playwright/test";
+import { expect, type Locator, type Page } from "@playwright/test";
 import { DEFAULT_WEEKLY_AVAILABILITY } from "@core/types/booking.contracts";
 
 /** ObjectId-shaped id for stubbed Google calendar in host settings e2e. */
@@ -1242,6 +1242,27 @@ export const dispatchBlur = async (
   await locator.evaluate((el) => {
     el.dispatchEvent(new Event("focusout", { bubbles: true }));
   });
+};
+
+/**
+ * Settings hold-Mod chips appear on the initial Mod press (`holdMs: 0`).
+ * This VM resolves Mod to Control; a second modifier cancels the hold.
+ */
+export const holdSettingsMod = async (page: Page) => {
+  await page.keyboard.down("Control");
+};
+
+export const releaseSettingsMod = async (page: Page) => {
+  await page.keyboard.up("Control");
+};
+
+const MEETING_SHORTCUT_CHIPS = ["4", "5", "6", "7", "8", "9", "U"] as const;
+
+/** Assert hold-Mod chips for Meeting sections (`4`–`9`) and copy-link (`U`). */
+export const expectMeetingShortcutChips = async (settingsDialog: Locator) => {
+  for (const key of MEETING_SHORTCUT_CHIPS) {
+    await expect(settingsDialog.getByText(key, { exact: true })).toBeVisible();
+  }
 };
 
 export function formatSlotButtonLabel(

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -6,7 +6,10 @@ import {
   dispatchBlur,
   dispatchClick,
   dispatchFill,
+  expectMeetingShortcutChips,
+  holdSettingsMod,
   prepareSignedInBookingSettingsPage,
+  releaseSettingsMod,
 } from "./booking-harness";
 
 test.use({ viewport: { width: 1600, height: 900 } });
@@ -179,6 +182,79 @@ test("turns on a not-live page in one click", async ({ page }) => {
 
   await expect.poll(() => captured.putBodies.length).toBe(1);
   expect(captured.putBodies[0]).toMatchObject({ enabled: true });
+});
+
+test("first visit: address, hours, switch on", async ({ page, context }) => {
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+  const captured = await prepareSignedInBookingSettingsPage(page, {
+    configured: false,
+    enabled: false,
+  });
+
+  const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+  await expect(
+    settingsDialog.getByRole("heading", { name: "Your meeting page" }),
+  ).toBeVisible();
+  await expect(settingsDialog.getByLabel("Page address")).toHaveValue(
+    "hostuser",
+  );
+
+  await dispatchClick(settingsDialog.getByRole("button", { name: /Continue/ }));
+
+  await expect.poll(() => captured.putBodies.length).toBe(1);
+  expect(captured.putBodies[0]).toMatchObject({
+    enabled: false,
+    slug: "hostuser",
+    weeklyAvailability: DEFAULT_WEEKLY_AVAILABILITY,
+  });
+
+  const meetingSwitch = settingsDialog.getByRole("switch", {
+    name: "Meeting page",
+  });
+  await expect(meetingSwitch).toHaveAttribute("aria-checked", "false");
+
+  const hours = settingsDialog.getByRole("textbox", { name: /Hours for/ });
+  await dispatchFill(hours, "10-6");
+  await dispatchBlur(hours);
+  await expect(hours).toHaveValue("10am-6pm");
+
+  const editedHours = ([1, 2, 3, 4, 5] as const).map((weekday) => ({
+    weekday,
+    start: "10:00",
+    end: "18:00",
+  }));
+
+  await dispatchClick(meetingSwitch);
+
+  await expect.poll(() => captured.putBodies.length).toBe(2);
+  expect(captured.putBodies[1]).toMatchObject({
+    enabled: true,
+    weeklyAvailability: editedHours,
+  });
+
+  await expect(settingsDialog.getByText("Live at")).toBeVisible();
+  await expect(
+    page.getByText("Your meeting page is live. Link copied."),
+  ).toBeVisible();
+  await expect(
+    settingsDialog.getByRole("textbox", { name: "Meeting link" }),
+  ).toHaveValue("https://compasscalendar.com/meet/hostuser");
+  await expect
+    .poll(async () => page.evaluate(() => navigator.clipboard.readText()))
+    .toBe("https://compasscalendar.com/meet/hostuser");
+
+  await holdSettingsMod(page);
+  try {
+    await expectMeetingShortcutChips(settingsDialog);
+  } finally {
+    await releaseSettingsMod(page);
+  }
+
+  await page.goto("/book/hostuser?token=abc", {
+    waitUntil: "domcontentloaded",
+  });
+  await expect(page).toHaveURL(/\/meet\/hostuser/);
+  expect(new URL(page.url()).searchParams.get("token")).toBe("abc");
 });
 
 test("turns a not-live unconfigured page on in one click", async ({ page }) => {

--- a/packages/web/src/booking/BookingCopyLink.test.tsx
+++ b/packages/web/src/booking/BookingCopyLink.test.tsx
@@ -113,8 +113,8 @@ describe("copyText", () => {
     const writeText = mock(() => Promise.resolve());
     setClipboard({ writeText });
 
-    expect(await copyText("https://example.com/book/tyler")).toBe(true);
-    expect(writeText).toHaveBeenCalledWith("https://example.com/book/tyler");
+    expect(await copyText("https://example.com/meet/tyler")).toBe(true);
+    expect(writeText).toHaveBeenCalledWith("https://example.com/meet/tyler");
   });
 
   it("reports failure instead of rejecting when permission is denied", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3509

## What and why

Booking v1.7 WP-08 closeout. One host-settings e2e walks the first visit (address setup, Continue, hours edit, switch on, copied link, hold-Mod chips `4`–`9` and `U`, legacy `/book` redirect keeping `?token=`). Axe covers those chips. Docs name v1.7, drop leftover `/book/` paths outside the legacy redirect constants and tests, and the product-audit prompt will not re-propose the locked Meeting page decisions.

Spec: `docs/features/booking.md`.

## Verify

`VERDICT: PASS`

Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad52e327-6e23-450a-a5cb-22a43d90c4f6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad52e327-6e23-450a-a5cb-22a43d90c4f6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

