### PR TITLE
fix(web): keep series base rows cached so edit-all rebases onto the series

### DIFF
--- a/packages/web/src/events/mutations/useEventMutations.test.tsx
+++ b/packages/web/src/events/mutations/useEventMutations.test.tsx
@@ -446,6 +446,68 @@ describe("useEventMutations", () => {
     });
   });
 
+  test("remote promote all refuses to send an occurrence's dates when the series base is not cached", async () => {
+    const { port, mocks } = createTestToastPort();
+    registerToastPort(port);
+    const context = setup("remote");
+    const seriesId = EventIdSchema.parse("aaaaaaaaaaaaaaaaaaaaaaaa");
+    const birthday = composedOccurrence(seriesId, "2026-09-14T00:00:00.000Z", {
+      schedule: allDaySchedule("2026-09-14", "2026-09-15"),
+    });
+    // Only the occurrence is cached: the series base (first occurrence in
+    // 2024) never made it into the window's entry.
+    context.queryClient.setQueryData(
+      calendarKeyFor("remote"),
+      normalized(birthday),
+    );
+
+    const opportunity = replaceAndGetOpportunity(context, birthday.id, {
+      content: {
+        kind: "details",
+        title: "My Birthday",
+        description: "",
+        location: "",
+      },
+      schedule: allDaySchedule("2026-09-14", "2026-09-15"),
+    });
+
+    act(() =>
+      context.hook.result.current.mutations.promoteRecurring(
+        opportunity,
+        "all",
+      ),
+    );
+
+    // Refused before anything is queued: the ask closes with an error toast,
+    // and no mutation ran, so the narrow scope-"this" write is not coalesced
+    // away and still reaches the repository on its own.
+    expect(mocks.error).toHaveBeenCalledWith(
+      expect.stringMatching(/still loading/),
+      expect.anything(),
+    );
+    expect(
+      useRecurrenceScopeOpportunityStore.getState().opportunity,
+    ).toBeNull();
+    await waitFor(() => expect(context.calls).toHaveLength(1));
+    act(() => context.pending.resolve());
+    await waitFor(() =>
+      expect(context.hook.result.current.hasPending).toBe(false),
+    );
+    expect(context.errors).toEqual([]);
+    expect(context.calls).toEqual([
+      {
+        method: "replace",
+        value: {
+          id: birthday.id,
+          input: expect.objectContaining({
+            scope: "this",
+            schedule: allDaySchedule("2026-09-14", "2026-09-15"),
+          }),
+        },
+      },
+    ]);
+  });
+
   test("remote promote all rebases a middle all-day occurrence onto the series master", async () => {
     const context = setup("remote");
     const seriesId = EventIdSchema.parse("bbbbbbbbbbbbbbbbbbbbbbbb");

--- a/packages/web/src/events/mutations/useEventMutations.ts
+++ b/packages/web/src/events/mutations/useEventMutations.ts
@@ -189,6 +189,29 @@ function snapshotSeriesMasterSchedule(
   return master?.recurrence.kind === "series" ? master.schedule : undefined;
 }
 
+const SERIES_BASE_MISSING_MESSAGE =
+  "This series is still loading. Reload the page and try again.";
+
+// A remote scope-"all" edit addressed through an occurrence needs the series
+// base to rebase the occurrence's dates onto. Without it the absolute dates
+// would become the series start: sync moves the master to them and shifts
+// every instance by the same distance. Checked BEFORE a mutation is queued,
+// because a queued promotion coalesces the narrow write away and a failure
+// after that point would lose both edits.
+function isMissingSeriesBase(
+  source: EventRepositorySource,
+  scope: RecurrenceScope,
+  id: EventId,
+  seriesMasterSchedule: EventSchedule | undefined,
+): boolean {
+  return (
+    source === "remote" &&
+    scope === "all" &&
+    decodeOccurrenceId(id) !== null &&
+    seriesMasterSchedule === undefined
+  );
+}
+
 function resolveRemoteReplaceSchedule(
   source: EventRepositorySource,
   id: EventId,
@@ -199,7 +222,8 @@ function resolveRemoteReplaceSchedule(
 
   const parts = decodeOccurrenceId(id);
   if (!parts) return input;
-  if (!seriesMasterSchedule) return input;
+  // Backstop for the entry-point check above; never send absolute dates.
+  if (!seriesMasterSchedule) throw new Error(SERIES_BASE_MISSING_MESSAGE);
 
   return {
     ...input,
@@ -968,6 +992,21 @@ export function useEventMutations(
         ) {
           return false;
         }
+        const seriesMasterSchedule =
+          source === "remote" && payload.input.scope === "all"
+            ? snapshotSeriesMasterSchedule(queryClient, source, payload.id)
+            : undefined;
+        if (
+          isMissingSeriesBase(
+            source,
+            payload.input.scope,
+            payload.id,
+            seriesMasterSchedule,
+          )
+        ) {
+          showErrorToast(SERIES_BASE_MISSING_MESSAGE);
+          return false;
+        }
         const writeKey = seriesWriteKey(
           original,
           payload.input.scope,
@@ -1004,10 +1043,7 @@ export function useEventMutations(
             writeKey,
             opportunityId,
             callbacks,
-            seriesMasterSchedule:
-              source === "remote" && payload.input.scope === "all"
-                ? snapshotSeriesMasterSchedule(queryClient, source, payload.id)
-                : undefined,
+            seriesMasterSchedule,
           },
           callbacks,
         );
@@ -1079,6 +1115,30 @@ export function useEventMutations(
           recurrenceScopeOpportunityActions.complete(opportunity.id);
           return;
         }
+        const seriesMasterSchedule =
+          opportunity.kind === "replace" &&
+          source === "remote" &&
+          scope === "all"
+            ? snapshotSeriesMasterSchedule(
+                queryClient,
+                source,
+                opportunity.original.id as EventId,
+              )
+            : undefined;
+        if (
+          opportunity.kind === "replace" &&
+          isMissingSeriesBase(
+            source,
+            scope,
+            opportunity.original.id as EventId,
+            seriesMasterSchedule,
+          )
+        ) {
+          showErrorToast(SERIES_BASE_MISSING_MESSAGE);
+          dismissRecurrenceScopeToast(opportunity.id);
+          recurrenceScopeOpportunityActions.complete(opportunity.id);
+          return;
+        }
         // Broader recurring operations rewrite/split this series, so its
         // narrow client snapshots are no longer safe to replay. Keep history
         // for unrelated events the user changed while this toast was live.
@@ -1102,10 +1162,7 @@ export function useEventMutations(
               // deleted/overridden cache entry cannot lose the promotion.
               writeKey: id,
               originalOverride: opportunity.original,
-              seriesMasterSchedule:
-                source === "remote" && scope === "all"
-                  ? snapshotSeriesMasterSchedule(queryClient, source, id)
-                  : undefined,
+              seriesMasterSchedule,
             },
             { onSuccess, onSettled },
           );

--- a/packages/web/src/events/queries/day.event.query.test.ts
+++ b/packages/web/src/events/queries/day.event.query.test.ts
@@ -1,5 +1,7 @@
+import { EventIdSchema } from "@core/types/domain-primitives";
 import { EventScheduleSchema } from "@core/types/event.contracts";
 import dayjs, { type Dayjs } from "@core/util/date/dayjs";
+import { composeOccurrenceId } from "@core/util/occurrence-id";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { toUTCOffset } from "@web/common/utils/datetime/web.date.util";
 import { type EventRepository } from "@web/events/repositories/event.repository.types";
@@ -62,6 +64,83 @@ describe("fetchDayEvents remote Sync startAt skew", () => {
     expect(mondayResult.entities[mondayAllDay.id]?.content).toMatchObject({
       title: "AW-0-#",
     });
+  });
+
+  it("keeps a series base whose first occurrence predates the window", async () => {
+    const base = createMockEvent({
+      id: EventIdSchema.parse("aaaaaaaaaaaaaaaaaaaaaaaa"),
+      content: { kind: "details", title: "My Birthday", description: "" },
+      schedule: EventScheduleSchema.parse({
+        kind: "allDay",
+        start: "2024-09-14",
+        end: "2024-09-15",
+      }),
+      recurrence: { kind: "series", rules: ["RRULE:FREQ=YEARLY"] },
+    });
+    const occurrence = createMockEvent({
+      id: EventIdSchema.parse(
+        composeOccurrenceId({
+          eventId: base.id,
+          recurrenceId: "2026-09-14T00:00:00.000Z",
+        }),
+      ),
+      content: { kind: "details", title: "My Birthday", description: "" },
+      schedule: EventScheduleSchema.parse({
+        kind: "allDay",
+        start: "2026-09-14",
+        end: "2026-09-15",
+      }),
+      recurrence: { kind: "occurrence", seriesId: base.id },
+    });
+    const staleSingle = createMockEvent({
+      schedule: EventScheduleSchema.parse({
+        kind: "allDay",
+        start: "2024-09-14",
+        end: "2024-09-15",
+      }),
+    });
+    // A series whose only instance sits in the padded day outside the window
+    // brings its base along from Sync, but neither belongs to this day.
+    const paddedBase = createMockEvent({
+      id: EventIdSchema.parse("bbbbbbbbbbbbbbbbbbbbbbbb"),
+      schedule: EventScheduleSchema.parse({
+        kind: "allDay",
+        start: "2020-01-15",
+        end: "2020-01-16",
+      }),
+      recurrence: { kind: "series", rules: ["RRULE:FREQ=MONTHLY"] },
+    });
+    const paddedOccurrence = createMockEvent({
+      id: EventIdSchema.parse(
+        composeOccurrenceId({
+          eventId: paddedBase.id,
+          recurrenceId: "2026-09-15T00:00:00.000Z",
+        }),
+      ),
+      schedule: EventScheduleSchema.parse({
+        kind: "allDay",
+        start: "2026-09-15",
+        end: "2026-09-16",
+      }),
+      recurrence: { kind: "occurrence", seriesId: paddedBase.id },
+    });
+    const list = mock(async () => [
+      occurrence,
+      paddedOccurrence,
+      base,
+      paddedBase,
+      staleSingle,
+    ]);
+    const repository = { list } as unknown as EventRepository;
+
+    const result = await fetchDayEvents(
+      dayRange(dayjs.tz("2026-09-14 12:00", "America/Denver")),
+      repository,
+      "remote",
+    );
+
+    expect(result.ids).toEqual([occurrence.id, base.id]);
+    expect(result.entities[base.id]?.schedule).toEqual(base.schedule);
   });
 
   it("does not pad or call the repository for an empty calendarIds list", async () => {

--- a/packages/web/src/events/queries/day.event.query.ts
+++ b/packages/web/src/events/queries/day.event.query.ts
@@ -65,9 +65,27 @@ export async function fetchDayEvents(
   });
 
   const events = await repository.list(query);
-  return normalizeEventList(
-    events.filter((event) =>
-      eventMatchesRange(event, payload.startDate, payload.endDate),
+  const inRange = events.filter((event) =>
+    eventMatchesRange(event, payload.startDate, payload.endDate),
+  );
+  // Sync appends one series base row per series that has an instance in the
+  // (padded) window. The base's schedule is the FIRST occurrence, so for any
+  // series older than the window it fails the range test. Keep the base of
+  // every occurrence kept above: the grid never renders a base, but a
+  // scope-"all" edit rebases the occurrence's dates onto it. Dropping it once
+  // sent an occurrence's date as the series start, which moved a yearly
+  // birthday series forward by two years at the provider. A base whose only
+  // instance fell in the padding stays out, so an empty window stays empty.
+  const referencedSeries = new Set(
+    inRange.flatMap((event) =>
+      event.recurrence.kind === "occurrence" ? [event.recurrence.seriesId] : [],
     ),
   );
+  const bases = events.filter(
+    (event) =>
+      event.recurrence.kind === "series" &&
+      referencedSeries.has(event.id) &&
+      !inRange.includes(event),
+  );
+  return normalizeEventList([...inRange, ...bases]);
 }


### PR DESCRIPTION
Fixes #3584

## What and why

A scope-"all" edit made from one occurrence rebases that occurrence's dates onto the cached series base before submitting. Sync appends the base row to every range list, but `fetchDayEvents` filtered list rows by the visible window, and a base whose first occurrence predates the window never survived. With no base in cache the rebase silently sent the occurrence's absolute dates as the series start: sync moved the master to them and shifted every instance by the same distance at the provider. On production this moved one yearly birthday series forward two years and another twelve, hiding both from the calendar. Both were repaired by hand at the provider before this PR.

This keeps series base rows in the normalized cache when one of their occurrences is in the window (the grid already skips bases when rendering), and refuses a remote scope-"all" edit with an error toast when the base is still missing. The refusal runs before any mutation is queued, because a queued promotion coalesces the narrow write away and a later failure would lose both edits. Regression tests cover both.

## Verify

`VERDICT: FAIL` locally on macOS, from `bun run verify --strict` (lint, knip, type-check, test:web, test:a11y, test:e2e).

Every failure is environmental and none touches a file this diff can reach:

- 50 of 53 Playwright failures wait on `getByRole('dialog', { name: 'Settings' })`, which `Control+Comma` never opens on macOS (`booking-a11y`, `host-settings`, `connect-onboarding-a11y`, `microsoft-surfaces`, `public-booking-v15` discard).
- 1 is the known local hold-Mod page-jump failure in `account-page-jump.spec.ts`.
- 1 is `app-a11y.spec.ts:43` (event action row color contrast), which passed 3 of 3 reruns in isolation on this branch and once against `origin/main` web sources; it only failed under two local workers.

Green locally: lint, knip, type-check, `test:web` (including the two new regression tests), and the rest of a11y and e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)