### PR TITLE
feat(core): add hidden event visibility contracts

### DIFF
--- a/packages/core/src/types/event-visibility.contracts.test.ts
+++ b/packages/core/src/types/event-visibility.contracts.test.ts
@@ -1,0 +1,85 @@
+import {
+  HiddenEventIdsResponseSchema,
+  SetEventHiddenInputSchema,
+} from "@core/types/event-visibility.contracts";
+import { describe, expect, it } from "bun:test";
+
+describe("HiddenEventIdsResponseSchema", () => {
+  it("parses a valid response", () => {
+    const parsed = HiddenEventIdsResponseSchema.parse({
+      hiddenEventIds: ["evt-1", "evt-2"],
+    });
+
+    expect(parsed).toEqual({ hiddenEventIds: ["evt-1", "evt-2"] });
+  });
+
+  it("accepts an empty list", () => {
+    expect(
+      HiddenEventIdsResponseSchema.safeParse({ hiddenEventIds: [] }).success,
+    ).toBe(true);
+  });
+
+  it("accepts a composed occurrence id", () => {
+    const occurrenceId = "evt-1::2026-07-14T15:00:00.000Z";
+    const parsed = HiddenEventIdsResponseSchema.parse({
+      hiddenEventIds: [occurrenceId],
+    });
+
+    expect(parsed.hiddenEventIds).toEqual([occurrenceId]);
+  });
+
+  it("rejects an extra key", () => {
+    expect(
+      HiddenEventIdsResponseSchema.safeParse({
+        hiddenEventIds: ["evt-1"],
+        extra: true,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects an empty eventId", () => {
+    expect(
+      HiddenEventIdsResponseSchema.safeParse({ hiddenEventIds: [""] }).success,
+    ).toBe(false);
+  });
+});
+
+describe("SetEventHiddenInputSchema", () => {
+  it("parses a valid input", () => {
+    const parsed = SetEventHiddenInputSchema.parse({
+      eventId: "evt-1",
+      hidden: true,
+    });
+
+    expect(parsed).toEqual({ eventId: "evt-1", hidden: true });
+  });
+
+  it("accepts a composed occurrence id", () => {
+    const occurrenceId = "evt-1::2026-07-14T15:00:00.000Z";
+    const parsed = SetEventHiddenInputSchema.parse({
+      eventId: occurrenceId,
+      hidden: false,
+    });
+
+    expect(parsed).toEqual({ eventId: occurrenceId, hidden: false });
+  });
+
+  it("rejects an extra key", () => {
+    expect(
+      SetEventHiddenInputSchema.safeParse({
+        eventId: "evt-1",
+        hidden: true,
+        extra: true,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects an empty eventId", () => {
+    expect(
+      SetEventHiddenInputSchema.safeParse({
+        eventId: "",
+        hidden: true,
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/core/src/types/event-visibility.contracts.ts
+++ b/packages/core/src/types/event-visibility.contracts.ts
@@ -1,0 +1,19 @@
+import { z } from "zod/v4";
+import { EventIdSchema } from "@core/types/domain-primitives";
+
+// Per-user view preference for hiding an event on the calendar. Never a
+// field on the event itself: EventSchema stays untouched, and the backend
+// stores one hiddenEvent row per (user, event id).
+
+export const HiddenEventIdsResponseSchema = z.strictObject({
+  hiddenEventIds: z.array(EventIdSchema),
+});
+export type HiddenEventIdsResponse = z.infer<
+  typeof HiddenEventIdsResponseSchema
+>;
+
+export const SetEventHiddenInputSchema = z.strictObject({
+  eventId: EventIdSchema,
+  hidden: z.boolean(),
+});
+export type SetEventHiddenInput = z.infer<typeof SetEventHiddenInputSchema>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3617

## What and why

Adds the shared Zod contracts for per-user hidden event ids (`HiddenEventIdsResponseSchema` and `SetEventHiddenInputSchema`) so WP-02 (backend) and WP-03 (web) can share one request/response shape. `EventSchema` is untouched: hidden state is a view preference, not a field on the event.

Tracking: #3616. Spec: locked decisions on the tracking issue.

## Verify

`VERDICT: PASS`

Checks run: `test:core`, `type-check`, `lint`, `knip`

Issue verify commands also passed: `bun test:core` (761 pass, 0 fail, including `event-visibility.contracts.test.ts`), `bun run type-check`, `bun run lint`, `bun knip`, `bun run verify --strict`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6562b00-704c-43c1-aef8-a4299e3a7038?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6562b00-704c-43c1-aef8-a4299e3a7038&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

