### PR TITLE
chore(test): type check node tests

### DIFF
--- a/docs/development/testing-playbook.md
+++ b/docs/development/testing-playbook.md
@@ -60,9 +60,8 @@ Unit workflow (`test-unit.yml`):
   even when an earlier one fails, so one run reports every class of error.
   Every constraint hit prints how to fix it and which allowlist documents
   exceptions.
-- `bun run type-check:tests` type-checks the core/backend/sync/scripts test
-  files (`tsconfig.tests.json`). It is informational until the backlog it
-  exposed is cleared; run it on the test files you touch.
+- `bun run type-check` includes core/backend/sync/scripts tests via
+  `tsconfig.tests.json` referenced from `tsconfig.typecheck.json`.
 
 Local parity commands:
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "test:scripts:fast": "bun packages/scripts/src/testing/test-parallel.ts scripts-fast -- --path-ignore-patterns '**/*.db.test.ts'",
     "test:scripts:db": "bun packages/scripts/src/testing/test-mongo-env.ts scripts -- './packages/scripts/src/**/*.db.test.ts'",
     "type-check": "bunx typescript@7.0.2 -b tsconfig.typecheck.json --noEmit",
-    "type-check:tests": "bunx typescript@7.0.2 -p tsconfig.tests.json --noEmit",
     "verify": "bun packages/scripts/src/testing/verify.ts",
     "build:backend": "bun packages/scripts/src/commands/build.backend.ts",
     "build:sync": "bun packages/scripts/src/commands/build.sync.ts",

--- a/packages/core/src/types/event-visibility.contracts.test.ts
+++ b/packages/core/src/types/event-visibility.contracts.test.ts
@@ -1,9 +1,8 @@
+import { type EventId, EventIdSchema } from "@core/types/domain-primitives";
 import {
   HiddenEventIdsResponseSchema,
   SetEventHiddenInputSchema,
 } from "@core/types/event-visibility.contracts";
-import { EventIdSchema } from "@core/types/domain-primitives";
-import type { EventId } from "@core/types/domain-primitives";
 import { describe, expect, it } from "bun:test";
 
 const eventId = (value: string) => EventIdSchema.parse(value);
@@ -45,7 +44,9 @@ describe("HiddenEventIdsResponseSchema", () => {
 
   it("rejects an empty eventId", () => {
     expect(
-      HiddenEventIdsResponseSchema.safeParse({ hiddenEventIds: ["" as EventId] }).success,
+      HiddenEventIdsResponseSchema.safeParse({
+        hiddenEventIds: ["" as EventId],
+      }).success,
     ).toBe(false);
   });
 });

--- a/packages/core/src/types/event-visibility.contracts.test.ts
+++ b/packages/core/src/types/event-visibility.contracts.test.ts
@@ -2,15 +2,21 @@ import {
   HiddenEventIdsResponseSchema,
   SetEventHiddenInputSchema,
 } from "@core/types/event-visibility.contracts";
+import { EventIdSchema } from "@core/types/domain-primitives";
+import type { EventId } from "@core/types/domain-primitives";
 import { describe, expect, it } from "bun:test";
