### PR TITLE
feat(web): tell same-email accounts apart by provider

### DIFF
--- a/docs/features/calendar-providers.md
+++ b/docs/features/calendar-providers.md
@@ -49,7 +49,7 @@ each with a tracking issue:
   Manage Accounts.
 - **An account is provider + email, never email alone.** The same address can
   be a Google account and a Microsoft account, so the web app keys sidebar
-  sections, collapse state, and Settings rows by `accountKey(provider, email)`
+  sections, collapse state, and Settings rows by `accountKey` (provider + email)
   and shows a provider mark (the monochrome logo) beside every account email.
 - **No em-dashes** in user-facing copy.
 

--- a/docs/features/calendar-providers.md
+++ b/docs/features/calendar-providers.md
@@ -47,6 +47,10 @@ each with a tracking issue:
   Calendar, parallel to Google Calendar). "Outlook" is not shown in the product
   UI; command-palette search still accepts "outlook" as a keyword for
   Manage Accounts.
+- **An account is provider + email, never email alone.** The same address can
+  be a Google account and a Microsoft account, so the web app keys sidebar
+  sections, collapse state, and Settings rows by `accountKey(provider, email)`
+  and shows a provider mark (the monochrome logo) beside every account email.
 - **No em-dashes** in user-facing copy.
 
 ## Capability matrix

--- a/packages/core/src/types/calendar.contracts.ts
+++ b/packages/core/src/types/calendar.contracts.ts
@@ -4,13 +4,16 @@ import {
   HexColorSchema,
   TimeZoneSchema,
 } from "@core/types/domain-primitives";
-import { type ProviderCapability } from "@core/types/sync/identity.contracts";
+import {
+  type ProviderCapability,
+  ProviderKindSchema,
+} from "@core/types/sync/identity.contracts";
 
