### PR TITLE
fix(backend): disable SuperTokens automatic account linking

### DIFF
--- a/docs/features/calendar-providers.md
+++ b/docs/features/calendar-providers.md
@@ -245,13 +245,14 @@ video link and says so.
 `user.identities[]` records `{provider, subjectId, email}` per login method
 (milestone I). Identity is the provider subject, never email alone.
 
-The same verified email across login methods resolves to one Compass user
-through SuperTokens AccountLinking (`shouldAutomaticallyLink: true`,
-`shouldRequireVerification: true`). Google and Microsoft emails from the
-id_token count as verified when the token says so. Email/password accounts
-link only after email verification. Apple private-relay addresses
-(`@privaterelay.appleid.com`) never link automatically; Sign in with Apple
-identifies by `sub`.
+Compass resolves the same verified email across Google and Microsoft to one
+Compass user in `userService.getCanonicalCompassUserId`. SuperTokens automatic
+account linking is deliberately not enabled because the SuperTokens Cloud plan
+lacks the feature and the core rejects `createPrimaryUser` with 402. Google and
+Microsoft emails from the id_token count as verified when the token says so.
+Email/password accounts link only after email verification. Apple private-relay
+addresses (`@privaterelay.appleid.com`) never link automatically; Sign in with
+Apple identifies by `sub`.
 
 Linking merges `identities[]` and keeps every calendar connection of both
 users.

--- a/docs/features/password-auth-flow.md
+++ b/docs/features/password-auth-flow.md
@@ -32,8 +32,9 @@ Compass still treats the MongoDB `userId` as the canonical identity.
 
 SuperTokens is configured so that:
 
-- AccountLinking is initialized with automatic linking that requires
-  verification
+- SuperTokens automatic account linking is not enabled; SuperTokens Cloud
+  rejects `createPrimaryUser` with 402, so Compass joins same-email logins
+  in `userService.getCanonicalCompassUserId`
 - password sign-up ensures there is an external user id mapping, and that external id is a Mongo `ObjectId` string
 - backend user upserts can canonicalize to an existing Compass user id by
   normalized email when both sides already have a verified login method, then
@@ -43,8 +44,10 @@ SuperTokens is configured so that:
 
 Important constraints:
 
-- SuperTokens `AccountLinking` joins verified Google and Microsoft logins that
-  share an email into one Compass user.
+- Compass joins verified Google and Microsoft logins that share an email into
+  one Compass user in `userService.getCanonicalCompassUserId`. SuperTokens
+  automatic account linking stays off because the SuperTokens Cloud plan lacks
+  the feature.
 - Unverified email/password accounts do not link to a Google or Microsoft
   login until the email is verified.
 - Apple private-relay addresses never auto-link. Identity is the Apple `sub`.

--- a/packages/backend/src/auth/services/account-linking.util.test.ts
+++ b/packages/backend/src/auth/services/account-linking.util.test.ts
@@ -3,7 +3,6 @@ import {
   emailForVerifiedAccountLinkLookup,
   hasVerifiedLoginMethod,
   isApplePrivateRelayEmail,
-  shouldAutomaticallyLinkAccounts,
 } from "@backend/auth/services/account-linking.util";
 import { describe, expect, it } from "bun:test";
 
@@ -83,25 +82,6 @@ describe("account-linking.util", () => {
           incomingHasVerifiedLogin: false,
         }),
       ).toBe(false);
-    });
-  });
-
-  describe("shouldAutomaticallyLinkAccounts", () => {
-    it("requires verification for ordinary emails", () => {
-      expect(
-        shouldAutomaticallyLinkAccounts({ email: "a@example.com" }),
-      ).toEqual({
-        shouldAutomaticallyLink: true,
-        shouldRequireVerification: true,
-      });
-    });
-
-    it("never auto-links an Apple private-relay address", () => {
-      expect(
-        shouldAutomaticallyLinkAccounts({
-          email: "hide@privaterelay.appleid.com",
-        }),
-      ).toEqual({ shouldAutomaticallyLink: false });
     });
   });
 });

--- a/packages/backend/src/auth/services/account-linking.util.ts
+++ b/packages/backend/src/auth/services/account-linking.util.ts
@@ -8,10 +8,6 @@ type LoginMethodFields = {
   identities?: Schema_UserIdentity[];
 };
 
