### PR TITLE
fix(web): booking setup wizard dead-ends, Back button, address focus

### DIFF
--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -286,11 +286,18 @@ scrolls, so the first wheel tick does not re-rasterize the backdrop.
 - **First run:** before any draft exists, Meeting settings open a guided
   setup wizard: one question per screen with "Step N of M", a title, one
   sentence, and **Continue** (Mod+Enter). Steps are address, weekly hours,
-  duration, destination calendar (only when more than one writable calendar
-  exists), then go live. Plain Enter continues from the address input or the
-  Continue button; `k` continues and `j` goes back when focus is not in an
-  editable target; Esc goes back one step (on step 1 it closes Settings).
-  Address **Continue** saves a disabled draft so the slug is reserved.
+  duration, destination calendar (hidden only when exactly one writable
+  calendar exists; with zero writable calendars the destination step shows
+  "Connect a calendar you can write to before going live." and connect
+  buttons, **Continue** stays disabled, and go live is unreachable until a
+  writable calendar exists), then go live. Every step after the first shows
+  a **Back** button beside **Continue**. The keyboard hint row labels its
+  keys ("Enter Continue", "Esc Back", "K Next", "J Back"). Plain Enter
+  continues from the address input or the Continue button; `k` continues and
+  `j` goes back when focus is not in an editable target; Esc goes back one
+  step (on step 1 it closes Settings). When the address step fails with
+  "That address is already taken. Try another.", focus moves to the address
+  field. Address **Continue** saves a disabled draft so the slug is reserved.
   **Turn on and copy link** on the last step saves with `enabled: true`,
   copies the link, and then shows the full form with the switch focused.
 - **Timezone** uses the same searchable combobox as time travel. The

--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -649,6 +649,47 @@ test.describe("settings booking section", () => {
     });
   });
 
