### PR TITLE
fix(web): hide first-event prompt while the form is open

### DIFF
--- a/e2e/onboarding/first-run.spec.ts
+++ b/e2e/onboarding/first-run.spec.ts
@@ -73,6 +73,7 @@ test("welcomes a first-time user and seeds sample events", async ({
 
   const title = createEventTitle("First-run event");
   await openTimedEventFormWithKeyboard(page);
+  await expect(prompt).toBeHidden();
   await fillTitleAndSaveEventForm(page, title);
 
   // The prompt celebrates the first real event, then retires.

--- a/packages/web/src/components/FirstEventPrompt/FirstEventPrompt.test.tsx
+++ b/packages/web/src/components/FirstEventPrompt/FirstEventPrompt.test.tsx
@@ -14,6 +14,11 @@ import {
   useShortcutShowcaseStore,
 } from "@web/components/ShortcutShowcase/showcase.store";
 import {
+  createGridEventDraft,
+  timedGridSchedule,
+} from "@web/events/grid-event-draft.adapter";
+import { draftActions } from "@web/events/stores/draft.store";
+import {
   initialSettingsState,
   settingsActions,
   useSettingsStore,
@@ -26,6 +31,7 @@ const markShowcaseSeen = () => {
 
 describe("FirstEventPrompt", () => {
   beforeEach(() => {
+    draftActions.discard();
     useFirstEventPromptStore.setState({ ...initialFirstEventPromptState });
     useShortcutShowcaseStore.setState(initialShortcutShowcaseState);
     useSettingsStore.setState(initialSettingsState);
@@ -35,6 +41,7 @@ describe("FirstEventPrompt", () => {
   });
 
   afterEach(() => {
+    draftActions.discard();
     useFirstEventPromptStore.setState({ ...initialFirstEventPromptState });
     useShortcutShowcaseStore.setState(initialShortcutShowcaseState);
     useSettingsStore.setState(initialSettingsState);
@@ -83,6 +90,36 @@ describe("FirstEventPrompt", () => {
     expect(
       screen.queryByRole("complementary", { name: "Create your first event" }),
     ).toBeNull();
+  });
+
+  it("hides while the event form is open, then returns when discarded", () => {
+    markShowcaseSeen();
+    render(<FirstEventPrompt />);
+    expect(
+      screen.getByRole("complementary", { name: "Create your first event" }),
+    ).toBeTruthy();
+
+    act(() => {
+      draftActions.startGridDraft({
+        activity: "createShortcut",
+        draft: createGridEventDraft(
+          timedGridSchedule(
+            new Date("2026-05-20T09:00:00.000"),
+            new Date("2026-05-20T10:00:00.000"),
+          ),
+        ),
+      });
+    });
+
+    expect(
+      screen.queryByRole("complementary", { name: "Create your first event" }),
+    ).toBeNull();
+    expect(persistentBrowserStore.get(STORAGE_KEYS.FIRST_EVENT_DONE)).toBe("");
+
+    act(() => draftActions.discard());
+    expect(
+      screen.getByRole("complementary", { name: "Create your first event" }),
+    ).toBeTruthy();
   });
 
   it("shows the handoff copy and a C keycap once the showcase has been seen", () => {

--- a/packages/web/src/components/FirstEventPrompt/FirstEventPrompt.tsx
+++ b/packages/web/src/components/FirstEventPrompt/FirstEventPrompt.tsx
@@ -18,6 +18,10 @@ import {
 } from "@web/components/ShortcutShowcase/showcase.store";
 import { ShortcutKeys } from "@web/components/Shortcuts/ShortcutKeys";
 import {
+  selectIsEventFormOpen,
+  useDraftStore,
+} from "@web/events/stores/draft.store";
+import {
   selectIsAboutOpen,
   selectIsSettingsOpen,
   useSettingsStore,
@@ -104,15 +108,19 @@ export const FirstEventPrompt: FC = () => {
   const isDone = useFirstEventPromptStore(selectFirstEventDone);
   const isSettingsOpen = useSettingsStore(selectIsSettingsOpen);
   const isAboutOpen = useSettingsStore(selectIsAboutOpen);
+  const isFormOpen = useDraftStore(selectIsEventFormOpen);
   // Without storage (private mode), completion and dismissal can never
   // persist, so the card would haunt every reload; better to not show it.
   // Sit above the auth modal in z-index, so stay hidden while login/signup
-  // is open even if the showcase flag is already set. Settings and About
-  // paint below this tooltip layer, so hide rather than compete.
+  // is open even if the showcase flag is already set. Settings, About, and
+  // the event form paint below this tooltip layer, so hide rather than
+  // compete. Opening the form is not completion: cancel brings the card
+  // back, and a real create still celebrates after the form closes.
   const isLive =
     !isAuthModalOpen &&
     !isSettingsOpen &&
     !isAboutOpen &&
+    !isFormOpen &&
     !isDone &&
     persistentBrowserStore.isAvailable() &&
     isShowcaseHandoffEligible(isShowcaseActive, seenThisSession);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

The first-event handoff card sits at the bottom-right of the calendar. After a new user follows it and opens the event form, the card covers Save. Hide the card while the form is open, without marking the prompt done: cancel brings it back, and a real create still celebrates after the form closes. The sidebar status bar already teaches "Type a title, then Enter" in that state.

## Verify

`bun run verify --strict` selected web plus Playwright.

Passed locally: lint, knip, type-check, `test:web`.
`e2e/onboarding/first-run.spec.ts` passed (8.1s), including the new assertion that the prompt is hidden while the form is open.

The full Playwright wave failed on `e2e/accessibility/booking-a11y.spec.ts` (`settings booking first-run hours`) axe color-contrast on the booking Continue control. That spec is not reachable by this diff. CI decides.

VERDICT: FAIL (unrelated booking a11y color-contrast; changed first-run spec passed)

![Event form open with Save unobstructed](https://cursor.com/artifacts/c/art-d409f46d-1cab-452b-8c5d-c087ffcf1d02)
![Tooltip returns after canceling the form](https://cursor.com/artifacts/c/art-f573a7be-827f-442c-bd99-8c11650af4c1)
![Celebration after saving the first event](https://cursor.com/artifacts/c/art-10d9ed05-9851-414b-8d3e-4e2bfe9c7095)
<a href="https://cursor.com/agents/bc-07ccd2a7-d4ef-4188-a27b-94bf3ad01e62/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffirst_event_tooltip_hides_when_form_opens.mp4"><img src="https://cursor.com/artifacts/c/art-c92c6079-20db-4df7-885e-d8fdc94e1dac" alt="first_event_tooltip_hides_when_form_opens.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07ccd2a7-d4ef-4188-a27b-94bf3ad01e62?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07ccd2a7-d4ef-4188-a27b-94bf3ad01e62&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

