### PR TITLE
feat(web): re-surface the connect calendar prompt

### DIFF
--- a/packages/web/src/auth/providers/provider-copy.util.ts
+++ b/packages/web/src/auth/providers/provider-copy.util.ts
@@ -20,6 +20,23 @@ export const CALENDAR_PRODUCT_NAME: Record<ProviderKind, string> = {
 /** Heading for the first-connect onboarding step and the multi-provider chooser. */
 export const CONNECT_THE_CALENDAR_YOU_USE = "Connect the calendar you use";
 
+/**
+ * The connect step is where Compass starts being useful, and where a new user
+ * is asked to hand over calendar access before they have seen it do anything.
+ * These three lines answer why, what changes, and what Compass can reach.
+ */
+export const CONNECT_CALENDAR_WHY =
+  "Compass works on your real calendar, so it needs to read and write the events already on it.";
+
+export const CONNECT_CALENDAR_BENEFITS: readonly string[] = [
+  "Your existing events show up in the week, right away.",
+  "Edits sync both ways, so your other apps stay in step.",
+  "Every keyboard shortcut works on real events, not a demo.",
+];
+
+export const CONNECT_CALENDAR_REASSURANCE =
+  "Compass only touches calendar events, and you can disconnect the account anytime from Settings.";
+
 /** Spec host-explainer: Apple Calendar.app is not the same as iCloud hosting. */
 export const CALENDAR_HOST_EXPLAINER =
   "If you view your calendar in Apple Calendar, it may still be hosted by Google or Microsoft.";

--- a/packages/web/src/common/constants/storage.constants.ts
+++ b/packages/web/src/common/constants/storage.constants.ts
@@ -69,7 +69,7 @@ export const STORAGE_KEYS: Record<
   | "SHORTCUT_SHOWCASE_STEP"
   | "HAS_PENDING_SHOWCASE_OFFER"
   | "FIRST_EVENT_DONE"
-  | "HAS_DISMISSED_CONNECT_CALENDAR_PROMPT"
+  | "CONNECT_CALENDAR_PROMPT_SNOOZED_AT"
   | "SHORTCUT_TIPS_MUTED"
   | "SHORTCUT_TIPS_DEMONSTRATED"
   | "SHORTCUT_PERSONALIZATION"
@@ -102,7 +102,9 @@ export const STORAGE_KEYS: Record<
   SHORTCUT_SHOWCASE_STEP: "compass.onboarding.shortcut-showcase-step",
   HAS_PENDING_SHOWCASE_OFFER: "compass.onboarding.has-pending-showcase-offer",
   FIRST_EVENT_DONE: "compass.onboarding.first-event-done",
-  HAS_DISMISSED_CONNECT_CALENDAR_PROMPT:
+  // Holds an epoch-ms timestamp. Older browsers hold the literal "true" from
+  // when dismissing was permanent; the reader treats that as a lapsed snooze.
+  CONNECT_CALENDAR_PROMPT_SNOOZED_AT:
     "compass.onboarding.has-dismissed-connect-calendar-prompt",
   SHORTCUT_TIPS_MUTED: "compass.shortcuts.tips-muted",
   SHORTCUT_TIPS_DEMONSTRATED: "compass.shortcuts.tips-demonstrated",

--- a/packages/web/src/components/ConnectCalendarPrompt/ConnectCalendarPrompt.test.tsx
+++ b/packages/web/src/components/ConnectCalendarPrompt/ConnectCalendarPrompt.test.tsx
@@ -7,6 +7,9 @@ import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
 import { SessionContext } from "@web/auth/compass/session/session.context";
 import {
   CALENDAR_HOST_EXPLAINER,
+  CONNECT_CALENDAR_BENEFITS,
+  CONNECT_CALENDAR_REASSURANCE,
+  CONNECT_CALENDAR_WHY,
   CONNECT_THE_CALENDAR_YOU_USE,
 } from "@web/auth/providers/provider-copy.util";
 import * as realAvailableProviders from "@web/auth/providers/useAvailableConnectProviders";
@@ -16,6 +19,10 @@ import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 import { AuthModalContext } from "@web/components/AuthModal/hooks/useAuthModal";
 import { CONNECT_CALENDAR_LATER_LABEL } from "@web/components/ConnectCalendarPrompt/ConnectCalendarPrompt";
+import {
+  CONNECT_CALENDAR_SNOOZE_MS,
+  isConnectCalendarPromptSnoozed,
+} from "@web/components/ConnectCalendarPrompt/connect-calendar.storage";
 import {
   initialConnectCalendarPromptState,
   useConnectCalendarPromptStore,
@@ -112,10 +119,10 @@ describe("ConnectCalendarPromptGate", () => {
     mockConnectApple.mockClear();
     useConnectCalendarPromptStore.setState({
       ...initialConnectCalendarPromptState,
-      isDismissed: false,
+      isSnoozed: false,
     });
     persistentBrowserStore.set(
-      STORAGE_KEYS.HAS_DISMISSED_CONNECT_CALENDAR_PROMPT,
+      STORAGE_KEYS.CONNECT_CALENDAR_PROMPT_SNOOZED_AT,
       "",
     );
     userMetadataActions.set(emptyMetadata);
@@ -133,6 +140,12 @@ describe("ConnectCalendarPromptGate", () => {
     ).toBeInTheDocument();
     expect(screen.getByText(CONNECT_THE_CALENDAR_YOU_USE)).toBeInTheDocument();
     expect(screen.getByText(CALENDAR_HOST_EXPLAINER)).toBeInTheDocument();
+    // The value case is the point of this step, not decoration.
+    expect(screen.getByText(CONNECT_CALENDAR_WHY)).toBeInTheDocument();
+    expect(screen.getByText(CONNECT_CALENDAR_REASSURANCE)).toBeInTheDocument();
+    for (const benefit of CONNECT_CALENDAR_BENEFITS) {
+      expect(screen.getByText(benefit)).toBeInTheDocument();
+    }
     expect(
       screen.getByRole("button", { name: CONNECT_CALENDAR_LATER_LABEL }),
     ).toBeInTheDocument();
@@ -154,17 +167,52 @@ describe("ConnectCalendarPromptGate", () => {
     ).toBeNull();
   });
 
-  it("does not render after dismissal", () => {
+  it("does not render inside the snooze window", () => {
     persistentBrowserStore.set(
-      STORAGE_KEYS.HAS_DISMISSED_CONNECT_CALENDAR_PROMPT,
-      "true",
+      STORAGE_KEYS.CONNECT_CALENDAR_PROMPT_SNOOZED_AT,
+      String(Date.now()),
     );
-    useConnectCalendarPromptStore.setState({ isDismissed: true });
+    useConnectCalendarPromptStore.setState({
+      isSnoozed: isConnectCalendarPromptSnoozed(),
+    });
     renderGate();
 
     expect(
       screen.queryByRole("dialog", { name: CONNECT_THE_CALENDAR_YOU_USE }),
     ).toBeNull();
+  });
+
+  it("renders again once the snooze window has passed", () => {
+    persistentBrowserStore.set(
+      STORAGE_KEYS.CONNECT_CALENDAR_PROMPT_SNOOZED_AT,
+      String(Date.now() - CONNECT_CALENDAR_SNOOZE_MS - 1),
+    );
+    useConnectCalendarPromptStore.setState({
+      isSnoozed: isConnectCalendarPromptSnoozed(),
+    });
+    renderGate();
+
+    expect(
+      screen.getByRole("dialog", { name: CONNECT_THE_CALENDAR_YOU_USE }),
+    ).toBeInTheDocument();
+  });
+
+  // Browsers that dismissed the prompt when dismissal was permanent still
+  // hold the literal "true". They are exactly the users this change is for,
+  // so it has to read as a lapsed snooze rather than hide the prompt forever.
+  it("renders again for a browser carrying the legacy permanent dismissal", () => {
+    persistentBrowserStore.set(
+      STORAGE_KEYS.CONNECT_CALENDAR_PROMPT_SNOOZED_AT,
+      "true",
+    );
+    useConnectCalendarPromptStore.setState({
+      isSnoozed: isConnectCalendarPromptSnoozed(),
+    });
+    renderGate();
+
+    expect(
+      screen.getByRole("dialog", { name: CONNECT_THE_CALENDAR_YOU_USE }),
+    ).toBeInTheDocument();
   });
 
   it("routes each provider button to its connect flow", async () => {
@@ -187,8 +235,9 @@ describe("ConnectCalendarPromptGate", () => {
     expect(mockConnectApple).toHaveBeenCalledTimes(1);
   });
 
-  it("persists dismissal from I'll do this later", async () => {
+  it("records a snooze timestamp when the user skips for now", async () => {
     const user = userEvent.setup();
+    const before = Date.now();
     renderGate();
 
     await user.click(
@@ -197,14 +246,16 @@ describe("ConnectCalendarPromptGate", () => {
 
     await waitFor(
       () => {
-        expect(
+        const stored = Number(
           persistentBrowserStore.get(
-            STORAGE_KEYS.HAS_DISMISSED_CONNECT_CALENDAR_PROMPT,
+            STORAGE_KEYS.CONNECT_CALENDAR_PROMPT_SNOOZED_AT,
           ),
-        ).toBe("true");
+        );
+        expect(Number.isFinite(stored)).toBe(true);
+        expect(stored).toBeGreaterThanOrEqual(before);
       },
       { timeout: 1000 },
     );
-    expect(useConnectCalendarPromptStore.getState().isDismissed).toBe(true);
+    expect(useConnectCalendarPromptStore.getState().isSnoozed).toBe(true);
   });
 });

--- a/packages/web/src/components/ConnectCalendarPrompt/ConnectCalendarPrompt.tsx
+++ b/packages/web/src/components/ConnectCalendarPrompt/ConnectCalendarPrompt.tsx
@@ -1,7 +1,11 @@
-import { type FC, useRef } from "react";
+import { CheckIcon } from "@phosphor-icons/react";
+import { type FC, useEffect, useRef } from "react";
 import { ConnectProviderChooser } from "@web/auth/providers/ConnectProviderChooser";
 import {
   CALENDAR_HOST_EXPLAINER,
+  CONNECT_CALENDAR_BENEFITS,
+  CONNECT_CALENDAR_REASSURANCE,
+  CONNECT_CALENDAR_WHY,
   CONNECT_THE_CALENDAR_YOU_USE,
 } from "@web/auth/providers/provider-copy.util";
 import { MODAL_DISMISS_MS } from "@web/common/constants/motion.constants";
@@ -10,13 +14,20 @@ import { connectCalendarPromptActions } from "@web/components/ConnectCalendarPro
 import { OverlayPanel } from "@web/components/OverlayPanel/OverlayPanel";
 import { pointerPassAttributes } from "@web/shortcuts/keyboard-only/pointer-action";
 
-export const CONNECT_CALENDAR_LATER_LABEL = "I'll do this later";
+// Names the consequence rather than just offering an exit, so skipping is an
+// informed choice instead of a reflex. It comes back in a week either way.
+export const CONNECT_CALENDAR_LATER_LABEL =
+  "Skip for now, my calendar stays empty";
 
 export const ConnectCalendarPrompt: FC = () => {
   const { closing, beginDismiss } = useDismissTransition(MODAL_DISMISS_MS);
   const skipFocusRestoreRef = useRef(false);
 
-  const dismiss = () => beginDismiss(connectCalendarPromptActions.dismiss);
+  const dismiss = () => beginDismiss(connectCalendarPromptActions.snooze);
+
+  useEffect(() => {
+    connectCalendarPromptActions.markShown();
+  }, []);
 
   return (
     <OverlayPanel
@@ -33,9 +44,28 @@ export const ConnectCalendarPrompt: FC = () => {
           <h2 className="font-bold text-2xl text-text leading-snug">
             {CONNECT_THE_CALENDAR_YOU_USE}
           </h2>
-          <p className="text-sm text-text-muted">{CALENDAR_HOST_EXPLAINER}</p>
+          <p className="text-sm text-text-muted">{CONNECT_CALENDAR_WHY}</p>
         </div>
+        <ul className="flex w-full flex-col gap-1.5 text-sm text-text">
+          {CONNECT_CALENDAR_BENEFITS.map((benefit) => (
+            <li className="flex items-start gap-2" key={benefit}>
+              <CheckIcon
+                aria-hidden
+                className="mt-0.5 shrink-0 text-accent"
+                size={16}
+                weight="bold"
+              />
+              <span>{benefit}</span>
+            </li>
+          ))}
+        </ul>
         <ConnectProviderChooser variant="prompt" />
+        <div className="flex w-full flex-col gap-1">
+          <p className="text-text-muted text-xs">
+            {CONNECT_CALENDAR_REASSURANCE}
+          </p>
+          <p className="text-text-muted text-xs">{CALENDAR_HOST_EXPLAINER}</p>
+        </div>
         <button
           className="c-focus-ring self-center rounded-md px-2 py-1 text-text-muted text-xs hover:bg-surface-overlay hover:text-text"
           onClick={dismiss}

--- a/packages/web/src/components/ConnectCalendarPrompt/ConnectCalendarPromptGate.tsx
+++ b/packages/web/src/components/ConnectCalendarPrompt/ConnectCalendarPromptGate.tsx
@@ -14,7 +14,7 @@ import { persistentBrowserStore } from "@web/common/storage/browser-key-value.st
 import { AuthModalContext } from "@web/components/AuthModal/hooks/useAuthModal";
 import { ConnectCalendarPrompt } from "@web/components/ConnectCalendarPrompt/ConnectCalendarPrompt";
 import {
-  selectConnectCalendarPromptDismissed,
+  selectConnectCalendarPromptSnoozed,
   useConnectCalendarPromptStore,
 } from "@web/components/ConnectCalendarPrompt/connect-calendar.store";
 import {
@@ -28,8 +28,8 @@ export const ConnectCalendarPromptGate: FC = () => {
   const { isOpen: isAuthModalOpen } = useContext(AuthModalContext);
   const connections = useUserMetadataStore(selectSyncConnections);
   const metadataStatus = useUserMetadataStore(selectUserMetadataStatus);
-  const isDismissed = useConnectCalendarPromptStore(
-    selectConnectCalendarPromptDismissed,
+  const isSnoozed = useConnectCalendarPromptStore(
+    selectConnectCalendarPromptSnoozed,
   );
   const availableProviders = useAvailableConnectProviders();
   const isSettingsOpen = useSettingsStore(selectIsSettingsOpen);
@@ -40,7 +40,7 @@ export const ConnectCalendarPromptGate: FC = () => {
     authenticated &&
     metadataStatus === "loaded" &&
     connections.length === 0 &&
-    !isDismissed &&
+    !isSnoozed &&
     availableProviders.length > 0 &&
     persistentBrowserStore.isAvailable() &&
     !isAuthModalOpen &&

--- a/packages/web/src/components/ConnectCalendarPrompt/connect-calendar.storage.ts
+++ b/packages/web/src/components/ConnectCalendarPrompt/connect-calendar.storage.ts
@@ -1,18 +1,35 @@
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 
-export function getConnectCalendarPromptDismissed(): boolean {
+/**
+ * How long "I'll set this up later" holds. Long enough not to nag, short
+ * enough that someone who signed up without connecting gets a few more
+ * chances in their first month.
+ */
+export const CONNECT_CALENDAR_SNOOZE_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function isConnectCalendarPromptSnoozed(now = Date.now()): boolean {
   if (!persistentBrowserStore.isAvailable()) return false;
-  return (
-    persistentBrowserStore.get(
-      STORAGE_KEYS.HAS_DISMISSED_CONNECT_CALENDAR_PROMPT,
-    ) === "true"
+
+  const raw = persistentBrowserStore.get(
+    STORAGE_KEYS.CONNECT_CALENDAR_PROMPT_SNOOZED_AT,
   );
+  // Must come before the Number() below: Number("") is 0, which would read as
+  // a snooze set in 1970 and hide the prompt forever.
+  if (!raw) return false;
+
+  const snoozedAt = Number(raw);
+  // The literal "true" this key used to hold, back when dismissing was
+  // permanent, parses to NaN. Treat it as a lapsed snooze: those users are
+  // exactly the ones this is for.
+  if (!Number.isFinite(snoozedAt)) return false;
+
+  return now - snoozedAt < CONNECT_CALENDAR_SNOOZE_MS;
 }
 
-export function markConnectCalendarPromptDismissed(): void {
+export function markConnectCalendarPromptSnoozed(now = Date.now()): void {
   persistentBrowserStore.set(
-    STORAGE_KEYS.HAS_DISMISSED_CONNECT_CALENDAR_PROMPT,
-    "true",
+    STORAGE_KEYS.CONNECT_CALENDAR_PROMPT_SNOOZED_AT,
+    String(now),
   );
 }

--- a/packages/web/src/components/ConnectCalendarPrompt/connect-calendar.store.ts
+++ b/packages/web/src/components/ConnectCalendarPrompt/connect-calendar.store.ts
@@ -1,16 +1,23 @@
 import { create } from "zustand";
+import { trackSignupStep } from "@web/auth/posthog/signup-funnel";
 import { track } from "@web/auth/posthog/track";
 import {
-  getConnectCalendarPromptDismissed,
-  markConnectCalendarPromptDismissed,
+  CONNECT_CALENDAR_SNOOZE_MS,
+  isConnectCalendarPromptSnoozed,
+  markConnectCalendarPromptSnoozed,
 } from "@web/components/ConnectCalendarPrompt/connect-calendar.storage";
 
 export type ConnectCalendarPromptState = {
-  isDismissed: boolean;
+  isSnoozed: boolean;
 };
 
+const SNOOZE_DAYS = CONNECT_CALENDAR_SNOOZE_MS / (24 * 60 * 60 * 1000);
+
+// Read once, at module load. A snooze that lapses mid-session surfaces on the
+// next load, which is the right cadence for an onboarding nudge and saves a
+// timer.
 export const initialConnectCalendarPromptState: ConnectCalendarPromptState = {
-  isDismissed: getConnectCalendarPromptDismissed(),
+  isSnoozed: isConnectCalendarPromptSnoozed(),
 };
 
 export const useConnectCalendarPromptStore = create<ConnectCalendarPromptState>(
@@ -19,21 +26,36 @@ export const useConnectCalendarPromptStore = create<ConnectCalendarPromptState>(
   }),
 );
 
+// Module scope, not a component ref: the gate unmounts the prompt whenever
+// Settings, About or the Apple form opens, so a ref would re-fire the
+// impression on every reopen.
+let hasTrackedShown = false;
+
 export const connectCalendarPromptActions = {
-  dismiss: () => {
-    track("connect_calendar_prompt_dismissed");
-    markConnectCalendarPromptDismissed();
-    useConnectCalendarPromptStore.setState({ isDismissed: true });
+  markShown: () => {
+    if (hasTrackedShown) return;
+    hasTrackedShown = true;
+    trackSignupStep("connect_prompt_shown");
+  },
+  snooze: () => {
+    // Same event name as when dismissing was permanent, so existing insights
+    // keep working; the added property records that it now comes back.
+    track("connect_calendar_prompt_dismissed", { snooze_days: SNOOZE_DAYS });
+    markConnectCalendarPromptSnoozed();
+    useConnectCalendarPromptStore.setState({ isSnoozed: true });
   },
 };
 
 export const resetConnectCalendarPromptStoreForTests = (): void => {
+  hasTrackedShown = false;
+  // Re-derived rather than replayed from the frozen initial state: the reset
+  // helpers clear storage first, and a stale `true` here would outlive it.
   useConnectCalendarPromptStore.setState(
-    initialConnectCalendarPromptState,
+    { isSnoozed: isConnectCalendarPromptSnoozed() },
     true,
   );
 };
 
-export const selectConnectCalendarPromptDismissed = (
+export const selectConnectCalendarPromptSnoozed = (
   state: ConnectCalendarPromptState,
-): boolean => state.isDismissed;
+): boolean => state.isSnoozed;

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
@@ -39,6 +39,11 @@ export const CalendarList: FC = () => {
   const collapsedKeys = useCollapsedAccountKeys();
 
   const isAnonymous = !email;
+  // CalendarListHeader renders a working connect button under exactly this
+  // condition, so the empty-state text below would only restate the problem
+  // directly beneath the control that solves it.
+  const showConnectCta =
+    authenticated && connections.length === 0 && availableProviders.length > 0;
   // Session expiry already surfaces SessionExpiredToast — don't also show
   // "Couldn't load calendars" / Retry (or a false empty-list story) for it.
   const showCalendarsLoadError = shouldShowContextualLoadError(isError, error);
@@ -102,13 +107,9 @@ export const CalendarList: FC = () => {
           </button>
         </div>
       ) : calendars.length === 0 && groups.length === 0 ? (
-        <p className="text-text-muted text-xs">
-          {authenticated &&
-          connections.length === 0 &&
-          availableProviders.length > 0
-            ? "Connect a calendar provider to see your calendars."
-            : "No calendars yet."}
-        </p>
+        showConnectCta ? null : (
+          <p className="text-text-muted text-xs">No calendars yet.</p>
+        )
       ) : (
         <div className="flex flex-col gap-3">
           {groups.map((group) => (


### PR DESCRIPTION
Follow-up to #3611 (uses `trackSignupStep` for the `connect_prompt_shown` step).

## Why

**Dismissing the connect prompt was permanent.** `markConnectCalendarPromptDismissed` wrote `"true"` to localStorage and nothing ever cleared it, so a user who clicked "I'll do this later" once never saw the prompt again, on any visit, forever, while the calendar it was offering to fill stayed empty.

**The prompt also did not make its case.** It asked for calendar access under a heading and a single line about Apple hosting: no why, no what-you-get, and no word on what Compass can actually reach. That is a lot to ask of someone who has not yet seen the product do anything.

## What

**Seven day snooze, with migration.** The storage key is unchanged and now holds an epoch-ms timestamp. Browsers still carrying the old `"true"` parse to `NaN`, which reads as a lapsed snooze, so the users this change is for get the prompt back on their next visit. No dual-key migration, no write-on-read. The `!raw` guard comes first on purpose: `Number("")` is `0`, which would otherwise read as a snooze set in 1970.

`connect_calendar_prompt_dismissed` keeps its name (so existing insights survive) and gains one additive `snooze_days` property.

**The value case.** Leads with why access is needed, lists three concrete things that change, and states plainly that Compass touches only calendar events and can be disconnected anytime. The skip label names the consequence instead of just offering an exit. No layout restructuring: same `OverlayPanel`, same provider buttons, same focus order.

**Removes a dead-end paragraph.** `CalendarList` rendered "Connect a calendar provider to see your calendars." under exactly the condition where `CalendarListHeader` already renders a working connect button, restating the problem directly beneath the control that solves it. The persistent sidebar CTA this leaves behind is the empty state that guides a snoozing user back.

## Notes for review

- `connectCalendarPromptActions.markShown` uses a module-scoped flag, not a component ref: the gate unmounts the prompt whenever Settings, About or the Apple form opens, so a ref would re-fire the impression on every reopen.
- `resetConnectCalendarPromptStoreForTests` now re-derives from storage instead of replaying the frozen initial state, because the reset helpers clear localStorage first and a stale `true` would outlive it.
- Snooze expiry is evaluated at module load, so a snooze that lapses mid-session surfaces on the next load. That is the right cadence for an onboarding nudge and avoids a timer; noted in a comment.

## Verification

Three new gate tests: inside the snooze window, after it has passed, and **for a browser carrying the legacy `"true"`** (the migration regression test). The prompt test also asserts every new copy line renders. All queries are `getByRole`/`getByText`.

Checked the real rendered prompt in a browser: `e2e/accessibility/connect-onboarding-a11y.spec.ts` "the signed-in connect-calendar prompt has no automatically detectable accessibility violations" passes.

`bun test:web`, `bun type-check`, `bun run lint`, `bun knip` pass.

Local `test:e2e` failures on booking and settings specs are environmental: a clean `origin/main` worktree fails 15 of the same specs on this machine. CI decides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)