### PR TITLE
test(booking): cover unbookable guest state and v1.8 closeout docs

### DIFF
--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -486,7 +486,7 @@ With a grid event focused (form closed, not typing in an input), Cmd+C (Mac) or 
 
 ### UX
 
-Settings > Meeting hold-Mod reveals only sidebar digits `1` / `2` / `3` and Enter on Save. `Mod+4` through `Mod+9` and `Mod+U` do nothing. Save is Mod+Enter. Meeting settings do not use a letter leader.
+Settings > Meeting hold-Mod reveals only sidebar digits `1` / `2` / `3` and Enter on Save. Extra digit chords and the Accounts copy chord do nothing. Save is Mod+Enter. Meeting settings do not use a letter leader.
 
 ### Steps
 
@@ -498,8 +498,8 @@ Settings > Meeting hold-Mod reveals only sidebar digits `1` / `2` / `3` and Ente
 ### Expected Results
 
 - Chips `1`, `2` (when billing is present), `3`, and the save bar's `Enter` appear while Mod is held. The nav hint **Hold Mod to see shortcuts.** hides while chips are visible. No Meeting field, legend, summary, or icon button shows a chip.
-- `Mod+5` changes focus to nothing and toggles nothing.
-- `Mod+U` does not write to the clipboard.
+- Extra digit chords change focus to nothing and toggle nothing.
+- Holding Mod and pressing U does not write to the clipboard.
 - Releasing Mod hides the nav chips and restores the nav hint.
 
 ---
@@ -529,4 +529,4 @@ If time is limited, run these checks before shipping shortcut-related changes:
 19. `Z` opens time travel in Day and Week view; Cmd+Z / Ctrl+Z still undoes and does not open the picker.
 20. On Day view, hold Mod then a column digit (2+) focuses that writable calendar column; Shift+Arrow / `C` seed a draft there.
 21. Cmd+C / Ctrl+C copies a focused event; Cmd+V / Ctrl+V pastes a duplicate at the original time without requiring focus. A later copy replaces the clipboard. Empty paste is a no-op. Copy/paste do not fire while typing in an input (native text clipboard). Cmd+D is unchanged.
-22. In Settings > Meeting, hold Mod to reveal chips `1`/`2`/`3` and Enter; `Mod+5` focuses nothing; `Mod+U` does not copy.
+22. In Settings > Meeting, hold Mod to reveal chips `1`/`2`/`3` and Enter; extra digits focus nothing; U with Mod held does not copy.

--- a/docs/architecture/glossary.md
+++ b/docs/architecture/glossary.md
@@ -180,7 +180,8 @@ Google event organizer field
 **Guest** (booking):
 The unauthenticated person who picks a day and time on a public booking
 page (month grid plus that day's slots), then confirms. Times show in
-their timezone.
+their timezone. When Sync reports the host calendar is not ready, the
+page shows Meeting temporarily unavailable instead of slots.
 _Avoid_: attendee when you mean the public booking user rather than a
 calendar guest-list row (the created event does add them as an
 attendee)

--- a/docs/development/feature-file-map.md
+++ b/docs/development/feature-file-map.md
@@ -72,7 +72,8 @@ Product spec: [Compass Calendar Booking (v1)](../features/booking.md).
   `packages/web/src/booking/setup/`, `weekly-hours.rows.ts`,
   `packages/web/src/components/Switch/Switch.tsx`
 - Public guest UI: `packages/web/src/booking/PublicBookingPage.tsx`,
-  `PublicBookingConfirmedPage.tsx`, `PublicBookingCancelPage.tsx`
+  `PublicBookingConfirmedPage.tsx`, `PublicBookingCancelPage.tsx`,
+  `PublicBookingReschedulePage.tsx`
 - Web API client: `packages/web/src/api/public-booking.api.ts`
 - E2e: `e2e/booking/`, `e2e/accessibility/booking-a11y.spec.ts`
 - Architecture: [Product Suite Boundaries](../architecture/product-suite-boundaries.md)

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -1,4 +1,4 @@
-# Compass Calendar Booking (v1 / v1.1 / v1.3 / v1.5 / v1.6 / v1.7)
+# Compass Calendar Booking (v1 / v1.1 / v1.3 / v1.5 / v1.6 / v1.7 / v1.8)
 
 Locked product spec for public scheduling on Compass Cloud
 (`https://compasscalendar.com`). Approved 2026-08-30. v1.1 shipped
@@ -10,15 +10,16 @@ reschedule) is specified here and implemented. v1.6 shipped one-click
 turn on, Essentials / More options, editable address, default hours,
 branded connect pills, and funnel analytics. v1.7 shipped the Meeting
 page redesign: `/meet` URLs, meeting copy, hold-Mod section chords, the
