### PR TITLE
fix(web): announce unavailable booking days and close v1.10 docs

### DIFF
--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -29,6 +29,7 @@ Use this guide to validate:
 - toggling the sidebar (])
 - undoing / redoing with the keyboard (Cmd+Z / Cmd+Shift+Z)
 - confirming Settings > Meeting hold-Mod reveals only sidebar digits and Save Enter
+- confirming the first-run Meeting wizard Continue / Back keys (Enter, Esc, K, J)
 - confirming that shortcuts do not fire while typing in inputs
 
 Do not use this guide to validate:
@@ -504,6 +505,33 @@ Settings > Meeting hold-Mod reveals only sidebar digits `1` / `2` / `3` and Ente
 
 ---
 
+## Scenario 19: First-run Meeting Wizard Continue and Back
+
+### UX
+
+The first-run Meeting wizard Continue and Back keys are Enter, Esc, K,
+and J. Hints label them (`Enter Continue`, `Esc Back`, `K Next`,
+`J Back`). Those keys do not fire while typing in an input, except
+Enter from the address field.
+
+### Steps
+
+1. Open Settings and go to Meeting with no saved page.
+2. Confirm the address step shows **Continue** and hides **Back**.
+3. Press Enter.
+4. Confirm weekly hours shows **Back**.
+5. Press J, then K.
+
+### Expected Results
+
+- Step 1 has Continue and no Back. The hint row includes Enter Continue.
+- After Enter, Step 2 shows Back. The hint row includes Esc Back, K Next,
+  and J Back.
+- J returns to the address step. K returns to weekly hours.
+- With focus in the address field, K does not continue. Enter does.
+
+---
+
 ## Focused Regression Checks
 
 If time is limited, run these checks before shipping shortcut-related changes:
@@ -530,3 +558,4 @@ If time is limited, run these checks before shipping shortcut-related changes:
 20. On Day view, hold Mod then a column digit (2+) focuses that writable calendar column; Shift+Arrow / `C` seed a draft there.
 21. Cmd+C / Ctrl+C copies a focused event; Cmd+V / Ctrl+V pastes a duplicate at the original time without requiring focus. A later copy replaces the clipboard. Empty paste is a no-op. Copy/paste do not fire while typing in an input (native text clipboard). Cmd+D is unchanged.
 22. In Settings > Meeting, hold Mod to reveal chips `1`/`2`/`3` and Enter; extra digits focus nothing; U with Mod held does not copy.
+23. On the first-run Meeting wizard, Enter continues, Esc and J go back after step 1, and K continues when focus is not in an editable target.

--- a/docs/architecture/glossary.md
+++ b/docs/architecture/glossary.md
@@ -159,7 +159,9 @@ The one v1 scheduling page owned by a Compass user, shown to users as
 Meeting page. Settings configure it; guests open it at `/meet/:username`.
 Old `/book` username links redirect client-side. Host weekly hours are a
 per-day list; a weekday can hold several blocks. Meeting timezone is
-edited under More options.
+edited under More options. First-run uses a guided wizard. A signed-in
+host whose page is not live sees a sidebar card to set it up. A live page
+shows whether guests can book right now.
 _Avoid_: event type (v1 has one duration per user, not Calendly-style
 multiple event types)
 

--- a/docs/development/feature-file-map.md
+++ b/docs/development/feature-file-map.md
@@ -71,8 +71,8 @@ Product spec: [Compass Calendar Booking](../features/booking.md).
   `POST /internal/availability/busy`
 - Host Settings: `packages/web/src/booking/BookingSettingsSection.tsx`,
   `packages/web/src/booking/setup/`, `BookingStatusHeader.tsx`,
-  `BookingConnectionBanner.tsx`, `BookingWeeklyHoursEditor.tsx`,
-  `weekly-hours.ts`, `useNewMeetingsNotice.ts`,
+  `BookingConnectionBanner.tsx`, `BookingBookabilityNotice.tsx`,
+  `BookingWeeklyHoursEditor.tsx`, `weekly-hours.ts`, `useNewMeetingsNotice.ts`,
   `packages/web/src/components/Switch/Switch.tsx`
 - Description flattening: `packages/web/src/components/DescriptionEditor/plain-text-description.ts`
 - Sidebar discovery: `packages/web/src/components/Sidebar/MeetingPageNudge/`
