### PR TITLE
fix(ci): let dispatched autofix runs reach the agent

### DIFF
--- a/.github/workflows/error-autofix.yml
+++ b/.github/workflows/error-autofix.yml
@@ -130,7 +130,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: "posthog"
+          # posthog[bot] opens the issues. github-actions[bot] is the actor
+          # when the sweep or the one-shot retry dispatches this workflow
+          # with the default GITHUB_TOKEN; dispatching already requires
+          # write access, so this widens nothing.
+          allowed_bots: "posthog,github-actions"
           # Scoped on purpose. The agent's output carries PostHog query
           # results and whatever it reads out of the repo, and this repo is
           # public, so bot-triggered runs stay redacted. But a redacted run


### PR DESCRIPTION
Fixes #

## What and why

The `autofix` job in `.github/workflows/error-autofix.yml` failed on every `workflow_dispatch` run with `Workflow initiated by non-human actor: github-actions (type: Bot)`. Both the hourly production sweep (`autofix-sweep.sh`) and the automatic one-shot retry after a failed agent run dispatch this workflow via `gh workflow run`, which makes the run's actor `github-actions[bot]`. `allowed_bots` only listed `posthog`, so `claude-code-action` rejected the agent step before it could run, on every dispatched run. This adds `github-actions` to `allowed_bots`. Dispatching the workflow already requires write access to the repo, so this doesn't widen who can trigger the agent, it just lets our own automation's dispatches reach it. No tracked issue exists for this; it was reported directly from a failing Actions run.

## Verify

```
VERDICT: PASS
Checks run: type-check, lint, knip
Checks skipped: (none)
Selected packages: (none)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)