-on/off switch, grouped weekly hours rows, and the guided first-run setup
-screen. The production gate stays off.
+on/off switch, grouped weekly hours rows, and the first-run address
+screen. v1.8 replaced that screen with a guided setup wizard and dropped
+host knobs that are no longer in Settings. The production gate stays off.
 
 Compass never sends email itself. Google emails the guest when Compass
 creates the calendar event with `invitation: "all"`.
 
 ## Status
 
-v1, v1.1, v1.3, v1.5, v1.6, and v1.7 are implemented in the Compass
+v1, v1.1, v1.3, v1.5, v1.6, v1.7, and v1.8 are implemented in the Compass
 monorepo (public `/meet/:username`, host Settings, backend APIs, guest
 cancel, guest reschedule, edit-details, one-click turn on, Essentials /
 More options, editable address, default hours, branded connect pills,
@@ -58,7 +59,7 @@ the permalink so a reload, bookmark, or self-sent link keeps cancel and
 edit. The public reservation GET does not return `cancelUrl` or the
 token. A permalink without `token` still shows the booking from GET,
 with no cancel or edit actions. Cancel and reschedule links always appear in
-the event description because guests cannot invite others.
+the event description because guests cannot add other attendees.
 Reschedule copy stays history-only (v1.3).
 
 Cancel: `/meet/cancel/:reservationId?token=…`.
@@ -208,7 +209,7 @@ Reschedule links stay history state only (v1.3).
 **Event title:** `{Guest name} and {Host name}`.
 
 **Event description:** guest notes (if any), plus cancel and reschedule
-URLs. Guests cannot invite others, so those URLs are safe in the
+URLs. Guests cannot add other attendees, so those URLs are safe in the
 description every invitee sees.
 
 ## Host inputs
@@ -225,14 +226,14 @@ One booking-page record per user.
 
 **Slot grid:** 15-minute starts in the host timezone, filtered so a slot
 of `duration` fits inside an availability interval after busy blocks.
-Back-to-back meetings are allowed; there is no buffer or per-day cap.
+Back-to-back meetings are allowed.
 
 ### Host Settings controls
 
 The Settings **Meeting** page is keyboard-first. It is split into a
 status header, an Essentials group, and a collapsed **More options**
-group. It is not a native timezone `<select>` plus a checkbox and two
-time inputs per weekday.
+group. Hours use grouped day pills with Start and End menus, not a
+checkbox and typed times for each weekday.
 
 - **Status:** a **Meeting page** switch reflects whether the page is
   live. When on, it shows "Live at" and the meeting link with Copy and
@@ -267,8 +268,8 @@ time inputs per weekday.
   stored day with two intervals keeps only the first.
 - **Jump:** hold Mod to see sidebar digits `1/2/3` and Enter on Save
   (or Continue). Meeting fields, legends, summaries, and the Copy
-  button have no shortcut chips. `Mod+4` through `Mod+9` and `Mod+U`
-  do nothing. Save stays Mod+Enter. Save-error focus still uses
+  button have no shortcut chips. Save stays Mod+Enter. Save-error focus
+  still uses
   `data-booking-field` and does not click, so focusing a checkbox does
   not toggle it. Before focusing, the helper opens any ancestor
   `<details>`. The Settings nav shows one hint, **Hold Mod to see
@@ -358,8 +359,8 @@ There is no host reservation inbox.
 - In-place Google PATCH of the existing event: same `calendarEventId`,
   same Meet URL, same attendees. `invitation: "all"`,
   `attendeesEdit: "preserve"`. Compass still sends no email.
-- While choosing a new time, this reservation must not occupy slots or
-  count toward max-per-day. Other overlapping host events still occupy.
+- While choosing a new time, this reservation must not occupy slots.
+  Other overlapping host events still occupy.
   Tokenized slots: `GET /api/booking/reservations/:id/slots`.
 - Status stays `confirmed`; mutate `slotStart` / `slotEnd`. Same slot is
   an idempotent success (no second Google write). Cancelled or bad token

--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -77,6 +77,30 @@ test("the public booking slots error has no automatically detectable accessibili
   });
 });
 
