### PR TITLE
fix(web): start signup from connect chooser when signed out

### DIFF
--- a/packages/web/src/auth/posthog/signup-funnel.ts
+++ b/packages/web/src/auth/posthog/signup-funnel.ts
@@ -40,6 +40,7 @@ export type SignupSource =
   | `welcome_modal_${ProviderKind}`
   | "anon_nudge"
   | "command_palette"
+  | "connect_chooser"
   | "shortcut_showcase";
 
 export type SignupFailureReason =

--- a/packages/web/src/auth/providers/ConnectProviderChooser.test.tsx
+++ b/packages/web/src/auth/providers/ConnectProviderChooser.test.tsx
@@ -148,7 +148,7 @@ describe("ConnectProviderChooser", () => {
     const user = userEvent.setup();
     available = ["google", "microsoft", "apple"];
 
-    render(<ConnectProviderChooser idleLabel="Add account" />);
+    renderChooser(<ConnectProviderChooser idleLabel="Add account" />);
 
     await user.click(screen.getByRole("button", { name: /Add account/ }));
 

--- a/packages/web/src/auth/providers/ConnectProviderChooser.test.tsx
+++ b/packages/web/src/auth/providers/ConnectProviderChooser.test.tsx
@@ -1,10 +1,20 @@
 import "@testing-library/jest-dom";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { type ReactElement } from "react";
 import { type ProviderKind } from "@core/types/sync/identity.contracts";
 import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
+import { SessionContext } from "@web/auth/compass/session/session.context";
+import {
+  registerUseStartProviderAuthorizationForTests,
+  resetUseStartProviderAuthorizationForTests,
+} from "@web/auth/providers/authorization/useStartProviderAuthorization";
 import * as realAvailableProviders from "@web/auth/providers/useAvailableConnectProviders";
 import * as realConnectProvider from "@web/auth/providers/useConnectProvider";
+import {
+  resetProviderAvailabilityForTests,
+  setProviderAvailabilityForTests,
+} from "@web/auth/providers/useIsProviderAvailable";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
 let available: ProviderKind[] = ["google"];
@@ -57,6 +67,20 @@ const { ConnectProviderChooser } = (await import(
   chooserModuleUrl.href
 )) as typeof import("./ConnectProviderChooser");
 
+const renderChooser = (
+  ui: ReactElement,
+  options: { authenticated?: boolean } = {},
+) => {
+  const authenticated = options.authenticated ?? true;
+  return render(
+    <SessionContext.Provider
+      value={{ authenticated, setAuthenticated: mock() }}
+    >
+      {ui}
+    </SessionContext.Provider>,
+  );
+};
+
 describe("ConnectProviderChooser", () => {
   beforeEach(() => {
     available = ["google"];
@@ -68,10 +92,14 @@ describe("ConnectProviderChooser", () => {
 
   afterEach(() => {
     cleanup();
+    resetUseStartProviderAuthorizationForTests();
+    resetProviderAvailabilityForTests();
   });
 
   it("renders a single Google button and no chooser menu when only Google is available", () => {
-    render(<ConnectProviderChooser idleLabel="Connect Google Calendar" />);
+    renderChooser(
+      <ConnectProviderChooser idleLabel="Connect Google Calendar" />,
+    );
 
     expect(
       screen.getByRole("button", { name: "Connect Google Calendar" }),
@@ -86,7 +114,9 @@ describe("ConnectProviderChooser", () => {
     const user = userEvent.setup();
     available = ["google", "microsoft"];
 
-    render(<ConnectProviderChooser idleLabel="Connect the calendar you use" />);
+    renderChooser(
+      <ConnectProviderChooser idleLabel="Connect the calendar you use" />,
+    );
 
     const trigger = screen.getByRole("button", {
       name: /Connect the calendar you use/,
@@ -118,7 +148,7 @@ describe("ConnectProviderChooser", () => {
     const user = userEvent.setup();
     available = ["google", "microsoft", "apple"];
 
-    render(<ConnectProviderChooser variant="prompt" />);
+    renderChooser(<ConnectProviderChooser variant="prompt" />);
 
     expect(
       screen.getByRole("button", { name: "Connect Google Calendar" }),
@@ -142,7 +172,7 @@ describe("ConnectProviderChooser", () => {
     available = ["google", "microsoft", "apple"];
     connectingKind = "microsoft";
 
-    render(<ConnectProviderChooser variant="prompt" />);
+    renderChooser(<ConnectProviderChooser variant="prompt" />);
 
     const busy = screen.getByRole("button", { name: "Opening Microsoft…" });
     expect(busy).toHaveAttribute("aria-busy", "true");
@@ -153,5 +183,63 @@ describe("ConnectProviderChooser", () => {
     expect(
       screen.getByRole("button", { name: "Connect Apple Calendar" }),
     ).toBeDisabled();
+  });
+
+  describe("when signed out", () => {
+    const startGoogleAuthorization = mock();
+    const startMicrosoftAuthorization = mock();
+    const startAppleAuthorization = mock();
+
+    beforeEach(() => {
+      startGoogleAuthorization.mockClear();
+      startMicrosoftAuthorization.mockClear();
+      startAppleAuthorization.mockClear();
+      registerUseStartProviderAuthorizationForTests((provider) => ({
+        loading: false,
+        startAuthorization: {
+          google: startGoogleAuthorization,
+          microsoft: startMicrosoftAuthorization,
+          apple: startAppleAuthorization,
+        }[provider],
+      }));
+      resetProviderAvailabilityForTests();
+      setProviderAvailabilityForTests("google", "available");
+    });
+
+    it("keeps the Connect Google Calendar label and starts sign-in, not connect", async () => {
+      const user = userEvent.setup();
+      renderChooser(
+        <ConnectProviderChooser idleLabel="Connect Google Calendar" />,
+        { authenticated: false },
+      );
+
+      const button = screen.getByRole("button", {
+        name: "Connect Google Calendar",
+      });
+      await user.click(button);
+
+      expect(startGoogleAuthorization).toHaveBeenCalledTimes(1);
+      expect(mockConnectGoogle).not.toHaveBeenCalled();
+    });
+
+    it("shows Opening Google… when the sign-in hook reports loading", () => {
+      registerUseStartProviderAuthorizationForTests((provider) => ({
+        loading: provider === "google",
+        startAuthorization: {
+          google: startGoogleAuthorization,
+          microsoft: startMicrosoftAuthorization,
+          apple: startAppleAuthorization,
+        }[provider],
+      }));
+
+      renderChooser(
+        <ConnectProviderChooser idleLabel="Connect Google Calendar" />,
+        { authenticated: false },
+      );
+
+      const busy = screen.getByRole("button", { name: "Opening Google…" });
+      expect(busy).toHaveAttribute("aria-busy", "true");
+      expect(busy).toBeDisabled();
+    });
   });
 });

--- a/packages/web/src/auth/providers/ConnectProviderChooser.tsx
+++ b/packages/web/src/auth/providers/ConnectProviderChooser.tsx
@@ -12,11 +12,14 @@ import {
   type ProviderKind,
   providerDisplayName,
 } from "@core/types/sync/identity.contracts";
+import { useSession } from "@web/auth/compass/session/useSession";
+import { trackSignupStarted } from "@web/auth/posthog/signup-funnel";
 import { openingProviderLabel } from "@web/auth/providers/connection-provider.util";
 import { PROVIDER_LOGO } from "@web/auth/providers/ProviderMark";
 import { CONNECT_CALENDAR_LABEL } from "@web/auth/providers/provider-copy.util";
 import { useAvailableConnectProviders } from "@web/auth/providers/useAvailableConnectProviders";
 import { useConnectProvider } from "@web/auth/providers/useConnectProvider";
+import { useSignInProviders } from "@web/auth/providers/useSignInProviders";
 import { focusOnPointerEnter } from "@web/common/utils/focus-on-pointer-enter";
 import { SignInProviderButtons } from "@web/components/AuthModal/components/SignInProviderButtons";
 import { OverlayPanelActionButton } from "@web/components/OverlayPanel/OverlayPanel";
@@ -48,6 +51,8 @@ export const ConnectProviderChooser: FC<ConnectProviderChooserProps> = ({
   shortcut,
   shortcutAttrs,
 }) => {
+  const { authenticated } = useSession();
+  const signIn = useSignInProviders();
   const available = useAvailableConnectProviders();
   const google = useConnectProvider("google", { newAccount });
   const microsoft = useConnectProvider("microsoft", { newAccount });
@@ -61,7 +66,10 @@ export const ConnectProviderChooser: FC<ConnectProviderChooserProps> = ({
   const rootRef = useRef<HTMLDivElement>(null);
   const [menuOpen, setMenuOpen] = useState(false);
 
-  const connectingKind = available.find((kind) => byKind[kind].isConnecting);
+  const kinds = authenticated ? available : signIn.available;
+  const connectingKind = authenticated
+    ? available.find((kind) => byKind[kind].isConnecting)
+    : signIn.loadingKind;
   const isConnecting = connectingKind != null;
   const firstItemRef = useRef<HTMLButtonElement>(null);
 
@@ -81,11 +89,16 @@ export const ConnectProviderChooser: FC<ConnectProviderChooserProps> = ({
     return () => document.removeEventListener("pointerdown", onPointerDown);
   }, [menuOpen]);
 
-  if (available.length === 0) return null;
+  if (kinds.length === 0) return null;
 
   const runConnect = (kind: ProviderKind) => {
     setMenuOpen(false);
-    byKind[kind].connect();
+    if (authenticated) {
+      byKind[kind].connect();
+      return;
+    }
+    trackSignupStarted("connect_chooser");
+    signIn.startSignIn(kind);
   };
 
   const onMenuKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
@@ -138,7 +151,7 @@ export const ConnectProviderChooser: FC<ConnectProviderChooserProps> = ({
   if (variant === "prompt") {
     return (
       <SignInProviderButtons
-        available={available}
+        available={kinds}
         busyLabel={openingProviderLabel}
         labels={CONNECT_CALENDAR_LABEL}
         loadingKind={connectingKind ?? null}
@@ -152,8 +165,9 @@ export const ConnectProviderChooser: FC<ConnectProviderChooserProps> = ({
     ? openingProviderLabel(connectingKind ?? "google")
     : idleLabel;
 
-  if (available.length === 1) {
-    const kind = available[0];
+  if (kinds.length === 1) {
+    const kind = kinds[0];
+    if (kind === undefined) return null;
     const singleLabel = isConnecting
       ? buttonLabel
       : (byKind[kind].commandAction?.label ?? idleLabel);
@@ -196,7 +210,7 @@ export const ConnectProviderChooser: FC<ConnectProviderChooserProps> = ({
       onKeyDown={onMenuKeyDown}
       role="menu"
     >
-      {available.map((kind, index) => {
+      {kinds.map((kind, index) => {
         const Icon = PROVIDER_LOGO[kind];
         return (
           <button

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -65,8 +65,23 @@ mock.module("@web/auth/posthog/track", () => ({
     isTrackMocked ? mockTrack(...args) : actualTrack.track(...args),
 }));
 
+// Booking settings is a signed-in surface. The chooser starts sign-up when
+// SessionContext is unsigned, so tests that only mark connect availability
+// would hide the Connect Google Calendar button.
+const actualUseSession = (await import("@web/auth/compass/session/useSession"))
+  .useSession;
+let isSessionMocked = true;
+mock.module("@web/auth/compass/session/useSession", () => ({
+  useSession: (...args: Parameters<typeof actualUseSession>) =>
+    isSessionMocked
+      ? { authenticated: true, setAuthenticated: mock() }
+      : actualUseSession(...args),
+}));
+
 afterAll(() => {
+  isAppAccessMocked = false;
   isTrackMocked = false;
+  isSessionMocked = false;
 });
 
 afterEach(() => {

--- a/packages/web/src/booking/setup/BookingSetupWizard.test.tsx
+++ b/packages/web/src/booking/setup/BookingSetupWizard.test.tsx
@@ -7,6 +7,7 @@ import { buildDefaultAdminPutInput } from "@core/types/booking.contracts";
 import { TimeZoneSchema } from "@core/types/domain-primitives";
 import { type ProviderKind } from "@core/types/sync/identity.contracts";
 import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
+import { SessionContext } from "@web/auth/compass/session/session.context";
 import * as realAvailableProviders from "@web/auth/providers/useAvailableConnectProviders";
 import * as realConnectProvider from "@web/auth/providers/useConnectProvider";
 import { BOOKING_SAVE_ERROR_COPY } from "@web/booking/booking.query";
@@ -52,27 +53,31 @@ const renderWizard = (
   const onBack = mock(() => {});
   const onContinue = mock(() => {});
   render(
-    <HotkeysProvider>
-      <BookingSetupWizard
-        bookingUrl={null}
-        continueRef={continueRef}
-        destinationCalendar={undefined}
-        form={defaultForm}
-        isPending={false}
-        onAddressChange={mock(() => {})}
-        onBack={onBack}
-        onContinue={onContinue}
-        onDestinationChange={mock(() => {})}
-        onDurationChange={mock(() => {})}
-        onHoursChange={mock(() => {})}
-        setupError={null}
-        setupStep="address"
-        syncConnections={[]}
-        writableCalendarCount={0}
-        writableCalendars={[]}
-        {...props}
-      />
-    </HotkeysProvider>,
+    <SessionContext.Provider
+      value={{ authenticated: true, setAuthenticated: mock() }}
+    >
+      <HotkeysProvider>
+        <BookingSetupWizard
+          bookingUrl={null}
+          continueRef={continueRef}
+          destinationCalendar={undefined}
+          form={defaultForm}
+          isPending={false}
+          onAddressChange={mock(() => {})}
+          onBack={onBack}
+          onContinue={onContinue}
+          onDestinationChange={mock(() => {})}
+          onDurationChange={mock(() => {})}
+          onHoursChange={mock(() => {})}
+          setupError={null}
+          setupStep="address"
+          syncConnections={[]}
+          writableCalendarCount={0}
+          writableCalendars={[]}
+          {...props}
+        />
+      </HotkeysProvider>
+    </SessionContext.Provider>,
   );
   return { continueRef, onBack, onContinue };
 };

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -17,9 +17,17 @@ import { createMockCalendar } from "@web/__tests__/utils/factories/calendar.fact
 import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
 import { AuthApi } from "@web/api/auth.api";
 import {
+  registerUseStartProviderAuthorizationForTests,
+  resetUseStartProviderAuthorizationForTests,
+} from "@web/auth/providers/authorization/useStartProviderAuthorization";
+import {
   markAccountReconnectRequired,
   resetGoogleReconnectRequiredForTests,
 } from "@web/auth/providers/reconnect.state";
+import {
+  resetProviderAvailabilityForTests,
+  setProviderAvailabilityForTests,
+} from "@web/auth/providers/useIsProviderAvailable";
 import { userMetadataActions } from "@web/auth/state/user-metadata.store";
 import { UpgradeConfirmationProvider } from "@web/billing/UpgradeConfirmation/UpgradeConfirmationProvider";
 import { type AppAccess } from "@web/billing/useAppAccess";
@@ -776,6 +784,41 @@ describe("SettingsModal", () => {
     renderSettings({ authenticated: false });
 
     expect(screen.queryByRole("button", { name: "Log out" })).toBeNull();
+  });
+
+  it("starts Google sign-up from Connect Google Calendar when signed out", async () => {
+    const user = userEvent.setup({ delay: null });
+    const startGoogleAuthorization = mock();
+    const { port: toastPort, mocks: toastMocks } = createTestToastPort();
+    registerToastPort(toastPort);
+    registerUseStartProviderAuthorizationForTests((provider) => ({
+      loading: false,
+      startAuthorization:
+        provider === "google" ? startGoogleAuthorization : mock(),
+    }));
+    resetProviderAvailabilityForTests();
+    setProviderAvailabilityForTests("google", "available");
+    const beginConnection = spyOn(AuthApi, "beginConnection");
+
+    try {
+      renderSettings({ authenticated: false, connections: [] });
+      userMetadataActions.set({
+        google: { connectionState: "NOT_CONNECTED", connections: [] },
+      });
+
+      await user.click(
+        screen.getByRole("button", { name: "Connect Google Calendar" }),
+      );
+
+      expect(startGoogleAuthorization).toHaveBeenCalledTimes(1);
+      expect(beginConnection).not.toHaveBeenCalled();
+      expect(toastMocks.error).not.toHaveBeenCalled();
+    } finally {
+      beginConnection.mockRestore();
+      resetUseStartProviderAuthorizationForTests();
+      resetProviderAvailabilityForTests();
+      resetToastPort();
+    }
   });
 
   it("shows Booking for a signed-in user", () => {

--- a/packages/web/src/components/Settings/SettingsModal.test.tsx
+++ b/packages/web/src/components/Settings/SettingsModal.test.tsx
@@ -1,5 +1,12 @@
 import { HotkeysProvider, resolveModifier } from "@tanstack/react-hotkeys";
-import { act, render, screen, waitFor, within } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { rest } from "msw";
 import { DEFAULT_WEEKLY_AVAILABILITY } from "@core/types/booking.contracts";
@@ -802,8 +809,10 @@ describe("SettingsModal", () => {
 
     try {
       renderSettings({ authenticated: false, connections: [] });
-      userMetadataActions.set({
-        google: { connectionState: "NOT_CONNECTED", connections: [] },
+      act(() => {
+        userMetadataActions.set({
+          google: { connectionState: "NOT_CONNECTED", connections: [] },
+        });
       });
 
       await user.click(
@@ -814,6 +823,7 @@ describe("SettingsModal", () => {
       expect(beginConnection).not.toHaveBeenCalled();
       expect(toastMocks.error).not.toHaveBeenCalled();
     } finally {
+      cleanup();
       beginConnection.mockRestore();
       resetUseStartProviderAuthorizationForTests();
       resetProviderAvailabilityForTests();

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.test.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
+import { SessionContext } from "@web/auth/compass/session/session.context";
 import * as realAuthStateUtil from "@web/auth/compass/state/auth.state.util";
 import * as realUserHook from "@web/auth/compass/user/hooks/useUser";
 import { type GoogleUiState } from "@web/auth/providers/connect.types";
@@ -91,9 +92,13 @@ const { CalendarListHeader } = (await import(
 
 const renderHeader = () =>
   render(
-    <QueryClientProvider client={new QueryClient()}>
-      <CalendarListHeader />
-    </QueryClientProvider>,
+    <SessionContext.Provider
+      value={{ authenticated: true, setAuthenticated: mock() }}
+    >
+      <QueryClientProvider client={new QueryClient()}>
+        <CalendarListHeader />
+      </QueryClientProvider>
+    </SessionContext.Provider>,
   );
 
 describe("CalendarListHeader", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Anonymous Settings (and every other ConnectProviderChooser surface) started the session-backed POST /api/auth/connections/begin flow. That route correctly requires a session, so a signed-out visitor got 401.

With no session, the chooser now starts Google sign-up OAuth and counts the click as signup_started with source=connect_chooser. Labels, shortcuts, and the signed-in connect path are unchanged.

Merged origin/main so CI includes the add-account logo test from #3626. That test now uses the signed-in renderChooser helper.

## Verify

Local VERDICT: FAIL only on sandbox Playwright timeouts in specs this diff cannot reach. CI decides.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f190d0a0-85a7-444d-b583-63096271a914?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f190d0a0-85a7-444d-b583-63096271a914&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

