### PR TITLE
fix(web): lead the mobile intro with the desktop pitch before the game

### DIFF
--- a/packages/web/src/components/MobileGate/MobileGate.test.tsx
+++ b/packages/web/src/components/MobileGate/MobileGate.test.tsx
@@ -43,10 +43,25 @@ describe("MobileGate", () => {
   });
 
   describe("Intro", () => {
-    it("pitches the game with play and skip actions", () => {
+    it("leads with the desktop pitch, then the game with play and skip actions", () => {
       render(<MobileGate />);
 
-      expect(screen.getByText("Time Block Party")).toBeInTheDocument();
+      // The product comes first so phone visitors don't mistake the game
+      // for the app; the game is framed as a bonus while they're here.
+      expect(
+        screen.getByRole("heading", {
+          level: 1,
+          name: "Compass is a keyboard-first calendar",
+        }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "It's built for the desktop, so it doesn't run on phones yet. While you're here, we made you a little game for fun.",
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { level: 2, name: "Time Block Party" }),
+      ).toBeInTheDocument();
       expect(
         screen.getByRole("button", { name: /^play$/i }),
       ).toBeInTheDocument();

--- a/packages/web/src/components/MobileGate/MobileGate.tsx
+++ b/packages/web/src/components/MobileGate/MobileGate.tsx
@@ -24,7 +24,10 @@ import { pointerPassAttributes } from "@web/shortcuts/keyboard-only/pointer-acti
  * The mobile landing experience: instead of a cold "use a desktop" wall,
  * visitors get Time Block Party, a short drag-the-event-into-place game, and
  * the desktop handoff (copy link + waitlist) arrives with their score at the
- * end. The intro's skip link goes straight to the handoff.
+ * end. The intro leads with what Compass actually is (a keyboard-first
+ * desktop calendar) before pitching the game, so first-time phone visitors
+ * don't mistake the game for the product. The intro's skip link goes
+ * straight to the handoff.
  */
 export const MobileGate: React.FC<{
   /** Test seam: start from a mid-game or finished state. */
@@ -74,12 +77,21 @@ export const MobileGate: React.FC<{
         <div className="flex min-h-dvh items-center justify-center p-4">
           <div className="flex w-[400px] max-w-[90vw] flex-col items-center rounded border border-border bg-surface p-8 text-center">
             <h1 className="mb-3 font-medium font-sans text-2xl text-text">
-              Time Block Party
+              Compass is a keyboard-first calendar
             </h1>
-            <p className="mb-8 font-sans text-base text-text-muted leading-relaxed">
-              Compass turns your week into blocks of time. Drag each event to
-              its spot on the calendar and rack up points.
+            <p className="mb-6 font-sans text-base text-text-muted leading-relaxed">
+              It&apos;s built for the desktop, so it doesn&apos;t run on phones
+              yet. While you&apos;re here, we made you a little game for fun.
             </p>
+            <div className="mb-6 w-full rounded border border-border bg-surface-overlay px-4 py-3">
+              <h2 className="font-medium font-sans text-lg text-text">
+                Time Block Party
+              </h2>
+              <p className="mt-1 font-sans text-sm text-text-muted leading-relaxed">
+                Compass turns your week into blocks of time. Drag each event to
+                its spot on the calendar and rack up points.
+              </p>
+            </div>
             <button
               type="button"
               onClick={() => setGame((state) => startGame(state, Date.now()))}


### PR DESCRIPTION
Fixes: no linked issue (founder request in session).

## What and why

First-time phone visitors to compasscalendar.com land on the Time Block Party intro and read the game as the product. The intro now leads with what Compass is (a keyboard-first calendar built for the desktop, not on phones yet) and frames the game as a bonus while they are here. The game title moves to an h2 inside a card that reuses the final-score card styling, so the intro and the end screen read as the same object.

The heading and button names the mobile gate e2e spec locates (`Time Block Party` heading, `Play`, `Skip to desktop link`) are unchanged, so no e2e edits. The unit test now pins the heading levels and the new pitch copy.

## Verify

`VERDICT: FAIL` locally. Checks run: test:web, type-check, lint, knip, Playwright e2e (145 passed, 32 failed).

All 32 failures are the documented macOS-local false failures, none in a file this diff can affect:

- 31 wait on `getByRole('dialog', { name: 'Settings' })` in `booking-a11y.spec.ts`, `host-settings.spec.ts`, `public-booking-v15.spec.ts`, `connect-onboarding-a11y.spec.ts`, and `microsoft-surfaces.spec.ts`. The booking harness opens Settings with Control+Comma, which is Meta+Comma on macOS.
- 1 is `account-page-jump.spec.ts` hold-Mod, which fails locally even against `origin/main`.

Both `e2e/onboarding/mobile-gate.spec.ts` specs passed. The `MobileGate` unit file passes (11/11). Also verified in the browser preview at 375x812 with a mobile user agent: intro renders the new pitch, Play still starts Level 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
