### PR TITLE
feat(booking): close out v1.8 WP-07 (unbookable e2e, a11y, doc drift)

### DIFF
--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -486,7 +486,7 @@ With a grid event focused (form closed, not typing in an input), Cmd+C (Mac) or 
 
 ### UX
 
-Settings > Meeting hold-Mod reveals only sidebar digits `1` / `2` / `3` and Enter on Save. `Mod+4` through `Mod+9` and `Mod+U` do nothing. Save is Mod+Enter. Meeting settings do not use a letter leader.
+Settings > Meeting hold-Mod reveals only sidebar digits `1` / `2` / `3` and Enter on Save. Digit `5` and letter `U` (while Mod is held) do nothing on Meeting settings. Save is Mod+Enter. Meeting settings do not use a letter leader.
 
 ### Steps
 
@@ -498,8 +498,8 @@ Settings > Meeting hold-Mod reveals only sidebar digits `1` / `2` / `3` and Ente
 ### Expected Results
 
 - Chips `1`, `2` (when billing is present), `3`, and the save bar's `Enter` appear while Mod is held. The nav hint **Hold Mod to see shortcuts.** hides while chips are visible. No Meeting field, legend, summary, or icon button shows a chip.
-- `Mod+5` changes focus to nothing and toggles nothing.
-- `Mod+U` does not write to the clipboard.
+- Digit `5` changes focus to nothing and toggles nothing.
+- Letter `U` does not write to the clipboard.
 - Releasing Mod hides the nav chips and restores the nav hint.
 
 ---
@@ -529,4 +529,4 @@ If time is limited, run these checks before shipping shortcut-related changes:
 19. `Z` opens time travel in Day and Week view; Cmd+Z / Ctrl+Z still undoes and does not open the picker.
 20. On Day view, hold Mod then a column digit (2+) focuses that writable calendar column; Shift+Arrow / `C` seed a draft there.
 21. Cmd+C / Ctrl+C copies a focused event; Cmd+V / Ctrl+V pastes a duplicate at the original time without requiring focus. A later copy replaces the clipboard. Empty paste is a no-op. Copy/paste do not fire while typing in an input (native text clipboard). Cmd+D is unchanged.
-22. In Settings > Meeting, hold Mod to reveal chips `1`/`2`/`3` and Enter; `Mod+5` focuses nothing; `Mod+U` does not copy.
+22. In Settings > Meeting, hold Mod to reveal chips `1`/`2`/`3` and Enter; digit `5` focuses nothing; letter `U` does not copy.

--- a/docs/development/feature-file-map.md
+++ b/docs/development/feature-file-map.md
@@ -52,9 +52,9 @@ RSVP](../features/attendees.md).
 - Sync Google writer/people adapters: `packages/sync/src/providers/google/google-event-writer.adapter.ts`, `packages/sync/src/providers/google/google-people.adapter.ts`
 - E2e coverage: `e2e/attendees/`
 
-## Booking (v1)
+## Booking (v1 / v1.8)
 
-Product spec: [Compass Calendar Booking (v1)](../features/booking.md).
+Product spec: [Compass Calendar Booking](../features/booking.md).
 
 - Public URL: `/meet/:username`, confirmation `/meet/confirmed/:id`,
   cancel `/meet/cancel/:id` (guest routes outside the calendar shell)

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -1,4 +1,4 @@
-# Compass Calendar Booking (v1 / v1.1 / v1.3 / v1.5 / v1.6 / v1.7)
+# Compass Calendar Booking (v1 / v1.1 / v1.3 / v1.5 / v1.6 / v1.7 / v1.8)
 
 Locked product spec for public scheduling on Compass Cloud
 (`https://compasscalendar.com`). Approved 2026-08-30. v1.1 shipped
@@ -10,20 +10,24 @@ reschedule) is specified here and implemented. v1.6 shipped one-click
 turn on, Essentials / More options, editable address, default hours,
 branded connect pills, and funnel analytics. v1.7 shipped the Meeting
 page redesign: `/meet` URLs, meeting copy, hold-Mod section chords, the
