### PR TITLE
fix(web): align weekly hours lines and show timezone on go-live

### DIFF
--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -269,14 +269,16 @@ open over about 200 ms, and reduced motion disables the animation.
   copies the link, and then shows the full form with the switch focused.
 - **Timezone** uses the same searchable combobox as time travel. The
   trigger is one tab stop and still renders a stored non-canonical alias.
-  Under weekly hours a muted line reads the city and abbreviation and
-  points to More options. Every Start and End menu is described by that
-  line.
+  It lives under More options on the configured form. The setup wizard
+  hours step shows a muted line with the city and abbreviation. The
+  go-live summary lists a **Timezone** row with the same label.
 - **Weekly hours** are a list of the seven ISO weekdays, Monday first.
   Each line is a checkbox named with the full weekday, the short label,
   a Start menu, the word "to", an End menu, and one action cell. Menus
   step by 15 minutes with 12-hour labels (`9:00 AM`). An unchecked day
-  shows only the checkbox and label and keeps the same line height.
+  shows only the checkbox and label and keeps the same line height and
+  column widths. Extra lines under a day align with the first line's
+  Start and End menus.
   The default is Monday to Friday, 9:00 AM to 5:00 PM. **Add hours to
   Monday** on a day's first line adds a second block under that day;
   each extra line's action cell removes that block. Start and End

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -309,6 +309,49 @@ test("essentials fit without scrolling at 1440x900", async ({ page }) => {
   );
 });
 
