### PR TITLE
fix(web): align weekly hours rows and drop the timezone footnote

### DIFF
--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -271,14 +271,16 @@ open over about 200 ms, and reduced motion disables the animation.
   copies the link, and then shows the full form with the switch focused.
 - **Timezone** uses the same searchable combobox as time travel. The
   trigger is one tab stop and still renders a stored non-canonical alias.
-  Under weekly hours a muted line reads the city and abbreviation and
-  points to More options. Every Start and End menu is described by that
-  line.
+  It lives under More options. The first-run hours step still says
+  "Times are in {city} ({abbr}). You can change this later." The go-live
+  summary has a Timezone row with that same label. The configured form
+  has no timezone footnote under Weekly hours.
 - **Weekly hours** are a list of the seven ISO weekdays, Monday first.
-  Each line is a checkbox named with the full weekday, the short label,
-  a Start menu, the word "to", an End menu, and one action cell. Menus
-  step by 15 minutes with 12-hour labels (`9:00 AM`). An unchecked day
-  shows only the checkbox and label and keeps the same line height.
+  Each line is a six-column grid with a fixed 1rem checkbox track so extra
+  blocks on a day line up with the first. Each line is a checkbox named
+  with the full weekday, the short label, a Start menu, the word "to", an
+  End menu, and one action cell. Menus step by 15 minutes with 12-hour
+  labels (`9:00 AM`). An unchecked day keeps the same column widths.
   The default is Monday to Friday, 9:00 AM to 5:00 PM. **Add hours to
   Monday** on a day's first line adds a second block under that day;
   each extra line's action cell removes that block. Start and End
@@ -574,6 +576,11 @@ Guest bookings onto a Google destination calendar now request Google Meet
 on the real `events.insert` call (`conferenceDataVersion: 1`). Before this,
 the adapter passed the conference payload but the googleapis wrapper dropped
 the version flag, so Google ignored Meet.
+
+The configured Meeting form no longer shows a timezone footnote under
+Weekly hours. Extra hour blocks on a day share the first line's left edge
+and width. The first-run go-live summary gained a Timezone row; the wizard
+hours step still names the zone.
 
 ### v1.9
 

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -208,10 +208,12 @@ holds the app lock first.
 On confirm, Compass creates a timed event on the host's destination
 calendar, invites the guest, and adds a conference link when the
 destination supports one (Google Meet, Microsoft Teams, or none). The
-provider emails the invite. Compass shows a confirmation screen with the
-booked time (guest timezone) and names that conference kind. Cancel and
-edit-details are present when the permalink carries `?token=`.
-Reschedule links stay history state only (v1.3).
+Google insert request includes `conferenceDataVersion: 1` so Meet is
+actually minted on the event. The provider emails the invite. Compass
+shows a confirmation screen with the booked time (guest timezone) and
+names that conference kind. Cancel and edit-details are present when the
+permalink carries `?token=`. Reschedule links stay history state only
+(v1.3).
 
 **Event title:** `{Guest name} and {Host name}`.
 
@@ -492,7 +494,8 @@ Guest reschedule is **in scope for v1.3**, not v1 / v1.1.
 - Flipping the production gate
 - Host reservation inbox
 - Meet URL on the confirmation screen (Google creates conference
-  asynchronously; the invite email already has it)
+  asynchronously; the invite email already has it once
+  `conferenceDataVersion` is forwarded on insert)
 
 ## Implementation
 
@@ -564,6 +567,13 @@ routes; these are the named events in `packages/web/src/auth/posthog/track.ts`.
   in the wire contract or Settings UI.
 
 ## Changelog
+
+### v1.10
+
+Guest bookings onto a Google destination calendar now request Google Meet
+on the real `events.insert` call (`conferenceDataVersion: 1`). Before this,
+the adapter passed the conference payload but the googleapis wrapper dropped
+the version flag, so Google ignored Meet.
 
 ### v1.9
 

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -340,15 +340,19 @@ test("second hours line aligns with the first", async ({ page }) => {
   );
   const mondayStart = settingsDialog.getByRole("combobox", {
     name: "Monday start",
+    exact: true,
   });
   const mondayStart2 = settingsDialog.getByRole("combobox", {
     name: "Monday start 2",
+    exact: true,
   });
   const mondayEnd = settingsDialog.getByRole("combobox", {
     name: "Monday end",
+    exact: true,
   });
   const mondayEnd2 = settingsDialog.getByRole("combobox", {
     name: "Monday end 2",
+    exact: true,
   });
   await expect(mondayStart2).toBeVisible();
 

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -331,6 +331,41 @@ test.describe("reduced motion", () => {
   });
 });
 
