### PR TITLE
fix(web): explain blocked edge-focus while editing an event

### DIFF
--- a/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
+++ b/packages/web/src/grid/shortcuts/useGridEventEditShortcuts.ts
@@ -71,6 +71,10 @@ import {
 } from "@web/grid/shortcuts/focus-adjacent-grid-event";
 import { isHigherEscapeOwner } from "@web/shortcuts/escape-ownership";
 import { KEYMAP } from "@web/shortcuts/keymap";
+import {
+  EVENT_EDITING_SHORTCUT_UNAVAILABLE_MESSAGE,
+  promptShortcutUnavailableWhileEditingEvent,
+} from "@web/shortcuts/prompt-shortcut-unavailable";
 import { swallowNextKeyup } from "@web/shortcuts/swallow-next-keyup";
 import { shortcutHintProgressActions } from "@web/shortcuts/tips/shortcut-tips.progress.store";
 import {
@@ -549,8 +553,15 @@ export function useGridEventEditShortcuts({
   };
 
   const cycleEdgeFocus = (keyboardEvent: KeyboardEvent) => {
-    if (isEventFormOpen() || isEditableKeyboardTarget(keyboardEvent)) return;
-    if (isFocusInSidebar()) return;
+    // Form fields and the sidebar keep native Tab. Explain when the form is
+    // open and Tab would otherwise no-op on the grid.
+    if (isEditableKeyboardTarget(keyboardEvent) || isFocusInSidebar()) return;
+    if (isEventFormOpen()) {
+      if (!isEventFormKeyboardTarget(keyboardEvent)) {
+        promptShortcutUnavailableWhileEditingEvent();
+      }
+      return;
+    }
 
     const event =
       getFocusedMutableCalendarEvent() ?? getFocusedFormClosedDraft();
@@ -761,8 +772,13 @@ export function useGridEventEditShortcuts({
   useAppShortcut(KEYMAP.edgeFocus.hotkey, cycleEdgeFocus, {
     ...DRAFT_MOVEMENT_HOTKEY_OPTIONS,
     ...WRITE_EDIT_SHORTCUT,
+    overlayUnavailableMessage: EVENT_EDITING_SHORTCUT_UNAVAILABLE_MESSAGE,
     telemetryHintId: "edge-focus",
   });
-  useAppShortcut("Shift+Tab", cycleEdgeFocus, DRAFT_MOVEMENT_HOTKEY_OPTIONS);
+  useAppShortcut("Shift+Tab", cycleEdgeFocus, {
+    ...DRAFT_MOVEMENT_HOTKEY_OPTIONS,
+    overlayUnavailableMessage: EVENT_EDITING_SHORTCUT_UNAVAILABLE_MESSAGE,
+    telemetryHintId: "edge-focus",
+  });
   useAppShortcut("Escape", onEscape, DRAFT_MOVEMENT_HOTKEY_OPTIONS);
 }

--- a/packages/web/src/shortcuts/prompt-shortcut-unavailable.test.ts
+++ b/packages/web/src/shortcuts/prompt-shortcut-unavailable.test.ts
@@ -1,0 +1,41 @@
+import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
+import { registerToastPort } from "@web/common/utils/toast/toast.port";
+import {
+  EVENT_EDITING_SHORTCUT_UNAVAILABLE_MESSAGE,
+  promptShortcutUnavailable,
+  promptShortcutUnavailableWhileEditingEvent,
+  SHORTCUT_UNAVAILABLE_TOAST_ID,
+} from "@web/shortcuts/prompt-shortcut-unavailable";
+import { beforeEach, describe, expect, it } from "bun:test";
+
+describe("promptShortcutUnavailable", () => {
+  const { port, mocks } = createTestToastPort();
+
+  beforeEach(() => {
+    mocks.toast.mockClear();
+    mocks.update.mockClear();
+    registerToastPort(port);
+  });
+
+  it("shows the message on the shared overlay-unavailable toast", () => {
+    promptShortcutUnavailable("Shortcut unavailable (press Esc to close)");
+
+    expect(mocks.toast).toHaveBeenCalledWith(
+      "Shortcut unavailable (press Esc to close)",
+      expect.objectContaining({ toastId: SHORTCUT_UNAVAILABLE_TOAST_ID }),
+    );
+  });
+
+  it("explains that event-editing shortcuts stand down until Esc closes the form", () => {
+    promptShortcutUnavailableWhileEditingEvent();
+
+    expect(mocks.toast).toHaveBeenCalledWith(
+      EVENT_EDITING_SHORTCUT_UNAVAILABLE_MESSAGE,
+      expect.objectContaining({
+        toastId: SHORTCUT_UNAVAILABLE_TOAST_ID,
+        closeButton: false,
+        hideProgressBar: true,
+      }),
+    );
+  });
+});

--- a/packages/web/src/shortcuts/prompt-shortcut-unavailable.ts
+++ b/packages/web/src/shortcuts/prompt-shortcut-unavailable.ts
@@ -1,0 +1,16 @@
+import { type Id } from "react-toastify";
+import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
+
+export const SHORTCUT_UNAVAILABLE_TOAST_ID: Id = "shortcut-unavailable-overlay";
+
+export const EVENT_EDITING_SHORTCUT_UNAVAILABLE_MESSAGE =
+  "Shortcut unavailable while editing an event (press Esc to close)";
+
+/** One status toast for a blocked shortcut so repeated presses do not stack. */
+export function promptShortcutUnavailable(message: string): void {
+  showStatusToast(SHORTCUT_UNAVAILABLE_TOAST_ID, message);
+}
+
+export function promptShortcutUnavailableWhileEditingEvent(): void {
+  promptShortcutUnavailable(EVENT_EDITING_SHORTCUT_UNAVAILABLE_MESSAGE);
+}

--- a/packages/web/src/shortcuts/useAppShortcut.test.ts
+++ b/packages/web/src/shortcuts/useAppShortcut.test.ts
@@ -9,9 +9,14 @@ import {
 import { registerToastPort } from "@web/common/utils/toast/toast.port";
 import { setAppLockReason } from "@web/shortcuts/app-lock";
 import {
+  EVENT_EDITING_SHORTCUT_UNAVAILABLE_MESSAGE,
+  SHORTCUT_UNAVAILABLE_TOAST_ID,
+} from "@web/shortcuts/prompt-shortcut-unavailable";
+import {
   useAppShortcut,
   useAppShortcutUp,
   WRITE_CREATE_SHORTCUT,
+  WRITE_EDIT_SHORTCUT,
 } from "@web/shortcuts/useAppShortcut";
 import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
 
@@ -269,6 +274,72 @@ describe("useAppShortcut", () => {
     });
     expect(mocks.toast).not.toHaveBeenCalled();
     setAppLockReason("settingsModal", false);
+  });
+
+  it("explains overlayUnavailableMessage when a non-billing overlay owns the keyboard", async () => {
+    setAppLockReason("settingsModal", true);
+
+    renderHook(() =>
+      useAppShortcut("Tab", mockHandler, {
+        overlayUnavailableMessage: EVENT_EDITING_SHORTCUT_UNAVAILABLE_MESSAGE,
+        telemetryHintId: "edge-focus",
+      }),
+    );
+
+    dispatchKeyEvent("Tab", "keydown");
+
+    await waitFor(() => {
+      expect(mockHandler).not.toHaveBeenCalled();
+      expect(mocks.toast).toHaveBeenCalledWith(
+        EVENT_EDITING_SHORTCUT_UNAVAILABLE_MESSAGE,
+        expect.objectContaining({ toastId: SHORTCUT_UNAVAILABLE_TOAST_ID }),
+      );
+    });
+    setAppLockReason("settingsModal", false);
+  });
+
+  it("does not show overlayUnavailableMessage while the onboarding game owns the keys", async () => {
+    setAppLockReason("shortcutShowcase", true);
+
+    renderHook(() =>
+      useAppShortcut("Tab", mockHandler, {
+        overlayUnavailableMessage: EVENT_EDITING_SHORTCUT_UNAVAILABLE_MESSAGE,
+        telemetryHintId: "edge-focus",
+      }),
+    );
+
+    dispatchKeyEvent("Tab", "keydown");
+
+    await waitFor(() => {
+      expect(mockHandler).not.toHaveBeenCalled();
+    });
+    expect(mocks.toast).not.toHaveBeenCalled();
+    setAppLockReason("shortcutShowcase", false);
+  });
+
+  it("prefers the billing upgrade prompt over overlayUnavailableMessage", async () => {
+    setBillingWriteLock({ locked: true, status: "awaiting_checkout" });
+    setAppLockReason("billingGate", true);
+
+    renderHook(() =>
+      useAppShortcut("Tab", mockHandler, {
+        ...WRITE_EDIT_SHORTCUT,
+        overlayUnavailableMessage: EVENT_EDITING_SHORTCUT_UNAVAILABLE_MESSAGE,
+        telemetryHintId: "edge-focus",
+      }),
+    );
+
+    dispatchKeyEvent("Tab", "keydown");
+
+    await waitFor(() => {
+      expect(mockHandler).not.toHaveBeenCalled();
+      expect(mocks.toast).toHaveBeenCalled();
+    });
+    expect(mocks.toast).not.toHaveBeenCalledWith(
+      EVENT_EDITING_SHORTCUT_UNAVAILABLE_MESSAGE,
+      expect.anything(),
+    );
+    setAppLockReason("billingGate", false);
   });
 
   describe("unavailable-attempt telemetry", () => {

--- a/packages/web/src/shortcuts/useAppShortcut.ts
+++ b/packages/web/src/shortcuts/useAppShortcut.ts
@@ -6,6 +6,7 @@ import {
 import { isBillingWriteLocked } from "@web/billing/billing-write-lock";
 import { promptShortcutUpgrade } from "@web/billing/prompt-shortcut-upgrade";
 import { hasAppLockReason, isAppLocked } from "@web/shortcuts/app-lock";
+import { promptShortcutUnavailable } from "@web/shortcuts/prompt-shortcut-unavailable";
 import { recordShortcutUnavailableAttempt } from "@web/shortcuts/tips/shortcut-telemetry";
 import {
   getShortcutHint,
@@ -46,6 +47,12 @@ export interface UseAppShortcutOptions {
   requiresWrite?: boolean;
   /** Feature area for the upgrade prompt when `requiresWrite` is set. */
   upgradeFeatureArea?: ShortcutFeatureArea;
+  /**
+   * Shown when a non-billing overlay holds the app lock so the handler never
+   * runs. Use for shortcuts whose silent no-op is confusing (Tab edge-focus
+   * while a dialog owns the keyboard).
+   */
+  overlayUnavailableMessage?: string;
   /** @default 'allow' — multiple features often register the same global key (e.g. Escape). */
   conflictBehavior?: ConflictBehavior;
 }
@@ -79,6 +86,7 @@ export function useAppShortcut(
     telemetryHintId,
     requiresWrite = false,
     upgradeFeatureArea,
+    overlayUnavailableMessage,
     conflictBehavior = "allow",
   } = options;
 
@@ -103,6 +111,11 @@ export function useAppShortcut(
           hasAppLockReason("billingGate")
         ) {
           promptLockedWriteShortcut(telemetryHintId, upgradeFeatureArea);
+        } else if (
+          overlayUnavailableMessage &&
+          !hasAppLockReason("shortcutShowcase")
+        ) {
+          promptShortcutUnavailable(overlayUnavailableMessage);
         }
         return;
       }

--- a/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
+++ b/packages/web/src/views/Week/hooks/shortcuts/useWeekShortcutOwner.test.tsx
@@ -9,6 +9,7 @@ import {
 import { CalendarIdSchema, EventIdSchema } from "@core/types/domain-primitives";
 import { type Event, EventScheduleSchema } from "@core/types/event.contracts";
 import dayjs from "@core/util/date/dayjs";
+import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import {
   seedPendingEventMutations,
   toNormalizedEventQueryData,
@@ -20,6 +21,7 @@ import { ID_EVENT_FORM, ID_SIDEBAR } from "@web/common/constants/web.constants";
 import { getBrowserTimeZone } from "@web/common/utils/datetime/web.date.util";
 import { emitViewCommand } from "@web/common/utils/dom/view-command-bus";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
+import { registerToastPort } from "@web/common/utils/toast/toast.port";
 import {
   createGridEventDraft,
   getGridDraftId,
@@ -37,6 +39,10 @@ import {
   initialEdgeFocusState,
   useEdgeFocusStore,
 } from "@web/grid/shortcuts/edge-focus.store";
+import {
+  EVENT_EDITING_SHORTCUT_UNAVAILABLE_MESSAGE,
+  SHORTCUT_UNAVAILABLE_TOAST_ID,
+} from "@web/shortcuts/prompt-shortcut-unavailable";
 import {
   eventJumpActions,
   useEventJumpStore,
@@ -1438,6 +1444,32 @@ describe("useWeekShortcutOwner edge focus", () => {
     expect(input.schedule.start).toBe("2026-05-22");
     expect(input.schedule.end).toBe("2026-05-25");
   });
+
+  it("explains that Tab cannot pick an edge while the event form is open", () => {
+    const { port, mocks } = createTestToastPort();
+    registerToastPort(port);
+    const button = addCalendarTarget();
+    button.focus();
+    draftActions.startGridDraft({
+      activity: "keyboardEdit",
+      draft: createGridEventDraft(
+        timedGridSchedule(
+          new Date("2026-05-20T09:00:00.000"),
+          new Date("2026-05-20T10:00:00.000"),
+        ),
+        EVENT_1_ID,
+      ),
+    });
+    renderShortcuts();
+
+    pressKey("Tab");
+
+    expect(useEdgeFocusStore.getState().eventId).toBeNull();
+    expect(mocks.toast).toHaveBeenCalledWith(
+      EVENT_EDITING_SHORTCUT_UNAVAILABLE_MESSAGE,
+      expect.objectContaining({ toastId: SHORTCUT_UNAVAILABLE_TOAST_ID }),
+    );
+  });
 });
 
 describe("useWeekShortcutOwner draft edge focus", () => {
@@ -1475,6 +1507,8 @@ describe("useWeekShortcutOwner draft edge focus", () => {
   });
 
   it("does not cycle edge focus on a draft while the form is open", () => {
+    const { port, mocks } = createTestToastPort();
+    registerToastPort(port);
     seedFocusedKeyboardPlaceDraft();
     draftActions.setFormOpen(true);
     renderShortcuts();
@@ -1482,6 +1516,29 @@ describe("useWeekShortcutOwner draft edge focus", () => {
     pressKey("Tab");
 
     expect(useEdgeFocusStore.getState().eventId).toBeNull();
+    expect(mocks.toast).toHaveBeenCalledWith(
+      EVENT_EDITING_SHORTCUT_UNAVAILABLE_MESSAGE,
+      expect.objectContaining({ toastId: SHORTCUT_UNAVAILABLE_TOAST_ID }),
+    );
+  });
+
+  it("does not explain blocked edge-focus while Tab is navigating the event form", () => {
+    const { port, mocks } = createTestToastPort();
+    registerToastPort(port);
+    seedFocusedKeyboardPlaceDraft();
+    draftActions.setFormOpen(true);
+    const form = document.createElement("form");
+    form.setAttribute("name", ID_EVENT_FORM);
+    const input = document.createElement("input");
+    form.appendChild(input);
+    document.body.appendChild(form);
+    input.focus();
+    renderShortcuts();
+
+    pressKey("Tab", {}, input);
+
+    expect(useEdgeFocusStore.getState().eventId).toBeNull();
+    expect(mocks.toast).not.toHaveBeenCalled();
   });
 
   it("moves only the draft start edge with Shift+ArrowUp when that edge is focused", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Tab edge-focus still stands down while the event form or a dialog owns the keyboard, so form fields and overlay buttons keep native Tab. The silent no-op is what left a user pressing the shortcut with no feedback (PostHog `shortcut_unavailable_attempt` / `overlay_open`, 28 times in 24 hours).

When the shortcut is blocked, Compass now shows a brief status toast: "Shortcut unavailable while editing an event (press Esc to close)". Tab through the form itself still does not toast. Repeated presses reuse one toast id, so they do not stack.

## What and why

Edge-focus (Tab) is registered as an event-editing shortcut. Unblocking it while editing would steal form and dialog navigation, so the overlay/form guard stays.

Feedback is added on both silent paths:
- App lock / overlay (`useAppShortcut` with `overlayUnavailableMessage`): toast instead of a silent return, still recording `overlay_open` telemetry. Skipped during shortcut showcase. Billing upgrade prompt still wins when the billing gate is up.
- Event form open with focus still on the grid (`cycleEdgeFocus`): same toast. Tab inside the form or sidebar still navigates natively with no toast.

![Toast when Tab is pressed on a grid event while the form is open](https://cursor.com/artifacts/c/art-ed416081-49a8-4369-8031-e6c2139a881d)
![Tab inside the event form moves to the start time with no toast](https://cursor.com/artifacts/c/art-d422840f-1659-468d-942c-8dee96f094cc)
<a href="https://cursor.com/agents/bc-a4928669-7c86-403a-8180-7876fc14a2ce/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fedge_focus_blocked_toast_while_editing.mp4"><img src="https://cursor.com/artifacts/c/art-8ba100a8-9105-48ec-bd50-81fc89d64702" alt="edge_focus_blocked_toast_while_editing.mp4" /></a>

## Verify

Local `bun run verify --strict` selected web: lint, knip, type-check, test:web, test:a11y, test:e2e.

Passed: lint, knip, type-check, test:web, test:a11y.

`test:e2e` failed on specs the diff cannot reach. Isolated reruns of those specs passed:

- `e2e/calendars/calendar-experience.spec.ts` (hidden card width 153 vs &lt;12; snapshot showed a leftover Keyboard shortcuts dialog). Isolated rerun passed in 8.8s.
- `e2e/timed/mouse-inert.spec.ts` (`toBeVisible` 10s timeout for `/Untitled event, 1:00 /` while the grid already showed `Timed event: Untitled event, 1 - 2 PM`). Isolated rerun passed in 1.7s.

`VERDICT: FAIL` (sandbox Playwright only; CI decides)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4928669-7c86-403a-8180-7876fc14a2ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4928669-7c86-403a-8180-7876fc14a2ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

