### PR TITLE
fix(ci): re-enter autofix on recurrence and failed runs

### DIFF
--- a/.github/prompts/error-autofix.md
+++ b/.github/prompts/error-autofix.md
@@ -1,8 +1,10 @@
 # Error autofix agent instructions
 
-You are triaging a GitHub issue that PostHog's error-tracking integration
-filed automatically (author `posthog[bot]`). Your job depends on the `Mode`
-you were given:
+You are triaging a GitHub issue that reached the error-autofix workflow.
+That issue may have been opened by PostHog's error-tracking integration
+(`posthog[bot]`), reopened after a later spike, or created by the hourly
+sweep when production exceptions had no GitHub ticket. Your job depends
+on the `Mode` you were given:
 
 - **triage** — investigate and report. Never open a PR.
 - **pr** — investigate, and for genuine code bugs open a fix PR. Never merge
@@ -14,6 +16,11 @@ you were given:
   when uncertain.
 
 In every mode, do the investigation and triage classification below first.
+
+Recurrence on an already-seen fingerprint is in scope. A closed GitHub
+issue, a prior autofix comment, or an earlier "wait for the next burst"
+close is not a reason to no-op. Treat the latest production events as a
+new wave.
 
 ## Step 1 — get the real error, not just the issue body
 
@@ -111,6 +118,12 @@ full picture. Specifically:
    the source issue automatically.
 7. Apply label `autofix` to the PR (this marks it as pipeline-authored and
    is required for the post-deploy verification step to find it later).
+8. Resolve the PostHog error-tracking issue so a later recurrence fires
+   `$error_tracking_issue_reopened` instead of silent volume on an `active`
+   issue. Use the PostHog MCP tool `error-tracking-issues-partial-update`
+   with `status: resolved` and the issue UUID from the GitHub body or from
+   `query-error-tracking-issue`. Do **not** resolve ops/transient or unknown
+   buckets. Do **not** suppress.
 
 ## Confidence rubric — when to add `automerge-candidate` (mode `merge` only)
 

--- a/.github/scripts/autofix-lib.sh
+++ b/.github/scripts/autofix-lib.sh
@@ -2,9 +2,57 @@
 # Shared helpers for the error-autofix scripts. Source, don't execute:
 #   SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 #   source "$SCRIPT_DIR/autofix-lib.sh"
