### PR TITLE
fix(web): close booking v1.9 a11y sweep and spec drift

### DIFF
--- a/docs/CI-CD/loop-velocity-2026-09-03.md
+++ b/docs/CI-CD/loop-velocity-2026-09-03.md
@@ -131,7 +131,7 @@ it appears. Exit with bun's pass/fail, not with the leak.
 
 ### 7. Every PR conflicts with every other PR
 
-Each WP appends one row to `.agents/ledger.md`, so every squash merge on main
+Each WP appends a ledger line to `.agents/ledger.md`, so every squash merge on main
 conflicts with every open PR. That is why #3285 carried eight `merge(main)`
 commits, each of which cost a full CI round. Handoff files under
 `.agents/handoffs/<issue>.md` already hold the same information.

--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -351,7 +351,7 @@ The sidebar month picker is a keyboard cursor, not a click target. `I` (or hold 
 ### Expected Results
 
 - After `I`, the first day of the highlighted week row has focus and the whole row shows the focus ring.
-- Each arrow moves the ring one row; the calendar grid does not move yet.
+- Each arrow moves the ring to the next week; the calendar grid does not move yet.
 - After `Mod+Shift+.`, the next month is shown and focus is still on a day in that month.
 - Enter anchors the week view on the focused row and the muted week capsule matches the visible window. Today is an ink circle, not an accent fill.
 - Clicks do not navigate. Hovering the picker shows `I focuses the picker`. Focusing it replaces that with up/down arrow keycaps and `move by week`. After an arrow, `Enter opens it` appears with `Enter` as a keycap. The keyboard hint says to press `I`, then use the arrow keys and Enter.
@@ -497,7 +497,7 @@ Settings > Meeting hold-Mod reveals only sidebar digits `1` / `2` / `3` and Ente
 
 ### Expected Results
 
-- Chips `1`, `2` (when billing is present), `3`, and the save bar's `Enter` appear while Mod is held. The nav hint **Hold Mod to see shortcuts.** hides while chips are visible. No Meeting field, legend, summary, or icon button shows a chip.
+- Chips `1`, `2` (when billing is present), `3`, and the save bar's `Enter` appear while Mod is held. The nav hint **Hold Mod to see shortcuts.** hides while chips are visible. No Meeting field, legend, summary, weekly hours plus or minus, or icon button shows a chip.
 - Extra digit chords change focus to nothing and toggle nothing.
 - Holding Mod and pressing U does not write to the clipboard.
 - Releasing Mod hides the nav chips and restores the nav hint.

--- a/docs/architecture/glossary.md
+++ b/docs/architecture/glossary.md
@@ -157,7 +157,9 @@ Browsers connect with `GET /api/events/stream`.
 **Booking page**:
 The one v1 scheduling page owned by a Compass user, shown to users as
 Meeting page. Settings configure it; guests open it at `/meet/:username`.
-Old `/book` username links redirect client-side.
+Old `/book` username links redirect client-side. Host weekly hours are a
+per-day list; a weekday can hold several blocks. Meeting timezone is
+edited under More options.
 _Avoid_: event type (v1 has one duration per user, not Calendly-style
 multiple event types)
 

--- a/docs/development/feature-file-map.md
+++ b/docs/development/feature-file-map.md
@@ -69,7 +69,8 @@ Product spec: [Compass Calendar Booking](../features/booking.md).
   `packages/sync/src/domain/busy-query.service.ts`,
   `POST /internal/availability/busy`
 - Host Settings: `packages/web/src/booking/BookingSettingsSection.tsx`,
-  `packages/web/src/booking/setup/`, `weekly-hours.ts`,
+  `packages/web/src/booking/setup/`, `BookingWeeklyHoursEditor.tsx`,
+  `weekly-hours.ts`,
   `packages/web/src/components/Switch/Switch.tsx`
 - Public guest UI: `packages/web/src/booking/PublicBookingPage.tsx`,
   `PublicBookingConfirmedPage.tsx`, `PublicBookingCancelPage.tsx`,

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -1,4 +1,4 @@
-# Compass Calendar Booking (v1 / v1.1 / v1.3 / v1.5 / v1.6 / v1.7 / v1.8)
+# Compass Calendar Booking (v1 / v1.1 / v1.3 / v1.5 / v1.6 / v1.7 / v1.8 / v1.9)
 
 Locked product spec for public scheduling on Compass Cloud
 (`https://compasscalendar.com`). Approved 2026-08-30. v1.1 shipped
@@ -10,23 +10,26 @@ reschedule) is specified here and implemented. v1.6 shipped one-click
 turn on, Essentials / More options, editable address, default hours,
 branded connect pills, and funnel analytics. v1.7 shipped the Meeting
 page redesign: `/meet` URLs, meeting copy, hold-Mod section chords, the
