### PR TITLE
feat(web): show sidebar nudge to set up the meeting page

### DIFF
--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -293,6 +293,12 @@ scrolls, so the first wheel tick does not re-rasterize the backdrop.
   Address **Continue** saves a disabled draft so the slug is reserved.
   **Turn on and copy link** on the last step saves with `enabled: true`,
   copies the link, and then shows the full form with the switch focused.
+- **Discovery:** a signed-in host whose page is not live sees a sidebar
+  card, **Let people book time with you**, under the calendar list. **Set
+  up meeting page** opens Settings on the Meeting tab. **Dismiss** hides
+  the card on that browser. Turning the page on hides it everywhere. The
+  card does not show on mobile, while the booking gate is off, or while
+  the first-event prompt is still pending.
 - **Timezone** uses the same searchable combobox as time travel. The
   trigger is one tab stop and still renders a stored non-canonical alias.
   It lives under More options on the configured form. The setup wizard
@@ -622,6 +628,10 @@ first scroll: the panel is promoted at mount, and an inner wrapper owns
 overflow so the transform transition is not on the scroll container. The
 Meeting tab's lazy chunk reserves height so the dialog does not collapse
 to the nav column while it loads.
+
+A signed-in host whose Meeting page is not live sees a sidebar card that
+opens Settings on the Meeting tab. Dismissing it is per browser; turning
+the page on hides it everywhere.
 
 ### v1.9
 

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -999,10 +999,16 @@ export interface HostBookingSettingsStubOptions {
     bookable: boolean;
     reasons: Array<Record<string, unknown>>;
   };
