### PR TITLE
test(e2e): cover the consent-screen cancel path

### DIFF
--- a/e2e/oauth/google-auth-callback.spec.ts
+++ b/e2e/oauth/google-auth-callback.spec.ts
@@ -117,6 +117,38 @@ test("finishes a saved Google sign-in callback", async ({ page }) => {
   ).toBeNull();
 });
 
+// Cancelling at Google's consent screen used to share the generic
+// authorization error, so a deliberate choice read as a Compass crash.
+test("returns the user calmly after a consent-screen cancel", async ({
+  page,
+}) => {
+  const state = "cancelled-state";
+  const apiMocks = await prepareGoogleAuthCallbackPage(page);
+
+  await page.goto("/week");
+  await page.evaluate(
+    ({ key, value }) => {
+      sessionStorage.setItem(key, JSON.stringify(value));
+    },
+    {
+      key: getIntentStorageKey(state),
+      value: { intent: "signIn", returnPath: "/week", createdAt: Date.now() },
+    },
+  );
+
+  await page.goto(
+    `${CALLBACK_PATH}?state=${encodeURIComponent(state)}&error=access_denied`,
+  );
+
+  await expect(
+    page.getByText(
+      "No problem, nothing was connected. You can sign in anytime.",
+    ),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/\/week$/);
+  expect(apiMocks.loginOrSignupRequests).toHaveLength(0);
+});
+
 // WP-06: the optional contacts grant rides the SAME sign-in callback. Either
 // outcome — granted or denied — must land the user signed in on /week with a
 // healthy connection; only the suggestContacts capability differs.


### PR DESCRIPTION
Closes out the signup-conversion work behind #3611, #3612 and #3613.

## What

One spec on the behavior #3612 changed: cancelling at Google's consent screen (`?error=access_denied`) lands the user back on the week with the calm message, and issues no `signinup` request. Previously that path shared the generic "We couldn't connect your Google account" error, so a deliberate choice looked like a crash.

Split out from #3612 on purpose: Playwright is the flakiest signal in the repo and `bun run verify` reports `INCOMPLETE` when Chromium is missing, so a sandbox-bound timeout should not be able to block a product change.

## What I did not add

I wrote a second spec for the missing-`.catch()` backstop in the provider callback and then deleted it. It passed, but not for the reason it claimed: `sessionBrowserStore.get` wraps every access in try/catch and returns `null`, so the "blocked storage" setup never actually threw and the test was really just re-asserting the missing-intent path. A test that passes without exercising the code it names is worse than no test, so it is gone. The `.catch()` in #3612 stands as a backstop against an unrecoverable one-shot failure, described honestly there.

## Verification

`bun test:e2e -- e2e/oauth/google-auth-callback.spec.ts`: 4 passed, including the new case, against current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)