### PR TITLE
fix(web): recover from provider callback failures

### DIFF
--- a/packages/web/src/auth/providers/authorization/complete-provider-authorization.test.ts
+++ b/packages/web/src/auth/providers/authorization/complete-provider-authorization.test.ts
@@ -1,7 +1,11 @@
 import { GOOGLE_SCOPES } from "@core/providers/google.scopes";
 import { MICROSOFT_SCOPES } from "@core/providers/microsoft.scopes";
 import { completeProviderAuthorization } from "./complete-provider-authorization";
-import { PROVIDER_AUTH_SCOPES_REQUIRED } from "./provider-authorization.constants";
+import {
+  MISSING_PROVIDER_SCOPES_ERROR_MESSAGE,
+  PROVIDER_AUTH_CANCELLED_MESSAGE,
+  PROVIDER_AUTH_SCOPES_REQUIRED,
+} from "./provider-authorization.constants";
 import {
   consumeGoogleAuthNeedsConsentRetry,
   readProviderAuthorizationIntent,
@@ -129,8 +133,93 @@ describe("completeProviderAuthorization", () => {
       status: "failed",
       message: "Google did not grant a fresh authorization. Please try again.",
       returnPath: "/week",
+      reason: "oauth_exchange_failed",
     });
 
     expect(consumeGoogleAuthNeedsConsentRetry()).toBe(true);
+  });
+
+  // Declining at the consent screen used to share the generic authorization
+  // error, which read as a Compass crash and hid a whole class of drop-off
+  // inside the error count.
+  it("reports a consent-screen cancel as its own calm outcome", async () => {
+    const deps = makeDeps();
+    writeProviderAuthorizationIntent("google", "state-5", {
+      intent: "signIn",
+      returnPath: "/week",
+      createdAt: Date.now(),
+    });
+
+    await expect(
+      completeProviderAuthorization({
+        provider: "google",
+        ...deps,
+        search: "?state=state-5&error=access_denied",
+      }),
+    ).resolves.toEqual({
+      status: "failed",
+      message: PROVIDER_AUTH_CANCELLED_MESSAGE,
+      returnPath: "/week",
+      reason: "oauth_user_cancelled",
+    });
+
+    expect(deps.authApi.loginOrSignup).not.toHaveBeenCalled();
+  });
+
+  it("names the reason for each early return", async () => {
+    const deps = makeDeps();
+    // The stored intent is consumed on read, so each case seeds its own.
+    const seed = (state: string) =>
+      writeProviderAuthorizationIntent("google", state, {
+        intent: "signIn",
+        returnPath: "/week",
+        createdAt: Date.now(),
+      });
+
+    seed("state-6a");
+    await expect(
+      completeProviderAuthorization({
+        provider: "google",
+        ...deps,
+        search: "?code=abc",
+      }),
+    ).resolves.toMatchObject({ reason: "oauth_missing_state" });
+
+    await expect(
+      completeProviderAuthorization({
+        provider: "google",
+        ...deps,
+        search: "?state=unknown-state&code=abc",
+      }),
+    ).resolves.toMatchObject({ reason: "oauth_missing_intent" });
+
+    seed("state-6b");
+    await expect(
+      completeProviderAuthorization({
+        provider: "google",
+        ...deps,
+        search: "?state=state-6b",
+      }),
+    ).resolves.toMatchObject({ reason: "oauth_missing_code" });
+  });
+
+  it("reports short scopes separately from a generic failure", async () => {
+    const deps = makeDeps();
+    writeProviderAuthorizationIntent("google", "state-7", {
+      intent: "signIn",
+      returnPath: "/week",
+      createdAt: Date.now(),
+    });
+
+    await expect(
+      completeProviderAuthorization({
+        provider: "google",
+        ...deps,
+        search: callbackSearch("state-7", "openid email"),
+      }),
+    ).resolves.toMatchObject({
+      reason: "oauth_missing_scopes",
+      message: MISSING_PROVIDER_SCOPES_ERROR_MESSAGE,
+    });
   });
 });

