### PR TITLE
fix(web): tell one reconnect story across banner sidebar and toasts

### DIFF
--- a/docs/acceptance/google-sync.md
+++ b/docs/acceptance/google-sync.md
@@ -329,19 +329,22 @@ save an event.
 2. In a separate browser tab, go to `myaccount.google.com/permissions`.
 3. Find Compass and remove its access.
 4. Return to Compass and wait for the app to detect the revocation (may require triggering a sync action or waiting for the next background sync cycle).
-5. Before creating or editing any event, inspect the bottom-left toast, the
-   sidebar account status, and Settings → Accounts for the affected account.
+5. Before creating or editing any event, inspect the calendar banner, the
+   sidebar account Reconnect action, and Settings → Accounts for the affected
+   account.
 6. Attempt to create an event only after confirming the reconnect-required UX
    is already visible (this step checks that CRUD is not the first signal).
 
 ### Expected Results
 
-- As soon as revocation is known, a reconnect toast appears that **names the
-  affected account** (for example “Google Calendar disconnected
-  (`lance.essert@gmail.com`)”) with **Reconnect Google Calendar**.
-- Sidebar status for the affected account shows reconnect-required copy and a
-  **Reconnect Google Calendar** action — not “Calendar connected”, not
-  “Syncing in the background…”, and not a calm/healthy state.
+- As soon as revocation is known, the week/day banner names the affected
+  account (or “Google Calendar needs reconnecting.” when the email is
+  unknown) with **Reconnect**. The sidebar account row shows **Reconnect
+  Google Calendar**. The sidebar footer does not repeat the reconnect
+  sentence.
+- A named reconnect toast appears only for a live revoke (`410` /
+  `GOOGLE_REVOKED`) or a blocked write, not again from a metadata refresh
+  while the banner is already on screen.
 - Settings → Accounts for the affected account matches the sidebar: it does
   not claim “Calendar connected” / “Updated just now” while reconnect is
   required.
@@ -372,22 +375,22 @@ leave a stale “everything is fine” or stale “please reconnect” message b
 1. Start from Scenario 7 after revocation has been detected at least once.
 2. Leave the tab open for at least one background sync / focus-refresh cycle
    (wait ~30–60 seconds, or hide the tab for 30+ seconds and return).
-3. Open Settings → Accounts and compare it with the sidebar status and any
-   visible toast.
+3. Open Settings → Accounts and compare it with the calendar banner, the
+   sidebar account CTA, and any live-revoke toast.
 4. If Google events briefly reappear or the grid goes blank, keep watching the
    status surfaces rather than interacting with events.
-5. Complete reconnect from the toast or account CTA, then confirm every
-   reconnect warning clears.
+5. Complete reconnect from the banner, sidebar account CTA, or live-revoke
+   toast, then confirm every reconnect warning clears.
 
 ### Expected Results
 
-- Throughout the wait, toast / sidebar / Settings never contradict each other
+- Throughout the wait, banner / sidebar / Settings never contradict each other
   for more than a brief transition: reconnect-required and healthy/syncing
   must not be shown as simultaneous truths for the affected account.
 - A reconnect toast does not linger after the account is healthy again.
-- After a successful reconnect, sidebar and Settings both settle to “Calendar
-  connected” (optional “Updated …” timestamp), with no reconnect CTA and no
-  disconnected toast.
+- After a successful reconnect, the banner is gone, the sidebar account CTA
+  is gone, and Settings settles to “Calendar connected” (optional
+  “Updated …” timestamp). OAuth return does not toast “Calendar connected.”
 - Attempting create/edit/delete on the affected account is hard-blocked and
   steers the user back to reconnect rather than sending a doomed `410`.
 - UpNext / “All clear” is unrelated to sync health and is not required to
@@ -400,26 +403,28 @@ leave a stale “everything is fine” or stale “please reconnect” message b
 ### UX
 
 After revocation, the user can reconnect Google using the same flow as the
-initial connection (sidebar/Settings CTA or the reconnect toast). A new import
-runs and Google events repopulate the calendar. All previously action-required
-surfaces clear together.
+initial connection (banner, sidebar/Settings CTA, or a live-revoke toast). A
+new import runs and Google events repopulate the calendar. All previously
+action-required surfaces clear together.
 
 ### Steps
 
 1. Complete Scenario 7 so the connection is in the reconnect-required state.
-2. Choose either the toast **Reconnect Google Calendar** action or the matching
-   sidebar / Settings CTA.
+2. Choose the banner **Reconnect** action, the matching sidebar / Settings
+   CTA, or a live-revoke toast if one is visible.
 3. Complete the Google authorization redirect.
 4. Wait for the import to complete.
 
 ### Expected Results
 
 - The Google authorization redirect returns to Compass without error.
-- The sidebar shows “Adding your calendar…” with the syncing shimmer during import.
+- Compass does not toast “Google Calendar connected.” The sidebar shows
+  “Adding your calendar…” with the syncing shimmer during import.
 - Google events repopulate the calendar after import completes.
 - The sidebar status returns to “Calendar connected” (HEALTHY).
 - Settings → Accounts matches the sidebar healthy state.
-- The reconnect toast is dismissed once reconnect is no longer required.
+- The reconnect banner, account CTA, and any live-revoke toast are dismissed
+  once reconnect is no longer required.
 - Previously revoked-and-removed events reappear if they still exist in Google Calendar.
 
 ---
@@ -632,12 +637,14 @@ If time is limited, run these checks before shipping Google sync changes:
 7. An ATTENTION state shows warning status copy and a **Refresh calendar** button.
 8. After the refresh completes, status returns to HEALTHY.
 9. Returning to a HEALTHY/ATTENTION tab after 30+ seconds hidden triggers a silent refresh with no failure toast.
-10. Revoking access shows reconnect-required UX early (named-account toast +
-    account status) before any failed event create/edit; last-known events
-    stay visible read-only and writes to that account are hard-blocked.
-11. While reconnect is required, toast / sidebar / Settings tell one story for
-    the affected account — never “disconnected” beside “Calendar connected”
-    or “Syncing in the background…”. A healthy sibling account keeps working.
+10. Revoking access shows reconnect-required UX early (calendar banner +
+    per-account Reconnect CTA; named toast only on live `410` / blocked
+    write) before any failed event create/edit; last-known events stay
+    visible read-only and writes to that account are hard-blocked.
+11. While reconnect is required, banner / sidebar / Settings tell one story
+    for the affected account — never “disconnected” beside “Calendar
+    connected” or “Syncing in the background…”. A healthy sibling account
+    (including the other provider on the same email) keeps working.
 12. Re-connecting after revocation triggers a fresh import, restores writes,
     and clears every reconnect warning together.
 13. Hiding/showing a calendar in the sidebar persists across reload, and the server excludes hidden-calendar events from event reads.

--- a/e2e/calendars/microsoft-surfaces.spec.ts
+++ b/e2e/calendars/microsoft-surfaces.spec.ts
@@ -44,11 +44,23 @@ test("does not toast success after a Microsoft connected redirect", async ({
 }) => {
   await stubAnonymousApis(page);
 
+  const metadata = page.waitForResponse("**/user/metadata**");
   await page.goto("/week?provider=microsoft&status=connected", {
     waitUntil: "domcontentloaded",
   });
+  await metadata;
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      }),
+  );
 
-  await expect(page.getByRole("button", { name: "Today" })).toBeVisible();
+  await expect(
+    page.getByRole("region", {
+      name: "Week calendar horizontal scroll area",
+    }),
+  ).toBeVisible();
   await expect(page.getByText("Microsoft connected.")).toHaveCount(0);
 });
 

--- a/e2e/calendars/microsoft-surfaces.spec.ts
+++ b/e2e/calendars/microsoft-surfaces.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import { prepareSignedInMicrosoftPage } from "../attendees/attendee-harness";
 import { prepareSignedInBookingSettingsPage } from "../booking/booking-harness";
 
