### PR TITLE
fix(sync): held-off calendars are not stale for the booking gate

### DIFF
--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -313,6 +313,14 @@ decides whether a busy interval occupies a slot
   unhealthy, or incomplete), the slot is not offered and confirm is
   rejected (`409`). See
   [Product Suite Boundaries](../architecture/product-suite-boundaries.md).
+- **Cursor-expiry hold-off freshness:** when Sync is holding off
+  incremental pulls on a calendar because its watch cursor keeps expiring
+  (`cursorExpiredBackoffUntil`), booking treats the resource as fresh for
+  the hold-off window plus a short reconcile grace. Sync chose not to poll,
+  so the last completed repair stays authoritative; the grace covers the
+  sweep lap after hold-off expiry. The rule keys on the hold-off timestamp,
+  not watch support, so unwatchable Apple CalDAV calendars still use the
+  normal 30-minute `maxAgeMs` gate.
 - The public busy wire never includes titles, attendees, or emails.
   Optional facts are `hostIsOrganizer` and `hostResponseStatus` only.
 

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -22,6 +22,7 @@ import { CalendarBookingService } from "@backend/booking/services/calendar-booki
 import {
   PublicBookingService,
   publicBookingCompensationLog,
+  publicBookingSlotsLog,
 } from "@backend/booking/services/public-booking.service";
 import calendarService from "@backend/calendar/services/calendar.service";
 import { type SyncServiceClient } from "@backend/common/services/sync-service/sync-service.client";
