### PR TITLE
refactor(web): collapse booking destination and weekly-hours duplication

### DIFF
--- a/packages/web/src/booking/BookingDestinationCalendarField.tsx
+++ b/packages/web/src/booking/BookingDestinationCalendarField.tsx
@@ -1,0 +1,72 @@
+import { BOOKING_PLACEHOLDER_CALENDAR_ID } from "@core/types/booking.contracts";
+import { type Calendar } from "@core/types/calendar.contracts";
+import { type CalendarId } from "@core/types/domain-primitives";
+import { type SyncConnectionSummary } from "@core/types/user.types";
+import { BookingDestinationCalendarOptions } from "@web/booking/BookingDestinationCalendarOptions";
+import { bookingDestinationConferenceHint } from "@web/booking/booking-conference.copy";
+import { BOOKING_SELECT_CLASS_NAME } from "@web/booking/booking-form.styles";
+import {
+  type BookingField,
+  bookingFieldAttrs,
+} from "@web/booking/booking-sequence.fields";
+
+interface BookingDestinationCalendarFieldProps {
+  connections: SyncConnectionSummary[];
+  /** Sequence attributes for host settings; the wizard step has no field sequence. */
+  field?: BookingField;
+  id: string;
+  onChange: (destinationCalendarId: CalendarId) => void;
+  value: CalendarId;
+  writableCalendars: Calendar[];
+}
+
+/**
+ * The destination `<select>` plus the hint explaining that the chosen calendar
+ * cannot mint a video link. Shared by host settings and the first-run wizard so
+ * the hint and its `aria-describedby` can never drift apart.
+ */
+export function BookingDestinationCalendarField({
+  connections,
+  field,
+  id,
+  onChange,
+  value,
+  writableCalendars,
+}: BookingDestinationCalendarFieldProps) {
+  const destinationCalendar = writableCalendars.find(
+    (calendar) => calendar.id === value,
+  );
+  const conferenceHint = destinationCalendar
+    ? bookingDestinationConferenceHint(destinationCalendar)
+    : null;
+  const hintId = `${id}-meet-warning`;
+
+  return (
+    <>
+      <select
+        {...(field ? bookingFieldAttrs(field) : {})}
+        aria-describedby={conferenceHint ? hintId : undefined}
+        className={BOOKING_SELECT_CLASS_NAME}
+        id={id}
+        onChange={(event) => onChange(event.target.value as CalendarId)}
+        value={value}
+      >
+        {writableCalendars.length === 0 ? (
+          <option value={BOOKING_PLACEHOLDER_CALENDAR_ID}>
+            No writable calendars
+          </option>
+        ) : (
+          <BookingDestinationCalendarOptions
+            calendars={writableCalendars}
+            connections={connections}
+          />
+        )}
+      </select>
+      {conferenceHint ? (
+        <p className="mt-1 text-sm text-warning" id={hintId} role="status">
+          {conferenceHint}
+        </p>
+      ) : null}
+    </>
+  );
+}

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -32,7 +32,7 @@ import {
 import { BookingBlockingCalendarsField } from "@web/booking/BookingBlockingCalendarsField";
 import { BookingConnectionBanner } from "@web/booking/BookingConnectionBanner";
 import { BookingConnectPrompt } from "@web/booking/BookingConnectPrompt";
-import { BookingDestinationCalendarOptions } from "@web/booking/BookingDestinationCalendarOptions";
+import { BookingDestinationCalendarField } from "@web/booking/BookingDestinationCalendarField";
 import { BookingFieldLabel } from "@web/booking/BookingFieldLabel";
 import { BookingMoreOptions } from "@web/booking/BookingMoreOptions";
 import { BookingNumberField } from "@web/booking/BookingNumberField";
@@ -58,10 +58,6 @@ import {
   toBookingPageInput,
   validateBookingForm,
 } from "@web/booking/booking.util";
-import {
-  bookingDestinationConferenceHint,
-  resolveBookingConference,
-} from "@web/booking/booking-conference.copy";
 import { BOOKING_SELECT_CLASS_NAME } from "@web/booking/booking-form.styles";
 import {
   type BookingField,
@@ -444,17 +440,6 @@ export function BookingSettingsSection({
   const destinationCalendar = writableCalendars.find(
     (calendar) => calendar.id === form.destinationCalendarId,
   );
-  const destinationConference = destinationCalendar
-    ? resolveBookingConference(
-        destinationCalendar.conference,
-        destinationCalendar.createsGoogleMeet,
-      )
-    : "meet";
-  const destinationCannotMintMeet = destinationConference === "none";
-  const destinationConferenceHint = destinationCalendar
-    ? bookingDestinationConferenceHint(destinationCalendar)
-    : null;
-  const destinationMeetWarningId = "booking-destination-meet-warning";
   const updateForm = (patch: Partial<AdminPutBookingPageInput>) => {
     setForm((current) => ({ ...current, ...patch }));
     setSaveError(null);
@@ -733,38 +718,14 @@ export function BookingSettingsSection({
             <BookingFieldLabel htmlFor="booking-destination-calendar">
               Destination calendar
             </BookingFieldLabel>
-            <select
-              {...bookingFieldAttrs("destination")}
-              aria-describedby={
-                destinationCannotMintMeet ? destinationMeetWarningId : undefined
-              }
-              className={BOOKING_SELECT_CLASS_NAME}
+            <BookingDestinationCalendarField
+              connections={connections}
+              field="destination"
               id="booking-destination-calendar"
-              onChange={(event) =>
-                handleDestinationChange(event.target.value as CalendarId)
-              }
+              onChange={handleDestinationChange}
               value={form.destinationCalendarId}
-            >
-              {writableCalendars.length === 0 ? (
-                <option value={BOOKING_PLACEHOLDER_CALENDAR_ID}>
-                  No writable calendars
-                </option>
-              ) : (
-                <BookingDestinationCalendarOptions
-                  calendars={writableCalendars}
-                  connections={connections}
-                />
-              )}
-            </select>
-            {destinationConferenceHint ? (
-              <p
-                className="mt-1 text-sm text-warning"
-                id={destinationMeetWarningId}
-                role="status"
-              >
-                {destinationConferenceHint}
-              </p>
-            ) : null}
+              writableCalendars={writableCalendars}
+            />
           </div>
 
           <div className="min-w-0" {...bookingFieldAttrs("timezone")}>

--- a/packages/web/src/booking/setup/BookingSetupDestinationStep.tsx
+++ b/packages/web/src/booking/setup/BookingSetupDestinationStep.tsx
@@ -2,9 +2,7 @@ import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
 import { type SyncConnectionSummary } from "@core/types/user.types";
 import { ConnectProviderChooser } from "@web/auth/providers/ConnectProviderChooser";
-import { BookingDestinationCalendarOptions } from "@web/booking/BookingDestinationCalendarOptions";
-import { bookingDestinationConferenceHint } from "@web/booking/booking-conference.copy";
-import { BOOKING_SELECT_CLASS_NAME } from "@web/booking/booking-form.styles";
+import { BookingDestinationCalendarField } from "@web/booking/BookingDestinationCalendarField";
 
 interface BookingSetupDestinationStepProps {
   connections: SyncConnectionSummary[];
@@ -23,42 +21,18 @@ export function BookingSetupDestinationStep({
     return <ConnectProviderChooser variant="prompt" />;
   }
 
-  const destinationCalendar = writableCalendars.find(
-    (calendar) => calendar.id === destinationCalendarId,
-  );
-  const destinationConferenceHint = destinationCalendar
-    ? bookingDestinationConferenceHint(destinationCalendar)
-    : null;
-  const destinationMeetWarningId = "booking-setup-destination-meet-warning";
-
   return (
-    <div className="flex flex-col gap-1">
+    <div className="flex flex-col">
       <label className="sr-only" htmlFor="booking-setup-destination-calendar">
         Destination calendar
       </label>
-      <select
-        aria-describedby={
-          destinationConferenceHint ? destinationMeetWarningId : undefined
-        }
-        className={BOOKING_SELECT_CLASS_NAME}
+      <BookingDestinationCalendarField
+        connections={connections}
         id="booking-setup-destination-calendar"
-        onChange={(event) => onChange(event.target.value as CalendarId)}
+        onChange={onChange}
         value={destinationCalendarId}
-      >
-        <BookingDestinationCalendarOptions
-          calendars={writableCalendars}
-          connections={connections}
-        />
-      </select>
-      {destinationConferenceHint ? (
-        <p
-          className="text-sm text-warning"
-          id={destinationMeetWarningId}
-          role="status"
-        >
-          {destinationConferenceHint}
-        </p>
-      ) : null}
+        writableCalendars={writableCalendars}
+      />
     </div>
   );
 }

--- a/packages/web/src/booking/setup/BookingSetupWizard.tsx
+++ b/packages/web/src/booking/setup/BookingSetupWizard.tsx
@@ -73,18 +73,10 @@ const focusStepFirstControl = (
         .querySelector<HTMLElement>("#booking-setup-destination-calendar")
         ?.focus();
       break;
-    case "live":
-      continueRefFallback(root)?.focus();
-      break;
     default:
       break;
   }
 };
-
-const continueRefFallback = (root: HTMLElement) =>
-  root.querySelector<HTMLButtonElement>(
-    '[data-settings-shortcut="save-booking"]',
-  );
 
 export function BookingSetupWizard({
   bookingUrl,
@@ -145,23 +137,19 @@ export function BookingSetupWizard({
     const target = event.target;
     if (!(target instanceof HTMLElement)) return;
 
-    if (
-      (event.key === "k" || event.key === "K") &&
-      !isEditableKeyboardTarget(event)
-    ) {
-      if (!canContinue) return;
-      event.preventDefault();
-      onContinue();
-      return;
-    }
-
-    if (
-      (event.key === "j" || event.key === "J") &&
-      !isEditableKeyboardTarget(event)
-    ) {
-      event.preventDefault();
-      onBack();
-      return;
+    if (!isEditableKeyboardTarget(event)) {
+      const navKey = event.key.toLowerCase();
+      if (navKey === "k") {
+        if (!canContinue) return;
+        event.preventDefault();
+        onContinue();
+        return;
+      }
+      if (navKey === "j") {
+        event.preventDefault();
+        onBack();
+        return;
+      }
     }
 
     if (event.key !== "Enter" || event.shiftKey || event.altKey) return;

--- a/packages/web/src/booking/weekly-hours.ts
+++ b/packages/web/src/booking/weekly-hours.ts
@@ -37,6 +37,17 @@ const sortAvailability = (
         left.weekday - right.weekday || left.start.localeCompare(right.start),
     );
 
+/** Swap one weekday's intervals for `intervals`, leaving the other days alone. */
+const withDayIntervals = (
+  value: WeeklyAvailability,
+  weekday: IsoWeekday,
+  intervals: readonly WeeklyAvailabilityInterval[],
+): WeeklyAvailability =>
+  sortAvailability([
+    ...value.filter((entry) => entry.weekday !== weekday),
+    ...intervals,
+  ]);
+
 export function intervalsForDay(
   value: WeeklyAvailability,
   weekday: IsoWeekday,
@@ -76,8 +87,7 @@ export function addBlock(
   value: WeeklyAvailability,
   weekday: IsoWeekday,
 ): WeeklyAvailability {
-  const day = intervalsForDay(value, weekday);
-  const last = day[day.length - 1];
+  const last = intervalsForDay(value, weekday).at(-1);
   if (last == null) return value;
   const startMinutes = localTimeToMinutes(last.end) + 60;
   if (startMinutes >= localTimeToMinutes(LAST_TIME)) return value;
@@ -93,22 +103,12 @@ export function removeBlock(
   weekday: IsoWeekday,
   index: number,
 ): WeeklyAvailability {
-  const target = intervalsForDay(value, weekday)[index];
-  if (target == null) return sortAvailability(value);
-  let removed = false;
-  return sortAvailability(
-    value.filter((entry) => {
-      if (
-        !removed &&
-        entry.weekday === weekday &&
-        entry.start === target.start &&
-        entry.end === target.end
-      ) {
-        removed = true;
-        return false;
-      }
-      return true;
-    }),
+  const day = intervalsForDay(value, weekday);
+  if (day[index] == null) return sortAvailability(value);
+  return withDayIntervals(
+    value,
+    weekday,
+    day.filter((_, position) => position !== index),
   );
 }
 
@@ -133,20 +133,12 @@ export function updateBlock(
       end = next.start;
     }
   }
-  let replaced = false;
-  return sortAvailability(
-    value.map((entry) => {
-      if (
-        replaced ||
-        entry.weekday !== weekday ||
-        entry.start !== current.start ||
-        entry.end !== current.end
-      ) {
-        return entry;
-      }
-      replaced = true;
-      return { ...entry, start, end };
-    }),
+  return withDayIntervals(
+    value,
+    weekday,
+    day.map((entry, position) =>
+      position === index ? { ...entry, start, end } : entry,
+    ),
   );
 }
 


### PR DESCRIPTION
## What and why

Technical-debt sweep over the merged booking work of the last 7 days (#3527-#3609). Three items, no behavior change:

1. **Duplicated destination field.** Host settings (`BookingSettingsSection`) and the first-run wizard (`BookingSetupDestinationStep`) each built their own destination `<select>`, conference hint `<p>`, and `aria-describedby` wiring. Settings additionally derived `destinationConference` and `destinationCannotMintMeet` purely to gate that `aria-describedby`, even though `bookingDestinationConferenceHint` is non-null under exactly the same condition, so the attribute and the element it pointed at were two independent expressions that could drift. A new `BookingDestinationCalendarField` owns the select, the hint, and the shared description id for both callers.

2. **Dead focus fallback in the wizard.** `focusStepFirstControl` carried a `case "live"` and a `continueRefFallback` that looked the Continue button up by `data-settings-shortcut`, but the effect calling it returns early on `"live"` and focuses `continueRef` directly, so neither could ever run. Both are gone, and the duplicated `j`/`k` branches fold into one `isEditableKeyboardTarget` guard.

3. **Clunky interval editing.** `weekly-hours.ts` `removeBlock` and `updateBlock` located an interval by index via `intervalsForDay`, then threw that away and walked the entire week with a mutable `removed`/`replaced` flag matching on `(weekday, start, end)` value equality. They now rebuild just the affected weekday through a small `withDayIntervals` helper.

## Verify

`bun run verify --strict` selected the `web` package and ran `test:web` (838 pass, 0 fail), `type-check`, `lint`, and `knip`, all green. `bun test:a11y` passes standalone: 58 passed.

`test:e2e` reports `VERDICT: FAIL` in this sandbox with 9 failures, but the identical 9 fail on a clean `origin/main` checkout in the same container, so none is this diff's:

```
e2e/accessibility/booking-a11y.spec.ts:795 › first-run taken-address error ... a11y violations
e2e/auth/sign-in-providers.spec.ts:97 › starts Microsoft sign-in with the M shortcut
e2e/calendars/calendar-experience.spec.ts:432 › day view separates visible calendars
e2e/calendars/microsoft-surfaces.spec.ts:63 › Add account starts Microsoft OAuth
e2e/oauth/apple-auth-callback.spec.ts:68 › finishes a saved Apple Sign in callback
e2e/oauth/google-auth-callback.spec.ts:86 › finishes a saved Google sign-in callback
e2e/oauth/microsoft-auth-callback.spec.ts:82 › finishes a saved Microsoft sign-in callback
e2e/oauth/microsoft-auth-callback.spec.ts:127 › rejects a Microsoft callback missing scopes
e2e/onboarding/mobile-gate.spec.ts:23 › phone users can skip the game ...
```

The OAuth and mobile-gate specs land on `chrome-error://chromewebdata/` because the sandbox proxy blocks their external hosts; the booking-a11y one is a `color-contrast` reading on the Continue button that resolves as `incomplete` ("background color could not be determined") in an isolated run and only hardens into a violation under full-suite load. CI decides.

VERDICT: FAIL (test:e2e only, same 9 specs red on clean main in this sandbox; test:web, type-check, lint, knip, test:a11y all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVLtce4n3Grb3vrvdY3vgK

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVLtce4n3Grb3vrvdY3vgK)_