### PR TITLE
fix(web): hide sidebar provider marks except on shared-email hover

### DIFF
--- a/docs/features/calendar-providers.md
+++ b/docs/features/calendar-providers.md
@@ -50,7 +50,9 @@ each with a tracking issue:
 - **An account is provider + email, never email alone.** The same address can
   be a Google account and a Microsoft account, so the web app keys sidebar
   sections, collapse state, and Settings rows by `accountKey` (provider + email)
-  and shows a provider mark (the monochrome logo) beside every account email.
+  and, in Settings, shows a provider mark (the monochrome logo) beside every
+  account email. The sidebar shows that mark on hover only when the same
+  address is connected on more than one provider.
 - **No em-dashes** in user-facing copy.
 
 ## Capability matrix

--- a/packages/web/src/calendars/calendar.util.test.ts
+++ b/packages/web/src/calendars/calendar.util.test.ts
@@ -8,6 +8,7 @@ import {
   accountKey,
   canInviteOnCalendar,
   compareCalendars,
+  emailsSharedAcrossProviders,
   getDefaultTargetCalendar,
   getLocalCalendar,
   getWritableCalendars,
@@ -433,6 +434,36 @@ describe("spansMultipleAccounts", () => {
         }),
       ]),
     ).toBe(true);
+  });
+});
+
+describe("emailsSharedAcrossProviders", () => {
+  it("is empty when every address is unique", () => {
+    expect(
+      emailsSharedAcrossProviders([
+        { accountEmail: "a@x.com" },
+        { accountEmail: "b@x.com" },
+      ]).size,
+    ).toBe(0);
+  });
+
+  it("includes an address connected on more than one provider", () => {
+    const shared = emailsSharedAcrossProviders([
+      { accountEmail: "lance@gmail.com" },
+      { accountEmail: "ahab@pequod.com" },
+      { accountEmail: "lance@gmail.com" },
+    ]);
+    expect(shared.size).toBe(1);
+    expect(shared.has("lance@gmail.com")).toBe(true);
+  });
+
+  it("treats the same address as shared when casing differs", () => {
+    const shared = emailsSharedAcrossProviders([
+      { accountEmail: "Lance@Gmail.com" },
+      { accountEmail: "lance@gmail.com" },
+    ]);
+    expect(shared.size).toBe(1);
+    expect(shared.has("lance@gmail.com")).toBe(true);
   });
 });
 

--- a/packages/web/src/calendars/calendar.util.ts
+++ b/packages/web/src/calendars/calendar.util.ts
@@ -144,6 +144,27 @@ export const accountKey = ({ provider, accountEmail }: AccountRef): string =>
 export const accountLabel = ({ provider, accountEmail }: AccountRef): string =>
   `${accountEmail} (${providerDisplayName(provider)})`;
 
