### PR TITLE
fix(sync): request Google Meet on booking event inserts

### DIFF
--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -208,10 +208,12 @@ holds the app lock first.
 On confirm, Compass creates a timed event on the host's destination
 calendar, invites the guest, and adds a conference link when the
 destination supports one (Google Meet, Microsoft Teams, or none). The
-provider emails the invite. Compass shows a confirmation screen with the
-booked time (guest timezone) and names that conference kind. Cancel and
-edit-details are present when the permalink carries `?token=`.
-Reschedule links stay history state only (v1.3).
+Google insert request includes `conferenceDataVersion: 1` so Meet is
+actually minted on the event. The provider emails the invite. Compass
+shows a confirmation screen with the booked time (guest timezone) and
+names that conference kind. Cancel and edit-details are present when the
+permalink carries `?token=`. Reschedule links stay history state only
+(v1.3).
 
 **Event title:** `{Guest name} and {Host name}`.
 
@@ -492,7 +494,8 @@ Guest reschedule is **in scope for v1.3**, not v1 / v1.1.
 - Flipping the production gate
 - Host reservation inbox
 - Meet URL on the confirmation screen (Google creates conference
-  asynchronously; the invite email already has it)
+  asynchronously; the invite email already has it once
+  `conferenceDataVersion` is forwarded on insert)
 
 ## Implementation
 
@@ -564,6 +567,13 @@ routes; these are the named events in `packages/web/src/auth/posthog/track.ts`.
   in the wire contract or Settings UI.
 
 ## Changelog
+
+### v1.10
+
+Guest bookings onto a Google destination calendar now request Google Meet
+on the real `events.insert` call (`conferenceDataVersion: 1`). Before this,
+the adapter passed the conference payload but the googleapis wrapper dropped
+the version flag, so Google ignored Meet.
 
 ### v1.9
 

--- a/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
@@ -5,6 +5,7 @@ import {
   deriveGoogleEventId,
   type GoogleEventsApi,
   GoogleEventWriter,
+  googleEventsApiFromClient,
 } from "@sync/providers/google/google-event-writer.adapter";
 import { googleInstanceEventId } from "@sync/providers/google/google-instance-id";
 import { ProviderWriteError } from "@sync/providers/provider-event-writer.port";
@@ -1132,6 +1133,45 @@ describe("GoogleEventWriter", () => {
       .catch((e) => e)) as ProviderWriteError;
 
     expect(error.reason).toBe("permanentProviderError");
+  });
+});
+
+describe("googleEventsApiFromClient", () => {
+  it("forwards conferenceDataVersion on insert only when it is set", async () => {
+    const insertCalls: unknown[] = [];
+    const insert = async (params: unknown) => {
+      insertCalls.push(params);
+      return { data: scriptedEvent("abc12deadbeef00000000000") };
+    };
+    const unused = async () => ({
+      data: scriptedEvent("abc12deadbeef00000000000"),
+    });
+    const api = googleEventsApiFromClient({
+      events: {
+        insert,
+        patch: unused,
+        delete: unused,
+        get: unused,
+        instances: unused,
+      },
+    } as never);
+
+    await api.insert({
+      calendarId: "cal",
+      requestBody: {},
+      sendUpdates: "all",
+      conferenceDataVersion: 1,
+    });
+    await api.insert({
+      calendarId: "cal",
+      requestBody: {},
+      sendUpdates: "none",
+    });
+
+    expect(insertCalls[0]).toEqual(
+      expect.objectContaining({ conferenceDataVersion: 1 }),
+    );
+    expect(insertCalls[1]).not.toHaveProperty("conferenceDataVersion");
   });
 });
 

--- a/packages/sync/src/providers/google/google-event-writer.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.ts
@@ -85,24 +85,28 @@ export interface GoogleEventsApi {
 
 export type GoogleEventsApiFactory = (accessToken: string) => GoogleEventsApi;
 
-const defaultApiFactory: GoogleEventsApiFactory = (accessToken) => {
-  const auth = new OAuth2Client();
-  auth.setCredentials({ access_token: accessToken });
-  const gcal: gCalendar = calendar({
-    version: "v3",
-    auth,
-    timeout: GOOGLE_REQUEST_TIMEOUT_MS,
-  });
+// Thin googleapis wrapper so tests can drive the real insert/patch param
+// mapping without OAuth. `conferenceDataVersion` must reach
+// `events.insert` or Google ignores `conferenceData.createRequest`.
+export const googleEventsApiFromClient = (gcal: gCalendar): GoogleEventsApi => {
   // An If-Match precondition is passed as a request header; googleapis takes
   // per-call gaxios options as the second argument.
   const ifMatchOptions = (ifMatch: string | null) =>
     ifMatch ? { headers: { "If-Match": ifMatch } } : undefined;
   return {
-    async insert({ calendarId, requestBody, sendUpdates }) {
+    async insert({
+      calendarId,
+      requestBody,
+      sendUpdates,
+      conferenceDataVersion,
+    }) {
       const { data } = await gcal.events.insert({
         calendarId,
         requestBody,
         sendUpdates,
+        ...(conferenceDataVersion !== undefined
+          ? { conferenceDataVersion }
+          : {}),
       });
       return data;
     },
@@ -146,6 +150,17 @@ const defaultApiFactory: GoogleEventsApiFactory = (accessToken) => {
       return data;
     },
   };
+};
+
+const defaultApiFactory: GoogleEventsApiFactory = (accessToken) => {
+  const auth = new OAuth2Client();
+  auth.setCredentials({ access_token: accessToken });
+  const gcal: gCalendar = calendar({
+    version: "v3",
+    auth,
+    timeout: GOOGLE_REQUEST_TIMEOUT_MS,
+  });
+  return googleEventsApiFromClient(gcal);
 };
 
 // Google implementation of the event mutation port. Create is idempotent at a


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3563

## What and why

Guest bookings onto a Google destination calendar already built `conferenceData.createRequest` and passed `conferenceDataVersion: 1` into the adapter's `GoogleEventsApi.insert`. The real googleapis wrapper then destructured only `calendarId`, `requestBody`, and `sendUpdates`, so Google never saw the version flag and silently ignored Meet. This extracts `googleEventsApiFromClient` from that wrapper and forwards `conferenceDataVersion` the same way `patch` already forwards `eventLabelVersion`. A new test drives the wrapper (not `FakeEventsApi`) and asserts the flag is present only when requested.

Microsoft Graph was checked: `FetchMicrosoftEventWriteApi.create` POSTs `params.body` as-is, including `isOnlineMeeting` / `onlineMeetingProvider`. No equivalent drop.

Manual staging check the loop cannot run: book a meeting on a Google-destination page, open the invite email, confirm the Meet link is present. Do not block this PR on that check.

## Verify

`VERDICT: PASS`

Selected packages: sync
Checks run: test:sync:fast, type-check, lint, knip
Checks skipped: (none)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8d28ca7-decd-49e5-a5f2-a6c88cc4f61a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8d28ca7-decd-49e5-a5f2-a6c88cc4f61a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