-on/off switch, grouped weekly hours rows, and the first-run address
+on/off switch, a per-day weekly hours list, and the first-run address
 screen. v1.8 replaced that screen with a guided setup wizard, Start and End
 menus for weekly hours, fewer host scheduling knobs, sidebar-only Mod chords,
-no horizontal scroll, and the stale-holiday-calendar booking gate fix. The
-production gate stays off.
+no horizontal scroll, and the stale-holiday-calendar booking gate fix. v1.9
+anchored Settings to the top, animated More options, let a day hold several
+hour blocks, moved meeting timezone under More options, and trimmed helper
+copy. The production gate stays off.
 
 Compass never sends email itself. Google emails the guest when Compass
 creates the calendar event with `invitation: "all"`.
 
 ## Status
 
-v1, v1.1, v1.3, v1.5, v1.6, v1.7, and v1.8 are implemented in the Compass
+v1, v1.1, v1.3, v1.5, v1.6, v1.7, v1.8, and v1.9 are implemented in the Compass
 monorepo (public `/meet/:username`, host Settings, backend APIs, guest
 cancel, guest reschedule, edit-details, one-click turn on, Essentials /
 More options, editable address, default hours, branded connect pills,
 funnel analytics, meeting copy, hold-Mod section chords, the on/off
-switch, grouped weekly hours, the guided first-run setup wizard, Start
+switch, a per-day weekly hours list that can hold several blocks, meeting
+timezone under More options, the guided first-run setup wizard, Start
 and End time menus, and the v1.8 booking gate fix). Booking
 is enabled in development and staging (`runtime.nodeEnv` other than
 `production`) and disabled in production. Do not flip `isBookingEnabled`.
@@ -505,7 +508,7 @@ Guest reschedule is **in scope for v1.3**, not v1 / v1.1.
 | Reservations + cancel tokens | `packages/backend/src/booking/booking-reservation.repository.ts`, `booking-cancel-token.ts` |
 | Calendar application port | `packages/backend/src/booking/services/calendar-booking.port.ts` (`updateBookingEvent`), `services/calendar-booking.service.ts` |
 | Sync busy occupancy | `packages/sync/src/domain/occurrence-projection.ts`, `busy-query.service.ts`, `booking-occupancy-facts.ts` |
-| Host Settings UI | `packages/web/src/booking/BookingSettingsSection.tsx`, `packages/web/src/booking/setup/`, `BookingStatusHeader.tsx`, `BookingMoreOptions.tsx`, `BookingSaveBar.tsx`, `BookingAddressField.tsx`, `BookingBlockingCalendarsField.tsx`, `weekly-hours.ts`, `packages/web/src/components/Switch/Switch.tsx`, `packages/web/src/components/Settings/SettingsModal.tsx` |
+| Host Settings UI | `packages/web/src/booking/BookingSettingsSection.tsx`, `packages/web/src/booking/setup/`, `BookingStatusHeader.tsx`, `BookingMoreOptions.tsx`, `BookingSaveBar.tsx`, `BookingAddressField.tsx`, `BookingBlockingCalendarsField.tsx`, `BookingWeeklyHoursEditor.tsx`, `weekly-hours.ts`, `packages/web/src/components/Switch/Switch.tsx`, `packages/web/src/components/Settings/SettingsModal.tsx` |
 | Public guest UI | `packages/web/src/booking/PublicBookingPage.tsx`, `PublicBookingConfirmedPage.tsx`, `PublicBookingCancelPage.tsx`, `PublicBookingReschedulePage.tsx`, `PublicBookingCopyGuestAction.tsx`, `PublicBookingEditDetailsForm.tsx` |
 | Public web API client | `packages/web/src/api/public-booking.api.ts` |
 | E2e | `e2e/booking/`, `e2e/booking/public-booking-reschedule.spec.ts`, `e2e/accessibility/booking-a11y.spec.ts` |
