### PR TITLE
feat(web): hide or show focused event with x

### DIFF
--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -31,6 +31,7 @@ Use this guide to validate:
 - confirming Settings > Meeting hold-Mod reveals only sidebar digits and Save Enter
 - confirming the first-run Meeting wizard Continue / Back keys (Enter, Esc, K, J)
 - confirming that shortcuts do not fire while typing in inputs
+- hiding and showing an event with `x`, from the event menu, and confirming the strip stays focusable
 
 Do not use this guide to validate:
 

--- a/docs/development/feature-file-map.md
+++ b/docs/development/feature-file-map.md
@@ -118,6 +118,7 @@ Product rules (hold-Mod discovery, "chip the field", typing always types):
 - Sidebar tip progress (demonstrated primitives): `packages/web/src/shortcuts/tips/shortcut-tips.progress.store.ts`
 - Global shell shortcuts (sidebar `]`, palette, settings, navigation): `packages/web/src/shortcuts/useGlobalShortcuts.ts`
 - Event-jump chips (`H`): `packages/web/src/shortcuts/shift-hint/`
+- Hide/show focused event (`x`): `packages/web/src/shortcuts/hide-event/useHideEventShortcut.ts`
 - Pointer suppression (mouse permanently inert; keyboard clicks pass): `packages/web/src/shortcuts/keyboard-only/`
 - Escape ownership (modals/form before lower handlers): `packages/web/src/shortcuts/escape-ownership.ts`
 - App lock (suppress shortcuts while a modal owns the UI): `packages/web/src/shortcuts/app-lock.ts`

--- a/packages/web/src/components/RootShell/RootShell.tsx
+++ b/packages/web/src/components/RootShell/RootShell.tsx
@@ -33,6 +33,7 @@ import {
 } from "@web/components/WelcomeModal/welcome.guide.store";
 import { useUpcomingEventNotifier } from "@web/notifications/useUpcomingEventNotifier";
 import { useEventContextMenuShortcut } from "@web/shortcuts/context-menu/useEventContextMenuShortcut";
+import { useHideEventShortcut } from "@web/shortcuts/hide-event/useHideEventShortcut";
 import { usePointerHintTracker } from "@web/shortcuts/keyboard-only/usePointerHintTracker";
 import { useFocusNoticeShortcut } from "@web/shortcuts/notice-focus/useFocusNoticeShortcut";
 import {
@@ -66,6 +67,7 @@ export function RootShell() {
   usePointerHintTracker(!isLifeView);
   useFocusNoticeShortcut();
   useEventContextMenuShortcut();
+  useHideEventShortcut();
   // Must stay mounted on every route, including Life, so the 5-minute
   // heads-up still fires while the calendar grid is not on screen.
   useUpcomingEventNotifier();

--- a/packages/web/src/shortcuts/hide-event/hide-event.constants.ts
+++ b/packages/web/src/shortcuts/hide-event/hide-event.constants.ts
@@ -1,0 +1,1 @@
+export const HIDE_EVENT_LETTER = "x";

--- a/packages/web/src/shortcuts/hide-event/useHideEventShortcut.test.tsx
+++ b/packages/web/src/shortcuts/hide-event/useHideEventShortcut.test.tsx
@@ -1,0 +1,132 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { type PropsWithChildren } from "react";
+import { seedHiddenEventIds } from "@web/__tests__/utils/hidden-events-test-data";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { persistentBrowserStore } from "@web/common/storage/browser-key-value.store";
+import { useHiddenEventIds } from "@web/events/hidden/hidden-events.query";
+import { resetEventRepositorySourceForTests } from "@web/events/repositories/event.repository.source.store";
+import { clearAppLockReasons, setAppLockReason } from "@web/shortcuts/app-lock";
+import { useHideEventShortcut } from "@web/shortcuts/hide-event/useHideEventShortcut";
+import { eventJumpActions } from "@web/shortcuts/shift-hint/event-jump.store";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+const pressX = () => {
+  (document.activeElement ?? document).dispatchEvent(
+    new KeyboardEvent("keydown", {
+      key: "x",
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+};
+
+const addEventCard = (eventId: string) => {
+  const card = document.createElement("div");
+  card.setAttribute("data-week-interaction-event-id", eventId);
+  card.tabIndex = 0;
+  document.body.appendChild(card);
+  return card;
+};
+
+describe("useHideEventShortcut", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    clearAppLockReasons();
+    eventJumpActions.reset();
+    resetEventRepositorySourceForTests();
+    document.body.innerHTML = "";
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    seedHiddenEventIds(queryClient, []);
+  });
+
+  afterEach(() => {
+    clearAppLockReasons();
+    eventJumpActions.reset();
+    resetEventRepositorySourceForTests();
+    document.body.innerHTML = "";
+    persistentBrowserStore.remove(STORAGE_KEYS.HIDDEN_EVENT_IDS);
+  });
+
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  it("toggles the focused event in the hidden set, and a second x unhides it", async () => {
+    const { result } = renderHook(
+      () => {
+        useHideEventShortcut();
+        return useHiddenEventIds();
+      },
+      { wrapper },
+    );
+    const card = addEventCard("event-1");
+    card.focus();
+
+    act(() => {
+      pressX();
+    });
+    await waitFor(() => {
+      expect(result.current.has("event-1")).toBe(true);
+    });
+
+    act(() => {
+      pressX();
+    });
+    await waitFor(() => {
+      expect(result.current.has("event-1")).toBe(false);
+    });
+  });
+
+  it("does nothing when focus is not on an event card", async () => {
+    const { result } = renderHook(
+      () => {
+        useHideEventShortcut();
+        return useHiddenEventIds();
+      },
+      { wrapper },
+    );
+    const button = document.createElement("button");
+    document.body.appendChild(button);
+    button.focus();
+
+    act(() => {
+      pressX();
+    });
+
+    await waitFor(() => {
+      expect(result.current.size).toBe(0);
+    });
+  });
+
+  it("yields while app-locked or event jump is active", async () => {
+    const { result } = renderHook(
+      () => {
+        useHideEventShortcut();
+        return useHiddenEventIds();
+      },
+      { wrapper },
+    );
+    const card = addEventCard("event-1");
+    card.focus();
+
+    setAppLockReason("commandPalette", true);
+    act(() => {
+      pressX();
+    });
+    expect(result.current.has("event-1")).toBe(false);
+    clearAppLockReasons();
+
+    eventJumpActions.setActive(true);
+    act(() => {
+      pressX();
+    });
+    expect(result.current.has("event-1")).toBe(false);
+  });
+});

--- a/packages/web/src/shortcuts/hide-event/useHideEventShortcut.ts
+++ b/packages/web/src/shortcuts/hide-event/useHideEventShortcut.ts
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+import { getCalendarEventIdFromElement } from "@web/common/utils/event/event.util";
+import { useToggleEventHidden } from "@web/events/hidden/hidden-events.query";
+import { shouldStandDownBareLetterShortcut } from "@web/shortcuts/bare-letter-stand-down";
+import { HIDE_EVENT_LETTER } from "@web/shortcuts/hide-event/hide-event.constants";
+import { isBareLetterKey } from "@web/shortcuts/is-bare-letter-key";
+
+/**
+ * Bare `x` toggles the focused event's hidden state. Same capture-listener
+ * style and yields as `m`: stands down while app-locked, typing, an `e`…
+ * sequence is armed, or event jump owns letters.
+ */
+export function useHideEventShortcut() {
+  const toggleEventHidden = useToggleEventHidden();
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      if (!isBareLetterKey(event, HIDE_EVENT_LETTER)) return;
+      if (shouldStandDownBareLetterShortcut(event)) return;
+
+      const active = document.activeElement;
+      if (!(active instanceof HTMLElement)) return;
+      const eventId = getCalendarEventIdFromElement(active);
+      if (!eventId) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      toggleEventHidden(eventId);
+    };
+
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [toggleEventHidden]);
+}