@@ -23,9 +23,7 @@ function cssColorAlpha(color: string): number {
 
 test.use({ viewport: { width: 1600, height: 900 } });
 
-test("shows a Microsoft connected toast from the connect-status query", async ({
-  page,
-}) => {
+async function stubAnonymousApis(page: Page) {
   await page.addInitScript(() => {
     (
       window as Window & { __COMPASS_E2E_TEST__?: boolean }
@@ -39,12 +37,35 @@ test("shows a Microsoft connected toast from the connect-status query", async ({
       body: "{}",
     });
   });
+}
+
+test("does not toast success after a Microsoft connected redirect", async ({
+  page,
+}) => {
+  await stubAnonymousApis(page);
 
   await page.goto("/week?provider=microsoft&status=connected", {
     waitUntil: "domcontentloaded",
   });
 
-  await expect(page.getByText("Microsoft connected.")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Today" })).toBeVisible();
+  await expect(page.getByText("Microsoft connected.")).toHaveCount(0);
+});
+
+test("shows an account-mismatch toast from the connect-status query", async ({
+  page,
+}) => {
+  await stubAnonymousApis(page);
+
+  await page.goto("/week?provider=microsoft&status=accountMismatch", {
+    waitUntil: "domcontentloaded",
+  });
+
+  await expect(
+    page.getByText(
+      "That wasn't the same account. Reconnect again and pick the account Compass already has.",
+    ),
+  ).toBeVisible();
 });
 
 test("shows the admin-consent banner for a Microsoft connection", async ({

--- a/packages/sync/src/providers/apple/apple-auth.adapter.ts
+++ b/packages/sync/src/providers/apple/apple-auth.adapter.ts
@@ -41,6 +41,7 @@ export class AppleAuthAdapter implements PasswordCredentialAuthAdapter {
     state: string;
     redirectUri: string;
     selectAccount?: boolean;
+    loginHint?: string;
     extraScopes?: readonly string[];
   }): string {
     throw new ProviderAuthError(

--- a/packages/sync/src/providers/google/google-auth.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-auth.adapter.test.ts
@@ -143,6 +143,20 @@ describe("GoogleAuthAdapter", () => {
       expect(client.authUrlOptions[0].access_type).toBe("offline");
     });
 
+    it("passes login_hint on reconnect so the same account is pre-selected", () => {
+      const client = new FakeGoogleClient();
+      const { adapter } = adapterWith(client);
+
+      adapter.buildAuthorizationUrl({
+        state: "opaque-state",
+        redirectUri: "https://staging.example.com/sync/google",
+        loginHint: "reconnect@example.com",
+      });
+
+      expect(client.authUrlOptions[0].login_hint).toBe("reconnect@example.com");
+      expect(client.authUrlOptions[0].prompt).toBe("consent");
+    });
+
     it("appends optional feature scopes after the base scopes", () => {
       const client = new FakeGoogleClient();
       const { adapter } = adapterWith(client);

--- a/packages/sync/src/providers/google/google-auth.adapter.ts
+++ b/packages/sync/src/providers/google/google-auth.adapter.ts
@@ -24,6 +24,7 @@ export interface GoogleOAuthClient {
     scope: string[];
     state?: string;
     include_granted_scopes?: boolean;
+    login_hint?: string;
   }): string;
   getToken(code: string): Promise<{ tokens: Credentials }>;
   verifyIdToken(options: { idToken: string; audience: string }): Promise<{
@@ -65,6 +66,7 @@ export class GoogleAuthAdapter implements ProviderAuthAdapter {
     state: string;
     redirectUri: string;
     selectAccount?: boolean;
+    loginHint?: string;
     extraScopes?: readonly string[];
   }): string {
     return this.#makeClient(input.redirectUri).generateAuthUrl({
@@ -80,6 +82,7 @@ export class GoogleAuthAdapter implements ProviderAuthAdapter {
       // the caller asked for them, so a plain connect URL stays byte-identical.
       scope: [...GOOGLE_SCOPES, ...(input.extraScopes ?? [])],
       state: input.state,
+      ...(input.loginHint ? { login_hint: input.loginHint } : {}),
     });
   }
 

--- a/packages/sync/src/providers/microsoft/microsoft-auth.adapter.test.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-auth.adapter.test.ts
@@ -181,6 +181,24 @@ describe("MicrosoftAuthAdapter", () => {
       expect(url.searchParams.get("prompt")).toBe("select_account");
     });
 
+    it("passes login_hint on reconnect so the same account is pre-selected", () => {
+      const adapter = adapterWith(
+        new FakeTokenEndpoint(),
+        new FakeIdTokenVerifier(),
+      );
+
+      const url = new URL(
+        adapter.buildAuthorizationUrl({
+          state: "opaque-state",
+          redirectUri: "https://staging.example.com/sync/microsoft",
+          loginHint: "ada@contoso.com",
+        }),
+      );
+
+      expect(url.searchParams.get("login_hint")).toBe("ada@contoso.com");
+      expect(url.searchParams.get("prompt")).toBeNull();
+    });
+
     it("appends optional feature scopes after the base scopes", () => {
       const adapter = adapterWith(
         new FakeTokenEndpoint(),

--- a/packages/sync/src/providers/microsoft/microsoft-auth.adapter.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-auth.adapter.ts
@@ -92,6 +92,7 @@ export class MicrosoftAuthAdapter implements ProviderAuthAdapter {
     state: string;
     redirectUri: string;
     selectAccount?: boolean;
+    loginHint?: string;
     extraScopes?: readonly string[];
   }): string {
     const url = new URL(MICROSOFT_AUTHORIZE_URL);
@@ -106,6 +107,9 @@ export class MicrosoftAuthAdapter implements ProviderAuthAdapter {
     url.searchParams.set("redirect_uri", input.redirectUri);
     if (input.selectAccount) {
       url.searchParams.set("prompt", "select_account");
+    }
+    if (input.loginHint) {
+      url.searchParams.set("login_hint", input.loginHint);
     }
     return url.toString();
   }

--- a/packages/sync/src/providers/provider-auth.port.ts
+++ b/packages/sync/src/providers/provider-auth.port.ts
@@ -40,6 +40,10 @@ export interface ProviderAuthAdapter {
     // with one signed-in session silently re-authorizes that same account, so
     // the user never gets to pick the account they meant to add.
     readonly selectAccount?: boolean;
+    // Hint the provider to pre-select this account on reconnect. Without it
+    // a signed-in browser session can consent as a different account, and
+    // Compass refuses the grant rather than silently creating a second row.
+    readonly loginHint?: string;
     // Optional feature scopes to request ON TOP of the adapter's base scopes
     // (e.g. the contacts scopes behind attendee suggestions). Absent or empty
     // leaves the consent request byte-identical to a plain connect; the user

--- a/packages/sync/src/server/connection.routes.db.test.ts
+++ b/packages/sync/src/server/connection.routes.db.test.ts
@@ -110,12 +110,14 @@ class FakeAuthAdapter implements ProviderAuthAdapter {
     state: string;
     redirectUri: string;
     selectAccount?: boolean;
+    loginHint?: string;
     extraScopes?: readonly string[];
   }> = [];
   buildAuthorizationUrl(input: {
     state: string;
     redirectUri: string;
     selectAccount?: boolean;
+    loginHint?: string;
     extraScopes?: readonly string[];
   }): string {
     this.authorizations.push(input);
@@ -627,6 +629,7 @@ describe("POST /internal/connections/begin", () => {
     await begin(tenantId, principalId, { connectionId: existing._id });
 
     expect(adapter.authorizations[0].selectAccount).toBe(false);
+    expect(adapter.authorizations[0].loginHint).toBe("reconnect@example.com");
   });
 
   it("binds the state to an owned connection for reconnect", async () => {
@@ -1040,7 +1043,7 @@ describe("GET /sync/google", () => {
       `code=c&state=${encodeURIComponent(reconnectState(tenantId, principalId, existing._id))}`,
     );
 
-    expect(statusOf(res)).toBe("error");
+    expect(statusOf(res)).toBe("accountMismatch");
     // No second connection was created; the original is untouched.
     const all = await connections.listByPrincipal(
       tenantId as TenantId,

--- a/packages/sync/src/server/connection.routes.ts
+++ b/packages/sync/src/server/connection.routes.ts
@@ -99,6 +99,15 @@ import { syncRepositories } from "@sync/storage/sync-repositories";
 
 const logger = Logger("sync:connection.routes");
 
+export class ReconnectAccountMismatchError extends Error {
+  readonly status = "accountMismatch" as const;
+
+  constructor() {
+    super("Reconnect account does not match the named connection");
+    this.name = "ReconnectAccountMismatchError";
+  }
+}
+
 export const CONNECTIONS_PATH = "/internal/connections";
 export const CALENDARS_PATH = "/internal/calendars";
 export const EVENTS_FULL_PATH = "/internal/events/full";
@@ -547,6 +556,7 @@ export function registerConnectionRoutes(
       // Optional connectionId means reconnect: validate it is a real id owned by
       // this principal, so the state cannot bind a flow to a foreign connection.
       let connectionId = null;
+      let loginHint: string | undefined;
       const rawConnectionId = (req.body as { connectionId?: unknown })
         ?.connectionId;
       if (rawConnectionId !== undefined && rawConnectionId !== null) {
@@ -565,6 +575,8 @@ export function registerConnectionRoutes(
             res.status(Status.NOT_FOUND).json({ error: "not_found" });
             return;
           }
+          const email = owned.account.email?.trim();
+          if (email) loginHint = email;
         } catch (error) {
           logger.error(
             "Failed to look up connection for reconnect",
@@ -625,6 +637,7 @@ export function registerConnectionRoutes(
           state,
           redirectUri: `${deps.callbackBaseUrl}${registration.callbackPath}`,
           selectAccount,
+          ...(loginHint ? { loginHint } : {}),
           // Undefined (not an empty array) when no feature was asked for, so a
           // plain begin's adapter input — and therefore its consent URL — stays
           // byte-identical to before features existed.
@@ -904,6 +917,9 @@ export function registerConnectionRoutes(
         await linkConnection(deps, verified.payload, authorization);
         return redirect("connected");
       } catch (error) {
+        if (error instanceof ReconnectAccountMismatchError) {
+          return redirect("accountMismatch");
+        }
         logger.error(
           "Failed to link connection after OAuth consent",
           redactedCause(error),
@@ -1168,7 +1184,7 @@ async function linkConnection(
       existing.account.providerAccountId !==
         authorization.account.providerAccountId
     ) {
-      throw new Error("Reconnect account does not match the named connection");
+      throw new ReconnectAccountMismatchError();
     }
   }
 

--- a/packages/web/src/app.bootstrap.tsx
+++ b/packages/web/src/app.bootstrap.tsx
@@ -4,9 +4,8 @@ import "react-toastify/dist/ReactToastify.css";
 import "./common/styles/toastify-theme.css";
 import { sessionInit } from "@web/auth/compass/session/SessionProvider";
 import {
+  applyConnectRedirect,
   readConnectStatus,
-  refreshUserMetadataAfterConnect,
-  showConnectStatusToast,
 } from "@web/auth/providers/connect-status.util";
 import { configureGoogleRevocationApiHandler } from "@web/auth/providers/revocation-api.config";
 import {
@@ -46,7 +45,6 @@ export async function bootstrapApp(): Promise<void> {
     showDbInitErrorToast(dbInitError);
   }
   if (connectStatus) {
-    showConnectStatusToast(connectStatus);
-    refreshUserMetadataAfterConnect(connectStatus.status);
+    void applyConnectRedirect(connectStatus);
   }
 }

--- a/packages/web/src/auth/compass/user/util/user-metadata.util.test.ts
+++ b/packages/web/src/auth/compass/user/util/user-metadata.util.test.ts
@@ -12,6 +12,22 @@ import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 
 const healthy: UserMetadata = { google: { connectionState: "HEALTHY" } };
 const attention: UserMetadata = { google: { connectionState: "ATTENTION" } };
+const reconnectRequired: UserMetadata = {
+  google: { connectionState: "RECONNECT_REQUIRED" },
+  connections: [
+    {
+      id: "conn-1",
+      provider: "google",
+      state: "actionRequired",
+      stateReason: "authorizationRevoked",
+      lastSyncedAt: null,
+      lastHealthyAt: null,
+      accountEmail: "lance@example.com",
+      connectionState: "RECONNECT_REQUIRED",
+      canSuggestContacts: false,
+    },
+  ],
+};
 
 describe("applyUserMetadataSideEffects - delayed toast lifecycle", () => {
   const { port, mocks } = createTestToastPort();
@@ -66,6 +82,22 @@ describe("applyUserMetadataSideEffects - delayed toast lifecycle", () => {
       expect.anything(),
       expect.objectContaining({ toastId: GOOGLE_DELAYED_TOAST_ID }),
     );
+  });
+});
+
+describe("applyUserMetadataSideEffects - reconnect toast", () => {
+  const { port, mocks } = createTestToastPort();
+
+  beforeEach(() => {
+    mocks.error.mockClear();
+    registerToastPort(port);
+    resetGoogleReconnectRequiredForTests();
+  });
+
+  it("does not raise a reconnect toast from metadata load", () => {
+    applyUserMetadataSideEffects(reconnectRequired);
+
+    expect(mocks.error).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/web/src/auth/compass/user/util/user-metadata.util.ts
+++ b/packages/web/src/auth/compass/user/util/user-metadata.util.ts
@@ -1,13 +1,9 @@
 import { Status } from "@core/errors/status.codes";
 import { type UserMetadata } from "@core/types/user.types";
 import { UserApi } from "@web/api/user.api";
+import { connectionHasReconnectRequired } from "@web/auth/providers/connect.util";
+import { syncReconnectRequiredFromConnections } from "@web/auth/providers/reconnect.state";
 import {
-  getGoogleReconnectRequiredAccountEmails,
-  hasGoogleReconnectRequired,
-  syncReconnectRequiredFromConnections,
-} from "@web/auth/providers/reconnect.state";
-import {
-  findPrimaryGoogleSyncConnectionFromMetadata,
   findSyncConnectionsFromMetadata,
   userMetadataActions,
 } from "@web/auth/state/user-metadata.store";
@@ -18,8 +14,7 @@ import {
 import {
   clearGoogleReconnectToastGate,
   dismissGoogleReconnectToast,
-  hasShownGoogleReconnectToastThisLoad,
-  showGoogleReconnectToast,
+  dismissGoogleReconnectToastIfRecovered,
 } from "@web/common/utils/toast/google-reconnect.toast";
 
 let refreshUserMetadataRequest: Promise<void> | null = null;
@@ -27,39 +22,22 @@ let hasShownDelayedToastThisLoad = false;
 let metadataFetchEpoch = 0;
 
 /**
- * Keep session reconnect overrides and sticky toasts congruent with the latest
+ * Keep session reconnect overrides and delayed toasts congruent with the latest
  * metadata payload, whether it arrived from REST refresh or SSE.
+ *
+ * Reconnect toasts are not raised here: week/day already have the banner and
+ * per-account sidebar CTA. The named toast is the interrupt for a live 410 /
+ * failed write (`handleConnectionRevoked`).
  */
 export const applyUserMetadataSideEffects = (metadata: UserMetadata): void => {
   const connections = findSyncConnectionsFromMetadata(metadata);
   syncReconnectRequiredFromConnections(connections);
 
-  const needsReconnect =
-    metadata.google?.connectionState === "RECONNECT_REQUIRED" ||
-    hasGoogleReconnectRequired();
-
-  if (needsReconnect) {
-    const stickyEmails = getGoogleReconnectRequiredAccountEmails();
-    const broken =
-      connections.find(
-        (connection) => connection.connectionState === "RECONNECT_REQUIRED",
-      ) ??
-      connections.find((connection) => {
-        const email = connection.accountEmail?.toLowerCase();
-        return Boolean(email && stickyEmails.has(email));
-      }) ??
-      // Only fall back to primary when Sync itself says reconnect is required —
-      // never invent a target from sticky alone pointing at a healthy primary.
-      (metadata.google?.connectionState === "RECONNECT_REQUIRED"
-        ? findPrimaryGoogleSyncConnectionFromMetadata(metadata)
-        : null);
-
-    if (!hasShownGoogleReconnectToastThisLoad()) {
-      showGoogleReconnectToast({
-        connectionId: broken?.id,
-        accountEmail: broken?.accountEmail,
-      });
-    }
+  const stillBroken = connections.some((connection) =>
+    connectionHasReconnectRequired(connection),
+  );
+  if (stillBroken) {
+    dismissGoogleReconnectToastIfRecovered(connections);
   } else {
     dismissGoogleReconnectToast();
     clearGoogleReconnectToastGate();

--- a/packages/web/src/auth/posthog/signup-funnel.ts
+++ b/packages/web/src/auth/posthog/signup-funnel.ts
@@ -58,6 +58,7 @@ export type SignupFailureReason =
   | "connect_missing_scopes"
   | "connect_state_mismatch"
   | "connect_consent_required"
+  | "connect_account_mismatch"
   | "connect_error";
 
 type StepProperties = {

--- a/packages/web/src/auth/providers/connect-status.util.test.ts
+++ b/packages/web/src/auth/providers/connect-status.util.test.ts
@@ -3,6 +3,7 @@ import * as userMetadataUtil from "@web/auth/compass/user/util/user-metadata.uti
 import { CONSENT_REQUIRED_COPY } from "@web/auth/providers/provider-copy.util";
 import { registerToastPort } from "@web/common/utils/toast/toast.port";
 import {
+  applyConnectRedirect,
   readConnectStatus,
   refreshUserMetadataAfterConnect,
   showConnectStatusToast,
@@ -68,7 +69,7 @@ describe("connect-status.util", () => {
 
     // These two are redirected by the sync callback. Dropping them here left
     // the user on the calendar after a failed connect with no toast at all.
-    it("reads the sync callback's stateMismatch and consentRequired", () => {
+    it("reads the sync callback's stateMismatch, consentRequired, and accountMismatch", () => {
       expect(
         readConnectStatus("?provider=google&status=stateMismatch"),
       ).toEqual({
@@ -81,33 +82,33 @@ describe("connect-status.util", () => {
         provider: "microsoft",
         status: "consentRequired",
       });
+      expect(
+        readConnectStatus("?provider=microsoft&status=accountMismatch"),
+      ).toEqual({
+        provider: "microsoft",
+        status: "accountMismatch",
+      });
     });
   });
 
   describe("showConnectStatusToast", () => {
-    it("keeps the Google connected toast unchanged", () => {
+    it("does not toast success after a connected redirect", () => {
       showConnectStatusToast({ provider: "google", status: "connected" });
       runToastAfterPaint();
-      expect(mocks.success).toHaveBeenCalledWith(
-        "Google Calendar connected.",
-        expect.objectContaining({ toastId: "google-connect-success" }),
-      );
+      expect(mocks.success).not.toHaveBeenCalled();
     });
 
-    it("shows a Microsoft connected toast", () => {
+    it("does not toast success for a Microsoft connected redirect", () => {
       showConnectStatusToast({ provider: "microsoft", status: "connected" });
       runToastAfterPaint();
-      expect(mocks.success).toHaveBeenCalledWith(
-        "Microsoft connected.",
-        expect.objectContaining({ toastId: "connect-success" }),
-      );
+      expect(mocks.success).not.toHaveBeenCalled();
     });
 
     it("explains an expired connection link", () => {
       showConnectStatusToast({ provider: "google", status: "stateMismatch" });
       runToastAfterPaint();
       expect(mocks.error).toHaveBeenCalledWith(
-        "That connection link expired. Please try connecting again from Settings.",
+        "That connection link expired. Please try connecting again.",
         expect.objectContaining({
           autoClose: false,
           toastId: "connect-state-mismatch",
@@ -128,6 +129,48 @@ describe("connect-status.util", () => {
           toastId: "connect-consent-required",
         }),
       );
+    });
+
+    it("explains a reconnect that consented as a different account", () => {
+      showConnectStatusToast({
+        provider: "microsoft",
+        status: "accountMismatch",
+      });
+      runToastAfterPaint();
+      expect(mocks.error).toHaveBeenCalledWith(
+        "That wasn't the same account. Reconnect again and pick the account Compass already has.",
+        expect.objectContaining({
+          autoClose: false,
+          toastId: "connect-account-mismatch",
+        }),
+      );
+    });
+
+    it("explains a generic connect error without sending the user to Settings", () => {
+      showConnectStatusToast({ provider: "microsoft", status: "error" });
+      runToastAfterPaint();
+      expect(mocks.error).toHaveBeenCalledWith(
+        "We couldn't connect your Microsoft account. Please try again.",
+        expect.objectContaining({ autoClose: false }),
+      );
+    });
+  });
+
+  describe("applyConnectRedirect", () => {
+    it("force-refreshes metadata for every OAuth return", async () => {
+      const refreshSpy = spyOn(
+        userMetadataUtil,
+        "refreshUserMetadata",
+      ).mockResolvedValue(undefined);
+
+      await applyConnectRedirect({ provider: "google", status: "connected" });
+      expect(refreshSpy).toHaveBeenCalledWith({ force: true });
+
+      refreshSpy.mockClear();
+      await applyConnectRedirect({ provider: "microsoft", status: "error" });
+      expect(refreshSpy).toHaveBeenCalledWith({ force: true });
+
+      refreshSpy.mockRestore();
     });
   });
 

--- a/packages/web/src/auth/providers/connect-status.util.ts
+++ b/packages/web/src/auth/providers/connect-status.util.ts
@@ -10,11 +10,18 @@ import {
   trackSignupStep,
 } from "@web/auth/posthog/signup-funnel";
 import { track } from "@web/auth/posthog/track";
+import { connectionProviderKind } from "@web/auth/providers/connection-provider.util";
 import { CONSENT_REQUIRED_COPY } from "@web/auth/providers/provider-copy.util";
+import { clearAccountReconnectRequired } from "@web/auth/providers/reconnect.state";
+import {
+  selectSyncConnections,
+  useUserMetadataStore,
+} from "@web/auth/state/user-metadata.store";
 import {
   GOOGLE_CONNECT_FAILED_TOAST_ID,
   getToastDefaultOptions,
 } from "@web/common/constants/toast.constants";
+import { dismissGoogleReconnectToastIfRecovered } from "@web/common/utils/toast/google-reconnect.toast";
 import { getToast } from "@web/common/utils/toast/toast.port";
 
 /**
@@ -29,6 +36,7 @@ export type ConnectStatus =
   | "missingScopes"
   | "stateMismatch"
   | "consentRequired"
+  | "accountMismatch"
   | "error";
 
 export type ConnectRedirect = {
@@ -42,14 +50,9 @@ const STATUS_VALUES: readonly ConnectStatus[] = [
   "missingScopes",
   "stateMismatch",
   "consentRequired",
+  "accountMismatch",
   "error",
 ];
-
-const SUCCESS_TOAST_ID: Record<ProviderKind, string> = {
-  google: "google-connect-success",
-  microsoft: "connect-success",
-  apple: "connect-success",
-};
 
 const DECLINED_TOAST_ID: Record<ProviderKind, string> = {
   google: "google-connect-declined",
@@ -59,6 +62,7 @@ const DECLINED_TOAST_ID: Record<ProviderKind, string> = {
 
 const STATE_MISMATCH_TOAST_ID = "connect-state-mismatch";
 const CONSENT_REQUIRED_TOAST_ID = "connect-consent-required";
+const ACCOUNT_MISMATCH_TOAST_ID = "connect-account-mismatch";
 
 const FAILURE_REASON: Record<
   Exclude<ConnectStatus, "connected">,
@@ -68,6 +72,7 @@ const FAILURE_REASON: Record<
   missingScopes: "connect_missing_scopes",
   stateMismatch: "connect_state_mismatch",
   consentRequired: "connect_consent_required",
+  accountMismatch: "connect_account_mismatch",
   error: "connect_error",
 };
 
@@ -75,12 +80,6 @@ const MISSING_SCOPES_TOAST_ID: Record<ProviderKind, string> = {
   google: "google-connect-missing-scopes",
   microsoft: "connect-missing-scopes",
   apple: "connect-missing-scopes",
-};
-
-const CONNECTED_COPY: Record<ProviderKind, string> = {
-  google: "Google Calendar connected.",
-  microsoft: "Microsoft connected.",
-  apple: "Apple connected.",
 };
 
 export function readConnectStatus(
@@ -103,18 +102,51 @@ export function showConnectStatusToast(redirect: ConnectRedirect): void {
   });
 }
 
-export function refreshUserMetadataAfterConnect(status: ConnectStatus): void {
-  if (status !== "connected") return;
+/**
+ * Refresh metadata for every OAuth return, then toast from confirmed state.
+ * A `connected` redirect never claims success while that provider still has a
+ * reconnect-required row, and does not toast when import/health already
+ * covers it.
+ */
+export async function applyConnectRedirect(
+  redirect: ConnectRedirect,
+): Promise<void> {
+  await refreshUserMetadata({ force: true });
+  if (redirect.status === "connected") {
+    clearReconnectOverrideForProvider(redirect.provider);
+    dismissGoogleReconnectToastIfRecovered(
+      selectSyncConnections(useUserMetadataStore.getState()),
+    );
+    track("calendar_connected", {
+      source: "connect_redirect",
+      provider: redirect.provider,
+    });
+    trackSignupStep("calendar_connected", { method: redirect.provider });
+    return;
+  }
+  showConnectStatusToast(redirect);
+}
+
+export function refreshUserMetadataAfterConnect(_status?: ConnectStatus): void {
   void refreshUserMetadata({ force: true });
 }
 
-function connectedCopy(provider: ProviderKind): string {
-  return CONNECTED_COPY[provider];
+function clearReconnectOverrideForProvider(provider: ProviderKind): void {
+  const connections = selectSyncConnections(useUserMetadataStore.getState());
+  for (const connection of connections) {
+    if (connectionProviderKind(connection) !== provider) continue;
+    if (connection.connectionState === "RECONNECT_REQUIRED") continue;
+    clearAccountReconnectRequired({
+      connectionId: connection.id,
+      accountEmail: connection.accountEmail,
+      provider: connectionProviderKind(connection),
+    });
+  }
 }
 
 function errorCopy(provider: ProviderKind): string {
   const name = providerDisplayName(provider);
-  return `We couldn't connect your ${name} account. Please try again from Settings.`;
+  return `We couldn't connect your ${name} account. Please try again.`;
 }
 
 function fireConnectStatusToast({ provider, status }: ConnectRedirect): void {
@@ -127,12 +159,6 @@ function fireConnectStatusToast({ provider, status }: ConnectRedirect): void {
   }
   switch (status) {
     case "connected":
-      track("calendar_connected", { source: "connect_redirect", provider });
-      trackSignupStep("calendar_connected", { method: provider });
-      toast.success(connectedCopy(provider), {
-        ...getToastDefaultOptions(),
-        toastId: SUCCESS_TOAST_ID[provider],
-      });
       return;
     case "declined":
       toast.info(
@@ -142,7 +168,7 @@ function fireConnectStatusToast({ provider, status }: ConnectRedirect): void {
       return;
     case "missingScopes":
       toast.error(
-        "Compass needs calendar permission to sync. Reconnect from Settings and leave the calendar box checked.",
+        "Compass needs calendar permission to sync. Reconnect and leave the calendar box checked.",
         {
           ...getToastDefaultOptions(),
           autoClose: false,
@@ -152,7 +178,7 @@ function fireConnectStatusToast({ provider, status }: ConnectRedirect): void {
       return;
     case "stateMismatch":
       toast.error(
-        "That connection link expired. Please try connecting again from Settings.",
+        "That connection link expired. Please try connecting again.",
         {
           ...getToastDefaultOptions(),
           autoClose: false,
@@ -166,6 +192,16 @@ function fireConnectStatusToast({ provider, status }: ConnectRedirect): void {
         autoClose: false,
         toastId: CONSENT_REQUIRED_TOAST_ID,
       });
+      return;
+    case "accountMismatch":
+      toast.error(
+        "That wasn't the same account. Reconnect again and pick the account Compass already has.",
+        {
+          ...getToastDefaultOptions(),
+          autoClose: false,
+          toastId: ACCOUNT_MISMATCH_TOAST_ID,
+        },
+      );
       return;
     case "error":
       toast.error(errorCopy(provider), {

--- a/packages/web/src/auth/providers/connect.util.test.ts
+++ b/packages/web/src/auth/providers/connect.util.test.ts
@@ -8,6 +8,7 @@ import {
   getSidebarSyncStatus,
   isFirstImportFailed,
   isFirstImportInProgress,
+  pickCalendarBannerTarget,
 } from "./connect.util";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
@@ -659,6 +660,61 @@ describe("getCalendarConnectionBannerKind", () => {
     expect(
       getCalendarConnectionBannerKind("HEALTHY", makeConnection()),
     ).toBeNull();
+  });
+});
+
+describe("pickCalendarBannerTarget", () => {
+  const makeConnection = (
+    overrides: Partial<GoogleSyncConnectionSummary> = {},
+  ): GoogleSyncConnectionSummary => ({
+    id: "c1",
+    state: "healthy",
+    stateReason: null,
+    lastSyncedAt: null,
+    lastHealthyAt: "2026-07-24T11:45:00.000Z",
+    accountEmail: "a@example.com",
+    connectionState: "HEALTHY",
+    canSuggestContacts: false,
+    ...overrides,
+  });
+
+  it("picks a Microsoft reconnect over a healthy Google primary", () => {
+    const google = makeConnection({
+      id: "google-1",
+      provider: "google",
+      accountEmail: "shared@example.com",
+    });
+    const microsoft = makeConnection({
+      id: "ms-1",
+      provider: "microsoft",
+      accountEmail: "shared@example.com",
+      state: "actionRequired",
+      stateReason: "authorizationRevoked",
+      connectionState: "RECONNECT_REQUIRED",
+    });
+
+    expect(pickCalendarBannerTarget([google, microsoft])).toEqual({
+      connection: microsoft,
+      kind: "reconnect",
+    });
+  });
+
+  it("does not invent a Google banner when only Microsoft needs reconnect", () => {
+    const microsoft = makeConnection({
+      id: "ms-1",
+      provider: "microsoft",
+      state: "actionRequired",
+      stateReason: "authorizationRevoked",
+      connectionState: "RECONNECT_REQUIRED",
+    });
+
+    expect(pickCalendarBannerTarget([microsoft])?.connection.provider).toBe(
+      "microsoft",
+    );
+  });
+
+  it("returns null when every connection is healthy", () => {
+    expect(pickCalendarBannerTarget([makeConnection()])).toBeNull();
   });
 });
 

--- a/packages/web/src/auth/providers/connect.util.ts
+++ b/packages/web/src/auth/providers/connect.util.ts
@@ -13,7 +13,11 @@ import {
   pickAggregateSidebarStatus,
   type SidebarStatusEntry,
 } from "@web/auth/providers/connection-health-copy.util";
-import { CONSENT_REQUIRED_COPY } from "@web/auth/providers/provider-copy.util";
+import { connectionProviderKind } from "@web/auth/providers/connection-provider.util";
+import {
+  CONSENT_REQUIRED_COPY,
+  RECONNECT_BANNER_MESSAGE,
+} from "@web/auth/providers/provider-copy.util";
 import {
   isAccountReconnectRequired,
   isConnectionReconnectRequired,
@@ -60,7 +64,10 @@ export const connectionHasReconnectRequired = (
   connection?.connectionState === "RECONNECT_REQUIRED" ||
   connection?.state === "disconnected" ||
   isConnectionReconnectRequired(connection?.id) ||
-  isAccountReconnectRequired(connection?.accountEmail);
+  isAccountReconnectRequired(
+    connection?.accountEmail,
+    connectionProviderKind(connection),
+  );
 
 /** Aggregate UI state or a specific connection needs reconnect. */
 export const connectionNeedsReconnect = (
@@ -242,7 +249,12 @@ export const getGoogleConnectionConfig = (
 
 export const calendarReconnectBannerMessage = (
   provider: ProviderKind,
-): string => `${providerDisplayName(provider)} Calendar needs reconnecting.`;
+  accountEmail?: string | null,
+): string => {
+  const named = accountEmail?.trim();
+  if (named) return `${named} needs reconnecting.`;
+  return RECONNECT_BANNER_MESSAGE[provider];
+};
 
 const delayedSettingsStatus = (
   connection: GoogleSyncConnectionSummary,
@@ -412,6 +424,13 @@ export type CalendarConnectionBannerKind =
   | "importFailed"
   | "delayed";
 
+const BANNER_KIND_RANK: Record<CalendarConnectionBannerKind, number> = {
+  reconnect: 0,
+  consentRequired: 1,
+  importFailed: 2,
+  delayed: 3,
+};
+
 // Persistent in-calendar banner. Reconnect wins, then a failed first import,
 // then an established account's delayed catch-up. First-import-in-progress
 // stays on the grid overlay, not this banner.
@@ -426,6 +445,35 @@ export const getCalendarConnectionBannerKind = (
     return "delayed";
   }
   return null;
+};
+
+export type CalendarBannerTarget = {
+  connection: GoogleSyncConnectionSummary;
+  kind: CalendarConnectionBannerKind;
+};
+
+/**
+ * Highest-precedence connection the week/day banner should speak for.
+ * Walks every provider account so a Microsoft reconnect cannot hide behind a
+ * healthy Google primary, and a Google row stays quiet when only Microsoft
+ * needs help.
+ */
+export const pickCalendarBannerTarget = (
+  connections: readonly GoogleSyncConnectionSummary[],
+): CalendarBannerTarget | null => {
+  let best: (CalendarBannerTarget & { rank: number }) | null = null;
+  for (const connection of connections) {
+    const kind = getCalendarConnectionBannerKind(
+      connection.connectionState,
+      connection,
+    );
+    if (!kind) continue;
+    const rank = BANNER_KIND_RANK[kind];
+    if (!best || rank < best.rank) {
+      best = { connection, kind, rank };
+    }
+  }
+  return best ? { connection: best.connection, kind: best.kind } : null;
 };
 
 /**
@@ -559,6 +607,14 @@ export const getAggregateSidebarSyncStatus = ({
 }): SyncStatus | null => {
   const entries: SidebarStatusEntry[] = [];
   for (const connection of connections) {
+    // Banner + per-account Reconnect already own action-required. Repeating
+    // it on the footer stacked a third sentence on the same problem.
+    if (
+      connectionHasReconnectRequired(connection) ||
+      connectionNeedsAdminConsent(connection)
+    ) {
+      continue;
+    }
     const status = getSidebarSyncStatus({
       connection,
       isConnecting,

--- a/packages/web/src/auth/providers/connection-revoked.util.factory.ts
+++ b/packages/web/src/auth/providers/connection-revoked.util.factory.ts
@@ -59,8 +59,8 @@ export function createGoogleAuthUtil({
 
     // Refresh metadata so Sync's actionRequired row can confirm the account,
     // but keep last-known events and the remote repository so healthy sibling
-    // accounts continue CRUD. Named toast also lands from metadata side
-    // effects once Sync identifies the broken connection.
+    // accounts continue CRUD. Named toast lands here for the live revoke
+    // interrupt; the calendar banner is the persistent reminder.
     refreshUserMetadata();
 
     closeStream();

--- a/packages/web/src/auth/providers/connection-revoked.util.test.ts
+++ b/packages/web/src/auth/providers/connection-revoked.util.test.ts
@@ -33,9 +33,11 @@ const mockResolveRevokedAccount = mock(
   (): {
     connectionId: string;
     accountEmail: string;
+    provider: "google";
   } | null => ({
     connectionId: "conn-1",
     accountEmail: "lance@example.com",
+    provider: "google",
   }),
 );
 
@@ -163,13 +165,17 @@ describe("google-auth.util", () => {
       expect(mockMarkAccountReconnectRequired).toHaveBeenCalledWith({
         connectionId: "conn-1",
         accountEmail: "lance@example.com",
+        provider: "google",
       });
       expect(mockShowReconnectToast).toHaveBeenCalledWith({
         connectionId: "conn-1",
         accountEmail: "lance@example.com",
+        provider: "google",
       });
       expect(mockRefreshUserMetadata).toHaveBeenCalledTimes(1);
-      expect(isAccountReconnectRequired("lance@example.com")).toBe(true);
+      expect(isAccountReconnectRequired("lance@example.com", "google")).toBe(
+        true,
+      );
       expect(hasGoogleReconnectRequired()).toBe(true);
     });
 

--- a/packages/web/src/auth/providers/connection-revoked.util.ts
+++ b/packages/web/src/auth/providers/connection-revoked.util.ts
@@ -1,6 +1,11 @@
 import { type Calendar } from "@core/types/calendar.contracts";
+import { type SyncConnectionSummary } from "@core/types/user.types";
 import { queryClient } from "@web/api/query-client";
 import { refreshUserMetadata } from "@web/auth/compass/user/util/user-metadata.util";
+import {
+  calendarProviderKind,
+  connectionProviderKind,
+} from "@web/auth/providers/connection-provider.util";
 import {
   type GoogleReconnectTarget,
   markAccountReconnectRequired,
@@ -19,6 +24,29 @@ import {
   type GoogleRevokedContext,
 } from "./connection-revoked.util.factory";
 
+const toTarget = (
+  connection: SyncConnectionSummary | undefined,
+  fallback: GoogleReconnectTarget,
+): GoogleReconnectTarget => ({
+  connectionId: fallback.connectionId ?? connection?.id ?? null,
+  accountEmail: fallback.accountEmail ?? connection?.accountEmail ?? null,
+  provider: connection ? connectionProviderKind(connection) : fallback.provider,
+});
+
+const connectionMatchingEmail = (
+  connections: readonly SyncConnectionSummary[],
+  accountEmail: string,
+  provider?: ReturnType<typeof connectionProviderKind> | null,
+): SyncConnectionSummary | undefined => {
+  const matches = connections.filter(
+    (entry) => entry.accountEmail === accountEmail,
+  );
+  if (provider) {
+    return matches.find((entry) => connectionProviderKind(entry) === provider);
+  }
+  return matches.length === 1 ? matches[0] : undefined;
+};
+
 /**
  * Resolve which account a revoke signal belongs to. Returns null when the
  * signal is ambiguous across multiple accounts — callers must not invent a
@@ -33,20 +61,27 @@ const resolveRevokedAccount = (
     const connection = connections.find(
       (entry) => entry.id === context.connectionId,
     );
-    return {
+    return toTarget(connection, {
       connectionId: context.connectionId,
       accountEmail: context.accountEmail ?? connection?.accountEmail ?? null,
-    };
+    });
   }
 
   if (context?.accountEmail) {
-    const connection = connections.find(
-      (entry) => entry.accountEmail === context.accountEmail,
+    const connection = connectionMatchingEmail(
+      connections,
+      context.accountEmail,
     );
-    return {
+    if (
+      !connection &&
+      connections.some((entry) => entry.accountEmail === context.accountEmail)
+    ) {
+      return null;
+    }
+    return toTarget(connection, {
       connectionId: connection?.id ?? null,
       accountEmail: context.accountEmail,
-    };
+    });
   }
 
   if (context?.calendarId) {
@@ -54,13 +89,17 @@ const resolveRevokedAccount = (
       queryClient.getQueryData<Calendar[]>(calendarQueryKeys.all) ?? [];
     const calendar = calendars.find((entry) => entry.id === context.calendarId);
     if (calendar?.accountEmail) {
-      const connection = connections.find(
-        (entry) => entry.accountEmail === calendar.accountEmail,
+      const provider = calendarProviderKind(calendar);
+      const connection = connectionMatchingEmail(
+        connections,
+        calendar.accountEmail,
+        provider,
       );
-      return {
+      return toTarget(connection, {
         connectionId: connection?.id ?? null,
         accountEmail: calendar.accountEmail,
-      };
+        provider: provider ?? null,
+      });
     }
   }
 
@@ -68,17 +107,17 @@ const resolveRevokedAccount = (
     (connection) => connection.connectionState === "RECONNECT_REQUIRED",
   );
   if (alreadyBroken) {
-    return {
+    return toTarget(alreadyBroken, {
       connectionId: alreadyBroken.id,
       accountEmail: alreadyBroken.accountEmail,
-    };
+    });
   }
 
   if (connections.length === 1) {
-    return {
+    return toTarget(connections[0], {
       connectionId: connections[0]?.id ?? null,
       accountEmail: connections[0]?.accountEmail ?? null,
-    };
+    });
   }
 
   // Multi-account with no identity: wait for metadata Sync actionRequired.

--- a/packages/web/src/auth/providers/reconnect.calendar.ts
+++ b/packages/web/src/auth/providers/reconnect.calendar.ts
@@ -1,25 +1,34 @@
 import { type Calendar } from "@core/types/calendar.contracts";
+import { calendarProviderKind } from "@web/auth/providers/connection-provider.util";
+import { connectionProvider } from "@web/auth/providers/provider-copy.util";
 import {
   isAccountReconnectRequired,
   isConnectionReconnectRequired,
 } from "@web/auth/providers/reconnect.state";
 import {
-  selectGoogleSyncConnections,
+  selectSyncConnections,
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
 
 /**
- * True when this calendar's Google account needs reconnect, whether the
- * session override was keyed by email or by connection id.
+ * True when this calendar's provider account needs reconnect, whether the
+ * session override was keyed by email+provider or by connection id.
  */
 export function isCalendarReconnectRequired(
-  calendar: Pick<Calendar, "accountEmail"> | null | undefined,
+  calendar: Pick<Calendar, "accountEmail" | "provider"> | null | undefined,
 ): boolean {
   if (!calendar?.accountEmail) return false;
-  if (isAccountReconnectRequired(calendar.accountEmail)) return true;
+  const provider = calendarProviderKind(calendar);
+  if (provider && isAccountReconnectRequired(calendar.accountEmail, provider)) {
+    return true;
+  }
 
-  const connection = selectGoogleSyncConnections(
+  const connection = selectSyncConnections(
     useUserMetadataStore.getState(),
-  ).find((entry) => entry.accountEmail === calendar.accountEmail);
+  ).find(
+    (entry) =>
+      entry.accountEmail === calendar.accountEmail &&
+      (!provider || connectionProvider(entry) === provider),
+  );
   return isConnectionReconnectRequired(connection?.id);
 }

--- a/packages/web/src/auth/providers/reconnect.state.test.ts
+++ b/packages/web/src/auth/providers/reconnect.state.test.ts
@@ -2,10 +2,14 @@ import {
   clearAccountReconnectRequired,
   clearAllGoogleReconnectRequired,
   getGoogleReconnectRequiredAccountEmails,
+  getReconnectRequiredAccountKeys,
+  hasAnyReconnectRequired,
   hasGoogleReconnectRequired,
+  hasProviderReconnectRequired,
   isAccountReconnectRequired,
   isConnectionReconnectRequired,
   markAccountReconnectRequired,
+  reconnectAccountKey,
   resetGoogleReconnectRequiredForTests,
   syncReconnectRequiredFromConnections,
 } from "./reconnect.state";
@@ -16,28 +20,58 @@ afterEach(() => {
 });
 
 describe("google.reconnect.state", () => {
-  it("marks and queries reconnect-required by connection id and email", () => {
+  it("marks and queries reconnect-required by connection id and email+provider", () => {
     markAccountReconnectRequired({
       connectionId: "conn-1",
       accountEmail: "Lance@Example.com",
+      provider: "google",
     });
 
     expect(isConnectionReconnectRequired("conn-1")).toBe(true);
-    expect(isAccountReconnectRequired("lance@example.com")).toBe(true);
+    expect(isAccountReconnectRequired("lance@example.com", "google")).toBe(
+      true,
+    );
+    expect(isAccountReconnectRequired("lance@example.com", "microsoft")).toBe(
+      false,
+    );
+    expect(isAccountReconnectRequired("lance@example.com")).toBe(false);
     expect(hasGoogleReconnectRequired()).toBe(true);
     expect([...getGoogleReconnectRequiredAccountEmails()]).toEqual([
       "lance@example.com",
     ]);
+    expect([...getReconnectRequiredAccountKeys()]).toEqual([
+      reconnectAccountKey("google", "lance@example.com"),
+    ]);
+  });
+
+  it("does not treat a Microsoft reconnect as a Google reconnect for the same email", () => {
+    markAccountReconnectRequired({
+      connectionId: "ms-1",
+      accountEmail: "lance@example.com",
+      provider: "microsoft",
+    });
+
+    expect(isAccountReconnectRequired("lance@example.com", "microsoft")).toBe(
+      true,
+    );
+    expect(isAccountReconnectRequired("lance@example.com", "google")).toBe(
+      false,
+    );
+    expect(hasGoogleReconnectRequired()).toBe(false);
+    expect(hasProviderReconnectRequired("microsoft")).toBe(true);
+    expect(hasAnyReconnectRequired()).toBe(true);
   });
 
   it("adds RECONNECT_REQUIRED rows and drops overrides only when the account disappears", () => {
     markAccountReconnectRequired({
       connectionId: "stale",
       accountEmail: "gone@example.com",
+      provider: "google",
     });
     markAccountReconnectRequired({
       connectionId: "lagging",
       accountEmail: "lag@example.com",
+      provider: "google",
     });
 
     syncReconnectRequiredFromConnections([
@@ -45,43 +79,79 @@ describe("google.reconnect.state", () => {
         id: "healthy",
         accountEmail: "ok@example.com",
         connectionState: "HEALTHY",
+        provider: "google",
       },
       {
         id: "lagging",
         accountEmail: "lag@example.com",
         // Still healthy in metadata after a 410 — must not clear the override.
         connectionState: "HEALTHY",
+        provider: "google",
       },
       {
         id: "broken",
         accountEmail: "bad@example.com",
         connectionState: "RECONNECT_REQUIRED",
+        provider: "google",
       },
     ]);
 
     expect(isConnectionReconnectRequired("stale")).toBe(false);
-    expect(isAccountReconnectRequired("gone@example.com")).toBe(false);
+    expect(isAccountReconnectRequired("gone@example.com", "google")).toBe(
+      false,
+    );
     expect(isConnectionReconnectRequired("lagging")).toBe(true);
-    expect(isAccountReconnectRequired("lag@example.com")).toBe(true);
+    expect(isAccountReconnectRequired("lag@example.com", "google")).toBe(true);
     expect(isConnectionReconnectRequired("broken")).toBe(true);
-    expect(isAccountReconnectRequired("bad@example.com")).toBe(true);
+    expect(isAccountReconnectRequired("bad@example.com", "google")).toBe(true);
     expect(isConnectionReconnectRequired("healthy")).toBe(false);
+  });
+
+  it("clears one provider's override without clearing a sibling on the same email", () => {
+    markAccountReconnectRequired({
+      connectionId: "google-1",
+      accountEmail: "shared@example.com",
+      provider: "google",
+    });
+    markAccountReconnectRequired({
+      connectionId: "ms-1",
+      accountEmail: "shared@example.com",
+      provider: "microsoft",
+    });
+
+    clearAccountReconnectRequired({
+      connectionId: "google-1",
+      accountEmail: "shared@example.com",
+      provider: "google",
+    });
+
+    expect(isConnectionReconnectRequired("google-1")).toBe(false);
+    expect(isAccountReconnectRequired("shared@example.com", "google")).toBe(
+      false,
+    );
+    expect(isConnectionReconnectRequired("ms-1")).toBe(true);
+    expect(isAccountReconnectRequired("shared@example.com", "microsoft")).toBe(
+      true,
+    );
   });
 
   it("clearAccountReconnectRequired and clearAll remove overrides", () => {
     markAccountReconnectRequired({
       connectionId: "conn-1",
       accountEmail: "a@example.com",
+      provider: "google",
     });
     clearAccountReconnectRequired({
       connectionId: "conn-1",
       accountEmail: "a@example.com",
+      provider: "google",
     });
     expect(hasGoogleReconnectRequired()).toBe(false);
 
     markAccountReconnectRequired({
       connectionId: "conn-2",
       accountEmail: "b@example.com",
+      provider: "google",
     });
     clearAllGoogleReconnectRequired();
     expect(hasGoogleReconnectRequired()).toBe(false);

--- a/packages/web/src/auth/providers/reconnect.state.ts
+++ b/packages/web/src/auth/providers/reconnect.state.ts
@@ -1,21 +1,30 @@
 /**
- * Session-scoped reconnect-required overrides for Google accounts.
+ * Session-scoped reconnect-required overrides for connected accounts.
  *
  * Sync metadata can lag behind a live `410 GOOGLE_REVOKED` (or briefly report
  * healthy/catchingUp while credentials are already dead). This store keeps a
- * durable per-account truth so toast, sidebar, Settings, and write gates stay
+ * durable per-connection truth so toast, sidebar, Settings, and write gates stay
  * congruent until metadata catches up or the user reconnects.
+ *
+ * Email matches only with a provider: the same address can back both a Google
+ * and a Microsoft connection, and one broken grant must not pin the other.
  */
 
 import { useSyncExternalStore } from "react";
+import {
+  type ProviderKind,
+  ProviderKindSchema,
+} from "@core/types/sync/identity.contracts";
 
 export type GoogleReconnectTarget = {
   connectionId?: string | null;
   accountEmail?: string | null;
+  provider?: ProviderKind | null;
 };
 
 const reconnectRequiredConnectionIds = new Set<string>();
-const reconnectRequiredAccountEmails = new Set<string>();
+const reconnectRequiredAccounts = new Set<string>();
+const connectionProviders = new Map<string, ProviderKind>();
 const listeners = new Set<() => void>();
 let version = 0;
 
@@ -32,11 +41,34 @@ const normalizeEmail = (email: string | null | undefined): string | null => {
   return trimmed.length > 0 ? trimmed : null;
 };
 
+const parseProvider = (
+  provider: string | null | undefined,
+): ProviderKind | null => {
+  const parsed = ProviderKindSchema.safeParse(provider);
+  return parsed.success ? parsed.data : null;
+};
+
+const connectionProvider = (
+  provider: string | null | undefined,
+): ProviderKind => parseProvider(provider) ?? "google";
+
+export function reconnectAccountKey(
+  provider: ProviderKind,
+  email: string,
+): string {
+  return `${provider}:${email.trim().toLowerCase()}`;
+}
+
 const normalizeTarget = (
   target: GoogleReconnectTarget,
-): { connectionId: string | null; accountEmail: string | null } => ({
+): {
+  connectionId: string | null;
+  accountEmail: string | null;
+  provider: ProviderKind | null;
+} => ({
   connectionId: target.connectionId?.trim() || null,
   accountEmail: normalizeEmail(target.accountEmail),
+  provider: parseProvider(target.provider),
 });
 
 export function subscribeToGoogleReconnectRequired(
@@ -69,17 +101,26 @@ export function useGoogleReconnectRequiredVersion(): number {
 export function markAccountReconnectRequired(
   target: GoogleReconnectTarget,
 ): void {
-  const { connectionId, accountEmail } = normalizeTarget(target);
-  if (!connectionId && !accountEmail) return;
+  const { connectionId, accountEmail, provider } = normalizeTarget(target);
+  if (!connectionId && !(accountEmail && provider)) return;
 
   let changed = false;
   if (connectionId && !reconnectRequiredConnectionIds.has(connectionId)) {
     reconnectRequiredConnectionIds.add(connectionId);
     changed = true;
   }
-  if (accountEmail && !reconnectRequiredAccountEmails.has(accountEmail)) {
-    reconnectRequiredAccountEmails.add(accountEmail);
-    changed = true;
+  if (connectionId && provider) {
+    if (connectionProviders.get(connectionId) !== provider) {
+      connectionProviders.set(connectionId, provider);
+      changed = true;
+    }
+  }
+  if (accountEmail && provider) {
+    const key = reconnectAccountKey(provider, accountEmail);
+    if (!reconnectRequiredAccounts.has(key)) {
+      reconnectRequiredAccounts.add(key);
+      changed = true;
+    }
   }
   if (changed) notify();
 }
@@ -87,13 +128,20 @@ export function markAccountReconnectRequired(
 export function clearAccountReconnectRequired(
   target: GoogleReconnectTarget,
 ): void {
-  const { connectionId, accountEmail } = normalizeTarget(target);
+  const { connectionId, accountEmail, provider } = normalizeTarget(target);
   let changed = false;
   if (connectionId && reconnectRequiredConnectionIds.delete(connectionId)) {
+    connectionProviders.delete(connectionId);
     changed = true;
   }
-  if (accountEmail && reconnectRequiredAccountEmails.delete(accountEmail)) {
-    changed = true;
+  if (accountEmail && provider) {
+    if (
+      reconnectRequiredAccounts.delete(
+        reconnectAccountKey(provider, accountEmail),
+      )
+    ) {
+      changed = true;
+    }
   }
   if (changed) notify();
 }
@@ -101,12 +149,13 @@ export function clearAccountReconnectRequired(
 export function clearAllGoogleReconnectRequired(): void {
   if (
     reconnectRequiredConnectionIds.size === 0 &&
-    reconnectRequiredAccountEmails.size === 0
+    reconnectRequiredAccounts.size === 0
   ) {
     return;
   }
   reconnectRequiredConnectionIds.clear();
-  reconnectRequiredAccountEmails.clear();
+  reconnectRequiredAccounts.clear();
+  connectionProviders.clear();
   notify();
 }
 
@@ -117,48 +166,61 @@ export function clearAllGoogleReconnectRequired(): void {
  *
  * Do **not** clear an override just because metadata still reports healthy /
  * catchingUp — that lag is exactly why the session override exists after a
- * live `410 GOOGLE_REVOKED`. Successful reconnect uses a full navigation, which
- * drops this in-memory state; Disconnect removes the connection row.
+ * live `410 GOOGLE_REVOKED`. A confirmed OAuth `connected` round-trip clears
+ * the rows that completed; Disconnect removes the connection row.
  */
 export function syncReconnectRequiredFromConnections(
   connections: ReadonlyArray<{
     id: string;
     accountEmail: string | null;
     connectionState: string;
+    provider?: string | null;
   }>,
 ): void {
   const presentIds = new Set(connections.map((connection) => connection.id));
-  const presentEmails = new Set(
-    connections
-      .map((connection) => normalizeEmail(connection.accountEmail))
-      .filter((email): email is string => Boolean(email)),
-  );
+  const presentKeys = new Set<string>();
+  for (const connection of connections) {
+    const email = normalizeEmail(connection.accountEmail);
+    if (!email) continue;
+    presentKeys.add(
+      reconnectAccountKey(connectionProvider(connection.provider), email),
+    );
+  }
   let changed = false;
 
   for (const connection of connections) {
     if (connection.connectionState !== "RECONNECT_REQUIRED") continue;
+    const provider = connectionProvider(connection.provider);
 
     if (!reconnectRequiredConnectionIds.has(connection.id)) {
       reconnectRequiredConnectionIds.add(connection.id);
       changed = true;
     }
-    const email = normalizeEmail(connection.accountEmail);
-    if (email && !reconnectRequiredAccountEmails.has(email)) {
-      reconnectRequiredAccountEmails.add(email);
+    if (connectionProviders.get(connection.id) !== provider) {
+      connectionProviders.set(connection.id, provider);
       changed = true;
+    }
+    const email = normalizeEmail(connection.accountEmail);
+    if (email) {
+      const key = reconnectAccountKey(provider, email);
+      if (!reconnectRequiredAccounts.has(key)) {
+        reconnectRequiredAccounts.add(key);
+        changed = true;
+      }
     }
   }
 
   for (const connectionId of [...reconnectRequiredConnectionIds]) {
     if (!presentIds.has(connectionId)) {
       reconnectRequiredConnectionIds.delete(connectionId);
+      connectionProviders.delete(connectionId);
       changed = true;
     }
   }
 
-  for (const email of [...reconnectRequiredAccountEmails]) {
-    if (!presentEmails.has(email)) {
-      reconnectRequiredAccountEmails.delete(email);
+  for (const key of [...reconnectRequiredAccounts]) {
+    if (!presentKeys.has(key)) {
+      reconnectRequiredAccounts.delete(key);
       changed = true;
     }
   }
@@ -175,25 +237,57 @@ export function isConnectionReconnectRequired(
 
 export function isAccountReconnectRequired(
   accountEmail: string | null | undefined,
+  provider?: ProviderKind | null,
 ): boolean {
   const email = normalizeEmail(accountEmail);
-  return Boolean(email && reconnectRequiredAccountEmails.has(email));
+  const kind = parseProvider(provider);
+  if (!email || !kind) return false;
+  return reconnectRequiredAccounts.has(reconnectAccountKey(kind, email));
 }
 
+/** True when any Google connection or Google email+provider pair needs reconnect. */
 export function hasGoogleReconnectRequired(): boolean {
+  return hasProviderReconnectRequired("google");
+}
+
+export function hasProviderReconnectRequired(provider: ProviderKind): boolean {
+  for (const key of reconnectRequiredAccounts) {
+    if (key.startsWith(`${provider}:`)) return true;
+  }
+  for (const [connectionId, kind] of connectionProviders) {
+    if (kind === provider && reconnectRequiredConnectionIds.has(connectionId)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function hasAnyReconnectRequired(): boolean {
   return (
     reconnectRequiredConnectionIds.size > 0 ||
-    reconnectRequiredAccountEmails.size > 0
+    reconnectRequiredAccounts.size > 0
   );
 }
 
+/** `provider:email` keys for every session override that named an account. */
+export function getReconnectRequiredAccountKeys(): ReadonlySet<string> {
+  return reconnectRequiredAccounts;
+}
+
+/** @deprecated Prefer {@link getReconnectRequiredAccountKeys}. Google emails only. */
 export function getGoogleReconnectRequiredAccountEmails(): ReadonlySet<string> {
-  return reconnectRequiredAccountEmails;
+  const emails = new Set<string>();
+  for (const key of reconnectRequiredAccounts) {
+    if (!key.startsWith("google:")) continue;
+    emails.add(key.slice("google:".length));
+  }
+  return emails;
 }
 
 /** Test-only reset. */
 export function resetGoogleReconnectRequiredForTests(): void {
   reconnectRequiredConnectionIds.clear();
-  reconnectRequiredAccountEmails.clear();
+  reconnectRequiredAccounts.clear();
+  connectionProviders.clear();
   version = 0;
 }

--- a/packages/web/src/calendars/calendar.util.ts
+++ b/packages/web/src/calendars/calendar.util.ts
@@ -27,8 +27,9 @@ export interface GetWritableCalendarsOptions {
    */
   hasConnectedAccount?: boolean;
   /**
-   * Account emails that currently need Google reconnect. Their calendars stay
-   * visible on the grid as read-only but must not be offered as create targets.
+   * Account keys (`provider:email`) that currently need reconnect. Their
+   * calendars stay visible on the grid as read-only but must not be offered
+   * as create targets. Email-only values still match for older callers.
    * Defaults to the session reconnect-required set.
    */
   reconnectRequiredEmails?: ReadonlySet<string> | readonly string[];
@@ -48,9 +49,15 @@ const calendarNeedsReconnect = (
   reconnectRequiredEmails: ReadonlySet<string> | null,
 ): boolean => {
   if (!calendar.accountEmail) return false;
+  const email = calendar.accountEmail.toLowerCase();
+  const provider = calendarProviderKind(calendar);
   if (reconnectRequiredEmails) {
+    const keyed = provider
+      ? reconnectRequiredEmails.has(`${provider}:${email}`)
+      : false;
     return (
-      reconnectRequiredEmails.has(calendar.accountEmail.toLowerCase()) ||
+      keyed ||
+      reconnectRequiredEmails.has(email) ||
       isCalendarReconnectRequired(calendar)
     );
   }

--- a/packages/web/src/calendars/isEventReadOnly.test.ts
+++ b/packages/web/src/calendars/isEventReadOnly.test.ts
@@ -58,6 +58,7 @@ describe("isEventReadOnly", () => {
     markAccountReconnectRequired({
       connectionId: "conn-1",
       accountEmail: "lance@example.com",
+      provider: "google",
     });
     const lookup = buildCalendarLookup([calendar]);
 

--- a/packages/web/src/calendars/useDefaultTargetCalendar.ts
+++ b/packages/web/src/calendars/useDefaultTargetCalendar.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import {
-  getGoogleReconnectRequiredAccountEmails,
+  getReconnectRequiredAccountKeys,
   useGoogleReconnectRequiredVersion,
 } from "@web/auth/providers/reconnect.state";
 import {
@@ -30,7 +30,7 @@ export function useDefaultTargetCalendar(
   const preferredCalendarId = useDefaultCalendarId();
   const accountEmailOrder = useConnectedAccountEmails();
   useGoogleReconnectRequiredVersion();
-  const reconnectRequiredEmails = getGoogleReconnectRequiredAccountEmails();
+  const reconnectRequiredEmails = getReconnectRequiredAccountKeys();
 
   return getDefaultTargetCalendar(calendars, {
     preferredCalendarId,

--- a/packages/web/src/common/utils/toast/google-reconnect.toast.tsx
+++ b/packages/web/src/common/utils/toast/google-reconnect.toast.tsx
@@ -8,7 +8,10 @@ import {
   reconnectToastBody,
   reconnectToastTitle,
 } from "@web/auth/providers/provider-copy.util";
-import { type GoogleReconnectTarget } from "@web/auth/providers/reconnect.state";
+import {
+  type GoogleReconnectTarget,
+  isConnectionReconnectRequired,
+} from "@web/auth/providers/reconnect.state";
 import { useConnectProvider } from "@web/auth/providers/useConnectProvider";
 import {
   selectSyncConnections,
@@ -31,10 +34,6 @@ import { CONNECTION_BANNER_SHORTCUT_KEY } from "@web/shortcuts/notice-focus/useN
 
 let hasShownReconnectToastThisLoad = false;
 let lastReconnectTarget: GoogleReconnectTarget = {};
-
-/** True after any path has already raised the reconnect toast this page load. */
-export const hasShownGoogleReconnectToastThisLoad = (): boolean =>
-  hasShownReconnectToastThisLoad;
 
 export const clearGoogleReconnectToastGate = (): void => {
   hasShownReconnectToastThisLoad = false;
@@ -132,6 +131,7 @@ export function showGoogleReconnectToast(
       toastId: GOOGLE_REVOKED_TOAST_ID,
       accountEmail: target.accountEmail,
       connectionId: target.connectionId,
+      provider: target.provider ?? undefined,
     }),
     {
       toastId: GOOGLE_REVOKED_TOAST_ID,
@@ -158,4 +158,36 @@ export function flushDeferredGoogleReconnectToast(): void {
 
 export function dismissGoogleReconnectToast(): void {
   getToast().dismiss(GOOGLE_REVOKED_TOAST_ID);
+}
+
+/** Drop a live-410 toast once its target is no longer reconnect-required. */
+export function dismissGoogleReconnectToastIfRecovered(
+  connections: readonly SyncConnectionSummary[],
+): void {
+  const target = lastReconnectTarget;
+  if (!target.connectionId && !target.accountEmail) {
+    dismissGoogleReconnectToast();
+    clearGoogleReconnectToastGate();
+    return;
+  }
+
+  const targetStillBroken = connections.some((connection) => {
+    const matchesId =
+      Boolean(target.connectionId) && connection.id === target.connectionId;
+    const matchesAccount =
+      Boolean(target.accountEmail) &&
+      connection.accountEmail?.toLowerCase() ===
+        target.accountEmail?.toLowerCase() &&
+      (!target.provider || connectionProvider(connection) === target.provider);
+    if (!matchesId && !matchesAccount) return false;
+    return (
+      connection.connectionState === "RECONNECT_REQUIRED" ||
+      connection.state === "disconnected" ||
+      isConnectionReconnectRequired(connection.id)
+    );
+  });
+  if (targetStillBroken) return;
+
+  dismissGoogleReconnectToast();
+  clearGoogleReconnectToastGate();
 }

--- a/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.test.tsx
+++ b/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.test.tsx
@@ -65,6 +65,24 @@ describe("CalendarConnectionBanner", () => {
     );
   });
 
+  it("names the account when a reconnect banner has an email", () => {
+    const onAction = mock();
+    render(
+      <HotkeysProvider>
+        <CalendarConnectionBanner
+          kind="reconnect"
+          onAction={onAction}
+          provider="microsoft"
+          accountEmail="lance.essert@gmail.com"
+        />
+      </HotkeysProvider>,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "lance.essert@gmail.com needs reconnecting.",
+    );
+  });
+
   it("renders the consentRequired copy whole with a learn-more action", async () => {
     const onAction = mock();
     render(

--- a/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.tsx
+++ b/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBanner.tsx
@@ -36,17 +36,19 @@ interface CalendarConnectionBannerProps {
   kind: CalendarConnectionBannerKind;
   onAction: () => void;
   provider?: ProviderKind;
+  accountEmail?: string | null;
 }
 
 export const CalendarConnectionBanner: FC<CalendarConnectionBannerProps> = ({
   kind,
   onAction,
   provider = "google",
+  accountEmail,
 }) => {
   const { message, action } =
     kind === "reconnect"
       ? {
-          message: calendarReconnectBannerMessage(provider),
+          message: calendarReconnectBannerMessage(provider, accountEmail),
           action: "Reconnect",
         }
       : kind === "consentRequired"

--- a/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBannerGate.tsx
+++ b/packages/web/src/components/CalendarConnectionBanner/CalendarConnectionBannerGate.tsx
@@ -1,30 +1,31 @@
 import { type FC } from "react";
-import { getCalendarConnectionBannerKind } from "@web/auth/providers/connect.util";
+import { pickCalendarBannerTarget } from "@web/auth/providers/connect.util";
 import { connectionProviderKind } from "@web/auth/providers/connection-provider.util";
+import { useGoogleReconnectRequiredVersion } from "@web/auth/providers/reconnect.state";
 import { useConnectProvider } from "@web/auth/providers/useConnectProvider";
 import {
-  selectPrimaryGoogleSyncConnection,
+  selectSyncConnections,
   useUserMetadataStore,
 } from "@web/auth/state/user-metadata.store";
 import { CalendarConnectionBanner } from "@web/components/CalendarConnectionBanner/CalendarConnectionBanner";
 
 export const CalendarConnectionBannerGate: FC = () => {
-  const primaryConnection = useUserMetadataStore(
-    selectPrimaryGoogleSyncConnection,
-  );
-  const provider = connectionProviderKind(primaryConnection);
-  const { connect, connection, refresh, state } = useConnectProvider(
+  const connections = useUserMetadataStore(selectSyncConnections);
+  useGoogleReconnectRequiredVersion();
+  const target = pickCalendarBannerTarget(connections);
+  const provider = connectionProviderKind(target?.connection);
+  const { connect, refresh } = useConnectProvider(
     provider,
-    primaryConnection ? { connection: primaryConnection } : undefined,
+    target?.connection ? { connection: target.connection } : undefined,
   );
-  const kind = getCalendarConnectionBannerKind(state, connection);
-  if (!kind) return null;
+  if (!target) return null;
 
   return (
     <CalendarConnectionBanner
-      kind={kind}
-      onAction={kind === "reconnect" ? connect : () => refresh()}
-      provider={connectionProviderKind(connection)}
+      kind={target.kind}
+      onAction={target.kind === "reconnect" ? connect : () => refresh()}
+      provider={provider}
+      accountEmail={target.connection.accountEmail}
     />
   );
 };

--- a/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarStatusBar.test.tsx
@@ -269,7 +269,7 @@ describe("SidebarStatusBar", () => {
     );
   });
 
-  it("names the worse account when two connections disagree", () => {
+  it("keeps delayed copy in the footer when a sibling needs reconnect", () => {
     googleState = "RECONNECT_REQUIRED";
     const delayed = createMockConnection("work@example.com", {
       state: "delayed",
@@ -287,8 +287,26 @@ describe("SidebarStatusBar", () => {
     render(<SidebarStatusBar />, { wrapper });
 
     expect(screen.getByRole("status")).toHaveTextContent(
-      "home@example.com needs reconnecting",
+      "Calendar updates are delayed",
     );
+    expect(screen.queryByRole("status")).not.toHaveTextContent(
+      "needs reconnecting",
+    );
+  });
+
+  it("does not repeat reconnect copy in the footer", () => {
+    googleState = "RECONNECT_REQUIRED";
+    connection = createMockConnection("home@example.com", {
+      state: "actionRequired",
+      stateReason: "authorizationRevoked",
+      connectionState: "RECONNECT_REQUIRED",
+    });
+    seedSidebarConnections([connection], googleState);
+    const { wrapper } = createStoreWrapper();
+
+    render(<SidebarStatusBar />, { wrapper });
+
+    expect(screen.queryByText(/needs reconnecting/)).not.toBeInTheDocument();
   });
 
   it("shows Calendar updates are delayed for delayed workOverdue", () => {

--- a/packages/web/src/events/mutations/useEventMutations.ts
+++ b/packages/web/src/events/mutations/useEventMutations.ts
@@ -30,6 +30,7 @@ import { shiftSeriesScheduleByOccurrenceEdit } from "@core/util/event/shift-seri
 import { decodeOccurrenceId } from "@core/util/occurrence-id";
 import { getApiErrorCode, isApiError } from "@web/api/util/api.util";
 import { track } from "@web/auth/posthog/track";
+import { connectionProviderKind } from "@web/auth/providers/connection-provider.util";
 import { isCalendarReconnectRequired } from "@web/auth/providers/reconnect.calendar";
 import {
   selectGoogleSyncConnections,
@@ -536,10 +537,15 @@ export function useEventMutations(
 
       const connection = selectGoogleSyncConnections(
         useUserMetadataStore.getState(),
-      ).find((entry) => entry.accountEmail === calendar.accountEmail);
+      ).find(
+        (entry) =>
+          entry.accountEmail === calendar.accountEmail &&
+          connectionProviderKind(entry) === calendar.provider,
+      );
       showGoogleReconnectToast({
         connectionId: connection?.id,
         accountEmail: calendar.accountEmail,
+        provider: calendar.provider === "local" ? undefined : calendar.provider,
       });
       console.warn(
         `[useEventMutations] blocked write on reconnect-required calendar ${calendarId}`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Staging showed competing reconnect stories: a Google-only banner, OAuth URL toasts that fired before metadata, and an email-keyed session override that marked a healthy Google row reconnect-required when Microsoft used the same address. This change keys reconnect overrides by connection id and `provider:email`, drives one chrome banner from the highest-priority reconnect-required connection across providers, keeps the per-account sidebar Reconnect CTA, silences footer reconnect copy, refreshes metadata after OAuth before toasting (never success-toast while that row still needs reconnect or is already healthy/importing), and pins reconnect OAuth with `login_hint` plus a dedicated `accountMismatch` status.

## Verify

VERDICT: PASS

Checks run: test:sync, test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-222cafa6-e657-4ab1-9118-1145db9861ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-222cafa6-e657-4ab1-9118-1145db9861ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

