### PR TITLE
feat(web): move meeting timezone under More options

### DIFF
--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -245,12 +245,12 @@ open over about 200 ms, and reduced motion disables the animation.
   live. When on, it shows "Live at" and the meeting link with Copy and
   **Open meeting page**. When off, it shows "Off. Turn it on to share
   your link." and the address the page will use.
-- **Essentials:** duration, meeting timezone, weekly hours, and
+- **Essentials:** duration, weekly hours, and
   destination calendar. These fit without scrolling at 1440x900.
 - **More options:** an uncontrolled native `<details>` that starts
   collapsed. It holds page address (with "Links using your old address
-  will stop working." when the slug changes), blocking calendars,
-  minimum notice, and maximum horizon. Jumping to a field inside it, or
+  will stop working." when the slug changes), meeting timezone,
+  blocking calendars, minimum notice, and maximum horizon. Jumping to a field inside it, or
   an invalid field in the group, opens it. Do not control the `open`
   prop from React: the jump-key code opens the element imperatively.
 - **First run:** before any draft exists, Meeting settings open a guided
@@ -265,6 +265,9 @@ open over about 200 ms, and reduced motion disables the animation.
   copies the link, and then shows the full form with the switch focused.
 - **Timezone** uses the same searchable combobox as time travel. The
   trigger is one tab stop and still renders a stored non-canonical alias.
+  Under weekly hours a muted line reads the city and abbreviation and
+  points to More options. Every Start and End menu is described by that
+  line.
 - **Weekly hours** are a list of the seven ISO weekdays, Monday first.
   Each line is a checkbox named with the full weekday, the short label,
   a Start menu, the word "to", an End menu, and one action cell. Menus

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -314,6 +314,9 @@ test("settings dialog never scrolls horizontally with more options open", async 
   await prepareSignedInBookingSettingsPage(page);
 
   const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+  await expect(
+    settingsDialog.getByRole("button", { name: /Meeting timezone:/ }),
+  ).toHaveCount(0);
   await openMoreOptions(settingsDialog);
   await settingsDialog
     .getByRole("button", { name: /Meeting timezone:/ })

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -547,10 +547,101 @@ describe("BookingSettingsSection", () => {
       { wrapper },
     );
 
-    const trigger = await screen.findByRole("button", {
+    await userEvent
+      .setup({ delay: null })
+      .click(await screen.findByText(BOOKING_MORE_OPTIONS_LABEL));
+    const trigger = screen.getByRole("button", {
       name: /^Meeting timezone:/,
     });
     expect(trigger).toHaveAccessibleName("Meeting timezone: UTC (UTC)");
+  });
+
+  it("describes weekly hours from the muted timezone line and keeps the trigger in More options", async () => {
+    const user = userEvent.setup({ delay: null });
+    userMetadataActions.set(healthyGoogleMetadata);
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(
+          ctx.json({
+            ...savedOffPage(),
+            timeZone: "America/Denver",
+          }),
+        ),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    const mondayStart = await screen.findByRole("combobox", {
+      name: "Monday start",
+    });
+    expect(mondayStart).toHaveAccessibleDescription(/Times in/);
+    expect(mondayStart).toHaveAccessibleDescription(/More options/);
+
+    await user.click(screen.getByText(BOOKING_MORE_OPTIONS_LABEL));
+    const address = screen.getByLabelText("Page address");
+    const trigger = screen.getByRole("button", {
+      name: /^Meeting timezone:/,
+    });
+    expect(
+      address.compareDocumentPosition(trigger) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it("opens More options and focuses the timezone trigger on a TIMEZONE_REQUIRED save error", async () => {
+    const user = userEvent.setup({ delay: null });
+    const { port, mocks } = createTestToastPort();
+    registerToastPort(port);
+    userMetadataActions.set(healthyGoogleMetadata);
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(savedOffPage())),
+      ),
+      rest.put(bookingPageUrl, (_req, res, ctx) =>
+        res(
+          ctx.status(400),
+          ctx.json({
+            code: "TIMEZONE_REQUIRED",
+            message: "Timezone is required",
+          }),
+        ),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    await user.click(
+      await screen.findByRole("switch", { name: "Meeting page" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        BOOKING_SAVE_ERROR_COPY.TIMEZONE_REQUIRED,
+      );
+    });
+    expect(mocks.error).not.toHaveBeenCalled();
+    const trigger = screen.getByRole("button", {
+      name: /^Meeting timezone:/,
+    });
+    expect(trigger.closest("details")).toHaveAttribute("open");
+    await waitFor(() => {
+      expect(document.activeElement).toBe(trigger);
+    });
   });
 
   it("shows step 1 of 4 on an unconfigured page with the address input focused", async () => {

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -36,7 +36,10 @@ import { BookingMoreOptions } from "@web/booking/BookingMoreOptions";
 import { BookingNumberField } from "@web/booking/BookingNumberField";
 import { BookingSaveBar } from "@web/booking/BookingSaveBar";
 import { BookingStatusHeader } from "@web/booking/BookingStatusHeader";
-import { BookingTimezoneField } from "@web/booking/BookingTimezoneField";
+import {
+  BookingTimezoneField,
+  formatBookingTimezoneLabel,
+} from "@web/booking/BookingTimezoneField";
 import { BookingWeeklyHoursEditor } from "@web/booking/BookingWeeklyHoursEditor";
 import {
   bookingSaveErrorInline,
@@ -88,6 +91,7 @@ const DURATION_OPTIONS: BookingDurationMinutes[] = [15, 30, 45, 60];
 
 const MORE_OPTIONS_FIELDS = new Set<BookingField>([
   "address",
+  "timezone",
   "blocking",
   "notice",
   "horizon",
@@ -638,47 +642,43 @@ export function BookingSettingsSection({
           onToggle={(next) => submit(next)}
         />
 
-        <div className="grid grid-cols-2 gap-3">
-          <div className="min-w-0">
-            <BookingFieldLabel htmlFor="booking-duration">
-              Duration
-            </BookingFieldLabel>
-            <select
-              {...bookingFieldAttrs("duration")}
-              className={BOOKING_SELECT_CLASS_NAME}
-              id="booking-duration"
-              onChange={(event) =>
-                updateForm({
-                  durationMinutes: Number(
-                    event.target.value,
-                  ) as BookingDurationMinutes,
-                })
-              }
-              value={form.durationMinutes}
-            >
-              {DURATION_OPTIONS.map((minutes) => (
-                <option key={minutes} value={minutes}>
-                  {minutes} minutes
-                </option>
-              ))}
-            </select>
-          </div>
-
-          <div className="min-w-0" {...bookingFieldAttrs("timezone")}>
-            <BookingTimezoneField
-              onChange={(timeZone) => updateForm({ timeZone })}
-              timeZone={form.timeZone}
-            />
-          </div>
+        <div className="max-w-[50%]">
+          <BookingFieldLabel htmlFor="booking-duration">
+            Duration
+          </BookingFieldLabel>
+          <select
+            {...bookingFieldAttrs("duration")}
+            className={BOOKING_SELECT_CLASS_NAME}
+            id="booking-duration"
+            onChange={(event) =>
+              updateForm({
+                durationMinutes: Number(
+                  event.target.value,
+                ) as BookingDurationMinutes,
+              })
+            }
+            value={form.durationMinutes}
+          >
+            {DURATION_OPTIONS.map((minutes) => (
+              <option key={minutes} value={minutes}>
+                {minutes} minutes
+              </option>
+            ))}
+          </select>
         </div>
 
         <div className="flex flex-col gap-1" {...bookingFieldAttrs("hours")}>
           <BookingWeeklyHoursEditor
+            describedBy="booking-hours-timezone"
             onChange={(weeklyAvailability) =>
               updateForm({ weeklyAvailability })
             }
             value={form.weeklyAvailability}
           />
+          <p className="text-sm text-text-muted" id="booking-hours-timezone">
+            Times in {formatBookingTimezoneLabel(form.timeZone)}. Change it
+            under More options.
+          </p>
         </div>
 
         <div>
@@ -744,6 +744,13 @@ export function BookingSettingsSection({
             savedSlug={savedSlug}
             slug={form.slug ?? ""}
           />
+
+          <div className="min-w-0" {...bookingFieldAttrs("timezone")}>
+            <BookingTimezoneField
+              onChange={(timeZone) => updateForm({ timeZone })}
+              timeZone={form.timeZone}
+            />
+          </div>
 
           <BookingBlockingCalendarsField
             availabilityCalendars={availabilityCalendars}

--- a/packages/web/src/booking/BookingTimezoneField.tsx
+++ b/packages/web/src/booking/BookingTimezoneField.tsx
@@ -19,6 +19,10 @@ interface BookingTimezoneFieldProps {
  * nothing. Now it is one tab stop, and the trigger renders whatever zone is
  * stored - including a non-canonical alias, which had no <option> at all.
  */
+export function formatBookingTimezoneLabel(timeZone: TimeZone): string {
+  return `${timeZoneCityName(timeZone)} (${formatTimeZoneAbbreviation(timeZone)})`;
+}
+
 export function BookingTimezoneField({
   timeZone,
   onChange,
@@ -27,8 +31,7 @@ export function BookingTimezoneField({
   const [isOpen, setIsOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
-
-  const label = `${timeZoneCityName(timeZone)} (${formatTimeZoneAbbreviation(timeZone)})`;
+  const label = formatBookingTimezoneLabel(timeZone);
 
   return (
     <div>

--- a/packages/web/src/booking/setup/BookingSetupHoursStep.tsx
+++ b/packages/web/src/booking/setup/BookingSetupHoursStep.tsx
@@ -1,18 +1,13 @@
 import { useCallback } from "react";
 import { type WeeklyAvailability } from "@core/types/booking.contracts";
 import { type TimeZone } from "@core/types/domain-primitives";
+import { formatBookingTimezoneLabel } from "@web/booking/BookingTimezoneField";
 import { BookingWeeklyHoursEditor } from "@web/booking/BookingWeeklyHoursEditor";
-import { formatTimeZoneAbbreviation } from "@web/timezone/format-timezone-abbreviation";
-import { timeZoneCityName } from "@web/timezone/timezone-catalog";
 
 interface BookingSetupHoursStepProps {
   onChange: (weeklyAvailability: WeeklyAvailability) => void;
   timeZone: TimeZone;
   value: WeeklyAvailability;
-}
-
-export function formatBookingSetupTimezoneLabel(timeZone: TimeZone): string {
-  return `${timeZoneCityName(timeZone)} (${formatTimeZoneAbbreviation(timeZone)})`;
 }
 
 export function BookingSetupHoursStep({
@@ -32,8 +27,8 @@ export function BookingSetupHoursStep({
         value={value}
       />
       <p className="text-sm text-text-muted" id="booking-setup-hours-timezone">
-        Times are in {formatBookingSetupTimezoneLabel(timeZone)}. You can change
-        this later.
+        Times are in {formatBookingTimezoneLabel(timeZone)}. You can change this
+        later.
       </p>
     </div>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3554

## What and why

The configured Meeting form reads: status header, Duration, Weekly hours, Destination calendar, More options, Save. Meeting timezone lives inside More options, directly after Page address. Under Weekly hours a muted line reads the stored city and abbreviation and points to More options. Every Start and End menu is described by that line. A TIMEZONE save error still opens More options and focuses the trigger. See https://github.com/KeepSoftwareSimple/compass-calendar/issues/3554 and `docs/features/booking.md`.

## Verify

`VERDICT: PASS`

Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8213e129-a1b6-4820-8846-4ab5d4f0d668?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8213e129-a1b6-4820-8846-4ab5d4f0d668&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

