### PR TITLE
fix(web): align billing receipts and group plan actions

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -88,7 +88,7 @@ jobs:
           - shard: 1
             specs: e2e/accessibility e2e/allday
           - shard: 2
-            specs: e2e/booking e2e/oauth e2e/auth
+            specs: e2e/booking e2e/oauth e2e/auth e2e/billing
           - shard: 3
             specs: e2e/timed
           - shard: 4

--- a/e2e/billing/plan-section-layout.spec.ts
+++ b/e2e/billing/plan-section-layout.spec.ts
@@ -1,0 +1,185 @@
+import { expect, test } from "@playwright/test";
+
+test.use({ viewport: { width: 1600, height: 900 } });
+
+const jsonResponse = (body: unknown) => ({
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify(body),
+});
+
+test("keeps billing receipts aligned and plan actions on one row", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    (
+      window as Window & { __COMPASS_E2E_TEST__?: boolean }
+    ).__COMPASS_E2E_TEST__ = true;
+    localStorage.setItem(
+      "compass.auth",
+      JSON.stringify({
+        hasAuthenticated: true,
+        lastKnownEmail: "host@example.com",
+      }),
+    );
+    localStorage.setItem("compass.onboarding.has-seen-welcome", "true");
+    localStorage.setItem(
+      "compass.onboarding.has-seen-shortcut-showcase",
+      "true",
+    );
+    localStorage.setItem("compass.onboarding.first-event-done", "dismissed");
+  });
+
+  await page.route("**/api/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+
+    if (path.endsWith("/api/config")) {
+      return route.fulfill(
+        jsonResponse({
+          google: { isConfigured: true },
+          billing: {
+            isConfigured: true,
+            enforcement: true,
+            trialLengthDays: 7,
+            publishableKey: "pk_test_e2e",
+          },
+        }),
+      );
+    }
+
+    if (path.endsWith("/api/billing/status")) {
+      return route.fulfill(
+        jsonResponse({
+          subscriptionStatus: "active",
+          trialEndsAt: null,
+          isReadOnly: false,
+        }),
+      );
+    }
+
+    if (path.endsWith("/api/billing/subscription")) {
+      return route.fulfill(
+        jsonResponse({
+          subscriptionStatus: "active",
+          currentPeriodEnd: "2026-10-04T12:00:00.000Z",
+          cancelAtPeriodEnd: false,
+          trialEndsAt: null,
+          price: { amount: 799, currency: "usd", interval: "month" },
+          paymentMethod: {
+            brand: "mastercard",
+            last4: "9200",
+            expMonth: 10,
+            expYear: 2029,
+          },
+          invoices: [
+            {
+              id: "in_paid",
+              createdAt: "2026-09-04T12:00:00.000Z",
+              amountPaid: 799,
+              currency: "usd",
+              status: "paid",
+              hostedInvoiceUrl: "https://invoice.stripe.com/paid",
+            },
+            {
+              id: "in_trial",
+              createdAt: "2026-08-28T12:00:00.000Z",
+              amountPaid: 0,
+              currency: "usd",
+              status: "paid",
+              hostedInvoiceUrl: "https://invoice.stripe.com/trial",
+            },
+          ],
+        }),
+      );
+    }
+
+    if (path.endsWith("/api/calendars")) {
+      return route.fulfill(jsonResponse({ calendars: [] }));
+    }
+
+    if (path.endsWith("/api/event") && route.request().method() === "GET") {
+      return route.fulfill(jsonResponse({ events: [] }));
+    }
+
+    if (path.endsWith("/api/user/metadata")) {
+      return route.fulfill(
+        jsonResponse({
+          google: { connectionState: "NOT_CONNECTED", connections: [] },
+        }),
+      );
+    }
+
+    return route.fulfill(jsonResponse({}));
+  });
+
+  await page.goto("/week", { waitUntil: "domcontentloaded" });
+  await expect(
+    page.getByRole("heading", { level: 1 }).getByRole("button"),
+  ).toBeVisible({ timeout: 15000 });
+
+  await page.waitForFunction(
+    () =>
+      (
+        window as Window & {
+          __COMPASS_E2E_HOOKS__?: { setAuthenticated: (v: boolean) => void };
+        }
+      ).__COMPASS_E2E_HOOKS__ !== undefined,
+  );
+  await page.evaluate(() => {
+    (
+      window as Window & {
+        __COMPASS_E2E_HOOKS__?: { setAuthenticated: (v: boolean) => void };
+      }
+    ).__COMPASS_E2E_HOOKS__?.setAuthenticated(true);
+  });
+
+  await page.keyboard.press("Escape");
+  await page.keyboard.press("Control+Comma");
+
+  const settings = page.getByRole("dialog", { name: "Settings" });
+  await expect(settings).toBeVisible({ timeout: 10000 });
+  await settings.getByRole("button", { name: "Billing" }).click();
+
+  const updateCard = settings.getByRole("button", { name: "Update card" });
+  const cancel = settings.getByRole("button", { name: "Cancel subscription" });
+  await expect(updateCard).toBeVisible();
+  await expect(cancel).toBeVisible();
+
+  const updateBox = await updateCard.boundingBox();
+  const cancelBox = await cancel.boundingBox();
+  expect(updateBox).not.toBeNull();
+  expect(cancelBox).not.toBeNull();
+  expect(Math.abs((updateBox?.y ?? 0) - (cancelBox?.y ?? 0))).toBeLessThan(2);
+  expect(cancelBox?.x ?? 0).toBeGreaterThan(updateBox?.x ?? 0);
+
+  const cancelBackground = await cancel.evaluate(
+    (el) => getComputedStyle(el).backgroundColor,
+  );
+  expect(cancelBackground).toBe("rgb(173, 101, 83)");
+
+  const receipts = settings.getByRole("table", { name: "Receipts" });
+  await expect(receipts).toBeVisible();
+  const amounts = receipts.getByRole("cell", { name: /^\$/ });
+  await expect(amounts).toHaveCount(2);
+  const firstAmount = await amounts.nth(0).boundingBox();
+  const secondAmount = await amounts.nth(1).boundingBox();
+  expect(firstAmount).not.toBeNull();
+  expect(secondAmount).not.toBeNull();
+  expect(Math.abs((firstAmount?.x ?? 0) - (secondAmount?.x ?? 0))).toBeLessThan(
+    1,
+  );
+
+  const statuses = receipts.getByRole("cell", { name: "Paid" });
+  const firstStatus = await statuses.nth(0).boundingBox();
+  const secondStatus = await statuses.nth(1).boundingBox();
+  expect(Math.abs((firstStatus?.x ?? 0) - (secondStatus?.x ?? 0))).toBeLessThan(
+    1,
+  );
+
+  const receiptLinks = receipts.getByRole("link", { name: "Receipt" });
+  const firstReceipt = await receiptLinks.nth(0).boundingBox();
+  const secondReceipt = await receiptLinks.nth(1).boundingBox();
+  expect(
+    Math.abs((firstReceipt?.x ?? 0) - (secondReceipt?.x ?? 0)),
+  ).toBeLessThan(1);
+});