@@ -559,6 +562,25 @@ routes; these are the named events in `packages/web/src/auth/posthog/track.ts`.
   max meetings per day, welcome text, and guest-invite permission were
   removed in Booking v1.8. Zod strips those keys on read; they are not
   in the wire contract or Settings UI.
+
+## Changelog
+
+### v1.9
+
+Settings > Meeting now anchors to the top of the viewport, More options
+animates open (reduced motion skips it), weekly hours are a per-day list
+that can hold several blocks, meeting timezone lives under More options,
+and helper copy is gone from the live form.
+
+v1.8 treated extra intervals on a weekday as out of scope. v1.9 reversed
+that: a day can have several blocks, and Start and End menus are bounded
+by neighbouring blocks so they cannot overlap. These are not current
+behaviour; they were removed or reversed in v1.9: `Unavailable:` on an
+unchecked day, Add hours seeding a first row, a weekday belongs to at
+most one row, keeps only the first interval, grouped weekly hours rows,
+`weekly-hours.rows.ts`, Live at, the always-visible slug helper
+(`3 to 32 lowercase letters, digits, or hyphens.`), and the
+Pending, maybe invite footnote.
 
 ## Related docs
 

--- a/docs/frontend/shortcut-commandments.md
+++ b/docs/frontend/shortcut-commandments.md
@@ -81,9 +81,11 @@ Billing: `U` Update card,
 `E` Export, `D` Delete account, `O` Log out. `B` (trial badge / Start
 Premium) is registered by `UpgradeConfirmationProvider` and keeps working
 while Settings is open. Meeting settings reveal only sidebar digits
-`Mod+1/2/3` and Enter on Save or Continue. Inside the Meeting setup wizard,
-`j` and `k` step back and forward because the calendar period keys are
-locked out by the modal. Meeting settings do not use an
+`Mod+1/2/3` and Enter on Save or Continue. Weekly hours plus and minus
+buttons and weekday checkboxes have no chips. A weekday checkbox is not
+an editable target, so `j` and `k` still step the wizard. Inside the
+Meeting setup wizard, `j` and `k` step back and forward because the
+calendar period keys are locked out by the modal. Meeting settings do not use an
 `e` leader. The `?` overlay remains the catalog; hold-Mod still reveals
 the chips.
 

--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -423,6 +423,28 @@ test.describe("settings booking section", () => {
     });
   });
 