@@ -559,6 +560,29 @@ describe("PublicBookingService", () => {
 
     expect(response).toEqual({ slots: [], bookable: false });
     expect(JSON.stringify(response)).not.toContain("intervals");
+  });
+
+  it("logs slug and issueCalendarIds when slots are unbookable", async () => {
+    const { slug, userId, calendarId } = await enableBookingPage();
+    getAvailability.mockImplementation(async () => ({
+      ...busyResponse(false),
+      complete: false,
+      issues: [{ calendarId, reason: "stale" }],
+    }));
+    const logSpy = spyOn(publicBookingSlotsLog, "unbookable");
+
+    await service.getSlots(slug, {
+      start: `${BOOKING_MONDAY}T00:00:00.000Z`,
+      end: `${BOOKING_TUESDAY}T00:00:00.000Z`,
+      timeZone: "UTC",
+    });
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toMatchObject({
+      slug,
+      userId: userId.toString(),
+      issueCalendarIds: [calendarId],
+    });
   });
 
   it("does not occupy a slot for a needsAction invite", async () => {

--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -132,6 +132,19 @@ export const publicBookingCompensationLog = {
   },
 };
 
+export const publicBookingSlotsLog = {
+  unbookable(meta: {
+    slug: string;
+    userId: string;
+    complete: boolean;
+    issueReasons: string[];
+    issueCalendarIds: string[];
+    connectionStates: string[];
+  }): void {
+    logger.warn("Public booking slots unbookable", meta);
+  },
+};
+
 const buildGuestActionUrl = (
   action: "cancel" | "reschedule",
   reservationId: string,
@@ -484,9 +497,12 @@ export class PublicBookingService {
     );
 
     if (!availability.bookable) {
-      logger.warn("Public booking slots unbookable", {
+      publicBookingSlotsLog.unbookable({
+        slug: page.bookingSlug ?? "",
+        userId: page.userId.toString(),
         complete: availability.complete,
         issueReasons: availability.issues.map((issue) => issue.reason),
+        issueCalendarIds: availability.issues.map((issue) => issue.calendarId),
         connectionStates: availability.connections.map(
           (connection) => connection.state,
         ),

--- a/packages/sync/src/domain/busy-availability.service.db.test.ts
+++ b/packages/sync/src/domain/busy-availability.service.db.test.ts
@@ -82,6 +82,7 @@ describe("computeBusyAvailability", () => {
   const seedCalendar = async (opts: {
     connectionId: ConnectionId;
     lastSuccessAt?: Date | null;
+    cursorExpiredBackoffUntil?: Date;
     intervals?: Array<[string, string]>;
   }): Promise<SyncEventCalendarId> => {
     const calendarId = objectId() as SyncEventCalendarId;
@@ -99,6 +100,14 @@ describe("computeBusyAvailability", () => {
         resource._id,
         "cursor",
         opts.lastSuccessAt,
+      );
+    }
+    if (opts.cursorExpiredBackoffUntil) {
+      await resources.recordCursorExpiry(
+        tenantId,
+        principalId,
+        resource._id,
+        opts.cursorExpiredBackoffUntil,
       );
     }
     for (const [start, end] of opts.intervals ?? []) {
@@ -145,6 +154,8 @@ describe("computeBusyAvailability", () => {
 
   const fresh = new Date(NOW.getTime() - 60_000); // 1 min ago
   const old = new Date(NOW.getTime() - 60 * 60_000); // 1 hour ago (> maxAge)
+  const bookingMaxAgeMs = 30 * 60_000; // 30 minutes, matches booking confirmation
+  const threeHoursAgo = new Date(NOW.getTime() - 3 * 60 * 60_000);
 
   it("is complete and bookable when every calendar is fresh and its connection is healthy", async () => {
     const conn = await seedConnection("healthy", fresh);
@@ -284,6 +295,65 @@ describe("computeBusyAvailability", () => {
       result.intervals.map((i) => [i.start.toISOString(), i.end.toISOString()]),
     ).toEqual([["2026-07-14T13:00:00.000Z", "2026-07-14T14:00:00.000Z"]]);
     // ...but its staleness is disclosed and it is not bookable.
+    expect(result.issues).toEqual([{ calendarId: cal, reason: "stale" }]);
+    expect(result.complete).toBe(false);
+    expect(result.bookable).toBe(false);
+  });
+
+  it("a resource under an active cursor-expiry hold-off is not stale", async () => {
+    const conn = await seedConnection("healthy", threeHoursAgo);
+    const holdOffUntil = new Date(NOW.getTime() + 60 * 60_000);
+    const cal = await seedCalendar({
+      connectionId: conn,
+      lastSuccessAt: threeHoursAgo,
+      cursorExpiredBackoffUntil: holdOffUntil,
+      intervals: [["2026-07-14T13:00Z", "2026-07-14T14:00Z"]],
+    });
+
+    const result = await computeBusyAvailability(
+      { occurrences, resources, connections, calendars },
+      {
+        tenantId,
+        principalId,
+        calendarIds: [cal],
+        start: WINDOW_START,
+        end: WINDOW_END,
+        maxAgeMs: bookingMaxAgeMs,
+        now: NOW,
+      },
+    );
+
+    expect(result.complete).toBe(true);
+    expect(result.bookable).toBe(true);
+    expect(result.issues).toEqual([]);
+    expect(
+      result.intervals.map((i) => [i.start.toISOString(), i.end.toISOString()]),
+    ).toEqual([["2026-07-14T13:00:00.000Z", "2026-07-14T14:00:00.000Z"]]);
+  });
+
+  it("a hold-off that expired more than the grace ago is stale again", async () => {
+    const conn = await seedConnection("healthy", threeHoursAgo);
+    const expiredHoldOff = new Date(NOW.getTime() - 20 * 60_000);
+    const cal = await seedCalendar({
+      connectionId: conn,
+      lastSuccessAt: threeHoursAgo,
+      cursorExpiredBackoffUntil: expiredHoldOff,
+      intervals: [["2026-07-14T13:00Z", "2026-07-14T14:00Z"]],
+    });
+
+    const result = await computeBusyAvailability(
+      { occurrences, resources, connections, calendars },
+      {
+        tenantId,
+        principalId,
+        calendarIds: [cal],
+        start: WINDOW_START,
+        end: WINDOW_END,
+        maxAgeMs: bookingMaxAgeMs,
+        now: NOW,
+      },
+    );
+
     expect(result.issues).toEqual([{ calendarId: cal, reason: "stale" }]);
     expect(result.complete).toBe(false);
     expect(result.bookable).toBe(false);

--- a/packages/sync/src/domain/busy-query.service.ts
+++ b/packages/sync/src/domain/busy-query.service.ts
@@ -22,6 +22,11 @@ import { type SyncResourceRepository } from "@sync/storage/repositories/sync-res
 // generation 0. See `buildCloudEventRecord` in cloud-command.service.ts.
 const UNBACKED_CALENDAR_GENERATION = 0;
 
+// After a cursor-expiry hold-off ends, reconcile may not sweep the resource
+// until the next lap. Treat lastSuccessAt as fresh through this grace so
+// booking does not flap unbookable between hold-off expiry and the next pull.
+const HOLD_OFF_SWEEP_GRACE_MS = 15 * 60 * 1000;
+
 // A normalized, half-open [start, end) busy interval on the UTC instant axis.
 export interface BusyInterval {
   start: Date;
@@ -264,9 +269,15 @@ export async function computeBusyAvailability(
       calendarId,
       generation: resource.activeGeneration,
     });
-    const ageMs = now.getTime() - resource.lastSuccessAt.getTime();
-    if (ageMs > input.maxAgeMs) {
-      issues.push({ calendarId, reason: "stale" });
+    const holdOffActive =
+      resource.cursorExpiredBackoffUntil !== null &&
+      now.getTime() <
+        resource.cursorExpiredBackoffUntil.getTime() + HOLD_OFF_SWEEP_GRACE_MS;
+    if (!holdOffActive) {
+      const ageMs = now.getTime() - resource.lastSuccessAt.getTime();
+      if (ageMs > input.maxAgeMs) {
+        issues.push({ calendarId, reason: "stale" });
+      }
     }
   }
 

--- a/packages/sync/src/storage/repositories/sync-resource.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.db.test.ts
@@ -570,4 +570,33 @@ describe("SyncResourceRepository", () => {
       expect(results.map((r) => r._id)).toEqual([google._id]);
     });
   });
+
+  it("listEventResourceFreshnessByCalendar projects cursorExpiredBackoffUntil", async () => {
+    const tenantId = objectId() as never;
+    const principalId = objectId() as never;
+    const calendarId = objectId() as never;
+    const resource = await repo.ensure(
+      upsert({ tenantId, principalId, calendarId }) as SyncResourceUpsert,
+    );
+    const holdOffUntil = new Date("2026-07-14T15:00:00.000Z");
+    await repo.recordCursorExpiry(
+      tenantId,
+      principalId,
+      resource._id,
+      holdOffUntil,
+    );
+
+    const freshness = await repo.listEventResourceFreshnessByCalendar(
+      tenantId,
+      principalId,
+      [calendarId],
+    );
+
+    expect(freshness.get(calendarId)).toMatchObject({
+      connectionId: resource.connectionId,
+      activeGeneration: 0,
+      lastSuccessAt: null,
+      cursorExpiredBackoffUntil: holdOffUntil,
+    });
+  });
 });

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -498,6 +498,7 @@ export class SyncResourceRepository {
         connectionId: ConnectionId;
         activeGeneration: number;
         lastSuccessAt: Date | null;
+        cursorExpiredBackoffUntil: Date | null;
       }
     >
   > {
@@ -513,11 +514,13 @@ export class SyncResourceRepository {
         connectionId: ConnectionId;
         activeGeneration: number;
         lastSuccessAt: Date | null;
+        cursorExpiredBackoffUntil: Date | null;
       }>({
         calendarId: 1,
         connectionId: 1,
         activeGeneration: 1,
         lastSuccessAt: 1,
+        cursorExpiredBackoffUntil: 1,
       })
       .toArray();
     return new Map(
@@ -527,6 +530,7 @@ export class SyncResourceRepository {
           connectionId: r.connectionId,
           activeGeneration: r.activeGeneration,
           lastSuccessAt: r.lastSuccessAt,
+          cursorExpiredBackoffUntil: r.cursorExpiredBackoffUntil ?? null,
         },
       ]),
     );


### PR DESCRIPTION
Fixes #3531

## What and why

Hosts whose blocking calendars include unwatchable Google calendars (holidays, birthdays) were marked unbookable for most of the cursor-expiry hold-off window because `lastSuccessAt` froze while Sync skipped incremental pulls. This projects `cursorExpiredBackoffUntil` into freshness queries and skips the stale check during hold-off plus a 15-minute reconcile grace, keyed on the hold-off timestamp rather than watch support so Apple CalDAV calendars keep the normal 30-minute gate. The unbookable warn log now includes slug, userId, and issue calendar ids for operator lookup.

Spec: [docs/features/booking.md](https://github.com/KeepSoftwareSimple/compass-calendar/blob/main/docs/features/booking.md)

## Verify

```
bun test:sync
bun test:backend
bun run type-check
bun run lint
bun run verify --strict
```

VERDICT: PASS