--- a/packages/web/src/billing/PlanSection.test.tsx
+++ b/packages/web/src/billing/PlanSection.test.tsx
@@ -188,6 +188,31 @@ describe("PlanSection", () => {
     expect(receipt).toHaveAttribute("href", "https://invoice.stripe.com/paid");
     expect(receipt).toHaveAttribute("target", "_blank");
     expect(receipt).toHaveAttribute("rel", "noreferrer");
+
+    const receipts = screen.getByRole("table", { name: "Receipts" });
+    expect(
+      within(receipts).getByRole("columnheader", { name: "Date" }),
+    ).toBeInTheDocument();
+    expect(
+      within(receipts).getByRole("columnheader", { name: "Amount" }),
+    ).toBeInTheDocument();
+    expect(
+      within(receipts).getByRole("columnheader", { name: "Status" }),
+    ).toBeInTheDocument();
+    expect(
+      within(receipts).getByRole("columnheader", { name: "Receipt" }),
+    ).toBeInTheDocument();
+    expect(within(receipts).getAllByRole("row")).toHaveLength(3);
+  });
+
+  it("puts update card and cancel on one row, with cancel in red", async () => {
+    await renderPlan();
+
+    const update = await screen.findByRole("button", { name: "Update card" });
+    const cancel = screen.getByRole("button", { name: "Cancel subscription" });
+    expect(update.parentElement).toBe(cancel.parentElement);
+    expect(cancel).toHaveClass("bg-error");
+    expect(update).not.toHaveClass("bg-error");
   });
 
   it("opens confirm with C and cancels at period end", async () => {
@@ -272,6 +297,11 @@ describe("PlanSection", () => {
     expect(
       screen.queryByRole("button", { name: "Cancel subscription" }),
     ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Update card" }).parentElement,
+    ).toBe(
+      screen.getByRole("button", { name: "Resume subscription" }).parentElement,
+    );
     expect(screen.getByText(`Ends ${PERIOD_END_LABEL}`)).toBeInTheDocument();
 
     await user.keyboard("r");

--- a/packages/web/src/billing/PlanSection.tsx
+++ b/packages/web/src/billing/PlanSection.tsx
@@ -236,78 +236,92 @@ export const PlanSection: FC<PlanSectionProps> = ({
             ) : (
               <p className="text-sm text-text-muted">Loading checkout...</p>
             )
-          ) : (
-            <OverlayPanelActions align="start">
-              <OverlayPanelActionButton
-                ref={updateCardButtonRef}
-                disabled={isSubmitting}
-                onClick={cardUpdateActions.open}
-                shortcut="U"
-                showShortcut={showShortcuts}
-                variant="secondary"
-                {...settingsShortcutAttrs("update-card")}
-              >
-                Update card
-              </OverlayPanelActionButton>
-            </OverlayPanelActions>
-          )}
+          ) : null}
 
-          {canManageCancellation ? (
+          {!isCardUpdateOpen || canManageCancellation ? (
             <OverlayPanelActions align="start">
-              {summary.cancelAtPeriodEnd ? (
+              {!isCardUpdateOpen ? (
                 <OverlayPanelActionButton
+                  ref={updateCardButtonRef}
                   disabled={isSubmitting}
-                  onClick={handleResume}
-                  shortcut="R"
+                  onClick={cardUpdateActions.open}
+                  shortcut="U"
                   showShortcut={showShortcuts}
                   variant="secondary"
-                  {...settingsShortcutAttrs("resume-subscription")}
+                  {...settingsShortcutAttrs("update-card")}
                 >
-                  Resume subscription
+                  Update card
                 </OverlayPanelActionButton>
-              ) : (
-                <OverlayPanelActionButton
-                  disabled={isSubmitting || confirmOpen}
-                  onClick={() => setConfirmOpen(true)}
-                  shortcut="C"
-                  showShortcut={showShortcuts}
-                  variant="secondary"
-                  {...settingsShortcutAttrs("cancel-subscription")}
-                >
-                  Cancel subscription
-                </OverlayPanelActionButton>
-              )}
+              ) : null}
+              {canManageCancellation ? (
+                summary.cancelAtPeriodEnd ? (
+                  <OverlayPanelActionButton
+                    disabled={isSubmitting}
+                    onClick={handleResume}
+                    shortcut="R"
+                    showShortcut={showShortcuts}
+                    variant="secondary"
+                    {...settingsShortcutAttrs("resume-subscription")}
+                  >
+                    Resume subscription
+                  </OverlayPanelActionButton>
+                ) : (
+                  <OverlayPanelActionButton
+                    disabled={isSubmitting || confirmOpen}
+                    onClick={() => setConfirmOpen(true)}
+                    shortcut="C"
+                    showShortcut={showShortcuts}
+                    variant="destructive"
+                    {...settingsShortcutAttrs("cancel-subscription")}
+                  >
+                    Cancel subscription
+                  </OverlayPanelActionButton>
+                )
+              ) : null}
             </OverlayPanelActions>
           ) : null}
 
           {receipts.length > 0 ? (
-            <div>
-              <p className="mb-1 block text-sm text-text">Receipts</p>
-              <ul className="flex flex-col gap-1">
+            <table className="w-full border-collapse text-sm text-text">
+              <caption className="mb-1 caption-top text-left text-sm text-text">
+                Receipts
+              </caption>
+              <thead className="sr-only">
+                <tr>
+                  <th scope="col">Date</th>
+                  <th scope="col">Amount</th>
+                  <th scope="col">Status</th>
+                  <th scope="col">Receipt</th>
+                </tr>
+              </thead>
+              <tbody>
                 {receipts.map((invoice) => (
-                  <li
-                    className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1 text-sm text-text"
-                    key={invoice.id}
-                  >
-                    <span>{formatBillingDate(invoice.createdAt)}</span>
-                    <span>
+                  <tr key={invoice.id}>
+                    <td className="w-full py-0.5 pr-3 whitespace-nowrap">
+                      {formatBillingDate(invoice.createdAt)}
+                    </td>
+                    <td className="px-3 py-0.5 text-right tabular-nums whitespace-nowrap">
                       {formatBillingMoney(invoice.amountPaid, invoice.currency)}
-                    </span>
-                    <span>{formatInvoiceStatus(invoice.status)}</span>
-                    {invoice.hostedInvoiceUrl ? (
-                      <a
-                        className="text-text underline-offset-4 hover:underline"
-                        href={invoice.hostedInvoiceUrl}
-                        rel="noreferrer"
-                        target="_blank"
-                      >
-                        Receipt
-                      </a>
-                    ) : null}
-                  </li>
+                    </td>
+                    <td className="px-3 py-0.5 whitespace-nowrap">
+                      {formatInvoiceStatus(invoice.status)}
+                    </td>
+                    <td className="py-0.5 pl-3 whitespace-nowrap">
+                      {invoice.hostedInvoiceUrl ? (
+                        <a
+                          className="text-text underline-offset-4 hover:underline"
+                          href={invoice.hostedInvoiceUrl}
+                          rel="noreferrer"
+                          target="_blank"
+                        >
+                          Receipt
+                        </a>
+                      ) : null}
+                    </td>
+                  </tr>
                 ))}
-              </ul>
-            </div>
+              </tbody>
+            </table>
           ) : null}
         </>
       ) : null}

--- a/packages/web/src/billing/PlanSection.tsx
+++ b/packages/web/src/billing/PlanSection.tsx
@@ -297,16 +297,16 @@ export const PlanSection: FC<PlanSectionProps> = ({
               <tbody>
                 {receipts.map((invoice) => (
                   <tr key={invoice.id}>
-                    <td className="w-full py-0.5 pr-3 whitespace-nowrap">
+                    <td className="w-full whitespace-nowrap py-0.5 pr-3">
                       {formatBillingDate(invoice.createdAt)}
                     </td>
-                    <td className="px-3 py-0.5 text-right tabular-nums whitespace-nowrap">
+                    <td className="whitespace-nowrap px-3 py-0.5 text-right tabular-nums">
                       {formatBillingMoney(invoice.amountPaid, invoice.currency)}
                     </td>
-                    <td className="px-3 py-0.5 whitespace-nowrap">
+                    <td className="whitespace-nowrap px-3 py-0.5">
                       {formatInvoiceStatus(invoice.status)}
                     </td>
-                    <td className="py-0.5 pl-3 whitespace-nowrap">
+                    <td className="whitespace-nowrap py-0.5 pl-3">
                       {invoice.hostedInvoiceUrl ? (
                         <a
                           className="text-text underline-offset-4 hover:underline"

--- a/packages/web/src/billing/PlanSection.tsx
+++ b/packages/web/src/billing/PlanSection.tsx
@@ -283,7 +283,7 @@ export const PlanSection: FC<PlanSectionProps> = ({
 
           {receipts.length > 0 ? (
             <table className="w-full border-collapse text-sm text-text">
-              <caption className="mb-1 caption-top text-left text-sm text-text">
+              <caption className="mb-1 caption-top text-left font-normal text-sm text-text">
                 Receipts
               </caption>
               <thead className="sr-only">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Settings > Billing laid receipts out with `flex` + `justify-between`, so date, amount, status, and Receipt drifted from row to row when those values had different widths. Update card and Cancel subscription also stacked as separate action rows.

Receipts are now a table with shared columns so every row stays aligned. Update card and Cancel (or Resume) sit on one action row, matching Accounts. Cancel uses the destructive red style.

The merge queue also required assigning the new `e2e/billing` directory to a Playwright shard so scripts' shard-coverage test passes.

![Settings Billing with aligned receipts and red Cancel subscription on one row with Update card](https://cursor.com/artifacts/c/art-bca24598-1623-44c4-8572-abe3fe12d2ba)

## Verify

VERDICT: PASS

Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3ff25fb-e372-46d6-9c3c-64615514fbb3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3ff25fb-e372-46d6-9c3c-64615514fbb3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

