### PR TITLE
fix(web): close booking v1.10 a11y sweep and spec drift

### DIFF
--- a/docs/architecture/glossary.md
+++ b/docs/architecture/glossary.md
@@ -159,7 +159,9 @@ The one v1 scheduling page owned by a Compass user, shown to users as
 Meeting page. Settings configure it; guests open it at `/meet/:username`.
 Old `/book` username links redirect client-side. Host weekly hours are a
 per-day list; a weekday can hold several blocks. Meeting timezone is
-edited under More options.
+edited under More options on the configured form; the setup wizard shows
+timezone inline on the hours and go-live steps. A live page shows whether
+guests can book; hosts who have not gone live may see a sidebar setup nudge.
 _Avoid_: event type (v1 has one duration per user, not Calendly-style
 multiple event types)
 

--- a/docs/development/feature-file-map.md
+++ b/docs/development/feature-file-map.md
@@ -52,7 +52,7 @@ RSVP](../features/attendees.md).
 - Sync Google writer/people adapters: `packages/sync/src/providers/google/google-event-writer.adapter.ts`, `packages/sync/src/providers/google/google-people.adapter.ts`
 - E2e coverage: `e2e/attendees/`
 
-## Booking (v1 / v1.8)
+## Booking (v1 / v1.10)
 
 Product spec: [Compass Calendar Booking](../features/booking.md).
 
@@ -61,7 +61,7 @@ Product spec: [Compass Calendar Booking](../features/booking.md).
 - Shared contracts: `packages/core/src/types/booking.contracts.ts`
 - Slot engine: `packages/core/src/booking/compute-booking-slots.ts`
 - Backend admin: `packages/backend/src/booking/controllers/booking.controller.ts`,
-  `services/booking-page.service.ts`
+  `services/booking-page.service.ts`, `services/booking-readiness.ts`
 - Backend public API: `packages/backend/src/booking/services/public-booking.service.ts`
 - Calendar port: `packages/backend/src/booking/services/calendar-booking.port.ts`,
   `services/calendar-booking.service.ts`
@@ -69,13 +69,17 @@ Product spec: [Compass Calendar Booking](../features/booking.md).
   `packages/sync/src/domain/busy-query.service.ts`,
   `POST /internal/availability/busy`
 - Host Settings: `packages/web/src/booking/BookingSettingsSection.tsx`,
-  `packages/web/src/booking/setup/`, `BookingWeeklyHoursEditor.tsx`,
-  `weekly-hours.ts`,
+  `packages/web/src/booking/setup/`, `BookingConnectionBanner.tsx`,
+  `BookingBookabilityNotice.tsx`, `BookingStatusHeader.tsx`,
+  `BookingWeeklyHoursEditor.tsx`, `weekly-hours.ts`, `useNewMeetingsNotice.ts`,
   `packages/web/src/components/Switch/Switch.tsx`
+- Sidebar setup nudge: `packages/web/src/components/Sidebar/MeetingPageNudge/`
 - Public guest UI: `packages/web/src/booking/PublicBookingPage.tsx`,
   `PublicBookingConfirmedPage.tsx`, `PublicBookingCancelPage.tsx`,
-  `PublicBookingReschedulePage.tsx`
-- Web API client: `packages/web/src/api/public-booking.api.ts`
+  `PublicBookingReschedulePage.tsx`, `PublicBookingMonthGrid.tsx`
+- Description formatting: `packages/web/src/components/DescriptionEditor/plain-text-description.ts`
+- Web API client: `packages/web/src/api/public-booking.api.ts`,
+  `packages/web/src/api/booking.api.ts`
 - E2e: `e2e/booking/`, `e2e/accessibility/booking-a11y.spec.ts`
 - Architecture: [Product Suite Boundaries](../architecture/product-suite-boundaries.md)
 

