### PR TITLE
feat(booking): show host when guests cannot book

### DIFF
--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -259,6 +259,16 @@ open over about 200 ms, and reduced motion disables the animation.
   button), or not connected (`Connect a calendar to turn your page
   back on.` with the connect buttons). The first-run connect prompt
   is only for a host who has no saved page.
+  When the page is live, a **Host status** line under the link reports
+  whether guests can book right now. It uses the same readiness probe
+  as guest slots (`GET /api/booking/page/status`). If they cannot, the
+  line is `Guests can't book right now:` plus the reason and the fix:
+  reconnect for `actionRequired` / `disconnected`; importing and delayed
+  copy for those connection states; calendar name plus catch-up or
+  remove-from-blocking copy for `stale` / `neverSynced` / `notImported`;
+  the existing paid-subscription sentence for billing. The Settings
+  nav **Meeting** button shows a warning dot and sr-only
+  `needs attention` while the page is live and not bookable.
 - **Essentials:** duration and weekly hours. These fit without scrolling
   at 1440x900.
 - **More options:** an uncontrolled native `<details>` that starts
@@ -484,6 +494,9 @@ Unauthenticated:
 Authenticated (host session + writable billing, same as event writes):
 
 - `GET /api/booking/page` — host page, including slug and copyable URL.
+- `GET /api/booking/page/status` — whether guests can book right now.
+  `{ bookable, reasons }` from the same readiness probe guest slots use.
+  A disabled page, or no record, answers `{ bookable: true, reasons: [] }`.
 - `PUT /api/booking/page` — replace settings. Accepts optional `slug`.
   Allocates slug on first enable when none is stored. `409` with
   `SLUG_TAKEN` when the requested address belongs to another host.
@@ -520,7 +533,7 @@ Guest reschedule is **in scope for v1.3**, not v1 / v1.1.
 | Slot engine | `packages/core/src/booking/compute-booking-slots.ts` |
 | Occupancy policy | `packages/core/src/booking/occupies-booking-slot.ts` |
 | Backend admin API | `packages/backend/src/booking/controllers/booking.controller.ts`, `services/booking-page.service.ts` |
-| Backend public API | `packages/backend/src/booking/booking.routes.config.ts`, `services/public-booking.service.ts` |
+| Backend public API | `packages/backend/src/booking/booking.routes.config.ts`, `services/public-booking.service.ts`, `services/booking-readiness.ts` |
 | Reservations + cancel tokens | `packages/backend/src/booking/booking-reservation.repository.ts`, `booking-cancel-token.ts` |
 | Calendar application port | `packages/backend/src/booking/services/calendar-booking.port.ts` (`updateBookingEvent`), `services/calendar-booking.service.ts` |
 | Sync busy occupancy | `packages/sync/src/domain/occurrence-projection.ts`, `busy-query.service.ts`, `booking-occupancy-facts.ts` |
@@ -537,7 +550,7 @@ routes; these are the named events in `packages/web/src/auth/posthog/track.ts`.
 
 | Event | Properties | When |
 | --- | --- | --- |
-| `booking_settings_opened` | `has_connection: boolean`, `is_live: boolean` | Settings > Meeting mounts (after the page is known, or immediately on the connect prompt) |
+| `booking_settings_opened` | `has_connection: boolean`, `is_live: boolean`, `is_bookable: boolean` | Settings > Meeting mounts (after the page is known, or immediately on the connect prompt) |
 | `booking_page_enabled` | `first_time: boolean` | Turn-on save succeeds. `first_time` is true when the page had no `bookingUrl` before this save |
 | `booking_link_copied` | `source: "button" \| "save"` | Successful copy from the Copy button, or auto-copy after a successful turn-on / save |
 | `booking_page_viewed` | `duration_minutes: number` | Public page query succeeds with `enabled: true`, once per slug |
@@ -588,15 +601,17 @@ on the real `events.insert` call (`conferenceDataVersion: 1`). Before this,
 the adapter passed the conference payload but the googleapis wrapper dropped
 the version flag, so Google ignored Meet.
 
-<<<<<<< HEAD
+The guest confirmation page dropped **Copy cancel link** and **Copy
+reschedule link**. Meeting actions are the two links only.
+
 A saved Meeting page stays on screen when the calendar connection is
 unhealthy. A banner above the status header tells the host to reconnect,
 wait for import, or connect again. The first-run connect prompt is only
 for hosts who have never saved a page.
-=======
-The guest confirmation page dropped **Copy cancel link** and **Copy
-reschedule link**. Meeting actions are the two links only.
->>>>>>> origin/main
+
+A live Meeting page shows whether guests can book right now, with the
+fix for each blocker, and the Settings Meeting nav warns when they
+cannot.
 
 ### v1.9
 

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -995,6 +995,10 @@ export interface HostBookingSettingsStubOptions {
     start: string;
     end: string;
   }>;
+  pageStatus?: {
+    bookable: boolean;
+    reasons: Array<Record<string, unknown>>;
+  };
 }
 
 export interface CapturedHostBookingRequests {
@@ -1118,6 +1122,15 @@ export async function prepareSignedInBookingSettingsPage(
 
     if (path.endsWith("/api/event") && request.method() === "GET") {
       return route.fulfill(jsonResponse({ events: [] }));
+    }
+
+    if (
+      path.endsWith("/api/booking/page/status") &&
+      request.method() === "GET"
+    ) {
+      return route.fulfill(
+        jsonResponse(options.pageStatus ?? { bookable: true, reasons: [] }),
+      );
     }
 
     if (path.endsWith("/api/booking/page") && request.method() === "GET") {

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -444,3 +444,36 @@ test("keeps the meeting form visible when Google needs reconnecting", async ({
     include: "[role='dialog']",
   });
 });
+
+test("shows why guests cannot book when a blocking calendar is stale", async ({
+  page,
+}) => {
+  await prepareSignedInBookingSettingsPage(page, {
+    pageStatus: {
+      bookable: false,
+      reasons: [
+        {
+          kind: "calendar",
+          reason: "stale",
+          calendarId: BOOKING_CALENDAR_ID,
+        },
+      ],
+    },
+  });
+  const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+  await expect(
+    settingsDialog.getByText("Guests can't book right now"),
+  ).toBeVisible();
+  await expect(
+    settingsDialog.getByText(
+      "Work hasn't synced recently. Guests can book once it catches up.",
+    ),
+  ).toBeVisible();
+  await expect(
+    settingsDialog.getByRole("button", { name: /Meeting/ }),
+  ).toContainText("needs attention");
+  await expectNoAxeViolations(page, {
+    checkpoint: "settings booking stale calendar status",
+    include: "[role='dialog']",
+  });
+});

--- a/packages/backend/src/booking/booking.rate-limit.db.test.ts
+++ b/packages/backend/src/booking/booking.rate-limit.db.test.ts
@@ -149,6 +149,12 @@ describe("Host admin booking rate limits", () => {
       .get("/api/booking/page")
       .set("Cookie", sessionCookie(userId));
 
+  const getAdminPageStatus = (userId: string) =>
+    baseDriver
+      .getServer()
+      .get("/api/booking/page/status")
+      .set("Cookie", sessionCookie(userId));
+
   const putAdminPage = (userId: string) =>
     baseDriver
       .getServer()
@@ -163,6 +169,16 @@ describe("Host admin booking rate limits", () => {
       await getAdminPage(userId);
     }
     const throttled = await getAdminPage(userId);
+    expect(throttled.status).toBe(429);
+  });
+
+  it("throttles GET /api/booking/page/status after 60 requests in a minute", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const userId = user._id.toString();
+    for (let i = 0; i < 60; i += 1) {
+      await getAdminPageStatus(userId);
+    }
+    const throttled = await getAdminPageStatus(userId);
     expect(throttled.status).toBe(429);
   });
 

--- a/packages/backend/src/booking/booking.routes.config.test.ts
+++ b/packages/backend/src/booking/booking.routes.config.test.ts
@@ -35,6 +35,7 @@ describe("BookingRoutes production gate", () => {
     const app = express();
     new BookingRoutes(app);
     expect(bookingRoutePaths(app)).toContain("/api/booking/page");
+    expect(bookingRoutePaths(app)).toContain("/api/booking/page/status");
     expect(bookingRoutePaths(app)).toContain("/api/booking/pages/:slug");
   });
 });