-export type AutomaticAccountLinkingDecision =
-  | { shouldAutomaticallyLink: false }
-  | { shouldAutomaticallyLink: true; shouldRequireVerification: true };
-
 export function isApplePrivateRelayEmail(email: string): boolean {
   return normalizeEmail(email).endsWith(`@${APPLE_PRIVATE_RELAY_DOMAIN}`);
 }
@@ -42,16 +38,4 @@ export function canReuseCompassUserByEmail(args: {
   return (
     hasVerifiedLoginMethod(args.existing) === args.incomingHasVerifiedLogin
   );
-}
-
-export function shouldAutomaticallyLinkAccounts(args: {
-  email?: string;
-}): AutomaticAccountLinkingDecision {
-  if (args.email && isApplePrivateRelayEmail(args.email)) {
-    return { shouldAutomaticallyLink: false };
-  }
-  return {
-    shouldAutomaticallyLink: true,
-    shouldRequireVerification: true,
-  };
 }

--- a/packages/backend/src/common/middleware/supertokens.middleware.test.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.test.ts
@@ -1,6 +1,5 @@
 import * as corsLib from "cors";
 import superTokensNode from "supertokens-node";
-import AccountLinking from "supertokens-node/recipe/accountlinking";
 import Dashboard from "supertokens-node/recipe/dashboard";
 import EmailPassword from "supertokens-node/recipe/emailpassword";
 import Session from "supertokens-node/recipe/session";
@@ -53,7 +52,6 @@ describe("supertokens.middleware", () => {
         >,
     );
     spyOn(Dashboard, "init");
-    spyOn(AccountLinking, "init");
     spyOn(EmailPassword, "init");
     spyOn(Session, "getAllSessionHandlesForUser");
     spyOn(Session, "createNewSession");
@@ -97,7 +95,6 @@ describe("supertokens.middleware", () => {
 
     (corsLib.default as Mock).mockClear();
     (superTokensNode.init as Mock).mockClear();
-    (AccountLinking.init as Mock).mockClear();
     (Dashboard.init as Mock).mockClear();
     (EmailPassword.init as Mock).mockClear();
     (Session.getAllSessionHandlesForUser as Mock).mockClear();
@@ -124,9 +121,6 @@ describe("supertokens.middleware", () => {
     // the `recipeList` composition.
     (ThirdParty.init as Mock).mockReturnValue({
       recipe: "thirdparty",
-    } as never);
-    (AccountLinking.init as Mock).mockReturnValue({
-      recipe: "accountlinking",
     } as never);
     (EmailPassword.init as Mock).mockReturnValue({
       recipe: "emailpassword",
@@ -167,56 +161,12 @@ describe("supertokens.middleware", () => {
       expect(initArg.framework).toBe("express");
 
       expect(initArg.recipeList).toEqual([
-        { recipe: "accountlinking" },
         { recipe: "thirdparty" },
         { recipe: "emailpassword" },
         { recipe: "dashboard" },
         { recipe: "session" },
         { recipe: "usermetadata" },
       ]);
-    });
-
-    it("requires verification for automatic account linking and skips Apple relay emails", async () => {
-      initSupertokens();
-
-      expect(AccountLinking.init).toHaveBeenCalledTimes(1);
-      const accountLinkingConfig = getFirstCallArg<{
-        shouldDoAutomaticAccountLinking: (
-          newAccountInfo: { email?: string },
-          user: undefined,
-          session: undefined,
-          tenantId: string,
-          userContext: Record<string, unknown>,
-        ) => Promise<
-          | { shouldAutomaticallyLink: false }
-          | {
-              shouldAutomaticallyLink: true;
-              shouldRequireVerification: boolean;
-            }
-        >;
-      }>(AccountLinking.init);
-
-      await expect(
-        accountLinkingConfig.shouldDoAutomaticAccountLinking(
-          { email: "user@example.com" },
-          undefined,
-          undefined,
-          "public",
-          {},
-        ),
-      ).resolves.toEqual({
-        shouldAutomaticallyLink: true,
-        shouldRequireVerification: true,
-      });
-      await expect(
-        accountLinkingConfig.shouldDoAutomaticAccountLinking(
-          { email: "hide@privaterelay.appleid.com" },
-          undefined,
-          undefined,
-          "public",
-          {},
-        ),
-      ).resolves.toEqual({ shouldAutomaticallyLink: false });
     });
 
     it("uses configured public URLs for SuperTokens domains", () => {
@@ -280,7 +230,6 @@ describe("supertokens.middleware", () => {
       }>(superTokensNode.init);
 
       expect(initArg.recipeList).toEqual([
-        { recipe: "accountlinking" },
         { recipe: "emailpassword" },
         { recipe: "dashboard" },
         { recipe: "session" },
@@ -325,7 +274,6 @@ describe("supertokens.middleware", () => {
       }>(superTokensNode.init);
 
       expect(initArg.recipeList).toEqual([
-        { recipe: "accountlinking" },
         { recipe: "emailpassword" },
         { recipe: "dashboard" },
         { recipe: "session" },

--- a/packages/backend/src/common/middleware/supertokens.middleware.ts
+++ b/packages/backend/src/common/middleware/supertokens.middleware.ts
@@ -1,6 +1,5 @@
 import cors from "cors";
 import SuperTokens from "supertokens-node";
-import AccountLinking from "supertokens-node/recipe/accountlinking";
 import Dashboard from "supertokens-node/recipe/dashboard";
 import EmailPassword from "supertokens-node/recipe/emailpassword";
 import Session from "supertokens-node/recipe/session";
@@ -14,7 +13,6 @@ import { APP_NAME } from "@core/constants/core.constants";
 import { BaseError } from "@core/errors/errors.base";
 import { Status } from "@core/errors/status.codes";
 import { MICROSOFT_SCOPES } from "@core/providers/microsoft.scopes";
-import { shouldAutomaticallyLinkAccounts } from "@backend/auth/services/account-linking.util";
 import { GOOGLE_AUTH_SCOPES_REQUESTED } from "@backend/auth/services/google/google.auth.scopes";
 import { CONFIG } from "@backend/common/constants/config.constants";
 import {
@@ -217,10 +215,12 @@ export const initSupertokens = () => {
       // see added endpoints
       // https://app.swaggerhub.com/apis/supertokens/FDI/3.0.0
       // https://supertokens.com/docs/references/fdi/introduction
-      AccountLinking.init({
-        shouldDoAutomaticAccountLinking: async (newAccountInfo) =>
-          shouldAutomaticallyLinkAccounts({ email: newAccountInfo.email }),
-      }),
+      // SuperTokens Cloud does not include the account-linking feature.
+      // createPrimaryUser returns 402 and breaks every sign-in-up, so
+      // automatic linking must stay off. Compass links same-email logins
+      // itself in userService.getCanonicalCompassUserId. The SDK
+      // auto-registers the accountlinking recipe with linking disabled
+      // when it is absent from recipeList.
       ...getThirdPartyRecipes(),
       EmailPassword.init({
         signUpFeature: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Reverts the SuperTokens-side half of #3436. `AccountLinking.init({ shouldDoAutomaticAccountLinking })` made the SDK call `createPrimaryUser` on every sign-in-up. SuperTokens Cloud does not include that paid feature, so the core answers 402 and `POST /api/signinup` 500s. That has blocked every new Google signup (and likely returning Google sign-ins) since the 2026-09-08 production deploy.

Compass still joins the same verified email across Google and Microsoft in `userService.getCanonicalCompassUserId`. SuperTokens automatic linking stays off.

Docs in `calendar-providers.md` and `password-auth-flow.md` match that split.

Production deploy is a manual `Deploy production` workflow_dispatch. Staging auto-deploys on merge; production needs Tyler immediately after, because every Google sign-up is failing.

## Verify

`VERDICT: PASS`

Checks run: `test:backend:fast`, `type-check`, `lint`, `knip`

Also ran locally: `bun test:backend` on `supertokens.middleware.test.ts`, `account-linking.util.test.ts`, and `account-linking.db.test.ts` (Mongo).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f190d0a0-85a7-444d-b583-63096271a914?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f190d0a0-85a7-444d-b583-63096271a914&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