--- a/docs/features/booking.md
+++ b/docs/features/booking.md
@@ -1,4 +1,4 @@
-# Compass Calendar Booking (v1 / v1.1 / v1.3 / v1.5 / v1.6 / v1.7 / v1.8 / v1.9)
+# Compass Calendar Booking (v1 / v1.1 / v1.3 / v1.5 / v1.6 / v1.7 / v1.8 / v1.9 / v1.10)
 
 Locked product spec for public scheduling on Compass Cloud
 (`https://compasscalendar.com`). Approved 2026-08-30. v1.1 shipped
@@ -16,21 +16,30 @@ menus for weekly hours, fewer host scheduling knobs, sidebar-only Mod chords,
 no horizontal scroll, and the stale-holiday-calendar booking gate fix. v1.9
 anchored Settings to the top, animated More options, let a day hold several
 hour blocks, moved meeting timezone under More options, and trimmed helper
-copy. The production gate stays off.
+copy. v1.10 fixed Google Meet on insert, aligned weekly hours, moved
+destination calendar under More options, dropped confirmation copy buttons,
+formatted meeting descriptions with linked paragraphs, kept the meeting tab
+visible on broken connections, surfaced host bookability status, stopped
+Settings scroll flash, fixed setup wizard dead-ends, toasts new bookings,
+added a sidebar setup nudge, and kept the meeting link when the page is off.
+The production gate stays off.
 
 Compass never sends email itself. Google emails the guest when Compass
 creates the calendar event with `invitation: "all"`.
 
 ## Status
 
-v1, v1.1, v1.3, v1.5, v1.6, v1.7, v1.8, and v1.9 are implemented in the Compass
-monorepo (public `/meet/:username`, host Settings, backend APIs, guest
-cancel, guest reschedule, edit-details, one-click turn on, Essentials /
+v1, v1.1, v1.3, v1.5, v1.6, v1.7, v1.8, v1.9, and v1.10 are implemented in
+the Compass monorepo (public `/meet/:username`, host Settings, backend APIs,
+guest cancel, guest reschedule, edit-details, one-click turn on, Essentials /
 More options, editable address, default hours, branded connect pills,
 funnel analytics, meeting copy, hold-Mod section chords, the on/off
 switch, a per-day weekly hours list that can hold several blocks, meeting
-timezone under More options, the guided first-run setup wizard, Start
-and End time menus, and the v1.8 booking gate fix). Booking
+timezone under More options (configured form only; the wizard hours step
+shows timezone inline), the guided first-run setup wizard, Start and End
+time menus, the v1.8 booking gate fix, Google Meet on insert,
+host bookability status, connection banners, new-booking toasts, and the
+sidebar setup nudge). Booking
 is enabled in development and staging (`runtime.nodeEnv` other than
 `production`) and disabled in production. Do not flip `isBookingEnabled`.
 A standalone Compass Booking product (separate brand, domain, or
@@ -556,9 +565,6 @@ Guest reschedule is **in scope for v1.3**, not v1 / v1.1.
   calendar write gate)
 - Flipping the production gate
 - Host reservation inbox
-- Meet URL on the confirmation screen (Google creates conference
-  asynchronously; the invite email already has it once
-  `conferenceDataVersion` is forwarded on insert)
 
 ## Implementation
 
@@ -574,9 +580,10 @@ Guest reschedule is **in scope for v1.3**, not v1 / v1.1.
 | Reservations + cancel tokens | `packages/backend/src/booking/booking-reservation.repository.ts`, `booking-cancel-token.ts` |
 | Calendar application port | `packages/backend/src/booking/services/calendar-booking.port.ts` (`updateBookingEvent`), `services/calendar-booking.service.ts` |
 | Sync busy occupancy | `packages/sync/src/domain/occurrence-projection.ts`, `busy-query.service.ts`, `booking-occupancy-facts.ts` |
