### PR TITLE
fix(web): move destination calendar under More options in booking settings

### DIFF
--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -250,15 +250,16 @@ open over about 200 ms, and reduced motion disables the animation.
   live. When on, it shows the meeting link with Copy and
   **Open meeting page**. When off, it shows "Off. Turn it on to share
   your link." and the address the page will use.
-- **Essentials:** duration, weekly hours, and
-  destination calendar. These fit without scrolling at 1440x900.
+- **Essentials:** duration and weekly hours. These fit without scrolling
+  at 1440x900.
 - **More options:** an uncontrolled native `<details>` that starts
   collapsed. It holds page address (the slug rule appears only as an
   error; "Links using your old address will stop working." when the
-  slug changes), meeting timezone, blocking calendars, minimum notice,
-  and maximum horizon. Jumping to a field inside it, or
-  an invalid field in the group, opens it. Do not control the `open`
-  prop from React: the jump-key code opens the element imperatively.
+  slug changes), destination calendar, meeting timezone, blocking
+  calendars, minimum notice, and maximum horizon. Jumping to a field
+  inside it, or an invalid field in the group, opens it. Do not
+  control the `open` prop from React: the jump-key code opens the
+  element imperatively.
 - **First run:** before any draft exists, Meeting settings open a guided
   setup wizard: one question per screen with "Step N of M", a title, one
   sentence, and **Continue** (Mod+Enter). Steps are address, weekly hours,

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -382,9 +382,15 @@ test("settings dialog never scrolls horizontally with more options open", async 
 
   const settingsDialog = page.getByRole("dialog", { name: "Settings" });
   await expect(
+    settingsDialog.getByRole("combobox", { name: "Destination calendar" }),
+  ).toHaveCount(0);
+  await expect(
     settingsDialog.getByRole("button", { name: /Meeting timezone:/ }),
   ).toHaveCount(0);
   await openMoreOptions(settingsDialog);
+  await expect(
+    settingsDialog.getByRole("combobox", { name: "Destination calendar" }),
+  ).toBeVisible();
   await settingsDialog
     .getByRole("button", { name: /Meeting timezone:/ })
     .click();

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -417,7 +417,7 @@ describe("BookingSettingsSection", () => {
     ]);
   });
 
