### PR TITLE
feat(web): render hidden events as a narrow strip

### DIFF
--- a/packages/web/src/grid/components/AllDayEventCard.tsx
+++ b/packages/web/src/grid/components/AllDayEventCard.tsx
@@ -38,6 +38,7 @@ export interface AllDayEventCardProps {
   /** Calendar backgroundColor for focus chrome; null falls back to --text. */
   focusColor?: string | null;
   interactionAttributes?: Record<string, string | undefined>;
+  isHidden?: boolean;
   isPlaceholder: boolean;
   onEventKeyDown?: (event: GridEvent) => void;
   onMouseEnter?: (e: MouseEvent<HTMLDivElement>) => void;
@@ -51,6 +52,7 @@ const AllDayEventCardBase = (
     event,
     focusColor = null,
     interactionAttributes,
+    isHidden = false,
     isPlaceholder,
     onEventKeyDown,
     onMouseEnter,
@@ -66,7 +68,10 @@ const AllDayEventCardBase = (
   const isInPast = dayjs().isAfter(dayjs(event.endDate));
   const isRecurring = isRecurringEvent(event);
   const showRepeatIcon =
-    isRecurring && !isPlaceholder && position.width >= REPEAT_ICON_MIN_WIDTH;
+    !isHidden &&
+    isRecurring &&
+    !isPlaceholder &&
+    position.width >= REPEAT_ICON_MIN_WIDTH;
   // Past events recede in the direction of the theme's grid, matching
   // TimedEventCard: the dark theme's light steel fill dims slightly, the
   // light theme's ink fill fades toward the paper. Only the fill moves — a
@@ -97,14 +102,14 @@ const AllDayEventCardBase = (
     "--event-focus-color": focusColorCss,
     height: position.height,
     left: position.left,
-    opacity: isPlaceholder ? 0.5 : undefined,
+    opacity: isHidden ? 0.6 : isPlaceholder ? 0.5 : undefined,
     top: position.top,
     width: position.width,
     zIndex: position.zIndex ?? ZIndex.LAYER_1,
     boxShadow: edgeFocusShadow,
   } as CSSProperties;
 
-  const baseAccessibleLabel = `${isRecurring ? "Recurring " : ""}${event.isDemo ? "Sample " : ""}All-day event: ${event.title || "Untitled event"}`;
+  const baseAccessibleLabel = `${isHidden ? "Hidden " : ""}${isRecurring ? "Recurring " : ""}${event.isDemo ? "Sample " : ""}All-day event: ${event.title || "Untitled event"}`;
   // Fill stays a flat neutral color; the accent + this suffix are the only
   // calendar signal, and the name (never color alone) is what makes it
   // accessible (A9).
@@ -129,8 +134,10 @@ const AllDayEventCardBase = (
       ref={ref}
       role="button"
       tabIndex={0}
+      title={isHidden ? event.title : undefined}
       className={cn(
-        "absolute min-h-2.5 overflow-hidden rounded-xs bg-(--event-bg) pr-0.75 pl-1.25 transition-[background-color,filter] duration-260 ease-[cubic-bezier(0.16,1,0.3,1)] hover:bg-(--event-hover-bg)",
+        "absolute min-h-2.5 overflow-hidden bg-(--event-bg) pr-0.75 pl-1.25 transition-[background-color,filter] duration-260 ease-[cubic-bezier(0.16,1,0.3,1)] hover:bg-(--event-hover-bg)",
+        isHidden ? "rounded-full" : "rounded-xs",
         {
           "hover:cursor-pointer": !isPlaceholder,
           "outline outline-dashed outline-1 outline-text-muted/50":
@@ -151,27 +158,29 @@ const AllDayEventCardBase = (
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
-      {calendarIdentity && (
+      {!isHidden && calendarIdentity && (
         <div
           aria-hidden="true"
           className="absolute inset-y-0 left-0 w-[3px]"
           style={calendarAccentStyle(calendarIdentity)}
         />
       )}
-      <div
-        className={cn("flex min-w-0 items-center", {
-          // Reserve room so a long title truncates before the bottom-right icon.
-          "pr-3.5": showRepeatIcon,
-        })}
-      >
-        <span
-          className="relative min-w-0 truncate text-xs"
-          style={{ color: titleColor }}
+      {!isHidden && (
+        <div
+          className={cn("flex min-w-0 items-center", {
+            // Reserve room so a long title truncates before the bottom-right icon.
+            "pr-3.5": showRepeatIcon,
+          })}
         >
-          {event.title}
-          {"\u00A0"}
-        </span>
-      </div>
+          <span
+            className="relative min-w-0 truncate text-xs"
+            style={{ color: titleColor }}
+          >
+            {event.title}
+            {"\u00A0"}
+          </span>
+        </div>
+      )}
       {showRepeatIcon && <EventRepeatIcon baseColor={bgColor} />}
     </div>
   );

--- a/packages/web/src/grid/components/EventCard.test.tsx
+++ b/packages/web/src/grid/components/EventCard.test.tsx
@@ -6,6 +6,7 @@ import {
   GRID_EVENT_TITLE_COMPACT_FONT_SIZE,
   GRID_EVENT_TITLE_COMPACT_LINE_HEIGHT,
   GRID_EVENT_TITLE_FONT_SIZE,
+  HIDDEN_EVENT_STRIP_WIDTH,
 } from "@web/grid/grid.constants";
 import {
   initialEdgeFocusState,
@@ -529,5 +530,62 @@ describe("EventCard", () => {
     expect(card).toHaveAttribute("data-edge-focus", "endDate");
     expect(card.style.boxShadow).toContain("3px 0 0 0 #3b82f6");
     expect(card.className).not.toContain("ring-accent");
+  });
+
+  it("renders a hidden timed event as a nameless strip that still opens on Enter", () => {
+    const onEventKeyDown = mock();
+
+    render(
+      <TimedEventCard
+        displayMode="saved"
+        event={createEvent({
+          startDate: "2099-01-15T09:00:00.000Z",
+          endDate: "2099-01-15T10:00:00.000Z",
+        })}
+        isHidden
+        motionMode="idle"
+        onEventKeyDown={onEventKeyDown}
+        position={{ ...position, width: HIDDEN_EVENT_STRIP_WIDTH }}
+      />,
+    );
+
+    const card = screen.getByRole("button", {
+      name: "Hidden Timed event: Planning block, 9 - 10 AM",
+    });
+    expect(parseFloat(card.style.width)).toBe(HIDDEN_EVENT_STRIP_WIDTH);
+    expect(card.style.opacity).toBe("0.6");
+    expect(card).toHaveAttribute("title", "Planning block");
+    expect(screen.queryByText("Planning block")).not.toBeInTheDocument();
+
+    fireEvent.keyDown(card, { key: "Enter" });
+    expect(onEventKeyDown).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a hidden all-day event as a nameless strip that still opens on Enter", () => {
+    const onEventKeyDown = mock();
+
+    render(
+      <AllDayEventCard
+        event={createEvent({
+          isAllDay: true,
+          title: "Conference",
+        })}
+        isHidden
+        isPlaceholder={false}
+        onEventKeyDown={onEventKeyDown}
+        position={{ ...position, width: HIDDEN_EVENT_STRIP_WIDTH }}
+      />,
+    );
+
+    const card = screen.getByRole("button", {
+      name: "Hidden All-day event: Conference",
+    });
+    expect(parseFloat(card.style.width)).toBe(HIDDEN_EVENT_STRIP_WIDTH);
+    expect(card.style.opacity).toBe("0.6");
+    expect(card).toHaveAttribute("title", "Conference");
+    expect(screen.queryByText("Conference")).not.toBeInTheDocument();
+
+    fireEvent.keyDown(card, { key: "Enter" });
+    expect(onEventKeyDown).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/web/src/grid/components/TimedEventCard.tsx
+++ b/packages/web/src/grid/components/TimedEventCard.tsx
@@ -66,6 +66,7 @@ interface TimedEventCardProps {
   /** Calendar backgroundColor for focus chrome; null falls back to --text. */
   focusColor?: string | null;
   interactionAttributes?: Record<string, string | undefined>;
+  isHidden?: boolean;
   isSelected?: boolean;
   motionMode: "dragging" | "idle" | "resizing";
   onBlur?: () => void;
@@ -84,6 +85,7 @@ const TimedEventCardBase = (
     event,
     focusColor = null,
     interactionAttributes,
+    isHidden = false,
     isSelected = false,
     motionMode,
     onBlur,
@@ -106,12 +108,14 @@ const TimedEventCardBase = (
     "minute",
   );
   const showRepeatIcon =
+    !isHidden &&
     isRecurring &&
     !isPlaceholder &&
     durationMinutes >= REPEAT_ICON_MIN_DURATION_MINUTES &&
     position.width >= REPEAT_ICON_MIN_WIDTH;
 
   const showTimeLabel =
+    !isHidden &&
     !event.isAllDay &&
     (isDraft || !isInPast) &&
     position.height >= MIN_EVENT_HEIGHT_FOR_TIME_LABEL &&
@@ -187,7 +191,7 @@ const TimedEventCardBase = (
     "--event-focus-color": focusColorCss,
     height: position.height || 0,
     left: position.left,
-    opacity: isPlaceholder ? 0.5 : undefined,
+    opacity: isHidden ? 0.6 : isPlaceholder ? 0.5 : undefined,
     top: position.top,
     width: position.width || 0,
     zIndex: position.zIndex ?? ZIndex.LAYER_1,
@@ -231,6 +235,7 @@ const TimedEventCardBase = (
     ? `${recurringPrefix}All-day event: ${eventTitle}`
     : `${recurringPrefix}Timed event: ${eventTitle}, ${timeRange ?? "time not set"}`;
   const samplePrefix = event.isDemo ? "Sample " : "";
+  const hiddenPrefix = isHidden ? "Hidden " : "";
   // Fill stays a flat neutral color; the accent + this suffix are the only
   // calendar signal, and the name (never color alone) is what makes it
   // accessible (A9).
@@ -242,8 +247,9 @@ const TimedEventCardBase = (
         : "";
   const accessibleLabel =
     (calendarIdentity
-      ? `${samplePrefix}${baseAccessibleLabel}${calendarAccentAccessibleSuffix(calendarIdentity)}`
-      : `${samplePrefix}${baseAccessibleLabel}`) + edgeFocusSuffix;
+      ? `${hiddenPrefix}${samplePrefix}${baseAccessibleLabel}${calendarAccentAccessibleSuffix(calendarIdentity)}`
+      : `${hiddenPrefix}${samplePrefix}${baseAccessibleLabel}`) +
+    edgeFocusSuffix;
 
   return (
     // biome-ignore lint/a11y/useSemanticElements: Grid events are draggable/resizable blocks, not native buttons.
@@ -255,8 +261,10 @@ const TimedEventCardBase = (
       ref={ref}
       role="button"
       tabIndex={0}
+      title={isHidden ? event.title : undefined}
       className={cn(
-        "absolute min-h-2.5 overflow-hidden rounded-xs pr-0.75 pl-1.25 transition-[background-color,filter] duration-[260ms] ease-[cubic-bezier(0.16,1,0.3,1)]",
+        "absolute min-h-2.5 overflow-hidden pr-0.75 pl-1.25 transition-[background-color,filter] duration-[260ms] ease-[cubic-bezier(0.16,1,0.3,1)]",
+        isHidden ? "rounded-full" : "rounded-xs",
         "bg-(--event-bg) hover:bg-(--event-hover-bg)",
         "hover:cursor-pointer",
         eventFocusOutlineClass(focusedEdge),
@@ -282,29 +290,31 @@ const TimedEventCardBase = (
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
-      {calendarIdentity && (
+      {!isHidden && calendarIdentity && (
         <div
           aria-hidden="true"
           className="absolute inset-y-0 left-0 w-[3px]"
           style={calendarAccentStyle(calendarIdentity)}
         />
       )}
-      <div
-        className="flex flex-col flex-wrap items-start"
-        style={{ color: contentColor }}
-        {...{ [EVENT_CONTENT_ATTRIBUTE]: "true" }}
-      >
-        <span style={titleStyle}>{event.title}</span>
-        {!event.isAllDay && showTimeLabel && (
-          <span
-            className="relative"
-            {...{ [EVENT_TIME_LABEL_ATTRIBUTE]: "true" }}
-            style={{ ...timeLabelStyle, zIndex: ZIndex.LAYER_3 }}
-          >
-            {timeRange}
-          </span>
-        )}
-      </div>
+      {!isHidden && (
+        <div
+          className="flex flex-col flex-wrap items-start"
+          style={{ color: contentColor }}
+          {...{ [EVENT_CONTENT_ATTRIBUTE]: "true" }}
+        >
+          <span style={titleStyle}>{event.title}</span>
+          {!event.isAllDay && showTimeLabel && (
+            <span
+              className="relative"
+              {...{ [EVENT_TIME_LABEL_ATTRIBUTE]: "true" }}
+              style={{ ...timeLabelStyle, zIndex: ZIndex.LAYER_3 }}
+            >
+              {timeRange}
+            </span>
+          )}
+        </div>
+      )}
       {showRepeatIcon && <EventRepeatIcon baseColor={bgColor} />}
     </div>
   );

--- a/packages/web/src/grid/grid.constants.ts
+++ b/packages/web/src/grid/grid.constants.ts
@@ -37,6 +37,7 @@ export const TIMED_EVENT_WIDTH_RATIO = 0.6;
 export const TIMED_EVENT_MIN_WIDTH = 280;
 export const TIMED_EVENT_FAN_INDENT = 44;
 export const TIMED_EVENT_FAN_GUTTER = 120;
+export const HIDDEN_EVENT_STRIP_WIDTH = 8;
 export const GRID_PADDING_BOTTOM = 20;
 export const GRID_TIME_COLUMN_WIDTH = 50;
 export const GRID_MARGIN_LEFT = GRID_TIME_COLUMN_WIDTH;

--- a/packages/web/src/grid/layout/timed-deck.layout.test.ts
+++ b/packages/web/src/grid/layout/timed-deck.layout.test.ts
@@ -6,6 +6,7 @@ import {
   DECK_MIN_WIDTH,
   DECK_RIGHT_RESERVE,
   EVENT_WIDTH_MINIMUM,
+  HIDDEN_EVENT_STRIP_WIDTH,
   TIMED_EVENT_COLUMN_INSET,
   TIMED_EVENT_FAN_GUTTER,
   TIMED_EVENT_FAN_INDENT,
@@ -142,6 +143,20 @@ describe("createTimedEventLayout", () => {
 
     expect(deckOf(laid, "morning")).toBeNull();
     expect(deckOf(laid, "afternoon")).toBeNull();
+  });
+
+  it("excludes a hidden event from overlap fanning", () => {
+    const events = [
+      event("visible-a", "2026-05-20T09:00:00", "2026-05-20T10:00:00"),
+      event("hidden", "2026-05-20T09:30:00", "2026-05-20T10:30:00"),
+      event("visible-b", "2026-05-20T09:45:00", "2026-05-20T10:15:00"),
+    ];
+
+    const laid = createTimedEventLayout(events, new Set(["hidden"]));
+
+    expect(deckOf(laid, "visible-a")).toEqual({ order: 0, groupSize: 2 });
+    expect(deckOf(laid, "visible-b")).toEqual({ order: 1, groupSize: 2 });
+    expect(deckOf(laid, "hidden")).toBeNull();
   });
 });
 
@@ -285,5 +300,17 @@ describe("applyTimedEventDisplayPosition", () => {
     expect(front.left + front.width).toBe(
       narrowPosition.left + narrowPosition.width,
     );
+  });
+
+  it("returns the strip width and original left when hidden", () => {
+    const someDeck = { order: 1, groupSize: 2 };
+    const position = applyTimedEventDisplayPosition(
+      widePosition,
+      someDeck,
+      true,
+    );
+
+    expect(position.width).toBe(HIDDEN_EVENT_STRIP_WIDTH);
+    expect(position.left).toBe(widePosition.left);
   });
 });

--- a/packages/web/src/grid/layout/timed-deck.layout.ts
+++ b/packages/web/src/grid/layout/timed-deck.layout.ts
@@ -5,6 +5,7 @@ import {
   DECK_INDENT,
   DECK_MIN_WIDTH,
   DECK_RIGHT_RESERVE,
+  HIDDEN_EVENT_STRIP_WIDTH,
   TIMED_EVENT_FAN_GUTTER,
   TIMED_EVENT_FAN_INDENT,
   TIMED_EVENT_MIN_WIDTH,
@@ -29,14 +30,19 @@ interface DeckCandidate {
   start: Dayjs;
 }
 
+const NO_HIDDEN_EVENT_IDS: ReadonlySet<string> = new Set();
+
 export const createTimedEventLayout = (
   events: GridEvent[],
+  hiddenEventIds: ReadonlySet<string> = NO_HIDDEN_EVENT_IDS,
 ): TimedEventLayoutItem[] => {
   const items: TimedEventLayoutItem[] = events.map((event) => ({
     deckLayout: null,
     event,
   }));
-  const candidates = items.map(toDeckCandidate);
+  const candidates = items
+    .filter((item) => !item.event._id || !hiddenEventIds.has(item.event._id))
+    .map(toDeckCandidate);
 
   for (const dayBucket of bucketByStartDay(candidates)) {
     for (const group of groupByOverlap(dayBucket)) {
@@ -54,7 +60,12 @@ export const createTimedEventLayout = (
 export const applyTimedEventDisplayPosition = (
   position: EventPosition,
   deckLayout: TimedDeckLayout | null,
+  isHidden = false,
 ): EventPosition => {
+  if (isHidden) {
+    return { ...position, width: HIDDEN_EVENT_STRIP_WIDTH };
+  }
+
   const cardWidth = getTimedEventCardWidth(position.width);
 
   if (!deckLayout) {

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarEventCards.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarEventCards.tsx
@@ -4,6 +4,7 @@ import { ZIndex } from "@web/common/constants/web.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { AllDayEventCard } from "@web/grid/components/AllDayEventCard";
 import { TimedEventCard } from "@web/grid/components/TimedEventCard";
+import { HIDDEN_EVENT_STRIP_WIDTH } from "@web/grid/grid.constants";
 import {
   getAllDayEventPosition,
   getTimedEventPosition,
@@ -27,6 +28,7 @@ interface DayEventCardProps {
   event: GridEvent;
   focusColor?: string | null;
   isActiveDraft: boolean;
+  isHidden?: boolean;
   isPlaceholder: boolean;
   isReadOnly: boolean;
   measurements: GridMeasurements;
@@ -44,6 +46,7 @@ export const DayAllDayCalendarEvent = ({
   event,
   focusColor = null,
   isActiveDraft,
+  isHidden = false,
   isPlaceholder,
   isReadOnly,
   measurements,
@@ -56,7 +59,7 @@ export const DayAllDayCalendarEvent = ({
   // non-read-only card.
   const hasEventIdentity = Boolean(event._id);
   const isRegisteredForDragResize =
-    hasEventIdentity && !isPlaceholder && !isReadOnly;
+    hasEventIdentity && !isPlaceholder && !isReadOnly && !isHidden;
   const registrationRef = useDayEventRegistrationRef({
     eventId: event._id,
     eventType: "all-day",
@@ -79,6 +82,9 @@ export const DayAllDayCalendarEvent = ({
     measurements,
     visibleDates,
   });
+  const displayPosition = isHidden
+    ? { ...position, width: HIDDEN_EVENT_STRIP_WIDTH }
+    : position;
 
   return (
     <AllDayEventCard
@@ -86,13 +92,14 @@ export const DayAllDayCalendarEvent = ({
       event={event}
       focusColor={focusColor}
       interactionAttributes={interactionAttributes}
+      isHidden={isHidden}
       isPlaceholder={isPlaceholder}
       onEventKeyDown={onOpenEvent}
       position={{
-        ...position,
+        ...displayPosition,
         zIndex: isActiveDraft
           ? ZIndex.MAX
-          : (position.zIndex ?? ZIndex.LAYER_1),
+          : (displayPosition.zIndex ?? ZIndex.LAYER_1),
       }}
       ref={registrationRef}
     />
@@ -106,6 +113,7 @@ export const DayTimedCalendarEvent = ({
   event,
   focusColor = null,
   isActiveDraft,
+  isHidden = false,
   isPlaceholder,
   isReadOnly,
   measurements,
@@ -118,7 +126,7 @@ export const DayTimedCalendarEvent = ({
   // non-read-only card.
   const hasEventIdentity = Boolean(event._id);
   const isRegisteredForDragResize =
-    hasEventIdentity && !isPlaceholder && !isReadOnly;
+    hasEventIdentity && !isPlaceholder && !isReadOnly && !isHidden;
   const isDeck = Boolean(deckLayout);
   const [isFocused, setIsFocused] = useState(false);
   const registrationRef = useDayEventRegistrationRef({
@@ -151,6 +159,7 @@ export const DayTimedCalendarEvent = ({
     columnIndex,
     deckLayout,
     event,
+    isHidden,
     isPlaceholder,
     measurements,
     visibleDates,
@@ -167,6 +176,7 @@ export const DayTimedCalendarEvent = ({
       event={event}
       focusColor={focusColor}
       interactionAttributes={interactionAttributes}
+      isHidden={isHidden}
       isSelected={isActiveDraft}
       motionMode="idle"
       onBlur={isDeck ? () => setIsFocused(false) : undefined}
@@ -182,6 +192,7 @@ const getDayTimedEventPosition = ({
   columnIndex,
   deckLayout,
   event,
+  isHidden,
   isPlaceholder,
   measurements,
   visibleDates,
@@ -189,6 +200,7 @@ const getDayTimedEventPosition = ({
   columnIndex: number;
   deckLayout: TimedDeckLayout | null;
   event: GridEvent;
+  isHidden: boolean;
   isPlaceholder: boolean;
   measurements: GridMeasurements;
   visibleDates: GridVisibleDate[];
@@ -200,5 +212,5 @@ const getDayTimedEventPosition = ({
     visibleDates,
   });
 
-  return applyTimedEventDisplayPosition(position, deckLayout);
+  return applyTimedEventDisplayPosition(position, deckLayout, isHidden);
 };

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarEventLayers.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarEventLayers.tsx
@@ -11,6 +11,7 @@ import {
 } from "@web/common/constants/web.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { type GridEventDraft } from "@web/events/event-draft.types";
+import { useHiddenEventIds } from "@web/events/hidden/hidden-events.query";
 import { useGridMarginLeft } from "@web/grid/grid-margin";
 import { createTimedEventLayout } from "@web/grid/layout/timed-deck.layout";
 import {
@@ -59,6 +60,7 @@ export const DayCalendarAllDayEventsLayer = ({
 }: DayAllDayEventsProps) => {
   // One lookup build for the whole list (packet 08 step 5) - not per card.
   const calendarLookup = useCalendarLookup();
+  const hiddenEventIds = useHiddenEventIds();
   const marginLeft = useGridMarginLeft();
 
   return (
@@ -77,6 +79,7 @@ export const DayCalendarAllDayEventsLayer = ({
           event={event}
           focusColor={resolveCalendarFocusColor(calendarLookup, event)}
           isActiveDraft={isActiveDraftEvent(event, draft, savedEventIds)}
+          isHidden={Boolean(event._id && hiddenEventIds.has(event._id))}
           isPlaceholder={isDraftOnlyEvent(event, draft, savedEventIds)}
           isReadOnly={isGridEventScheduleLocked(calendarLookup, event)}
           key={event._id ?? "all-day-draft"}
@@ -100,6 +103,7 @@ export const DayCalendarTimedEventsLayer = ({
 }: DayTimedEventsProps) => {
   // One lookup build for the whole list (packet 08 step 5) - not per card.
   const calendarLookup = useCalendarLookup();
+  const hiddenEventIds = useHiddenEventIds();
   const savedEventIds = useMemo(
     () => getCalendarEventIdSet(timedEvents),
     [timedEvents],
@@ -122,8 +126,10 @@ export const DayCalendarTimedEventsLayer = ({
       columnEvents.push(event);
       eventsByColumn.set(columnIndex, columnEvents);
     }
-    return [...eventsByColumn.values()].flatMap(createTimedEventLayout);
-  }, [getCalendarColumnIndex, renderedEvents]);
+    return [...eventsByColumn.values()].flatMap((columnEvents) =>
+      createTimedEventLayout(columnEvents, hiddenEventIds),
+    );
+  }, [getCalendarColumnIndex, hiddenEventIds, renderedEvents]);
 
   return (
     <div id={ID_GRID_EVENTS_TIMED}>
@@ -135,6 +141,7 @@ export const DayCalendarTimedEventsLayer = ({
           event={event}
           focusColor={resolveCalendarFocusColor(calendarLookup, event)}
           isActiveDraft={isActiveDraftEvent(event, draft, savedEventIds)}
+          isHidden={Boolean(event._id && hiddenEventIds.has(event._id))}
           isPlaceholder={isDraftOnlyEvent(event, draft, savedEventIds)}
           isReadOnly={isGridEventScheduleLocked(calendarLookup, event)}
           key={event._id ?? "timed-draft"}

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -18,6 +18,7 @@ import {
 } from "@web/__tests__/__mocks__/mock.render";
 import { server } from "@web/__tests__/__mocks__/server/mock.server";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import { seedHiddenEventIds } from "@web/__tests__/utils/hidden-events-test-data";
 import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
 import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
 import { createCompassQueryClient } from "@web/api/query-client";
@@ -39,10 +40,14 @@ import {
   selectIsEventFormOpen,
   useDraftStore,
 } from "@web/events/stores/draft.store";
-import { TIMED_EVENT_FAN_INDENT } from "@web/grid/grid.constants";
+import {
+  HIDDEN_EVENT_STRIP_WIDTH,
+  TIMED_EVENT_FAN_INDENT,
+} from "@web/grid/grid.constants";
 import * as realUsegridmeasurements from "@web/grid/hooks/useGridMeasurements";
 import { type GridMeasurements } from "@web/grid/types/grid.types";
 import * as realUsedateinview from "@web/views/Day/hooks/navigation/useDateInView";
+import { dayEventRegistry } from "@web/views/Day/interaction/registry/day-event.registry";
 import {
   afterEach,
   beforeEach,
@@ -138,8 +143,12 @@ const EventFormProbe = () => {
 const { DayCalendarGrid } =
   require("./DayCalendarGrid") as typeof import("./DayCalendarGrid");
 
-const renderDayCalendarGrid = (calendars?: Calendar[]) => {
+const renderDayCalendarGrid = (
+  calendars?: Calendar[],
+  hiddenEventIds: readonly string[] = [],
+) => {
   const queryClient = createCompassQueryClient();
+  seedHiddenEventIds(queryClient, hiddenEventIds);
   if (calendars) {
     queryClient.setQueryData(calendarQueryKeys.all, calendars);
     // Seeded fixtures must survive the calendars query mount-fetch. Without
@@ -304,6 +313,7 @@ afterEach(() => {
     delete (HTMLElement.prototype as { scroll?: unknown }).scroll;
   }
   resetDraft();
+  dayEventRegistry.clear();
   // Storage clearing + the hidden-ids store resync are both handled by the
   // global test-lifecycle afterEach (resetBrowserState + resetAllStores).
 });
@@ -436,6 +446,57 @@ describe("DayCalendarGrid", () => {
     expect(Number(early.style.zIndex)).toBeLessThan(Number(late.style.zIndex));
     expect(parseFloat(solo.style.width)).toBeGreaterThan(
       parseFloat(early.style.width),
+    );
+  });
+
+  it("renders hidden timed and all-day events as strips outside the drag registry", () => {
+    const hiddenTimed = createTimedEvent({
+      _id: "hidden-timed",
+      endDate: "2026-05-20T10:30:00.000",
+      startDate: "2026-05-20T09:00:00.000",
+      title: "Hidden timed",
+    });
+    const visibleTimed = createTimedEvent({
+      _id: "visible-timed",
+      endDate: "2026-05-20T10:45:00.000",
+      startDate: "2026-05-20T09:30:00.000",
+      title: "Visible timed",
+    });
+    const hiddenAllDay = createTimedEvent({
+      _id: "hidden-all-day",
+      endDate: "2026-05-21T00:00:00.000",
+      isAllDay: true,
+      startDate: "2026-05-20T00:00:00.000",
+      title: "Hidden all day",
+    });
+    setDayEvents([hiddenTimed, visibleTimed, hiddenAllDay]);
+
+    renderDayCalendarGrid(undefined, [hiddenTimed._id!, hiddenAllDay._id!]);
+
+    const visibleCard = screen.getByRole("button", {
+      name: /timed event: visible timed/i,
+    });
+    const hiddenTimedCard = screen.getByRole("button", {
+      name: /^Hidden Timed event: Hidden timed/,
+    });
+    const hiddenAllDayCard = screen.getByRole("button", {
+      name: /^Hidden All-day event: Hidden all day/,
+    });
+
+    expect(Number(visibleCard.style.zIndex)).toBe(ZIndex.LAYER_1);
+    expect(parseFloat(hiddenTimedCard.style.width)).toBe(
+      HIDDEN_EVENT_STRIP_WIDTH,
+    );
+    expect(parseFloat(hiddenAllDayCard.style.width)).toBe(
+      HIDDEN_EVENT_STRIP_WIDTH,
+    );
+    expect(parseFloat(visibleCard.style.width)).toBeGreaterThan(
+      HIDDEN_EVENT_STRIP_WIDTH,
+    );
+    expect(dayEventRegistry.resolve(hiddenTimed._id!, "timed")).toBeNull();
+    expect(dayEventRegistry.resolve(hiddenAllDay._id!, "all-day")).toBeNull();
+    expect(dayEventRegistry.resolve(visibleTimed._id!, "timed")).toBe(
+      visibleCard,
     );
   });
 

--- a/packages/web/src/views/Week/components/Event/Grid/GridEvent/GridEvent.tsx
+++ b/packages/web/src/views/Week/components/Event/Grid/GridEvent/GridEvent.tsx
@@ -19,6 +19,7 @@ interface Props {
   event: GridEventEntity;
   focusColor?: string | null;
   interactionAttributes?: Record<string, string | undefined>;
+  isHidden?: boolean;
   measurements: Measurements_Grid;
   motionMode?: GridEventMotionMode;
   onEventKeyDown?: (event: GridEventEntity) => void;
@@ -36,6 +37,7 @@ const GridEventBase = (
     event: _event,
     focusColor = null,
     interactionAttributes,
+    isHidden = false,
     measurements,
     motionMode = "idle",
     onEventKeyDown,
@@ -76,7 +78,7 @@ const GridEventBase = (
   });
   const position = shouldUseDraftSizing
     ? basePosition
-    : applyTimedEventDisplayPosition(basePosition, deckLayout);
+    : applyTimedEventDisplayPosition(basePosition, deckLayout, isHidden);
 
   const shouldFloatAboveDeck = isDragging || isResizing || (isDraft && !isDeck);
   const zIndex = shouldFloatAboveDeck
@@ -102,6 +104,7 @@ const GridEventBase = (
       focusColor={focusColor}
       onFocus={isDeck ? () => setIsFocused(true) : undefined}
       interactionAttributes={interactionAttributes}
+      isHidden={isHidden}
       motionMode={motionMode}
       onEventKeyDown={onEventKeyDown}
       position={{ ...position, zIndex }}
@@ -119,6 +122,7 @@ export const GridEventMemo = memo(GridEvent, (prev, next) => {
     prev.event === next.event &&
     prev.focusColor === next.focusColor &&
     prev.interactionAttributes === next.interactionAttributes &&
+    prev.isHidden === next.isHidden &&
     prev.measurements === next.measurements &&
     prev.motionMode === next.motionMode &&
     // The visible window can move without the event or measurements changing

--- a/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvent.tsx
+++ b/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvent.tsx
@@ -3,6 +3,7 @@ import { YEAR_MONTH_DAY_FORMAT } from "@core/constants/date.constants";
 import { type CalendarCardIdentity } from "@web/calendars/useCalendarLookup";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { AllDayEventCard } from "@web/grid/components/AllDayEventCard";
+import { HIDDEN_EVENT_STRIP_WIDTH } from "@web/grid/grid.constants";
 import { getAllDayEventPosition } from "@web/grid/layout/event.position";
 import { type Measurements_Grid } from "@web/views/Week/hooks/grid/useGridLayout";
 import { type WeekProps } from "@web/views/Week/hooks/useWeek";
@@ -12,6 +13,7 @@ interface Props {
   event: GridEvent;
   focusColor?: string | null;
   interactionAttributes?: Record<string, string | undefined>;
+  isHidden?: boolean;
   isPlaceholder: boolean;
   measurements: Measurements_Grid;
   weekDays: WeekProps["component"]["weekDays"];
@@ -24,6 +26,7 @@ const AllDayEventBase = (
     event,
     focusColor = null,
     interactionAttributes,
+    isHidden = false,
     isPlaceholder,
     measurements,
     weekDays,
@@ -42,6 +45,9 @@ const AllDayEventBase = (
     measurements,
     visibleDates,
   });
+  const displayPosition = isHidden
+    ? { ...position, width: HIDDEN_EVENT_STRIP_WIDTH }
+    : position;
 
   return (
     <AllDayEventCard
@@ -49,9 +55,10 @@ const AllDayEventBase = (
       event={event}
       focusColor={focusColor}
       interactionAttributes={interactionAttributes}
+      isHidden={isHidden}
       isPlaceholder={isPlaceholder}
       onEventKeyDown={onKeyDown}
-      position={position}
+      position={displayPosition}
       ref={ref}
     />
   );
@@ -65,6 +72,7 @@ export const AllDayEventMemo = memo(AllDayEvent, (prev, next) => {
     prev.event === next.event &&
     prev.focusColor === next.focusColor &&
     prev.interactionAttributes === next.interactionAttributes &&
+    prev.isHidden === next.isHidden &&
     prev.isPlaceholder === next.isPlaceholder &&
     prev.measurements === next.measurements &&
     // The visible window can move without the event or measurements changing

--- a/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/AllDayRow/AllDayEvents.tsx
@@ -8,6 +8,7 @@ import {
 } from "@web/calendars/useCalendarLookup";
 import { ID_GRID_EVENTS_ALLDAY } from "@web/common/constants/web.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
+import { useHiddenEventIds } from "@web/events/hidden/hidden-events.query";
 import {
   mergeGridEventWithDraftOverlay,
   useGridDraftOverlay,
@@ -50,6 +51,7 @@ export const AllDayEvents = ({
   const draftId = useDraftStore(selectDraftId);
   // One lookup build for the whole list (packet 08 step 5) - not per card.
   const calendarLookup = useCalendarLookup();
+  const hiddenEventIds = useHiddenEventIds();
   // The query covers the full week; only mount events overlapping the visible
   // window so off-window events never land in the DOM or the interaction
   // registry.
@@ -74,13 +76,14 @@ export const AllDayEvents = ({
         event,
         calendarIdentity: resolveCalendarCardIdentity(calendarLookup, event),
         focusColor: resolveCalendarFocusColor(calendarLookup, event),
+        isHidden: Boolean(event._id && hiddenEventIds.has(event._id)),
         // Read-only (unwritable calendar or busy content) events never
         // attach interaction attributes/registration below, so the drag/
         // resize engine can't find them as a target - blocked before any
         // optimistic state change (packet 08 step 8).
         isReadOnly: isGridEventScheduleLocked(calendarLookup, event),
       })),
-    [visibleAllDayEvents, calendarLookup],
+    [visibleAllDayEvents, calendarLookup, hiddenEventIds],
   );
 
   const { onEventKeyDown, onOpenReadOnlyDetails } =
@@ -95,7 +98,7 @@ export const AllDayEvents = ({
     >
       {!isLoadingWeekView &&
         visibleAllDayEventsWithIdentity.map(
-          ({ event, calendarIdentity, focusColor, isReadOnly }) => {
+          ({ event, calendarIdentity, focusColor, isHidden, isReadOnly }) => {
             const isPlaceholder = event._id === draftId;
             // Never overlay timed draft dates onto a multi-day timed display
             // bar — that would replace YYYY-MM-DD span dates with datetimes.
@@ -117,6 +120,7 @@ export const AllDayEvents = ({
                 calendarIdentity={identityForDisplay}
                 event={eventForDisplay}
                 focusColor={focusColorForDisplay}
+                isHidden={isHidden}
                 isPlaceholder={isPlaceholder}
                 isReadOnly={isReadOnly}
                 key={event._id}
@@ -136,6 +140,7 @@ interface AllDayEventItemProps {
   calendarIdentity: CalendarCardIdentity | null;
   event: GridEvent;
   focusColor: string | null;
+  isHidden: boolean;
   isPlaceholder: boolean;
   isReadOnly: boolean;
   measurements: Measurements_Grid;
@@ -148,6 +153,7 @@ const AllDayEventItem = ({
   calendarIdentity,
   event,
   focusColor,
+  isHidden,
   isPlaceholder,
   isReadOnly,
   measurements,
@@ -160,7 +166,7 @@ const AllDayEventItem = ({
   // separately via registry registration.
   const hasEventIdentity = Boolean(event._id);
   const isRegisteredForDragResize =
-    hasEventIdentity && !isPlaceholder && !isReadOnly;
+    hasEventIdentity && !isPlaceholder && !isReadOnly && !isHidden;
   const registrationRef = useWeekEventRegistrationRef({
     eventId: event._id,
     eventType: "all-day",
@@ -184,6 +190,7 @@ const AllDayEventItem = ({
       event={event}
       focusColor={focusColor}
       interactionAttributes={interactionAttributes}
+      isHidden={isHidden}
       isPlaceholder={isPlaceholder}
       measurements={measurements}
       onKeyDown={isReadOnly ? onOpenReadOnlyDetails : onKeyDown}

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGrid.test.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGrid.test.tsx
@@ -15,6 +15,7 @@ import {
   seedPendingEventMutations,
 } from "@web/__tests__/utils/event-query-test-data";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import { seedHiddenEventIds } from "@web/__tests__/utils/hidden-events-test-data";
 import { createCompassQueryClient } from "@web/api/query-client";
 import { ZIndex } from "@web/common/constants/web.constants";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
@@ -27,7 +28,10 @@ import {
   initialDraftState,
   useDraftStore,
 } from "@web/events/stores/draft.store";
-import { DECK_INDENT } from "@web/grid/grid.constants";
+import {
+  DECK_INDENT,
+  HIDDEN_EVENT_STRIP_WIDTH,
+} from "@web/grid/grid.constants";
 import { type Measurements_Grid } from "@web/views/Week/hooks/grid/useGridLayout";
 import {
   WEEK_INTERACTION_EVENT_ID_ATTRIBUTE,
@@ -40,6 +44,7 @@ import { Categories_Event } from "@web/common/types/web.event.types";
 
 let pendingEventIds: string[] = [];
 let seededWeekEvents: CompassEvent[] = [];
+let seededHiddenEventIds: readonly string[] = [];
 
 // DateTimeSchema requires an explicit offset; several fixtures below already
 // carry one ("Z"), but normalize defensively.
@@ -77,6 +82,7 @@ function Provider({ children }: PropsWithChildren) {
     const client = createCompassQueryClient();
     seedPendingEventMutations(client, pendingEventIds);
     seedEventQueries(client, seededWeekEvents.map(toStrictEvent));
+    seedHiddenEventIds(client, seededHiddenEventIds);
     return client;
   });
 
@@ -96,6 +102,7 @@ afterEach(() => {
   weekEventRegistry.clear();
   pendingEventIds = [];
   seededWeekEvents = [];
+  seededHiddenEventIds = [];
   useDraftStore.setState(initialDraftState);
 });
 
@@ -499,5 +506,44 @@ describe("saved Week event ownership", () => {
 
     fireEvent.blur(back);
     expect(Number(back.style.zIndex)).toBe(initialBackZIndex);
+  });
+
+  it("renders a hidden overlap as a strip so the neighbour keeps solo width", () => {
+    const hidden = createSavedEvent({
+      endDate: "2024-01-15T19:30:00.000Z",
+      startDate: "2024-01-15T18:30:00.000Z",
+      title: "Hidden overlap",
+    });
+    const visible = createSavedEvent({
+      endDate: "2024-01-15T19:45:00.000Z",
+      startDate: "2024-01-15T19:00:00.000Z",
+      title: "Visible overlap",
+    });
+    seededHiddenEventIds = [hidden._id!];
+    seedGrid([hidden, visible]);
+
+    render(
+      <Provider>
+        <MainGridEvents
+          measurements={measurements}
+          weekProps={createWeekProps()}
+        />
+      </Provider>,
+    );
+
+    const visibleCard = screen.getByRole("button", {
+      name: /timed event: visible overlap/i,
+    });
+    const hiddenCard = screen.getByRole("button", {
+      name: /^Hidden Timed event: Hidden overlap/,
+    });
+
+    expect(Number(visibleCard.style.zIndex)).toBe(ZIndex.LAYER_1);
+    expect(parseFloat(hiddenCard.style.width)).toBe(HIDDEN_EVENT_STRIP_WIDTH);
+    expect(parseFloat(visibleCard.style.width)).toBeGreaterThan(
+      HIDDEN_EVENT_STRIP_WIDTH,
+    );
+    expect(weekEventRegistry.resolve(hidden._id!, "timed")).toBeNull();
+    expect(weekEventRegistry.resolve(visible._id!, "timed")).toBe(visibleCard);
   });
 });

--- a/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
+++ b/packages/web/src/views/Week/components/Grid/MainGrid/MainGridEvents.tsx
@@ -9,6 +9,7 @@ import {
 import { ID_GRID_EVENTS_TIMED } from "@web/common/constants/web.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { suppressedSeriesIdForDraft } from "@web/events/grid-event-draft.adapter";
+import { useHiddenEventIds } from "@web/events/hidden/hidden-events.query";
 import {
   mergeGridEventWithDraftOverlay,
   useGridDraftOverlay,
@@ -53,6 +54,7 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
   const weekDays = weekProps.component.weekDays;
   // One lookup build for the whole list (packet 08 step 5) - not per card.
   const calendarLookup = useCalendarLookup();
+  const hiddenEventIds = useHiddenEventIds();
   // While the user is actively changing a series' recurrence, its saved
   // sibling occurrences are stale (they reflect the rule before this edit) -
   // the draft's own recurring-preview cards are the live truth for the
@@ -82,8 +84,8 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
     ],
   );
   const timedEventItems = useMemo(
-    () => createTimedEventLayout(visibleTimedEvents),
-    [visibleTimedEvents],
+    () => createTimedEventLayout(visibleTimedEvents, hiddenEventIds),
+    [hiddenEventIds, visibleTimedEvents],
   );
   // Resolved once per event here (not inside each card) and kept referentially
   // stable across renders where neither the events nor the calendars changed,
@@ -97,13 +99,14 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
           item.event,
         ),
         focusColor: resolveCalendarFocusColor(calendarLookup, item.event),
+        isHidden: Boolean(item.event._id && hiddenEventIds.has(item.event._id)),
         // Read-only (unwritable calendar or busy content) events never
         // attach interaction attributes/registration below, so the drag/
         // resize engine can't find them as a target - blocked before any
         // optimistic state change (packet 08 step 8).
         isReadOnly: isGridEventScheduleLocked(calendarLookup, item.event),
       })),
-    [timedEventItems, calendarLookup],
+    [timedEventItems, calendarLookup, hiddenEventIds],
   );
 
   const { onEventKeyDown, onOpenReadOnlyDetails } =
@@ -113,7 +116,14 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
     <div id={ID_GRID_EVENTS_TIMED}>
       {!isLoadingWeekView &&
         timedEventItemsWithIdentity.map(
-          ({ deckLayout, event, calendarIdentity, focusColor, isReadOnly }) => {
+          ({
+            deckLayout,
+            event,
+            calendarIdentity,
+            focusColor,
+            isHidden,
+            isReadOnly,
+          }) => {
             const isPlaceholder = event._id === draftId;
             const eventForDisplay = mergeGridEventWithDraftOverlay(
               event,
@@ -135,6 +145,7 @@ export const MainGridEvents = ({ measurements, weekProps }: Props) => {
                 deckLayout={deckLayout}
                 event={eventForDisplay}
                 focusColor={focusColorForDisplay}
+                isHidden={isHidden}
                 isPlaceholder={isPlaceholder}
                 isReadOnly={isReadOnly}
                 key={`initial-${event._id}`}
@@ -155,6 +166,7 @@ interface MainGridEventItemProps {
   deckLayout: TimedDeckLayout | null;
   event: GridEvent;
   focusColor: string | null;
+  isHidden: boolean;
   isPlaceholder: boolean;
   isReadOnly: boolean;
   measurements: Measurements_Grid;
@@ -168,6 +180,7 @@ const MainGridEventItem = ({
   deckLayout,
   event,
   focusColor,
+  isHidden,
   isPlaceholder,
   isReadOnly,
   measurements,
@@ -181,7 +194,7 @@ const MainGridEventItem = ({
   // cards only.
   const hasEventIdentity = Boolean(event._id);
   const isRegisteredForDragResize =
-    hasEventIdentity && !isPlaceholder && !isReadOnly;
+    hasEventIdentity && !isPlaceholder && !isReadOnly && !isHidden;
   const registrationRef = useWeekEventRegistrationRef({
     eventId: event._id,
     eventType: "timed",
@@ -206,6 +219,7 @@ const MainGridEventItem = ({
       event={event}
       focusColor={focusColor}
       interactionAttributes={interactionAttributes}
+      isHidden={isHidden}
       measurements={measurements}
       onEventKeyDown={isReadOnly ? onOpenReadOnlyDetails : onEventKeyDown}
       ref={registrationRef}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3620

## What and why

Hidden events in Week and Day now render as an 8px rounded strip in the event color at 60% opacity, with no title, time, repeat icon, or calendar accent. They stay focusable and keyboard-openable, drop out of timed overlap fanning so neighbours regain solo width, and are not registered for drag/resize. The hidden set is unchanged; tests seed it with `seedHiddenEventIds`.

Tracking: #3616. Spec: locked decisions on the tracking issue.

## Verify

Independent checks from `bun run verify --strict` (selected package `web`): `test:web` 857 pass, `type-check`, `lint`, `knip`. Local `test:a11y` passed in that run. Local `test:e2e` failed in this sandbox on specs the diff cannot reach:

- `e2e/auth/sign-in-providers.spec.ts` (timeouts waiting for sign-in provider buttons)
- `e2e/booking/public-booking.spec.ts` (extra slots GET, 3 vs 2)
- `e2e/onboarding/welcome-cta-width.spec.ts` (timeout waiting for the welcome Google button)

Timed/calendar Playwright specs passed, including `e2e/timed/event-smoke.spec.ts` and keyboard-grid-parity. GitHub E2E (shards 1-4) and Unit on this PR are SUCCESS on the same commit. Per ship skill, sandbox Playwright failures in specs the diff cannot reach are not a local blocker; CI is the gate.

Issue verify commands: `cd packages/web && bun test ./src/grid ./src/views/Week/components/Grid/MainGrid ./src/views/Day/components/Calendar`, `bun test:web`, `bun run type-check`, `bun run lint`, `bun knip`.

Browser check against `bun run dev:web`: two overlapping timed events at 72px; after writing `compass.events.hidden-ids`, Strip A is `Hidden Timed event: Strip A...` at `8px` with no title text, and Strip B is a solo-width titled card.

VERDICT: PASS

![Week grid before hiding, two overlapping Strip A and Strip B cards](https://cursor.com/artifacts/c/art-53be214b-12ab-49cc-b867-90c9c9f7fcc4)
![Week grid after hiding Strip A, neighbour at solo width](https://cursor.com/artifacts/c/art-804ea136-5d40-4c33-b396-9ff9d8db84b7)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6562b00-704c-43c1-aef8-a4299e3a7038?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6562b00-704c-43c1-aef8-a4299e3a7038&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