--- a/packages/backend/src/booking/booking.routes.config.ts
+++ b/packages/backend/src/booking/booking.routes.config.ts
@@ -93,6 +93,14 @@ const adminPageGetLimiter = rateLimit({
   keyGenerator: bookingAdminKey,
 });
 
+const adminPageStatusGetLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: bookingAdminKey,
+});
+
 // PUT is a save. A host retries a handful of times, not sixty.
 const adminPagePutLimiter = rateLimit({
   windowMs: 60 * 1000,
@@ -114,6 +122,11 @@ export class BookingRoutes extends CommonRoutesConfig {
     if (!isBookingEnabled(CONFIG.NODE_ENV)) {
       return this.app;
     }
+
+    this.app
+      .route(`/api/booking/page/status`)
+      .all(verifySession())
+      .get(adminPageStatusGetLimiter, bookingController.getPageStatus);
 
     this.app
       .route(`/api/booking/page`)

--- a/packages/backend/src/booking/controllers/booking.controller.ts
+++ b/packages/backend/src/booking/controllers/booking.controller.ts
@@ -21,6 +21,17 @@ class BookingController {
     }
   };
 
+  getPageStatus = async (req: SessionRequest, res: Response) => {
+    try {
+      const userId = zObjectId.parse(req.session?.getUserId());
+      const response = await publicBookingService.getHostPageStatus(userId);
+      res.status(Status.OK).json(response);
+    } catch (error) {
+      const { status, body } = toBookingErrorResponse(error);
+      res.status(status).json(body);
+    }
+  };
+
   putPage = async (req: SessionRequest, res: Response) => {
     try {
       const userId = zObjectId.parse(req.session?.getUserId());

--- a/packages/backend/src/booking/services/booking-readiness.test.ts
+++ b/packages/backend/src/booking/services/booking-readiness.test.ts
@@ -1,0 +1,142 @@
+import { ObjectId } from "mongodb";
+import { CalendarIdSchema } from "@core/types/domain-primitives";
+import * as billingGuard from "@backend/billing/billing.guard";
+import { type BookingPageRecord } from "@backend/booking/booking-page.record";
+import {
+  emptyBookableStatus,
+  mapProbeToStatus,
+  probeBookability,
+} from "@backend/booking/services/booking-readiness";
+import { type CalendarBookingPort } from "@backend/booking/services/calendar-booking.port";
+import { eventMutationError } from "@backend/event/event.error";
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+
+const calendarId = () => CalendarIdSchema.parse(new ObjectId().toString());
+const connectionId = () => new ObjectId().toString();
+
+const page = (
+  overrides: Partial<BookingPageRecord> = {},
+): BookingPageRecord => {
+  const destination = calendarId();
+  return {
+    _id: new ObjectId(),
+    userId: new ObjectId(),
+    bookingSlug: "hostuser",
+    enabled: true,
+    durationMinutes: 30,
+    destinationCalendarId: destination,
+    blockingCalendarIds: [destination],
+    timeZone: "UTC",
+    weeklyAvailability: [{ weekday: 1, start: "09:00", end: "17:00" }],
+    minNoticeHours: 4,
+    maxHorizonDays: 60,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+};
+
+const busy = (bookable: boolean, extras: Record<string, unknown> = {}) => ({
+  intervals: [],
+  computedAt: "2026-09-07T12:00:00.000Z",
+  connections: [],
+  complete: bookable,
+  issues: [],
+  bookable,
+  ...extras,
+});
+
+const probeWindow = {
+  start: new Date("2026-09-07T08:00:00.000Z"),
+  end: new Date("2026-11-06T08:00:00.000Z"),
+};
+
+describe("probeBookability", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+  it("reports a stale blocking calendar as unbookable", async () => {
+    const blocking = calendarId();
+    const getAvailability = mock(async () =>
+      busy(false, {
+        complete: false,
+        issues: [{ calendarId: blocking, reason: "stale" }],
+      }),
+    );
+    spyOn(billingGuard, "assertBillingAllowsWrites").mockResolvedValue(
+      undefined,
+    );
+
+    const probe = await probeBookability(
+      page({ blockingCalendarIds: [blocking] }),
+      probeWindow,
+      { getAvailability } as unknown as CalendarBookingPort,
+    );
+
+    expect(probe.bookable).toBe(false);
+    expect(mapProbeToStatus(probe)).toEqual({
+      bookable: false,
+      reasons: [{ kind: "calendar", reason: "stale", calendarId: blocking }],
+    });
+  });
+
+  it("reports an actionRequired connection as unbookable", async () => {
+    const getAvailability = mock(async () =>
+      busy(false, {
+        connections: [
+          {
+            connectionId: connectionId(),
+            state: "actionRequired",
+            lastSyncedAt: null,
+            lastHealthyAt: null,
+          },
+        ],
+      }),
+    );
+    spyOn(billingGuard, "assertBillingAllowsWrites").mockResolvedValue(
+      undefined,
+    );
+
+    const probe = await probeBookability(page(), probeWindow, {
+      getAvailability,
+    } as unknown as CalendarBookingPort);
+
+    expect(probe.bookable).toBe(false);
+    expect(mapProbeToStatus(probe)).toEqual({
+      bookable: false,
+      reasons: [
+        {
+          kind: "connection",
+          reason: "actionRequired",
+          connectionState: "actionRequired",
+        },
+      ],
+    });
+  });
+
+  it("skips availability when billing blocks writes", async () => {
+    const getAvailability = mock(async () => busy(true));
+    spyOn(billingGuard, "assertBillingAllowsWrites").mockRejectedValue(
+      eventMutationError(
+        "BILLING_REQUIRED",
+        "A paid subscription is required to make changes",
+      ),
+    );
+
+    const probe = await probeBookability(page(), probeWindow, {
+      getAvailability,
+    } as unknown as CalendarBookingPort);
+
+    expect(getAvailability).not.toHaveBeenCalled();
+    expect(mapProbeToStatus(probe)).toEqual({
+      bookable: false,
+      reasons: [{ kind: "billing", reason: "BILLING_REQUIRED" }],
+    });
+  });
+});
+
+describe("emptyBookableStatus", () => {
+  it("is the disabled-page and missing-page answer", () => {
+    expect(emptyBookableStatus()).toEqual({ bookable: true, reasons: [] });
+  });
+});

--- a/packages/backend/src/booking/services/booking-readiness.ts
+++ b/packages/backend/src/booking/services/booking-readiness.ts
@@ -1,0 +1,127 @@
+import { type ObjectId } from "mongodb";
+import { BaseError } from "@core/errors/errors.base";
+import {
+  type BookingPageStatusResponse,
+  BookingPageStatusResponseSchema,
+} from "@core/types/booking.contracts";
+import {
+  CalendarIdSchema,
+  DateTimeSchema,
+  type EventId,
+} from "@core/types/domain-primitives";
+import { type BusyAvailabilityResponse } from "@core/types/sync/availability.contracts";
+import { assertBillingAllowsWrites } from "@backend/billing/billing.guard";
+import { type BookingPageRecord } from "@backend/booking/booking-page.record";
+import { type CalendarBookingPort } from "@backend/booking/services/calendar-booking.port";
+
+const isBillingRequiredError = (error: unknown): boolean =>
+  error instanceof BaseError && error.code === "BILLING_REQUIRED";
+
+export const hostAllowsGuestWrites = async (
+  userId: ObjectId,
+): Promise<boolean> => {
+  try {
+    await assertBillingAllowsWrites(userId.toString());
+    return true;
+  } catch (error) {
+    if (isBillingRequiredError(error)) {
+      return false;
+    }
+    throw error;
+  }
+};
+
+export type BookabilityProbe = {
+  bookable: boolean;
+  billingBlocked: boolean;
+  availability: BusyAvailabilityResponse | null;
+};
+
+export async function probeBookability(
+  page: BookingPageRecord,
+  window: { start: Date; end: Date },
+  calendarBooking: CalendarBookingPort,
+  options: { excludeEventIds?: readonly EventId[] } = {},
+): Promise<BookabilityProbe> {
+  if (!(await hostAllowsGuestWrites(page.userId))) {
+    return {
+      bookable: false,
+      billingBlocked: true,
+      availability: null,
+    };
+  }
+
+  if (window.end.getTime() <= window.start.getTime()) {
+    return {
+      bookable: true,
+      billingBlocked: false,
+      availability: null,
+    };
+  }
+
+  const availability = await calendarBooking.getAvailability(
+    page.userId.toString(),
+    {
+      calendarIds: page.blockingCalendarIds,
+      start: DateTimeSchema.parse(window.start.toISOString()),
+      end: DateTimeSchema.parse(window.end.toISOString()),
+      ...(options.excludeEventIds
+        ? { excludeEventIds: options.excludeEventIds }
+        : {}),
+    },
+  );
+
+  return {
+    bookable: availability.bookable,
+    billingBlocked: false,
+    availability,
+  };
+}
+
+export const emptyBookableStatus = (): BookingPageStatusResponse =>
+  BookingPageStatusResponseSchema.parse({
+    bookable: true,
+    reasons: [],
+  });
+
+export function mapProbeToStatus(
+  probe: BookabilityProbe,
+): BookingPageStatusResponse {
+  if (probe.billingBlocked) {
+    return BookingPageStatusResponseSchema.parse({
+      bookable: false,
+      reasons: [{ kind: "billing", reason: "BILLING_REQUIRED" }],
+    });
+  }
+
+  if (probe.bookable) {
+    return emptyBookableStatus();
+  }
+
+  const reasons: BookingPageStatusResponse["reasons"] = [];
+  for (const issue of probe.availability?.issues ?? []) {
+    const calendarId = CalendarIdSchema.safeParse(issue.calendarId);
+    reasons.push({
+      kind: "calendar",
+      reason: issue.reason,
+      ...(calendarId.success ? { calendarId: calendarId.data } : {}),
+    });
+  }
+
+  const seen = new Set<string>();
+  for (const connection of probe.availability?.connections ?? []) {
+    if (connection.state === "healthy") continue;
+    if (seen.has(connection.connectionId)) continue;
+    seen.add(connection.connectionId);
+    reasons.push({
+      kind: "connection",
+      reason: connection.state,
+      connectionState: connection.state,
+    });
+  }
+
+  return BookingPageStatusResponseSchema.parse({
+    bookable: false,
+    reasons,
+  });
+}

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -581,6 +581,75 @@ describe("PublicBookingService", () => {
     });
   });
 
+  it("reports a stale blocking calendar on host status and keeps slots unbookable", async () => {
+    const { userId, slug, calendarId } = await enableBookingPage();
+    getAvailability.mockImplementation(async () => ({
+      ...busyResponse(false),
+      complete: false,
+      issues: [{ calendarId, reason: "stale" }],
+    }));
+
+    await expect(service.getHostPageStatus(userId)).resolves.toEqual({
+      bookable: false,
+      reasons: [{ kind: "calendar", reason: "stale", calendarId }],
+    });
+    await expect(
+      service.getSlots(slug, {
+        start: `${BOOKING_MONDAY}T00:00:00.000Z`,
+        end: `${BOOKING_TUESDAY}T00:00:00.000Z`,
+        timeZone: "UTC",
+      }),
+    ).resolves.toEqual({ slots: [], bookable: false });
+  });
+
+  it("reports an actionRequired connection on host status", async () => {
+    const { userId } = await enableBookingPage();
+    getAvailability.mockImplementation(async () => ({
+      ...busyResponse(false),
+      connections: [
+        {
+          connectionId: new ObjectId().toString(),
+          state: "actionRequired",
+          lastSyncedAt: null,
+          lastHealthyAt: null,
+        },
+      ],
+    }));
+
+    await expect(service.getHostPageStatus(userId)).resolves.toEqual({
+      bookable: false,
+      reasons: [
+        {
+          kind: "connection",
+          reason: "actionRequired",
+          connectionState: "actionRequired",
+        },
+      ],
+    });
+  });
+
+  it("answers bookable with no reasons for a disabled page", async () => {
+    const { userId } = await enableBookingPage("Disabled Host", {
+      enabled: false,
+    });
+
+    await expect(service.getHostPageStatus(userId)).resolves.toEqual({
+      bookable: true,
+      reasons: [],
+    });
+    expect(getAvailability).not.toHaveBeenCalled();
+  });
+
+  it("answers bookable with no reasons when the host has no page", async () => {
+    const userId = await createNamedUser("No Page Host");
+
+    await expect(service.getHostPageStatus(userId)).resolves.toEqual({
+      bookable: true,
+      reasons: [],
+    });
+    expect(getAvailability).not.toHaveBeenCalled();
+  });
+
   it("does not occupy a slot for a needsAction invite", async () => {
     const { slug } = await enableBookingPage();
     getAvailability.mockImplementation(async () => ({

--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -8,6 +8,8 @@ import { BaseError } from "@core/errors/errors.base";
 import { Logger } from "@core/logger/winston.logger";
 import {
   BookingDurationMinutesSchema,
+  type BookingPageStatusResponse,
+  BookingPageStatusResponseSchema,
   BookingReservationSlotsQuerySchema,
   BookingSlotsQuerySchema,
   type BookingSlotsResponse,
@@ -36,7 +38,6 @@ import {
   type BusyAvailabilityResponse,
 } from "@core/types/sync/availability.contracts";
 import dayjs from "@core/util/date/dayjs";
-import { assertBillingAllowsWrites } from "@backend/billing/billing.guard";
 import { bookingError } from "@backend/booking/booking.error";
 import {
   generateCancelToken,
@@ -51,6 +52,12 @@ import {
   bookingReservationRepository,
   confirmedReservationScanRange,
 } from "@backend/booking/booking-reservation.repository";
+import {
+  emptyBookableStatus,
+  hostAllowsGuestWrites,
+  mapProbeToStatus,
+  probeBookability,
+} from "@backend/booking/services/booking-readiness";
 import { type CalendarBookingPort } from "@backend/booking/services/calendar-booking.port";
 import { CalendarBookingService } from "@backend/booking/services/calendar-booking.service";
 import calendarService from "@backend/calendar/services/calendar.service";
@@ -62,21 +69,6 @@ const logger = Logger("app:booking.public");
 
 const GUEST_PAGE_NOT_ACCEPTING_BOOKINGS =
   "This page is not accepting meetings.";
-
-const isBillingRequiredError = (error: unknown): boolean =>
-  error instanceof BaseError && error.code === "BILLING_REQUIRED";
-
-const hostAllowsGuestWrites = async (userId: ObjectId): Promise<boolean> => {
-  try {
-    await assertBillingAllowsWrites(userId.toString());
-    return true;
-  } catch (error) {
-    if (isBillingRequiredError(error)) {
-      return false;
-    }
-    throw error;
-  }
-};
 
 const assertHostAllowsGuestWrites = async (userId: ObjectId): Promise<void> => {
   if (!(await hostAllowsGuestWrites(userId))) {
@@ -392,17 +384,30 @@ export class PublicBookingService {
     );
   }
 
+  async getHostPageStatus(
+    userId: ObjectId,
+  ): Promise<BookingPageStatusResponse> {
+    const page = await bookingPageRepository.findByUserId(userId);
+    if (!page?.enabled) {
+      return emptyBookableStatus();
+    }
+    const now = new Date();
+    const probe = await probeBookability(
+      page,
+      {
+        start: now,
+        end: dayjs(now).add(page.maxHorizonDays, "day").toDate(),
+      },
+      this.calendarBooking,
+    );
+    return BookingPageStatusResponseSchema.parse(mapProbeToStatus(probe));
+  }
+
   async getSlots(
     slug: string,
     rawQuery: unknown,
   ): Promise<BookingSlotsResponse> {
     const page = await resolveEnabledPage(slug);
-    if (!(await hostAllowsGuestWrites(page.userId))) {
-      return BookingSlotsResponseSchema.parse({
-        slots: [],
-        bookable: false,
-      });
-    }
     const query = parseSlotsQuery(rawQuery);
     return this.computeSlotsForPage(page, query);
   }
@@ -421,12 +426,6 @@ export class PublicBookingService {
       throw reservationNotFound();
     }
     const page = await resolveReservationPublicPage(reservation);
-    if (!(await hostAllowsGuestWrites(page.userId))) {
-      return BookingSlotsResponseSchema.parse({
-        slots: [],
-        bookable: false,
-      });
-    }
     parseSlotsQuery({
       start: query.start,
       end: query.end,
@@ -455,39 +454,39 @@ export class PublicBookingService {
     const windowEnd =
       requestedEnd.getTime() > horizonEnd.getTime() ? horizonEnd : requestedEnd;
 
-    if (windowEnd.getTime() <= windowStart.getTime()) {
-      return BookingSlotsResponseSchema.parse({
-        slots: [],
-        bookable: true,
-      });
-    }
-
-    const availability = await this.calendarBooking.getAvailability(
-      page.userId.toString(),
-      {
-        calendarIds: page.blockingCalendarIds,
-        start: DateTimeSchema.parse(query.start),
-        end: DateTimeSchema.parse(windowEnd.toISOString()),
-        ...(options.excludeEventIds
-          ? { excludeEventIds: options.excludeEventIds }
-          : {}),
-      },
+    const probe = await probeBookability(
+      page,
+      { start: windowStart, end: windowEnd },
+      this.calendarBooking,
+      { excludeEventIds: options.excludeEventIds },
     );
 
-    if (!availability.bookable) {
-      publicBookingSlotsLog.unbookable({
-        slug: page.bookingSlug ?? "",
-        userId: page.userId.toString(),
-        complete: availability.complete,
-        issueReasons: availability.issues.map((issue) => issue.reason),
-        issueCalendarIds: availability.issues.map((issue) => issue.calendarId),
-        connectionStates: availability.connections.map(
-          (connection) => connection.state,
-        ),
-      });
+    if (!probe.bookable) {
+      if (probe.availability) {
+        publicBookingSlotsLog.unbookable({
+          slug: page.bookingSlug ?? "",
+          userId: page.userId.toString(),
+          complete: probe.availability.complete,
+          issueReasons: probe.availability.issues.map((issue) => issue.reason),
+          issueCalendarIds: probe.availability.issues.map(
+            (issue) => issue.calendarId,
+          ),
+          connectionStates: probe.availability.connections.map(
+            (connection) => connection.state,
+          ),
+        });
+      }
       return BookingSlotsResponseSchema.parse({
         slots: [],
         bookable: false,
+      });
+    }
+
+    const availability = probe.availability;
+    if (!availability) {
+      return BookingSlotsResponseSchema.parse({
+        slots: [],
+        bookable: true,
       });
     }
 

--- a/packages/core/src/types/booking.contracts.test.ts
+++ b/packages/core/src/types/booking.contracts.test.ts
@@ -8,6 +8,7 @@ import {
   BOOKING_MAX_MIN_NOTICE_HOURS,
   BOOKING_PLACEHOLDER_CALENDAR_ID,
   BookingPageSchema,
+  BookingPageStatusResponseSchema,
   BookingReservationSlotsQuerySchema,
   BookingSlugSchema,
   buildDefaultAdminPutInput,
@@ -662,5 +663,47 @@ describe("HTTP booking contracts", () => {
 
   it("rejects reserved slug reschedule", () => {
     expect(BookingSlugSchema.safeParse("reschedule").success).toBe(false);
+  });
+});
+
+describe("BookingPageStatusResponseSchema", () => {
+  it("accepts a bookable empty status", () => {
+    expect(
+      BookingPageStatusResponseSchema.safeParse({
+        bookable: true,
+        reasons: [],
+      }).success,
+    ).toBe(true);
+  });
+
+  it("accepts calendar, connection, and billing reasons", () => {
+    expect(
+      BookingPageStatusResponseSchema.safeParse({
+        bookable: false,
+        reasons: [
+          {
+            kind: "calendar",
+            reason: "stale",
+            calendarId: calendarId(),
+          },
+          {
+            kind: "connection",
+            reason: "actionRequired",
+            connectionState: "actionRequired",
+            provider: "google",
+          },
+          { kind: "billing", reason: "BILLING_REQUIRED" },
+        ],
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects invented reason strings", () => {
+    expect(
+      BookingPageStatusResponseSchema.safeParse({
+        bookable: false,
+        reasons: [{ kind: "calendar", reason: "offline" }],
+      }).success,
+    ).toBe(false);
   });
 });

--- a/packages/core/src/types/booking.contracts.ts
+++ b/packages/core/src/types/booking.contracts.ts
@@ -10,6 +10,9 @@ import {
   type TimeZone,
   TimeZoneSchema,
 } from "@core/types/domain-primitives";
+import { CalendarFreshnessIssueReasonSchema } from "@core/types/sync/availability.contracts";
+import { ConnectionStateSchema } from "@core/types/sync/connection.contracts";
+import { ProviderKindSchema } from "@core/types/sync/identity.contracts";
 import { ObjectIdStringSchema } from "@core/types/type.utils";
 
 export const BOOKING_RESERVED_SLUGS = [
@@ -256,6 +259,39 @@ export const BookingSlotsResponseSchema = z.strictObject({
   bookable: z.boolean(),
 });
 export type BookingSlotsResponse = z.infer<typeof BookingSlotsResponseSchema>;
+
+export const BookingPageStatusReasonKindSchema = z.enum([
+  "connection",
+  "calendar",
+  "billing",
+]);
+export type BookingPageStatusReasonKind = z.infer<
+  typeof BookingPageStatusReasonKindSchema
+>;
+
+export const BookingPageStatusReasonSchema = z.strictObject({
+  kind: BookingPageStatusReasonKindSchema,
+  reason: z.union([
+    CalendarFreshnessIssueReasonSchema,
+    ConnectionStateSchema,
+    z.literal("BILLING_REQUIRED"),
+  ]),
+  calendarId: CalendarIdSchema.optional(),
+  connectionState: ConnectionStateSchema.optional(),
+  provider: ProviderKindSchema.optional(),
+  accountEmail: z.string().min(1).max(320).optional(),
+});
+export type BookingPageStatusReason = z.infer<
+  typeof BookingPageStatusReasonSchema
+>;
+
+export const BookingPageStatusResponseSchema = z.strictObject({
+  bookable: z.boolean(),
+  reasons: z.array(BookingPageStatusReasonSchema),
+});
+export type BookingPageStatusResponse = z.infer<
+  typeof BookingPageStatusResponseSchema
+>;
 
 /** Same shape the guest form and public reservation service enforce. */
 export const GUEST_EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;

--- a/packages/web/src/__tests__/__mocks__/server/mock.handlers.ts
+++ b/packages/web/src/__tests__/__mocks__/server/mock.handlers.ts
@@ -128,6 +128,12 @@ export const globalHandlers = [
       }),
     );
   }),
+  rest.get(`${ENV_WEB.API_BASEURL}/booking/page/status`, (_req, res, ctx) => {
+    return res(
+      ctx.status(Status.OK),
+      ctx.json({ bookable: true, reasons: [] }),
+    );
+  }),
   rest.get(`${ENV_WEB.API_BASEURL}/booking/pages/:slug`, (_req, res, ctx) => {
     return res(ctx.status(Status.NOT_FOUND), ctx.json({ code: "NOT_FOUND" }));
   }),

--- a/packages/web/src/api/booking.api.ts
+++ b/packages/web/src/api/booking.api.ts
@@ -3,6 +3,8 @@ import {
   type AdminGetBookingPageResult,
   AdminGetBookingPageSetupResponseSchema,
   type AdminPutBookingPageInput,
+  type BookingPageStatusResponse,
+  BookingPageStatusResponseSchema,
   isSavedBookingPage,
 } from "@core/types/booking.contracts";
 import { BaseApi } from "@web/api/base/base.api";
@@ -16,6 +18,11 @@ const BookingApi = {
   async getPage(): Promise<AdminGetBookingPageResult> {
     const response = await BaseApi.get<unknown>(`/booking/page`);
     return parseBookingPage(response.data);
+  },
+
+  async getPageStatus(): Promise<BookingPageStatusResponse> {
+    const response = await BaseApi.get<unknown>(`/booking/page/status`);
+    return BookingPageStatusResponseSchema.parse(response.data);
   },
 
   async putPage(

--- a/packages/web/src/booking/BookingBookabilityNotice.tsx
+++ b/packages/web/src/booking/BookingBookabilityNotice.tsx
@@ -1,0 +1,107 @@
+import { type BookingPageStatusResponse } from "@core/types/booking.contracts";
+import { type Calendar } from "@core/types/calendar.contracts";
+import { type SyncConnectionSummary } from "@core/types/user.types";
+import {
+  connectionProvider,
+  RECONNECT_BANNER_MESSAGE,
+} from "@web/auth/providers/provider-copy.util";
+import { BookingReconnectButton } from "@web/booking/BookingReconnectButton";
+import {
+  BOOKING_BILLING_STATUS_COPY,
+  BOOKING_NOT_BOOKABLE_PREFIX,
+  bookingCalendarName,
+  bookingCalendarUnbookableCopy,
+  bookingConnectionUnbookableCopy,
+  isReconnectConnectionState,
+} from "@web/booking/booking-bookability.copy";
+
+const FALLBACK_RECONNECT_CONNECTION: SyncConnectionSummary = {
+  id: "booking-status-reconnect-fallback",
+  provider: "google",
+  state: "actionRequired",
+  stateReason: null,
+  lastSyncedAt: null,
+  lastHealthyAt: null,
+  accountEmail: null,
+  connectionState: "RECONNECT_REQUIRED",
+  canSuggestContacts: false,
+};
+
+interface BookingBookabilityNoticeProps {
+  calendars: readonly Calendar[];
+  connections: readonly SyncConnectionSummary[];
+  status: BookingPageStatusResponse;
+}
+
+export function BookingBookabilityNotice({
+  calendars,
+  connections,
+  status,
+}: BookingBookabilityNoticeProps) {
+  if (status.bookable) return null;
+
+  const reconnecting = connections.filter(
+    (connection) => connection.connectionState === "RECONNECT_REQUIRED",
+  );
+
+  return (
+    <div className="flex flex-col items-start gap-2" role="status">
+      {status.reasons.length === 0 ? (
+        <p className="text-sm text-text">{BOOKING_NOT_BOOKABLE_PREFIX}.</p>
+      ) : null}
+      {status.reasons.map((reason) => {
+        const reasonKey = [
+          reason.kind,
+          reason.reason,
+          reason.calendarId ?? reason.connectionState ?? "",
+        ].join("-");
+        if (reason.kind === "billing") {
+          return (
+            <p className="text-sm text-text" key={reasonKey}>
+              {BOOKING_NOT_BOOKABLE_PREFIX}: {BOOKING_BILLING_STATUS_COPY}
+            </p>
+          );
+        }
+        if (reason.kind === "calendar") {
+          const copy = bookingCalendarUnbookableCopy(
+            bookingCalendarName(calendars, reason.calendarId),
+            reason.reason,
+          );
+          return (
+            <p className="text-sm text-text" key={reasonKey}>
+              {BOOKING_NOT_BOOKABLE_PREFIX}: {copy}
+            </p>
+          );
+        }
+        const state = reason.connectionState;
+        if (state && isReconnectConnectionState(state)) {
+          const kind = connectionProvider(reconnecting[0]);
+          const targets =
+            reconnecting.length > 0
+              ? reconnecting
+              : [FALLBACK_RECONNECT_CONNECTION];
+          return (
+            <div className="flex flex-col items-start gap-2" key={reasonKey}>
+              <p className="text-sm text-text">
+                {BOOKING_NOT_BOOKABLE_PREFIX}: {RECONNECT_BANNER_MESSAGE[kind]}
+              </p>
+              {targets.map((connection) => (
+                <BookingReconnectButton
+                  connection={connection}
+                  key={connection.id}
+                />
+              ))}
+            </div>
+          );
+        }
+        const copy = state ? bookingConnectionUnbookableCopy(state) : null;
+        return (
+          <p className="text-sm text-text" key={reasonKey}>
+            {BOOKING_NOT_BOOKABLE_PREFIX}
+            {copy ? `: ${copy}` : "."}
+          </p>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -286,6 +286,7 @@ describe("BookingSettingsSection", () => {
     expect(mockTrack).toHaveBeenCalledWith("booking_settings_opened", {
       has_connection: false,
       is_live: false,
+      is_bookable: false,
     });
   });
 
@@ -1505,6 +1506,7 @@ describe("BookingSettingsSection", () => {
     expect(mockTrack).toHaveBeenCalledWith("booking_settings_opened", {
       has_connection: false,
       is_live: false,
+      is_bookable: false,
     });
   });
 
@@ -1544,9 +1546,12 @@ describe("BookingSettingsSection", () => {
     );
 
     await screen.findByLabelText("Page address");
-    expect(mockTrack).toHaveBeenCalledWith("booking_settings_opened", {
-      has_connection: true,
-      is_live: true,
+    await waitFor(() => {
+      expect(mockTrack).toHaveBeenCalledWith("booking_settings_opened", {
+        has_connection: true,
+        is_live: true,
+        is_bookable: true,
+      });
     });
   });
 

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -42,6 +42,7 @@ import { BookingWeeklyHoursEditor } from "@web/booking/BookingWeeklyHoursEditor"
 import {
   bookingSaveErrorInline,
   useBookingPageQuery,
+  useBookingStatusQuery,
   useSaveBookingPageMutation,
 } from "@web/booking/booking.query";
 import {
@@ -250,6 +251,9 @@ export function BookingSettingsSection({
   ]);
 
   const { data: serverPage, isPending } = useBookingPageQuery(true);
+  const isLiveSavedPage =
+    isSavedBookingPage(serverPage) && serverPage.enabled === true;
+  const statusQuery = useBookingStatusQuery(isLiveSavedPage);
   const saveMutation = useSaveBookingPageMutation();
   const [form, setForm] = useState<AdminPutBookingPageInput>(() =>
     buildInitialForm(
@@ -382,16 +386,27 @@ export function BookingSettingsSection({
       track("booking_settings_opened", {
         has_connection: false,
         is_live: false,
+        is_bookable: false,
       });
       return;
     }
     if (isSeedingForm) return;
+    const isLive =
+      isSavedBookingPage(serverPage) && serverPage.enabled === true;
+    if (isLive && !statusQuery.isFetched) return;
     settingsOpenedRef.current = true;
     track("booking_settings_opened", {
       has_connection: true,
-      is_live: isSavedBookingPage(serverPage) && serverPage.enabled === true,
+      is_live: isLive,
+      is_bookable: isLive && statusQuery.data?.bookable === true,
     });
-  }, [hasHealthyConnection, isSeedingForm, serverPage]);
+  }, [
+    hasHealthyConnection,
+    isSeedingForm,
+    serverPage,
+    statusQuery.data?.bookable,
+    statusQuery.isFetched,
+  ]);
 
   const showFirstRunConnectPrompt =
     !hasHealthyConnection &&
@@ -646,9 +661,12 @@ export function BookingSettingsSection({
         <BookingStatusHeader
           addressPreview={addressPreview}
           bookingUrl={savedPage?.bookingUrl ?? null}
+          calendars={calendars}
+          connections={connections}
           isLive={isLive}
           isPending={saveMutation.isPending}
           onToggle={(next) => submit(next)}
+          status={statusQuery.data}
         />
 
         <div className="max-w-[50%]">

--- a/packages/web/src/booking/BookingStatusHeader.test.tsx
+++ b/packages/web/src/booking/BookingStatusHeader.test.tsx
@@ -1,0 +1,210 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import {
+  type BookingPageStatusReason,
+  type BookingPageStatusResponse,
+} from "@core/types/booking.contracts";
+import { CalendarIdSchema } from "@core/types/domain-primitives";
+import { createStoreWrapper } from "@web/__tests__/render-with-store";
+import {
+  createMockCalendar,
+  createMockConnection,
+} from "@web/__tests__/utils/factories/calendar.factory";
+import { RECONNECT_CALENDAR_LABEL } from "@web/auth/providers/provider-copy.util";
+import { userMetadataActions } from "@web/auth/state/user-metadata.store";
+import { BookingStatusHeader } from "@web/booking/BookingStatusHeader";
+import {
+  BOOKING_BILLING_STATUS_COPY,
+  BOOKING_DELAYED_STATUS_COPY,
+  BOOKING_IMPORTING_STATUS_COPY,
+  BOOKING_NOT_BOOKABLE_PREFIX,
+} from "@web/booking/booking-bookability.copy";
+import { createObjectIdString } from "@web/common/utils/id/object-id.util";
+import { describe, expect, it } from "bun:test";
+
+const calendarId = CalendarIdSchema.parse(createObjectIdString());
+const workCalendar = createMockCalendar({ id: calendarId, name: "Work" });
+const bookingUrl = "https://compasscalendar.com/meet/hostuser";
+const connection = createMockConnection("host@example.com", {
+  connectionState: "RECONNECT_REQUIRED",
+  state: "actionRequired",
+});
+
+const renderHeader = (
+  status: BookingPageStatusResponse | undefined,
+  reasonOverrides: {
+    connections?: (typeof connection)[];
+  } = {},
+) => {
+  userMetadataActions.set({
+    google: {
+      connectionState: "HEALTHY",
+      connections: reasonOverrides.connections ?? [connection],
+    },
+  });
+  const { wrapper } = createStoreWrapper();
+  return render(
+    <BookingStatusHeader
+      addressPreview={null}
+      bookingUrl={bookingUrl}
+      calendars={[workCalendar]}
+      connections={reasonOverrides.connections ?? [connection]}
+      isLive
+      isPending={false}
+      onToggle={() => undefined}
+      status={status}
+    />,
+    { wrapper },
+  );
+};
+
+const unbookable = (
+  reasons: BookingPageStatusReason[],
+): BookingPageStatusResponse => ({
+  bookable: false,
+  reasons,
+});
+
+describe("BookingStatusHeader", () => {
+  it("renders no bookability line when status is bookable", () => {
+    renderHeader({ bookable: true, reasons: [] });
+
+    expect(screen.getByLabelText("Meeting link")).toHaveValue(bookingUrl);
+    expect(
+      screen.queryByText(new RegExp(BOOKING_NOT_BOOKABLE_PREFIX)),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: RECONNECT_CALENDAR_LABEL.google }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders reconnect only for actionRequired connections", () => {
+    renderHeader(
+      unbookable([
+        {
+          kind: "connection",
+          reason: "actionRequired",
+          connectionState: "actionRequired",
+        },
+      ]),
+    );
+
+    expect(
+      screen.getByText(
+        /Guests can't book right now: Google Calendar needs reconnecting/,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: RECONNECT_CALENDAR_LABEL.google }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders reconnect for a disconnected connection", () => {
+    const disconnected = createMockConnection("host@example.com", {
+      connectionState: "RECONNECT_REQUIRED",
+      state: "disconnected",
+    });
+    renderHeader(
+      unbookable([
+        {
+          kind: "connection",
+          reason: "disconnected",
+          connectionState: "disconnected",
+        },
+      ]),
+      { connections: [disconnected] },
+    );
+
+    expect(
+      screen.getByRole("button", { name: RECONNECT_CALENDAR_LABEL.google }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders importing copy without a reconnect button", () => {
+    renderHeader(
+      unbookable([
+        {
+          kind: "connection",
+          reason: "importing",
+          connectionState: "importing",
+        },
+      ]),
+      { connections: [] },
+    );
+
+    expect(
+      screen.getByText(
+        `${BOOKING_NOT_BOOKABLE_PREFIX}: ${BOOKING_IMPORTING_STATUS_COPY}`,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: RECONNECT_CALENDAR_LABEL.google }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders delayed copy without a reconnect button", () => {
+    renderHeader(
+      unbookable([
+        {
+          kind: "connection",
+          reason: "delayed",
+          connectionState: "delayed",
+        },
+      ]),
+      { connections: [] },
+    );
+
+    expect(
+      screen.getByText(
+        `${BOOKING_NOT_BOOKABLE_PREFIX}: ${BOOKING_DELAYED_STATUS_COPY}`,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: RECONNECT_CALENDAR_LABEL.google }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("names a stale blocking calendar", () => {
+    renderHeader(
+      unbookable([{ kind: "calendar", reason: "stale", calendarId }]),
+      { connections: [] },
+    );
+
+    expect(
+      screen.getByText(
+        `${BOOKING_NOT_BOOKABLE_PREFIX}: Work hasn't synced recently. Guests can book once it catches up.`,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: RECONNECT_CALENDAR_LABEL.google }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("falls back when a notImported calendar is unnamed", () => {
+    renderHeader(unbookable([{ kind: "calendar", reason: "notImported" }]), {
+      connections: [],
+    });
+
+    expect(
+      screen.getByText(
+        `${BOOKING_NOT_BOOKABLE_PREFIX}: A blocking calendar is no longer synced. Remove it from Blocking calendars or reconnect the account.`,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders billing copy", () => {
+    renderHeader(
+      unbookable([{ kind: "billing", reason: "BILLING_REQUIRED" }]),
+      { connections: [] },
+    );
+
+    expect(
+      screen.getByText(
+        `${BOOKING_NOT_BOOKABLE_PREFIX}: ${BOOKING_BILLING_STATUS_COPY}`,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: RECONNECT_CALENDAR_LABEL.google }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/booking/BookingStatusHeader.tsx
+++ b/packages/web/src/booking/BookingStatusHeader.tsx
@@ -1,3 +1,7 @@
+import { type BookingPageStatusResponse } from "@core/types/booking.contracts";
+import { type Calendar } from "@core/types/calendar.contracts";
+import { type SyncConnectionSummary } from "@core/types/user.types";
+import { BookingBookabilityNotice } from "@web/booking/BookingBookabilityNotice";
 import { BookingCopyLink } from "@web/booking/BookingCopyLink";
 import { bookingFieldAttrs } from "@web/booking/booking-sequence.fields";
 import { Switch } from "@web/components/Switch/Switch";
@@ -8,6 +12,9 @@ interface BookingStatusHeaderProps {
   onToggle: (next: boolean) => void;
   bookingUrl: string | null;
   addressPreview: string | null;
+  calendars: readonly Calendar[];
+  connections: readonly SyncConnectionSummary[];
+  status: BookingPageStatusResponse | undefined;
 }
 
 export function BookingStatusHeader({
@@ -16,6 +23,9 @@ export function BookingStatusHeader({
   onToggle,
   bookingUrl,
   addressPreview,
+  calendars,
+  connections,
+  status,
 }: BookingStatusHeaderProps) {
   return (
     <div className="flex flex-col gap-2">
@@ -43,6 +53,13 @@ export function BookingStatusHeader({
           ) : null}
         </>
       )}
+      {isLive && status ? (
+        <BookingBookabilityNotice
+          calendars={calendars}
+          connections={connections}
+          status={status}
+        />
+      ) : null}
     </div>
   );
 }

--- a/packages/web/src/booking/booking-bookability.copy.ts
+++ b/packages/web/src/booking/booking-bookability.copy.ts
@@ -1,0 +1,55 @@
+import { type Calendar } from "@core/types/calendar.contracts";
+import { type CalendarId } from "@core/types/domain-primitives";
+import { type ConnectionState } from "@core/types/sync/connection.contracts";
+
+export const BOOKING_NOT_BOOKABLE_PREFIX = "Guests can't book right now";
+export const BOOKING_NAV_NEEDS_ATTENTION = "needs attention";
+export const BOOKING_BLOCKING_CALENDAR_FALLBACK = "A blocking calendar";
+export const BOOKING_BILLING_STATUS_COPY =
+  "A paid subscription is required to make changes";
+export const BOOKING_IMPORTING_STATUS_COPY =
+  "Your calendar is still importing. Guests can book once it finishes.";
+export const BOOKING_DELAYED_STATUS_COPY =
+  "Your calendar sync is delayed. Compass is retrying.";
+
+const reconnectStates = new Set<ConnectionState>([
+  "actionRequired",
+  "disconnected",
+]);
+
+export function isReconnectConnectionState(state: ConnectionState): boolean {
+  return reconnectStates.has(state);
+}
+
+export function bookingCalendarName(
+  calendars: readonly Calendar[],
+  calendarId: CalendarId | undefined,
+): string {
+  if (!calendarId) return BOOKING_BLOCKING_CALENDAR_FALLBACK;
+  return (
+    calendars.find((calendar) => calendar.id === calendarId)?.name ??
+    BOOKING_BLOCKING_CALENDAR_FALLBACK
+  );
+}
+
+export function bookingCalendarUnbookableCopy(
+  calendarName: string,
+  reason: string,
+): string {
+  if (reason === "notImported") {
+    return `${calendarName} is no longer synced. Remove it from Blocking calendars or reconnect the account.`;
+  }
+  return `${calendarName} hasn't synced recently. Guests can book once it catches up.`;
+}
+
+export function bookingConnectionUnbookableCopy(
+  state: ConnectionState,
+): string | null {
+  if (state === "importing" || state === "connecting") {
+    return BOOKING_IMPORTING_STATUS_COPY;
+  }
+  if (state === "delayed" || state === "catchingUp") {
+    return BOOKING_DELAYED_STATUS_COPY;
+  }
+  return null;
+}

--- a/packages/web/src/booking/booking.query.ts
+++ b/packages/web/src/booking/booking.query.ts
@@ -5,6 +5,7 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
+import { useEffect } from "react";
 import { ZodError } from "zod/v4";
 import {
   type AdminPutBookingPageInput,
@@ -12,6 +13,7 @@ import {
 } from "@core/types/booking.contracts";
 import { BookingApi } from "@web/api/booking.api";
 import { getApiErrorCode, isApiError } from "@web/api/util/api.util";
+import { useUserMetadataStore } from "@web/auth/state/user-metadata.store";
 import { billingQueryKeys } from "@web/billing/billing.query";
 import { billingPreviewActions } from "@web/billing/billing-preview.store";
 import { BOOKING_AVAILABILITY_REQUIRED_MESSAGE } from "@web/booking/booking.util";
@@ -20,6 +22,7 @@ import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
 
 export const bookingQueryKeys = {
   page: ["booking", "page"] as const,
+  status: ["booking", "page", "status"] as const,
 };
 
 export function bookingPageQueryOptions() {
@@ -30,9 +33,32 @@ export function bookingPageQueryOptions() {
   });
 }
 
+export function bookingStatusQueryOptions() {
+  return queryOptions({
+    queryKey: bookingQueryKeys.status,
+    queryFn: () => BookingApi.getPageStatus(),
+    staleTime: 30_000,
+    refetchOnWindowFocus: "always" as const,
+  });
+}
+
 export function useBookingPageQuery(enabled: boolean) {
   return useQuery({
     ...bookingPageQueryOptions(),
+    enabled,
+  });
+}
+
+export function useBookingStatusQuery(enabled: boolean) {
+  const queryClient = useQueryClient();
+  const metadata = useUserMetadataStore((state) => state.current);
+  useEffect(() => {
+    if (!enabled) return;
+    void metadata;
+    void queryClient.invalidateQueries({ queryKey: bookingQueryKeys.status });
+  }, [enabled, metadata, queryClient]);
+  return useQuery({
+    ...bookingStatusQueryOptions(),
     enabled,
   });
 }
@@ -110,6 +136,7 @@ export function useSaveBookingPageMutation() {
     },
     onSuccess: (data) => {
       queryClient.setQueryData(bookingQueryKeys.page, data);
+      void queryClient.invalidateQueries({ queryKey: bookingQueryKeys.status });
     },
     onError: (error) => handleBookingSaveError(error, queryClient),
   });

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -735,6 +735,66 @@ describe("SettingsModal", () => {
     expect(screen.getByRole("button", { name: "Meeting" })).toBeInTheDocument();
   });
 
+  it("marks Meeting as needing attention when the live page is not bookable", async () => {
+    const calendar = createMockCalendar({ name: "Work" });
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(
+          ctx.json({
+            id: createObjectIdString(),
+            slug: "hostuser",
+            hostUserId: createObjectIdString(),
+            enabled: true,
+            durationMinutes: 30,
+            destinationCalendarId: calendar.id,
+            blockingCalendarIds: [calendar.id],
+            timeZone: "UTC",
+            weeklyAvailability: DEFAULT_WEEKLY_AVAILABILITY,
+            minNoticeHours: 4,
+            maxHorizonDays: 60,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            bookingUrl: "https://compasscalendar.com/meet/hostuser",
+          }),
+        ),
+      ),
+      rest.get(`${bookingPageUrl}/status`, (_req, res, ctx) =>
+        res(
+          ctx.json({
+            bookable: false,
+            reasons: [
+              {
+                kind: "calendar",
+                reason: "stale",
+                calendarId: calendar.id,
+              },
+            ],
+          }),
+        ),
+      ),
+    );
+
+    renderSettings({
+      authenticated: true,
+      calendars: [calendar],
+    });
+
+    await waitFor(() => {
+      expect(
+        within(screen.getByRole("button", { name: /Meeting/ })).getByText(
+          "needs attention",
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("does not mark Meeting as needing attention when the page is bookable", async () => {
+    renderSettings({ authenticated: true });
+
+    const meeting = screen.getByRole("button", { name: "Meeting" });
+    expect(within(meeting).queryByText("needs attention")).toBeNull();
+  });
+
   it("hides Booking for a signed-out session", () => {
     renderSettings({ authenticated: false });
 

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -1,4 +1,5 @@
 import { type FC, Suspense, useEffect, useRef, useState } from "react";
+import { isSavedBookingPage } from "@core/types/booking.contracts";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
 import { providerDisplayName } from "@core/types/sync/identity.contracts";
@@ -25,6 +26,11 @@ import { getPlanBadge } from "@web/billing/planBadge";
 import { useUpgradeConfirmation } from "@web/billing/UpgradeConfirmation/hooks/useUpgradeConfirmation";
 import { useAppAccess } from "@web/billing/useAppAccess";
 import { LazyBookingSettingsSection as BookingSettingsSection } from "@web/booking/BookingSettingsSection.lazy";
+import {
+  useBookingPageQuery,
+  useBookingStatusQuery,
+} from "@web/booking/booking.query";
+import { BOOKING_NAV_NEEDS_ATTENTION } from "@web/booking/booking-bookability.copy";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import {
   compareCalendars,
@@ -144,6 +150,15 @@ export const SettingsModal: FC = () => {
 
   const { data } = useCalendarsQuery();
   const connections = useUserMetadataStore(selectSyncConnections);
+  const showBookingNav = authenticated && IS_BOOKING_ENABLED;
+  const { data: bookingPage } = useBookingPageQuery(isOpen && showBookingNav);
+  const isLiveBookingPage =
+    isSavedBookingPage(bookingPage) && bookingPage.enabled === true;
+  const { data: bookingStatus } = useBookingStatusQuery(
+    isOpen && showBookingNav && isLiveBookingPage,
+  );
+  const bookingNeedsAttention =
+    isLiveBookingPage && bookingStatus?.bookable === false;
   const accountEmailOrder = useConnectedAccountEmails();
   // useDefaultTargetCalendar subscribes to session reconnect overrides, so
   // writableCalendars recomputes when a 410 lands before Sync metadata catches up.
@@ -251,7 +266,18 @@ export const SettingsModal: FC = () => {
               type="button"
               {...settingsShortcutAttrs("nav-booking")}
             >
-              Meeting
+              <span className="flex items-center gap-2">
+                Meeting
+                {bookingNeedsAttention ? (
+                  <span
+                    aria-hidden
+                    className="size-1.5 shrink-0 rounded-full bg-warning"
+                  />
+                ) : null}
+                {bookingNeedsAttention ? (
+                  <span className="sr-only">{BOOKING_NAV_NEEDS_ATTENTION}</span>
+                ) : null}
+              </span>
               {areHintsVisible ? <ShortcutKeys keys="3" /> : null}
             </button>
           ) : null}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3569

## What and why

A live Meeting page now tells the host whether guests can book right now. `GET /api/booking/page/status` runs the same readiness probe as guest slots (availability plus billing). When guests cannot book, the status header keeps the meeting link and adds `Guests can't book right now:` plus the fix: reconnect, importing/delayed copy, blocking-calendar catch-up or remove copy, or the paid-subscription sentence. The Settings Meeting nav shows a warning dot and sr-only `needs attention` while the page is live and not bookable. Spec: `docs/features/booking.md`.

## Verify

`VERDICT: PASS`

Checks run: `test:core`, `test:web`, `test:backend`, `type-check`, `lint`, `knip`, `test:e2e`, `test:a11y`

The first `bun run verify --strict` failed `test:a11y` on `e2e/accessibility/booking-a11y.spec.ts` first-run hours (Enter keycap / `.h-11` contrast). That spec is outside this diff's UI. Isolated rerun and a full `bun test:a11y` retry both passed (54/54).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8d28ca7-decd-49e5-a5f2-a6c88cc4f61a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8d28ca7-decd-49e5-a5f2-a6c88cc4f61a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