+  test("first-run zero-calendar destination step has no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await prepareSignedInBookingSettingsPage(page, {
+      configured: false,
+      enabled: false,
+      noWritableCalendars: true,
+    });
+    const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+    await dispatchClick(
+      settingsDialog.getByRole("button", { name: /Continue/ }),
+    );
+    await expect(
+      settingsDialog
+        .locator("p.text-text-muted")
+        .filter({ hasText: /^Step 2 of \d+$/ }),
+    ).toBeVisible();
+    await page.keyboard.press("k");
+    await page.keyboard.press("k");
+    await expect(
+      settingsDialog
+        .locator("p.text-text-muted")
+        .filter({ hasText: /^Step 4 of 5$/ }),
+    ).toBeVisible();
+    await expect(
+      settingsDialog.getByText(
+        "Connect a calendar you can write to before going live.",
+      ),
+    ).toBeVisible();
+    await expect(
+      settingsDialog.getByRole("button", { name: "Connect Google Calendar" }),
+    ).toBeVisible();
+    await expect(
+      settingsDialog.getByRole("button", { name: /Continue/ }),
+    ).toBeDisabled();
+    await expectNoAxeViolations(page, {
+      checkpoint: "settings booking first-run zero-calendar destination",
+      include: "[role='dialog']",
+    });
+  });
+
   test("first-run go-live step has no automatically detectable accessibility violations", async ({
     page,
   }) => {

--- a/e2e/booking/booking-harness.ts
+++ b/e2e/booking/booking-harness.ts
@@ -124,6 +124,15 @@ const googleCalendar = {
   accountEmail: HOST_ACCOUNT_EMAIL,
 };
 
+const readOnlyGoogleCalendar = {
+  ...googleCalendar,
+  capabilities: {
+    ...googleCalendar.capabilities,
+    canWrite: false,
+    canManage: false,
+  },
+};
+
 const compassCalendar = {
   id: COMPASS_CALENDAR_ID,
   name: "Compass",
@@ -999,6 +1008,8 @@ export interface HostBookingSettingsStubOptions {
     bookable: boolean;
     reasons: Array<Record<string, unknown>>;
   };
+  /** When true, host calendars load but none are writable. */
+  noWritableCalendars?: boolean;
 }
 
 export interface CapturedHostBookingRequests {
@@ -1115,9 +1126,10 @@ export async function prepareSignedInBookingSettingsPage(
     const path = url.pathname;
 
     if (path.endsWith("/api/calendars")) {
-      return route.fulfill(
-        jsonResponse({ calendars: [googleCalendar, compassCalendar] }),
-      );
+      const calendars = options.noWritableCalendars
+        ? [readOnlyGoogleCalendar]
+        : [googleCalendar, compassCalendar];
+      return route.fulfill(jsonResponse({ calendars }));
     }
 
     if (path.endsWith("/api/event") && request.method() === "GET") {

--- a/packages/web/src/__tests__/setup/test-lifecycle.ts
+++ b/packages/web/src/__tests__/setup/test-lifecycle.ts
@@ -62,6 +62,11 @@ function resetBrowserState() {
 }
 
 beforeEach(() => {
+  // bun's fake clock is process-global across files in a shard. A leaked
+  // pin makes later findBy/waitFor hang forever because Date.now never
+  // advances past their timeout. Reset before the test, not only after,
+  // so a previous afterEach that threw still cannot poison this file.
+  setSystemTime();
   installDefaultWebTestSeams();
 });
 
@@ -70,6 +75,7 @@ beforeAll(async () => {
   server.listen({ onUnhandledRequest: "error" });
 });
 afterEach(async () => {
+  setSystemTime();
   await Promise.resolve();
   cleanup();
   resetDocument();
@@ -78,10 +84,6 @@ afterEach(async () => {
   resetWebTestSeams();
   billingPreviewActions.exit();
   HotkeyManager.resetInstance();
-  // bun's fake clock is process-global across files in a shard. A leaked
-  // pin makes later findBy/waitFor hang forever because Date.now never
-  // advances past their timeout.
-  setSystemTime();
   BaseApi.defaults.adapter = undefined;
   server.resetHandlers();
 });

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -7,6 +7,7 @@ import {
   DEFAULT_WEEKLY_AVAILABILITY,
   type WeeklyAvailability,
 } from "@core/types/booking.contracts";
+import { getCalendarCapabilities } from "@core/types/calendar.contracts";
 import { CalendarIdSchema } from "@core/types/domain-primitives";
 import { server } from "@web/__tests__/__mocks__/server/mock.server";
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
@@ -1221,6 +1222,53 @@ describe("BookingSettingsSection", () => {
     expect(await screen.findByText("Step 5 of 5")).toBeInTheDocument();
     expect(screen.getByText("Timezone")).toBeInTheDocument();
     expect(screen.getByText("UTC (UTC)")).toBeInTheDocument();
+  });
+
+  it("shows the destination connect prompt and disables Continue with zero writable calendars", async () => {
+    const user = userEvent.setup({ delay: null });
+    setProviderAvailabilityForTests("google", "available", "connect");
+    const readOnlyCalendar = createMockCalendar({
+      id: CalendarIdSchema.parse(createObjectIdString()),
+      name: "Shared",
+      accountEmail: "host@example.com",
+      access: "reader",
+      capabilities: getCalendarCapabilities("reader"),
+    });
+    userMetadataActions.set(healthyGoogleMetadata);
+
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(unconfiguredPage())),
+      ),
+      rest.put(bookingPageUrl, async (req, res, ctx) => {
+        const body = await req.json();
+        return res(ctx.json(putSavedPage(body as Record<string, unknown>)));
+      }),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [readOnlyCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    await user.click(await screen.findByRole("button", { name: /^Continue/ }));
+    await user.keyboard("k");
+    await user.keyboard("k");
+    expect(await screen.findByText("Step 4 of 5")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Connect a calendar you can write to before going live.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: CONNECT_CALENDAR_LABEL.google }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Continue/ })).toBeDisabled();
+    expect(screen.queryByText("Step 5 of 5")).not.toBeInTheDocument();
   });
 
   it("keeps the go-live step visible when enable fails", async () => {

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -599,7 +599,13 @@ export function BookingSettingsSection({
       return;
     }
 
-    if (setupStep === "duration" || setupStep === "destination") {
+    if (setupStep === "duration") {
+      advanceSetupStep();
+      return;
+    }
+
+    if (setupStep === "destination") {
+      if (writableCalendars.length === 0) return;
       advanceSetupStep();
       return;
     }

--- a/packages/web/src/booking/setup/BookingSetupDestinationStep.tsx
+++ b/packages/web/src/booking/setup/BookingSetupDestinationStep.tsx
@@ -1,14 +1,13 @@
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
 import { type SyncConnectionSummary } from "@core/types/user.types";
+import { ConnectProviderChooser } from "@web/auth/providers/ConnectProviderChooser";
 import {
   bookingDestinationConferenceHint,
   formatBookingDestinationOptionLabel,
 } from "@web/booking/booking-conference.copy";
+import { BOOKING_SELECT_CLASS_NAME } from "@web/booking/booking-form.styles";
 import { groupCalendarsByAccount } from "@web/calendars/calendar.util";
-
-const BOOKING_SELECT_CLASS_NAME =
-  "c-focus-ring w-full rounded border border-border bg-surface-overlay px-2 py-1 text-sm text-text hover:bg-surface-panel";
 
 interface BookingSetupDestinationStepProps {
   connections: SyncConnectionSummary[];
@@ -23,6 +22,10 @@ export function BookingSetupDestinationStep({
   onChange,
   writableCalendars,
 }: BookingSetupDestinationStepProps) {
+  if (writableCalendars.length === 0) {
+    return <ConnectProviderChooser variant="prompt" />;
+  }
+
   const { groups: writableGroups, ungrouped: writableUngrouped } =
     groupCalendarsByAccount(writableCalendars, connections);
   const destinationCalendar = writableCalendars.find(

--- a/packages/web/src/booking/setup/BookingSetupWizard.test.tsx
+++ b/packages/web/src/booking/setup/BookingSetupWizard.test.tsx
@@ -1,0 +1,148 @@
+import "@testing-library/jest-dom";
+import { HotkeysProvider } from "@tanstack/react-hotkeys";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { type ComponentProps, createRef } from "react";
+import { buildDefaultAdminPutInput } from "@core/types/booking.contracts";
+import { TimeZoneSchema } from "@core/types/domain-primitives";
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
+import * as realAvailableProviders from "@web/auth/providers/useAvailableConnectProviders";
+import * as realConnectProvider from "@web/auth/providers/useConnectProvider";
+import { BOOKING_SAVE_ERROR_COPY } from "@web/booking/booking.query";
+import { BookingSetupWizard } from "@web/booking/setup/BookingSetupWizard";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+let available: ProviderKind[] = ["google"];
+const mockConnectGoogle = mock();
+
+mockModuleForFile(
+  "@web/auth/providers/useAvailableConnectProviders",
+  realAvailableProviders,
+  { useAvailableConnectProviders: () => available },
+);
+
+mockModuleForFile(
+  "@web/auth/providers/useConnectProvider",
+  realConnectProvider,
+  {
+    useConnectProvider: (_kind: ProviderKind) => ({
+      state: "NOT_CONNECTED",
+      isAvailable: true,
+      isConnecting: false,
+      isRefreshing: false,
+      commandAction: {
+        label: "Connect Google Calendar",
+        onSelect: mockConnectGoogle,
+      },
+      connect: mockConnectGoogle,
+    }),
+  },
+);
+
+const defaultForm = {
+  ...buildDefaultAdminPutInput(TimeZoneSchema.parse("UTC")),
+  slug: "hostuser",
+};
+
+const renderWizard = (
+  props: Partial<ComponentProps<typeof BookingSetupWizard>> = {},
+) => {
+  const continueRef = createRef<HTMLButtonElement>();
+  const onBack = mock(() => {});
+  const onContinue = mock(() => {});
+  render(
+    <HotkeysProvider>
+      <BookingSetupWizard
+        bookingUrl={null}
+        continueRef={continueRef}
+        destinationCalendar={undefined}
+        form={defaultForm}
+        isPending={false}
+        onAddressChange={mock(() => {})}
+        onBack={onBack}
+        onContinue={onContinue}
+        onDestinationChange={mock(() => {})}
+        onDurationChange={mock(() => {})}
+        onHoursChange={mock(() => {})}
+        setupError={null}
+        setupStep="address"
+        syncConnections={[]}
+        writableCalendarCount={0}
+        writableCalendars={[]}
+        {...props}
+      />
+    </HotkeysProvider>,
+  );
+  return { continueRef, onBack, onContinue };
+};
+
+beforeEach(() => {
+  available = ["google"];
+});
+
+afterEach(() => {
+  mockConnectGoogle.mockClear();
+});
+
+describe("BookingSetupWizard", () => {
+  it("shows the zero-calendar destination step with connect and disabled Continue", async () => {
+    renderWizard({ setupStep: "destination" });
+
+    expect(
+      screen.getByText(
+        "Connect a calendar you can write to before going live.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Connect Google Calendar" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Continue/ })).toBeDisabled();
+  });
+
+  it("shows Back on step 2", async () => {
+    const user = userEvent.setup({ delay: null });
+    const { onBack } = renderWizard({
+      setupStep: "hours",
+      writableCalendarCount: 1,
+    });
+
+    const backButton = screen.getByRole("button", { name: "Back" });
+    expect(backButton).toBeInTheDocument();
+    await user.click(backButton);
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides Back on step 1", () => {
+    renderWizard({ setupStep: "address", writableCalendarCount: 1 });
+    expect(
+      screen.queryByRole("button", { name: "Back" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("labels keyboard hint chips", () => {
+    renderWizard({ setupStep: "hours", writableCalendarCount: 1 });
+
+    const hintRow = screen.getByText("Next").closest(".text-text-muted");
+    expect(hintRow).not.toBeNull();
+    const hints = within(hintRow as HTMLElement);
+    expect(hints.getByText("Continue")).toBeInTheDocument();
+    expect(hints.getByText("Next")).toBeInTheDocument();
+    expect(hints.getAllByText("Back")).toHaveLength(2);
+  });
+
+  it("focuses the address field after a SLUG_TAKEN error", async () => {
+    renderWizard({
+      forceAddressInvalid: true,
+      setupError: BOOKING_SAVE_ERROR_COPY.SLUG_TAKEN,
+      setupStep: "address",
+      writableCalendarCount: 1,
+    });
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(
+        screen.getByLabelText("Page address"),
+      );
+    });
+  });
+});

--- a/packages/web/src/booking/setup/BookingSetupWizard.tsx
+++ b/packages/web/src/booking/setup/BookingSetupWizard.tsx
@@ -15,6 +15,8 @@ import {
   type SetupStepId,
   setupStepDefinition,
   setupStepProgress,
+  setupStepSentence,
+  visibleSetupSteps,
 } from "@web/booking/setup/setup-steps";
 import { isEditableKeyboardTarget } from "@web/common/utils/form/form.util";
 import {
@@ -49,6 +51,7 @@ interface BookingSetupWizardProps {
 const focusStepFirstControl = (
   stepId: SetupStepId,
   root: HTMLElement | null,
+  writableCalendarCount: number,
 ) => {
   if (root == null) return;
   switch (stepId) {
@@ -62,6 +65,10 @@ const focusStepFirstControl = (
       root.querySelector<HTMLElement>('[role="radio"][tabindex="0"]')?.focus();
       break;
     case "destination":
+      if (writableCalendarCount === 0) {
+        root.querySelector<HTMLElement>("button")?.focus();
+        break;
+      }
       root
         .querySelector<HTMLElement>("#booking-setup-destination-calendar")
         ?.focus();
@@ -100,19 +107,39 @@ export function BookingSetupWizard({
 }: BookingSetupWizardProps) {
   const stepBodyRef = useRef<HTMLDivElement>(null);
   const stepMeta = setupStepDefinition(setupStep);
+  const stepSentence = setupStepSentence(setupStep, writableCalendarCount);
   const { current, total } = setupStepProgress(
     setupStep,
     writableCalendarCount,
   );
   const isGoLive = setupStep === "live";
+  const isFirstStep = setupStep === visibleSetupSteps(writableCalendarCount)[0];
+  const canContinue =
+    !(setupStep === "destination" && writableCalendarCount === 0) && !isPending;
 
   useEffect(() => {
+    if (setupStep === "address" && (forceAddressInvalid || setupError)) {
+      stepBodyRef.current
+        ?.querySelector<HTMLElement>("#booking-address")
+        ?.focus();
+      return;
+    }
     if (setupStep === "live") {
       continueRef.current?.focus();
       return;
     }
-    focusStepFirstControl(setupStep, stepBodyRef.current);
-  }, [continueRef, setupStep]);
+    focusStepFirstControl(
+      setupStep,
+      stepBodyRef.current,
+      writableCalendarCount,
+    );
+  }, [
+    continueRef,
+    forceAddressInvalid,
+    setupError,
+    setupStep,
+    writableCalendarCount,
+  ]);
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     const target = event.target;
@@ -122,6 +149,7 @@ export function BookingSetupWizard({
       (event.key === "k" || event.key === "K") &&
       !isEditableKeyboardTarget(event)
     ) {
+      if (!canContinue) return;
       event.preventDefault();
       onContinue();
       return;
@@ -145,6 +173,7 @@ export function BookingSetupWizard({
         target.type === "");
     const isContinueButton = target === continueRef.current;
     if (!isTextInput && !isContinueButton) return;
+    if (!canContinue) return;
 
     event.preventDefault();
     onContinue();
@@ -161,7 +190,7 @@ export function BookingSetupWizard({
       </p>
       <div className="flex flex-col gap-2">
         <h2 className="font-medium text-lg text-text">{stepMeta.title}</h2>
-        <p className="text-sm text-text">{stepMeta.sentence}</p>
+        <p className="text-sm text-text">{stepSentence}</p>
       </div>
 
       <div ref={stepBodyRef}>
@@ -219,13 +248,21 @@ export function BookingSetupWizard({
           <span>Continue</span>
           <ShortcutKeys keys="Esc" />
           <span>Back</span>
-          <ShortcutKeys keys={["J", "K"]} />
+          <ShortcutKeys keys="K" />
+          <span>Next</span>
+          <ShortcutKeys keys="J" />
+          <span>Back</span>
         </span>
         <OverlayPanelActions>
+          {!isFirstStep ? (
+            <OverlayPanelActionButton onClick={onBack} type="button">
+              Back
+            </OverlayPanelActionButton>
+          ) : null}
           <OverlayPanelActionButton
             aria-busy={isPending || undefined}
             aria-keyshortcuts="Meta+Enter Control+Enter"
-            disabled={isPending}
+            disabled={!canContinue}
             onClick={onContinue}
             ref={continueRef}
             shortcut={["Mod", "Enter"]}

--- a/packages/web/src/booking/setup/setup-steps.test.ts
+++ b/packages/web/src/booking/setup/setup-steps.test.ts
@@ -2,27 +2,20 @@ import {
   nextSetupStep,
   prevSetupStep,
   setupStepProgress,
+  setupStepSentence,
   visibleSetupSteps,
 } from "@web/booking/setup/setup-steps";
 import { describe, expect, it } from "bun:test";
 
 describe("visibleSetupSteps", () => {
-  it("omits destination for zero or one writable calendar", () => {
+  it("includes destination for zero or two or more writable calendars", () => {
     expect(visibleSetupSteps(0)).toEqual([
       "address",
       "hours",
       "duration",
+      "destination",
       "live",
     ]);
-    expect(visibleSetupSteps(1)).toEqual([
-      "address",
-      "hours",
-      "duration",
-      "live",
-    ]);
-  });
-
-  it("includes destination for two or more writable calendars", () => {
     expect(visibleSetupSteps(2)).toEqual([
       "address",
       "hours",
@@ -30,6 +23,26 @@ describe("visibleSetupSteps", () => {
       "destination",
       "live",
     ]);
+  });
+
+  it("omits destination for exactly one writable calendar", () => {
+    expect(visibleSetupSteps(1)).toEqual([
+      "address",
+      "hours",
+      "duration",
+      "live",
+    ]);
+  });
+});
+
+describe("setupStepSentence", () => {
+  it("uses the connect prompt copy on destination with zero writable calendars", () => {
+    expect(setupStepSentence("destination", 0)).toBe(
+      "Connect a calendar you can write to before going live.",
+    );
+    expect(setupStepSentence("destination", 1)).toBe(
+      "New meetings you accept are added to this calendar.",
+    );
   });
 });
 
@@ -46,6 +59,11 @@ describe("nextSetupStep", () => {
     expect(nextSetupStep("destination", 2)).toBe("live");
     expect(nextSetupStep("live", 2)).toBeNull();
   });
+
+  it("includes destination when no writable calendars exist", () => {
+    expect(nextSetupStep("duration", 0)).toBe("destination");
+    expect(nextSetupStep("destination", 0)).toBe("live");
+  });
 });
 
 describe("prevSetupStep", () => {
@@ -60,6 +78,11 @@ describe("prevSetupStep", () => {
     expect(prevSetupStep("live", 2)).toBe("destination");
     expect(prevSetupStep("destination", 2)).toBe("duration");
   });
+
+  it("includes destination when no writable calendars exist", () => {
+    expect(prevSetupStep("live", 0)).toBe("destination");
+    expect(prevSetupStep("destination", 0)).toBe("duration");
+  });
 });
 
 describe("setupStepProgress", () => {
@@ -67,5 +90,9 @@ describe("setupStepProgress", () => {
     expect(setupStepProgress("address", 1)).toEqual({ current: 1, total: 4 });
     expect(setupStepProgress("live", 2)).toEqual({ current: 5, total: 5 });
     expect(setupStepProgress("duration", 2)).toEqual({ current: 3, total: 5 });
+    expect(setupStepProgress("destination", 0)).toEqual({
+      current: 4,
+      total: 5,
+    });
   });
 });

--- a/packages/web/src/booking/setup/setup-steps.ts
+++ b/packages/web/src/booking/setup/setup-steps.ts
@@ -11,6 +11,9 @@ export interface SetupStepDefinition {
   sentence: string;
 }
 
+export const DESTINATION_ZERO_WRITABLE_SENTENCE =
+  "Connect a calendar you can write to before going live.";
+
 export const SETUP_STEPS: readonly SetupStepDefinition[] = [
   {
     id: "address",
@@ -52,12 +55,22 @@ export function setupStepDefinition(id: SetupStepId): SetupStepDefinition {
   return step;
 }
 
-/** Ordered step ids for the wizard; destination appears only with 2+ writable calendars. */
+export function setupStepSentence(
+  id: SetupStepId,
+  writableCalendarCount: number,
+): string {
+  if (id === "destination" && writableCalendarCount === 0) {
+    return DESTINATION_ZERO_WRITABLE_SENTENCE;
+  }
+  return setupStepDefinition(id).sentence;
+}
+
+/** Ordered step ids for the wizard; destination is hidden only with exactly one writable calendar. */
 export function visibleSetupSteps(
   writableCalendarCount: number,
 ): readonly SetupStepId[] {
   const steps: SetupStepId[] = ["address", "hours", "duration"];
-  if (writableCalendarCount >= 2) {
+  if (writableCalendarCount !== 1) {
     steps.push("destination");
   }
   steps.push("live");

--- a/packages/web/src/components/Sidebar/SidebarActions/useVersionCheck.test.ts
+++ b/packages/web/src/components/Sidebar/SidebarActions/useVersionCheck.test.ts
@@ -1,6 +1,8 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { act } from "react";
+import * as realEnvConstants from "@web/common/constants/env.constants";
 import {
+  afterAll,
   afterEach,
   beforeEach,
   describe,
@@ -13,16 +15,19 @@ import {
 
 let mockIsDev = false;
 const fetchMock = mock();
-const originalFetch = globalThis.fetch;
+const envConstantsSnapshot = { ...realEnvConstants };
 
 const MIN_HIDDEN_DURATION_MS = 30_000;
 const BACKUP_CHECK_INTERVAL_MS = 5 * 60 * 1000;
 
 async function renderVersionCheckHook() {
+  // Snapshot first: mock.module rebinds the live import, so spreading
+  // realEnvConstants inside the factory would copy the mock into itself and
+  // drop ENV_WEB for every later file in the shard.
   mock.module("@web/common/constants/env.constants", () => ({
+    ...envConstantsSnapshot,
     IS_DEV: mockIsDev,
   }));
-
   const moduleUrl = new URL(
     `./useVersionCheck.ts?test=${Math.random().toString(36).slice(2)}`,
     import.meta.url,
@@ -36,6 +41,7 @@ describe("useVersionCheck", () => {
   let visibilityState = "visible";
   let intervalCallback: (() => void) | undefined;
   let setIntervalSpy: ReturnType<typeof spyOn>;
+  let fetchSpy: ReturnType<typeof spyOn>;
 
   /** Lets checkVersion's fetch → json → setState chain finish inside act (microtasks). */
   const flushVersionCheckAsync = async () => {
@@ -71,13 +77,26 @@ describe("useVersionCheck", () => {
       ok: true,
       json: async () => ({ version: "dev" }),
     });
-    global.fetch = fetchMock as unknown as typeof fetch;
+    // spyOn so afterEach can restore MSW's fetch patch. Assigning
+    // global.fetch and putting back a copy taken at module load (before
+    // server.listen) leaves BaseApi talking to native fetch, so later
+    // mutation tests never hit their PUT/POST handlers.
+    fetchSpy = spyOn(globalThis, "fetch").mockImplementation(
+      fetchMock as unknown as typeof fetch,
+    );
   });
 
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    fetchSpy.mockRestore();
     setSystemTime();
     setIntervalSpy.mockRestore();
+  });
+
+  afterAll(() => {
+    mock.module(
+      "@web/common/constants/env.constants",
+      () => envConstantsSnapshot,
+    );
   });
 
   it("checks version on initial mount", async () => {


### PR DESCRIPTION
Fixes #3571

## What and why

Hosts with zero writable calendars no longer reach a dead-end go-live step. The setup wizard now shows the destination step with connect buttons and disabled Continue, adds a visible Back button on steps after the first, labels keyboard hint chips, and focuses the address field when the slug is taken. Spec: `docs/features/booking.md` first-run section.

## Verify

```
Selected packages: web
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)

✓ All checks passed
VERDICT: PASS
```