### PR TITLE
feat(web): keep booking settings from scrolling horizontally

### DIFF
--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -340,3 +340,40 @@ test("essentials fit without scrolling at 1440x900", async ({ page }) => {
     dialogBox!.y + dialogBox!.height,
   );
 });
+
+test("settings dialog never scrolls horizontally with more options open", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await prepareSignedInBookingSettingsPage(page);
+
+  const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+  await openMoreOptions(settingsDialog);
+  await settingsDialog
+    .getByRole("button", { name: /Meeting timezone:/ })
+    .click();
+
+  const timezoneDialog = page.getByRole("dialog", { name: "Meeting timezone" });
+  await dispatchFill(
+    timezoneDialog.getByRole("combobox", { name: "Search meeting timezones" }),
+    "Buenos Aires",
+  );
+  await timezoneDialog.getByRole("option", { name: /Buenos Aires/ }).click();
+  await expect(
+    settingsDialog.getByRole("button", { name: /Buenos Aires/ }),
+  ).toBeVisible();
+
+  const noHorizontalOverflow = async () => {
+    const { scrollWidth, clientWidth } = await settingsDialog.evaluate(
+      (el) => ({
+        scrollWidth: el.scrollWidth,
+        clientWidth: el.clientWidth,
+      }),
+    );
+    expect(scrollWidth).toBeLessThanOrEqual(clientWidth);
+  };
+
+  await noHorizontalOverflow();
+  await page.setViewportSize({ width: 1024, height: 768 });
+  await noHorizontalOverflow();
+});