+test("second hours line aligns with the first", async ({ page }) => {
+  await prepareSignedInBookingSettingsPage(page);
+
+  const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+  await dispatchClick(
+    settingsDialog.getByRole("button", { name: "Add hours to Monday" }),
+  );
+  const mondayStart = settingsDialog.getByRole("combobox", {
+    name: "Monday start",
+  });
+  const mondayStart2 = settingsDialog.getByRole("combobox", {
+    name: "Monday start 2",
+  });
+  const mondayEnd = settingsDialog.getByRole("combobox", {
+    name: "Monday end",
+  });
+  const mondayEnd2 = settingsDialog.getByRole("combobox", {
+    name: "Monday end 2",
+  });
+  await expect(mondayStart2).toBeVisible();
+
+  const startBox = await mondayStart.boundingBox();
+  const start2Box = await mondayStart2.boundingBox();
+  const endBox = await mondayEnd.boundingBox();
+  const end2Box = await mondayEnd2.boundingBox();
+  expect(startBox).not.toBeNull();
+  expect(start2Box).not.toBeNull();
+  expect(endBox).not.toBeNull();
+  expect(end2Box).not.toBeNull();
+  expect(start2Box!.x).toBe(startBox!.x);
+  expect(start2Box!.width).toBe(startBox!.width);
+  expect(end2Box!.x).toBe(endBox!.x);
+  expect(end2Box!.width).toBe(endBox!.width);
+});
+
 test("settings dialog never scrolls horizontally with more options open", async ({
   page,
 }) => {

--- a/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
@@ -5,6 +5,7 @@ import {
   deriveGoogleEventId,
   type GoogleEventsApi,
   GoogleEventWriter,
+  googleEventsApiFromClient,
 } from "@sync/providers/google/google-event-writer.adapter";
 import { googleInstanceEventId } from "@sync/providers/google/google-instance-id";
 import { ProviderWriteError } from "@sync/providers/provider-event-writer.port";
@@ -1132,6 +1133,45 @@ describe("GoogleEventWriter", () => {
       .catch((e) => e)) as ProviderWriteError;
 
     expect(error.reason).toBe("permanentProviderError");
+  });
+});
+
+describe("googleEventsApiFromClient", () => {
+  it("forwards conferenceDataVersion on insert only when it is set", async () => {
+    const insertCalls: unknown[] = [];
+    const insert = async (params: unknown) => {
+      insertCalls.push(params);
+      return { data: scriptedEvent("abc12deadbeef00000000000") };
+    };
+    const unused = async () => ({
+      data: scriptedEvent("abc12deadbeef00000000000"),
+    });
+    const api = googleEventsApiFromClient({
+      events: {
+        insert,
+        patch: unused,
+        delete: unused,
+        get: unused,
+        instances: unused,
+      },
+    } as never);
+
+    await api.insert({
+      calendarId: "cal",
+      requestBody: {},
+      sendUpdates: "all",
+      conferenceDataVersion: 1,
+    });
+    await api.insert({
+      calendarId: "cal",
+      requestBody: {},
+      sendUpdates: "none",
+    });
+
+    expect(insertCalls[0]).toEqual(
+      expect.objectContaining({ conferenceDataVersion: 1 }),
+    );
+    expect(insertCalls[1]).not.toHaveProperty("conferenceDataVersion");
   });
 });
 

