### PR TITLE
feat(web): add hide and show event to the context menu

### DIFF
--- a/packages/web/src/components/ContextMenu/ContextMenuItems.test.tsx
+++ b/packages/web/src/components/ContextMenu/ContextMenuItems.test.tsx
@@ -15,7 +15,9 @@ import {
   toNormalizedEventQueryData,
 } from "@web/__tests__/utils/event-query-test-data";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
+import { seedHiddenEventIds } from "@web/__tests__/utils/hidden-events-test-data";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
+import { ID_CONTEXT_MENU_ITEMS } from "@web/common/constants/web.constants";
 import { type GridEvent } from "@web/common/types/web.event.types";
 import { gridEventDefaultPosition } from "@web/common/utils/event/event.util";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
@@ -74,15 +76,20 @@ const renderWithTheme = (
     pendingEventIds = [],
     calendars,
     event,
+    hiddenEventIds,
   }: {
     pendingEventIds?: string[];
     calendars?: Calendar[];
     event?: GridEvent;
+    hiddenEventIds?: readonly string[];
   } = {},
 ) => {
   const queryClient = new QueryClient();
   seedPendingEventMutations(queryClient, pendingEventIds);
   queryClient.setQueryData(calendarQueryKeys.all, calendars ?? []);
+  if (hiddenEventIds) {
+    seedHiddenEventIds(queryClient, hiddenEventIds);
+  }
   if (event?._id) {
     queryClient.setQueryData(
       eventQueryKeys.week({
@@ -117,6 +124,7 @@ describe("ContextMenuItems", () => {
 
     expect(screen.getByText("Edit")).toBeInTheDocument();
     expect(screen.getByText("Duplicate")).toBeInTheDocument();
+    expect(screen.getByText("Hide event")).toBeInTheDocument();
     expect(screen.getByText("Delete")).toBeInTheDocument();
     expect(
       screen.getByRole("menuitemradio", { name: "Blue" }),
@@ -142,6 +150,7 @@ describe("ContextMenuItems", () => {
           duplicate: mock(),
           edit: mock(),
           setColor,
+          toggleHidden: mock(),
         }}
       />,
       { event },
@@ -168,6 +177,7 @@ describe("ContextMenuItems", () => {
           duplicate: mock(),
           edit: mock(),
           setColor,
+          toggleHidden: mock(),
         }}
       />,
       { event },
@@ -332,6 +342,9 @@ describe("ContextMenuItems read-only gate", () => {
       screen.getByRole("menuitem", { name: "Duplicate" }),
     ).toBeInTheDocument();
     expect(
+      screen.getByRole("menuitem", { name: "Hide event" }),
+    ).toBeInTheDocument();
+    expect(
       screen.queryByRole("menuitem", { name: "Delete" }),
     ).not.toBeInTheDocument();
     expect(
@@ -357,6 +370,9 @@ describe("ContextMenuItems read-only gate", () => {
 
     expect(screen.getByRole("menuitem", { name: "View" })).toBeInTheDocument();
     expect(
+      screen.getByRole("menuitem", { name: "Hide event" }),
+    ).toBeInTheDocument();
+    expect(
       screen.queryByRole("menuitem", { name: "Delete" }),
     ).not.toBeInTheDocument();
   });
@@ -378,7 +394,94 @@ describe("ContextMenuItems read-only gate", () => {
 
     expect(screen.getByRole("menuitem", { name: "Edit" })).toBeInTheDocument();
     expect(
+      screen.getByRole("menuitem", { name: "Hide event" }),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole("menuitem", { name: "Delete" }),
     ).toBeInTheDocument();
+  });
+});
+
+describe("ContextMenuItems hide event", () => {
+  const mockToggleHidden = mock();
+
+  beforeEach(() => {
+    mockClose.mockClear();
+    mockToggleHidden.mockClear();
+    useDraftStore.setState({ gridDraft: null, status: null });
+  });
+
+  const renderView = (event: GridEvent) => {
+    const { ContextMenuItemsView } =
+      require("./ContextMenuItems") as typeof import("./ContextMenuItems");
+
+    return renderWithTheme(
+      <ContextMenuItemsView
+        event={event}
+        close={mockClose}
+        actions={{
+          delete: mock(),
+          duplicate: mock(),
+          edit: mock(),
+          setColor: mock(),
+          toggleHidden: mockToggleHidden,
+        }}
+      />,
+      { event },
+    );
+  };
+
+  it("keeps menuitem accessible names free of the x keycap", () => {
+    const event = createMockGridEvent({ title: "Test Event" });
+    renderWithTheme(<ContextMenuItems event={event} close={mockClose} />, {
+      event,
+    });
+
+    expect(screen.getByRole("menuitem", { name: "Edit" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Duplicate" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Hide event" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Delete" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("menuitem")).toHaveLength(4);
+  });
+
+  it("labels the item Show event when the id is already hidden", () => {
+    const event = createMockGridEvent({ title: "Hidden Event" });
+    renderWithTheme(<ContextMenuItems event={event} close={mockClose} />, {
+      event,
+      hiddenEventIds: [EVENT_ID],
+    });
+
+    expect(
+      screen.getByRole("menuitem", { name: "Show event" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: "Hide event" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("toggles hidden state from the item click and from x, then closes", async () => {
+    const user = userEvent.setup();
+    const event = createMockGridEvent({ title: "Test Event" });
+    renderView(event);
+
+    await user.click(screen.getByRole("menuitem", { name: "Hide event" }));
+    expect(mockToggleHidden).toHaveBeenCalledTimes(1);
+    expect(mockClose).toHaveBeenCalledTimes(1);
+
+    mockToggleHidden.mockClear();
+    mockClose.mockClear();
+    renderView(event);
+
+    fireEvent.keyDown(document.getElementById(ID_CONTEXT_MENU_ITEMS)!, {
+      key: "x",
+    });
+    expect(mockToggleHidden).toHaveBeenCalledTimes(1);
+    expect(mockClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/web/src/components/ContextMenu/ContextMenuItems.tsx
+++ b/packages/web/src/components/ContextMenu/ContextMenuItems.tsx
@@ -1,4 +1,4 @@
-import { Copy, PenNib, Trash } from "@phosphor-icons/react";
+import { Copy, Eye, EyeSlash, PenNib, Trash } from "@phosphor-icons/react";
 import type React from "react";
 import { createContext, useContext } from "react";
 import {
@@ -15,11 +15,18 @@ import {
   eventColorLabel,
 } from "@web/common/styles/theme.util";
 import { type GridEvent } from "@web/common/types/web.event.types";
+import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
+import {
+  useHiddenEventIds,
+  useToggleEventHidden,
+} from "@web/events/hidden/hidden-events.query";
 import { draftActions } from "@web/events/stores/draft.store";
 import {
   digitPickIndex,
   PICK_KEY_LABELS,
 } from "@web/shortcuts/digit-pick.util";
+import { HIDE_EVENT_LETTER } from "@web/shortcuts/hide-event/hide-event.constants";
+import { isBareLetterKey } from "@web/shortcuts/is-bare-letter-key";
 import { useDeleteEvent } from "@web/views/Forms/hooks/useDeleteEvent";
 import { useDuplicateEvent } from "@web/views/Forms/hooks/useDuplicateEvent";
 import { useSetEventColor } from "@web/views/Forms/hooks/useSetEventColor";
@@ -29,6 +36,7 @@ export interface ContextMenuAction {
   label: string;
   onClick: () => void;
   icon: React.ReactNode;
+  keys?: string[];
 }
 
 // Supplied by ContextMenu so each item can wire into floating-ui's roving-focus
@@ -51,6 +59,7 @@ export interface ContextMenuItemsActions {
   duplicate: () => void;
   edit: () => void;
   setColor: (color: EventColorSlot | null) => void;
+  toggleHidden: () => void;
 }
 
 interface ContextMenuItemsProps {
@@ -85,6 +94,7 @@ export function ContextMenuItemsView({
     event.calendarId,
     event.isBusy ?? false,
   );
+  const isHidden = useHiddenEventIds().has(event._id ?? "");
 
   const menuActions: ContextMenuAction[] = [
     {
@@ -98,6 +108,17 @@ export function ContextMenuItemsView({
       label: "Duplicate",
       onClick: actions.duplicate,
       icon: <Copy aria-hidden="true" size={20} />,
+    },
+    {
+      id: "hide",
+      label: isHidden ? "Show event" : "Hide event",
+      keys: [HIDE_EVENT_LETTER],
+      onClick: actions.toggleHidden,
+      icon: isHidden ? (
+        <Eye aria-hidden="true" size={20} />
+      ) : (
+        <EyeSlash aria-hidden="true" size={20} />
+      ),
     },
     ...(isReadOnly
       ? []
@@ -122,7 +143,19 @@ export function ContextMenuItemsView({
     // role="none" keeps the menu -> menuitem ownership valid across this
     // container. Escape ownership is registered via useFloatingLayer on
     // ContextMenu; the id remains a stable test/DOM anchor.
-    <div id={ID_CONTEXT_MENU_ITEMS} role="none">
+    <div
+      id={ID_CONTEXT_MENU_ITEMS}
+      role="none"
+      onKeyDown={(keyEvent) => {
+        if (!isBareLetterKey(keyEvent.nativeEvent, HIDE_EVENT_LETTER)) {
+          return;
+        }
+        keyEvent.preventDefault();
+        keyEvent.stopPropagation();
+        actions.toggleHidden();
+        close();
+      }}
+    >
       {menuActions.map((item, index) => {
         const select = () => {
           item.onClick();
@@ -145,6 +178,7 @@ export function ContextMenuItemsView({
           >
             {item.icon}
             <span className="text-l">{item.label}</span>
+            {item.keys && <ShortcutKeys keys={item.keys} className="ml-auto" />}
           </button>
         );
       })}
@@ -223,6 +257,7 @@ export function ContextMenuItems({ event, close }: ContextMenuItemsProps) {
   const deleteEvent = useDeleteEvent(eventId);
   const duplicateEvent = useDuplicateEvent(eventId);
   const setEventColor = useSetEventColor(eventId);
+  const toggleEventHidden = useToggleEventHidden();
 
   const menuActions: ContextMenuItemsActions = {
     delete: () => {
@@ -237,6 +272,9 @@ export function ContextMenuItems({ event, close }: ContextMenuItemsProps) {
     },
     setColor: (color) => {
       setEventColor(color);
+    },
+    toggleHidden: () => {
+      toggleEventHidden(eventId);
     },
   };
 

--- a/packages/web/src/components/ContextMenu/ContextMenuKeyboard.test.tsx
+++ b/packages/web/src/components/ContextMenu/ContextMenuKeyboard.test.tsx
@@ -30,6 +30,7 @@ const actions: ContextMenuItemsActions = {
   duplicate: mock(),
   edit: mock(),
   setColor: mock(),
+  toggleHidden: mock(),
 };
 
 // Mirrors how the day/week wrappers mount the menu: a virtual cursor reference
@@ -114,17 +115,20 @@ describe("ContextMenu keyboard operability", () => {
     expect(screen.getByRole("menuitem", { name: "Duplicate" })).toHaveFocus();
 
     fireEvent.keyDown(menu, { key: "ArrowDown" });
+    expect(screen.getByRole("menuitem", { name: "Hide event" })).toHaveFocus();
+
+    fireEvent.keyDown(menu, { key: "ArrowDown" });
     expect(screen.getByRole("menuitem", { name: "Delete" })).toHaveFocus();
 
     fireEvent.keyDown(menu, { key: "ArrowUp" });
-    expect(screen.getByRole("menuitem", { name: "Duplicate" })).toHaveFocus();
+    expect(screen.getByRole("menuitem", { name: "Hide event" })).toHaveFocus();
   });
 
   it("exposes the menu with valid menu -> menuitem semantics", () => {
     render(<OpenMenuHarness />);
 
     expect(getMenu()).toBeInTheDocument();
-    expect(screen.getAllByRole("menuitem")).toHaveLength(3);
+    expect(screen.getAllByRole("menuitem")).toHaveLength(4);
     expect(screen.getAllByRole("menuitemradio").length).toBeGreaterThan(0);
   });
 
@@ -133,6 +137,7 @@ describe("ContextMenu keyboard operability", () => {
     await flushFocusSeat();
 
     const menu = getMenu();
+    fireEvent.keyDown(menu, { key: "ArrowDown" });
     fireEvent.keyDown(menu, { key: "ArrowDown" });
     fireEvent.keyDown(menu, { key: "ArrowDown" });
     expect(screen.getByRole("menuitem", { name: "Delete" })).toHaveFocus();

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarContextMenu.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarContextMenu.tsx
@@ -14,6 +14,7 @@ import {
   contextMenuStyle,
   cursorReference,
 } from "@web/components/ContextMenu/contextMenu.floating";
+import { useToggleEventHidden } from "@web/events/hidden/hidden-events.query";
 import { useDeleteEvent } from "@web/views/Forms/hooks/useDeleteEvent";
 import { useDuplicateEvent } from "@web/views/Forms/hooks/useDuplicateEvent";
 import { useSetEventColor } from "@web/views/Forms/hooks/useSetEventColor";
@@ -33,6 +34,7 @@ export const useDayCalendarContextMenu = ({
   const duplicateContextMenuEvent = useDuplicateEvent(contextMenuEventId);
   const deleteContextMenuEvent = useDeleteEvent(contextMenuEventId);
   const setContextMenuEventColor = useSetEventColor(contextMenuEventId);
+  const toggleEventHidden = useToggleEventHidden();
 
   const { context, refs, floatingStyles } = useFloating({
     ...CONTEXT_MENU_FLOATING_OPTIONS,
@@ -93,13 +95,21 @@ export const useDayCalendarContextMenu = ({
       setColor: (color) => {
         setContextMenuEventColor(color);
       },
+      toggleHidden: () => {
+        if (!contextMenuEventId) {
+          return;
+        }
+        toggleEventHidden(contextMenuEventId);
+      },
     }),
     [
       contextMenuEvent,
+      contextMenuEventId,
       deleteContextMenuEvent,
       duplicateContextMenuEvent,
       onOpenEvent,
       setContextMenuEventColor,
+      toggleEventHidden,
     ],
   );
 

--- a/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
+++ b/packages/web/src/views/Day/components/Calendar/DayCalendarGrid.test.tsx
@@ -622,6 +622,7 @@ describe("DayCalendarGrid", () => {
       expect(screen.getByText("Edit")).toBeInTheDocument();
     });
     expect(screen.getByText("Duplicate")).toBeInTheDocument();
+    expect(screen.getByText("Hide event")).toBeInTheDocument();
     expect(screen.getByText("Delete")).toBeInTheDocument();
     expect(screen.queryByText("Delete Event")).not.toBeInTheDocument();
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3622

## What and why

The event context menu (right-click or `m`) now offers Hide event / Show event after Duplicate on every event, including read-only ones, with an `x` keycap. Clicking the item or pressing `x` while the menu is open toggles visibility and closes the menu. Spec: locked decisions on #3616.

## Verify

`VERDICT: PASS`

Selected from the diff: `web`. Independent checks: `test:web`, `type-check`, `lint`, `knip` (all passed). GitHub Unit and E2E on this branch succeeded, including the accessibility shard.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6562b00-704c-43c1-aef8-a4299e3a7038?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6562b00-704c-43c1-aef8-a4299e3a7038&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

