### PR TITLE
fix(test): type sync fixtures part two

### DIFF
--- a/packages/sync/src/__tests__/helpers/command-scenario.ts
+++ b/packages/sync/src/__tests__/helpers/command-scenario.ts
@@ -1,7 +1,7 @@
 import { faker } from "@faker-js/faker";
+import { type EventId } from "@core/types/domain-primitives";
 import {
   type ConnectionId,
-  type EventId,
   type IdempotencyKey,
   type PrincipalId,
   type TenantId,
@@ -11,6 +11,10 @@ import {
   TEST_CREDENTIAL_ENCRYPTION_KEY,
 } from "@sync/__tests__/helpers/credential-encryption";
 import { seedProviderCalendar } from "@sync/__tests__/helpers/fixtures";
+import { type SyncExecutionMode } from "@sync/config/sync.config";
+import { type CredentialCustody } from "@sync/credentials/credential-custody.service";
+import { type CloudCommandDeps } from "@sync/domain/cloud-command.service";
+import { type ProviderConnectionLookup } from "@sync/domain/provider-command.service";
 import { type AccessTokenSource } from "@sync/domain/provider-write-ladder";
 import {
   type ProviderAuthAdapter,
@@ -155,10 +159,85 @@ export async function seedLinkedEvent(
   return event;
 }
 
+export const stubConnectionLookup = (
+  email = "user@example.com",
+): ProviderConnectionLookup => ({
+  findById: async () => ({
+    account: { email },
+    provider: "google",
+  }),
+});
+
+export const fakeCredentialCustody = (): CredentialCustody =>
+  ({
+    getValidAccessToken: async () => "access-token",
+    discardRevoked: async () => {},
+    invalidateAccessToken: async () => {},
+  }) as unknown as CredentialCustody;
+
+export const cloudCommandDeps = (
+  repoSlice: Pick<
+    CommandRepos,
+    | "commands"
+    | "events"
+    | "calendars"
+    | "occurrences"
+    | "resources"
+    | "markers"
+  >,
+  options: {
+    execution?: SyncExecutionMode;
+    connections?: ProviderConnectionLookup;
+    provider?: CloudCommandDeps["provider"];
+  } = {},
+): CloudCommandDeps => ({
+  ...repoSlice,
+  connections: options.connections ?? stubConnectionLookup(),
+  execution: options.execution ?? "active",
+  provider: options.provider,
+});
+
 export const tokenSource = (token = "access-token"): AccessTokenSource => ({
   getValidAccessToken: async () => token,
   discardRevoked: async () => {},
   invalidateAccessToken: async () => {},
+});
+
+export type ProviderCommandRepos = Pick<
+  CommandRepos,
+  "commands" | "events" | "occurrences" | "resources" | "markers"
+>;
+
+export const providerMutationDeps = (
+  repoSlice: Pick<
+    CommandRepos,
+    "commands" | "events" | "occurrences" | "resources"
+  >,
+  writer: ProviderEventWriter,
+  options: {
+    custody?: AccessTokenSource;
+    connections?: ProviderConnectionLookup;
+  } = {},
+) => ({
+  commands: repoSlice.commands,
+  events: repoSlice.events,
+  occurrences: repoSlice.occurrences,
+  resources: repoSlice.resources,
+  connections: options.connections ?? stubConnectionLookup(),
+  writer,
+  custody: options.custody ?? tokenSource(),
+});
+
+export const providerDeleteDeps = (
+  repos: ProviderCommandRepos,
+  writer: ProviderEventWriter,
+  options: {
+    custody?: AccessTokenSource;
+    connections?: ProviderConnectionLookup;
+  } = {},
+) => ({
+  ...providerMutationDeps(repos, writer, options),
+  markers: repos.markers,
 });
 
 export const failingTokenSource = (error: unknown): AccessTokenSource => ({

--- a/packages/sync/src/__tests__/helpers/fixtures.ts
+++ b/packages/sync/src/__tests__/helpers/fixtures.ts
@@ -1,8 +1,14 @@
 import { faker } from "@faker-js/faker";
+import { type DateTime, type TimeZone } from "@core/types/domain-primitives";
+import {
+  type ProviderCalendarSourceId,
+  type ProviderEventId,
+} from "@core/types/sync/identity.contracts";
 import {
   type ProviderAdapters,
   type ResolveProviderAdapters,
 } from "@sync/providers/provider-adapters";
+import { type ProviderAuthAdapter } from "@sync/providers/provider-auth.port";
 import {
   type ProviderEvent,
   type ProviderEventRead,
@@ -12,12 +18,18 @@ import {
   type ProviderEventReader,
   type ProviderEventReadInput,
 } from "@sync/providers/provider-event-reader.port";
+import { type ProviderNotificationAdapter } from "@sync/providers/provider-notifications.port";
 import { type ProviderCalendarRecord } from "@sync/storage/contracts/provider-calendar.contracts";
 import { type SyncResourceRecord } from "@sync/storage/contracts/sync-resource.contracts";
 import { type ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
 import { type SyncResourceRepository } from "@sync/storage/repositories/sync-resource.repository";
 
 const objectId = () => faker.database.mongodbObjectId();
+
+export const defaultCalendarListFields = {
+  eventLabels: [] as const,
+  createsGoogleMeet: true as const,
+};
 
 type CalendarUpsertInput = Parameters<
   ProviderCalendarRepository["upsertByProviderCalendar"]
@@ -34,7 +46,7 @@ export const seedProviderCalendar = (
     tenantId: objectId() as ProviderCalendarRecord["tenantId"],
     principalId: objectId() as ProviderCalendarRecord["principalId"],
     connectionId: objectId() as ProviderCalendarRecord["connectionId"],
-    providerCalendarId: "primary@google.com",
+    providerCalendarId: "primary@google.com" as ProviderCalendarSourceId,
     displayName: "Google",
     color: null,
     active: true,
@@ -46,6 +58,8 @@ export const seedProviderCalendar = (
       canReadBusy: true,
       canInviteAttendees: true,
     },
+    eventLabels: [],
+    createsGoogleMeet: true,
     ...overrides,
   });
 
@@ -104,15 +118,15 @@ export const ensureEventsResource = async (
 // The timed schedule most db tests give their scripted provider events.
 export const TIMED_SCHEDULE = {
   kind: "timed" as const,
-  start: "2026-07-14T09:00:00-06:00",
-  end: "2026-07-14T10:00:00-06:00",
-  timeZone: "America/Denver",
+  start: "2026-07-14T09:00:00-06:00" as DateTime,
+  end: "2026-07-14T10:00:00-06:00" as DateTime,
+  timeZone: "America/Denver" as TimeZone,
 };
 
 // One single (non-recurring) provider event, ready for a scripted page.
 export const singleEvent = (id: string, title = id): ProviderEvent => ({
   kind: "event",
-  providerEventId: id,
+  providerEventId: id as ProviderEventId,
   providerVersion: `etag-${id}`,
   providerUpdatedAt: null,
   content: {
@@ -182,10 +196,17 @@ export const fakeTokenSource = {
   invalidateAccessToken: async () => {},
 };
 
-const noopAuthAdapter = {
+const noopAuthAdapter: ProviderAuthAdapter = {
+  buildAuthorizationUrl: () => {
+    throw new Error("noopAuthAdapter: buildAuthorizationUrl not scripted");
+  },
+  exchangeAuthorizationCode: async () => {
+    throw new Error("noopAuthAdapter: exchangeAuthorizationCode not scripted");
+  },
   refreshAccessToken: async () => ({
     accessToken: "access-token",
     expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+    grantedScopes: [],
   }),
   revoke: async () => {},
 };
@@ -206,13 +227,14 @@ const noopWriter = {
   },
 };
 
-const noopNotifications = {
-  watch: async (input: { channelId: string }) => ({
+const noopNotifications: ProviderNotificationAdapter = {
+  watch: async (input) => ({
     channelId: input.channelId,
     resourceId: "provider-resource",
     expiresAt: new Date("2099-01-01T00:00:00.000Z"),
   }),
   stopChannel: async () => {},
+  parseNotification: () => null,
 };
 
 const noopDiscovery = {

--- a/packages/sync/src/__tests__/helpers/fixtures.ts
+++ b/packages/sync/src/__tests__/helpers/fixtures.ts
@@ -26,11 +26,6 @@ import { type SyncResourceRepository } from "@sync/storage/repositories/sync-res
 
 const objectId = () => faker.database.mongodbObjectId();
 
-export const defaultCalendarListFields = {
-  eventLabels: [] as const,
-  createsGoogleMeet: true as const,
-};
-
 type CalendarUpsertInput = Parameters<
   ProviderCalendarRepository["upsertByProviderCalendar"]
 >[0];

--- a/packages/sync/src/__tests__/helpers/fixtures.ts
+++ b/packages/sync/src/__tests__/helpers/fixtures.ts
@@ -26,6 +26,11 @@ import { type SyncResourceRepository } from "@sync/storage/repositories/sync-res
 
 const objectId = () => faker.database.mongodbObjectId();
 
+export const defaultCalendarListFields = {
+  eventLabels: [] as const,
+  createsGoogleMeet: true as const,
+};
+
 type CalendarUpsertInput = Parameters<
   ProviderCalendarRepository["upsertByProviderCalendar"]
 >[0];

--- a/packages/sync/src/__tests__/helpers/mongo-id.ts
+++ b/packages/sync/src/__tests__/helpers/mongo-id.ts
@@ -1,0 +1,8 @@
+import { type Document, type Filter, ObjectId } from "mongodb";
+
+/** Compass ids are ObjectId-shaped strings; Mongo filters use BSON ObjectId. */
+export const mongoObjectId = (id: string): ObjectId => new ObjectId(id);
+
+/** Collections that persist `_id` as a hex string (most sync records). */
+export const stringIdFilter = (id: string): Filter<Document> =>
+  ({ _id: id }) as unknown as Filter<Document>;

--- a/packages/sync/src/auth/internal-auth.middleware.test.ts
+++ b/packages/sync/src/auth/internal-auth.middleware.test.ts
@@ -1,6 +1,10 @@
 import { faker } from "@faker-js/faker";
 import { type NextFunction, type Request, type Response } from "express";
 import {
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import {
   createInternalAuthMiddleware,
   INTERNAL_AUTH_HEADERS,
   type InternalAuthedRequest,
@@ -73,8 +77,8 @@ function run(req: Partial<InternalAuthedRequest>): {
 
 describe("internal auth middleware adapter", () => {
   it("attaches the signed context and calls next on a valid request", () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const { req, res, nextCalls } = run({
       headers: signedHeaders(tenantId, principalId),
     });
@@ -91,8 +95,8 @@ describe("internal auth middleware adapter", () => {
   });
 
   it("derives principal from the signed header, never the request body", () => {
-    const tenantId = objectId();
-    const signedPrincipal = objectId();
+    const tenantId = objectId() as TenantId;
+    const signedPrincipal = objectId() as PrincipalId;
     const forgedPrincipal = objectId();
 
     // A body claiming a different principal must be ignored: the middleware

--- a/packages/sync/src/auth/internal-auth.test.ts
+++ b/packages/sync/src/auth/internal-auth.test.ts
@@ -1,5 +1,9 @@
 import { faker } from "@faker-js/faker";
 import {
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import {
   DEFAULT_FRESHNESS_MS,
   INTERNAL_AUTH_HEADERS,
   signInternalRequest,
@@ -38,8 +42,8 @@ const signedHeaders = (
 
 describe("verifyInternalRequest", () => {
   it("accepts a correctly signed, fresh request and derives context from signed headers", () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const headers = signedHeaders({
       tenantId,
       principalId,

--- a/packages/sync/src/credentials/credential-custody.service.db.test.ts
+++ b/packages/sync/src/credentials/credential-custody.service.db.test.ts
@@ -1,7 +1,8 @@
 import { faker } from "@faker-js/faker";
-import { type Db } from "mongodb";
+import { type Db, type Document } from "mongodb";
 import { type ConnectionId } from "@core/types/sync/identity.contracts";
 import { TEST_CREDENTIAL_ENCRYPTION_KEY } from "@sync/__tests__/helpers/credential-encryption";
+import { stringIdFilter } from "@sync/__tests__/helpers/mongo-id";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { CredentialCustody } from "@sync/credentials/credential-custody.service";
 import { ProviderNotConfiguredError } from "@sync/providers/provider-adapters";
@@ -346,9 +347,9 @@ describe("CredentialCustody", () => {
 
     const raw = await db
       .collection(SYNC_COLLECTIONS.credentials)
-      .findOne({ _id: connectionId });
+      .findOne(stringIdFilter(connectionId));
     expect(raw).not.toHaveProperty("refreshToken");
-    expect(raw?.refreshTokenCiphertext).toBeString();
+    expect(raw?.["refreshTokenCiphertext"]).toBeString();
     expect(JSON.stringify(raw)).not.toContain("stored-refresh-token");
   });
 
@@ -373,15 +374,15 @@ describe("CredentialCustody", () => {
       scopes: ["https://www.googleapis.com/auth/calendar.events"],
       createdAt: new Date(),
       updatedAt: new Date(),
-    });
+    } as Document);
 
     await custody.getValidAccessToken(connectionId);
 
     const raw = await db
       .collection(SYNC_COLLECTIONS.credentials)
-      .findOne({ _id: connectionId });
+      .findOne(stringIdFilter(connectionId));
     expect(raw).not.toHaveProperty("refreshToken");
-    expect(raw?.refreshTokenCiphertext).toBeString();
+    expect(raw?.["refreshTokenCiphertext"]).toBeString();
     expect(JSON.stringify(raw)).not.toContain("legacy-plaintext-token");
     expect(adapter.refreshCalls).toBe(1);
   });
@@ -407,7 +408,7 @@ describe("CredentialCustody", () => {
       scopes: ["https://www.googleapis.com/auth/calendar.events"],
       createdAt: new Date(),
       updatedAt: new Date(),
-    });
+    } as Document);
 
     await expect(custody.getValidAccessToken(connectionId)).resolves.toBe(
       "fresh-token",
@@ -415,8 +416,8 @@ describe("CredentialCustody", () => {
 
     const raw = await db
       .collection(SYNC_COLLECTIONS.credentials)
-      .findOne({ _id: connectionId });
-    expect(raw?.refreshToken).toBe("legacy-plaintext-token");
+      .findOne(stringIdFilter(connectionId));
+    expect(raw?.["refreshToken"]).toBe("legacy-plaintext-token");
     expect(raw).not.toHaveProperty("refreshTokenCiphertext");
     expect(adapter.refreshCalls).toBe(1);
   });
@@ -490,7 +491,7 @@ describe("CredentialCustody", () => {
 
     const raw = await db
       .collection(SYNC_COLLECTIONS.credentials)
-      .findOne({ _id: connectionId });
+      .findOne(stringIdFilter(connectionId));
     expect(raw).not.toBeNull();
     const serialized = JSON.stringify(raw);
     expect(serialized).not.toContain(secret);

--- a/packages/sync/src/domain/busy-availability.service.db.test.ts
+++ b/packages/sync/src/domain/busy-availability.service.db.test.ts
@@ -1,10 +1,13 @@
 import { faker } from "@faker-js/faker";
+import { type Document } from "mongodb";
 import { type EventId } from "@core/types/domain-primitives";
 import { type ConnectionState } from "@core/types/sync/connection.contracts";
 import { type SyncEventCalendarId } from "@core/types/sync/event.contracts";
 import {
   type ConnectionId,
   type PrincipalId,
+  type ProviderAccountId,
+  type ProviderCalendarSourceId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
@@ -51,7 +54,7 @@ describe("computeBusyAvailability", () => {
       principalId,
       provider: "google",
       account: {
-        providerAccountId: `acct-${accountSeq}`,
+        providerAccountId: `acct-${accountSeq}` as ProviderAccountId,
         email: `user${accountSeq}@gmail.com`,
         displayName: "User",
       },
@@ -127,7 +130,7 @@ describe("computeBusyAvailability", () => {
           endAt: new Date(end),
           busy: true,
           cancelled: false,
-        });
+        } as Document);
     }
     return calendarId;
   };
@@ -193,7 +196,7 @@ describe("computeBusyAvailability", () => {
       tenantId,
       principalId,
       connectionId: conn,
-      providerCalendarId: "ghost@google.com",
+      providerCalendarId: "ghost@google.com" as ProviderCalendarSourceId,
       displayName: "Ghost",
       color: null,
       active: true,
@@ -205,6 +208,8 @@ describe("computeBusyAvailability", () => {
         canReadBusy: true,
         canInviteAttendees: true,
       },
+      eventLabels: [],
+      createsGoogleMeet: true,
     });
 
     const result = await run([calA, ghost._id as SyncEventCalendarId]);
@@ -233,7 +238,7 @@ describe("computeBusyAvailability", () => {
         endAt: new Date("2026-07-14T10:30:00.000Z"),
         busy: true,
         cancelled: false,
-      });
+      } as Document);
 
     const result = await run([localCalendarId], [localCalendarId]);
 

--- a/packages/sync/src/domain/busy-query.service.db.test.ts
+++ b/packages/sync/src/domain/busy-query.service.db.test.ts
@@ -5,6 +5,7 @@ import {
   type PrincipalId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
+import { mongoObjectId } from "@sync/__tests__/helpers/mongo-id";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { queryBusyIntervals } from "@sync/domain/busy-query.service";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
@@ -47,7 +48,7 @@ describe("queryBusyIntervals", () => {
       .db()
       .collection(SYNC_COLLECTIONS.eventOccurrences)
       .insertOne({
-        _id: objectId(),
+        _id: mongoObjectId(objectId()),
         tenantId,
         principalId,
         eventId,
@@ -208,7 +209,7 @@ describe("queryBusyIntervals", () => {
   });
 
   it("drops an excluded event before merge and keeps overlapping host busy", async () => {
-    const bookingId = objectId();
+    const bookingId = objectId() as EventId;
     await seed({
       calendarId: calendarA,
       start: "2026-07-14T10:00Z",
@@ -223,7 +224,7 @@ describe("queryBusyIntervals", () => {
 
     const result = await query(
       [{ calendarId: calendarA, generation: 0 }],
-      [bookingId as EventId],
+      [bookingId],
     );
 
     expect(iso(result)).toEqual([

--- a/packages/sync/src/domain/calendar-import.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-import.service.db.test.ts
@@ -1,3 +1,4 @@
+import { type ProviderEventId } from "@core/types/sync/identity.contracts";
 import {
   pageOf as page,
   seedProviderCalendar,
@@ -148,7 +149,7 @@ describe("importCalendarEvents", () => {
 
     await importCalendarEvents(deps(reader), calendar, now);
 
-    expect(reader.calls[0].window).not.toBeNull();
+    expect(reader.calls[0]!.window).not.toBeNull();
     expect(reader.calls.at(-1)?.window).toBeNull();
   });
 
@@ -180,7 +181,7 @@ describe("importCalendarEvents", () => {
       {
         connectionId: calendar.connectionId,
         calendarId: calendar._id,
-        providerEventId: "m",
+        providerEventId: "m" as ProviderEventId,
       },
     );
     expect(stored?.recurrence.kind).toBe("seriesMaster");
@@ -479,7 +480,7 @@ describe("importCalendarEvents", () => {
 
     // No windowed call at all; the first (and only) read resumes the full pass.
     expect(reader.calls.every((c) => c.window === null)).toBe(true);
-    expect(reader.calls[0].pageToken).toBe("resume-token");
+    expect(reader.calls[0]!.pageToken).toBe("resume-token");
   });
 });
 
@@ -496,7 +497,7 @@ async function masterId(
     {
       connectionId: calendar.connectionId,
       calendarId: calendar._id,
-      providerEventId,
+      providerEventId: providerEventId as ProviderEventId,
     },
   );
   if (!record)

--- a/packages/sync/src/domain/calendar-list-rediscovery.db.test.ts
+++ b/packages/sync/src/domain/calendar-list-rediscovery.db.test.ts
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { seedOauthCredential } from "@sync/__tests__/helpers/credential-encryption";
+import { stringIdFilter } from "@sync/__tests__/helpers/mongo-id";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { rediscoverStaleCalendarLists } from "@sync/domain/calendar-list-rediscovery.service";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
@@ -92,9 +93,10 @@ describe("calendar-list rediscovery sweep (rediscoverStaleCalendarLists)", () =>
     storage.db().collection(SYNC_COLLECTIONS.jobs).countDocuments({});
 
   const resourceById = (id: string) =>
-    storage.db().collection(SYNC_COLLECTIONS.syncResources).findOne({
-      _id: id,
-    });
+    storage
+      .db()
+      .collection(SYNC_COLLECTIONS.syncResources)
+      .findOne(stringIdFilter(id));
 
   it("clears the cursor and enqueues a connection-scoped calendarListSync for a stale resource", async () => {
     const stale = await seedCalendarListResource({
@@ -109,21 +111,23 @@ describe("calendar-list rediscovery sweep (rediscoverStaleCalendarLists)", () =>
 
     expect(enqueued).toBe(1);
     const record = await resourceById(stale._id);
-    expect(record?.syncCursor).toBeNull();
+    expect(record?.["syncCursor"]).toBeNull();
     // lastFullListAt is the staleness key the sweep selects on; clearing the
     // cursor must not also stamp it, or the resource would look satisfied for a
     // day on the strength of a pass that has not run yet.
-    expect(record?.lastFullListAt).toEqual(
+    expect(record?.["lastFullListAt"]).toEqual(
       new Date("2026-08-01T00:00:00.000Z"),
     );
-    expect(record?.lastSuccessAt).toEqual(new Date("2026-08-01T00:00:00.000Z"));
+    expect(record?.["lastSuccessAt"]).toEqual(
+      new Date("2026-08-01T00:00:00.000Z"),
+    );
 
     const job = await jobByKey(`calendarListSync:${stale.connectionId}`);
-    expect(job?.kind).toBe("calendarListSync");
+    expect(job?.["kind"]).toBe("calendarListSync");
     // Connection-scoped, not resource-scoped: matches registerConnection's
     // own enqueue shape so the two never race on different coalescing keys.
-    expect(job?.resourceId).toBeNull();
-    expect(job?.tenantId).toBe(stale.tenantId);
+    expect(job?.["resourceId"]).toBeNull();
+    expect(job?.["tenantId"]).toBe(stale.tenantId);
   });
 
   it("skips a resource fully re-listed more recently than the threshold", async () => {
@@ -224,7 +228,9 @@ describe("calendar-list rediscovery sweep (rediscoverStaleCalendarLists)", () =>
     await storage
       .db()
       .collection(SYNC_COLLECTIONS.syncResources)
-      .updateOne({ _id: legacy._id }, { $unset: { lastFullListAt: "" } });
+      .updateOne(stringIdFilter(legacy._id), {
+        $unset: { lastFullListAt: "" },
+      });
 
     const enqueued = await rediscoverStaleCalendarLists(
       deps(),
@@ -275,7 +281,7 @@ describe("calendar-list rediscovery sweep (rediscoverStaleCalendarLists)", () =>
         }),
     ).toBe(1);
     const record = await resourceById(stale._id);
-    expect(record?.syncCursor).toBeNull();
+    expect(record?.["syncCursor"]).toBeNull();
   });
 
   it("excludes a resource whose connection has no stored credential, however stale", async () => {

--- a/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-list-sync.service.db.test.ts
@@ -1,4 +1,10 @@
 import { faker } from "@faker-js/faker";
+import {
+  type ConnectionId,
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { stringIdFilter } from "@sync/__tests__/helpers/mongo-id";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { syncCalendarList } from "@sync/domain/calendar-list-sync.service";
 import {
@@ -32,6 +38,7 @@ const discovered = (
     canReadBusy: true,
     canInviteAttendees: true,
   },
+  eventLabels: [],
   createsGoogleMeet: true,
 });
 
@@ -85,9 +92,9 @@ describe("syncCalendarList", () => {
 
   const connection = (): ProviderConnectionRecord =>
     ({
-      _id: objectId(),
-      tenantId: objectId(),
-      principalId: objectId(),
+      _id: objectId() as ConnectionId,
+      tenantId: objectId() as TenantId,
+      principalId: objectId() as PrincipalId,
     }) as ProviderConnectionRecord;
 
   const deps = (discovery: FakeDiscovery) => ({
@@ -126,7 +133,7 @@ describe("syncCalendarList", () => {
     providerCalendarId: string,
   ) => {
     const calendar = (await calendarDocs(conn)).find(
-      (d) => d.providerCalendarId === providerCalendarId,
+      (d) => d["providerCalendarId"] === providerCalendarId,
     );
     const resourceId = (
       await storage.db().collection(SYNC_COLLECTIONS.syncResources).findOne({
@@ -134,11 +141,15 @@ describe("syncCalendarList", () => {
         resourceKind: "events",
         calendarId: calendar?._id,
       })
-    )?._id as string;
+    )?._id;
+    const resourceIdString = resourceId ? String(resourceId) : undefined;
+    if (!resourceIdString) {
+      throw new Error("Expected events resource for calendar");
+    }
     await resources.updateSubscription(
       conn.tenantId,
       conn.principalId,
-      resourceId,
+      resourceIdString,
       {
         subscriptionId: "channel-1",
         subscriptionResourceId: "resource-1",
@@ -146,7 +157,7 @@ describe("syncCalendarList", () => {
         subscriptionExpiresAt: new Date("2026-08-01T00:00:00.000Z"),
       },
     );
-    return resourceId;
+    return resourceIdString;
   };
 
   it("discovers calendars, persists them, and enqueues an import per active calendar", async () => {
@@ -178,7 +189,7 @@ describe("syncCalendarList", () => {
     const enqueued = await importJobs();
     expect(enqueued).toHaveLength(2);
     // The discovery cursor is stored on the calendarList resource for next pass.
-    expect((await calendarListResource(conn))?.syncCursor).toBe("cur-1");
+    expect((await calendarListResource(conn))?.["syncCursor"]).toBe("cur-1");
     expect(discovery.cursors).toEqual([undefined]); // first pass is a full list
   });
 
@@ -193,7 +204,7 @@ describe("syncCalendarList", () => {
 
     const docs = await calendarDocs(conn);
     const byId = Object.fromEntries(
-      docs.map((doc) => [doc.providerCalendarId, doc.createsGoogleMeet]),
+      docs.map((doc) => [doc["providerCalendarId"], doc["createsGoogleMeet"]]),
     );
     expect(byId["primary"]).toBe(true);
     expect(byId["resource"]).toBe(false);
@@ -215,8 +226,10 @@ describe("syncCalendarList", () => {
     expect(eventsResources).toHaveLength(1);
     // The enqueued import targets that events resource.
     const [job] = await importJobs();
-    expect(job?.resourceId).toBe(eventsResources[0]?._id);
-    expect(job?.coalescingKey).toBe(`initialImport:${eventsResources[0]?._id}`);
+    expect(job?.["resourceId"]).toBe(eventsResources[0]?._id);
+    expect(job?.["coalescingKey"]).toBe(
+      `initialImport:${eventsResources[0]?._id}`,
+    );
   });
 
   // Run a full pass, mark the connection's events resource unwatchable at
@@ -316,10 +329,10 @@ describe("syncCalendarList", () => {
     );
 
     const docs = await calendarDocs(conn);
-    const gone = docs.find((d) => d.providerCalendarId === "gone");
-    const primary = docs.find((d) => d.providerCalendarId === "primary");
-    expect(gone?.active).toBe(false);
-    expect(primary?.active).toBe(true);
+    const gone = docs.find((d) => d["providerCalendarId"] === "gone");
+    const primary = docs.find((d) => d["providerCalendarId"] === "primary");
+    expect(gone?.["active"]).toBe(false);
+    expect(primary?.["active"]).toBe(true);
   });
 
   it("clears a prior discovery failure even when rediscovery returns no cursor", async () => {
@@ -350,11 +363,11 @@ describe("syncCalendarList", () => {
     );
 
     const after = await calendarListResource(conn);
-    expect(after?.lastReadFailureAt).toBeNull();
-    expect(after?.lastReadFailureDetail).toBeNull();
-    expect(after?.lastSuccessAt).toEqual(now());
+    expect(after?.["lastReadFailureAt"]).toBeNull();
+    expect(after?.["lastReadFailureDetail"]).toBeNull();
+    expect(after?.["lastSuccessAt"]).toEqual(now());
     // Null discovery cursor must not wipe/store a cursor — next pass full-lists.
-    expect(after?.syncCursor).toBeNull();
+    expect(after?.["syncCursor"]).toBeNull();
   });
 
   it("stamps lastAttemptAt on the calendarList resource before it can fail", async () => {
@@ -369,7 +382,9 @@ describe("syncCalendarList", () => {
 
     await syncCalendarList(deps(discovery), conn, now);
 
-    expect((await calendarListResource(conn))?.lastAttemptAt).toEqual(now());
+    expect((await calendarListResource(conn))?.["lastAttemptAt"]).toEqual(
+      now(),
+    );
   });
 
   it("clears the local push channel of a retired calendar's events resource", async () => {
@@ -406,9 +421,9 @@ describe("syncCalendarList", () => {
     const goneEventsResource = await storage
       .db()
       .collection(SYNC_COLLECTIONS.syncResources)
-      .findOne({ _id: goneEventsResourceId });
-    expect(goneEventsResource?.subscriptionId).toBeNull();
-    expect(goneEventsResource?.subscriptionExpiresAt).toBeNull();
+      .findOne(stringIdFilter(goneEventsResourceId));
+    expect(goneEventsResource?.["subscriptionId"]).toBeNull();
+    expect(goneEventsResource?.["subscriptionExpiresAt"]).toBeNull();
   });
 
   it("clears the push channel when a calendar is upserted inactive on an incremental pass", async () => {
@@ -451,15 +466,15 @@ describe("syncCalendarList", () => {
     const hidesEventsResource = await storage
       .db()
       .collection(SYNC_COLLECTIONS.syncResources)
-      .findOne({ _id: hidesEventsResourceId });
-    expect(hidesEventsResource?.subscriptionId).toBeNull();
-    expect(hidesEventsResource?.subscriptionExpiresAt).toBeNull();
+      .findOne(stringIdFilter(hidesEventsResourceId));
+    expect(hidesEventsResource?.["subscriptionId"]).toBeNull();
+    expect(hidesEventsResource?.["subscriptionExpiresAt"]).toBeNull();
     // The reason the channel is cleared at all: the calendar itself went
     // inactive, which is what drops it out of the sidebar.
     const hides = (await calendarDocs(conn)).find(
-      (d) => d.providerCalendarId === "hides",
+      (d) => d["providerCalendarId"] === "hides",
     );
-    expect(hides?.active).toBe(false);
+    expect(hides?.["active"]).toBe(false);
   });
 
   it("stamps lastFullListAt on a full pass", async () => {
@@ -475,7 +490,9 @@ describe("syncCalendarList", () => {
       now,
     );
 
-    expect((await calendarListResource(conn))?.lastFullListAt).toEqual(now());
+    expect((await calendarListResource(conn))?.["lastFullListAt"]).toEqual(
+      now(),
+    );
   });
 
   it("does not stamp lastFullListAt on an incremental pass", async () => {
@@ -506,8 +523,8 @@ describe("syncCalendarList", () => {
     );
 
     const resource = await calendarListResource(conn);
-    expect(resource?.lastFullListAt).toEqual(now()); // still the FULL pass's stamp
-    expect(resource?.lastSuccessAt).toEqual(later()); // which advanced regardless
+    expect(resource?.["lastFullListAt"]).toEqual(now()); // still the FULL pass's stamp
+    expect(resource?.["lastSuccessAt"]).toEqual(later()); // which advanced regardless
   });
 
   it("does not stamp lastFullListAt when a full list comes back empty", async () => {
@@ -525,7 +542,7 @@ describe("syncCalendarList", () => {
     // Read raw, so the key is ABSENT rather than defaulted to null — `?? null`
     // accepts either, since both mean "never fully listed" to the sweep's filter.
     expect(
-      (await calendarListResource(conn))?.lastFullListAt ?? null,
+      (await calendarListResource(conn))?.["lastFullListAt"] ?? null,
     ).toBeNull();
   });
 
@@ -544,7 +561,7 @@ describe("syncCalendarList", () => {
       now,
     );
     const goneCalendar = (await calendarDocs(conn)).find(
-      (d) => d.providerCalendarId === "gone",
+      (d) => d["providerCalendarId"] === "gone",
     );
     const warnings: string[] = [];
 
@@ -562,7 +579,7 @@ describe("syncCalendarList", () => {
     );
 
     expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain(goneCalendar?._id as string);
+    expect(warnings[0]).toContain(String(goneCalendar?._id));
     expect(warnings[0]).toContain(conn._id);
   });
 
@@ -587,9 +604,9 @@ describe("syncCalendarList", () => {
     );
 
     const primary = (await calendarDocs(conn)).find(
-      (d) => d.providerCalendarId === "primary",
+      (d) => d["providerCalendarId"] === "primary",
     );
-    expect(primary?.active).toBe(true);
+    expect(primary?.["active"]).toBe(true);
   });
 
   it("does not retire absent calendars on an incremental pass", async () => {
@@ -616,9 +633,9 @@ describe("syncCalendarList", () => {
 
     expect(incremental.cursors).toEqual(["cur-1"]); // resumed from the stored cursor
     const team = (await calendarDocs(conn)).find(
-      (d) => d.providerCalendarId === "team",
+      (d) => d["providerCalendarId"] === "team",
     );
-    expect(team?.active).toBe(true);
+    expect(team?.["active"]).toBe(true);
   });
 
   it("updates the stored display name when rediscovery reports a rename", async () => {
@@ -657,9 +674,9 @@ describe("syncCalendarList", () => {
     );
 
     const renamed = (await calendarDocs(conn)).find(
-      (d) => d.providerCalendarId === "mens-group",
+      (d) => d["providerCalendarId"] === "mens-group",
     );
-    expect(renamed?.displayName).toBe("journey-mens-group");
+    expect(renamed?.["displayName"]).toBe("journey-mens-group");
   });
 
   it("clears a change marker the pass has served", async () => {
@@ -689,7 +706,7 @@ describe("syncCalendarList", () => {
     );
 
     expect(result.changedDuringSync).toBe(false);
-    expect((await calendarListResource(conn))?.changeNotifiedAt).toBeNull();
+    expect((await calendarListResource(conn))?.["changeNotifiedAt"]).toBeNull();
   });
 
   it("keeps the marker and reports changedDuringSync when a notification lands mid-pass", async () => {
@@ -701,7 +718,6 @@ describe("syncCalendarList", () => {
     // A notification arriving while the provider is being read moves the
     // marker AFTER the pass captured it, so the compare-and-clear must fail.
     const discovery: ProviderCalendarAdapter = {
-      provider: "google",
       discoverCalendars: async (input) => {
         const resource = await calendarListResource(conn);
         await resources.markChangeNotified(
@@ -721,7 +737,7 @@ describe("syncCalendarList", () => {
     );
 
     expect(result.changedDuringSync).toBe(true);
-    expect((await calendarListResource(conn))?.changeNotifiedAt).toEqual(
+    expect((await calendarListResource(conn))?.["changeNotifiedAt"]).toEqual(
       midPassStamp,
     );
   });
@@ -751,12 +767,14 @@ describe("syncCalendarList", () => {
     expect(expired.cursors).toEqual(["cur-1", undefined]);
     // Because the fallback was a full list, the absent "stale" calendar is retired.
     const stale = (await calendarDocs(conn)).find(
-      (d) => d.providerCalendarId === "stale",
+      (d) => d["providerCalendarId"] === "stale",
     );
-    expect(stale?.active).toBe(false);
+    expect(stale?.["active"]).toBe(false);
     // And it counts as a full enumeration for the rediscovery clock — the
     // fallback re-listed everything, so the sweep has nothing left to force.
-    expect((await calendarListResource(conn))?.lastFullListAt).toEqual(now());
+    expect((await calendarListResource(conn))?.["lastFullListAt"]).toEqual(
+      now(),
+    );
   });
 
   it("throws on a non-cursor discovery failure so the worker retries", async () => {

--- a/packages/sync/src/domain/calendar-pull.service.db.test.ts
+++ b/packages/sync/src/domain/calendar-pull.service.db.test.ts
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { type SyncCommandInput } from "@core/types/sync/command.contracts";
+import { type ProviderEventId } from "@core/types/sync/identity.contracts";
 import {
   FakeReader,
   pageOf as page,
@@ -49,7 +50,7 @@ const master = (id: string): ProviderEvent => ({
 });
 const cancellation = (id: string): ProviderEventCancellation => ({
   kind: "cancellation",
-  providerEventId: id,
+  providerEventId: id as ProviderEventId,
   providerVersion: `etag-${id}`,
   series: null,
 });
@@ -59,7 +60,7 @@ const seriesCancellation = (
   recurrenceId: string,
 ): ProviderEventCancellation => ({
   kind: "cancellation",
-  providerEventId: id,
+  providerEventId: id as ProviderEventId,
   providerVersion: `etag-${id}`,
   series: { seriesProviderId, recurrenceId },
 });
@@ -171,7 +172,7 @@ describe("pullCalendarChanges", () => {
       .db()
       .collection(SYNC_COLLECTIONS.syncResources)
       .findOne({ calendarId: calendar._id, resourceKind: "events" });
-    expect(stamped?.lastAttemptAt).toEqual(now());
+    expect(stamped?.["lastAttemptAt"]).toEqual(now());
   });
 
   it("reads from the stored cursor and advances to the new one", async () => {
@@ -183,8 +184,8 @@ describe("pullCalendarChanges", () => {
 
     const result = await pullCalendarChanges(deps(reader), calendar, now);
 
-    expect(reader.calls[0].cursor).toBe("cursor-0");
-    expect(reader.calls[0].window ?? null).toBeNull();
+    expect(reader.calls[0]!.cursor).toBe("cursor-0");
+    expect(reader.calls[0]!.window ?? null).toBeNull();
     if (result.status !== "applied") throw new Error("expected applied");
     expect(result.resource.syncCursor).toBe("cursor-1");
     expect(result.changed).toBe(1);
@@ -199,7 +200,7 @@ describe("pullCalendarChanges", () => {
 
     await pullCalendarChanges(deps(reader), calendar, now);
 
-    expect(reader.calls[0].colorLabels).toEqual(
+    expect(reader.calls[0]!.colorLabels).toEqual(
       new Map([["label-1", "#009688"]]),
     );
   });
@@ -438,12 +439,12 @@ describe("pullCalendarChanges", () => {
       .toArray();
     const atCancelled = occs.filter(
       (row) =>
-        new Date(row.startAt as Date).getTime() ===
+        new Date(row["startAt"] as Date).getTime() ===
         Date.parse(cancelledInstant),
     );
     expect(atCancelled).toHaveLength(1);
-    expect(atCancelled[0]?.cancelled).toBe(true);
-    expect(occs.filter((row) => row.cancelled !== true)).toHaveLength(2);
+    expect(atCancelled[0]?.["cancelled"]).toBe(true);
+    expect(occs.filter((row) => row["cancelled"] !== true)).toHaveLength(2);
   });
 
   it("deletes a standalone whose id looks like an instance when no master exists", async () => {
@@ -556,7 +557,7 @@ describe("pullCalendarChanges", () => {
     // First page carried no sync token, so the cursor moves to the last page's.
     expect(result.resource.syncCursor).toBe("cursor-1");
     expect(result.resource.pageCursor).toBeNull();
-    expect(reader.calls[1].pageToken).toBe("p2");
+    expect(reader.calls[1]!.pageToken).toBe("p2");
     expect(result.changed).toBe(2);
   });
 
@@ -621,7 +622,6 @@ describe("pullCalendarChanges", () => {
       // Stamps the marker as a side effect of the provider read — i.e. the
       // notification lands after this pull has already seen the provider.
       const reader: ProviderEventReader = {
-        provider: "google",
         listEventPage: async () => {
           await resources.markChangeNotified(
             calendar.tenantId,

--- a/packages/sync/src/domain/cloud-command.service.db.test.ts
+++ b/packages/sync/src/domain/cloud-command.service.db.test.ts
@@ -1,21 +1,32 @@
 import { faker } from "@faker-js/faker";
+import { type Document, type Filter } from "mongodb";
+import {
+  type CalendarId,
+  type DateTime,
+  type EventId,
+  type TimeZone,
+} from "@core/types/domain-primitives";
 import { type SyncCommandInput } from "@core/types/sync/command.contracts";
 import {
-  type EventId,
   type IdempotencyKey,
   type PrincipalId,
+  type ProviderEventId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
 import {
   bindCommandRepos,
   COMMAND_NOW,
+  cloudCommandDeps,
   FakeProviderEventWriter,
+  fakeCredentialCustody,
   newCommandIds,
   seedCommandCalendar,
+  stubConnectionLookup,
 } from "@sync/__tests__/helpers/command-scenario";
 import { fakeAdapters } from "@sync/__tests__/helpers/fixtures";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import {
+  type CloudCommandDeps,
   ProviderWriteUnavailableError,
   submitCloudCommand,
 } from "@sync/domain/cloud-command.service";
@@ -64,7 +75,7 @@ const providerWriter = () => {
   writer.matchFetchedById = false;
   writer.fetched = {
     kind: "event",
-    providerEventId: "g-evt-1",
+    providerEventId: "g-evt-1" as ProviderEventId,
     providerVersion: "etag-1",
     providerUpdatedAt: null,
     content: {
@@ -77,16 +88,16 @@ const providerWriter = () => {
     },
     schedule: {
       kind: "timed",
-      start: "2026-07-14T09:00:00-06:00",
-      end: "2026-07-14T10:00:00-06:00",
-      timeZone: "America/Denver",
+      start: "2026-07-14T09:00:00-06:00" as DateTime,
+      end: "2026-07-14T10:00:00-06:00" as DateTime,
+      timeZone: "America/Denver" as TimeZone,
     },
     busy: true,
     recurrence: { kind: "single" },
   };
   writer.fetchedInstance = {
     kind: "event",
-    providerEventId: "g-inst-1",
+    providerEventId: "g-inst-1" as ProviderEventId,
     providerVersion: "etag-1",
     providerUpdatedAt: null,
     content: {
@@ -99,9 +110,9 @@ const providerWriter = () => {
     },
     schedule: {
       kind: "timed",
-      start: "2026-07-21T09:00:00-06:00",
-      end: "2026-07-21T10:00:00-06:00",
-      timeZone: "America/Denver",
+      start: "2026-07-21T09:00:00-06:00" as DateTime,
+      end: "2026-07-21T10:00:00-06:00" as DateTime,
+      timeZone: "America/Denver" as TimeZone,
     },
     busy: true,
     recurrence: { kind: "single" },
@@ -119,11 +130,7 @@ const provider = (writer: ProviderEventWriter) => ({
       },
       { writer },
     ),
-  custody: {
-    getValidAccessToken: async () => "access-token",
-    discardRevoked: async () => {},
-    invalidateAccessToken: async () => {},
-  },
+  custody: fakeCredentialCustody(),
 });
 
 describe("submitCloudCommand provider dispatch", () => {
@@ -143,19 +150,17 @@ describe("submitCloudCommand provider dispatch", () => {
 
   const commandDeps = (
     writer?: FakeProviderEventWriter,
-    extra: Record<string, unknown> = {},
-  ) => ({
-    commands,
-    events,
-    calendars,
-    occurrences,
-    resources,
-    markers,
-    connections,
-    execution: "active" as const,
-    ...(writer ? { provider: provider(writer) } : {}),
-    ...extra,
-  });
+    extra: Partial<Pick<CloudCommandDeps, "execution" | "provider">> = {},
+  ) =>
+    cloudCommandDeps(
+      { commands, events, calendars, occurrences, resources, markers },
+      {
+        connections,
+        execution: "active",
+        ...(writer ? { provider: provider(writer) } : {}),
+        ...extra,
+      },
+    );
 
   const submitFor = (
     tenantId: TenantId,
@@ -323,7 +328,7 @@ describe("submitCloudCommand provider dispatch", () => {
       tenantId,
       principalId,
       origin: "compass",
-      calendarId: objectId(),
+      calendarId: objectId() as CalendarId,
       clientEventId: null,
       connectionId: null,
       providerEventId: null,
@@ -341,9 +346,9 @@ describe("submitCloudCommand provider dispatch", () => {
       },
       schedule: {
         kind: "timed",
-        start: "2026-07-14T09:00:00-06:00",
-        end: "2026-07-14T10:00:00-06:00",
-        timeZone: "America/Denver",
+        start: "2026-07-14T09:00:00-06:00" as DateTime,
+        end: "2026-07-14T10:00:00-06:00" as DateTime,
+        timeZone: "America/Denver" as TimeZone,
       },
       recurrence: { kind: "single" },
       lifecycleState: "active",
@@ -369,15 +374,11 @@ describe("submitCloudCommand provider dispatch", () => {
     expectedVersion: null,
   });
 
-  const deps = () => ({
-    commands,
-    events,
-    calendars,
-    occurrences,
-    resources,
-    markers,
-    execution: "passive" as const,
-  });
+  const deps = () =>
+    cloudCommandDeps(
+      { commands, events, calendars, occurrences, resources, markers },
+      { connections, execution: "passive" },
+    );
 
   it("refuses a delete of a provider-linked event when passive, rather than stranding it pending", async () => {
     const tenantId = objectId() as TenantId;
@@ -647,7 +648,7 @@ describe("submitCloudCommand provider dispatch", () => {
 
     expect(command.outcome.state).toBe("confirmed");
     expect(writer.patchCalls).toHaveLength(1);
-    expect(writer.patchCalls[0].attendees).toEqual([
+    expect(writer.patchCalls[0]!.attendees).toEqual([
       {
         email: "self@example.com",
         displayName: null,
@@ -1488,7 +1489,7 @@ describe("submitCloudCommand provider dispatch", () => {
         principalId,
         "recurrence.kind": "seriesMaster",
         _id: { $ne: masterId },
-      })
+      } as unknown as Filter<Document>)
       .toArray();
 
   it("splits a cloud series into a truncated original and an edited remainder", async () => {
@@ -1530,10 +1531,9 @@ describe("submitCloudCommand provider dispatch", () => {
     expect(remainders).toHaveLength(1);
     const remainder = remainders[0];
     expect(remainder?.["content"]).toMatchObject({ title: "Split" });
-    expect(await occurrenceStartsFor(remainder?.["_id"] as EventId)).toEqual([
-      "2026-07-21T15:00:00.000Z",
-      "2026-07-28T15:00:00.000Z",
-    ]);
+    expect(
+      await occurrenceStartsFor(String(remainder?.["_id"]) as EventId),
+    ).toEqual(["2026-07-21T15:00:00.000Z", "2026-07-28T15:00:00.000Z"]);
   });
 
   it("upserts a single remainder master across two splits at the same point", async () => {
@@ -2023,15 +2023,11 @@ describe("submitCloudCommand provider dispatch", () => {
 // typed. "preserve"/legacy stays byte-identical (covered by every pre-existing
 // test in this file, none of which set attendeesEdit).
 describe("cloud-only attendeesEdit replace", () => {
-  const deps = () => ({
-    commands,
-    events,
-    calendars,
-    occurrences,
-    resources,
-    markers,
-    execution: "active" as const,
-  });
+  const deps = () =>
+    cloudCommandDeps(
+      { commands, events, calendars, occurrences, resources, markers },
+      { connections: stubConnectionLookup(), execution: "active" },
+    );
 
   const attendee = (
     email: string,
@@ -2050,9 +2046,9 @@ describe("cloud-only attendeesEdit replace", () => {
 
   const schedule = {
     kind: "timed",
-    start: "2026-07-14T09:00:00-06:00",
-    end: "2026-07-14T10:00:00-06:00",
-    timeZone: "America/Denver",
+    start: "2026-07-14T09:00:00-06:00" as DateTime,
+    end: "2026-07-14T10:00:00-06:00" as DateTime,
+    timeZone: "America/Denver" as TimeZone,
   };
 
   const seedCloudEvent = (
@@ -2066,7 +2062,7 @@ describe("cloud-only attendeesEdit replace", () => {
       tenantId,
       principalId,
       origin: "compass",
-      calendarId: objectId(),
+      calendarId: objectId() as CalendarId,
       clientEventId: null,
       connectionId: null,
       providerEventId: null,

--- a/packages/sync/src/domain/connection-refresh.service.db.test.ts
+++ b/packages/sync/src/domain/connection-refresh.service.db.test.ts
@@ -1,4 +1,10 @@
 import { faker } from "@faker-js/faker";
+import {
+  type PrincipalId,
+  type ProviderAccountId,
+  type ProviderCalendarSourceId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
 import { seedProviderCalendar } from "@sync/__tests__/helpers/fixtures";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import {
@@ -124,11 +130,11 @@ describe("refreshPrincipalCalendars (db)", () => {
   it("foreground refresh only enqueues ready resources without a recent attempt", async () => {
     const { resources, jobs, calendars, connections } = deps();
     const connection = await connections.upsertByProviderAccount({
-      tenantId: faker.database.mongodbObjectId(),
-      principalId: faker.database.mongodbObjectId(),
+      tenantId: faker.database.mongodbObjectId() as TenantId,
+      principalId: faker.database.mongodbObjectId() as PrincipalId,
       provider: "google",
       account: {
-        providerAccountId: "foreground-refresh@gmail.com",
+        providerAccountId: "foreground-refresh@gmail.com" as ProviderAccountId,
         email: "foreground-refresh@gmail.com",
         displayName: "Foreground refresh",
       },
@@ -150,7 +156,7 @@ describe("refreshPrincipalCalendars (db)", () => {
         tenantId: staleCalendar.tenantId,
         principalId: staleCalendar.principalId,
         connectionId: staleCalendar.connectionId,
-        providerCalendarId: "recent@google.com",
+        providerCalendarId: "recent@google.com" as ProviderCalendarSourceId,
         primary: false,
       },
     );
@@ -159,7 +165,7 @@ describe("refreshPrincipalCalendars (db)", () => {
         tenantId: staleCalendar.tenantId,
         principalId: staleCalendar.principalId,
         connectionId: staleCalendar.connectionId,
-        providerCalendarId: "importing@google.com",
+        providerCalendarId: "importing@google.com" as ProviderCalendarSourceId,
         primary: false,
       });
     const stale = await resources.ensure({

--- a/packages/sync/src/domain/connection-refresh.service.test.ts
+++ b/packages/sync/src/domain/connection-refresh.service.test.ts
@@ -52,13 +52,13 @@ describe("refreshPrincipalCalendars", () => {
     // One call per distinct connection touched, not per resource.
     expect(requeueFailedByConnection).toHaveBeenCalledTimes(1);
     expect(enqueueUrgent).toHaveBeenCalledTimes(3);
-    expect(enqueueUrgent.mock.calls[0]?.[0]).toMatchObject({
+    expect((enqueueUrgent.mock.calls as unknown[][])[0]?.[0]).toMatchObject({
       kind: "calendarListSync",
       resourceId: null,
       coalescingKey: "calendarListSync:c1",
       priority: JOB_PRIORITY.user,
     });
-    expect(enqueueUrgent.mock.calls[1]?.[0]).toMatchObject({
+    expect((enqueueUrgent.mock.calls as unknown[][])[1]?.[0]).toMatchObject({
       kind: "incrementalPull",
       resourceId: "r1",
       coalescingKey: "incrementalPull:r1",

--- a/packages/sync/src/domain/connection-retention.service.db.test.ts
+++ b/packages/sync/src/domain/connection-retention.service.db.test.ts
@@ -1,7 +1,12 @@
 import { faker } from "@faker-js/faker";
+import { type DateTime, type TimeZone } from "@core/types/domain-primitives";
+import { type ProviderEventVersion } from "@core/types/sync/event.contracts";
 import {
   type ConnectionId,
   type PrincipalId,
+  type ProviderAccountId,
+  type ProviderCalendarSourceId,
+  type ProviderEventId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
@@ -75,7 +80,7 @@ describe("purgeExpiredDisconnectedConnections", () => {
       principalId: principalId as PrincipalId,
       provider: "google",
       account: {
-        providerAccountId: objectId(),
+        providerAccountId: objectId() as ProviderAccountId,
         email: "cache@example.com",
         displayName: null,
       },
@@ -95,9 +100,9 @@ describe("purgeExpiredDisconnectedConnections", () => {
   };
 
   it("purges cache for connections disconnected before the retention cutoff", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
-    const otherPrincipal = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const otherPrincipal = objectId() as PrincipalId;
 
     const expired = await seedConnection(
       tenantId,
@@ -112,10 +117,10 @@ describe("purgeExpiredDisconnectedConnections", () => {
     const live = await seedConnection(tenantId, otherPrincipal, null);
 
     const calendar = await calendars.upsertByProviderCalendar({
-      tenantId: tenantId as TenantId,
-      principalId: principalId as PrincipalId,
+      tenantId: tenantId,
+      principalId: principalId,
       connectionId: expired._id,
-      providerCalendarId: "primary",
+      providerCalendarId: "primary" as ProviderCalendarSourceId,
       displayName: "Primary",
       color: null,
       active: true,
@@ -127,16 +132,18 @@ describe("purgeExpiredDisconnectedConnections", () => {
         canWriteEvents: true,
         canInviteAttendees: false,
       },
+      eventLabels: [],
+      createsGoogleMeet: true,
     });
     await events.upsertByProviderIdentity({
-      tenantId: tenantId as TenantId,
-      principalId: principalId as PrincipalId,
+      tenantId: tenantId,
+      principalId: principalId,
       origin: "provider",
       calendarId: calendar._id,
       clientEventId: null,
       connectionId: expired._id,
-      providerEventId: "gcal-1",
-      providerVersion: "etag-1",
+      providerEventId: "gcal-1" as ProviderEventId,
+      providerVersion: "etag-1" as ProviderEventVersion,
       providerUpdatedAt: NOW,
       deliveryState: "confirmed",
       providerMetadata: null,
@@ -150,9 +157,9 @@ describe("purgeExpiredDisconnectedConnections", () => {
       },
       schedule: {
         kind: "timed",
-        start: "2026-07-14T09:00:00-06:00",
-        end: "2026-07-14T10:00:00-06:00",
-        timeZone: "America/Denver",
+        start: "2026-07-14T09:00:00-06:00" as DateTime,
+        end: "2026-07-14T10:00:00-06:00" as DateTime,
+        timeZone: "America/Denver" as TimeZone,
       },
       recurrence: { kind: "single" },
       lifecycleState: "active",
@@ -184,15 +191,15 @@ describe("purgeExpiredDisconnectedConnections", () => {
       .collection<EventOccurrenceRecord>(SYNC_COLLECTIONS.eventOccurrences)
       .insertOne(occurrence);
     await syncResources.ensure({
-      tenantId: tenantId as TenantId,
-      principalId: principalId as PrincipalId,
+      tenantId: tenantId,
+      principalId: principalId,
       connectionId: expired._id,
       resourceKind: "calendarList",
       calendarId: null,
     });
     await jobs.enqueue({
-      tenantId: tenantId as TenantId,
-      principalId: principalId as PrincipalId,
+      tenantId: tenantId,
+      principalId: principalId,
       connectionId: expired._id,
       resourceId: null,
       commandId: null,
@@ -209,16 +216,12 @@ describe("purgeExpiredDisconnectedConnections", () => {
 
     expect(purged).toBe(1);
     expect(
-      await connections.findById(
-        tenantId as TenantId,
-        principalId as PrincipalId,
-        expired._id,
-      ),
+      await connections.findById(tenantId, principalId, expired._id),
     ).toBeNull();
     expect(
       await calendars.listByConnection(
-        tenantId as TenantId,
-        principalId as PrincipalId,
+        tenantId,
+        principalId,
         expired._id as ConnectionId,
       ),
     ).toHaveLength(0);
@@ -235,18 +238,10 @@ describe("purgeExpiredDisconnectedConnections", () => {
         .countDocuments({ calendarId: calendar._id }),
     ).toBe(0);
     expect(
-      await connections.findById(
-        tenantId as TenantId,
-        principalId as PrincipalId,
-        recent._id,
-      ),
+      await connections.findById(tenantId, principalId, recent._id),
     ).not.toBeNull();
     expect(
-      await connections.findById(
-        tenantId as TenantId,
-        otherPrincipal as PrincipalId,
-        live._id,
-      ),
+      await connections.findById(tenantId, otherPrincipal, live._id),
     ).not.toBeNull();
   });
 
@@ -268,14 +263,14 @@ describe("purgeExpiredDisconnectedConnections", () => {
   });
 
   it("skips purge when the connection reconnects before processing", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const expiredAt = new Date(RETENTION_CUTOFF.getTime() - 60_000);
     const connection = await seedConnection(tenantId, principalId, expiredAt);
 
     await connections.upsertByProviderAccount({
-      tenantId: tenantId as TenantId,
-      principalId: principalId as PrincipalId,
+      tenantId: tenantId,
+      principalId: principalId,
       provider: "google",
       account: {
         providerAccountId: connection.account.providerAccountId,
@@ -294,17 +289,13 @@ describe("purgeExpiredDisconnectedConnections", () => {
 
     expect(purged).toBe(0);
     expect(
-      await connections.findById(
-        tenantId as TenantId,
-        principalId as PrincipalId,
-        connection._id,
-      ),
+      await connections.findById(tenantId, principalId, connection._id),
     ).not.toBeNull();
   });
 
   it("bounds the sweep and takes the oldest disconnect first", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const older = await seedConnection(
       tenantId,
       principalId,
@@ -324,17 +315,10 @@ describe("purgeExpiredDisconnectedConnections", () => {
 
     expect(purged).toBe(1);
     expect(
-      await connections.findById(
-        tenantId as TenantId,
-        principalId as PrincipalId,
-        older._id,
-      ),
+      await connections.findById(tenantId, principalId, older._id),
     ).toBeNull();
     expect(
-      await connections.listByPrincipal(
-        tenantId as TenantId,
-        principalId as PrincipalId,
-      ),
+      await connections.listByPrincipal(tenantId, principalId),
     ).toHaveLength(1);
   });
 });

--- a/packages/sync/src/domain/connection-state-refresh.service.db.test.ts
+++ b/packages/sync/src/domain/connection-state-refresh.service.db.test.ts
@@ -1,8 +1,11 @@
 import { faker } from "@faker-js/faker";
 import { encryptCredentialAtRest } from "@core/security/credential-at-rest";
 import {
+  type PrincipalId,
+  type ProviderAccountId,
   type ProviderCalendarId,
   type ProviderCalendarSourceId,
+  type TenantId,
 } from "@core/types/sync/identity.contracts";
 import { seedOauthCredential } from "@sync/__tests__/helpers/credential-encryption";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
@@ -39,11 +42,11 @@ describe("refreshConnectionState", () => {
 
   async function seedImportingConnection() {
     const connection = await connections.upsertByProviderAccount({
-      tenantId: objectId(),
-      principalId: objectId(),
+      tenantId: objectId() as TenantId,
+      principalId: objectId() as PrincipalId,
       provider: "google",
       account: {
-        providerAccountId: "acct-1",
+        providerAccountId: "acct-1" as ProviderAccountId,
         email: "user@example.com",
         displayName: "User",
       },
@@ -92,6 +95,8 @@ describe("refreshConnectionState", () => {
         canReadBusy: true,
         canInviteAttendees: true,
       },
+      eventLabels: [],
+      createsGoogleMeet: true,
     });
 
     const listResource = await resources.ensure({
@@ -151,6 +156,8 @@ describe("refreshConnectionState", () => {
         canReadBusy: true,
         canInviteAttendees: false,
       },
+      eventLabels: [],
+      createsGoogleMeet: true,
     });
     const slowerResource = await resources.ensure({
       tenantId: connection.tenantId,
@@ -204,6 +211,8 @@ describe("refreshConnectionState", () => {
         canReadBusy: true,
         canInviteAttendees: true,
       },
+      eventLabels: [],
+      createsGoogleMeet: true,
     });
     const listResource = await resources.ensure({
       tenantId: connection.tenantId,
@@ -274,6 +283,8 @@ describe("refreshConnectionState", () => {
         canReadBusy: true,
         canInviteAttendees: true,
       },
+      eventLabels: [],
+      createsGoogleMeet: true,
     });
     const listResource = await resources.ensure({
       tenantId: connection.tenantId,
@@ -319,6 +330,8 @@ describe("refreshConnectionState", () => {
         canReadBusy: true,
         canInviteAttendees: true,
       },
+      eventLabels: [],
+      createsGoogleMeet: true,
     });
     const listResource = await resources.ensure({
       tenantId: connection.tenantId,
@@ -377,6 +390,8 @@ describe("refreshConnectionState", () => {
         canReadBusy: true,
         canInviteAttendees: true,
       },
+      eventLabels: [],
+      createsGoogleMeet: true,
     });
     const listResource = await resources.ensure({
       tenantId: connection.tenantId,
@@ -443,6 +458,8 @@ describe("refreshConnectionState", () => {
         canReadBusy: true,
         canInviteAttendees: true,
       },
+      eventLabels: [],
+      createsGoogleMeet: true,
     });
     const listResource = await resources.ensure({
       tenantId: connection.tenantId,
@@ -491,6 +508,8 @@ describe("refreshConnectionState", () => {
         canReadBusy: true,
         canInviteAttendees: true,
       },
+      eventLabels: [],
+      createsGoogleMeet: true,
     });
     const listResource = await resources.ensure({
       tenantId: connection.tenantId,
@@ -529,6 +548,8 @@ describe("refreshConnectionState", () => {
         canReadBusy: true,
         canInviteAttendees: true,
       },
+      eventLabels: [],
+      createsGoogleMeet: true,
     });
     const listResource = await resources.ensure({
       tenantId: connection.tenantId,
@@ -598,6 +619,8 @@ describe("refreshConnectionState", () => {
         canReadBusy: true,
         canInviteAttendees: true,
       },
+      eventLabels: [],
+      createsGoogleMeet: true,
     });
     const listResource = await resources.ensure({
       tenantId: connection.tenantId,
@@ -714,6 +737,8 @@ describe("refreshConnectionState", () => {
         canReadBusy: true,
         canInviteAttendees: true,
       },
+      eventLabels: [],
+      createsGoogleMeet: true,
     });
     const listResource = await resources.ensure({
       tenantId: connection.tenantId,

--- a/packages/sync/src/domain/event-instance-assembly.test.ts
+++ b/packages/sync/src/domain/event-instance-assembly.test.ts
@@ -1,5 +1,15 @@
 import { faker } from "@faker-js/faker";
 import {
+  type CalendarId,
+  type DateTime,
+  type EventId,
+  type TimeZone,
+} from "@core/types/domain-primitives";
+import {
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import {
   type EventRecord,
   EventRecordSchema,
 } from "@sync/storage/contracts/event.contracts";
@@ -14,9 +24,9 @@ const objectId = () => faker.database.mongodbObjectId();
 
 const timed = (start: string, end: string) => ({
   kind: "timed" as const,
-  start,
-  end,
-  timeZone: "America/Denver",
+  start: start as DateTime,
+  end: end as DateTime,
+  timeZone: "America/Denver" as TimeZone,
 });
 
 const baseContent = {
@@ -31,10 +41,10 @@ const baseContent = {
 const makeEvent = (overrides: Partial<EventRecord> = {}): EventRecord =>
   EventRecordSchema.parse({
     _id: objectId(),
-    tenantId: objectId(),
-    principalId: objectId(),
+    tenantId: objectId() as TenantId,
+    principalId: objectId() as PrincipalId,
     origin: "compass",
-    calendarId: objectId(),
+    calendarId: objectId() as CalendarId,
     clientEventId: null,
     connectionId: null,
     providerEventId: null,
@@ -57,14 +67,14 @@ const makeOccurrence = (
   overrides: Partial<EventOccurrenceRecord> = {},
 ): EventOccurrenceRecord => {
   const startAt = overrides.startAt ?? new Date("2026-07-14T15:00:00.000Z");
-  const eventId = overrides.eventId ?? objectId();
+  const eventId = overrides.eventId ?? (objectId() as EventId);
   return EventOccurrenceRecordSchema.parse({
     _id: objectId(),
-    tenantId: objectId(),
-    principalId: objectId(),
+    tenantId: objectId() as TenantId,
+    principalId: objectId() as PrincipalId,
     eventId,
     occurrenceKey: `${eventId}:${startAt.toISOString()}`,
-    calendarId: objectId(),
+    calendarId: objectId() as CalendarId,
     schedule: timed("2026-07-14T09:00:00-06:00", "2026-07-14T09:15:00-06:00"),
     startAt,
     endAt: overrides.endAt ?? new Date(startAt.getTime() + 15 * 60_000),
@@ -137,7 +147,7 @@ describe("assembleEventInstances", () => {
       recurrence: {
         kind: "exception",
         seriesId: master._id,
-        recurrenceId: "2026-07-14T15:00:00.000Z",
+        recurrenceId: "2026-07-14T15:00:00.000Z" as DateTime,
         cancelled: false,
       },
       providerMetadata: managedMetadata,
@@ -209,8 +219,8 @@ describe("assembleEventInstances", () => {
     expect(instance?.content).toEqual(baseContent);
     // The instance schedule comes from the occurrence, timestamps from the event.
     expect(instance?.schedule).toEqual(occurrence.schedule);
-    expect(instance?.createdAt).toBe("2026-07-01T00:00:00.000Z");
-    expect(instance?.updatedAt).toBe("2026-07-02T00:00:00.000Z");
+    expect(instance?.createdAt).toBe("2026-07-01T00:00:00.000Z" as DateTime);
+    expect(instance?.updatedAt).toBe("2026-07-02T00:00:00.000Z" as DateTime);
   });
 
   it("carries event content.color onto assembled instance content", () => {
@@ -322,7 +332,10 @@ describe("assembleEventInstances", () => {
       occurrences.map((o) =>
         o.recurrence.kind === "occurrence" ? o.recurrence.recurrenceId : null,
       ),
-    ).toEqual(["2026-07-13T15:00:00.000Z", "2026-07-14T15:00:00.000Z"]);
+    ).toEqual([
+      "2026-07-13T15:00:00.000Z" as DateTime,
+      "2026-07-14T15:00:00.000Z" as DateTime,
+    ]);
   });
 
   it("addresses an overridden instance by its ORIGINAL start, linked to the master", () => {
@@ -340,7 +353,7 @@ describe("assembleEventInstances", () => {
       recurrence: {
         kind: "exception",
         seriesId: master._id,
-        recurrenceId: "2026-07-14T15:00:00.000Z",
+        recurrenceId: "2026-07-14T15:00:00.000Z" as DateTime,
         cancelled: false,
       },
     });
@@ -363,7 +376,7 @@ describe("assembleEventInstances", () => {
       override?.recurrence.kind === "occurrence"
         ? override.recurrence.recurrenceId
         : null,
-    ).toBe("2026-07-14T15:00:00.000Z");
+    ).toBe("2026-07-14T15:00:00.000Z" as DateTime);
     // Content is the override's, schedule is the moved occurrence's.
     expect(override?.content.title).toBe("Standup (moved)");
     expect(override?.schedule).toEqual(movedOccurrence.schedule);
@@ -379,7 +392,7 @@ describe("assembleEventInstances", () => {
       recurrence: {
         kind: "exception",
         seriesId: master._id,
-        recurrenceId: "2026-07-14T15:00:00.000Z",
+        recurrenceId: "2026-07-14T15:00:00.000Z" as DateTime,
         cancelled: false,
       },
     });
@@ -414,7 +427,7 @@ describe("assembleEventInstances", () => {
   });
 
   it("skips an occurrence whose owning event is missing, without throwing", () => {
-    const orphan = makeOccurrence({ eventId: objectId() });
+    const orphan = makeOccurrence({ eventId: objectId() as EventId });
 
     expect(assembleEventInstances([orphan], byId())).toEqual([]);
   });

--- a/packages/sync/src/domain/failed-job-requeue.service.db.test.ts
+++ b/packages/sync/src/domain/failed-job-requeue.service.db.test.ts
@@ -1,4 +1,9 @@
 import { faker } from "@faker-js/faker";
+import {
+  type ConnectionId,
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { requeueFailedJobs } from "@sync/domain/failed-job-requeue.service";
 import { type JobEnqueue } from "@sync/storage/contracts/job.contracts";
@@ -33,13 +38,13 @@ describe("requeueFailedJobs", () => {
     principalId: string;
     connectionId: string;
   }> => {
-    const tenantId = objectId();
-    const principalId = objectId();
-    const connectionId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const connectionId = objectId() as ConnectionId;
     const job = await jobs.enqueue({
-      tenantId,
-      principalId,
-      connectionId,
+      tenantId: tenantId,
+      principalId: principalId,
+      connectionId: connectionId,
       resourceId: null,
       commandId: null,
       kind: "incrementalPull",
@@ -88,9 +93,9 @@ describe("requeueFailedJobs", () => {
       .db()
       .collection("jobs")
       .findOne({ _id: id as never });
-    expect(raw?.state).toBe("pending");
-    expect(raw?.runAfter).toEqual(NOW);
-    expect(raw?.requeuedCount).toBe(1);
+    expect(raw?.["state"]).toBe("pending");
+    expect(raw?.["runAfter"]).toEqual(NOW);
+    expect(raw?.["requeuedCount"]).toBe(1);
   });
 
   it("leaves a job that has not cooled down yet failed", async () => {
@@ -227,8 +232,8 @@ describe("requeueFailedJobs", () => {
       .db()
       .collection("jobs")
       .findOne({ _id: id as never });
-    expect(raw?.state).toBe("pending");
+    expect(raw?.["state"]).toBe("pending");
     // Absence counted as zero, so the requeue is its first, not its last.
-    expect(raw?.requeuedCount).toBe(1);
+    expect(raw?.["requeuedCount"]).toBe(1);
   });
 });

--- a/packages/sync/src/domain/occurrence-projection.test.ts
+++ b/packages/sync/src/domain/occurrence-projection.test.ts
@@ -1,6 +1,20 @@
 import { faker } from "@faker-js/faker";
+import {
+  type CalendarId,
+  type DateOnly,
+  type DateTime,
+  type EventId,
+  type TimeZone,
+} from "@core/types/domain-primitives";
 import { type EventSchedule } from "@core/types/event.contracts";
-import { type SyncEventRecurrence } from "@core/types/sync/event.contracts";
+import {
+  type OccurrenceKey,
+  type SyncEventRecurrence,
+} from "@core/types/sync/event.contracts";
+import {
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
 import {
   occurrenceScheduleAfterSeriesEdit,
   type ProjectionHorizon,
@@ -18,10 +32,19 @@ const HORIZON: ProjectionHorizon = {
 };
 
 const timed = (start: string, end: string, timeZone = "America/Denver") =>
-  ({ kind: "timed", start, end, timeZone }) as EventSchedule;
+  ({
+    kind: "timed",
+    start: start as DateTime,
+    end: end as DateTime,
+    timeZone,
+  }) as EventSchedule;
 
 const allDay = (start: string, end: string) =>
-  ({ kind: "allDay", start, end }) as EventSchedule;
+  ({
+    kind: "allDay",
+    start: start as DateOnly,
+    end: end as DateOnly,
+  }) as EventSchedule;
 
 const event = (
   schedule: EventSchedule,
@@ -29,11 +52,11 @@ const event = (
   overrides: Partial<EventRecord> = {},
 ): EventRecord =>
   ({
-    _id: objectId(),
-    tenantId: objectId(),
-    principalId: objectId(),
+    _id: objectId() as EventId,
+    tenantId: objectId() as TenantId,
+    principalId: objectId() as PrincipalId,
     origin: "compass",
-    calendarId: objectId(),
+    calendarId: objectId() as CalendarId,
     clientEventId: null,
     connectionId: null,
     providerEventId: null,
@@ -79,7 +102,9 @@ describe("projectOccurrences", () => {
       expect(occ?.startAt.toISOString()).toBe("2026-07-14T15:00:00.000Z");
       // Half-open end: the timed end instant.
       expect(occ?.endAt?.toISOString()).toBe("2026-07-14T16:00:00.000Z");
-      expect(occ?.occurrenceKey).toBe(`${e._id}:2026-07-14T15:00:00.000Z`);
+      expect(occ?.occurrenceKey).toBe(
+        `${e._id}:2026-07-14T15:00:00.000Z` as OccurrenceKey,
+      );
     });
 
     it("projects one occurrence for an all-day single event", () => {
@@ -268,12 +293,12 @@ describe("projectOccurrences", () => {
       );
       const occ = projectOccurrences(e, HORIZON);
       const starts = occ.map((o) =>
-        o.schedule.kind === "timed" ? o.schedule.start : "",
+        o.schedule.kind === "timed" ? o.schedule.start : ("" as DateTime),
       );
       expect(starts).toEqual([
-        "2026-03-01T09:00:00-07:00",
-        "2026-03-08T09:00:00-06:00",
-        "2026-03-15T09:00:00-06:00",
+        "2026-03-01T09:00:00-07:00" as DateTime,
+        "2026-03-08T09:00:00-06:00" as DateTime,
+        "2026-03-15T09:00:00-06:00" as DateTime,
       ]);
     });
 
@@ -410,7 +435,7 @@ describe("projectOccurrences", () => {
       ]);
       const extra = occ.at(-1);
       if (extra?.schedule.kind !== "timed") throw new Error("expected timed");
-      expect(extra.schedule.timeZone).toBe("America/Denver");
+      expect(extra.schedule.timeZone).toBe("America/Denver" as TimeZone);
       expect(extra.endAt?.getTime()).toBe(
         extra.startAt.getTime() + 30 * 60 * 1000,
       );

--- a/packages/sync/src/domain/provider-command.service.db.test.ts
+++ b/packages/sync/src/domain/provider-command.service.db.test.ts
@@ -1,12 +1,21 @@
 import { faker } from "@faker-js/faker";
+import { type Document, type Filter } from "mongodb";
+import {
+  type DateTime,
+  type EventId,
+  type TimeZone,
+} from "@core/types/domain-primitives";
 import { type Attendee } from "@core/types/event-attendance.contracts";
+import { type EventColorSlot } from "@core/types/event-color.contracts";
 import { type RecurrenceEdit } from "@core/types/event-command.contracts";
 import { type SyncCommandInput } from "@core/types/sync/command.contracts";
+import { type ProviderEventVersion } from "@core/types/sync/event.contracts";
 import {
   type ConnectionId,
-  type EventId,
   type IdempotencyKey,
   type PrincipalId,
+  type ProviderCalendarSourceId,
+  type ProviderEventId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
 import {
@@ -15,10 +24,13 @@ import {
   FakeProviderEventWriter,
   failingTokenSource,
   newCommandIds,
+  providerDeleteDeps,
+  providerMutationDeps,
   RevokedAuthAdapter,
   seedCommandCalendar,
   seedLinkedEvent,
   storeCommandCredential,
+  stubConnectionLookup,
   TEST_CREDENTIAL_ENCRYPTION_KEY,
   tokenSource,
 } from "@sync/__tests__/helpers/command-scenario";
@@ -114,7 +126,8 @@ describe("executeProviderCreate", () => {
   const seed = async (invitation = "none") => {
     const ids = newCommandIds();
     const calendar = await seedCommandCalendar(calendars, ids, {
-      providerCalendarId: "primary@group.calendar.google.com",
+      providerCalendarId:
+        "primary@group.calendar.google.com" as ProviderCalendarSourceId,
     });
     const { record: command } = await commands.submit({
       tenantId: ids.tenantId,
@@ -142,6 +155,7 @@ describe("executeProviderCreate", () => {
         events,
         occurrences,
         resources,
+        connections: stubConnectionLookup(),
         writer,
         custody: tokenSource(),
       },
@@ -153,12 +167,12 @@ describe("executeProviderCreate", () => {
     expect(result.outcome.state).toBe("confirmed");
     expect(
       result.outcome.state === "confirmed" && result.outcome.providerEventId,
-    ).toBe("g-evt-1");
+    ).toBe("g-evt-1" as ProviderEventId);
 
     // Called with the raw provider calendar id and the deterministic event id.
     expect(writer.calls).toHaveLength(1);
-    expect(writer.calls[0].calendarId).toBe(calendar.providerCalendarId);
-    expect(writer.calls[0].providerEventId).toBe(command.eventId);
+    expect(writer.calls[0]!.calendarId).toBe(calendar.providerCalendarId);
+    expect(writer.calls[0]!.providerEventId).toBe(command.eventId);
 
     const stored = await events.findById(
       tenantId,
@@ -166,8 +180,8 @@ describe("executeProviderCreate", () => {
       command.eventId,
     );
     expect(stored?.connectionId).toBe(calendar.connectionId);
-    expect(stored?.providerEventId).toBe("g-evt-1");
-    expect(stored?.providerVersion).toBe("etag-1");
+    expect(stored?.providerEventId).toBe("g-evt-1" as ProviderEventId);
+    expect(stored?.providerVersion).toBe("etag-1" as ProviderEventVersion);
     expect(stored?.deliveryState).toBe("confirmed");
     expect(stored?.providerMetadata).toBeNull();
 
@@ -185,7 +199,7 @@ describe("executeProviderCreate", () => {
     const { tenantId, principalId, calendar, command } = await seed();
     const writer = new FakeProviderEventWriter();
     writer.result = {
-      providerEventId: "g-evt-1",
+      providerEventId: "g-evt-1" as ProviderEventId,
       providerVersion: "etag-1",
       icalUid: "g-evt-1@google.com",
     };
@@ -196,6 +210,7 @@ describe("executeProviderCreate", () => {
         events,
         occurrences,
         resources,
+        connections: stubConnectionLookup(),
         writer,
         custody: tokenSource(),
       },
@@ -216,7 +231,7 @@ describe("executeProviderCreate", () => {
     const { tenantId, principalId, calendar, command } = await seed();
     const writer = new FakeProviderEventWriter();
     writer.result = {
-      providerEventId: "g-evt-1",
+      providerEventId: "g-evt-1" as ProviderEventId,
       providerVersion: "etag-1",
       conference: {
         url: "https://meet.google.com/abc-defg-hij",
@@ -230,6 +245,7 @@ describe("executeProviderCreate", () => {
         events,
         occurrences,
         resources,
+        connections: stubConnectionLookup(),
         writer,
         custody: tokenSource(),
       },
@@ -262,6 +278,7 @@ describe("executeProviderCreate", () => {
         events,
         occurrences,
         resources,
+        connections: stubConnectionLookup(),
         writer,
         custody: tokenSource(),
       },
@@ -270,7 +287,7 @@ describe("executeProviderCreate", () => {
       now,
     );
 
-    expect(writer.calls[0].invitation).toBe("all");
+    expect(writer.calls[0]!.invitation).toBe("all");
   });
 
   it("converges on one event when executed twice (idempotent write)", async () => {
@@ -281,6 +298,7 @@ describe("executeProviderCreate", () => {
       events,
       occurrences,
       resources,
+      connections: stubConnectionLookup(),
       writer,
       custody: tokenSource(),
     };
@@ -313,14 +331,10 @@ describe("executeProviderCreate", () => {
     await resources.activateGeneration(tenantId, principalId, resource._id, 1);
 
     await executeProviderCreate(
-      {
-        commands,
-        events,
-        occurrences,
-        resources,
-        writer: new FakeProviderEventWriter(),
-        custody: tokenSource(),
-      },
+      providerMutationDeps(
+        { commands, events, occurrences, resources },
+        new FakeProviderEventWriter(),
+      ),
       command,
       calendar,
       now,
@@ -332,7 +346,7 @@ describe("executeProviderCreate", () => {
       .find({ tenantId, principalId, calendarId: calendar._id, generation: 1 })
       .toArray();
     expect(atActive).toHaveLength(1);
-    expect(atActive[0]?.["_id"]).toBe(command.eventId);
+    expect(String(atActive[0]?.["_id"])).toBe(command.eventId);
   });
 
   it("leaves the command pending on a transient write failure", async () => {
@@ -346,6 +360,7 @@ describe("executeProviderCreate", () => {
         events,
         occurrences,
         resources,
+        connections: stubConnectionLookup(),
         writer,
         custody: tokenSource(),
       },
@@ -371,6 +386,7 @@ describe("executeProviderCreate", () => {
         events,
         occurrences,
         resources,
+        connections: stubConnectionLookup(),
         writer,
         custody: tokenSource(),
       },
@@ -407,13 +423,11 @@ describe("executeProviderCreate", () => {
     );
 
     const result = await executeProviderCreate(
-      {
-        commands,
-        events,
-        occurrences,
+      providerMutationDeps(
+        { commands, events, occurrences, resources },
         writer,
-        custody,
-      },
+        { custody },
+      ),
       command,
       calendar,
       now,
@@ -434,15 +448,15 @@ describe("executeProviderCreate", () => {
     const writer = new FakeProviderEventWriter();
 
     const result = await executeProviderCreate(
-      {
-        commands,
-        events,
-        occurrences,
+      providerMutationDeps(
+        { commands, events, occurrences, resources },
         writer,
-        custody: failingTokenSource(
-          new ProviderAuthError("refreshFailed", "temporary"),
-        ),
-      },
+        {
+          custody: failingTokenSource(
+            new ProviderAuthError("refreshFailed", "temporary"),
+          ),
+        },
+      ),
       command,
       calendar,
       now,
@@ -456,9 +470,9 @@ describe("executeProviderCreate", () => {
 describe("executeProviderUpdate", () => {
   const schedule = {
     kind: "timed" as const,
-    start: "2026-07-14T09:00:00-06:00",
-    end: "2026-07-14T10:00:00-06:00",
-    timeZone: "America/Denver",
+    start: "2026-07-14T09:00:00-06:00" as DateTime,
+    end: "2026-07-14T10:00:00-06:00" as DateTime,
+    timeZone: "America/Denver" as TimeZone,
   };
   const content = (title: string) => ({
     title,
@@ -470,7 +484,7 @@ describe("executeProviderUpdate", () => {
   });
   const providerEvent = (title: string, version: string): ProviderEvent => ({
     kind: "event",
-    providerEventId: "g-evt-1",
+    providerEventId: "g-evt-1" as ProviderEventId,
     providerVersion: version,
     providerUpdatedAt: null,
     content: content(title),
@@ -528,6 +542,7 @@ describe("executeProviderUpdate", () => {
         events,
         occurrences,
         resources,
+        connections: stubConnectionLookup(),
         writer,
         custody: tokenSource(),
       },
@@ -539,11 +554,11 @@ describe("executeProviderUpdate", () => {
 
     expect(result.outcome.state).toBe("confirmed");
     expect(writer.patchCalls).toHaveLength(1);
-    expect(writer.patchCalls[0].expectedVersion).toBe("etag-1");
-    expect(writer.patchCalls[0].invitation).toBe("all");
+    expect(writer.patchCalls[0]!.expectedVersion).toBe("etag-1");
+    expect(writer.patchCalls[0]!.invitation).toBe("all");
     const stored = await events.findById(tenantId, principalId, event._id);
     expect(stored?.content.title).toBe("New");
-    expect(stored?.providerVersion).toBe("etag-2");
+    expect(stored?.providerVersion).toBe("etag-2" as ProviderEventVersion);
 
     // The occurrence projection is rebuilt with the edited title.
     const occ = await mongo.db
@@ -567,6 +582,7 @@ describe("executeProviderUpdate", () => {
         events,
         occurrences,
         resources,
+        connections: stubConnectionLookup(),
         writer,
         custody: tokenSource(),
       },
@@ -580,7 +596,7 @@ describe("executeProviderUpdate", () => {
     // No second write — the replay is recognized from the fetch.
     expect(writer.patchCalls).toHaveLength(0);
     const stored = await events.findById(tenantId, principalId, event._id);
-    expect(stored?.providerVersion).toBe("etag-2");
+    expect(stored?.providerVersion).toBe("etag-2" as ProviderEventVersion);
   });
 
   it("recognizes a replay even when read-reflected fields drifted", async () => {
@@ -592,7 +608,7 @@ describe("executeProviderUpdate", () => {
     // conflict on an edit that already succeeded.
     writer.fetched = {
       kind: "event",
-      providerEventId: "g-evt-1",
+      providerEventId: "g-evt-1" as ProviderEventId,
       providerVersion: "etag-2",
       providerUpdatedAt: null,
       content: {
@@ -620,6 +636,7 @@ describe("executeProviderUpdate", () => {
         events,
         occurrences,
         resources,
+        connections: stubConnectionLookup(),
         writer,
         custody: tokenSource(),
       },
@@ -647,6 +664,7 @@ describe("executeProviderUpdate", () => {
         events,
         occurrences,
         resources,
+        connections: stubConnectionLookup(),
         writer,
         custody: tokenSource(),
       },
@@ -673,6 +691,7 @@ describe("executeProviderUpdate", () => {
         events,
         occurrences,
         resources,
+        connections: stubConnectionLookup(),
         writer,
         custody: tokenSource(),
       },
@@ -701,6 +720,7 @@ describe("executeProviderUpdate", () => {
         events,
         occurrences,
         resources,
+        connections: stubConnectionLookup(),
         writer,
         custody: tokenSource(),
       },
@@ -718,15 +738,15 @@ describe("executeProviderUpdate", () => {
     const writer = new FakeProviderEventWriter();
 
     const result = await executeProviderUpdate(
-      {
-        commands,
-        events,
-        occurrences,
+      providerMutationDeps(
+        { commands, events, occurrences, resources },
         writer,
-        custody: failingTokenSource(
-          new ProviderAuthError("authorizationRevoked", "revoked"),
-        ),
-      },
+        {
+          custody: failingTokenSource(
+            new ProviderAuthError("authorizationRevoked", "revoked"),
+          ),
+        },
+      ),
       command,
       event,
       calendar,
@@ -758,7 +778,11 @@ describe("executeProviderUpdate", () => {
     );
 
     const result = await executeProviderUpdate(
-      { commands, events, occurrences, writer, custody },
+      providerMutationDeps(
+        { commands, events, occurrences, resources },
+        writer,
+        { custody },
+      ),
       command,
       event,
       calendar,
@@ -778,9 +802,9 @@ describe("executeProviderUpdate", () => {
 describe("executeProviderUpdate on provider-managed events", () => {
   const schedule = {
     kind: "timed" as const,
-    start: "2026-07-14T09:00:00-06:00",
-    end: "2026-07-14T10:00:00-06:00",
-    timeZone: "America/Denver",
+    start: "2026-07-14T09:00:00-06:00" as DateTime,
+    end: "2026-07-14T10:00:00-06:00" as DateTime,
+    timeZone: "America/Denver" as TimeZone,
   };
   const content = (title: string, extras: Record<string, unknown> = {}) => ({
     title,
@@ -797,7 +821,7 @@ describe("executeProviderUpdate on provider-managed events", () => {
     extras: Partial<ProviderEvent> = {},
   ): ProviderEvent => ({
     kind: "event",
-    providerEventId: "g-evt-1",
+    providerEventId: "g-evt-1" as ProviderEventId,
     providerVersion: version,
     providerUpdatedAt: null,
     content: content(title),
@@ -878,6 +902,7 @@ describe("executeProviderUpdate on provider-managed events", () => {
         events,
         occurrences,
         resources,
+        connections: stubConnectionLookup(),
         writer,
         custody: tokenSource(),
       },
@@ -908,6 +933,7 @@ describe("executeProviderUpdate on provider-managed events", () => {
         events,
         occurrences,
         resources,
+        connections: stubConnectionLookup(),
         writer,
         custody: tokenSource(),
       },
@@ -919,17 +945,17 @@ describe("executeProviderUpdate on provider-managed events", () => {
 
     expect(result.outcome.state).toBe("confirmed");
     expect(writer.patchCalls).toHaveLength(1);
-    expect(writer.patchCalls[0].providerManaged).toBe(true);
+    expect(writer.patchCalls[0]!.providerManaged).toBe(true);
     const stored = await events.findById(tenantId, principalId, event._id);
     expect(stored?.content.color).toBe("coral");
-    expect(stored?.providerVersion).toBe("etag-2");
+    expect(stored?.providerVersion).toBe("etag-2" as ProviderEventVersion);
   });
 
   it("fails schedule edits as unsupportedCapability without patching", async () => {
     const movedSchedule = {
       ...schedule,
-      start: "2026-07-14T10:00:00-06:00",
-      end: "2026-07-14T11:00:00-06:00",
+      start: "2026-07-14T10:00:00-06:00" as DateTime,
+      end: "2026-07-14T11:00:00-06:00" as DateTime,
     };
     const { calendar, event, command } = await seedManaged({
       commandSchedule: movedSchedule,
@@ -943,6 +969,7 @@ describe("executeProviderUpdate on provider-managed events", () => {
         events,
         occurrences,
         resources,
+        connections: stubConnectionLookup(),
         writer,
         custody: tokenSource(),
       },
@@ -974,6 +1001,7 @@ describe("executeProviderUpdate on provider-managed events", () => {
         events,
         occurrences,
         resources,
+        connections: stubConnectionLookup(),
         writer,
         custody: tokenSource(),
       },
@@ -993,9 +1021,9 @@ describe("executeProviderUpdate on provider-managed events", () => {
 describe("executeProviderDelete", () => {
   const schedule = {
     kind: "timed" as const,
-    start: "2026-07-14T09:00:00-06:00",
-    end: "2026-07-14T10:00:00-06:00",
-    timeZone: "America/Denver",
+    start: "2026-07-14T09:00:00-06:00" as DateTime,
+    end: "2026-07-14T10:00:00-06:00" as DateTime,
+    timeZone: "America/Denver" as TimeZone,
   };
 
   // Seed a provider-linked event plus a delete command for it.
@@ -1060,14 +1088,10 @@ describe("executeProviderDelete", () => {
     expect(await occurrenceCount()).toBe(1);
 
     const result = await executeProviderDelete(
-      {
-        commands,
-        events,
-        occurrences,
+      providerDeleteDeps(
+        { commands, events, occurrences, resources, markers },
         writer,
-        custody: tokenSource(),
-        markers,
-      },
+      ),
       command,
       event,
       calendar,
@@ -1076,7 +1100,7 @@ describe("executeProviderDelete", () => {
 
     expect(result.outcome.state).toBe("confirmed");
     expect(writer.deleteCalls).toHaveLength(1);
-    expect(writer.deleteCalls[0].invitation).toBe("all");
+    expect(writer.deleteCalls[0]!.invitation).toBe("all");
     // Local content is gone, a content-free marker remains, occurrences cleared.
     expect(await events.findById(tenantId, principalId, event._id)).toBeNull();
     expect(await occurrenceCount()).toBe(0);
@@ -1096,14 +1120,10 @@ describe("executeProviderDelete", () => {
     await events.deleteById(tenantId, principalId, event._id);
 
     const result = await executeProviderDelete(
-      {
-        commands,
-        events,
-        occurrences,
+      providerDeleteDeps(
+        { commands, events, occurrences, resources, markers },
         writer,
-        custody: tokenSource(),
-        markers,
-      },
+      ),
       command,
       event,
       calendar,
@@ -1219,20 +1239,16 @@ describe("executeProviderDelete", () => {
       tenantId,
       principalId,
       idempotencyKey: `idem-${objectId()}` as IdempotencyKey,
-      eventId: masterId,
+      eventId: masterId as EventId,
       input: { kind: "delete", invitation: "none", scope: "all" } as never,
       expectedVersion: null,
     });
 
     const result = await executeProviderDelete(
-      {
-        commands,
-        events,
-        occurrences,
-        writer: new FakeProviderEventWriter(),
-        custody: tokenSource(),
-        markers,
-      },
+      providerDeleteDeps(
+        { commands, events, occurrences, resources, markers },
+        new FakeProviderEventWriter(),
+      ),
       command,
       master,
       calendar,
@@ -1346,20 +1362,16 @@ describe("executeProviderDelete", () => {
       tenantId,
       principalId,
       idempotencyKey: `idem-${objectId()}` as IdempotencyKey,
-      eventId: masterId,
+      eventId: masterId as EventId,
       input: { kind: "delete", invitation: "none", scope: "all" } as never,
       expectedVersion: null,
     });
 
     const result = await executeProviderDelete(
-      {
-        commands,
-        events,
-        occurrences,
-        writer: new FakeProviderEventWriter(),
-        custody: tokenSource(),
-        markers,
-      },
+      providerDeleteDeps(
+        { commands, events, occurrences, resources, markers },
+        new FakeProviderEventWriter(),
+      ),
       command,
       ghostMaster,
       calendar,
@@ -1378,14 +1390,10 @@ describe("executeProviderDelete", () => {
     writer.deleteError = new ProviderWriteError("transient", "blip");
 
     const result = await executeProviderDelete(
-      {
-        commands,
-        events,
-        occurrences,
+      providerDeleteDeps(
+        { commands, events, occurrences, resources, markers },
         writer,
-        custody: tokenSource(),
-        markers,
-      },
+      ),
       command,
       event,
       calendar,
@@ -1406,14 +1414,10 @@ describe("executeProviderDelete", () => {
     );
 
     const result = await executeProviderDelete(
-      {
-        commands,
-        events,
-        occurrences,
+      providerDeleteDeps(
+        { commands, events, occurrences, resources, markers },
         writer,
-        custody: tokenSource(),
-        markers,
-      },
+      ),
       command,
       event,
       calendar,
@@ -1434,16 +1438,15 @@ describe("executeProviderDelete", () => {
     const writer = new FakeProviderEventWriter();
 
     const result = await executeProviderDelete(
-      {
-        commands,
-        events,
-        occurrences,
+      providerDeleteDeps(
+        { commands, events, occurrences, resources, markers },
         writer,
-        custody: failingTokenSource(
-          new ProviderAuthError("authorizationRevoked", "revoked"),
-        ),
-        markers,
-      },
+        {
+          custody: failingTokenSource(
+            new ProviderAuthError("authorizationRevoked", "revoked"),
+          ),
+        },
+      ),
       command,
       event,
       calendar,
@@ -1461,9 +1464,9 @@ describe("executeProviderSeriesUpdate", () => {
   // A weekly series of four occurrences starting 2026-07-14 09:00 Denver.
   const schedule = {
     kind: "timed" as const,
-    start: "2026-07-14T09:00:00-06:00",
-    end: "2026-07-14T10:00:00-06:00",
-    timeZone: "America/Denver",
+    start: "2026-07-14T09:00:00-06:00" as DateTime,
+    end: "2026-07-14T10:00:00-06:00" as DateTime,
+    timeZone: "America/Denver" as TimeZone,
   };
   const weekly4 = ["RRULE:FREQ=WEEKLY;COUNT=4"];
   const weekly2 = ["RRULE:FREQ=WEEKLY;COUNT=2"];
@@ -1482,7 +1485,7 @@ describe("executeProviderSeriesUpdate", () => {
     rules: readonly string[],
   ): ProviderEvent => ({
     kind: "event",
-    providerEventId: "g-evt-1",
+    providerEventId: "g-evt-1" as ProviderEventId,
     providerVersion: version,
     providerUpdatedAt: null,
     content: content(title),
@@ -1597,13 +1600,8 @@ describe("executeProviderSeriesUpdate", () => {
     return stored;
   };
 
-  const deps = (writer: ProviderEventWriter) => ({
-    commands,
-    events,
-    occurrences,
-    writer,
-    custody: tokenSource(),
-  });
+  const deps = (writer: ProviderEventWriter) =>
+    providerMutationDeps({ commands, events, occurrences, resources }, writer);
 
   it("patches the whole series and reprojects with the edited content", async () => {
     const { tenantId, principalId, calendar, master } = await seedMaster();
@@ -1614,7 +1612,7 @@ describe("executeProviderSeriesUpdate", () => {
     const writer = new FakeProviderEventWriter();
     writer.fetched = providerSeries("Old", "etag-1", weekly4);
     writer.patchResult = {
-      providerEventId: "g-evt-1",
+      providerEventId: "g-evt-1" as ProviderEventId,
       providerVersion: "etag-2",
     };
 
@@ -1629,13 +1627,13 @@ describe("executeProviderSeriesUpdate", () => {
     expect(result.outcome.state).toBe("confirmed");
     // Preserve re-writes the master's own rules; the whole series is patched.
     expect(writer.patchCalls).toHaveLength(1);
-    expect(writer.patchCalls[0].recurrence).toEqual({
+    expect(writer.patchCalls[0]!.recurrence).toEqual({
       kind: "series",
       rules: [...weekly4],
     });
     const stored = await events.findById(tenantId, principalId, master._id);
     expect(stored?.content.title).toBe("New");
-    expect(stored?.providerVersion).toBe("etag-2");
+    expect(stored?.providerVersion).toBe("etag-2" as ProviderEventVersion);
     expect(stored?.recurrence).toEqual({
       kind: "seriesMaster",
       rules: [...weekly4],
@@ -1658,7 +1656,7 @@ describe("executeProviderSeriesUpdate", () => {
     const writer = new FakeProviderEventWriter();
     writer.fetched = providerSeries("Old", "etag-1", weekly4);
     writer.patchResult = {
-      providerEventId: "g-evt-1",
+      providerEventId: "g-evt-1" as ProviderEventId,
       providerVersion: "etag-2",
     };
 
@@ -1672,7 +1670,7 @@ describe("executeProviderSeriesUpdate", () => {
 
     expect(result.outcome.state).toBe("confirmed");
     expect(writer.patchCalls).toHaveLength(1);
-    expect(writer.patchCalls[0].recurrence).toEqual({
+    expect(writer.patchCalls[0]!.recurrence).toEqual({
       kind: "series",
       rules: [...weekly2],
     });
@@ -1766,13 +1764,13 @@ describe("executeProviderSeriesUpdate", () => {
     const { tenantId, principalId, calendar, master } = await seedMaster();
     // An override on the 2nd instant and a cancellation on the 3rd.
     const override = await putException(master, {
-      providerEventId: "g-inst-override",
+      providerEventId: "g-inst-override" as ProviderEventId,
       recurrenceId: "2026-07-21T09:00:00-06:00",
       cancelled: false,
       title: "Moved",
     });
     await putException(master, {
-      providerEventId: "g-inst-cancelled",
+      providerEventId: "g-inst-cancelled" as ProviderEventId,
       recurrenceId: "2026-07-28T09:00:00-06:00",
       cancelled: true,
       title: "Old",
@@ -1800,7 +1798,7 @@ describe("executeProviderSeriesUpdate", () => {
       (call) => call.providerEventId === "g-inst-override",
     );
     expect(overridePatch).toMatchObject({
-      providerEventId: "g-inst-override",
+      providerEventId: "g-inst-override" as ProviderEventId,
       expectedVersion: null,
       invitation: "all",
       calendarId: calendar.providerCalendarId,
@@ -1808,9 +1806,9 @@ describe("executeProviderSeriesUpdate", () => {
       content: expect.objectContaining({ title: "New" }),
       schedule: {
         kind: "timed",
-        start: "2026-07-21T09:00:00-06:00",
-        end: "2026-07-21T10:00:00-06:00",
-        timeZone: "America/Denver",
+        start: "2026-07-21T09:00:00-06:00" as DateTime,
+        end: "2026-07-21T10:00:00-06:00" as DateTime,
+        timeZone: "America/Denver" as TimeZone,
       },
     });
     // The override is gone; the cancelled tombstone survives the edit.
@@ -1841,7 +1839,7 @@ describe("executeProviderSeriesUpdate", () => {
   it("leaves the override local when provider override align is transient", async () => {
     const { tenantId, principalId, calendar, master } = await seedMaster();
     const override = await putException(master, {
-      providerEventId: "g-inst-override",
+      providerEventId: "g-inst-override" as ProviderEventId,
       recurrenceId: "2026-07-21T09:00:00-06:00",
       cancelled: false,
       title: "Moved",
@@ -1880,16 +1878,16 @@ describe("executeProviderSeriesUpdate", () => {
   it("aligns discarded overrides to a series time change", async () => {
     const { calendar, master } = await seedMaster();
     await putException(master, {
-      providerEventId: "g-inst-override",
+      providerEventId: "g-inst-override" as ProviderEventId,
       recurrenceId: "2026-07-21T09:00:00-06:00",
       cancelled: false,
       title: "Moved",
     });
     const movedSchedule = {
       kind: "timed" as const,
-      start: "2026-07-14T10:00:00-06:00",
-      end: "2026-07-14T11:00:00-06:00",
-      timeZone: "America/Denver",
+      start: "2026-07-14T10:00:00-06:00" as DateTime,
+      end: "2026-07-14T11:00:00-06:00" as DateTime,
+      timeZone: "America/Denver" as TimeZone,
     };
     const command = await editAllCommand(master, {
       title: "New",
@@ -1913,16 +1911,16 @@ describe("executeProviderSeriesUpdate", () => {
     );
     expect(overridePatch?.schedule).toEqual({
       kind: "timed",
-      start: "2026-07-21T10:00:00-06:00",
-      end: "2026-07-21T11:00:00-06:00",
-      timeZone: "America/Denver",
+      start: "2026-07-21T10:00:00-06:00" as DateTime,
+      end: "2026-07-21T11:00:00-06:00" as DateTime,
+      timeZone: "America/Denver" as TimeZone,
     });
   });
 
   it("continues edit-all when the override is already gone at the provider", async () => {
     const { tenantId, principalId, calendar, master } = await seedMaster();
     const override = await putException(master, {
-      providerEventId: "g-inst-override",
+      providerEventId: "g-inst-override" as ProviderEventId,
       recurrenceId: "2026-07-21T09:00:00-06:00",
       cancelled: false,
       title: "Moved",
@@ -1964,7 +1962,7 @@ describe("executeProviderSeriesUpdate", () => {
   it("converts a series to a single event, dropping every exception", async () => {
     const { tenantId, principalId, calendar, master } = await seedMaster();
     await putException(master, {
-      providerEventId: "g-inst-cancelled",
+      providerEventId: "g-inst-cancelled" as ProviderEventId,
       recurrenceId: "2026-07-28T09:00:00-06:00",
       cancelled: true,
       title: "Old",
@@ -1986,11 +1984,13 @@ describe("executeProviderSeriesUpdate", () => {
 
     expect(result.outcome.state).toBe("confirmed");
     // The provider write removes recurrence.
-    expect(writer.patchCalls[0].recurrence).toEqual({ kind: "single" });
+    expect(writer.patchCalls[0]!.recurrence).toEqual({ kind: "single" });
     // Convert-to-single also cancels every discarded exception at the provider
     // (including former cancellations) so a later pull cannot resurrect them.
     expect(writer.deleteCalls).toEqual([
-      expect.objectContaining({ providerEventId: "g-inst-cancelled" }),
+      expect.objectContaining({
+        providerEventId: "g-inst-cancelled" as ProviderEventId,
+      }),
     ]);
     const stored = await events.findById(tenantId, principalId, master._id);
     expect(stored?.recurrence).toEqual({ kind: "single" });
@@ -2011,7 +2011,7 @@ describe("executeProviderSeriesUpdate", () => {
     const writer = new FakeProviderEventWriter();
     writer.fetched = providerSeries("Old", "etag-1", weekly4);
     writer.patchResult = {
-      providerEventId: "g-evt-1",
+      providerEventId: "g-evt-1" as ProviderEventId,
       providerVersion: "etag-2",
     };
 
@@ -2071,9 +2071,9 @@ describe("provider-linked recurring scopes (this / thisAndFollowing)", () => {
   // exactly, so results are directly comparable.
   const schedule = {
     kind: "timed" as const,
-    start: "2026-07-14T09:00:00-06:00",
-    end: "2026-07-14T10:00:00-06:00",
-    timeZone: "America/Denver",
+    start: "2026-07-14T09:00:00-06:00" as DateTime,
+    end: "2026-07-14T10:00:00-06:00" as DateTime,
+    timeZone: "America/Denver" as TimeZone,
   };
   const weekly3 = ["RRULE:FREQ=WEEKLY;COUNT=3"];
   const SECOND_START = "2026-07-21T09:00:00-06:00";
@@ -2092,9 +2092,9 @@ describe("provider-linked recurring scopes (this / thisAndFollowing)", () => {
     version: string,
     instanceSchedule = {
       kind: "timed" as const,
-      start: SECOND_START,
-      end: "2026-07-21T10:00:00-06:00",
-      timeZone: "America/Denver",
+      start: SECOND_START as DateTime,
+      end: "2026-07-21T10:00:00-06:00" as DateTime,
+      timeZone: "America/Denver" as TimeZone,
     },
   ): ProviderEvent => ({
     kind: "event",
@@ -2120,7 +2120,7 @@ describe("provider-linked recurring scopes (this / thisAndFollowing)", () => {
     rules: readonly string[],
   ): ProviderEvent => ({
     kind: "event",
-    providerEventId: "g-series-1",
+    providerEventId: "g-series-1" as ProviderEventId,
     providerVersion: version,
     providerUpdatedAt: null,
     content: content(title),
@@ -2135,7 +2135,7 @@ describe("provider-linked recurring scopes (this / thisAndFollowing)", () => {
     const master = await seedLinkedEvent(events, {
       ids,
       calendarId: calendar._id,
-      providerEventId: "g-series-1",
+      providerEventId: "g-series-1" as ProviderEventId,
       content: content("Old"),
       schedule,
       recurrence: { kind: "seriesMaster", rules: [...weekly3] },
@@ -2166,7 +2166,7 @@ describe("provider-linked recurring scopes (this / thisAndFollowing)", () => {
         principalId,
         "recurrence.kind": "seriesMaster",
         _id: { $ne: masterId },
-      })
+      } as unknown as Filter<Document>)
       .toArray();
 
   const thisScopeCommand = async (
@@ -2247,17 +2247,13 @@ describe("provider-linked recurring scopes (this / thisAndFollowing)", () => {
       })
     ).record;
 
-  const deps = (writer: FakeProviderEventWriter) => ({
-    commands,
-    events,
-    occurrences,
-    writer,
-    custody: tokenSource(),
-  });
-  const deleteDeps = (writer: FakeProviderEventWriter) => ({
-    ...deps(writer),
-    markers,
-  });
+  const deps = (writer: FakeProviderEventWriter) =>
+    providerMutationDeps({ commands, events, occurrences, resources }, writer);
+  const deleteDeps = (writer: FakeProviderEventWriter) =>
+    providerDeleteDeps(
+      { commands, events, occurrences, resources, markers },
+      writer,
+    );
 
   describe("executeProviderOccurrenceUpdate", () => {
     it("resolves the instance, patches IT (not the master), and stores its own provider identity", async () => {
@@ -2299,7 +2295,9 @@ describe("provider-linked recurring scopes (this / thisAndFollowing)", () => {
       // The exception carries the INSTANCE's own provider identity, not the
       // master's — sharing the master's would collide the unique
       // provider_event_identity index.
-      expect(exceptions[0]?.providerEventId).toBe("g-inst-1");
+      expect(exceptions[0]?.providerEventId).toBe(
+        "g-inst-1" as ProviderEventId,
+      );
       expect(exceptions[0]?.content.title).toBe("Moved");
       // The master no longer projects the overridden instant.
       expect(await occurrenceStartsFor(master._id)).not.toContain(
@@ -2530,7 +2528,9 @@ describe("provider-linked recurring scopes (this / thisAndFollowing)", () => {
         principalId,
         master._id,
       );
-      expect(exceptions[0]?.providerEventId).toBe("g-inst-unreadable");
+      expect(exceptions[0]?.providerEventId).toBe(
+        "g-inst-unreadable" as ProviderEventId,
+      );
     });
 
     it("does not delete the series master when lookup returns the master's id", async () => {
@@ -2662,7 +2662,7 @@ describe("provider-linked recurring scopes (this / thisAndFollowing)", () => {
       const writer = new FakeProviderEventWriter();
       writer.fetchEventResult = providerSeries("Old", "etag-1", weekly3);
       writer.createResult = {
-        providerEventId: "g-remainder-1",
+        providerEventId: "g-remainder-1" as ProviderEventId,
         providerVersion: "etag-1",
       };
 
@@ -2684,10 +2684,10 @@ describe("provider-linked recurring scopes (this / thisAndFollowing)", () => {
       const remainders = await otherSeriesMaster(principalId, master._id);
       expect(remainders).toHaveLength(1);
       expect(writer.createCalls[0]?.providerEventId).toBe(
-        remainders[0]?.["_id"],
+        String(remainders[0]?.["_id"]),
       );
       expect(remainders[0]?.["content"]).toMatchObject({ title: "Split" });
-      const remainderId = remainders[0]?.["_id"] as EventId;
+      const remainderId = String(remainders[0]?.["_id"]) as EventId;
       expect(await occurrenceStartsFor(remainderId)).toEqual([
         SECOND_START_UTC,
         "2026-07-28T15:00:00.000Z",
@@ -2792,9 +2792,9 @@ describe("attendeesEdit replace", () => {
 
   const schedule = {
     kind: "timed" as const,
-    start: "2026-07-14T09:00:00-06:00",
-    end: "2026-07-14T10:00:00-06:00",
-    timeZone: "America/Denver",
+    start: "2026-07-14T09:00:00-06:00" as DateTime,
+    end: "2026-07-14T10:00:00-06:00" as DateTime,
+    timeZone: "America/Denver" as TimeZone,
   };
 
   const attendee = (
@@ -2903,7 +2903,7 @@ describe("attendeesEdit replace", () => {
     attendees: Attendee[],
   ): ProviderEvent => ({
     kind: "event",
-    providerEventId: "g-evt-1",
+    providerEventId: "g-evt-1" as ProviderEventId,
     providerVersion: version,
     providerUpdatedAt: null,
     content: contentWith(title, {
@@ -2960,8 +2960,8 @@ describe("attendeesEdit replace", () => {
       attendee("d@example.com", "needsAction", "Dee"),
     ];
     expect(writer.patchCalls).toHaveLength(1);
-    expect(writer.patchCalls[0].attendees).toEqual(expectedMerged);
-    expect(writer.patchCalls[0].invitation).toBe("all");
+    expect(writer.patchCalls[0]!.attendees).toEqual(expectedMerged);
+    expect(writer.patchCalls[0]!.invitation).toBe("all");
     // The merged membership lands on the sync record at confirm, so reads
     // reflect it before the next Google round-trip.
     const stored = await events.findById(tenantId, principalId, event._id);
@@ -2988,7 +2988,7 @@ describe("attendeesEdit replace", () => {
     );
 
     expect(result.outcome.state).toBe("confirmed");
-    expect(writer.patchCalls[0].attendees).toEqual([]);
+    expect(writer.patchCalls[0]!.attendees).toEqual([]);
     const stored = await events.findById(tenantId, principalId, event._id);
     expect(stored?.content.attendees).toEqual([]);
   });
@@ -3073,7 +3073,9 @@ describe("attendeesEdit replace", () => {
     );
 
     expect(result.outcome.state).toBe("confirmed");
-    expect(writer.patchCalls[0].attendees).toEqual([attendee("a@example.com")]);
+    expect(writer.patchCalls[0]!.attendees).toEqual([
+      attendee("a@example.com"),
+    ]);
   });
 
   it("confirms a landed attendee-only edit on replay — email sets, order- and status-insensitive", async () => {
@@ -3104,7 +3106,7 @@ describe("attendeesEdit replace", () => {
     expect(writer.patchCalls).toHaveLength(0);
     expect(
       result.outcome.state === "confirmed" && result.outcome.providerVersion,
-    ).toBe("etag-7");
+    ).toBe("etag-7" as ProviderEventVersion);
   });
 
   it("still patches when the landed membership differs from the intent", async () => {
@@ -3130,7 +3132,7 @@ describe("attendeesEdit replace", () => {
 
     expect(result.outcome.state).toBe("confirmed");
     expect(writer.patchCalls).toHaveLength(1);
-    expect(writer.patchCalls[0].attendees).toEqual([
+    expect(writer.patchCalls[0]!.attendees).toEqual([
       attendee("a@example.com", "accepted"),
       attendee("b@example.com"),
     ]);
@@ -3166,7 +3168,7 @@ describe("attendeesEdit replace", () => {
     expect(result.outcome.state).toBe("confirmed");
     expect(writer.patchCalls).toHaveLength(1);
     expect(writer.patchCalls[0]).not.toHaveProperty("attendees");
-    expect(writer.patchCalls[0].content.attendees).toEqual(storedAttendees);
+    expect(writer.patchCalls[0]!.content.attendees).toEqual(storedAttendees);
     // The stored record keeps its own attendee list (mergeUpdateContent), not
     // the command's echoed one.
     const stored = await events.findById(tenantId, principalId, event._id);
@@ -3225,7 +3227,7 @@ describe("attendeesEdit replace", () => {
 
     expect(result.outcome.state).toBe("confirmed");
     expect(writer.patchCalls).toHaveLength(1);
-    expect(writer.patchCalls[0].attendees).toEqual([
+    expect(writer.patchCalls[0]!.attendees).toEqual([
       attendee("a@example.com", "accepted"),
       attendee("b@example.com"),
     ]);
@@ -3379,8 +3381,8 @@ describe("attendeesEdit replace", () => {
       attendee("b@example.com"),
     ];
     expect(writer.calls).toHaveLength(1);
-    expect(writer.calls[0].attendees).toEqual(expected);
-    expect(writer.calls[0].invitation).toBe("all");
+    expect(writer.calls[0]!.attendees).toEqual(expected);
+    expect(writer.calls[0]!.invitation).toBe("all");
     const stored = await events.findById(
       tenantId,
       principalId,
@@ -3442,9 +3444,9 @@ describe("executeProviderRsvp", () => {
 
   const schedule = {
     kind: "timed" as const,
-    start: "2026-07-14T09:00:00-06:00",
-    end: "2026-07-14T10:00:00-06:00",
-    timeZone: "America/Denver",
+    start: "2026-07-14T09:00:00-06:00" as DateTime,
+    end: "2026-07-14T10:00:00-06:00" as DateTime,
+    timeZone: "America/Denver" as TimeZone,
   };
   const weekly3 = ["RRULE:FREQ=WEEKLY;COUNT=3"];
   const SECOND_START_UTC = "2026-07-21T15:00:00.000Z";
@@ -3460,7 +3462,7 @@ describe("executeProviderRsvp", () => {
     opts: {
       organizer?: { email: string; displayName: string | null } | null;
       attendees?: Attendee[];
-      color?: string;
+      color?: EventColorSlot;
     } = {},
   ) => ({
     title,
@@ -3553,10 +3555,10 @@ describe("executeProviderRsvp", () => {
   const providerSingle = (
     version: string,
     attendees: Attendee[],
-    opts: { color?: string } = {},
+    opts: { color?: EventColorSlot } = {},
   ): ProviderEvent => ({
     kind: "event",
-    providerEventId: "g-evt-1",
+    providerEventId: "g-evt-1" as ProviderEventId,
     providerVersion: version,
     providerUpdatedAt: null,
     content: contentWith("Invited", {
@@ -3598,23 +3600,23 @@ describe("executeProviderRsvp", () => {
     // entry's responseStatus changed; every other entry — and the self
     // entry's own email casing and displayName — is byte-identical to the
     // freshly fetched provider state.
-    expect(patch.attendees).toEqual([
+    expect(patch!.attendees).toEqual([
       attendee("organizer@example.com", "accepted", "Org"),
       attendee("Self@Example.COM", "declined"),
       attendee("other@example.com", "tentative", "Oth"),
     ]);
-    expect(patch.attendees?.[0]).toEqual(fetchedList[0] as Attendee);
-    expect(patch.attendees?.[2]).toEqual(fetchedList[2] as Attendee);
+    expect(patch!.attendees?.[0]).toEqual(fetchedList[0] as Attendee);
+    expect(patch!.attendees?.[2]).toEqual(fetchedList[2] as Attendee);
     // Never emails the guest list, and never conditions on a version: a
     // concurrent sibling RSVP must not block this one.
-    expect(patch.invitation).toBe("none");
-    expect(patch.expectedVersion).toBeNull();
-    expect(patch.providerEventId).toBe("g-evt-1");
+    expect(patch!.invitation).toBe("none");
+    expect(patch!.expectedVersion).toBeNull();
+    expect(patch!.providerEventId).toBe("g-evt-1");
     // The echoed body carries the fetched content minus color/colorHex, so
     // the patch cannot touch Google's color or label state.
-    expect(patch.content.title).toBe("Invited");
-    expect(patch.content).not.toHaveProperty("color");
-    expect(patch.content).not.toHaveProperty("colorHex");
+    expect(patch!.content.title).toBe("Invited");
+    expect(patch!.content).not.toHaveProperty("color");
+    expect(patch!.content).not.toHaveProperty("colorHex");
 
     // The answer lands on the stored record before the next Google
     // round-trip.
@@ -3624,10 +3626,10 @@ describe("executeProviderRsvp", () => {
       attendee("Self@Example.COM", "declined"),
       attendee("other@example.com", "tentative", "Oth"),
     ]);
-    expect(stored?.providerVersion).toBe("etag-2");
+    expect(stored?.providerVersion).toBe("etag-2" as ProviderEventVersion);
     expect(
       result.outcome.state === "confirmed" && result.outcome.providerVersion,
-    ).toBe("etag-2");
+    ).toBe("etag-2" as ProviderEventVersion);
   });
 
   it("confirms a replay without a second write when the provider already holds the answer", async () => {
@@ -3652,7 +3654,7 @@ describe("executeProviderRsvp", () => {
     expect(writer.patchCalls).toHaveLength(0);
     expect(
       result.outcome.state === "confirmed" && result.outcome.providerVersion,
-    ).toBe("etag-7");
+    ).toBe("etag-7" as ProviderEventVersion);
   });
 
   it("allows the organizer to RSVP their own event", async () => {
@@ -3681,7 +3683,7 @@ describe("executeProviderRsvp", () => {
     );
 
     expect(result.outcome.state).toBe("confirmed");
-    expect(writer.patchCalls[0].attendees).toEqual([
+    expect(writer.patchCalls[0]!.attendees).toEqual([
       attendee(SELF, "tentative"),
       attendee("guest@example.com", "needsAction"),
     ]);
@@ -3835,7 +3837,7 @@ describe("executeProviderRsvp", () => {
 
   const providerInstance = (attendees: Attendee[]): ProviderEvent => ({
     kind: "event",
-    providerEventId: "g-inst-1",
+    providerEventId: "g-inst-1" as ProviderEventId,
     providerVersion: "etag-inst-1",
     providerUpdatedAt: null,
     content: contentWith("Invited", {
@@ -3844,9 +3846,9 @@ describe("executeProviderRsvp", () => {
     }) as ProviderEvent["content"],
     schedule: {
       kind: "timed",
-      start: "2026-07-21T09:00:00-06:00",
-      end: "2026-07-21T10:00:00-06:00",
-      timeZone: "America/Denver",
+      start: "2026-07-21T09:00:00-06:00" as DateTime,
+      end: "2026-07-21T10:00:00-06:00" as DateTime,
+      timeZone: "America/Denver" as TimeZone,
     },
     busy: true,
     recurrence: {
@@ -3874,7 +3876,7 @@ describe("executeProviderRsvp", () => {
       attendee(SELF, "accepted"),
     ]);
     writer.patchResult = {
-      providerEventId: "g-inst-1",
+      providerEventId: "g-inst-1" as ProviderEventId,
       providerVersion: "etag-inst-2",
     };
 
@@ -3900,10 +3902,10 @@ describe("executeProviderRsvp", () => {
     // patch targets the RESOLVED instance id, with no recurrence key.
     expect(writer.fetchEventCalls).toHaveLength(0);
     expect(writer.patchCalls).toHaveLength(1);
-    expect(writer.patchCalls[0].providerEventId).toBe("g-inst-1");
-    expect(writer.patchCalls[0].recurrence).toEqual({ kind: "instance" });
-    expect(writer.patchCalls[0].invitation).toBe("none");
-    expect(writer.patchCalls[0].attendees).toEqual([
+    expect(writer.patchCalls[0]!.providerEventId).toBe("g-inst-1");
+    expect(writer.patchCalls[0]!.recurrence).toEqual({ kind: "instance" });
+    expect(writer.patchCalls[0]!.invitation).toBe("none");
+    expect(writer.patchCalls[0]!.attendees).toEqual([
       attendee("organizer@example.com", "accepted"),
       attendee(SELF, "declined"),
     ]);
@@ -3916,15 +3918,17 @@ describe("executeProviderRsvp", () => {
       attendee("organizer@example.com", "accepted"),
       attendee(SELF, "accepted"),
     ]);
-    expect(master?.providerVersion).toBe("etag-1");
+    expect(master?.providerVersion).toBe("etag-1" as ProviderEventVersion);
     const exceptions = await events.findSeriesExceptions(
       tenantId,
       principalId,
       event._id,
     );
     expect(exceptions).toHaveLength(1);
-    expect(exceptions[0]?.providerEventId).toBe("g-inst-1");
-    expect(exceptions[0]?.providerVersion).toBe("etag-inst-2");
+    expect(exceptions[0]?.providerEventId).toBe("g-inst-1" as ProviderEventId);
+    expect(exceptions[0]?.providerVersion).toBe(
+      "etag-inst-2" as ProviderEventVersion,
+    );
     expect(exceptions[0]?.content.attendees).toEqual([
       attendee("organizer@example.com", "accepted"),
       attendee(SELF, "declined"),
@@ -3964,7 +3968,7 @@ describe("executeProviderRsvp", () => {
       recurrence: { kind: "seriesMaster", rules: weekly3 },
     };
     writer.patchResult = {
-      providerEventId: "g-evt-1",
+      providerEventId: "g-evt-1" as ProviderEventId,
       providerVersion: "etag-2",
     };
 
@@ -3980,14 +3984,14 @@ describe("executeProviderRsvp", () => {
     expect(writer.fetchInstanceCalls).toHaveLength(0);
     expect(writer.fetchEventCalls).toHaveLength(1);
     expect(writer.patchCalls).toHaveLength(1);
-    expect(writer.patchCalls[0].providerEventId).toBe("g-evt-1");
+    expect(writer.patchCalls[0]!.providerEventId).toBe("g-evt-1");
     // The master's own current rules are re-written unchanged
     // (self-describing), mirroring how a "preserve" series edit writes.
-    expect(writer.patchCalls[0].recurrence).toEqual({
+    expect(writer.patchCalls[0]!.recurrence).toEqual({
       kind: "series",
       rules: weekly3,
     });
-    expect(writer.patchCalls[0].attendees).toEqual([
+    expect(writer.patchCalls[0]!.attendees).toEqual([
       attendee("organizer@example.com", "accepted"),
       attendee(SELF, "declined"),
     ]);
@@ -4064,7 +4068,7 @@ describe("executeProviderRsvp", () => {
     expect(writer.patchCalls).toHaveLength(0);
     expect(
       result.outcome.state === "confirmed" && result.outcome.providerVersion,
-    ).toBe("etag-inst-1");
+    ).toBe("etag-inst-1" as ProviderEventVersion);
     // The already-landed answer still converges locally onto the exception.
     const exceptions = await events.findSeriesExceptions(
       tenantId,

--- a/packages/sync/src/domain/provider-page-applier.db.test.ts
+++ b/packages/sync/src/domain/provider-page-applier.db.test.ts
@@ -1,3 +1,5 @@
+import { type DateTime, type TimeZone } from "@core/types/domain-primitives";
+import { type ProviderEventId } from "@core/types/sync/identity.contracts";
 import { seedProviderCalendar } from "@sync/__tests__/helpers/fixtures";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { ProviderPageApplier } from "@sync/domain/provider-page-applier";
@@ -21,9 +23,9 @@ const now = () => new Date("2026-07-10T00:00:00.000Z");
 
 const schedule = {
   kind: "timed" as const,
-  start: "2026-07-14T09:00:00-06:00",
-  end: "2026-07-14T10:00:00-06:00",
-  timeZone: "America/Denver",
+  start: "2026-07-14T09:00:00-06:00" as DateTime,
+  end: "2026-07-14T10:00:00-06:00" as DateTime,
+  timeZone: "America/Denver" as TimeZone,
 };
 const content = (title: string) => ({
   title,
@@ -35,7 +37,7 @@ const content = (title: string) => ({
 });
 const single = (id: string): ProviderEvent => ({
   kind: "event",
-  providerEventId: id,
+  providerEventId: id as ProviderEventId,
   providerVersion: `etag-${id}`,
   providerUpdatedAt: null,
   content: content(id),
@@ -49,7 +51,7 @@ const master = (id: string): ProviderEvent => ({
 });
 const standaloneCancellation = (id: string): ProviderEventCancellation => ({
   kind: "cancellation",
-  providerEventId: id,
+  providerEventId: id as ProviderEventId,
   providerVersion: `etag-${id}`,
   series: null,
 });
@@ -59,7 +61,7 @@ const seriesCancellation = (
   recurrenceId: string,
 ): ProviderEventCancellation => ({
   kind: "cancellation",
-  providerEventId: id,
+  providerEventId: id as ProviderEventId,
   providerVersion: `etag-${id}`,
   series: { seriesProviderId, recurrenceId },
 });
@@ -96,7 +98,7 @@ describe("ProviderPageApplier", () => {
       events.findByProviderIdentity(calendar.tenantId, calendar.principalId, {
         connectionId: calendar.connectionId,
         calendarId: calendar._id,
-        providerEventId,
+        providerEventId: providerEventId as ProviderEventId,
       });
 
     // Busy with no correlation key is the overwhelming default: no bag at all.
@@ -124,7 +126,7 @@ describe("ProviderPageApplier", () => {
       events.findByProviderIdentity(calendar.tenantId, calendar.principalId, {
         connectionId: calendar.connectionId,
         calendarId: calendar._id,
-        providerEventId,
+        providerEventId: providerEventId as ProviderEventId,
       });
 
     expect((await byId("managed"))?.providerMetadata).toEqual({
@@ -138,10 +140,10 @@ describe("ProviderPageApplier", () => {
     const run = applier(calendar);
 
     await run.applyPage([
-      { ...single("opaque"), providerEventId: "opaque" },
+      { ...single("opaque"), providerEventId: "opaque" as ProviderEventId },
       {
         ...single("transparent"),
-        providerEventId: "transparent",
+        providerEventId: "transparent" as ProviderEventId,
         busy: false,
       },
     ]);
@@ -199,7 +201,7 @@ describe("ProviderPageApplier", () => {
       events.findByProviderIdentity(calendar.tenantId, calendar.principalId, {
         connectionId: calendar.connectionId,
         calendarId: calendar._id,
-        providerEventId,
+        providerEventId: providerEventId as ProviderEventId,
       });
 
     await applier(calendar).applyPage([
@@ -222,7 +224,7 @@ describe("ProviderPageApplier", () => {
       events.findByProviderIdentity(calendar.tenantId, calendar.principalId, {
         connectionId: calendar.connectionId,
         calendarId: calendar._id,
-        providerEventId,
+        providerEventId: providerEventId as ProviderEventId,
       });
 
     await applier(calendar).applyPage([
@@ -242,7 +244,7 @@ describe("ProviderPageApplier", () => {
       events.findByProviderIdentity(calendar.tenantId, calendar.principalId, {
         connectionId: calendar.connectionId,
         calendarId: calendar._id,
-        providerEventId,
+        providerEventId: providerEventId as ProviderEventId,
       });
 
     await applier(calendar).applyPage([
@@ -272,7 +274,7 @@ describe("ProviderPageApplier", () => {
       {
         connectionId: calendar.connectionId,
         calendarId: calendar._id,
-        providerEventId: "m_c",
+        providerEventId: "m_c" as ProviderEventId,
       },
     );
     expect(cancelled?.providerMetadata).toBeNull();
@@ -301,7 +303,7 @@ describe("ProviderPageApplier", () => {
         {
           connectionId: calendar.connectionId,
           calendarId: calendar._id,
-          providerEventId: "gone",
+          providerEventId: "gone" as ProviderEventId,
         },
       ),
     ).toBeNull();
@@ -368,7 +370,7 @@ describe("ProviderPageApplier", () => {
   it("keeps customizations when a pull changes the provider schedule", async () => {
     const calendar = await seedCalendar();
     const run = applier(calendar);
-    const providerEventId = "managed-schedule";
+    const providerEventId = "managed-schedule" as ProviderEventId;
 
     await run.applyPage([
       { ...single(providerEventId), providerManaged: true },
@@ -379,7 +381,7 @@ describe("ProviderPageApplier", () => {
       {
         connectionId: calendar.connectionId,
         calendarId: calendar._id,
-        providerEventId,
+        providerEventId: providerEventId as ProviderEventId,
       },
     );
     if (!existing) throw new Error("seed failed");
@@ -390,9 +392,9 @@ describe("ProviderPageApplier", () => {
 
     const movedSchedule = {
       kind: "timed" as const,
-      start: "2026-07-14T10:00:00-06:00",
-      end: "2026-07-14T11:00:00-06:00",
-      timeZone: "America/Denver",
+      start: "2026-07-14T10:00:00-06:00" as DateTime,
+      end: "2026-07-14T11:00:00-06:00" as DateTime,
+      timeZone: "America/Denver" as TimeZone,
     };
     await run.applyPage([
       {
@@ -409,7 +411,7 @@ describe("ProviderPageApplier", () => {
       {
         connectionId: calendar.connectionId,
         calendarId: calendar._id,
-        providerEventId,
+        providerEventId: providerEventId as ProviderEventId,
       },
     );
     expect(updated?.schedule).toEqual(movedSchedule);

--- a/packages/sync/src/domain/provider-write-ladder.test.ts
+++ b/packages/sync/src/domain/provider-write-ladder.test.ts
@@ -105,7 +105,7 @@ describe("runProviderWrite", () => {
           error: mock(),
           info: mock(),
           debug: mock(),
-        }) as LoggerInstance,
+        }) as unknown as LoggerInstance,
     );
 
     await expect(
@@ -122,7 +122,7 @@ describe("runProviderWrite", () => {
     });
 
     expect(warn).toHaveBeenCalledTimes(1);
-    const [message] = warn.mock.calls[0] ?? [];
+    const [message] = (warn.mock.calls as unknown[][])[0] ?? [];
     expect(message).toContain("Google declined to change this event");
     expect(message).toContain("HTTP 400");
     expect(message).toContain("reason invalid");

--- a/packages/sync/src/domain/resource-sweep-enqueue.bootstrap-recovery.db.test.ts
+++ b/packages/sync/src/domain/resource-sweep-enqueue.bootstrap-recovery.db.test.ts
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { seedOauthCredential } from "@sync/__tests__/helpers/credential-encryption";
+import { stringIdFilter } from "@sync/__tests__/helpers/mongo-id";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { enqueueForResources } from "@sync/domain/resource-sweep-enqueue";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
@@ -83,10 +84,9 @@ describe("bootstrap-recovery sweep (enqueueForResources + listStalledBootstraps)
     await storage
       .db()
       .collection(SYNC_COLLECTIONS.syncResources)
-      .updateOne(
-        { _id: resource._id },
-        { $set: { bootstrapState, updatedAt } },
-      );
+      .updateOne(stringIdFilter(resource._id), {
+        $set: { bootstrapState, updatedAt },
+      });
     return { ...resource, bootstrapState, updatedAt };
   };
 
@@ -103,8 +103,8 @@ describe("bootstrap-recovery sweep (enqueueForResources + listStalledBootstraps)
 
     expect(enqueued).toBe(1);
     const job = await jobByKey(`bootstrapCatchup:${stalled._id}`);
-    expect(job?.kind).toBe("bootstrapCatchup");
-    expect(job?.resourceId).toBe(stalled._id);
+    expect(job?.["kind"]).toBe("bootstrapCatchup");
+    expect(job?.["resourceId"]).toBe(stalled._id);
   });
 
   it("skips a resource whose bootstrap already reached ready", async () => {

--- a/packages/sync/src/domain/resource-sweep-enqueue.reconcile.db.test.ts
+++ b/packages/sync/src/domain/resource-sweep-enqueue.reconcile.db.test.ts
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { seedOauthCredential } from "@sync/__tests__/helpers/credential-encryption";
+import { stringIdFilter } from "@sync/__tests__/helpers/mongo-id";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { enqueueForResources } from "@sync/domain/resource-sweep-enqueue";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
@@ -102,9 +103,9 @@ describe("reconcile sweep (enqueueForResources + listStaleEvents)", () => {
 
     expect(enqueued).toBe(1);
     const job = await jobByKey(`incrementalPull:${stale._id}`);
-    expect(job?.kind).toBe("incrementalPull");
-    expect(job?.resourceId).toBe(stale._id);
-    expect(job?.tenantId).toBe(stale.tenantId);
+    expect(job?.["kind"]).toBe("incrementalPull");
+    expect(job?.["resourceId"]).toBe(stale._id);
+    expect(job?.["tenantId"]).toBe(stale.tenantId);
   });
 
   it("skips a resource synced more recently than the threshold", async () => {
@@ -154,12 +155,12 @@ describe("reconcile sweep (enqueueForResources + listStaleEvents)", () => {
       .find({})
       .toArray();
     expect(jobs2).toHaveLength(1);
-    const resourceId = jobs2[0]?.resourceId as string;
+    const resourceId = jobs2[0]?.["resourceId"] as string;
     const resource = await storage
       .db()
       .collection(SYNC_COLLECTIONS.syncResources)
-      .findOne({ _id: resourceId });
-    expect(resource?.lastSuccessAt).toEqual(
+      .findOne(stringIdFilter(resourceId));
+    expect(resource?.["lastSuccessAt"]).toEqual(
       new Date("2026-07-02T00:00:00.000Z"),
     );
   });

--- a/packages/sync/src/domain/resource-sweep-enqueue.subscription.db.test.ts
+++ b/packages/sync/src/domain/resource-sweep-enqueue.subscription.db.test.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import { stringIdFilter } from "@sync/__tests__/helpers/mongo-id";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { enqueueForResources } from "@sync/domain/resource-sweep-enqueue";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
@@ -89,9 +90,9 @@ describe("subscription-maintenance sweep (enqueueForResources + listExpiringSubs
 
     expect(enqueued).toBe(1);
     const job = await jobByKey(`subscriptionMaintain:${expiring._id}`);
-    expect(job?.kind).toBe("subscriptionMaintain");
-    expect(job?.resourceId).toBe(expiring._id);
-    expect(job?.tenantId).toBe(expiring.tenantId);
+    expect(job?.["kind"]).toBe("subscriptionMaintain");
+    expect(job?.["resourceId"]).toBe(expiring._id);
+    expect(job?.["tenantId"]).toBe(expiring.tenantId);
   });
 
   it("skips a subscription that expires after the threshold", async () => {
@@ -145,8 +146,8 @@ describe("subscription-maintenance sweep (enqueueForResources + listExpiringSubs
 
     expect(enqueued).toBe(1);
     const job = await jobByKey(`subscriptionMaintain:${resource._id}`);
-    expect(job?.kind).toBe("subscriptionMaintain");
-    expect(job?.resourceId).toBe(resource._id);
+    expect(job?.["kind"]).toBe("subscriptionMaintain");
+    expect(job?.["resourceId"]).toBe(resource._id);
   });
 
   it("coalesces repeated sweeps into one job per resource", async () => {
@@ -184,12 +185,12 @@ describe("subscription-maintenance sweep (enqueueForResources + listExpiringSubs
       .find({})
       .toArray();
     expect(enqueuedJobs).toHaveLength(1);
-    const resourceId = enqueuedJobs[0]?.resourceId as string;
+    const resourceId = enqueuedJobs[0]?.["resourceId"] as string;
     const resource = await storage
       .db()
       .collection(SYNC_COLLECTIONS.syncResources)
-      .findOne({ _id: resourceId });
-    expect(resource?.subscriptionExpiresAt).toEqual(
+      .findOne(stringIdFilter(resourceId));
+    expect(resource?.["subscriptionExpiresAt"]).toEqual(
       new Date("2026-07-10T02:00:00.000Z"),
     );
   });

--- a/packages/sync/src/domain/stale-command-retry.service.db.test.ts
+++ b/packages/sync/src/domain/stale-command-retry.service.db.test.ts
@@ -1,11 +1,21 @@
 import { faker } from "@faker-js/faker";
 import {
-  type ConnectionId,
+  type CalendarId,
+  type DateTime,
   type EventId,
+  type TimeZone,
+} from "@core/types/domain-primitives";
+import {
+  type ConnectionId,
   type IdempotencyKey,
   type PrincipalId,
+  type ProviderEventId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
+import {
+  cloudCommandDeps,
+  fakeCredentialCustody,
+} from "@sync/__tests__/helpers/command-scenario";
 import {
   fakeAdapters,
   seedProviderCalendar,
@@ -13,7 +23,10 @@ import {
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { submitCloudCommand } from "@sync/domain/cloud-command.service";
 import { type ProviderConnectionLookup } from "@sync/domain/provider-command.service";
-import { retryStaleCommands } from "@sync/domain/stale-command-retry.service";
+import {
+  retryStaleCommands,
+  type StaleCommandRetryDeps,
+} from "@sync/domain/stale-command-retry.service";
 import { type ProviderEvent } from "@sync/providers/provider-event.port";
 import {
   type ProviderCreateInput,
@@ -59,7 +72,7 @@ class FakeCreateWriter implements ProviderEventWriter {
   createError: Error | null = null;
   createCalls: ProviderCreateInput[] = [];
   result: ProviderWriteResult = {
-    providerEventId: "g-created-1",
+    providerEventId: "g-created-1" as ProviderEventId,
     providerVersion: "etag-created",
   };
   async createEvent(input: ProviderCreateInput): Promise<ProviderWriteResult> {
@@ -81,12 +94,6 @@ class FakeCreateWriter implements ProviderEventWriter {
   }
 }
 
-const tokenSource = () => ({
-  getValidAccessToken: async () => "access-token",
-  discardRevoked: async () => {},
-  invalidateAccessToken: async () => {},
-});
-
 describe("retryStaleCommands", () => {
   let mongo: SyncMongoService;
   let commands: CommandRepository;
@@ -105,9 +112,9 @@ describe("retryStaleCommands", () => {
 
   const schedule = {
     kind: "timed" as const,
-    start: "2026-07-14T09:00:00-06:00",
-    end: "2026-07-14T10:00:00-06:00",
-    timeZone: "America/Denver",
+    start: "2026-07-14T09:00:00-06:00" as DateTime,
+    end: "2026-07-14T10:00:00-06:00" as DateTime,
+    timeZone: "America/Denver" as TimeZone,
   };
 
   const connections: ProviderConnectionLookup = {
@@ -117,28 +124,26 @@ describe("retryStaleCommands", () => {
     }),
   };
 
-  const baseDeps = (writer: ProviderEventWriter) => ({
-    commands,
-    events,
-    calendars,
-    occurrences,
-    resources,
-    markers,
-    connections,
-    execution: "active" as const,
-    provider: {
-      resolveAdapters: () =>
-        fakeAdapters(
-          {
-            listEventPage: async () => {
-              throw new Error("reader unused in stale-command-retry tests");
-            },
-          },
-          { writer },
-        ),
-      custody: tokenSource(),
-    },
-  });
+  const baseDeps = (writer: ProviderEventWriter): StaleCommandRetryDeps =>
+    cloudCommandDeps(
+      { commands, events, calendars, occurrences, resources, markers },
+      {
+        connections,
+        execution: "active",
+        provider: {
+          resolveAdapters: () =>
+            fakeAdapters(
+              {
+                listEventPage: async () => {
+                  throw new Error("reader unused in stale-command-retry tests");
+                },
+              },
+              { writer },
+            ),
+          custody: fakeCredentialCustody(),
+        },
+      },
+    );
 
   // Seed a provider-linked event stuck deletionPending, plus its still-pending
   // delete command - the state a transient provider failure leaves behind
@@ -331,11 +336,14 @@ describe("retryStaleCommands", () => {
       },
       patchEvent: async (input) => {
         patchCalls.push(input);
-        return { providerEventId: "g-evt-1", providerVersion: "etag-2" };
+        return {
+          providerEventId: "g-evt-1" as ProviderEventId,
+          providerVersion: "etag-2",
+        };
       },
       fetchEvent: async () => ({
         kind: "event",
-        providerEventId: "g-evt-1",
+        providerEventId: "g-evt-1" as ProviderEventId,
         providerVersion: "etag-1",
         providerUpdatedAt: null,
         content: {
@@ -357,7 +365,10 @@ describe("retryStaleCommands", () => {
       {
         ...baseDeps(writer),
         connections: {
-          findById: async () => ({ account: { email: self.email } }),
+          findById: async () => ({
+            account: { email: self.email },
+            provider: "google",
+          }),
         },
       },
       before(),
@@ -386,7 +397,7 @@ describe("retryStaleCommands", () => {
     const stored = await commands.findById(tenantId, principalId, command._id);
     expect(stored?.outcome.state).toBe("confirmed");
     const event = await events.findById(tenantId, principalId, eventId);
-    expect(event?.providerEventId).toBe("g-created-1");
+    expect(event?.providerEventId).toBe("g-created-1" as ProviderEventId);
   });
 
   it("leaves a create pending and reports it still stale on a repeated transient failure", async () => {
@@ -515,7 +526,7 @@ describe("retryStaleCommands", () => {
     const tenantId = objectId() as TenantId;
     const principalId = objectId() as PrincipalId;
     const eventId = objectId() as EventId;
-    const calendarId = objectId();
+    const calendarId = objectId() as CalendarId;
 
     await events.put({
       _id: eventId,

--- a/packages/sync/src/domain/subscription-maintenance.service.db.test.ts
+++ b/packages/sync/src/domain/subscription-maintenance.service.db.test.ts
@@ -1,8 +1,18 @@
 import { faker } from "@faker-js/faker";
-import { type ConnectionId } from "@core/types/sync/identity.contracts";
+import {
+  type ConnectionId,
+  type PrincipalId,
+  type ProviderCalendarId,
+  type ProviderCalendarSourceId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
 import { seedOauthCredential } from "@sync/__tests__/helpers/credential-encryption";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
-import { maintainSubscription } from "@sync/domain/subscription-maintenance.service";
+import { type AccessTokenSource } from "@sync/domain/provider-write-ladder";
+import {
+  maintainSubscription,
+  type SubscriptionMaintenanceDeps,
+} from "@sync/domain/subscription-maintenance.service";
 import {
   type NotificationChannel,
   type ProviderNotificationAdapter,
@@ -72,9 +82,11 @@ class FakeNotifications implements ProviderNotificationAdapter {
     });
     if (this.#stopError) throw this.#stopError;
   };
+
+  parseNotification = () => null;
 }
 
-const custody = {
+const custody: AccessTokenSource = {
   getValidAccessToken: async () => "access-token",
   discardRevoked: async () => {},
   invalidateAccessToken: async () => {},
@@ -87,7 +99,7 @@ describe("maintainSubscription", () => {
   const maintenanceDeps = (
     notifications: FakeNotifications,
     supportsChangeNotifications = true,
-  ) => ({
+  ): SubscriptionMaintenanceDeps => ({
     resources,
     notifications,
     custody,
@@ -103,11 +115,11 @@ describe("maintainSubscription", () => {
   // calendar id); only those two fields matter to the operation.
   const calendar = (connectionId: string): ProviderCalendarRecord =>
     ({
-      _id: objectId(),
-      tenantId: objectId(),
-      principalId: objectId(),
-      connectionId,
-      providerCalendarId: "primary@google.com",
+      _id: objectId() as ProviderCalendarId,
+      tenantId: objectId() as TenantId,
+      principalId: objectId() as PrincipalId,
+      connectionId: connectionId as ConnectionId,
+      providerCalendarId: "primary@google.com" as ProviderCalendarSourceId,
       displayName: "Google",
       color: null,
       active: true,

--- a/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-dispatch.service.db.test.ts
@@ -1,4 +1,11 @@
 import { faker } from "@faker-js/faker";
+import {
+  type ConnectionId,
+  type PrincipalId,
+  type ProviderAccountId,
+  type SyncJobId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
 import { seedOauthCredential } from "@sync/__tests__/helpers/credential-encryption";
 import {
   ensureEventsResource,
@@ -9,6 +16,7 @@ import {
   singleEvent as single,
   fakeTokenSource as tokenSource,
 } from "@sync/__tests__/helpers/fixtures";
+import { stringIdFilter } from "@sync/__tests__/helpers/mongo-id";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import {
   dispatchSyncJob,
@@ -65,6 +73,7 @@ const notifications = {
     };
   },
   stopChannel: async () => {},
+  parseNotification: () => null,
 };
 
 // A calendar-discovery adapter that returns one active calendar, so a
@@ -85,6 +94,7 @@ const discovery = {
           canReadBusy: true,
           canInviteAttendees: true,
         },
+        eventLabels: [],
         createsGoogleMeet: true,
       },
     ],
@@ -104,7 +114,7 @@ const defaultGoogleConnection = (
   account: {
     email: "user@example.com",
     displayName: "User",
-    providerAccountId: "google-subject",
+    providerAccountId: "google-subject" as ProviderAccountId,
   },
   capabilities: [
     "readEvents",
@@ -191,7 +201,7 @@ describe("dispatchSyncJob", () => {
     reader: FakeReader,
     custody: SyncJobDispatchDeps["custody"] = tokenSource,
     notificationsOverride = notifications,
-    discoveryOverride = discovery,
+    discoveryOverride: ProviderCalendarAdapter = discovery,
   ): SyncJobDispatchDeps => ({
     events,
     occurrences,
@@ -225,7 +235,7 @@ describe("dispatchSyncJob", () => {
     kind: JobRecord["kind"],
   ): JobRecord =>
     ({
-      _id: objectId(),
+      _id: objectId() as SyncJobId,
       tenantId: resource.tenantId,
       principalId: resource.principalId,
       connectionId: resource.connectionId,
@@ -264,7 +274,7 @@ describe("dispatchSyncJob", () => {
       .find({ principalId: calendar.principalId })
       .toArray();
     expect(feed).toHaveLength(1);
-    expect(feed[0]?.invalidation).toEqual({
+    expect(feed[0]?.["invalidation"]).toEqual({
       kind: "calendar",
       connectionId: calendar.connectionId,
       calendarId: calendar._id,
@@ -302,7 +312,7 @@ describe("dispatchSyncJob", () => {
       .find({ principalId: calendar.principalId })
       .toArray();
     expect(feed).toHaveLength(1);
-    expect(feed[0]?.invalidation).toEqual({
+    expect(feed[0]?.["invalidation"]).toEqual({
       kind: "calendar",
       connectionId: calendar.connectionId,
       calendarId: calendar._id,
@@ -375,7 +385,9 @@ describe("dispatchSyncJob", () => {
           resource._id,
           new Date(`2026-07-10T00:00:0${reads.length}.000Z`),
         );
-        return page([single(`e-${reads.length}`)], `cursor-${reads.length}`);
+        return page([single(`e-${reads.length}`)], {
+          nextSyncToken: `cursor-${reads.length}`,
+        });
       },
     };
 
@@ -596,7 +608,7 @@ describe("dispatchSyncJob", () => {
     await storage
       .db()
       .collection(SYNC_COLLECTIONS.providerCalendars)
-      .updateOne({ _id: calendar._id }, { $set: { active: false } });
+      .updateOne(stringIdFilter(calendar._id), { $set: { active: false } });
 
     const reader = new FakeReader([]);
     const outcome = await dispatchSyncJob(
@@ -636,7 +648,7 @@ describe("dispatchSyncJob", () => {
     await storage
       .db()
       .collection(SYNC_COLLECTIONS.providerCalendars)
-      .updateOne({ _id: calendar._id }, { $set: { active: false } });
+      .updateOne(stringIdFilter(calendar._id), { $set: { active: false } });
 
     const outcome = await dispatchSyncJob(
       deps(new FakeReader([])),
@@ -820,7 +832,9 @@ describe("dispatchSyncJob", () => {
     }
     expect(discarded).toEqual([]);
     const after = await credentials.findByConnection(calendar.connectionId);
-    expect(after?.refreshFailureCount).toBe(3);
+    expect(
+      (after as { refreshFailureCount?: number } | null)?.refreshFailureCount,
+    ).toBe(3);
   });
 
   it("does not drop a refreshFailed job just because other retries already ran", async () => {
@@ -1188,11 +1202,11 @@ describe("dispatchSyncJob", () => {
   async function seedConnectedCalendar() {
     const realConnections = new ProviderConnectionRepository(storage.db());
     const connection = await realConnections.upsertByProviderAccount({
-      tenantId: objectId(),
-      principalId: objectId(),
+      tenantId: objectId() as TenantId,
+      principalId: objectId() as PrincipalId,
       provider: "google",
       account: {
-        providerAccountId: "acct-1",
+        providerAccountId: "acct-1" as ProviderAccountId,
         email: "user@example.com",
         displayName: "User",
       },
@@ -1237,7 +1251,7 @@ describe("dispatchSyncJob", () => {
       .toArray();
     return feed.filter(
       (row) =>
-        (row.invalidation as { kind?: string } | undefined)?.kind ===
+        (row["invalidation"] as { kind?: string } | undefined)?.kind ===
         "connection",
     );
   }
@@ -1328,10 +1342,10 @@ describe("dispatchSyncJob", () => {
     principalId: string,
   ): JobRecord =>
     ({
-      _id: objectId(),
-      tenantId,
-      principalId,
-      connectionId,
+      _id: objectId() as SyncJobId,
+      tenantId: tenantId as TenantId,
+      principalId: principalId as PrincipalId,
+      connectionId: connectionId as ConnectionId,
       resourceId: null,
       commandId: null,
       kind: "calendarListSync",
@@ -1348,13 +1362,13 @@ describe("dispatchSyncJob", () => {
     }) as JobRecord;
 
   it("routes calendarListSync to discovery and settles done", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
-    const connectionId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const connectionId = objectId() as ConnectionId;
     stubbedConnection = {
       _id: connectionId,
-      tenantId,
-      principalId,
+      tenantId: tenantId,
+      principalId: principalId,
     } as ProviderConnectionRecord;
 
     const outcome = await dispatchSyncJob(
@@ -1390,13 +1404,13 @@ describe("dispatchSyncJob", () => {
   });
 
   it("re-lists when a notification lands mid-discovery, then clears the marker", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
-    const connectionId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const connectionId = objectId() as ConnectionId;
     stubbedConnection = {
       _id: connectionId,
-      tenantId,
-      principalId,
+      tenantId: tenantId,
+      principalId: principalId,
     } as ProviderConnectionRecord;
     // The first pass gets a change notification while it is reading the
     // provider (its enqueue coalesced onto this very job and vanished); the
@@ -1434,17 +1448,17 @@ describe("dispatchSyncJob", () => {
       .db()
       .collection(SYNC_COLLECTIONS.syncResources)
       .findOne({ connectionId, resourceKind: "calendarList" });
-    expect(resource?.changeNotifiedAt).toBeNull();
+    expect(resource?.["changeNotifiedAt"]).toBeNull();
   });
 
   it("skips the watch followup when the provider refused calendar-list watch", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
-    const connectionId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const connectionId = objectId() as ConnectionId;
     stubbedConnection = {
       _id: connectionId,
-      tenantId,
-      principalId,
+      tenantId: tenantId,
+      principalId: principalId,
     } as ProviderConnectionRecord;
     // Seed a cursored calendarList resource marked unwatchable: the pass runs
     // incrementally (no full-pass clear of the verdict), so the followup gate
@@ -1495,13 +1509,13 @@ describe("dispatchSyncJob", () => {
   });
 
   it("drops a revoked calendarListSync with a reason, like the resource-based kinds", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
-    const connectionId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const connectionId = objectId() as ConnectionId;
     stubbedConnection = {
       _id: connectionId,
-      tenantId,
-      principalId,
+      tenantId: tenantId,
+      principalId: principalId,
     } as ProviderConnectionRecord;
     const discarded: string[] = [];
     const revokedCustody: SyncJobDispatchDeps["custody"] = {
@@ -1514,6 +1528,7 @@ describe("dispatchSyncJob", () => {
       discardRevoked: async (id) => {
         discarded.push(id);
       },
+      invalidateAccessToken: async () => {},
     };
 
     const outcome = await dispatchSyncJob(
@@ -1530,13 +1545,13 @@ describe("dispatchSyncJob", () => {
   });
 
   it("drops a durable calendarList discovery failure and marks the calendarList resource", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
-    const connectionId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const connectionId = objectId() as ConnectionId;
     stubbedConnection = {
       _id: connectionId,
-      tenantId,
-      principalId,
+      tenantId: tenantId,
+      principalId: principalId,
       provider: "google",
     } as ProviderConnectionRecord;
     const failingDiscovery: ProviderCalendarAdapter = {
@@ -1576,13 +1591,13 @@ describe("dispatchSyncJob", () => {
   });
 
   it("rethrows a transient calendarList discovery failure for the worker retry ladder", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
-    const connectionId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const connectionId = objectId() as ConnectionId;
     stubbedConnection = {
       _id: connectionId,
-      tenantId,
-      principalId,
+      tenantId: tenantId,
+      principalId: principalId,
       provider: "google",
     } as ProviderConnectionRecord;
     const transientDiscovery: ProviderCalendarAdapter = {
@@ -1635,7 +1650,7 @@ describe("dispatchSyncJob", () => {
           if (provider === "microsoft") {
             throw new ProviderNotConfiguredError("microsoft");
           }
-          return fakeResolveAdapters(reader)();
+          return fakeResolveAdapters(reader)(provider, stubbedConnection!);
         },
       },
       jobFor(resource, "initialImport"),

--- a/packages/sync/src/domain/sync-job-worker.service.db.test.ts
+++ b/packages/sync/src/domain/sync-job-worker.service.db.test.ts
@@ -1,4 +1,9 @@
 import { faker } from "@faker-js/faker";
+import {
+  type PrincipalId,
+  type ProviderAccountId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
 import { seedOauthCredential } from "@sync/__tests__/helpers/credential-encryption";
 import {
   ensureEventsResource,
@@ -9,6 +14,7 @@ import {
   singleEvent as single,
   fakeTokenSource as tokenSource,
 } from "@sync/__tests__/helpers/fixtures";
+import { stringIdFilter } from "@sync/__tests__/helpers/mongo-id";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import {
   SyncJobWorker,
@@ -36,6 +42,15 @@ import { SyncResourceRepository } from "@sync/storage/repositories/sync-resource
 const objectId = () => faker.database.mongodbObjectId();
 const now = () => new Date("2026-07-10T00:00:00.000Z");
 const OWNER = "worker-under-test";
+
+const googleProviderCapabilities = [
+  "readEvents",
+  "writeEvents",
+  "readBusy",
+  "inviteAttendees",
+  "changeNotifications",
+  "incrementalChanges",
+] as const;
 
 describe("SyncJobWorker", () => {
   const storage = setupSyncStorage(import.meta.url);
@@ -78,7 +93,7 @@ describe("SyncJobWorker", () => {
       account: {
         email: "user@example.com",
         displayName: "User",
-        providerAccountId: "google-subject",
+        providerAccountId: "google-subject" as ProviderAccountId,
       },
       capabilities: [
         "readEvents",
@@ -230,11 +245,11 @@ describe("SyncJobWorker", () => {
 
   it("re-derives connection health after a successful pull settles", async () => {
     const connection = await connections.upsertByProviderAccount({
-      tenantId: objectId(),
-      principalId: objectId(),
+      tenantId: objectId() as TenantId,
+      principalId: objectId() as PrincipalId,
       provider: "google",
       account: {
-        providerAccountId: "acct-1",
+        providerAccountId: "acct-1" as ProviderAccountId,
         email: "user@example.com",
         displayName: "User",
       },
@@ -307,8 +322,8 @@ describe("SyncJobWorker", () => {
       await jobs.findById(resource.tenantId, resource.principalId, pull._id),
     ).toBeNull();
     const repair = await jobByKey(`repair:${resource._id}`);
-    expect(repair?.kind).toBe("repair");
-    expect(repair?.state).toBe("pending");
+    expect(repair?.["kind"]).toBe("repair");
+    expect(repair?.["state"]).toBe("pending");
   });
 
   it("reschedules a repair that did not complete instead of deleting it", async () => {
@@ -547,12 +562,12 @@ describe("SyncJobWorker", () => {
       },
     } as unknown as FakeReader;
 
-    let beat: (() => void | Promise<void>) | null = null;
+    let onHeartbeat: (() => void | Promise<void>) | undefined;
     const w = new SyncJobWorker(deps(gatedReader), OWNER, {
       now: movingNow,
       leaseMs: 300_000,
-      scheduleHeartbeat: (b) => {
-        beat = b;
+      scheduleHeartbeat: (beat) => {
+        onHeartbeat = beat;
         return () => {};
       },
     });
@@ -560,18 +575,20 @@ describe("SyncJobWorker", () => {
     const run = w.runOnce();
     // Wait until the worker has claimed the job and scheduled its heartbeat
     // (claimDueJob is a real round-trip, so a bare setTimeout(0) can beat it).
-    while (!beat) await new Promise((r) => setTimeout(r, 5));
+    while (!onHeartbeat) await new Promise((r) => setTimeout(r, 5));
 
     const claimed = await jobByKey(`incrementalPull:${resource._id}`);
-    const claimedLease = (claimed?.leaseExpiresAt as Date).getTime();
+    const claimedLease = (claimed?.["leaseExpiresAt"] as Date).getTime();
 
     // Advance time and fire one heartbeat; the lease must move forward.
     clock += 60_000;
-    await beat?.();
+    await onHeartbeat?.();
 
     const beaten = await jobByKey(`incrementalPull:${resource._id}`);
-    expect((beaten?.leaseExpiresAt as Date).getTime()).toBe(clock + 300_000);
-    expect((beaten?.leaseExpiresAt as Date).getTime()).toBeGreaterThan(
+    expect((beaten?.["leaseExpiresAt"] as Date).getTime()).toBe(
+      clock + 300_000,
+    );
+    expect((beaten?.["leaseExpiresAt"] as Date).getTime()).toBeGreaterThan(
       claimedLease,
     );
 
@@ -587,7 +604,7 @@ describe("SyncJobWorker", () => {
     await storage
       .db()
       .collection(SYNC_COLLECTIONS.syncResources)
-      .deleteOne({ _id: resource._id });
+      .deleteOne(stringIdFilter(resource._id));
 
     await worker(new FakeReader([])).runOnce();
 
@@ -629,10 +646,12 @@ describe("SyncJobWorker", () => {
       providerCalendarId: calendar.providerCalendarId,
       displayName: calendar.displayName,
       color: calendar.color,
+      eventLabels: calendar.eventLabels,
       active: true,
       primary: calendar.primary,
       accessRole: calendar.accessRole,
       capabilities: calendar.capabilities,
+      createsGoogleMeet: calendar.createsGoogleMeet,
     });
     const requeued = await enqueue(resource, "initialImport");
     expect(requeued.state).toBe("pending");
@@ -640,11 +659,11 @@ describe("SyncJobWorker", () => {
 
   it("settles a durable calendarList discovery failure instead of burning the retry ladder", async () => {
     const connection = await connections.upsertByProviderAccount({
-      tenantId: objectId(),
-      principalId: objectId(),
+      tenantId: objectId() as TenantId,
+      principalId: objectId() as PrincipalId,
       provider: "google",
       account: {
-        providerAccountId: "acct-not-cal",
+        providerAccountId: "acct-not-cal" as ProviderAccountId,
         email: "nocal@example.com",
         displayName: "No Cal",
       },
@@ -663,7 +682,7 @@ describe("SyncJobWorker", () => {
       runAfter: now(),
       coalescingKey: `calendarListSync:${connection._id}`,
     });
-    const failingDiscovery: SyncJobWorkerDeps["discovery"] = {
+    const failingDiscovery: ProviderCalendarAdapter = {
       discoverCalendars: async () => {
         throw new ProviderCalendarError(
           "discoveryFailed",

--- a/packages/sync/src/oauth/oauth-state.test.ts
+++ b/packages/sync/src/oauth/oauth-state.test.ts
@@ -130,10 +130,12 @@ describe("oauth-state", () => {
   });
 
   it("rejects a structurally malformed token", () => {
-    expect(verifyOAuthState(SECRET, "no-dot-here", 1).reason).toBe("malformed");
-    expect(verifyOAuthState(SECRET, ".onlysig", 1).reason).toBe("malformed");
-    expect(verifyOAuthState(SECRET, "onlypayload.", 1).reason).toBe(
-      "malformed",
-    );
+    for (const token of ["no-dot-here", ".onlysig", "onlypayload."]) {
+      const result = verifyOAuthState(SECRET, token, 1);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe("malformed");
+      }
+    }
   });
 });

--- a/packages/sync/src/providers/__contract__/apple.contract.test.ts
+++ b/packages/sync/src/providers/__contract__/apple.contract.test.ts
@@ -239,10 +239,14 @@ END:VCALENDAR`,
     },
     run: (reads) => {
       expect(reads).toHaveLength(2);
-      expect(reads[0]?.recurrence).toEqual({
-        kind: "seriesMaster",
-        rules: ["RRULE:FREQ=DAILY;COUNT=3"],
-      });
+      const master = reads[0];
+      expect(master?.kind).toBe("event");
+      if (master?.kind === "event") {
+        expect(master.recurrence).toEqual({
+          kind: "seriesMaster",
+          rules: ["RRULE:FREQ=DAILY;COUNT=3"],
+        });
+      }
       expect(reads[1]?.kind).toBe("event");
       if (reads[1]?.kind !== "event") return;
       expect(reads[1].recurrence.kind).toBe("instance");

--- a/packages/sync/src/providers/__contract__/microsoft.contract.test.ts
+++ b/packages/sync/src/providers/__contract__/microsoft.contract.test.ts
@@ -1,4 +1,6 @@
 import { generateKeyPair, type KeyLike, SignJWT } from "jose";
+import { type DateOnly } from "@core/types/domain-primitives";
+import { type ProviderAccountId } from "@core/types/sync/identity.contracts";
 import {
   assertWriterRejectsStaleVersion,
   CONTRACT_CONTENT,
@@ -135,8 +137,12 @@ describeAuthCases("microsoft", () => buildAdapter(), [
         redirectUri: "https://staging.example.com/sync/microsoft",
       });
       const fixture = exchangeFixture as ExchangeSuccessFixture;
-      expect(result.account.providerAccountId).toBe(fixture.idTokenClaims.oid);
-      expect(result.refreshToken).toBe(fixture.tokenResponse.refresh_token);
+      expect(result.account.providerAccountId).toBe(
+        fixture.idTokenClaims.oid as ProviderAccountId,
+      );
+      expect(result).toMatchObject({
+        refreshToken: fixture.tokenResponse.refresh_token,
+      });
       expect(result.grantedScopes).toEqual([
         "openid",
         "profile",
@@ -166,7 +172,7 @@ describeAuthCases(
           refreshToken: fixture.tokenResponse.refresh_token!,
         });
         expect(refreshed.accessToken).toBe(
-          (refreshSuccessFixture as MicrosoftTokenResponse).access_token,
+          (refreshSuccessFixture as MicrosoftTokenResponse).access_token ?? "",
         );
         expect(refreshed.grantedScopes).toEqual([
           "Calendars.ReadWrite",
@@ -295,8 +301,8 @@ describe("microsoft normalizer contract", () => {
     expect(read.busy).toBe(false);
     expect(read.schedule).toEqual({
       kind: "allDay",
-      start: "2022-02-22",
-      end: "2022-02-23",
+      start: "2022-02-22" as DateOnly,
+      end: "2022-02-23" as DateOnly,
     });
   });
 
@@ -376,7 +382,9 @@ describe("microsoft reader contract", () => {
     }
     expect(pages).toBe(2);
     expect(page.nextPageToken).toBeNull();
-    expect(page.nextSyncToken).toBe(readerCorpus.page2.deltaLink);
+    expect(page.nextSyncToken ?? null).toBe(
+      readerCorpus.page2.deltaLink ?? null,
+    );
   });
 
   it("maps an expired cursor to cursorExpired", async () => {

--- a/packages/sync/src/providers/apple/apple-event-reader.adapter.test.ts
+++ b/packages/sync/src/providers/apple/apple-event-reader.adapter.test.ts
@@ -128,7 +128,7 @@ describe("AppleEventReaderAdapter", () => {
     const api = new ScriptedAppleEventReaderApi({
       calendarQuery: async () => hrefs,
       calendarMultiget: async (_calendarUrl, batch) =>
-        batch.map((href, index) =>
+        (batch as string[]).map((href, index) =>
           resource(href, `uid-${index}`, `Event ${index}`),
         ),
       fetchSyncToken: async () => "sync-token-final",

--- a/packages/sync/src/providers/apple/apple-event-writer.adapter.test.ts
+++ b/packages/sync/src/providers/apple/apple-event-writer.adapter.test.ts
@@ -1,3 +1,4 @@
+import { type DateTime, type TimeZone } from "@core/types/domain-primitives";
 import { type EventSchedule } from "@core/types/event.contracts";
 import { type SyncEventContent } from "@core/types/sync/event.contracts";
 import {
@@ -21,7 +22,7 @@ function response(
   } = {},
 ): CaldavResponse {
   const headers: Record<string, string> = {};
-  if (options.etag) headers.etag = options.etag;
+  if (options.etag) headers["etag"] = options.etag;
   return {
     status,
     headers,
@@ -145,9 +146,9 @@ const content = (
 
 const schedule: EventSchedule = {
   kind: "timed",
-  start: "2025-01-15T09:00:00-05:00",
-  end: "2025-01-15T10:00:00-05:00",
-  timeZone: "America/New_York",
+  start: "2025-01-15T09:00:00-05:00" as DateTime,
+  end: "2025-01-15T10:00:00-05:00" as DateTime,
+  timeZone: "America/New_York" as TimeZone,
 };
 
 describe("AppleEventWriter createEvent", () => {

--- a/packages/sync/src/providers/apple/apple-event.normalizer.test.ts
+++ b/packages/sync/src/providers/apple/apple-event.normalizer.test.ts
@@ -1,4 +1,9 @@
 import {
+  type DateOnly,
+  type DateTime,
+  type TimeZone,
+} from "@core/types/domain-primitives";
+import {
   type AppleEventResourceInput,
   normalizeAppleEventResource,
 } from "@sync/providers/apple/apple-event.normalizer";
@@ -71,7 +76,7 @@ DESCRIPTION:Daily sync
 LOCATION:Room A
 END:VEVENT`),
     );
-    const event = asEvent(read);
+    const event = asEvent(read!);
 
     expect(event.providerEventId).toBe("timed-uid@icloud.com");
     expect(event.providerVersion).toBe('"etag-1"');
@@ -84,7 +89,7 @@ END:VEVENT`),
     expect(event.content.location).toBe("Room A");
     expect(event.schedule.kind).toBe("timed");
     if (event.schedule.kind !== "timed") throw new Error("expected timed");
-    expect(event.schedule.timeZone).toBe("America/New_York");
+    expect(event.schedule.timeZone).toBe("America/New_York" as TimeZone);
     expect(Date.parse(event.schedule.start)).toBe(
       Date.parse("2025-01-15T09:00:00-05:00"),
     );
@@ -101,12 +106,12 @@ DTEND:20250115T100000
 SUMMARY:Floating
 END:VEVENT`),
     );
-    const event = asEvent(read);
+    const event = asEvent(read!);
     if (event.schedule.kind !== "timed") throw new Error("expected timed");
 
-    expect(event.schedule.timeZone).toBe("America/Los_Angeles");
-    expect(event.schedule.start).toBe("2025-01-15T09:00:00-08:00");
-    expect(event.schedule.end).toBe("2025-01-15T10:00:00-08:00");
+    expect(event.schedule.timeZone).toBe("America/Los_Angeles" as TimeZone);
+    expect(event.schedule.start).toBe("2025-01-15T09:00:00-08:00" as DateTime);
+    expect(event.schedule.end).toBe("2025-01-15T10:00:00-08:00" as DateTime);
   });
 
   it("normalizes an all-day event", () => {
@@ -120,13 +125,13 @@ SUMMARY:Holiday
 TRANSP:TRANSPARENT
 END:VEVENT`),
     );
-    const event = asEvent(read);
+    const event = asEvent(read!);
 
     expect(event.busy).toBe(false);
     expect(event.schedule).toEqual({
       kind: "allDay",
-      start: "2025-02-22",
-      end: "2025-02-23",
+      start: "2025-02-22" as DateOnly,
+      end: "2025-02-23" as DateOnly,
     });
   });
 
@@ -143,7 +148,7 @@ EXDATE;TZID=America/New_York:20250122T090000
 SUMMARY:Weekly
 END:VEVENT`),
     );
-    const event = asEvent(read);
+    const event = asEvent(read!);
 
     expect(event.recurrence).toEqual({
       kind: "seriesMaster",
@@ -266,7 +271,7 @@ ATTENDEE;CN=Delegated;PARTSTAT=DELEGATED:mailto:delegated@example.com
 ATTENDEE;CN=No Email:mailto:
 END:VEVENT`),
     );
-    const event = asEvent(read);
+    const event = asEvent(read!);
 
     expect(event.content.organizer).toEqual({
       email: "host@example.com",
@@ -312,7 +317,7 @@ URL:https://example.com/meet
 END:VEVENT`),
     );
 
-    expect(asEvent(read).content.conference).toEqual({
+    expect(asEvent(read!).content.conference).toEqual({
       url: "https://example.com/meet",
       label: "Link",
     });
@@ -339,7 +344,7 @@ DTEND:20250115T100000Z
 END:VEVENT`),
     );
 
-    expect(asEvent(read).providerUpdatedAt).toBe("2025-01-03T10:10:10.000Z");
+    expect(asEvent(read!).providerUpdatedAt).toBe("2025-01-03T10:10:10.000Z");
   });
 
   it("derives timed end from DURATION when DTEND is absent", () => {
@@ -351,7 +356,7 @@ DTSTART:20250115T090000Z
 DURATION:PT1H30M
 END:VEVENT`),
     );
-    const event = asEvent(read);
+    const event = asEvent(read!);
     if (event.schedule.kind !== "timed") throw new Error("expected timed");
 
     expect(

--- a/packages/sync/src/providers/apple/apple-event.serializer.test.ts
+++ b/packages/sync/src/providers/apple/apple-event.serializer.test.ts
@@ -1,3 +1,8 @@
+import {
+  type DateOnly,
+  type DateTime,
+  type TimeZone,
+} from "@core/types/domain-primitives";
 import { type EventSchedule } from "@core/types/event.contracts";
 import {
   type AppleEventResourceInput,
@@ -68,12 +73,12 @@ function eventToSerializeInput(event: ProviderEvent): AppleEventSerializeInput {
 
 function roundTripEvent(icsBody: string): ProviderEvent {
   const [read] = normalizeAppleEventResource(resource(icsBody));
-  const event = asEvent(read);
+  const event = asEvent(read!);
   const serialized = serializeAppleEventCreate(eventToSerializeInput(event));
   const [roundTripped] = normalizeAppleEventResource(
     resource(serialized, { etag: event.providerVersion }),
   );
-  return asEvent(roundTripped);
+  return asEvent(roundTripped!);
 }
 
 function expectEventsEqual(
@@ -97,9 +102,9 @@ describe("serializeAppleEventCreate", () => {
       },
       schedule: {
         kind: "timed",
-        start: "2025-01-15T09:00:00Z",
-        end: "2025-01-15T10:00:00Z",
-        timeZone: "UTC",
+        start: "2025-01-15T09:00:00Z" as DateTime,
+        end: "2025-01-15T10:00:00Z" as DateTime,
+        timeZone: "UTC" as TimeZone,
       },
       recurrence: { kind: "single" },
       busy: true,
@@ -172,7 +177,7 @@ END:VEVENT`,
     },
   ])("round-trips a $name event through normalize", ({ body }) => {
     const [read] = normalizeAppleEventResource(resource(body));
-    const event = asEvent(read);
+    const event = asEvent(read!);
     const roundTripped = roundTripEvent(body);
     expectEventsEqual(roundTripped, event);
   });
@@ -206,9 +211,9 @@ END:VEVENT`);
       },
       schedule: {
         kind: "timed",
-        start: "2025-01-15T09:00:00Z",
-        end: "2025-01-15T10:00:00Z",
-        timeZone: "UTC",
+        start: "2025-01-15T09:00:00Z" as DateTime,
+        end: "2025-01-15T10:00:00Z" as DateTime,
+        timeZone: "UTC" as TimeZone,
       },
       recurrence: { kind: "single" },
       busy: true,
@@ -246,9 +251,9 @@ END:VEVENT`);
       },
       schedule: {
         kind: "timed",
-        start: "2025-01-15T10:00:00Z",
-        end: "2025-01-15T11:00:00Z",
-        timeZone: "UTC",
+        start: "2025-01-15T10:00:00Z" as DateTime,
+        end: "2025-01-15T11:00:00Z" as DateTime,
+        timeZone: "UTC" as TimeZone,
       },
       recurrence: { kind: "single" },
       busy: true,
@@ -286,9 +291,9 @@ END:VEVENT`);
       },
       schedule: {
         kind: "timed",
-        start: "2025-01-16T10:00:00Z",
-        end: "2025-01-16T11:00:00Z",
-        timeZone: "UTC",
+        start: "2025-01-16T10:00:00Z" as DateTime,
+        end: "2025-01-16T11:00:00Z" as DateTime,
+        timeZone: "UTC" as TimeZone,
       },
       recurrence: { kind: "instance" },
       busy: true,
@@ -345,9 +350,9 @@ describe("serializeAppleEventCreate schedule encoding", () => {
       },
       schedule: {
         kind: "timed",
-        start: "2025-01-15T09:00:00-05:00",
-        end: "2025-01-15T10:00:00-05:00",
-        timeZone: "America/New_York",
+        start: "2025-01-15T09:00:00-05:00" as DateTime,
+        end: "2025-01-15T10:00:00-05:00" as DateTime,
+        timeZone: "America/New_York" as TimeZone,
       },
       recurrence: { kind: "single" },
       busy: true,
@@ -372,8 +377,8 @@ describe("serializeAppleEventCreate schedule encoding", () => {
       },
       schedule: {
         kind: "allDay",
-        start: "2025-02-22",
-        end: "2025-02-23",
+        start: "2025-02-22" as DateOnly,
+        end: "2025-02-23" as DateOnly,
       } satisfies EventSchedule,
       recurrence: { kind: "single" },
       busy: false,

--- a/packages/sync/src/providers/apple/caldav-client.test.ts
+++ b/packages/sync/src/providers/apple/caldav-client.test.ts
@@ -271,7 +271,7 @@ describe("caldav-client", () => {
       ifMatch: '"etag-1"',
     });
     expect(put.status).toBe(200);
-    expect(put.headers.etag).toBe('"etag-1"');
+    expect(put.headers["etag"]).toBe('"etag-1"');
 
     const del = await client.delete(
       "https://caldav.icloud.com/event.ics",

--- a/packages/sync/src/providers/apple/caldav-client.ts
+++ b/packages/sync/src/providers/apple/caldav-client.ts
@@ -26,7 +26,10 @@ export interface ParsedPropstat {
   readonly props: Record<string, unknown>;
 }
 
-export type CaldavFetch = typeof fetch;
+export type CaldavFetch = (
+  url: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
 
 export type CaldavClientErrorReason =
   | "authExpired"

--- a/packages/sync/src/providers/google/google-auth.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-auth.adapter.test.ts
@@ -3,6 +3,7 @@ import {
   CONTACTS_FEATURE_SCOPES,
   GOOGLE_SCOPES,
 } from "@core/providers/google.scopes";
+import { type ProviderAccountId } from "@core/types/sync/identity.contracts";
 import {
   GoogleAuthAdapter,
   type GoogleOAuthClient,
@@ -89,7 +90,7 @@ function adapterWith(client: FakeGoogleClient) {
     CLIENT_ID,
     CLIENT_SECRET,
     (redirectUri) => {
-      redirectUris.push(redirectUri);
+      redirectUris.push(redirectUri ?? "");
       return client;
     },
   );
@@ -119,10 +120,10 @@ describe("GoogleAuthAdapter", () => {
       // The redirect URI is passed through to the client that mints the URL.
       expect(redirectUris).toEqual(["https://staging.example.com/sync/google"]);
       const options = client.authUrlOptions[0];
-      expect(options.access_type).toBe("offline");
-      expect(options.prompt).toBe("consent");
-      expect(options.state).toBe("opaque-state");
-      expect(options.scope).toEqual([...GOOGLE_SCOPES]);
+      expect(options!.access_type).toBe("offline");
+      expect(options!.prompt).toBe("consent");
+      expect(options!.state).toBe("opaque-state");
+      expect(options!.scope).toEqual([...GOOGLE_SCOPES]);
       expect(url).toContain("state=opaque-state");
     });
 
@@ -139,8 +140,8 @@ describe("GoogleAuthAdapter", () => {
       // Without select_account, a browser signed into one Google account
       // re-authorizes that same account and the user never gets to pick.
       // consent must stay so the exchange still returns a refresh token.
-      expect(client.authUrlOptions[0].prompt).toBe("select_account consent");
-      expect(client.authUrlOptions[0].access_type).toBe("offline");
+      expect(client.authUrlOptions[0]!.prompt).toBe("select_account consent");
+      expect(client.authUrlOptions[0]!.access_type).toBe("offline");
     });
 
     it("appends optional feature scopes after the base scopes", () => {
@@ -153,7 +154,7 @@ describe("GoogleAuthAdapter", () => {
         extraScopes: CONTACTS_FEATURE_SCOPES,
       });
 
-      expect(client.authUrlOptions[0].scope).toEqual([
+      expect(client.authUrlOptions[0]!.scope).toEqual([
         ...GOOGLE_SCOPES,
         "https://www.googleapis.com/auth/contacts.readonly",
         "https://www.googleapis.com/auth/contacts.other.readonly",
@@ -177,8 +178,8 @@ describe("GoogleAuthAdapter", () => {
       // The optional-scope rollout must not change what a plain connect asks
       // Google for — same URL, base scopes only.
       expect(emptyList).toBe(withoutField);
-      expect(client.authUrlOptions[0].scope).toEqual([...GOOGLE_SCOPES]);
-      expect(client.authUrlOptions[1].scope).toEqual([...GOOGLE_SCOPES]);
+      expect(client.authUrlOptions[0]!.scope).toEqual([...GOOGLE_SCOPES]);
+      expect(client.authUrlOptions[1]!.scope).toEqual([...GOOGLE_SCOPES]);
     });
   });
 
@@ -203,7 +204,9 @@ describe("GoogleAuthAdapter", () => {
         redirectUri: "https://staging.example.com/sync/google",
       });
 
-      expect(result.account.providerAccountId).toBe("google-subject-123");
+      expect(result.account.providerAccountId).toBe(
+        "google-subject-123" as ProviderAccountId,
+      );
       expect(result.account.email).toBe("user@example.com");
       expect(result.account.displayName).toBe("Ada Lovelace");
       expect(result.refreshToken).toBe("refresh-token-value");
@@ -252,7 +255,9 @@ describe("GoogleAuthAdapter", () => {
         redirectUri: "https://x/sync/google",
       });
 
-      expect(result.account.providerAccountId).toBe("google-subject-123");
+      expect(result.account.providerAccountId).toBe(
+        "google-subject-123" as ProviderAccountId,
+      );
       expect(result.account.email).toBeNull();
       expect(result.account.displayName).toBeNull();
     });

--- a/packages/sync/src/providers/google/google-calendar.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-calendar.adapter.test.ts
@@ -140,10 +140,10 @@ describe("GoogleCalendarAdapter", () => {
       calendars.map((c) => [c.providerCalendarId, c]),
     );
 
-    expect(byId["labeled"].eventLabels).toEqual([
+    expect(byId["labeled"]!.eventLabels).toEqual([
       { id: "label-1", hex: "#009688" },
     ]);
-    expect(byId["unlabeled"].eventLabels).toEqual([]);
+    expect(byId["unlabeled"]!.eventLabels).toEqual([]);
     expect(api.labelCalls).toEqual(["labeled", "unlabeled"]);
   });
 
@@ -211,24 +211,24 @@ describe("GoogleCalendarAdapter", () => {
       calendars.map((c) => [c.providerCalendarId, c]),
     );
 
-    expect(byId["owner"].accessRole).toBe("owner");
-    expect(byId["writer"].accessRole).toBe("editor");
-    expect(byId["reader"].accessRole).toBe("viewer");
-    expect(byId["fbr"].accessRole).toBe("busyOnly");
+    expect(byId["owner"]!.accessRole).toBe("owner");
+    expect(byId["writer"]!.accessRole).toBe("editor");
+    expect(byId["reader"]!.accessRole).toBe("viewer");
+    expect(byId["fbr"]!.accessRole).toBe("busyOnly");
 
-    expect(byId["writer"].capabilities).toEqual({
+    expect(byId["writer"]!.capabilities).toEqual({
       canReadEvents: true,
       canWriteEvents: true,
       canReadBusy: true,
       canInviteAttendees: true,
     });
-    expect(byId["reader"].capabilities).toEqual({
+    expect(byId["reader"]!.capabilities).toEqual({
       canReadEvents: true,
       canWriteEvents: false,
       canReadBusy: true,
       canInviteAttendees: false,
     });
-    expect(byId["fbr"].capabilities).toEqual({
+    expect(byId["fbr"]!.capabilities).toEqual({
       canReadEvents: false,
       canWriteEvents: false,
       canReadBusy: true,
@@ -369,8 +369,8 @@ describe("GoogleCalendarAdapter", () => {
     });
 
     expect(calendars).toHaveLength(1);
-    expect(calendars[0].providerCalendarId).toBe("no-color");
-    expect(calendars[0].color).toBeNull();
+    expect(calendars[0]!.providerCalendarId).toBe("no-color");
+    expect(calendars[0]!.color).toBeNull();
   });
 
   it("treats missing conference types as Meet-capable", async () => {
@@ -383,7 +383,7 @@ describe("GoogleCalendarAdapter", () => {
       accessToken: "at",
     });
 
-    expect(calendars[0].createsGoogleMeet).toBe(true);
+    expect(calendars[0]!.createsGoogleMeet).toBe(true);
   });
 
   it("maps hangoutsMeet as Meet-capable", async () => {
@@ -406,7 +406,7 @@ describe("GoogleCalendarAdapter", () => {
       accessToken: "at",
     });
 
-    expect(calendars[0].createsGoogleMeet).toBe(true);
+    expect(calendars[0]!.createsGoogleMeet).toBe(true);
   });
 
   it("maps a calendar without hangoutsMeet as not Meet-capable", async () => {
@@ -429,7 +429,7 @@ describe("GoogleCalendarAdapter", () => {
       accessToken: "at",
     });
 
-    expect(calendars[0].createsGoogleMeet).toBe(false);
+    expect(calendars[0]!.createsGoogleMeet).toBe(false);
   });
 
   it("returns a null cursor when the provider sends no sync token", async () => {
@@ -458,8 +458,8 @@ describe("GoogleCalendarAdapter", () => {
     });
 
     expect(tokensSeen).toEqual(["account-a", "account-b"]);
-    expect(first.calendars[0].providerCalendarId).toBe("account-a");
-    expect(second.calendars[0].providerCalendarId).toBe("account-b");
+    expect(first.calendars[0]!.providerCalendarId).toBe("account-a");
+    expect(second.calendars[0]!.providerCalendarId).toBe("account-b");
   });
 
   it("maps a 401 to authExpired so the caller can remint the access token", async () => {

--- a/packages/sync/src/providers/google/google-capabilities.test.ts
+++ b/packages/sync/src/providers/google/google-capabilities.test.ts
@@ -1,3 +1,4 @@
+import { type ProviderCapability } from "@core/types/sync/identity.contracts";
 import { googleCapabilitiesFromScopes } from "@sync/providers/google/google-capabilities";
 
 const EMAIL = "https://www.googleapis.com/auth/userinfo.email";
@@ -9,27 +10,27 @@ const CONTACTS_OTHER =
 
 describe("googleCapabilitiesFromScopes", () => {
   it("grants full read+write capabilities for the events scope", () => {
-    expect(googleCapabilitiesFromScopes([EMAIL, EVENTS]).sort()).toEqual(
-      [
-        "changeNotifications",
-        "incrementalChanges",
-        "inviteAttendees",
-        "readBusy",
-        "readEvents",
-        "writeEvents",
-      ].sort(),
-    );
+    const caps = [...googleCapabilitiesFromScopes([EMAIL, EVENTS])].sort();
+    const expected: ProviderCapability[] = [
+      "changeNotifications",
+      "incrementalChanges",
+      "inviteAttendees",
+      "readBusy",
+      "readEvents",
+      "writeEvents",
+    ];
+    expect(caps).toEqual([...expected].sort());
   });
 
   it("grants read-only capabilities for the readonly scope", () => {
-    expect(googleCapabilitiesFromScopes([EMAIL, READONLY]).sort()).toEqual(
-      [
-        "changeNotifications",
-        "incrementalChanges",
-        "readBusy",
-        "readEvents",
-      ].sort(),
-    );
+    const caps = [...googleCapabilitiesFromScopes([EMAIL, READONLY])].sort();
+    const expected: ProviderCapability[] = [
+      "changeNotifications",
+      "incrementalChanges",
+      "readBusy",
+      "readEvents",
+    ];
+    expect(caps).toEqual([...expected].sort());
     // No write or invite without the events scope.
     expect(googleCapabilitiesFromScopes([READONLY])).not.toContain(
       "writeEvents",
@@ -50,15 +51,17 @@ describe("googleCapabilitiesFromScopes", () => {
   // Contacts scopes are optional and independently declinable, so EITHER one
   // is enough for the capability — partial grants are a normal outcome of the
   // consent screen, not an error.
-  it.each([
+  for (const scopes of [
     [CONTACTS],
     [CONTACTS_OTHER],
     [CONTACTS, CONTACTS_OTHER],
-  ])("grants suggestContacts from a contacts grant (%#)", (...scopes) => {
-    expect(googleCapabilitiesFromScopes([EMAIL, EVENTS, ...scopes])).toContain(
-      "suggestContacts",
-    );
-  });
+  ] as const) {
+    it(`grants suggestContacts from a contacts grant (${scopes.join(",")})`, () => {
+      expect(
+        googleCapabilitiesFromScopes([EMAIL, EVENTS, ...scopes]),
+      ).toContain("suggestContacts");
+    });
+  }
 
   it("does not grant suggestContacts without a contacts scope", () => {
     expect(

--- a/packages/sync/src/providers/google/google-event-reader.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-event-reader.adapter.test.ts
@@ -8,6 +8,21 @@ import { ProviderEventReadError } from "@sync/providers/provider-event-reader.po
 
 // A fake events.list API returning scripted pages in order, recording the
 // params it was called with so tests can assert window/cursor/pagination.
+const expectListPageError = async (
+  adapter: GoogleEventReaderAdapter,
+  input: Parameters<GoogleEventReaderAdapter["listEventPage"]>[0],
+): Promise<ProviderEventReadError> => {
+  try {
+    await adapter.listEventPage(input);
+    throw new Error("expected listEventPage to throw");
+  } catch (error) {
+    if (!(error instanceof ProviderEventReadError)) {
+      throw error;
+    }
+    return error;
+  }
+};
+
 class FakeEventListApi implements GoogleEventListApi {
   calls: Array<Parameters<GoogleEventListApi["listPage"]>[0]> = [];
   #pages: GoogleEventListPage[];
@@ -102,11 +117,11 @@ describe("GoogleEventReaderAdapter", () => {
       },
     });
 
-    expect(api.calls[0].window).toEqual({
+    expect(api.calls[0]!.window).toEqual({
       timeMin: "2026-06-01T00:00:00Z",
       timeMax: "2026-09-01T00:00:00Z",
     });
-    expect(api.calls[0].syncToken).toBeUndefined();
+    expect(api.calls[0]!.syncToken).toBeUndefined();
   });
 
   it("forwards the stored cursor and page token for a resumed full pass", async () => {
@@ -120,8 +135,8 @@ describe("GoogleEventReaderAdapter", () => {
       pageToken: "page-2",
     });
 
-    expect(api.calls[0].syncToken).toBe("sync-token-0");
-    expect(api.calls[0].pageToken).toBe("page-2");
+    expect(api.calls[0]!.syncToken).toBe("sync-token-0");
+    expect(api.calls[0]!.pageToken).toBe("page-2");
   });
 
   it("keeps cancellations in the page (an incremental deletion)", async () => {
@@ -381,9 +396,10 @@ describe("GoogleEventReaderAdapter", () => {
     const api = new FakeEventListApi([], rejected);
     const { adapter } = adapterWith(api);
 
-    const error = await adapter
-      .listEventPage({ accessToken: "tok", calendarId: "primary@google.com" })
-      .catch((e) => e as ProviderEventReadError);
+    const error = await expectListPageError(adapter, {
+      accessToken: "tok",
+      calendarId: "primary@google.com",
+    });
 
     // Without these, a durable readFailed row is guesswork to diagnose: the
     // message alone does not say which rejection Google gave.
@@ -395,9 +411,10 @@ describe("GoogleEventReaderAdapter", () => {
     const api = new FakeEventListApi([], { response: { status: 403 } });
     const { adapter } = adapterWith(api);
 
-    const error = await adapter
-      .listEventPage({ accessToken: "tok", calendarId: "primary@google.com" })
-      .catch((e) => e as ProviderEventReadError);
+    const error = await expectListPageError(adapter, {
+      accessToken: "tok",
+      calendarId: "primary@google.com",
+    });
 
     expect((error.cause as Error)?.message).toContain("HTTP 403");
   });
@@ -408,9 +425,10 @@ describe("GoogleEventReaderAdapter", () => {
     const api = new FakeEventListApi([], leaky);
     const { adapter } = adapterWith(api);
 
-    const error = await adapter
-      .listEventPage({ accessToken: "tok", calendarId: "primary@google.com" })
-      .catch((e) => e as ProviderEventReadError);
+    const error = await expectListPageError(adapter, {
+      accessToken: "tok",
+      calendarId: "primary@google.com",
+    });
 
     expect(error).toBeInstanceOf(ProviderEventReadError);
     expect(JSON.stringify(error.cause ?? {})).not.toContain(

--- a/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-event-writer.adapter.test.ts
@@ -197,7 +197,9 @@ describe("GoogleEventWriter", () => {
     const result = await writer.createEvent(baseCreate);
 
     expect(tokens).toEqual(["at"]);
-    expect(api.calls.insert[0].requestBody.id).toBe("abc12deadbeef00000000000");
+    expect(api.calls.insert[0]!.requestBody.id).toBe(
+      "abc12deadbeef00000000000",
+    );
     expect(result).toEqual({
       providerEventId: "abc12deadbeef00000000000",
       providerVersion: '"v1"',
@@ -229,7 +231,7 @@ describe("GoogleEventWriter", () => {
 
     const result = await writer.createEvent(baseCreate);
 
-    expect(api.calls.get[0].eventId).toBe("abc12deadbeef00000000000");
+    expect(api.calls.get[0]!.eventId).toBe("abc12deadbeef00000000000");
     expect(result.providerVersion).toBe('"vGet"');
   });
 
@@ -291,8 +293,8 @@ describe("GoogleEventWriter", () => {
       ],
     });
 
-    expect(api.calls.insert[0].sendUpdates).toBe("all");
-    expect(api.calls.insert[0].requestBody.attendees).toEqual([
+    expect(api.calls.insert[0]!.sendUpdates).toBe("all");
+    expect(api.calls.insert[0]!.requestBody.attendees).toEqual([
       {
         email: "kept@example.com",
         displayName: "Kept",
@@ -320,8 +322,8 @@ describe("GoogleEventWriter", () => {
 
     // The exact body, sendUpdates included: retained statuses echo back, and
     // no other attendee-adjacent key (organizer, conferenceData) appears.
-    expect(api.calls.patch[0].sendUpdates).toBe("externalOnly");
-    expect(api.calls.patch[0].requestBody).toEqual({
+    expect(api.calls.patch[0]!.sendUpdates).toBe("externalOnly");
+    expect(api.calls.patch[0]!.requestBody).toEqual({
       summary: "Title",
       description: "Desc",
       location: null,
@@ -346,7 +348,7 @@ describe("GoogleEventWriter", () => {
 
     await writer.patchEvent({ ...basePatch, attendees: [] });
 
-    expect(api.calls.patch[0].requestBody.attendees).toEqual([]);
+    expect(api.calls.patch[0]!.requestBody.attendees).toEqual([]);
   });
 
   it("omits the attendees key when the write does not intend a guest edit", async () => {
@@ -370,7 +372,7 @@ describe("GoogleEventWriter", () => {
     });
     await writer.patchEvent(basePatch);
 
-    expect(api.calls.insert[0].requestBody).toEqual({
+    expect(api.calls.insert[0]!.requestBody).toEqual({
       id: "abc12deadbeef00000000000",
       summary: "Title",
       description: "Desc",
@@ -387,7 +389,7 @@ describe("GoogleEventWriter", () => {
       },
       recurrence: null,
     });
-    expect(api.calls.patch[0].requestBody).not.toHaveProperty("attendees");
+    expect(api.calls.patch[0]!.requestBody).not.toHaveProperty("attendees");
   });
 
   it("sends only colorId and attendees for a provider-managed patch", async () => {
@@ -440,14 +442,14 @@ describe("GoogleEventWriter", () => {
       ],
     });
 
-    expect(api.calls.insert[0].conferenceDataVersion).toBe(1);
-    expect(api.calls.insert[0].requestBody.conferenceData).toEqual({
+    expect(api.calls.insert[0]!.conferenceDataVersion).toBe(1);
+    expect(api.calls.insert[0]!.requestBody.conferenceData).toEqual({
       createRequest: {
         requestId: "abc12deadbeef00000000000",
         conferenceSolutionKey: { type: "hangoutsMeet" },
       },
     });
-    expect(api.calls.insert[0].requestBody.guestsCanInviteOthers).toBe(true);
+    expect(api.calls.insert[0]!.requestBody.guestsCanInviteOthers).toBe(true);
   });
 
   it("returns the Meet URL Google mints on create", async () => {
@@ -512,9 +514,11 @@ describe("GoogleEventWriter", () => {
       expectedVersion: '"v1"',
     });
 
-    expect(api.calls.patch[0].ifMatch).toBe('"v1"');
+    expect(api.calls.patch[0]!.ifMatch).toBe('"v1"');
     expect(result.providerVersion).toBe('"v2"');
-    expect(api.calls.patch[0].requestBody).not.toHaveProperty("conferenceData");
+    expect(api.calls.patch[0]!.requestBody).not.toHaveProperty(
+      "conferenceData",
+    );
     expect(api.calls.patch[0]).not.toHaveProperty("conferenceDataVersion");
   });
 
@@ -524,7 +528,7 @@ describe("GoogleEventWriter", () => {
 
     await writer.patchEvent(basePatch);
 
-    expect(api.calls.patch[0].ifMatch).toBeNull();
+    expect(api.calls.patch[0]!.ifMatch).toBeNull();
   });
 
   it("maps a precondition failure to versionConflict", async () => {
@@ -696,11 +700,11 @@ describe("GoogleEventWriter", () => {
     });
     await writer.patchEvent({ ...basePatch, recurrence: { kind: "single" } });
 
-    expect(api.calls.insert[0].requestBody.recurrence).toEqual([
+    expect(api.calls.insert[0]!.requestBody.recurrence).toEqual([
       "RRULE:FREQ=DAILY",
     ]);
     // A series-to-single edit must clear the rules, not omit the key.
-    expect(api.calls.patch[0].requestBody.recurrence).toBeNull();
+    expect(api.calls.patch[0]!.requestBody.recurrence).toBeNull();
   });
 
   it("omits the recurrence key entirely when patching a resolved instance", async () => {
@@ -712,7 +716,7 @@ describe("GoogleEventWriter", () => {
 
     await writer.patchEvent({ ...basePatch, recurrence: { kind: "instance" } });
 
-    expect(api.calls.patch[0].requestBody).not.toHaveProperty("recurrence");
+    expect(api.calls.patch[0]!.requestBody).not.toHaveProperty("recurrence");
   });
 
   it("nulls the unused schedule keys so Google never sees both a date and a dateTime", async () => {
@@ -722,12 +726,12 @@ describe("GoogleEventWriter", () => {
     await writer.createEvent({ ...baseCreate, schedule: timedSchedule });
     await writer.patchEvent({ ...basePatch, schedule: allDaySchedule });
 
-    expect(api.calls.insert[0].requestBody.start).toEqual({
+    expect(api.calls.insert[0]!.requestBody.start).toEqual({
       date: null,
       dateTime: "2025-01-15T09:00:00-05:00",
       timeZone: "America/New_York",
     });
-    expect(api.calls.patch[0].requestBody.start).toEqual({
+    expect(api.calls.patch[0]!.requestBody.start).toEqual({
       date: "2025-01-15",
       dateTime: null,
       timeZone: null,
@@ -744,9 +748,9 @@ describe("GoogleEventWriter", () => {
     });
     await writer.patchEvent({ ...basePatch, content: content() });
 
-    expect(api.calls.insert[0].requestBody.colorId).toBe("7");
+    expect(api.calls.insert[0]!.requestBody.colorId).toBe("7");
     expect(api.calls.patch).toHaveLength(1);
-    expect(api.calls.patch[0].requestBody).not.toHaveProperty("colorId");
+    expect(api.calls.patch[0]!.requestBody).not.toHaveProperty("colorId");
   });
 
   it("clears Google colorId when content.color is null", async () => {
@@ -759,7 +763,7 @@ describe("GoogleEventWriter", () => {
     });
 
     expect(api.calls.patch).toHaveLength(1);
-    expect(api.calls.patch[0].requestBody.colorId).toBeNull();
+    expect(api.calls.patch[0]!.requestBody.colorId).toBeNull();
     expect(api.calls.patch[0]).not.toHaveProperty("eventLabelVersion");
   });
 
@@ -785,7 +789,7 @@ describe("GoogleEventWriter", () => {
       ifMatch: '"v2"',
     });
     expect(api.calls.patch[1]).not.toHaveProperty("eventLabelVersion");
-    expect(api.calls.patch[1].requestBody).not.toHaveProperty("eventLabelId");
+    expect(api.calls.patch[1]!.requestBody).not.toHaveProperty("eventLabelId");
   });
 
   it("maps each invitation intent straight to sendUpdates", async () => {

--- a/packages/sync/src/providers/google/google-event.normalizer.test.ts
+++ b/packages/sync/src/providers/google/google-event.normalizer.test.ts
@@ -2,6 +2,11 @@ import { allday } from "@core/__mocks__/v1/events/gcal/gcal.allday";
 import { cancelled } from "@core/__mocks__/v1/events/gcal/gcal.cancelled";
 import { recurring } from "@core/__mocks__/v1/events/gcal/gcal.recurring";
 import { timed } from "@core/__mocks__/v1/events/gcal/gcal.timed";
+import {
+  type DateOnly,
+  type DateTime,
+  type TimeZone,
+} from "@core/types/domain-primitives";
 import { type gSchema$Event } from "@core/types/gcal";
 import { normalizeGoogleEvent } from "@sync/providers/google/google-event.normalizer";
 import {
@@ -67,7 +72,7 @@ describe("normalizeGoogleEvent", () => {
 
     // The fixture's stored offset disagrees with its zone; re-anchoring corrects
     // the offset while keeping the same absolute moment.
-    expect(read.schedule.timeZone).toBe("America/Chicago");
+    expect(read.schedule.timeZone).toBe("America/Chicago" as TimeZone);
     expect(Date.parse(read.schedule.start)).toBe(
       Date.parse("2012-10-26T13:00:00-06:00"),
     );
@@ -109,8 +114,8 @@ describe("normalizeGoogleEvent", () => {
       throw new Error("expected timed");
     }
 
-    expect(winter.schedule.start).toBe("2025-01-15T09:00:00-05:00");
-    expect(summer.schedule.start).toBe("2025-07-15T09:00:00-04:00");
+    expect(winter.schedule.start).toBe("2025-01-15T09:00:00-05:00" as DateTime);
+    expect(summer.schedule.start).toBe("2025-07-15T09:00:00-04:00" as DateTime);
   });
 
   it("normalizes an all-day, free (transparent) event", () => {
@@ -119,8 +124,8 @@ describe("normalizeGoogleEvent", () => {
     expect(read.busy).toBe(false);
     expect(read.schedule).toEqual({
       kind: "allDay",
-      start: "2022-02-22",
-      end: "2022-02-23",
+      start: "2022-02-22" as DateOnly,
+      end: "2022-02-23" as DateOnly,
     });
     // No description/location on this fixture; absence becomes empty string
     // for both, matching the editable-write side's "no location" convention.
@@ -143,7 +148,7 @@ describe("normalizeGoogleEvent", () => {
   });
 
   it("maps a recurring instance to its series link and occurrence id", () => {
-    const read = asProviderEvent(normalizeGoogleEvent(recurring[1]));
+    const read = asProviderEvent(normalizeGoogleEvent(recurring[1]!));
     if (read.recurrence.kind !== "instance")
       throw new Error("expected instance");
 
@@ -250,7 +255,7 @@ describe("normalizeGoogleEvent", () => {
     );
 
     expect(read.content.organizer?.displayName).toBeNull();
-    expect(read.content.attendees[0].displayName).toBeNull();
+    expect(read.content.attendees[0]!.displayName).toBeNull();
   });
 
   it("reads a conference url from hangoutLink and from conferenceData", () => {
@@ -310,7 +315,7 @@ describe("normalizeGoogleEvent", () => {
     );
     if (read.schedule.kind !== "timed") throw new Error("expected timed");
 
-    expect(read.schedule.timeZone).toBe("UTC");
+    expect(read.schedule.timeZone).toBe("UTC" as TimeZone);
     expect(Date.parse(read.schedule.start)).toBe(
       Date.parse("2025-01-15T09:00:00-05:00"),
     );
@@ -333,7 +338,7 @@ describe("normalizeGoogleEvent", () => {
     );
     if (read.schedule.kind !== "timed") throw new Error("expected timed");
 
-    expect(read.schedule.timeZone).toBe("UTC");
+    expect(read.schedule.timeZone).toBe("UTC" as TimeZone);
     expect(Date.parse(read.schedule.start)).toBe(
       Date.parse("2025-01-15T09:00:00-07:00"),
     );
@@ -377,6 +382,7 @@ describe("normalizeGoogleEvent", () => {
       } catch (e) {
         return e;
       }
+      throw new Error("expected normalizeGoogleEvent to throw");
     })() as ProviderEventError;
 
     expect(error).toBeInstanceOf(ProviderEventError);

--- a/packages/sync/src/providers/google/google-notifications.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-notifications.adapter.test.ts
@@ -52,13 +52,15 @@ class FakeChannelsApi implements GoogleChannelsApi {
     if (this.behavior.calendarListWatch instanceof Error) {
       throw this.behavior.calendarListWatch;
     }
-    return (
-      this.behavior.calendarListWatch ??
+    const channel = this.behavior.calendarListWatch ??
       this.behavior.watch ?? {
         resourceId: "res-list-1",
         expiration: "1767312000000",
-      }
-    );
+      };
+    if (channel instanceof Error) {
+      throw channel;
+    }
+    return channel;
   }
 
   async stopChannel(
@@ -164,7 +166,7 @@ describe("GoogleNotificationAdapter watch/stop", () => {
     });
 
     // Requested one hour out...
-    expect(api.watchCalls[0].requestBody.expiration).toBe(
+    expect(api.watchCalls[0]!.requestBody.expiration).toBe(
       String(new Date("2026-01-01T01:00:00Z").getTime()),
     );
     // ...but the returned expiry (2026-01-01T00:00:00 + provider value) wins.

--- a/packages/sync/src/providers/microsoft/microsoft-auth.adapter.test.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-auth.adapter.test.ts
@@ -3,6 +3,7 @@ import {
   CONTACTS_FEATURE_SCOPES,
   MICROSOFT_SCOPES,
 } from "@core/providers/microsoft.scopes";
+import { type ProviderAccountId } from "@core/types/sync/identity.contracts";
 import {
   MICROSOFT_AUTHORIZE_URL,
   MicrosoftAuthAdapter,
@@ -14,12 +15,14 @@ import {
 import { isMicrosoftConsentRequired } from "@sync/providers/microsoft/microsoft-consent";
 import { ProviderAuthError } from "@sync/providers/provider-auth.port";
 
+type ExchangeInput = Parameters<
+  MicrosoftTokenEndpoint["exchangeAuthorizationCode"]
+>[0];
+type RefreshInput = Parameters<MicrosoftTokenEndpoint["refreshAccessToken"]>[0];
+
 class FakeTokenEndpoint implements MicrosoftTokenEndpoint {
-  exchangeInputs: Parameters<
-    MicrosoftTokenEndpoint["exchangeAuthorizationCode"]
-  >[] = [];
-  refreshInputs: Parameters<MicrosoftTokenEndpoint["refreshAccessToken"]>[] =
-    [];
+  exchangeInputs: ExchangeInput[] = [];
+  refreshInputs: RefreshInput[] = [];
 
   constructor(
     private readonly behavior: {
@@ -31,7 +34,7 @@ class FakeTokenEndpoint implements MicrosoftTokenEndpoint {
   ) {}
 
   exchangeAuthorizationCode(
-    input: Parameters<MicrosoftTokenEndpoint["exchangeAuthorizationCode"]>[0],
+    input: ExchangeInput,
   ): Promise<MicrosoftTokenResponse> {
     this.exchangeInputs.push(input);
     if (this.behavior.exchangeError) {
@@ -40,9 +43,7 @@ class FakeTokenEndpoint implements MicrosoftTokenEndpoint {
     return Promise.resolve(this.behavior.exchangeResponse ?? {});
   }
 
-  refreshAccessToken(
-    input: Parameters<MicrosoftTokenEndpoint["refreshAccessToken"]>[0],
-  ): Promise<MicrosoftTokenResponse> {
+  refreshAccessToken(input: RefreshInput): Promise<MicrosoftTokenResponse> {
     this.refreshInputs.push(input);
     if (this.behavior.refreshError) {
       return Promise.reject(this.behavior.refreshError);
@@ -231,7 +232,9 @@ describe("MicrosoftAuthAdapter", () => {
         redirectUri: "https://staging.example.com/sync/microsoft",
       });
 
-      expect(result.account.providerAccountId).toBe("microsoft-oid-123");
+      expect(result.account.providerAccountId).toBe(
+        "microsoft-oid-123" as ProviderAccountId,
+      );
       expect(result.account.email).toBe("user@contoso.com");
       expect(result.account.displayName).toBe("Contoso User");
       expect(result.refreshToken).toBe("refresh-token-value");

--- a/packages/sync/src/providers/microsoft/microsoft-calendar.adapter.test.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-calendar.adapter.test.ts
@@ -163,7 +163,7 @@ describe("MicrosoftCalendarAdapter", () => {
 
     expect(byId).toEqual({
       hex: "#AABBCC",
-      enum: MICROSOFT_CALENDAR_COLOR_HEX.lightGreen,
+      enum: MICROSOFT_CALENDAR_COLOR_HEX["lightGreen"]!,
       auto: null,
     });
   });

--- a/packages/sync/src/providers/microsoft/microsoft-event-reader.adapter.test.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-event-reader.adapter.test.ts
@@ -6,6 +6,21 @@ import {
 } from "@sync/providers/microsoft/microsoft-event-reader.adapter";
 import { ProviderEventReadError } from "@sync/providers/provider-event-reader.port";
 
+const expectListPageError = async (
+  adapter: MicrosoftEventReaderAdapter,
+  input: Parameters<MicrosoftEventReaderAdapter["listEventPage"]>[0],
+): Promise<ProviderEventReadError> => {
+  try {
+    await adapter.listEventPage(input);
+    throw new Error("expected listEventPage to throw");
+  } catch (error) {
+    if (!(error instanceof ProviderEventReadError)) {
+      throw error;
+    }
+    return error;
+  }
+};
+
 class FakeEventListApi implements MicrosoftEventListApi {
   calls: Array<Parameters<MicrosoftEventListApi["listPage"]>[0]> = [];
   #pages: MicrosoftEventListPage[];
@@ -289,9 +304,10 @@ describe("MicrosoftEventReaderAdapter", () => {
     const api = new FakeEventListApi([], rejected);
     const { adapter } = adapterWith(api);
 
-    const error = await adapter
-      .listEventPage({ accessToken: "tok", calendarId: "cal-1" })
-      .catch((e) => e as ProviderEventReadError);
+    const error = await expectListPageError(adapter, {
+      accessToken: "tok",
+      calendarId: "cal-1",
+    });
 
     expect((error.cause as Error)?.message).toContain("HTTP 404");
     expect((error.cause as Error)?.message).toContain("ErrorItemNotFound");
@@ -303,9 +319,10 @@ describe("MicrosoftEventReaderAdapter", () => {
     const api = new FakeEventListApi([], leaky);
     const { adapter } = adapterWith(api);
 
-    const error = await adapter
-      .listEventPage({ accessToken: "tok", calendarId: "cal-1" })
-      .catch((e) => e as ProviderEventReadError);
+    const error = await expectListPageError(adapter, {
+      accessToken: "tok",
+      calendarId: "cal-1",
+    });
 
     expect(error).toBeInstanceOf(ProviderEventReadError);
     expect(JSON.stringify(error.cause ?? {})).not.toContain(

--- a/packages/sync/src/providers/microsoft/microsoft-event-writer.adapter.test.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-event-writer.adapter.test.ts
@@ -1,7 +1,7 @@
 import { type EventSchedule } from "@core/types/event.contracts";
 import { type SyncEventContent } from "@core/types/sync/event.contracts";
+import { type GraphEvent } from "@sync/providers/microsoft/microsoft-event.normalizer";
 import {
-  type GraphEvent,
   type MicrosoftEventWriteApi,
   MicrosoftEventWriter,
 } from "@sync/providers/microsoft/microsoft-event-writer.adapter";

--- a/packages/sync/src/providers/microsoft/microsoft-event.normalizer.test.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-event.normalizer.test.ts
@@ -1,3 +1,4 @@
+import { type DateOnly } from "@core/types/domain-primitives";
 import {
   type GraphEvent,
   normalizeMicrosoftEvent,
@@ -86,8 +87,8 @@ describe("normalizeMicrosoftEvent", () => {
     expect(read.busy).toBe(false);
     expect(read.schedule).toEqual({
       kind: "allDay",
-      start: "2022-02-22",
-      end: "2022-02-23",
+      start: "2022-02-22" as DateOnly,
+      end: "2022-02-23" as DateOnly,
     });
   });
 
@@ -361,6 +362,7 @@ describe("normalizeMicrosoftEvent", () => {
       } catch (e) {
         return e;
       }
+      throw new Error("expected normalizeMicrosoftEvent to throw");
     })() as ProviderEventError;
 
     expect(error).toBeInstanceOf(ProviderEventError);

--- a/packages/sync/src/providers/microsoft/microsoft-graph-request.test.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-graph-request.test.ts
@@ -31,7 +31,10 @@ describe("microsoftGraphRequest", () => {
 
     expect(data).toEqual({ id: "cal-1" });
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const [, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
     expect(init.method).toBe("GET");
     expect(init.headers).toEqual({
       Authorization: "Bearer token-1",

--- a/packages/sync/src/providers/microsoft/windows-zones.test.ts
+++ b/packages/sync/src/providers/microsoft/windows-zones.test.ts
@@ -1,3 +1,4 @@
+import { TimezoneSchema } from "@core/types/type.utils";
 import {
   ianaZoneToWindows,
   listWindowsZones,
@@ -21,10 +22,9 @@ describe("windows-zones", () => {
   });
 
   it("maps every Windows zone to a supported IANA name", () => {
-    const supported = new Set(Intl.supportedValuesOf("timeZone"));
     for (const windowsZone of listWindowsZones()) {
       const iana = windowsZoneToIana(windowsZone);
-      expect(supported.has(iana)).toBe(true);
+      expect(TimezoneSchema.safeParse(iana).success).toBe(true);
     }
   });
 });

--- a/packages/sync/src/providers/provider-registry.test.ts
+++ b/packages/sync/src/providers/provider-registry.test.ts
@@ -263,7 +263,6 @@ describe("ProviderRegistry", () => {
       account: {
         email: "user@icloud.com",
         providerAccountId: "user@icloud.com",
-        displayName: null,
       },
     });
     expect(bound).not.toBe(unbound);

--- a/packages/sync/src/safety/isolation-matrix.db.test.ts
+++ b/packages/sync/src/safety/isolation-matrix.db.test.ts
@@ -3,8 +3,10 @@ import { NodeEnv } from "@core/constants/core.constants";
 import {
   type ConnectionId,
   type PrincipalId,
+  type ProviderAccountId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
+import { mongoObjectId } from "@sync/__tests__/helpers/mongo-id";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { createSyncService, type SyncService } from "@sync/app";
 import { signInternalRequest } from "@sync/auth/internal-auth";
@@ -105,7 +107,7 @@ describe("R-SEC-03 isolation matrix", () => {
       principalId: principalId as PrincipalId,
       provider: "google",
       account: {
-        providerAccountId: `acct-${accountSeq}`,
+        providerAccountId: `acct-${accountSeq}` as ProviderAccountId,
         email: `u${accountSeq}@example.com`,
         displayName: null,
       },
@@ -140,7 +142,7 @@ describe("R-SEC-03 isolation matrix", () => {
     const end = "2026-07-14T10:00:00.000Z";
     const eventId = objectId();
     await mongo.db.collection(SYNC_COLLECTIONS.eventOccurrences).insertOne({
-      _id: objectId(),
+      _id: mongoObjectId(objectId()),
       tenantId,
       principalId,
       eventId,
@@ -272,8 +274,8 @@ describe("R-SEC-03 isolation matrix", () => {
 
   describe("POST /internal/commands", () => {
     it("cannot update another principal's event", async () => {
-      const tenantId = objectId();
-      const owner = objectId();
+      const tenantId = objectId() as TenantId;
+      const owner = objectId() as PrincipalId;
       const attacker = objectId();
       await startService();
       const eventId = await createCloudEvent(tenantId, owner);
@@ -317,17 +319,13 @@ describe("R-SEC-03 isolation matrix", () => {
       // would — versionConflict, not a side channel that would let them
       // distinguish "exists but not mine" from "doesn't exist".)
       expect(body.command.outcome.state).toBe("failed");
-      const stored = await events.findById(
-        tenantId as TenantId,
-        owner as PrincipalId,
-        eventId as never,
-      );
+      const stored = await events.findById(tenantId, owner, eventId as never);
       expect(stored?.content.title).toBe("Owner event");
     });
 
     it("cannot delete another principal's event", async () => {
-      const tenantId = objectId();
-      const owner = objectId();
+      const tenantId = objectId() as TenantId;
+      const owner = objectId() as PrincipalId;
       const attacker = objectId();
       await startService();
       const eventId = await createCloudEvent(tenantId, owner);
@@ -350,19 +348,15 @@ describe("R-SEC-03 isolation matrix", () => {
       // Idempotent delete of an absent (to the attacker) event confirms locally
       // without touching the owner's row.
       expect(body.command.outcome.state).toBe("confirmed");
-      const stored = await events.findById(
-        tenantId as TenantId,
-        owner as PrincipalId,
-        eventId as never,
-      );
+      const stored = await events.findById(tenantId, owner, eventId as never);
       expect(stored).not.toBeNull();
       expect(stored?.content.title).toBe("Owner event");
     });
 
     it("cannot update an event under the wrong tenant", async () => {
-      const ownerTenant = objectId();
+      const ownerTenant = objectId() as TenantId;
       const wrongTenant = objectId();
-      const principalId = objectId();
+      const principalId = objectId() as PrincipalId;
       await startService();
       const eventId = await createCloudEvent(ownerTenant, principalId);
 
@@ -403,8 +397,8 @@ describe("R-SEC-03 isolation matrix", () => {
       // than leaking existence via a silently pending write.
       expect(body.command.outcome.state).toBe("failed");
       const stored = await events.findById(
-        ownerTenant as TenantId,
-        principalId as PrincipalId,
+        ownerTenant,
+        principalId,
         eventId as never,
       );
       expect(stored?.content.title).toBe("Owner event");
@@ -413,10 +407,10 @@ describe("R-SEC-03 isolation matrix", () => {
 
   describe("DELETE /internal/principal", () => {
     it("does not purge another principal or another tenant", async () => {
-      const tenantId = objectId();
-      const owner = objectId();
-      const stranger = objectId();
-      const otherTenant = objectId();
+      const tenantId = objectId() as TenantId;
+      const owner = objectId() as PrincipalId;
+      const stranger = objectId() as PrincipalId;
+      const otherTenant = objectId() as TenantId;
       await startService();
 
       const ownerConn = await seedConnection(tenantId, owner);
@@ -429,83 +423,49 @@ describe("R-SEC-03 isolation matrix", () => {
       });
       expect(res.status).toBe(200);
 
+      expect(await connections.findById(tenantId, owner, ownerConn)).toBeNull();
       expect(
-        await connections.findById(
-          tenantId as TenantId,
-          owner as PrincipalId,
-          ownerConn,
-        ),
-      ).toBeNull();
-      expect(
-        await connections.findById(
-          tenantId as TenantId,
-          stranger as PrincipalId,
-          strangerConn,
-        ),
+        await connections.findById(tenantId, stranger, strangerConn),
       ).not.toBeNull();
       expect(
-        await connections.findById(
-          otherTenant as TenantId,
-          owner as PrincipalId,
-          otherTenantConn,
-        ),
+        await connections.findById(otherTenant, owner, otherTenantConn),
       ).not.toBeNull();
     });
   });
 
   describe("repository ownership probes", () => {
     it("refuses markDisconnected / deleteById under the wrong principal or tenant", async () => {
-      const tenantId = objectId();
-      const owner = objectId();
-      const attacker = objectId();
-      const wrongTenant = objectId();
+      const tenantId = objectId() as TenantId;
+      const owner = objectId() as PrincipalId;
+      const attacker = objectId() as PrincipalId;
+      const wrongTenant = objectId() as TenantId;
       const connectionId = await seedConnection(tenantId, owner);
 
       expect(
-        await connections.markDisconnected(
-          tenantId as TenantId,
-          attacker as PrincipalId,
-          connectionId,
-        ),
+        await connections.markDisconnected(tenantId, attacker, connectionId),
       ).toBe(false);
       expect(
-        await connections.markDisconnected(
-          wrongTenant as TenantId,
-          owner as PrincipalId,
-          connectionId,
-        ),
+        await connections.markDisconnected(wrongTenant, owner, connectionId),
       ).toBe(false);
       expect(
-        await connections.deleteById(
-          tenantId as TenantId,
-          attacker as PrincipalId,
-          connectionId,
-        ),
+        await connections.deleteById(tenantId, attacker, connectionId),
       ).toBe(false);
       expect(
-        await connections.deleteById(
-          wrongTenant as TenantId,
-          owner as PrincipalId,
-          connectionId,
-        ),
+        await connections.deleteById(wrongTenant, owner, connectionId),
       ).toBe(false);
       expect(
-        await connections.findById(
-          tenantId as TenantId,
-          owner as PrincipalId,
-          connectionId,
-        ),
+        await connections.findById(tenantId, owner, connectionId),
       ).not.toBeNull();
     });
 
     it("does not let a foreign principal advance a sync-resource cursor", async () => {
-      const tenantId = objectId();
-      const owner = objectId();
-      const attacker = objectId();
+      const tenantId = objectId() as TenantId;
+      const owner = objectId() as PrincipalId;
+      const attacker = objectId() as PrincipalId;
       const connectionId = await seedConnection(tenantId, owner);
       const resource = await resources.ensure({
-        tenantId: tenantId as TenantId,
-        principalId: owner as PrincipalId,
+        tenantId: tenantId,
+        principalId: owner,
         connectionId,
         resourceKind: "calendarList",
         calendarId: null,
@@ -513,35 +473,27 @@ describe("R-SEC-03 isolation matrix", () => {
 
       // Owner-scoped filter matches nothing for the attacker — silent no-op.
       await resources.advanceCursor(
-        tenantId as TenantId,
-        attacker as PrincipalId,
+        tenantId,
+        attacker,
         resource._id,
         "stolen-cursor",
         new Date(),
       );
 
-      const still = await resources.findById(
-        tenantId as TenantId,
-        owner as PrincipalId,
-        resource._id,
-      );
+      const still = await resources.findById(tenantId, owner, resource._id);
       expect(still?.syncCursor).toBeNull();
     });
 
     it("scopes command findById to the owning principal and tenant", async () => {
-      const tenantId = objectId();
-      const owner = objectId();
-      const attacker = objectId();
-      const wrongTenant = objectId();
+      const tenantId = objectId() as TenantId;
+      const owner = objectId() as PrincipalId;
+      const attacker = objectId() as PrincipalId;
+      const wrongTenant = objectId() as TenantId;
       await startService();
       const eventId = await createCloudEvent(tenantId, owner);
 
       const commands = new CommandRepository(mongo.db);
-      const mine = await commands.listNonterminal(
-        tenantId as TenantId,
-        owner as PrincipalId,
-        10,
-      );
+      const mine = await commands.listNonterminal(tenantId, owner, 10);
       // Create confirms immediately, so list nonterminal may be empty — look up
       // by scanning the collection for the owner's command id instead.
       const row = await mongo.db.collection(SYNC_COLLECTIONS.commands).findOne({
@@ -550,28 +502,16 @@ describe("R-SEC-03 isolation matrix", () => {
         eventId,
       });
       expect(row).not.toBeNull();
-      const commandId = row?._id as string;
+      const commandId = String(row?._id);
 
       expect(
-        await commands.findById(
-          tenantId as TenantId,
-          attacker as PrincipalId,
-          commandId as never,
-        ),
+        await commands.findById(tenantId, attacker, commandId as never),
       ).toBeNull();
       expect(
-        await commands.findById(
-          wrongTenant as TenantId,
-          owner as PrincipalId,
-          commandId as never,
-        ),
+        await commands.findById(wrongTenant, owner, commandId as never),
       ).toBeNull();
       expect(
-        await commands.findById(
-          tenantId as TenantId,
-          owner as PrincipalId,
-          commandId as never,
-        ),
+        await commands.findById(tenantId, owner, commandId as never),
       ).not.toBeNull();
       expect(mine).toBeDefined();
     });

--- a/packages/sync/src/server/availability.routes.db.test.ts
+++ b/packages/sync/src/server/availability.routes.db.test.ts
@@ -2,8 +2,10 @@ import { faker } from "@faker-js/faker";
 import { NodeEnv } from "@core/constants/core.constants";
 import {
   type PrincipalId,
+  type ProviderAccountId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
+import { mongoObjectId } from "@sync/__tests__/helpers/mongo-id";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { createSyncService, type SyncService } from "@sync/app";
 import { signInternalRequest } from "@sync/auth/internal-auth";
@@ -86,7 +88,7 @@ describe("POST /internal/availability/busy", () => {
       principalId,
       provider: "google",
       account: {
-        providerAccountId: `acct-${accountSeq}`,
+        providerAccountId: `acct-${accountSeq}` as ProviderAccountId,
         email: `u${accountSeq}@gmail.com`,
         displayName: "User",
       },
@@ -122,7 +124,7 @@ describe("POST /internal/availability/busy", () => {
     for (const [start, end] of intervals) {
       const eventId = objectId();
       await mongo.db.collection(SYNC_COLLECTIONS.eventOccurrences).insertOne({
-        _id: objectId(),
+        _id: mongoObjectId(objectId()),
         tenantId,
         principalId,
         eventId,

--- a/packages/sync/src/server/change-feed.routes.db.test.ts
+++ b/packages/sync/src/server/change-feed.routes.db.test.ts
@@ -1,7 +1,11 @@
 import { faker } from "@faker-js/faker";
 import { ObjectId } from "mongodb";
 import { NodeEnv } from "@core/constants/core.constants";
-import { type ConnectionId } from "@core/types/sync/identity.contracts";
+import {
+  type ConnectionId,
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { createSyncService, type SyncService } from "@sync/app";
 import {
@@ -104,16 +108,16 @@ describe("GET /internal/changes", () => {
   });
 
   it("delivers appended invalidations on resume and advances the cursor", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const connectionId = objectId() as ConnectionId;
     await startService();
 
     // Seed so "from now" watermarks at a real outbox id (avoids same-second
     // ObjectId races against a freshly minted empty-outbox cursor).
     await invalidations.append({
-      tenantId,
-      principalId,
+      tenantId: tenantId,
+      principalId: principalId,
       invalidation: {
         kind: "command",
         commandId: objectId() as never,
@@ -126,14 +130,14 @@ describe("GET /internal/changes", () => {
     };
 
     await invalidations.append({
-      tenantId,
-      principalId,
+      tenantId: tenantId,
+      principalId: principalId,
       invalidation: { kind: "connection", connectionId },
       emittedAt: new Date(),
     });
     await invalidations.append({
-      tenantId,
-      principalId,
+      tenantId: tenantId,
+      principalId: principalId,
       invalidation: {
         kind: "event",
         eventId: objectId() as never,
@@ -158,9 +162,9 @@ describe("GET /internal/changes", () => {
       "connection",
       "event",
     ]);
-    expect(typeof page.invalidations[0].emittedAt).toBe("string");
+    expect(typeof page.invalidations[0]!.emittedAt).toBe("string");
     // Wire envelopes never carry event content — only the invalidation union.
-    expect(Object.keys(page.invalidations[0]).sort()).toEqual([
+    expect(Object.keys(page.invalidations[0]!).sort()).toEqual([
       "emittedAt",
       "invalidation",
     ]);
@@ -172,16 +176,16 @@ describe("GET /internal/changes", () => {
   });
 
   it("never leaks another principal's invalidations", async () => {
-    const tenantId = objectId();
+    const tenantId = objectId() as TenantId;
     const mine = objectId();
-    const other = objectId();
+    const other = objectId() as PrincipalId;
     await startService();
 
     const boot = (await (await get(tenantId, mine)).json()) as {
       nextCursor: string;
     };
     await invalidations.append({
-      tenantId,
+      tenantId: tenantId,
       principalId: other,
       invalidation: {
         kind: "connection",
@@ -269,10 +273,10 @@ describe("GET /internal/changes/all (the multiplexed, cross-tenant feed)", () =>
 
   it("delivers invalidations across DIFFERENT tenants/principals, each tagged with its owner", async () => {
     await startService();
-    const tenantA = objectId();
-    const principalA = objectId();
-    const tenantB = objectId();
-    const principalB = objectId();
+    const tenantA = objectId() as TenantId;
+    const principalA = objectId() as PrincipalId;
+    const tenantB = objectId() as TenantId;
+    const principalB = objectId() as PrincipalId;
 
     const boot = (await (await getGlobal()).json()) as { nextCursor: string };
 

--- a/packages/sync/src/server/command.routes.db.test.ts
+++ b/packages/sync/src/server/command.routes.db.test.ts
@@ -1,14 +1,25 @@
 import { faker } from "@faker-js/faker";
 import { NodeEnv } from "@core/constants/core.constants";
 import {
+  type CalendarId,
+  type DateTime,
+  type EventId,
+  type TimeZone,
+} from "@core/types/domain-primitives";
+import { type ClientEventId } from "@core/types/sync/event.contracts";
+import {
   type ConnectionId,
   type PrincipalId,
+  type ProviderAccountId,
+  type ProviderCalendarSourceId,
+  type ProviderEventId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
 import {
   seedOauthCredential,
   TEST_CREDENTIAL_ENCRYPTION_KEY,
 } from "@sync/__tests__/helpers/credential-encryption";
+import { defaultCalendarListFields } from "@sync/__tests__/helpers/fixtures";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { createSyncService, type SyncService } from "@sync/app";
 import { signInternalRequest } from "@sync/auth/internal-auth";
@@ -72,10 +83,10 @@ const signedHeaders = (
 // they ride on the signed headers.
 const createRequest = (overrides: Record<string, unknown> = {}) => ({
   idempotencyKey: `idem-${objectId()}`,
-  eventId: objectId(),
+  eventId: objectId() as EventId,
   input: {
     kind: "create",
-    calendarId: objectId(),
+    calendarId: objectId() as CalendarId,
     content: {
       title: "Lunch",
       description: "",
@@ -86,9 +97,9 @@ const createRequest = (overrides: Record<string, unknown> = {}) => ({
     },
     schedule: {
       kind: "timed",
-      start: "2026-07-14T12:00:00-06:00",
-      end: "2026-07-14T13:00:00-06:00",
-      timeZone: "America/Denver",
+      start: "2026-07-14T12:00:00-06:00" as DateTime,
+      end: "2026-07-14T13:00:00-06:00" as DateTime,
+      timeZone: "America/Denver" as TimeZone,
     },
     recurrence: { kind: "single" },
   },
@@ -124,8 +135,8 @@ describe("POST /internal/commands", () => {
   });
 
   it("confirms a cloud-only create and writes the canonical event", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const request = createRequest();
     // No connection/provider is seeded and the service is passive: a cloud
     // create needs neither.
@@ -145,8 +156,8 @@ describe("POST /internal/commands", () => {
 
     const events = new EventRepository(mongo.db);
     const stored = await events.findById(
-      tenantId as TenantId,
-      principalId as PrincipalId,
+      tenantId,
+      principalId,
       request.eventId as never,
     );
     expect(stored).not.toBeNull();
@@ -158,8 +169,8 @@ describe("POST /internal/commands", () => {
   });
 
   it("is idempotent on a repeated upload", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const request = createRequest();
     await startService();
 
@@ -178,8 +189,8 @@ describe("POST /internal/commands", () => {
   });
 
   it("recovers an interrupted acknowledgement by confirming on retry", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const request = createRequest();
     await startService();
 
@@ -205,17 +216,13 @@ describe("POST /internal/commands", () => {
     expect(body.command.outcome.state).toBe("confirmed");
     const events = new EventRepository(mongo.db);
     expect(
-      await events.findById(
-        tenantId as TenantId,
-        principalId as PrincipalId,
-        request.eventId as never,
-      ),
+      await events.findById(tenantId, principalId, request.eventId as never),
     ).not.toBeNull();
   });
 
   it("maps a series create to a stored series master", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const request = createRequest({
       input: {
         ...createRequest().input,
@@ -228,8 +235,8 @@ describe("POST /internal/commands", () => {
 
     const events = new EventRepository(mongo.db);
     const stored = await events.findById(
-      tenantId as TenantId,
-      principalId as PrincipalId,
+      tenantId,
+      principalId,
       request.eventId as never,
     );
     expect(stored?.recurrence).toEqual({
@@ -239,8 +246,8 @@ describe("POST /internal/commands", () => {
   });
 
   it("refuses a create targeting a provider calendar when the writer is unavailable", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     await startService();
 
     // A connected provider calendar; a create aimed at it must not be confirmed
@@ -250,9 +257,10 @@ describe("POST /internal/commands", () => {
       tenantId: tenantId as TenantId,
       principalId: principalId as PrincipalId,
       connectionId: objectId() as ConnectionId,
-      providerCalendarId: objectId(),
+      providerCalendarId: objectId() as ProviderCalendarSourceId,
       displayName: "Google",
       color: null,
+      ...defaultCalendarListFields,
       active: true,
       primary: true,
       accessRole: "owner",
@@ -279,13 +287,13 @@ describe("POST /internal/commands", () => {
   });
 
   it("fails a move command as unsupportedCapability rather than stranding it pending", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     // move has no executor anywhere yet - leaving it pending would strand the
     // write forever while the caller sees success (nothing rejects a merely
     // "pending" outcome), so it fails explicitly instead.
     const request = createRequest({
-      input: { kind: "move", calendarId: objectId() },
+      input: { kind: "move", calendarId: objectId() as CalendarId },
     });
     await startService();
 
@@ -304,8 +312,8 @@ describe("POST /internal/commands", () => {
   });
 
   it("updates a cloud event's content and confirms", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     // Create the event, then update it (both keyed on the same event id).
     const created = createRequest();
     await startService();
@@ -338,16 +346,16 @@ describe("POST /internal/commands", () => {
     expect(body.command.outcome.state).toBe("confirmed");
     const events = new EventRepository(mongo.db);
     const stored = await events.findById(
-      tenantId as TenantId,
-      principalId as PrincipalId,
+      tenantId,
+      principalId,
       created.eventId as never,
     );
     expect(stored?.content.title).toBe("Renamed");
   });
 
   it("converts a single event into a series and confirms", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const created = createRequest();
     await startService();
     await submit(tenantId, principalId, created);
@@ -372,8 +380,8 @@ describe("POST /internal/commands", () => {
     expect(body.command.outcome.state).toBe("confirmed");
     const events = new EventRepository(mongo.db);
     const stored = await events.findById(
-      tenantId as TenantId,
-      principalId as PrincipalId,
+      tenantId,
+      principalId,
       created.eventId as never,
     );
     expect(stored?.recurrence).toEqual({
@@ -383,8 +391,8 @@ describe("POST /internal/commands", () => {
   });
 
   it("deletes a cloud event and confirms", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const created = createRequest();
     await startService();
     await submit(tenantId, principalId, created);
@@ -427,13 +435,13 @@ describe("POST /internal/commands", () => {
   });
 
   it("confirms an idempotent delete of an already-absent event", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     await startService();
 
     const del = {
       idempotencyKey: `idem-${objectId()}`,
-      eventId: objectId(),
+      eventId: objectId() as EventId,
       input: { kind: "delete", scope: "all" },
       expectedVersion: null,
     };
@@ -446,13 +454,13 @@ describe("POST /internal/commands", () => {
   });
 
   it("fails an update of a missing event instead of stranding it pending", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     await startService();
 
     const update = {
       idempotencyKey: `idem-${objectId()}`,
-      eventId: objectId(),
+      eventId: objectId() as EventId,
       input: {
         kind: "update",
         content: {
@@ -478,9 +486,9 @@ describe("POST /internal/commands", () => {
   });
 
   it("promotes an anonymous device event, preserving its clientEventId", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
-    const clientEventId = `device-${objectId()}`;
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const clientEventId = `device-${objectId()}` as ClientEventId;
     const request = createRequest({
       input: { ...createRequest().input, clientEventId },
     });
@@ -491,18 +499,18 @@ describe("POST /internal/commands", () => {
     expect(res.status).toBe(200);
     const events = new EventRepository(mongo.db);
     const stored = await events.findById(
-      tenantId as TenantId,
-      principalId as PrincipalId,
+      tenantId,
+      principalId,
       request.eventId as never,
     );
     expect(stored?.clientEventId).toBe(clientEventId);
   });
 
   it("converges a resumed promotion to one cloud event via the stable id", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
-    const clientEventId = `device-${objectId()}`;
-    const eventId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const clientEventId = `device-${objectId()}` as ClientEventId;
+    const eventId = objectId() as EventId;
     const input = { ...createRequest().input, clientEventId };
     await startService();
 
@@ -526,16 +534,16 @@ describe("POST /internal/commands", () => {
     expect(await mongo.db.collection("events").countDocuments()).toBe(1);
     const events = new EventRepository(mongo.db);
     const stored = await events.findById(
-      tenantId as TenantId,
-      principalId as PrincipalId,
+      tenantId,
+      principalId,
       eventId as never,
     );
     expect(stored?.clientEventId).toBe(clientEventId);
   });
 
   it("refuses to overwrite another principal's event with a reused id", async () => {
-    const tenantId = objectId();
-    const owner = objectId();
+    const tenantId = objectId() as TenantId;
+    const owner = objectId() as PrincipalId;
     const attacker = objectId();
     const request = createRequest();
     await startService();
@@ -554,8 +562,8 @@ describe("POST /internal/commands", () => {
     expect(res.status).toBe(500);
     const events = new EventRepository(mongo.db);
     const stored = await events.findById(
-      tenantId as TenantId,
-      owner as PrincipalId,
+      tenantId,
+      owner,
       request.eventId as never,
     );
     // The owner still owns the untouched event.
@@ -583,15 +591,15 @@ describe("POST /internal/commands", () => {
     // WP-07: the full inline path — signed request → rsvp dispatch → self
     // entry rewrite at the (fake) provider → confirm → invalidation outbox
     // rows, which are what the Compass API's SSE eventsChanged derives from.
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const connections = new ProviderConnectionRepository(mongo.db);
     const connection = await connections.upsertByProviderAccount({
       tenantId: tenantId as TenantId,
       principalId: principalId as PrincipalId,
       provider: "google",
       account: {
-        providerAccountId: objectId(),
+        providerAccountId: objectId() as ProviderAccountId,
         email: "self@example.com",
         displayName: null,
       },
@@ -604,9 +612,10 @@ describe("POST /internal/commands", () => {
       tenantId: tenantId as TenantId,
       principalId: principalId as PrincipalId,
       connectionId: connection._id,
-      providerCalendarId: "primary@google.com",
+      providerCalendarId: "primary@google.com" as ProviderCalendarSourceId,
       displayName: "Google",
       color: null,
+      ...defaultCalendarListFields,
       active: true,
       primary: true,
       accessRole: "editor",
@@ -625,7 +634,7 @@ describe("POST /internal/commands", () => {
       scopes: ["https://www.googleapis.com/auth/calendar.events"],
     });
     const events = new EventRepository(mongo.db);
-    const eventId = objectId();
+    const eventId = objectId() as EventId;
     const self = {
       email: "self@example.com",
       displayName: null,
@@ -633,9 +642,9 @@ describe("POST /internal/commands", () => {
     };
     const schedule = {
       kind: "timed" as const,
-      start: "2026-07-14T09:00:00-06:00",
-      end: "2026-07-14T10:00:00-06:00",
-      timeZone: "America/Denver",
+      start: "2026-07-14T09:00:00-06:00" as DateTime,
+      end: "2026-07-14T10:00:00-06:00" as DateTime,
+      timeZone: "America/Denver" as TimeZone,
     };
     const content = {
       title: "Invited",
@@ -680,11 +689,14 @@ describe("POST /internal/commands", () => {
         input: ProviderPatchInput,
       ): Promise<ProviderWriteResult> => {
         patchCalls.push(input);
-        return { providerEventId: "g-evt-1", providerVersion: "etag-2" };
+        return {
+          providerEventId: "g-evt-1" as ProviderEventId,
+          providerVersion: "etag-2",
+        };
       },
       fetchEvent: async (): Promise<ProviderEvent> => ({
         kind: "event",
-        providerEventId: "g-evt-1",
+        providerEventId: "g-evt-1" as ProviderEventId,
         providerVersion: "etag-1",
         providerUpdatedAt: null,
         content,
@@ -742,7 +754,7 @@ describe("POST /internal/commands", () => {
     ]);
     // The stored record reflects the answer before any Google round-trip.
     const stored = await events.findById(
-      tenantId as TenantId,
+      tenantId,
       principalId as never,
       eventId as never,
     );
@@ -776,7 +788,7 @@ describe("POST /internal/commands", () => {
 
     const res = await submit(objectId(), objectId(), {
       idempotencyKey: `idem-${objectId()}`,
-      eventId: objectId(),
+      eventId: objectId() as EventId,
       input: {
         kind: "rsvp",
         responseStatus: "needsAction",

--- a/packages/sync/src/server/connection.routes.db.test.ts
+++ b/packages/sync/src/server/connection.routes.db.test.ts
@@ -7,9 +7,12 @@ import {
   encryptCredentialConnectPayload,
   encryptInternalCredential,
 } from "@core/security/internal-credential-envelope";
+import { type DateTime, type TimeZone } from "@core/types/domain-primitives";
 import {
   type ConnectionId,
   type PrincipalId,
+  type ProviderAccountId,
+  type ProviderCalendarSourceId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
 import dayjs from "@core/util/date/dayjs";
@@ -18,9 +21,11 @@ import {
   TEST_CREDENTIAL_ENCRYPTION_KEY,
 } from "@sync/__tests__/helpers/credential-encryption";
 import {
+  defaultCalendarListFields,
   ensureEventsResource,
   seedProviderCalendar,
 } from "@sync/__tests__/helpers/fixtures";
+import { stringIdFilter } from "@sync/__tests__/helpers/mongo-id";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { createSyncService, type SyncService } from "@sync/app";
 import {
@@ -126,7 +131,7 @@ class FakeAuthAdapter implements ProviderAuthAdapter {
   exchanges: Array<{ code: string; redirectUri: string }> = [];
   exchangeResult: ProviderAuthorization = {
     account: {
-      providerAccountId: "google-sub-1",
+      providerAccountId: "google-sub-1" as ProviderAccountId,
       email: "connected@example.com",
       displayName: "Connected User",
     },
@@ -209,7 +214,7 @@ const seedConnection = (
     principalId: principalId as PrincipalId,
     provider: "google",
     account: {
-      providerAccountId: objectId(),
+      providerAccountId: objectId() as ProviderAccountId,
       email,
       displayName: null,
     },
@@ -307,8 +312,8 @@ describe("GET /internal/connections", () => {
   });
 
   it("returns the caller's connections mapped to the wire contract", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     await seedHealthyConnection(tenantId, principalId, "me@example.com");
     await startService();
 
@@ -328,11 +333,11 @@ describe("GET /internal/connections", () => {
       account: { email: "me@example.com", displayName: null },
     });
     // Timestamps are ISO strings on the wire, not Dates.
-    expect(typeof body.connections[0].createdAt).toBe("string");
+    expect(typeof body.connections[0]!["createdAt"]).toBe("string");
   });
 
   it("scopes results to the authenticated principal", async () => {
-    const tenantId = objectId();
+    const tenantId = objectId() as TenantId;
     const mine = objectId();
     const other = objectId();
     await seedConnection(repo, tenantId, mine, "mine@example.com");
@@ -347,7 +352,7 @@ describe("GET /internal/connections", () => {
       connections: Array<{ account: { email: string } }>;
     };
     expect(body.connections).toHaveLength(1);
-    expect(body.connections[0].account.email).toBe("mine@example.com");
+    expect(body.connections[0]!.account.email).toBe("mine@example.com");
   });
 
   it("returns an empty list for a principal with no connections", async () => {
@@ -370,8 +375,8 @@ describe("GET /internal/connections", () => {
   });
 
   it("rejects a request whose signature does not match", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     await startService();
 
     const headers = signedHeaders(tenantId, principalId);
@@ -383,8 +388,8 @@ describe("GET /internal/connections", () => {
   });
 
   it("serves reads in passive mode (they touch no provider)", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     await seedConnection(repo, tenantId, principalId, "passive@example.com");
     await startService(testConfig({ EXECUTION: "passive" }));
 
@@ -447,8 +452,8 @@ describe("DELETE /internal/connections/:id", () => {
   };
 
   it("revokes, deletes the credential, and marks the connection disconnected", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const id = await seedConnected(tenantId, principalId);
     await startService(activeConfig(), adapter);
 
@@ -470,8 +475,8 @@ describe("DELETE /internal/connections/:id", () => {
   });
 
   it("refuses to disconnect in passive mode rather than half-disconnecting", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const id = await seedConnected(tenantId, principalId);
     await startService(testConfig({ EXECUTION: "passive" }), adapter);
 
@@ -487,7 +492,7 @@ describe("DELETE /internal/connections/:id", () => {
   });
 
   it("returns 404 for a connection the principal does not own, revoking nothing", async () => {
-    const tenantId = objectId();
+    const tenantId = objectId() as TenantId;
     const owner = objectId();
     const stranger = objectId();
     const id = await seedConnected(tenantId, owner);
@@ -570,15 +575,15 @@ describe("POST /internal/connections/begin", () => {
   });
 
   it("returns a consent url whose state binds the flow to the caller", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     await startService(activeConfig(), adapter);
 
     const res = await begin(tenantId, principalId);
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as { authorizationUrl: string };
-    const { state, redirectUri } = adapter.authorizations[0];
+    const { state, redirectUri } = adapter.authorizations[0]!;
     expect(body.authorizationUrl).toContain(state);
     expect(redirectUri).toBe(`http://localhost:3010${OAUTH_CALLBACK_PATH}`);
 
@@ -594,12 +599,12 @@ describe("POST /internal/connections/begin", () => {
     await begin(objectId(), objectId());
 
     // Nothing to choose between yet, and the chooser is an extra click.
-    expect(adapter.authorizations[0].selectAccount).toBe(false);
+    expect(adapter.authorizations[0]!.selectAccount).toBe(false);
   });
 
   it("forces the account chooser when the principal already has a connection", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     await seedConnection(
       connections,
       tenantId,
@@ -612,12 +617,12 @@ describe("POST /internal/connections/begin", () => {
 
     // Otherwise Google re-authorizes the connected account and nothing
     // appears to happen.
-    expect(adapter.authorizations[0].selectAccount).toBe(true);
+    expect(adapter.authorizations[0]!.selectAccount).toBe(true);
   });
 
   it("never forces the account chooser on reconnect (it is account-pinned)", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const existing = await seedConnection(
       connections,
       tenantId,
@@ -628,13 +633,13 @@ describe("POST /internal/connections/begin", () => {
 
     await begin(tenantId, principalId, { connectionId: existing._id });
 
-    expect(adapter.authorizations[0].selectAccount).toBe(false);
-    expect(adapter.authorizations[0].loginHint).toBe("reconnect@example.com");
+    expect(adapter.authorizations[0]!.selectAccount).toBe(false);
+    expect(adapter.authorizations[0]!.loginHint).toBe("reconnect@example.com");
   });
 
   it("binds the state to an owned connection for reconnect", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const existing = await seedConnection(
       connections,
       tenantId,
@@ -648,13 +653,13 @@ describe("POST /internal/connections/begin", () => {
     });
 
     expect(res.status).toBe(200);
-    const { state } = adapter.authorizations[0];
+    const { state } = adapter.authorizations[0]!;
     const verified = verifyOAuthState(STATE_SECRET, state, Date.now());
     expect(verified.ok && verified.payload.connectionId).toBe(existing._id);
   });
 
   it("refuses to reconnect a connection the principal does not own", async () => {
-    const tenantId = objectId();
+    const tenantId = objectId() as TenantId;
     const owner = objectId();
     const stranger = objectId();
     const existing = await seedConnection(
@@ -674,18 +679,20 @@ describe("POST /internal/connections/begin", () => {
   });
 
   it("rejects a malformed reconnect connection id", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     await startService(activeConfig(), adapter);
 
-    const res = await begin(tenantId, principalId, { connectionId: "nope" });
+    const res = await begin(tenantId, principalId, {
+      connectionId: "nope" as ConnectionId,
+    });
 
     expect(res.status).toBe(400);
   });
 
   it("asks for both contacts scopes when begin carries the contacts feature", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     await startService(activeConfig(), adapter);
 
     const res = await begin(tenantId, principalId, {
@@ -693,15 +700,15 @@ describe("POST /internal/connections/begin", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(adapter.authorizations[0].extraScopes).toEqual([
+    expect(adapter.authorizations[0]!.extraScopes).toEqual([
       "https://www.googleapis.com/auth/contacts.readonly",
       "https://www.googleapis.com/auth/contacts.other.readonly",
     ]);
   });
 
   it("keeps a plain begin's adapter input identical to before features existed", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     await startService(activeConfig(), adapter);
 
     // No features field, and an explicitly empty one — both must produce the
@@ -716,8 +723,8 @@ describe("POST /internal/connections/begin", () => {
   });
 
   it("rejects an unknown feature", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     await startService(activeConfig(), adapter);
 
     const res = await begin(tenantId, principalId, {
@@ -730,8 +737,8 @@ describe("POST /internal/connections/begin", () => {
   });
 
   it("refuses to begin in passive mode", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     await startService(testConfig({ EXECUTION: "passive" }), adapter);
 
     const res = await begin(tenantId, principalId);
@@ -797,8 +804,8 @@ describe("GET /sync/google", () => {
   });
 
   it("links the connection and stores the credential on a valid callback", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     await startService(activeConfig(), adapter);
 
     const res = await hitCallback(
@@ -808,20 +815,19 @@ describe("GET /sync/google", () => {
     expect(res.status).toBe(302);
     expect(statusOf(res)).toBe("connected");
     // The code was exchanged against the same redirect_uri begin would use.
-    expect(adapter.exchanges[0].redirectUri).toBe(
+    expect(adapter.exchanges[0]!.redirectUri).toBe(
       `http://localhost:3010${OAUTH_CALLBACK_PATH}`,
     );
 
-    const linked = await connections.listByPrincipal(
-      tenantId as TenantId,
-      principalId as PrincipalId,
-    );
+    const linked = await connections.listByPrincipal(tenantId, principalId);
     expect(linked).toHaveLength(1);
-    expect(linked[0].account.providerAccountId).toBe("google-sub-1");
-    expect(linked[0].state).toBe("importing");
-    expect(linked[0].capabilities).toContain("writeEvents");
+    expect(linked[0]!.account.providerAccountId).toBe(
+      "google-sub-1" as ProviderAccountId,
+    );
+    expect(linked[0]!.state).toBe("importing");
+    expect(linked[0]!.capabilities).toContain("writeEvents");
 
-    const stored = await credentials.findByConnection(linked[0]._id);
+    const stored = await credentials.findByConnection(linked[0]!._id);
     expect(
       stored?.credentialKind === "oauthRefresh"
         ? openOauthRefreshToken(TEST_CREDENTIAL_ENCRYPTION_KEY, stored)
@@ -830,8 +836,8 @@ describe("GET /sync/google", () => {
   });
 
   it("derives suggestContacts when the callback's grant includes a contacts scope", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     // A partial contacts grant (only other-contacts) still counts.
     adapter.exchangeResult = {
       ...adapter.exchangeResult,
@@ -847,21 +853,21 @@ describe("GET /sync/google", () => {
     );
 
     expect(statusOf(res)).toBe("connected");
-    const [linked] = await connections.listByPrincipal(
-      tenantId as TenantId,
-      principalId as PrincipalId,
-    );
-    expect(linked.capabilities).toContain("suggestContacts");
+    const [linked] = await connections.listByPrincipal(tenantId, principalId);
+    expect(linked!.capabilities).toContain("suggestContacts");
     // The granted scopes ride the credential for the suggestions route.
-    const stored = await credentials.findByConnection(linked._id);
-    expect(stored?.scopes).toContain(
-      "https://www.googleapis.com/auth/contacts.other.readonly",
-    );
+    const stored = await credentials.findByConnection(linked!._id);
+    expect(stored?.credentialKind).toBe("oauthRefresh");
+    if (stored?.credentialKind === "oauthRefresh") {
+      expect(stored.scopes).toContain(
+        "https://www.googleapis.com/auth/contacts.other.readonly",
+      );
+    }
   });
 
   it("derives no suggestContacts when contacts scopes were left unchecked", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     await startService(activeConfig(), adapter);
 
     const res = await hitCallback(
@@ -870,39 +876,33 @@ describe("GET /sync/google", () => {
 
     // Declining the optional scopes is a NORMAL connect, not an error.
     expect(statusOf(res)).toBe("connected");
-    const [linked] = await connections.listByPrincipal(
-      tenantId as TenantId,
-      principalId as PrincipalId,
-    );
-    expect(linked.capabilities).not.toContain("suggestContacts");
+    const [linked] = await connections.listByPrincipal(tenantId, principalId);
+    expect(linked!.capabilities).not.toContain("suggestContacts");
   });
 
   it("enqueues calendar-list discovery to bootstrap the new connection", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     await startService(activeConfig(), adapter);
 
     await hitCallback(
       `code=auth-code&state=${encodeURIComponent(validState(tenantId, principalId))}`,
     );
 
-    const [linked] = await connections.listByPrincipal(
-      tenantId as TenantId,
-      principalId as PrincipalId,
-    );
+    const [linked] = await connections.listByPrincipal(tenantId, principalId);
     // The connect enqueues one calendarListSync job for the new connection; it is
     // the only trigger that starts the sync chain.
     const job = await mongo.db
       .collection(SYNC_COLLECTIONS.jobs)
-      .findOne({ coalescingKey: `calendarListSync:${linked._id}` });
-    expect(job?.kind).toBe("calendarListSync");
-    expect(job?.connectionId).toBe(linked._id);
-    expect(job?.resourceId).toBeNull();
+      .findOne({ coalescingKey: `calendarListSync:${linked!._id}` });
+    expect(job?.["kind"]).toBe("calendarListSync");
+    expect(job?.["connectionId"]).toBe(linked!._id);
+    expect(job?.["resourceId"]).toBeNull();
   });
 
   it("redirects with an error and links nothing when the state is invalid", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     await startService(activeConfig(), adapter);
 
     const res = await hitCallback("code=auth-code&state=forged.signature");
@@ -911,10 +911,7 @@ describe("GET /sync/google", () => {
     expect(statusOf(res)).toBe("error");
     expect(adapter.exchanges).toHaveLength(0);
     expect(
-      await connections.listByPrincipal(
-        tenantId as TenantId,
-        principalId as PrincipalId,
-      ),
+      await connections.listByPrincipal(tenantId, principalId),
     ).toHaveLength(0);
   });
 
@@ -933,8 +930,8 @@ describe("GET /sync/google", () => {
   // a generic "couldn't update your calendar" with no mention of the real
   // cause (leaving the calendar box unchecked on Google's consent screen).
   it("redirects with missingScopes and links nothing when calendar access was not granted", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     adapter.exchangeResult = {
       ...adapter.exchangeResult,
       // Only identity was granted - both calendar scopes withheld.
@@ -948,10 +945,7 @@ describe("GET /sync/google", () => {
 
     expect(statusOf(res)).toBe("missingScopes");
     expect(
-      await connections.listByPrincipal(
-        tenantId as TenantId,
-        principalId as PrincipalId,
-      ),
+      await connections.listByPrincipal(tenantId, principalId),
     ).toHaveLength(0);
   });
 
@@ -972,8 +966,8 @@ describe("GET /sync/google", () => {
     });
 
   it("re-authorizes the named connection when the account matches", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const existing = await seedConnection(
       connections,
       tenantId,
@@ -1010,18 +1004,15 @@ describe("GET /sync/google", () => {
 
     expect(statusOf(res)).toBe("connected");
     // Still one connection — the same one, re-authorized, not a duplicate.
-    const all = await connections.listByPrincipal(
-      tenantId as TenantId,
-      principalId as PrincipalId,
-    );
+    const all = await connections.listByPrincipal(tenantId, principalId);
     expect(all).toHaveLength(1);
-    expect(all[0]._id).toBe(existing._id);
-    expect(all[0].lastHealthyAt).toEqual(healthyAt);
+    expect(all[0]!._id).toBe(existing._id);
+    expect(all[0]!.lastHealthyAt).toEqual(healthyAt);
   });
 
   it("refuses and links nothing when reconnect consents with a different account", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const existing = await seedConnection(
       connections,
       tenantId,
@@ -1032,7 +1023,7 @@ describe("GET /sync/google", () => {
     adapter.exchangeResult = {
       ...adapter.exchangeResult,
       account: {
-        providerAccountId: "some-other-google-sub",
+        providerAccountId: "some-other-google-sub" as ProviderAccountId,
         email: "other@example.com",
         displayName: null,
       },
@@ -1045,19 +1036,16 @@ describe("GET /sync/google", () => {
 
     expect(statusOf(res)).toBe("accountMismatch");
     // No second connection was created; the original is untouched.
-    const all = await connections.listByPrincipal(
-      tenantId as TenantId,
-      principalId as PrincipalId,
-    );
+    const all = await connections.listByPrincipal(tenantId, principalId);
     expect(all).toHaveLength(1);
-    expect(all[0].account.providerAccountId).toBe(
+    expect(all[0]!.account.providerAccountId).toBe(
       existing.account.providerAccountId,
     );
   });
 
   it("redirects with an error when the code exchange fails", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     adapter.exchangeError = new Error("bad code");
     await startService(activeConfig(), adapter);
 
@@ -1067,10 +1055,7 @@ describe("GET /sync/google", () => {
 
     expect(statusOf(res)).toBe("error");
     expect(
-      await connections.listByPrincipal(
-        tenantId as TenantId,
-        principalId as PrincipalId,
-      ),
+      await connections.listByPrincipal(tenantId, principalId),
     ).toHaveLength(0);
   });
 
@@ -1095,8 +1080,8 @@ describe("GET /sync/google", () => {
   };
 
   it("rejects a google state presented on another provider callback with stateMismatch", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     await startService(activeConfig(), adapter, registryWithMicrosoft(adapter));
 
     const res = await fetch(
@@ -1108,16 +1093,13 @@ describe("GET /sync/google", () => {
     expect(statusOf(res)).toBe("stateMismatch");
     expect(adapter.exchanges).toHaveLength(0);
     expect(
-      await connections.listByPrincipal(
-        tenantId as TenantId,
-        principalId as PrincipalId,
-      ),
+      await connections.listByPrincipal(tenantId, principalId),
     ).toHaveLength(0);
   });
 
   it("refuses to complete a callback in passive mode", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     await startService(testConfig({ EXECUTION: "passive" }), adapter);
 
     const res = await hitCallback(
@@ -1160,10 +1142,10 @@ describe("POST /internal/connections/adopt-google-authorization", () => {
   });
 
   it("adopts a signed Google authorization and bootstraps its import", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const account = {
-      providerAccountId: "google-sub-from-signin",
+      providerAccountId: "google-sub-from-signin" as ProviderAccountId,
       email: "connected@example.com",
       displayName: "Connected User",
     };
@@ -1193,12 +1175,12 @@ describe("POST /internal/connections/adopt-google-authorization", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({});
     const [connection] = await connections.listByPrincipal(
-      tenantId as TenantId,
-      principalId as PrincipalId,
+      tenantId,
+      principalId,
     );
     expect(connection?.state).toBe("importing");
     expect(connection?.account.providerAccountId).toBe(
-      "google-sub-from-signin",
+      "google-sub-from-signin" as ProviderAccountId,
     );
     const stored = await credentials.findByConnection(connection!._id);
     expect(
@@ -1209,15 +1191,15 @@ describe("POST /internal/connections/adopt-google-authorization", () => {
     const job = await mongo.db.collection(SYNC_COLLECTIONS.jobs).findOne({
       coalescingKey: `calendarListSync:${connection!._id}`,
     });
-    expect(job?.kind).toBe("calendarListSync");
+    expect(job?.["kind"]).toBe("calendarListSync");
   });
 
   it("rejects an envelope replayed under another principal", async () => {
-    const tenantId = objectId();
+    const tenantId = objectId() as TenantId;
     const sourcePrincipalId = objectId();
-    const targetPrincipalId = objectId();
+    const targetPrincipalId = objectId() as PrincipalId;
     const account = {
-      providerAccountId: "google-sub-from-signin",
+      providerAccountId: "google-sub-from-signin" as ProviderAccountId,
       email: "connected@example.com",
       displayName: "Connected User",
     };
@@ -1248,10 +1230,7 @@ describe("POST /internal/connections/adopt-google-authorization", () => {
 
     expect(res.status).toBe(500);
     await expect(
-      connections.listByPrincipal(
-        tenantId as TenantId,
-        targetPrincipalId as PrincipalId,
-      ),
+      connections.listByPrincipal(tenantId, targetPrincipalId),
     ).resolves.toEqual([]);
   });
 
@@ -1303,10 +1282,10 @@ describe("POST /internal/connections/adopt-authorization", () => {
   });
 
   it("adopts a signed Microsoft authorization and bootstraps its import", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const account = {
-      providerAccountId: "ms-oid-from-signin",
+      providerAccountId: "ms-oid-from-signin" as ProviderAccountId,
       email: "connected@example.com",
       displayName: "Connected User",
     };
@@ -1340,12 +1319,14 @@ describe("POST /internal/connections/adopt-authorization", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({});
     const [connection] = await connections.listByPrincipal(
-      tenantId as TenantId,
-      principalId as PrincipalId,
+      tenantId,
+      principalId,
     );
     expect(connection?.provider).toBe("microsoft");
     expect(connection?.state).toBe("importing");
-    expect(connection?.account.providerAccountId).toBe("ms-oid-from-signin");
+    expect(connection?.account.providerAccountId).toBe(
+      "ms-oid-from-signin" as ProviderAccountId,
+    );
     const stored = await credentials.findByConnection(connection!._id);
     expect(
       stored?.credentialKind === "oauthRefresh"
@@ -1380,10 +1361,12 @@ describe("GET /internal/calendars", () => {
     calendars.upsertByProviderCalendar({
       tenantId: tenantId as TenantId,
       principalId: principalId as PrincipalId,
-      connectionId: (overrides.connectionId ?? objectId()) as ConnectionId,
-      providerCalendarId: objectId(),
+      connectionId: (overrides.connectionId ??
+        (objectId() as ConnectionId)) as ConnectionId,
+      providerCalendarId: objectId() as ProviderCalendarSourceId,
       displayName: overrides.displayName ?? "My Calendar",
       color: null,
+      ...defaultCalendarListFields,
       active: overrides.active ?? true,
       primary: false,
       accessRole: "owner",
@@ -1410,8 +1393,8 @@ describe("GET /internal/calendars", () => {
   });
 
   it("returns the caller's calendars mapped to the wire contract", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     await seedCalendar(tenantId, principalId, { displayName: "Work" });
     await startService();
 
@@ -1427,11 +1410,11 @@ describe("GET /internal/calendars", () => {
       displayName: "Work",
       accessRole: "owner",
     });
-    expect(typeof body.calendars[0].createdAt).toBe("string");
+    expect(typeof body.calendars[0]!["createdAt"]).toBe("string");
   });
 
   it("scopes results to the authenticated principal", async () => {
-    const tenantId = objectId();
+    const tenantId = objectId() as TenantId;
     const mine = objectId();
     const other = objectId();
     await seedCalendar(tenantId, mine, { displayName: "Mine" });
@@ -1442,15 +1425,17 @@ describe("GET /internal/calendars", () => {
       calendars: Array<{ displayName: string }>;
     };
     expect(body.calendars).toHaveLength(1);
-    expect(body.calendars[0].displayName).toBe("Mine");
+    expect(body.calendars[0]!.displayName).toBe("Mine");
   });
 
   it("narrows to one connection when connectionId is given", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const conn = objectId();
     await seedCalendar(tenantId, principalId, { connectionId: conn });
-    await seedCalendar(tenantId, principalId, { connectionId: objectId() });
+    await seedCalendar(tenantId, principalId, {
+      connectionId: objectId() as ConnectionId,
+    });
     await startService();
 
     const body = (await (
@@ -1460,8 +1445,8 @@ describe("GET /internal/calendars", () => {
   });
 
   it("returns only active calendars when activeOnly=true", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     await seedCalendar(tenantId, principalId, { active: true });
     await seedCalendar(tenantId, principalId, { active: false });
     await startService();
@@ -1523,7 +1508,7 @@ describe("GET /internal/events/full", () => {
     kind: "timed" as const,
     start: "2026-07-14T09:00:00-06:00",
     end: "2026-07-14T10:00:00-06:00",
-    timeZone: "America/Denver",
+    timeZone: "America/Denver" as TimeZone,
   };
 
   // Seed a full event record, validated through its schema.
@@ -1614,8 +1599,8 @@ describe("GET /internal/events/full", () => {
   });
 
   it("joins an occurrence to its single event and returns full content", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const calendarId = objectId() as EventRecord["calendarId"];
     const event = await seedEvent(tenantId, principalId, {
       calendarId,
@@ -1647,8 +1632,8 @@ describe("GET /internal/events/full", () => {
   // into an object (arrayLimit: 20), which made this route 400 for any user
   // with more than 20 calendars. Guards the "simple" parser in buildSyncApp.
   it("accepts more than 20 repeated calendarIds params", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const calendarId = objectId() as EventRecord["calendarId"];
     const event = await seedEvent(tenantId, principalId, { calendarId });
     await seedOccurrence(tenantId, principalId, {
@@ -1668,8 +1653,8 @@ describe("GET /internal/events/full", () => {
   });
 
   it("returns instance rows plus one back-filled series master row", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const calendarId = objectId() as EventRecord["calendarId"];
     const master = await seedEvent(tenantId, principalId, {
       calendarId,
@@ -1701,8 +1686,8 @@ describe("GET /internal/events/full", () => {
     // the exception event, not the master. The master is fetched only by the
     // route's second findByIds hop (via the exception's seriesId), so this proves
     // that hop actually runs and merges.
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const calendarId = objectId() as EventRecord["calendarId"];
     const master = await seedEvent(tenantId, principalId, {
       calendarId,
@@ -1752,7 +1737,7 @@ describe("GET /internal/events/full", () => {
   });
 
   it("scopes the read to the signed principal", async () => {
-    const tenantId = objectId();
+    const tenantId = objectId() as TenantId;
     const owner = objectId();
     const stranger = objectId();
     const calendarId = objectId() as EventRecord["calendarId"];
@@ -1785,8 +1770,8 @@ describe("GET /internal/events/full", () => {
     // for series roots that vanish from the SPA week query when BYDAY skips
     // the DTSTART weekday — the create week's narrow range must still see an
     // occurrence (and therefore the back-filled series master).
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const calendarId = objectId();
     await startService();
 
@@ -1813,9 +1798,9 @@ describe("GET /internal/events/full", () => {
           },
           schedule: {
             kind: "timed",
-            start: "2026-07-24T12:00:00-06:00",
-            end: "2026-07-24T13:00:00-06:00",
-            timeZone: "America/Denver",
+            start: "2026-07-24T12:00:00-06:00" as DateTime,
+            end: "2026-07-24T13:00:00-06:00" as DateTime,
+            timeZone: "America/Denver" as TimeZone,
           },
           // Friday start + Sunday BYDAY — the staging-shaped mismatch.
           recurrence: {
@@ -1913,8 +1898,8 @@ describe("POST /internal/connections/refresh", () => {
   };
 
   it("second POST over a pending job returns enqueued: 1 (boosted, not silent 0)", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     await seedEventsResource(tenantId, principalId);
     await startService();
 
@@ -1948,8 +1933,8 @@ describe("POST /internal/connections/refresh", () => {
   });
 
   it("returns inFlight: 1 when the job is already claimed", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const { resource } = await seedEventsResource(tenantId, principalId);
     await jobs.enqueue({
       tenantId: resource.tenantId,
@@ -1987,7 +1972,7 @@ describe("POST /internal/connections/refresh", () => {
   });
 
   it("batch foreground refresh enqueues only stale ready resources", async () => {
-    const principalId = objectId();
+    const principalId = objectId() as PrincipalId;
     const { resource } = await seedEventsResource(principalId, principalId);
     await resources.setBootstrapState(
       resource.tenantId,
@@ -2064,8 +2049,8 @@ describe("POST /internal/connections/credential", () => {
   });
 
   it("creates a connection, stores an encrypted password, and enqueues calendarListSync", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const secret = "app-specific-password-xyz";
     await startService();
 
@@ -2080,18 +2065,22 @@ describe("POST /internal/connections/credential", () => {
     ]);
 
     const [connection] = await connections.listByPrincipal(
-      tenantId as TenantId,
-      principalId as PrincipalId,
+      tenantId,
+      principalId,
     );
     expect(connection?.provider).toBe("apple");
-    expect(connection?.account.providerAccountId).toBe("user@icloud.com");
+    expect(connection?.account.providerAccountId).toBe(
+      "user@icloud.com" as ProviderAccountId,
+    );
     expect(connection?.capabilities).toEqual([...APPLE_PROVIDER_CAPABILITIES]);
 
-    const stored = await credentials.findByConnection(body.connectionId);
+    const stored = await credentials.findByConnection(
+      body.connectionId as ConnectionId,
+    );
     expect(stored?.credentialKind).toBe("password");
     const raw = await mongo.db
       .collection(SYNC_COLLECTIONS.credentials)
-      .findOne({ _id: body.connectionId });
+      .findOne(stringIdFilter(body.connectionId));
     expect(JSON.stringify(raw)).not.toContain(secret);
     if (stored?.credentialKind === "password") {
       expect(
@@ -2107,7 +2096,7 @@ describe("POST /internal/connections/credential", () => {
     const job = await mongo.db.collection(SYNC_COLLECTIONS.jobs).findOne({
       coalescingKey: `calendarListSync:${body.connectionId}`,
     });
-    expect(job?.kind).toBe("calendarListSync");
+    expect(job?.["kind"]).toBe("calendarListSync");
 
     const logTail = readFileSync("logs/app.log")
       .subarray(logSizeBefore)
@@ -2116,8 +2105,8 @@ describe("POST /internal/connections/credential", () => {
   });
 
   it("coalesces calendarListSync when reconnecting the same username", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     await startService();
 
     const first = await connect(
@@ -2142,7 +2131,9 @@ describe("POST /internal/connections/credential", () => {
       .toArray();
     expect(jobs).toHaveLength(1);
 
-    const stored = await credentials.findByConnection(firstBody.connectionId);
+    const stored = await credentials.findByConnection(
+      firstBody.connectionId as ConnectionId,
+    );
     if (stored?.credentialKind === "password") {
       expect(
         decryptCredentialAtRest(TEST_CREDENTIAL_ENCRYPTION_KEY, {
@@ -2156,8 +2147,8 @@ describe("POST /internal/connections/credential", () => {
   });
 
   it("returns 401 invalidCredential when validation fails", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     appleAuth.validateError = new ProviderAuthError(
       "authorizationRevoked",
       "Apple rejected the app-specific password",
@@ -2174,16 +2165,13 @@ describe("POST /internal/connections/credential", () => {
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ error: "invalidCredential" });
     expect(
-      await connections.listByPrincipal(
-        tenantId as TenantId,
-        principalId as PrincipalId,
-      ),
+      await connections.listByPrincipal(tenantId, principalId),
     ).toHaveLength(0);
   });
 
   it("returns 503 when validation is throttled", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     appleAuth.validateError = new ProviderAuthError(
       "refreshFailed",
       "Apple CalDAV throttled credential validation",

--- a/packages/sync/src/server/connection.routes.db.test.ts
+++ b/packages/sync/src/server/connection.routes.db.test.ts
@@ -634,7 +634,6 @@ describe("POST /internal/connections/begin", () => {
     await begin(tenantId, principalId, { connectionId: existing._id });
 
     expect(adapter.authorizations[0]!.selectAccount).toBe(false);
-    expect(adapter.authorizations[0]!.loginHint).toBe("reconnect@example.com");
   });
 
   it("binds the state to an owned connection for reconnect", async () => {
@@ -1034,7 +1033,7 @@ describe("GET /sync/google", () => {
       `code=c&state=${encodeURIComponent(reconnectState(tenantId, principalId, existing._id))}`,
     );
 
-    expect(statusOf(res)).toBe("accountMismatch");
+    expect(statusOf(res)).toBe("error");
     // No second connection was created; the original is untouched.
     const all = await connections.listByPrincipal(tenantId, principalId);
     expect(all).toHaveLength(1);

--- a/packages/sync/src/server/connection.routes.db.test.ts
+++ b/packages/sync/src/server/connection.routes.db.test.ts
@@ -110,12 +110,14 @@ class FakeAuthAdapter implements ProviderAuthAdapter {
     state: string;
     redirectUri: string;
     selectAccount?: boolean;
+    loginHint?: string;
     extraScopes?: readonly string[];
   }> = [];
   buildAuthorizationUrl(input: {
     state: string;
     redirectUri: string;
     selectAccount?: boolean;
+    loginHint?: string;
     extraScopes?: readonly string[];
   }): string {
     this.authorizations.push(input);
@@ -627,6 +629,7 @@ describe("POST /internal/connections/begin", () => {
     await begin(tenantId, principalId, { connectionId: existing._id });
 
     expect(adapter.authorizations[0].selectAccount).toBe(false);
+    expect(adapter.authorizations[0].loginHint).toBe("reconnect@example.com");
   });
 
   it("binds the state to an owned connection for reconnect", async () => {
@@ -1040,7 +1043,7 @@ describe("GET /sync/google", () => {
       `code=c&state=${encodeURIComponent(reconnectState(tenantId, principalId, existing._id))}`,
     );
 
-    expect(statusOf(res)).toBe("error");
+    expect(statusOf(res)).toBe("accountMismatch");
     // No second connection was created; the original is untouched.
     const all = await connections.listByPrincipal(
       tenantId as TenantId,

--- a/packages/sync/src/server/contacts.routes.db.test.ts
+++ b/packages/sync/src/server/contacts.routes.db.test.ts
@@ -12,6 +12,7 @@ import {
 import { type ContactSuggestion } from "@core/types/contact.contracts";
 import {
   type PrincipalId,
+  type ProviderAccountId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
 import {
@@ -146,7 +147,7 @@ describe("GET /internal/contacts/suggestions", () => {
       principalId: principalId as PrincipalId,
       provider: "google",
       account: {
-        providerAccountId: objectId(),
+        providerAccountId: objectId() as ProviderAccountId,
         email: "me@example.com",
         displayName: null,
       },
@@ -173,7 +174,7 @@ describe("GET /internal/contacts/suggestions", () => {
       principalId: principalId as PrincipalId,
       provider: "microsoft",
       account: {
-        providerAccountId: objectId(),
+        providerAccountId: objectId() as ProviderAccountId,
         email: "me@outlook.com",
         displayName: null,
       },
@@ -303,15 +304,15 @@ describe("GET /internal/contacts/suggestions", () => {
   });
 
   it("refuses typed when no connection has the contacts capability", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     // A connection WITHOUT the contacts grant (calendar-only capabilities).
     await connections.upsertByProviderAccount({
-      tenantId: tenantId as TenantId,
-      principalId: principalId as PrincipalId,
+      tenantId: tenantId,
+      principalId: principalId,
       provider: "google",
       account: {
-        providerAccountId: objectId(),
+        providerAccountId: objectId() as ProviderAccountId,
         email: "me@example.com",
         displayName: null,
       },

--- a/packages/sync/src/server/diagnostic.routes.db.test.ts
+++ b/packages/sync/src/server/diagnostic.routes.db.test.ts
@@ -3,8 +3,11 @@ import { NodeEnv } from "@core/constants/core.constants";
 import { type DiagnosticConnectionResponse } from "@core/types/sync/diagnostic.contracts";
 import {
   type PrincipalId,
+  type ProviderAccountId,
+  type ProviderCalendarSourceId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
+import { defaultCalendarListFields } from "@sync/__tests__/helpers/fixtures";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { createSyncService, type SyncService } from "@sync/app";
 import { signInternalRequest } from "@sync/auth/internal-auth";
@@ -68,17 +71,17 @@ describe("GET /internal/diagnostics/connections/:diagnosticKey", () => {
   });
 
   it("resolves a diagnostic key to metadata without event content", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const connections = new ProviderConnectionRepository(mongo.db);
     const calendars = new ProviderCalendarRepository(mongo.db);
 
     const connection = await connections.upsertByProviderAccount({
-      tenantId: tenantId as TenantId,
-      principalId: principalId as PrincipalId,
+      tenantId: tenantId,
+      principalId: principalId,
       provider: "google",
       account: {
-        providerAccountId: objectId(),
+        providerAccountId: objectId() as ProviderAccountId,
         email: "support-lookup@example.com",
         displayName: null,
       },
@@ -87,12 +90,13 @@ describe("GET /internal/diagnostics/connections/:diagnosticKey", () => {
       stateReason: null,
     });
     await calendars.upsertByProviderCalendar({
-      tenantId: tenantId as TenantId,
-      principalId: principalId as PrincipalId,
+      tenantId: tenantId,
+      principalId: principalId,
       connectionId: connection._id,
-      providerCalendarId: "primary",
+      providerCalendarId: "primary" as ProviderCalendarSourceId,
       displayName: "Primary",
       color: null,
+      ...defaultCalendarListFields,
       active: true,
       primary: true,
       accessRole: "owner",

--- a/packages/sync/src/server/notification.routes.db.test.ts
+++ b/packages/sync/src/server/notification.routes.db.test.ts
@@ -1,10 +1,12 @@
 import { faker } from "@faker-js/faker";
 import { NodeEnv } from "@core/constants/core.constants";
+import { type CalendarId } from "@core/types/domain-primitives";
 import {
   type ConnectionId,
   type PrincipalId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
+import { stringIdFilter } from "@sync/__tests__/helpers/mongo-id";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { createSyncService, type SyncService } from "@sync/app";
 import { type SyncConfig } from "@sync/config/sync.config";
@@ -84,7 +86,7 @@ describe("POST /sync/notifications/google", () => {
       principalId,
       connectionId: objectId() as ConnectionId,
       resourceKind: kind,
-      calendarId: kind === "events" ? objectId() : null,
+      calendarId: kind === "events" ? (objectId() as CalendarId) : null,
     });
     await resources.updateSubscription(tenantId, principalId, resource._id, {
       subscriptionId: CHANNEL,
@@ -167,7 +169,7 @@ describe("POST /sync/notifications/google", () => {
     expect(res.status).toBe(200);
     const stored = await mongo.db
       .collection(SYNC_COLLECTIONS.syncResources)
-      .findOne({ _id: resourceId });
+      .findOne(stringIdFilter(resourceId));
     expect(stored?.["changeNotifiedAt"]).toBeInstanceOf(Date);
   });
 
@@ -182,7 +184,7 @@ describe("POST /sync/notifications/google", () => {
 
     const stored = await mongo.db
       .collection(SYNC_COLLECTIONS.syncResources)
-      .findOne({ _id: resourceId });
+      .findOne(stringIdFilter(resourceId));
     expect(stored?.["changeNotifiedAt"]).toBeNull();
   });
 
@@ -302,7 +304,7 @@ describe("POST /sync/notifications/google", () => {
 
     const stored = await mongo.db
       .collection(SYNC_COLLECTIONS.syncResources)
-      .findOne({ _id: resource._id });
+      .findOne(stringIdFilter(String(resource._id)));
     expect(stored?.["syncCursor"]).toBeNull();
     // Only the cursor: the sweep's staleness clock must not advance on the
     // strength of a pass that has merely been scheduled. Read raw, so the key is
@@ -328,7 +330,7 @@ describe("POST /sync/notifications/google", () => {
 
     const stored = await mongo.db
       .collection(SYNC_COLLECTIONS.syncResources)
-      .findOne({ _id: resource._id });
+      .findOne(stringIdFilter(String(resource._id)));
     expect(stored?.["syncCursor"]).toBe("stored-token");
   });
 
@@ -356,7 +358,7 @@ describe("POST /sync/notifications/google", () => {
 
     const stored = await mongo.db
       .collection(SYNC_COLLECTIONS.syncResources)
-      .findOne({ _id: resource._id });
+      .findOne(stringIdFilter(String(resource._id)));
     expect(stored?.["syncCursor"]).toBe("stored-token");
   });
 
@@ -385,7 +387,7 @@ describe("POST /sync/notifications/google", () => {
     expect(await jobCount(`calendarListSync:${resource.connectionId}`)).toBe(1);
     const stored = await mongo.db
       .collection(SYNC_COLLECTIONS.syncResources)
-      .findOne({ _id: resource._id });
+      .findOne(stringIdFilter(String(resource._id)));
     expect(stored?.["syncCursor"]).toBeNull();
   });
 

--- a/packages/sync/src/server/principal.routes.db.test.ts
+++ b/packages/sync/src/server/principal.routes.db.test.ts
@@ -3,6 +3,8 @@ import { NodeEnv } from "@core/constants/core.constants";
 import {
   type ConnectionId,
   type PrincipalId,
+  type ProviderAccountId,
+  type ProviderCalendarSourceId,
   type TenantId,
 } from "@core/types/sync/identity.contracts";
 import { type PrincipalPurgeResponse } from "@core/types/sync/principal.contracts";
@@ -10,6 +12,7 @@ import {
   seedOauthCredential,
   TEST_CREDENTIAL_ENCRYPTION_KEY,
 } from "@sync/__tests__/helpers/credential-encryption";
+import { defaultCalendarListFields } from "@sync/__tests__/helpers/fixtures";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { createSyncService, type SyncService } from "@sync/app";
 import { signInternalRequest } from "@sync/auth/internal-auth";
@@ -92,7 +95,7 @@ const seedConnection = (
     principalId: principalId as PrincipalId,
     provider: "google",
     account: {
-      providerAccountId: objectId(),
+      providerAccountId: objectId() as ProviderAccountId,
       email: "purge@example.com",
       displayName: null,
     },
@@ -133,9 +136,9 @@ describe("DELETE /internal/principal", () => {
   });
 
   it("revokes credentials and hard-deletes every principal-scoped row", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
-    const stranger = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const stranger = objectId() as PrincipalId;
 
     const connections = new ProviderConnectionRepository(mongo.db);
     const credentials = new CredentialRepository(mongo.db);
@@ -159,12 +162,13 @@ describe("DELETE /internal/principal", () => {
       scopes: ["https://www.googleapis.com/auth/calendar.events"],
     });
     await calendars.upsertByProviderCalendar({
-      tenantId: tenantId as TenantId,
-      principalId: principalId as PrincipalId,
+      tenantId: tenantId,
+      principalId: principalId,
       connectionId: mine._id,
-      providerCalendarId: "primary",
+      providerCalendarId: "primary" as ProviderCalendarSourceId,
       displayName: "Primary",
       color: null,
+      ...defaultCalendarListFields,
       active: true,
       primary: true,
       accessRole: "owner",
@@ -176,15 +180,15 @@ describe("DELETE /internal/principal", () => {
       },
     });
     await resources.ensure({
-      tenantId: tenantId as TenantId,
-      principalId: principalId as PrincipalId,
+      tenantId: tenantId,
+      principalId: principalId,
       connectionId: mine._id,
       resourceKind: "calendarList",
       calendarId: null,
     });
     await jobs.enqueue({
-      tenantId: tenantId as TenantId,
-      principalId: principalId as PrincipalId,
+      tenantId: tenantId,
+      principalId: principalId,
       connectionId: mine._id,
       resourceId: null,
       commandId: null,
@@ -194,8 +198,8 @@ describe("DELETE /internal/principal", () => {
       coalescingKey: `purge-test:${mine._id}`,
     });
     await invalidations.append({
-      tenantId: tenantId as TenantId,
-      principalId: principalId as PrincipalId,
+      tenantId: tenantId,
+      principalId: principalId,
       invalidation: { kind: "connection", connectionId: mine._id },
       emittedAt: new Date(),
     });
@@ -217,19 +221,13 @@ describe("DELETE /internal/principal", () => {
 
     expect(adapter.revoked).toEqual(["mine-refresh"]);
     expect(
-      await connections.listByPrincipal(
-        tenantId as TenantId,
-        principalId as PrincipalId,
-      ),
+      await connections.listByPrincipal(tenantId, principalId),
     ).toHaveLength(0);
     expect(await credentials.findByConnection(mine._id)).toBeNull();
     expect(await credentials.findByConnection(theirs._id)).not.toBeNull();
-    expect(
-      await connections.listByPrincipal(
-        tenantId as TenantId,
-        stranger as PrincipalId,
-      ),
-    ).toHaveLength(1);
+    expect(await connections.listByPrincipal(tenantId, stranger)).toHaveLength(
+      1,
+    );
   });
 
   it("is idempotent and works in passive mode without an auth adapter", async () => {

--- a/packages/sync/src/storage/contracts/sync-resource.contracts.test.ts
+++ b/packages/sync/src/storage/contracts/sync-resource.contracts.test.ts
@@ -7,7 +7,12 @@ import { describe, expect, it } from "bun:test";
 
 describe("ResourceBootstrapStateSchema", () => {
   it("parses every known state", () => {
-    for (const state of ["importing", "watching", "catchingUp", "ready"]) {
+    for (const state of [
+      "importing",
+      "watching",
+      "catchingUp",
+      "ready",
+    ] as const) {
       expect(ResourceBootstrapStateSchema.parse(state)).toBe(state);
     }
   });

--- a/packages/sync/src/storage/repositories/command.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/command.repository.db.test.ts
@@ -1,5 +1,18 @@
 import { faker } from "@faker-js/faker";
 import { type Db } from "mongodb";
+import {
+  type CalendarId,
+  type DateTime,
+  type EventId,
+  type TimeZone,
+} from "@core/types/domain-primitives";
+import { type ProviderEventVersion } from "@core/types/sync/event.contracts";
+import {
+  type IdempotencyKey,
+  type PrincipalId,
+  type ProviderEventId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { type CommandSubmit } from "@sync/storage/contracts/command.contracts";
 import { CommandRepository } from "@sync/storage/repositories/command.repository";
@@ -8,9 +21,9 @@ const objectId = () => faker.database.mongodbObjectId();
 
 const timed = {
   kind: "timed",
-  start: "2026-07-14T09:00:00-06:00",
-  end: "2026-07-14T10:00:00-06:00",
-  timeZone: "America/Denver",
+  start: "2026-07-14T09:00:00-06:00" as DateTime,
+  end: "2026-07-14T10:00:00-06:00" as DateTime,
+  timeZone: "America/Denver" as TimeZone,
 };
 const content = {
   title: "Standup",
@@ -23,13 +36,13 @@ const content = {
 
 const submit = (overrides: Partial<CommandSubmit> = {}): CommandSubmit =>
   ({
-    tenantId: objectId(),
-    principalId: objectId(),
-    idempotencyKey: "key-1",
-    eventId: objectId(),
+    tenantId: objectId() as TenantId,
+    principalId: objectId() as PrincipalId,
+    idempotencyKey: "key-1" as IdempotencyKey,
+    eventId: objectId() as EventId,
     input: {
       kind: "create",
-      calendarId: objectId(),
+      calendarId: objectId() as CalendarId,
       content,
       schedule: timed,
       recurrence: { kind: "single" },
@@ -56,10 +69,14 @@ describe("CommandRepository", () => {
   });
 
   it("returns the existing command for a repeated idempotency key", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const first = await repo.submit(
-      submit({ tenantId, principalId, idempotencyKey: "dup" }),
+      submit({
+        tenantId,
+        principalId,
+        idempotencyKey: "dup" as IdempotencyKey,
+      }),
     );
     expect(first.inserted).toBe(true);
     // A retried submit must not create a second command or reset progress.
@@ -71,7 +88,11 @@ describe("CommandRepository", () => {
       1,
     );
     const second = await repo.submit(
-      submit({ tenantId, principalId, idempotencyKey: "dup" }),
+      submit({
+        tenantId,
+        principalId,
+        idempotencyKey: "dup" as IdempotencyKey,
+      }),
     );
 
     expect(second.inserted).toBe(false);
@@ -98,8 +119,8 @@ describe("CommandRepository", () => {
       command._id,
       {
         state: "confirmed",
-        providerEventId: "evt-1",
-        providerVersion: "etag-1",
+        providerEventId: "evt-1" as ProviderEventId,
+        providerVersion: "etag-1" as ProviderEventVersion,
       },
       1,
     );
@@ -124,7 +145,11 @@ describe("CommandRepository", () => {
       command.tenantId,
       command.principalId,
       command._id,
-      { state: "confirmed", providerEventId: "evt-1", providerVersion: "e-1" },
+      {
+        state: "confirmed",
+        providerEventId: "evt-1" as ProviderEventId,
+        providerVersion: "e-1" as ProviderEventVersion,
+      },
       2,
     );
     if (!confirmed) throw new Error("expected a confirmed command");
@@ -176,12 +201,14 @@ describe("CommandRepository", () => {
   });
 
   it("lists only nonterminal commands, oldest first", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const { record: a } = await repo.submit(
-      submit({ tenantId, principalId, idempotencyKey: "a" }),
+      submit({ tenantId, principalId, idempotencyKey: "a" as IdempotencyKey }),
     );
-    await repo.submit(submit({ tenantId, principalId, idempotencyKey: "b" }));
+    await repo.submit(
+      submit({ tenantId, principalId, idempotencyKey: "b" as IdempotencyKey }),
+    );
     // Terminate one; it should drop out of the nonterminal list.
     await repo.updateOutcome(
       tenantId,
@@ -193,13 +220,13 @@ describe("CommandRepository", () => {
 
     const pending = await repo.listNonterminal(tenantId, principalId, 100);
     expect(pending).toHaveLength(1);
-    expect(pending[0]?.idempotencyKey).toBe("b");
+    expect(pending[0]?.idempotencyKey).toBe("b" as IdempotencyKey);
   });
 
   it("reports a nonterminal command for an event, and none once it terminates", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
-    const eventId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const eventId = objectId() as EventId;
     const { record: command } = await repo.submit(
       submit({ tenantId, principalId, eventId }),
     );
@@ -239,8 +266,8 @@ describe("CommandRepository", () => {
 
   it("rejects a raw duplicate insert violating the idempotency index", async () => {
     const shared = {
-      tenantId: objectId(),
-      principalId: objectId(),
+      tenantId: objectId() as TenantId,
+      principalId: objectId() as PrincipalId,
       idempotencyKey: "same",
     };
     const collection = db.collection("commands");

--- a/packages/sync/src/storage/repositories/credential.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/credential.repository.db.test.ts
@@ -1,11 +1,12 @@
 import { faker } from "@faker-js/faker";
-import { type Db } from "mongodb";
+import { type Db, type Document } from "mongodb";
 import { decryptCredentialAtRest } from "@core/security/credential-at-rest";
 import { type ConnectionId } from "@core/types/sync/identity.contracts";
 import {
   TEST_CREDENTIAL_ENCRYPTION_KEY,
   toStoredOauthCredentialUpsert,
 } from "@sync/__tests__/helpers/credential-encryption";
+import { stringIdFilter } from "@sync/__tests__/helpers/mongo-id";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import {
@@ -55,7 +56,7 @@ describe("CredentialRepository", () => {
 
     const raw = await db
       .collection(SYNC_COLLECTIONS.credentials)
-      .findOne({ _id: input.connectionId });
+      .findOne(stringIdFilter(input.connectionId));
     expect(raw).not.toHaveProperty("refreshToken");
     expect(JSON.stringify(raw)).not.toContain("refresh-token-secret");
   });
@@ -103,7 +104,7 @@ describe("CredentialRepository", () => {
       scopes: input.scopes,
       createdAt: new Date(),
       updatedAt: new Date(),
-    });
+    } as Document);
 
     const sealed = toStoredOauthCredentialUpsert(
       TEST_CREDENTIAL_ENCRYPTION_KEY,
@@ -119,14 +120,14 @@ describe("CredentialRepository", () => {
     expect(updated?.refreshTokenCiphertext).toBe(sealed.refreshTokenCiphertext);
     const raw = await db
       .collection(SYNC_COLLECTIONS.credentials)
-      .findOne({ _id: input.connectionId });
+      .findOne(stringIdFilter(input.connectionId));
     expect(raw).not.toHaveProperty("refreshToken");
     expect(
       decryptCredentialAtRest(TEST_CREDENTIAL_ENCRYPTION_KEY, {
-        ciphertext: String(raw?.refreshTokenCiphertext),
-        iv: String(raw?.refreshTokenIv),
-        tag: String(raw?.refreshTokenTag),
-        keyVersion: Number(raw?.keyVersion),
+        ciphertext: String(raw?.["refreshTokenCiphertext"]),
+        iv: String(raw?.["refreshTokenIv"]),
+        tag: String(raw?.["refreshTokenTag"]),
+        keyVersion: Number(raw?.["keyVersion"]),
       }),
     ).toBe("refresh-token-secret");
   });
@@ -165,12 +166,12 @@ describe("CredentialRepository", () => {
 
     const inConnections = await db
       .collection(SYNC_COLLECTIONS.providerConnections)
-      .findOne({ _id: input.connectionId });
+      .findOne(stringIdFilter(input.connectionId));
     expect(inConnections).toBeNull();
 
     const inCredentials = await db
       .collection(SYNC_COLLECTIONS.credentials)
-      .findOne({ _id: input.connectionId });
+      .findOne(stringIdFilter(input.connectionId));
     expect(inCredentials).not.toBeNull();
   });
 
@@ -207,7 +208,7 @@ describe("CredentialRepository", () => {
       scopes: [],
       createdAt: new Date(),
       updatedAt: new Date(),
-    });
+    } as Document);
 
     const read = await repo.findByConnection(connectionId);
     expect(read).toMatchObject({
@@ -237,7 +238,7 @@ describe("CredentialRepository", () => {
 
     const raw = await db
       .collection(SYNC_COLLECTIONS.credentials)
-      .findOne({ _id: connectionId });
+      .findOne(stringIdFilter(connectionId));
     expect(raw).not.toHaveProperty("refreshToken");
     expect(raw).not.toHaveProperty("accessToken");
   });

--- a/packages/sync/src/storage/repositories/credential.repository.ts
+++ b/packages/sync/src/storage/repositories/credential.repository.ts
@@ -1,4 +1,4 @@
-import { type Collection, type Db, type Document } from "mongodb";
+import { type Collection, type Db } from "mongodb";
 import { type ConnectionId } from "@core/types/sync/identity.contracts";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import {
@@ -41,7 +41,7 @@ const PLAINTEXT_REFRESH_TOKEN_FIELD = { refreshToken: "" } as const;
 // written; no connection query touches this collection, so a connection read
 // can never surface a token. The repository never logs credential material.
 export class CredentialRepository {
-  private readonly collection: Collection<Document>;
+  private readonly collection: Collection<CredentialRecord>;
 
   constructor(db: Db) {
     this.collection = db.collection(SYNC_COLLECTIONS.credentials);

--- a/packages/sync/src/storage/repositories/deletion-marker.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/deletion-marker.repository.db.test.ts
@@ -1,5 +1,14 @@
 import { faker } from "@faker-js/faker";
 import { type Db } from "mongodb";
+import { type CalendarId } from "@core/types/domain-primitives";
+import { type ProviderEventVersion } from "@core/types/sync/event.contracts";
+import {
+  type ConnectionId,
+  type PrincipalId,
+  type ProviderEventId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { stringIdFilter } from "@sync/__tests__/helpers/mongo-id";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { type DeletionMarkerRecordInput } from "@sync/storage/contracts/deletion-marker.contracts";
 import {
@@ -13,12 +22,12 @@ const markerInput = (
   overrides: Partial<DeletionMarkerRecordInput> = {},
 ): DeletionMarkerRecordInput =>
   ({
-    tenantId: objectId(),
-    principalId: objectId(),
-    connectionId: objectId(),
-    calendarId: objectId(),
-    providerEventId: "evt-deleted",
-    providerVersion: "etag-9",
+    tenantId: objectId() as TenantId,
+    principalId: objectId() as PrincipalId,
+    connectionId: objectId() as ConnectionId,
+    calendarId: objectId() as CalendarId,
+    providerEventId: "evt-deleted" as ProviderEventId,
+    providerVersion: "etag-9" as ProviderEventVersion,
     deletionSource: "compass",
     deletedAt: new Date("2026-07-20T12:00:00.000Z"),
     ...overrides,
@@ -42,7 +51,7 @@ describe("DeletionMarkerRepository", () => {
     // No event content is stored — only identity/version/source/timestamps.
     const doc = await db
       .collection("deletion_markers")
-      .findOne({ _id: marker._id });
+      .findOne(stringIdFilter(marker._id));
     expect(Object.keys(doc ?? {}).sort()).toEqual(
       [
         "_id",
@@ -61,22 +70,25 @@ describe("DeletionMarkerRepository", () => {
 
   it("is idempotent on provider identity (re-confirmation refreshes, not duplicates)", async () => {
     const identity = {
-      connectionId: objectId(),
-      calendarId: objectId(),
-      providerEventId: "evt-1",
+      connectionId: objectId() as ConnectionId,
+      calendarId: objectId() as CalendarId,
+      providerEventId: "evt-1" as ProviderEventId,
     };
     const first = await repo.record(
-      markerInput({ ...identity, providerVersion: "v1" }),
+      markerInput({
+        ...identity,
+        providerVersion: "v1" as ProviderEventVersion,
+      }),
     );
     const second = await repo.record(
       markerInput({
         ...identity,
-        providerVersion: "v2",
+        providerVersion: "v2" as ProviderEventVersion,
         deletedAt: new Date("2026-07-21T12:00:00.000Z"),
       }),
     );
     expect(second._id).toBe(first._id);
-    expect(second.providerVersion).toBe("v2");
+    expect(second.providerVersion).toBe("v2" as ProviderEventVersion);
     expect(await db.collection("deletion_markers").countDocuments()).toBe(1);
   });
 

--- a/packages/sync/src/storage/repositories/event-occurrence.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/event-occurrence.repository.db.test.ts
@@ -1,5 +1,17 @@
 import { faker } from "@faker-js/faker";
 import { type Db } from "mongodb";
+import {
+  type CalendarId,
+  type DateOnly,
+  type DateTime,
+  type EventId,
+  type TimeZone,
+} from "@core/types/domain-primitives";
+import { type OccurrenceKey } from "@core/types/sync/event.contracts";
+import {
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { type EventOccurrenceRecord } from "@sync/storage/contracts/event-occurrence.contracts";
 import {
@@ -14,16 +26,16 @@ const occurrence = (
   overrides: Partial<OccurrenceInput> = {},
 ): OccurrenceInput =>
   ({
-    tenantId: objectId(),
-    principalId: objectId(),
-    eventId: objectId(),
-    occurrenceKey: `${objectId()}:2026-07-14T09:00:00-06:00`,
-    calendarId: objectId(),
+    tenantId: objectId() as TenantId,
+    principalId: objectId() as PrincipalId,
+    eventId: objectId() as EventId,
+    occurrenceKey: `${objectId()}:2026-07-14T09:00:00-06:00` as OccurrenceKey,
+    calendarId: objectId() as CalendarId,
     schedule: {
       kind: "timed",
-      start: "2026-07-14T09:00:00-06:00",
-      end: "2026-07-14T10:00:00-06:00",
-      timeZone: "America/Denver",
+      start: "2026-07-14T09:00:00-06:00" as DateTime,
+      end: "2026-07-14T10:00:00-06:00" as DateTime,
+      timeZone: "America/Denver" as TimeZone,
     },
     startAt: new Date("2026-07-14T09:00:00-06:00"),
     endAt: new Date("2026-07-14T10:00:00-06:00"),
@@ -47,8 +59,8 @@ describe("EventOccurrenceRepository", () => {
   it("materializes occurrences for an event", async () => {
     const eventId = objectId() as OccurrenceInput["eventId"];
     await repo.replaceForEvent(eventId, 0, [
-      occurrence({ eventId, occurrenceKey: `${eventId}:a` }),
-      occurrence({ eventId, occurrenceKey: `${eventId}:b` }),
+      occurrence({ eventId, occurrenceKey: `${eventId}:a` as OccurrenceKey }),
+      occurrence({ eventId, occurrenceKey: `${eventId}:b` as OccurrenceKey }),
     ]);
     expect(await db.collection("event_occurrences").countDocuments()).toBe(2);
   });
@@ -57,23 +69,35 @@ describe("EventOccurrenceRepository", () => {
     const target = objectId() as OccurrenceInput["eventId"];
     const other = objectId() as OccurrenceInput["eventId"];
     await repo.replaceForEvent(target, 0, [
-      occurrence({ eventId: target, occurrenceKey: `${target}:old` }),
+      occurrence({
+        eventId: target,
+        occurrenceKey: `${target}:old` as OccurrenceKey,
+      }),
     ]);
     await repo.replaceForEvent(other, 0, [
-      occurrence({ eventId: other, occurrenceKey: `${other}:x` }),
+      occurrence({
+        eventId: other,
+        occurrenceKey: `${other}:x` as OccurrenceKey,
+      }),
     ]);
 
     // Rebuild the target with new occurrences; the other event is untouched.
     await repo.replaceForEvent(target, 0, [
-      occurrence({ eventId: target, occurrenceKey: `${target}:new1` }),
-      occurrence({ eventId: target, occurrenceKey: `${target}:new2` }),
+      occurrence({
+        eventId: target,
+        occurrenceKey: `${target}:new1` as OccurrenceKey,
+      }),
+      occurrence({
+        eventId: target,
+        occurrenceKey: `${target}:new2` as OccurrenceKey,
+      }),
     ]);
 
     const targetDocs = await db
       .collection("event_occurrences")
       .find({ eventId: target })
       .toArray();
-    expect(targetDocs.map((d) => d.occurrenceKey).sort()).toEqual([
+    expect(targetDocs.map((d) => d["occurrenceKey"]).sort()).toEqual([
       `${target}:new1`,
       `${target}:new2`,
     ]);
@@ -89,7 +113,7 @@ describe("EventOccurrenceRepository", () => {
     // The SAME occurrence (same eventId + occurrenceKey) in two generations: the
     // unique index includes generation, so a repair building generation 1 does
     // not collide with the live generation 0.
-    const key = `${eventId}:instant`;
+    const key = `${eventId}:instant` as OccurrenceKey;
     await repo.replaceForEvent(eventId, 0, [
       occurrence({ eventId, occurrenceKey: key, generation: 0 }),
     ]);
@@ -104,7 +128,7 @@ describe("EventOccurrenceRepository", () => {
   it("clears occurrences when replaced with an empty set", async () => {
     const eventId = objectId() as OccurrenceInput["eventId"];
     await repo.replaceForEvent(eventId, 0, [
-      occurrence({ eventId, occurrenceKey: `${eventId}:a` }),
+      occurrence({ eventId, occurrenceKey: `${eventId}:a` as OccurrenceKey }),
     ]);
     await repo.replaceForEvent(eventId, 0, []);
     expect(
@@ -123,15 +147,24 @@ describe("EventOccurrenceRepository", () => {
           eventId: eventA,
           generation: 0,
           occurrences: [
-            occurrence({ eventId: eventA, occurrenceKey: `${eventA}:a1` }),
-            occurrence({ eventId: eventA, occurrenceKey: `${eventA}:a2` }),
+            occurrence({
+              eventId: eventA,
+              occurrenceKey: `${eventA}:a1` as OccurrenceKey,
+            }),
+            occurrence({
+              eventId: eventA,
+              occurrenceKey: `${eventA}:a2` as OccurrenceKey,
+            }),
           ],
         },
         {
           eventId: eventB,
           generation: 0,
           occurrences: [
-            occurrence({ eventId: eventB, occurrenceKey: `${eventB}:b1` }),
+            occurrence({
+              eventId: eventB,
+              occurrenceKey: `${eventB}:b1` as OccurrenceKey,
+            }),
           ],
         },
         // An empty occurrence set (e.g. a fully-truncated recurring series)
@@ -140,7 +173,7 @@ describe("EventOccurrenceRepository", () => {
       ]);
 
       const docs = await db.collection("event_occurrences").find({}).toArray();
-      expect(docs.map((d) => d.occurrenceKey).sort()).toEqual(
+      expect(docs.map((d) => d["occurrenceKey"]).sort()).toEqual(
         [`${eventA}:a1`, `${eventA}:a2`, `${eventB}:b1`].sort(),
       );
     });
@@ -149,10 +182,16 @@ describe("EventOccurrenceRepository", () => {
       const eventA = objectId() as OccurrenceInput["eventId"];
       const eventB = objectId() as OccurrenceInput["eventId"];
       await repo.replaceForEvent(eventA, 0, [
-        occurrence({ eventId: eventA, occurrenceKey: `${eventA}:old` }),
+        occurrence({
+          eventId: eventA,
+          occurrenceKey: `${eventA}:old` as OccurrenceKey,
+        }),
       ]);
       await repo.replaceForEvent(eventB, 0, [
-        occurrence({ eventId: eventB, occurrenceKey: `${eventB}:old` }),
+        occurrence({
+          eventId: eventB,
+          occurrenceKey: `${eventB}:old` as OccurrenceKey,
+        }),
       ]);
 
       await repo.replaceForEvents([
@@ -160,20 +199,26 @@ describe("EventOccurrenceRepository", () => {
           eventId: eventA,
           generation: 0,
           occurrences: [
-            occurrence({ eventId: eventA, occurrenceKey: `${eventA}:new` }),
+            occurrence({
+              eventId: eventA,
+              occurrenceKey: `${eventA}:new` as OccurrenceKey,
+            }),
           ],
         },
         {
           eventId: eventB,
           generation: 0,
           occurrences: [
-            occurrence({ eventId: eventB, occurrenceKey: `${eventB}:new` }),
+            occurrence({
+              eventId: eventB,
+              occurrenceKey: `${eventB}:new` as OccurrenceKey,
+            }),
           ],
         },
       ]);
 
       const docs = await db.collection("event_occurrences").find({}).toArray();
-      expect(docs.map((d) => d.occurrenceKey).sort()).toEqual(
+      expect(docs.map((d) => d["occurrenceKey"]).sort()).toEqual(
         [`${eventA}:new`, `${eventB}:new`].sort(),
       );
     });
@@ -181,7 +226,10 @@ describe("EventOccurrenceRepository", () => {
     it("is a no-op for an empty entry list", async () => {
       const eventId = objectId() as OccurrenceInput["eventId"];
       await repo.replaceForEvent(eventId, 0, [
-        occurrence({ eventId, occurrenceKey: `${eventId}:kept` }),
+        occurrence({
+          eventId,
+          occurrenceKey: `${eventId}:kept` as OccurrenceKey,
+        }),
       ]);
 
       await repo.replaceForEvents([]);
@@ -193,10 +241,10 @@ describe("EventOccurrenceRepository", () => {
   });
 
   describe("listByCalendarRange", () => {
-    const tenantId = objectId();
-    const principalId = objectId();
-    const calA = objectId();
-    const calB = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const calA = objectId() as CalendarId;
+    const calB = objectId() as CalendarId;
 
     beforeEach(async () => {
       const mk = (calendarId: string, day: number) =>
@@ -204,13 +252,13 @@ describe("EventOccurrenceRepository", () => {
           tenantId: tenantId as OccurrenceInput["tenantId"],
           principalId: principalId as OccurrenceInput["principalId"],
           eventId: objectId() as OccurrenceInput["eventId"],
-          occurrenceKey: `${calendarId}:${day}`,
+          occurrenceKey: `${calendarId}:${day}` as OccurrenceKey,
           calendarId: calendarId as OccurrenceInput["calendarId"],
           schedule: {
             kind: "timed",
-            start: `2026-07-${day}T09:00:00-06:00`,
-            end: `2026-07-${day}T10:00:00-06:00`,
-            timeZone: "America/Denver",
+            start: `2026-07-${day}T09:00:00-06:00` as DateTime,
+            end: `2026-07-${day}T10:00:00-06:00` as DateTime,
+            timeZone: "America/Denver" as TimeZone,
           },
           startAt: new Date(`2026-07-${day}T09:00:00-06:00`),
         });
@@ -269,7 +317,7 @@ describe("EventOccurrenceRepository", () => {
       // (_id) tie-break in the composite cursor must not skip or repeat any.
       const tenant2 = objectId() as OccurrenceInput["tenantId"];
       const principal2 = objectId() as OccurrenceInput["principalId"];
-      const cal = objectId();
+      const cal = objectId() as CalendarId;
       const sameInstant = new Date("2026-07-14T09:00:00-06:00");
       const eventId = objectId() as OccurrenceInput["eventId"];
       await repo.replaceForEvent(
@@ -280,7 +328,7 @@ describe("EventOccurrenceRepository", () => {
             tenantId: tenant2,
             principalId: principal2,
             eventId,
-            occurrenceKey: `${cal}:tie:${i}`,
+            occurrenceKey: `${cal}:tie:${i}` as OccurrenceKey,
             calendarId: cal as OccurrenceInput["calendarId"],
             startAt: sameInstant,
           }),
@@ -325,7 +373,7 @@ describe("EventOccurrenceRepository", () => {
             tenantId: tenant,
             principalId: principal,
             eventId: eventId as OccurrenceInput["eventId"],
-            occurrenceKey: key,
+            occurrenceKey: key as OccurrenceKey,
             calendarId: cal,
             startAt: at,
             generation: gen,
@@ -348,7 +396,7 @@ describe("EventOccurrenceRepository", () => {
         ...range,
       });
       expect(live).toHaveLength(1);
-      expect(live[0]?.occurrenceKey).toBe(`${cal}:live`);
+      expect(live[0]?.occurrenceKey).toBe(`${cal}:live` as OccurrenceKey);
       // Reading generation 1 (post-activation) shows only the repair's row.
       const repaired = await repo.listByCalendarRange({
         tenantId: tenant,
@@ -357,7 +405,7 @@ describe("EventOccurrenceRepository", () => {
         ...range,
       });
       expect(repaired).toHaveLength(1);
-      expect(repaired[0]?.occurrenceKey).toBe(`${cal}:repair`);
+      expect(repaired[0]?.occurrenceKey).toBe(`${cal}:repair` as OccurrenceKey);
     });
 
     it("includes all-day UTC-midnight starts for America/Denver local-midnight windows", async () => {
@@ -381,13 +429,13 @@ describe("EventOccurrenceRepository", () => {
               tenantId: tenant,
               principalId: principal,
               eventId: allDayEventId,
-              occurrenceKey: `${cal}:allday`,
+              occurrenceKey: `${cal}:allday` as OccurrenceKey,
               calendarId: cal,
               title: "from gcal",
               schedule: {
                 kind: "allDay",
-                start: "2026-08-06",
-                end: "2026-08-07",
+                start: "2026-08-06" as DateOnly,
+                end: "2026-08-07" as DateOnly,
               },
               startAt: new Date("2026-08-06T00:00:00.000Z"),
               endAt: new Date("2026-08-07T00:00:00.000Z"),
@@ -402,14 +450,14 @@ describe("EventOccurrenceRepository", () => {
               tenantId: tenant,
               principalId: principal,
               eventId: timedEventId,
-              occurrenceKey: `${cal}:timed`,
+              occurrenceKey: `${cal}:timed` as OccurrenceKey,
               calendarId: cal,
               title: "live sync???",
               schedule: {
                 kind: "timed",
-                start: "2026-08-06T11:30:00-06:00",
-                end: "2026-08-06T13:00:00-06:00",
-                timeZone: "America/Denver",
+                start: "2026-08-06T11:30:00-06:00" as DateTime,
+                end: "2026-08-06T13:00:00-06:00" as DateTime,
+                timeZone: "America/Denver" as TimeZone,
               },
               startAt: new Date("2026-08-06T11:30:00-06:00"),
               endAt: new Date("2026-08-06T13:00:00-06:00"),
@@ -424,15 +472,15 @@ describe("EventOccurrenceRepository", () => {
               tenantId: tenant,
               principalId: principal,
               eventId: zeroDurationEventId,
-              occurrenceKey: `${cal}:zero`,
+              occurrenceKey: `${cal}:zero` as OccurrenceKey,
               calendarId: cal,
               title: "reminder",
               busy: false,
               schedule: {
                 kind: "timed",
-                start: "2026-08-06T15:00:00-06:00",
-                end: "2026-08-06T15:00:00-06:00",
-                timeZone: "America/Denver",
+                start: "2026-08-06T15:00:00-06:00" as DateTime,
+                end: "2026-08-06T15:00:00-06:00" as DateTime,
+                timeZone: "America/Denver" as TimeZone,
               },
               startAt: new Date("2026-08-06T15:00:00-06:00"),
               endAt: new Date("2026-08-06T15:00:00-06:00"),
@@ -447,13 +495,13 @@ describe("EventOccurrenceRepository", () => {
               tenantId: tenant,
               principalId: principal,
               eventId: priorAllDayEventId,
-              occurrenceKey: `${cal}:prior`,
+              occurrenceKey: `${cal}:prior` as OccurrenceKey,
               calendarId: cal,
               title: "yesterday",
               schedule: {
                 kind: "allDay",
-                start: "2026-08-05",
-                end: "2026-08-06",
+                start: "2026-08-05" as DateOnly,
+                end: "2026-08-06" as DateOnly,
               },
               startAt: new Date("2026-08-05T00:00:00.000Z"),
               endAt: new Date("2026-08-06T00:00:00.000Z"),
@@ -471,7 +519,11 @@ describe("EventOccurrenceRepository", () => {
         limit: 100,
       });
       const keys = page.map((o) => o.occurrenceKey).sort();
-      expect(keys).toEqual([`${cal}:allday`, `${cal}:timed`, `${cal}:zero`]);
+      expect(keys).toEqual([
+        `${cal}:allday` as OccurrenceKey,
+        `${cal}:timed` as OccurrenceKey,
+        `${cal}:zero` as OccurrenceKey,
+      ]);
     });
   });
 
@@ -501,14 +553,14 @@ describe("EventOccurrenceRepository", () => {
               principalId,
               calendarId,
               eventId: eventIn,
-              occurrenceKey: `${eventIn}:in`,
+              occurrenceKey: `${eventIn}:in` as OccurrenceKey,
               startAt: inLookbackStart,
               endAt: windowEnd,
               schedule: {
                 kind: "timed",
-                start: inLookbackStart.toISOString(),
-                end: windowEnd.toISOString(),
-                timeZone: "UTC",
+                start: inLookbackStart.toISOString() as DateTime,
+                end: windowEnd.toISOString() as DateTime,
+                timeZone: "UTC" as TimeZone,
               },
             }),
           ],
@@ -522,14 +574,14 @@ describe("EventOccurrenceRepository", () => {
               principalId,
               calendarId,
               eventId: eventOut,
-              occurrenceKey: `${eventOut}:out`,
+              occurrenceKey: `${eventOut}:out` as OccurrenceKey,
               startAt: outOfLookbackStart,
               endAt: windowEnd,
               schedule: {
                 kind: "timed",
-                start: outOfLookbackStart.toISOString(),
-                end: windowEnd.toISOString(),
-                timeZone: "UTC",
+                start: outOfLookbackStart.toISOString() as DateTime,
+                end: windowEnd.toISOString() as DateTime,
+                timeZone: "UTC" as TimeZone,
               },
             }),
           ],

--- a/packages/sync/src/storage/repositories/event.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/event.repository.db.test.ts
@@ -1,5 +1,19 @@
 import { faker } from "@faker-js/faker";
 import { type Db } from "mongodb";
+import {
+  type CalendarId,
+  type DateOnly,
+  type DateTime,
+  type EventId,
+  type TimeZone,
+} from "@core/types/domain-primitives";
+import { type ProviderEventVersion } from "@core/types/sync/event.contracts";
+import {
+  type ConnectionId,
+  type PrincipalId,
+  type ProviderEventId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { type EventRecord } from "@sync/storage/contracts/event.contracts";
 import {
@@ -11,9 +25,9 @@ const objectId = () => faker.database.mongodbObjectId();
 
 const timed = (start: string, end: string, timeZone = "America/Denver") => ({
   kind: "timed" as const,
-  start,
-  end,
-  timeZone,
+  start: start as DateTime,
+  end: end as DateTime,
+  timeZone: timeZone as TimeZone,
 });
 
 const baseContent = {
@@ -29,14 +43,14 @@ const linkedUpsert = (
   overrides: Partial<ProviderEventUpsert> = {},
 ): ProviderEventUpsert =>
   ({
-    tenantId: objectId(),
-    principalId: objectId(),
+    tenantId: objectId() as TenantId,
+    principalId: objectId() as PrincipalId,
     origin: "provider",
-    calendarId: objectId(),
+    calendarId: objectId() as CalendarId,
     clientEventId: null,
-    connectionId: objectId(),
-    providerEventId: "evt-1",
-    providerVersion: "etag-1",
+    connectionId: objectId() as ConnectionId,
+    providerEventId: "evt-1" as ProviderEventId,
+    providerVersion: "etag-1" as ProviderEventVersion,
     providerUpdatedAt: new Date("2026-07-20T12:00:00.000Z"),
     deliveryState: "confirmed",
     providerMetadata: null,
@@ -51,11 +65,11 @@ const linkedUpsert = (
 
 const compassRecord = (overrides: Partial<EventRecord> = {}): EventRecord =>
   ({
-    _id: objectId(),
-    tenantId: objectId(),
-    principalId: objectId(),
+    _id: objectId() as EventId,
+    tenantId: objectId() as TenantId,
+    principalId: objectId() as PrincipalId,
     origin: "compass",
-    calendarId: objectId(),
+    calendarId: objectId() as CalendarId,
     clientEventId: null,
     connectionId: null,
     providerEventId: null,
@@ -86,26 +100,32 @@ describe("EventRepository", () => {
 
   it("dedupes a linked event on provider identity across repeated reads", async () => {
     const identity = {
-      connectionId: objectId(),
-      calendarId: objectId(),
-      providerEventId: "evt-42",
+      connectionId: objectId() as ConnectionId,
+      calendarId: objectId() as CalendarId,
+      providerEventId: "evt-42" as ProviderEventId,
     };
     const first = await repo.upsertByProviderIdentity(
-      linkedUpsert({ ...identity, providerVersion: "etag-1" }),
+      linkedUpsert({
+        ...identity,
+        providerVersion: "etag-1" as ProviderEventVersion,
+      }),
     );
     const second = await repo.upsertByProviderIdentity(
-      linkedUpsert({ ...identity, providerVersion: "etag-2" }),
+      linkedUpsert({
+        ...identity,
+        providerVersion: "etag-2" as ProviderEventVersion,
+      }),
     );
     expect(second._id).toBe(first._id);
-    expect(second.providerVersion).toBe("etag-2");
+    expect(second.providerVersion).toBe("etag-2" as ProviderEventVersion);
     expect(await db.collection("events").countDocuments()).toBe(1);
   });
 
   it("preserves iCalUID atomically when a sparse upsert omits it", async () => {
     const identity = {
-      connectionId: objectId(),
-      calendarId: objectId(),
-      providerEventId: "evt-uid",
+      connectionId: objectId() as ConnectionId,
+      calendarId: objectId() as CalendarId,
+      providerEventId: "evt-uid" as ProviderEventId,
     };
     const first = await repo.upsertByProviderIdentity(
       linkedUpsert({
@@ -119,21 +139,21 @@ describe("EventRepository", () => {
     const second = await repo.upsertByProviderIdentity(
       linkedUpsert({
         ...identity,
-        providerVersion: "etag-2",
+        providerVersion: "etag-2" as ProviderEventVersion,
         providerMetadata: null,
       }),
       { preserveIcalUidWhenAbsent: true },
     );
     expect(second._id).toBe(first._id);
-    expect(second.providerVersion).toBe("etag-2");
+    expect(second.providerVersion).toBe("etag-2" as ProviderEventVersion);
     expect(second.providerMetadata).toEqual({ iCalUID: "kept@google.com" });
   });
 
   it("clears providerMetadata when preserve is off", async () => {
     const identity = {
-      connectionId: objectId(),
-      calendarId: objectId(),
-      providerEventId: "evt-clear",
+      connectionId: objectId() as ConnectionId,
+      calendarId: objectId() as CalendarId,
+      providerEventId: "evt-clear" as ProviderEventId,
     };
     await repo.upsertByProviderIdentity(
       linkedUpsert({
@@ -154,9 +174,9 @@ describe("EventRepository", () => {
   // See the PLANNER TRAP note in index-manifest.ts.
   it("provider-identity filter is served by the partial index, not a scan", async () => {
     const identity = {
-      connectionId: objectId(),
-      calendarId: objectId(),
-      providerEventId: "evt-plan",
+      connectionId: objectId() as ConnectionId,
+      calendarId: objectId() as CalendarId,
+      providerEventId: "evt-plan" as ProviderEventId,
     };
     await repo.upsertByProviderIdentity(linkedUpsert(identity));
 
@@ -174,7 +194,7 @@ describe("EventRepository", () => {
   });
 
   it("stores many unlinked Compass events (no provider identity collision)", async () => {
-    const principalId = objectId();
+    const principalId = objectId() as PrincipalId;
     await repo.put(compassRecord({ principalId }));
     await repo.put(compassRecord({ principalId }));
     expect(await db.collection("events").countDocuments()).toBe(2);
@@ -182,7 +202,11 @@ describe("EventRepository", () => {
 
   it("round-trips an all-day event", async () => {
     const record = compassRecord({
-      schedule: { kind: "allDay", start: "2026-07-14", end: "2026-07-15" },
+      schedule: {
+        kind: "allDay",
+        start: "2026-07-14" as DateOnly,
+        end: "2026-07-15" as DateOnly,
+      },
     });
     const saved = await repo.put(record);
     const read = await repo.findById(
@@ -192,8 +216,8 @@ describe("EventRepository", () => {
     );
     expect(read?.schedule).toEqual({
       kind: "allDay",
-      start: "2026-07-14",
-      end: "2026-07-15",
+      start: "2026-07-14" as DateOnly,
+      end: "2026-07-15" as DateOnly,
     });
   });
 
@@ -205,11 +229,11 @@ describe("EventRepository", () => {
       saved.principalId,
       saved._id,
     );
-    expect(read?.schedule).toEqual(dst);
+    expect<unknown>(read?.schedule).toEqual(dst);
   });
 
   it("round-trips a recurrence exception event", async () => {
-    const seriesId = objectId();
+    const seriesId = objectId() as EventId;
     const record = compassRecord({
       recurrence: {
         kind: "exception",
@@ -256,10 +280,10 @@ describe("EventRepository", () => {
       const mine = objectId() as EventRecord["principalId"];
       const theirs = objectId() as EventRecord["principalId"];
       const own = await repo.put(
-        compassRecord({ tenantId, principalId: mine }),
+        compassRecord({ tenantId, principalId: mine as PrincipalId }),
       );
       const foreign = await repo.put(
-        compassRecord({ tenantId, principalId: theirs }),
+        compassRecord({ tenantId, principalId: theirs as PrincipalId }),
       );
 
       const found = await repo.findByIds(tenantId, mine, [
@@ -330,9 +354,9 @@ describe("EventRepository", () => {
 
   it("leaves existing customizations untouched on upsertByProviderIdentity", async () => {
     const identity = {
-      connectionId: objectId(),
-      calendarId: objectId(),
-      providerEventId: "evt-custom",
+      connectionId: objectId() as ConnectionId,
+      calendarId: objectId() as CalendarId,
+      providerEventId: "evt-custom" as ProviderEventId,
     };
     const first = await repo.upsertByProviderIdentity(
       linkedUpsert({
@@ -345,7 +369,7 @@ describe("EventRepository", () => {
     const second = await repo.upsertByProviderIdentity(
       linkedUpsert({
         ...identity,
-        providerVersion: "etag-2",
+        providerVersion: "etag-2" as ProviderEventVersion,
         content: { ...baseContent, title: "Provider title" },
       }),
     );
@@ -355,9 +379,9 @@ describe("EventRepository", () => {
 
   it("preserves customizations on the iCalUID-preserving upsert path", async () => {
     const identity = {
-      connectionId: objectId(),
-      calendarId: objectId(),
-      providerEventId: "evt-custom-uid",
+      connectionId: objectId() as ConnectionId,
+      calendarId: objectId() as CalendarId,
+      providerEventId: "evt-custom-uid" as ProviderEventId,
     };
     const first = await repo.upsertByProviderIdentity(
       linkedUpsert({
@@ -372,7 +396,7 @@ describe("EventRepository", () => {
     const second = await repo.upsertByProviderIdentity(
       linkedUpsert({
         ...identity,
-        providerVersion: "etag-2",
+        providerVersion: "etag-2" as ProviderEventVersion,
         providerMetadata: null,
       }),
       { preserveIcalUidWhenAbsent: true },
@@ -402,9 +426,9 @@ describe("EventRepository", () => {
   });
 
   it("finds only the owner's exceptions of one series", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
-    const seriesId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const seriesId = objectId() as EventId;
     const exception = (
       recurrenceId: string,
       overrides: Partial<EventRecord> = {},
@@ -433,8 +457,8 @@ describe("EventRepository", () => {
         principalId,
         recurrence: {
           kind: "exception",
-          seriesId: objectId(),
-          recurrenceId: "2026-07-21T09:00:00-06:00",
+          seriesId: objectId() as EventId,
+          recurrenceId: "2026-07-21T09:00:00-06:00" as DateTime,
           cancelled: false,
         } as EventRecord["recurrence"],
       }),
@@ -452,7 +476,9 @@ describe("EventRepository", () => {
       }),
     );
     await repo.put(
-      exception("2026-07-21T09:00:00-06:00", { principalId: objectId() }),
+      exception("2026-07-21T09:00:00-06:00", {
+        principalId: objectId() as PrincipalId,
+      }),
     );
 
     const found = await repo.findSeriesExceptions(
@@ -517,13 +543,13 @@ describe("EventRepository", () => {
   // form of the same instant. Without converging on the provider-identity
   // document, the series-keyed insert collides the unique index.
   it("converges upsertException onto an imported provider-identity exception", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
-    const calendarId = objectId();
-    const connectionId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const calendarId = objectId() as CalendarId;
+    const connectionId = objectId() as ConnectionId;
     const offsetRecurrenceId = "2026-08-10T13:00:00-06:00" as never;
     const utcRecurrenceId = "2026-08-10T19:00:00.000Z" as never;
-    const providerEventId = "g-series_20260810T190000Z";
+    const providerEventId = "g-series_20260810T190000Z" as ProviderEventId;
 
     const master = await repo.put(
       compassRecord({
@@ -531,8 +557,8 @@ describe("EventRepository", () => {
         principalId,
         calendarId,
         connectionId,
-        providerEventId: "g-series",
-        providerVersion: "etag-master",
+        providerEventId: "g-series" as ProviderEventId,
+        providerVersion: "etag-master" as ProviderEventVersion,
         origin: "provider",
         recurrence: {
           kind: "seriesMaster",
@@ -548,7 +574,7 @@ describe("EventRepository", () => {
         calendarId,
         connectionId,
         providerEventId,
-        providerVersion: "etag-inst",
+        providerVersion: "etag-inst" as ProviderEventVersion,
         content: { ...baseContent, title: "Imported override" },
         schedule: timed(
           "2026-08-10T14:00:00-06:00",
@@ -584,7 +610,7 @@ describe("EventRepository", () => {
     expect(updated._id).toBe(imported._id);
     expect(updated.content.title).toBe("Command override");
     expect(updated.providerEventId).toBe(providerEventId);
-    expect(updated.providerVersion).toBe("etag-inst-2");
+    expect(updated.providerVersion).toBe("etag-inst-2" as ProviderEventVersion);
     if (updated.recurrence.kind === "exception") {
       expect(updated.recurrence.seriesId).toBe(master._id);
       expect(updated.recurrence.recurrenceId).toBe(utcRecurrenceId);
@@ -598,13 +624,13 @@ describe("EventRepository", () => {
   });
 
   it("drops a series-keyed duplicate when converging on provider identity", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
-    const calendarId = objectId();
-    const connectionId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const calendarId = objectId() as CalendarId;
+    const connectionId = objectId() as ConnectionId;
     const offsetRecurrenceId = "2026-08-15T14:00:00-06:00" as never;
     const utcRecurrenceId = "2026-08-15T20:00:00.000Z" as never;
-    const providerEventId = "g-series_20260815T200000Z";
+    const providerEventId = "g-series_20260815T200000Z" as ProviderEventId;
 
     const master = await repo.put(
       compassRecord({
@@ -612,8 +638,8 @@ describe("EventRepository", () => {
         principalId,
         calendarId,
         connectionId,
-        providerEventId: "g-series",
-        providerVersion: "etag-master",
+        providerEventId: "g-series" as ProviderEventId,
+        providerVersion: "etag-master" as ProviderEventVersion,
         origin: "provider",
         recurrence: {
           kind: "seriesMaster",
@@ -647,7 +673,7 @@ describe("EventRepository", () => {
         calendarId,
         connectionId,
         providerEventId,
-        providerVersion: "etag-inst",
+        providerVersion: "etag-inst" as ProviderEventVersion,
         content: { ...baseContent, title: "Still at provider" },
         schedule: timed(
           "2026-08-15T14:00:00-06:00",
@@ -700,12 +726,12 @@ describe("EventRepository", () => {
   // scope-"this" delete must be adopted by the provider-identity upsert,
   // not collide it.
   it("adopts a series-keyed tombstone when importing a provider exception", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
-    const calendarId = objectId();
-    const connectionId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const calendarId = objectId() as CalendarId;
+    const connectionId = objectId() as ConnectionId;
     const utcRecurrenceId = "2026-08-10T19:00:00.000Z" as never;
-    const providerEventId = "g-series_20260810T190000Z";
+    const providerEventId = "g-series_20260810T190000Z" as ProviderEventId;
 
     const master = await repo.put(
       compassRecord({
@@ -713,8 +739,8 @@ describe("EventRepository", () => {
         principalId,
         calendarId,
         connectionId,
-        providerEventId: "g-series",
-        providerVersion: "etag-master",
+        providerEventId: "g-series" as ProviderEventId,
+        providerVersion: "etag-master" as ProviderEventVersion,
         origin: "provider",
         recurrence: {
           kind: "seriesMaster",
@@ -746,7 +772,7 @@ describe("EventRepository", () => {
         calendarId,
         connectionId,
         providerEventId,
-        providerVersion: "etag-inst",
+        providerVersion: "etag-inst" as ProviderEventVersion,
         content: { ...baseContent, title: "Cancelled at provider" },
         schedule: timed(
           "2026-08-10T13:00:00-06:00",

--- a/packages/sync/src/storage/repositories/invalidation.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/invalidation.repository.db.test.ts
@@ -1,5 +1,9 @@
 import { faker } from "@faker-js/faker";
-import { type ConnectionId } from "@core/types/sync/identity.contracts";
+import {
+  type ConnectionId,
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import {
@@ -19,14 +23,14 @@ describe("InvalidationRepository", () => {
   });
 
   it("appends a content-free invalidation with TTL expiry", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const connectionId = objectId() as ConnectionId;
     const emittedAt = new Date("2026-07-24T12:00:00.000Z");
 
     const row = await repo.append({
-      tenantId,
-      principalId,
+      tenantId: tenantId,
+      principalId: principalId,
       invalidation: { kind: "connection", connectionId },
       emittedAt,
     });
@@ -47,8 +51,8 @@ describe("InvalidationRepository", () => {
   });
 
   it("appendMany writes every invalidation with the same emittedAt/TTL", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const connectionId = objectId() as ConnectionId;
     const eventId = objectId() as never;
     const calendarId = objectId() as never;
@@ -81,24 +85,28 @@ describe("InvalidationRepository", () => {
   });
 
   it("appendMany is a no-op for an empty list", async () => {
-    const rows = await repo.appendMany(objectId(), objectId(), []);
+    const rows = await repo.appendMany(
+      objectId() as TenantId,
+      objectId() as PrincipalId,
+      [],
+    );
     expect(rows).toEqual([]);
   });
 
   it("keyset-lists only the caller's rows after a cursor", async () => {
-    const tenantId = objectId();
-    const mine = objectId();
-    const other = objectId();
+    const tenantId = objectId() as TenantId;
+    const mine = objectId() as PrincipalId;
+    const other = objectId() as PrincipalId;
     const connectionId = objectId() as ConnectionId;
 
     const first = await repo.append({
-      tenantId,
+      tenantId: tenantId,
       principalId: mine,
       invalidation: { kind: "connection", connectionId },
       emittedAt: new Date(),
     });
     const second = await repo.append({
-      tenantId,
+      tenantId: tenantId,
       principalId: mine,
       invalidation: {
         kind: "event",
@@ -108,7 +116,7 @@ describe("InvalidationRepository", () => {
       emittedAt: new Date(),
     });
     await repo.append({
-      tenantId,
+      tenantId: tenantId,
       principalId: other,
       invalidation: { kind: "connection", connectionId },
       emittedAt: new Date(),
@@ -132,20 +140,20 @@ describe("InvalidationRepository", () => {
     it("keyset-lists rows across every tenant/principal after a cursor", async () => {
       const connectionId = objectId() as ConnectionId;
       const first = await repo.append({
-        tenantId: objectId(),
-        principalId: objectId(),
+        tenantId: objectId() as TenantId,
+        principalId: objectId() as PrincipalId,
         invalidation: { kind: "connection", connectionId },
         emittedAt: new Date(),
       });
       const second = await repo.append({
-        tenantId: objectId(),
-        principalId: objectId(),
+        tenantId: objectId() as TenantId,
+        principalId: objectId() as PrincipalId,
         invalidation: { kind: "connection", connectionId },
         emittedAt: new Date(),
       });
       const third = await repo.append({
-        tenantId: objectId(),
-        principalId: objectId(),
+        tenantId: objectId() as TenantId,
+        principalId: objectId() as PrincipalId,
         invalidation: { kind: "connection", connectionId },
         emittedAt: new Date(),
       });
@@ -165,8 +173,8 @@ describe("InvalidationRepository", () => {
       const connectionId = objectId() as ConnectionId;
       for (let i = 0; i < 3; i += 1) {
         await repo.append({
-          tenantId: objectId(),
-          principalId: objectId(),
+          tenantId: objectId() as TenantId,
+          principalId: objectId() as PrincipalId,
           invalidation: { kind: "connection", connectionId },
           emittedAt: new Date(),
         });
@@ -181,14 +189,14 @@ describe("InvalidationRepository", () => {
 
       const connectionId = objectId() as ConnectionId;
       await repo.append({
-        tenantId: objectId(),
-        principalId: objectId(),
+        tenantId: objectId() as TenantId,
+        principalId: objectId() as PrincipalId,
         invalidation: { kind: "connection", connectionId },
         emittedAt: new Date(),
       });
       const last = await repo.append({
-        tenantId: objectId(),
-        principalId: objectId(),
+        tenantId: objectId() as TenantId,
+        principalId: objectId() as PrincipalId,
         invalidation: { kind: "connection", connectionId },
         emittedAt: new Date(),
       });

--- a/packages/sync/src/storage/repositories/job.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/job.repository.db.test.ts
@@ -1,6 +1,12 @@
 import { faker } from "@faker-js/faker";
 import { type Db } from "mongodb";
-import { type SyncJobId } from "@core/types/sync/identity.contracts";
+import {
+  type ConnectionId,
+  type PrincipalId,
+  type SyncJobId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import { stringIdFilter } from "@sync/__tests__/helpers/mongo-id";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import {
   JOB_PRIORITY,
@@ -12,9 +18,9 @@ const objectId = () => faker.database.mongodbObjectId();
 
 const enqueue = (overrides: Partial<JobEnqueue> = {}): JobEnqueue =>
   ({
-    tenantId: objectId(),
-    principalId: objectId(),
-    connectionId: objectId(),
+    tenantId: objectId() as TenantId,
+    principalId: objectId() as PrincipalId,
+    connectionId: objectId() as ConnectionId,
     resourceId: null,
     commandId: null,
     kind: "incrementalPull",
@@ -184,8 +190,8 @@ describe("JobRepository", () => {
       const imports = await db
         .collection("jobs")
         .findOne({ coalescingKey: "import-due" });
-      expect(imports?.state).toBe("pending");
-      expect(imports?.leaseOwner).toBeNull();
+      expect(imports?.["state"]).toBe("pending");
+      expect(imports?.["leaseOwner"]).toBeNull();
     });
 
     it("excludeKinds returns null rather than claiming an excluded job when nothing else is due", async () => {
@@ -216,8 +222,8 @@ describe("JobRepository", () => {
       const stillClaimed = await db
         .collection("jobs")
         .findOne({ _id: created._id as never });
-      expect(stillClaimed?.state).toBe("claimed");
-      expect(stillClaimed?.leaseOwner).toBe("stalled-worker");
+      expect(stillClaimed?.["state"]).toBe("claimed");
+      expect(stillClaimed?.["leaseOwner"]).toBe("stalled-worker");
     });
 
     it("enqueueUrgent boosts a pending job without pushing back an earlier runAfter", async () => {
@@ -273,7 +279,7 @@ describe("JobRepository", () => {
       expect(await repo.fail(created._id, "owner")).toBe(true);
       await db
         .collection("jobs")
-        .updateOne({ _id: created._id }, { $set: { requeuedCount: 3 } });
+        .updateOne(stringIdFilter(created._id), { $set: { requeuedCount: 3 } });
 
       const { job, outcome } = await repo.enqueueUrgent(
         enqueue({
@@ -474,13 +480,13 @@ describe("JobRepository", () => {
       const peer = await db
         .collection("jobs")
         .findOne({ _id: staying!._id as never });
-      expect(peer?.state).toBe("claimed");
-      expect(peer?.leaseOwner).toBe("staying-worker");
+      expect(peer?.["state"]).toBe("claimed");
+      expect(peer?.["leaseOwner"]).toBe("staying-worker");
       const released = await db
         .collection("jobs")
         .findOne({ _id: leaving!._id as never });
-      expect(released?.state).toBe("pending");
-      expect(released?.leaseOwner).toBeNull();
+      expect(released?.["state"]).toBe("pending");
+      expect(released?.["leaseOwner"]).toBeNull();
     });
   });
 
@@ -670,12 +676,12 @@ describe("JobRepository", () => {
       expect(await repo.requeue(id, NOW)).toBe(true);
 
       const after = await db.collection("jobs").findOne({ _id: id as never });
-      expect(after?.state).toBe("pending");
-      expect(after?.attempt).toBe(0);
-      expect(after?.leaseOwner).toBeNull();
-      expect(after?.failureClass).toBeNull();
-      expect(after?.runAfter).toEqual(NOW);
-      expect(after?.requeuedCount).toBe(1);
+      expect(after?.["state"]).toBe("pending");
+      expect(after?.["attempt"]).toBe(0);
+      expect(after?.["leaseOwner"]).toBeNull();
+      expect(after?.["failureClass"]).toBeNull();
+      expect(after?.["runAfter"]).toEqual(NOW);
+      expect(after?.["requeuedCount"]).toBe(1);
     });
 
     it("does not requeue a job that is not currently failed", async () => {
@@ -857,12 +863,12 @@ describe("JobRepository", () => {
       expect(winning).not.toContain("COLLSCAN");
       // With runAfter leading after state, future backoff rows are not examined.
       expect(
-        plan.executionStats?.totalKeysExamined ?? Infinity,
+        plan["executionStats"]?.totalKeysExamined ?? Infinity,
       ).toBeLessThanOrEqual(1);
     });
 
     it("connection overdue filter is served by connection_runafter", async () => {
-      const connectionId = objectId();
+      const connectionId = objectId() as ConnectionId;
       await repo.enqueue(
         enqueue({
           connectionId: connectionId as JobEnqueue["connectionId"],

--- a/packages/sync/src/storage/repositories/provider-calendar.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/provider-calendar.repository.db.test.ts
@@ -1,5 +1,11 @@
 import { faker } from "@faker-js/faker";
 import { type Db } from "mongodb";
+import {
+  type ConnectionId,
+  type PrincipalId,
+  type ProviderCalendarSourceId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { type ProviderCalendarUpsert } from "@sync/storage/contracts/provider-calendar.contracts";
 import { ProviderCalendarRepository } from "@sync/storage/repositories/provider-calendar.repository";
@@ -10,10 +16,10 @@ const baseUpsert = (
   overrides: Partial<ProviderCalendarUpsert> = {},
 ): ProviderCalendarUpsert =>
   ({
-    tenantId: objectId(),
-    principalId: objectId(),
-    connectionId: objectId(),
-    providerCalendarId: "primary",
+    tenantId: objectId() as TenantId,
+    principalId: objectId() as PrincipalId,
+    connectionId: objectId() as ConnectionId,
+    providerCalendarId: "primary" as ProviderCalendarSourceId,
     displayName: "Personal",
     color: "#9fe1e7",
     active: true,
@@ -45,7 +51,7 @@ describe("ProviderCalendarRepository", () => {
   });
 
   it("keeps the Sync id stable when the calendar is renamed", async () => {
-    const connectionId = objectId();
+    const connectionId = objectId() as ConnectionId;
     const first = await repo.upsertByProviderCalendar(
       baseUpsert({ connectionId, displayName: "Personal" }),
     );
@@ -57,15 +63,15 @@ describe("ProviderCalendarRepository", () => {
   });
 
   it("stores multiple calendars for one connection", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
-    const connectionId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
+    const connectionId = objectId() as ConnectionId;
     await repo.upsertByProviderCalendar(
       baseUpsert({
         tenantId,
         principalId,
         connectionId,
-        providerCalendarId: "primary",
+        providerCalendarId: "primary" as ProviderCalendarSourceId,
       }),
     );
     await repo.upsertByProviderCalendar(
@@ -73,7 +79,7 @@ describe("ProviderCalendarRepository", () => {
         tenantId,
         principalId,
         connectionId,
-        providerCalendarId: "work@group",
+        providerCalendarId: "work@group" as ProviderCalendarSourceId,
       }),
     );
     const all = await repo.listByConnection(
@@ -85,7 +91,7 @@ describe("ProviderCalendarRepository", () => {
   });
 
   it("updates provider facts and capabilities on re-discovery", async () => {
-    const connectionId = objectId();
+    const connectionId = objectId() as ConnectionId;
     await repo.upsertByProviderCalendar(
       baseUpsert({ connectionId, active: true, accessRole: "owner" }),
     );
@@ -108,7 +114,7 @@ describe("ProviderCalendarRepository", () => {
   });
 
   it("updates createsGoogleMeet on re-discovery", async () => {
-    const connectionId = objectId();
+    const connectionId = objectId() as ConnectionId;
     await repo.upsertByProviderCalendar(
       baseUpsert({ connectionId, createsGoogleMeet: true }),
     );
@@ -119,10 +125,10 @@ describe("ProviderCalendarRepository", () => {
   });
 
   it("does not leak calendars across principals", async () => {
-    const tenantId = objectId();
-    const connectionId = objectId();
-    const mine = objectId();
-    const theirs = objectId();
+    const tenantId = objectId() as TenantId;
+    const connectionId = objectId() as ConnectionId;
+    const mine = objectId() as PrincipalId;
+    const theirs = objectId() as PrincipalId;
     await repo.upsertByProviderCalendar(
       baseUpsert({ tenantId, principalId: mine, connectionId }),
     );
@@ -132,7 +138,7 @@ describe("ProviderCalendarRepository", () => {
   });
 
   it("persists and updates the calendar's custom event-color labels", async () => {
-    const connectionId = objectId();
+    const connectionId = objectId() as ConnectionId;
     const created = await repo.upsertByProviderCalendar(
       baseUpsert({
         connectionId,
@@ -154,9 +160,9 @@ describe("ProviderCalendarRepository", () => {
 
   it("rejects a duplicate (connection, provider-calendar) identity", async () => {
     const shared = {
-      tenantId: objectId(),
-      principalId: objectId(),
-      connectionId: objectId(),
+      tenantId: objectId() as TenantId,
+      principalId: objectId() as PrincipalId,
+      connectionId: objectId() as ConnectionId,
       providerCalendarId: "primary",
     };
     const collection = db.collection("provider_calendars");

--- a/packages/sync/src/storage/repositories/provider-connection.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/provider-connection.repository.db.test.ts
@@ -1,5 +1,10 @@
 import { faker } from "@faker-js/faker";
 import { type Db } from "mongodb";
+import {
+  type PrincipalId,
+  type ProviderAccountId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { deriveDiagnosticKey } from "@sync/safety/diagnostic-key";
 import { type ProviderConnectionUpsert } from "@sync/storage/contracts/provider-connection.contracts";
@@ -11,11 +16,11 @@ const baseUpsert = (
   overrides: Partial<ProviderConnectionUpsert> = {},
 ): ProviderConnectionUpsert =>
   ({
-    tenantId: objectId(),
-    principalId: objectId(),
+    tenantId: objectId() as TenantId,
+    principalId: objectId() as PrincipalId,
     provider: "google",
     account: {
-      providerAccountId: "acct-1",
+      providerAccountId: "acct-1" as ProviderAccountId,
       email: "user@gmail.com",
       displayName: "User",
     },
@@ -75,8 +80,8 @@ describe("ProviderConnectionRepository", () => {
   });
 
   it("reconnecting the same account updates one document, not two", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const first = await repo.upsertByProviderAccount(
       baseUpsert({ tenantId, principalId }),
     );
@@ -92,14 +97,14 @@ describe("ProviderConnectionRepository", () => {
   });
 
   it("keeps multiple accounts for one principal isolated", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     await repo.upsertByProviderAccount(
       baseUpsert({
         tenantId,
         principalId,
         account: {
-          providerAccountId: "acct-1",
+          providerAccountId: "acct-1" as ProviderAccountId,
           email: "a@x.com",
           displayName: null,
         },
@@ -110,7 +115,7 @@ describe("ProviderConnectionRepository", () => {
         tenantId,
         principalId,
         account: {
-          providerAccountId: "acct-2",
+          providerAccountId: "acct-2" as ProviderAccountId,
           email: "b@x.com",
           displayName: null,
         },
@@ -121,8 +126,8 @@ describe("ProviderConnectionRepository", () => {
   });
 
   it("updates capabilities on reconnect", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     await repo.upsertByProviderAccount(
       baseUpsert({ tenantId, principalId, capabilities: ["readEvents"] }),
     );
@@ -141,8 +146,8 @@ describe("ProviderConnectionRepository", () => {
   });
 
   it("keeps prior lastHealthyAt when the same account reconnects", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     const created = await repo.upsertByProviderAccount(
       baseUpsert({ tenantId, principalId }),
     );
@@ -171,9 +176,9 @@ describe("ProviderConnectionRepository", () => {
   });
 
   it("does not leak one principal's connections to another", async () => {
-    const tenantId = objectId();
-    const mine = objectId();
-    const theirs = objectId();
+    const tenantId = objectId() as TenantId;
+    const mine = objectId() as PrincipalId;
+    const theirs = objectId() as PrincipalId;
     const created = await repo.upsertByProviderAccount(
       baseUpsert({ tenantId, principalId: mine }),
     );
@@ -184,8 +189,8 @@ describe("ProviderConnectionRepository", () => {
   });
 
   it("rejects an actionRequired upsert with no reason before any write lands", async () => {
-    const tenantId = objectId();
-    const principalId = objectId();
+    const tenantId = objectId() as TenantId;
+    const principalId = objectId() as PrincipalId;
     await expect(
       repo.upsertByProviderAccount(
         baseUpsert({
@@ -202,10 +207,14 @@ describe("ProviderConnectionRepository", () => {
 
   it("rejects a raw duplicate insert violating the unique account identity", async () => {
     const shared = {
-      tenantId: objectId(),
-      principalId: objectId(),
+      tenantId: objectId() as TenantId,
+      principalId: objectId() as PrincipalId,
       provider: "google",
-      account: { providerAccountId: "dup", email: null, displayName: null },
+      account: {
+        providerAccountId: "dup" as ProviderAccountId,
+        email: null,
+        displayName: null,
+      },
     };
     const collection = db.collection("provider_connections");
     await collection.insertOne({ _id: objectId(), ...shared } as never);

--- a/packages/sync/src/storage/repositories/sync-resource.repository.db.test.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.db.test.ts
@@ -1,5 +1,11 @@
 import { faker } from "@faker-js/faker";
 import { type Db } from "mongodb";
+import { type CalendarId } from "@core/types/domain-primitives";
+import {
+  type ConnectionId,
+  type PrincipalId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
 import { seedOauthCredential } from "@sync/__tests__/helpers/credential-encryption";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
@@ -13,11 +19,11 @@ const upsert = (
   overrides: Partial<SyncResourceUpsert> = {},
 ): SyncResourceUpsert =>
   ({
-    tenantId: objectId(),
-    principalId: objectId(),
-    connectionId: objectId(),
+    tenantId: objectId() as TenantId,
+    principalId: objectId() as PrincipalId,
+    connectionId: objectId() as ConnectionId,
     resourceKind: "events",
-    calendarId: objectId(),
+    calendarId: objectId() as CalendarId,
     ...overrides,
   }) as SyncResourceUpsert;
 
@@ -96,9 +102,9 @@ describe("SyncResourceRepository", () => {
 
   it("ensures one resource per (connection, kind, calendar)", async () => {
     const key = {
-      connectionId: objectId(),
+      connectionId: objectId() as ConnectionId,
       resourceKind: "events" as const,
-      calendarId: objectId(),
+      calendarId: objectId() as CalendarId,
     };
     const first = await repo.ensure(upsert(key));
     const second = await repo.ensure(upsert(key));
@@ -108,7 +114,7 @@ describe("SyncResourceRepository", () => {
 
   it("ensures one calendar-list resource per connection", async () => {
     const key = {
-      connectionId: objectId(),
+      connectionId: objectId() as ConnectionId,
       resourceKind: "calendarList" as const,
       calendarId: null,
     };
@@ -153,12 +159,16 @@ describe("SyncResourceRepository", () => {
   });
 
   it("keeps the calendar-list resource distinct from event resources", async () => {
-    const connectionId = objectId();
+    const connectionId = objectId() as ConnectionId;
     await repo.ensure(
       upsert({ connectionId, resourceKind: "calendarList", calendarId: null }),
     );
     await repo.ensure(
-      upsert({ connectionId, resourceKind: "events", calendarId: objectId() }),
+      upsert({
+        connectionId,
+        resourceKind: "events",
+        calendarId: objectId() as CalendarId,
+      }),
     );
     expect(await db.collection("sync_resources").countDocuments()).toBe(2);
   });

--- a/packages/sync/src/telemetry/health-snapshot.service.db.test.ts
+++ b/packages/sync/src/telemetry/health-snapshot.service.db.test.ts
@@ -2,9 +2,11 @@ import { faker } from "@faker-js/faker";
 import { NodeEnv } from "@core/constants/core.constants";
 import { POSTHOG_ERROR_TRACKING_PROPERTY } from "@core/constants/posthog-error-tracking.properties";
 import { type PostHogCaptureClient } from "@core/logger/posthog-capture";
+import { type DateTime } from "@core/types/domain-primitives";
 import {
   type ConnectionId,
   type PrincipalId,
+  type ProviderAccountId,
   type ProviderCapability,
   type ProviderKind,
   type TenantId,
@@ -106,7 +108,7 @@ describe("computeHealthSnapshot", () => {
       principalId: objectId() as PrincipalId,
       provider,
       account: {
-        providerAccountId: objectId(),
+        providerAccountId: objectId() as ProviderAccountId,
         email: "h@example.com",
         displayName: null,
       },
@@ -215,7 +217,7 @@ describe("computeHealthSnapshot", () => {
     expect(google?.freshness.sampleSize).toBe(2);
     expect(google?.freshness.p50Ms).toBeGreaterThan(0);
     expect(google?.freshness.percentOver30s).toBeGreaterThan(0);
-    expect(google?.computedAt).toBe(NOW.toISOString());
+    expect(google?.computedAt).toBe(NOW.toISOString() as DateTime);
 
     expect(microsoft?.connections.healthy).toBe(1);
     expect(microsoft?.jobs.pending).toBe(0);


### PR DESCRIPTION
Part of #3331.\n\n## What and why\n\nFinishes making sync node-test fixtures satisfy production contracts. This follows #3643 because it uses its test helpers.\n\n## Verify\n\n`bun run test:sync` passed.