### PR TITLE
fix(sync): count only live channels in the never-notified gauge

### DIFF
--- a/packages/sync/src/telemetry/health-snapshot.service.db.test.ts
+++ b/packages/sync/src/telemetry/health-snapshot.service.db.test.ts
@@ -292,6 +292,65 @@ describe("computeHealthSnapshot", () => {
     expect(snapshot.subscriptions.neverNotified).toBe(0);
   });
 
+  // The push-delivery alarm compares neverNotified against the LIVE channels
+  // (healthy + renewSoon), so the gauge must count the same population. It
+  // did not: staging fired the alarm on 2026-09-09 while its only live channel
+  // was receiving pushes, because a dead connection's channel had expired
+  // unrenewed without ever being notified and made neverNotified >= live on
+  // its own. Google cannot notify an expired channel; it says nothing about
+  // delivery.
+  it("does not count an expired subscription that was never notified", async () => {
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const googleConnection = await seedConnection("google", "healthy");
+    const connectionId = googleConnection._id as ConnectionId;
+
+    const live = await resources.ensure({
+      tenantId,
+      principalId,
+      connectionId,
+      resourceKind: "events",
+      calendarId: objectId() as never,
+    });
+    await resources.updateSubscription(tenantId, principalId, live._id, {
+      subscriptionId: "ch-live",
+      subscriptionResourceId: "res-live",
+      subscriptionToken: "tok-live",
+      subscriptionExpiresAt: new Date(
+        NOW.getTime() + HEALTH_SUBSCRIPTION_RENEW_BEFORE_MS + 60_000,
+      ),
+    });
+    await resources.markChangeNotified(
+      tenantId,
+      principalId,
+      live._id,
+      new Date(NOW.getTime() - 60_000),
+    );
+
+    const expired = await resources.ensure({
+      tenantId,
+      principalId,
+      connectionId,
+      resourceKind: "events",
+      calendarId: objectId() as never,
+    });
+    await resources.updateSubscription(tenantId, principalId, expired._id, {
+      subscriptionId: "ch-expired",
+      subscriptionResourceId: "res-expired",
+      subscriptionToken: "tok-expired",
+      subscriptionExpiresAt: new Date(NOW.getTime() - 60_000),
+    });
+
+    const snapshot = await computeHealthSnapshotForProvider(deps(), "google");
+    expect(snapshot.subscriptions).toEqual({
+      healthy: 1,
+      renewSoon: 0,
+      expired: 1,
+      missing: 0,
+      neverNotified: 0,
+    });
+  });
+
   it("emits one PostHog event per registered provider", async () => {
     const captured: Array<{
       event: string;

--- a/packages/sync/src/telemetry/health-snapshot.service.ts
+++ b/packages/sync/src/telemetry/health-snapshot.service.ts
@@ -229,9 +229,18 @@ async function summarizeSubscriptions(
       // `$eq: null` matches a missing field too, which is what a resource
       // predating the field looks like — deliberately counted, since such a
       // resource has equally never been observed receiving a push.
+      //
+      // Live channels only, the same population as healthy + renewSoon. The
+      // push-delivery alarm compares this number against that population, so
+      // an expired channel counted here is a phantom: staging fired the alarm
+      // on 2026-09-09 with its one live channel receiving pushes fine, because
+      // a dead connection's channel had expired unrenewed without ever being
+      // notified and made neverNotified >= live on its own. Google cannot
+      // notify an expired channel, so it says nothing about delivery.
       collection.countDocuments({
         ...eventsFilter,
         subscriptionId: { $ne: null },
+        subscriptionExpiresAt: { $gte: now },
         pushLastReceivedAt: null,
       }),
     ]);


### PR DESCRIPTION
Fixes #3605

## What and why

The push-delivery alarm in `packages/sync/src/app.ts` fires when `subscriptions.neverNotified >= healthy + renewSoon`, i.e. when every LIVE channel has gone without a push. But `neverNotified` in `health-snapshot.service.ts` counted every resource with a `subscriptionId`, expired ones included, while the live side excluded them. The two sides counted different populations.

That is exactly what fired on staging on 2026-09-09 23:05Z: connection `6a97367c…` (state `actionRequired`, `authorizationRevoked`) held two channels that expired unrenewed at 20:47Z and 21:02Z; one had never received a push. That one expired row gave `neverNotified = 1 >= live = 1` while the only live channel (`6a99feb9…`) had a push at 16:04Z the same day and pulled successfully at 00:53Z. Both staging proxies pass the POST `/sync/notifications/google` probe. The alarm was a phantom.

Google cannot notify an expired channel, so an expired channel says nothing about delivery. The gauge now requires `subscriptionExpiresAt >= now`, matching the live population. Production never hit this because 359 live channels dwarf any expired stragglers; a fleet of one to three is where it bites. Regression test added; it fails on the old query (`neverNotified: 1`) and passes on the new one.

The alarm text still names the reverse proxy. Left as is: this PR is the count fix only.

## Verify

`bun run verify --strict` locally:

```
Selected packages: sync
Checks run: type-check, lint, knip
Failed: test:sync
VERDICT: FAIL
```

The one failing test is `packages/sync/src/providers/microsoft/windows-zones.test.ts` ("maps every Windows zone to a supported IANA name"), which this diff does not touch. It fails identically on the unmodified file at `origin/main` (`0f91ed40`) on this Mac because the local ICU's `Intl.supportedValuesOf("timeZone")` returns legacy aliases (e.g. `Europe/Kiev`, `America/Buenos_Aires`) rather than `Europe/Kyiv`, `America/Argentina/Buenos_Aires`, `America/Nuuk`, `Asia/Kolkata`, `Asia/Yangon`, `Asia/Kathmandu`, `America/Indiana/Indianapolis`. The Unit workflow on that same main commit is green in CI. Environmental; CI decides.

The changed suite passes: `bun test:sync -- packages/sync/src/telemetry/health-snapshot.service.db.test.ts` → 5 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
