### PR TITLE
fix(web): booking setup wizard dead-ends, Back button, address focus

### DIFF
--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -276,12 +276,17 @@ scrolls, so the first wheel tick does not re-rasterize the backdrop.
 - **First run:** before any draft exists, Meeting settings open a guided
   setup wizard: one question per screen with "Step N of M", a title, one
   sentence, and **Continue** (Mod+Enter). Steps are address, weekly hours,
-  duration, destination calendar (only when more than one writable calendar
-  exists), then go live. Plain Enter continues from the address input or the
-  Continue button; `k` continues and `j` goes back when focus is not in an
-  editable target; Esc goes back one step (on step 1 it closes Settings).
-  Address **Continue** saves a disabled draft so the slug is reserved.
-  **Turn on and copy link** on the last step saves with `enabled: true`,
+  duration, destination calendar (hidden only when exactly one writable
+  calendar exists), then go live. With zero writable calendars the destination
+  step shows "Connect a calendar you can write to before going live." with the
+  connect buttons, **Continue** stays disabled, and go live is unreachable
+  until a writable calendar exists. Every step after the first also shows
+  **Back** beside **Continue**. Plain Enter continues from the address input or
+  the Continue button; `k` continues and `j` goes back when focus is not in an
+  editable target; Esc goes back one step (on step 1 it closes Settings). The
+  hint row labels Enter, Esc, K, and J. Address **Continue** saves a disabled
+  draft so the slug is reserved; a taken-address error focuses the address
+  field. **Turn on and copy link** on the last step saves with `enabled: true`,
   copies the link, and then shows the full form with the switch focused.
 - **Timezone** uses the same searchable combobox as time travel. The
   trigger is one tab stop and still renders a stored non-canonical alias.

--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -649,6 +649,42 @@ test.describe("settings booking section", () => {
     });
   });
 
