### PR TITLE
fix(ci): join deploy health-check version probe onto /config

### DIFF
--- a/.github/scripts/deploy-health-check.sh
+++ b/.github/scripts/deploy-health-check.sh
@@ -353,7 +353,8 @@ validate_backend_config_version() {
   require_env BACKEND_API_URL || return 1
 
   local url expected actual body
-  url="${BACKEND_API_URL%/}/api/config"
+  # BACKEND_API_URL already includes /api, same join as validate_backend_health.
+  url="${BACKEND_API_URL%/}/config"
   expected=$(expected_version) || return 1
 
   if is_local_url "$url" && [ -n "${SSH_TARGET:-}" ]; then

--- a/packages/scripts/src/testing/deploy-health-check.test.ts
+++ b/packages/scripts/src/testing/deploy-health-check.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const HEALTH_CHECK_SCRIPT = ".github/scripts/deploy-health-check.sh";
+
+async function runHealthScriptFunction(
+  command: string,
+  env: Record<string, string> = {},
+) {
+  const proc = Bun.spawn(
+    ["bash", "-c", `. ${HEALTH_CHECK_SCRIPT}; ${command}`],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        SSH_TARGET: "",
+        ...env,
+      },
+      stderr: "pipe",
+      stdout: "pipe",
+    },
+  );
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  return { exitCode, stderr, stdout };
+}
+
+describe("deploy health check script contract", () => {
+  it("joins BACKEND_API_URL onto /config, not /api/config", () => {
+    const script = readFileSync(HEALTH_CHECK_SCRIPT, "utf8");
+
+    expect(script).toContain('url="${BACKEND_API_URL%/}/health"');
+    expect(script).toContain('url="${BACKEND_API_URL%/}/config"');
+    expect(script).not.toContain('url="${BACKEND_API_URL%/}/api/config"');
+  });
+
+  it("probes /api/config when BACKEND_API_URL already ends in /api", async () => {
+    const requested: string[] = [];
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(req) {
+        const path = new URL(req.url).pathname;
+        requested.push(path);
+        if (path === "/api/config") {
+          return Response.json({ version: "0.5.27" });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+
+    try {
+      const result = await runHealthScriptFunction(
+        "validate_backend_config_version; exit $?",
+        {
+          BACKEND_API_URL: `http://127.0.0.1:${server.port}/api`,
+          RELEASE_TAG: "v0.5.27",
+        },
+      );
+
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("ok backend-config-version");
+      expect(requested).toEqual(["/api/config"]);
+    } finally {
+      server.stop(true);
+    }
+  });
+});

--- a/self-host/docker-compose.test.ts
+++ b/self-host/docker-compose.test.ts
@@ -808,4 +808,46 @@ describe("deploy health check script", () => {
     expect(result.stdout).toContain("COMPOSE_PROFILES=selfhosted,sync");
     expect(result.stdout).toContain("docker compose --project-name compass");
   });
+
+  it("joins BACKEND_API_URL onto /config the same way as /health", () => {
+    const script = readRepoFile(".github/scripts/deploy-health-check.sh");
+
+    expect(script).toContain('url="${BACKEND_API_URL%/}/health"');
+    expect(script).toContain('url="${BACKEND_API_URL%/}/config"');
+    expect(script).not.toContain('url="${BACKEND_API_URL%/}/api/config"');
+  });
+
+  it("probes /api/config when BACKEND_API_URL already ends in /api", async () => {
+    const requested: string[] = [];
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(req) {
+        const path = new URL(req.url).pathname;
+        requested.push(path);
+        if (path === "/api/config") {
+          return Response.json({ version: "0.5.27" });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+
+    try {
+      const result = await runHealthScriptFunction(
+        "validate_backend_config_version; exit $?",
+        {
+          BACKEND_API_URL: `http://127.0.0.1:${server.port}/api`,
+          RELEASE_TAG: "v0.5.27",
+          SSH_TARGET: "",
+        },
+      );
+
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("ok backend-config-version");
+      expect(requested).toEqual(["/api/config"]);
+    } finally {
+      server.stop(true);
+    }
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #3625.

## What and why

Since #3625, Release on main fails both staging health checks with `failed backend-config-version: curl: (22) The requested URL returned error: 404`. Deploys succeed and `GET https://staging.compasscalendar.com/api/config` returns 200 with `version`, so the probe URL is wrong.

`validate_backend_config_version` joined `BACKEND_API_URL` (already `https://staging.compasscalendar.com/api`) onto `/api/config`, producing `/api/api/config`. The health probe already joins the same variable onto `/health`. This matches that join (`/config`) and pins it in `bun test:scripts` plus the existing docker-compose health-check suite.

## Verify

`VERDICT: PASS`

Checks run: `test:scripts:fast`, `type-check`, `lint`, `knip`
Checks skipped: (none)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bcc61043-6317-4da3-9852-16bf5e50b398?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bcc61043-6317-4da3-9852-16bf5e50b398&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

