### PR TITLE
feat(backend): store hidden event ids per user

### DIFF
--- a/docs/backend/README.md
+++ b/docs/backend/README.md
@@ -24,7 +24,7 @@ Backend routes are registered from
 | Health | `packages/backend/src/health/health.routes.config.ts` | `GET /api/health` is unauthenticated and checks Mongo reachability. |
 | Config | `packages/backend/src/config/config.routes.config.ts` | Public runtime config used by the web app. |
 | Auth | `packages/backend/src/auth/auth.routes.config.ts` | Compass-owned auth helpers and authenticated Google connect. SuperTokens also mounts recipe routes under `/api`. |
-| User | `packages/backend/src/user/user.routes.config.ts` | Profile and metadata for the active session. |
+| User | `packages/backend/src/user/user.routes.config.ts` | Profile, metadata, and hidden event ids for the active session. |
 | Billing | `packages/backend/src/billing/billing.routes.config.ts` | Session status, embedded Checkout, setup-mode payment-method session, `GET /api/billing/subscription`, cancel and resume, and unauthenticated Stripe webhook. Self-host omits Stripe keys and stays fully writable. |
 | Events | `packages/backend/src/event/event.routes.config.ts` | Event CRUD and reorder/delete helpers. |
 | Event stream | `packages/backend/src/events/events.routes.config.ts` | Authenticated SSE stream at `GET /api/events/stream`. |

--- a/packages/backend/src/common/constants/collections.ts
+++ b/packages/backend/src/common/constants/collections.ts
@@ -15,5 +15,6 @@ export const Collections = {
   BOOKING_RESERVATION: IS_DEV
     ? "_dev.bookingReservation"
     : "bookingReservation",
+  HIDDEN_EVENT: IS_DEV ? "_dev.hiddenEvent" : "hiddenEvent",
   USER: IS_DEV ? "_dev.user" : "user",
 };

--- a/packages/backend/src/common/services/mongo.service.ts
+++ b/packages/backend/src/common/services/mongo.service.ts
@@ -19,6 +19,7 @@ import { type CalendarRecord } from "@backend/calendar/calendar.record";
 import { Collections } from "@backend/common/constants/collections";
 import { CONFIG } from "@backend/common/constants/config.constants";
 import { type EventRecord } from "@backend/event/event.record";
+import { type HiddenEventRecord } from "@backend/user/hidden-event.record";
 import { type PendingAccountDeletionRecord } from "@backend/user/pending-account-deletion.record";
 
 const logger = Logger("app:mongo.service");
@@ -31,6 +32,7 @@ interface InternalClient {
   bookingReservation: Collection<BookingReservationRecord>;
   calendar: Collection<CalendarRecord>;
   event: Collection<EventRecord>;
+  hiddenEvent: Collection<HiddenEventRecord>;
   pendingAccountDeletion: Collection<PendingAccountDeletionRecord>;
   user: Collection<Schema_User>;
 }