+test("second hours line aligns with the first", async ({ page }) => {
+  await prepareSignedInBookingSettingsPage(page);
+
+  const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+  await dispatchClick(
+    settingsDialog.getByRole("button", { name: "Add hours to Monday" }),
+  );
+  await expect(
+    settingsDialog.getByRole("combobox", { name: "Monday start 2" }),
+  ).toBeVisible();
+
+  const mondayStart = settingsDialog.getByRole("combobox", {
+    name: "Monday start",
+    exact: true,
+  });
+  const mondayStart2 = settingsDialog.getByRole("combobox", {
+    name: "Monday start 2",
+    exact: true,
+  });
+  const mondayEnd = settingsDialog.getByRole("combobox", {
+    name: "Monday end",
+    exact: true,
+  });
+  const mondayEnd2 = settingsDialog.getByRole("combobox", {
+    name: "Monday end 2",
+    exact: true,
+  });
+
+  const startBox = await mondayStart.boundingBox();
+  const start2Box = await mondayStart2.boundingBox();
+  const endBox = await mondayEnd.boundingBox();
+  const end2Box = await mondayEnd2.boundingBox();
+
+  expect(startBox).not.toBeNull();
+  expect(start2Box).not.toBeNull();
+  expect(endBox).not.toBeNull();
+  expect(end2Box).not.toBeNull();
+  expect(start2Box!.x).toBe(startBox!.x);
+  expect(start2Box!.width).toBe(startBox!.width);
+  expect(end2Box!.x).toBe(endBox!.x);
+  expect(end2Box!.width).toBe(endBox!.width);
+});
+
 test.describe("reduced motion", () => {
   test.use({ contextOptions: { reducedMotion: "reduce" } });
 

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -610,7 +610,7 @@ describe("BookingSettingsSection", () => {
     expect(trigger).toHaveAccessibleName("Meeting timezone: UTC (UTC)");
   });
 
-  it("describes weekly hours from the muted timezone line and keeps the trigger in More options", async () => {
+  it("keeps the timezone trigger in More options", async () => {
     const user = userEvent.setup({ delay: null });
     userMetadataActions.set(healthyGoogleMetadata);
     server.use(
@@ -633,11 +633,10 @@ describe("BookingSettingsSection", () => {
       { wrapper },
     );
 
-    const mondayStart = await screen.findByRole("combobox", {
+    await screen.findByRole("combobox", {
       name: "Monday start",
     });
-    expect(mondayStart).toHaveAccessibleDescription(/Times in/);
-    expect(mondayStart).toHaveAccessibleDescription(/More options/);
+    expect(screen.queryByText(/Times in/)).not.toBeInTheDocument();
 
     await user.click(screen.getByText(BOOKING_MORE_OPTIONS_LABEL));
     const address = screen.getByLabelText("Page address");
@@ -1035,6 +1034,9 @@ describe("BookingSettingsSection", () => {
     await user.click(await screen.findByRole("button", { name: /^Continue/ }));
     await user.keyboard("k");
     await user.keyboard("k");
+    expect(screen.getByText("Step 4 of 4")).toBeInTheDocument();
+    expect(screen.getByText("Timezone")).toBeInTheDocument();
+    expect(screen.getByText("UTC (UTC)")).toBeInTheDocument();
     await user.click(
       await screen.findByRole("button", { name: /Turn on and copy link/ }),
     );
@@ -1097,6 +1099,10 @@ describe("BookingSettingsSection", () => {
     await user.keyboard("k");
     expect(await screen.findByText("Step 4 of 5")).toBeInTheDocument();
     expect(screen.getByLabelText("Destination calendar")).toBeInTheDocument();
+    await user.click(await screen.findByRole("button", { name: /^Continue/ }));
+    expect(await screen.findByText("Step 5 of 5")).toBeInTheDocument();
+    expect(screen.getByText("Timezone")).toBeInTheDocument();
+    expect(screen.getByText("UTC (UTC)")).toBeInTheDocument();
   });
 
   it("keeps the go-live step visible when enable fails", async () => {

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -36,10 +36,7 @@ import { BookingMoreOptions } from "@web/booking/BookingMoreOptions";
 import { BookingNumberField } from "@web/booking/BookingNumberField";
 import { BookingSaveBar } from "@web/booking/BookingSaveBar";
 import { BookingStatusHeader } from "@web/booking/BookingStatusHeader";
-import {
-  BookingTimezoneField,
-  formatBookingTimezoneLabel,
-} from "@web/booking/BookingTimezoneField";
+import { BookingTimezoneField } from "@web/booking/BookingTimezoneField";
 import { BookingWeeklyHoursEditor } from "@web/booking/BookingWeeklyHoursEditor";
 import {
   bookingSaveErrorInline,
@@ -669,16 +666,11 @@ export function BookingSettingsSection({
 
         <div className="flex flex-col gap-1" {...bookingFieldAttrs("hours")}>
           <BookingWeeklyHoursEditor
-            describedBy="booking-hours-timezone"
             onChange={(weeklyAvailability) =>
               updateForm({ weeklyAvailability })
             }
             value={form.weeklyAvailability}
           />
-          <p className="text-sm text-text-muted" id="booking-hours-timezone">
-            Times in {formatBookingTimezoneLabel(form.timeZone)}. Change it
-            under More options.
-          </p>
         </div>
 
         <div>

--- a/packages/web/src/booking/BookingWeeklyHoursEditor.tsx
+++ b/packages/web/src/booking/BookingWeeklyHoursEditor.tsx
@@ -32,7 +32,7 @@ interface BookingWeeklyHoursEditorProps {
 }
 
 const HOURS_LINE_CLASS_NAME =
-  "grid min-h-8 grid-cols-[auto_2.5rem_1fr_auto_1fr_2rem] items-center gap-2";
+  "grid min-h-8 grid-cols-[1rem_2.5rem_1fr_auto_1fr_2rem] items-center gap-2";
 
 const blockSelectLabel = (
   weekday: IsoWeekday,

--- a/packages/web/src/booking/setup/BookingSetupGoLiveStep.tsx
+++ b/packages/web/src/booking/setup/BookingSetupGoLiveStep.tsx
@@ -3,7 +3,9 @@ import {
   type WeeklyAvailability,
 } from "@core/types/booking.contracts";
 import { type Calendar } from "@core/types/calendar.contracts";
+import { type TimeZone } from "@core/types/domain-primitives";
 import { bookingAddressPrefix } from "@web/booking/BookingAddressField";
+import { formatBookingTimezoneLabel } from "@web/booking/BookingTimezoneField";
 import { formatBookingDestinationOptionLabel } from "@web/booking/booking-conference.copy";
 import { summarizeAvailability } from "@web/booking/weekly-hours";
 
@@ -12,6 +14,7 @@ interface BookingSetupGoLiveStepProps {
   destinationCalendar: Calendar | undefined;
   durationMinutes: BookingDurationMinutes;
   slug: string;
+  timeZone: TimeZone;
   weeklyAvailability: WeeklyAvailability;
 }
 
@@ -20,6 +23,7 @@ export function BookingSetupGoLiveStep({
   destinationCalendar,
   durationMinutes,
   slug,
+  timeZone,
   weeklyAvailability,
 }: BookingSetupGoLiveStepProps) {
   const prefix = bookingAddressPrefix(bookingUrl);
@@ -37,6 +41,8 @@ export function BookingSetupGoLiveStep({
       </dd>
       <dt className="text-text-muted">Hours</dt>
       <dd>{hoursSummary}</dd>
+      <dt className="text-text-muted">Timezone</dt>
+      <dd>{formatBookingTimezoneLabel(timeZone)}</dd>
       <dt className="text-text-muted">Duration</dt>
       <dd>{durationMinutes} minutes</dd>
       <dt className="text-text-muted">Destination</dt>

--- a/packages/web/src/booking/setup/BookingSetupWizard.tsx
+++ b/packages/web/src/booking/setup/BookingSetupWizard.tsx
@@ -201,6 +201,7 @@ export function BookingSetupWizard({
             destinationCalendar={destinationCalendar}
             durationMinutes={form.durationMinutes}
             slug={form.slug ?? ""}
+            timeZone={form.timeZone}
             weeklyAvailability={form.weeklyAvailability}
           />
         ) : null}


### PR DESCRIPTION
Fixes #3564

## What and why

Booking v1.10 WP-02: weekly hours extra lines now align with the first line by using a fixed 1rem checkbox column, the configured Settings form no longer shows the muted timezone footnote under Weekly hours, and the setup wizard go-live summary adds a Timezone row so hosts confirm the zone before turning the page on. Spec: `docs/features/booking.md`.

## Verify

```
Selected packages: web
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)

✓ All checks passed
VERDICT: PASS
```