### PR TITLE
feat(web): add hidden-events query and local fallback

### DIFF
--- a/packages/web/src/__tests__/utils/hidden-events-test-data.ts
+++ b/packages/web/src/__tests__/utils/hidden-events-test-data.ts
@@ -1,0 +1,11 @@
+import { type QueryClient } from "@tanstack/react-query";
+import { hiddenEventsQueryKeys } from "@web/events/hidden/hidden-events.query";
+import { type EventRepositorySource } from "@web/events/repositories/event.repository.factory";
+
+export const seedHiddenEventIds = (
+  queryClient: QueryClient,
+  ids: readonly string[],
+  source: EventRepositorySource = "local",
+) => {
+  queryClient.setQueryData(hiddenEventsQueryKeys.source(source), ids);
+};

--- a/packages/web/src/common/constants/storage.constants.ts
+++ b/packages/web/src/common/constants/storage.constants.ts
@@ -35,6 +35,9 @@ type StorageKey =
   // S39 A2: client-owned calendar visibility (default visible). Device-local,
   // matching other compass.* prefs — not synced across browsers.
   | "compass.calendars.hidden-ids"
+  // Client-owned, device-local, anonymous fallback only. Signed-in users
+  // persist hidden event ids on the server.
+  | "compass.events.hidden-ids"
   // Which calendar new events are created on. Device-local like the rest;
   // an unknown or stale id falls back to the derived default.
   | "compass.calendars.default-id"
@@ -78,6 +81,7 @@ export const STORAGE_KEYS: Record<
   | "SIDEBAR_OPEN"
   | "THEME"
   | "HIDDEN_CALENDAR_IDS"
+  | "HIDDEN_EVENT_IDS"
   | "DEFAULT_CALENDAR_ID"
   | "COLLAPSED_ACCOUNTS"
   | "RECENT_COMMANDS"
@@ -114,6 +118,7 @@ export const STORAGE_KEYS: Record<
   SIDEBAR_OPEN: "compass.view.sidebar-open",
   THEME: "compass.theme",
   HIDDEN_CALENDAR_IDS: "compass.calendars.hidden-ids",
+  HIDDEN_EVENT_IDS: "compass.events.hidden-ids",
   DEFAULT_CALENDAR_ID: "compass.calendars.default-id",
   COLLAPSED_ACCOUNTS: "compass.calendars.collapsed-accounts",
   RECENT_COMMANDS: "compass.commands.recent",