--- a/packages/sync/src/providers/google/google-event-writer.adapter.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.ts
@@ -85,24 +85,28 @@ export interface GoogleEventsApi {
 
 export type GoogleEventsApiFactory = (accessToken: string) => GoogleEventsApi;
 
-const defaultApiFactory: GoogleEventsApiFactory = (accessToken) => {
-  const auth = new OAuth2Client();
-  auth.setCredentials({ access_token: accessToken });
-  const gcal: gCalendar = calendar({
-    version: "v3",
-    auth,
-    timeout: GOOGLE_REQUEST_TIMEOUT_MS,
-  });
+// Thin googleapis wrapper so tests can drive the real insert/patch param
+// mapping without OAuth. `conferenceDataVersion` must reach
+// `events.insert` or Google ignores `conferenceData.createRequest`.
+export const googleEventsApiFromClient = (gcal: gCalendar): GoogleEventsApi => {
   // An If-Match precondition is passed as a request header; googleapis takes
   // per-call gaxios options as the second argument.
   const ifMatchOptions = (ifMatch: string | null) =>
     ifMatch ? { headers: { "If-Match": ifMatch } } : undefined;
   return {
-    async insert({ calendarId, requestBody, sendUpdates }) {
+    async insert({
+      calendarId,
+      requestBody,
+      sendUpdates,
+      conferenceDataVersion,
+    }) {
       const { data } = await gcal.events.insert({
         calendarId,
         requestBody,
         sendUpdates,
+        ...(conferenceDataVersion !== undefined
+          ? { conferenceDataVersion }
+          : {}),
       });
       return data;
     },
@@ -146,6 +150,17 @@ const defaultApiFactory: GoogleEventsApiFactory = (accessToken) => {
       return data;
     },
   };
+};
+
+const defaultApiFactory: GoogleEventsApiFactory = (accessToken) => {
+  const auth = new OAuth2Client();
+  auth.setCredentials({ access_token: accessToken });
+  const gcal: gCalendar = calendar({
+    version: "v3",
+    auth,
+    timeout: GOOGLE_REQUEST_TIMEOUT_MS,
+  });
+  return googleEventsApiFromClient(gcal);
 };
 
 // Google implementation of the event mutation port. Create is idempotent at a

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -610,7 +610,7 @@ describe("BookingSettingsSection", () => {
     expect(trigger).toHaveAccessibleName("Meeting timezone: UTC (UTC)");
   });
 
-  it("describes weekly hours from the muted timezone line and keeps the trigger in More options", async () => {
+  it("keeps the timezone trigger in More options", async () => {
     const user = userEvent.setup({ delay: null });
     userMetadataActions.set(healthyGoogleMetadata);
     server.use(
@@ -633,11 +633,10 @@ describe("BookingSettingsSection", () => {
       { wrapper },
     );
 
-    const mondayStart = await screen.findByRole("combobox", {
+    await screen.findByRole("combobox", {
       name: "Monday start",
     });
-    expect(mondayStart).toHaveAccessibleDescription(/Times in/);
-    expect(mondayStart).toHaveAccessibleDescription(/More options/);
+    expect(screen.queryByText(/Times in/)).not.toBeInTheDocument();
 
     await user.click(screen.getByText(BOOKING_MORE_OPTIONS_LABEL));
     const address = screen.getByLabelText("Page address");
@@ -1011,6 +1010,7 @@ describe("BookingSettingsSection", () => {
     setClipboard({ writeText });
     const savedBodies: unknown[] = [];
     userMetadataActions.set(healthyGoogleMetadata);
+    setPinnedTimeZone(HOST_TIME_ZONE);
 
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
@@ -1035,6 +1035,8 @@ describe("BookingSettingsSection", () => {
     await user.click(await screen.findByRole("button", { name: /^Continue/ }));
     await user.keyboard("k");
     await user.keyboard("k");
+    expect(screen.getByText("Timezone")).toBeInTheDocument();
+    expect(screen.getByText("Chicago (CDT)")).toBeInTheDocument();
     await user.click(
       await screen.findByRole("button", { name: /Turn on and copy link/ }),
     );
@@ -1102,6 +1104,7 @@ describe("BookingSettingsSection", () => {
   it("keeps the go-live step visible when enable fails", async () => {
     const user = userEvent.setup({ delay: null });
     userMetadataActions.set(healthyGoogleMetadata);
+    setPinnedTimeZone(HOST_TIME_ZONE);
 
     server.use(
       rest.get(bookingPageUrl, (_req, res, ctx) =>
@@ -1134,6 +1137,8 @@ describe("BookingSettingsSection", () => {
     await user.click(await screen.findByRole("button", { name: /^Continue/ }));
     await user.keyboard("k");
     await user.keyboard("k");
+    expect(screen.getByText("Timezone")).toBeInTheDocument();
+    expect(screen.getByText("Chicago (CDT)")).toBeInTheDocument();
     await user.click(
       await screen.findByRole("button", { name: /Turn on and copy link/ }),
     );

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -36,10 +36,7 @@ import { BookingMoreOptions } from "@web/booking/BookingMoreOptions";
 import { BookingNumberField } from "@web/booking/BookingNumberField";
 import { BookingSaveBar } from "@web/booking/BookingSaveBar";
 import { BookingStatusHeader } from "@web/booking/BookingStatusHeader";
-import {
-  BookingTimezoneField,
-  formatBookingTimezoneLabel,
-} from "@web/booking/BookingTimezoneField";
+import { BookingTimezoneField } from "@web/booking/BookingTimezoneField";
 import { BookingWeeklyHoursEditor } from "@web/booking/BookingWeeklyHoursEditor";
 import {
   bookingSaveErrorInline,
@@ -669,16 +666,11 @@ export function BookingSettingsSection({
 
         <div className="flex flex-col gap-1" {...bookingFieldAttrs("hours")}>
           <BookingWeeklyHoursEditor
-            describedBy="booking-hours-timezone"
             onChange={(weeklyAvailability) =>
               updateForm({ weeklyAvailability })
             }
             value={form.weeklyAvailability}
           />
-          <p className="text-sm text-text-muted" id="booking-hours-timezone">
-            Times in {formatBookingTimezoneLabel(form.timeZone)}. Change it
-            under More options.
-          </p>
         </div>
 
         <div>

--- a/packages/web/src/booking/BookingWeeklyHoursEditor.tsx
+++ b/packages/web/src/booking/BookingWeeklyHoursEditor.tsx
@@ -32,7 +32,7 @@ interface BookingWeeklyHoursEditorProps {
 }
 
 const HOURS_LINE_CLASS_NAME =
-  "grid min-h-8 grid-cols-[auto_2.5rem_1fr_auto_1fr_2rem] items-center gap-2";
+  "grid min-h-8 grid-cols-[1rem_2.5rem_1fr_auto_1fr_2rem] items-center gap-2";
 
 const blockSelectLabel = (
   weekday: IsoWeekday,

--- a/packages/web/src/booking/setup/BookingSetupGoLiveStep.tsx
+++ b/packages/web/src/booking/setup/BookingSetupGoLiveStep.tsx
@@ -3,7 +3,9 @@ import {
   type WeeklyAvailability,
 } from "@core/types/booking.contracts";
 import { type Calendar } from "@core/types/calendar.contracts";
+import { type TimeZone } from "@core/types/domain-primitives";
 import { bookingAddressPrefix } from "@web/booking/BookingAddressField";
+import { formatBookingTimezoneLabel } from "@web/booking/BookingTimezoneField";
 import { formatBookingDestinationOptionLabel } from "@web/booking/booking-conference.copy";
 import { summarizeAvailability } from "@web/booking/weekly-hours";
 
@@ -12,6 +14,7 @@ interface BookingSetupGoLiveStepProps {
   destinationCalendar: Calendar | undefined;
   durationMinutes: BookingDurationMinutes;
   slug: string;
+  timeZone: TimeZone;
   weeklyAvailability: WeeklyAvailability;
 }
 
@@ -20,6 +23,7 @@ export function BookingSetupGoLiveStep({
   destinationCalendar,
   durationMinutes,
   slug,
+  timeZone,
   weeklyAvailability,
 }: BookingSetupGoLiveStepProps) {
   const prefix = bookingAddressPrefix(bookingUrl);
@@ -37,6 +41,8 @@ export function BookingSetupGoLiveStep({
       </dd>
       <dt className="text-text-muted">Hours</dt>
       <dd>{hoursSummary}</dd>
+      <dt className="text-text-muted">Timezone</dt>
+      <dd>{formatBookingTimezoneLabel(timeZone)}</dd>
       <dt className="text-text-muted">Duration</dt>
       <dd>{durationMinutes} minutes</dd>
       <dt className="text-text-muted">Destination</dt>

--- a/packages/web/src/booking/setup/BookingSetupWizard.tsx
+++ b/packages/web/src/booking/setup/BookingSetupWizard.tsx
@@ -201,6 +201,7 @@ export function BookingSetupWizard({
             destinationCalendar={destinationCalendar}
             durationMinutes={form.durationMinutes}
             slug={form.slug ?? ""}
+            timeZone={form.timeZone}
             weeklyAvailability={form.weeklyAvailability}
           />
         ) : null}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3564

## What and why

Extra weekly-hours blocks sat 16px left of the first line because column 1 was `auto` (16px checkbox vs empty span). The first track is now a fixed `1rem`, matching the checkbox, so Start and End menus share left edge and width. The configured form no longer has "Times in Denver (MDT). Change it under More options." under Weekly hours. The wizard hours line stays. Go-live gained a Timezone row so a first-run host still confirms the zone once.

Stacked on #3576 until that Meet fix merges; this PR's unique commits are the hours/timezone UI change.

## Verify

`VERDICT: PASS`

Selected packages: sync, web
Checks run: test:sync:fast, test:web, type-check, lint, knip, test:a11y, test:e2e
`bun run verify --strict` exited 0 after the e2e locator used exact accessible names for Monday start/end.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8d28ca7-decd-49e5-a5f2-a6c88cc4f61a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8d28ca7-decd-49e5-a5f2-a6c88cc4f61a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