@@ -80,7 +80,8 @@ Product spec: [Compass Calendar Booking](../features/booking.md).
   `PublicBookingMonthGrid.tsx`, `PublicBookingConfirmedPage.tsx`,
   `PublicBookingCancelPage.tsx`,
   `PublicBookingReschedulePage.tsx`
-- Web API client: `packages/web/src/api/public-booking.api.ts`
+- Web API client: `packages/web/src/api/public-booking.api.ts`,
+  `packages/web/src/api/booking.api.ts`
 - E2e: `e2e/booking/`, `e2e/accessibility/booking-a11y.spec.ts`
 - Architecture: [Product Suite Boundaries](../architecture/product-suite-boundaries.md)
 

--- a/docs/development/feature-file-map.md
+++ b/docs/development/feature-file-map.md
@@ -52,7 +52,7 @@ RSVP](../features/attendees.md).
 - Sync Google writer/people adapters: `packages/sync/src/providers/google/google-event-writer.adapter.ts`, `packages/sync/src/providers/google/google-people.adapter.ts`
 - E2e coverage: `e2e/attendees/`
 
-## Booking (v1 / v1.8)
+## Booking (v1 / v1.10)
 
 Product spec: [Compass Calendar Booking](../features/booking.md).
 
@@ -62,18 +62,23 @@ Product spec: [Compass Calendar Booking](../features/booking.md).
 - Slot engine: `packages/core/src/booking/compute-booking-slots.ts`
 - Backend admin: `packages/backend/src/booking/controllers/booking.controller.ts`,
   `services/booking-page.service.ts`
-- Backend public API: `packages/backend/src/booking/services/public-booking.service.ts`
+- Backend public API: `packages/backend/src/booking/services/public-booking.service.ts`,
+  `services/booking-readiness.ts`
 - Calendar port: `packages/backend/src/booking/services/calendar-booking.port.ts`,
   `services/calendar-booking.service.ts`
 - Occupancy: `packages/sync/src/domain/occurrence-projection.ts`,
   `packages/sync/src/domain/busy-query.service.ts`,
   `POST /internal/availability/busy`
 - Host Settings: `packages/web/src/booking/BookingSettingsSection.tsx`,
-  `packages/web/src/booking/setup/`, `BookingWeeklyHoursEditor.tsx`,
-  `weekly-hours.ts`,
+  `packages/web/src/booking/setup/`, `BookingStatusHeader.tsx`,
+  `BookingConnectionBanner.tsx`, `BookingWeeklyHoursEditor.tsx`,
+  `weekly-hours.ts`, `useNewMeetingsNotice.ts`,
   `packages/web/src/components/Switch/Switch.tsx`
+- Description flattening: `packages/web/src/components/DescriptionEditor/plain-text-description.ts`
+- Sidebar discovery: `packages/web/src/components/Sidebar/MeetingPageNudge/`
 - Public guest UI: `packages/web/src/booking/PublicBookingPage.tsx`,
-  `PublicBookingConfirmedPage.tsx`, `PublicBookingCancelPage.tsx`,
+  `PublicBookingMonthGrid.tsx`, `PublicBookingConfirmedPage.tsx`,
+  `PublicBookingCancelPage.tsx`,
   `PublicBookingReschedulePage.tsx`
 - Web API client: `packages/web/src/api/public-booking.api.ts`
 - E2e: `e2e/booking/`, `e2e/accessibility/booking-a11y.spec.ts`

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -582,11 +582,11 @@ Guest reschedule is **in scope for v1.3**, not v1 / v1.1.
 | Reservations + cancel tokens | `packages/backend/src/booking/booking-reservation.repository.ts`, `booking-cancel-token.ts` |
 | Calendar application port | `packages/backend/src/booking/services/calendar-booking.port.ts` (`updateBookingEvent`), `services/calendar-booking.service.ts` |
 | Sync busy occupancy | `packages/sync/src/domain/occurrence-projection.ts`, `busy-query.service.ts`, `booking-occupancy-facts.ts` |