-| Host Settings UI | `packages/web/src/booking/BookingSettingsSection.tsx`, `packages/web/src/booking/setup/`, `BookingStatusHeader.tsx`, `BookingConnectionBanner.tsx`, `BookingMoreOptions.tsx`, `BookingSaveBar.tsx`, `BookingAddressField.tsx`, `BookingBlockingCalendarsField.tsx`, `BookingWeeklyHoursEditor.tsx`, `weekly-hours.ts`, `packages/web/src/components/Switch/Switch.tsx`, `packages/web/src/components/Settings/SettingsModal.tsx` |
-| Public guest UI | `packages/web/src/booking/PublicBookingPage.tsx`, `PublicBookingConfirmedPage.tsx`, `PublicBookingCancelPage.tsx`, `PublicBookingReschedulePage.tsx`, `PublicBookingEditDetailsForm.tsx` |
-| Public web API client | `packages/web/src/api/public-booking.api.ts` |
+| Host Settings UI | `packages/web/src/booking/BookingSettingsSection.tsx`, `packages/web/src/booking/setup/`, `BookingStatusHeader.tsx`, `BookingConnectionBanner.tsx`, `BookingBookabilityNotice.tsx`, `BookingMoreOptions.tsx`, `BookingSaveBar.tsx`, `BookingAddressField.tsx`, `BookingBlockingCalendarsField.tsx`, `BookingWeeklyHoursEditor.tsx`, `weekly-hours.ts`, `useNewMeetingsNotice.ts`, `packages/web/src/components/Switch/Switch.tsx`, `packages/web/src/components/Settings/SettingsModal.tsx`, `packages/web/src/components/Sidebar/MeetingPageNudge/` |
+| Public guest UI | `packages/web/src/booking/PublicBookingPage.tsx`, `PublicBookingConfirmedPage.tsx`, `PublicBookingCancelPage.tsx`, `PublicBookingReschedulePage.tsx`, `PublicBookingEditDetailsForm.tsx`, `PublicBookingMonthGrid.tsx` |
+| Description formatting | `packages/web/src/components/DescriptionEditor/plain-text-description.ts` |
+| Public web API client | `packages/web/src/api/public-booking.api.ts`, `packages/web/src/api/booking.api.ts` |
 | E2e | `e2e/booking/`, `e2e/booking/public-booking-reschedule.spec.ts`, `e2e/accessibility/booking-a11y.spec.ts` |
 
 ### Analytics
@@ -628,6 +635,9 @@ routes; these are the named events in `packages/web/src/auth/posthog/track.ts`.
   max meetings per day, welcome text, and guest-invite permission were
   removed in Booking v1.8. Zod strips those keys on read; they are not
   in the wire contract or Settings UI.
+- **New-meetings claim has no `createdAt` index.** The host-notice query
+  filters reservations by `createdAt` after the previous notice stamp.
+  Accepted for v1.10 while booking stays off in production.
 
 ## Changelog
 
@@ -667,6 +677,17 @@ email.
 A signed-in host whose Meeting page is not live sees a sidebar card that
 opens Settings on the Meeting tab. Dismissing it is per browser; turning
 the page on hides it everywhere.
+
+The configured Meeting form no longer shows the v1.9 timezone helper line
+(`Times in … Change it under More options.`). The wizard hours step and
+go-live summary still show timezone inline.
+
+The setup wizard no longer dead-ends when no writable calendar exists: the
+destination step always appears, shows connect pills, and blocks Continue
+until a calendar is writable. Back and address focus behave on every step.
+
+Unavailable days on the guest month grid expose `aria-disabled="true"` and
+screen-reader text that the day has no open times.
 
 ### v1.9
 