-  it("shows only address, blocking calendars, notice, and horizon in More options", async () => {
+  it("shows only address, destination calendar, blocking calendars, notice, and horizon in More options", async () => {
     userMetadataActions.set(healthyGoogleMetadata);
 
     server.use(
@@ -440,6 +440,7 @@ describe("BookingSettingsSection", () => {
     await userEvent.setup({ delay: null }).click(summary);
 
     expect(screen.getByLabelText("Page address")).toBeInTheDocument();
+    expect(screen.getByLabelText("Destination calendar")).toBeInTheDocument();
     expect(screen.getByText("Blocking calendars")).toBeInTheDocument();
     expect(screen.getByLabelText("Minimum notice (hours)")).toBeInTheDocument();
     expect(screen.getByLabelText("Maximum horizon (days)")).toBeInTheDocument();
@@ -640,11 +641,18 @@ describe("BookingSettingsSection", () => {
 
     await user.click(screen.getByText(BOOKING_MORE_OPTIONS_LABEL));
     const address = screen.getByLabelText("Page address");
+    const destination = screen.getByRole("combobox", {
+      name: "Destination calendar",
+    });
     const trigger = screen.getByRole("button", {
       name: /^Meeting timezone:/,
     });
     expect(
-      address.compareDocumentPosition(trigger) &
+      address.compareDocumentPosition(destination) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(
+      destination.compareDocumentPosition(trigger) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
@@ -2857,6 +2865,9 @@ describe("BookingSettingsSection", () => {
         screen.getByRole("combobox", { name: "Destination calendar" }),
       );
     });
+    const summary = screen.getByText(BOOKING_MORE_OPTIONS_LABEL);
+    const details = summary.closest("details");
+    expect(details).toHaveAttribute("open");
   });
 });
 

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -88,6 +88,7 @@ const DURATION_OPTIONS: BookingDurationMinutes[] = [15, 30, 45, 60];
 
 const MORE_OPTIONS_FIELDS = new Set<BookingField>([
   "address",
+  "destination",
   "timezone",
   "blocking",
   "notice",
@@ -673,61 +674,6 @@ export function BookingSettingsSection({
           />
         </div>
 
-        <div>
-          <BookingFieldLabel htmlFor="booking-destination-calendar">
-            Destination calendar
-          </BookingFieldLabel>
-          <select
-            {...bookingFieldAttrs("destination")}
-            aria-describedby={
-              destinationCannotMintMeet ? destinationMeetWarningId : undefined
-            }
-            className={BOOKING_SELECT_CLASS_NAME}
-            id="booking-destination-calendar"
-            onChange={(event) =>
-              handleDestinationChange(event.target.value as CalendarId)
-            }
-            value={form.destinationCalendarId}
-          >
-            {writableCalendars.length === 0 ? (
-              <option value={BOOKING_PLACEHOLDER_CALENDAR_ID}>
-                No writable calendars
-              </option>
-            ) : (
-              <>
-                {writableGroups
-                  .filter((group) => group.calendars.length > 0)
-                  .map((group) => (
-                    <optgroup
-                      key={group.accountEmail}
-                      label={group.accountEmail}
-                    >
-                      {group.calendars.map((calendar) => (
-                        <option key={calendar.id} value={calendar.id}>
-                          {formatBookingDestinationOptionLabel(calendar)}
-                        </option>
-                      ))}
-                    </optgroup>
-                  ))}
-                {writableUngrouped.map((calendar) => (
-                  <option key={calendar.id} value={calendar.id}>
-                    {formatBookingDestinationOptionLabel(calendar)}
-                  </option>
-                ))}
-              </>
-            )}
-          </select>
-          {destinationConferenceHint ? (
-            <p
-              className="mt-1 text-sm text-warning"
-              id={destinationMeetWarningId}
-              role="status"
-            >
-              {destinationConferenceHint}
-            </p>
-          ) : null}
-        </div>
-
         <BookingMoreOptions forceOpen={forceOpenMoreOptions}>
           <BookingAddressField
             bookingUrl={savedPage?.bookingUrl ?? null}
@@ -736,6 +682,61 @@ export function BookingSettingsSection({
             savedSlug={savedSlug}
             slug={form.slug ?? ""}
           />
+
+          <div>
+            <BookingFieldLabel htmlFor="booking-destination-calendar">
+              Destination calendar
+            </BookingFieldLabel>
+            <select
+              {...bookingFieldAttrs("destination")}
+              aria-describedby={
+                destinationCannotMintMeet ? destinationMeetWarningId : undefined
+              }
+              className={BOOKING_SELECT_CLASS_NAME}
+              id="booking-destination-calendar"
+              onChange={(event) =>
+                handleDestinationChange(event.target.value as CalendarId)
+              }
+              value={form.destinationCalendarId}
+            >
+              {writableCalendars.length === 0 ? (
+                <option value={BOOKING_PLACEHOLDER_CALENDAR_ID}>
+                  No writable calendars
+                </option>
+              ) : (
+                <>
+                  {writableGroups
+                    .filter((group) => group.calendars.length > 0)
+                    .map((group) => (
+                      <optgroup
+                        key={group.accountEmail}
+                        label={group.accountEmail}
+                      >
+                        {group.calendars.map((calendar) => (
+                          <option key={calendar.id} value={calendar.id}>
+                            {formatBookingDestinationOptionLabel(calendar)}
+                          </option>
+                        ))}
+                      </optgroup>
+                    ))}
+                  {writableUngrouped.map((calendar) => (
+                    <option key={calendar.id} value={calendar.id}>
+                      {formatBookingDestinationOptionLabel(calendar)}
+                    </option>
+                  ))}
+                </>
+              )}
+            </select>
+            {destinationConferenceHint ? (
+              <p
+                className="mt-1 text-sm text-warning"
+                id={destinationMeetWarningId}
+                role="status"
+              >
+                {destinationConferenceHint}
+              </p>
+            ) : null}
+          </div>
 
           <div className="min-w-0" {...bookingFieldAttrs("timezone")}>
             <BookingTimezoneField


### PR DESCRIPTION
Fixes #3565

## What and why

Moves the configured Meeting form's **Destination calendar** field from Essentials into **More options**, directly after Page address and before Meeting timezone. Essentials now shows status header, Duration, Weekly hours, More options, and Save. Save errors on the destination field open More options and focus the select (via existing `focusBookingField` and `MORE_OPTIONS_FIELDS`). The setup wizard destination step is unchanged.

Spec: [docs/features/booking.md](https://github.com/KeepSoftwareSimple/compass-calendar/blob/main/docs/features/booking.md)

## Verify

```
bun run verify --strict
```

Selected packages: web
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e

VERDICT: PASS