### PR TITLE
fix(web): booking v1.8 WP-05 no horizontal scroll and address field cleanup

### DIFF
--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -340,3 +340,40 @@ test("essentials fit without scrolling at 1440x900", async ({ page }) => {
     dialogBox!.y + dialogBox!.height,
   );
 });
+
+test("never scrolls horizontally", async ({ page }) => {
+  for (const viewport of [
+    { width: 1440, height: 900 },
+    { width: 1024, height: 768 },
+  ] as const) {
+    await page.setViewportSize(viewport);
+    await prepareSignedInBookingSettingsPage(page);
+
+    const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+    await openMoreOptions(settingsDialog);
+
+    await dispatchClick(
+      settingsDialog.getByRole("button", { name: /^Meeting timezone:/ }),
+    );
+    const timezonePanel = page.getByRole("dialog", {
+      name: "Meeting timezone",
+    });
+    const timezoneSearch = timezonePanel.getByRole("combobox");
+    await dispatchFill(timezoneSearch, "buenos aires");
+    await timezoneSearch.press("Enter");
+
+    await expect(
+      settingsDialog.getByRole("button", {
+        name: /Meeting timezone: Buenos Aires/,
+      }),
+    ).toBeVisible();
+
+    const scrollMetrics = await settingsDialog.evaluate((el) => ({
+      clientWidth: el.clientWidth,
+      scrollWidth: el.scrollWidth,
+    }));
+    expect(scrollMetrics.scrollWidth).toBeLessThanOrEqual(
+      scrollMetrics.clientWidth,
+    );
+  }
+});