+
+const eventId = (value: string) => EventIdSchema.parse(value);
 
 describe("HiddenEventIdsResponseSchema", () => {
   it("parses a valid response", () => {
     const parsed = HiddenEventIdsResponseSchema.parse({
-      hiddenEventIds: ["evt-1", "evt-2"],
+      hiddenEventIds: [eventId("evt-1"), eventId("evt-2")],
     });
 
-    expect(parsed).toEqual({ hiddenEventIds: ["evt-1", "evt-2"] });
+    expect(parsed).toEqual({
+      hiddenEventIds: [eventId("evt-1"), eventId("evt-2")],
+    });
   });
 
   it("accepts an empty list", () => {
@@ -20,7 +26,7 @@ describe("HiddenEventIdsResponseSchema", () => {
   });
 
   it("accepts a composed occurrence id", () => {
-    const occurrenceId = "evt-1::2026-07-14T15:00:00.000Z";
+    const occurrenceId = eventId("evt-1::2026-07-14T15:00:00.000Z");
     const parsed = HiddenEventIdsResponseSchema.parse({
       hiddenEventIds: [occurrenceId],
     });
@@ -31,7 +37,7 @@ describe("HiddenEventIdsResponseSchema", () => {
   it("rejects an extra key", () => {
     expect(
       HiddenEventIdsResponseSchema.safeParse({
-        hiddenEventIds: ["evt-1"],
+        hiddenEventIds: [eventId("evt-1")],
         extra: true,
       }).success,
     ).toBe(false);
@@ -39,7 +45,7 @@ describe("HiddenEventIdsResponseSchema", () => {
 
   it("rejects an empty eventId", () => {
     expect(
-      HiddenEventIdsResponseSchema.safeParse({ hiddenEventIds: [""] }).success,
+      HiddenEventIdsResponseSchema.safeParse({ hiddenEventIds: ["" as EventId] }).success,
     ).toBe(false);
   });
 });
@@ -47,15 +53,15 @@ describe("HiddenEventIdsResponseSchema", () => {
 describe("SetEventHiddenInputSchema", () => {
   it("parses a valid input", () => {
     const parsed = SetEventHiddenInputSchema.parse({
-      eventId: "evt-1",
+      eventId: eventId("evt-1"),
       hidden: true,
     });
 
-    expect(parsed).toEqual({ eventId: "evt-1", hidden: true });
+    expect(parsed).toEqual({ eventId: eventId("evt-1"), hidden: true });
   });
 
   it("accepts a composed occurrence id", () => {
-    const occurrenceId = "evt-1::2026-07-14T15:00:00.000Z";
+    const occurrenceId = eventId("evt-1::2026-07-14T15:00:00.000Z");
     const parsed = SetEventHiddenInputSchema.parse({
       eventId: occurrenceId,
       hidden: false,
@@ -67,7 +73,7 @@ describe("SetEventHiddenInputSchema", () => {
   it("rejects an extra key", () => {
     expect(
       SetEventHiddenInputSchema.safeParse({
-        eventId: "evt-1",
+        eventId: eventId("evt-1"),
         hidden: true,
         extra: true,
       }).success,
@@ -77,7 +83,7 @@ describe("SetEventHiddenInputSchema", () => {
   it("rejects an empty eventId", () => {
     expect(
       SetEventHiddenInputSchema.safeParse({
-        eventId: "",
+        eventId: "" as EventId,
         hidden: true,
       }).success,
     ).toBe(false);

--- a/packages/scripts/src/commands/audit-connection-identity/audit.db.test.ts
+++ b/packages/scripts/src/commands/audit-connection-identity/audit.db.test.ts
@@ -1,6 +1,11 @@
 import { auditConnectionIdentity } from "@scripts/commands/audit-connection-identity/audit";
 import { ObjectId } from "mongodb";
 import {
+  type PrincipalId,
+  type ProviderAccountId,
+  type TenantId,
+} from "@core/types/sync/identity.contracts";
+import {
   cleanupCollections,
   cleanupTestDb,
   setupTestDb,
@@ -69,10 +74,14 @@ describe("auditConnectionIdentity provider filter (db)", () => {
   ) => {
     connections = new ProviderConnectionRepository(syncStorage.db());
     return connections.upsertByProviderAccount({
-      tenantId: principalId,
-      principalId,
+      tenantId: principalId as TenantId,
+      principalId: principalId as PrincipalId,
       provider,
-      account: { providerAccountId, email, displayName: null },
+      account: {
+        providerAccountId: providerAccountId as ProviderAccountId,
+        email,
+        displayName: null,
+      },
       capabilities: ["readEvents", "readBusy", "writeEvents"],
       state: "healthy",
       stateReason: null,

--- a/packages/scripts/src/commands/encrypt-credentials.db.test.ts
+++ b/packages/scripts/src/commands/encrypt-credentials.db.test.ts
@@ -1,10 +1,13 @@
 import { encryptCredentials } from "@scripts/commands/encrypt-credentials/backfill";
+import { type Document, ObjectId } from "mongodb";
 import { decryptCredentialAtRest } from "@core/security/credential-at-rest";
 import { type ConnectionId } from "@core/types/sync/identity.contracts";
 import { setupSyncStorage } from "@sync/__tests__/helpers/storage";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";
 import { describe, expect, it } from "bun:test";
 import { randomBytes } from "node:crypto";
+
+const objectId = () => new ObjectId().toHexString();
 
 const KEY = randomBytes(32).toString("base64");
 const NOW = new Date("2026-09-04T12:00:00.000Z");
@@ -13,22 +16,31 @@ describe("encrypt-credentials (db)", () => {
   const storage = setupSyncStorage(import.meta.url);
 
   it("dry-run reports matches without writing", async () => {
-    const connectionId = "conn-1" as ConnectionId;
-    await storage.db().collection(SYNC_COLLECTIONS.credentials).insertOne({
-      _id: connectionId,
-      credentialKind: "oauthRefresh",
-      provider: "google",
-      refreshToken: "legacy-token",
-      accessToken: null,
-      accessTokenExpiresAt: null,
-      refreshFailureCount: 0,
-      scopes: [],
-      createdAt: NOW,
-      updatedAt: NOW,
-    });
+    const connectionId = objectId() as ConnectionId;
+    await storage
+      .db()
+      .collection<Document & { _id: ConnectionId }>(
+        SYNC_COLLECTIONS.credentials,
+      )
+      .insertOne({
+        _id: connectionId,
+        credentialKind: "oauthRefresh",
+        provider: "google",
+        refreshToken: "legacy-token",
+        accessToken: null,
+        accessTokenExpiresAt: null,
+        refreshFailureCount: 0,
+        scopes: [],
+        createdAt: NOW,
+        updatedAt: NOW,
+      });
 
     const report = await encryptCredentials(
-      storage.db().collection(SYNC_COLLECTIONS.credentials),
+      storage
+        .db()
+        .collection<Document & { _id: ConnectionId }>(
+          SYNC_COLLECTIONS.credentials,
+        ),
       { dryRun: true, batchSize: 50, encryptionKey: KEY, now: NOW },
     );
 
@@ -36,16 +48,22 @@ describe("encrypt-credentials (db)", () => {
     expect(report.modified).toBe(0);
     const raw = await storage
       .db()
-      .collection(SYNC_COLLECTIONS.credentials)
+      .collection<Document & { _id: ConnectionId }>(
+        SYNC_COLLECTIONS.credentials,
+      )
       .findOne({ _id: connectionId });
-    expect(raw?.refreshToken).toBe("legacy-token");
+    expect(raw?.["refreshToken"]).toBe("legacy-token");
     expect(raw).not.toHaveProperty("refreshTokenCiphertext");
   });
 
   it("encrypts plaintext rows and is idempotent and resumable", async () => {
-    const firstId = "conn-a" as ConnectionId;
-    const secondId = "conn-b" as ConnectionId;
-    const collection = storage.db().collection(SYNC_COLLECTIONS.credentials);
+    const firstId = objectId() as ConnectionId;
+    const secondId = objectId() as ConnectionId;
+    const collection = storage
+      .db()
+      .collection<Document & { _id: ConnectionId }>(
+        SYNC_COLLECTIONS.credentials,
+      );
     await collection.insertMany([
       {
         _id: firstId,
@@ -96,15 +114,17 @@ describe("encrypt-credentials (db)", () => {
       [firstId, "token-a"],
       [secondId, "token-b"],
     ] as const) {
-      const raw = await collection.findOne({ _id: connectionId });
+      const raw = await collection.findOne({
+        _id: connectionId,
+      });
       expect(raw).not.toHaveProperty("refreshToken");
-      expect(raw?.refreshTokenCiphertext).toBeString();
+      expect(raw?.["refreshTokenCiphertext"]).toBeString();
       expect(
         decryptCredentialAtRest(KEY, {
-          ciphertext: String(raw?.refreshTokenCiphertext),
-          iv: String(raw?.refreshTokenIv),
-          tag: String(raw?.refreshTokenTag),
-          keyVersion: Number(raw?.keyVersion),
+          ciphertext: String(raw?.["refreshTokenCiphertext"]),
+          iv: String(raw?.["refreshTokenIv"]),
+          tag: String(raw?.["refreshTokenTag"]),
+          keyVersion: Number(raw?.["keyVersion"]),
         }),
       ).toBe(plaintext);
       expect(JSON.stringify(raw)).not.toContain(plaintext);

--- a/packages/scripts/src/commands/encrypt-credentials/backfill.ts
+++ b/packages/scripts/src/commands/encrypt-credentials/backfill.ts
@@ -15,7 +15,7 @@ type PlaintextOauthCredentialRow = {
 };
 
 export async function encryptCredentials(
-  credentials: Collection<Document>,
+  credentials: Collection<Document & { _id: ConnectionId }>,
   options: {
     dryRun: boolean;
     batchSize: number;

--- a/packages/scripts/src/commands/purge-user.db.test.ts
+++ b/packages/scripts/src/commands/purge-user.db.test.ts
@@ -59,7 +59,7 @@ describe("purge-user (db)", () => {
       .db()
       .collection(SYNC_COLLECTIONS.jobs)
       .insertOne({
-        _id: new ObjectId().toString(),
+        _id: new ObjectId(),
         tenantId: userId.toString(),
         principalId: userId.toString(),
         // The jobs collection carries a unique index on coalescingKey, so a

--- a/packages/scripts/src/testing/agent-loop-launch.test.ts
+++ b/packages/scripts/src/testing/agent-loop-launch.test.ts
@@ -75,7 +75,7 @@ printf '%s' "$AGENT_LOOP_TEST_STATUS"
         CURSOR_API_KEY: "test-key",
         GITHUB_OUTPUT: output,
         GITHUB_REPOSITORY: "example/compass",
-        PATH: `${bin}:${process.env.PATH}`,
+        PATH: `${bin}:${process.env["PATH"]}`,
       },
     },
   );
@@ -119,7 +119,7 @@ exit 1
       AGENT_LOOP_MILESTONES: "Compass Booking v1",
       GITHUB_OUTPUT: output,
       GITHUB_REPOSITORY: "example/compass",
-      PATH: `${bin}:${process.env.PATH}`,
+      PATH: `${bin}:${process.env["PATH"]}`,
     },
   });
 
@@ -177,7 +177,7 @@ printf '%s\\n' "$*" >> "$AGENT_LOOP_TEST_LOG"
           AGENT_LOOP_TEST_LOG: log,
           GITHUB_OUTPUT: output,
           GITHUB_REPOSITORY: "example/compass",
-          PATH: `${bin}:${process.env.PATH}`,
+          PATH: `${bin}:${process.env["PATH"]}`,
           CURSOR_API_KEY: "",
         },
       },

--- a/packages/scripts/src/testing/check-agent-constraints.test.ts
+++ b/packages/scripts/src/testing/check-agent-constraints.test.ts
@@ -149,7 +149,7 @@ describe("formatHit", () => {
     });
     expect(text).toContain("self-host/Dockerfile.backend:1 bun-pin");
     expect(text).toContain("oven/bun:1.2.18 but CI pins 1.3.14");
-    expect(text).toContain(RULE_HELP["bun-pin"]);
+    expect(text).toContain(RULE_HELP["bun-pin"]!);
   });
 
   it("documents every rule the scanner can emit", () => {

--- a/packages/scripts/src/testing/detect-code-changes.test.ts
+++ b/packages/scripts/src/testing/detect-code-changes.test.ts
@@ -47,7 +47,7 @@ printf '%s' "$DETECT_CODE_CHANGES_TEST_FILES"
         DETECT_CODE_CHANGES_TEST_LOG: log,
         DETECT_CODE_CHANGES_TEST_STATUS: String(ghStatus),
         GITHUB_OUTPUT: output,
-        PATH: `${bin}:${process.env.PATH}`,
+        PATH: `${bin}:${process.env["PATH"]}`,
       },
     },
   );

--- a/packages/sync/src/providers/google/google-auth.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-auth.adapter.test.ts
@@ -154,8 +154,8 @@ describe("GoogleAuthAdapter", () => {
         loginHint: "reconnect@example.com",
       });
 
-      expect(client.authUrlOptions[0].login_hint).toBe("reconnect@example.com");
-      expect(client.authUrlOptions[0].prompt).toBe("consent");
+      expect(client.authUrlOptions[0]!.login_hint).toBe("reconnect@example.com");
+      expect(client.authUrlOptions[0]!.prompt).toBe("consent");
     });
 
     it("appends optional feature scopes after the base scopes", () => {

--- a/packages/sync/src/providers/google/google-auth.adapter.test.ts
+++ b/packages/sync/src/providers/google/google-auth.adapter.test.ts
@@ -154,7 +154,9 @@ describe("GoogleAuthAdapter", () => {
         loginHint: "reconnect@example.com",
       });
 
-      expect(client.authUrlOptions[0]!.login_hint).toBe("reconnect@example.com");
+      expect(client.authUrlOptions[0]!.login_hint).toBe(
+        "reconnect@example.com",
+      );
       expect(client.authUrlOptions[0]!.prompt).toBe("consent");
     });
 

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,16 +1,18 @@
 {
   "extends": "./tsconfig.json",
   "include": [
+    "packages/scripts/src/testing/node-test-globals.d.ts",
     "packages/core/src/**/*.ts",
     "packages/backend/src/**/*.ts",
     "packages/sync/src/**/*.ts",
     "packages/scripts/src/**/*.ts",
-    "packages/scripts/src/**/*.d.ts"
+    "packages/scripts/src/**/*.d.ts",
+    "**/*.json"
   ],
   "exclude": [],
   "compilerOptions": {
-    "composite": false,
-    "declaration": false,
+    "composite": true,
+    "declaration": true,
     "declarationMap": false,
     "types": ["bun-types", "bun-types/test-globals", "node"],
     "noEmit": true,

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.json" },
+    { "path": "./tsconfig.tests.json" },
     { "path": "./packages/web/tsconfig.app.json" },
     { "path": "./packages/web/tsconfig.test.json" },
     { "path": "./e2e/tsconfig.json" }


### PR DESCRIPTION
Fixes #3331

`bun run type-check` now checks core, backend, sync, and scripts node tests against production contracts. Fixture identities use real branded types; no test-only contract aliases or relaxed compiler flags remain.

## Verify

Selected packages: core, sync, scripts
Checks run: test:core, test:sync:fast, test:scripts, type-check, lint, knip
Checks skipped: (none)

VERDICT: PASS