+  /** When false, stay on week view instead of opening Settings. */
+  openSettings?: boolean;
+  /** Mark welcome, showcase, and first-event as done so sidebar nudges can show. */
+  completeOnboarding?: boolean;
 }
 
 export interface CapturedHostBookingRequests {
   putBodies: Array<Record<string, unknown>>;
+  hostMetadata: Record<string, unknown>;
+  setGetPayload: (next: Record<string, unknown>) => void;
 }
 
 export async function prepareSignedInBookingSettingsPage(
@@ -1020,17 +1026,36 @@ export async function prepareSignedInBookingSettingsPage(
   const enabled = options.enabled ?? configured;
   const weeklyAvailability =
     options.weeklyAvailability ?? DEFAULT_WEEKLY_AVAILABILITY;
-  const captured: CapturedHostBookingRequests = { putBodies: [] };
 
-  await page.addInitScript((accountEmail) => {
-    (
-      window as Window & { __COMPASS_E2E_TEST__?: boolean }
-    ).__COMPASS_E2E_TEST__ = true;
-    localStorage.setItem(
-      "compass.auth",
-      JSON.stringify({ hasAuthenticated: true, lastKnownEmail: accountEmail }),
-    );
-  }, HOST_ACCOUNT_EMAIL);
+  await page.addInitScript(
+    ({ accountEmail, completeOnboarding }) => {
+      (
+        window as Window & { __COMPASS_E2E_TEST__?: boolean }
+      ).__COMPASS_E2E_TEST__ = true;
+      localStorage.setItem(
+        "compass.auth",
+        JSON.stringify({
+          hasAuthenticated: true,
+          lastKnownEmail: accountEmail,
+        }),
+      );
+      if (completeOnboarding) {
+        localStorage.setItem("compass.onboarding.has-seen-welcome", "true");
+        localStorage.setItem(
+          "compass.onboarding.has-seen-shortcut-showcase",
+          "true",
+        );
+        localStorage.setItem(
+          "compass.onboarding.first-event-done",
+          "dismissed",
+        );
+      }
+    },
+    {
+      accountEmail: HOST_ACCOUNT_EMAIL,
+      completeOnboarding: options.completeOnboarding === true,
+    },
+  );
 
   const bookingPagePayload = {
     enabled,
@@ -1058,6 +1083,13 @@ export async function prepareSignedInBookingSettingsPage(
   let getPayload: Record<string, unknown> = configured
     ? { ...bookingPagePayload, ...savedPageFields }
     : { ...bookingPagePayload, enabled: false, ...setupPageFields };
+  const captured: CapturedHostBookingRequests = {
+    putBodies: [],
+    hostMetadata: {},
+    setGetPayload: (next) => {
+      getPayload = next;
+    },
+  };
   const hostMetadata = healthyConnection
     ? {
         google: {
@@ -1108,6 +1140,8 @@ export async function prepareSignedInBookingSettingsPage(
           },
           connections: [],
         };
+
+  captured.hostMetadata = hostMetadata;
 
   await page.route("**/api/**", async (route) => {
     const request = route.request();
@@ -1222,6 +1256,10 @@ export async function prepareSignedInBookingSettingsPage(
   }, hostMetadata);
 
   await page.keyboard.press("Escape");
+  if (options.openSettings === false) {
+    return captured;
+  }
+
   await page.keyboard.press("Control+Comma");
 
   const settingsDialog = page.getByRole("dialog", { name: "Settings" });

--- a/e2e/booking/host-settings.spec.ts
+++ b/e2e/booking/host-settings.spec.ts
@@ -496,3 +496,90 @@ test("shows why guests cannot book when a blocking calendar is stale", async ({
     include: "[role='dialog']",
   });
 });
+
+test("sidebar nudge opens Meeting settings and hides once the page is live", async ({
+  page,
+}) => {
+  const captured = await prepareSignedInBookingSettingsPage(page, {
+    configured: false,
+    openSettings: false,
+    completeOnboarding: true,
+  });
+
+  const nudge = page.getByRole("region", { name: "Meeting page" });
+  await expect(nudge).toBeVisible();
+  await nudge.getByRole("button", { name: "Set up meeting page" }).click();
+
+  const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+  await expect(settingsDialog).toBeVisible();
+  await expect(
+    settingsDialog.getByRole("button", { name: "Meeting" }),
+  ).toHaveAttribute("aria-current", "true");
+  await expect(
+    settingsDialog
+      .locator("p.text-text-muted")
+      .filter({ hasText: /^Step 1 of \d+$/ }),
+  ).toBeVisible();
+
+  await page.keyboard.press("Escape");
+  await expect(settingsDialog).toHaveCount(0);
+
+  captured.setGetPayload({
+    enabled: true,
+    durationMinutes: 45,
+    destinationCalendarId: BOOKING_CALENDAR_ID,
+    blockingCalendarIds: [BOOKING_CALENDAR_ID],
+    timeZone: "America/New_York",
+    weeklyAvailability: DEFAULT_WEEKLY_AVAILABILITY,
+    minNoticeHours: 4,
+    maxHorizonDays: 60,
+    id: "000000000000000000000001",
+    slug: "hostuser",
+    hostUserId: "000000000000000000000002",
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+    bookingUrl: "https://compasscalendar.com/meet/hostuser",
+  });
+
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await expect(
+    page.getByRole("heading", { level: 1 }).getByRole("button"),
+  ).toBeVisible({ timeout: 15000 });
+  await page.waitForFunction(
+    () =>
+      (
+        window as Window & {
+          __COMPASS_E2E_HOOKS__?: { setAuthenticated: (v: boolean) => void };
+        }
+      ).__COMPASS_E2E_HOOKS__ !== undefined,
+  );
+  await page.evaluate(() => {
+    (
+      window as Window & {
+        __COMPASS_E2E_HOOKS__?: { setAuthenticated: (v: boolean) => void };
+      }
+    ).__COMPASS_E2E_HOOKS__?.setAuthenticated(true);
+  });
+  await page.waitForFunction(() => {
+    const bridge = (
+      window as Window & {
+        __COMPASS_E2E_STORE__?: { userMetadata?: unknown };
+      }
+    ).__COMPASS_E2E_STORE__;
+    return Boolean(bridge?.userMetadata);
+  });
+  await page.evaluate((metadata) => {
+    const bridge = (
+      window as Window & {
+        __COMPASS_E2E_STORE__?: {
+          userMetadata?: { set: (metadata: unknown) => void };
+        };
+      }
+    ).__COMPASS_E2E_STORE__;
+    bridge?.userMetadata?.set(metadata);
+  }, captured.hostMetadata);
+
+  await expect(page.getByRole("region", { name: "Meeting page" })).toHaveCount(
+    0,
+  );
+});

--- a/packages/web/src/common/constants/storage.constants.ts
+++ b/packages/web/src/common/constants/storage.constants.ts
@@ -4,6 +4,9 @@ type StorageKey =
   | "compass.onboarding.has-seen-anonymous-save-toast"
   | "compass.onboarding.has-dismissed-demo-events-banner"
   | "compass.onboarding.has-dismissed-tasks-removal-notice"
+  // Set when the host dismisses the sidebar meeting-page nudge. Device-local;
+  // turning the page on hides the card everywhere without this key.
+  | "compass.onboarding.has-dismissed-meeting-page-nudge"
   // Set when the user finishes or skips the Shortcut Showcase, so it never
   // auto-launches twice (palette replay ignores it).
   | "compass.onboarding.has-seen-shortcut-showcase"
@@ -63,6 +66,7 @@ export const STORAGE_KEYS: Record<
   | "HAS_SEEN_ANONYMOUS_SAVE_TOAST"
   | "HAS_DISMISSED_DEMO_EVENTS_BANNER"
   | "HAS_DISMISSED_TASKS_REMOVAL_NOTICE"
+  | "HAS_DISMISSED_MEETING_PAGE_NUDGE"
   | "HAS_SEEN_SHORTCUT_SHOWCASE"
   | "SHORTCUT_SHOWCASE_STEP"
   | "HAS_PENDING_SHOWCASE_OFFER"
@@ -96,6 +100,8 @@ export const STORAGE_KEYS: Record<
     "compass.onboarding.has-dismissed-demo-events-banner",
   HAS_DISMISSED_TASKS_REMOVAL_NOTICE:
     "compass.onboarding.has-dismissed-tasks-removal-notice",
+  HAS_DISMISSED_MEETING_PAGE_NUDGE:
+    "compass.onboarding.has-dismissed-meeting-page-nudge",
   HAS_SEEN_SHORTCUT_SHOWCASE: "compass.onboarding.has-seen-shortcut-showcase",
   SHORTCUT_SHOWCASE_STEP: "compass.onboarding.shortcut-showcase-step",
   HAS_PENDING_SHOWCASE_OFFER: "compass.onboarding.has-pending-showcase-offer",

--- a/packages/web/src/components/Sidebar/MeetingPageNudge/MeetingPageNudge.test.tsx
+++ b/packages/web/src/components/Sidebar/MeetingPageNudge/MeetingPageNudge.test.tsx
@@ -1,0 +1,175 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { rest } from "msw";
+import { type PropsWithChildren } from "react";
+import { DEFAULT_WEEKLY_AVAILABILITY } from "@core/types/booking.contracts";
+import { server } from "@web/__tests__/__mocks__/server/mock.server";
+import { createStoreWrapper } from "@web/__tests__/render-with-store";
+import { SessionContext } from "@web/auth/compass/session/session.context";
+import { bookingQueryKeys } from "@web/booking/booking.query";
+import { ENV_WEB } from "@web/common/constants/env.constants";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import {
+  initialFirstEventPromptState,
+  useFirstEventPromptStore,
+} from "@web/components/FirstEventPrompt/first-event.store";
+import {
+  selectIsSettingsOpen,
+  selectSettingsPage,
+  useSettingsStore,
+} from "@web/settings/settings.store";
+import { MeetingPageNudge } from "./MeetingPageNudge";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+const bookingPageUrl = `${ENV_WEB.API_BASEURL}/booking/page`;
+
+const savedOffPage = {
+  id: "000000000000000000000001",
+  slug: "hostuser",
+  hostUserId: "000000000000000000000002",
+  enabled: false,
+  durationMinutes: 30,
+  destinationCalendarId: "000000000000000000000001",
+  blockingCalendarIds: ["000000000000000000000001"],
+  timeZone: "UTC",
+  weeklyAvailability: DEFAULT_WEEKLY_AVAILABILITY,
+  minNoticeHours: 4,
+  maxHorizonDays: 60,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  bookingUrl: "https://compasscalendar.com/meet/hostuser",
+};
+
+const livePage = { ...savedOffPage, enabled: true };
+
+function renderNudge({
+  authenticated = true,
+  bookingEnabled,
+  isMobile,
+}: {
+  authenticated?: boolean;
+  bookingEnabled?: boolean;
+  isMobile?: boolean;
+} = {}) {
+  const { wrapper: StoreWrapper, queryClient } = createStoreWrapper();
+
+  function Wrapper({ children }: PropsWithChildren) {
+    return (
+      <StoreWrapper>
+        <SessionContext.Provider
+          value={{ authenticated, setAuthenticated: () => {} }}
+        >
+          {children}
+        </SessionContext.Provider>
+      </StoreWrapper>
+    );
+  }
+
+  return {
+    queryClient,
+    ...render(
+      <MeetingPageNudge bookingEnabled={bookingEnabled} isMobile={isMobile} />,
+      { wrapper: Wrapper },
+    ),
+  };
+}
+
+describe("MeetingPageNudge", () => {
+  beforeEach(() => {
+    useFirstEventPromptStore.setState(
+      { ...initialFirstEventPromptState, isDone: true },
+      true,
+    );
+  });
+
+  it("renders for a signed-in user with no live page", async () => {
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) => res(ctx.json(savedOffPage))),
+    );
+    renderNudge();
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "Let people book time with you",
+      }),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Share a link and guests pick a time that is free on your calendar.",
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Set up meeting page" }),
+    ).toBeTruthy();
+  });
+
+  it("opens Settings on the Meeting tab from Set up meeting page", async () => {
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) => res(ctx.json(savedOffPage))),
+    );
+    const user = userEvent.setup({ delay: null });
+    renderNudge();
+
+    await user.click(
+      await screen.findByRole("button", { name: "Set up meeting page" }),
+    );
+
+    expect(selectIsSettingsOpen(useSettingsStore.getState())).toBe(true);
+    expect(selectSettingsPage(useSettingsStore.getState())).toBe("booking");
+  });
+
+  it("hides after Dismiss and sets the storage key", async () => {
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) => res(ctx.json(savedOffPage))),
+    );
+    const user = userEvent.setup({ delay: null });
+    renderNudge();
+
+    await user.click(await screen.findByRole("button", { name: "Dismiss" }));
+
+    expect(screen.queryByRole("region", { name: "Meeting page" })).toBeNull();
+    expect(
+      persistentBrowserStore.get(STORAGE_KEYS.HAS_DISMISSED_MEETING_PAGE_NUDGE),
+    ).toBe("true");
+  });
+
+  it("hides when the meeting page is live", async () => {
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) => res(ctx.json(livePage))),
+    );
+    const { queryClient } = renderNudge();
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(bookingQueryKeys.page)).toMatchObject({
+        enabled: true,
+        bookingUrl: livePage.bookingUrl,
+      });
+    });
+    expect(screen.queryByRole("region", { name: "Meeting page" })).toBeNull();
+  });
+
+  it("does not render when booking is disabled", async () => {
+    renderNudge({ bookingEnabled: false });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("region", { name: "Meeting page" })).toBeNull();
+    });
+  });
+
+  it("does not render for an anonymous user", async () => {
+    renderNudge({ authenticated: false });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("region", { name: "Meeting page" })).toBeNull();
+    });
+  });
+
+  it("does not render on mobile", async () => {
+    renderNudge({ isMobile: true });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("region", { name: "Meeting page" })).toBeNull();
+    });
+  });
+});

