### PR TITLE
fix(sync): force microsoft consent so reconnect returns a refresh token

### DIFF
--- a/packages/sync/src/providers/microsoft/microsoft-auth.adapter.test.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-auth.adapter.test.ts
@@ -159,7 +159,7 @@ describe("MicrosoftAuthAdapter", () => {
       expect(url.searchParams.get("redirect_uri")).toBe(
         "https://staging.example.com/sync/microsoft",
       );
-      expect(url.searchParams.get("prompt")).toBeNull();
+      expect(url.searchParams.get("prompt")).toBe("consent");
       expect(url.searchParams.get("scope")?.split(" ")).toEqual([
         ...MICROSOFT_SCOPES,
       ]);
@@ -179,7 +179,10 @@ describe("MicrosoftAuthAdapter", () => {
         }),
       );
 
-      expect(url.searchParams.get("prompt")).toBe("select_account");
+      // Without select_account, a browser signed into one Microsoft account
+      // re-authorizes that same account and the user never gets to pick.
+      // consent must stay so the exchange still returns a refresh token.
+      expect(url.searchParams.get("prompt")).toBe("select_account consent");
     });
 
     it("passes login_hint on reconnect so the same account is pre-selected", () => {
@@ -197,7 +200,7 @@ describe("MicrosoftAuthAdapter", () => {
       );
 
       expect(url.searchParams.get("login_hint")).toBe("ada@contoso.com");
-      expect(url.searchParams.get("prompt")).toBeNull();
+      expect(url.searchParams.get("prompt")).toBe("consent");
     });
 
     it("appends optional feature scopes after the base scopes", () => {

--- a/packages/sync/src/providers/microsoft/microsoft-auth.adapter.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-auth.adapter.ts
@@ -105,9 +105,15 @@ export class MicrosoftAuthAdapter implements ProviderAuthAdapter {
     );
     url.searchParams.set("state", input.state);
     url.searchParams.set("redirect_uri", input.redirectUri);
-    if (input.selectAccount) {
-      url.searchParams.set("prompt", "select_account");
-    }
+    // offline_access + consent guarantees a refresh token even on
+    // re-authorization, which Microsoft otherwise omits after the first
+    // consent. select_account additionally forces the chooser, so adding an
+    // account cannot silently re-authorize the one already connected.
+    // Microsoft takes prompt as a space-delimited list, same as Google.
+    url.searchParams.set(
+      "prompt",
+      input.selectAccount ? "select_account consent" : "consent",
+    );
     if (input.loginHint) {
       url.searchParams.set("login_hint", input.loginHint);
     }

--- a/packages/sync/src/providers/provider-auth.port.ts
+++ b/packages/sync/src/providers/provider-auth.port.ts
@@ -43,6 +43,8 @@ export interface ProviderAuthAdapter {
     // Hint the provider to pre-select this account on reconnect. Without it
     // a signed-in browser session can consent as a different account, and
     // Compass refuses the grant rather than silently creating a second row.
+    // Adapters must still force consent so the exchange returns a refresh
+    // token; login_hint alone lets Microsoft skip re-consent and omit it.
     readonly loginHint?: string;
     // Optional feature scopes to request ON TOP of the adapter's base scopes
     // (e.g. the contacts scopes behind attendee suggestions). Absent or empty


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #3640. Staging showed Microsoft reconnect completing OAuth, then landing on `?provider=microsoft&status=error` with the reconnect banner still up. PostHog recorded repeated `signup_failed` `connect_error` events on `/week?provider=microsoft&status=error` (five times in a few minutes after G / Reconnect). The same session's Google reconnect returned `status=connected`. An earlier first-time Microsoft grant on staging had succeeded (`calendar_connected` at 19:52).

#3640 pinned reconnect with `login_hint` but Microsoft still omitted `prompt=consent`. After the first grant, Microsoft can finish login without issuing a new refresh token. Compass then fails the code exchange and the banner stays. Google already requests `consent` (and `select_account consent` when adding an account) for this reason. Microsoft now matches that.

## Verify

VERDICT: PASS

Checks run: test:sync:fast, type-check, lint, knip
Checks skipped: (none)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1230d159-24e3-46f2-8666-0df86c186e59?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1230d159-24e3-46f2-8666-0df86c186e59&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