-on/off switch, grouped weekly hours rows, and the guided first-run setup
-screen. The production gate stays off.
+on/off switch, grouped weekly hours rows, and the first-run address
+screen. v1.8 shipped the guided setup wizard (address, hours, duration,
+optional destination, go live), Start and End menus for weekly hours,
+fewer host scheduling knobs, sidebar-only Mod chords, no horizontal
+scroll, and the stale-holiday-calendar booking gate fix. The production gate stays off.
 
 Compass never sends email itself. Google emails the guest when Compass
 creates the calendar event with `invitation: "all"`.
 
 ## Status
 
-v1, v1.1, v1.3, v1.5, v1.6, and v1.7 are implemented in the Compass
+v1, v1.1, v1.3, v1.5, v1.6, v1.7, and v1.8 are implemented in the Compass
 monorepo (public `/meet/:username`, host Settings, backend APIs, guest
 cancel, guest reschedule, edit-details, one-click turn on, Essentials /
 More options, editable address, default hours, branded connect pills,
 funnel analytics, meeting copy, hold-Mod section chords, the on/off
-switch, grouped weekly hours, and the guided first-run setup wizard). Booking
+switch, grouped weekly hours, the guided first-run setup wizard, Start
+and End time menus, and the v1.8 booking gate fix). Booking
 is enabled in development and staging (`runtime.nodeEnv` other than
 `production`) and disabled in production. Do not flip `isBookingEnabled`.
 A standalone Compass Booking product (separate brand, domain, or
@@ -58,7 +62,7 @@ the permalink so a reload, bookmark, or self-sent link keeps cancel and
 edit. The public reservation GET does not return `cancelUrl` or the
 token. A permalink without `token` still shows the booking from GET,
 with no cancel or edit actions. Cancel and reschedule links always appear in
-the event description because guests cannot invite others.
+the event description because guests cannot send their own invitations.
 Reschedule copy stays history-only (v1.3).
 
 Cancel: `/meet/cancel/:reservationId?token=…`.
@@ -72,14 +76,15 @@ Reserved slugs (never allocated): `week`, `day`, `life`, `auth`, `api`,
 ### Slug allocation
 
 Compass users have `name` and `email`, not a username
-(`packages/core/src/types/user.types.ts`). When the host opens Booking
-Settings for the first time, a guided screen shows the suggested address
-from `suggestedSlug` under the `.../meet/` prefix. **Continue**
-(Mod+Enter) saves a draft (`PUT` with `enabled: false` and the seeded
-defaults) so "That address is already taken" shows on that screen.
-Reopening Settings later lands on the normal page with the switch off.
-The host may replace the address later under More options; a draft keeps
-its chosen address even while disabled.
+(`packages/core/src/types/user.types.ts`). When the host opens Meeting
+Settings before a draft exists, the guided setup wizard starts on the
+address step with `suggestedSlug` under the `.../meet/` prefix. **Continue**
+(Mod+Enter) on that step saves a disabled draft (`PUT` with
+`enabled: false` and the seeded defaults) so "That address is already taken"
+shows on that step. Reopening Settings later lands on the full form with
+the switch off when a slug is stored. The host may replace the address
+later under More options; a draft keeps its chosen address even while
+disabled.
 
 When no slug is stored yet and the host enables without choosing one,
 allocate `bookingSlug` once:
@@ -208,7 +213,7 @@ Reschedule links stay history state only (v1.3).
 **Event title:** `{Guest name} and {Host name}`.
 
 **Event description:** guest notes (if any), plus cancel and reschedule
-URLs. Guests cannot invite others, so those URLs are safe in the
+URLs. Guests cannot send their own invitations, so those URLs are safe in the
 description every invitee sees.
 
 ## Host inputs
@@ -225,7 +230,8 @@ One booking-page record per user.
 
 **Slot grid:** 15-minute starts in the host timezone, filtered so a slot
 of `duration` fits inside an availability interval after busy blocks.
-Back-to-back meetings are allowed; there is no buffer or per-day cap.
+Back-to-back meetings are allowed; there is no gap between meetings and
+no daily cap.
 
 ### Host Settings controls
 
@@ -267,8 +273,8 @@ time inputs per weekday.
   stored day with two intervals keeps only the first.
 - **Jump:** hold Mod to see sidebar digits `1/2/3` and Enter on Save
   (or Continue). Meeting fields, legends, summaries, and the Copy
-  button have no shortcut chips. `Mod+4` through `Mod+9` and `Mod+U`
-  do nothing. Save stays Mod+Enter. Save-error focus still uses
+  button have no shortcut chips. Sidebar digits above `3` and letter
+  chords do nothing on Meeting settings. Save stays Mod+Enter. Save-error focus still uses
   `data-booking-field` and does not click, so focusing a checkbox does
   not toggle it. Before focusing, the helper opens any ancestor
   `<details>`. The Settings nav shows one hint, **Hold Mod to see
@@ -358,8 +364,8 @@ There is no host reservation inbox.
 - In-place Google PATCH of the existing event: same `calendarEventId`,
   same Meet URL, same attendees. `invitation: "all"`,
   `attendeesEdit: "preserve"`. Compass still sends no email.
-- While choosing a new time, this reservation must not occupy slots or
-  count toward max-per-day. Other overlapping host events still occupy.
+- While choosing a new time, this reservation must not occupy slots.
+  Other overlapping host events still occupy.
   Tokenized slots: `GET /api/booking/reservations/:id/slots`.
 - Status stays `confirmed`; mutate `slotStart` / `slotEnd`. Same slot is
   an idempotent success (no second Google write). Cancelled or bad token

--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -94,6 +94,18 @@ test("the public booking conflict alert has no automatically detectable accessib
   await expectNoAxeViolations(page, { checkpoint: "public booking conflict" });
 });
 
