### PR TITLE
fix: stop transient sync blips from failing an event save

### DIFF
--- a/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
@@ -994,6 +994,208 @@ describe("SyncServiceClient", () => {
     expect(result.error.kind).toBe("timeout");
   });
 
+  // Restarting Sync leaves the backend holding dead pooled sockets, so the
+  // next write fails with ECONNRESET before Sync is reachable again. That
+  // used to surface as an error toast on an edit that would have succeeded.
+  describe("transient failure retry", () => {
+    const failThen = (
+      failures: Array<{ status: number } | "connection-failure">,
+    ) => {
+      let call = 0;
+      const calls: Array<Record<string, string>> = [];
+      const fn: SyncServiceClientOptions["fetch"] = async (_url, init) => {
+        calls.push(init.headers);
+        const scripted = failures[call];
+        call += 1;
+        if (scripted === "connection-failure") throw new Error("ECONNRESET");
+        if (scripted) {
+          return { status: scripted.status, json: async () => ({}) };
+        }
+        return { status: 200, json: async () => okBody() };
+      };
+      return { fn, calls, attempts: () => call };
+    };
+
+    it("retries a dropped connection and succeeds", async () => {
+      const { fn, attempts } = failThen(["connection-failure"]);
+
+      const result = await client(fn).queryBusyAvailability(
+        principal(),
+        request([objectId()]),
+      );
+
+      if (!result.ok) throw new Error(`expected ok, got ${result.error.kind}`);
+      expect(result.value.bookable).toBe(true);
+      expect(attempts()).toBe(2);
+    });
+
+    it("retries a 503 readiness window and succeeds", async () => {
+      const { fn, attempts } = failThen([{ status: 503 }, { status: 503 }]);
+
+      const result = await client(fn).queryBusyAvailability(
+        principal(),
+        request([objectId()]),
+      );
+
+      expect(result.ok).toBe(true);
+      expect(attempts()).toBe(3);
+    });
+
+    it("does not retry a 429", async () => {
+      // Sync's own shared 300/min limiter. Retrying tightly would only
+      // deepen the backlog it is reporting.
+      const { fn, attempts } = failThen([{ status: 429 }]);
+
+      const result = await client(fn).queryBusyAvailability(
+        principal(),
+        request([objectId()]),
+      );
+
+      expect(result.ok).toBe(false);
+      expect(attempts()).toBe(1);
+    });
+
+    it("does not retry a timeout", async () => {
+      // The caller already waited out the full deadline; a retry would just
+      // double the wait before the same failure.
+      let call = 0;
+      const fn: SyncServiceClientOptions["fetch"] = (_url, init) => {
+        call += 1;
+        return new Promise((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () => {
+            const error = new Error("aborted");
+            error.name = "AbortError";
+            reject(error);
+          });
+        });
+      };
+
+      const result = await client(fn).queryBusyAvailability(
+        principal(),
+        request([objectId()]),
+      );
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.kind).toBe("timeout");
+      expect(call).toBe(1);
+    });
+
+    it("gives up after three attempts and returns the typed failure", async () => {
+      const { fn, attempts } = failThen([
+        "connection-failure",
+        "connection-failure",
+        "connection-failure",
+        "connection-failure",
+      ]);
+
+      const result = await client(fn).queryBusyAvailability(
+        principal(),
+        request([objectId()]),
+      );
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.kind).toBe("unavailable");
+      expect(attempts()).toBe(3);
+    });
+
+    it("re-signs every attempt while holding the correlation id steady", async () => {
+      // Sync rejects a timestamp outside its freshness window, so a retry
+      // must carry a fresh signature rather than replaying the first one.
+      let clock = NOW;
+      const { fn, calls } = failThen(["connection-failure"]);
+      const retryClient = new SyncServiceClient({
+        baseUrl: BASE_URL,
+        secret: SECRET,
+        timeoutMs: 5_000,
+        fetch: fn,
+        now: () => {
+          clock += 1_000;
+          return clock;
+        },
+        newCorrelationId: () => "corr-retry",
+      });
+
+      await retryClient.queryBusyAvailability(
+        principal(),
+        request([objectId()]),
+      );
+
+      expect(calls).toHaveLength(2);
+      expect(calls[0]?.["x-correlation-id"]).toBe("corr-retry");
+      expect(calls[1]?.["x-correlation-id"]).toBe("corr-retry");
+      expect(calls[1]?.["x-sync-timestamp"]).not.toBe(
+        calls[0]?.["x-sync-timestamp"],
+      );
+      expect(calls[1]?.["x-sync-signature"]).not.toBe(
+        calls[0]?.["x-sync-signature"],
+      );
+    });
+
+    it("reports every retry so a self-healed blip is not silent", async () => {
+      const { fn } = failThen(["connection-failure", { status: 503 }]);
+      const seen: Array<{ kind: string; status?: number; attempt: number }> =
+        [];
+
+      const retryClient = new SyncServiceClient({
+        baseUrl: BASE_URL,
+        secret: SECRET,
+        timeoutMs: 5_000,
+        fetch: fn,
+        now: () => NOW,
+        newCorrelationId: () => "corr-1",
+        onRetry: (info) =>
+          seen.push({
+            kind: info.kind,
+            status: info.status,
+            attempt: info.attempt,
+          }),
+      });
+
+      await retryClient.queryBusyAvailability(
+        principal(),
+        request([objectId()]),
+      );
+
+      expect(seen).toEqual([
+        { kind: "unavailable", status: undefined, attempt: 1 },
+        { kind: "unavailable", status: 503, attempt: 2 },
+      ]);
+    });
+
+    it("stops retrying once the caller's deadline has passed", async () => {
+      // Retries must fit inside the timeout the caller was promised, so a
+      // nominally 50ms read cannot quietly become a multi-second one.
+      const { fn, attempts } = failThen([
+        "connection-failure",
+        "connection-failure",
+        "connection-failure",
+      ]);
+      let clock = NOW;
+      const deadlineClient = new SyncServiceClient({
+        baseUrl: BASE_URL,
+        secret: SECRET,
+        timeoutMs: 50,
+        fetch: fn,
+        // Each read of the clock jumps past the 50ms budget.
+        now: () => {
+          clock += 500;
+          return clock;
+        },
+        newCorrelationId: () => "corr-1",
+      });
+
+      const result = await deadlineClient.queryBusyAvailability(
+        principal(),
+        request([objectId()]),
+      );
+
+      expect(result.ok).toBe(false);
+      expect(attempts()).toBe(1);
+    });
+  });
+
   it("keeps submitCommand open longer than the default read deadline", async () => {
     // Default client timeout is 20ms; a 50ms response must still succeed for
     // commands (provider deletes run inline and routinely exceed the read

--- a/packages/backend/src/common/services/sync-service/sync-service.client.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.ts
@@ -1,3 +1,4 @@
+import { backOff } from "exponential-backoff";
 import { type z } from "zod/v4";
 import {
   encryptAdoptAuthorizationCredential,
@@ -77,6 +78,17 @@ const PRINCIPAL_PATH = "/internal/principal";
 const CONTACTS_SUGGESTIONS_PATH = "/internal/contacts/suggestions";
 
 const DEFAULT_TIMEOUT_MS = 5_000;
+
+// Restarting Sync leaves the backend holding pooled keep-alive sockets that
+// are already dead, so the next write fails with ECONNRESET before Sync is
+// even reachable again. That failure returns in milliseconds, which makes a
+// couple of retries nearly free and spares the user a toast on an edit that
+// was always going to succeed. Two retries at ~100ms then ~300ms (full
+// jitter) add under half a second in the worst case.
+const RETRY_ATTEMPTS = 3;
+const RETRY_STARTING_DELAY_MS = 100;
+// Not mongo.service.ts's `timeMultiple: 5`, which is tuned for its 1s start.
+const RETRY_TIME_MULTIPLE = 3;
 // Provider create/update/delete run inline inside POST /internal/commands.
 // The default read deadline is too short for a Google round-trip; aborting
 // mid-delete leaves Sync applying the mutation while Compass API returns an
@@ -129,6 +141,38 @@ export type SyncClientResult<T> =
   | { ok: true; value: T; correlationId: string }
   | { ok: false; error: SyncClientError };
 
+// What a retry reports to the caller's logger. Same log-safe fields as
+// SyncClientError plus which attempt failed and what it was reaching for.
+export interface SyncClientRetryInfo {
+  kind: SyncClientErrorKind;
+  status?: number;
+  attempt: number;
+  correlationId: string;
+  method: string;
+  path: string;
+}
+
+// `unavailable` with no status is the #send catch: ECONNRESET or a refused
+// connection, which is the dead-pooled-socket case a retry exists for. With
+// a status it is Sync's readiness window (503), equally worth retrying.
+// Excluded: 429, which is Sync's own shared 300/min internal limiter, where
+// retrying tightly only deepens the backlog it is reporting; and `timeout`,
+// where the caller has already waited out the whole deadline and a retry
+// would just double the wait before the same failure.
+function isRetryableSyncError(error: SyncClientError): boolean {
+  return error.kind === "unavailable" && error.status !== 429;
+}
+
+// `backOff` retries on a *thrown* error, but #send returns a typed result and
+// deliberately never throws. This sentinel carries a failed result through
+// backOff's throw-based control flow; it never escapes this module.
+class RetryableSyncFailure extends Error {
+  constructor(readonly syncError: SyncClientError) {
+    super("retryable sync failure");
+    this.name = "RetryableSyncFailure";
+  }
+}
+
 type FetchFn = (
   url: string,
   init: {
@@ -155,6 +199,9 @@ export interface SyncServiceClientOptions {
   secret: string;
   // Per-request deadline; a slow/hung service fails as `timeout` not a hang.
   timeoutMs?: number;
+  // Called once per retry. The client has no logger of its own; the factory
+  // wires this to one so a self-healed blip still leaves a trail.
+  onRetry?: (info: SyncClientRetryInfo) => void;
   // Injectable seams for tests.
   fetch?: FetchFn;
   now?: () => number;
@@ -201,6 +248,7 @@ export class SyncServiceClient {
   readonly #fetch: FetchFn;
   readonly #now: () => number;
   readonly #newCorrelationId: () => string;
+  readonly #onRetry?: (info: SyncClientRetryInfo) => void;
 
   constructor(options: SyncServiceClientOptions) {
     this.#baseUrl = options.baseUrl.replace(/\/+$/, "");
@@ -209,6 +257,7 @@ export class SyncServiceClient {
     this.#fetch = options.fetch ?? (globalThis.fetch as unknown as FetchFn);
     this.#now = options.now ?? Date.now;
     this.#newCorrelationId = options.newCorrelationId ?? randomUUID;
+    this.#onRetry = options.onRetry;
   }
 
   // The caller's provider connections, scoped to the signed principal. A read;
@@ -566,16 +615,21 @@ export class SyncServiceClient {
     timeoutMs?: number;
   }): Promise<SyncClientResult<T>> {
     const correlationId = input.correlationId ?? this.#newCorrelationId();
-    const timestamp = this.#now();
-    const headers: Record<string, string> = {
-      "content-type": "application/json",
-      "x-sync-tenant": input.principal.tenantId,
-      "x-sync-principal": input.principal.principalId,
-      "x-sync-timestamp": String(timestamp),
-      "x-sync-signature": signRequest(this.#secret, timestamp, input.principal),
-      "x-correlation-id": correlationId,
-    };
-    return this.#send({ ...input, headers, correlationId });
+    return this.#sendWithRetry(input, correlationId, () => {
+      const timestamp = this.#now();
+      return {
+        "content-type": "application/json",
+        "x-sync-tenant": input.principal.tenantId,
+        "x-sync-principal": input.principal.principalId,
+        "x-sync-timestamp": String(timestamp),
+        "x-sync-signature": signRequest(
+          this.#secret,
+          timestamp,
+          input.principal,
+        ),
+        "x-correlation-id": correlationId,
+      };
+    });
   }
 
   // Same signed-request/timeout/parse machinery as #request, for a route that
@@ -593,14 +647,81 @@ export class SyncServiceClient {
     timeoutMs?: number;
   }): Promise<SyncClientResult<T>> {
     const correlationId = input.correlationId ?? this.#newCorrelationId();
-    const timestamp = this.#now();
-    const headers: Record<string, string> = {
-      "content-type": "application/json",
-      "x-sync-timestamp": String(timestamp),
-      "x-sync-signature": signServiceRequest(this.#secret, timestamp),
-      "x-correlation-id": correlationId,
+    return this.#sendWithRetry(input, correlationId, () => {
+      const timestamp = this.#now();
+      return {
+        "content-type": "application/json",
+        "x-sync-timestamp": String(timestamp),
+        "x-sync-signature": signServiceRequest(this.#secret, timestamp),
+        "x-correlation-id": correlationId,
+      };
+    });
+  }
+
+  // Retries a transient connection failure a couple of times before the
+  // caller ever sees it. Headers are rebuilt per attempt rather than reused:
+  // Sync's verifier rejects a timestamp outside its freshness window, so
+  // replaying attempt 1's signature is fragile by construction. The
+  // correlationId is held constant so one user action stays one id in
+  // Sync's logs.
+  async #sendWithRetry<T>(
+    input: {
+      method: "GET" | "POST" | "DELETE";
+      path: string;
+      query?: URLSearchParams;
+      body?: unknown;
+      schema?: z.ZodType<T>;
+      timeoutMs?: number;
+    },
+    correlationId: string,
+    buildHeaders: () => Record<string, string>,
+  ): Promise<SyncClientResult<T>> {
+    // Retries have to fit inside the deadline the caller was promised, so a
+    // nominally 5s read can never quietly become a 15s one. submitCommand's
+    // 30s budget affords more retry room than a 5s read for free, which is
+    // why reads and writes need no separate policy.
+    const retryDeadline = this.#now() + (input.timeoutMs ?? this.#timeoutMs);
+    let attempt = 0;
+
+    const attemptSend = async (): Promise<SyncClientResult<T>> => {
+      attempt += 1;
+      const result = await this.#send({
+        ...input,
+        headers: buildHeaders(),
+        correlationId,
+      });
+      if (result.ok || !isRetryableSyncError(result.error)) return result;
+      if (this.#now() >= retryDeadline) return result;
+      throw new RetryableSyncFailure(result.error);
     };
-    return this.#send({ ...input, headers, correlationId });
+
+    try {
+      return await backOff(attemptSend, {
+        jitter: "full",
+        numOfAttempts: RETRY_ATTEMPTS,
+        startingDelay: RETRY_STARTING_DELAY_MS,
+        timeMultiple: RETRY_TIME_MULTIPLE,
+        retry: (error: unknown) => {
+          if (!(error instanceof RetryableSyncFailure)) return false;
+          this.#onRetry?.({
+            kind: error.syncError.kind,
+            status: error.syncError.status,
+            attempt,
+            correlationId,
+            method: input.method,
+            path: input.path,
+          });
+          return true;
+        },
+      });
+    } catch (error) {
+      // The last attempt still failed: unwrap the sentinel back into the
+      // typed result the caller expects.
+      if (error instanceof RetryableSyncFailure) {
+        return { ok: false, error: error.syncError };
+      }
+      throw error;
+    }
   }
 
   async #send<T>(input: {

--- a/packages/backend/src/common/services/sync-service/sync-service.factory.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.factory.ts
@@ -1,5 +1,8 @@
+import { Logger } from "@core/logger/winston.logger";
 import { CONFIG } from "@backend/common/constants/config.constants";
 import { SyncServiceClient } from "./sync-service.client";
+
+const logger = Logger("app:sync-service.client");
 
 // Build a client from an explicit URL + secret. Kept separate from the config
 // singleton so it is testable without the global CONFIG.
@@ -12,6 +15,16 @@ export function buildSyncServiceClient(options: {
     baseUrl: options.serviceUrl,
     secret: options.secret,
     timeoutMs: options.timeoutMs,
+    // `warn`, not `error`: a retry that goes on to succeed is a self-healed
+    // blip, and filing it as an exception would bury the failures that
+    // actually reached a user. An exhausted retry is still logged by the
+    // caller (event.controller's send), so this never double-reports.
+    onRetry: (info) =>
+      logger.warn(
+        `Retrying sync request ${info.method} ${info.path} after ${info.kind}` +
+          `${info.status === undefined ? "" : ` (${info.status})`}` +
+          ` [attempt=${info.attempt} correlationId=${info.correlationId}]`,
+      ),
   });
 }
 

--- a/packages/web/src/common/constants/toast.constants.ts
+++ b/packages/web/src/common/constants/toast.constants.ts
@@ -17,6 +17,7 @@ export const ACCOUNT_DISCONNECTED_TOAST_ID: Id = "account-disconnected";
 export const EXPORT_MY_DATA_TOAST_ID: Id = "export-my-data";
 export const LOGGED_OUT_TOAST_ID: Id = "logged-out";
 export const EVENT_SAVE_UNAVAILABLE_TOAST_ID: Id = "event-save-unavailable";
+export const EVENT_SAVE_RETRYABLE_TOAST_ID: Id = "event-save-retryable";
 export const NOTIFICATIONS_STATUS_TOAST_ID: Id = "notifications-status";
 export const BILLING_SUBSCRIBED_TOAST_ID: Id = "billing-subscribed";
 export const BILLING_PLAN_ENDS_TOAST_ID: Id = "billing-plan-ends";

--- a/packages/web/src/common/utils/event/event.util.test.ts
+++ b/packages/web/src/common/utils/event/event.util.test.ts
@@ -6,6 +6,7 @@ import { mockModuleForFile } from "@web/__tests__/utils/mock-module.test.util";
 import { type ApiError, type ApiResponse } from "@web/api/api.types";
 import * as realPosthogBootstrap from "@web/auth/posthog/posthog.bootstrap";
 import {
+  EVENT_SAVE_RETRYABLE_TOAST_ID,
   EVENT_SAVE_UNAVAILABLE_TOAST_ID,
   GENERIC_ERROR_TOAST_ID,
 } from "@web/common/constants/toast.constants";
@@ -212,6 +213,95 @@ describe("handleError", () => {
     expect(message).toBe(
       "Google doesn't allow this change for this event (for example events created from an email, birthdays, or holidays). Delete it or manage it in your calendar.",
     );
+  });
+
+  it("explains a brief sync outage instead of the catch-all", () => {
+    // The 503 a Sync restart produces. It used to land on "Something went
+    // wrong behind the scenes", which reads as a crash rather than the
+    // recoverable blip it is.
+    const error = createServerError(Status.SERVICE_UNAVAILABLE);
+    error.response = {
+      status: Status.SERVICE_UNAVAILABLE,
+      data: {
+        code: "SYNC_UNAVAILABLE",
+        message: "backend contract message, not toast copy",
+        retryable: true,
+      },
+    } as ApiResponse<unknown>;
+
+    handleError(error);
+
+    expect(mockCaptureException).not.toHaveBeenCalled();
+    const [message] = mocks.error.mock.calls[0] ?? [];
+    expect(message).toBe(
+      "Couldn't save that change, the calendar service is briefly unavailable. Your edit was not applied.",
+    );
+  });
+
+  it("offers a retry the caller can re-dispatch when the backend says retryable", () => {
+    const onRetry = mock(() => {});
+    const error = createServerError(Status.SERVICE_UNAVAILABLE);
+    error.response = {
+      status: Status.SERVICE_UNAVAILABLE,
+      data: {
+        code: "SYNC_UNAVAILABLE",
+        message: "backend contract message, not toast copy",
+        retryable: true,
+      },
+    } as ApiResponse<unknown>;
+
+    handleError(error, onRetry);
+
+    expect(mocks.error).toHaveBeenCalledTimes(1);
+    const [content, options] = mocks.error.mock.calls[0] ?? [];
+    // Its own toastId: a recoverable save failure must not dedupe against
+    // the generic error toast.
+    expect(options).toMatchObject({ toastId: EVENT_SAVE_RETRYABLE_TOAST_ID });
+    expect(EVENT_SAVE_RETRYABLE_TOAST_ID).not.toBe(GENERIC_ERROR_TOAST_ID);
+
+    const props = (content as { props: { onRetry: () => void } }).props;
+    props.onRetry();
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the plain toast when a retryable failure has no retry to offer", () => {
+    // handleError is also called from paths with no mutation to re-dispatch;
+    // those must not render a dead "Try again" button.
+    const error = createServerError(Status.SERVICE_UNAVAILABLE);
+    error.response = {
+      status: Status.SERVICE_UNAVAILABLE,
+      data: {
+        code: "SYNC_UNAVAILABLE",
+        message: "backend contract message, not toast copy",
+        retryable: true,
+      },
+    } as ApiResponse<unknown>;
+
+    handleError(error);
+
+    expect(mocks.error.mock.calls[0]?.[1]).toMatchObject({
+      toastId: GENERIC_ERROR_TOAST_ID,
+    });
+  });
+
+  it("does not offer a retry on a refusal the backend marked final", () => {
+    const onRetry = mock(() => {});
+    const error = createServerError(Status.FORBIDDEN);
+    error.response = {
+      status: Status.FORBIDDEN,
+      data: {
+        code: "CALENDAR_READ_ONLY",
+        message: "Calendar is read-only",
+        retryable: false,
+      },
+    } as ApiResponse<unknown>;
+
+    handleError(error, onRetry);
+
+    expect(mocks.error.mock.calls[0]?.[1]).toMatchObject({
+      toastId: GENERIC_ERROR_TOAST_ID,
+    });
+    expect(onRetry).not.toHaveBeenCalled();
   });
 
   it("does not toast a BILLING_REQUIRED refusal — the gate is the feedback", () => {

--- a/packages/web/src/common/utils/event/event.util.ts
+++ b/packages/web/src/common/utils/event/event.util.ts
@@ -1,3 +1,4 @@
+import { createElement } from "react";
 import { Origin } from "@core/constants/core.constants";
 import { YEAR_MONTH_DAY_COMPACT_FORMAT } from "@core/constants/date.constants";
 import { Status } from "@core/errors/status.codes";
@@ -17,6 +18,7 @@ import { isBackendUnavailableError } from "@web/api/util/backend-unavailable-err
 import { getUserId } from "@web/auth/compass/session/session.util";
 import { getPosthogClient } from "@web/auth/posthog/posthog.bootstrap";
 import {
+  EVENT_SAVE_RETRYABLE_TOAST_ID,
   EVENT_SAVE_UNAVAILABLE_TOAST_ID,
   GENERIC_ERROR_TOAST_ID,
 } from "@web/common/constants/toast.constants";
@@ -27,6 +29,7 @@ import {
 } from "@web/common/types/web.event.types";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import { showErrorToast } from "@web/common/utils/toast/error-toast.util";
+import { RetryableSaveToast } from "@web/common/utils/toast/retryable-save.toast";
 import {
   calendarEventIdValueSelector,
   readCalendarEventIdFromElement,
@@ -232,12 +235,20 @@ const MUTATION_ERROR_TOAST_MESSAGES: Partial<
     "This event was changed somewhere else. Refresh to load the latest version, then try again.",
   GOOGLE_REVOKED:
     "Calendar access expired or was revoked. Reconnect your calendar in Compass to resume syncing.",
+  SYNC_UNAVAILABLE:
+    "Couldn't save that change, the calendar service is briefly unavailable. Your edit was not applied.",
+  // Covers a failed round-trip and a response that broke the contract, so
+  // the copy must not claim which one happened.
+  PROVIDER_FAILURE:
+    "Couldn't save that change, the calendar service had a problem. Your edit was not applied.",
+  MAINTENANCE:
+    "Couldn't save that change, Compass is updating the calendar service. Your edit was not applied.",
 };
 
 const showCatchallToast = (message: string) =>
   showErrorToast(message, { toastId: GENERIC_ERROR_TOAST_ID });
 
-export const handleError = (error: Error) => {
+export const handleError = (error: Error, onRetry?: () => void) => {
   if (isBackendUnavailableError(error)) {
     // No HTTP response reached us at all (offline, DNS, dropped connection)
     // or a 502/503/504 - the optimistic edit is about to roll back with
@@ -277,10 +288,28 @@ export const handleError = (error: Error) => {
     // actually happened when we have copy for it (a generic toast on a
     // deterministic refusal reads as "try again", which can never work).
     // No error-tracking capture either way — these are expected outcomes.
-    showCatchallToast(
+    const message =
       MUTATION_ERROR_TOAST_MESSAGES[mutationError.code] ??
-        CATCHALL_TOAST_MESSAGE,
-    );
+      CATCHALL_TOAST_MESSAGE;
+
+    // The backend already decided whether the same request could succeed
+    // (RETRYABLE_BY_CODE in event.error.ts). When it can, hand the user the
+    // retry instead of making them redo the edit. Retrying is safe: the
+    // command's idempotency key is a hash of the payload, so a replay
+    // dedupes rather than applying twice.
+    if (mutationError.retryable && onRetry) {
+      showErrorToast(
+        createElement(RetryableSaveToast, {
+          message,
+          toastId: EVENT_SAVE_RETRYABLE_TOAST_ID,
+          onRetry,
+        }),
+        { toastId: EVENT_SAVE_RETRYABLE_TOAST_ID },
+      );
+      return;
+    }
+
+    showCatchallToast(message);
     return;
   }
 

--- a/packages/web/src/common/utils/toast/retryable-save.toast.test.tsx
+++ b/packages/web/src/common/utils/toast/retryable-save.toast.test.tsx
@@ -1,0 +1,63 @@
+import { HotkeyManager, HotkeysProvider } from "@tanstack/react-hotkeys";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
+import { pressKey } from "@web/__tests__/utils/keyboard.test.util";
+import { RetryableSaveToast } from "@web/common/utils/toast/retryable-save.toast";
+import { registerToastPort } from "@web/common/utils/toast/toast.port";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const MESSAGE =
+  "Couldn't save that change, the calendar service is briefly unavailable. Your edit was not applied.";
+
+describe("RetryableSaveToast", () => {
+  const { port, mocks } = createTestToastPort();
+
+  beforeEach(() => {
+    HotkeyManager.resetInstance();
+    document.body.removeAttribute("data-app-locked");
+    mocks.dismiss.mockClear();
+    registerToastPort(port);
+  });
+
+  it("retries and dismisses itself when the button is clicked", async () => {
+    const onRetry = mock();
+    render(
+      <HotkeysProvider>
+        <RetryableSaveToast
+          message={MESSAGE}
+          onRetry={onRetry}
+          toastId="event-save-retryable"
+        />
+      </HotkeysProvider>,
+    );
+
+    expect(screen.getByText(MESSAGE)).toBeTruthy();
+
+    await userEvent.click(screen.getByRole("button", { name: /Try again/ }));
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    // Dismiss before re-dispatching: a stale toast sitting over a retry that
+    // is already in flight reads as though nothing happened.
+    expect(mocks.dismiss).toHaveBeenCalledWith("event-save-retryable");
+  });
+
+  it("retries from the keyboard, so a save can recover without the mouse", () => {
+    const onRetry = mock();
+    render(
+      <HotkeysProvider>
+        <RetryableSaveToast
+          message={MESSAGE}
+          onRetry={onRetry}
+          toastId="event-save-retryable"
+        />
+      </HotkeysProvider>,
+    );
+
+    // `S`, the shared action-toast CTA key. A session-expired error returns
+    // before this toast is ever shown, so the two never compete for it.
+    pressKey("S");
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/src/common/utils/toast/retryable-save.toast.tsx
+++ b/packages/web/src/common/utils/toast/retryable-save.toast.tsx
@@ -1,0 +1,31 @@
+import { type Id } from "react-toastify";
+import { ToastActionButton } from "@web/common/utils/toast/ToastActionButton";
+import { ToastNotice } from "@web/common/utils/toast/ToastNotice";
+import { getToast } from "@web/common/utils/toast/toast.port";
+
+interface RetryableSaveToastProps {
+  message: string;
+  toastId: Id;
+  onRetry: () => void;
+}
+
+// Shown when the backend reported the failure as retryable, which is a
+// different situation from a refusal: the same request is expected to work.
+// Re-dispatching costs the user one click instead of redoing the edit.
+export const RetryableSaveToast = ({
+  message,
+  toastId,
+  onRetry,
+}: RetryableSaveToastProps) => {
+  const handleRetry = () => {
+    getToast().dismiss(toastId);
+    onRetry();
+  };
+
+  return (
+    <ToastNotice>
+      <p className="text-sm text-text">{message}</p>
+      <ToastActionButton onClick={handleRetry}>Try again</ToastActionButton>
+    </ToastNotice>
+  );
+};

--- a/packages/web/src/events/mutations/useEventMutations.test.tsx
+++ b/packages/web/src/events/mutations/useEventMutations.test.tsx
@@ -181,6 +181,9 @@ const setup = (source: EventRepositorySource = "local") => {
   };
   const markedWrites: string[] = [];
   const errors: Error[] = [];
+  // The retry the toast would offer, captured alongside each error so a test
+  // can invoke it the way the "Try again" button does.
+  const retries: Array<(() => void) | undefined> = [];
   const wrapper = ({ children }: PropsWithChildren) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
@@ -190,13 +193,25 @@ const setup = (source: EventRepositorySource = "local") => {
         source,
         repository,
         markWrite: async () => markedWrites.push("marked"),
-        reportError: (error) => errors.push(error),
+        reportError: (error, onRetry) => {
+          errors.push(error);
+          retries.push(onRetry);
+        },
       }),
       hasPending: useHasPendingEventMutations(),
     }),
     { wrapper },
   );
-  return { calls, errors, hook, markedWrites, pending, queryClient, source };
+  return {
+    calls,
+    errors,
+    hook,
+    markedWrites,
+    pending,
+    queryClient,
+    retries,
+    source,
+  };
 };
 
 const replacePayload = (
@@ -1271,6 +1286,57 @@ describe("useEventMutations", () => {
       expect(
         context.queryClient.getQueryState(calendarKey)?.isInvalidated,
       ).toBe(true);
+    });
+  });
+
+  test("re-dispatches the identical replace when the offered retry is taken", async () => {
+    // A Sync blip fails the save, the edit rolls back, and the user clicks
+    // "Try again". Re-dispatching must send the same payload: the command's
+    // idempotency key is a hash of it, so an identical replay dedupes in
+    // Sync rather than applying twice.
+    const context = setup();
+    const original = event();
+    context.queryClient.setQueryData(calendarKey, normalized(original));
+
+    act(() =>
+      context.hook.result.current.mutations.replace(
+        replacePayload(original.id, {
+          content: {
+            kind: "details",
+            title: "Changed",
+            description: "",
+            location: "",
+          },
+        }),
+      ),
+    );
+
+    await waitFor(() => expect(context.calls).toHaveLength(1));
+    act(() => context.pending.rejectNext(new Error("sync unavailable")));
+
+    await waitFor(() => {
+      expect(context.errors[0]?.message).toBe("sync unavailable");
+      // Rollback still happens first: the grid shows the truth, and the
+      // retry is what re-applies the edit.
+      expect(
+        context.queryClient.getQueryData<NormalizedEventQueryData>(calendarKey)
+          ?.entities[original.id].content,
+      ).toMatchObject({ title: "Original" });
+    });
+
+    const retry = context.retries[0];
+    if (!retry) throw new Error("expected a retry to be offered");
+    act(() => retry());
+
+    await waitFor(() => expect(context.calls).toHaveLength(2));
+    expect(context.calls[1]).toEqual(context.calls[0]!);
+
+    act(() => context.pending.resolve());
+    await waitFor(() => {
+      expect(
+        context.queryClient.getQueryData<NormalizedEventQueryData>(calendarKey)
+          ?.entities[original.id].content,
+      ).toMatchObject({ title: "Changed" });
     });
   });
 

--- a/packages/web/src/events/mutations/useEventMutations.ts
+++ b/packages/web/src/events/mutations/useEventMutations.ts
@@ -3,7 +3,7 @@ import {
   useMutation,
   useQueryClient,
 } from "@tanstack/react-query";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
 import {
   DateTimeSchema,
@@ -469,7 +469,7 @@ export type EventMutationDependencies = {
   source?: EventRepositorySource;
   repository?: EventRepository;
   markWrite?: () => Promise<unknown>;
-  reportError?: (error: Error) => void;
+  reportError?: (error: Error, onRetry?: () => void) => void;
 };
 
 export function useEventMutations(
@@ -488,6 +488,14 @@ export function useEventMutations(
       ? showAnonymousSaveToastIfEligible
       : undefined;
   const reportError = dependencies.reportError ?? handleError;
+
+  // Re-dispatch seams for the "Try again" toast, filled in below once the
+  // mutations exist. onError can't reach its own mutation object, and going
+  // back through `.mutate` (rather than re-calling mutationFn) is what
+  // re-applies the optimistic edit and re-runs rollback on a second failure.
+  const redispatch = useRef<
+    Partial<Record<EventMutationOperation, (variables: never) => void>>
+  >({});
 
   // Shared by the create and replace optimistic callbacks: the query-cache
   // ranges a series expansion should materialize instances into.
@@ -621,7 +629,13 @@ export function useEventMutations(
           queryKey: billingQueryKeys.status,
         });
       }
-      reportError(error);
+      reportError(error, () =>
+        // A fresh object, not the original: the write-serialization queue
+        // identifies a mutation by its variables *reference*, so replaying
+        // the same one resolves back to this failed mutation and the retry
+        // is skipped as superseded by itself.
+        redispatch.current[operation]?.({ ...variables } as never),
+      );
       const opportunityId = (variables as { opportunityId?: number })
         .opportunityId;
       if (opportunityId) {
@@ -933,6 +947,13 @@ export function useEventMutations(
       },
     ),
   );
+
+  redispatch.current = {
+    create: createMutation.mutate,
+    replace: replaceMutation.mutate,
+    delete: deleteMutation.mutate,
+    rsvp: rsvpMutation.mutate,
+  };
 
   // Undo recording happens here at the `.mutate()` boundary: it's the one
   // place every caller funnels through and the cache still holds the


### PR DESCRIPTION
## What and why

Rescheduling a recurring event failed with "Something went wrong behind the scenes. Please try again later." An immediate retry succeeded. Two defects behind one bad moment:

**The backend never retried Sync.** `#send` was a single bare `fetch` with no retry or backoff, even though `sync-proxy-error.ts` already documented that a caller must retry with the same idempotency key. When the Sync container restarts, the backend is left holding pooled keep-alive sockets that are already dead, so the next call fails with `ECONNRESET` before Sync is reachable again. That failure returns in milliseconds, which makes a couple of retries nearly free.

Retry is now bounded and narrow: two attempts with full-jitter backoff, only for fast connection failures and Sync's 503 readiness window. A 429 is Sync's own shared 300/min limiter, where retrying tightly would only deepen the backlog it reports, and a `timeout` means the caller already waited out the full deadline, so neither is retried. Retries must fit inside the caller's original deadline, so a nominally 5s read cannot quietly become a 15s one. Each attempt is re-signed, because the verifier rejects a timestamp outside its freshness window; the correlation id is held constant so one user action stays one id in Sync's logs. Retries log at `warn`, not `error`: a self-healed blip should leave a trail without filing an exception.

Retrying is safe on every route this touches. Commands dedupe on `hashedIdempotencyKey`, a hash of the payload, so an identical replay cannot double-apply; credential and adopt paths use `upsertByProviderAccount`; `begin` only mints a URL; reads are GETs.

**The web ignored the backend's own `retryable` flag.** `toEventMutationError` has always emitted `{code, message, retryable}`, but nothing in `packages/web` read `retryable`, and `SYNC_UNAVAILABLE` had no copy entry, so it fell to the catch-all. Retryable failures now get copy that says what actually happened plus a "Try again" button that re-dispatches the identical mutation. Rollback is unchanged, so the grid still shows the truth while the toast is up.

One subtlety worth flagging for review: the retry re-dispatches a **shallow clone** of the variables. The write-serialization queue identifies a mutation by its variables *reference*, so replaying the same object resolves back to the failed mutation and the retry gets silently coalesced away as superseded by itself. An integration test pins this.

Global `retry: false` defaults in `query-client.ts` are untouched. The 2026-08-21 request-storm comment there stays true: that incident was 16 React observers each re-firing a GET, which a single server-side retry is not.

## Verify

`VERDICT: FAIL`

```
Selected packages: web, backend
Checks run: test:web, test:backend:fast, type-check, lint, knip
Checks skipped: (none)
Failed: test:a11y, test:e2e
```

Every required check passed. Both failures are pre-existing and unreachable from this diff:

- `booking-a11y.spec.ts:45` (light + dark), `booking-a11y.spec.ts:105`, `connect-onboarding-a11y.spec.ts:135`
- All are 30s Playwright timeouts on `locator.click` waiting for `getByRole('button', { name: /12:00 PM/i })` on the public booking page, not assertion failures.
- Confirmed pre-existing: reverting the web changes and re-running `booking-a11y.spec.ts --grep "the details step"` fails identically at baseline.
- Neither the booking pages nor the add-account chooser imports `useEventMutations` or `event.util`.

Full `bun test:backend` (738 pass) and `bun test:web` (3,608 pass) are green, as are `type-check` and `lint`.

Not verified end to end in a browser: reproducing a live `ECONNRESET` needs the full local stack (Mongo + Sync + a connected account), and Docker was unavailable in this environment. The retry policy and the toast are covered by unit and integration tests instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)