+test("the unbookable public page has no automatically detectable accessibility violations", async ({
+  page,
+}) => {
+  await preparePublicBookingPage(page, { bookable: false });
+  await expect(
+    page.getByRole("heading", { name: "Meeting temporarily unavailable" }),
+  ).toBeVisible();
+  await expectNoAxeViolations(page, {
+    checkpoint: "public booking unbookable",
+  });
+});
+
+test("the unbookable reschedule page has no automatically detectable accessibility violations", async ({
+  page,
+}) => {
+  await preparePublicBookingReschedulePage(page, { bookable: false });
+  await expect(
+    page.getByRole("heading", { name: "Meeting temporarily unavailable" }),
+  ).toBeVisible();
+  await expectNoAxeViolations(page, {
+    checkpoint: "public booking reschedule unbookable",
+  });
+});
+
 test("the public booking conflict alert has no automatically detectable accessibility violations", async ({
   page,
 }) => {
@@ -526,6 +550,31 @@ test.describe("settings booking section", () => {
     ).toBeVisible();
     await expectNoAxeViolations(page, {
       checkpoint: "settings booking first-run address",
+      include: "[role='dialog']",
+    });
+  });
+
+  test("first-run hours step has no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await prepareSignedInBookingSettingsPage(page, {
+      configured: false,
+      enabled: false,
+    });
+    const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+    await dispatchClick(
+      settingsDialog.getByRole("button", { name: /Continue/ }),
+    );
+    await expect(
+      settingsDialog.getByRole("heading", {
+        name: "When can people meet with you?",
+      }),
+    ).toBeVisible();
+    await expect(
+      settingsDialog.getByRole("combobox", { name: /Start for/ }),
+    ).toHaveAccessibleDescription(/Start and End apply to every selected day/);
+    await expectNoAxeViolations(page, {
+      checkpoint: "settings booking first-run hours",
       include: "[role='dialog']",
     });
   });

--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -571,6 +571,9 @@ test.describe("settings booking section", () => {
       }),
     ).toBeVisible();
     await expect(
+      settingsDialog.getByRole("button", { name: /Continue/ }),
+    ).toBeEnabled();
+    await expect(
       settingsDialog.getByRole("combobox", { name: /Start for/ }),
     ).toHaveAccessibleDescription(/Start and End apply to every selected day/);
     await expectNoAxeViolations(page, {

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -603,6 +603,12 @@ export async function preparePublicBookingPage(
     ).toBeVisible({ timeout: 15000 });
     return captured;
   }
+  if (options.bookable === false) {
+    await expect(
+      page.getByRole("heading", { name: "Meeting temporarily unavailable" }),
+    ).toBeVisible({ timeout: 15000 });
+    return captured;
+  }
   await expect(
     page.getByRole("heading", { name: "Meet with Tyler Dane" }),
   ).toBeVisible({ timeout: 15000 });

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -964,6 +964,12 @@ export async function preparePublicBookingReschedulePage(
     waitUntil: "domcontentloaded",
   });
 
