### PR TITLE
chore(deps): bump @faker-js/faker to 10 across packages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "compass",
@@ -46,7 +47,7 @@
         "zod": "^4.5.4",
       },
       "devDependencies": {
-        "@faker-js/faker": "^9.6.0",
+        "@faker-js/faker": "^10.5.0",
         "@types/cors": "^2.8.12",
         "@types/express": "^4.17.13",
         "@types/lodash": "^4.17.24",
@@ -81,7 +82,7 @@
         "zod": "^4.5.4",
       },
       "devDependencies": {
-        "@faker-js/faker": "^9.6.0",
+        "@faker-js/faker": "^10.5.0",
         "@types/lodash": "^4.17.24",
         "mongodb": "^7.2.0",
         "supertokens-node": "^23.0.1",
@@ -124,7 +125,7 @@
         "zod": "^4.5.4",
       },
       "devDependencies": {
-        "@faker-js/faker": "^9.6.0",
+        "@faker-js/faker": "^10.5.0",
         "@types/express": "^4.17.13",
         "@types/node": "^22.13.10",
         "mongodb-memory-server": "^9.2.0",
@@ -168,7 +169,7 @@
         "zustand": "^5.0.14",
       },
       "devDependencies": {
-        "@faker-js/faker": "^9.6.0",
+        "@faker-js/faker": "^10.5.0",
         "@tailwindcss/postcss": "^4.1.14",
         "@tanstack/react-query-devtools": "^5",
         "@testing-library/dom": "^9.3.0",
@@ -302,7 +303,7 @@
 
     "@emotion/weak-memoize": ["@emotion/weak-memoize@0.4.0", "", {}, "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="],
 
-    "@faker-js/faker": ["@faker-js/faker@9.9.0", "", {}, "sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA=="],
+    "@faker-js/faker": ["@faker-js/faker@10.6.0", "", {}, "sha512-3RQHgEtvL1Frl/d1cSreo7qhJ3Gk1OdNUai/CtZ8G+wYeRQnJih3s9xJ9/kgYekPQRdwgh0HXRPqMlzWGwivIQ=="],
 
     "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -21,7 +21,7 @@
     "zod": "^4.5.4"
   },
   "devDependencies": {
-    "@faker-js/faker": "^9.6.0",
+    "@faker-js/faker": "^10.5.0",
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",
     "@types/lodash": "^4.17.24",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,7 @@
     "zod": "^4.5.4"
   },
   "devDependencies": {
-    "@faker-js/faker": "^9.6.0",
+    "@faker-js/faker": "^10.5.0",
     "@types/lodash": "^4.17.24",
     "mongodb": "^7.2.0",
     "supertokens-node": "^23.0.1",

--- a/packages/core/src/types/type.utils.test.ts
+++ b/packages/core/src/types/type.utils.test.ts
@@ -25,7 +25,7 @@ describe("IDSchemaV4", () => {
 
 describe("TimezoneSchema", () => {
   it("validates a correct timezone string", () => {
-    const timezone = faker.date.timeZone();
+    const timezone = faker.location.timeZone();
 
     expect(TimezoneSchema.safeParse(timezone).success).toBe(true);
   });

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -20,7 +20,7 @@
     "zod": "^4.5.4"
   },
   "devDependencies": {
-    "@faker-js/faker": "^9.6.0",
+    "@faker-js/faker": "^10.5.0",
     "@types/express": "^4.17.13",
     "@types/node": "^22.13.10",
     "mongodb-memory-server": "^9.2.0"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -40,7 +40,7 @@
     "zustand": "^5.0.14"
   },
   "devDependencies": {
-    "@faker-js/faker": "^9.6.0",
+    "@faker-js/faker": "^10.5.0",
     "@tailwindcss/postcss": "^4.1.14",
     "@tanstack/react-query-devtools": "^5",
     "@testing-library/dom": "^9.3.0",


### PR DESCRIPTION
Fixes: none (closes the four open high-severity Dependabot alerts for `@faker-js/faker`, "helpers.fake exploitable into arbitrary code execution", fixed in 10.5.0)

## What and why

Bumps `@faker-js/faker` from ^9.6.0 to ^10.5.0 in core, backend, sync, and web. Faker is only imported by test code, so this is dev-only. Every faker API the tests call still exists in v10 except the deprecated `faker.date.timeZone`, which moves to `faker.location.timeZone` in the one core test that used it.

## Verify

`bun run verify --strict` on macOS:

```
Checks run: test:core, test:web, test:backend:fast, type-check, lint, knip
Failed: test:sync:fast, test:a11y, test:e2e
VERDICT: FAIL
```

All three failures reproduce on `main` in this sandbox and none is reachable by a test-only dependency:

- `test:sync:fast`: 786 pass, 1 fail. The one failure is `windows-zones > maps every Windows zone to a supported IANA name`, the macOS ICU alias problem tracked in #3470.
- `test:a11y` (21 failed / 37 passed) and `test:e2e` (40 failed / 150 passed): 59 of the 61 failures are the same `expect(settingsDialog).toBeVisible` timeout in `e2e/booking/booking-harness.ts:1278`, and the other two are the `settings` visibility wait and the `[data-page-jump-hints]` wait. Both are the documented macOS-local gotchas (Settings shortcut is dead on Mac, hold-Mod page jump), not assertions on behaviour the diff touches.

Passing locally: test:core 752, test:backend:fast 448, test:web all four shards, type-check, lint, knip. CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)