-| Host Settings UI | `packages/web/src/booking/BookingSettingsSection.tsx`, `packages/web/src/booking/setup/`, `BookingStatusHeader.tsx`, `BookingConnectionBanner.tsx`, `BookingMoreOptions.tsx`, `BookingSaveBar.tsx`, `BookingAddressField.tsx`, `BookingBlockingCalendarsField.tsx`, `BookingWeeklyHoursEditor.tsx`, `weekly-hours.ts`, `useNewMeetingsNotice.ts`, `packages/web/src/components/Switch/Switch.tsx`, `packages/web/src/components/Settings/SettingsModal.tsx` |
+| Host Settings UI | `packages/web/src/booking/BookingSettingsSection.tsx`, `packages/web/src/booking/setup/`, `BookingStatusHeader.tsx`, `BookingConnectionBanner.tsx`, `BookingBookabilityNotice.tsx`, `BookingMoreOptions.tsx`, `BookingSaveBar.tsx`, `BookingAddressField.tsx`, `BookingBlockingCalendarsField.tsx`, `BookingWeeklyHoursEditor.tsx`, `weekly-hours.ts`, `useNewMeetingsNotice.ts`, `packages/web/src/components/Switch/Switch.tsx`, `packages/web/src/components/Settings/SettingsModal.tsx` |
 | Sidebar discovery | `packages/web/src/components/Sidebar/MeetingPageNudge/` |
 | Description flattening | `packages/web/src/components/DescriptionEditor/plain-text-description.ts` |
 | Public guest UI | `packages/web/src/booking/PublicBookingPage.tsx`, `PublicBookingMonthGrid.tsx`, `PublicBookingConfirmedPage.tsx`, `PublicBookingCancelPage.tsx`, `PublicBookingReschedulePage.tsx`, `PublicBookingEditDetailsForm.tsx` |
-| Public web API client | `packages/web/src/api/public-booking.api.ts` |
+| Public web API client | `packages/web/src/api/public-booking.api.ts`, `packages/web/src/api/booking.api.ts` |
 | E2e | `e2e/booking/`, `e2e/booking/public-booking-reschedule.spec.ts`, `e2e/accessibility/booking-a11y.spec.ts` |
 
 ### Analytics

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -1,4 +1,4 @@
-# Compass Calendar Booking (v1 / v1.1 / v1.3 / v1.5 / v1.6 / v1.7 / v1.8 / v1.9)
+# Compass Calendar Booking (v1 / v1.1 / v1.3 / v1.5 / v1.6 / v1.7 / v1.8 / v1.9 / v1.10)
 
 Locked product spec for public scheduling on Compass Cloud
 (`https://compasscalendar.com`). Approved 2026-08-30. v1.1 shipped
@@ -16,21 +16,27 @@ menus for weekly hours, fewer host scheduling knobs, sidebar-only Mod chords,
 no horizontal scroll, and the stale-holiday-calendar booking gate fix. v1.9
 anchored Settings to the top, animated More options, let a day hold several
 hour blocks, moved meeting timezone under More options, and trimmed helper
-copy. The production gate stays off.
+copy. v1.10 shipped the staging meeting-flow fixes: Meet on insert, hours
+alignment, destination under More options, confirmation links only, host
+reconnect and bookability status, the setup wizard dead-end fixes, host
+new-meeting notice, sidebar discovery, an off page that keeps its
+link, and unavailable guest-month days that announce no times available.
+The production gate stays off.
 
 Compass never sends email itself. Google emails the guest when Compass
 creates the calendar event with `invitation: "all"`.
 
 ## Status
 
-v1, v1.1, v1.3, v1.5, v1.6, v1.7, v1.8, and v1.9 are implemented in the Compass
+v1, v1.1, v1.3, v1.5, v1.6, v1.7, v1.8, v1.9, and v1.10 are implemented in the Compass
 monorepo (public `/meet/:username`, host Settings, backend APIs, guest
 cancel, guest reschedule, edit-details, one-click turn on, Essentials /
 More options, editable address, default hours, branded connect pills,
 funnel analytics, meeting copy, hold-Mod section chords, the on/off
 switch, a per-day weekly hours list that can hold several blocks, meeting
 timezone under More options, the guided first-run setup wizard, Start
-and End time menus, and the v1.8 booking gate fix). Booking
+and End time menus, the v1.8 booking gate fix, and the v1.10 meeting-flow
+fixes). Booking
 is enabled in development and staging (`runtime.nodeEnv` other than
 `production`) and disabled in production. Do not flip `isBookingEnabled`.
 A standalone Compass Booking product (separate brand, domain, or
@@ -168,7 +174,9 @@ focus uses the accent ring. Intended Tab order on the picker:
 1. **Skip to open times** (focus-revealed link) jumps to **Pick a time**,
    skipping the month grid.
 2. Timezone control, then previous/next month, then one tab stop on the
-   selected day (arrow keys move among days).
+   selected day (arrow keys move among available days). Unavailable days
+   stay out of the tab order, keep `aria-disabled="true"`, and include
+   an sr-only suffix `no times available`.
 3. One tab stop on that day's times (arrow keys move among slots, Home
    and End jump to first and last). Enter or Space on a day moves focus
    to the first slot. Enter or Space on a slot opens **Your details**