+  test("two Tuesday blocks with More options open have no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await prepareSignedInBookingSettingsPage(page);
+    const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+    await dispatchClick(
+      settingsDialog.getByRole("button", { name: "Add hours to Tuesday" }),
+    );
+    await expect(
+      settingsDialog.getByRole("combobox", { name: "Tuesday start 2" }),
+    ).toBeVisible();
+    await settingsDialog.getByText("More options", { exact: true }).click();
+    await expect(settingsDialog.getByLabel("Page address")).toBeVisible();
+    await expect(
+      settingsDialog.getByRole("button", { name: /Meeting timezone:/ }),
+    ).toBeVisible();
+    await expectNoAxeViolations(page, {
+      checkpoint: "settings booking two blocks more options",
+      include: "[role='dialog']",
+    });
+  });
+
   test("address errors have no automatically detectable accessibility violations", async ({
     page,
   }) => {

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -309,6 +309,28 @@ test("essentials fit without scrolling at 1440x900", async ({ page }) => {
   );
 });
 
+test.describe("reduced motion", () => {
+  test.use({ reducedMotion: "reduce" });
+
+  test("opening More options and adding Monday hours does not move the dialog", async ({
+    page,
+  }) => {
+    await prepareSignedInBookingSettingsPage(page);
+
+    const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+    const topBefore = (await settingsDialog.boundingBox())?.y;
+    await openMoreOptions(settingsDialog);
+    await dispatchClick(
+      settingsDialog.getByRole("button", { name: "Add hours to Monday" }),
+    );
+    await expect(
+      settingsDialog.getByRole("combobox", { name: "Monday start 2" }),
+    ).toBeVisible();
+    const topAfter = (await settingsDialog.boundingBox())?.y;
+    expect(topAfter).toBe(topBefore);
+  });
+});
+
 test("settings dialog never scrolls horizontally with more options open", async ({
   page,
 }) => {

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -310,7 +310,7 @@ test("essentials fit without scrolling at 1440x900", async ({ page }) => {
 });
 
 test.describe("reduced motion", () => {
-  test.use({ reducedMotion: "reduce" });
+  test.use({ contextOptions: { reducedMotion: "reduce" } });
 
   test("opening More options and adding Monday hours does not move the dialog", async ({
     page,

--- a/packages/scripts/src/testing/booking-doc-drift.test.ts
+++ b/packages/scripts/src/testing/booking-doc-drift.test.ts
@@ -14,13 +14,33 @@ const BOOKING_SUPPORT_DOC_PATHS = [
 const STALE_BOOKING_TERMS =
   /\b(?:BookingAddressSetup|BookingLimitsFieldset|weekly-hours\.parse|9-12,\s*1-5|buffer|max meetings per day|welcome text|invite others)\b/i;
 
+const STALE_V19_BOOKING_TERMS =
+  /grouped weekly hours|weekly-hours\.rows|\bUnavailable:|\bLive at\b|Pending, maybe|keeps only the first interval|a weekday belongs to at most one row/i;
+
 const STALE_MEETING_MOD_CHORDS = /\bMod\+(?:[4-9]|U)\b/;
 
 const REMOVED_IN_V18 = /removed in Booking v1\.8/i;
+const REMOVED_IN_V19 =
+  /removed or reversed in v1\.9|reversed in v1\.9|removed in Booking v1\.9/i;
+
+function inChangelogSection(lines: string[], index: number): boolean {
+  for (let cursor = index; cursor >= 0; cursor -= 1) {
+    const line = lines[cursor] ?? "";
+    if (/^## Changelog\b/.test(line)) return true;
+    if (/^## /.test(line)) return false;
+  }
+  return false;
+}
 
 function lineAllowedInBookingSpec(line: string, nearby: string[]): boolean {
-  if (REMOVED_IN_V18.test(line)) return true;
-  if (nearby.some((other) => REMOVED_IN_V18.test(other))) return true;
+  if (REMOVED_IN_V18.test(line) || REMOVED_IN_V19.test(line)) return true;
+  if (
+    nearby.some(
+      (other) => REMOVED_IN_V18.test(other) || REMOVED_IN_V19.test(other),
+    )
+  ) {
+    return true;
+  }
   return false;
 }
 
@@ -29,14 +49,20 @@ function staleLines(
   options: {
     includeMeetingModChords: boolean;
     allowV18RemovalBlock?: boolean;
+    allowV19Changelog?: boolean;
   },
 ): string[] {
   const lines = content.split("\n");
   return lines.flatMap((line, index) => {
-    const matchesStaleTerm = STALE_BOOKING_TERMS.test(line);
+    const matchesV18Term = STALE_BOOKING_TERMS.test(line);
+    const matchesV19Term = STALE_V19_BOOKING_TERMS.test(line);
     const matchesMeetingMod =
       options.includeMeetingModChords && STALE_MEETING_MOD_CHORDS.test(line);
-    if (!matchesStaleTerm && !matchesMeetingMod) return [];
+    if (!matchesV18Term && !matchesV19Term && !matchesMeetingMod) return [];
+
+    if (options.allowV19Changelog && matchesV19Term && !matchesV18Term) {
+      if (inChangelogSection(lines, index)) return [];
+    }
 
     if (options.allowV18RemovalBlock) {
       const nearby = lines.slice(Math.max(0, index - 2), index + 3);
@@ -47,13 +73,14 @@ function staleLines(
   });
 }
 
-describe("booking v1.8 doc drift", () => {
-  it("docs/features/booking.md has no stale terms outside the v1.8 removal wart", () => {
+describe("booking doc drift", () => {
+  it("docs/features/booking.md has no stale terms outside the removal wart and v1.9 changelog", () => {
     const content = readFileSync(BOOKING_SPEC_PATH, "utf8");
     expect(
       staleLines(content, {
         includeMeetingModChords: true,
         allowV18RemovalBlock: true,
+        allowV19Changelog: true,
       }),
     ).toEqual([]);
   });

--- a/packages/web/src/booking/BookingWeeklyHoursEditor.test.tsx
+++ b/packages/web/src/booking/BookingWeeklyHoursEditor.test.tsx
@@ -31,6 +31,27 @@ const renderEditor = (
 const lastCall = (onChange: ReturnType<typeof renderEditor>) =>
   onChange.mock.calls[onChange.mock.calls.length - 1]?.[0];
 
+const renderStatefulEditor = (
+  initial: WeeklyAvailability = DEFAULT_WEEKLY_AVAILABILITY,
+) => {
+  const onChange = mock((_next: WeeklyAvailability) => {});
+  function Harness() {
+    const [value, setValue] = useState(initial);
+    return (
+      <BookingWeeklyHoursEditor
+        describedBy="booking-hours-timezone"
+        onChange={(next) => {
+          onChange(next);
+          setValue(next);
+        }}
+        value={value}
+      />
+    );
+  }
+  render(<Harness />);
+  return onChange;
+};
+
 const mondayStart = () =>
   screen.getByRole("combobox", { name: "Monday start" });
 const mondayEnd = () => screen.getByRole("combobox", { name: "Monday end" });
@@ -89,23 +110,9 @@ describe("BookingWeeklyHoursEditor", () => {
     );
   });
 
-  it("Add hours to Tuesday emits two intervals and renders Tuesday start 2", async () => {
+  it("Add hours to Tuesday emits two intervals and focuses Tuesday start 2", async () => {
     const user = userEvent.setup({ delay: null });
-    const onChange = mock((_next: WeeklyAvailability) => {});
-    function Harness() {
-      const [value, setValue] = useState(DEFAULT_WEEKLY_AVAILABILITY);
-      return (
-        <BookingWeeklyHoursEditor
-          describedBy="booking-hours-timezone"
-          onChange={(next) => {
-            onChange(next);
-            setValue(next);
-          }}
-          value={value}
-        />
-      );
-    }
-    render(<Harness />);
+    const onChange = renderStatefulEditor();
 
     await user.click(
       screen.getByRole("button", { name: "Add hours to Tuesday" }),
@@ -115,19 +122,24 @@ describe("BookingWeeklyHoursEditor", () => {
       { weekday: 2, start: "09:00", end: "17:00" },
       { weekday: 2, start: "18:00", end: "19:00" },
     ]);
-    expect(
-      screen.getByRole("combobox", { name: "Tuesday start 2" }),
-    ).toHaveAttribute("aria-describedby", "booking-hours-timezone");
+    const secondStart = screen.getByRole("combobox", {
+      name: "Tuesday start 2",
+    });
+    expect(secondStart).toHaveAttribute(
+      "aria-describedby",
+      "booking-hours-timezone",
+    );
+    expect(secondStart).toHaveFocus();
   });
 
-  it("renders Tuesday start 2 and the minus button removes it", async () => {
+  it("renders Tuesday start 2 and the minus button removes it and focuses Tuesday start", async () => {
     const user = userEvent.setup({ delay: null });
     const twoBlocks: WeeklyAvailability = [
       ...DEFAULT_WEEKLY_AVAILABILITY.filter((entry) => entry.weekday !== 2),
       { weekday: 2, start: "09:00", end: "17:00" },
       { weekday: 2, start: "18:00", end: "19:00" },
     ];
-    const onChange = renderEditor(twoBlocks);
+    const onChange = renderStatefulEditor(twoBlocks);
 
     expect(
       screen.getByRole("combobox", { name: "Tuesday start 2" }),
@@ -140,6 +152,9 @@ describe("BookingWeeklyHoursEditor", () => {
     expect(lastCall(onChange)?.filter((entry) => entry.weekday === 2)).toEqual([
       { weekday: 2, start: "09:00", end: "17:00" },
     ]);
+    expect(
+      screen.getByRole("combobox", { name: "Tuesday start" }),
+    ).toHaveFocus();
   });
 
   it("Tuesday end options never include a time at or before start, and never after Tuesday start 2", () => {

--- a/packages/web/src/booking/BookingWeeklyHoursEditor.tsx
+++ b/packages/web/src/booking/BookingWeeklyHoursEditor.tsx
@@ -1,4 +1,5 @@
 import { Minus, Plus } from "@phosphor-icons/react";
+import { useLayoutEffect, useRef } from "react";
 import {
   type LocalTimeOfDay,
   type WeeklyAvailability,
@@ -42,6 +43,12 @@ const blockSelectLabel = (
   return index === 0 ? `${day} ${kind}` : `${day} ${kind} ${index + 1}`;
 };
 
+const hoursSelectId = (
+  weekday: IsoWeekday,
+  kind: "start" | "end",
+  index: number,
+): string => `booking-hours-${weekday}-${kind}-${index}`;
+
 const renderMenus = (
   value: WeeklyAvailability,
   weekday: IsoWeekday,
@@ -63,6 +70,7 @@ const renderMenus = (
         aria-describedby={describedBy}
         aria-label={blockSelectLabel(weekday, "start", index)}
         className={BOOKING_SELECT_CLASS_NAME}
+        id={hoursSelectId(weekday, "start", index)}
         onChange={(event) =>
           onChange(
             updateBlock(value, weekday, index, {
@@ -83,6 +91,7 @@ const renderMenus = (
         aria-describedby={describedBy}
         aria-label={blockSelectLabel(weekday, "end", index)}
         className={BOOKING_SELECT_CLASS_NAME}
+        id={hoursSelectId(weekday, "end", index)}
         onChange={(event) =>
           onChange(
             updateBlock(value, weekday, index, {
@@ -111,6 +120,17 @@ export function BookingWeeklyHoursEditor({
   disabled = false,
   describedBy,
 }: BookingWeeklyHoursEditorProps) {
+  const pendingFocusIdRef = useRef<string | null>(null);
+
+  useLayoutEffect(() => {
+    const id = pendingFocusIdRef.current;
+    if (!id) return;
+    const node = document.getElementById(id);
+    if (!(node instanceof HTMLElement)) return;
+    pendingFocusIdRef.current = null;
+    node.focus();
+  }, [value]);
+
   return (
     <fieldset className="flex flex-col gap-2" disabled={disabled}>
       <legend className="mb-1 text-sm text-text">Weekly hours</legend>
@@ -149,7 +169,14 @@ export function BookingWeeklyHoursEditor({
                     aria-label={`Add hours to ${weekdayLabel(weekday)}`}
                     className="size-8 text-text"
                     disabled={!canAddBlock(value, weekday)}
-                    onClick={() => onChange(addBlock(value, weekday))}
+                    onClick={() => {
+                      pendingFocusIdRef.current = hoursSelectId(
+                        weekday,
+                        "start",
+                        blocks.length,
+                      );
+                      onChange(addBlock(value, weekday));
+                    }}
                     size="small"
                   >
                     <Plus aria-hidden="true" size={16} />
@@ -160,7 +187,7 @@ export function BookingWeeklyHoursEditor({
             {blocks.slice(1).map((block, offset) => {
               const index = offset + 1;
               return (
-                <div className="c-grow-in" key={`${weekday}-${index}`}>
+                <div className="c-grow-in" key={`${weekday}-${block.start}`}>
                   <div className={HOURS_LINE_CLASS_NAME}>
                     <span />
                     <span />
@@ -169,9 +196,14 @@ export function BookingWeeklyHoursEditor({
                       <IconButton
                         aria-label={`Remove ${weekdayLabel(weekday)} ${formatTimeLabel(block.start)} to ${formatTimeLabel(block.end)}`}
                         className="size-8 text-text"
-                        onClick={() =>
-                          onChange(removeBlock(value, weekday, index))
-                        }
+                        onClick={() => {
+                          pendingFocusIdRef.current = hoursSelectId(
+                            weekday,
+                            "start",
+                            index - 1,
+                          );
+                          onChange(removeBlock(value, weekday, index));
+                        }}
                         size="small"
                       >
                         <Minus aria-hidden="true" size={16} />

--- a/packages/web/src/booking/BookingWeeklyHoursEditor.tsx
+++ b/packages/web/src/booking/BookingWeeklyHoursEditor.tsx
@@ -1,5 +1,5 @@
 import { Minus, Plus } from "@phosphor-icons/react";
-import { useLayoutEffect, useRef } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import {
   type LocalTimeOfDay,
   type WeeklyAvailability,
@@ -121,15 +121,22 @@ export function BookingWeeklyHoursEditor({
   describedBy,
 }: BookingWeeklyHoursEditorProps) {
   const pendingFocusIdRef = useRef<string | null>(null);
+  const [focusToken, setFocusToken] = useState(0);
 
   useLayoutEffect(() => {
+    if (focusToken === 0) return;
     const id = pendingFocusIdRef.current;
     if (!id) return;
     const node = document.getElementById(id);
     if (!(node instanceof HTMLElement)) return;
     pendingFocusIdRef.current = null;
     node.focus();
-  }, [value]);
+  }, [focusToken]);
+
+  const requestFocus = (id: string) => {
+    pendingFocusIdRef.current = id;
+    setFocusToken((token) => token + 1);
+  };
 
   return (
     <fieldset className="flex flex-col gap-2" disabled={disabled}>
@@ -170,10 +177,8 @@ export function BookingWeeklyHoursEditor({
                     className="size-8 text-text"
                     disabled={!canAddBlock(value, weekday)}
                     onClick={() => {
-                      pendingFocusIdRef.current = hoursSelectId(
-                        weekday,
-                        "start",
-                        blocks.length,
+                      requestFocus(
+                        hoursSelectId(weekday, "start", blocks.length),
                       );
                       onChange(addBlock(value, weekday));
                     }}
@@ -197,10 +202,8 @@ export function BookingWeeklyHoursEditor({
                         aria-label={`Remove ${weekdayLabel(weekday)} ${formatTimeLabel(block.start)} to ${formatTimeLabel(block.end)}`}
                         className="size-8 text-text"
                         onClick={() => {
-                          pendingFocusIdRef.current = hoursSelectId(
-                            weekday,
-                            "start",
-                            index - 1,
+                          requestFocus(
+                            hoursSelectId(weekday, "start", index - 1),
                           );
                           onChange(removeBlock(value, weekday, index));
                         }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3555

## What and why

Booking v1.9 closeout. Weekly hours now move keyboard focus onto the new Start menu after adding a block and onto the previous Start menu after removing one. Playwright covers two blocks with More options open and a reduced-motion pass that opens More options and adds Monday hours without moving the Settings dialog. The spec, glossary, feature map, and shortcut docs describe the shipped layout; stale v1.8 one-row-per-day language lives only in the v1.9 changelog as reversed.

## Verify

VERDICT: PASS
Checks run: test:web, test:scripts:fast, type-check, lint, knip, test:a11y, test:e2e

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8213e129-a1b6-4820-8846-4ab5d4f0d668?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8213e129-a1b6-4820-8846-4ab5d4f0d668&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