--- a/packages/web/src/booking/BookingAddressField.tsx
+++ b/packages/web/src/booking/BookingAddressField.tsx
@@ -47,29 +47,28 @@ export function BookingAddressField({
     .join(" ");
 
   return (
-    <div>
+    <div className="min-w-0">
       <BookingFieldLabel htmlFor="booking-address">
         Page address
       </BookingFieldLabel>
-      <div
-        className={`flex min-w-0 items-center rounded border bg-surface-overlay ${
+      <input
+        {...bookingFieldAttrs("address")}
+        aria-describedby={describedBy}
+        aria-invalid={showError || undefined}
+        autoCapitalize="none"
+        className={`c-focus-ring w-full min-w-0 rounded border bg-surface-overlay px-2 py-1 text-sm text-text ${
           showError ? "border-error" : "border-border"
         }`}
-      >
-        <span className="shrink-0 pl-2 text-sm text-text-muted">{prefix}</span>
-        <input
-          {...bookingFieldAttrs("address")}
-          aria-describedby={describedBy}
-          aria-invalid={showError || undefined}
-          autoCapitalize="none"
-          className="c-focus-ring min-w-0 flex-1 rounded border-0 bg-transparent px-1 py-1 text-sm text-text"
-          id="booking-address"
-          onBlur={() => setBlurred(true)}
-          onChange={(event) => onChange(event.target.value.toLowerCase())}
-          spellCheck={false}
-          value={slug}
-        />
-      </div>
+        id="booking-address"
+        onBlur={() => setBlurred(true)}
+        onChange={(event) => onChange(event.target.value.toLowerCase())}
+        spellCheck={false}
+        value={slug}
+      />
+      <p className="break-all text-text-muted text-xs">
+        Your link: {prefix}
+        {slug}
+      </p>
       <p className="text-text-muted text-xs" id={helperId}>
         {BOOKING_ADDRESS_HELPER}
       </p>

--- a/packages/web/src/booking/BookingBlockingCalendarsField.tsx
+++ b/packages/web/src/booking/BookingBlockingCalendarsField.tsx
@@ -23,6 +23,10 @@ export function BookingBlockingCalendarsField({
     availabilityCalendars,
     connections,
   );
+  const groupsWithCalendars = groups.filter(
+    (group) => group.calendars.length > 0,
+  );
+  const showAccountCaption = groupsWithCalendars.length > 1;
 
   const renderBlockingCalendar = (calendar: Calendar) => (
     <BookingCheckboxRow
@@ -44,14 +48,17 @@ export function BookingBlockingCalendarsField({
         <p className="text-sm text-text-muted">No calendars available.</p>
       ) : (
         <>
-          {groups
-            .filter((group) => group.calendars.length > 0)
-            .map((group) => (
-              <div className="flex flex-col gap-1" key={group.accountEmail}>
+          {groupsWithCalendars.map((group) => (
+            <div
+              className="flex min-w-0 flex-col gap-1"
+              key={group.accountEmail}
+            >
+              {showAccountCaption ? (
                 <p className="text-text-muted text-xs">{group.accountEmail}</p>
-                {group.calendars.map(renderBlockingCalendar)}
-              </div>
-            ))}
+              ) : null}
+              {group.calendars.map(renderBlockingCalendar)}
+            </div>
+          ))}
           {ungrouped.map(renderBlockingCalendar)}
         </>
       )}

--- a/packages/web/src/booking/BookingSaveBar.tsx
+++ b/packages/web/src/booking/BookingSaveBar.tsx
@@ -23,12 +23,9 @@ export function BookingSaveBar({
   const pendingLabel = isPending ? "Saving…" : BOOKING_SAVE_CHANGES_LABEL;
 
   return (
-    <div className={BOOKING_SETTINGS_SAVE_BAR_CLASS_NAME}>
-      {error ? (
-        <p className="mb-2 font-medium text-sm text-text" role="alert">
-          {error}
-        </p>
-      ) : null}
+    <div
+      className={`${BOOKING_SETTINGS_SAVE_BAR_CLASS_NAME} flex flex-wrap items-center justify-end gap-3`}
+    >
       {/* Default align=end keeps the always-on chip Save off the hours column. */}
       <OverlayPanelActions>
         <OverlayPanelActionButton
@@ -45,6 +42,14 @@ export function BookingSaveBar({
           {pendingLabel}
         </OverlayPanelActionButton>
       </OverlayPanelActions>
+      {error ? (
+        <p
+          className="min-w-0 basis-full font-medium text-sm text-text"
+          role="alert"
+        >
+          {error}
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -584,6 +584,9 @@ describe("BookingSettingsSection", () => {
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Page address")).toHaveValue("hostuser");
     expect(
+      screen.getByText(`Your link: ${window.location.origin}/meet/hostuser`),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole("button", { name: "Continue" }),
     ).toBeInTheDocument();
     expect(screen.queryByLabelText("Duration")).not.toBeInTheDocument();
@@ -804,6 +807,10 @@ describe("BookingSettingsSection", () => {
     );
 
     const address = await screen.findByLabelText("Page address");
+    expect(address).toHaveValue("hostuser");
+    expect(
+      screen.getByText("Your link: https://compasscalendar.com/meet/hostuser"),
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole("heading", { name: "Your meeting page" }),
     ).not.toBeInTheDocument();
@@ -2255,6 +2262,88 @@ describe("BookingSettingsSection", () => {
 
     expect(control).not.toHaveFocus();
     expect(control).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("hides the blocking-calendar account caption for a single account", async () => {
+    const user = userEvent.setup({ delay: null });
+    userMetadataActions.set(healthyGoogleMetadata);
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(savedOffPage())),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    await user.click(await screen.findByText(BOOKING_MORE_OPTIONS_LABEL));
+
+    const blocking = screen.getByRole("group", { name: "Blocking calendars" });
+    expect(
+      within(blocking).getByRole("checkbox", { name: "Work" }),
+    ).toBeInTheDocument();
+    expect(
+      within(blocking).queryByText("host@example.com"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows blocking-calendar account captions when two accounts have calendars", async () => {
+    const user = userEvent.setup({ delay: null });
+    const secondCalendar = createMockCalendar({
+      name: "Personal",
+      accountEmail: "second@example.com",
+    });
+    userMetadataActions.set({
+      google: {
+        connectionState: "HEALTHY" as const,
+        connections: [
+          createMockConnection("host@example.com"),
+          createMockConnection("second@example.com"),
+        ],
+      },
+    });
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(
+          ctx.json({
+            ...savedOffPage(),
+            blockingCalendarIds: [writableCalendar.id, secondCalendar.id],
+          }),
+        ),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [
+      writableCalendar,
+      secondCalendar,
+    ]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    await user.click(await screen.findByText(BOOKING_MORE_OPTIONS_LABEL));
+
+    const blocking = screen.getByRole("group", { name: "Blocking calendars" });
+    expect(within(blocking).getByText("host@example.com")).toBeInTheDocument();
+    expect(
+      within(blocking).getByText("second@example.com"),
+    ).toBeInTheDocument();
+    expect(
+      within(blocking).getByRole("checkbox", { name: "Work" }),
+    ).toBeInTheDocument();
+    expect(
+      within(blocking).getByRole("checkbox", { name: "Personal" }),
+    ).toBeInTheDocument();
   });
 
   it("keeps More options closed by default", async () => {

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -536,7 +536,7 @@ export function BookingSettingsSection({
         />
 
         <div className="grid grid-cols-2 gap-3">
-          <div>
+          <div className="min-w-0">
             <BookingFieldLabel htmlFor="booking-duration">
               Duration
             </BookingFieldLabel>
@@ -561,7 +561,7 @@ export function BookingSettingsSection({
             </select>
           </div>
 
-          <div {...bookingFieldAttrs("timezone")}>
+          <div className="min-w-0" {...bookingFieldAttrs("timezone")}>
             <BookingTimezoneField
               onChange={(timeZone) => updateForm({ timeZone })}
               timeZone={form.timeZone}
@@ -650,40 +650,44 @@ export function BookingSettingsSection({
           />
 
           <div className="grid grid-cols-2 gap-3">
-            <BookingNumberField
-              field="notice"
-              id="booking-min-notice"
-              invalid={minNoticeInvalid}
-              invalidMessage={`Enter 0 to ${BOOKING_MAX_MIN_NOTICE_HOURS} hours.`}
-              label="Minimum notice (hours)"
-              max={BOOKING_MAX_MIN_NOTICE_HOURS}
-              min={0}
-              onChange={(raw) => {
-                setMinNoticeText(raw);
-                const parsed = parseBookingCount(raw, MIN_NOTICE_BOUNDS);
-                if (parsed !== null) {
-                  updateForm({ minNoticeHours: parsed });
-                }
-              }}
-              value={minNoticeText}
-            />
-            <BookingNumberField
-              field="horizon"
-              id="booking-max-horizon"
-              invalid={horizonInvalid}
-              invalidMessage={`Enter 1 to ${BOOKING_MAX_HORIZON_DAYS} days.`}
-              label="Maximum horizon (days)"
-              max={BOOKING_MAX_HORIZON_DAYS}
-              min={1}
-              onChange={(raw) => {
-                setHorizonText(raw);
-                const parsed = parseBookingCount(raw, HORIZON_BOUNDS);
-                if (parsed !== null) {
-                  updateForm({ maxHorizonDays: parsed });
-                }
-              }}
-              value={horizonText}
-            />
+            <div className="min-w-0">
+              <BookingNumberField
+                field="notice"
+                id="booking-min-notice"
+                invalid={minNoticeInvalid}
+                invalidMessage={`Enter 0 to ${BOOKING_MAX_MIN_NOTICE_HOURS} hours.`}
+                label="Minimum notice (hours)"
+                max={BOOKING_MAX_MIN_NOTICE_HOURS}
+                min={0}
+                onChange={(raw) => {
+                  setMinNoticeText(raw);
+                  const parsed = parseBookingCount(raw, MIN_NOTICE_BOUNDS);
+                  if (parsed !== null) {
+                    updateForm({ minNoticeHours: parsed });
+                  }
+                }}
+                value={minNoticeText}
+              />
+            </div>
+            <div className="min-w-0">
+              <BookingNumberField
+                field="horizon"
+                id="booking-max-horizon"
+                invalid={horizonInvalid}
+                invalidMessage={`Enter 1 to ${BOOKING_MAX_HORIZON_DAYS} days.`}
+                label="Maximum horizon (days)"
+                max={BOOKING_MAX_HORIZON_DAYS}
+                min={1}
+                onChange={(raw) => {
+                  setHorizonText(raw);
+                  const parsed = parseBookingCount(raw, HORIZON_BOUNDS);
+                  if (parsed !== null) {
+                    updateForm({ maxHorizonDays: parsed });
+                  }
+                }}
+                value={horizonText}
+              />
+            </div>
           </div>
         </BookingMoreOptions>
 

--- a/packages/web/src/booking/BookingTimezoneField.tsx
+++ b/packages/web/src/booking/BookingTimezoneField.tsx
@@ -39,14 +39,15 @@ export function BookingTimezoneField({
         aria-expanded={isOpen}
         aria-haspopup="listbox"
         aria-label={`Meeting timezone: ${label}`}
-        className="c-focus-ring w-full rounded border border-border bg-surface-overlay px-2 py-1 text-left text-sm text-text hover:bg-surface-panel disabled:pointer-events-none disabled:opacity-60"
+        className="c-focus-ring w-full min-w-0 rounded border border-border bg-surface-overlay px-2 py-1 text-left text-sm text-text hover:bg-surface-panel disabled:pointer-events-none disabled:opacity-60"
         disabled={disabled}
         id="booking-timezone"
         onClick={() => setIsOpen(true)}
         ref={triggerRef}
+        title={label}
         type="button"
       >
-        {label}
+        <span className="block truncate">{label}</span>
       </button>
 
       {isOpen ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3535

## What and why

Settings Meeting never scrolls horizontally: the page address input holds the slug alone with a wrapping `Your link:` preview, two-column grids get `min-w-0`, the timezone trigger truncates with a full `title`, blocking-calendar account emails show only when more than one account has calendars, and the save-bar error wraps under the button. Spec: [docs/features/booking.md](https://github.com/KeepSoftwareSimple/compass-calendar/blob/main/docs/features/booking.md).

## Verify

VERDICT: PASS
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4af0b498-74fb-4fad-b1b2-dec814cff3b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4af0b498-74fb-4fad-b1b2-dec814cff3b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

