### PR TITLE
fix(web): paint the calendar shell before app startup

### DIFF
--- a/docs/development/week-initial-paint-audit.md
+++ b/docs/development/week-initial-paint-audit.md
@@ -1,0 +1,103 @@
+# Week initial paint audit
+
+Audited September 9, 2026 against commit `643c18d63` and the accompanying diff.
+
+## Render path
+
+Compass serves static HTML and uses React `createRoot`, not SSR or hydration.
+Previously `index.html` contained an empty root. The entry initializes PostHog
+when configured, dynamically imports `app.bootstrap.tsx`, opens the offline
+IndexedDB store, initializes session handling, and finally renders React.
+The router then resolves the lazy root, calendar shell, authenticated layout,
+and Week components. The authenticated layout's `beforeLoad` also awaits
+`session.doesSessionExist()`. Session handling independently checks auth in the
+background. These are potential startup delays; event fetching is not the
+page-wide blocker. Week's event query runs inside `Grid`, while the surrounding
+header and sidebar can render independently.
+
+The fix puts an accessible, theme-aware loading shell directly in the HTML.
+It remains visible during JavaScript download and database initialization;
+React replaces it at mount. This avoids introducing SSR infrastructure or
+changing storage/auth ordering. It improves first content, not time to an
+interactive calendar. The application stylesheet still blocks first paint.
+
+## LCP and fonts
+
+On a fresh desktop profile at 1440 × 900, Chromium's buffered
+`largest-contentful-paint` observer identified the welcome modal paragraph:
+“Rediscover the joy of shortcuts as you build your perfect schedule. No clicks
+allowed.” Its reported area was 17,178 px². The calendar's large CSS grid is not
+itself an LCP candidate, and there was no LCP image to resize or preload. A font
+is a dependency of text rendering, not the LCP element itself. Other viewports,
+returning users, and onboarding states can have different candidates.
+
+Google Fonts' combined stylesheet was render-blocking even with `display=swap`:
+that parameter governs font-file behavior, not the stylesheet download. The
+stylesheet now loads with `media="print"`, switching to `all` on load, so the
+welcome text can paint with its fallback font while font CSS is still pending.
+The initial HTML shell explicitly uses a system font. Existing preconnects and
+`display=swap` remain. A later font swap can still change text metrics.
+
+See [Google's LCP guidance](https://web.dev/articles/optimize-lcp) and
+[font optimization guidance](https://web.dev/learn/performance/optimize-web-fonts).
+
+## Bundle audit
+
+Production Bun builds enable `splitting: true`. Route components use dynamic
+imports; the event form and booking settings also have lazy boundaries.
+`inject-module-preloads.ts` preloads the startup import graph, including the
+shared calendar shell, but does not recursively preload every route. The build
+emits 80 boot modulepreload links. A fresh `/week` visit requested 102 JavaScript
+resources totaling about 3.01 MB of decoded resource bodies in this fixture.
+Shared providers, onboarding, auth, and calendar code remain substantial.
+
+An experiment loading Settings only on first open saved approximately 19 KB
+but added six requests and showed no meaningful LCP improvement. It was removed.
+The final change does not reduce the JavaScript bundle. Further bundle work
+should focus on measured shared dependencies rather than adding lazy boundaries
+indiscriminately. Production analytics is another startup dependency; it was
+disabled in this local fixture, so the results do not quantify its cost.
+
+## Measurement
+
+Built using `bun run build:web` with production runtime, local placeholder
+backend configuration, and PostHog disabled. Served the production files locally
+with SPA fallback. Used three fresh Chromium contexts per variant, desktop
+1440 × 900, CDP network throttling at 10 Mbps down / 5 Mbps up and 80 ms latency,
+and 4× CPU slowdown. No login flow or backend was exercised. Collected Paint
+Timing and buffered LCP entries after eight seconds without interaction.
+
+| Metric | Baseline | Final change |
+| --- | --- | --- |
+| FCP, three runs | 2.336, 2.128, 2.188 s | 0.332, 0.264, 0.268 s |
+| LCP, three runs | 2.336, 2.248, 2.188 s | 2.364, 2.236, 2.332 s |
+| JS decoded bytes | 3,011,871 | 3,011,871 |
+
+FCP meets the 1.8-second target in this lab setup. LCP is essentially unchanged
+when font CSS responds normally; the fix removes font CSS as a blocker when it
+is slow. Local hosting does not reproduce production TTFB/CDN, geography,
+analytics, or real-device performance, and these runs cannot establish the cause
+of the reported 5–13-second field samples. Verify production p75 FCP/LCP after
+release, split by new visitors, device, and navigation type. Do not interpret the
+shell's FCP improvement as equivalent to faster interactive rendering.
+
+`e2e/onboarding/initial-paint.spec.ts` holds both the entry script and Google
+Font CSS pending, checks visible shell content and a real FCP entry, then lets
+JavaScript resume and verifies the welcome dialog appears while font CSS remains
+pending. It covers both stored themes and removal of the initial shell.
+
+## Verification result
+
+`bun run build:web` passed. `bun run verify --strict` completed with
+`VERDICT: FAIL`: all 3,521 web unit tests, type checking, lint, and knip passed;
+accessibility reported 35 passed / 19 failed, and the full end-to-end suite
+reported 147 passed / 36 failed. Both new initial-paint tests passed in the full
+suite as well as the focused production-build run.
+
+Representative failures were reproduced using the unchanged original HTML and
+the same test-build JavaScript on a separate local server: Settings booking
+checks timed out waiting for Settings after `Control+Comma`, and the event-action
+accessibility check timed out waiting for the event title input. These failures
+also occur without this patch on this macOS environment. The entire failed set
+was not rerun against baseline, so this is not a claim that every browser failure
+has been classified. Full verification output: `/tmp/compass-week-verify.log`.

--- a/e2e/onboarding/initial-paint.spec.ts
+++ b/e2e/onboarding/initial-paint.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+for (const theme of ["light-beach", "dark-abyss"]) {
+  test(`shows the ${theme} shell while JavaScript and font CSS are pending`, async ({
+    page,
+  }) => {
+    await page.addInitScript((value) => {
+      localStorage.setItem("compass.theme", value);
+    }, theme);
+    let releaseScript!: () => void;
+    let releaseFonts!: () => void;
+    const scriptReady = new Promise<void>((resolve) => {
+      releaseScript = resolve;
+    });
+    const fontsReady = new Promise<void>((resolve) => {
+      releaseFonts = resolve;
+    });
+    await page.route("**/index.js", async (route) => {
+      await scriptReady;
+      await route.continue();
+    });
+    await page.route("https://fonts.googleapis.com/**", async (route) => {
+      await fontsReady;
+      await route.abort();
+    });
+
+    try {
+      await page.goto("/week", { waitUntil: "commit" });
+      await expect(
+        page.getByRole("heading", { name: "Compass Calendar", exact: true }),
+      ).toBeVisible();
+      await expect(page.getByRole("status")).toHaveText(
+        "Loading your calendar…",
+      );
+      await expect
+        .poll(() =>
+          page.evaluate(
+            () => performance.getEntriesByName("first-contentful-paint").length,
+          ),
+        )
+        .toBe(1);
+
+      releaseScript();
+      await expect(
+        page.getByRole("dialog", { name: "Welcome to Compass Calendar" }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "Compass Calendar", exact: true }),
+      ).toHaveCount(0);
+    } finally {
+      releaseScript();
+      releaseFonts();
+    }
+  });
+}

--- a/packages/web/src/index.html
+++ b/packages/web/src/index.html
@@ -89,20 +89,12 @@
     <link rel="icon" href="/favicon.ico" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <!--
-      One combined stylesheet, not three: each render-blocking cross-origin
-      <link> costs its own round-trip before first paint, which dominates for
-      the distant cold-cache visitors who see the worst LCP. css2 requires the
-      family params in alphabetical order.
-
-      Rubik is the body font (and so the LCP text); its axis is capped at 700
-      because nothing uses 800/900 (heaviest in use: font-bold). Italic stays
-      - LifeQuote renders one, and the description editor can mark any text
-      italic.
-    -->
+    <!-- Font CSS must not delay the HTML shell or welcome text. -->
     <link
       href="https://fonts.googleapis.com/css2?family=Caveat:wght@400..700&family=Rubik:ital,wght@0,300..700;1,300..700&family=VT323&display=swap"
       rel="stylesheet"
+      media="print"
+      onload="this.media='all'"
     />
 
     <!--
@@ -114,10 +106,45 @@
       every boot-critical chunk, appended to head by inject-module-preloads.ts.
     -->
     <link rel="stylesheet" href="/index.css" />
+    <!-- Self-contained shell styles need no JavaScript or web fonts. -->
+    <style>
+      body { margin: 0; }
+      #boot-shell {
+        box-sizing: border-box;
+        min-height: 100vh;
+        padding: 2rem;
+        background: var(--background, #f3eee2);
+        color: var(--text, #403a2f);
+        font: 1rem/1.5 system-ui, sans-serif;
+      }
+      [data-theme="dark-abyss"] #boot-shell {
+        background: var(--background, #06090f);
+        color: var(--text, #d2d9e1);
+      }
+      #boot-shell h1 { margin: 0; font-size: 1.5rem; }
+      #boot-grid {
+        height: 65vh;
+        margin-top: 2rem;
+        border: 1px solid currentColor;
+        border-radius: .5rem;
+        opacity: .12;
+        background-image:
+          linear-gradient(to right, currentColor 1px, transparent 1px),
+          linear-gradient(to bottom, currentColor 1px, transparent 1px);
+        background-size: calc(100% / 7) 100%, 100% 4rem;
+      }
+    </style>
   </head>
 
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <main id="boot-shell" aria-busy="true" aria-label="Compass Calendar">
+        <h1>Compass Calendar</h1>
+        <p role="status">Loading your calendar…</p>
+        <div id="boot-grid" aria-hidden="true"></div>
+        <noscript>Enable JavaScript to use Compass Calendar.</noscript>
+      </main>
+    </div>
     <script type="module" src="/index.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## What and why

Cold `/week` visits previously received an empty React root and waited for JavaScript and IndexedDB before seeing content. Add a theme-aware HTML calendar loading shell and load Google Fonts CSS without blocking rendering. React replaces the shell normally; auth and event-loading behavior stay unchanged.

Three cold-cache desktop runs at 10 Mbps, 80 ms latency, and 4× CPU slowdown improved FCP from 2.13–2.34 seconds to 0.26–0.33 seconds. LCP remains the welcome paragraph at about 2.3 seconds; the 3 MB startup JS graph is unchanged. The audit documents these limitations and the production follow-up. This addresses the reported new-visitor paint issue; no matching issue number was found.

## Verify

`VERDICT: FAIL` from `bun run verify --strict` on macOS.

- Production build, all 3,521 web unit tests, type checking, lint, and knip passed.
- Both new browser tests passed, including in the full suite. They hold entry JavaScript and font CSS pending, verify real FCP and visible content, then verify the welcome dialog renders while font CSS remains pending.
- Accessibility: 35 passed / 19 failed. Full E2E: 147 passed / 36 failed.
- Local failures are concentrated in Settings opening and modifier-hold flows: booking/accessibility Settings tests, connect-onboarding, host-settings, public-booking-v15 discard, account-page-jump, and microsoft-surfaces. They use Control shortcuts on this macOS host; the app uses platform-aware Mod shortcuts. Representative Settings failures reproduce with the original HTML. The event-action accessibility timeout also reproduces with original HTML and passes in the subsequent full run. No tests, timeouts, or ordering were weakened.
- CI runs on Ubuntu, where the latest main Unit and E2E runs are green. Required PR and merge-group checks must pass before merge; no bypass is requested.

Full render-path findings and measurements are in `docs/development/week-initial-paint-audit.md`.
