### PR TITLE
fix(web): stop the settings dialog flashing the calendar on first scroll

### DIFF
--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -245,6 +245,8 @@ group. Hours are a per-day list: a checkbox, short label, Start and
 End menus, and an action cell. Settings is anchored to
 the top of the viewport and grows downward; More options animates
 open over about 200 ms, and reduced motion disables the animation.
+The dialog panel is a compositor layer at mount. An inner wrapper
+scrolls, so the first wheel tick does not re-rasterize the backdrop.
 
 - **Status:** a **Meeting page** switch reflects whether the page is
   live. When on, it shows the meeting link with Copy and
@@ -581,6 +583,12 @@ the version flag, so Google ignored Meet.
 
 The guest confirmation page dropped **Copy cancel link** and **Copy
 reschedule link**. Meeting actions are the two links only.
+
+Opening Settings no longer flashes the calendar behind the dialog on the
+first scroll: the panel is promoted at mount, and an inner wrapper owns
+overflow so the transform transition is not on the scroll container. The
+Meeting tab's lazy chunk reserves height so the dialog does not collapse
+to the nav column while it loads.
 
 ### v1.9
 

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -17,6 +17,18 @@ const openMoreOptions = async (settingsDialog: Locator) => {
   await settingsDialog.getByText("More options", { exact: true }).click();
 };
 