--- a/packages/web/src/events/hidden/hidden-events.api.test.ts
+++ b/packages/web/src/events/hidden/hidden-events.api.test.ts
@@ -1,0 +1,34 @@
+import { rest } from "msw";
+import { SetEventHiddenInputSchema } from "@core/types/event-visibility.contracts";
+import { server } from "@web/__tests__/__mocks__/server/mock.server";
+import { ENV_WEB } from "@web/common/constants/env.constants";
+import { HiddenEventsApi } from "@web/events/hidden/hidden-events.api";
+import { describe, expect, it } from "bun:test";
+
+const hiddenEventsUrl = `${ENV_WEB.API_BASEURL}/user/hidden-events`;
+
+describe("HiddenEventsApi", () => {
+  it("throws when a list response fails the schema", async () => {
+    server.use(
+      rest.get(hiddenEventsUrl, (_req, res, ctx) =>
+        res(ctx.json({ hiddenEventIds: [], extra: true })),
+      ),
+    );
+
+    await expect(HiddenEventsApi.list()).rejects.toThrow();
+  });
+
+  it("throws when a set response fails the schema", async () => {
+    server.use(
+      rest.put(hiddenEventsUrl, (_req, res, ctx) =>
+        res(ctx.json({ hiddenEventIds: "evt-1" })),
+      ),
+    );
+
+    await expect(
+      HiddenEventsApi.set(
+        SetEventHiddenInputSchema.parse({ eventId: "evt-1", hidden: true }),
+      ),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/web/src/events/hidden/hidden-events.api.ts
+++ b/packages/web/src/events/hidden/hidden-events.api.ts
@@ -1,0 +1,23 @@
+import {
+  HiddenEventIdsResponseSchema,
+  type SetEventHiddenInput,
+  SetEventHiddenInputSchema,
+} from "@core/types/event-visibility.contracts";
+import { BaseApi } from "@web/api/base/base.api";
+
+const HiddenEventsApi = {
+  list: async (): Promise<readonly string[]> => {
+    const response = await BaseApi.get<unknown>("/user/hidden-events");
+    return HiddenEventIdsResponseSchema.parse(response.data).hiddenEventIds;
+  },
+
+  set: async (input: SetEventHiddenInput): Promise<readonly string[]> => {
+    const response = await BaseApi.put<unknown>(
+      "/user/hidden-events",
+      SetEventHiddenInputSchema.parse(input),
+    );
+    return HiddenEventIdsResponseSchema.parse(response.data).hiddenEventIds;
+  },
+};
+
+export { HiddenEventsApi };

--- a/packages/web/src/events/hidden/hidden-events.query.test.tsx
+++ b/packages/web/src/events/hidden/hidden-events.query.test.tsx
@@ -1,0 +1,136 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { rest } from "msw";
+import { type PropsWithChildren } from "react";
+import { server } from "@web/__tests__/__mocks__/server/mock.server";
+import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
+import { seedHiddenEventIds } from "@web/__tests__/utils/hidden-events-test-data";
+import { ENV_WEB } from "@web/common/constants/env.constants";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import { registerToastPort } from "@web/common/utils/toast/toast.port";
+import {
+  HIDDEN_EVENT_FAILURE_MESSAGE,
+  useHiddenEventIds,
+  useToggleEventHidden,
+} from "@web/events/hidden/hidden-events.query";
+import { readHiddenEventIds } from "@web/events/hidden/hidden-events.storage";
+import { refreshEventRepositorySource } from "@web/events/repositories/event.repository.source.store";
+import { afterEach, describe, expect, it } from "bun:test";
+
+const hiddenEventsUrl = `${ENV_WEB.API_BASEURL}/user/hidden-events`;
+
+const createWrapper = (client?: QueryClient) => {
+  const queryClient =
+    client ??
+    new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+  return {
+    queryClient,
+    wrapper: ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  };
+};
+
+describe("hidden-events.query", () => {
+  afterEach(() => {
+    persistentBrowserStore.remove(STORAGE_KEYS.HIDDEN_EVENT_IDS);
+  });
+
+  it("reads and toggles hidden ids from local storage without a network call", async () => {
+    persistentBrowserStore.set(
+      STORAGE_KEYS.HIDDEN_EVENT_IDS,
+      JSON.stringify(["evt-stored"]),
+    );
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => ({
+        ids: useHiddenEventIds(),
+        toggle: useToggleEventHidden(),
+      }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect([...result.current.ids]).toEqual(["evt-stored"]);
+    });
+
+    act(() => {
+      result.current.toggle("evt-2");
+    });
+
+    await waitFor(() => {
+      expect(result.current.ids.has("evt-stored")).toBe(true);
+      expect(result.current.ids.has("evt-2")).toBe(true);
+    });
+    expect(readHiddenEventIds()).toEqual(["evt-stored", "evt-2"]);
+  });
+
+  it("sends one PUT, updates before the response, and rolls back with a toast on 500", async () => {
+    act(() => refreshEventRepositorySource(true));
+    const { port, mocks } = createTestToastPort();
+    registerToastPort(port);
+
+    let resolvePut: ((value: unknown) => void) | undefined;
+    const putHold = new Promise((resolve) => {
+      resolvePut = resolve;
+    });
+    const putBodies: unknown[] = [];
+
+    server.use(
+      rest.get(hiddenEventsUrl, (_req, res, ctx) =>
+        res(ctx.json({ hiddenEventIds: [] })),
+      ),
+      rest.put(hiddenEventsUrl, async (req, res, ctx) => {
+        putBodies.push(await req.json());
+        await putHold;
+        return res(ctx.status(500), ctx.json({ message: "fail" }));
+      }),
+    );
+
+    const { wrapper, queryClient } = createWrapper();
+    seedHiddenEventIds(queryClient, [], "remote");
+
+    const { result } = renderHook(
+      () => ({
+        ids: useHiddenEventIds(),
+        toggle: useToggleEventHidden(),
+      }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.ids.size).toBe(0);
+    });
+
+    act(() => {
+      result.current.toggle("evt-1");
+    });
+
+    await waitFor(() => {
+      expect(result.current.ids.has("evt-1")).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(putBodies).toEqual([{ eventId: "evt-1", hidden: true }]);
+    });
+
+    act(() => {
+      resolvePut?.(undefined);
+    });
+
+    await waitFor(() => {
+      expect(result.current.ids.has("evt-1")).toBe(false);
+    });
+    expect(mocks.error).toHaveBeenCalledTimes(1);
+    expect(mocks.error).toHaveBeenCalledWith(
+      HIDDEN_EVENT_FAILURE_MESSAGE,
+      expect.anything(),
+    );
+  });
+});

--- a/packages/web/src/events/hidden/hidden-events.query.ts
+++ b/packages/web/src/events/hidden/hidden-events.query.ts
@@ -1,0 +1,129 @@
+import {
+  queryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { useCallback } from "react";
+import {
+  type SetEventHiddenInput,
+  SetEventHiddenInputSchema,
+} from "@core/types/event-visibility.contracts";
+import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
+import { HiddenEventsApi } from "@web/events/hidden/hidden-events.api";
+import {
+  readHiddenEventIds,
+  writeHiddenEventIds,
+} from "@web/events/hidden/hidden-events.storage";
+import { type EventRepositorySource } from "@web/events/repositories/event.repository.factory";
+import { useEventRepositorySource } from "@web/events/repositories/event.repository.source.store";
+
+export const HIDDEN_EVENT_FAILURE_MESSAGE =
+  "Couldn't update event visibility. The change was undone.";
+
+export const hiddenEventsQueryKeys = {
+  all: ["hidden-events"] as const,
+  source: (source: EventRepositorySource) => ["hidden-events", source] as const,
+};
+
+export const EMPTY_HIDDEN_EVENT_IDS: ReadonlySet<string> = Object.freeze(
+  new Set<string>(),
+);
+
+const hiddenEventIdSetCache = new WeakMap<
+  readonly string[],
+  ReadonlySet<string>
+>();
+
+function selectHiddenEventIdSet(ids: readonly string[]): ReadonlySet<string> {
+  let cached = hiddenEventIdSetCache.get(ids);
+  if (!cached) {
+    cached = new Set(ids);
+    hiddenEventIdSetCache.set(ids, cached);
+  }
+  return cached;
+}
+
+function withHiddenEventId(
+  ids: readonly string[],
+  eventId: string,
+  hidden: boolean,
+): readonly string[] {
+  if (hidden) {
+    return ids.includes(eventId) ? ids : [...ids, eventId];
+  }
+  return ids.filter((id) => id !== eventId);
+}
+
+export function hiddenEventsQueryOptions(source: EventRepositorySource) {
+  return queryOptions({
+    queryKey: hiddenEventsQueryKeys.source(source),
+    queryFn: (): Promise<readonly string[]> | readonly string[] =>
+      source === "remote" ? HiddenEventsApi.list() : readHiddenEventIds(),
+    staleTime: 60_000,
+  });
+}
+
+export function useHiddenEventIds(): ReadonlySet<string> {
+  const source = useEventRepositorySource();
+  const { data } = useQuery({
+    ...hiddenEventsQueryOptions(source),
+    select: selectHiddenEventIdSet,
+  });
+
+  return data ?? EMPTY_HIDDEN_EVENT_IDS;
+}
+
+export function useToggleEventHidden(): (eventId: string) => void {
+  const source = useEventRepositorySource();
+  const queryClient = useQueryClient();
+  const queryKey = hiddenEventsQueryKeys.source(source);
+
+  const mutation = useMutation({
+    mutationFn: async (
+      input: SetEventHiddenInput,
+    ): Promise<readonly string[]> => {
+      if (source === "remote") {
+        return HiddenEventsApi.set(input);
+      }
+
+      const next = withHiddenEventId(
+        readHiddenEventIds(),
+        input.eventId,
+        input.hidden,
+      );
+      writeHiddenEventIds(next);
+      return next;
+    },
+    onMutate: async (input) => {
+      await queryClient.cancelQueries({ queryKey });
+      const snapshot =
+        queryClient.getQueryData<readonly string[]>(queryKey) ?? [];
+      queryClient.setQueryData(
+        queryKey,
+        withHiddenEventId(snapshot, input.eventId, input.hidden),
+      );
+      return { snapshot };
+    },
+    onError: (_error, _input, context) => {
+      queryClient.setQueryData(queryKey, context?.snapshot ?? []);
+      showErrorToast(HIDDEN_EVENT_FAILURE_MESSAGE);
+    },
+    onSuccess: (list) => {
+      queryClient.setQueryData(queryKey, list);
+    },
+  });
+
+  return useCallback(
+    (eventId: string) => {
+      const current =
+        queryClient.getQueryData<readonly string[]>(queryKey) ?? [];
+      const input = SetEventHiddenInputSchema.parse({
+        eventId,
+        hidden: !current.includes(eventId),
+      });
+      mutation.mutate(input);
+    },
+    [mutation, queryClient, queryKey],
+  );
+}

--- a/packages/web/src/events/hidden/hidden-events.storage.test.ts
+++ b/packages/web/src/events/hidden/hidden-events.storage.test.ts
@@ -1,0 +1,26 @@
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import {
+  readHiddenEventIds,
+  writeHiddenEventIds,
+} from "@web/events/hidden/hidden-events.storage";
+import { afterEach, describe, expect, it } from "bun:test";
+
+afterEach(() => {
+  persistentBrowserStore.remove(STORAGE_KEYS.HIDDEN_EVENT_IDS);
+});
+
+describe("hidden-events.storage", () => {
+  it("treats malformed JSON as empty", () => {
+    persistentBrowserStore.set(STORAGE_KEYS.HIDDEN_EVENT_IDS, "{not-json");
+    expect(readHiddenEventIds()).toEqual([]);
+  });
+
+  it("removes the key when writing an empty list", () => {
+    writeHiddenEventIds(["evt-1"]);
+    writeHiddenEventIds([]);
+    expect(
+      persistentBrowserStore.get(STORAGE_KEYS.HIDDEN_EVENT_IDS),
+    ).toBeNull();
+  });
+});

--- a/packages/web/src/events/hidden/hidden-events.storage.ts
+++ b/packages/web/src/events/hidden/hidden-events.storage.ts
@@ -1,0 +1,26 @@
+import { z } from "zod/v4";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+
+const HiddenEventIdsSchema = z.array(z.string().trim().min(1)).readonly();
+
+export function readHiddenEventIds(): readonly string[] {
+  const raw = persistentBrowserStore.get(STORAGE_KEYS.HIDDEN_EVENT_IDS);
+  if (!raw) return [];
+
+  try {
+    return HiddenEventIdsSchema.parse(JSON.parse(raw));
+  } catch {
+    return [];
+  }
+}
+
+export function writeHiddenEventIds(ids: readonly string[]): boolean {
+  if (ids.length === 0) {
+    return persistentBrowserStore.remove(STORAGE_KEYS.HIDDEN_EVENT_IDS);
+  }
+  return persistentBrowserStore.set(
+    STORAGE_KEYS.HIDDEN_EVENT_IDS,
+    JSON.stringify(ids),
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3619

## What and why

Adds the web data layer for hidden event ids: one TanStack query keyed on the event repository source, an optimistic toggle with snapshot rollback and a toast on failure, a remote GET/PUT client, and a localStorage fallback for anonymous mode. Nothing renders differently yet; later WPs consume these hooks.

Tracking: #3616. Spec: locked decisions on the tracking issue.

## Verify

Independent checks from `bun run verify --strict` (selected package `web`): `test:web` 972 pass, `type-check`, `lint`, `knip`.

That combined run then reported `Failed: test:a11y, test:e2e` after the 110s web suite, with Playwright's output truncated in this sandbox. Isolated retry: `bunx playwright test e2e/accessibility` — 58 passed (1.9m). The diff is `packages/web/src/events/hidden/**`, a storage key, and a test helper; it does not touch `e2e/`. GitHub E2E (shards 1-4) and Unit on this PR are SUCCESS on the same commit. Per ship skill, sandbox Playwright failures in specs the diff cannot reach are not a local blocker; CI is the gate.

Issue verify commands: `cd packages/web && bun test ./src/events/hidden` (6 pass), `bun test:web`, `bun run type-check`, `bun run lint`, `bun knip`.

VERDICT: PASS

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6562b00-704c-43c1-aef8-a4299e3a7038?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6562b00-704c-43c1-aef8-a4299e3a7038&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