+  test("first-run zero-calendar destination step has no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await prepareSignedInBookingSettingsPage(page, {
+      configured: false,
+      enabled: false,
+      writableCalendars: false,
+    });
+    const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+    await dispatchClick(
+      settingsDialog.getByRole("button", { name: /Continue/ }),
+    );
+    await expect(
+      settingsDialog
+        .locator("p.text-text-muted")
+        .filter({ hasText: /^Step 2 of \d+$/ }),
+    ).toBeVisible();
+    await page.keyboard.press("k");
+    await page.keyboard.press("k");
+    await expect(
+      settingsDialog.getByText(
+        "Connect a calendar you can write to before going live.",
+      ),
+    ).toBeVisible();
+    await expect(
+      settingsDialog.getByRole("button", { name: "Connect Google Calendar" }),
+    ).toBeVisible();
+    await expect(
+      settingsDialog.getByRole("button", { name: /Continue/ }),
+    ).toBeDisabled();
+    await expectNoAxeViolations(page, {
+      checkpoint: "settings booking first-run zero-calendar destination",
+      include: "[role='dialog']",
+    });
+  });
+
   test("first-run go-live step has no automatically detectable accessibility violations", async ({
     page,
   }) => {

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -995,6 +995,8 @@ export interface HostBookingSettingsStubOptions {
     start: string;
     end: string;
   }>;
+  /** When false, stub calendars are read-only so the host has none writable. */
+  writableCalendars?: boolean;
 }
 
 export interface CapturedHostBookingRequests {
@@ -1111,9 +1113,19 @@ export async function prepareSignedInBookingSettingsPage(
     const path = url.pathname;
 
     if (path.endsWith("/api/calendars")) {
-      return route.fulfill(
-        jsonResponse({ calendars: [googleCalendar, compassCalendar] }),
-      );
+      const calendars =
+        options.writableCalendars === false
+          ? [
+              {
+                ...googleCalendar,
+                capabilities: {
+                  ...googleCalendar.capabilities,
+                  canWrite: false,
+                },
+              },
+            ]
+          : [googleCalendar, compassCalendar];
+      return route.fulfill(jsonResponse({ calendars }));
     }
 
     if (path.endsWith("/api/event") && request.method() === "GET") {

--- a/packages/web/src/booking/setup/BookingSetupDestinationStep.tsx
+++ b/packages/web/src/booking/setup/BookingSetupDestinationStep.tsx
@@ -1,14 +1,13 @@
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
 import { type SyncConnectionSummary } from "@core/types/user.types";
+import { ConnectProviderChooser } from "@web/auth/providers/ConnectProviderChooser";
 import {
   bookingDestinationConferenceHint,
   formatBookingDestinationOptionLabel,
 } from "@web/booking/booking-conference.copy";
+import { BOOKING_SELECT_CLASS_NAME } from "@web/booking/booking-form.styles";
 import { groupCalendarsByAccount } from "@web/calendars/calendar.util";
-
-const BOOKING_SELECT_CLASS_NAME =
-  "c-focus-ring w-full rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text hover:bg-surface-panel";
 
 interface BookingSetupDestinationStepProps {
   connections: SyncConnectionSummary[];
@@ -23,6 +22,10 @@ export function BookingSetupDestinationStep({
   onChange,
   writableCalendars,
 }: BookingSetupDestinationStepProps) {
+  if (writableCalendars.length === 0) {
+    return <ConnectProviderChooser variant="prompt" />;
+  }
+
   const { groups: writableGroups, ungrouped: writableUngrouped } =
     groupCalendarsByAccount(writableCalendars, connections);
   const destinationCalendar = writableCalendars.find(
@@ -75,4 +78,10 @@ export function BookingSetupDestinationStep({
       ) : null}
     </div>
   );
+}
+
+export function destinationStepCanContinue(
+  writableCalendarCount: number,
+): boolean {
+  return writableCalendarCount > 0;
 }

--- a/packages/web/src/booking/setup/BookingSetupWizard.test.tsx
+++ b/packages/web/src/booking/setup/BookingSetupWizard.test.tsx
@@ -1,0 +1,153 @@
+import "@testing-library/jest-dom";
+import { HotkeysProvider } from "@tanstack/react-hotkeys";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useRef, useState } from "react";
+import {
+  type AdminPutBookingPageInput,
+  DEFAULT_WEEKLY_AVAILABILITY,
+} from "@core/types/booking.contracts";
+import {
+  CalendarIdSchema,
+  TimeZoneSchema,
+} from "@core/types/domain-primitives";
+import { createStoreWrapper } from "@web/__tests__/render-with-store";
+import {
+  resetProviderAvailabilityForTests,
+  setProviderAvailabilityForTests,
+} from "@web/auth/providers/useIsProviderAvailable";
+import { BOOKING_SAVE_ERROR_COPY } from "@web/booking/booking.query";
+import { BookingSetupWizard } from "@web/booking/setup/BookingSetupWizard";
+import {
+  nextSetupStep,
+  prevSetupStep,
+  SETUP_DESTINATION_ZERO_CALENDARS_SENTENCE,
+  type SetupStepId,
+} from "@web/booking/setup/setup-steps";
+import { createObjectIdString } from "@web/common/utils/id/object-id.util";
+import { afterEach, describe, expect, it } from "bun:test";
+
+const destinationCalendarId = CalendarIdSchema.parse(createObjectIdString());
+
+const defaultForm: AdminPutBookingPageInput = {
+  slug: "hostuser",
+  enabled: false,
+  durationMinutes: 30,
+  destinationCalendarId,
+  blockingCalendarIds: [destinationCalendarId],
+  timeZone: TimeZoneSchema.parse("UTC"),
+  weeklyAvailability: DEFAULT_WEEKLY_AVAILABILITY,
+  minNoticeHours: 4,
+  maxHorizonDays: 60,
+};
+
+function WizardHarness({
+  initialStep = "address",
+  writableCalendarCount = 1,
+  forceAddressInvalid = false,
+  setupError = null,
+}: {
+  initialStep?: SetupStepId;
+  writableCalendarCount?: number;
+  forceAddressInvalid?: boolean;
+  setupError?: string | null;
+}) {
+  const [step, setStep] = useState(initialStep);
+  const continueRef = useRef<HTMLButtonElement>(null);
+
+  return (
+    <HotkeysProvider>
+      <BookingSetupWizard
+        bookingUrl={null}
+        continueRef={continueRef}
+        destinationCalendar={undefined}
+        forceAddressInvalid={forceAddressInvalid}
+        form={defaultForm}
+        isPending={false}
+        onAddressChange={() => {}}
+        onBack={() => {
+          setStep(
+            (current) =>
+              prevSetupStep(current, writableCalendarCount) ?? current,
+          );
+        }}
+        onContinue={() => {
+          setStep(
+            (current) =>
+              nextSetupStep(current, writableCalendarCount) ?? current,
+          );
+        }}
+        onDestinationChange={() => {}}
+        onDurationChange={() => {}}
+        onHoursChange={() => {}}
+        setupError={setupError}
+        setupStep={step}
+        syncConnections={[]}
+        writableCalendarCount={writableCalendarCount}
+        writableCalendars={[]}
+      />
+    </HotkeysProvider>
+  );
+}
+
+const renderWizard = (props: Parameters<typeof WizardHarness>[0] = {}) => {
+  const { wrapper } = createStoreWrapper();
+  return render(<WizardHarness {...props} />, { wrapper });
+};
+
+afterEach(() => {
+  resetProviderAvailabilityForTests();
+});
+
+describe("BookingSetupWizard", () => {
+  it("shows the zero-calendar destination prompt with Continue disabled", async () => {
+    setProviderAvailabilityForTests("google", "available", "connect");
+
+    renderWizard({ initialStep: "destination", writableCalendarCount: 0 });
+
+    expect(
+      screen.getByText(SETUP_DESTINATION_ZERO_CALENDARS_SENTENCE),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Connect Google Calendar" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Continue/ })).toBeDisabled();
+  });
+
+  it("shows Back from step 2 and hides it on step 1", async () => {
+    const user = userEvent.setup({ delay: null });
+
+    renderWizard({ initialStep: "hours" });
+
+    expect(screen.getByRole("button", { name: "Back" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Back" }));
+    expect(
+      screen.getByRole("heading", { name: "Pick your address" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Back" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("labels keyboard hint chips", () => {
+    renderWizard({ initialStep: "hours" });
+
+    const hintRow = screen.getByText("Next").closest(".inline-flex");
+    expect(hintRow?.textContent).toMatch(/Continue/);
+    expect(hintRow?.textContent).toMatch(/Back/);
+    expect(hintRow?.textContent).toMatch(/Next/);
+  });
+
+  it("focuses the address field after a SLUG_TAKEN error", async () => {
+    renderWizard({
+      forceAddressInvalid: true,
+      setupError: BOOKING_SAVE_ERROR_COPY.SLUG_TAKEN,
+    });
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(
+        screen.getByLabelText("Page address"),
+      );
+    });
+  });
+});

--- a/packages/web/src/booking/setup/BookingSetupWizard.tsx
+++ b/packages/web/src/booking/setup/BookingSetupWizard.tsx
@@ -7,7 +7,10 @@ import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
 import { type SyncConnectionSummary } from "@core/types/user.types";
 import { BookingSetupAddressStep } from "@web/booking/setup/BookingSetupAddressStep";
-import { BookingSetupDestinationStep } from "@web/booking/setup/BookingSetupDestinationStep";
+import {
+  BookingSetupDestinationStep,
+  destinationStepCanContinue,
+} from "@web/booking/setup/BookingSetupDestinationStep";
 import { BookingSetupDurationStep } from "@web/booking/setup/BookingSetupDurationStep";
 import { BookingSetupGoLiveStep } from "@web/booking/setup/BookingSetupGoLiveStep";
 import { BookingSetupHoursStep } from "@web/booking/setup/BookingSetupHoursStep";
@@ -64,7 +67,7 @@ const focusStepFirstControl = (
     case "destination":
       root
         .querySelector<HTMLElement>("#booking-setup-destination-calendar")
-        ?.focus();
+        ?.focus() ?? root.querySelector<HTMLElement>("button")?.focus();
       break;
     case "live":
       continueRefFallback(root)?.focus();
@@ -99,20 +102,30 @@ export function BookingSetupWizard({
   writableCalendars,
 }: BookingSetupWizardProps) {
   const stepBodyRef = useRef<HTMLDivElement>(null);
-  const stepMeta = setupStepDefinition(setupStep);
+  const stepMeta = setupStepDefinition(setupStep, writableCalendarCount);
   const { current, total } = setupStepProgress(
     setupStep,
     writableCalendarCount,
   );
   const isGoLive = setupStep === "live";
+  const isFirstStep = setupStep === "address";
+  const canContinue =
+    setupStep !== "destination" ||
+    destinationStepCanContinue(writableCalendarCount);
 
   useEffect(() => {
+    if (setupStep === "address" && forceAddressInvalid) {
+      stepBodyRef.current
+        ?.querySelector<HTMLElement>("#booking-address")
+        ?.focus();
+      return;
+    }
     if (setupStep === "live") {
       continueRef.current?.focus();
       return;
     }
     focusStepFirstControl(setupStep, stepBodyRef.current);
-  }, [continueRef, setupStep]);
+  }, [continueRef, forceAddressInvalid, setupStep]);
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     const target = event.target;
@@ -122,6 +135,7 @@ export function BookingSetupWizard({
       (event.key === "k" || event.key === "K") &&
       !isEditableKeyboardTarget(event)
     ) {
+      if (!canContinue) return;
       event.preventDefault();
       onContinue();
       return;
@@ -145,6 +159,7 @@ export function BookingSetupWizard({
         target.type === "");
     const isContinueButton = target === continueRef.current;
     if (!isTextInput && !isContinueButton) return;
+    if (!canContinue) return;
 
     event.preventDefault();
     onContinue();
@@ -219,13 +234,26 @@ export function BookingSetupWizard({
           <span>Continue</span>
           <ShortcutKeys keys="Esc" />
           <span>Back</span>
-          <ShortcutKeys keys={["J", "K"]} />
+          <ShortcutKeys keys="K" />
+          <span>Next</span>
+          <ShortcutKeys keys="J" />
+          <span>Back</span>
         </span>
         <OverlayPanelActions>
+          {!isFirstStep ? (
+            <OverlayPanelActionButton
+              disabled={isPending}
+              onClick={onBack}
+              showShortcut={false}
+              variant="secondary"
+            >
+              Back
+            </OverlayPanelActionButton>
+          ) : null}
           <OverlayPanelActionButton
             aria-busy={isPending || undefined}
             aria-keyshortcuts="Meta+Enter Control+Enter"
-            disabled={isPending}
+            disabled={isPending || !canContinue}
             onClick={onContinue}
             ref={continueRef}
             shortcut={["Mod", "Enter"]}

--- a/packages/web/src/booking/setup/setup-steps.test.ts
+++ b/packages/web/src/booking/setup/setup-steps.test.ts
@@ -1,19 +1,25 @@
 import {
   nextSetupStep,
   prevSetupStep,
+  SETUP_DESTINATION_ZERO_CALENDARS_SENTENCE,
+  setupStepDefinition,
   setupStepProgress,
   visibleSetupSteps,
 } from "@web/booking/setup/setup-steps";
 import { describe, expect, it } from "bun:test";
 
 describe("visibleSetupSteps", () => {
-  it("omits destination for zero or one writable calendar", () => {
+  it("includes destination for zero writable calendars", () => {
     expect(visibleSetupSteps(0)).toEqual([
       "address",
       "hours",
       "duration",
+      "destination",
       "live",
     ]);
+  });
+
+  it("omits destination for exactly one writable calendar", () => {
     expect(visibleSetupSteps(1)).toEqual([
       "address",
       "hours",
@@ -33,6 +39,17 @@ describe("visibleSetupSteps", () => {
   });
 });
 
+describe("setupStepDefinition", () => {
+  it("uses the connect prompt sentence on destination with zero writable calendars", () => {
+    expect(setupStepDefinition("destination", 0).sentence).toBe(
+      SETUP_DESTINATION_ZERO_CALENDARS_SENTENCE,
+    );
+    expect(setupStepDefinition("destination", 1).sentence).toBe(
+      "New meetings you accept are added to this calendar.",
+    );
+  });
+});
+
 describe("nextSetupStep", () => {
   it("advances through visible steps and clamps at the end", () => {
     expect(nextSetupStep("address", 1)).toBe("hours");
@@ -45,6 +62,12 @@ describe("nextSetupStep", () => {
     expect(nextSetupStep("duration", 2)).toBe("destination");
     expect(nextSetupStep("destination", 2)).toBe("live");
     expect(nextSetupStep("live", 2)).toBeNull();
+  });
+
+  it("includes destination when no writable calendars exist", () => {
+    expect(nextSetupStep("duration", 0)).toBe("destination");
+    expect(nextSetupStep("destination", 0)).toBe("live");
+    expect(nextSetupStep("live", 0)).toBeNull();
   });
 });
 
@@ -60,6 +83,11 @@ describe("prevSetupStep", () => {
     expect(prevSetupStep("live", 2)).toBe("destination");
     expect(prevSetupStep("destination", 2)).toBe("duration");
   });
+
+  it("includes destination when no writable calendars exist", () => {
+    expect(prevSetupStep("live", 0)).toBe("destination");
+    expect(prevSetupStep("destination", 0)).toBe("duration");
+  });
 });
 
 describe("setupStepProgress", () => {
@@ -67,5 +95,10 @@ describe("setupStepProgress", () => {
     expect(setupStepProgress("address", 1)).toEqual({ current: 1, total: 4 });
     expect(setupStepProgress("live", 2)).toEqual({ current: 5, total: 5 });
     expect(setupStepProgress("duration", 2)).toEqual({ current: 3, total: 5 });
+    expect(setupStepProgress("destination", 0)).toEqual({
+      current: 4,
+      total: 5,
+    });
+    expect(setupStepProgress("live", 0)).toEqual({ current: 5, total: 5 });
   });
 });

--- a/packages/web/src/booking/setup/setup-steps.ts
+++ b/packages/web/src/booking/setup/setup-steps.ts
@@ -11,6 +11,9 @@ export interface SetupStepDefinition {
   sentence: string;
 }
 
+export const SETUP_DESTINATION_ZERO_CALENDARS_SENTENCE =
+  "Connect a calendar you can write to before going live.";
+
 export const SETUP_STEPS: readonly SetupStepDefinition[] = [
   {
     id: "address",
@@ -44,20 +47,26 @@ const SETUP_STEP_BY_ID = new Map(
   SETUP_STEPS.map((step) => [step.id, step] as const),
 );
 
-export function setupStepDefinition(id: SetupStepId): SetupStepDefinition {
+export function setupStepDefinition(
+  id: SetupStepId,
+  writableCalendarCount?: number,
+): SetupStepDefinition {
   const step = SETUP_STEP_BY_ID.get(id);
   if (step == null) {
     throw new Error(`Unknown setup step: ${id}`);
   }
+  if (id === "destination" && writableCalendarCount === 0) {
+    return { ...step, sentence: SETUP_DESTINATION_ZERO_CALENDARS_SENTENCE };
+  }
   return step;
 }
 
-/** Ordered step ids for the wizard; destination appears only with 2+ writable calendars. */
+/** Ordered step ids for the wizard; destination is hidden only with exactly one writable calendar. */
 export function visibleSetupSteps(
   writableCalendarCount: number,
 ): readonly SetupStepId[] {
   const steps: SetupStepId[] = ["address", "hours", "duration"];
-  if (writableCalendarCount >= 2) {
+  if (writableCalendarCount !== 1) {
     steps.push("destination");
   }
   steps.push("live");


### PR DESCRIPTION
Fixes #3571

## What and why

First-run hosts with zero writable calendars could reach go live and hit a dead-end error. This shows the destination step with a connect prompt and disables Continue until a writable calendar exists, adds a visible Back button on wizard steps after the first, labels keyboard hint chips, and focuses the address field when the slug is already taken. Spec: `docs/features/booking.md` first-run section.

## Verify

```
Selected packages: web
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)

✓ All checks passed
VERDICT: PASS
```