### PR TITLE
fix(web): send shortcut identity properties to posthog

### DIFF
--- a/packages/web/src/auth/posthog/track.test.ts
+++ b/packages/web/src/auth/posthog/track.test.ts
@@ -32,7 +32,7 @@ const {
 const { clearAppLockReasons, setAppLockReason } = await import(
   "@web/shortcuts/app-lock"
 );
-const { getShortcutHint } = await import(
+const { getHintPlainText, getShortcutHint } = await import(
   "@web/shortcuts/tips/shortcut-tips.data"
 );
 const { readShortcutUsageProfile } = await import(
@@ -86,7 +86,9 @@ describe("shortcut telemetry", () => {
       outcome: "shown",
       rank: 1,
       reason_code: "calendar_idle",
+      shortcut_type: "page-jump",
       source: "sidebar_status",
+      suggestion_text: getHintPlainText(suggestion),
     });
     expect(
       readShortcutUsageProfile().actions["calendar.page_jump"],
@@ -109,17 +111,25 @@ describe("shortcut telemetry", () => {
     expect(capture).toHaveBeenNthCalledWith(1, "shortcut_invoked", {
       action_id: "calendar.page_jump",
       feature_area: "calendar_navigation",
+      invocation_method: "keyboard",
       outcome: "succeeded",
       reason_code: "registered_shortcut",
+      shortcut_type: "page-jump",
       source: "keyboard",
+      suggestion_text: getHintPlainText(getShortcutHint("page-jump")),
+      was_suggested: true,
     });
     expect(capture).toHaveBeenNthCalledWith(2, "shortcut_suggestion_engaged", {
       action_id: "calendar.page_jump",
       feature_area: "calendar_navigation",
+      invocation_method: "keyboard",
       outcome: "invoked",
       rank: 1,
       reason_code: "local_discovery",
+      shortcut_type: "page-jump",
       source: "sidebar_status",
+      suggestion_text: getHintPlainText(getShortcutHint("page-jump")),
+      was_suggested: true,
     });
     expect(
       readShortcutUsageProfile().actions["calendar.page_jump"],
@@ -152,11 +162,14 @@ describe("shortcut telemetry", () => {
       active_element: "input",
       context: "billingGate+overlayPanel:settings+settingsModal",
       feature_area: "event_editing",
+      invocation_method: "keyboard",
       is_repeat: true,
       outcome: "unavailable",
       reason_code: "billing_locked",
       shortcut_key: "Tab",
+      shortcut_type: "edge-focus",
       source: "keyboard",
+      suggestion_text: getHintPlainText(getShortcutHint("edge-focus")),
       view: "week_view",
       was_modifier_held: false,
     });
@@ -181,10 +194,62 @@ describe("shortcut telemetry", () => {
       "shortcut_unavailable_attempt",
       expect.objectContaining({
         context: "unknown",
+        invocation_method: "keyboard",
         reason_code: "overlay_open",
         shortcut_key: "Shift+ArrowLeft",
+        shortcut_type: "nudge",
         view: "day_view",
         was_modifier_held: true,
+      }),
+    );
+  });
+
+  it("marks an independent invocation as not suggested", () => {
+    recordShortcutInvocation("create-event", 200_000);
+
+    expect(capture).toHaveBeenCalledWith("shortcut_invoked", {
+      action_id: "calendar.create_timed_event",
+      feature_area: "event_creation",
+      invocation_method: "keyboard",
+      outcome: "succeeded",
+      reason_code: "registered_shortcut",
+      shortcut_type: "create-event",
+      source: "keyboard",
+      suggestion_text: getHintPlainText(getShortcutHint("create-event")),
+      was_suggested: false,
+    });
+    expect(capture).not.toHaveBeenCalledWith(
+      "shortcut_suggestion_engaged",
+      expect.anything(),
+    );
+  });
+
+  it("records click invocation method and click unavailable attempts", () => {
+    recordShortcutInvocation("save-draft", 200_000, "click");
+
+    expect(capture).toHaveBeenCalledWith(
+      "shortcut_invoked",
+      expect.objectContaining({
+        invocation_method: "click",
+        shortcut_type: "save-draft",
+        source: "click",
+        was_suggested: false,
+      }),
+    );
+
+    capture.mockClear();
+    recordShortcutUnavailableAttempt("create-event", "billing_locked", {
+      invocationMethod: "click",
+    });
+
+    expect(capture).toHaveBeenCalledWith(
+      "shortcut_unavailable_attempt",
+      expect.objectContaining({
+        invocation_method: "click",
+        reason_code: "billing_locked",
+        shortcut_type: "create-event",
+        source: "click",
+        suggestion_text: getHintPlainText(getShortcutHint("create-event")),
       }),
     );
   });

--- a/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.test.tsx
@@ -10,6 +10,7 @@ import {
 import dayjs from "@core/util/date/dayjs";
 import { renderWithStore } from "@web/__tests__/render-with-store";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import * as Track from "@web/auth/posthog/track";
 import { type AppAccess } from "@web/billing/useAppAccess";
 import { onViewCommand } from "@web/common/utils/dom/view-command-bus";
 import { type EventMutationDependencies } from "@web/events/mutations/useEventMutations";
@@ -25,7 +26,15 @@ import {
 } from "@web/settings/settings.store";
 import { usePointerSuppression } from "@web/shortcuts/keyboard-only/usePointerSuppression";
 import { recordRecentCommand } from "./recent-commands.store";
-import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
 
 const mockNavigate = mock();
 // Bun's mock.module is process-wide, so mock the router's useNavigate directly
@@ -185,6 +194,30 @@ describe("CommandPalette", () => {
 
     const row = rowLabel("Create event").closest("button") as HTMLElement;
     expect(within(row).getByText("Premium")).toBeInTheDocument();
+  });
+
+  it("records a click unavailable attempt for a Premium create action", () => {
+    authenticated = true;
+    access = {
+      kind: "server",
+      status: "awaiting_checkout",
+      isReadOnly: true,
+      trialEndsAt: null,
+    };
+    const track = spyOn(Track, "track");
+    renderPalette();
+
+    fireEvent.click(rowLabel("Create event").closest("button") as HTMLElement);
+
+    expect(track).toHaveBeenCalledWith(
+      "shortcut_unavailable_attempt",
+      expect.objectContaining({
+        invocation_method: "click",
+        reason_code: "billing_locked",
+        shortcut_type: "create-event",
+      }),
+    );
+    track.mockRestore();
   });
 
   it("renders all sections with items and focuses the input on mount", () => {

--- a/packages/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/packages/web/src/components/CommandPalette/CommandPalette.tsx
@@ -48,6 +48,7 @@ import {
 import { useAppLockReason } from "@web/shortcuts/app-lock";
 import { pointerShortcutAttributes } from "@web/shortcuts/keyboard-only/pointer-action";
 import { type ViewName } from "@web/shortcuts/shortcuts.constants";
+import { recordShortcutUnavailableAttempt } from "@web/shortcuts/tips/shortcut-telemetry";
 import { useTimezoneCmdItems } from "@web/timezone/useTimezoneCmdItems";
 import { filterSections, getLabelMatchRanges } from "./command-palette.search";
 import { type CommandItem, type CommandSection } from "./command-palette.types";
@@ -308,12 +309,18 @@ export const CommandPalette = ({
     ? eventCommandPaletteItems.map((item) => ({
         ...item,
         badge: "Premium",
-        onClick: () =>
+        onClick: () => {
+          if (item.id === "create-event") {
+            recordShortcutUnavailableAttempt("create-event", "billing_locked", {
+              invocationMethod: "click",
+            });
+          }
           promptShortcutUpgrade({
             featureArea: "event_creation",
             actionId: "calendar.create_timed_event",
             source: "command_palette",
-          }),
+          });
+        },
       }))
     : eventCommandPaletteItems;
   const navigate = useNavigate();

--- a/packages/web/src/shortcuts/tips/ShortcutTipIndicator.tsx
+++ b/packages/web/src/shortcuts/tips/ShortcutTipIndicator.tsx
@@ -7,7 +7,10 @@ import {
 import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
 import { ShortcutTipParts } from "@web/shortcuts/tips/ShortcutTipParts";
 import { beginShortcutSuggestionPresentation } from "@web/shortcuts/tips/shortcut-telemetry";
-import { type RankedShortcutHint } from "@web/shortcuts/tips/shortcut-tips.data";
+import {
+  getHintPlainText,
+  type RankedShortcutHint,
+} from "@web/shortcuts/tips/shortcut-tips.data";
 
 const isWriteHint = (featureArea: RankedShortcutHint["featureArea"]) =>
   featureArea === "event_creation" || featureArea === "event_editing";
@@ -21,6 +24,7 @@ export const ShortcutTipIndicator: FC<{
   locked?: boolean;
 }> = ({ hint, locked = false }) => {
   const { actionId, featureArea, id, reasonCode } = hint;
+  const suggestionText = getHintPlainText(hint);
   useEffect(
     () =>
       beginShortcutSuggestionPresentation({
@@ -28,8 +32,9 @@ export const ShortcutTipIndicator: FC<{
         featureArea,
         id,
         reasonCode,
+        suggestionText,
       }),
-    [actionId, featureArea, id, reasonCode],
+    [actionId, featureArea, id, reasonCode, suggestionText],
   );
 
   const showLock = locked && isWriteHint(featureArea);

--- a/packages/web/src/shortcuts/tips/shortcut-telemetry.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-telemetry.ts
@@ -13,28 +13,60 @@ import {
   writeShortcutUsageProfile,
 } from "@web/shortcuts/tips/shortcut-personalization.storage";
 import {
+  getHintPlainText,
   getShortcutHint,
   type RankedShortcutHint,
+  type ShortcutHint,
   type ShortcutHintId,
 } from "@web/shortcuts/tips/shortcut-tips.data";
 
 const IMPRESSION_WINDOW_MS = 24 * 60 * 60 * 1000;
 const PRESENTATION_DEDUPE_MS = 30 * 1000;
 
+export type ShortcutInvocationMethod = "keyboard" | "click";
+
 type ActiveSuggestion = Pick<
   RankedShortcutHint,
   "actionId" | "featureArea" | "id" | "reasonCode"
->;
+> & { suggestionText: string };
+
+type SuggestionPresentation = Omit<ActiveSuggestion, "suggestionText"> & {
+  suggestionText?: string;
+  parts?: ShortcutHint["parts"];
+};
 
 let activeSuggestion: ActiveSuggestion | null = null;
 const lastPresentationByKey = new Map<string, number>();
+
+const hintIdentityProperties = (
+  hint: Pick<ShortcutHint, "actionId" | "featureArea" | "id" | "parts">,
+) => ({
+  action_id: hint.actionId,
+  feature_area: hint.featureArea,
+  shortcut_type: hint.id,
+  suggestion_text: getHintPlainText(hint),
+});
 
 const suggestionProperties = (suggestion: ActiveSuggestion) => ({
   action_id: suggestion.actionId,
   feature_area: suggestion.featureArea,
   rank: 1,
   reason_code: suggestion.reasonCode,
+  shortcut_type: suggestion.id,
   source: "sidebar_status",
+  suggestion_text: suggestion.suggestionText,
+});
+
+const resolvePresentedSuggestion = (
+  suggestion: SuggestionPresentation,
+): ActiveSuggestion => ({
+  actionId: suggestion.actionId,
+  featureArea: suggestion.featureArea,
+  id: suggestion.id,
+  reasonCode: suggestion.reasonCode,
+  suggestionText:
+    suggestion.suggestionText ??
+    getHintPlainText({ parts: suggestion.parts ?? [] }),
 });
 
 const emptyUsage = (): ShortcutActionUsage => ({
@@ -63,19 +95,20 @@ function updateUsage(
  * presentations are locally deduplicated for 30 seconds.
  */
 export function beginShortcutSuggestionPresentation(
-  suggestion: ActiveSuggestion,
+  suggestion: SuggestionPresentation,
   now = Date.now(),
 ): () => void {
-  activeSuggestion = suggestion;
+  const presented = resolvePresentedSuggestion(suggestion);
+  activeSuggestion = presented;
 
-  const dedupeKey = `${suggestion.id}:${suggestion.reasonCode}`;
+  const dedupeKey = `${presented.id}:${presented.reasonCode}:${presented.suggestionText}`;
   const lastPresentation = lastPresentationByKey.get(dedupeKey);
   if (
     lastPresentation === undefined ||
     now - lastPresentation >= PRESENTATION_DEDUPE_MS
   ) {
     lastPresentationByKey.set(dedupeKey, now);
-    updateUsage(suggestion.actionId, (current) => {
+    updateUsage(presented.actionId, (current) => {
       const isRecent =
         current.lastShownAt !== undefined &&
         now - current.lastShownAt < IMPRESSION_WINDOW_MS;
@@ -86,13 +119,13 @@ export function beginShortcutSuggestionPresentation(
       };
     });
     track("shortcut_suggestion_shown", {
-      ...suggestionProperties(suggestion),
+      ...suggestionProperties(presented),
       outcome: "shown",
     });
   }
 
   return () => {
-    if (activeSuggestion === suggestion) activeSuggestion = null;
+    if (activeSuggestion === presented) activeSuggestion = null;
   };
 }
 
@@ -101,9 +134,10 @@ export function beginShortcutSuggestionPresentation(
 export function recordShortcutInvocation(
   hintId: ShortcutHintId,
   now = Date.now(),
+  invocationMethod: ShortcutInvocationMethod = "keyboard",
 ): void {
   const hint = getShortcutHint(hintId);
-  const engaged = activeSuggestion?.actionId === hint.actionId;
+  const wasSuggested = activeSuggestion?.actionId === hint.actionId;
   updateUsage(hint.actionId, (current) => ({
     ...current,
     invocations: current.invocations + 1,
@@ -111,17 +145,24 @@ export function recordShortcutInvocation(
   }));
 
   track("shortcut_invoked", {
-    action_id: hint.actionId,
-    feature_area: hint.featureArea,
+    ...hintIdentityProperties(hint),
+    invocation_method: invocationMethod,
     outcome: "succeeded",
     reason_code: "registered_shortcut",
-    source: "keyboard",
+    source: invocationMethod,
+    suggestion_text:
+      wasSuggested && activeSuggestion
+        ? activeSuggestion.suggestionText
+        : getHintPlainText(hint),
+    was_suggested: wasSuggested,
   });
 
-  if (engaged && activeSuggestion) {
+  if (wasSuggested && activeSuggestion) {
     track("shortcut_suggestion_engaged", {
       ...suggestionProperties(activeSuggestion),
+      invocation_method: invocationMethod,
       outcome: "invoked",
+      was_suggested: true,
     });
   }
 }
@@ -160,10 +201,12 @@ function registeredHotkeyLabel(hotkey: RegisterableHotkey): string {
 }
 
 export type ShortcutUnavailableAttempt = {
+  /** How the user tried to run the shortcut. Defaults from `event`. */
+  invocationMethod?: ShortcutInvocationMethod;
   /** The hotkey as registered, never the raw key the user typed. */
-  hotkey: RegisterableHotkey;
+  hotkey?: RegisterableHotkey;
   /** The keydown/keyup that matched the registration. */
-  event: Pick<
+  event?: Pick<
     KeyboardEvent,
     "altKey" | "ctrlKey" | "metaKey" | "shiftKey" | "repeat"
   >;
@@ -186,23 +229,33 @@ export type ShortcutUnavailableReason = "billing_locked" | "overlay_open";
 export function recordShortcutUnavailableAttempt(
   hintId: ShortcutHintId,
   reasonCode: ShortcutUnavailableReason,
-  attempt: ShortcutUnavailableAttempt,
+  attempt: ShortcutUnavailableAttempt = {},
 ): void {
   const hint = getShortcutHint(hintId);
-  const { event } = attempt;
+  const invocationMethod =
+    attempt.invocationMethod ?? (attempt.event ? "keyboard" : "click");
+  const { event, hotkey } = attempt;
+
   track("shortcut_unavailable_attempt", {
-    action_id: hint.actionId,
-    active_element: document.activeElement?.tagName.toLowerCase() ?? "none",
-    context: lockContext(),
-    feature_area: hint.featureArea,
-    is_repeat: event.repeat,
+    ...hintIdentityProperties(hint),
+    invocation_method: invocationMethod,
     outcome: "unavailable",
     reason_code: reasonCode,
-    shortcut_key: registeredHotkeyLabel(attempt.hotkey),
-    source: "keyboard",
+    source: invocationMethod,
     view: viewFromPathname(window.location.pathname),
-    was_modifier_held:
-      event.altKey || event.ctrlKey || event.metaKey || event.shiftKey,
+    ...(hotkey !== undefined
+      ? { shortcut_key: registeredHotkeyLabel(hotkey) }
+      : {}),
+    ...(event
+      ? {
+          active_element:
+            document.activeElement?.tagName.toLowerCase() ?? "none",
+          context: lockContext(),
+          is_repeat: event.repeat,
+          was_modifier_held:
+            event.altKey || event.ctrlKey || event.metaKey || event.shiftKey,
+        }
+      : { context: lockContext() }),
   });
 }
 

--- a/packages/web/src/shortcuts/tips/shortcut-tips.data.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-tips.data.ts
@@ -88,7 +88,7 @@ const partPlainText = (part: ShortcutTipPart): string => {
 export const getPartsPlainText = (parts: readonly ShortcutTipPart[]): string =>
   parts.map(partPlainText).join("");
 
-export const getHintPlainText = (hint: ShortcutHint): string =>
+export const getHintPlainText = (hint: Pick<ShortcutHint, "parts">): string =>
   getPartsPlainText(hint.parts);
 
 const [createKey] = KEYMAP.createEvent.keycaps;

--- a/packages/web/src/shortcuts/tips/shortcut-tips.progress.store.ts
+++ b/packages/web/src/shortcuts/tips/shortcut-tips.progress.store.ts
@@ -5,7 +5,10 @@ import {
   subscribeToStorageKey,
 } from "@web/common/utils/external-store.util";
 import { useShortcutShowcaseStore } from "@web/components/ShortcutShowcase/showcase.store";
-import { recordShortcutInvocation } from "@web/shortcuts/tips/shortcut-telemetry";
+import {
+  recordShortcutInvocation,
+  type ShortcutInvocationMethod,
+} from "@web/shortcuts/tips/shortcut-telemetry";
 import { type ShortcutHintId } from "@web/shortcuts/tips/shortcut-tips.data";
 import {
   readShortcutHintProgress,
@@ -46,10 +49,13 @@ export const shortcutHintProgressActions = {
    * Records that the user performed a taught primitive. No-ops while the
    * Shortcut Showcase is open so practice does not skip real-calendar tips.
    */
-  demonstrate: (id: ShortcutHintId): void => {
+  demonstrate: (
+    id: ShortcutHintId,
+    invocationMethod: ShortcutInvocationMethod = "keyboard",
+  ): void => {
     if (useShortcutShowcaseStore.getState().isActive) return;
 
-    recordShortcutInvocation(id);
+    recordShortcutInvocation(id, Date.now(), invocationMethod);
 
     const current = progressStore.get();
     if (current[current.length - 1] === id) return;

--- a/packages/web/src/shortcuts/useAppShortcut.test.ts
+++ b/packages/web/src/shortcuts/useAppShortcut.test.ts
@@ -297,7 +297,9 @@ describe("useAppShortcut", () => {
         expect.objectContaining({
           action_id: "calendar.create_timed_event",
           context: "settingsModal",
+          invocation_method: "keyboard",
           reason_code: "overlay_open",
+          shortcut_type: "create-event",
         }),
       );
       setAppLockReason("settingsModal", false);

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -441,7 +441,9 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
       handleIgnoredKeys(e);
     };
 
-    const onSubmitForm = () => {
+    const onSubmitForm = (
+      invocationMethod: "keyboard" | "click" = "keyboard",
+    ) => {
       // Belt for the read-only gate above: the Save button doesn't render,
       // but Enter/Mod+Enter shortcuts below call this directly regardless
       // of what's on screen, so the block has to live here too (packet 08
@@ -483,7 +485,7 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
           : { kind: "timed", start, end, timeZone: schedule.timeZone },
       );
 
-      shortcutHintProgressActions.demonstrate("save-draft");
+      shortcutHintProgressActions.demonstrate("save-draft", invocationMethod);
       onSubmit(withSchedule);
     };
 
@@ -936,7 +938,7 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
                   ))}
                 </ul>
               ) : null}
-              <SaveSection onSubmit={onSubmitForm} />
+              <SaveSection onSubmit={() => onSubmitForm("click")} />
             </>
           )}
         </EventFormShell>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

`shortcut_suggestion_shown` and `shortcut_invoked` were reaching PostHog without `shortcut_type` and `suggestion_text`, so we could see a ~7% suggestion-to-invoke rate but not which shortcuts users were shown versus which they used. These events now send `shortcut_type` (the taught hint id) and `suggestion_text` (the visible tip). `shortcut_invoked` and `shortcut_suggestion_engaged` also send `invocation_method` (`keyboard` or `click`) and `was_suggested`. `shortcut_unavailable_attempt` sends `shortcut_type` plus the existing `reason_code` (`billing_locked` or `overlay_open`), including Premium create-event clicks in the command palette.

Existing `action_id` / `feature_area` / `reason_code` properties are unchanged so current insights keep working.

## Verify

`bun run verify --strict`

Selected packages: web
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)

VERDICT: PASS
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ede519a-ae58-442e-8fb7-758503cd5011?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ede519a-ae58-442e-8fb7-758503cd5011&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

