### PR TITLE
refactor(booking): share the guest slot picker across booking and reschedule

### DIFF
--- a/packages/web/src/booking/public-booking.query.ts
+++ b/packages/web/src/booking/public-booking.query.ts
@@ -376,6 +376,8 @@ function usePrefetchAdjacentPublicMonths(
   const queryClient = useQueryClient();
   const previousMonthKey = shiftBookingMonthKey(monthKey, -1, timeZone);
   const nextMonthKey = shiftBookingMonthKey(monthKey, 1, timeZone);
+  // Flattened to primitives so the effect below re-runs on a real change
+  // rather than on `target`'s new object identity every render.
   const slug = target.kind === "page" ? target.slug : "";
   const reservationId =
     target.kind === "reservation" ? target.reservationId : "";
@@ -385,41 +387,28 @@ function usePrefetchAdjacentPublicMonths(
     if (!enabled || maxHorizonDays == null) {
       return;
     }
-    if (slug) {
-      void prefetchPublicBookingMonth(
-        queryClient,
-        slug,
-        previousMonthKey,
-        timeZone,
-        maxHorizonDays,
-      );
-      void prefetchPublicBookingMonth(
-        queryClient,
-        slug,
-        nextMonthKey,
-        timeZone,
-        maxHorizonDays,
-      );
-      return;
-    }
-    if (reservationId && token) {
-      void prefetchPublicBookingReservationMonth(
-        queryClient,
-        reservationId,
-        token,
-        previousMonthKey,
-        timeZone,
-        maxHorizonDays,
-      );
-      void prefetchPublicBookingReservationMonth(
-        queryClient,
-        reservationId,
-        token,
-        nextMonthKey,
-        timeZone,
-        maxHorizonDays,
-      );
-    }
+    // Both prefetchers no-op on a missing id or token, so the caller's
+    // `enabled` guard is the only one needed here.
+    const prefetchMonth = (cursor: string) =>
+      slug
+        ? prefetchPublicBookingMonth(
+            queryClient,
+            slug,
+            cursor,
+            timeZone,
+            maxHorizonDays,
+          )
+        : prefetchPublicBookingReservationMonth(
+            queryClient,
+            reservationId,
+            token,
+            cursor,
+            timeZone,
+            maxHorizonDays,
+          );
+
+    void prefetchMonth(previousMonthKey);
+    void prefetchMonth(nextMonthKey);
   }, [
     enabled,
     maxHorizonDays,

--- a/packages/web/src/booking/use-public-booking-flow.ts
+++ b/packages/web/src/booking/use-public-booking-flow.ts
@@ -1,19 +1,13 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { CreateBookingReservationInputSchema } from "@core/types/booking.contracts";
-import dayjs from "@core/util/date/dayjs";
 import { getErrorStatus } from "@web/api/util/api.util";
 import { track } from "@web/auth/posthog/track";
 import {
   type PublicBookingGuestDetails,
   type PublicBookingGuestFormValues,
 } from "@web/booking/PublicBookingGuestForm";
-import {
-  formatBookingDateKey,
-  formatBookingMonthKey,
-  listBookingAvailableDateKeysInMonth,
-} from "@web/booking/public-booking.format";
 import {
   isPublicBookingConflictError,
   prefetchPublicBookingMonth,
@@ -28,10 +22,13 @@ import {
   type PublicBookingSearch,
   tokenFromGuestActionUrl,
 } from "@web/booking/public-booking-search";
+import {
+  usePublicBookingSelectionKeys,
+  usePublicBookingSlotSelection,
+} from "@web/booking/use-public-booking-slot-selection";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
 import { isHigherEscapeOwner } from "@web/shortcuts/escape-ownership";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
-import { getBrowserTimeZone } from "@web/timezone/browser-timezone";
 
 const EMPTY_GUEST_DETAILS: PublicBookingGuestDetails = {
   guestName: "",
@@ -40,10 +37,9 @@ const EMPTY_GUEST_DETAILS: PublicBookingGuestDetails = {
 };
 
 /**
- * All state and behavior of the guest booking flow. The URL is the source of
- * truth for the selection (month, day, slot, timezone): Back returns from the
- * details step to the picker instead of leaving the site, refresh keeps the
- * selection, and the link is shareable. The page component only renders.
+ * All state and behavior of the guest booking flow. The shared slot picker
+ * lives in `usePublicBookingSlotSelection`; what stays here is the details
+ * step, the 409 conflict handling, and confirming the reservation.
  */
 export function usePublicBookingFlow() {
   const { username } = useParams({ from: ROOT_ROUTES.BOOK });
@@ -52,16 +48,8 @@ export function usePublicBookingFlow() {
   const search: PublicBookingSearch = useSearch({ from: ROOT_ROUTES.BOOK });
   const queryClient = useQueryClient();
 
-  const browserTimeZone = useMemo(getBrowserTimeZone, []);
-  const guestTimeZone = search.tz ?? browserTimeZone;
-  const selectedSlotStart = search.slot ?? null;
-  const slotDateKey = selectedSlotStart
-    ? formatBookingDateKey(selectedSlotStart, guestTimeZone)
-    : null;
-  const monthKey =
-    search.month ??
-    slotDateKey?.slice(0, 7) ??
-    formatBookingMonthKey(dayjs(), guestTimeZone);
+  const keys = usePublicBookingSelectionKeys(search);
+  const { guestTimeZone, monthKey, selectedSlotStart } = keys;
 
   const pageQuery = usePublicBookingPageQuery(slug);
   const slotsQuery = usePublicBookingSlotsQuery(
@@ -77,30 +65,43 @@ export function usePublicBookingFlow() {
   // "Change time" shows the picker with the chosen slot still highlighted, so
   // the slot stays in the URL and only this local flag flips the view.
   const [changingTime, setChangingTime] = useState(false);
-  const [alertMessage, setAlertMessage] = useState<string | null>(null);
-  const alertRef = useRef<HTMLParagraphElement>(null);
   const detailsHeadingRef = useRef<HTMLHeadingElement>(null);
-  const pickerHeadingRef = useRef<HTMLHeadingElement>(null);
   const submitInFlightRef = useRef(false);
-  const pendingPickerFocusRef = useRef(false);
 
   const showDetailsStep = selectedSlotStart !== null && !changingTime;
 
-  useEffect(() => {
-    if (alertMessage) {
-      alertRef.current?.focus();
-    }
-  }, [alertMessage]);
+  const selection = usePublicBookingSlotSelection({
+    search,
+    keys,
+    slotsQuery,
+    horizonDays: pageQuery.data?.maxHorizonDays ?? null,
+    pickerFocusSuspended: showDetailsStep,
+    prefetchMonth: (nextMonthKey, maxHorizonDays) => {
+      void prefetchPublicBookingMonth(
+        queryClient,
+        slug,
+        nextMonthKey,
+        guestTimeZone,
+        maxHorizonDays,
+      );
+    },
+    resolveNextAvailableDate: (afterDateKey, todayKey, maxHorizonDays) =>
+      resolveNextAvailableBookingDate(
+        queryClient,
+        slug,
+        monthKey,
+        afterDateKey,
+        guestTimeZone,
+        todayKey,
+        maxHorizonDays,
+      ),
+  });
+  const { alertMessage, setAlertMessage, updateSearch } = selection;
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: jump remounts the picker heading
+  // biome-ignore lint/correctness/useExhaustiveDependencies: jump remounts the details heading
   useEffect(() => {
     if (showDetailsStep) {
       detailsHeadingRef.current?.focus();
-      return;
-    }
-    if (pendingPickerFocusRef.current) {
-      pendingPickerFocusRef.current = false;
-      pickerHeadingRef.current?.focus();
     }
   }, [monthKey, search.date, showDetailsStep]);
 
@@ -112,94 +113,23 @@ export function usePublicBookingFlow() {
     pageQuery.isSuccess && pageQuery.data.enabled && slotsQuery.isSuccess,
   );
 
-  const todayKey = formatBookingDateKey(dayjs(), guestTimeZone);
-  const availableDateKeys = useMemo(
-    () =>
-      slotsQuery.data?.bookable
-        ? listBookingAvailableDateKeysInMonth(
-            slotsQuery.data.slots,
-            monthKey,
-            guestTimeZone,
-            todayKey,
-          )
-        : [],
-    [guestTimeZone, monthKey, slotsQuery.data, todayKey],
-  );
-
-  // The guest's explicit day pick wins while it is in the month in view (even
-  // when it has no open times); otherwise the picked slot's day, otherwise the
-  // first day with open times.
-  const selectedDateKey =
-    (search.date?.startsWith(monthKey) ? search.date : null) ??
-    (slotDateKey?.startsWith(monthKey) ? slotDateKey : null) ??
-    availableDateKeys[0] ??
-    null;
-
   // 409 only: keep typed details while they pick another slot. Other alerts
   // (empty horizon, confirm failure) must not open the guest form.
   const showConflictForm =
     !showDetailsStep && alertMessage === PUBLIC_BOOKING_SLOT_CONFLICT;
-  const slotsHasData = Boolean(slotsQuery.data);
-  const slotsFetching =
-    !slotsHasData && (slotsQuery.isPending || slotsQuery.isFetching);
-  const slotsError = Boolean(slotsQuery.isError && !slotsHasData);
-  const slotsPending = slotsFetching && !slotsError;
-
-  const updateSearch = (
-    patch: Partial<PublicBookingSearch>,
-    { push = false }: { push?: boolean } = {},
-  ) => {
-    void navigate({
-      to: ".",
-      search: (previous: PublicBookingSearch) => ({ ...previous, ...patch }),
-      replace: !push,
-    });
-  };
 
   const handleSelectSlot = (slotStart: string) => {
-    setAlertMessage(null);
     setChangingTime(false);
-    // Push, not replace: Back from the details step returns to the picker.
-    updateSearch(
-      { slot: slotStart, date: formatBookingDateKey(slotStart, guestTimeZone) },
-      { push: true },
-    );
-  };
-
-  const handleSelectDay = (dateKey: string) => {
-    updateSearch({
-      date: dateKey,
-      slot: slotDateKey !== dateKey ? undefined : search.slot,
-    });
+    selection.handleSelectSlot(slotStart);
   };
 
   const handleMonthChange = (nextMonthKey: string) => {
-    setAlertMessage(null);
     setChangingTime(false);
-    updateSearch({ month: nextMonthKey, date: undefined, slot: undefined });
-  };
-
-  const handleTimeZoneChange = (nextTimeZone: string) => {
-    if (nextTimeZone === guestTimeZone) {
-      return;
-    }
-    if (selectedSlotStart) {
-      // Keep the slot; its day and month re-derive in the new zone.
-      updateSearch({ tz: nextTimeZone, month: undefined, date: undefined });
-      return;
-    }
-    const currentMonthInOldZone = formatBookingMonthKey(dayjs(), guestTimeZone);
-    updateSearch({
-      tz: nextTimeZone,
-      date: undefined,
-      // Re-snap to "this month" in the new zone; keep an explicitly browsed
-      // month as-is.
-      month: monthKey === currentMonthInOldZone ? undefined : search.month,
-    });
+    selection.handleMonthChange(nextMonthKey);
   };
 
   const handleChangeTime = () => {
-    pendingPickerFocusRef.current = true;
+    selection.requestPickerFocus();
     setChangingTime(true);
   };
 
@@ -217,49 +147,6 @@ export function usePublicBookingFlow() {
     },
     { enabled: showDetailsStep, ignoreInputs: false },
   );
-
-  const handlePrefetchMonth = (nextMonthKey: string) => {
-    if (!pageQuery.data) {
-      return;
-    }
-    void prefetchPublicBookingMonth(
-      queryClient,
-      slug,
-      nextMonthKey,
-      guestTimeZone,
-      pageQuery.data.maxHorizonDays,
-    );
-  };
-
-  const handleJumpToNextAvailable = async () => {
-    if (!pageQuery.data) {
-      return;
-    }
-    const next = await resolveNextAvailableBookingDate(
-      queryClient,
-      slug,
-      monthKey,
-      selectedDateKey,
-      guestTimeZone,
-      todayKey,
-      pageQuery.data.maxHorizonDays,
-    );
-    if (next) {
-      pendingPickerFocusRef.current = true;
-      setAlertMessage(null);
-      updateSearch({
-        month: next.monthKey,
-        date: next.dateKey,
-        slot: undefined,
-      });
-      return;
-    }
-    // Every month up to the horizon came back empty - say so instead of
-    // silently doing nothing.
-    setAlertMessage(
-      `No open times in the next ${pageQuery.data.maxHorizonDays} days. Check back later.`,
-    );
-  };
 
   const handleSubmit = async (values: PublicBookingGuestFormValues) => {
     if (!selectedSlotStart || !pageQuery.data || submitInFlightRef.current) {
@@ -325,25 +212,25 @@ export function usePublicBookingFlow() {
     guestTimeZone,
     monthKey,
     selectedSlotStart,
-    selectedDateKey,
+    selectedDateKey: selection.selectedDateKey,
     guestDetails,
     setGuestDetails,
     alertMessage,
     showDetailsStep,
     showConflictForm,
-    slotsPending,
-    slotsError,
-    slotsFetching,
-    alertRef,
+    slotsPending: selection.slotsPending,
+    slotsError: selection.slotsError,
+    slotsFetching: selection.slotsFetching,
+    alertRef: selection.alertRef,
     detailsHeadingRef,
-    pickerHeadingRef,
+    pickerHeadingRef: selection.pickerHeadingRef,
     handleSelectSlot,
-    handleSelectDay,
+    handleSelectDay: selection.handleSelectDay,
     handleMonthChange,
-    handleTimeZoneChange,
+    handleTimeZoneChange: selection.handleTimeZoneChange,
     handleChangeTime,
-    handlePrefetchMonth,
-    handleJumpToNextAvailable,
+    handlePrefetchMonth: selection.handlePrefetchMonth,
+    handleJumpToNextAvailable: selection.handleJumpToNextAvailable,
     handleSubmit,
   };
 }

--- a/packages/web/src/booking/use-public-booking-reschedule-flow.ts
+++ b/packages/web/src/booking/use-public-booking-reschedule-flow.ts
@@ -1,15 +1,9 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useRef } from "react";
 import { RescheduleBookingReservationInputSchema } from "@core/types/booking.contracts";
-import dayjs from "@core/util/date/dayjs";
 import { PublicBookingNotFoundError } from "@web/api/public-booking.api";
 import { getErrorStatus } from "@web/api/util/api.util";
-import {
-  formatBookingDateKey,
-  formatBookingMonthKey,
-  listBookingAvailableDateKeysInMonth,
-} from "@web/booking/public-booking.format";
 import {
   isPublicBookingConflictError,
   prefetchPublicBookingReservationMonth,
@@ -26,11 +20,19 @@ import {
   publicCancelUrlForReservation,
   publicRescheduleUrlForReservation,
 } from "@web/booking/public-booking-search";
+import {
+  usePublicBookingSelectionKeys,
+  usePublicBookingSlotSelection,
+} from "@web/booking/use-public-booking-slot-selection";
 import { ROOT_ROUTES } from "@web/common/constants/routes";
 import { isHigherEscapeOwner } from "@web/shortcuts/escape-ownership";
 import { useAppShortcut } from "@web/shortcuts/useAppShortcut";
-import { getBrowserTimeZone } from "@web/timezone/browser-timezone";
 
+/**
+ * The guest reschedule flow. The shared slot picker lives in
+ * `usePublicBookingSlotSelection`; what stays here is the token-guarded
+ * reservation lookup and confirming the new time.
+ */
 export function usePublicBookingRescheduleFlow() {
   const { reservationId } = useParams({
     from: ROOT_ROUTES.BOOK_RESCHEDULE,
@@ -52,16 +54,8 @@ export function usePublicBookingRescheduleFlow() {
       : "";
   const pageQuery = usePublicBookingPageQuery(bookingSlug);
 
-  const browserTimeZone = useMemo(getBrowserTimeZone, []);
-  const guestTimeZone = search.tz ?? browserTimeZone;
-  const selectedSlotStart = search.slot ?? null;
-  const slotDateKey = selectedSlotStart
-    ? formatBookingDateKey(selectedSlotStart, guestTimeZone)
-    : null;
-  const monthKey =
-    search.month ??
-    slotDateKey?.slice(0, 7) ??
-    formatBookingMonthKey(dayjs(), guestTimeZone);
+  const keys = usePublicBookingSelectionKeys(search);
+  const { guestTimeZone, monthKey, selectedSlotStart } = keys;
 
   const slotsQuery = usePublicBookingReservationSlotsQuery(
     canLoad && reservationQuery.data?.status === "confirmed"
@@ -75,25 +69,37 @@ export function usePublicBookingRescheduleFlow() {
   const rescheduleReservation =
     useReschedulePublicBookingReservationMutation(reservationId);
 
-  const [alertMessage, setAlertMessage] = useState<string | null>(null);
-  const alertRef = useRef<HTMLParagraphElement>(null);
-  const pickerHeadingRef = useRef<HTMLHeadingElement>(null);
   const submitInFlightRef = useRef(false);
-  const pendingPickerFocusRef = useRef(false);
 
-  useEffect(() => {
-    if (alertMessage) {
-      alertRef.current?.focus();
-    }
-  }, [alertMessage]);
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: jump remounts the picker heading
-  useEffect(() => {
-    if (pendingPickerFocusRef.current) {
-      pendingPickerFocusRef.current = false;
-      pickerHeadingRef.current?.focus();
-    }
-  }, [monthKey, search.date]);
+  const selection = usePublicBookingSlotSelection({
+    search,
+    keys,
+    slotsQuery,
+    // Every month walk here is token-authenticated, so no token means no walk.
+    horizonDays: token ? (pageQuery.data?.maxHorizonDays ?? null) : null,
+    prefetchMonth: (nextMonthKey, maxHorizonDays) => {
+      void prefetchPublicBookingReservationMonth(
+        queryClient,
+        reservationId,
+        token,
+        nextMonthKey,
+        guestTimeZone,
+        maxHorizonDays,
+      );
+    },
+    resolveNextAvailableDate: (afterDateKey, todayKey, maxHorizonDays) =>
+      resolveNextAvailableReservationDate(
+        queryClient,
+        reservationId,
+        token,
+        monthKey,
+        afterDateKey,
+        guestTimeZone,
+        todayKey,
+        maxHorizonDays,
+      ),
+  });
+  const { setAlertMessage, updateSearch } = selection;
 
   usePrefetchAdjacentReservationMonths(
     reservationId,
@@ -106,82 +112,6 @@ export function usePublicBookingRescheduleFlow() {
       pageQuery.data.enabled &&
       slotsQuery.isSuccess,
   );
-
-  const todayKey = formatBookingDateKey(dayjs(), guestTimeZone);
-  const availableDateKeys = useMemo(
-    () =>
-      slotsQuery.data?.bookable
-        ? listBookingAvailableDateKeysInMonth(
-            slotsQuery.data.slots,
-            monthKey,
-            guestTimeZone,
-            todayKey,
-          )
-        : [],
-    [guestTimeZone, monthKey, slotsQuery.data, todayKey],
-  );
-
-  const selectedDateKey =
-    (search.date?.startsWith(monthKey) ? search.date : null) ??
-    (slotDateKey?.startsWith(monthKey) ? slotDateKey : null) ??
-    availableDateKeys[0] ??
-    null;
-
-  const slotsHasData = Boolean(slotsQuery.data);
-  const slotsFetching =
-    !slotsHasData && (slotsQuery.isPending || slotsQuery.isFetching);
-  const slotsError = Boolean(slotsQuery.isError && !slotsHasData);
-  const slotsPending = slotsFetching && !slotsError;
-
-  const updateSearch = (
-    patch: Partial<PublicBookingRescheduleSearch>,
-    { push = false }: { push?: boolean } = {},
-  ) => {
-    void navigate({
-      to: ".",
-      search: (previous: PublicBookingRescheduleSearch) => ({
-        ...previous,
-        ...patch,
-      }),
-      replace: !push,
-    });
-  };
-
-  const handleSelectSlot = (slotStart: string) => {
-    setAlertMessage(null);
-    updateSearch(
-      { slot: slotStart, date: formatBookingDateKey(slotStart, guestTimeZone) },
-      { push: true },
-    );
-  };
-
-  const handleSelectDay = (dateKey: string) => {
-    updateSearch({
-      date: dateKey,
-      slot: slotDateKey !== dateKey ? undefined : search.slot,
-    });
-  };
-
-  const handleMonthChange = (nextMonthKey: string) => {
-    setAlertMessage(null);
-    updateSearch({ month: nextMonthKey, date: undefined, slot: undefined });
-  };
-
-  const handleTimeZoneChange = (nextTimeZone: string) => {
-    if (nextTimeZone === guestTimeZone) {
-      return;
-    }
-    if (selectedSlotStart) {
-      updateSearch({ tz: nextTimeZone, month: undefined, date: undefined });
-      return;
-    }
-    const currentMonthInOldZone = formatBookingMonthKey(dayjs(), guestTimeZone);
-    updateSearch({
-      tz: nextTimeZone,
-      date: undefined,
-      month: monthKey === currentMonthInOldZone ? undefined : search.month,
-    });
-  };
 
   useAppShortcut(
     "Escape",
@@ -204,49 +134,6 @@ export function usePublicBookingRescheduleFlow() {
       ignoreInputs: false,
     },
   );
-
-  const handlePrefetchMonth = (nextMonthKey: string) => {
-    if (!pageQuery.data || !token) {
-      return;
-    }
-    void prefetchPublicBookingReservationMonth(
-      queryClient,
-      reservationId,
-      token,
-      nextMonthKey,
-      guestTimeZone,
-      pageQuery.data.maxHorizonDays,
-    );
-  };
-
-  const handleJumpToNextAvailable = async () => {
-    if (!pageQuery.data || !token) {
-      return;
-    }
-    const next = await resolveNextAvailableReservationDate(
-      queryClient,
-      reservationId,
-      token,
-      monthKey,
-      selectedDateKey,
-      guestTimeZone,
-      todayKey,
-      pageQuery.data.maxHorizonDays,
-    );
-    if (next) {
-      pendingPickerFocusRef.current = true;
-      setAlertMessage(null);
-      updateSearch({
-        month: next.monthKey,
-        date: next.dateKey,
-        slot: undefined,
-      });
-      return;
-    }
-    setAlertMessage(
-      `No open times in the next ${pageQuery.data.maxHorizonDays} days. Check back later.`,
-    );
-  };
 
   const handleConfirm = async () => {
     if (
@@ -318,19 +205,19 @@ export function usePublicBookingRescheduleFlow() {
     guestTimeZone,
     monthKey,
     selectedSlotStart,
-    selectedDateKey,
-    alertMessage,
-    slotsPending,
-    slotsError,
-    slotsFetching,
-    alertRef,
-    pickerHeadingRef,
-    handleSelectSlot,
-    handleSelectDay,
-    handleMonthChange,
-    handleTimeZoneChange,
-    handlePrefetchMonth,
-    handleJumpToNextAvailable,
+    selectedDateKey: selection.selectedDateKey,
+    alertMessage: selection.alertMessage,
+    slotsPending: selection.slotsPending,
+    slotsError: selection.slotsError,
+    slotsFetching: selection.slotsFetching,
+    alertRef: selection.alertRef,
+    pickerHeadingRef: selection.pickerHeadingRef,
+    handleSelectSlot: selection.handleSelectSlot,
+    handleSelectDay: selection.handleSelectDay,
+    handleMonthChange: selection.handleMonthChange,
+    handleTimeZoneChange: selection.handleTimeZoneChange,
+    handlePrefetchMonth: selection.handlePrefetchMonth,
+    handleJumpToNextAvailable: selection.handleJumpToNextAvailable,
     handleConfirm,
   };
 }

--- a/packages/web/src/booking/use-public-booking-slot-selection.ts
+++ b/packages/web/src/booking/use-public-booking-slot-selection.ts
@@ -1,0 +1,260 @@
+import { useNavigate } from "@tanstack/react-router";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { type BookingSlotsResponse } from "@core/types/booking.contracts";
+import dayjs from "@core/util/date/dayjs";
+import {
+  formatBookingDateKey,
+  formatBookingMonthKey,
+  listBookingAvailableDateKeysInMonth,
+} from "@web/booking/public-booking.format";
+import { type PublicBookingSearch } from "@web/booking/public-booking-search";
+import { getBrowserTimeZone } from "@web/timezone/browser-timezone";
+
+/**
+ * The month, day, slot, and timezone the guest is looking at, derived from the
+ * URL. Call this before the slots query: the query key is built from `monthKey`
+ * and `guestTimeZone`.
+ */
+export function usePublicBookingSelectionKeys(search: PublicBookingSearch) {
+  const browserTimeZone = useMemo(getBrowserTimeZone, []);
+  const guestTimeZone = search.tz ?? browserTimeZone;
+  const selectedSlotStart = search.slot ?? null;
+  const slotDateKey = selectedSlotStart
+    ? formatBookingDateKey(selectedSlotStart, guestTimeZone)
+    : null;
+  const monthKey =
+    search.month ??
+    slotDateKey?.slice(0, 7) ??
+    formatBookingMonthKey(dayjs(), guestTimeZone);
+
+  return { guestTimeZone, selectedSlotStart, slotDateKey, monthKey };
+}
+
+export type PublicBookingSelectionKeys = ReturnType<
+  typeof usePublicBookingSelectionKeys
+>;
+
+/** The parts of a slots query this hook reads, so it stays query-library agnostic. */
+interface PublicBookingSlotsQueryState {
+  data: BookingSlotsResponse | undefined;
+  isPending: boolean;
+  isFetching: boolean;
+  isError: boolean;
+}
+
+interface PublicBookingSlotSelectionParams {
+  search: PublicBookingSearch;
+  keys: PublicBookingSelectionKeys;
+  slotsQuery: PublicBookingSlotsQueryState;
+  /**
+   * Booking horizon in days, or null until everything a month walk needs has
+   * loaded (page meta, plus the guest token when rescheduling).
+   */
+  horizonDays: number | null;
+  /** True while another step owns focus, so the picker heading must not take it. */
+  pickerFocusSuspended?: boolean;
+  prefetchMonth: (monthKey: string, maxHorizonDays: number) => void;
+  resolveNextAvailableDate: (
+    afterDateKey: string | null,
+    todayKey: string,
+    maxHorizonDays: number,
+  ) => Promise<{ monthKey: string; dateKey: string } | null>;
+}
+
+/**
+ * Everything the guest slot picker needs, shared by the booking and reschedule
+ * flows. The URL is the source of truth for the selection (month, day, slot,
+ * timezone): Back returns to the previous step instead of leaving the site,
+ * refresh keeps the selection, and the link is shareable.
+ *
+ * Each flow keeps only what is genuinely its own: the details step and its
+ * conflict handling for booking, the reservation lookup for reschedule.
+ */
+export function usePublicBookingSlotSelection({
+  search,
+  keys,
+  slotsQuery,
+  horizonDays,
+  pickerFocusSuspended = false,
+  prefetchMonth,
+  resolveNextAvailableDate,
+}: PublicBookingSlotSelectionParams) {
+  const navigate = useNavigate();
+  const { guestTimeZone, monthKey, selectedSlotStart, slotDateKey } = keys;
+
+  const [alertMessage, setAlertMessage] = useState<string | null>(null);
+  const alertRef = useRef<HTMLParagraphElement>(null);
+  const pickerHeadingRef = useRef<HTMLHeadingElement>(null);
+  const pendingPickerFocusRef = useRef(false);
+
+  useEffect(() => {
+    if (alertMessage) {
+      alertRef.current?.focus();
+    }
+  }, [alertMessage]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: jump remounts the picker heading
+  useEffect(() => {
+    if (pickerFocusSuspended) {
+      return;
+    }
+    if (pendingPickerFocusRef.current) {
+      pendingPickerFocusRef.current = false;
+      pickerHeadingRef.current?.focus();
+    }
+  }, [monthKey, search.date, pickerFocusSuspended]);
+
+  const todayKey = formatBookingDateKey(dayjs(), guestTimeZone);
+  const availableDateKeys = useMemo(
+    () =>
+      slotsQuery.data?.bookable
+        ? listBookingAvailableDateKeysInMonth(
+            slotsQuery.data.slots,
+            monthKey,
+            guestTimeZone,
+            todayKey,
+          )
+        : [],
+    [guestTimeZone, monthKey, slotsQuery.data, todayKey],
+  );
+
+  // The guest's explicit day pick wins while it is in the month in view (even
+  // when it has no open times); otherwise the picked slot's day, otherwise the
+  // first day with open times.
+  const selectedDateKey =
+    (search.date?.startsWith(monthKey) ? search.date : null) ??
+    (slotDateKey?.startsWith(monthKey) ? slotDateKey : null) ??
+    availableDateKeys[0] ??
+    null;
+
+  const slotsHasData = Boolean(slotsQuery.data);
+  const slotsFetching =
+    !slotsHasData && (slotsQuery.isPending || slotsQuery.isFetching);
+  const slotsError = Boolean(slotsQuery.isError && !slotsHasData);
+  const slotsPending = slotsFetching && !slotsError;
+
+  const updateSearch = (
+    patch: Partial<PublicBookingSearch>,
+    { push = false }: { push?: boolean } = {},
+  ) => {
+    void navigate({
+      to: ".",
+      // The spread keeps params this hook does not own, such as the guest
+      // `?token=` on the reschedule route.
+      search: (previous: PublicBookingSearch) => ({ ...previous, ...patch }),
+      replace: !push,
+    });
+  };
+
+  /** Move focus to the picker heading once the picker next renders. */
+  const requestPickerFocus = () => {
+    pendingPickerFocusRef.current = true;
+  };
+
+  const handleSelectSlot = (slotStart: string) => {
+    setAlertMessage(null);
+    // Push, not replace: Back from the next step returns to the picker.
+    updateSearch(
+      {
+        slot: slotStart,
+        date: formatBookingDateKey(slotStart, guestTimeZone),
+      },
+      { push: true },
+    );
+  };
+
+  const handleSelectDay = (dateKey: string) => {
+    updateSearch({
+      date: dateKey,
+      slot: slotDateKey !== dateKey ? undefined : search.slot,
+    });
+  };
+
+  const handleMonthChange = (nextMonthKey: string) => {
+    setAlertMessage(null);
+    updateSearch({
+      month: nextMonthKey,
+      date: undefined,
+      slot: undefined,
+    });
+  };
+
+  const handleTimeZoneChange = (nextTimeZone: string) => {
+    if (nextTimeZone === guestTimeZone) {
+      return;
+    }
+    if (selectedSlotStart) {
+      // Keep the slot; its day and month re-derive in the new zone.
+      updateSearch({
+        tz: nextTimeZone,
+        month: undefined,
+        date: undefined,
+      });
+      return;
+    }
+    const currentMonthInOldZone = formatBookingMonthKey(dayjs(), guestTimeZone);
+    updateSearch({
+      tz: nextTimeZone,
+      date: undefined,
+      // Re-snap to "this month" in the new zone; keep an explicitly browsed
+      // month as-is.
+      month: monthKey === currentMonthInOldZone ? undefined : search.month,
+    });
+  };
+
+  const handlePrefetchMonth = (nextMonthKey: string) => {
+    if (horizonDays == null) {
+      return;
+    }
+    prefetchMonth(nextMonthKey, horizonDays);
+  };
+
+  const handleJumpToNextAvailable = async () => {
+    if (horizonDays == null) {
+      return;
+    }
+    const next = await resolveNextAvailableDate(
+      selectedDateKey,
+      todayKey,
+      horizonDays,
+    );
+    if (next) {
+      requestPickerFocus();
+      setAlertMessage(null);
+      updateSearch({
+        month: next.monthKey,
+        date: next.dateKey,
+        slot: undefined,
+      });
+      return;
+    }
+    // Every month up to the horizon came back empty - say so instead of
+    // silently doing nothing.
+    setAlertMessage(
+      `No open times in the next ${horizonDays} days. Check back later.`,
+    );
+  };
+
+  return {
+    guestTimeZone,
+    monthKey,
+    selectedSlotStart,
+    selectedDateKey,
+    todayKey,
+    alertMessage,
+    setAlertMessage,
+    alertRef,
+    pickerHeadingRef,
+    slotsPending,
+    slotsError,
+    slotsFetching,
+    updateSearch,
+    requestPickerFocus,
+    handleSelectSlot,
+    handleSelectDay,
+    handleMonthChange,
+    handleTimeZoneChange,
+    handlePrefetchMonth,
+    handleJumpToNextAvailable,
+  };
+}


### PR DESCRIPTION
## What and why

Technical-debt sweep over the last seven days of merged work. The booking
package was by far the hottest area (18 commits touching
`packages/web/src/booking`), and the guest-facing flow hooks had drifted into
near-copies of each other.

`usePublicBookingFlow` and `usePublicBookingRescheduleFlow` each derived the
same month/day/slot/timezone keys from the URL, each held the same alert state
and focus refs, and each repeated `updateSearch`, `handleSelectSlot`,
`handleSelectDay`, `handleMonthChange`, `handleTimeZoneChange`,
`handlePrefetchMonth`, and `handleJumpToNextAvailable` line for line, comments
included. Roughly 150 duplicated lines, and any fix to the picker had to land
twice.

This moves that shared surface into `usePublicBookingSlotSelection`. The
URL-to-keys derivation is split out as `usePublicBookingSelectionKeys` because
it has to run before the slots query whose key it builds. What varies between
the two flows is injected: the horizon (null until the page meta, and for
reschedule the guest token, have loaded), a `prefetchMonth` callback, and a
`resolveNextAvailableDate` callback. Each flow keeps only what is genuinely its
own, the details step and 409 conflict handling for booking, the token-guarded
reservation lookup for reschedule.

`usePrefetchAdjacentPublicMonths` had the same page-versus-reservation
duplication in smaller form: four prefetch calls where two would do, plus a
discriminated union that was flattened to primitives and then re-discriminated
by testing `slug` for truthiness. It now builds one `prefetchMonth` callback and
calls it for the previous and next month, and a comment explains why the union
is flattened (so the effect depends on primitives rather than a fresh object
identity each render).

Behavior preserving. Both hooks return the same shape as before, so
`PublicBookingPage` and `PublicBookingReschedulePage` are untouched. Net 367
lines removed against 390 added, of which 260 are the new shared hook.

## Verify

All 18 CI checks green on `ca148dd`, including the shards that exercise the
refactored flows end to end:

- `static` (type-check, lint, knip) pass
- `unit-leg (core | sync | backend | scripts | web 1 | web 2)` pass
- `e2e-shard (2, e2e/booking e2e/oauth e2e/auth)` pass
- `e2e-shard (1, e2e/accessibility e2e/allday)` pass
- `e2e-shard (3, e2e/timed)` and `e2e-shard (4, ...)` pass
- `CodeQL`, `Analyze (actions)`, `Analyze (javascript-typescript)` pass

Locally on this diff: `bun type-check`, `bun lint`, `bun knip`, and
`bun test:web` (855 tests across 100 files, 0 fail) all pass. The
`bun run verify --strict` run started before CI and was still going when CI
finished green; CI is the authoritative signal here and it covers a superset
of what verify selects for this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KzAMWymCmnJ4JHLJkhbnN