@@ -242,7 +250,7 @@ One booking-page record per user.
 | Duration | `15` / `30` / `45` / `60` minutes. Default `30`. Custom minutes later. |
 | Destination calendar | Writable calendar (`canWriteEvents`) on a healthy connection. Receives the created event. |
 | Blocking calendars | Calendars whose busy intervals occupy slots. Any calendar the host can read availability for, including `freeBusyReader`. Default: every imported calendar on the destination account. |
-| General availability | Weekly intervals in the **host booking timezone**. Empty weekday = unavailable. Default Mon-Fri 09:00-17:00, shown as one grouped hours row. Turning on requires at least one window (`AVAILABILITY_REQUIRED`). Default timezone: the timezone currently in the host's calendar view when they first enable booking, not UTC. An unconfigured admin GET uses the host's primary calendar timezone. |
+| General availability | Weekly intervals in the **host booking timezone**. Empty weekday = unavailable. Default Mon-Fri 09:00-17:00 as one block per weekday on the per-day list. Turning on requires at least one window (`AVAILABILITY_REQUIRED`). Default timezone: the timezone currently in the host's calendar view when they first enable booking, not UTC. An unconfigured admin GET uses the host's primary calendar timezone. |
 | Scheduling window | Minimum notice default **4 hours**, capped at **1440 hours** (the 60-day horizon in hours). Maximum horizon default **60 days**. The 60-day cap matches Sync's busy-query bound (`BUSY_QUERY_MAX_WINDOW_MS` in `packages/core/src/types/sync/availability.contracts.ts`). |
 
 **Slot grid:** 15-minute starts in the host timezone, filtered so a slot
@@ -574,8 +582,10 @@ Guest reschedule is **in scope for v1.3**, not v1 / v1.1.
 | Reservations + cancel tokens | `packages/backend/src/booking/booking-reservation.repository.ts`, `booking-cancel-token.ts` |
 | Calendar application port | `packages/backend/src/booking/services/calendar-booking.port.ts` (`updateBookingEvent`), `services/calendar-booking.service.ts` |
 | Sync busy occupancy | `packages/sync/src/domain/occurrence-projection.ts`, `busy-query.service.ts`, `booking-occupancy-facts.ts` |
-| Host Settings UI | `packages/web/src/booking/BookingSettingsSection.tsx`, `packages/web/src/booking/setup/`, `BookingStatusHeader.tsx`, `BookingConnectionBanner.tsx`, `BookingMoreOptions.tsx`, `BookingSaveBar.tsx`, `BookingAddressField.tsx`, `BookingBlockingCalendarsField.tsx`, `BookingWeeklyHoursEditor.tsx`, `weekly-hours.ts`, `packages/web/src/components/Switch/Switch.tsx`, `packages/web/src/components/Settings/SettingsModal.tsx` |
-| Public guest UI | `packages/web/src/booking/PublicBookingPage.tsx`, `PublicBookingConfirmedPage.tsx`, `PublicBookingCancelPage.tsx`, `PublicBookingReschedulePage.tsx`, `PublicBookingEditDetailsForm.tsx` |
+| Host Settings UI | `packages/web/src/booking/BookingSettingsSection.tsx`, `packages/web/src/booking/setup/`, `BookingStatusHeader.tsx`, `BookingConnectionBanner.tsx`, `BookingMoreOptions.tsx`, `BookingSaveBar.tsx`, `BookingAddressField.tsx`, `BookingBlockingCalendarsField.tsx`, `BookingWeeklyHoursEditor.tsx`, `weekly-hours.ts`, `useNewMeetingsNotice.ts`, `packages/web/src/components/Switch/Switch.tsx`, `packages/web/src/components/Settings/SettingsModal.tsx` |
+| Sidebar discovery | `packages/web/src/components/Sidebar/MeetingPageNudge/` |
+| Description flattening | `packages/web/src/components/DescriptionEditor/plain-text-description.ts` |
+| Public guest UI | `packages/web/src/booking/PublicBookingPage.tsx`, `PublicBookingMonthGrid.tsx`, `PublicBookingConfirmedPage.tsx`, `PublicBookingCancelPage.tsx`, `PublicBookingReschedulePage.tsx`, `PublicBookingEditDetailsForm.tsx` |
 | Public web API client | `packages/web/src/api/public-booking.api.ts` |
 | E2e | `e2e/booking/`, `e2e/booking/public-booking-reschedule.spec.ts`, `e2e/accessibility/booking-a11y.spec.ts` |
 
