### PR TITLE
feat(web): anchor settings dialog to the top

### DIFF
--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -237,7 +237,9 @@ Back-to-back meetings are allowed.
 The Settings **Meeting** page is keyboard-first. It is split into a
 status header, an Essentials group, and a collapsed **More options**
 group. Hours use grouped day pills with Start and End menus, not a
-checkbox and typed times for each weekday.
+checkbox and typed times for each weekday. Settings is anchored to
+the top of the viewport and grows downward; More options animates
+open over about 200 ms, and reduced motion disables the animation.
 
 - **Status:** a **Meeting page** switch reflects whether the page is
   live. When on, it shows "Live at" and the meeting link with Copy and

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -90,7 +90,10 @@ test("keyboard hint sits in the nav column and the last control stays above Save
   });
 
   const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+  const topBefore = (await settingsDialog.boundingBox())?.y;
   await openMoreOptions(settingsDialog);
+  const topAfter = (await settingsDialog.boundingBox())?.y;
+  expect(topAfter).toBe(topBefore);
   const hint = settingsDialog.locator("nav p", {
     hasText: "to see shortcuts.",
   });

--- a/packages/web/src/booking/BookingMoreOptions.tsx
+++ b/packages/web/src/booking/BookingMoreOptions.tsx
@@ -21,7 +21,10 @@ export function BookingMoreOptions({
   }, [forceOpen]);
 
   return (
-    <details className="flex flex-col gap-4" ref={detailsRef}>
+    <details
+      className="c-details-animated flex flex-col gap-4"
+      ref={detailsRef}
+    >
       <summary className="c-focus-ring cursor-pointer list-inside font-medium text-sm text-text">
         {BOOKING_MORE_OPTIONS_LABEL}
       </summary>

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
@@ -31,6 +31,27 @@ describe("OverlayPanel", () => {
     expect(dialog.className).toContain("overflow-y-auto");
   });
 
+  it("centers the backdrop by default", () => {
+    render(<OverlayPanel title="Confirm" onDismiss={() => {}} />);
+
+    const backdrop = screen.getByRole("dialog", {
+      name: "Confirm",
+    }).parentElement;
+    expect(backdrop).toHaveClass("items-center");
+    expect(backdrop).not.toHaveClass("items-start");
+  });
+
+  it("anchors the backdrop to the top when requested", () => {
+    render(<OverlayPanel anchor="top" title="Confirm" onDismiss={() => {}} />);
+
+    const backdrop = screen.getByRole("dialog", {
+      name: "Confirm",
+    }).parentElement;
+    expect(backdrop).toHaveClass("items-start");
+    expect(backdrop).toHaveClass("pt-[5vh]");
+    expect(backdrop).not.toHaveClass("items-center");
+  });
+
   it("keeps the app locked when multiple panels are stacked", () => {
     const { unmount: unmountFirst } = render(
       <OverlayPanel title="First" onDismiss={() => {}} />,

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
@@ -65,6 +65,11 @@ interface Props {
   /** Extra classes for the backdrop (e.g. overflow for tall dialogs) */
   backdropClassName?: string;
   /**
+   * Backdrop cross-axis alignment. `"top"` pins the panel under a 5vh inset
+   * so height changes grow downward instead of recentering.
+   */
+  anchor?: "center" | "top";
+  /**
    * Replaces the modal variant's default gap/background/shadow so callers can
    * keep a surface-specific look without fighting those utilities.
    */
@@ -93,6 +98,7 @@ export const OverlayPanel = ({
   backdropClassName,
   panelClassName,
   closing = false,
+  anchor = "center",
 }: Props) => {
   const panelRef = useRef<HTMLDivElement>(null);
   const baseId = useId();
@@ -126,7 +132,8 @@ export const OverlayPanel = ({
   }, [initialFocusRef, restoreFocus, role, skipFocusRestoreRef]);
 
   const backdropClasses = classNames(
-    "fixed inset-0 flex items-center justify-center bg-background/85 backdrop-blur-sm",
+    "fixed inset-0 flex justify-center bg-background/85 backdrop-blur-sm",
+    anchor === "top" ? "items-start pt-[5vh]" : "items-center",
     variant === "modal" &&
       "transition-opacity duration-400 ease-out data-closing:opacity-0 motion-reduce:transition-none",
     backdropClassName,

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -248,6 +248,16 @@ describe("SettingsModal", () => {
     ).toBeInTheDocument();
   });
 
+  it("anchors the Settings dialog to the top of the viewport", () => {
+    renderSettings();
+
+    const backdrop = screen.getByRole("dialog", {
+      name: "Settings",
+    }).parentElement;
+    expect(backdrop).toHaveClass("items-start");
+    expect(backdrop).not.toHaveClass("items-center");
+  });
+
   it("lists every connected account with its own status", () => {
     renderSettings({
       connections: [

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -195,6 +195,7 @@ export const SettingsModal: FC = () => {
   return (
     <OverlayPanel
       align="start"
+      anchor="top"
       initialFocusRef={initialFocusRef}
       onDismiss={handleDismiss}
       skipFocusRestoreRef={skipFocusRestoreRef}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -493,6 +493,29 @@
   }
 }
 
+/* Progressive: browsers without ::details-content ignore this and keep the instant toggle. */
+@utility c-details-animated {
+  interpolate-size: allow-keywords;
+
+  &::details-content {
+    block-size: 0;
+    overflow: clip;
+    transition:
+      block-size 200ms ease-out,
+      content-visibility 200ms allow-discrete;
+  }
+
+  &[open]::details-content {
+    block-size: auto;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    &::details-content {
+      transition: none;
+    }
+  }
+}
+
 @utility c-text-gradient {
   color: transparent;
   background: linear-gradient(var(--accent), var(--accent-strong));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3551

## What and why

Settings no longer recenters when content grows. `OverlayPanel` now accepts `anchor="top"` (5vh inset, grows downward); Settings uses it. More options uses a CSS-only `::details-content` open animation that reduced motion disables. Other OverlayPanel consumers stay centered.

## Verify

VERDICT: PASS
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)

The host-settings layout specs passed, including the new assertion that the Settings dialog `boundingBox().y` is unchanged after opening More options.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8213e129-a1b6-4820-8846-4ab5d4f0d668?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8213e129-a1b6-4820-8846-4ab5d4f0d668&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