--- a/packages/web/src/components/Sidebar/MeetingPageNudge/MeetingPageNudge.tsx
+++ b/packages/web/src/components/Sidebar/MeetingPageNudge/MeetingPageNudge.tsx
@@ -28,7 +28,7 @@ export function MeetingPageNudge({
     >
       <div className="flex items-start justify-between gap-2">
         <div className="flex min-w-0 flex-col gap-1">
-          <h2 className="text-sm font-medium text-text">
+          <h2 className="font-medium text-sm text-text">
             Let people book time with you
           </h2>
           <p className="text-text leading-relaxed">

--- a/packages/web/src/components/Sidebar/MeetingPageNudge/MeetingPageNudge.tsx
+++ b/packages/web/src/components/Sidebar/MeetingPageNudge/MeetingPageNudge.tsx
@@ -1,0 +1,56 @@
+import { XIcon } from "@phosphor-icons/react";
+import { IS_BOOKING_ENABLED } from "@web/common/constants/env.constants";
+import IconButton from "@web/components/IconButton/IconButton";
+import { settingsActions } from "@web/settings/settings.store";
+import { useMeetingPageNudge } from "./useMeetingPageNudge";
+
+type MeetingPageNudgeProps = {
+  bookingEnabled?: boolean;
+  isMobile?: boolean;
+};
+
+export function MeetingPageNudge({
+  bookingEnabled = IS_BOOKING_ENABLED,
+  isMobile,
+}: MeetingPageNudgeProps = {}) {
+  const { visible, dismiss } = useMeetingPageNudge({
+    bookingEnabled,
+    isMobile,
+  });
+
+  if (!visible) return null;
+
+  return (
+    <section
+      aria-label="Meeting page"
+      className="flex flex-col gap-2 rounded-lg bg-surface-overlay p-3 text-xs"
+      data-notice=""
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex min-w-0 flex-col gap-1">
+          <h2 className="text-sm font-medium text-text">
+            Let people book time with you
+          </h2>
+          <p className="text-text leading-relaxed">
+            Share a link and guests pick a time that is free on your calendar.
+          </p>
+        </div>
+        <IconButton
+          aria-label="Dismiss"
+          className="shrink-0 text-text-muted hover:text-text"
+          onClick={dismiss}
+          size="small"
+        >
+          <XIcon aria-hidden="true" size={14} />
+        </IconButton>
+      </div>
+      <button
+        className="c-button-compact c-button-primary self-start rounded-xs px-2 py-1 text-s"
+        onClick={() => settingsActions.openSettings("booking")}
+        type="button"
+      >
+        Set up meeting page
+      </button>
+    </section>
+  );
+}

--- a/packages/web/src/components/Sidebar/MeetingPageNudge/meeting-page-nudge.util.test.ts
+++ b/packages/web/src/components/Sidebar/MeetingPageNudge/meeting-page-nudge.util.test.ts
@@ -1,0 +1,19 @@
+import {
+  hasDismissedMeetingPageNudge,
+  markMeetingPageNudgeDismissed,
+} from "./meeting-page-nudge.util";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+describe("meeting-page-nudge.util", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("is not dismissed until markMeetingPageNudgeDismissed is called", () => {
+    expect(hasDismissedMeetingPageNudge()).toBe(false);
+
+    markMeetingPageNudgeDismissed();
+
+    expect(hasDismissedMeetingPageNudge()).toBe(true);
+  });
+});

--- a/packages/web/src/components/Sidebar/MeetingPageNudge/meeting-page-nudge.util.ts
+++ b/packages/web/src/components/Sidebar/MeetingPageNudge/meeting-page-nudge.util.ts
@@ -1,0 +1,18 @@
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+
+export function hasDismissedMeetingPageNudge(): boolean {
+  if (!persistentBrowserStore.isAvailable()) return true;
+  return (
+    persistentBrowserStore.get(
+      STORAGE_KEYS.HAS_DISMISSED_MEETING_PAGE_NUDGE,
+    ) === "true"
+  );
+}
+
+export function markMeetingPageNudgeDismissed(): void {
+  persistentBrowserStore.set(
+    STORAGE_KEYS.HAS_DISMISSED_MEETING_PAGE_NUDGE,
+    "true",
+  );
+}

--- a/packages/web/src/components/Sidebar/MeetingPageNudge/useMeetingPageNudge.ts
+++ b/packages/web/src/components/Sidebar/MeetingPageNudge/useMeetingPageNudge.ts
@@ -1,0 +1,50 @@
+import { useCallback, useState } from "react";
+import { isSavedBookingPage } from "@core/types/booking.contracts";
+import { useSession } from "@web/auth/compass/session/useSession";
+import { useBookingPageQuery } from "@web/booking/booking.query";
+import { IS_BOOKING_ENABLED } from "@web/common/constants/env.constants";
+import { isMobileOS } from "@web/common/utils/device/device.util";
+import {
+  selectFirstEventDone,
+  useFirstEventPromptStore,
+} from "@web/components/FirstEventPrompt/first-event.store";
+import {
+  hasDismissedMeetingPageNudge,
+  markMeetingPageNudgeDismissed,
+} from "./meeting-page-nudge.util";
+
+type MeetingPageNudgeOptions = {
+  bookingEnabled?: boolean;
+  isMobile?: boolean;
+};
+
+interface MeetingPageNudgeState {
+  visible: boolean;
+  dismiss: () => void;
+}
+
+export function useMeetingPageNudge({
+  bookingEnabled = IS_BOOKING_ENABLED,
+  isMobile = isMobileOS(),
+}: MeetingPageNudgeOptions = {}): MeetingPageNudgeState {
+  const { authenticated } = useSession();
+  const firstEventDone = useFirstEventPromptStore(selectFirstEventDone);
+  const [dismissed, setDismissed] = useState(hasDismissedMeetingPageNudge);
+
+  const eligible =
+    authenticated &&
+    bookingEnabled &&
+    !isMobile &&
+    firstEventDone &&
+    !dismissed;
+
+  const { data, isSuccess } = useBookingPageQuery(eligible);
+  const live = isSavedBookingPage(data) && data.enabled === true;
+
+  const dismiss = useCallback(() => {
+    markMeetingPageNudgeDismissed();
+    setDismissed(true);
+  }, []);
+
+  return { visible: eligible && isSuccess && !live, dismiss };
+}

--- a/packages/web/src/components/Sidebar/Sidebar.test.tsx
+++ b/packages/web/src/components/Sidebar/Sidebar.test.tsx
@@ -1,6 +1,12 @@
 import { render, screen } from "@testing-library/react";
+import { type PropsWithChildren } from "react";
 import dayjs from "@core/util/date/dayjs";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
+import { SessionContext } from "@web/auth/compass/session/session.context";
+import {
+  initialFirstEventPromptState,
+  useFirstEventPromptStore,
+} from "@web/components/FirstEventPrompt/first-event.store";
 import {
   createGridEventDraft,
   timedGridSchedule,
@@ -112,5 +118,37 @@ describe("Sidebar", () => {
 
     expect(screen.getByText("Event details")).toBeTruthy();
     expect(screen.queryByText("Calendar picker")).toBeNull();
+  });
+
+  it("shows the meeting page nudge after the calendar list for an eligible user", async () => {
+    useFirstEventPromptStore.setState(
+      { ...initialFirstEventPromptState, isDone: true },
+      true,
+    );
+    const { wrapper: StoreWrapper } = createStoreWrapper();
+
+    function Wrapper({ children }: PropsWithChildren) {
+      return (
+        <StoreWrapper>
+          <SessionContext.Provider
+            value={{ authenticated: true, setAuthenticated: () => {} }}
+          >
+            {children}
+          </SessionContext.Provider>
+        </StoreWrapper>
+      );
+    }
+
+    render(<Sidebar {...sidebarProps} />, { wrapper: Wrapper });
+
+    expect(await screen.findByText("Calendar list")).toBeTruthy();
+    const nudge = await screen.findByRole("heading", {
+      name: "Let people book time with you",
+    });
+    const calendarList = screen.getByText("Calendar list");
+    expect(
+      calendarList.compareDocumentPosition(nudge) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 });

--- a/packages/web/src/components/Sidebar/Sidebar.tsx
+++ b/packages/web/src/components/Sidebar/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
 } from "@web/events/stores/draft.store";
 import { type ShortcutOverlaySection } from "@web/shortcuts/shortcuts-overlay.types";
 import { CalendarList } from "./CalendarList/CalendarList";
+import { MeetingPageNudge } from "./MeetingPageNudge/MeetingPageNudge";
 import { SidebarShell } from "./SidebarShell";
 import { TasksRemovalNotice } from "./TasksRemovalNotice/TasksRemovalNotice";
 import { UpNextCard } from "./UpNextCard/UpNextCard";
@@ -78,6 +79,7 @@ export function Sidebar({
           </Suspense>
           <UpNextCard />
           <CalendarList />
+          <MeetingPageNudge />
           <TasksRemovalNotice />
         </div>
       )}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3573

A signed-in host whose meeting page is not live sees a sidebar card under the calendar list. Set up meeting page opens Settings on the Meeting tab. Dismiss hides it on that browser. Turning the page on hides it everywhere. The card does not show on mobile, while the booking gate is off, or while the first-event prompt is still pending.

Merged `origin/main` (WP-10 host toast) and kept both v1.10 changelog paragraphs.

**VERDICT: FAIL** on the full `bun run verify --strict` under load, with isolated retries passing.

Checks that passed in that run: type-check, lint, knip, test:e2e (including the new sidebar nudge spec).

Failures, all unrelated to this diff:
- `test:web`: 8 timeouts at 5000ms in `useEventMutations.attendees.test.tsx` and `useEventMutations.rsvp.test.tsx` on a 101-file shard. Isolated retries of both files passed (10/10).
- `test:a11y`: `booking-a11y.spec.ts:652` first-run go-live Enter keycap contrast 3.12 vs 4.5. Isolated retry of that spec passed. Same keycap flake as earlier Booking v1.10 PRs under load.

## Implementation
- `MeetingPageNudge` after the calendar list, modeled on the tasks-removal notice
- Query gated on authenticated + booking enabled + not mobile + first-event done + not dismissed
- Live page (`bookingUrl` and `enabled: true`) hides the card
- Storage key `compass.onboarding.has-dismissed-meeting-page-nudge`

## Tests
- Unit: signed-in with no live page, Set up opens Meeting settings, Dismiss persists, live/anonymous/gate-off/mobile hide
- Sidebar: card appears after the calendar list for an eligible user
- e2e: card visible without a live page, Set up opens Meeting, live page + reload hides it
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8d28ca7-decd-49e5-a5f2-a6c88cc4f61a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8d28ca7-decd-49e5-a5f2-a6c88cc4f61a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