+  if (options.bookable === false) {
+    await expect(
+      page.getByRole("heading", { name: "Meeting temporarily unavailable" }),
+    ).toBeVisible({ timeout: 15000 });
+  }
+
   return captured;
 }
 

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -617,12 +617,8 @@ export async function preparePublicBookingPage(
   // A test that starts typing right away (Tab to the skip link, Enter) would
   // race that request: the skip link finds no target and focus goes nowhere.
   // Wait for the picker itself unless the test is deliberately observing the
-  // pending, failed, or unavailable state.
-  if (
-    options.bookable !== false &&
-    !options.slotFailGate &&
-    !options.holdFirstSlots
-  ) {
+  // pending or failed state.
+  if (!options.slotFailGate && !options.holdFirstSlots) {
     await expect(
       page.getByRole("heading", { name: "Pick a time" }),
     ).toBeVisible();

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -203,6 +203,9 @@ test("first visit: keyboard setup wizard through go live", async ({
 
   await expect(settingsDialog.getByText("Live at")).toBeVisible();
   await expect(
+    settingsDialog.getByRole("switch", { name: "Meeting page" }),
+  ).toBeFocused();
+  await expect(
     page.getByText("Your meeting page is live. Link copied."),
   ).toBeVisible();
   await expect(

--- a/e2e/booking/public-booking-reschedule.spec.ts
+++ b/e2e/booking/public-booking-reschedule.spec.ts
@@ -138,4 +138,29 @@ test.describe("public booking reschedule", () => {
     expect(captured.reservationSlotGets).toBe(0);
     expect(captured.reschedulePosts).toHaveLength(0);
   });
+
+  test("shows unavailable when the host calendar is not bookable", async ({
+    page,
+  }) => {
+    await preparePublicBookingReschedulePage(page, { bookable: false });
+
+    const heading = page.getByRole("heading", {
+      name: "Meeting temporarily unavailable",
+    });
+    await expect(heading).toBeVisible();
+    await expect(heading).toBeFocused();
+    await expect(heading).toHaveAttribute("id", "booking-status-heading");
+    await expect(
+      page.getByText("The host calendar is not ready for new meetings."),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Pick a time" }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: "Previous month" }),
+    ).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Next month" })).toHaveCount(
+      0,
+    );
+  });
 });

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -115,6 +115,31 @@ test.describe("public booking page", () => {
     ).toBeVisible();
   });
 
+  test("shows unavailable when the host calendar is not bookable", async ({
+    page,
+  }) => {
+    await preparePublicBookingPage(page, { bookable: false });
+
+    const heading = page.getByRole("heading", {
+      name: "Meeting temporarily unavailable",
+    });
+    await expect(heading).toBeVisible();
+    await expect(heading).toBeFocused();
+    await expect(heading).toHaveAttribute("id", "booking-status-heading");
+    await expect(
+      page.getByText("The host calendar is not ready for new meetings."),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Pick a time" }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: "Previous month" }),
+    ).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Next month" })).toHaveCount(
+      0,
+    );
+  });
+
   test("shows Saturday times when Saturday has bookable slots", async ({
     page,
   }) => {

--- a/packages/web/src/booking/BookingWeeklyHoursEditor.test.tsx
+++ b/packages/web/src/booking/BookingWeeklyHoursEditor.test.tsx
@@ -52,6 +52,12 @@ describe("BookingWeeklyHoursEditor", () => {
     expect(
       screen.getByText("Unavailable: Saturday, Sunday"),
     ).toBeInTheDocument();
+    expect(startSelect()).toHaveAccessibleDescription(
+      /Start and End apply to every selected day in their row/,
+    );
+    expect(endSelect()).toHaveAccessibleDescription(
+      /Start and End apply to every selected day in their row/,
+    );
   });
 
   it("emits 17:15 for every selected day when End is 5:15 PM", async () => {
@@ -154,5 +160,25 @@ describe("BookingWeeklyHoursEditor", () => {
     expect(
       screen.queryByRole("button", { name: "Remove" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("wires an extra description onto Start and End", () => {
+    const onChange = mock((_next: WeeklyAvailability) => {});
+    render(
+      <>
+        <p id="hours-extra-hint">Times are in Chicago (CST).</p>
+        <BookingWeeklyHoursEditor
+          describedBy="hours-extra-hint"
+          onChange={onChange}
+          value={DEFAULT_WEEKLY_AVAILABILITY}
+        />
+      </>,
+    );
+
+    expect(startSelect()).toHaveAccessibleDescription(
+      /Start and End apply to every selected day in their row/,
+    );
+    expect(startSelect()).toHaveAccessibleDescription(/Times are in Chicago/);
+    expect(endSelect()).toHaveAccessibleDescription(/Times are in Chicago/);
   });
 });

--- a/packages/web/src/booking/BookingWeeklyHoursEditor.tsx
+++ b/packages/web/src/booking/BookingWeeklyHoursEditor.tsx
@@ -28,6 +28,7 @@ interface BookingWeeklyHoursEditorProps {
   value: WeeklyAvailability;
   onChange: (value: WeeklyAvailability) => void;
   disabled?: boolean;
+  describedBy?: string;
 }
 
 interface EditorRow extends HoursRow {
@@ -55,6 +56,8 @@ const toEditorRows = (
 const pillClassName =
   "c-focus-ring min-h-8 min-w-8 rounded border border-border px-1.5 text-xs text-text hover:bg-surface-panel aria-pressed:border-accent aria-pressed:bg-accent aria-pressed:text-on-accent";
 
+const HOURS_RANGE_HINT_ID = "booking-hours-range-hint";
+
 /**
  * Grouped day-pill rows: one Start and End menu shared by the days in that row.
  */
@@ -62,6 +65,7 @@ export function BookingWeeklyHoursEditor({
   value,
   onChange,
   disabled = false,
+  describedBy,
 }: BookingWeeklyHoursEditorProps) {
   const idRef = useRef(1);
   const allocId = () => {
@@ -151,6 +155,9 @@ export function BookingWeeklyHoursEditor({
       : null;
   const everyDayHasHours = unavailable.length === 0;
   const hoursSummary = summarizeHoursRows(rows);
+  const selectDescribedBy = [HOURS_RANGE_HINT_ID, describedBy]
+    .filter(Boolean)
+    .join(" ");
 
   return (
     <fieldset className="flex flex-col gap-2" disabled={disabled}>
@@ -159,6 +166,9 @@ export function BookingWeeklyHoursEditor({
         <p className="text-sm text-text-muted">{unavailableCopy}</p>
       ) : null}
 
+      <p className="sr-only" id={HOURS_RANGE_HINT_ID}>
+        Start and End apply to every selected day in their row.
+      </p>
       <span aria-live="polite" className="sr-only" role="status">
         {announcement}
       </span>
@@ -201,6 +211,7 @@ export function BookingWeeklyHoursEditor({
                 ))}
               </fieldset>
               <select
+                aria-describedby={selectDescribedBy}
                 aria-label={hoursSelectLabel("Start", row)}
                 className={BOOKING_SELECT_CLASS_NAME}
                 onChange={(event) =>
@@ -216,6 +227,7 @@ export function BookingWeeklyHoursEditor({
               </select>
               <span className="text-sm text-text">to</span>
               <select
+                aria-describedby={selectDescribedBy}
                 aria-label={hoursSelectLabel("End", row)}
                 className={BOOKING_SELECT_CLASS_NAME}
                 onChange={(event) =>

--- a/packages/web/src/booking/setup/BookingSetupDurationStep.tsx
+++ b/packages/web/src/booking/setup/BookingSetupDurationStep.tsx
@@ -1,4 +1,4 @@
-import { type KeyboardEvent, useState } from "react";
+import { type KeyboardEvent } from "react";
 import { type BookingDurationMinutes } from "@core/types/booking.contracts";
 
 const DURATION_OPTIONS: BookingDurationMinutes[] = [15, 30, 45, 60];
@@ -15,11 +15,8 @@ export function BookingSetupDurationStep({
   onChange,
   value,
 }: BookingSetupDurationStepProps) {
-  const [focusedMinutes, setFocusedMinutes] =
-    useState<BookingDurationMinutes>(value);
-
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    const index = DURATION_OPTIONS.indexOf(focusedMinutes);
+    const index = DURATION_OPTIONS.indexOf(value);
     if (index < 0) return;
 
     let nextIndex: number | null = null;
@@ -40,21 +37,19 @@ export function BookingSetupDurationStep({
         break;
       case " ":
         event.preventDefault();
-        onChange(focusedMinutes);
+        onChange(value);
         return;
       default:
         return;
     }
 
     const next = DURATION_OPTIONS[nextIndex ?? index];
-    if (next == null || next === focusedMinutes) return;
+    if (next == null || next === value) return;
     event.preventDefault();
-    setFocusedMinutes(next);
     onChange(next);
-    const button = event.currentTarget.querySelector<HTMLElement>(
-      `[data-duration="${next}"]`,
-    );
-    button?.focus();
+    const radios =
+      event.currentTarget.querySelectorAll<HTMLElement>('[role="radio"]');
+    radios[nextIndex ?? index]?.focus();
   };
 
   return (
@@ -69,15 +64,10 @@ export function BookingSetupDurationStep({
         <button
           aria-checked={value === minutes}
           className={pillClassName}
-          data-duration={minutes}
           key={minutes}
-          onClick={() => {
-            setFocusedMinutes(minutes);
-            onChange(minutes);
-          }}
-          onFocus={() => setFocusedMinutes(minutes)}
+          onClick={() => onChange(minutes)}
           role="radio"
-          tabIndex={minutes === focusedMinutes ? 0 : -1}
+          tabIndex={minutes === value ? 0 : -1}
           type="button"
         >
           {minutes} min

--- a/packages/web/src/booking/setup/BookingSetupHoursStep.tsx
+++ b/packages/web/src/booking/setup/BookingSetupHoursStep.tsx
@@ -26,8 +26,12 @@ export function BookingSetupHoursStep({
 
   return (
     <div className="flex flex-col gap-2" ref={rootRef}>
-      <BookingWeeklyHoursEditor onChange={onChange} value={value} />
-      <p className="text-sm text-text-muted">
+      <BookingWeeklyHoursEditor
+        describedBy="booking-setup-hours-timezone"
+        onChange={onChange}
+        value={value}
+      />
+      <p className="text-sm text-text-muted" id="booking-setup-hours-timezone">
         Times are in {formatBookingSetupTimezoneLabel(timeZone)}. You can change
         this later.
       </p>

--- a/packages/web/src/booking/setup/BookingSetupWizard.tsx
+++ b/packages/web/src/booking/setup/BookingSetupWizard.tsx
@@ -154,7 +154,7 @@ export function BookingSetupWizard({
     // biome-ignore lint/a11y/noStaticElementInteractions: keydown here is a wizard-scoped shortcut layer, not an interactive element in its own right
     <div className="flex flex-col gap-4" onKeyDown={handleKeyDown}>
       <p aria-live="polite" className="text-sm text-text-muted">
-        Step {current} of {total}
+        {`Step ${current} of ${total}`}
       </p>
       <div className="flex flex-col gap-2">
         <h2 className="font-medium text-lg text-text">{stepMeta.title}</h2>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3537

## What and why

Booking v1.8 closeout. Guests hitting a `bookable: false` page (and the reschedule equivalent) now have end-to-end coverage for the focused "Meeting temporarily unavailable" heading, host-calendar copy, and the missing month grid. The Meeting setup wizard announces "Step N of M" as one live-region string, duration pills keep radiogroup focus on the checked option, and Start/End menus describe that they apply to every selected day (plus the hours-step timezone line). Spec, glossary, feature-file map, and Meeting shortcut docs drop leftover buffer / max-per-day / Mod-digit / address-only-first-run wording except the v1.8 removal wart.

## Verify

```
Selected packages: web
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)

✓ All checks passed
VERDICT: PASS
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4af0b498-74fb-4fad-b1b2-dec814cff3b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4af0b498-74fb-4fad-b1b2-dec814cff3b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