+/**
+ * Emails that back more than one connected account (different providers).
+ * Those are the only sidebar rows whose provider mark is needed to tell
+ * them apart; unique addresses do not need it.
+ */
+export function emailsSharedAcrossProviders(
+  accounts: readonly Pick<AccountRef, "accountEmail">[],
+): ReadonlySet<string> {
+  const counts = new Map<string, number>();
+  for (const { accountEmail } of accounts) {
+    const email = accountEmail.trim().toLowerCase();
+    if (!email) continue;
+    counts.set(email, (counts.get(email) ?? 0) + 1);
+  }
+  const shared = new Set<string>();
+  for (const [email, count] of counts) {
+    if (count > 1) shared.add(email);
+  }
+  return shared;
+}
+
 /** Undefined when the connection reported no email. */
 export const connectionAccount = (
   connection: Pick<SyncConnectionSummary, "provider" | "accountEmail">,

--- a/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.test.tsx
@@ -11,9 +11,9 @@ import { toggleAccountCollapsed } from "@web/calendars/collapsed-accounts.store"
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 const EMAIL = "ahab@pequod.com";
-// The provider mark sits inside the collapse toggle, so the button's
-// accessible name is the email followed by the provider.
-const GOOGLE_TOGGLE_NAME = `${EMAIL} Google`;
+// Unique emails omit the provider mark, so the collapse toggle's
+// accessible name is just the email. Shared-email accounts keep the
+// mark (hidden until hover) and therefore include the provider.
 
 const actualUseConnectProvider = (
   await import("@web/auth/providers/useConnectProvider")
@@ -63,7 +63,10 @@ const { AccountSectionHeader } = (await import(
   headerModuleUrl.href
 )) as typeof import("./AccountSectionHeader");
 
-const renderHeader = (overrides: Partial<SyncConnectionSummary> = {}): void => {
+const renderHeader = (
+  overrides: Partial<SyncConnectionSummary> = {},
+  showProviderOnHover = false,
+): void => {
   const { wrapper } = createStoreWrapper();
   const connection = createMockConnection(EMAIL, overrides);
   const provider = connectionProviderKind(connection);
@@ -71,6 +74,7 @@ const renderHeader = (overrides: Partial<SyncConnectionSummary> = {}): void => {
     <AccountSectionHeader
       account={{ provider, accountEmail: EMAIL }}
       connection={connection}
+      showProviderOnHover={showProviderOnHover}
     />,
     { wrapper },
   );
@@ -86,7 +90,7 @@ describe("AccountSectionHeader", () => {
     const user = userEvent.setup({ delay: null });
     renderHeader();
 
-    const toggle = screen.getByRole("button", { name: GOOGLE_TOGGLE_NAME });
+    const toggle = screen.getByRole("button", { name: EMAIL });
     expect(toggle).toHaveAttribute("aria-expanded", "true");
 
     await user.click(toggle);
@@ -103,9 +107,10 @@ describe("AccountSectionHeader", () => {
 
     renderHeader();
 
-    expect(
-      screen.getByRole("button", { name: GOOGLE_TOGGLE_NAME }),
-    ).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByRole("button", { name: EMAIL })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
   });
 
   it("keeps collapse state per provider, not per email", () => {
@@ -117,19 +122,35 @@ describe("AccountSectionHeader", () => {
 
     renderHeader();
 
-    expect(
-      screen.getByRole("button", { name: GOOGLE_TOGGLE_NAME }),
-    ).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("button", { name: EMAIL })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
   });
 
-  it("names the account's provider with a mark beside the email", () => {
+  it("omits the provider mark when the email is unique across providers", () => {
     renderHeader();
 
-    expect(screen.getByRole("img", { name: "Google" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("img", { name: "Google" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: EMAIL })).toBeInTheDocument();
   });
 
-  it("marks a Microsoft connection as Microsoft", () => {
-    renderHeader({ provider: "microsoft" });
+  it("reveals the provider mark on hover when the same email is on another provider", () => {
+    renderHeader({}, true);
+
+    const mark = screen.getByRole("img", { name: "Google" });
+    expect(mark.parentElement).toHaveClass("opacity-0");
+    expect(mark.parentElement).toHaveClass("group-hover:opacity-100");
+    expect(mark.parentElement).toHaveClass("group-focus-visible:opacity-100");
+    expect(
+      screen.getByRole("button", { name: `${EMAIL} Google` }),
+    ).toBeInTheDocument();
+  });
+
+  it("marks a Microsoft connection as Microsoft when the email is shared", () => {
+    renderHeader({ provider: "microsoft" }, true);
 
     expect(screen.getByRole("img", { name: "Microsoft" })).toBeInTheDocument();
     expect(

--- a/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.tsx
@@ -71,7 +71,7 @@ export const AccountSectionHeader: FC<{
             {accountEmail}
           </span>
           {showProviderOnHover ? (
-            <span className="opacity-0 transition-opacity motion-reduce:transition-none group-hover:opacity-100 group-focus-visible:opacity-100">
+            <span className="opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100 motion-reduce:transition-none">
               <ProviderMark provider={provider} size={12} />
             </span>
           ) : null}

--- a/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/AccountSectionHeader.tsx
@@ -11,12 +11,14 @@ import {
 } from "@web/calendars/collapsed-accounts.store";
 import { useAccountHeaderStatus } from "./useAccountHeaderStatus";
 /**
- * Heading for one connected account's calendars: the account email and
- * provider mark (together the collapse toggle for its calendar rows, see
- * CalendarList.tsx), that account's own sync status, and its own
- * reconnect/refresh action. Every connected account gets one, a lone account
- * included - one account and five accounts render the same shape, so the two
- * can't drift apart the way a separate single-account header did.
+ * Heading for one connected account's calendars: the account email (the
+ * collapse toggle for its calendar rows, see CalendarList.tsx), that
+ * account's own sync status, and its own reconnect/refresh action. The
+ * provider mark only appears on hover when the same address is connected on
+ * another provider - otherwise the logo next to every unique email is noise.
+ * Every connected account gets one, a lone account included - one account
+ * and five accounts render the same shape, so the two can't drift apart the
+ * way a separate single-account header did.
  *
  * Adding/disconnecting accounts lives in the command palette's "Add account" /
  * "Show accounts" items - not a permanent row or icon here, which stayed noisy
@@ -25,7 +27,8 @@ import { useAccountHeaderStatus } from "./useAccountHeaderStatus";
 export const AccountSectionHeader: FC<{
   account: AccountRef;
   connection: SyncConnectionSummary | undefined;
-}> = ({ account, connection }) => {
+  showProviderOnHover?: boolean;
+}> = ({ account, connection, showProviderOnHover = false }) => {
   const key = accountKey(account);
   const { accountEmail, provider } = account;
   const {
@@ -67,7 +70,11 @@ export const AccountSectionHeader: FC<{
           >
             {accountEmail}
           </span>
-          <ProviderMark provider={provider} size={12} />
+          {showProviderOnHover ? (
+            <span className="opacity-0 transition-opacity motion-reduce:transition-none group-hover:opacity-100 group-focus-visible:opacity-100">
+              <ProviderMark provider={provider} size={12} />
+            </span>
+          ) : null}
         </button>
       </h2>
       {isAvailable && commandAction != null && actionLabel != null ? (

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.test.tsx
@@ -561,8 +561,11 @@ describe("CalendarList", () => {
     });
     expect(within(section).getByText("Work")).toBeInTheDocument();
     expect(
-      within(section).getByRole("button", { name: "ahab@pequod.com Google" }),
+      within(section).getByRole("button", { name: "ahab@pequod.com" }),
     ).toHaveAttribute("aria-expanded", "true");
+    expect(
+      within(section).queryByRole("img", { name: "Google" }),
+    ).not.toBeInTheDocument();
   });
 
   it("leaves the local calendar outside the account sections when no account is connected", () => {
@@ -647,8 +650,11 @@ describe("CalendarList", () => {
       }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "ahab@pequod.com Google" }),
+      screen.getByRole("button", { name: "ahab@pequod.com" }),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("img", { name: "Google" }),
+    ).not.toBeInTheDocument();
   });
 
   it("keeps the local calendar visible after a connected account disconnects", () => {
@@ -690,7 +696,7 @@ describe("CalendarList", () => {
 
     expect(screen.getByText("Work")).toBeInTheDocument();
     const toggle = screen.getByRole("button", {
-      name: "ahab@pequod.com Google",
+      name: "ahab@pequod.com",
     });
     expect(toggle).toHaveAttribute("aria-expanded", "true");
 
@@ -742,15 +748,19 @@ describe("CalendarList", () => {
     expect(
       within(googleSection).getByText("Google primary"),
     ).toBeInTheDocument();
-    expect(
-      within(googleSection).getByRole("img", { name: "Google" }),
-    ).toBeInTheDocument();
+    const googleMark = within(googleSection).getByRole("img", {
+      name: "Google",
+    });
+    expect(googleMark.parentElement).toHaveClass("opacity-0");
+    expect(googleMark.parentElement).toHaveClass("group-hover:opacity-100");
     expect(
       within(microsoftSection).getByText("Microsoft primary"),
     ).toBeInTheDocument();
-    expect(
-      within(microsoftSection).getByRole("img", { name: "Microsoft" }),
-    ).toBeInTheDocument();
+    const microsoftMark = within(microsoftSection).getByRole("img", {
+      name: "Microsoft",
+    });
+    expect(microsoftMark.parentElement).toHaveClass("opacity-0");
+    expect(microsoftMark.parentElement).toHaveClass("group-hover:opacity-100");
 
     // Collapsing one account leaves the same-address account alone.
     await user.click(
@@ -818,9 +828,7 @@ describe("CalendarList", () => {
     });
 
     expect(screen.getByText("Compass")).toBeInTheDocument();
-    await user.click(
-      screen.getByRole("button", { name: "ahab@pequod.com Google" }),
-    );
+    await user.click(screen.getByRole("button", { name: "ahab@pequod.com" }));
     expect(screen.queryByText("Compass")).not.toBeInTheDocument();
     expect(screen.queryByText("Work")).not.toBeInTheDocument();
   });
@@ -844,12 +852,8 @@ describe("CalendarList", () => {
       ],
     });
 
-    await user.click(
-      screen.getByRole("button", { name: "ahab@pequod.com Google" }),
-    );
-    await user.click(
-      screen.getByRole("button", { name: "ahab@gmail.com Google" }),
-    );
+    await user.click(screen.getByRole("button", { name: "ahab@pequod.com" }));
+    await user.click(screen.getByRole("button", { name: "ahab@gmail.com" }));
 
     expect(screen.getByText("Compass")).toBeInTheDocument();
   });

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
@@ -13,6 +13,7 @@ import {
   accountKey,
   accountLabel,
   compareCalendars,
+  emailsSharedAcrossProviders,
   groupCalendarsByAccount,
 } from "@web/calendars/calendar.util";
 import {
@@ -64,6 +65,7 @@ export const CalendarList: FC = () => {
     () => groupCalendarsByAccount(calendars, connections, email),
     [calendars, connections, email],
   );
+  const sharedEmails = emailsSharedAcrossProviders(groups);
 
   const renderRows = (rows: Calendar[], id?: string) => (
     <ul className="flex flex-col gap-1.5" id={id}>
@@ -125,6 +127,9 @@ export const CalendarList: FC = () => {
                 <AccountSectionHeader
                   account={group}
                   connection={group.connection}
+                  showProviderOnHover={sharedEmails.has(
+                    group.accountEmail.trim().toLowerCase(),
+                  )}
                 />
                 {renderCollapsible(key, group.calendars)}
               </section>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

The sidebar painted a provider logo next to every connected account email, which is visual noise when each address is unique. The mark now stays hidden unless the same address is connected on more than one provider, and even then it only appears on hover or keyboard focus. Settings still shows the mark on every row, where accounts are managed.

## Verify

```
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)

VERDICT: PASS
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9867bc6e-363d-4ae2-80ec-22fc486721d1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9867bc6e-363d-4ae2-80ec-22fc486721d1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