--- a/packages/web/src/shortcuts/shortcuts.menu.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.menu.test.ts
@@ -303,6 +303,10 @@ describe("shortcut menu sections", () => {
           keys: ["Enter"],
           label: "Open focused event",
         });
+        expect(stripMetadata(edit?.shortcuts ?? [])).toContainEqual({
+          keys: ["x"],
+          label: "Hide or show focused event",
+        });
       }
     });
 

--- a/packages/web/src/shortcuts/shortcuts.registry.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.test.ts
@@ -102,6 +102,9 @@ describe("shortcuts.registry", () => {
       expect(byId["focus-notice"]?.keys).toEqual(["f"]);
       expect(byId["edit-menu"]?.keys).toEqual(["m"]);
       expect(byId["edit-menu"]?.label).toBe("Open event menu");
+      expect(byId["edit-hide"]?.keys).toEqual(["x"]);
+      expect(byId["edit-hide"]?.label).toBe("Hide or show focused event");
+      expect(byId["edit-hide"]?.requiresWrite).toBeUndefined();
 
       // Shift+F10 still opens the menu where the OS has that key; it is just
       // not advertised, since it would duplicate the m row's label.

--- a/packages/web/src/shortcuts/shortcuts.registry.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.ts
@@ -4,6 +4,7 @@ import {
 } from "@web/components/Sidebar/MonthPicker/useMonthPickerShortcuts";
 import { EDIT_SEQUENCE_LETTER_FIELDS } from "@web/shortcuts/edit-sequence/edit-sequence.fields";
 import { type Shortcut } from "@web/shortcuts/global.shortcut.types";
+import { HIDE_EVENT_LETTER } from "@web/shortcuts/hide-event/hide-event.constants";
 import { KEYMAP } from "@web/shortcuts/keymap";
 import { type ShortcutOverlaySection } from "@web/shortcuts/shortcuts-overlay.types";
 
@@ -287,6 +288,12 @@ export const SHORTCUTS_REGISTRY: Shortcut[] = [
     label: "Open event menu",
     section: "edit",
     requiresWrite: true,
+  },
+  {
+    id: "edit-hide",
+    keys: [HIDE_EVENT_LETTER],
+    label: "Hide or show focused event",
+    section: "edit",
   },
   {
     id: "edit-save",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3621

## What and why

Pressing bare `x` while an event card (full or strip) is focused toggles that event's hidden state, using the same capture-listener and stand-down rules as `m`. The `?` legend lists it in Edit as "Hide or show focused event" with no `requiresWrite`. Spec: locked decisions on #3616.

## Verify

`VERDICT: PASS`

Selected from the diff: `web`. Independent checks: `test:web`, `type-check`, `lint`, `knip` (all passed). GitHub Unit and E2E on this branch succeeded, including the accessibility shard.

Local `bun run verify --strict` selected the same checks. `test:web` / `type-check` / `lint` / `knip` passed. Local `test:a11y` once failed in `e2e/accessibility/booking-a11y.spec.ts` (`settings booking first-run taken-address`, a save-booking color-contrast finding this diff cannot reach); that spec passed on isolated retry. GitHub E2E is the gate.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6562b00-704c-43c1-aef8-a4299e3a7038?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6562b00-704c-43c1-aef8-a4299e3a7038&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