-export const CalendarProviderSchema = z.enum([
-  "local",
-  "google",
-  "microsoft",
-  "apple",
+// "local" is the browser-only calendar; everything else is a connected
+// provider account, so the type is `"local" | ProviderKind` by construction.
+export const CalendarProviderSchema = z.union([
+  z.literal("local"),
+  ProviderKindSchema,
 ]);
 export type CalendarProvider = z.infer<typeof CalendarProviderSchema>;
 

--- a/packages/core/src/types/calendar.contracts.ts
+++ b/packages/core/src/types/calendar.contracts.ts
@@ -120,11 +120,12 @@ export const CalendarSchema = z.strictObject({
   // calendar's provider (`CONFERENCE_BY_PROVIDER`) and whether that calendar
   // can actually create a conference link.
   conference: CalendarConferenceSchema.optional(),
-  // Email of the connected provider account this calendar belongs to. This is
-  // the calendar's only account identity on the wire: emails are unique per
-  // user (one Google account = one connection), so grouping and labelling key
-  // off it directly. Absent for the local calendar, and for provider accounts
-  // that reported no email.
+  // Email of the connected provider account this calendar belongs to. With
+  // `provider` it forms the calendar's account identity on the wire: one
+  // email backs at most one account per provider, but the same address can
+  // be a Google account and a Microsoft account, so grouping and labelling
+  // key off (provider, accountEmail), never the email alone. Absent for the
+  // local calendar, and for provider accounts that reported no email.
   accountEmail: z.string().optional(),
 });
 export type Calendar = z.infer<typeof CalendarSchema>;

--- a/packages/web/src/__tests__/utils/factories/calendar.factory.ts
+++ b/packages/web/src/__tests__/utils/factories/calendar.factory.ts
@@ -4,9 +4,7 @@ import {
   getCalendarCapabilities,
 } from "@core/types/calendar.contracts";
 import { CalendarIdSchema } from "@core/types/domain-primitives";
-import { type ProviderKind } from "@core/types/sync/identity.contracts";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
-import { type AccountRef, accountKey } from "@web/calendars/calendar.util";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 
 /**
@@ -63,12 +61,4 @@ export function createMockConnection(
     provider: "google",
     ...overrides,
   };
-}
-
-/** The provider-scoped account ref a connection or calendar group resolves to. */
-export function createMockAccountRef(
-  accountEmail: string,
-  provider: ProviderKind = "google",
-): AccountRef {
-  return { key: accountKey(provider, accountEmail), provider, accountEmail };
 }

--- a/packages/web/src/__tests__/utils/factories/calendar.factory.ts
+++ b/packages/web/src/__tests__/utils/factories/calendar.factory.ts
@@ -4,7 +4,9 @@ import {
   getCalendarCapabilities,
 } from "@core/types/calendar.contracts";
 import { CalendarIdSchema } from "@core/types/domain-primitives";
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
+import { type AccountRef, accountKey } from "@web/calendars/calendar.util";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 
 /**
@@ -61,4 +63,12 @@ export function createMockConnection(
     provider: "google",
     ...overrides,
   };
+}
+
+/** The provider-scoped account ref a connection or calendar group resolves to. */
+export function createMockAccountRef(
+  accountEmail: string,
+  provider: ProviderKind = "google",
+): AccountRef {
+  return { key: accountKey(provider, accountEmail), provider, accountEmail };
 }

--- a/packages/web/src/auth/providers/ConnectProviderChooser.tsx
+++ b/packages/web/src/auth/providers/ConnectProviderChooser.tsx
@@ -13,18 +13,13 @@ import {
   providerDisplayName,
 } from "@core/types/sync/identity.contracts";
 import { openingProviderLabel } from "@web/auth/providers/connection-provider.util";
+import { PROVIDER_LOGO } from "@web/auth/providers/ProviderMark";
 import { CONNECT_CALENDAR_LABEL } from "@web/auth/providers/provider-copy.util";
 import { useAvailableConnectProviders } from "@web/auth/providers/useAvailableConnectProviders";
 import { useConnectProvider } from "@web/auth/providers/useConnectProvider";
 import { focusOnPointerEnter } from "@web/common/utils/focus-on-pointer-enter";
-import { MicrosoftLogo } from "@web/components/AuthModal/components/MicrosoftButton";
 import { SignInProviderButtons } from "@web/components/AuthModal/components/SignInProviderButtons";
 import { OverlayPanelActionButton } from "@web/components/OverlayPanel/OverlayPanel";
-
-const PROVIDER_MENU_ICON: Partial<Record<ProviderKind, typeof MicrosoftLogo>> =
-  {
-    microsoft: MicrosoftLogo,
-  };
 
 const SIDEBAR_PRIMARY_CLASSNAME =
   "c-button-compact c-button-primary mb-2 w-full rounded-xs px-2 py-1.5 text-left text-xs";
@@ -202,7 +197,7 @@ export const ConnectProviderChooser: FC<ConnectProviderChooserProps> = ({
       role="menu"
     >
       {available.map((kind, index) => {
-        const Icon = PROVIDER_MENU_ICON[kind];
+        const Icon = PROVIDER_LOGO[kind];
         return (
           <button
             className="c-focus-ring flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm text-text hover:bg-surface-panel"
@@ -213,7 +208,7 @@ export const ConnectProviderChooser: FC<ConnectProviderChooserProps> = ({
             role="menuitem"
             type="button"
           >
-            {Icon ? <Icon size={14} /> : null}
+            <Icon size={14} />
             {providerDisplayName(kind)}
           </button>
         );

--- a/packages/web/src/auth/providers/ProviderMark.tsx
+++ b/packages/web/src/auth/providers/ProviderMark.tsx
@@ -8,11 +8,9 @@ import { GoogleLogo } from "@web/components/Icons/GoogleLogo";
 import { MicrosoftLogo } from "@web/components/Icons/MicrosoftLogo";
 
 /**
- * One monochrome logo per provider kind. Exhaustive on purpose: adding a
- * provider to ProviderKindSchema fails type-check here until its logo is
- * registered, so every account surface picks it up without a code path per
- * provider. The logos are decorative (aria-hidden); use them bare only next
- * to text that already names the provider.
+ * One monochrome logo per provider kind, exhaustive so a new provider cannot
+ * ship without one. The logos are decorative (aria-hidden); use them bare
+ * only next to text that already names the provider.
  */
 export const PROVIDER_LOGO: Record<ProviderKind, FC<{ size?: number }>> = {
   google: GoogleLogo,

--- a/packages/web/src/auth/providers/ProviderMark.tsx
+++ b/packages/web/src/auth/providers/ProviderMark.tsx
@@ -1,0 +1,45 @@
+import { type FC } from "react";
+import {
+  type ProviderKind,
+  providerDisplayName,
+} from "@core/types/sync/identity.contracts";
+import { AppleLogo } from "@web/components/Icons/AppleLogo";
+import { GoogleLogo } from "@web/components/Icons/GoogleLogo";
+import { MicrosoftLogo } from "@web/components/Icons/MicrosoftLogo";
+
+/**
+ * One monochrome logo per provider kind. Exhaustive on purpose: adding a
+ * provider to ProviderKindSchema fails type-check here until its logo is
+ * registered, so every account surface picks it up without a code path per
+ * provider. The logos are decorative (aria-hidden); use them bare only next
+ * to text that already names the provider.
+ */
+export const PROVIDER_LOGO: Record<ProviderKind, FC<{ size?: number }>> = {
+  google: GoogleLogo,
+  microsoft: MicrosoftLogo,
+  apple: AppleLogo,
+};
+
+/**
+ * A provider's logo with the provider name as its accessible name, for
+ * account rows and headings where the email alone cannot say which
+ * provider an account belongs to (the same address can back a Google
+ * account and a Microsoft account).
+ */
+export const ProviderMark: FC<{ provider: ProviderKind; size?: number }> = ({
+  provider,
+  size = 14,
+}) => {
+  const Logo = PROVIDER_LOGO[provider];
+  const name = providerDisplayName(provider);
+  return (
+    <span
+      aria-label={name}
+      className="inline-flex shrink-0 text-text-muted"
+      role="img"
+      title={name}
+    >
+      <Logo size={size} />
+    </span>
+  );
+};

--- a/packages/web/src/auth/providers/connection-provider.util.test.ts
+++ b/packages/web/src/auth/providers/connection-provider.util.test.ts
@@ -1,20 +1,6 @@
 import { createMockCalendar } from "@web/__tests__/utils/factories/calendar.factory";
-import {
-  calendarProviderKind,
-  connectionProviderKind,
-} from "@web/auth/providers/connection-provider.util";
+import { calendarProviderKind } from "@web/auth/providers/connection-provider.util";
 import { describe, expect, it } from "bun:test";
-
-describe("connectionProviderKind", () => {
-  it("treats a legacy payload without provider as Google", () => {
-    expect(connectionProviderKind({})).toBe("google");
-    expect(connectionProviderKind(undefined)).toBe("google");
-  });
-
-  it("returns the connection's provider when present", () => {
-    expect(connectionProviderKind({ provider: "microsoft" })).toBe("microsoft");
-  });
-});
 
 describe("calendarProviderKind", () => {
   it("returns the provider kind of a provider-backed calendar", () => {

--- a/packages/web/src/auth/providers/connection-provider.util.test.ts
+++ b/packages/web/src/auth/providers/connection-provider.util.test.ts
@@ -1,0 +1,32 @@
+import { createMockCalendar } from "@web/__tests__/utils/factories/calendar.factory";
+import {
+  calendarProviderKind,
+  connectionProviderKind,
+} from "@web/auth/providers/connection-provider.util";
+import { describe, expect, it } from "bun:test";
+
+describe("connectionProviderKind", () => {
+  it("treats a legacy payload without provider as Google", () => {
+    expect(connectionProviderKind({})).toBe("google");
+    expect(connectionProviderKind(undefined)).toBe("google");
+  });
+
+  it("returns the connection's provider when present", () => {
+    expect(connectionProviderKind({ provider: "microsoft" })).toBe("microsoft");
+  });
+});
+
+describe("calendarProviderKind", () => {
+  it("returns the provider kind of a provider-backed calendar", () => {
+    expect(calendarProviderKind(createMockCalendar())).toBe("google");
+    expect(
+      calendarProviderKind(createMockCalendar({ provider: "microsoft" })),
+    ).toBe("microsoft");
+  });
+
+  it("is undefined for the local calendar, which belongs to no account", () => {
+    expect(
+      calendarProviderKind(createMockCalendar({ provider: "local" })),
+    ).toBeUndefined();
+  });
+});

--- a/packages/web/src/auth/providers/connection-provider.util.ts
+++ b/packages/web/src/auth/providers/connection-provider.util.ts
@@ -1,7 +1,6 @@
 import { type Calendar } from "@core/types/calendar.contracts";
 import {
   type ProviderKind,
-  ProviderKindSchema,
   providerDisplayName,
 } from "@core/types/sync/identity.contracts";
 import { type SyncConnectionSummary } from "@core/types/user.types";
@@ -17,16 +16,11 @@ export const connectionProviderKind = (
   connection?: Pick<SyncConnectionSummary, "provider"> | null,
 ): ProviderKind => connection?.provider ?? "google";
 
-/**
- * The provider account a calendar belongs to; undefined for the local
- * calendar, whose `provider` is outside ProviderKind.
- */
+/** The provider account a calendar belongs to; undefined for the local calendar. */
 export const calendarProviderKind = (
   calendar: Pick<Calendar, "provider">,
-): ProviderKind | undefined => {
-  const parsed = ProviderKindSchema.safeParse(calendar.provider);
-  return parsed.success ? parsed.data : undefined;
-};
+): ProviderKind | undefined =>
+  calendar.provider === "local" ? undefined : calendar.provider;
 
 export const openingProviderLabel = (kind: ProviderKind): string =>
   kind === "google"

--- a/packages/web/src/auth/providers/connection-provider.util.ts
+++ b/packages/web/src/auth/providers/connection-provider.util.ts
@@ -1,5 +1,7 @@
+import { type Calendar } from "@core/types/calendar.contracts";
 import {
   type ProviderKind,
+  ProviderKindSchema,
   providerDisplayName,
 } from "@core/types/sync/identity.contracts";
 import { type SyncConnectionSummary } from "@core/types/user.types";
@@ -14,6 +16,17 @@ export const ALL_PROVIDER_KINDS: ProviderKind[] = [
 export const connectionProviderKind = (
   connection?: Pick<SyncConnectionSummary, "provider"> | null,
 ): ProviderKind => connection?.provider ?? "google";
+
+/**
+ * The provider account a calendar belongs to; undefined for the local
+ * calendar, whose `provider` is outside ProviderKind.
+ */
+export const calendarProviderKind = (
+  calendar: Pick<Calendar, "provider">,
+): ProviderKind | undefined => {
+  const parsed = ProviderKindSchema.safeParse(calendar.provider);
+  return parsed.success ? parsed.data : undefined;
+};
 
 export const openingProviderLabel = (kind: ProviderKind): string =>
   kind === "google"

--- a/packages/web/src/auth/providers/provider-copy.util.test.ts
+++ b/packages/web/src/auth/providers/provider-copy.util.test.ts
@@ -4,7 +4,6 @@ import {
   CONNECT_CALENDAR_LABEL,
   calendarProductName,
   connectionProvider,
-  defaultCalendarGroupLabel,
   emptyCalendarsCopy,
   openingProviderCopy,
   RECONNECT_BANNER_MESSAGE,
@@ -32,9 +31,6 @@ describe("provider copy", () => {
     expect(openingProviderCopy("google")).toBe("Opening Google…");
     expect(emptyCalendarsCopy(["google"])).toBe(
       "Connect Google to see your calendars.",
-    );
-    expect(defaultCalendarGroupLabel("ahab@pequod.com", "google")).toBe(
-      "ahab@pequod.com (Google)",
     );
     expect(reconnectToastTitle("google", "lance@example.com")).toBe(
       "Google Calendar disconnected (lance@example.com)",
@@ -68,9 +64,6 @@ describe("provider copy", () => {
     expect(openingProviderCopy("microsoft")).toBe("Opening Microsoft…");
     expect(emptyCalendarsCopy(["microsoft"])).toBe(
       "Connect Microsoft to see your calendars.",
-    );
-    expect(defaultCalendarGroupLabel("ada@outlook.com", "microsoft")).toBe(
-      "ada@outlook.com (Microsoft)",
     );
     expect(reconnectPointerHint("microsoft")).toBe(
       "Press G to reconnect Microsoft Calendar.",

--- a/packages/web/src/auth/providers/provider-copy.util.ts
+++ b/packages/web/src/auth/providers/provider-copy.util.ts
@@ -110,13 +110,6 @@ export function bookingConnectPromptCopy(
   return "Connect a calendar account to enable your meeting page. Guests book through a public link and Compass creates events on your calendar.";
 }
 
-export function defaultCalendarGroupLabel(
-  accountEmail: string,
-  kind: ProviderKind,
-): string {
-  return `${accountEmail} (${providerDisplayName(kind)})`;
-}
-
 export function reconnectToastTitle(
   kind: ProviderKind,
   accountEmail?: string | null,

--- a/packages/web/src/auth/providers/useDisconnectAccount.test.tsx
+++ b/packages/web/src/auth/providers/useDisconnectAccount.test.tsx
@@ -55,7 +55,7 @@ describe("useDisconnectGoogleAccount", () => {
     const { result } = renderHook(() => useDisconnectGoogleAccount(), {
       wrapper,
     });
-    await act(() => result.current.disconnect("ms-conn", EMAIL));
+    await act(() => result.current.disconnect(microsoft));
 
     expect(disconnect).toHaveBeenCalledWith("ms-conn");
     // No calendar query is observed here, so the invalidation does not

--- a/packages/web/src/auth/providers/useDisconnectAccount.test.tsx
+++ b/packages/web/src/auth/providers/useDisconnectAccount.test.tsx
@@ -1,0 +1,69 @@
+import { act, renderHook } from "@testing-library/react";
+import { type Calendar } from "@core/types/calendar.contracts";
+import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
+import { createStoreWrapper } from "@web/__tests__/render-with-store";
+import {
+  createMockCalendar,
+  createMockConnection,
+} from "@web/__tests__/utils/factories/calendar.factory";
+import { AuthApi } from "@web/api/auth.api";
+import { useDisconnectGoogleAccount } from "@web/auth/providers/useDisconnectAccount";
+import { userMetadataActions } from "@web/auth/state/user-metadata.store";
+import { calendarQueryKeys } from "@web/calendars/calendar.query";
+import {
+  registerToastPort,
+  resetToastPort,
+} from "@web/common/utils/toast/toast.port";
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+
+const EMAIL = "lance@gmail.com";
+
+describe("useDisconnectGoogleAccount", () => {
+  afterEach(() => {
+    resetToastPort();
+  });
+
+  it("drops only the disconnected provider's calendars when another provider shares the address", async () => {
+    registerToastPort(createTestToastPort().port);
+    const disconnect = spyOn(
+      AuthApi,
+      "disconnectGoogleConnection",
+    ).mockResolvedValue(undefined);
+    const google = createMockConnection(EMAIL, { id: "google-conn" });
+    const microsoft = createMockConnection(EMAIL, {
+      id: "ms-conn",
+      provider: "microsoft",
+    });
+    userMetadataActions.set({
+      google: { connectionState: "HEALTHY", connections: [google, microsoft] },
+    });
+    const googleCal = createMockCalendar({
+      name: "Google primary",
+      accountEmail: EMAIL,
+    });
+    const microsoftCal = createMockCalendar({
+      name: "Microsoft primary",
+      provider: "microsoft",
+      accountEmail: EMAIL,
+    });
+    const { queryClient, wrapper } = createStoreWrapper();
+    queryClient.setQueryData<Calendar[]>(calendarQueryKeys.all, [
+      googleCal,
+      microsoftCal,
+    ]);
+
+    const { result } = renderHook(() => useDisconnectGoogleAccount(), {
+      wrapper,
+    });
+    await act(() => result.current.disconnect("ms-conn", EMAIL));
+
+    expect(disconnect).toHaveBeenCalledWith("ms-conn");
+    // No calendar query is observed here, so the invalidation does not
+    // refetch and the optimistic cache is what stays behind.
+    expect(queryClient.getQueryData<Calendar[]>(calendarQueryKeys.all)).toEqual(
+      [googleCal],
+    );
+
+    disconnect.mockRestore();
+  });
+});

--- a/packages/web/src/auth/providers/useDisconnectAccount.ts
+++ b/packages/web/src/auth/providers/useDisconnectAccount.ts
@@ -3,8 +3,16 @@ import { useCallback, useState } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { AuthApi } from "@web/api/auth.api";
 import { refreshUserMetadata } from "@web/auth/compass/user/util/user-metadata.util";
+import {
+  calendarProviderKind,
+  connectionProviderKind,
+} from "@web/auth/providers/connection-provider.util";
 import { clearAccountReconnectRequired } from "@web/auth/providers/reconnect.state";
-import { userMetadataActions } from "@web/auth/state/user-metadata.store";
+import {
+  selectSyncConnections,
+  userMetadataActions,
+  useUserMetadataStore,
+} from "@web/auth/state/user-metadata.store";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
 import {
   ACCOUNT_DISCONNECTED_TOAST_ID,
@@ -46,13 +54,21 @@ export function useDisconnectGoogleAccount(): {
           // caches right away - the calendars refetch below can still race
           // backend cleanup and return them for a beat, which was leaving the
           // disconnected account visible in the Accounts panel and the
-          // Default Calendar picker.
+          // Default Calendar picker. Match on provider as well as email so a
+          // same-address account on another provider keeps its calendars.
+          const provider = connectionProviderKind(
+            selectSyncConnections(useUserMetadataStore.getState()).find(
+              (connection) => connection.id === connectionId,
+            ),
+          );
           userMetadataActions.removeConnection(connectionId);
           queryClient.setQueryData<Calendar[]>(
             calendarQueryKeys.all,
             (calendars) =>
               calendars?.filter(
-                (calendar) => calendar.accountEmail !== accountEmail,
+                (calendar) =>
+                  calendar.accountEmail !== accountEmail ||
+                  calendarProviderKind(calendar) !== provider,
               ),
           );
 

--- a/packages/web/src/auth/providers/useDisconnectAccount.ts
+++ b/packages/web/src/auth/providers/useDisconnectAccount.ts
@@ -1,19 +1,17 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
+import { type SyncConnectionSummary } from "@core/types/user.types";
 import { AuthApi } from "@web/api/auth.api";
 import { refreshUserMetadata } from "@web/auth/compass/user/util/user-metadata.util";
-import {
-  calendarProviderKind,
-  connectionProviderKind,
-} from "@web/auth/providers/connection-provider.util";
 import { clearAccountReconnectRequired } from "@web/auth/providers/reconnect.state";
-import {
-  selectSyncConnections,
-  userMetadataActions,
-  useUserMetadataStore,
-} from "@web/auth/state/user-metadata.store";
+import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
+import {
+  accountKey,
+  calendarAccount,
+  connectionAccount,
+} from "@web/calendars/calendar.util";
 import {
   ACCOUNT_DISCONNECTED_TOAST_ID,
   GOOGLE_REVOKED_TOAST_ID,
@@ -31,14 +29,18 @@ import { eventQueryKeys } from "@web/events/queries/event.query.keys";
  * instance.
  */
 export function useDisconnectGoogleAccount(): {
-  disconnect: (connectionId: string, accountEmail: string) => Promise<void>;
+  disconnect: (connection: SyncConnectionSummary) => Promise<void>;
   disconnectingId: string | null;
 } {
   const queryClient = useQueryClient();
   const [disconnectingId, setDisconnectingId] = useState<string | null>(null);
 
   const disconnect = useCallback(
-    (connectionId: string, accountEmail: string) => {
+    (connection: SyncConnectionSummary) => {
+      const connectionId = connection.id;
+      const accountEmail = connection.accountEmail ?? "Unknown account";
+      const account = connectionAccount(connection);
+      const key = account && accountKey(account);
       setDisconnectingId(connectionId);
       return AuthApi.disconnectGoogleConnection(connectionId)
         .then(async () => {
@@ -54,22 +56,16 @@ export function useDisconnectGoogleAccount(): {
           // caches right away - the calendars refetch below can still race
           // backend cleanup and return them for a beat, which was leaving the
           // disconnected account visible in the Accounts panel and the
-          // Default Calendar picker. Match on provider as well as email so a
-          // same-address account on another provider keeps its calendars.
-          const provider = connectionProviderKind(
-            selectSyncConnections(useUserMetadataStore.getState()).find(
-              (connection) => connection.id === connectionId,
-            ),
-          );
+          // Default Calendar picker. Only this account's calendars go; a
+          // same-address account on another provider keeps its own.
           userMetadataActions.removeConnection(connectionId);
           queryClient.setQueryData<Calendar[]>(
             calendarQueryKeys.all,
             (calendars) =>
-              calendars?.filter(
-                (calendar) =>
-                  calendar.accountEmail !== accountEmail ||
-                  calendarProviderKind(calendar) !== provider,
-              ),
+              calendars?.filter((calendar) => {
+                const owner = calendarAccount(calendar);
+                return !owner || accountKey(owner) !== key;
+              }),
           );
 
           // The account's calendars and its events both disappear, and the

--- a/packages/web/src/booking/BookingBlockingCalendarsField.tsx
+++ b/packages/web/src/booking/BookingBlockingCalendarsField.tsx
@@ -3,7 +3,10 @@ import { type CalendarId } from "@core/types/domain-primitives";
 import { type SyncConnectionSummary } from "@core/types/user.types";
 import { BookingCheckboxRow } from "@web/booking/BookingCheckboxRow";
 import { bookingFieldAttrs } from "@web/booking/booking-sequence.fields";
-import { groupCalendarsByAccount } from "@web/calendars/calendar.util";
+import {
+  accountKey,
+  groupCalendarsByAccount,
+} from "@web/calendars/calendar.util";
 
 interface BookingBlockingCalendarsFieldProps {
   availabilityCalendars: Calendar[];
@@ -49,7 +52,10 @@ export function BookingBlockingCalendarsField({
       ) : (
         <>
           {groupsWithCalendars.map((group) => (
-            <div className="flex min-w-0 flex-col gap-2" key={group.key}>
+            <div
+              className="flex min-w-0 flex-col gap-2"
+              key={accountKey(group)}
+            >
               {showAccountCaption ? (
                 <p className="text-text-muted text-xs">{group.accountEmail}</p>
               ) : null}

--- a/packages/web/src/booking/BookingBlockingCalendarsField.tsx
+++ b/packages/web/src/booking/BookingBlockingCalendarsField.tsx
@@ -49,10 +49,7 @@ export function BookingBlockingCalendarsField({
       ) : (
         <>
           {groupsWithCalendars.map((group) => (
-            <div
-              className="flex min-w-0 flex-col gap-2"
-              key={group.accountEmail}
-            >
+            <div className="flex min-w-0 flex-col gap-2" key={group.key}>
               {showAccountCaption ? (
                 <p className="text-text-muted text-xs">{group.accountEmail}</p>
               ) : null}

--- a/packages/web/src/booking/BookingDestinationCalendarOptions.tsx
+++ b/packages/web/src/booking/BookingDestinationCalendarOptions.tsx
@@ -1,7 +1,10 @@
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type SyncConnectionSummary } from "@core/types/user.types";
 import { formatBookingDestinationOptionLabel } from "@web/booking/booking-conference.copy";
-import { groupCalendarsByAccount } from "@web/calendars/calendar.util";
+import {
+  accountKey,
+  groupCalendarsByAccount,
+} from "@web/calendars/calendar.util";
 
 interface BookingDestinationCalendarOptionsProps {
   calendars: Calendar[];
@@ -18,7 +21,7 @@ export function BookingDestinationCalendarOptions({
       {groups
         .filter((group) => group.calendars.length > 0)
         .map((group) => (
-          <optgroup key={group.key} label={group.accountEmail}>
+          <optgroup key={accountKey(group)} label={group.accountEmail}>
             {group.calendars.map((calendar) => (
               <option key={calendar.id} value={calendar.id}>
                 {formatBookingDestinationOptionLabel(calendar)}

--- a/packages/web/src/booking/BookingDestinationCalendarOptions.tsx
+++ b/packages/web/src/booking/BookingDestinationCalendarOptions.tsx
@@ -18,7 +18,7 @@ export function BookingDestinationCalendarOptions({
       {groups
         .filter((group) => group.calendars.length > 0)
         .map((group) => (
-          <optgroup key={group.accountEmail} label={group.accountEmail}>
+          <optgroup key={group.key} label={group.accountEmail}>
             {group.calendars.map((calendar) => (
               <option key={calendar.id} value={calendar.id}>
                 {formatBookingDestinationOptionLabel(calendar)}

--- a/packages/web/src/calendars/calendar.util.test.ts
+++ b/packages/web/src/calendars/calendar.util.test.ts
@@ -2,6 +2,7 @@ import {
   type Calendar,
   getCalendarCapabilities,
 } from "@core/types/calendar.contracts";
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import {
   canInviteOnCalendar,
@@ -435,8 +436,13 @@ describe("spansMultipleAccounts", () => {
 });
 
 describe("groupCalendarsByAccount", () => {
-  const connection = (accountEmail: string): GoogleSyncConnectionSummary => ({
-    id: `conn-${accountEmail}`,
+  // `provider` stays absent by default so the legacy (Google) payload path
+  // is what most cases exercise.
+  const connection = (
+    accountEmail: string,
+    provider?: ProviderKind,
+  ): GoogleSyncConnectionSummary => ({
+    id: `conn-${provider ?? "google"}-${accountEmail}`,
     state: "healthy",
     stateReason: null,
     lastSyncedAt: null,
@@ -444,12 +450,18 @@ describe("groupCalendarsByAccount", () => {
     accountEmail,
     connectionState: "HEALTHY",
     canSuggestContacts: false,
+    ...(provider ? { provider } : {}),
   });
 
   it("buckets by account in connection order and leaves the local calendar ungrouped", () => {
-    const work = makeCalendar({ name: "Work", accountEmail: "old@x.com" });
+    const work = makeCalendar({
+      name: "Work",
+      provider: "google",
+      accountEmail: "old@x.com",
+    });
     const personal = makeCalendar({
       name: "Personal",
+      provider: "google",
       accountEmail: "new@x.com",
       id: "507f1f77bcf86cd799439012" as Calendar["id"],
     });
@@ -472,7 +484,11 @@ describe("groupCalendarsByAccount", () => {
   });
 
   it("groups a lone connected account too - no two-account threshold", () => {
-    const work = makeCalendar({ name: "Work", accountEmail: "old@x.com" });
+    const work = makeCalendar({
+      name: "Work",
+      provider: "google",
+      accountEmail: "old@x.com",
+    });
 
     const { groups } = groupCalendarsByAccount(
       [work],
@@ -489,6 +505,74 @@ describe("groupCalendarsByAccount", () => {
     expect(groups).toHaveLength(1);
     expect(groups[0]?.accountEmail).toBe("old@x.com");
     expect(groups[0]?.calendars).toEqual([]);
+  });
+
+  it("keeps same-email Google and Microsoft accounts as separate groups", () => {
+    // A Gmail address can also be a Microsoft personal-account login, so the
+    // email alone does not identify an account: the provider does.
+    const googleCal = makeCalendar({
+      name: "Google primary",
+      provider: "google",
+      accountEmail: "lance@gmail.com",
+    });
+    const microsoftCal = makeCalendar({
+      name: "Microsoft primary",
+      provider: "microsoft",
+      accountEmail: "lance@gmail.com",
+      id: "507f1f77bcf86cd799439012" as Calendar["id"],
+    });
+    const google = connection("lance@gmail.com", "google");
+    const microsoft = connection("lance@gmail.com", "microsoft");
+
+    const { groups, ungrouped } = groupCalendarsByAccount(
+      [microsoftCal, googleCal],
+      [google, microsoft],
+    );
+
+    expect(ungrouped).toEqual([]);
+    expect(groups.map((group) => group.key)).toEqual([
+      "google:lance@gmail.com",
+      "microsoft:lance@gmail.com",
+    ]);
+    expect(groups[0]).toMatchObject({
+      provider: "google",
+      accountEmail: "lance@gmail.com",
+      connection: google,
+      calendars: [googleCal],
+    });
+    expect(groups[1]).toMatchObject({
+      provider: "microsoft",
+      accountEmail: "lance@gmail.com",
+      connection: microsoft,
+      calendars: [microsoftCal],
+    });
+  });
+
+  it("nests the local calendar under the oldest-connected account sharing the login email", () => {
+    const googleCal = makeCalendar({
+      name: "Google primary",
+      provider: "google",
+      accountEmail: "lance@gmail.com",
+    });
+    const local = makeCalendar({
+      name: "Compass",
+      provider: "local",
+      id: "507f1f77bcf86cd799439013" as Calendar["id"],
+    });
+
+    const { groups, ungrouped } = groupCalendarsByAccount(
+      [googleCal, local],
+      [
+        connection("lance@gmail.com", "microsoft"),
+        connection("lance@gmail.com", "google"),
+      ],
+      "lance@gmail.com",
+    );
+
+    expect(ungrouped).toEqual([]);
+    expect(groups[0]?.key).toBe("microsoft:lance@gmail.com");
+    expect(groups[0]?.calendars).toEqual([local]);
+    expect(groups[1]?.calendars).toEqual([googleCal]);
   });
 
   it("nests the local calendar under the Google account that matches compassEmail", () => {

--- a/packages/web/src/calendars/calendar.util.test.ts
+++ b/packages/web/src/calendars/calendar.util.test.ts
@@ -5,6 +5,7 @@ import {
 import { type ProviderKind } from "@core/types/sync/identity.contracts";
 import { type GoogleSyncConnectionSummary } from "@core/types/user.types";
 import {
+  accountKey,
   canInviteOnCalendar,
   compareCalendars,
   getDefaultTargetCalendar,
@@ -530,7 +531,7 @@ describe("groupCalendarsByAccount", () => {
     );
 
     expect(ungrouped).toEqual([]);
-    expect(groups.map((group) => group.key)).toEqual([
+    expect(groups.map(accountKey)).toEqual([
       "google:lance@gmail.com",
       "microsoft:lance@gmail.com",
     ]);
@@ -570,7 +571,10 @@ describe("groupCalendarsByAccount", () => {
     );
 
     expect(ungrouped).toEqual([]);
-    expect(groups[0]?.key).toBe("microsoft:lance@gmail.com");
+    expect(groups[0]).toMatchObject({
+      provider: "microsoft",
+      accountEmail: "lance@gmail.com",
+    });
     expect(groups[0]?.calendars).toEqual([local]);
     expect(groups[1]?.calendars).toEqual([googleCal]);
   });

--- a/packages/web/src/calendars/calendar.util.ts
+++ b/packages/web/src/calendars/calendar.util.ts
@@ -1,5 +1,8 @@
 import { type Calendar } from "@core/types/calendar.contracts";
-import { type ProviderKind } from "@core/types/sync/identity.contracts";
+import {
+  type ProviderKind,
+  providerDisplayName,
+} from "@core/types/sync/identity.contracts";
 import { type SyncConnectionSummary } from "@core/types/user.types";
 import {
   calendarProviderKind,
@@ -116,23 +119,44 @@ export function spansMultipleAccounts(calendars: Calendar[]): boolean {
 }
 
 /**
- * The web app's identity for one connected account. An email alone is not
- * enough: the same address can back a Google account and a Microsoft
- * account (a Gmail address used as a Microsoft login, or the reverse), and
- * both `Calendar` and `SyncConnectionSummary` carry `provider` next to
- * `accountEmail`, so the pair is what every account-shaped key uses.
+ * The web app's identity for one connected account: provider + email. An
+ * email alone is not enough, since the same address can be a Google account
+ * and a Microsoft account, and both `Calendar` and `SyncConnectionSummary`
+ * already carry `provider` next to `accountEmail`.
  */
-export const accountKey = (
-  provider: ProviderKind,
-  accountEmail: string,
-): string => `${provider}:${accountEmail}`;
-
 export interface AccountRef {
-  /** `accountKey(provider, accountEmail)`: React keys, DOM ids, collapse state. */
-  key: string;
   provider: ProviderKind;
   accountEmail: string;
 }
+
+/** String form, for React keys, DOM ids, collapse state, and page-jump ids. */
+export const accountKey = ({ provider, accountEmail }: AccountRef): string =>
+  `${provider}:${accountEmail}`;
+
+/** Human form: "ahab@pequod.com (Google)". */
+export const accountLabel = ({ provider, accountEmail }: AccountRef): string =>
+  `${accountEmail} (${providerDisplayName(provider)})`;
+
+/** Undefined when the connection reported no email. */
+export const connectionAccount = (
+  connection: Pick<SyncConnectionSummary, "provider" | "accountEmail">,
+): AccountRef | undefined =>
+  connection.accountEmail
+    ? {
+        provider: connectionProviderKind(connection),
+        accountEmail: connection.accountEmail,
+      }
+    : undefined;
+
+/** Undefined for the local calendar and for accounts that reported no email. */
+export const calendarAccount = (
+  calendar: Pick<Calendar, "provider" | "accountEmail">,
+): AccountRef | undefined => {
+  const provider = calendarProviderKind(calendar);
+  return provider && calendar.accountEmail
+    ? { provider, accountEmail: calendar.accountEmail }
+    : undefined;
+};
 
 export interface AccountGroup extends AccountRef {
   connection: SyncConnectionSummary | undefined;
@@ -160,49 +184,36 @@ export function groupCalendarsByAccount(
   const groups: AccountGroup[] = [];
   const byKey = new Map<string, AccountGroup>();
   const ungrouped: Calendar[] = [];
+  const ensureGroup = (
+    account: AccountRef,
+    connection: SyncConnectionSummary | undefined,
+  ): AccountGroup => {
+    const key = accountKey(account);
+    let group = byKey.get(key);
+    if (!group) {
+      group = { ...account, connection, calendars: [] };
+      byKey.set(key, group);
+      groups.push(group);
+    }
+    return group;
+  };
 
   // Seed in connection order so accounts appear oldest-connected first,
   // regardless of the order calendars came back in.
   for (const connection of connections) {
-    const { accountEmail } = connection;
-    if (!accountEmail) continue;
-    const provider = connectionProviderKind(connection);
-    const key = accountKey(provider, accountEmail);
-    if (byKey.has(key)) continue;
-    const group: AccountGroup = {
-      key,
-      provider,
-      accountEmail,
-      connection,
-      calendars: [],
-    };
-    byKey.set(key, group);
-    groups.push(group);
+    const account = connectionAccount(connection);
+    if (account) ensureGroup(account, connection);
   }
 
   for (const calendar of calendars) {
-    const { accountEmail } = calendar;
-    const provider = calendarProviderKind(calendar);
-    if (!accountEmail || !provider) {
+    const account = calendarAccount(calendar);
+    if (!account) {
       ungrouped.push(calendar);
       continue;
     }
-    const key = accountKey(provider, accountEmail);
-    let group = byKey.get(key);
-    if (!group) {
-      // A calendar whose account has no connection summary yet (metadata and
-      // the calendar list can load a moment apart). Still give it a section.
-      group = {
-        key,
-        provider,
-        accountEmail,
-        connection: undefined,
-        calendars: [],
-      };
-      byKey.set(key, group);
-      groups.push(group);
-    }
-    group.calendars.push(calendar);
+    // A calendar whose account has no connection summary yet (metadata and
+    // the calendar list can load a moment apart) still gets a section.
+    ensureGroup(account, undefined).calendars.push(calendar);
   }
 
   return nestLocalCalendarInMatchingGroup(groups, ungrouped, compassEmail);

--- a/packages/web/src/calendars/calendar.util.ts
+++ b/packages/web/src/calendars/calendar.util.ts
@@ -1,5 +1,10 @@
 import { type Calendar } from "@core/types/calendar.contracts";
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
 import { type SyncConnectionSummary } from "@core/types/user.types";
+import {
+  calendarProviderKind,
+  connectionProviderKind,
+} from "@web/auth/providers/connection-provider.util";
 import { isCalendarReconnectRequired } from "@web/auth/providers/reconnect.calendar";
 
 export function getLocalCalendar(calendars: Calendar[]): Calendar | undefined {
@@ -110,23 +115,42 @@ export function spansMultipleAccounts(calendars: Calendar[]): boolean {
   );
 }
 
-export interface AccountGroup {
+/**
+ * The web app's identity for one connected account. An email alone is not
+ * enough: the same address can back a Google account and a Microsoft
+ * account (a Gmail address used as a Microsoft login, or the reverse), and
+ * both `Calendar` and `SyncConnectionSummary` carry `provider` next to
+ * `accountEmail`, so the pair is what every account-shaped key uses.
+ */
+export const accountKey = (
+  provider: ProviderKind,
+  accountEmail: string,
+): string => `${provider}:${accountEmail}`;
+
+export interface AccountRef {
+  /** `accountKey(provider, accountEmail)`: React keys, DOM ids, collapse state. */
+  key: string;
+  provider: ProviderKind;
   accountEmail: string;
+}
+
+export interface AccountGroup extends AccountRef {
   connection: SyncConnectionSummary | undefined;
   calendars: Calendar[];
 }
 
 /**
- * Bucket calendars by the account they belong to, in connection order, with
- * anything lacking an account email (the local calendar) left ungrouped.
- * Empty groups are kept so a connected-but-still-importing account still
- * renders its section header. Callers that cannot show an empty optgroup
- * (the Settings default-calendar select) skip those groups inline.
+ * Bucket calendars by the account (provider + email) they belong to, in
+ * connection order, with anything lacking an account (the local calendar)
+ * left ungrouped. Empty groups are kept so a connected-but-still-importing
+ * account still renders its section header. Callers that cannot show an
+ * empty optgroup (the Settings default-calendar select) skip those groups
+ * inline.
  *
  * When `compassEmail` matches a group's account email (case-insensitive),
- * nest the local Compass calendar under that Google section instead of
- * leaving it ungrouped. Callers that paint a second "Compass email" parent
- * then only do so when no Google account shares the login address.
+ * nest the local Compass calendar under that section instead of leaving it
+ * ungrouped. Callers that paint a second "Compass email" parent then only
+ * do so when no connected account shares the login address.
  */
 export function groupCalendarsByAccount(
   calendars: Calendar[],
@@ -134,31 +158,48 @@ export function groupCalendarsByAccount(
   compassEmail?: string | null,
 ): { groups: AccountGroup[]; ungrouped: Calendar[] } {
   const groups: AccountGroup[] = [];
-  const byEmail = new Map<string, AccountGroup>();
+  const byKey = new Map<string, AccountGroup>();
   const ungrouped: Calendar[] = [];
 
   // Seed in connection order so accounts appear oldest-connected first,
   // regardless of the order calendars came back in.
   for (const connection of connections) {
     const { accountEmail } = connection;
-    if (!accountEmail || byEmail.has(accountEmail)) continue;
-    const group: AccountGroup = { accountEmail, connection, calendars: [] };
-    byEmail.set(accountEmail, group);
+    if (!accountEmail) continue;
+    const provider = connectionProviderKind(connection);
+    const key = accountKey(provider, accountEmail);
+    if (byKey.has(key)) continue;
+    const group: AccountGroup = {
+      key,
+      provider,
+      accountEmail,
+      connection,
+      calendars: [],
+    };
+    byKey.set(key, group);
     groups.push(group);
   }
 
   for (const calendar of calendars) {
     const { accountEmail } = calendar;
-    if (!accountEmail) {
+    const provider = calendarProviderKind(calendar);
+    if (!accountEmail || !provider) {
       ungrouped.push(calendar);
       continue;
     }
-    let group = byEmail.get(accountEmail);
+    const key = accountKey(provider, accountEmail);
+    let group = byKey.get(key);
     if (!group) {
       // A calendar whose account has no connection summary yet (metadata and
       // the calendar list can load a moment apart). Still give it a section.
-      group = { accountEmail, connection: undefined, calendars: [] };
-      byEmail.set(accountEmail, group);
+      group = {
+        key,
+        provider,
+        accountEmail,
+        connection: undefined,
+        calendars: [],
+      };
+      byKey.set(key, group);
       groups.push(group);
     }
     group.calendars.push(calendar);
@@ -175,8 +216,8 @@ const nestLocalCalendarInMatchingGroup = (
   const normalizedCompassEmail = compassEmail?.trim().toLowerCase();
   if (!normalizedCompassEmail) return { groups, ungrouped };
 
-  // Connection order is already the group order; first match wins if two
-  // accounts somehow share an email.
+  // Connection order is already the group order; when accounts on two
+  // providers share the login email, the oldest-connected one wins.
   const matchingGroup = groups.find(
     (group) =>
       group.accountEmail.trim().toLowerCase() === normalizedCompassEmail,

--- a/packages/web/src/calendars/collapsed-accounts.storage.ts
+++ b/packages/web/src/calendars/collapsed-accounts.storage.ts
@@ -3,9 +3,9 @@ import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 
 // Collapsed account keys only - absence means expanded (default). A Set of
-// `accountKey(provider, email)` strings; unknown or malformed storage (and
-// the email-only keys an older build wrote) falls back to expanded rather
-// than hiding every account's calendars.
+// `accountKey` strings; unknown or malformed storage (and the email-only keys
+// an older build wrote) falls back to expanded rather than hiding every
+// account's calendars.
 const CollapsedAccountsSchema = z.array(z.string().trim().min(1)).readonly();
 
 export function readCollapsedAccountKeys(): ReadonlySet<string> {

--- a/packages/web/src/calendars/collapsed-accounts.storage.ts
+++ b/packages/web/src/calendars/collapsed-accounts.storage.ts
@@ -3,8 +3,9 @@ import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
 
 // Collapsed account keys only - absence means expanded (default). A Set of
-// account emails; unknown or malformed storage falls back to empty
-// (everything expanded) rather than hiding every account's calendars.
+// `accountKey(provider, email)` strings; unknown or malformed storage (and
+// the email-only keys an older build wrote) falls back to expanded rather
+// than hiding every account's calendars.
 const CollapsedAccountsSchema = z.array(z.string().trim().min(1)).readonly();
 
 export function readCollapsedAccountKeys(): ReadonlySet<string> {

--- a/packages/web/src/calendars/collapsed-accounts.store.ts
+++ b/packages/web/src/calendars/collapsed-accounts.store.ts
@@ -12,9 +12,7 @@ import {
 /**
  * Deterministic id shared between an account's heading (aria-controls) and
  * its calendar list (id) - the two are separate sibling components, so this
- * can't be a useId(). Keys are `accountKey(provider, email)` values (see
- * calendar.util.ts), never bare emails: the same address can be two
- * accounts on two providers.
+ * can't be a useId(). Keys are `accountKey` values (calendar.util.ts).
  */
 export function accountCalendarListId(accountKey: string): string {
   return `account-calendars-${accountKey}`;

--- a/packages/web/src/calendars/collapsed-accounts.store.ts
+++ b/packages/web/src/calendars/collapsed-accounts.store.ts
@@ -12,10 +12,12 @@ import {
 /**
  * Deterministic id shared between an account's heading (aria-controls) and
  * its calendar list (id) - the two are separate sibling components, so this
- * can't be a useId(). Keys are account emails.
+ * can't be a useId(). Keys are `accountKey(provider, email)` values (see
+ * calendar.util.ts), never bare emails: the same address can be two
+ * accounts on two providers.
  */
-export function accountCalendarListId(accountEmail: string): string {
-  return `account-calendars-${accountEmail}`;
+export function accountCalendarListId(accountKey: string): string {
+  return `account-calendars-${accountKey}`;
 }
 
 const collapsedStore = createExternalStore<ReadonlySet<string>>(

--- a/packages/web/src/calendars/useDefaultTargetCalendar.ts
+++ b/packages/web/src/calendars/useDefaultTargetCalendar.ts
@@ -1,18 +1,16 @@
 import { useMemo } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
-import { connectionProviderKind } from "@web/auth/providers/connection-provider.util";
 import {
   getGoogleReconnectRequiredAccountEmails,
   useGoogleReconnectRequiredVersion,
 } from "@web/auth/providers/reconnect.state";
 import {
-  selectGoogleSyncConnections,
   selectSyncConnections,
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
 import {
   type AccountRef,
-  accountKey,
+  connectionAccount,
   getDefaultTargetCalendar,
 } from "@web/calendars/calendar.util";
 import { useDefaultCalendarId } from "@web/calendars/default-calendar.store";
@@ -41,38 +39,23 @@ export function useDefaultTargetCalendar(
   });
 }
 
-/** Connected account emails in connection order (oldest first). */
-export function useConnectedAccountEmails(): string[] {
-  const connections = useUserMetadataStore(selectGoogleSyncConnections);
-
-  return useMemo(
-    () =>
-      connections
-        .map((connection) => connection.accountEmail)
-        .filter((email): email is string => Boolean(email)),
-    [connections],
-  );
-}
-
-/**
- * Connected accounts in connection order (oldest first), keyed by provider
- * + email. Use this wherever an account becomes a React key, DOM id, or
- * label: two providers can share one address, and only the key tells them
- * apart. `useConnectedAccountEmails` stays for ordering by email.
- */
+/** Connected accounts in connection order (oldest first). */
 export function useConnectedAccounts(): AccountRef[] {
   const connections = useUserMetadataStore(selectSyncConnections);
 
   return useMemo(
     () =>
-      connections.flatMap((connection) => {
-        const { accountEmail } = connection;
-        if (!accountEmail) return [];
-        const provider = connectionProviderKind(connection);
-        return [
-          { key: accountKey(provider, accountEmail), provider, accountEmail },
-        ];
-      }),
+      connections.flatMap((connection) => connectionAccount(connection) ?? []),
     [connections],
+  );
+}
+
+/** The same accounts as emails, for callers that only order calendars by account. */
+export function useConnectedAccountEmails(): string[] {
+  const accounts = useConnectedAccounts();
+
+  return useMemo(
+    () => accounts.map((account) => account.accountEmail),
+    [accounts],
   );
 }

--- a/packages/web/src/calendars/useDefaultTargetCalendar.ts
+++ b/packages/web/src/calendars/useDefaultTargetCalendar.ts
@@ -1,14 +1,20 @@
 import { useMemo } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
+import { connectionProviderKind } from "@web/auth/providers/connection-provider.util";
 import {
   getGoogleReconnectRequiredAccountEmails,
   useGoogleReconnectRequiredVersion,
 } from "@web/auth/providers/reconnect.state";
 import {
   selectGoogleSyncConnections,
+  selectSyncConnections,
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
-import { getDefaultTargetCalendar } from "@web/calendars/calendar.util";
+import {
+  type AccountRef,
+  accountKey,
+  getDefaultTargetCalendar,
+} from "@web/calendars/calendar.util";
 import { useDefaultCalendarId } from "@web/calendars/default-calendar.store";
 
 /**
@@ -44,6 +50,29 @@ export function useConnectedAccountEmails(): string[] {
       connections
         .map((connection) => connection.accountEmail)
         .filter((email): email is string => Boolean(email)),
+    [connections],
+  );
+}
+
+/**
+ * Connected accounts in connection order (oldest first), keyed by provider
+ * + email. Use this wherever an account becomes a React key, DOM id, or
+ * label: two providers can share one address, and only the key tells them
+ * apart. `useConnectedAccountEmails` stays for ordering by email.
+ */
+export function useConnectedAccounts(): AccountRef[] {
+  const connections = useUserMetadataStore(selectSyncConnections);
+
+  return useMemo(
+    () =>
+      connections.flatMap((connection) => {
+        const { accountEmail } = connection;
+        if (!accountEmail) return [];
+        const provider = connectionProviderKind(connection);
+        return [
+          { key: accountKey(provider, accountEmail), provider, accountEmail },
+        ];
+      }),
     [connections],
   );
 }

--- a/packages/web/src/components/AuthModal/components/AppleButton.tsx
+++ b/packages/web/src/components/AuthModal/components/AppleButton.tsx
@@ -1,19 +1,7 @@
 import classNames from "classnames";
 import type React from "react";
+import { AppleLogo } from "@web/components/Icons/AppleLogo";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
-
-const AppleLogo = ({ size = 18 }: { size?: number }) => (
-  <svg
-    width={size}
-    height={size}
-    viewBox="0 0 24 24"
-    fill="currentColor"
-    xmlns="http://www.w3.org/2000/svg"
-    aria-hidden="true"
-  >
-    <path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
-  </svg>
-);
 
 export const AppleButton = ({
   onClick,

--- a/packages/web/src/components/AuthModal/components/GoogleButton.tsx
+++ b/packages/web/src/components/AuthModal/components/GoogleButton.tsx
@@ -1,38 +1,7 @@
 import classNames from "classnames";
 import type React from "react";
+import { GoogleLogo } from "@web/components/Icons/GoogleLogo";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
-
-/**
- * Monochrome Google "G" logo SVG
- * Based on the official Google "G" but rendered in black for monochromatic design
- */
-const GoogleGLogo = ({ size = 18 }: { size?: number }) => (
-  <svg
-    width={size}
-    height={size}
-    viewBox="0 0 24 24"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    aria-hidden="true"
-  >
-    <path
-      d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-      fill="currentColor"
-    />
-    <path
-      d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-      fill="currentColor"
-    />
-    <path
-      d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-      fill="currentColor"
-    />
-    <path
-      d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-      fill="currentColor"
-    />
-  </svg>
-);
 
 export const GoogleButton = ({
   onClick,
@@ -67,7 +36,7 @@ export const GoogleButton = ({
         ...style,
       }}
     >
-      <GoogleGLogo size={18} />
+      <GoogleLogo size={18} />
       <span>{label}</span>
       {shortcutKey ? (
         <ShortcutHint className="shrink-0">{shortcutKey}</ShortcutHint>

--- a/packages/web/src/components/AuthModal/components/MicrosoftButton.tsx
+++ b/packages/web/src/components/AuthModal/components/MicrosoftButton.tsx
@@ -1,26 +1,7 @@
 import classNames from "classnames";
 import type React from "react";
+import { MicrosoftLogo } from "@web/components/Icons/MicrosoftLogo";
 import { ShortcutHint } from "@web/components/Shortcuts/ShortcutHint";
-
-/**
- * Monochrome Microsoft four-square logo SVG, rendered in currentColor to
- * match the Google button's single-ink treatment.
- */
-export const MicrosoftLogo = ({ size = 18 }: { size?: number }) => (
-  <svg
-    width={size}
-    height={size}
-    viewBox="0 0 24 24"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    aria-hidden="true"
-  >
-    <path d="M3 3h8v8H3V3z" fill="currentColor" />
-    <path d="M13 3h8v8h-8V3z" fill="currentColor" />
-    <path d="M3 13h8v8H3v-8z" fill="currentColor" />
-    <path d="M13 13h8v8h-8v-8z" fill="currentColor" />
-  </svg>
-);
 
 export const MicrosoftButton = ({
   onClick,

--- a/packages/web/src/components/Icons/AppleLogo.tsx
+++ b/packages/web/src/components/Icons/AppleLogo.tsx
@@ -1,0 +1,16 @@
+/**
+ * Monochrome Apple logo SVG in currentColor. Decorative: callers that need
+ * an accessible name wrap it (see ProviderMark).
+ */
+export const AppleLogo = ({ size = 18 }: { size?: number }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+  >
+    <path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
+  </svg>
+);

--- a/packages/web/src/components/Icons/GoogleLogo.tsx
+++ b/packages/web/src/components/Icons/GoogleLogo.tsx
@@ -1,0 +1,33 @@
+/**
+ * Monochrome Google "G" logo SVG
+ * Based on the official Google "G" but rendered in currentColor for
+ * monochromatic design. Decorative: callers that need an accessible name
+ * wrap it (see ProviderMark).
+ */
+export const GoogleLogo = ({ size = 18 }: { size?: number }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+  >
+    <path
+      d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+      fill="currentColor"
+    />
+    <path
+      d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+      fill="currentColor"
+    />
+    <path
+      d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+      fill="currentColor"
+    />
+    <path
+      d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+      fill="currentColor"
+    />
+  </svg>
+);

--- a/packages/web/src/components/Icons/MicrosoftLogo.tsx
+++ b/packages/web/src/components/Icons/MicrosoftLogo.tsx
@@ -1,0 +1,20 @@
+/**
+ * Monochrome Microsoft four-square logo SVG, rendered in currentColor to
+ * match the Google logo's single-ink treatment. Decorative: callers that
+ * need an accessible name wrap it (see ProviderMark).
+ */
+export const MicrosoftLogo = ({ size = 18 }: { size?: number }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+  >
+    <path d="M3 3h8v8H3V3z" fill="currentColor" />
+    <path d="M13 3h8v8h-8V3z" fill="currentColor" />
+    <path d="M3 13h8v8H3v-8z" fill="currentColor" />
+    <path d="M13 13h8v8h-8v-8z" fill="currentColor" />
+  </svg>
+);

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -578,6 +578,7 @@ describe("SettingsModal", () => {
   it("labels a Microsoft account optgroup with Microsoft provider copy", () => {
     const work = createMockCalendar({
       name: "Work",
+      provider: "microsoft",
       accountEmail: "user@outlook.com",
     });
 
@@ -596,6 +597,54 @@ describe("SettingsModal", () => {
     expect(
       within(combobox).getByRole("group", {
         name: "user@outlook.com (Microsoft)",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("marks each account row with its provider and badges only the default account", () => {
+    // The same address connected on both providers: the rows are told apart
+    // by the provider mark, and only the account owning the default
+    // calendar wears the Default badge.
+    const googlePrimary = createMockCalendar({
+      name: "Google primary",
+      isPrimary: true,
+      accountEmail: "lance@gmail.com",
+    });
+    const microsoftPrimary = createMockCalendar({
+      name: "Microsoft primary",
+      isPrimary: true,
+      provider: "microsoft",
+      accountEmail: "lance@gmail.com",
+    });
+
+    renderSettings({
+      connections: [
+        connection({ id: "google-conn", accountEmail: "lance@gmail.com" }),
+        connection({
+          id: "ms-conn",
+          accountEmail: "lance@gmail.com",
+          provider: "microsoft",
+        }),
+      ],
+      calendars: [googlePrimary, microsoftPrimary],
+    });
+
+    expect(screen.getByRole("img", { name: "Google" })).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "Microsoft" })).toBeInTheDocument();
+
+    const badge = screen.getByText("Default");
+    expect(badge.parentElement).toHaveTextContent("lance@gmail.com");
+    expect(
+      within(badge.parentElement ?? badge).getByRole("img", { name: "Google" }),
+    ).toBeInTheDocument();
+
+    const combobox = screen.getByRole("combobox", { name: "Default Calendar" });
+    expect(
+      within(combobox).getByRole("group", { name: "lance@gmail.com (Google)" }),
+    ).toBeInTheDocument();
+    expect(
+      within(combobox).getByRole("group", {
+        name: "lance@gmail.com (Microsoft)",
       }),
     ).toBeInTheDocument();
   });

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -2,7 +2,6 @@ import { type FC, Suspense, useEffect, useRef, useState } from "react";
 import { isSavedBookingPage } from "@core/types/booking.contracts";
 import { type Calendar } from "@core/types/calendar.contracts";
 import { type CalendarId } from "@core/types/domain-primitives";
-import { providerDisplayName } from "@core/types/sync/identity.contracts";
 import { type SyncConnectionSummary } from "@core/types/user.types";
 import { useSession } from "@web/auth/compass/session/useSession";
 import { ConnectProviderChooser } from "@web/auth/providers/ConnectProviderChooser";
@@ -13,8 +12,15 @@ import {
   SSE_DEGRADED_STATUS,
 } from "@web/auth/providers/connect.util";
 import { MICROSOFT_SELF_HOSTING_DOC_URL } from "@web/auth/providers/connection-health-copy.util";
-import { connectionProviderKind } from "@web/auth/providers/connection-provider.util";
-import { CALENDAR_HOST_EXPLAINER } from "@web/auth/providers/provider-copy.util";
+import {
+  calendarProviderKind,
+  connectionProviderKind,
+} from "@web/auth/providers/connection-provider.util";
+import { ProviderMark } from "@web/auth/providers/ProviderMark";
+import {
+  CALENDAR_HOST_EXPLAINER,
+  defaultCalendarGroupLabel,
+} from "@web/auth/providers/provider-copy.util";
 import { useGoogleSyncRefreshSnapshot } from "@web/auth/providers/sync.refresh";
 import { useDisconnectGoogleAccount } from "@web/auth/providers/useDisconnectAccount";
 import {
@@ -390,8 +396,11 @@ const DefaultCalendarPicker: FC<DefaultCalendarPickerProps> = ({
           .filter((group) => group.calendars.length > 0)
           .map((group) => (
             <optgroup
-              key={group.accountEmail}
-              label={`${group.accountEmail} (${providerDisplayName(connectionProviderKind(group.connection))})`}
+              key={group.key}
+              label={defaultCalendarGroupLabel(
+                group.accountEmail,
+                group.provider,
+              )}
             >
               {group.calendars.map((calendar) => (
                 <option key={calendar.id} value={calendar.id}>
@@ -439,7 +448,10 @@ const AccountsSection: FC<AccountsSectionProps> = ({
               disconnect={disconnect}
               isConfirming={confirmingId === connection.id}
               isDefault={
-                connection.accountEmail === resolvedDefault?.accountEmail
+                resolvedDefault !== undefined &&
+                connection.accountEmail === resolvedDefault.accountEmail &&
+                connectionProviderKind(connection) ===
+                  calendarProviderKind(resolvedDefault)
               }
               isDisconnecting={disconnectingId === connection.id}
               key={connection.id}
@@ -476,7 +488,8 @@ interface AccountRowProps {
 }
 
 /**
- * One connected account: email, its own full sync status (including when
+ * One connected account: email with its provider mark (the same address can
+ * be connected on two providers), its own full sync status (including when
  * healthy - the sidebar hides that, but this is the one place a user comes
  * to check), a "Default" badge when it owns the default calendar, and a
  * two-step disconnect (not undoable without redoing the whole OAuth flow).
@@ -532,6 +545,7 @@ const AccountRow: FC<AccountRowProps> = ({
     <div className="flex items-center justify-between gap-2">
       <div className="min-w-0">
         <div className="flex min-w-0 items-center gap-1.5">
+          <ProviderMark provider={connectionProviderKind(connection)} />
           <p className="truncate text-sm text-text" translate="no">
             {accountEmail}
           </p>

--- a/packages/web/src/components/Settings/SettingsModal.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.tsx
@@ -12,15 +12,9 @@ import {
   SSE_DEGRADED_STATUS,
 } from "@web/auth/providers/connect.util";
 import { MICROSOFT_SELF_HOSTING_DOC_URL } from "@web/auth/providers/connection-health-copy.util";
-import {
-  calendarProviderKind,
-  connectionProviderKind,
-} from "@web/auth/providers/connection-provider.util";
+import { connectionProviderKind } from "@web/auth/providers/connection-provider.util";
 import { ProviderMark } from "@web/auth/providers/ProviderMark";
-import {
-  CALENDAR_HOST_EXPLAINER,
-  defaultCalendarGroupLabel,
-} from "@web/auth/providers/provider-copy.util";
+import { CALENDAR_HOST_EXPLAINER } from "@web/auth/providers/provider-copy.util";
 import { useGoogleSyncRefreshSnapshot } from "@web/auth/providers/sync.refresh";
 import { useDisconnectGoogleAccount } from "@web/auth/providers/useDisconnectAccount";
 import {
@@ -39,7 +33,11 @@ import {
 import { BOOKING_NAV_NEEDS_ATTENTION } from "@web/booking/booking-bookability.copy";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import {
+  accountKey,
+  accountLabel,
+  calendarAccount,
   compareCalendars,
+  connectionAccount,
   getWritableCalendars,
   groupCalendarsByAccount,
 } from "@web/calendars/calendar.util";
@@ -395,13 +393,7 @@ const DefaultCalendarPicker: FC<DefaultCalendarPickerProps> = ({
         {groups
           .filter((group) => group.calendars.length > 0)
           .map((group) => (
-            <optgroup
-              key={group.key}
-              label={defaultCalendarGroupLabel(
-                group.accountEmail,
-                group.provider,
-              )}
-            >
+            <optgroup key={accountKey(group)} label={accountLabel(group)}>
               {group.calendars.map((calendar) => (
                 <option key={calendar.id} value={calendar.id}>
                   {calendar.name}
@@ -435,6 +427,8 @@ const AccountsSection: FC<AccountsSectionProps> = ({
   showShortcuts,
 }) => {
   const { disconnect, disconnectingId } = useDisconnectGoogleAccount();
+  const defaultAccount = resolvedDefault && calendarAccount(resolvedDefault);
+  const defaultKey = defaultAccount && accountKey(defaultAccount);
 
   return (
     <div className="flex flex-col gap-3">
@@ -442,24 +436,24 @@ const AccountsSection: FC<AccountsSectionProps> = ({
         {connections.length === 0 ? (
           <p className="text-sm text-text-muted">No accounts connected yet.</p>
         ) : (
-          connections.map((connection) => (
-            <AccountRow
-              connection={connection}
-              disconnect={disconnect}
-              isConfirming={confirmingId === connection.id}
-              isDefault={
-                resolvedDefault !== undefined &&
-                connection.accountEmail === resolvedDefault.accountEmail &&
-                connectionProviderKind(connection) ===
-                  calendarProviderKind(resolvedDefault)
-              }
-              isDisconnecting={disconnectingId === connection.id}
-              key={connection.id}
-              setConfirming={(confirming) =>
-                setConfirmingId(confirming ? connection.id : null)
-              }
-            />
-          ))
+          connections.map((connection) => {
+            const account = connectionAccount(connection);
+            return (
+              <AccountRow
+                connection={connection}
+                disconnect={disconnect}
+                isConfirming={confirmingId === connection.id}
+                isDefault={
+                  account !== undefined && accountKey(account) === defaultKey
+                }
+                isDisconnecting={disconnectingId === connection.id}
+                key={connection.id}
+                setConfirming={(confirming) =>
+                  setConfirmingId(confirming ? connection.id : null)
+                }
+              />
+            );
+          })
         )}
       </div>
 
@@ -480,7 +474,7 @@ const AccountsSection: FC<AccountsSectionProps> = ({
 
 interface AccountRowProps {
   connection: SyncConnectionSummary;
-  disconnect: (connectionId: string, accountEmail: string) => Promise<void>;
+  disconnect: (connection: SyncConnectionSummary) => Promise<void>;
   isConfirming: boolean;
   isDefault: boolean;
   isDisconnecting: boolean;
@@ -590,9 +584,7 @@ const AccountRow: FC<AccountRowProps> = ({
             className={`${OUTLINE_BUTTON_CLASSNAME} text-error`}
             disabled={isDisconnecting}
             onClick={() =>
-              void disconnect(connection.id, accountEmail).finally(() =>
-                setConfirming(false),
-              )
+              void disconnect(connection).finally(() => setConfirming(false))
             }
             onPointerEnter={focusOnPointerEnter}
             ref={confirmButtonRef}

--- a/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.test.tsx
@@ -69,10 +69,8 @@ const renderHeader = (overrides: Partial<SyncConnectionSummary> = {}): void => {
   const provider = connectionProviderKind(connection);
   render(
     <AccountSectionHeader
-      accountEmail={EMAIL}
-      accountKey={accountKey(provider, EMAIL)}
+      account={{ provider, accountEmail: EMAIL }}
       connection={connection}
-      provider={provider}
     />,
     { wrapper },
   );
@@ -99,7 +97,9 @@ describe("AccountSectionHeader", () => {
   });
 
   it("starts collapsed when the account's key is already in the collapsed store", () => {
-    toggleAccountCollapsed(accountKey("google", EMAIL));
+    toggleAccountCollapsed(
+      accountKey({ provider: "google", accountEmail: EMAIL }),
+    );
 
     renderHeader();
 
@@ -111,7 +111,9 @@ describe("AccountSectionHeader", () => {
   it("keeps collapse state per provider, not per email", () => {
     // The same address connected on Microsoft was collapsed; the Google
     // account with that address must still start expanded.
-    toggleAccountCollapsed(accountKey("microsoft", EMAIL));
+    toggleAccountCollapsed(
+      accountKey({ provider: "microsoft", accountEmail: EMAIL }),
+    );
 
     renderHeader();
 

--- a/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.test.tsx
@@ -5,10 +5,15 @@ import { type SyncConnectionSummary } from "@core/types/user.types";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
 import { createMockConnection } from "@web/__tests__/utils/factories/calendar.factory";
 import { type GoogleUiState } from "@web/auth/providers/connect.types";
+import { connectionProviderKind } from "@web/auth/providers/connection-provider.util";
+import { accountKey } from "@web/calendars/calendar.util";
 import { toggleAccountCollapsed } from "@web/calendars/collapsed-accounts.store";
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const EMAIL = "ahab@pequod.com";
+// The provider mark sits inside the collapse toggle, so the button's
+// accessible name is the email followed by the provider.
+const GOOGLE_TOGGLE_NAME = `${EMAIL} Google`;
 
 const actualUseConnectProvider = (
   await import("@web/auth/providers/useConnectProvider")
@@ -60,10 +65,14 @@ const { AccountSectionHeader } = (await import(
 
 const renderHeader = (overrides: Partial<SyncConnectionSummary> = {}): void => {
   const { wrapper } = createStoreWrapper();
+  const connection = createMockConnection(EMAIL, overrides);
+  const provider = connectionProviderKind(connection);
   render(
     <AccountSectionHeader
       accountEmail={EMAIL}
-      connection={createMockConnection(EMAIL, overrides)}
+      accountKey={accountKey(provider, EMAIL)}
+      connection={connection}
+      provider={provider}
     />,
     { wrapper },
   );
@@ -79,7 +88,7 @@ describe("AccountSectionHeader", () => {
     const user = userEvent.setup({ delay: null });
     renderHeader();
 
-    const toggle = screen.getByRole("button", { name: EMAIL });
+    const toggle = screen.getByRole("button", { name: GOOGLE_TOGGLE_NAME });
     expect(toggle).toHaveAttribute("aria-expanded", "true");
 
     await user.click(toggle);
@@ -90,14 +99,40 @@ describe("AccountSectionHeader", () => {
   });
 
   it("starts collapsed when the account's key is already in the collapsed store", () => {
-    toggleAccountCollapsed(EMAIL);
+    toggleAccountCollapsed(accountKey("google", EMAIL));
 
     renderHeader();
 
-    expect(screen.getByRole("button", { name: EMAIL })).toHaveAttribute(
-      "aria-expanded",
-      "false",
-    );
+    expect(
+      screen.getByRole("button", { name: GOOGLE_TOGGLE_NAME }),
+    ).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("keeps collapse state per provider, not per email", () => {
+    // The same address connected on Microsoft was collapsed; the Google
+    // account with that address must still start expanded.
+    toggleAccountCollapsed(accountKey("microsoft", EMAIL));
+
+    renderHeader();
+
+    expect(
+      screen.getByRole("button", { name: GOOGLE_TOGGLE_NAME }),
+    ).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("names the account's provider with a mark beside the email", () => {
+    renderHeader();
+
+    expect(screen.getByRole("img", { name: "Google" })).toBeInTheDocument();
+  });
+
+  it("marks a Microsoft connection as Microsoft", () => {
+    renderHeader({ provider: "microsoft" });
+
+    expect(screen.getByRole("img", { name: "Microsoft" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: `${EMAIL} Microsoft` }),
+    ).toHaveAttribute("aria-expanded", "true");
   });
 
   it("stays quiet - no status line, no action - while the account is healthy", () => {

--- a/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.tsx
@@ -1,7 +1,9 @@
 import { CaretDownIcon } from "@phosphor-icons/react";
 import classNames from "classnames";
 import { type FC } from "react";
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
 import { type SyncConnectionSummary } from "@core/types/user.types";
+import { ProviderMark } from "@web/auth/providers/ProviderMark";
 import {
   accountCalendarListId,
   toggleAccountCollapsed,
@@ -9,9 +11,11 @@ import {
 } from "@web/calendars/collapsed-accounts.store";
 import { useAccountHeaderStatus } from "./useAccountHeaderStatus";
 /**
- * Heading for one connected account's calendars: the account email (also the
- * collapse toggle for its calendar rows, see CalendarList.tsx), that
- * account's own sync status, and its own reconnect/refresh action. Every
+ * Heading for one connected account's calendars: the account email and its
+ * provider mark (together the collapse toggle for its calendar rows, see
+ * CalendarList.tsx), that account's own sync status, and its own
+ * reconnect/refresh action. The mark is what tells two accounts apart when
+ * the same address is connected on two providers. Every
  * connected account gets one, a lone account included - one account and five
  * accounts render the same shape, so the two can't drift apart the way a
  * separate single-account header did.
@@ -21,9 +25,12 @@ import { useAccountHeaderStatus } from "./useAccountHeaderStatus";
  * for accounts with many subcalendars.
  */
 export const AccountSectionHeader: FC<{
+  /** `accountKey(provider, email)`: the collapse-state and aria-controls key. */
+  accountKey: string;
   accountEmail: string;
+  provider: ProviderKind;
   connection: SyncConnectionSummary | undefined;
-}> = ({ accountEmail, connection }) => {
+}> = ({ accountKey, accountEmail, provider, connection }) => {
   const {
     actionLabel,
     commandAction,
@@ -32,16 +39,16 @@ export const AccountSectionHeader: FC<{
     isRefreshing,
     syncStatus,
   } = useAccountHeaderStatus(connection);
-  const isCollapsed = useCollapsedAccountKeys().has(accountEmail);
+  const isCollapsed = useCollapsedAccountKeys().has(accountKey);
 
   return (
     <div className="mb-1.5">
       <h2 className="mb-0.5 font-semibold text-sm leading-none">
         <button
-          aria-controls={accountCalendarListId(accountEmail)}
+          aria-controls={accountCalendarListId(accountKey)}
           aria-expanded={!isCollapsed}
           className="c-focus-ring group flex w-full min-w-0 items-center gap-1 rounded-xs text-left"
-          onClick={() => toggleAccountCollapsed(accountEmail)}
+          onClick={() => toggleAccountCollapsed(accountKey)}
           type="button"
         >
           <CaretDownIcon
@@ -63,6 +70,7 @@ export const AccountSectionHeader: FC<{
           >
             {accountEmail}
           </span>
+          <ProviderMark provider={provider} size={12} />
         </button>
       </h2>
       {isAvailable && commandAction != null && actionLabel != null ? (

--- a/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.tsx
@@ -1,9 +1,9 @@
 import { CaretDownIcon } from "@phosphor-icons/react";
 import classNames from "classnames";
 import { type FC } from "react";
-import { type ProviderKind } from "@core/types/sync/identity.contracts";
 import { type SyncConnectionSummary } from "@core/types/user.types";
 import { ProviderMark } from "@web/auth/providers/ProviderMark";
+import { type AccountRef, accountKey } from "@web/calendars/calendar.util";
 import {
   accountCalendarListId,
   toggleAccountCollapsed,
@@ -11,26 +11,23 @@ import {
 } from "@web/calendars/collapsed-accounts.store";
 import { useAccountHeaderStatus } from "./useAccountHeaderStatus";
 /**
- * Heading for one connected account's calendars: the account email and its
+ * Heading for one connected account's calendars: the account email and
  * provider mark (together the collapse toggle for its calendar rows, see
  * CalendarList.tsx), that account's own sync status, and its own
- * reconnect/refresh action. The mark is what tells two accounts apart when
- * the same address is connected on two providers. Every
- * connected account gets one, a lone account included - one account and five
- * accounts render the same shape, so the two can't drift apart the way a
- * separate single-account header did.
+ * reconnect/refresh action. Every connected account gets one, a lone account
+ * included - one account and five accounts render the same shape, so the two
+ * can't drift apart the way a separate single-account header did.
  *
  * Adding/disconnecting accounts lives in the command palette's "Add account" /
  * "Show accounts" items - not a permanent row or icon here, which stayed noisy
  * for accounts with many subcalendars.
  */
 export const AccountSectionHeader: FC<{
-  /** `accountKey(provider, email)`: the collapse-state and aria-controls key. */
-  accountKey: string;
-  accountEmail: string;
-  provider: ProviderKind;
+  account: AccountRef;
   connection: SyncConnectionSummary | undefined;
-}> = ({ accountKey, accountEmail, provider, connection }) => {
+}> = ({ account, connection }) => {
+  const key = accountKey(account);
+  const { accountEmail, provider } = account;
   const {
     actionLabel,
     commandAction,
@@ -39,16 +36,16 @@ export const AccountSectionHeader: FC<{
     isRefreshing,
     syncStatus,
   } = useAccountHeaderStatus(connection);
-  const isCollapsed = useCollapsedAccountKeys().has(accountKey);
+  const isCollapsed = useCollapsedAccountKeys().has(key);
 
   return (
     <div className="mb-1.5">
       <h2 className="mb-0.5 font-semibold text-sm leading-none">
         <button
-          aria-controls={accountCalendarListId(accountKey)}
+          aria-controls={accountCalendarListId(key)}
           aria-expanded={!isCollapsed}
           className="c-focus-ring group flex w-full min-w-0 items-center gap-1 rounded-xs text-left"
-          onClick={() => toggleAccountCollapsed(accountKey)}
+          onClick={() => toggleAccountCollapsed(key)}
           type="button"
         >
           <CaretDownIcon

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -380,20 +380,28 @@ describe("CalendarList", () => {
     });
 
     expect(
-      screen.getByRole("region", { name: "Calendars for ahab@pequod.com" }),
+      screen.getByRole("region", {
+        name: "Calendars for ahab@pequod.com (Google)",
+      }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("region", { name: "Calendars for ahab@gmail.com" }),
+      screen.getByRole("region", {
+        name: "Calendars for ahab@gmail.com (Google)",
+      }),
     ).toBeInTheDocument();
     // Each account's calendars live under its own section, not one flat list.
     expect(
       within(
-        screen.getByRole("region", { name: "Calendars for ahab@pequod.com" }),
+        screen.getByRole("region", {
+          name: "Calendars for ahab@pequod.com (Google)",
+        }),
       ).getByText("Work"),
     ).toBeInTheDocument();
     expect(
       within(
-        screen.getByRole("region", { name: "Calendars for ahab@gmail.com" }),
+        screen.getByRole("region", {
+          name: "Calendars for ahab@gmail.com (Google)",
+        }),
       ).getByText("Personal"),
     ).toBeInTheDocument();
   });
@@ -416,11 +424,21 @@ describe("CalendarList", () => {
     });
 
     expect(
-      screen.getByRole("region", { name: "Calendars for ahab@pequod.com" }),
-    ).toHaveAttribute("data-page-jump", "calendar-account:ahab@pequod.com");
+      screen.getByRole("region", {
+        name: "Calendars for ahab@pequod.com (Google)",
+      }),
+    ).toHaveAttribute(
+      "data-page-jump",
+      "calendar-account:google:ahab@pequod.com",
+    );
     expect(
-      screen.getByRole("region", { name: "Calendars for ahab@gmail.com" }),
-    ).toHaveAttribute("data-page-jump", "calendar-account:ahab@gmail.com");
+      screen.getByRole("region", {
+        name: "Calendars for ahab@gmail.com (Google)",
+      }),
+    ).toHaveAttribute(
+      "data-page-jump",
+      "calendar-account:google:ahab@gmail.com",
+    );
     expect(
       screen.getByRole("region", { name: "Calendars" }),
     ).not.toHaveAttribute("data-page-jump");
@@ -443,7 +461,9 @@ describe("CalendarList", () => {
 
     expect(screen.queryByText(HEADER_EMAIL)).not.toBeInTheDocument();
     expect(
-      screen.getByRole("region", { name: "Calendars for ahab@pequod.com" }),
+      screen.getByRole("region", {
+        name: "Calendars for ahab@pequod.com (Google)",
+      }),
     ).toBeInTheDocument();
   });
 
@@ -506,10 +526,14 @@ describe("CalendarList", () => {
     });
 
     const healthy = within(
-      screen.getByRole("region", { name: "Calendars for ahab@pequod.com" }),
+      screen.getByRole("region", {
+        name: "Calendars for ahab@pequod.com (Google)",
+      }),
     );
     const broken = within(
-      screen.getByRole("region", { name: "Calendars for ahab@gmail.com" }),
+      screen.getByRole("region", {
+        name: "Calendars for ahab@gmail.com (Google)",
+      }),
     );
     // Neither account's own section renders status text - it moved to the
     // sidebar's pinned bottom bar (see SidebarStatusBar.test.tsx) so a
@@ -533,11 +557,11 @@ describe("CalendarList", () => {
     });
 
     const section = screen.getByRole("region", {
-      name: "Calendars for ahab@pequod.com",
+      name: "Calendars for ahab@pequod.com (Google)",
     });
     expect(within(section).getByText("Work")).toBeInTheDocument();
     expect(
-      within(section).getByRole("button", { name: "ahab@pequod.com" }),
+      within(section).getByRole("button", { name: "ahab@pequod.com Google" }),
     ).toHaveAttribute("aria-expanded", "true");
   });
 
@@ -582,7 +606,9 @@ describe("CalendarList", () => {
     for (const email of ["ahab@pequod.com", "ahab@gmail.com"]) {
       expect(
         within(
-          screen.getByRole("region", { name: `Calendars for ${email}` }),
+          screen.getByRole("region", {
+            name: `Calendars for ${email} (Google)`,
+          }),
         ).queryByText("Compass"),
       ).not.toBeInTheDocument();
     }
@@ -616,10 +642,12 @@ describe("CalendarList", () => {
     });
 
     expect(
-      screen.getByRole("region", { name: "Calendars for ahab@pequod.com" }),
+      screen.getByRole("region", {
+        name: "Calendars for ahab@pequod.com (Google)",
+      }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "ahab@pequod.com" }),
+      screen.getByRole("button", { name: "ahab@pequod.com Google" }),
     ).toBeInTheDocument();
   });
 
@@ -661,7 +689,9 @@ describe("CalendarList", () => {
     });
 
     expect(screen.getByText("Work")).toBeInTheDocument();
-    const toggle = screen.getByRole("button", { name: "ahab@pequod.com" });
+    const toggle = screen.getByRole("button", {
+      name: "ahab@pequod.com Google",
+    });
     expect(toggle).toHaveAttribute("aria-expanded", "true");
 
     await user.click(toggle);
@@ -673,6 +703,67 @@ describe("CalendarList", () => {
     await user.click(toggle);
     expect(toggle).toHaveAttribute("aria-expanded", "true");
     expect(screen.getByText("Work")).toBeInTheDocument();
+  });
+
+  it("keeps same-email Google and Microsoft accounts in separate sections with their own collapse", async () => {
+    // A Gmail address can also be a Microsoft personal-account login.
+    const googleCal = makeCalendar({
+      name: "Google primary",
+      accountEmail: "lance@gmail.com",
+    });
+    const microsoftCal = makeCalendar({
+      name: "Microsoft primary",
+      provider: "microsoft",
+      accountEmail: "lance@gmail.com",
+    });
+
+    const user = userEvent.setup({ delay: null });
+    renderCalendarList([googleCal, microsoftCal], {
+      connections: [
+        makeConnection("lance@gmail.com"),
+        makeConnection("lance@gmail.com", { provider: "microsoft" }),
+      ],
+    });
+
+    const googleSection = screen.getByRole("region", {
+      name: "Calendars for lance@gmail.com (Google)",
+    });
+    const microsoftSection = screen.getByRole("region", {
+      name: "Calendars for lance@gmail.com (Microsoft)",
+    });
+    expect(googleSection).toHaveAttribute(
+      "data-page-jump",
+      "calendar-account:google:lance@gmail.com",
+    );
+    expect(microsoftSection).toHaveAttribute(
+      "data-page-jump",
+      "calendar-account:microsoft:lance@gmail.com",
+    );
+    expect(
+      within(googleSection).getByText("Google primary"),
+    ).toBeInTheDocument();
+    expect(
+      within(googleSection).getByRole("img", { name: "Google" }),
+    ).toBeInTheDocument();
+    expect(
+      within(microsoftSection).getByText("Microsoft primary"),
+    ).toBeInTheDocument();
+    expect(
+      within(microsoftSection).getByRole("img", { name: "Microsoft" }),
+    ).toBeInTheDocument();
+
+    // Collapsing one account leaves the same-address account alone.
+    await user.click(
+      within(googleSection).getByRole("button", {
+        name: "lance@gmail.com Google",
+      }),
+    );
+    expect(
+      within(googleSection).queryByText("Google primary"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(microsoftSection).getByText("Microsoft primary"),
+    ).toBeInTheDocument();
   });
 
   it("nests Compass under the Google account that matches the Compass login email", () => {
@@ -695,18 +786,20 @@ describe("CalendarList", () => {
     });
 
     const matchingSection = screen.getByRole("region", {
-      name: "Calendars for ahab@pequod.com",
+      name: "Calendars for ahab@pequod.com (Google)",
     });
     expect(within(matchingSection).getByText("Work")).toBeInTheDocument();
     expect(within(matchingSection).getByText("Compass")).toBeInTheDocument();
     expect(
       screen.queryAllByRole("region", {
-        name: "Calendars for ahab@pequod.com",
+        name: "Calendars for ahab@pequod.com (Google)",
       }),
     ).toHaveLength(1);
     expect(
       within(
-        screen.getByRole("region", { name: "Calendars for ahab@gmail.com" }),
+        screen.getByRole("region", {
+          name: "Calendars for ahab@gmail.com (Google)",
+        }),
       ).queryByText("Compass"),
     ).not.toBeInTheDocument();
   });
@@ -725,7 +818,9 @@ describe("CalendarList", () => {
     });
 
     expect(screen.getByText("Compass")).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "ahab@pequod.com" }));
+    await user.click(
+      screen.getByRole("button", { name: "ahab@pequod.com Google" }),
+    );
     expect(screen.queryByText("Compass")).not.toBeInTheDocument();
     expect(screen.queryByText("Work")).not.toBeInTheDocument();
   });
@@ -749,8 +844,12 @@ describe("CalendarList", () => {
       ],
     });
 
-    await user.click(screen.getByRole("button", { name: "ahab@pequod.com" }));
-    await user.click(screen.getByRole("button", { name: "ahab@gmail.com" }));
+    await user.click(
+      screen.getByRole("button", { name: "ahab@pequod.com Google" }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: "ahab@gmail.com Google" }),
+    );
 
     expect(screen.getByText("Compass")).toBeInTheDocument();
   });

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
@@ -3,6 +3,7 @@ import { type Calendar } from "@core/types/calendar.contracts";
 import { shouldShowContextualLoadError } from "@web/api/util/api.util";
 import { useSession } from "@web/auth/compass/session/useSession";
 import { useUser } from "@web/auth/compass/user/hooks/useUser";
+import { defaultCalendarGroupLabel } from "@web/auth/providers/provider-copy.util";
 import { useAvailableConnectProviders } from "@web/auth/providers/useAvailableConnectProviders";
 import {
   selectSyncConnections,
@@ -114,15 +115,17 @@ export const CalendarList: FC = () => {
         <div className="flex flex-col gap-3">
           {groups.map((group) => (
             <section
-              aria-label={`Calendars for ${group.accountEmail}`}
-              key={group.accountEmail}
-              {...pageJumpAttrs(calendarAccountJumpId(group.accountEmail))}
+              aria-label={`Calendars for ${defaultCalendarGroupLabel(group.accountEmail, group.provider)}`}
+              key={group.key}
+              {...pageJumpAttrs(calendarAccountJumpId(group.key))}
             >
               <AccountSectionHeader
+                accountKey={group.key}
                 accountEmail={group.accountEmail}
                 connection={group.connection}
+                provider={group.provider}
               />
-              {renderCollapsible(group.accountEmail, group.calendars)}
+              {renderCollapsible(group.key, group.calendars)}
             </section>
           ))}
           {ungrouped.length > 0 ? (

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
@@ -3,7 +3,6 @@ import { type Calendar } from "@core/types/calendar.contracts";
 import { shouldShowContextualLoadError } from "@web/api/util/api.util";
 import { useSession } from "@web/auth/compass/session/useSession";
 import { useUser } from "@web/auth/compass/user/hooks/useUser";
-import { defaultCalendarGroupLabel } from "@web/auth/providers/provider-copy.util";
 import { useAvailableConnectProviders } from "@web/auth/providers/useAvailableConnectProviders";
 import {
   selectSyncConnections,
@@ -11,6 +10,8 @@ import {
 } from "@web/auth/state/user-metadata.store";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import {
+  accountKey,
+  accountLabel,
   compareCalendars,
   groupCalendarsByAccount,
 } from "@web/calendars/calendar.util";
@@ -113,21 +114,22 @@ export const CalendarList: FC = () => {
         )
       ) : (
         <div className="flex flex-col gap-3">
-          {groups.map((group) => (
-            <section
-              aria-label={`Calendars for ${defaultCalendarGroupLabel(group.accountEmail, group.provider)}`}
-              key={group.key}
-              {...pageJumpAttrs(calendarAccountJumpId(group.key))}
-            >
-              <AccountSectionHeader
-                accountKey={group.key}
-                accountEmail={group.accountEmail}
-                connection={group.connection}
-                provider={group.provider}
-              />
-              {renderCollapsible(group.key, group.calendars)}
-            </section>
-          ))}
+          {groups.map((group) => {
+            const key = accountKey(group);
+            return (
+              <section
+                aria-label={`Calendars for ${accountLabel(group)}`}
+                key={key}
+                {...pageJumpAttrs(calendarAccountJumpId(key))}
+              >
+                <AccountSectionHeader
+                  account={group}
+                  connection={group.connection}
+                />
+                {renderCollapsible(key, group.calendars)}
+              </section>
+            );
+          })}
           {ungrouped.length > 0 ? (
             groups.length > 0 && email ? (
               <section aria-label={`Calendars for ${email}`}>

--- a/packages/web/src/shortcuts/page-jump/PageJumpHintOverlay.test.tsx
+++ b/packages/web/src/shortcuts/page-jump/PageJumpHintOverlay.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render, screen } from "@testing-library/react";
+import { createMockAccountRef } from "@web/__tests__/utils/factories/calendar.factory";
 import { PageJumpHintOverlay } from "@web/shortcuts/page-jump/PageJumpHintOverlay";
 import {
   buildCalendarPageJumpTargets,
@@ -156,24 +157,23 @@ describe("PageJumpHintOverlay", () => {
     addAnchor("view-select");
     addAnchor("month-picker");
     addAnchor("up-next");
-    addAnchor(calendarAccountJumpId("ahab@pequod.com"));
-    addAnchor(calendarAccountJumpId("ahab@gmail.com"));
+    const work = createMockAccountRef("ahab@pequod.com");
+    const personal = createMockAccountRef("ahab@gmail.com");
+    addAnchor(calendarAccountJumpId(work.key));
+    addAnchor(calendarAccountJumpId(personal.key));
     render(
       <PageJumpHintOverlay
-        targets={buildCalendarPageJumpTargets([
-          "ahab@pequod.com",
-          "ahab@gmail.com",
-        ])}
+        targets={buildCalendarPageJumpTargets([work, personal])}
         visible={true}
       />,
     );
 
     expect(chipDigits()).toEqual(["1", "2", "3", "4", "5"]);
     expect(screen.getByRole("status").textContent).toContain(
-      "4 for ahab@pequod.com",
+      "4 for ahab@pequod.com (google)",
     );
     expect(screen.getByRole("status").textContent).toContain(
-      "5 for ahab@gmail.com",
+      "5 for ahab@gmail.com (google)",
     );
   });
 });

--- a/packages/web/src/shortcuts/page-jump/PageJumpHintOverlay.test.tsx
+++ b/packages/web/src/shortcuts/page-jump/PageJumpHintOverlay.test.tsx
@@ -1,5 +1,4 @@
 import { cleanup, render, screen } from "@testing-library/react";
-import { createMockAccountRef } from "@web/__tests__/utils/factories/calendar.factory";
 import { PageJumpHintOverlay } from "@web/shortcuts/page-jump/PageJumpHintOverlay";
 import {
   buildCalendarPageJumpTargets,
@@ -157,13 +156,14 @@ describe("PageJumpHintOverlay", () => {
     addAnchor("view-select");
     addAnchor("month-picker");
     addAnchor("up-next");
-    const work = createMockAccountRef("ahab@pequod.com");
-    const personal = createMockAccountRef("ahab@gmail.com");
-    addAnchor(calendarAccountJumpId(work.key));
-    addAnchor(calendarAccountJumpId(personal.key));
+    addAnchor(calendarAccountJumpId("google:ahab@pequod.com"));
+    addAnchor(calendarAccountJumpId("google:ahab@gmail.com"));
     render(
       <PageJumpHintOverlay
-        targets={buildCalendarPageJumpTargets([work, personal])}
+        targets={buildCalendarPageJumpTargets([
+          { provider: "google", accountEmail: "ahab@pequod.com" },
+          { provider: "google", accountEmail: "ahab@gmail.com" },
+        ])}
         visible={true}
       />,
     );

--- a/packages/web/src/shortcuts/page-jump/PageJumpHints.tsx
+++ b/packages/web/src/shortcuts/page-jump/PageJumpHints.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useConnectedAccountEmails } from "@web/calendars/useDefaultTargetCalendar";
+import { useConnectedAccounts } from "@web/calendars/useDefaultTargetCalendar";
 import { PageJumpHintOverlay } from "@web/shortcuts/page-jump/PageJumpHintOverlay";
 import {
   buildCalendarPageJumpTargets,
@@ -14,10 +14,10 @@ import { usePageJumpShortcut } from "@web/shortcuts/page-jump/usePageJumpShortcu
  * their own lists.
  */
 export function PageJumpHints({ targets }: { targets?: PageJumpTargets }) {
-  const accountEmails = useConnectedAccountEmails();
+  const accounts = useConnectedAccounts();
   const resolvedTargets = useMemo(
-    () => targets ?? buildCalendarPageJumpTargets(accountEmails),
-    [accountEmails, targets],
+    () => targets ?? buildCalendarPageJumpTargets(accounts),
+    [accounts, targets],
   );
   const { areHintsVisible } = usePageJumpShortcut(resolvedTargets);
   return (

--- a/packages/web/src/shortcuts/page-jump/page-jump.targets.test.ts
+++ b/packages/web/src/shortcuts/page-jump/page-jump.targets.test.ts
@@ -1,3 +1,4 @@
+import { createMockAccountRef as account } from "@web/__tests__/utils/factories/calendar.factory";
 import { PICK_KEY_LABELS } from "@web/shortcuts/digit-pick.util";
 import {
   buildCalendarPageJumpTargets,
@@ -43,8 +44,8 @@ describe("buildCalendarPageJumpTargets", () => {
   });
 
   it("replaces the list-level calendars slot with one target per account", () => {
-    const work = "ahab@pequod.com";
-    const personal = "ahab@gmail.com";
+    const work = account("ahab@pequod.com");
+    const personal = account("ahab@gmail.com");
     const targets = buildCalendarPageJumpTargets([work, personal]);
 
     expect(
@@ -53,17 +54,43 @@ describe("buildCalendarPageJumpTargets", () => {
       { digit: "1", id: "view-select", label: "View dropdown" },
       { digit: "2", id: "month-picker", label: "Month picker" },
       { digit: "3", id: "up-next", label: "Up next" },
-      { digit: "4", id: calendarAccountJumpId(work), label: work },
-      { digit: "5", id: calendarAccountJumpId(personal), label: personal },
+      {
+        digit: "4",
+        id: "calendar-account:google:ahab@pequod.com",
+        label: "ahab@pequod.com (Google)",
+      },
+      {
+        digit: "5",
+        id: "calendar-account:google:ahab@gmail.com",
+        label: "ahab@gmail.com (Google)",
+      },
+    ]);
+  });
+
+  it("gives same-email accounts on different providers distinct targets", () => {
+    const targets = buildCalendarPageJumpTargets([
+      account("lance@gmail.com", "google"),
+      account("lance@gmail.com", "microsoft"),
+    ]);
+
+    expect(targets.slice(3).map(({ id, label }) => ({ id, label }))).toEqual([
+      {
+        id: "calendar-account:google:lance@gmail.com",
+        label: "lance@gmail.com (Google)",
+      },
+      {
+        id: "calendar-account:microsoft:lance@gmail.com",
+        label: "lance@gmail.com (Microsoft)",
+      },
     ]);
   });
 
   it("omits extra accounts that would overflow the top-row keys", () => {
-    const emails = Array.from(
+    const accounts = Array.from(
       { length: PICK_KEY_LABELS.length },
-      (_, index) => `account${index}@x.com`,
+      (_, index) => account(`account${index}@x.com`),
     );
-    const targets = buildCalendarPageJumpTargets(emails);
+    const targets = buildCalendarPageJumpTargets(accounts);
 
     expect(targets).toHaveLength(PICK_KEY_LABELS.length);
     expect(targets[0]).toMatchObject({ id: "view-select" });
@@ -130,8 +157,8 @@ describe("buildDayPageJumpTargets", () => {
   });
 
   it("replaces the list-level calendars slot with one target per account", () => {
-    const work = "ahab@pequod.com";
-    const personal = "ahab@gmail.com";
+    const work = account("ahab@pequod.com");
+    const personal = account("ahab@gmail.com");
     const targets = buildDayPageJumpTargets(
       [{ id: "cal-work", name: "Work" }],
       [work, personal],
@@ -144,24 +171,34 @@ describe("buildDayPageJumpTargets", () => {
       { digit: "2", id: dayColumnJumpId("cal-work"), label: "Work" },
       { digit: "3", id: "month-picker", label: "Month picker" },
       { digit: "4", id: "up-next", label: "Up next" },
-      { digit: "5", id: calendarAccountJumpId(work), label: work },
-      { digit: "6", id: calendarAccountJumpId(personal), label: personal },
+      {
+        digit: "5",
+        id: calendarAccountJumpId(work.key),
+        label: "ahab@pequod.com (Google)",
+      },
+      {
+        digit: "6",
+        id: calendarAccountJumpId(personal.key),
+        label: "ahab@gmail.com (Google)",
+      },
     ]);
   });
 
   it("omits extra columns so per-account sidebar slots still fit", () => {
-    const emails = ["a@x.com", "b@x.com", "c@x.com"];
-    const sidebarCount = buildCalendarPageJumpTargets(emails).length - 1;
+    const accounts = ["a@x.com", "b@x.com", "c@x.com"].map((email) =>
+      account(email),
+    );
+    const sidebarCount = buildCalendarPageJumpTargets(accounts).length - 1;
     const maxColumns = PICK_KEY_LABELS.length - 1 - sidebarCount;
     const calendars = Array.from({ length: maxColumns + 3 }, (_, index) => ({
       id: `cal-${index}`,
       name: `Calendar ${index}`,
     }));
-    const targets = buildDayPageJumpTargets(calendars, emails);
+    const targets = buildDayPageJumpTargets(calendars, accounts);
 
     expect(targets).toHaveLength(PICK_KEY_LABELS.length);
     expect(targets.at(-1)).toMatchObject({
-      id: calendarAccountJumpId("c@x.com"),
+      id: calendarAccountJumpId(account("c@x.com").key),
       digit: PICK_KEY_LABELS.at(-1),
     });
     expect(
@@ -296,8 +333,8 @@ describe("focusPageJumpTarget", () => {
     expect(clicks).toBe(0);
   });
 
-  it("finds an account anchor whose email contains CSS-significant characters", () => {
-    const id = calendarAccountJumpId("tyler+work@gmail.com");
+  it("finds an account anchor whose key contains CSS-significant characters", () => {
+    const id = calendarAccountJumpId(account("tyler+work@gmail.com").key);
     const anchor = addAnchor(id);
     const toggle = document.createElement("button");
     anchor.append(toggle);

--- a/packages/web/src/shortcuts/page-jump/page-jump.targets.test.ts
+++ b/packages/web/src/shortcuts/page-jump/page-jump.targets.test.ts
@@ -1,4 +1,5 @@
-import { createMockAccountRef as account } from "@web/__tests__/utils/factories/calendar.factory";
+import { type ProviderKind } from "@core/types/sync/identity.contracts";
+import { type AccountRef, accountKey } from "@web/calendars/calendar.util";
 import { PICK_KEY_LABELS } from "@web/shortcuts/digit-pick.util";
 import {
   buildCalendarPageJumpTargets,
@@ -13,6 +14,11 @@ import {
   type PageJumpTargetId,
 } from "@web/shortcuts/page-jump/page-jump.targets";
 import { afterEach, describe, expect, it } from "bun:test";
+
+const account = (
+  accountEmail: string,
+  provider: ProviderKind = "google",
+): AccountRef => ({ provider, accountEmail });
 
 const addAnchor = (id: PageJumpTargetId): HTMLElement => {
   const anchor = document.createElement("section");
@@ -173,12 +179,12 @@ describe("buildDayPageJumpTargets", () => {
       { digit: "4", id: "up-next", label: "Up next" },
       {
         digit: "5",
-        id: calendarAccountJumpId(work.key),
+        id: calendarAccountJumpId(accountKey(work)),
         label: "ahab@pequod.com (Google)",
       },
       {
         digit: "6",
-        id: calendarAccountJumpId(personal.key),
+        id: calendarAccountJumpId(accountKey(personal)),
         label: "ahab@gmail.com (Google)",
       },
     ]);
@@ -198,7 +204,7 @@ describe("buildDayPageJumpTargets", () => {
 
     expect(targets).toHaveLength(PICK_KEY_LABELS.length);
     expect(targets.at(-1)).toMatchObject({
-      id: calendarAccountJumpId(account("c@x.com").key),
+      id: calendarAccountJumpId(accountKey(account("c@x.com"))),
       digit: PICK_KEY_LABELS.at(-1),
     });
     expect(
@@ -334,7 +340,9 @@ describe("focusPageJumpTarget", () => {
   });
 
   it("finds an account anchor whose key contains CSS-significant characters", () => {
-    const id = calendarAccountJumpId(account("tyler+work@gmail.com").key);
+    const id = calendarAccountJumpId(
+      accountKey(account("tyler+work@gmail.com")),
+    );
     const anchor = addAnchor(id);
     const toggle = document.createElement("button");
     anchor.append(toggle);

--- a/packages/web/src/shortcuts/page-jump/page-jump.targets.ts
+++ b/packages/web/src/shortcuts/page-jump/page-jump.targets.ts
@@ -23,8 +23,11 @@
  * and each account) are omitted so those chips still appear when mounted.
  */
 
-import { defaultCalendarGroupLabel } from "@web/auth/providers/provider-copy.util";
-import { type AccountRef } from "@web/calendars/calendar.util";
+import {
+  type AccountRef,
+  accountKey,
+  accountLabel,
+} from "@web/calendars/calendar.util";
 import { PICK_KEY_LABELS } from "@web/shortcuts/digit-pick.util";
 
 export const PAGE_JUMP_ATTRIBUTE = "data-page-jump";
@@ -82,7 +85,6 @@ const withPickDigits = (
     digit: PICK_KEY_LABELS[index] ?? "",
   }));
 
-/** `accountKey` is provider-scoped, so same-email accounts get distinct ids. */
 export const calendarAccountJumpId = (
   accountKey: string,
 ): `${typeof CALENDAR_ACCOUNT_JUMP_ID_PREFIX}${string}` =>
@@ -100,11 +102,8 @@ const calendarListJumpTargets = (
   accounts.length === 0
     ? [CALENDARS_LIST_TARGET]
     : accounts.map((account) => ({
-        id: calendarAccountJumpId(account.key),
-        label: defaultCalendarGroupLabel(
-          account.accountEmail,
-          account.provider,
-        ),
+        id: calendarAccountJumpId(accountKey(account)),
+        label: accountLabel(account),
       }));
 
 /**

--- a/packages/web/src/shortcuts/page-jump/page-jump.targets.ts
+++ b/packages/web/src/shortcuts/page-jump/page-jump.targets.ts
@@ -23,6 +23,8 @@
  * and each account) are omitted so those chips still appear when mounted.
  */
 
+import { defaultCalendarGroupLabel } from "@web/auth/providers/provider-copy.util";
+import { type AccountRef } from "@web/calendars/calendar.util";
 import { PICK_KEY_LABELS } from "@web/shortcuts/digit-pick.util";
 
 export const PAGE_JUMP_ATTRIBUTE = "data-page-jump";
@@ -80,10 +82,11 @@ const withPickDigits = (
     digit: PICK_KEY_LABELS[index] ?? "",
   }));
 
+/** `accountKey` is provider-scoped, so same-email accounts get distinct ids. */
 export const calendarAccountJumpId = (
-  accountEmail: string,
+  accountKey: string,
 ): `${typeof CALENDAR_ACCOUNT_JUMP_ID_PREFIX}${string}` =>
-  `${CALENDAR_ACCOUNT_JUMP_ID_PREFIX}${accountEmail}`;
+  `${CALENDAR_ACCOUNT_JUMP_ID_PREFIX}${accountKey}`;
 
 /**
  * Sidebar calendar slots after month picker / Up next: one numbered target
@@ -92,13 +95,16 @@ export const calendarAccountJumpId = (
  * calendar rows.
  */
 const calendarListJumpTargets = (
-  accountEmails: readonly string[],
+  accounts: readonly AccountRef[],
 ): PageJumpTargetDraft[] =>
-  accountEmails.length === 0
+  accounts.length === 0
     ? [CALENDARS_LIST_TARGET]
-    : accountEmails.map((accountEmail) => ({
-        id: calendarAccountJumpId(accountEmail),
-        label: accountEmail,
+    : accounts.map((account) => ({
+        id: calendarAccountJumpId(account.key),
+        label: defaultCalendarGroupLabel(
+          account.accountEmail,
+          account.provider,
+        ),
       }));
 
 /**
@@ -107,13 +113,13 @@ const calendarListJumpTargets = (
  * physical top-row keys are omitted — no chip, no binding.
  */
 export const buildCalendarPageJumpTargets = (
-  accountEmails: readonly string[] = [],
+  accounts: readonly AccountRef[] = [],
 ): PageJumpTargets =>
   withPickDigits([
     VIEW_SELECT_TARGET,
     MONTH_PICKER_TARGET,
     UP_NEXT_TARGET,
-    ...calendarListJumpTargets(accountEmails),
+    ...calendarListJumpTargets(accounts),
   ]);
 
 /** No-account Week map. Prefer `buildCalendarPageJumpTargets` when accounts exist. */
@@ -146,10 +152,10 @@ export const dayColumnJumpId = (
  */
 export const buildDayPageJumpTargets = (
   calendars: readonly DayColumnJumpCalendar[],
-  accountEmails: readonly string[] = [],
+  accounts: readonly AccountRef[] = [],
 ): PageJumpTargets => {
   const [viewSelect, ...sidebarTargets] =
-    buildCalendarPageJumpTargets(accountEmails);
+    buildCalendarPageJumpTargets(accounts);
   const maxColumns = PICK_KEY_LABELS.length - 1 - sidebarTargets.length;
   const columnTargets = calendars
     .slice(0, Math.max(0, maxColumns))
@@ -170,7 +176,7 @@ export const pageJumpAttrs = (
 
 /**
  * Match by attribute value rather than interpolating `id` into a selector:
- * account emails can contain CSS-significant characters (`+`, `.`).
+ * account keys can contain CSS-significant characters (`:`, `+`, `.`).
  */
 export const getPageJumpAnchor = (id: PageJumpTargetId): HTMLElement | null => {
   for (const element of document.querySelectorAll<HTMLElement>(

--- a/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.test.tsx
+++ b/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.test.tsx
@@ -1,6 +1,5 @@
 import { resolveModifier } from "@tanstack/react-hotkeys";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { createMockAccountRef } from "@web/__tests__/utils/factories/calendar.factory";
 import {
   createGridEventDraft,
   timedGridSchedule,
@@ -206,7 +205,7 @@ describe("usePageJumpShortcut", () => {
       const firstAnchor = document.createElement("section");
       firstAnchor.setAttribute(
         PAGE_JUMP_ATTRIBUTE,
-        calendarAccountJumpId(createMockAccountRef("ahab@pequod.com").key),
+        calendarAccountJumpId("google:ahab@pequod.com"),
       );
       firstAnchor.append(first);
       document.body.append(firstAnchor);
@@ -215,7 +214,7 @@ describe("usePageJumpShortcut", () => {
       const secondAnchor = document.createElement("section");
       secondAnchor.setAttribute(
         PAGE_JUMP_ATTRIBUTE,
-        calendarAccountJumpId(createMockAccountRef("ahab@gmail.com").key),
+        calendarAccountJumpId("google:ahab@gmail.com"),
       );
       secondAnchor.append(second);
       document.body.append(secondAnchor);
@@ -223,8 +222,8 @@ describe("usePageJumpShortcut", () => {
       renderHook(() =>
         usePageJumpShortcut(
           buildCalendarPageJumpTargets([
-            createMockAccountRef("ahab@pequod.com"),
-            createMockAccountRef("ahab@gmail.com"),
+            { provider: "google", accountEmail: "ahab@pequod.com" },
+            { provider: "google", accountEmail: "ahab@gmail.com" },
           ]),
         ),
       );

--- a/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.test.tsx
+++ b/packages/web/src/shortcuts/page-jump/usePageJumpShortcut.test.tsx
@@ -1,5 +1,6 @@
 import { resolveModifier } from "@tanstack/react-hotkeys";
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { createMockAccountRef } from "@web/__tests__/utils/factories/calendar.factory";
 import {
   createGridEventDraft,
   timedGridSchedule,
@@ -205,7 +206,7 @@ describe("usePageJumpShortcut", () => {
       const firstAnchor = document.createElement("section");
       firstAnchor.setAttribute(
         PAGE_JUMP_ATTRIBUTE,
-        calendarAccountJumpId("ahab@pequod.com"),
+        calendarAccountJumpId(createMockAccountRef("ahab@pequod.com").key),
       );
       firstAnchor.append(first);
       document.body.append(firstAnchor);
@@ -214,14 +215,17 @@ describe("usePageJumpShortcut", () => {
       const secondAnchor = document.createElement("section");
       secondAnchor.setAttribute(
         PAGE_JUMP_ATTRIBUTE,
-        calendarAccountJumpId("ahab@gmail.com"),
+        calendarAccountJumpId(createMockAccountRef("ahab@gmail.com").key),
       );
       secondAnchor.append(second);
       document.body.append(secondAnchor);
 
       renderHook(() =>
         usePageJumpShortcut(
-          buildCalendarPageJumpTargets(["ahab@pequod.com", "ahab@gmail.com"]),
+          buildCalendarPageJumpTargets([
+            createMockAccountRef("ahab@pequod.com"),
+            createMockAccountRef("ahab@gmail.com"),
+          ]),
         ),
       );
 

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.tsx
@@ -13,7 +13,7 @@ import { useConnectGoogle } from "@web/auth/providers/useConnectProvider";
 import { useCalendarsQuery } from "@web/calendars/calendar.query";
 import { getWritableCalendars } from "@web/calendars/calendar.util";
 import {
-  useConnectedAccountEmails,
+  useConnectedAccounts,
   useDefaultTargetCalendar,
 } from "@web/calendars/useDefaultTargetCalendar";
 import { type GridEvent } from "@web/common/types/web.event.types";
@@ -126,13 +126,13 @@ export function DayCalendarGrid() {
     isDisplayedEvent,
     visibleDates,
   } = useDayCalendarColumns({ allDayEvents, dateInView, timedEvents });
-  const connectedAccountEmails = useConnectedAccountEmails();
+  const connectedAccounts = useConnectedAccounts();
   const writableDisplayedCalendars = useMemo(
     () =>
       getWritableCalendars(displayedCalendars, {
-        hasConnectedAccount: connectedAccountEmails.length > 0,
+        hasConnectedAccount: connectedAccounts.length > 0,
       }),
-    [connectedAccountEmails.length, displayedCalendars],
+    [connectedAccounts.length, displayedCalendars],
   );
   const writableCalendarIds = useMemo(
     () =>
@@ -143,11 +143,8 @@ export function DayCalendarGrid() {
   );
   const pageJumpTargets = useMemo(
     () =>
-      buildDayPageJumpTargets(
-        writableDisplayedCalendars,
-        connectedAccountEmails,
-      ),
-    [connectedAccountEmails, writableDisplayedCalendars],
+      buildDayPageJumpTargets(writableDisplayedCalendars, connectedAccounts),
+    [connectedAccounts, writableDisplayedCalendars],
   );
   const [focusedColumnKey, setFocusedColumnKey] = useState<string | null>(null);
   const { gridRefs, measurements } = useGridMeasurements({


### PR DESCRIPTION
Refs #3210 (no dedicated issue; found on staging while testing Microsoft connect)

## What and why

A Gmail address can also be a Microsoft personal-account login, so the same email can be two connected accounts. The web app keyed everything account-shaped by email alone, which merged both providers' calendars under one sidebar header, left the two Settings rows indistinguishable, put the Default badge on both, and made disconnecting one provider drop the other's calendars from the cache for a beat.

An account is now `provider + email` (`AccountRef`, with `accountKey` / `accountLabel` derived from it in `calendar.util.ts`). Both `Calendar` and `SyncConnectionSummary` already carry `provider`, so there is no wire change. Sidebar sections, collapse state, page-jump ids, the Default badge, and the disconnect filter all key off it. A `ProviderMark` (exhaustive `Record<ProviderKind, Logo>`, the three brand SVGs moved to `components/Icons/`) shows the provider beside every account email in the sidebar and Settings; the Add-account menu picks up Google and Apple icons from the same registry. `CalendarProviderSchema` is now defined from `ProviderKindSchema`, so `"local" | ProviderKind` is explicit at the contract level.

Verified in the browser with two seeded same-email connections: two sidebar sections with distinct jump ids and `aria-controls`, collapse persisted as `google:<email>` while the Microsoft section stayed expanded, and Settings rows carrying the Google and Microsoft marks.

Follow-ups, not in this PR: reconnect-required state is still keyed by email (`reconnect.state.ts`); booking optgroup captions stay email-only; `compareCalendars` / `spansMultipleAccounts` still rank by email; `connectionProvider` in `provider-copy.util.ts` duplicates `connectionProviderKind`. Previously persisted collapse keys become inert once, so every account renders expanded after this deploys.

## Verify

```
VERDICT: FAIL
Selected packages: core, web
Checks run: test:core, test:web, type-check, lint, knip
Failed: test:a11y, test:e2e
```

`test:core`, `test:web` (861 pass), `type-check`, `lint`, and `knip` all pass. The local `FAIL` is the known macOS sandbox pattern, not the change: every e2e failure is a timeout rather than an assertion, and the two that land in calendar files reproduce identically on `origin/main` sources (checked by swapping in main's `packages/web/src` and rerunning them alone).

- 20x `accessibility/booking-a11y` and 14x `booking/host-settings`, plus `calendars/microsoft-surfaces` "Add account starts Microsoft OAuth": the harness opens Settings with `Control+Comma`, which is the Linux binding, so `getByRole("dialog", { name: "Settings" })` never appears on macOS.
- `calendars/account-page-jump` "hold-Mod gives each calendar account its own jump key": hold-Mod chips are suppressed locally by the already-open shortcuts legend; passes on CI.
- `oauth/google-auth-callback` (2), `onboarding/mobile-gate`, `billing/plan-section-layout`, `booking/public-booking-v15`, `accessibility/connect-onboarding`: 30s `page.goto` / popup timeouts from `test:a11y` and `test:e2e` sharing port 9150.

Rerunning the three calendar specs this diff touches alone: 9 passed, the same 2 environmental failures. CI on Linux is the gate.