+const scrollSettingsDialog = async (
+  settingsDialog: Locator,
+  scrollTop: number,
+) =>
+  settingsDialog.evaluate((el, top) => {
+    const scroller =
+      (el.querySelector(":scope > .overflow-y-auto") as HTMLElement | null) ??
+      el;
+    scroller.scrollTop = top;
+    return scroller.scrollTop;
+  }, scrollTop);
+
 test("settings booking page shows a copyable public link after save", async ({
   page,
 }) => {
@@ -105,9 +117,7 @@ test("keyboard hint sits in the nav column and the last control stays above Save
   await expect(hint).toBeVisible();
 
   await lastControl.scrollIntoViewIfNeeded();
-  await settingsDialog.evaluate((el) => {
-    el.scrollTop = el.scrollHeight;
-  });
+  await scrollSettingsDialog(settingsDialog, 10_000);
 
   const lastBox = await lastControl.boundingBox();
   const saveBarTop = await save.evaluate((el) => {
@@ -296,9 +306,7 @@ test("essentials fit without scrolling at 1440x900", async ({ page }) => {
   const summary = settingsDialog.getByText("More options", { exact: true });
   await expect(summary).toBeVisible();
 
-  await settingsDialog.evaluate((el) => {
-    el.scrollTop = 0;
-  });
+  await scrollSettingsDialog(settingsDialog, 0);
 
   const dialogBox = await settingsDialog.boundingBox();
   const summaryBox = await summary.boundingBox();
@@ -307,6 +315,17 @@ test("essentials fit without scrolling at 1440x900", async ({ page }) => {
   expect(summaryBox!.y + summaryBox!.height).toBeLessThanOrEqual(
     dialogBox!.y + dialogBox!.height,
   );
+});
+
+test("settings dialog body scrolls on an inner wrapper", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 700 });
+  await prepareSignedInBookingSettingsPage(page);
+  const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+  await openMoreOptions(settingsDialog);
+  const before = await scrollSettingsDialog(settingsDialog, 0);
+  expect(before).toBe(0);
+  const after = await scrollSettingsDialog(settingsDialog, 80);
+  expect(after).toBeGreaterThan(0);
 });
 
 test("second hours line aligns with the first", async ({ page }) => {

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.test.tsx
@@ -28,7 +28,13 @@ describe("OverlayPanel", () => {
 
     const dialog = screen.getByRole("dialog", { name: "Settings" });
     expect(dialog.className).toContain("max-h-[90vh]");
-    expect(dialog.className).toContain("overflow-y-auto");
+    expect(dialog.className).toContain("will-change-transform");
+    expect(dialog.className).toContain("transition-transform");
+    expect(dialog.className).not.toContain("overflow-y-auto");
+    const scroller = dialog.firstElementChild;
+    expect(scroller).not.toBeNull();
+    expect(scroller?.className).toContain("overflow-y-auto");
+    expect(dialog.parentElement?.className).toContain("bg-background/85");
   });
 
   it("centers the backdrop by default", () => {

--- a/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
+++ b/packages/web/src/components/OverlayPanel/OverlayPanel.tsx
@@ -144,7 +144,7 @@ export const OverlayPanel = ({
     align === "start" ? "items-start" : "items-center",
     variant === "modal" && [
       widthClassName,
-      "max-h-[90vh] max-w-[90vw] overflow-y-auto rounded-xl p-8",
+      "max-h-[90vh] max-w-[90vw] overflow-hidden rounded-xl will-change-transform",
       "transition-transform duration-400 ease-out data-closing:scale-105 motion-reduce:transition-none",
       panelClassName ??
         "gap-6 bg-surface-panel shadow-[0_20px_25px_-5px_rgba(0,0,0,0.1),0_10px_10px_-5px_rgba(0,0,0,0.04)]",
@@ -152,6 +152,11 @@ export const OverlayPanel = ({
     variant === "status" &&
       "max-w-sm gap-3 rounded-lg border border-border bg-surface/90 px-6 py-5 shadow-lg",
     variant === "status" && panelClassName,
+  );
+
+  const scrollBodyClasses = classNames(
+    "flex min-h-0 w-full flex-1 flex-col gap-6 overflow-y-auto p-8",
+    align === "start" ? "items-start" : "items-center",
   );
 
   const titleClasses = classNames(
@@ -204,6 +209,32 @@ export const OverlayPanel = ({
     }
   };
 
+  const panelBody = (
+    <>
+      {icon}
+      {title && (
+        <div className="flex w-full items-center justify-between gap-3">
+          {variant === "modal" ? (
+            <h2 id={titleId} className={titleClasses}>
+              {title}
+            </h2>
+          ) : (
+            <div id={titleId} className={titleClasses}>
+              {title}
+            </div>
+          )}
+          {titleAction}
+        </div>
+      )}
+      {message && (
+        <p id={messageId} className={messageClasses}>
+          {message}
+        </p>
+      )}
+      {children}
+    </>
+  );
+
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: The backdrop catches outside clicks, Tab/Mod+Enter, and in-tree Escape. Document Escape (useOverlayEscape) covers the case where focus is on body.
     <div
@@ -228,27 +259,11 @@ export const OverlayPanel = ({
         aria-describedby={message ? messageId : undefined}
         aria-live={role === "status" ? "polite" : undefined}
       >
-        {icon}
-        {title && (
-          <div className="flex w-full items-center justify-between gap-3">
-            {variant === "modal" ? (
-              <h2 id={titleId} className={titleClasses}>
-                {title}
-              </h2>
-            ) : (
-              <div id={titleId} className={titleClasses}>
-                {title}
-              </div>
-            )}
-            {titleAction}
-          </div>
+        {variant === "modal" ? (
+          <div className={scrollBodyClasses}>{panelBody}</div>
+        ) : (
+          panelBody
         )}
-        {message && (
-          <p id={messageId} className={messageClasses}>
-            {message}
-          </p>
-        )}
-        {children}
       </div>
     </div>
   );

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -1021,9 +1021,9 @@ describe("SettingsModal", () => {
 
   // The booking section is lazily imported (BookingSettingsSection.lazy) to
   // keep the booking admin stack off the boot chunk, behind a Suspense
-  // fallback of null. A chunk that never resolves would render an empty
-  // settings pane rather than throwing, so assert the section actually
-  // arrives instead of trusting the boundary.
+  // fallback that reserves the Meeting pane height. A chunk that never
+  // resolves would keep that reserved box rather than throwing, so assert
+  // the section actually arrives instead of trusting the boundary.
   it("resolves the lazily loaded booking section", async () => {
     renderSettings({ authenticated: true, page: "booking" });
 

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -265,7 +265,9 @@ export const SettingsModal: FC = () => {
           {page === "billing" ? (
             <PlanSection showShortcuts={areHintsVisible} />
           ) : page === "booking" && IS_BOOKING_ENABLED ? (
-            <Suspense fallback={null}>
+            <Suspense
+              fallback={<div aria-hidden className="min-h-[28rem] w-full" />}
+            >
               <BookingSettingsSection
                 dismissGuardRef={bookingDismissGuardRef}
                 onDiscardUnsaved={dismissToPalette}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3570

## What and why

Opening Settings > Meeting and scrolling for the first time could flash the calendar through the dimmed backdrop. The panel was both the scroll container and the node with `transition-transform`, so the first wheel tick promoted it to a compositor layer and re-rasterized the parent's `backdrop-filter`. The Meeting tab is also lazy-loaded behind `Suspense fallback={null}`, which collapsed the dialog to the nav column until the chunk landed.

The panel now keeps the close transform and is promoted at mount (`will-change-transform`). An inner wrapper owns `overflow-y-auto`. The Meeting `Suspense` fallback reserves `min-h-[28rem]` so the dialog does not snap.

## Measured

Before: the dialog node had `overflow-y: auto` and `transition-transform` together. `will-change` was `auto`. The first scroll is the usual moment Chrome promotes a scroller; that promotion changes the containing layer for `backdrop-blur-sm` on the fixed backdrop, so one frame shows the calendar undimmed.

After:
- dialog: `will-change-transform`, overflow hidden, still has `transition-transform`
- first child: `overflow-y-auto`
- backdrop: still `bg-background/85` plus `backdrop-blur-sm`

(a) inner scroll wrapper and (b) `will-change-transform` at mount. (c) opaque-without-blur backdrop was not needed.

## Verify

`bun run verify --strict`

Selected packages: web
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e

VERDICT: PASS

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8d28ca7-decd-49e5-a5f2-a6c88cc4f61a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8d28ca7-decd-49e5-a5f2-a6c88cc4f61a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