--- a/packages/web/src/auth/providers/authorization/complete-provider-authorization.ts
+++ b/packages/web/src/auth/providers/authorization/complete-provider-authorization.ts
@@ -4,10 +4,12 @@ import {
 } from "@core/types/auth.types";
 import { type ProviderKind } from "@core/types/sync/identity.contracts";
 import { type ApiError } from "@web/api/api.types";
+import { type SignupFailureReason } from "@web/auth/posthog/signup-funnel";
 import { DEFAULT_CALENDAR_ROUTE } from "@web/common/constants/routes";
 import {
   GOOGLE_AUTHORIZATION_ERROR_MESSAGE,
   MISSING_PROVIDER_SCOPES_ERROR_MESSAGE,
+  PROVIDER_AUTH_CANCELLED_MESSAGE,
   PROVIDER_AUTH_SCOPES_REQUIRED,
   PROVIDER_AUTHORIZATION_ERROR_MESSAGE,
 } from "./provider-authorization.constants";
@@ -51,6 +53,8 @@ export type CompleteProviderAuthorizationResult =
       message: string;
       returnPath: string;
       status: "failed";
+      /** Why it failed, so the callback can both report and count it. */
+      reason: SignupFailureReason;
     };
 
 const AUTHORIZATION_ERROR_MESSAGE: Record<ProviderKind, string> = {
@@ -67,10 +71,12 @@ const CONSENT_RETRY_ERROR_CODES_BY_PROVIDER: Partial<
 
 const fail = (
   provider: ProviderKind,
+  reason: SignupFailureReason,
   returnPath: string = DEFAULT_CALENDAR_ROUTE,
   message = AUTHORIZATION_ERROR_MESSAGE[provider],
 ): CompleteProviderAuthorizationResult => ({
   message,
+  reason,
   returnPath,
   status: "failed",
 });
@@ -102,21 +108,37 @@ export async function completeProviderAuthorization({
   const state = params.get("state");
 
   if (!state) {
-    return fail(provider);
+    return fail(provider, "oauth_missing_state");
   }
 
   const savedIntent = readProviderAuthorizationIntent(provider, state);
   clearProviderAuthorizationIntent(provider, state);
   const returnPath = savedIntent?.returnPath ?? DEFAULT_CALENDAR_ROUTE;
 
-  if (!savedIntent || params.get("error")) {
-    return fail(provider, returnPath);
+  // Declining at the consent screen is its own outcome. Reported separately
+  // so it stops inflating the generic-error count, and so the callback can
+  // show calm copy instead of an error toast.
+  if (params.get("error") === "access_denied") {
+    return fail(
+      provider,
+      "oauth_user_cancelled",
+      returnPath,
+      PROVIDER_AUTH_CANCELLED_MESSAGE,
+    );
+  }
+
+  if (!savedIntent) {
+    return fail(provider, "oauth_missing_intent", returnPath);
+  }
+
+  if (params.get("error")) {
+    return fail(provider, "oauth_exchange_failed", returnPath);
   }
 
   const code = params.get("code");
 
   if (!code) {
-    return fail(provider, returnPath);
+    return fail(provider, "oauth_missing_code", returnPath);
   }
 
   const requiredScopes = PROVIDER_AUTH_SCOPES_REQUIRED[provider];
@@ -126,7 +148,12 @@ export async function completeProviderAuthorization({
   );
 
   if (isMissingRequiredScope) {
-    return fail(provider, returnPath, MISSING_PROVIDER_SCOPES_ERROR_MESSAGE);
+    return fail(
+      provider,
+      "oauth_missing_scopes",
+      returnPath,
+      MISSING_PROVIDER_SCOPES_ERROR_MESSAGE,
+    );
   }
 
   const payload = buildProviderAuthCodePayload({
@@ -157,9 +184,14 @@ export async function completeProviderAuthorization({
     }
 
     if (parsedError?.message) {
-      return fail(provider, returnPath, parsedError.message);
+      return fail(
+        provider,
+        "oauth_exchange_failed",
+        returnPath,
+        parsedError.message,
+      );
     }
 
-    return fail(provider, returnPath);
+    return fail(provider, "oauth_exchange_failed", returnPath);
   }
 }

--- a/packages/web/src/auth/providers/authorization/provider-authorization.constants.ts
+++ b/packages/web/src/auth/providers/authorization/provider-authorization.constants.ts
@@ -29,6 +29,14 @@ export const MISSING_PROVIDER_SCOPES_ERROR_MESSAGE =
 export const GOOGLE_AUTHORIZATION_ERROR_MESSAGE =
   "We couldn't connect your Google account. Please try again.";
 
+/**
+ * Cancelling at the provider's consent screen is a choice, not a crash. It
+ * used to share the generic authorization error, which read as a Compass
+ * failure and gave no hint that trying again was all it took.
+ */
+export const PROVIDER_AUTH_CANCELLED_MESSAGE =
+  "No problem, nothing was connected. You can sign in anytime.";
+
 export function isSignInProviderKind(value: string): value is ProviderKind {
   return ProviderKindSchema.safeParse(value).success;
 }

--- a/packages/web/src/auth/providers/connect-status.util.test.ts
+++ b/packages/web/src/auth/providers/connect-status.util.test.ts
@@ -1,5 +1,6 @@
 import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import * as userMetadataUtil from "@web/auth/compass/user/util/user-metadata.util";
+import { CONSENT_REQUIRED_COPY } from "@web/auth/providers/provider-copy.util";
 import { registerToastPort } from "@web/common/utils/toast/toast.port";
 import {
   readConnectStatus,
@@ -64,6 +65,23 @@ describe("connect-status.util", () => {
       expect(readConnectStatus("?provider=google&status=pending")).toBeNull();
       expect(readConnectStatus("")).toBeNull();
     });
+
+    // These two are redirected by the sync callback. Dropping them here left
+    // the user on the calendar after a failed connect with no toast at all.
+    it("reads the sync callback's stateMismatch and consentRequired", () => {
+      expect(
+        readConnectStatus("?provider=google&status=stateMismatch"),
+      ).toEqual({
+        provider: "google",
+        status: "stateMismatch",
+      });
+      expect(
+        readConnectStatus("?provider=microsoft&status=consentRequired"),
+      ).toEqual({
+        provider: "microsoft",
+        status: "consentRequired",
+      });
+    });
   });
 
   describe("showConnectStatusToast", () => {
@@ -82,6 +100,33 @@ describe("connect-status.util", () => {
       expect(mocks.success).toHaveBeenCalledWith(
         "Microsoft connected.",
         expect.objectContaining({ toastId: "connect-success" }),
+      );
+    });
+
+    it("explains an expired connection link", () => {
+      showConnectStatusToast({ provider: "google", status: "stateMismatch" });
+      runToastAfterPaint();
+      expect(mocks.error).toHaveBeenCalledWith(
+        "That connection link expired. Please try connecting again from Settings.",
+        expect.objectContaining({
+          autoClose: false,
+          toastId: "connect-state-mismatch",
+        }),
+      );
+    });
+
+    it("explains that an admin has to approve Compass", () => {
+      showConnectStatusToast({
+        provider: "microsoft",
+        status: "consentRequired",
+      });
+      runToastAfterPaint();
+      expect(mocks.error).toHaveBeenCalledWith(
+        CONSENT_REQUIRED_COPY,
+        expect.objectContaining({
+          autoClose: false,
+          toastId: "connect-consent-required",
+        }),
       );
     });
   });

--- a/packages/web/src/auth/providers/connect-status.util.ts
+++ b/packages/web/src/auth/providers/connect-status.util.ts
@@ -4,18 +4,31 @@ import {
   providerDisplayName,
 } from "@core/types/sync/identity.contracts";
 import { refreshUserMetadata } from "@web/auth/compass/user/util/user-metadata.util";
-import { trackSignupStep } from "@web/auth/posthog/signup-funnel";
+import {
+  type SignupFailureReason,
+  trackSignupFailed,
+  trackSignupStep,
+} from "@web/auth/posthog/signup-funnel";
 import { track } from "@web/auth/posthog/track";
+import { CONSENT_REQUIRED_COPY } from "@web/auth/providers/provider-copy.util";
 import {
   GOOGLE_CONNECT_FAILED_TOAST_ID,
   getToastDefaultOptions,
 } from "@web/common/constants/toast.constants";
 import { getToast } from "@web/common/utils/toast/toast.port";
 
+/**
+ * Must stay in step with every status the sync callback can redirect with
+ * (`packages/sync/src/server/connection.routes.ts`). A status missing here
+ * makes `readConnectStatus` return null, which means the user lands on the
+ * calendar after a failed connect with no explanation at all.
+ */
 export type ConnectStatus =
   | "connected"
   | "declined"
   | "missingScopes"
+  | "stateMismatch"
+  | "consentRequired"
   | "error";
 
 export type ConnectRedirect = {
@@ -27,6 +40,8 @@ const STATUS_VALUES: readonly ConnectStatus[] = [
   "connected",
   "declined",
   "missingScopes",
+  "stateMismatch",
+  "consentRequired",
   "error",
 ];
 
@@ -40,6 +55,20 @@ const DECLINED_TOAST_ID: Record<ProviderKind, string> = {
   google: "google-connect-declined",
   microsoft: "connect-declined",
   apple: "connect-declined",
+};
+
+const STATE_MISMATCH_TOAST_ID = "connect-state-mismatch";
+const CONSENT_REQUIRED_TOAST_ID = "connect-consent-required";
+
+const FAILURE_REASON: Record<
+  Exclude<ConnectStatus, "connected">,
+  SignupFailureReason
+> = {
+  declined: "connect_declined",
+  missingScopes: "connect_missing_scopes",
+  stateMismatch: "connect_state_mismatch",
+  consentRequired: "connect_consent_required",
+  error: "connect_error",
 };
 
 const MISSING_SCOPES_TOAST_ID: Record<ProviderKind, string> = {
@@ -90,6 +119,12 @@ function errorCopy(provider: ProviderKind): string {
 
 function fireConnectStatusToast({ provider, status }: ConnectRedirect): void {
   const toast = getToast();
+  if (status !== "connected") {
+    trackSignupFailed(FAILURE_REASON[status], {
+      method: provider,
+      step: "calendar_connected",
+    });
+  }
   switch (status) {
     case "connected":
       track("calendar_connected", { source: "connect_redirect", provider });
@@ -114,6 +149,23 @@ function fireConnectStatusToast({ provider, status }: ConnectRedirect): void {
           toastId: MISSING_SCOPES_TOAST_ID[provider],
         },
       );
+      return;
+    case "stateMismatch":
+      toast.error(
+        "That connection link expired. Please try connecting again from Settings.",
+        {
+          ...getToastDefaultOptions(),
+          autoClose: false,
+          toastId: STATE_MISMATCH_TOAST_ID,
+        },
+      );
+      return;
+    case "consentRequired":
+      toast.error(CONSENT_REQUIRED_COPY, {
+        ...getToastDefaultOptions(),
+        autoClose: false,
+        toastId: CONSENT_REQUIRED_TOAST_ID,
+      });
       return;
     case "error":
       toast.error(errorCopy(provider), {

--- a/packages/web/src/components/AuthModal/hooks/useAuthFormHandlers.ts
+++ b/packages/web/src/components/AuthModal/hooks/useAuthFormHandlers.ts
@@ -10,6 +10,7 @@ import {
 } from "@web/auth/compass/schemas/auth.schemas";
 import {
   trackSignupCompleted,
+  trackSignupFailed,
   trackSignupStep,
 } from "@web/auth/posthog/signup-funnel";
 import { track } from "@web/auth/posthog/track";
@@ -84,13 +85,16 @@ export function useAuthFormHandlers({
             shortcutShowcaseActions.offerAfterSignupIfPending();
             return;
           case "FIELD_ERROR":
+            trackSignupFailed("email_field_error", { method: "email" });
             setSubmitError(response.formFields[0]?.error ?? "Sign up failed");
             return;
           case "SIGN_UP_NOT_ALLOWED":
+            trackSignupFailed("email_not_allowed", { method: "email" });
             setSubmitError(response.reason);
             return;
         }
       } catch (error) {
+        trackSignupFailed("email_request_failed", { method: "email" });
         setSubmitError(getAuthSubmitErrorMessage(error, "Unable to sign up"));
       } finally {
         setIsSubmitting(false);

--- a/packages/web/src/views/AppleAuthCallback/AppleAuthCallback.tsx
+++ b/packages/web/src/views/AppleAuthCallback/AppleAuthCallback.tsx
@@ -10,6 +10,7 @@ import { buildAppleAuthCodePayload } from "@web/auth/apple/authorization/apple-a
 import { useCompleteAuthentication } from "@web/auth/compass/hooks/useCompleteAuthentication";
 import {
   trackSignupCompleted,
+  trackSignupFailed,
   trackSignupStep,
 } from "@web/auth/posthog/signup-funnel";
 import { track } from "@web/auth/posthog/track";
@@ -97,10 +98,16 @@ export function AppleAuthCallbackView() {
 
     didRun.current = true;
 
-    void completeAppleAuthCallback({
+    // Same one-shot hazard as the provider callback: an uncaught rejection
+    // here strands the user on the spinner below with no way to retry.
+    completeAppleAuthCallback({
       completeAuthentication,
       navigate: (path) => router.history.replace(path),
       search: location.searchStr,
+    }).catch(() => {
+      trackSignupFailed("oauth_callback_crashed", { method: "apple" });
+      showErrorToast(APPLE_AUTHORIZATION_ERROR_MESSAGE);
+      router.history.replace(DEFAULT_CALENDAR_ROUTE);
     });
   }, [completeAuthentication, location.searchStr, router]);
 

--- a/packages/web/src/views/ProviderAuthCallback/ProviderAuthCallback.tsx
+++ b/packages/web/src/views/ProviderAuthCallback/ProviderAuthCallback.tsx
@@ -5,13 +5,19 @@ import { AuthApi } from "@web/api/auth.api";
 import { useCompleteAuthentication } from "@web/auth/compass/hooks/useCompleteAuthentication";
 import {
   trackSignupCompleted,
+  trackSignupFailed,
   trackSignupStep,
 } from "@web/auth/posthog/signup-funnel";
 import { track } from "@web/auth/posthog/track";
 import { completeProviderAuthorization } from "@web/auth/providers/authorization/complete-provider-authorization";
-import { isSignInProviderKind } from "@web/auth/providers/authorization/provider-authorization.constants";
+import {
+  isSignInProviderKind,
+  PROVIDER_AUTHORIZATION_ERROR_MESSAGE,
+} from "@web/auth/providers/authorization/provider-authorization.constants";
 import { DEFAULT_CALENDAR_ROUTE } from "@web/common/constants/routes";
+import { getToastDefaultOptions } from "@web/common/constants/toast.constants";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
+import { getToast } from "@web/common/utils/toast/toast.port";
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
 import { shortcutShowcaseActions } from "@web/components/ShortcutShowcase/showcase.store";
 
@@ -42,7 +48,17 @@ export async function completeProviderAuthCallback({
   });
 
   if (result.status === "failed") {
-    showErrorToast(result.message);
+    trackSignupFailed(result.reason, {
+      method: provider,
+      step: "oauth_callback_returned",
+    });
+    // Cancelling is a choice, not a fault. An error toast for it reads as a
+    // Compass failure and discourages the retry that would have worked.
+    if (result.reason === "oauth_user_cancelled") {
+      getToast().info(result.message, getToastDefaultOptions());
+    } else {
+      showErrorToast(result.message);
+    }
   } else if (result.isNewUser) {
     trackSignupCompleted(provider);
     track("calendar_connected", { source: `signup_${provider}` });
@@ -75,11 +91,20 @@ export function ProviderAuthCallbackView() {
       return;
     }
 
-    void completeProviderAuthCallback({
+    // `didRun` makes this a one-shot: if the promise rejects with nothing to
+    // catch it, the user sits on the spinner below permanently, with no toast
+    // and no way to retry. The storage reads inside swallow their own errors
+    // today, so this is a backstop rather than a fix for a reproduced case,
+    // but the failure mode it guards is unrecoverable.
+    completeProviderAuthCallback({
       provider: providerParam,
       completeAuthentication,
       navigate: (path) => router.history.replace(path),
       search: location.searchStr,
+    }).catch(() => {
+      trackSignupFailed("oauth_callback_crashed", { method: providerParam });
+      showErrorToast(PROVIDER_AUTHORIZATION_ERROR_MESSAGE);
+      router.history.replace(DEFAULT_CALENDAR_ROUTE);
     });
   }, [completeAuthentication, location.searchStr, providerParam, router]);
 


### PR DESCRIPTION
Follow-up to #3611, which added the `signup_failed` event and `SignupFailureReason` this builds on.

## Why

Three ways the signup callback could fail badly, in order of how confident I am they bite today.

**1. Two backend statuses produce no feedback at all.** The sync callback (`packages/sync/src/server/connection.routes.ts`) redirects with `status=stateMismatch` (expired or cross-provider state, 10 minute TTL) and `status=consentRequired` (Microsoft admin approval). The client's `ConnectStatus` accepted only four values, so `readConnectStatus` returned `null` and `app.bootstrap.tsx` fired nothing. The user landed on the calendar after a failed connect with no explanation whatsoever. Copy for `consentRequired` already existed in `provider-copy.util.ts` and was going unused for exactly this case.

**2. Cancelling reads as a crash.** `complete-provider-authorization.ts` lumped `?error=access_denied` in with a missing intent, so clicking Cancel at Google's consent screen produced "We couldn't connect your Google account." A deliberate choice looked like a Compass failure, discouraged the retry that would have worked, and inflated the generic-error count.

**3. The callbacks had no catch.** Both provider callbacks ran `void completeProviderAuthCallback(...)` with nothing to catch a rejection. To be straight about this one: the storage reads inside swallow their own errors, so I could not reproduce a live case, and this is a backstop rather than a fix for a demonstrated bug. It is worth having because `didRun` makes the callback one-shot: any rejection that did get through would leave the user on the "Just finishing up" spinner permanently, with no toast and no way to retry. Apple had the identical shape.

## What

- `ConnectStatus` gains `stateMismatch` and `consentRequired`, each with its own toast and toast id. A comment now ties the union to the sync route that produces it.
- `access_denied` becomes its own outcome with calm copy (`PROVIDER_AUTH_CANCELLED_MESSAGE`) shown as an info toast, not an error.
- `CompleteProviderAuthorizationResult` carries a `reason`, and every early return names its own, so the funnel can tell these apart instead of collapsing them into one error bucket.
- Both callbacks catch, report, and return the user to the calendar.
- Email signup's three non-OK outcomes each report a reason.

## Verification

New unit coverage: the cancel path and its copy, a reason for each early return, short scopes as their own outcome, and `readConnectStatus` plus toast severity for both new statuses. The connect-status tests fail without the fix.

`bun test:web`, `bun type-check`, `bun run lint`, `bun knip` pass.

Local `test:e2e` fails on booking, settings and a11y specs, but a clean `origin/main` worktree fails 15 of the same specs on this machine, so those are environmental and not from this diff. CI decides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)