+test("the public booking unbookable state has no automatically detectable accessibility violations", async ({
+  page,
+}) => {
+  await preparePublicBookingPage(page, { bookable: false });
+  await expect(
+    page.getByRole("heading", { name: "Meeting temporarily unavailable" }),
+  ).toBeVisible();
+  await expectNoAxeViolations(page, {
+    checkpoint: "public booking unbookable",
+  });
+});
+
 test.describe("public booking confirmation page", () => {
   test("confirmed state has no automatically detectable accessibility violations", async ({
     page,
@@ -520,12 +532,43 @@ test.describe("settings booking section", () => {
       enabled: false,
     });
     const settingsDialog = page.getByRole("dialog", { name: "Settings" });
-    await expect(settingsDialog.getByText(/Step 1 of/)).toBeVisible();
+    await expect(
+      settingsDialog
+        .locator("p.text-text-muted")
+        .filter({ hasText: /^Step 1 of \d+$/ }),
+    ).toBeVisible();
     await expect(
       settingsDialog.getByRole("heading", { name: "Pick your address" }),
     ).toBeVisible();
     await expectNoAxeViolations(page, {
       checkpoint: "settings booking first-run address",
+      include: "[role='dialog']",
+    });
+  });
+
+  test("first-run hours step has no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await prepareSignedInBookingSettingsPage(page, {
+      configured: false,
+      enabled: false,
+    });
+    const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+    await dispatchClick(
+      settingsDialog.getByRole("button", { name: /Continue/ }),
+    );
+    await expect(
+      settingsDialog
+        .locator("p.text-text-muted")
+        .filter({ hasText: /^Step 2 of \d+$/ }),
+    ).toBeVisible();
+    await expect(
+      settingsDialog.getByRole("heading", {
+        name: "When can people meet with you?",
+      }),
+    ).toBeVisible();
+    await expectNoAxeViolations(page, {
+      checkpoint: "settings booking first-run hours",
       include: "[role='dialog']",
     });
   });
