### PR TITLE
feat(web): keep the meeting link when the page is off

### DIFF
--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -252,8 +252,13 @@ scrolls, so the first wheel tick does not re-rasterize the backdrop.
 
 - **Status:** a **Meeting page** switch reflects whether the page is
   live. When on, it shows the meeting link with Copy and
-  **Open meeting page**. When off, it shows "Off. Turn it on to share
-  your link." and the address the page will use.
+  **Open meeting page**. When off and the page has been saved, it
+  still shows the meeting link with Copy (not Open, because the public
+  page answers not found) and the line "Off. Guests can use this link
+  once you turn it on." When off and the host has never saved a page,
+  it shows "Off. Turn it on to share your link." and "It will be at"
+  plus the address. Typed-but-unsaved address edits do not change the
+  copyable link until Save.
   Once a page has been saved, a broken calendar connection does not
   hide the switch or the link. A status banner above the header says
   what is wrong: reconnect (`Guests can't book right now.` plus the
@@ -622,6 +627,10 @@ first scroll: the panel is promoted at mount, and an inner wrapper owns
 overflow so the transform transition is not on the scroll container. The
 Meeting tab's lazy chunk reserves height so the dialog does not collapse
 to the nav column while it loads.
+
+An off Meeting page that already has an address still shows the meeting
+link with Copy, without Open, and the line that guests can use the link
+once the page is on.
 
 ### v1.9
 

--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -544,7 +544,9 @@ test.describe("settings booking section", () => {
       settingsDialog.getByRole("switch", { name: "Meeting page" }),
     ).toHaveAttribute("aria-checked", "false");
     await expect(
-      settingsDialog.getByText("Off. Turn it on to share your link."),
+      settingsDialog.getByText(
+        "Off. Guests can use this link once you turn it on.",
+      ),
     ).toBeVisible();
     await expectNoAxeViolations(page, {
       checkpoint: "settings booking not live",

--- a/packages/web/src/booking/BookingCopyLink.test.tsx
+++ b/packages/web/src/booking/BookingCopyLink.test.tsx
@@ -68,6 +68,25 @@ describe("BookingCopyLink", () => {
     expect(openLink).toHaveAttribute("rel", "noreferrer");
   });
 
+  it("hides the open-page link when showOpen is false", () => {
+    render(
+      <BookingCopyLink
+        bookingUrl="https://compasscalendar.com/meet/hostuser"
+        showOpen={false}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("link", { name: "Open meeting page" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Meeting link")).toHaveValue(
+      "https://compasscalendar.com/meet/hostuser",
+    );
+    expect(
+      screen.getByRole("button", { name: "Copy meeting link" }),
+    ).toBeInTheDocument();
+  });
+
   it("explains the copy icon in a tooltip", async () => {
     const user = userEvent.setup({ delay: null });
     render(

--- a/packages/web/src/booking/BookingCopyLink.tsx
+++ b/packages/web/src/booking/BookingCopyLink.tsx
@@ -10,11 +10,15 @@ import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
 
 interface BookingCopyLinkProps {
   bookingUrl: string;
+  showOpen?: boolean;
 }
 
 const ICON_SIZE = 18;
 
-export function BookingCopyLink({ bookingUrl }: BookingCopyLinkProps) {
+export function BookingCopyLink({
+  bookingUrl,
+  showOpen = true,
+}: BookingCopyLinkProps) {
   const { copied, copy } = useCopiedFlag(bookingUrl, (didCopy) => {
     if (didCopy) {
       track("booking_link_copied", { source: "button" });
@@ -47,17 +51,19 @@ export function BookingCopyLink({ bookingUrl }: BookingCopyLinkProps) {
             {copied ? <Check size={ICON_SIZE} /> : <Copy size={ICON_SIZE} />}
           </IconButton>
         </TooltipWrapper>
-        <TooltipWrapper description="Open meeting page">
-          <a
-            aria-label="Open meeting page"
-            className={iconButtonClassName("small")}
-            href={bookingUrl}
-            rel="noreferrer"
-            target="_blank"
-          >
-            <ArrowSquareOut size={ICON_SIZE} />
-          </a>
-        </TooltipWrapper>
+        {showOpen ? (
+          <TooltipWrapper description="Open meeting page">
+            <a
+              aria-label="Open meeting page"
+              className={iconButtonClassName("small")}
+              href={bookingUrl}
+              rel="noreferrer"
+              target="_blank"
+            >
+              <ArrowSquareOut size={ICON_SIZE} />
+            </a>
+          </TooltipWrapper>
+        ) : null}
       </div>
     </div>
   );

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -2614,6 +2614,115 @@ describe("BookingSettingsSection", () => {
     );
   });
 
+  it("keeps a copyable meeting link when a configured page is off", async () => {
+    userMetadataActions.set(healthyGoogleMetadata);
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(
+          ctx.json({
+            enabled: false,
+            durationMinutes: 30,
+            destinationCalendarId: writableCalendar.id,
+            blockingCalendarIds: [writableCalendar.id],
+            timeZone: "UTC",
+            weeklyAvailability: DEFAULT_WEEKLY_AVAILABILITY,
+            minNoticeHours: 4,
+            maxHorizonDays: 60,
+            isConfigured: true,
+            suggestedSlug: "hostuser",
+          }),
+        ),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    const meetingLink = await screen.findByLabelText("Meeting link");
+    expect(meetingLink).toHaveValue(`${window.location.origin}/meet/hostuser`);
+    expect(
+      screen.getByRole("button", { name: "Copy meeting link" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Open meeting page" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Off. Guests can use this link once you turn it on."),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show a copyable meeting link on a first-run page", async () => {
+    userMetadataActions.set(healthyGoogleMetadata);
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "Pick your address" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("Meeting link")).not.toBeInTheDocument();
+  });
+
+  it("does not change the off-page meeting link when the address is edited unsaved", async () => {
+    const user = userEvent.setup({ delay: null });
+    userMetadataActions.set(healthyGoogleMetadata);
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(
+          ctx.json({
+            enabled: false,
+            durationMinutes: 30,
+            destinationCalendarId: writableCalendar.id,
+            blockingCalendarIds: [writableCalendar.id],
+            timeZone: "UTC",
+            weeklyAvailability: DEFAULT_WEEKLY_AVAILABILITY,
+            minNoticeHours: 4,
+            maxHorizonDays: 60,
+            isConfigured: true,
+            suggestedSlug: "hostuser",
+          }),
+        ),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    const meetingLink = await screen.findByLabelText("Meeting link");
+    const savedUrl = `${window.location.origin}/meet/hostuser`;
+    expect(meetingLink).toHaveValue(savedUrl);
+
+    await user.click(screen.getByText(BOOKING_MORE_OPTIONS_LABEL));
+    const address = screen.getByLabelText("Page address");
+    await user.clear(address);
+    await user.type(address, "newhost");
+
+    expect(screen.getByLabelText("Meeting link")).toHaveValue(savedUrl);
+  });
+
   it("turns off a live page", async () => {
     const user = userEvent.setup({ delay: null });
     const { port, mocks } = createTestToastPort();

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -97,6 +97,20 @@ const MORE_OPTIONS_FIELDS = new Set<BookingField>([
   "horizon",
 ]);
 
+/** Public URL for a saved page that is currently off. Typed-but-unsaved slugs never qualify. */
+function savedMeetingLinkUrl(
+  page: AdminGetBookingPageResult | undefined,
+): string | null {
+  if (!page) return null;
+  if (isSavedBookingPage(page)) {
+    return page.enabled === true ? null : page.bookingUrl;
+  }
+  if (page.isConfigured) {
+    return `${bookingAddressPrefix(null)}${page.suggestedSlug}`;
+  }
+  return null;
+}
+
 /** Copy the public link, then report whichever of the two outcomes happened. */
 const copyBookingLinkThenToast = (
   bookingUrl: string,
@@ -661,6 +675,7 @@ export function BookingSettingsSection({
         <BookingStatusHeader
           addressPreview={addressPreview}
           bookingUrl={savedPage?.bookingUrl ?? null}
+          savedUrl={savedMeetingLinkUrl(serverPage)}
           calendars={calendars}
           connections={connections}
           isLive={isLive}

--- a/packages/web/src/booking/BookingStatusHeader.test.tsx
+++ b/packages/web/src/booking/BookingStatusHeader.test.tsx
@@ -47,6 +47,7 @@ const renderHeader = (
     <BookingStatusHeader
       addressPreview={null}
       bookingUrl={bookingUrl}
+      savedUrl={null}
       calendars={[workCalendar]}
       connections={reasonOverrides.connections ?? [connection]}
       isLive
@@ -206,5 +207,60 @@ describe("BookingStatusHeader", () => {
     expect(
       screen.queryByRole("button", { name: RECONNECT_CALENDAR_LABEL.google }),
     ).not.toBeInTheDocument();
+  });
+
+  it("shows a copyable meeting link without Open when the page is off", () => {
+    const { wrapper } = createStoreWrapper();
+    render(
+      <BookingStatusHeader
+        addressPreview={`${window.location.origin}/meet/hostuser`}
+        bookingUrl={null}
+        savedUrl={bookingUrl}
+        calendars={[workCalendar]}
+        connections={[]}
+        isLive={false}
+        isPending={false}
+        onToggle={() => undefined}
+        status={undefined}
+      />,
+      { wrapper },
+    );
+
+    expect(screen.getByLabelText("Meeting link")).toHaveValue(bookingUrl);
+    expect(
+      screen.getByRole("button", { name: "Copy meeting link" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Open meeting page" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Off. Guests can use this link once you turn it on."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows It will be at for a first-run page with no saved link", () => {
+    const { wrapper } = createStoreWrapper();
+    render(
+      <BookingStatusHeader
+        addressPreview={`${window.location.origin}/meet/hostuser`}
+        bookingUrl={null}
+        savedUrl={null}
+        calendars={[workCalendar]}
+        connections={[]}
+        isLive={false}
+        isPending={false}
+        onToggle={() => undefined}
+        status={undefined}
+      />,
+      { wrapper },
+    );
+
+    expect(screen.queryByLabelText("Meeting link")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Off. Turn it on to share your link."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(`It will be at ${window.location.origin}/meet/hostuser`),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/web/src/booking/BookingStatusHeader.tsx
+++ b/packages/web/src/booking/BookingStatusHeader.tsx
@@ -11,6 +11,7 @@ interface BookingStatusHeaderProps {
   isPending: boolean;
   onToggle: (next: boolean) => void;
   bookingUrl: string | null;
+  savedUrl: string | null;
   addressPreview: string | null;
   calendars: readonly Calendar[];
   connections: readonly SyncConnectionSummary[];
@@ -22,6 +23,7 @@ export function BookingStatusHeader({
   isPending,
   onToggle,
   bookingUrl,
+  savedUrl,
   addressPreview,
   calendars,
   connections,
@@ -41,6 +43,13 @@ export function BookingStatusHeader({
         bookingUrl ? (
           <BookingCopyLink bookingUrl={bookingUrl} />
         ) : null
+      ) : savedUrl ? (
+        <>
+          <BookingCopyLink bookingUrl={savedUrl} showOpen={false} />
+          <p className="text-sm text-text">
+            Off. Guests can use this link once you turn it on.
+          </p>
+        </>
       ) : (
         <>
           <p className="text-sm text-text">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3574

A host who turns the Meeting page off still sees the copyable meeting link under the switch. Open is hidden because the public page answers not found. First-run hosts still see It will be at. Typed-but-unsaved address edits do not change the copyable link.

**VERDICT: FAIL** on the full `bun run verify --strict` under load, with the only failure unrelated and passing in isolation.

Checks that passed: test:web, type-check, lint, knip, test:a11y. Host settings e2e including not-live status also passed.

Failure: `e2e/accessibility/booking-a11y.spec.ts:628` first-run duration Enter keycap contrast under the full Playwright run. Isolated retry of that spec passed. Same wizard keycap flake as earlier Booking v1.10 PRs.

## Implementation
- `BookingCopyLink` `showOpen` (default true) hides Open while the page is off
- `BookingStatusHeader` `savedUrl` shows the copyable link above "Off. Guests can use this link once you turn it on."
- First-run (never saved) keeps "Off. Turn it on to share your link." and "It will be at"
- `savedMeetingLinkUrl` uses the setup shape `suggestedSlug` when `isConfigured` is true, and a saved `bookingUrl` when the GET still carries one

## Tests
- Copy link hides Open when `showOpen={false}`
- Settings: configured-off shows the saved address and Copy, no Open; first-run has no Meeting link textbox; unsaved address edits do not change the copyable value
- a11y not-live checkpoint expects the new off copy
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8d28ca7-decd-49e5-a5f2-a6c88cc4f61a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8d28ca7-decd-49e5-a5f2-a6c88cc4f61a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