@@ -624,6 +634,10 @@ routes; these are the named events in `packages/web/src/auth/posthog/track.ts`.
   host edit can be overwritten. Accepted for v1.3.
 - **Confirm is fail-closed.** When Sync reports `bookable: false`, slots
   disappear and confirm returns `409`.
+- **New-meetings claim has no `createdAt` index.**
+  `POST /api/booking/page/new-meetings/claim` filters confirmed
+  reservations by `createdAt`. Accepted for v1.10 while the production
+  gate stays off.
 - **Removed host settings may linger on old Mongo documents.** Buffer,
   max meetings per day, welcome text, and guest-invite permission were
   removed in Booking v1.8. Zod strips those keys on read; they are not
@@ -667,6 +681,19 @@ email.
 A signed-in host whose Meeting page is not live sees a sidebar card that
 opens Settings on the Meeting tab. Dismissing it is per browser; turning
 the page on hides it everywhere.
+
+Weekly hours on the configured form no longer show a timezone line. That
+line lived on the v1.9 live form (`Times in … Change it under Meeting
+timezone.`); v1.10 moved timezone to the wizard hours hint and the
+go-live summary only.
+
+The first-run wizard shows the destination step unless exactly one
+writable calendar exists. With zero writables it asks the host to
+connect, keeps Continue disabled, and does not reach go live. Steps after
+the first show Back. A taken address focuses the address field.
+
+Unavailable days on the guest month grid stay non-focusable and announce
+`no times available`.
 
 ### v1.9
 