--- a/e2e/accessibility/booking-a11y.spec.ts
+++ b/e2e/accessibility/booking-a11y.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import {
+  BOOKING_CALENDAR_ID,
   buildBookableSlot,
   dispatchClick,
   dispatchFill,
@@ -531,6 +532,76 @@ test.describe("settings booking section", () => {
     } finally {
       await releaseSettingsMod(page);
     }
+  });
+
+  test("broken connection banner has no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await prepareSignedInBookingSettingsPage(page, {
+      connectionState: "RECONNECT_REQUIRED",
+      enabled: true,
+    });
+    const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+    await expect(
+      settingsDialog.getByRole("switch", { name: "Meeting page" }),
+    ).toHaveAttribute("aria-checked", "true");
+    await expect(settingsDialog.getByText(/needs reconnecting/)).toBeVisible();
+    await expect(
+      settingsDialog.getByRole("button", { name: "Reconnect Google Calendar" }),
+    ).toBeVisible();
+    await expectNoAxeViolations(page, {
+      checkpoint: "settings booking reconnect banner",
+      include: "[role='dialog']",
+    });
+  });
+
+  test("host bookability status line has no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await prepareSignedInBookingSettingsPage(page, {
+      pageStatus: {
+        bookable: false,
+        reasons: [
+          {
+            kind: "calendar",
+            reason: "stale",
+            calendarId: BOOKING_CALENDAR_ID,
+          },
+        ],
+      },
+    });
+    const settingsDialog = page.getByRole("dialog", { name: "Settings" });
+    await expect(
+      settingsDialog.getByText("Guests can't book right now"),
+    ).toBeVisible();
+    await expect(
+      settingsDialog.getByText(
+        "Work hasn't synced recently. Guests can book once it catches up.",
+      ),
+    ).toBeVisible();
+    await expectNoAxeViolations(page, {
+      checkpoint: "settings booking host bookability status",
+      include: "[role='dialog']",
+    });
+  });
+
+  test("sidebar meeting page nudge has no automatically detectable accessibility violations", async ({
+    page,
+  }) => {
+    await prepareSignedInBookingSettingsPage(page, {
+      configured: false,
+      openSettings: false,
+      completeOnboarding: true,
+    });
+    const nudge = page.getByRole("region", { name: "Meeting page" });
+    await expect(nudge).toBeVisible();
+    await expect(
+      nudge.getByRole("button", { name: "Set up meeting page" }),
+    ).toBeVisible();
+    await expectNoAxeViolations(page, {
+      checkpoint: "sidebar meeting page nudge",
+      include: "#sidebar",
+    });
   });
 
   test("not-live status has no automatically detectable accessibility violations", async ({

--- a/packages/scripts/src/testing/booking-doc-drift.test.ts
+++ b/packages/scripts/src/testing/booking-doc-drift.test.ts
@@ -17,11 +17,16 @@ const STALE_BOOKING_TERMS =
 const STALE_V19_BOOKING_TERMS =
   /grouped weekly hours|weekly-hours\.rows|\bUnavailable:|\bLive at\b|Pending, maybe|keeps only the first interval|a weekday belongs to at most one row/i;
 
+const STALE_V110_BOOKING_TERMS =
+  /Times in .*Change it under|Copy cancel link|Copy reschedule link|Essentials: duration, weekly hours, and destination/i;
+
 const STALE_MEETING_MOD_CHORDS = /\bMod\+(?:[4-9]|U)\b/;
 
 const REMOVED_IN_V18 = /removed in Booking v1\.8/i;
 const REMOVED_IN_V19 =
   /removed or reversed in v1\.9|reversed in v1\.9|removed in Booking v1\.9/i;
+const REMOVED_IN_V110 =
+  /removed or reversed in v1\.10|reversed in v1\.10|dropped in v1\.10|no longer shows the v1\.9 timezone helper line/i;
 
 function inChangelogSection(lines: string[], index: number): boolean {
   for (let cursor = index; cursor >= 0; cursor -= 1) {
@@ -33,10 +38,19 @@ function inChangelogSection(lines: string[], index: number): boolean {
 }
 
 function lineAllowedInBookingSpec(line: string, nearby: string[]): boolean {
-  if (REMOVED_IN_V18.test(line) || REMOVED_IN_V19.test(line)) return true;
+  if (
+    REMOVED_IN_V18.test(line) ||
+    REMOVED_IN_V19.test(line) ||
+    REMOVED_IN_V110.test(line)
+  ) {
+    return true;
+  }
   if (
     nearby.some(
-      (other) => REMOVED_IN_V18.test(other) || REMOVED_IN_V19.test(other),
+      (other) =>
+        REMOVED_IN_V18.test(other) ||
+        REMOVED_IN_V19.test(other) ||
+        REMOVED_IN_V110.test(other),
     )
   ) {
     return true;
@@ -50,17 +64,35 @@ function staleLines(
     includeMeetingModChords: boolean;
     allowV18RemovalBlock?: boolean;
     allowV19Changelog?: boolean;
+    allowV110Changelog?: boolean;
   },
 ): string[] {
   const lines = content.split("\n");
   return lines.flatMap((line, index) => {
     const matchesV18Term = STALE_BOOKING_TERMS.test(line);
     const matchesV19Term = STALE_V19_BOOKING_TERMS.test(line);
+    const matchesV110Term = STALE_V110_BOOKING_TERMS.test(line);
     const matchesMeetingMod =
       options.includeMeetingModChords && STALE_MEETING_MOD_CHORDS.test(line);
-    if (!matchesV18Term && !matchesV19Term && !matchesMeetingMod) return [];
+    if (
+      !matchesV18Term &&
+      !matchesV19Term &&
+      !matchesV110Term &&
+      !matchesMeetingMod
+    ) {
+      return [];
+    }
 
     if (options.allowV19Changelog && matchesV19Term && !matchesV18Term) {
+      if (inChangelogSection(lines, index)) return [];
+    }
+
+    if (
+      options.allowV110Changelog &&
+      matchesV110Term &&
+      !matchesV18Term &&
+      !matchesV19Term
+    ) {
       if (inChangelogSection(lines, index)) return [];
     }
 
@@ -74,13 +106,14 @@ function staleLines(
 }
 
 describe("booking doc drift", () => {
-  it("docs/features/booking.md has no stale terms outside the removal wart and v1.9 changelog", () => {
+  it("docs/features/booking.md has no stale terms outside the removal wart and v1.9/v1.10 changelog", () => {
     const content = readFileSync(BOOKING_SPEC_PATH, "utf8");
     expect(
       staleLines(content, {
         includeMeetingModChords: true,
         allowV18RemovalBlock: true,
         allowV19Changelog: true,
+        allowV110Changelog: true,
       }),
     ).toEqual([]);
   });

--- a/packages/web/src/booking/PublicBookingMonthGrid.test.tsx
+++ b/packages/web/src/booking/PublicBookingMonthGrid.test.tsx
@@ -90,6 +90,17 @@ describe("PublicBookingMonthGrid", () => {
     expect(screen.getByText("16")).toBeInTheDocument();
   });
 
+  it("marks unavailable days as disabled with an explanation for screen readers", () => {
+    renderGrid();
+
+    const unavailable = screen.getByText("16").closest("[aria-disabled]");
+    expect(unavailable).toHaveAttribute("aria-disabled", "true");
+    expect(
+      unavailable?.textContent?.trim().endsWith("no times available"),
+    ).toBe(true);
+    expect(unavailable).not.toHaveAttribute("tabindex");
+  });
+
   it("keeps a single day in the tab order and moves with arrow keys", async () => {
     const user = userEvent.setup({ delay: null });
     const { selected } = renderGrid();

--- a/packages/web/src/booking/PublicBookingMonthGrid.tsx
+++ b/packages/web/src/booking/PublicBookingMonthGrid.tsx
@@ -183,9 +183,11 @@ export function PublicBookingMonthGrid({
                     <div
                       key={day.dateKey}
                       aria-current={day.isToday ? "date" : undefined}
+                      aria-disabled="true"
                       className="flex h-10 w-full items-center justify-center rounded-md text-sm text-text-muted"
                     >
                       {day.dayOfMonth}
+                      <span className="sr-only">, no times available</span>
                     </div>
                   );
                 }


### PR DESCRIPTION
Fixes #3575

## What and why

Closes Booking v1.10 WP-13: the guest month grid announces unavailable days to screen readers, accessibility checkpoints cover the reconnect banner, host bookability status line, and sidebar meeting-page nudge, and booking docs plus doc-drift tests describe the shipped v1.10 behaviour with no v1.9 leftovers.

## Verify

```
VERDICT: PASS
```

Checks run: `test:web`, `test:scripts:fast`, `type-check`, `lint`, `knip`, `test:a11y`, `test:e2e` (via `bun run verify --strict`).