@@ -65,6 +67,10 @@ class MongoService {
 
   get bookingReservation(): InternalClient["bookingReservation"] {
     return this.#accessInternalCollectionProps("bookingReservation");
+  }
+
+  get hiddenEvent(): InternalClient["hiddenEvent"] {
+    return this.#accessInternalCollectionProps("hiddenEvent");
   }
 
   /**
@@ -130,6 +136,7 @@ class MongoService {
       ),
       calendar: db.collection<CalendarRecord>(Collections.CALENDAR),
       event: db.collection<EventRecord>(Collections.EVENT),
+      hiddenEvent: db.collection<HiddenEventRecord>(Collections.HIDDEN_EVENT),
       pendingAccountDeletion: db.collection<PendingAccountDeletionRecord>(
         Collections.PENDING_ACCOUNT_DELETION,
       ),

--- a/packages/backend/src/user/controllers/hidden-events.controller.db.test.ts
+++ b/packages/backend/src/user/controllers/hidden-events.controller.db.test.ts
@@ -1,0 +1,171 @@
+import { Status } from "@core/errors/status.codes";
+import { BaseDriver } from "@backend/__tests__/drivers/base.driver";
+import { UtilDriver } from "@backend/__tests__/drivers/util.driver";
+import {
+  cleanupCollections,
+  cleanupTestDb,
+  setupTestDb,
+} from "@backend/__tests__/helpers/mock.db.setup";
+import mongoService from "@backend/common/services/mongo.service";
+import { ensureUserIndexes } from "@backend/user/user-indexes";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
+
+describe("HiddenEventsController", () => {
+  const baseDriver = new BaseDriver();
+
+  beforeAll(async () => {
+    await setupTestDb(import.meta.url);
+    await ensureUserIndexes();
+  });
+  beforeEach(cleanupCollections);
+  afterAll(cleanupTestDb);
+
+  const sessionCookie = (userId: string) =>
+    `session=${JSON.stringify({ userId })}`;
+
+  it("GET returns an empty list", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+
+    const response = await baseDriver
+      .getServer()
+      .get("/api/user/hidden-events")
+      .set("Cookie", sessionCookie(user._id.toString()))
+      .expect(Status.OK);
+
+    expect(response.body).toEqual({ hiddenEventIds: [] });
+  });
+
+  it("PUT hidden true twice leaves one row and returns that id", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const cookie = sessionCookie(user._id.toString());
+
+    const first = await baseDriver
+      .getServer()
+      .put("/api/user/hidden-events")
+      .set("Cookie", cookie)
+      .send({ eventId: "evt-1", hidden: true })
+      .expect(Status.OK);
+    const second = await baseDriver
+      .getServer()
+      .put("/api/user/hidden-events")
+      .set("Cookie", cookie)
+      .send({ eventId: "evt-1", hidden: true })
+      .expect(Status.OK);
+
+    expect(first.body).toEqual({ hiddenEventIds: ["evt-1"] });
+    expect(second.body).toEqual({ hiddenEventIds: ["evt-1"] });
+    expect(
+      await mongoService.hiddenEvent.countDocuments({ userId: user._id }),
+    ).toBe(1);
+  });
+
+  it("PUT hidden false removes the id", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const cookie = sessionCookie(user._id.toString());
+
+    await baseDriver
+      .getServer()
+      .put("/api/user/hidden-events")
+      .set("Cookie", cookie)
+      .send({ eventId: "evt-1", hidden: true })
+      .expect(Status.OK);
+
+    const response = await baseDriver
+      .getServer()
+      .put("/api/user/hidden-events")
+      .set("Cookie", cookie)
+      .send({ eventId: "evt-1", hidden: false })
+      .expect(Status.OK);
+
+    expect(response.body).toEqual({ hiddenEventIds: [] });
+    expect(
+      await mongoService.hiddenEvent.countDocuments({ userId: user._id }),
+    ).toBe(0);
+  });
+
+  it("round-trips an occurrence id containing ::", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+    const occurrenceId = "evt-1::2026-07-14T15:00:00.000Z";
+
+    const response = await baseDriver
+      .getServer()
+      .put("/api/user/hidden-events")
+      .set("Cookie", sessionCookie(user._id.toString()))
+      .send({ eventId: occurrenceId, hidden: true })
+      .expect(Status.OK);
+
+    expect(response.body).toEqual({ hiddenEventIds: [occurrenceId] });
+  });
+
+  it("does not return another user's hidden ids", async () => {
+    const { user: userA } = await UtilDriver.setupTestUser();
+    const { user: userB } = await UtilDriver.setupTestUser();
+
+    await baseDriver
+      .getServer()
+      .put("/api/user/hidden-events")
+      .set("Cookie", sessionCookie(userA._id.toString()))
+      .send({ eventId: "evt-a", hidden: true })
+      .expect(Status.OK);
+
+    const response = await baseDriver
+      .getServer()
+      .get("/api/user/hidden-events")
+      .set("Cookie", sessionCookie(userB._id.toString()))
+      .expect(Status.OK);
+
+    expect(response.body).toEqual({ hiddenEventIds: [] });
+  });
+
+  it("PUT with an extra key is 400 INVALID_INPUT", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+
+    const response = await baseDriver
+      .getServer()
+      .put("/api/user/hidden-events")
+      .set("Cookie", sessionCookie(user._id.toString()))
+      .send({ eventId: "evt-1", hidden: true, extra: true })
+      .expect(Status.BAD_REQUEST);
+
+    expect(response.body).toEqual({
+      code: "INVALID_INPUT",
+      message: "Invalid input",
+    });
+  });
+
+  it("PUT with an empty eventId is 400 INVALID_INPUT", async () => {
+    const { user } = await UtilDriver.setupTestUser();
+
+    const response = await baseDriver
+      .getServer()
+      .put("/api/user/hidden-events")
+      .set("Cookie", sessionCookie(user._id.toString()))
+      .send({ eventId: "", hidden: true })
+      .expect(Status.BAD_REQUEST);
+
+    expect(response.body).toEqual({
+      code: "INVALID_INPUT",
+      message: "Invalid input",
+    });
+  });
+
+  it("returns 401 when there is no session", async () => {
+    await baseDriver
+      .getServer()
+      .get("/api/user/hidden-events")
+      .expect(Status.UNAUTHORIZED);
+
+    await baseDriver
+      .getServer()
+      .put("/api/user/hidden-events")
+      .send({ eventId: "evt-1", hidden: true })
+      .expect(Status.UNAUTHORIZED);
+  });
+});

--- a/packages/backend/src/user/controllers/user.controller.ts
+++ b/packages/backend/src/user/controllers/user.controller.ts
@@ -1,11 +1,18 @@
 import { type Request, type Response } from "express";
+import { ZodError } from "zod/v4";
 import { BaseError } from "@core/errors/errors.base";
 import { Status } from "@core/errors/status.codes";
 import { Logger } from "@core/logger/winston.logger";
+import {
+  type HiddenEventIdsResponse,
+  HiddenEventIdsResponseSchema,
+  SetEventHiddenInputSchema,
+} from "@core/types/event-visibility.contracts";
 import { zObjectId } from "@core/types/type.utils";
 import { type UserMetadata, type UserProfile } from "@core/types/user.types";
 import { toClientErrorPayload } from "@backend/common/errors/handlers/error.handler";
 import { type SReqBody } from "@backend/common/types/express.types";
+import hiddenEventService from "@backend/user/services/hidden-event.service";
 import userService from "@backend/user/services/user.service";
 import userMetadataService from "@backend/user/services/user-metadata.service";
 import { type Summary_Delete } from "@backend/user/types/user.types";
@@ -13,6 +20,18 @@ import { type Summary_Delete } from "@backend/user/types/user.types";
 const logger = Logger("app:user.controller");
 
 const sendUserError = (res: Response, e: unknown) => {
+  if (e instanceof ZodError) {
+    logger.warn(
+      `User input rejected: ${e.issues
+        .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+        .join("; ")}`,
+    );
+    res.status(Status.BAD_REQUEST).json({
+      code: "INVALID_INPUT",
+      message: "Invalid input",
+    });
+    return;
+  }
   if (e instanceof BaseError) {
     res.status(e.statusCode).json(toClientErrorPayload(e));
     return;
@@ -98,6 +117,42 @@ class UserController {
       });
 
       res.status(Status.OK).json(metadata);
+    } catch (e) {
+      sendUserError(res, e);
+    }
+  };
+
+  getHiddenEvents = async (
+    req: Request<never, HiddenEventIdsResponse, never, never>,
+    res: Response,
+  ) => {
+    try {
+      const user = zObjectId.parse(req.session?.getUserId());
+      const hiddenEventIds = await hiddenEventService.listHiddenEventIds(user);
+
+      res
+        .status(Status.OK)
+        .json(HiddenEventIdsResponseSchema.parse({ hiddenEventIds }));
+    } catch (e) {
+      sendUserError(res, e);
+    }
+  };
+
+  setEventHidden = async (
+    req: SReqBody<{ eventId: string; hidden: boolean }>,
+    res: Response,
+  ) => {
+    try {
+      const user = zObjectId.parse(req.session?.getUserId());
+      const input = SetEventHiddenInputSchema.parse(req.body);
+      const hiddenEventIds = await hiddenEventService.setEventHidden(
+        user,
+        input,
+      );
+
+      res
+        .status(Status.OK)
+        .json(HiddenEventIdsResponseSchema.parse({ hiddenEventIds }));
     } catch (e) {
       sendUserError(res, e);
     }

--- a/packages/backend/src/user/hidden-event.record.ts
+++ b/packages/backend/src/user/hidden-event.record.ts
@@ -1,0 +1,10 @@
+import { z } from "zod/v4";
+import { zObjectId } from "@core/types/type.utils";
+
+export const HiddenEventRecordSchema = z.object({
+  _id: zObjectId,
+  userId: zObjectId,
+  eventId: z.string().min(1).max(256),
+  createdAt: z.date(),
+});
+export type HiddenEventRecord = z.infer<typeof HiddenEventRecordSchema>;

--- a/packages/backend/src/user/services/hidden-event.service.ts
+++ b/packages/backend/src/user/services/hidden-event.service.ts
@@ -1,0 +1,49 @@
+import { type ClientSession, type ObjectId } from "mongodb";
+import { type SetEventHiddenInput } from "@core/types/event-visibility.contracts";
+import mongoService from "@backend/common/services/mongo.service";
+
+class HiddenEventService {
+  listHiddenEventIds = async (
+    userId: ObjectId,
+    session?: ClientSession,
+  ): Promise<string[]> => {
+    const docs = await mongoService.hiddenEvent
+      .find({ userId }, { projection: { eventId: 1 }, session })
+      .sort({ createdAt: 1 })
+      .toArray();
+
+    return docs.map((doc) => doc.eventId);
+  };
+
+  setEventHidden = async (
+    userId: ObjectId,
+    input: SetEventHiddenInput,
+  ): Promise<string[]> => {
+    const { eventId, hidden } = input;
+
+    if (hidden) {
+      await mongoService.hiddenEvent.updateOne(
+        { userId, eventId },
+        {
+          $setOnInsert: {
+            _id: mongoService.objectId(),
+            userId,
+            eventId,
+            createdAt: new Date(),
+          },
+        },
+        { upsert: true },
+      );
+    } else {
+      await mongoService.hiddenEvent.deleteOne({ userId, eventId });
+    }
+
+    return this.listHiddenEventIds(userId);
+  };
+
+  deleteAllByUser = async (userId: ObjectId, session?: ClientSession) => {
+    return mongoService.hiddenEvent.deleteMany({ userId }, { session });
+  };
+}
+
+export default new HiddenEventService();

--- a/packages/backend/src/user/services/user.service.db.test.ts
+++ b/packages/backend/src/user/services/user.service.db.test.ts
@@ -1020,6 +1020,58 @@ describe("UserService", () => {
       cleanupSpy.mockRestore();
     });
 
+    it("deletes hidden event rows and counts them in the summary", async () => {
+      const user = await UserDriver.createUser();
+      const userId = user._id.toString();
+
+      const resolveSpy = spyOn(
+        supertokensUserCleanupService,
+        "resolveByExternalUserId",
+      ).mockResolvedValue({
+        externalUserIds: [],
+        superTokensUserIds: [],
+      });
+      const revokeSpy = spyOn(
+        compassAuthService,
+        "revokeSessionsByUser",
+      ).mockResolvedValue({ sessionsRevoked: 0 });
+      const cleanupSpy = spyOn(
+        supertokensUserCleanupService,
+        "cleanupResolvedTarget",
+      ).mockResolvedValue({
+        superTokensUsers: 0,
+        superTokensMappings: 0,
+        superTokensMetadata: 0,
+      });
+
+      await mongoService.hiddenEvent.insertMany([
+        {
+          _id: mongoService.objectId(),
+          userId: user._id,
+          eventId: "evt-1",
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        },
+        {
+          _id: mongoService.objectId(),
+          userId: user._id,
+          eventId: "evt-2",
+          createdAt: new Date("2026-01-02T00:00:00.000Z"),
+        },
+      ]);
+
+      const summary: Summary_Delete =
+        await userService.deleteCompassDataForUser(userId);
+
+      expect(summary.hiddenEvents).toBe(2);
+      expect(
+        await mongoService.hiddenEvent.countDocuments({ userId: user._id }),
+      ).toBe(0);
+
+      resolveSpy.mockRestore();
+      revokeSpy.mockRestore();
+      cleanupSpy.mockRestore();
+    });
+
     it("deletes events owned by an archived calendar", async () => {
       const user = await UserDriver.createUser();
       const userId = user._id.toString();

--- a/packages/backend/src/user/services/user.service.ts
+++ b/packages/backend/src/user/services/user.service.ts
@@ -27,6 +27,7 @@ import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-prin
 import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
 import eventService from "@backend/event/services/event.service";
 import { findCanonicalCompassUser } from "@backend/user/queries/user.queries";
+import hiddenEventService from "@backend/user/services/hidden-event.service";
 import { type Summary_Delete } from "@backend/user/types/user.types";
 
 const logger = Logger("app:user.service");
@@ -246,6 +247,12 @@ class UserService {
           session,
         );
         summary.calendars = calendars.deletedCount;
+
+        const hiddenEvents = await hiddenEventService.deleteAllByUser(
+          _id,
+          session,
+        );
+        summary.hiddenEvents = hiddenEvents.deletedCount;
 
         // delete user
         const userDel = await mongoService.user.deleteOne({ _id }, { session });

--- a/packages/backend/src/user/types/user.types.ts
+++ b/packages/backend/src/user/types/user.types.ts
@@ -8,6 +8,7 @@ export type GetUserMetadataResponse = {
 export interface Summary_Delete {
   calendars?: number;
   events?: number;
+  hiddenEvents?: number;
   user?: number;
   sessions?: number;
   superTokensUsers?: number;

--- a/packages/backend/src/user/user-indexes.db.test.ts
+++ b/packages/backend/src/user/user-indexes.db.test.ts
@@ -8,6 +8,7 @@ import mongoService from "@backend/common/services/mongo.service";
 import { identitiesProviderSubjectFilter } from "@backend/user/queries/user.queries";
 import {
   ensureUserIndexes,
+  HIDDEN_EVENT_USER_EVENT_INDEX,
   USER_IDENTITIES_PROVIDER_SUBJECT_INDEX,
 } from "@backend/user/user-indexes";
 import {
@@ -95,5 +96,31 @@ describe("user indexes", () => {
       .queryPlanner?.winningPlan;
     const used = indexNamesFromPlan(plan);
     expect(used).toContain(USER_IDENTITIES_PROVIDER_SUBJECT_INDEX);
+  });
+
+  it("rejects a second hiddenEvent row for the same user and event id", async () => {
+    const userId = new ObjectId();
+    await mongoService.hiddenEvent.insertOne({
+      _id: new ObjectId(),
+      userId,
+      eventId: "evt-1",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
+
+    await expect(
+      mongoService.hiddenEvent.insertOne({
+        _id: new ObjectId(),
+        userId,
+        eventId: "evt-1",
+        createdAt: new Date("2026-01-02T00:00:00.000Z"),
+      }),
+    ).rejects.toMatchObject({ code: 11000 });
+  });
+
+  it("creates the unique hidden event index", async () => {
+    const indexes = await mongoService.hiddenEvent.indexes();
+    expect(indexes.map((index) => index.name)).toContain(
+      HIDDEN_EVENT_USER_EVENT_INDEX,
+    );
   });
 });

--- a/packages/backend/src/user/user-indexes.ts
+++ b/packages/backend/src/user/user-indexes.ts
@@ -3,6 +3,8 @@ import mongoService from "@backend/common/services/mongo.service";
 export const USER_IDENTITIES_PROVIDER_SUBJECT_INDEX =
   "user_identities_provider_subject_unique";
 
+export const HIDDEN_EVENT_USER_EVENT_INDEX = "hidden_event_user_event_unique";
+
 export async function ensureUserIndexes(): Promise<void> {
   await mongoService.user.createIndex(
     { "identities.provider": 1, "identities.subjectId": 1 },
@@ -11,5 +13,9 @@ export async function ensureUserIndexes(): Promise<void> {
       unique: true,
       partialFilterExpression: { identities: { $exists: true } },
     },
+  );
+  await mongoService.hiddenEvent.createIndex(
+    { userId: 1, eventId: 1 },
+    { name: HIDDEN_EVENT_USER_EVENT_INDEX, unique: true },
   );
 }

--- a/packages/backend/src/user/user.routes.config.ts
+++ b/packages/backend/src/user/user.routes.config.ts
@@ -1,5 +1,6 @@
 import type express from "express";
 import rateLimit from "express-rate-limit";
+import { type SessionRequest } from "supertokens-node/framework/express";
 import { verifySession } from "@backend/auth/session/session.middleware";
 import { CommonRoutesConfig } from "@backend/common/common.routes.config";
 import userController from "./controllers/user.controller";
@@ -9,6 +10,17 @@ const accountDeletionLimiter = rateLimit({
   limit: 3,
   standardHeaders: true,
   legacyHeaders: false,
+});
+
+const hiddenEventsKey = (req: express.Request): string =>
+  `hidden-events:${(req as SessionRequest).session?.getUserId?.() ?? "unknown"}`;
+
+const hiddenEventsLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: hiddenEventsKey,
 });
 
 /**
@@ -74,6 +86,26 @@ export class UserRoutes extends CommonRoutesConfig {
       .all(verifySession())
       .get(userController.getMetadata)
       .post(userController.updateMetadata);
+
+    /**
+     * GET /api/user/hidden-events
+     * Lists the current user's hidden event ids.
+     *
+     * PUT /api/user/hidden-events
+     * Hides or shows one event for the current user. Body is
+     * `{ eventId, hidden }`. Returns the full list so occurrence ids with
+     * `::` never need to be encoded in the path.
+     *
+     * @auth Required - Supertokens session
+     * @returns {Object} { hiddenEventIds: string[] }
+     * @throws {401} Unauthorized - Invalid or missing session
+     * @throws {400} Bad Request - Invalid input
+     */
+    this.app
+      .route("/api/user/hidden-events")
+      .all(verifySession())
+      .get(hiddenEventsLimiter, userController.getHiddenEvents)
+      .put(hiddenEventsLimiter, userController.setEventHidden);
 
     return this.app;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3618

## What and why

Stores per-user hidden event ids in a new `hiddenEvent` Mongo collection (one row per `(userId, eventId)`, unique compound index) and exposes `GET`/`PUT /api/user/hidden-events`. Hidden state is a view preference, not an event field and not user metadata. Account deletion removes the rows.

Tracking: #3616. Spec: locked decisions on the tracking issue.

## Verify

`VERDICT: PASS`

Checks run: `test:backend`, `type-check`, `lint`, `knip`

Issue verify commands also passed: `bun test:backend` (732 pass, 0 fail), `bun test:backend:fast` (448 pass), `bun run type-check`, `bun run lint`, `bun knip`, `bun run verify --strict`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6562b00-704c-43c1-aef8-a4299e3a7038?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6562b00-704c-43c1-aef8-a4299e3a7038&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