--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import {
+  BOOKING_CALENDAR_ID,
   buildBookableSlot,
   dispatchClick,
   dispatchFill,
@@ -531,6 +532,78 @@ test.describe("settings booking section", () => {
     } finally {
       await releaseSettingsMod(page);
     }
+  });
+
+  test("reconnect banner has no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await prepareSignedInBookingSettingsPage(page, {
+      connectionState: "RECONNECT_REQUIRED",
+      enabled: true,
+    });
+    const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+    await expect(
+      settingsDialog.getByRole("switch", { name: "Meeting page" }),
+    ).toHaveAttribute("aria-checked", "true");
+    await expect(
+      settingsDialog.getByRole("status").filter({
+        hasText: "Guests can't book right now",
+      }),
+    ).toBeVisible();
+    await expect(
+      settingsDialog.getByRole("button", { name: "Reconnect Google Calendar" }),
+    ).toBeVisible();
+    await expectNoAxeViolations(page, {
+      checkpoint: "settings booking reconnect banner",
+      include: "[role='dialog']",
+    });
+  });
+
+  test("unbookable host status has no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await prepareSignedInBookingSettingsPage(page, {
+      pageStatus: {
+        bookable: false,
+        reasons: [
+          {
+            kind: "calendar",
+            reason: "stale",
+            calendarId: BOOKING_CALENDAR_ID,
+          },
+        ],
+      },
+    });
+    const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+    await expect(
+      settingsDialog.getByText("Guests can't book right now"),
+    ).toBeVisible();
+    await expectNoAxeViolations(page, {
+      checkpoint: "settings booking host status",
+      include: "[role='dialog']",
+    });
+  });
+
+  test("sidebar meeting page nudge has no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await prepareSignedInBookingSettingsPage(page, {
+      configured: false,
+      openSettings: false,
+      completeOnboarding: true,
+    });
+    const nudge = page.getByRole("region", { name: "Meeting page" });
+    await expect(
+      nudge.getByRole("heading", { name: "Let people book time with you" }),
+    ).toBeVisible();
+    await expect(
+      nudge.getByRole("button", { name: "Set up meeting page" }),
+    ).toBeVisible();
+    await expect(nudge.getByRole("button", { name: "Dismiss" })).toBeVisible();
+    await expectNoAxeViolations(page, {
+      checkpoint: "sidebar meeting page nudge",
+      include: "[aria-label='Meeting page']",
+    });
   });
 
   test("not-live status has no automatically detectable accessibility violations", async ({

--- a/packages/scripts/src/testing/booking-doc-drift.test.ts
+++ b/packages/scripts/src/testing/booking-doc-drift.test.ts
@@ -17,11 +17,16 @@ const STALE_BOOKING_TERMS =
 const STALE_V19_BOOKING_TERMS =
   /grouped weekly hours|weekly-hours\.rows|\bUnavailable:|\bLive at\b|Pending, maybe|keeps only the first interval|a weekday belongs to at most one row/i;
 
+const STALE_V110_BOOKING_TERMS =
+  /Times in .*Change it under|Copy cancel link|Copy reschedule link|Essentials: duration, weekly hours, and destination/i;
+
 const STALE_MEETING_MOD_CHORDS = /\bMod\+(?:[4-9]|U)\b/;
 
 const REMOVED_IN_V18 = /removed in Booking v1\.8/i;
 const REMOVED_IN_V19 =
   /removed or reversed in v1\.9|reversed in v1\.9|removed in Booking v1\.9/i;
+const REMOVED_IN_V110 =
+  /removed or reversed in v1\.10|reversed in v1\.10|dropped in v1\.10|no longer show a timezone line|v1\.10 moved timezone/i;
 
 function inChangelogSection(lines: string[], index: number): boolean {
   for (let cursor = index; cursor >= 0; cursor -= 1) {
@@ -33,10 +38,19 @@ function inChangelogSection(lines: string[], index: number): boolean {
 }
 
 function lineAllowedInBookingSpec(line: string, nearby: string[]): boolean {
-  if (REMOVED_IN_V18.test(line) || REMOVED_IN_V19.test(line)) return true;
+  if (
+    REMOVED_IN_V18.test(line) ||
+    REMOVED_IN_V19.test(line) ||
+    REMOVED_IN_V110.test(line)
+  ) {
+    return true;
+  }
   if (
     nearby.some(
-      (other) => REMOVED_IN_V18.test(other) || REMOVED_IN_V19.test(other),
+      (other) =>
+        REMOVED_IN_V18.test(other) ||
+        REMOVED_IN_V19.test(other) ||
+        REMOVED_IN_V110.test(other),
     )
   ) {
     return true;
@@ -50,17 +64,35 @@ function staleLines(
     includeMeetingModChords: boolean;
     allowV18RemovalBlock?: boolean;
     allowV19Changelog?: boolean;
+    allowV110Changelog?: boolean;
   },
 ): string[] {
   const lines = content.split("\n");
   return lines.flatMap((line, index) => {
     const matchesV18Term = STALE_BOOKING_TERMS.test(line);
     const matchesV19Term = STALE_V19_BOOKING_TERMS.test(line);
+    const matchesV110Term = STALE_V110_BOOKING_TERMS.test(line);
     const matchesMeetingMod =
       options.includeMeetingModChords && STALE_MEETING_MOD_CHORDS.test(line);
-    if (!matchesV18Term && !matchesV19Term && !matchesMeetingMod) return [];
+    if (
+      !matchesV18Term &&
+      !matchesV19Term &&
+      !matchesV110Term &&
+      !matchesMeetingMod
+    ) {
+      return [];
+    }
 
     if (options.allowV19Changelog && matchesV19Term && !matchesV18Term) {
+      if (inChangelogSection(lines, index)) return [];
+    }
+
+    if (
+      options.allowV110Changelog &&
+      matchesV110Term &&
+      !matchesV18Term &&
+      !matchesV19Term
+    ) {
       if (inChangelogSection(lines, index)) return [];
     }
 
@@ -74,13 +106,14 @@ function staleLines(
 }
 
 describe("booking doc drift", () => {
-  it("docs/features/booking.md has no stale terms outside the removal wart and v1.9 changelog", () => {
+  it("docs/features/booking.md has no stale terms outside the removal wart and v1.9/v1.10 changelog", () => {
     const content = readFileSync(BOOKING_SPEC_PATH, "utf8");
     expect(
       staleLines(content, {
         includeMeetingModChords: true,
         allowV18RemovalBlock: true,
         allowV19Changelog: true,
+        allowV110Changelog: true,
       }),
     ).toEqual([]);
   });

--- a/packages/web/src/booking/PublicBookingMonthGrid.test.tsx
+++ b/packages/web/src/booking/PublicBookingMonthGrid.test.tsx
@@ -90,6 +90,23 @@ describe("PublicBookingMonthGrid", () => {
     expect(screen.getByText("16")).toBeInTheDocument();
   });
 
+  it("marks an unavailable cell as disabled and announces no times available", () => {
+    renderGrid();
+
+    const cell = screen.getByText((_, element) => {
+      const text = element?.textContent?.replace(/\s+/g, " ").trim() ?? "";
+      return (
+        element?.getAttribute("aria-disabled") === "true" &&
+        /^\d+ no times available$/.test(text) &&
+        text.startsWith("16")
+      );
+    });
+    expect(cell).toHaveAttribute("aria-disabled", "true");
+    expect(cell.textContent?.replace(/\s+/g, " ").trim()).toMatch(
+      /no times available$/,
+    );
+  });
+
   it("keeps a single day in the tab order and moves with arrow keys", async () => {
     const user = userEvent.setup({ delay: null });
     const { selected } = renderGrid();

--- a/packages/web/src/booking/PublicBookingMonthGrid.tsx
+++ b/packages/web/src/booking/PublicBookingMonthGrid.tsx
@@ -183,9 +183,11 @@ export function PublicBookingMonthGrid({
                     <div
                       key={day.dateKey}
                       aria-current={day.isToday ? "date" : undefined}
+                      aria-disabled="true"
                       className="flex h-10 w-full items-center justify-center rounded-md text-sm text-text-muted"
                     >
                       {day.dayOfMonth}
+                      <span className="sr-only"> no times available</span>
                     </div>
                   );
                 }

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -692,7 +692,9 @@
 }
 
 @utility c-keycap {
-  @apply inline-flex min-h-4.5 items-center justify-center rounded border border-border bg-surface-panel px-1.5 py-0.5 font-medium text-text-muted leading-none;
+  /* text-text, not muted: 11px keycap glyphs fail WCAG AA when muted ink
+     anti-aliases on surface-panel (axe 3.92:1 on the Enter chip). */
+  @apply inline-flex min-h-4.5 items-center justify-center rounded border border-border bg-surface-panel px-1.5 py-0.5 font-medium text-text leading-none;
 
   font-size: var(--font-size-s);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3575

## What and why

Booking v1.10 WP-13 closeout. Unavailable guest-month cells stay non-focusable, mark `aria-disabled="true"`, and include an sr-only `no times available` suffix. Accessibility checkpoints cover the reconnect banner, unbookable host status, zero-writable-calendar wizard step, and sidebar nudge. The go-live wizard step was failing axe on muted Enter keycaps; those chips now use `text-text`. Spec, glossary, feature file map, and shortcuts describe shipped v1.10 behaviour, including the reversal of the v1.9 configured-form timezone line (`Times in … Change it under Meeting timezone.`). Doc-drift tests pin those leftover phrases to the changelog.

An a11y sweep of the configured Meeting form, wizard steps, sidebar nudge, and confirmation links found no other user-facing changes.

Overlaps #3595 (same issue). This PR also covers wizard shortcut docs, the go-live keycap contrast fix, and the exact v1.9 timezone copy in the changelog.

## Verify

```
VERDICT: PASS
```

Checks run: `test:web`, `type-check`, `lint`, `knip`, `test:a11y`, `test:e2e` via `bun run verify --strict`. Also `bun test:scripts` (doc-drift) and `bun test:web packages/web/src/booking/PublicBookingMonthGrid.test.tsx`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8d28ca7-decd-49e5-a5f2-a6c88cc4f61a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8d28ca7-decd-49e5-a5f2-a6c88cc4f61a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

