### PR TITLE
fix(booking): meeting description blank lines and linked URLs in editor

### DIFF
--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -217,9 +217,11 @@ permalink carries `?token=`. Reschedule links stay history state only
 
 **Event title:** `{Guest name} and {Host name}`.
 
-**Event description:** guest notes (if any), plus cancel and reschedule
-URLs. Guests cannot add other attendees, so those URLs are safe in the
-description every invitee sees.
+**Event description:** three blocks separated by blank lines: guest notes
+(when present), `Cancel: <url>`, and `Reschedule: <url>`. In Compass the
+description editor renders each block as its own paragraph and autolinks
+bare URLs. Guests cannot add other attendees, so those URLs are safe in
+the description every invitee sees.
 
 ## Host inputs
 

--- a/packages/backend/src/booking/services/calendar-booking.service.test.ts
+++ b/packages/backend/src/booking/services/calendar-booking.service.test.ts
@@ -157,10 +157,13 @@ describe("CalendarBookingService", () => {
       submitCommand,
     } as unknown as SyncServiceClient);
 
+    const description =
+      "Cancel: https://compasscalendar.com/cancel/x\n\nReschedule: https://compasscalendar.com/reschedule/x";
+
     await service.createBookingEvent(userId(), {
       calendarId: calendarId(),
       title: "Ada and Tyler",
-      description: "Cancel: https://compasscalendar.com/cancel/x",
+      description,
       start: "2026-09-01T15:00:00.000Z",
       end: "2026-09-01T15:30:00.000Z",
       timeZone: "America/Denver",
@@ -170,6 +173,7 @@ describe("CalendarBookingService", () => {
 
     expect(submitCommand).toHaveBeenCalledTimes(1);
     const [, request] = submitCommand.mock.calls[0] ?? [];
+    expect(request.input.content.description).toBe(description);
     expect(request.input).toMatchObject({
       kind: "create",
       invitation: "all",

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -1438,10 +1438,8 @@ describe("PublicBookingService", () => {
     const eventInput = createBookingEvent.mock.calls[0]?.[1] as {
       description: string;
     };
-    expect(eventInput.description).toContain("bring coffee");
-    expect(eventInput.description).toContain(`Cancel: ${created.cancelUrl}`);
-    expect(eventInput.description).toContain(
-      `Reschedule: ${created.rescheduleUrl}`,
+    expect(eventInput.description).toBe(
+      `bring coffee\n\nCancel: ${created.cancelUrl}\n\nReschedule: ${created.rescheduleUrl}`,
     );
   });
 
@@ -1504,9 +1502,7 @@ describe("PublicBookingService", () => {
     const description = (
       updateBookingEvent.mock.calls[0]?.[1] as { description: string }
     ).description;
-    expect(description).toContain("bring tea");
-    expect(description).toContain("Cancel:");
-    expect(description).toContain("Reschedule:");
+    expect(description).toMatch(/^bring tea\n\nCancel: .+\n\nReschedule: .+$/);
     const stored = await bookingReservationRepository.findById(reservationId);
     expect(stored?.guestName).toBe("Grace Hopper");
     expect(stored?.notes).toBe("bring tea");

--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -207,7 +207,11 @@ const bookingEventDescription = (
   cancelUrl: string,
   rescheduleUrl: string,
 ): string =>
-  [notes?.trim() || null, `Cancel: ${cancelUrl}\nReschedule: ${rescheduleUrl}`]
+  [
+    notes?.trim() || null,
+    `Cancel: ${cancelUrl}`,
+    `Reschedule: ${rescheduleUrl}`,
+  ]
     .filter(Boolean)
     .join("\n\n");
 

--- a/packages/web/src/components/DescriptionEditor/DescriptionEditor.test.tsx
+++ b/packages/web/src/components/DescriptionEditor/DescriptionEditor.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { DescriptionEditor } from "@web/components/DescriptionEditor/DescriptionEditor";
 import { describe, expect, it, mock } from "bun:test";
@@ -183,6 +183,50 @@ describe("DescriptionEditor", () => {
     expect(textbox.innerHTML).not.toContain("javascript:");
     expect(screen.queryByRole("link")).toBeNull();
     expect(textbox.textContent).toBe("click me");
+  });
+
+  it("renders plain-text booking descriptions as three paragraphs with links", () => {
+    const cancelUrl = "https://x/meet/cancel/1?token=a";
+    const rescheduleUrl = "https://x/meet/reschedule/1?token=b";
+    render(
+      <DescriptionEditor
+        value={`Recovered\n\nCancel: ${cancelUrl}\n\nReschedule: ${rescheduleUrl}`}
+        onChange={mock()}
+        editable={false}
+        resetKey="test-booking-plain"
+      />,
+    );
+
+    const textbox = screen.getByRole("textbox", { name: "Description" });
+    const region = within(textbox);
+    expect(region.getByText("Recovered")).toBeTruthy();
+    expect(region.getByText(/^Cancel:/)).toBeTruthy();
+    expect(region.getByText(/^Reschedule:/)).toBeTruthy();
+    expect((textbox.innerHTML.match(/<p>/g) ?? []).length).toBe(3);
+    expect(screen.getByRole("link", { name: cancelUrl })).toHaveAttribute(
+      "href",
+      cancelUrl,
+    );
+    expect(screen.getByRole("link", { name: rescheduleUrl })).toHaveAttribute(
+      "href",
+      rescheduleUrl,
+    );
+  });
+
+  it("leaves existing HTML descriptions untouched", () => {
+    render(
+      <DescriptionEditor
+        value='<p>Notes</p><p><a href="https://example.com/meet">https://example.com/meet</a></p>'
+        onChange={mock()}
+        editable={false}
+        resetKey="test-booking-html"
+      />,
+    );
+
+    const textbox = screen.getByRole("textbox", { name: "Description" });
+    expect(within(textbox).getByText("Notes")).toBeTruthy();
+    expect((textbox.innerHTML.match(/<p>/g) ?? []).length).toBe(2);
+    expect(screen.getAllByRole("link")).toHaveLength(1);
   });
 
   it("re-syncs contenteditable when editable flips on the same event", () => {

--- a/packages/web/src/components/DescriptionEditor/DescriptionEditor.tsx
+++ b/packages/web/src/components/DescriptionEditor/DescriptionEditor.tsx
@@ -11,6 +11,10 @@ import { StarterKit } from "@tiptap/starter-kit";
 import classNames from "classnames";
 import DOMPurify from "dompurify";
 import { type KeyboardEvent, useEffect, useMemo, useState } from "react";
+import {
+  looksLikeHtml,
+  plainTextToDescriptionHtml,
+} from "@web/components/DescriptionEditor/plain-text-description";
 import { Divider } from "@web/components/Divider/Divider";
 
 // Google's description HTML is untrusted input - strip everything but the
@@ -94,7 +98,10 @@ export const DescriptionEditor = ({
   // resetKey only, matching useEditor's own [resetKey] below.
   // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on resetKey only, see the comment above
   const initialContent = useMemo(
-    () => sanitizeDescriptionHtml(value),
+    () =>
+      sanitizeDescriptionHtml(
+        looksLikeHtml(value) ? value : plainTextToDescriptionHtml(value),
+      ),
     [resetKey],
   );
 

--- a/packages/web/src/components/DescriptionEditor/plain-text-description.test.ts
+++ b/packages/web/src/components/DescriptionEditor/plain-text-description.test.ts
@@ -1,0 +1,40 @@
+import {
+  looksLikeHtml,
+  plainTextToDescriptionHtml,
+} from "@web/components/DescriptionEditor/plain-text-description";
+import { describe, expect, it } from "bun:test";
+
+describe("looksLikeHtml", () => {
+  it("returns true for HTML paragraph content", () => {
+    expect(looksLikeHtml("<p>x</p>")).toBe(true);
+  });
+
+  it("returns false for less-than comparisons in plain text", () => {
+    expect(looksLikeHtml("a < b")).toBe(false);
+  });
+});
+
+describe("plainTextToDescriptionHtml", () => {
+  it("turns booking descriptions into three paragraphs with linked URLs", () => {
+    const input =
+      "Recovered\n\nCancel: https://x/meet/cancel/1?token=a\n\nReschedule: https://x/meet/reschedule/1?token=b";
+    const html = plainTextToDescriptionHtml(input);
+
+    expect(html).toBe(
+      '<p>Recovered</p><p>Cancel: <a href="https://x/meet/cancel/1?token=a">https://x/meet/cancel/1?token=a</a></p><p>Reschedule: <a href="https://x/meet/reschedule/1?token=b">https://x/meet/reschedule/1?token=b</a></p>',
+    );
+  });
+
+  it("turns a single newline into a line break inside one paragraph", () => {
+    expect(plainTextToDescriptionHtml("line one\nline two")).toBe(
+      "<p>line one<br>line two</p>",
+    );
+  });
+
+  it("escapes script tags in plain text instead of rendering them", () => {
+    const html = plainTextToDescriptionHtml("<script>alert(1)</script>");
+
+    expect(html).toBe("<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>");
+    expect(html).not.toContain("<script");
+  });
+});

--- a/packages/web/src/components/DescriptionEditor/plain-text-description.ts
+++ b/packages/web/src/components/DescriptionEditor/plain-text-description.ts
@@ -1,0 +1,37 @@
+const HTML_TAG_PATTERN = /<(p|br|a|ul|ol|b|i|strong|em|div)\b/i;
+
+export const looksLikeHtml = (value: string): boolean =>
+  HTML_TAG_PATTERN.test(value);
+
+const escapeHtml = (text: string): string =>
+  text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+
+const linkifyUrls = (text: string): string =>
+  text.replace(/https?:\/\/[^\s]+/g, (match) => {
+    let url = match;
+    let suffix = "";
+    while (url.length > 0 && /[.,)>]$/.test(url)) {
+      suffix = url.slice(-1) + suffix;
+      url = url.slice(0, -1);
+    }
+    if (!url) {
+      return match;
+    }
+    return `<a href="${url}">${url}</a>${suffix}`;
+  });
+
+const paragraphToHtml = (block: string): string =>
+  block
+    .split("\n")
+    .map((line) => linkifyUrls(escapeHtml(line)))
+    .join("<br>");
+
+export const plainTextToDescriptionHtml = (value: string): string =>
+  value
+    .split(/\n\s*\n/)
+    .map((block) => `<p>${paragraphToHtml(block.trim())}</p>`)
+    .join("");

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -789,6 +789,10 @@
     @apply inline;
   }
 
+  & a {
+    @apply underline decoration-1 underline-offset-2 text-text;
+  }
+
   & p.is-editor-empty:first-child::before {
     @apply pointer-events-none float-left h-0 text-text-muted;
     content: attr(data-placeholder);


### PR DESCRIPTION
Fixes #3567

## What and why

Booking meeting events now store cancel and reschedule URLs in separate paragraphs (blank-line separated), matching the spec in [docs/features/booking.md](https://github.com/KeepSoftwareSimple/compass-calendar/blob/main/docs/features/booking.md). The web `DescriptionEditor` converts plain-text descriptions to sanitized HTML so bare `https://` URLs render as clickable links in three paragraphs, while existing HTML descriptions pass through unchanged. Added `c-rich-text` anchor styling so links are visibly underlined in the editor.

## Verify

```
Summary
Selected packages: web, backend
Checks run: test:web, test:backend, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)

✓ All checks passed
VERDICT: PASS
```

Also ran WP commands: `bun test:backend:fast`, `bun test:web`, `bun run type-check`, `bun run lint`.