-REPO=${GH_REPO:-$GITHUB_REPOSITORY}
+REPO=${GH_REPO:-${GITHUB_REPOSITORY:-}}
 AUTOFIX_SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 notify() {
   "$AUTOFIX_SCRIPT_DIR/discord-notify.sh" "$1" || true
+}
+
+# Best-effort: `gh issue edit --add-label` fails if the label does not exist
+# yet. Creating it is a no-op when it already does.
+ensure_label() {
+  local name=${1:?}
+  local color=${2:-B60205}
+  local description=${3:-}
+  gh label create "$name" --repo "$REPO" --color "$color" \
+    --description "$description" >/dev/null 2>&1 || true
+}
+
+# PostHog error-tracking issue ids look like UUIDs in GitHub issue bodies
+# (sweep writes "PostHog issue: <uuid>"; some alerts embed it in the URL).
+extract_posthog_issue_uuid() {
+  grep -oiE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' |
+    head -n1 || true
+}
+
+# After a code-bug GitHub issue is fixed, resolve the linked PostHog issue
+# so a later recurrence fires $error_tracking_issue_reopened instead of
+# silent volume on an active issue. Ops/unknown buckets never reach here.
+resolve_linked_posthog_issue() {
+  local number=$1
+  local key=${POSTHOG_PERSONAL_API_KEY:-}
+  local host=${POSTHOG_HOST:-https://us.posthog.com}
+  local project=${AUTOFIX_POSTHOG_PROJECT_ID:-165441}
+  if [ -z "$key" ]; then
+    printf 'POSTHOG_PERSONAL_API_KEY unset; skip resolving PostHog for #%s\n' "$number"
+    return 0
+  fi
+  local body uuid
+  body=$(gh issue view "$number" --repo "$REPO" --json body --jq '.body' 2>/dev/null)
+  uuid=$(printf '%s' "$body" | extract_posthog_issue_uuid)
+  if [ -z "$uuid" ]; then
+    printf 'no PostHog issue UUID in #%s body; skip resolve\n' "$number"
+    return 0
+  fi
+  curl -fsS -X PATCH \
+    -H "Authorization: Bearer ${key}" \
+    -H "Content-Type: application/json" \
+    -d '{"status":"resolved"}' \
+    "${host}/api/projects/${project}/error_tracking/issues/${uuid}/" \
+    >/dev/null || {
+    printf 'failed to resolve PostHog issue %s for GitHub #%s\n' "$uuid" "$number" >&2
+    return 1
+  }
+  printf 'resolved PostHog issue %s for GitHub #%s\n' "$uuid" "$number"
 }

--- a/.github/scripts/autofix-lib.test.sh
+++ b/.github/scripts/autofix-lib.test.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Local assertions for autofix-lib.sh helpers.
+# Run: bash .github/scripts/autofix-lib.test.sh
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+cd "$ROOT"
+
+PASS=0
+FAIL=0
+
+GH_REPO="example/compass"
+# shellcheck source=/dev/null
+source "${ROOT}/.github/scripts/autofix-lib.sh"
+
+assert_eq() {
+  local got=$1
+  local want=$2
+  local name=$3
+  if [ "$got" = "$want" ]; then
+    echo "ok ${name}"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL ${name}: wanted '${want}', got '${got}'" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+uuid=$(printf 'see https://us.posthog.com/project/165441/error_tracking/01a042b6-4e57-7611-9a1f-cdd9436e0ff2\n' |
+  extract_posthog_issue_uuid)
+assert_eq "$uuid" "01a042b6-4e57-7611-9a1f-cdd9436e0ff2" \
+  "extracts UUID from a PostHog error_tracking URL"
+
+uuid=$(printf 'PostHog issue: 01a02693-a9c0-72b0-b7f5-2ee68a0db95a\n' |
+  extract_posthog_issue_uuid)
+assert_eq "$uuid" "01a02693-a9c0-72b0-b7f5-2ee68a0db95a" \
+  "extracts UUID from sweep issue body"
+
+uuid=$(printf 'no identifier here\n' | extract_posthog_issue_uuid)
+assert_eq "$uuid" "" "empty when the body has no UUID"
+
+STUB_DIR=$(mktemp -d)
+CURL_LOG=$(mktemp)
+trap 'rm -rf "$STUB_DIR" "$CURL_LOG"' EXIT
+
+cat >"${STUB_DIR}/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "PostHog issue: 01a04156-2b7b-7580-90c0-05dc25299caa"
+STUB
+cat >"${STUB_DIR}/curl" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${AUTOFIX_TEST_CURL_LOG}"
+exit 0
+STUB
+chmod +x "${STUB_DIR}/gh" "${STUB_DIR}/curl"
+
+PATH="${STUB_DIR}:${PATH}" \
+  GH_REPO="example/compass" \
+  POSTHOG_PERSONAL_API_KEY="phx_test" \
+  AUTOFIX_TEST_CURL_LOG="$CURL_LOG" \
+  AUTOFIX_POSTHOG_PROJECT_ID="165441" \
+  POSTHOG_HOST="https://us.posthog.com" \
+  resolve_linked_posthog_issue 2899 >/dev/null
+
+if grep -Fq "error_tracking/issues/01a04156-2b7b-7580-90c0-05dc25299caa/" "$CURL_LOG"; then
+  echo "ok resolve PATCHes the PostHog issue"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL resolve did not PATCH the issue: $(cat "$CURL_LOG")" >&2
+  FAIL=$((FAIL + 1))
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "FAILED ${FAIL}  passed ${PASS}" >&2
+  exit 1
+fi
+echo "passed ${PASS}"

--- a/.github/scripts/autofix-postdeploy-notify.sh
+++ b/.github/scripts/autofix-postdeploy-notify.sh
@@ -44,6 +44,7 @@ main() {
     gh issue comment "$issue_number" --repo "$REPO" \
       --body "${tag} is live on staging via #${pr_number}. Production deploy: \`${prod_cmd}\`" \
       2>/dev/null || true
+    resolve_linked_posthog_issue "$issue_number" || true
   fi
 
   notify "Autofix release ${tag} verified on staging (PR #${pr_number}). Production deploy ready: \`${prod_cmd}\`"

--- a/.github/scripts/autofix-preflight.sh
+++ b/.github/scripts/autofix-preflight.sh
@@ -18,14 +18,47 @@ since_hours_ago() {
   date -u -d "${1} hours ago" +%Y-%m-%dT%H:%M:%SZ
 }
 
-already_labeled() {
+issue_labels() {
   gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json labels \
-    --jq '.labels[].name' | grep -qx 'autofix'
+    --jq '.labels[].name'
+}
+
+has_label() {
+  printf '%s\n' "$1" | grep -qx "$2"
+}
+
+issue_state() {
+  gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json state \
+    --jq '.state'
+}
+
+# A prior run that died before commenting or opening a PR leaves
+# autofix:failed (see autofix-unstick.sh). A GitHub reopen, the one-shot
+# automatic retry dispatch, or a closed issue the sweep is feeding back
+# in must not look "already handled" just because autofix is still on it.
+should_retry() {
+  local labels=$1
+  local state=$2
+  if has_label "$labels" 'autofix:failed'; then
+    return 0
+  fi
+  if [ "${GITHUB_EVENT_NAME:-}" = "issues" ] &&
+    [ "${GITHUB_EVENT_ACTION:-}" = "reopened" ]; then
+    return 0
+  fi
+  if [ "${AUTOFIX_RETRY_ATTEMPT:-0}" = "1" ]; then
+    return 0
+  fi
+  if [ "$state" = "CLOSED" ]; then
+    return 0
+  fi
+  return 1
 }
 
 # More than 3 posthog[bot] issues in 6h suggests a systemic incident (an
 # outage, a bad deploy) rather than N independent bugs — a human should
-# triage the incident, not N parallel agent runs.
+# triage the incident, not N parallel agent runs. The hourly sweep
+# retries these later because this path does not add the autofix label.
 too_many_recent_issues() {
   local since count
   since=$(since_hours_ago 6)
@@ -45,8 +78,20 @@ too_many_recent_merges() {
   [ "${count:-0}" -ge 2 ]
 }
 
+reopen_if_closed() {
+  local state=$1
+  if [ "$state" = "CLOSED" ]; then
+    gh issue reopen "$ISSUE_NUMBER" --repo "$REPO" >/dev/null
+    printf 'reopened closed issue #%s so autofix can comment\n' "$ISSUE_NUMBER"
+  fi
+}
+
 main() {
-  if already_labeled; then
+  local labels state
+  labels=$(issue_labels)
+  state=$(issue_state)
+
+  if has_label "$labels" 'autofix' && ! should_retry "$labels" "$state"; then
     printf 'issue #%s already has the autofix label; skipping\n' "$ISSUE_NUMBER"
     proceed false
     return 0
@@ -64,6 +109,11 @@ main() {
     return 0
   fi
 
+  reopen_if_closed "$state"
+  ensure_label autofix 5319E7 "Opened/handled by the error-autofix pipeline"
+  if has_label "$labels" 'autofix:failed'; then
+    gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --remove-label autofix:failed
+  fi
   gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label autofix
   proceed true
 }

--- a/.github/scripts/autofix-preflight.test.sh
+++ b/.github/scripts/autofix-preflight.test.sh
@@ -49,6 +49,8 @@ chmod +x "${STUB_DIR}/gh"
 run_preflight() {
   : >"$OUTPUT"
   : >"$GH_LOG"
+  # Do not inherit GITHUB_EVENT_* from the Actions runner: a pull_request
+  # job would otherwise make the reopen retry look like an opened event.
   PATH="${STUB_DIR}:${PATH}" \
     GITHUB_OUTPUT="$OUTPUT" \
     GH_REPO="example/compass" \
@@ -57,8 +59,8 @@ run_preflight() {
     AUTOFIX_TEST_STATE="${AUTOFIX_TEST_STATE:-OPEN}" \
     AUTOFIX_TEST_POSTHOG_COUNT="${AUTOFIX_TEST_POSTHOG_COUNT:-0}" \
     AUTOFIX_TEST_MERGED_COUNT="${AUTOFIX_TEST_MERGED_COUNT:-0}" \
-    GITHUB_EVENT_NAME="${GITHUB_EVENT_NAME:-issues}" \
-    GITHUB_EVENT_ACTION="${GITHUB_EVENT_ACTION:-opened}" \
+    GITHUB_EVENT_NAME="${AUTOFIX_TEST_EVENT_NAME:-issues}" \
+    GITHUB_EVENT_ACTION="${AUTOFIX_TEST_EVENT_ACTION:-opened}" \
     AUTOFIX_RETRY_ATTEMPT="${AUTOFIX_RETRY_ATTEMPT:-0}" \
     bash "${ROOT}/.github/scripts/autofix-preflight.sh" 42 >/dev/null
 }
@@ -114,10 +116,10 @@ assert_output "proceed=true" "autofix:failed is a retry"
 assert_gh_contains "--remove-label autofix:failed" x "retry clears the failed label"
 
 AUTOFIX_TEST_LABELS="autofix"
-GITHUB_EVENT_ACTION=reopened
+AUTOFIX_TEST_EVENT_ACTION=reopened
 run_preflight
 assert_output "proceed=true" "reopened event retries even with autofix"
-GITHUB_EVENT_ACTION=opened
+AUTOFIX_TEST_EVENT_ACTION=opened
 
 AUTOFIX_TEST_LABELS=""
 AUTOFIX_RETRY_ATTEMPT=1

--- a/.github/scripts/autofix-preflight.test.sh
+++ b/.github/scripts/autofix-preflight.test.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Local assertions for autofix-preflight.sh retry vs skip.
+# Run: bash .github/scripts/autofix-preflight.test.sh
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+cd "$ROOT"
+
+PASS=0
+FAIL=0
+
+STUB_DIR=$(mktemp -d)
+OUTPUT=$(mktemp)
+GH_LOG=$(mktemp)
+trap 'rm -rf "$STUB_DIR" "$OUTPUT" "$GH_LOG"' EXIT
+
+cat >"${STUB_DIR}/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${AUTOFIX_TEST_GH_LOG}"
+args="$*"
+if [[ "$args" == *"issue view"* && "$args" == *"--json labels"* ]]; then
+  printf '%s\n' "${AUTOFIX_TEST_LABELS:-}"
+  exit 0
+fi
+if [[ "$args" == *"issue view"* && "$args" == *"--json state"* ]]; then
+  printf '%s\n' "${AUTOFIX_TEST_STATE:-OPEN}"
+  exit 0
+fi
+if [[ "$args" == *"creator=posthog"* ]]; then
+  printf '%s\n' "${AUTOFIX_TEST_POSTHOG_COUNT:-0}"
+  exit 0
+fi
+if [[ "$args" == *"pr list"* ]]; then
+  printf '%s\n' "${AUTOFIX_TEST_MERGED_COUNT:-0}"
+  exit 0
+fi
+if [[ "$args" == *"label create"* ]]; then
+  exit 0
+fi
+if [[ "$args" == *"issue edit"* || "$args" == *"issue reopen"* ]]; then
+  exit 0
+fi
+printf 'unexpected gh invocation: %s\n' "$args" >&2
+exit 1
+STUB
+chmod +x "${STUB_DIR}/gh"
+
+run_preflight() {
+  : >"$OUTPUT"
+  : >"$GH_LOG"
+  PATH="${STUB_DIR}:${PATH}" \
+    GITHUB_OUTPUT="$OUTPUT" \
+    GH_REPO="example/compass" \
+    AUTOFIX_TEST_GH_LOG="$GH_LOG" \
+    AUTOFIX_TEST_LABELS="${AUTOFIX_TEST_LABELS-}" \
+    AUTOFIX_TEST_STATE="${AUTOFIX_TEST_STATE:-OPEN}" \
+    AUTOFIX_TEST_POSTHOG_COUNT="${AUTOFIX_TEST_POSTHOG_COUNT:-0}" \
+    AUTOFIX_TEST_MERGED_COUNT="${AUTOFIX_TEST_MERGED_COUNT:-0}" \
+    GITHUB_EVENT_NAME="${GITHUB_EVENT_NAME:-issues}" \
+    GITHUB_EVENT_ACTION="${GITHUB_EVENT_ACTION:-opened}" \
+    AUTOFIX_RETRY_ATTEMPT="${AUTOFIX_RETRY_ATTEMPT:-0}" \
+    bash "${ROOT}/.github/scripts/autofix-preflight.sh" 42 >/dev/null
+}
+
+assert_output() {
+  local want=$1
+  local name=$2
+  if grep -qx "$want" "$OUTPUT"; then
+    echo "ok ${name}"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL ${name}: wanted '${want}' in:$(cat "$OUTPUT")" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_gh_contains() {
+  local needle=$1
+  local name=$3
+  if grep -Fq -- "$needle" "$GH_LOG"; then
+    echo "ok ${name}"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL ${name}: missing '${needle}' in:$(cat "$GH_LOG")" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_gh_not_contains() {
+  local needle=$1
+  local name=$3
+  if grep -Fq -- "$needle" "$GH_LOG"; then
+    echo "FAIL ${name}: unexpectedly found '${needle}' in:$(cat "$GH_LOG")" >&2
+    FAIL=$((FAIL + 1))
+  else
+    echo "ok ${name}"
+    PASS=$((PASS + 1))
+  fi
+}
+
+AUTOFIX_TEST_LABELS=""
+run_preflight
+assert_output "proceed=true" "clean issue proceeds"
+assert_gh_contains "--add-label autofix" x "clean issue is labeled autofix"
+
+AUTOFIX_TEST_LABELS="autofix"
+run_preflight
+assert_output "proceed=false" "autofix label skips without retry"
+
+AUTOFIX_TEST_LABELS=$'autofix\nautofix:failed'
+run_preflight
+assert_output "proceed=true" "autofix:failed is a retry"
+assert_gh_contains "--remove-label autofix:failed" x "retry clears the failed label"
+
+AUTOFIX_TEST_LABELS="autofix"
+GITHUB_EVENT_ACTION=reopened
+run_preflight
+assert_output "proceed=true" "reopened event retries even with autofix"
+GITHUB_EVENT_ACTION=opened
+
+AUTOFIX_TEST_LABELS=""
+AUTOFIX_RETRY_ATTEMPT=1
+run_preflight
+assert_output "proceed=true" "automatic retry dispatch proceeds"
+AUTOFIX_RETRY_ATTEMPT=0
+
+AUTOFIX_TEST_LABELS=""
+AUTOFIX_TEST_STATE=CLOSED
+run_preflight
+assert_output "proceed=true" "closed issue proceeds after reopen"
+assert_gh_contains "issue reopen" x "closed issue is reopened"
+
+AUTOFIX_TEST_LABELS="autofix"
+AUTOFIX_TEST_STATE=CLOSED
+run_preflight
+assert_output "proceed=true" "closed issue with leftover autofix is a retry"
+assert_gh_contains "issue reopen" x "recurrence reopens the closed GitHub issue"
+AUTOFIX_TEST_STATE=OPEN
+AUTOFIX_TEST_LABELS=""
+
+AUTOFIX_TEST_LABELS="autofix"
+AUTOFIX_TEST_POSTHOG_COUNT=4
+run_preflight
+assert_output "proceed=false" "already-labeled skip happens before rate limit"
+
+AUTOFIX_TEST_LABELS=""
+AUTOFIX_TEST_POSTHOG_COUNT=4
+run_preflight
+assert_output "proceed=false" "more than 3 posthog issues in 6h pauses"
+assert_gh_not_contains "--add-label autofix" x "rate-limit skip does not add autofix"
+AUTOFIX_TEST_POSTHOG_COUNT=0
+
+AUTOFIX_TEST_MERGED_COUNT=2
+run_preflight
+assert_output "proceed=false" "2 autofix merges in 2h pauses"
+AUTOFIX_TEST_MERGED_COUNT=0
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "FAILED ${FAIL}  passed ${PASS}" >&2
+  exit 1
+fi
+echo "passed ${PASS}"

--- a/.github/scripts/autofix-sweep.sh
+++ b/.github/scripts/autofix-sweep.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# Hourly watchdog: find production PostHog exceptions that never got a
+# successful autofix run (no GitHub issue, closed issue whose fingerprint
+# fired again, or a stuck autofix:failed label) and feed them into the
+# existing error-autofix workflow via workflow_dispatch. No LLM here.
+set -uo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/autofix-lib.sh"
+
+POSTHOG_HOST=${POSTHOG_HOST:-https://us.posthog.com}
+POSTHOG_PROJECT_ID=${AUTOFIX_POSTHOG_PROJECT_ID:-165441}
+SWEEP_WINDOW_HOURS=${AUTOFIX_SWEEP_WINDOW_HOURS:-6}
+MAX_DISPATCHES=${AUTOFIX_SWEEP_MAX_DISPATCHES:-2}
+WORKFLOW_FILE=${AUTOFIX_WORKFLOW_FILE:-error-autofix.yml}
+DRY_RUN=${AUTOFIX_SWEEP_DRY_RUN:-0}
+
+# GitHub keeps one pending run per concurrency group. The autofix job uses a
+# single group, so a sweep that dispatched 3 would cancel the third. 2 =
+# one in flight + one queued. The next hour picks up the rest.
+IN_FLIGHT_MINUTES=${AUTOFIX_SWEEP_IN_FLIGHT_MINUTES:-90}
+
+log() {
+  printf '%s\n' "$*"
+}
+
+iso_to_epoch() {
+  date -u -d "$1" +%s 2>/dev/null || date -u -d "${1%.*}Z" +%s
+}
+
+now_epoch() {
+  date -u +%s
+}
+
+hogql_query() {
+  cat <<EOF
+SELECT
+  toString(properties.\$exception_issue_id) AS issue_id,
+  any(toString(properties.\$exception_fingerprint)) AS fingerprint,
+  any(toString(properties.\$exception_values)) AS message,
+  max(timestamp) AS last_seen,
+  count() AS occurrences
+FROM events
+WHERE event = '\$exception'
+  AND timestamp >= now() - INTERVAL ${SWEEP_WINDOW_HOURS} HOUR
+  AND (
+    properties.environment = 'production'
+    OR (
+      coalesce(toString(properties.environment), '') = ''
+      AND position(lower(coalesce(properties.\$host, '')), 'staging') = 0
+      AND position(lower(coalesce(properties.\$host, '')), 'localhost') = 0
+    )
+  )
+  AND notEmpty(toString(properties.\$exception_issue_id))
+GROUP BY issue_id
+ORDER BY last_seen DESC
+LIMIT 50
+EOF
+}
+
+fetch_exceptions() {
+  if [ -n "${AUTOFIX_SWEEP_FIXTURE:-}" ]; then
+    cat "$AUTOFIX_SWEEP_FIXTURE"
+    return 0
+  fi
+  if [ -z "${POSTHOG_PERSONAL_API_KEY:-}" ]; then
+    printf 'POSTHOG_PERSONAL_API_KEY unset; sweep cannot query PostHog\n' >&2
+    return 1
+  fi
+  local query json body
+  query=$(hogql_query)
+  json=$(jq -n --arg q "$query" '{query:{kind:"HogQLQuery",query:$q}}')
+  body=$(curl -fsS \
+    -H "Authorization: Bearer ${POSTHOG_PERSONAL_API_KEY}" \
+    -H "Content-Type: application/json" \
+    -d "$json" \
+    "${POSTHOG_HOST}/api/projects/${POSTHOG_PROJECT_ID}/query/")
+  jq -c '
+    (.results // .query.results // [])
+    | if length == 0 then [] else
+        if (.[0] | type) == "array" then
+          map({
+            issue_id: .[0],
+            fingerprint: .[1],
+            message: .[2],
+            last_seen: .[3],
+            occurrences: .[4]
+          })
+        else . end
+      end
+    | .[]
+  ' <<<"$body"
+}
+
+title_from_message() {
+  local raw=$1
+  printf '%s' "$raw" | tr '\n' ' ' | cut -c1-80
+}
+
+search_github_issue() {
+  local query=$1
+  [ -n "$query" ] || return 0
+  gh issue list --repo "$REPO" --state all --limit 5 \
+    --search "${query} in:body" \
+    --json number,state,closedAt,labels,updatedAt \
+    --jq '.[0] // empty'
+}
+
+# PostHog-created GitHub issues put the fingerprint in the body URL, not
+# always the issue UUID. Try UUID first, then fingerprint.
+find_github_issue() {
+  local issue_id=$1
+  local fingerprint=$2
+  local found
+  found=$(search_github_issue "$issue_id")
+  if [ -n "$found" ]; then
+    printf '%s' "$found"
+    return 0
+  fi
+  search_github_issue "$fingerprint"
+}
+
+last_bot_comment_at() {
+  local number=$1
+  gh api "repos/${REPO}/issues/${number}/comments?per_page=100" \
+    --jq '[.[] | select(.user.login == "claude" or .user.login == "claude[bot]" or .user.login == "github-actions[bot]")] | max_by(.created_at) | .created_at // empty' \
+    2>/dev/null
+}
+
+label_names() {
+  printf '%s' "$1" | jq -r '.labels[].name // empty'
+}
+
+issue_has_label() {
+  printf '%s\n' "$1" | grep -qx "$2"
+}
+
+dispatch() {
+  local number=$1
+  if [ "$DRY_RUN" = "1" ]; then
+    log "dispatch ${number}"
+    return 0
+  fi
+  gh workflow run "$WORKFLOW_FILE" --repo "$REPO" \
+    --field "issue_number=${number}"
+}
+
+create_issue() {
+  local issue_id=$1
+  local fingerprint=$2
+  local message=$3
+  local title body url created
+  title=$(title_from_message "$message")
+  if [ -z "$title" ]; then
+    title="Error"
+  fi
+  if [ -n "$fingerprint" ] && [ "$fingerprint" != "null" ]; then
+    url="${POSTHOG_HOST}/project/${POSTHOG_PROJECT_ID}/error_tracking/fingerprint/${fingerprint}"
+  else
+    url="${POSTHOG_HOST}/project/${POSTHOG_PROJECT_ID}/error_tracking/${issue_id}"
+  fi
+  body=$(printf '%s\n\n[View in PostHog](%s)\n\nPostHog issue: %s\n' \
+    "$message" "$url" "$issue_id")
+  if [ "$DRY_RUN" = "1" ]; then
+    printf '0\n'
+    return 0
+  fi
+  created=$(gh issue create --repo "$REPO" --title "$title" --body "$body")
+  printf '%s\n' "${created##*/}"
+}
+
+needs_dispatch() {
+  local last_seen=$1
+  local gh_issue=$2
+  local labels last_seen_epoch closed_epoch comment_at comment_epoch updated_at updated_epoch
+
+  if [ -z "$gh_issue" ]; then
+    printf 'create\n'
+    return 0
+  fi
+
+  labels=$(label_names "$gh_issue")
+  last_seen_epoch=$(iso_to_epoch "$last_seen")
+
+  local state
+  state=$(printf '%s' "$gh_issue" | jq -r '.state')
+  if [ "$state" = "CLOSED" ] || [ "$state" = "closed" ]; then
+    local closed_at
+    closed_at=$(printf '%s' "$gh_issue" | jq -r '.closedAt // empty')
+    if [ -z "$closed_at" ]; then
+      printf 'skip-closed-no-timestamp\n'
+      return 1
+    fi
+    closed_epoch=$(iso_to_epoch "$closed_at")
+    if [ "$last_seen_epoch" -gt "$closed_epoch" ]; then
+      printf 'recurrence\n'
+      return 0
+    fi
+    printf 'skip-still-quiet\n'
+    return 1
+  fi
+
+  if issue_has_label "$labels" 'autofix:failed'; then
+    printf 'failed\n'
+    return 0
+  fi
+
+  if issue_has_label "$labels" 'autofix'; then
+    local number
+    number=$(printf '%s' "$gh_issue" | jq -r '.number')
+    comment_at=$(last_bot_comment_at "$number")
+    if [ -n "$comment_at" ]; then
+      comment_epoch=$(iso_to_epoch "$comment_at")
+      if [ "$last_seen_epoch" -le "$comment_epoch" ]; then
+        printf 'skip-handled\n'
+        return 1
+      fi
+      printf 'recurrence-open\n'
+      return 0
+    fi
+    updated_at=$(printf '%s' "$gh_issue" | jq -r '.updatedAt // empty')
+    if [ -n "$updated_at" ]; then
+      updated_epoch=$(iso_to_epoch "$updated_at")
+      if [ $(($(now_epoch) - updated_epoch)) -lt $((IN_FLIGHT_MINUTES * 60)) ]; then
+        printf 'skip-in-flight\n'
+        return 1
+      fi
+    fi
+    printf 'stuck-no-comment\n'
+    return 0
+  fi
+
+  printf 'unlabeled\n'
+  return 0
+}
+
+main() {
+  local dispatched=0
+  local row issue_id fingerprint message last_seen gh_issue reason number
+  local rows
+  rows=$(mktemp)
+  if ! fetch_exceptions >"$rows"; then
+    notify "Error autofix sweep could not query PostHog"
+    rm -f "$rows"
+    return 1
+  fi
+
+  while IFS= read -r row; do
+    [ -n "$row" ] || continue
+    if [ "$dispatched" -ge "$MAX_DISPATCHES" ]; then
+      log "cap reached (${MAX_DISPATCHES}); remaining wait for the next sweep"
+      break
+    fi
+    issue_id=$(printf '%s' "$row" | jq -r '.issue_id')
+    fingerprint=$(printf '%s' "$row" | jq -r '.fingerprint // empty')
+    message=$(printf '%s' "$row" | jq -r '.message // "Error"')
+    last_seen=$(printf '%s' "$row" | jq -r '.last_seen')
+    gh_issue=$(find_github_issue "$issue_id" "$fingerprint")
+    if ! reason=$(needs_dispatch "$last_seen" "$gh_issue"); then
+      log "skip ${issue_id} (${reason})"
+      continue
+    fi
+    if [ -z "$gh_issue" ]; then
+      number=$(create_issue "$issue_id" "$fingerprint" "$message")
+    else
+      number=$(printf '%s' "$gh_issue" | jq -r '.number')
+    fi
+    if [ -z "$number" ] || [ "$number" = "null" ]; then
+      log "skip ${issue_id} (no GitHub issue number)"
+      continue
+    fi
+    log "${reason} #${number} (${issue_id})"
+    if dispatch "$number"; then
+      dispatched=$((dispatched + 1))
+    else
+      notify "Error autofix sweep could not dispatch #${number} for PostHog ${issue_id}"
+    fi
+  done <"$rows"
+  rm -f "$rows"
+
+  if [ "$dispatched" -gt 0 ]; then
+    notify "Error autofix sweep dispatched ${dispatched} issue(s) for a fresh run"
+  fi
+}
+
+main

--- a/.github/scripts/autofix-sweep.test.sh
+++ b/.github/scripts/autofix-sweep.test.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Local assertions for autofix-sweep.sh.
+# Run: bash .github/scripts/autofix-sweep.test.sh
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+cd "$ROOT"
+
+PASS=0
+FAIL=0
+
+STUB_DIR=$(mktemp -d)
+OUT=$(mktemp)
+GH_LOG=$(mktemp)
+FIXTURE=$(mktemp)
+trap 'rm -rf "$STUB_DIR" "$OUT" "$GH_LOG" "$FIXTURE"' EXIT
+
+cat >"${STUB_DIR}/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${AUTOFIX_TEST_GH_LOG}"
+args="$*"
+if [[ "$args" == *"issue list"* ]]; then
+  id=""
+  if [[ "$args" =~ ([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}) ]]; then
+    id="${BASH_REMATCH[1]}"
+  else
+    for token in "$@"; do
+      case "$token" in
+        *in:body*) id="${token%% *}" ;;
+      esac
+    done
+  fi
+  printf '%s' "${AUTOFIX_TEST_ISSUES:-"{}"}" | jq -c --arg id "$id" '.[$id] // empty'
+  exit 0
+fi
+if [[ "$args" == *"issues/"*"/comments"* ]]; then
+  printf '%s\n' "${AUTOFIX_TEST_COMMENT_AT:-}"
+  exit 0
+fi
+if [[ "$args" == *"workflow run"* || "$args" == *"issue create"* ]]; then
+  if [[ "$args" == *"issue create"* ]]; then
+    printf 'https://github.com/example/compass/issues/99\n'
+  fi
+  exit 0
+fi
+printf 'unexpected gh invocation: %s\n' "$args" >&2
+exit 1
+STUB
+chmod +x "${STUB_DIR}/gh"
+
+row() {
+  jq -nc --arg id "$1" --arg seen "$2" --arg msg "$3" --arg fp "${4:-fp}" \
+    '{issue_id:$id,fingerprint:$fp,message:$msg,last_seen:$seen,occurrences:1}'
+}
+
+run_sweep() {
+  : >"$GH_LOG"
+  PATH="${STUB_DIR}:${PATH}" \
+    GH_REPO="example/compass" \
+    AUTOFIX_TEST_GH_LOG="$GH_LOG" \
+    AUTOFIX_TEST_ISSUES="${AUTOFIX_TEST_ISSUES:-"{}"}" \
+    AUTOFIX_TEST_COMMENT_AT="${AUTOFIX_TEST_COMMENT_AT:-}" \
+    AUTOFIX_SWEEP_FIXTURE="$FIXTURE" \
+    AUTOFIX_SWEEP_DRY_RUN=1 \
+    AUTOFIX_SWEEP_MAX_DISPATCHES="${AUTOFIX_SWEEP_MAX_DISPATCHES:-2}" \
+    AUTOFIX_SWEEP_IN_FLIGHT_MINUTES=90 \
+    bash "${ROOT}/.github/scripts/autofix-sweep.sh" >"$OUT"
+}
+
+assert_out_contains() {
+  local needle=$1
+  local name=$2
+  if grep -Fq -- "$needle" "$OUT"; then
+    echo "ok ${name}"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL ${name}: missing '${needle}' in:$(cat "$OUT")" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_out_not_contains() {
+  local needle=$1
+  local name=$2
+  if grep -Fq -- "$needle" "$OUT"; then
+    echo "FAIL ${name}: unexpectedly found '${needle}' in:$(cat "$OUT")" >&2
+    FAIL=$((FAIL + 1))
+  else
+    echo "ok ${name}"
+    PASS=$((PASS + 1))
+  fi
+}
+
+ISSUE_A="01a042b6-4e57-7611-9a1f-cdd9436e0ff2"
+ISSUE_B="01a04156-2b7b-7580-90c0-05dc25299caa"
+ISSUE_C="01a02693-a9c0-72b0-b7f5-2ee68a0db95a"
+
+# No GitHub issue: create + dispatch.
+row "$ISSUE_A" "2026-09-11T12:00:00Z" "PROVIDER_FAILURE" >"$FIXTURE"
+AUTOFIX_TEST_ISSUES='{}'
+run_sweep
+assert_out_contains "create #0 (${ISSUE_A})" "missing GitHub issue is created and dispatched"
+
+# Closed after last_seen: skip.
+cat >"$FIXTURE" <<EOF
+$(row "$ISSUE_A" "2026-09-01T00:00:00Z" "PROVIDER_FAILURE")
+EOF
+AUTOFIX_TEST_ISSUES=$(jq -n --arg id "$ISSUE_A" '{
+  ($id): {number: 2901, state:"CLOSED", closedAt:"2026-09-10T00:00:00Z", labels:[], updatedAt:"2026-09-10T00:00:00Z"}
+}')
+run_sweep
+assert_out_contains "skip ${ISSUE_A} (skip-still-quiet)" "closed issue with no later event is skipped"
+
+# Closed before last_seen: recurrence dispatch.
+cat >"$FIXTURE" <<EOF
+$(row "$ISSUE_A" "2026-09-11T12:00:00Z" "PROVIDER_FAILURE")
+EOF
+AUTOFIX_TEST_ISSUES=$(jq -n --arg id "$ISSUE_A" '{
+  ($id): {number: 2901, state:"CLOSED", closedAt:"2026-09-08T00:00:00Z", labels:[{name:"autofix"}], updatedAt:"2026-09-10T00:00:00Z"}
+}')
+run_sweep
+assert_out_contains "recurrence #2901 (${ISSUE_A})" "closed issue with a later event is dispatched"
+
+# Open with autofix:failed: dispatch.
+AUTOFIX_TEST_ISSUES=$(jq -n --arg id "$ISSUE_A" '{
+  ($id): {number: 3369, state:"OPEN", closedAt:null, labels:[{name:"autofix:failed"}], updatedAt:"2026-09-05T00:00:00Z"}
+}')
+run_sweep
+assert_out_contains "failed #3369 (${ISSUE_A})" "autofix:failed is dispatched"
+
+# Open, handled after last_seen: skip.
+AUTOFIX_TEST_COMMENT_AT="2026-09-11T18:00:00Z"
+AUTOFIX_TEST_ISSUES=$(jq -n --arg id "$ISSUE_A" '{
+  ($id): {number: 3449, state:"OPEN", closedAt:null, labels:[{name:"autofix"}], updatedAt:"2026-09-11T18:00:00Z"}
+}')
+run_sweep
+assert_out_contains "skip ${ISSUE_A} (skip-handled)" "handled wave is not re-dispatched"
+AUTOFIX_TEST_COMMENT_AT=""
+
+# Cap: two create rows, third waits.
+{
+  row "$ISSUE_A" "2026-09-11T12:00:00Z" "a"
+  row "$ISSUE_B" "2026-09-11T12:01:00Z" "b"
+  row "$ISSUE_C" "2026-09-11T12:02:00Z" "c"
+} >"$FIXTURE"
+AUTOFIX_TEST_ISSUES='{}'
+AUTOFIX_SWEEP_MAX_DISPATCHES=2
+run_sweep
+assert_out_contains "cap reached (2)" "sweep stops at the pending-run cap"
+assert_out_contains "create #0 (${ISSUE_A})" "first uncapped row dispatches"
+assert_out_contains "create #0 (${ISSUE_B})" "second uncapped row dispatches"
+assert_out_not_contains "${ISSUE_C})" "third row is left for the next hour"
+
+# Fingerprint in the GitHub body, UUID not present: still a match.
+FP="deadbeeffingerprint"
+row "$ISSUE_A" "2026-09-11T12:00:00Z" "UnhandledRejection" "$FP" >"$FIXTURE"
+AUTOFIX_TEST_ISSUES=$(jq -n --arg id "$FP" '{
+  ($id): {number: 2829, state:"CLOSED", closedAt:"2026-08-01T00:00:00Z", labels:[], updatedAt:"2026-08-01T00:00:00Z"}
+}')
+run_sweep
+assert_out_contains "recurrence #2829 (${ISSUE_A})" "fingerprint-only GitHub body still matches"
+
+# Open unlabeled issue: dispatch.
+row "$ISSUE_A" "2026-09-11T12:00:00Z" "PROVIDER_FAILURE" >"$FIXTURE"
+AUTOFIX_TEST_ISSUES=$(jq -n --arg id "$ISSUE_A" '{
+  ($id): {number: 2912, state:"OPEN", closedAt:null, labels:[], updatedAt:"2026-09-10T00:00:00Z"}
+}')
+run_sweep
+assert_out_contains "unlabeled #2912 (${ISSUE_A})" "unlabeled open issue is dispatched"
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "FAILED ${FAIL}  passed ${PASS}" >&2
+  exit 1
+fi
+echo "passed ${PASS}"

--- a/.github/scripts/autofix-unstick.sh
+++ b/.github/scripts/autofix-unstick.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Called when the autofix agent step fails. A failed run used to leave the
+# autofix label on the issue, which made preflight treat it as handled, and
+# there was no Discord page. Unstick so the hourly sweep or one automatic
+# retry can take another pass.
+set -uo pipefail
+
+ISSUE_NUMBER=${1:?usage: autofix-unstick.sh <issue-number>}
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/autofix-lib.sh"
+
+WORKFLOW_FILE=${AUTOFIX_WORKFLOW_FILE:-error-autofix.yml}
+RUN_URL=${GITHUB_RUN_URL:-https://github.com/${REPO}/issues/${ISSUE_NUMBER}}
+
+comment_and_label() {
+  local extra=$1
+  ensure_label autofix:failed B60205 \
+    "Autofix agent run failed; eligible for retry"
+  gh issue edit "$ISSUE_NUMBER" --repo "$REPO" \
+    --remove-label autofix --add-label autofix:failed
+  gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
+    --body "Autofix agent failed before finishing triage. ${extra} Run: ${RUN_URL}"
+}
+
+dispatch_retry() {
+  gh workflow run "$WORKFLOW_FILE" --repo "$REPO" \
+    --field "issue_number=${ISSUE_NUMBER}" \
+    --field "retry=true"
+}
+
+main() {
+  if [ "${AUTOFIX_RETRY_ATTEMPT:-0}" = "1" ]; then
+    ensure_label "autofix:needs-human" B60205 \
+      "Autofix agent could not confidently auto-resolve or auto-fix this"
+    gh issue edit "$ISSUE_NUMBER" --repo "$REPO" \
+      --remove-label autofix --add-label autofix:failed \
+      --add-label "autofix:needs-human"
+    gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
+      --body "Autofix agent failed on the automatic retry as well. Leaving autofix:needs-human. Run: ${RUN_URL}"
+    notify "Error autofix failed twice on #${ISSUE_NUMBER}; needs a human look. ${RUN_URL}"
+    return 0
+  fi
+
+  comment_and_label "Dispatching one automatic retry with a fresh workflow snapshot. That retry logs the full agent error."
+  if dispatch_retry; then
+    notify "Error autofix failed on #${ISSUE_NUMBER}; retrying once. ${RUN_URL}"
+  else
+    notify "Error autofix failed on #${ISSUE_NUMBER} and could not dispatch a retry. Needs a human look. ${RUN_URL}"
+  fi
+}
+
+main

--- a/.github/scripts/autofix-unstick.test.sh
+++ b/.github/scripts/autofix-unstick.test.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Local assertions for autofix-unstick.sh.
+# Run: bash .github/scripts/autofix-unstick.test.sh
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+cd "$ROOT"
+
+PASS=0
+FAIL=0
+
+STUB_DIR=$(mktemp -d)
+GH_LOG=$(mktemp)
+trap 'rm -rf "$STUB_DIR" "$GH_LOG"' EXIT
+
+cat >"${STUB_DIR}/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${AUTOFIX_TEST_GH_LOG}"
+exit 0
+STUB
+chmod +x "${STUB_DIR}/gh"
+
+run_unstick() {
+  : >"$GH_LOG"
+  PATH="${STUB_DIR}:${PATH}" \
+    GH_REPO="example/compass" \
+    AUTOFIX_TEST_GH_LOG="$GH_LOG" \
+    AUTOFIX_RETRY_ATTEMPT="${AUTOFIX_RETRY_ATTEMPT:-0}" \
+    GITHUB_RUN_URL="https://example.test/run/1" \
+    bash "${ROOT}/.github/scripts/autofix-unstick.sh" 42 >/dev/null
+}
+
+assert_gh_contains() {
+  local needle=$1
+  local name=$2
+  if grep -Fq -- "$needle" "$GH_LOG"; then
+    echo "ok ${name}"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL ${name}: missing '${needle}' in:$(cat "$GH_LOG")" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_gh_not_contains() {
+  local needle=$1
+  local name=$2
+  if grep -Fq -- "$needle" "$GH_LOG"; then
+    echo "FAIL ${name}: unexpectedly found '${needle}' in:$(cat "$GH_LOG")" >&2
+    FAIL=$((FAIL + 1))
+  else
+    echo "ok ${name}"
+    PASS=$((PASS + 1))
+  fi
+}
+
+AUTOFIX_RETRY_ATTEMPT=0
+run_unstick
+assert_gh_contains "--remove-label autofix" "first failure removes autofix"
+assert_gh_contains "--add-label autofix:failed" "first failure adds failed"
+assert_gh_contains "issue comment" "first failure comments"
+assert_gh_contains "workflow run" "first failure dispatches a retry"
+assert_gh_contains "retry=true" "retry dispatch sets retry=true"
+assert_gh_not_contains "autofix:needs-human" "first failure does not yet need a human"
+
+AUTOFIX_RETRY_ATTEMPT=1
+run_unstick
+assert_gh_contains "autofix:needs-human" "second failure flags needs-human"
+assert_gh_not_contains "workflow run" "second failure does not dispatch again"
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "FAILED ${FAIL}  passed ${PASS}" >&2
+  exit 1
+fi
+echo "passed ${PASS}"

--- a/.github/workflows/error-autofix-postdeploy.yml
+++ b/.github/workflows/error-autofix-postdeploy.yml
@@ -28,6 +28,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           DISCORD_ERRORS_WEBHOOK_URL: ${{ secrets.DISCORD_ERRORS_WEBHOOK_URL }}
+          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         run: .github/scripts/autofix-postdeploy-notify.sh

--- a/.github/workflows/error-autofix.yml
+++ b/.github/workflows/error-autofix.yml
@@ -1,9 +1,9 @@
 name: Error autofix
 
 # Reacts to GitHub issues that PostHog's error-tracking integration files
-# automatically (author posthog[bot]). See .github/prompts/error-autofix.md
-# for the agent's triage/fix/confidence rubric, and
-# docs/CI-CD (or the compass-calendar-internal plan) for the rollout phases.
+# automatically (author posthog[bot]), plus an hourly sweep that feeds
+# production recurrences back into this same agent. See
+# .github/prompts/error-autofix.md and docs/CI-CD/error-autofix-routine.md.
 #
 # Kill switch: repo variable ERROR_AUTOFIX_ENABLED (default false/unset).
 # Mode: repo variable AUTOFIX_MODE — triage | pr | merge.
@@ -13,42 +13,89 @@ name: Error autofix
 #           the deterministic gate below agrees.
 # Manual re-runs: "Re-run jobs" on a failed run reuses the workflow file
 # snapshot from that run, so fixes to this file never apply — dispatch a
-# fresh run instead, passing the PostHog issue number. Remove the issue's
-# autofix label first or preflight will skip it as already handled.
+# fresh run instead, passing the PostHog issue number. A failed agent run
+# now unsticks the autofix label and retries once on its own.
 on:
   issues:
-    types: [opened]
+    types: [opened, reopened]
+  schedule:
+    # Offset from the agent-loop hourly job so the two watchdogs do not
+    # stampede the same minute.
+    - cron: "17 * * * *"
   workflow_dispatch:
     inputs:
       issue_number:
-        description: "PostHog error issue number to (re-)run the autofix flow for"
-        required: true
+        description: "GitHub issue number to (re-)run the autofix flow for. Leave blank to run the production sweep."
+        required: false
         type: string
-
-concurrency:
-  group: error-autofix
-  cancel-in-progress: false
+      retry:
+        description: "Set by the automatic one-shot retry after an agent failure"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
-  autofix:
-    # workflow_dispatch skips the posthog[bot] author check: dispatching
-    # already requires write access, and the operator names the issue.
+  sweep:
     if: >-
       vars.ERROR_AUTOFIX_ENABLED == 'true' &&
-      (github.event_name == 'workflow_dispatch' ||
-       github.event.issue.user.login == 'posthog[bot]')
+      (github.event_name == 'schedule' ||
+       (github.event_name == 'workflow_dispatch' &&
+        inputs.issue_number == ''))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      actions: write
+    concurrency:
+      group: error-autofix-sweep
+      cancel-in-progress: true
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Sweep production exceptions into autofix
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DISCORD_ERRORS_WEBHOOK_URL: ${{ secrets.DISCORD_ERRORS_WEBHOOK_URL }}
+          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+        run: .github/scripts/autofix-sweep.sh
+
+  autofix:
+    # workflow_dispatch skips the posthog[bot] author check: dispatching
+    # already requires write access, and the operator (or sweep) names the
+    # issue. Reopened issues may be sweep-created; those carry an autofix*
+    # label instead of a posthog[bot] author.
+    if: >-
+      vars.ERROR_AUTOFIX_ENABLED == 'true' &&
+      (
+        (github.event_name == 'workflow_dispatch' &&
+         inputs.issue_number != '') ||
+        (github.event_name == 'issues' &&
+         github.event.action == 'opened' &&
+         github.event.issue.user.login == 'posthog[bot]') ||
+        (github.event_name == 'issues' &&
+         github.event.action == 'reopened' &&
+         (github.event.issue.user.login == 'posthog[bot]' ||
+          contains(join(github.event.issue.labels.*.name, ','), 'autofix')))
+      )
     env:
       ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+      AUTOFIX_RETRY_ATTEMPT: ${{ github.event_name == 'workflow_dispatch' && inputs.retry && '1' || '0' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
       contents: write
       pull-requests: write
       issues: write
+      actions: write
       # Required by claude-code-action's OIDC exchange: with no github_token
       # passed (see below), it authenticates via the runner's OIDC token to
       # mint the Claude GitHub App installation token.
       id-token: write
+    concurrency:
+      group: error-autofix
+      cancel-in-progress: false
     outputs:
       proceed: ${{ steps.preflight.outputs.proceed }}
     steps:
@@ -62,6 +109,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           DISCORD_ERRORS_WEBHOOK_URL: ${{ secrets.DISCORD_ERRORS_WEBHOOK_URL }}
+          AUTOFIX_RETRY_ATTEMPT: ${{ env.AUTOFIX_RETRY_ATTEMPT }}
         run: .github/scripts/autofix-preflight.sh "${ISSUE_NUMBER}"
 
       - name: Write PostHog MCP config
@@ -77,6 +125,7 @@ jobs:
       # agent-opened PR would sit with zero checks and never satisfy the
       # required-status-checks gate added in Phase 3.
       - name: Run autofix agent
+        id: agent
         if: steps.preflight.outputs.proceed == 'true'
         uses: anthropics/claude-code-action@v1
         with:
@@ -88,7 +137,8 @@ jobs:
           # reports API-level failures (an expired token, exhausted quota)
           # as a bare `is_error: true` with no cause, which is undebuggable
           # without the real message. An operator dispatching by hand already
-          # has write access, so those runs get the full output.
+          # has write access, so those runs get the full output. The
+          # automatic retry is also a workflow_dispatch, so it is unredacted.
           show_full_output: ${{ github.event_name == 'workflow_dispatch' }}
           prompt: |
             Read .github/prompts/error-autofix.md and follow it exactly.
@@ -99,9 +149,20 @@ jobs:
             --allowedTools "Bash,Read,Write,Edit,Glob,Grep,mcp__posthog__*"
             --mcp-config ${{ runner.temp }}/posthog-mcp.json
 
+      - name: Unstick failed agent
+        if: failure() && steps.agent.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DISCORD_ERRORS_WEBHOOK_URL: ${{ secrets.DISCORD_ERRORS_WEBHOOK_URL }}
+          GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: .github/scripts/autofix-unstick.sh "${ISSUE_NUMBER}"
+
   gate-and-merge:
     needs: autofix
-    if: vars.AUTOFIX_MODE == 'merge' && needs.autofix.outputs.proceed == 'true'
+    if: >-
+      vars.AUTOFIX_MODE == 'merge' &&
+      needs.autofix.result == 'success' &&
+      needs.autofix.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -125,6 +125,10 @@ jobs:
           bash .github/scripts/agent-loop-next.test.sh
           bash .github/scripts/agent-loop-merge-guard.test.sh
           bash .github/scripts/detect-code-changes.test.sh
+          bash .github/scripts/autofix-preflight.test.sh
+          bash .github/scripts/autofix-unstick.test.sh
+          bash .github/scripts/autofix-sweep.test.sh
+          bash .github/scripts/autofix-lib.test.sh
 
   # A skipped MATRIX job collapses to one check run, so the `unit` rollup
   # below would see `skipped` for a docs-only PR only if every leg started.

--- a/docs/CI-CD/error-autofix-routine.md
+++ b/docs/CI-CD/error-autofix-routine.md
@@ -6,12 +6,12 @@ not flip them.
 
 ```text
 ROUTINE: error-autofix
-TRIGGER: issues opened by posthog[bot] | workflow_dispatch
+TRIGGER: issues opened|reopened by posthog[bot] (or autofix* on reopen) | hourly sweep | workflow_dispatch
 INPUT: GitHub issue + PostHog fingerprint
 SKILL/PROMPT: .github/prompts/error-autofix.md
 OUTPUT: issue comment and/or PR with Fixes #<n>
-IDEMPOTENCY: one PR per issue; preflight skips labeled/already-handled
-RETRY: dispatch a fresh run (do not “Re-run jobs” on a failed snapshot)
+IDEMPOTENCY: one PR per issue; preflight skips labeled/already-handled unless retry
+RETRY: one automatic workflow_dispatch after agent failure; then autofix:needs-human
 APPROVAL: AUTOFIX_MODE=triage|pr|merge; automerge-candidate + merge-guard
 STOP: repo var ERROR_AUTOFIX_ENABLED
 HEARTBEAT: Discord via existing notify scripts on skip/fail/needs-human
@@ -22,18 +22,35 @@ Sources of truth:
 
 | Concern | File |
 | --- | --- |
-| Trigger, concurrency, kill switch, mode | `.github/workflows/error-autofix.yml` |
-| Post-deploy Discord/GitHub follow-up | `.github/workflows/error-autofix-postdeploy.yml` |
+| Trigger, concurrency, kill switch, mode, sweep job | `.github/workflows/error-autofix.yml` |
+| Post-deploy Discord/GitHub follow-up + PostHog resolve | `.github/workflows/error-autofix-postdeploy.yml` |
 | Agent instructions | `.github/prompts/error-autofix.md` |
 | Preflight (cheap stop before the LLM) | `.github/scripts/autofix-preflight.sh` |
+| Failed-run unstick + one-shot retry | `.github/scripts/autofix-unstick.sh` |
+| Hourly production sweep (no LLM) | `.github/scripts/autofix-sweep.sh` |
 | Merge-guard Verifier (size) | `.github/scripts/autofix-merge-guard.sh` |
 | Shared notify helpers | `.github/scripts/autofix-lib.sh` |
+
+PostHog (project 165441) GitHub HogFunctions that feed this workflow:
+
+| Alert | Event | Id |
+| --- | --- | --- |
+| GitHub issue on issue created | `$error_tracking_issue_created` | `019f8174-8b63-0000-3bad-4c5eaf55c745` |
+| GitHub issue on issue reopened | `$error_tracking_issue_reopened` | `01a08de7-18cf-0000-3f87-9c79f828d2ef` |
+| GitHub issue on issue spiking | `$error_tracking_issue_spiking` | `01a08de7-1ab3-0000-ee95-397a959285ae` |
+
+Those templates **create** a GitHub issue (same as the original created
+alert). Recurrence on an issue that is still `active` in PostHog does not
+emit `reopened`; the hourly sweep is the backstop for that case. After a
+successful code-bug fix, the agent and post-deploy path resolve the PostHog
+issue so the next burst becomes `reopened`.
 
 ## Stop switch and mode
 
 - `ERROR_AUTOFIX_ENABLED` must be the string `true` or the workflow does
   not run. Flip it in GitHub → Settings → Variables. Turning it off does
-  not delete existing comments, PRs, or labels.
+  not delete existing comments, PRs, or labels. The sweep job uses the
+  same kill switch.
 - `AUTOFIX_MODE`:
   - `triage` — comment only, no PR
   - `pr` — may open a PR; a human merges
@@ -41,22 +58,53 @@ Sources of truth:
     is the Verifier and may strip that label / add `autofix:needs-human`
     when the size rails fail.
 - Production deploy is never automatic. Staging-only PostHog errors must
-  never receive `automerge-candidate`.
+  never receive `automerge-candidate`. The sweep queries production
+  exceptions only.
 
 ## Idempotency
 
 Key: **GitHub issue number** (plus the PostHog fingerprint in the issue
 body for humans). Preflight skips if the issue already has the `autofix`
-label. The prompt forbids a second PR that also says `Fixes #<n>`.
-`concurrency.group: error-autofix` with `cancel-in-progress: false` means
-a second issue **waits**, it does not cancel the first run.
+label **unless** this is a retry: `autofix:failed`, `issues.reopened`,
+`workflow_dispatch` with `retry=true`, or a closed issue the sweep is
+feeding back in. The prompt forbids a second PR that also says
+`Fixes #<n>`. `concurrency.group: error-autofix` with
+`cancel-in-progress: false` means a second issue **waits**, it does not
+cancel the first run. The sweep uses its own group and caps dispatches at
+2 (in flight + one queued).
+
+Rate-limit pauses (`too_many_recent_issues`, `too_many_recent_merges`)
+notify Discord and **do not** add the `autofix` label, so the next sweep
+can pick the issue up again.
 
 ## Retry
 
 Do not use “Re-run jobs” on a failed Autofix run — that reuses the
-workflow file snapshot from the failed attempt. Dispatch a **fresh** run
-(`workflow_dispatch` with the issue number) after removing the `autofix`
-label if preflight would skip it as already handled.
+workflow file snapshot from the failed attempt. On agent failure the
+unstick step comments, Discord-notifies, removes `autofix`, adds
+`autofix:failed`, and dispatches **one** fresh `workflow_dispatch` with
+`retry=true` (full agent output). A second failure adds
+`autofix:needs-human` and stops. Operators can still dispatch a fresh run
+after that.
+
+## Sweep
+
+`.github/scripts/autofix-sweep.sh` runs hourly (`17 * * * *`) and on
+`workflow_dispatch` with a blank issue number. It is a dispatcher, not a
+second agent:
+
+1. Query production `$exception` events in the last 6 hours, grouped by
+   `$exception_issue_id`.
+2. Find a GitHub issue whose body contains that UUID or fingerprint.
+3. Dispatch this same workflow when any of: no GitHub issue, GitHub
+   closed and `last_seen` is after `closedAt`, `autofix:failed`, unlabeled,
+   or last successful bot comment is older than `last_seen`.
+4. If there is no GitHub issue, open one as the Actions bot and
+   `workflow_dispatch` (GITHUB_TOKEN-created issues do not trigger
+   `issues.opened` workflows).
+
+Cap: `AUTOFIX_SWEEP_MAX_DISPATCHES` (default 2). Remaining rows wait for
+the next hour.
 
 ## Drills (documented, not run)
 
@@ -65,13 +113,16 @@ staging drill.
 
 | Drill | Expected evidence |
 | --- | --- |
-| Kill switch off | Workflow `if:` skips; no agent job |
+| Kill switch off | Workflow `if:` skips; no agent job and no sweep |
 | Missing PostHog fingerprint / MCP empty | Bucket **unknown / insufficient signal**; issue comment; `autofix:needs-human`; **no PR** |
 | Duplicate open for the same issue | Preflight skip and/or prompt “one PR per issue”; **no second PR** |
 | Second issue while a run is in flight | Queued behind `concurrency.group: error-autofix`; first run not cancelled |
 | Staging-only error | No `automerge-candidate` |
 | Merge-guard size fail | Same downgrade if files &gt; `MAX_FILES=8` or lines &gt; `MAX_LINES=250` in that script |
 | `workflow_dispatch` triage on a safe issue | Comment only; mode unchanged |
+| Failed agent run | Discord; issue comment with run URL; `autofix` removed; `autofix:failed`; one automatic retry; second failure → `autofix:needs-human` |
+| Production recurrence on a closed GitHub issue | Sweep or reopen/spike GitHub alert; preflight reopens; fresh agent run; not skipped as already labeled |
+| Sweep with no GitHub issue | Actions bot opens an issue; `workflow_dispatch`; agent runs |
 
 ## Recovery packet
 
@@ -80,9 +131,9 @@ workflow.
 
 ```text
 task_id: <GitHub issue number>
-last_successful_action: <preflight skip | comment | PR opened | merge-guard downgrade>
+last_successful_action: <preflight skip | comment | PR opened | merge-guard downgrade | unstick retry>
 writes_after_that_point: <files, labels, comments, Discord>
-external_state: <issue labels, open PRs with Fixes #<n>, Discord message>
+external_state: <issue labels, open PRs with Fixes #<n>, Discord message, PostHog issue status>
 rollback: <close stray PR, remove automerge-candidate, leave evidence>
 human_decision: <re-dispatch | leave | revert>
 ```

--- a/docs/CI-CD/workflows.md
+++ b/docs/CI-CD/workflows.md
@@ -8,7 +8,7 @@ Compass uses GitHub Actions for continuous integration, Docker Hub for image dis
 | E2E (`test-e2e.yml`) | Push / PR / merge_group to `main` | Playwright e2e in four shards behind one required `e2e` gate (PRs that touch only docs, or only `packages/backend`, `packages/sync`, `packages/scripts`, skip the shards; merge queue and `main` always run them) |
 | CodeQL | Push / PR to `main` | Static security analysis |
 | Performance budget | Push to `main` (web/core/lock/budget), nightly schedule, `workflow_dispatch`; PR only when `.github/perf/**` or the workflow file changes | Lighthouse budget (not a required merge check). Desktop script transfer is calibrated to 1,060 KB as of 2026-09-07 (main measured 1,034,338 bytes). |
-| Error autofix (`error-autofix.yml`) | `posthog[bot]` issue / `workflow_dispatch` | Governed Routine: triage or fix PostHog error issues |
+| Error autofix (`error-autofix.yml`) | `posthog[bot]` issue opened/reopened, hourly sweep, `workflow_dispatch` | Governed Routine: triage or fix PostHog error issues; sweep re-enters missed recurrences |
 | Error autofix post-deploy (`error-autofix-postdeploy.yml`) | `Release on main` completed | Notifies Discord/GitHub of autofix release outcome |
 | Agent review (`agent-review.yml`) | `workflow_dispatch` only (parked). Kill switch `AGENT_REVIEW_ENABLED` still in the job `if:`. Restore `pull_request` types to turn it on. | Independent read-only diff review posted as a PR comment (not a required check) |
 | Agent loop (`agent-loop.yml`) | `workflow_dispatch` / hourly cron / `agent-automerge` labeled or merged; `Release on main` smokes only | Governed Routine: next milestone WP → Cursor API → merge-guard → merge queue → staging smoke |

--- a/packages/scripts/src/testing/error-autofix-routine.test.ts
+++ b/packages/scripts/src/testing/error-autofix-routine.test.ts
@@ -66,6 +66,44 @@ describe("error-autofix Routine contract", () => {
     expect(prompt).not.toContain(".agents/handoffs");
   });
 
+  it("re-enters the loop on recurrence, failed runs, and the sweep", () => {
+    const workflow = readFileSync(
+      ".github/workflows/error-autofix.yml",
+      "utf8",
+    );
+    expect(workflow).toContain("types: [opened, reopened]");
+    expect(workflow).toContain('cron: "17 * * * *"');
+    expect(workflow).toContain("Sweep production exceptions into autofix");
+    expect(workflow).toContain("autofix-sweep.sh");
+    expect(workflow).toContain("autofix-unstick.sh");
+    expect(workflow).toContain("failure() && steps.agent.outcome == 'failure'");
+    expect(workflow).toContain("needs.autofix.result == 'success'");
+    expect(existsSync(".github/scripts/autofix-sweep.sh")).toBe(true);
+    expect(existsSync(".github/scripts/autofix-unstick.sh")).toBe(true);
+
+    const unit = readFileSync(".github/workflows/test-unit.yml", "utf8");
+    expect(unit).toContain("bash .github/scripts/autofix-preflight.test.sh");
+    expect(unit).toContain("bash .github/scripts/autofix-unstick.test.sh");
+    expect(unit).toContain("bash .github/scripts/autofix-sweep.test.sh");
+    expect(unit).toContain("bash .github/scripts/autofix-lib.test.sh");
+
+    const prompt = readFileSync(".github/prompts/error-autofix.md", "utf8");
+    expect(prompt).toContain("Recurrence on an already-seen fingerprint");
+    expect(prompt).toContain("error-tracking-issues-partial-update");
+    expect(prompt).toContain("Do **not** resolve ops/transient or unknown");
+
+    const postdeploy = readFileSync(
+      ".github/scripts/autofix-postdeploy-notify.sh",
+      "utf8",
+    );
+    expect(postdeploy).toContain("resolve_linked_posthog_issue");
+
+    const routine = readFileSync("docs/CI-CD/error-autofix-routine.md", "utf8");
+    expect(routine).toContain("Failed agent run");
+    expect(routine).toContain("Production recurrence on a closed GitHub issue");
+    expect(routine).toContain("Sweep with no GitHub issue");
+  });
+
   it("keeps the autofix prompt aligned with PostHog error property constants", () => {
     const prompt = readFileSync(".github/prompts/error-autofix.md", "utf8");
     expect(prompt).toContain(POSTHOG_ERROR_TRACKING_CONSTANTS_PATH);

--- a/packages/scripts/src/testing/error-autofix-routine.test.ts
+++ b/packages/scripts/src/testing/error-autofix-routine.test.ts
@@ -87,6 +87,16 @@ describe("error-autofix Routine contract", () => {
     expect(unit).toContain("bash .github/scripts/autofix-sweep.test.sh");
     expect(unit).toContain("bash .github/scripts/autofix-lib.test.sh");
 
+    const preflightTest = readFileSync(
+      ".github/scripts/autofix-preflight.test.sh",
+      "utf8",
+    );
+    expect(preflightTest).toContain("AUTOFIX_TEST_EVENT_NAME");
+    expect(preflightTest).toContain("AUTOFIX_TEST_EVENT_ACTION");
+    expect(preflightTest).not.toContain(
+      'GITHUB_EVENT_NAME="${GITHUB_EVENT_NAME:-issues}"',
+    );
+
     const prompt = readFileSync(".github/prompts/error-autofix.md", "utf8");
     expect(prompt).toContain("Recurrence on an already-seen fingerprint");
     expect(prompt).toContain("error-tracking-issues-partial-update");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

Production exceptions were captured in PostHog but never re-entered autofix unless PostHog opened a brand-new GitHub issue. Failed agent runs left the `autofix` label on, so later dispatches skipped, and there was no Discord or retry.

This keeps the existing error-autofix agent as the only fixer and adds intake:

- On agent failure: Discord, issue comment, remove `autofix`, add `autofix:failed`, and one `workflow_dispatch` retry. A second failure adds `autofix:needs-human`.
- Preflight retries on `autofix:failed`, `issues.reopened`, `retry=true`, or a closed GitHub issue the sweep is feeding back in. Rate-limit pauses still skip labeling so the next sweep can retry.
- Hourly sweep (same kill switch) queries production `$exception`s and dispatches this workflow when there is no GitHub issue, a closed issue with a later `last_seen`, or a stuck/failed run. Cap is 2 so we do not overflow the single pending-run concurrency slot.
- After a code-bug fix, the agent and post-deploy path resolve the PostHog issue so recurrence becomes `$error_tracking_issue_reopened`. GitHub HogFunctions now exist for reopen and spiking as well as created.

## Verify

VERDICT: PASS
Checks run: test:scripts:fast, type-check, lint, knip
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e2ffb89d-9ee8-4360-aa96-33a4c1d818f2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2ffb89d-9ee8-4360-aa96-33a4c1d818f2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