--- a/packages/web/src/booking/BookingAddressField.tsx
+++ b/packages/web/src/booking/BookingAddressField.tsx
@@ -32,6 +32,7 @@ export function BookingAddressField({
 }: BookingAddressFieldProps) {
   const [blurred, setBlurred] = useState(false);
   const prefix = bookingAddressPrefix(bookingUrl);
+  const previewLink = slug ? `${prefix}${slug}` : null;
   const parseMessage = bookingSlugParseMessage(slug);
   const showError = (blurred || forceInvalid) && parseMessage != null;
   const showWarning = savedSlug != null && slug !== savedSlug;
@@ -51,25 +52,25 @@ export function BookingAddressField({
       <BookingFieldLabel htmlFor="booking-address">
         Page address
       </BookingFieldLabel>
-      <div
-        className={`flex min-w-0 items-center rounded border bg-surface-overlay ${
+      <input
+        {...bookingFieldAttrs("address")}
+        aria-describedby={describedBy}
+        aria-invalid={showError || undefined}
+        autoCapitalize="none"
+        className={`c-focus-ring w-full rounded border bg-surface-overlay px-2 py-1 text-sm text-text ${
           showError ? "border-error" : "border-border"
         }`}
-      >
-        <span className="shrink-0 pl-2 text-sm text-text-muted">{prefix}</span>
-        <input
-          {...bookingFieldAttrs("address")}
-          aria-describedby={describedBy}
-          aria-invalid={showError || undefined}
-          autoCapitalize="none"
-          className="c-focus-ring min-w-0 flex-1 rounded border-0 bg-transparent px-1 py-1 text-sm text-text"
-          id="booking-address"
-          onBlur={() => setBlurred(true)}
-          onChange={(event) => onChange(event.target.value.toLowerCase())}
-          spellCheck={false}
-          value={slug}
-        />
-      </div>
+        id="booking-address"
+        onBlur={() => setBlurred(true)}
+        onChange={(event) => onChange(event.target.value.toLowerCase())}
+        spellCheck={false}
+        value={slug}
+      />
+      {previewLink ? (
+        <p className="break-all text-text-muted text-xs">
+          Your link: {previewLink}
+        </p>
+      ) : null}
       <p className="text-text-muted text-xs" id={helperId}>
         {BOOKING_ADDRESS_HELPER}
       </p>

--- a/packages/web/src/booking/BookingBlockingCalendarsField.tsx
+++ b/packages/web/src/booking/BookingBlockingCalendarsField.tsx
@@ -23,6 +23,10 @@ export function BookingBlockingCalendarsField({
     availabilityCalendars,
     connections,
   );
+  const groupsWithCalendars = groups.filter(
+    (group) => group.calendars.length > 0,
+  );
+  const showAccountCaptions = groupsWithCalendars.length > 1;
 
   const renderBlockingCalendar = (calendar: Calendar) => (
     <BookingCheckboxRow
@@ -44,14 +48,14 @@ export function BookingBlockingCalendarsField({
         <p className="text-sm text-text-muted">No calendars available.</p>
       ) : (
         <>
-          {groups
-            .filter((group) => group.calendars.length > 0)
-            .map((group) => (
-              <div className="flex flex-col gap-1" key={group.accountEmail}>
+          {groupsWithCalendars.map((group) => (
+            <div className="flex flex-col gap-1" key={group.accountEmail}>
+              {showAccountCaptions ? (
                 <p className="text-text-muted text-xs">{group.accountEmail}</p>
-                {group.calendars.map(renderBlockingCalendar)}
-              </div>
-            ))}
+              ) : null}
+              {group.calendars.map(renderBlockingCalendar)}
+            </div>
+          ))}
           {ungrouped.map(renderBlockingCalendar)}
         </>
       )}

--- a/packages/web/src/booking/BookingSaveBar.tsx
+++ b/packages/web/src/booking/BookingSaveBar.tsx
@@ -23,9 +23,11 @@ export function BookingSaveBar({
   const pendingLabel = isPending ? "Saving…" : BOOKING_SAVE_CHANGES_LABEL;
 
   return (
-    <div className={BOOKING_SETTINGS_SAVE_BAR_CLASS_NAME}>
+    <div
+      className={`${BOOKING_SETTINGS_SAVE_BAR_CLASS_NAME} flex flex-wrap items-center justify-end gap-3`}
+    >
       {error ? (
-        <p className="mb-2 font-medium text-sm text-text" role="alert">
+        <p className="min-w-0 font-medium text-sm text-text" role="alert">
           {error}
         </p>
       ) : null}

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -773,6 +773,124 @@ describe("BookingSettingsSection", () => {
     });
   });
 
+  it("shows the bare slug in Page address with a preview link below", async () => {
+    const user = userEvent.setup({ delay: null });
+    userMetadataActions.set(healthyGoogleMetadata);
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(savedOffPage())),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    await screen.findByRole("switch", { name: "Meeting page" });
+    await user.click(screen.getByText(BOOKING_MORE_OPTIONS_LABEL));
+
+    const address = screen.getByLabelText("Page address");
+    expect(address).toHaveValue("hostuser");
+    expect(
+      screen.getByText("Your link: https://compasscalendar.com/meet/hostuser"),
+    ).toBeInTheDocument();
+
+    await user.clear(address);
+    await user.type(address, "new-slug");
+    expect(address).toHaveValue("new-slug");
+    expect(
+      screen.getByText("Your link: https://compasscalendar.com/meet/new-slug"),
+    ).toBeInTheDocument();
+  });
+
+  it("hides blocking account captions when only one account has calendars", async () => {
+    const user = userEvent.setup({ delay: null });
+    userMetadataActions.set(healthyGoogleMetadata);
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(savedOffPage())),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    await user.click(await screen.findByText(BOOKING_MORE_OPTIONS_LABEL));
+    const blockingFieldset = screen
+      .getByText("Blocking calendars")
+      .closest("fieldset");
+    expect(blockingFieldset).not.toBeNull();
+    expect(
+      within(blockingFieldset as HTMLElement).queryByText("host@example.com"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "Work" })).toBeInTheDocument();
+  });
+
+  it("shows blocking account captions when two accounts have calendars", async () => {
+    const user = userEvent.setup({ delay: null });
+    const secondCalendar = createMockCalendar({
+      id: CalendarIdSchema.parse(createObjectIdString()),
+      name: "Personal",
+      accountEmail: "other@example.com",
+    });
+
+    userMetadataActions.set({
+      google: {
+        connectionState: "HEALTHY" as const,
+        connections: [
+          createMockConnection("host@example.com"),
+          createMockConnection("other@example.com"),
+        ],
+      },
+    });
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(savedOffPage())),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [
+      writableCalendar,
+      secondCalendar,
+    ]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    await user.click(await screen.findByText(BOOKING_MORE_OPTIONS_LABEL));
+    const blockingFieldset = screen
+      .getByText("Blocking calendars")
+      .closest("fieldset");
+    expect(blockingFieldset).not.toBeNull();
+    const blockingScope = within(blockingFieldset as HTMLElement);
+    expect(blockingScope.getByText("host@example.com")).toBeInTheDocument();
+    expect(blockingScope.getByText("other@example.com")).toBeInTheDocument();
+    expect(
+      blockingScope.getByRole("checkbox", { name: "Work" }),
+    ).toBeInTheDocument();
+    expect(
+      blockingScope.getByRole("checkbox", { name: "Personal" }),
+    ).toBeInTheDocument();
+  });
+
   it("PUTs slug when the host edits the page address", async () => {
     const user = userEvent.setup({ delay: null });
     let savedBody: unknown;

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -536,7 +536,7 @@ export function BookingSettingsSection({
         />
 
         <div className="grid grid-cols-2 gap-3">
-          <div>
+          <div className="min-w-0">
             <BookingFieldLabel htmlFor="booking-duration">
               Duration
             </BookingFieldLabel>
@@ -561,7 +561,7 @@ export function BookingSettingsSection({
             </select>
           </div>
 
-          <div {...bookingFieldAttrs("timezone")}>
+          <div className="min-w-0" {...bookingFieldAttrs("timezone")}>
             <BookingTimezoneField
               onChange={(timeZone) => updateForm({ timeZone })}
               timeZone={form.timeZone}
@@ -650,40 +650,44 @@ export function BookingSettingsSection({
           />
 
           <div className="grid grid-cols-2 gap-3">
-            <BookingNumberField
-              field="notice"
-              id="booking-min-notice"
-              invalid={minNoticeInvalid}
-              invalidMessage={`Enter 0 to ${BOOKING_MAX_MIN_NOTICE_HOURS} hours.`}
-              label="Minimum notice (hours)"
-              max={BOOKING_MAX_MIN_NOTICE_HOURS}
-              min={0}
-              onChange={(raw) => {
-                setMinNoticeText(raw);
-                const parsed = parseBookingCount(raw, MIN_NOTICE_BOUNDS);
-                if (parsed !== null) {
-                  updateForm({ minNoticeHours: parsed });
-                }
-              }}
-              value={minNoticeText}
-            />
-            <BookingNumberField
-              field="horizon"
-              id="booking-max-horizon"
-              invalid={horizonInvalid}
-              invalidMessage={`Enter 1 to ${BOOKING_MAX_HORIZON_DAYS} days.`}
-              label="Maximum horizon (days)"
-              max={BOOKING_MAX_HORIZON_DAYS}
-              min={1}
-              onChange={(raw) => {
-                setHorizonText(raw);
-                const parsed = parseBookingCount(raw, HORIZON_BOUNDS);
-                if (parsed !== null) {
-                  updateForm({ maxHorizonDays: parsed });
-                }
-              }}
-              value={horizonText}
-            />
+            <div className="min-w-0">
+              <BookingNumberField
+                field="notice"
+                id="booking-min-notice"
+                invalid={minNoticeInvalid}
+                invalidMessage={`Enter 0 to ${BOOKING_MAX_MIN_NOTICE_HOURS} hours.`}
+                label="Minimum notice (hours)"
+                max={BOOKING_MAX_MIN_NOTICE_HOURS}
+                min={0}
+                onChange={(raw) => {
+                  setMinNoticeText(raw);
+                  const parsed = parseBookingCount(raw, MIN_NOTICE_BOUNDS);
+                  if (parsed !== null) {
+                    updateForm({ minNoticeHours: parsed });
+                  }
+                }}
+                value={minNoticeText}
+              />
+            </div>
+            <div className="min-w-0">
+              <BookingNumberField
+                field="horizon"
+                id="booking-max-horizon"
+                invalid={horizonInvalid}
+                invalidMessage={`Enter 1 to ${BOOKING_MAX_HORIZON_DAYS} days.`}
+                label="Maximum horizon (days)"
+                max={BOOKING_MAX_HORIZON_DAYS}
+                min={1}
+                onChange={(raw) => {
+                  setHorizonText(raw);
+                  const parsed = parseBookingCount(raw, HORIZON_BOUNDS);
+                  if (parsed !== null) {
+                    updateForm({ maxHorizonDays: parsed });
+                  }
+                }}
+                value={horizonText}
+              />
+            </div>
           </div>
         </BookingMoreOptions>
 

--- a/packages/web/src/booking/BookingTimezoneField.tsx
+++ b/packages/web/src/booking/BookingTimezoneField.tsx
@@ -39,11 +39,12 @@ export function BookingTimezoneField({
         aria-expanded={isOpen}
         aria-haspopup="listbox"
         aria-label={`Meeting timezone: ${label}`}
-        className="c-focus-ring w-full rounded border border-border bg-surface-overlay px-2 py-1 text-left text-sm text-text hover:bg-surface-panel disabled:pointer-events-none disabled:opacity-60"
+        className="c-focus-ring w-full truncate rounded border border-border bg-surface-overlay px-2 py-1 text-left text-sm text-text hover:bg-surface-panel disabled:pointer-events-none disabled:opacity-60"
         disabled={disabled}
         id="booking-timezone"
         onClick={() => setIsOpen(true)}
         ref={triggerRef}
+        title={label}
         type="button"
       >
         {label}


### PR DESCRIPTION
Fixes #3535

## What and why

Booking v1.8 WP-05 keeps the Settings Meeting form from scrolling horizontally at narrow widths and simplifies the configured form layout. The page address field now holds only the slug with a full link preview below, two-column grids get `min-w-0` so children can shrink, long timezone labels truncate, single-account blocking calendars drop the redundant email caption, and the save bar uses flex-wrap so inline errors do not widen the modal.

## Verify

```
Selected packages: web
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)

✓ All checks passed
VERDICT: PASS
```