### PR TITLE
feat(web): drop slug helper, invite footnote, and live at

### DIFF
--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -242,15 +242,16 @@ the top of the viewport and grows downward; More options animates
 open over about 200 ms, and reduced motion disables the animation.
 
 - **Status:** a **Meeting page** switch reflects whether the page is
-  live. When on, it shows "Live at" and the meeting link with Copy and
+  live. When on, it shows the meeting link with Copy and
   **Open meeting page**. When off, it shows "Off. Turn it on to share
   your link." and the address the page will use.
 - **Essentials:** duration, meeting timezone, weekly hours, and
   destination calendar. These fit without scrolling at 1440x900.
 - **More options:** an uncontrolled native `<details>` that starts
-  collapsed. It holds page address (with "Links using your old address
-  will stop working." when the slug changes), blocking calendars,
-  minimum notice, and maximum horizon. Jumping to a field inside it, or
+  collapsed. It holds page address (the slug rule appears only as an
+  error; "Links using your old address will stop working." when the
+  slug changes), blocking calendars, minimum notice, and maximum
+  horizon. Jumping to a field inside it, or
   an invalid field in the group, opens it. Do not control the `open`
   prop from React: the jump-key code opens the element imperatively.
 - **First run:** before any draft exists, Meeting settings open a guided

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -220,7 +220,9 @@ test("first visit: keyboard setup wizard through go live", async ({
     weeklyAvailability: DEFAULT_WEEKLY_AVAILABILITY,
   });
 
-  await expect(settingsDialog.getByText("Live at")).toBeVisible();
+  await expect(
+    settingsDialog.getByRole("textbox", { name: "Meeting link" }),
+  ).toBeVisible();
   await expect(
     settingsDialog.getByRole("switch", { name: "Meeting page" }),
   ).toBeFocused();

--- a/packages/web/src/booking/BookingAddressField.tsx
+++ b/packages/web/src/booking/BookingAddressField.tsx
@@ -3,8 +3,6 @@ import { BookingFieldLabel } from "@web/booking/BookingFieldLabel";
 import { bookingSlugParseMessage } from "@web/booking/booking.util";
 import { bookingFieldAttrs } from "@web/booking/booking-sequence.fields";
 
-export const BOOKING_ADDRESS_HELPER =
-  "3 to 32 lowercase letters, digits, or hyphens.";
 export const BOOKING_ADDRESS_CHANGE_WARNING =
   "Links using your old address will stop working.";
 
@@ -37,11 +35,9 @@ export function BookingAddressField({
   const parseMessage = bookingSlugParseMessage(slug);
   const showError = (blurred || forceInvalid) && parseMessage != null;
   const showWarning = savedSlug != null && slug !== savedSlug;
-  const helperId = "booking-address-helper";
   const errorId = "booking-address-error";
   const warningId = "booking-address-warning";
   const describedBy = [
-    helperId,
     showError ? errorId : null,
     showWarning ? warningId : null,
   ]
@@ -55,7 +51,7 @@ export function BookingAddressField({
       </BookingFieldLabel>
       <input
         {...bookingFieldAttrs("address")}
-        aria-describedby={describedBy}
+        aria-describedby={describedBy || undefined}
         aria-invalid={showError || undefined}
         autoCapitalize="none"
         className={`c-focus-ring w-full min-w-0 rounded border bg-surface-overlay px-2 py-1 text-sm text-text ${
@@ -71,9 +67,6 @@ export function BookingAddressField({
       <p className="break-all text-text-muted text-xs">
         Your link: {prefix}
         {slug}
-      </p>
-      <p className="text-text-muted text-xs" id={helperId}>
-        {BOOKING_ADDRESS_HELPER}
       </p>
       {showError ? (
         <p className="font-medium text-sm text-text" id={errorId} role="alert">

--- a/packages/web/src/booking/BookingBlockingCalendarsField.tsx
+++ b/packages/web/src/booking/BookingBlockingCalendarsField.tsx
@@ -50,7 +50,7 @@ export function BookingBlockingCalendarsField({
         <>
           {groupsWithCalendars.map((group) => (
             <div
-              className="flex min-w-0 flex-col gap-1"
+              className="flex min-w-0 flex-col gap-2"
               key={group.accountEmail}
             >
               {showAccountCaption ? (

--- a/packages/web/src/booking/BookingBlockingCalendarsField.tsx
+++ b/packages/web/src/booking/BookingBlockingCalendarsField.tsx
@@ -62,10 +62,6 @@ export function BookingBlockingCalendarsField({
           {ungrouped.map(renderBlockingCalendar)}
         </>
       )}
-      <p className="text-text-muted text-xs">
-        Pending, maybe, and declined invites do not hold meeting times. Accepted
-        invites and events the host organizes do.
-      </p>
     </fieldset>
   );
 }

--- a/packages/web/src/booking/BookingCheckboxRow.tsx
+++ b/packages/web/src/booking/BookingCheckboxRow.tsx
@@ -18,7 +18,7 @@ export function BookingCheckboxRow({
   onChange,
 }: BookingCheckboxRowProps) {
   return (
-    <label className="flex items-center gap-2 text-sm text-text">
+    <label className="flex min-h-8 items-center gap-2 text-sm text-text">
       <input
         checked={checked}
         className="c-all-day-checkbox"

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -451,10 +451,64 @@ describe("BookingSettingsSection", () => {
       screen.queryByRole("checkbox", { name: "Guest can invite others" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByText(
-        "Pending, maybe, and declined invites do not hold meeting times. Accepted invites and events the host organizes do.",
+      screen.queryByText(/Pending, maybe, and declined/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the slug rule only as an error, not as standing helper copy", async () => {
+    const user = userEvent.setup({ delay: null });
+    userMetadataActions.set(healthyGoogleMetadata);
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(savedOffPage())),
       ),
-    ).toBeInTheDocument();
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    await user.click(await screen.findByText(BOOKING_MORE_OPTIONS_LABEL));
+    expect(
+      screen.queryByText(/3 to 32 lowercase letters, digits, or hyphens\./),
+    ).not.toBeInTheDocument();
+
+    const address = screen.getByLabelText("Page address");
+    await user.clear(address);
+    await user.type(address, "ab");
+    await user.tab();
+
+    expect(
+      screen.getByText("Use 3 to 32 lowercase letters, digits, or hyphens"),
+    ).toHaveAttribute("role", "alert");
+  });
+
+  it("renders a live page with the Meeting link field and no Live at line", async () => {
+    userMetadataActions.set(healthyGoogleMetadata);
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json({ ...savedOffPage(), enabled: true })),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    expect(await screen.findByLabelText("Meeting link")).toBeInTheDocument();
+    expect(screen.queryByText("Live at")).not.toBeInTheDocument();
   });
 
   it("seeds the booking timezone from the user's zone when never configured", async () => {

--- a/packages/web/src/booking/BookingStatusHeader.tsx
+++ b/packages/web/src/booking/BookingStatusHeader.tsx
@@ -28,10 +28,9 @@ export function BookingStatusHeader({
         onCheckedChange={onToggle}
       />
       {isLive ? (
-        <>
-          <p className="text-sm text-text">Live at</p>
-          {bookingUrl ? <BookingCopyLink bookingUrl={bookingUrl} /> : null}
-        </>
+        bookingUrl ? (
+          <BookingCopyLink bookingUrl={bookingUrl} />
+        ) : null
       ) : (
         <>
           <p className="text-sm text-text">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3553

## What and why

Three lines of standing copy leave Settings > Meeting. Page address shows the slug rule only when it is broken. Blocking calendars no longer footnotes occupancy. A live page shows the Meeting link field without a Live at line. Blocking calendar rows keep a 32px target so More options still meets WCAG 2.5.8 after the footnote is gone. See https://github.com/KeepSoftwareSimple/compass-calendar/issues/3553 and `docs/features/booking.md`.

## Verify

`VERDICT: PASS`

Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8213e129-a1b6-4820-8846-4ab5d4f0d668?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8213e129-a1b6-4820-8846-4ab5d4f0d668&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