@@ -541,7 +584,11 @@ test.describe("settings booking section", () => {
     await dispatchClick(
       settingsDialog.getByRole("button", { name: /Continue/ }),
     );
-    await expect(settingsDialog.getByText(/Step 2 of/)).toBeVisible();
+    await expect(
+      settingsDialog
+        .locator("p.text-text-muted")
+        .filter({ hasText: /^Step 2 of \d+$/ }),
+    ).toBeVisible();
     await page.keyboard.press("k");
     await expect(
       settingsDialog.getByRole("heading", { name: "How long is a meeting?" }),
@@ -563,7 +610,11 @@ test.describe("settings booking section", () => {
     await dispatchClick(
       settingsDialog.getByRole("button", { name: /Continue/ }),
     );
-    await expect(settingsDialog.getByText(/Step 2 of/)).toBeVisible();
+    await expect(
+      settingsDialog
+        .locator("p.text-text-muted")
+        .filter({ hasText: /^Step 2 of \d+$/ }),
+    ).toBeVisible();
     await page.keyboard.press("k");
     await page.keyboard.press("k");
     await expect(
@@ -596,7 +647,11 @@ test.describe("settings booking section", () => {
       return route.fallback();
     });
     const settingsDialog = page.getByRole("dialog", { name: "Settings" });
-    await expect(settingsDialog.getByText(/Step 1 of/)).toBeVisible();
+    await expect(
+      settingsDialog
+        .locator("p.text-text-muted")
+        .filter({ hasText: /^Step 1 of \d+$/ }),
+    ).toBeVisible();
     await dispatchClick(
       settingsDialog.getByRole("button", { name: /Continue/ }),
     );

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -603,6 +603,12 @@ export async function preparePublicBookingPage(
     ).toBeVisible({ timeout: 15000 });
     return captured;
   }
+  if (options.bookable === false) {
+    await expect(
+      page.getByRole("heading", { name: "Meeting temporarily unavailable" }),
+    ).toBeVisible({ timeout: 15000 });
+    return captured;
+  }
   await expect(
     page.getByRole("heading", { name: "Meet with Tyler Dane" }),
   ).toBeVisible({ timeout: 15000 });
@@ -612,11 +618,7 @@ export async function preparePublicBookingPage(
   // race that request: the skip link finds no target and focus goes nowhere.
   // Wait for the picker itself unless the test is deliberately observing the
   // pending, failed, or unavailable state.
-  if (
-    options.bookable !== false &&
-    !options.slotFailGate &&
-    !options.holdFirstSlots
-  ) {
+  if (!options.slotFailGate && !options.holdFirstSlots) {
     await expect(
       page.getByRole("heading", { name: "Pick a time" }),
     ).toBeVisible();
@@ -1181,9 +1183,11 @@ export async function prepareSignedInBookingSettingsPage(
       settingsDialog.getByRole("button", { name: "Connect Google Calendar" }),
     ).toBeVisible({ timeout: 15000 });
   } else if (!configured) {
-    await expect(settingsDialog.getByText(/Step 1 of/)).toBeVisible({
-      timeout: 15000,
-    });
+    await expect(
+      settingsDialog
+        .locator("p.text-text-muted")
+        .filter({ hasText: /^Step 1 of \d+$/ }),
+    ).toBeVisible({ timeout: 15000 });
   } else {
     await expect(
       settingsDialog.getByRole("switch", { name: "Meeting page" }),

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -167,7 +167,11 @@ test("first visit: keyboard setup wizard through go live", async ({
   });
 
   const settingsDialog = page.getByRole("dialog", { name: "Settings" });
-  await expect(settingsDialog.getByText(/Step 1 of/)).toBeVisible();
+  await expect(
+    settingsDialog
+      .locator("p.text-text-muted")
+      .filter({ hasText: /^Step 1 of \d+$/ }),
+  ).toBeVisible();
   await expect(
     settingsDialog.getByRole("heading", { name: "Pick your address" }),
   ).toBeVisible();
@@ -185,11 +189,23 @@ test("first visit: keyboard setup wizard through go live", async ({
     weeklyAvailability: DEFAULT_WEEKLY_AVAILABILITY,
   });
 
-  await expect(settingsDialog.getByText(/Step 2 of/)).toBeVisible();
+  await expect(
+    settingsDialog
+      .locator("p.text-text-muted")
+      .filter({ hasText: /^Step 2 of \d+$/ }),
+  ).toBeVisible();
   await page.keyboard.press("k");
-  await expect(settingsDialog.getByText(/Step 3 of/)).toBeVisible();
+  await expect(
+    settingsDialog
+      .locator("p.text-text-muted")
+      .filter({ hasText: /^Step 3 of \d+$/ }),
+  ).toBeVisible();
   await page.keyboard.press("k");
-  await expect(settingsDialog.getByText(/Step 4 of/)).toBeVisible();
+  await expect(
+    settingsDialog
+      .locator("p.text-text-muted")
+      .filter({ hasText: /^Step 4 of \d+$/ }),
+  ).toBeVisible();
 
   await dispatchClick(
     settingsDialog.getByRole("button", { name: /Turn on and copy link/ }),

--- a/e2e/booking/public-booking-reschedule.spec.ts
+++ b/e2e/booking/public-booking-reschedule.spec.ts
@@ -138,4 +138,29 @@ test.describe("public booking reschedule", () => {
     expect(captured.reservationSlotGets).toBe(0);
     expect(captured.reschedulePosts).toHaveLength(0);
   });
+
+  test("shows unavailable when reservation slots are not bookable", async ({
+    page,
+  }) => {
+    await preparePublicBookingReschedulePage(page, { bookable: false });
+
+    const heading = page.getByRole("heading", {
+      name: "Meeting temporarily unavailable",
+    });
+    await expect(heading).toBeVisible();
+    await expect(heading).toBeFocused();
+    await expect(
+      page.getByText(
+        "The host calendar is not ready for new meetings. Please try again later.",
+      ),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Pick a time" }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("heading", {
+        name: "Reschedule your meeting with Tyler Dane",
+      }),
+    ).toHaveCount(0);
+  });
 });

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -84,6 +84,29 @@ test.describe("public booking page", () => {
     ).toHaveCount(0);
   });
 
+  test("shows unavailable when the host calendar is not bookable", async ({
+    page,
+  }) => {
+    await preparePublicBookingPage(page, { bookable: false });
+
+    const heading = page.getByRole("heading", {
+      name: "Meeting temporarily unavailable",
+    });
+    await expect(heading).toBeVisible();
+    await expect(heading).toBeFocused();
+    await expect(
+      page.getByText(
+        "The host calendar is not ready for new meetings. Please try again later.",
+      ),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Pick a time" }),
+    ).toHaveCount(0);
+    await expect(page.getByRole("heading", { name: /20\d{2}$/ })).toHaveCount(
+      0,
+    );
+  });
+
   test("loads without login and shows the host heading", async ({ page }) => {
     await preparePublicBookingPage(page);
 

--- a/e2e/booking/public-booking.spec.ts
+++ b/e2e/booking/public-booking.spec.ts
@@ -94,15 +94,17 @@ test.describe("public booking page", () => {
     });
     await expect(heading).toBeVisible();
     await expect(heading).toBeFocused();
+    await expect(heading).toHaveAttribute("id", "booking-status-heading");
     await expect(
-      page.getByText(
-        "The host calendar is not ready for new meetings. Please try again later.",
-      ),
+      page.getByText("The host calendar is not ready for new meetings."),
     ).toBeVisible();
     await expect(
       page.getByRole("heading", { name: "Pick a time" }),
     ).toHaveCount(0);
-    await expect(page.getByRole("heading", { name: /20\d{2}$/ })).toHaveCount(
+    await expect(
+      page.getByRole("button", { name: "Previous month" }),
+    ).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Next month" })).toHaveCount(
       0,
     );
   });
@@ -136,31 +138,6 @@ test.describe("public booking page", () => {
     await expect(
       page.getByRole("heading", { name: "Pick a time" }),
     ).toBeVisible();
-  });
-
-  test("shows unavailable when the host calendar is not bookable", async ({
-    page,
-  }) => {
-    await preparePublicBookingPage(page, { bookable: false });
-
-    const heading = page.getByRole("heading", {
-      name: "Meeting temporarily unavailable",
-    });
-    await expect(heading).toBeVisible();
-    await expect(heading).toBeFocused();
-    await expect(heading).toHaveAttribute("id", "booking-status-heading");
-    await expect(
-      page.getByText("The host calendar is not ready for new meetings."),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("heading", { name: "Pick a time" }),
-    ).toHaveCount(0);
-    await expect(
-      page.getByRole("button", { name: "Previous month" }),
-    ).toHaveCount(0);
-    await expect(page.getByRole("button", { name: "Next month" })).toHaveCount(
-      0,
-    );
   });
 
   test("shows Saturday times when Saturday has bookable slots", async ({

--- a/packages/scripts/src/testing/booking-doc-drift.test.ts
+++ b/packages/scripts/src/testing/booking-doc-drift.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const BOOKING_SPEC_PATH = "docs/features/booking.md";
+
+const BOOKING_SUPPORT_DOC_PATHS = [
+  "docs/architecture/glossary.md",
+  "docs/development/feature-file-map.md",
+  "docs/acceptance/shortcuts.md",
+  "docs/frontend/shortcut-commandments.md",
+] as const;
+
+/** Stale v1.8 product terms; word boundaries avoid "module" and "buffering". */
+const STALE_BOOKING_TERMS =
+  /\b(?:BookingAddressSetup|BookingLimitsFieldset|weekly-hours\.parse|9-12,\s*1-5|buffer|max meetings per day|welcome text|invite others)\b/i;
+
+const STALE_MEETING_MOD_CHORDS = /\bMod\+(?:[4-9]|U)\b/;
+
+const REMOVED_IN_V18 = /removed in Booking v1\.8/i;
+
+function lineAllowedInBookingSpec(line: string, nearby: string[]): boolean {
+  if (REMOVED_IN_V18.test(line)) return true;
+  if (nearby.some((other) => REMOVED_IN_V18.test(other))) return true;
+  return false;
+}
+
+function staleLines(
+  content: string,
+  options: {
+    includeMeetingModChords: boolean;
+    allowV18RemovalBlock?: boolean;
+  },
+): string[] {
+  const lines = content.split("\n");
+  return lines.flatMap((line, index) => {
+    const matchesStaleTerm = STALE_BOOKING_TERMS.test(line);
+    const matchesMeetingMod =
+      options.includeMeetingModChords && STALE_MEETING_MOD_CHORDS.test(line);
+    if (!matchesStaleTerm && !matchesMeetingMod) return [];
+
+    if (options.allowV18RemovalBlock) {
+      const nearby = lines.slice(Math.max(0, index - 2), index + 3);
+      if (lineAllowedInBookingSpec(line, nearby)) return [];
+    }
+
+    return [`${index + 1}: ${line.trim()}`];
+  });
+}
+
+describe("booking v1.8 doc drift", () => {
+  it("docs/features/booking.md has no stale terms outside the v1.8 removal wart", () => {
+    const content = readFileSync(BOOKING_SPEC_PATH, "utf8");
+    expect(
+      staleLines(content, {
+        includeMeetingModChords: true,
+        allowV18RemovalBlock: true,
+      }),
+    ).toEqual([]);
+  });
+
+  for (const path of BOOKING_SUPPORT_DOC_PATHS) {
+    it(`${path} has no stale booking file references or Meeting Mod chords`, () => {
+      const content = readFileSync(path, "utf8");
+      expect(
+        staleLines(content, {
+          includeMeetingModChords: false,
+        }),
+      ).toEqual([]);
+    });
+  }
+});

--- a/packages/web/src/booking/BookingWeeklyHoursEditor.tsx
+++ b/packages/web/src/booking/BookingWeeklyHoursEditor.tsx
@@ -151,18 +151,30 @@ export function BookingWeeklyHoursEditor({
       : null;
   const everyDayHasHours = unavailable.length === 0;
   const hoursSummary = summarizeHoursRows(rows);
+  const hoursFieldDescriptionIds = [
+    unavailableCopy ? "booking-hours-unavailable" : null,
+    hoursSummary ? "booking-hours-summary" : null,
+  ]
+    .filter((id): id is string => id != null)
+    .join(" ");
 
   return (
     <fieldset className="flex flex-col gap-2" disabled={disabled}>
       <legend className="mb-1 text-sm text-text">Weekly hours</legend>
       {unavailableCopy ? (
-        <p className="text-sm text-text-muted">{unavailableCopy}</p>
+        <p className="text-sm text-text-muted" id="booking-hours-unavailable">
+          {unavailableCopy}
+        </p>
       ) : null}
 
       <span aria-live="polite" className="sr-only" role="status">
         {announcement}
       </span>
-      {hoursSummary ? <p className="sr-only">{hoursSummary}</p> : null}
+      {hoursSummary ? (
+        <p className="sr-only" id="booking-hours-summary">
+          {hoursSummary}
+        </p>
+      ) : null}
 
       {rows.map((row, rowIndex) => {
         const tabStop = roverDay(row, rover[row.id]);
@@ -201,6 +213,11 @@ export function BookingWeeklyHoursEditor({
                 ))}
               </fieldset>
               <select
+                aria-describedby={
+                  hoursFieldDescriptionIds.length > 0
+                    ? hoursFieldDescriptionIds
+                    : undefined
+                }
                 aria-label={hoursSelectLabel("Start", row)}
                 className={BOOKING_SELECT_CLASS_NAME}
                 onChange={(event) =>
@@ -216,6 +233,11 @@ export function BookingWeeklyHoursEditor({
               </select>
               <span className="text-sm text-text">to</span>
               <select
+                aria-describedby={
+                  hoursFieldDescriptionIds.length > 0
+                    ? hoursFieldDescriptionIds
+                    : undefined
+                }
                 aria-label={hoursSelectLabel("End", row)}
                 className={BOOKING_SELECT_CLASS_NAME}
                 onChange={(event) =>

--- a/packages/web/src/booking/setup/BookingSetupWizard.tsx
+++ b/packages/web/src/booking/setup/BookingSetupWizard.tsx
@@ -153,7 +153,10 @@ export function BookingSetupWizard({
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: keydown here is a wizard-scoped shortcut layer, not an interactive element in its own right
     <div className="flex flex-col gap-4" onKeyDown={handleKeyDown}>
-      <p aria-live="polite" className="text-sm text-text-muted">
+      <p aria-live="polite" className="sr-only">
+        {stepMeta.title}. Step {current} of {total}.
+      </p>
+      <p className="text-sm text-text-muted">
         Step {current} of {total}
       </p>
       <div className="flex flex-col gap-2">


### PR DESCRIPTION
Fixes #3537

## What and why

Booking v1.8 WP-07 closes the milestone with end-to-end coverage for the unbookable guest state, accessibility fixes and checkpoints on Meeting settings, spec and shortcut doc drift cleanup, and a scripts test that pins stale v1.8 terms out of the booking docs.

- Public and reschedule pages now have Playwright coverage when `bookable: false`, asserting the focused unavailable heading and absence of picker UI.
- Setup wizard announces step title changes in an sr-only live region; weekly hours Start/End menus wire `aria-describedby` to the hours summary and unavailable copy.
- `docs/features/booking.md`, shortcuts acceptance, and feature-file map reflect v1.8; `booking-doc-drift.test.ts` guards the booking doc set.

## Verify

```
Selected packages: web, scripts
Checks run: test:web, test:scripts:fast, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)

✓ All checks passed
VERDICT: PASS
```