### PR TITLE
feat(scripts): mint Microsoft refresh tokens for live-provider-smoke

### DIFF
--- a/docs/CI-CD/live-provider-smoke.md
+++ b/docs/CI-CD/live-provider-smoke.md
@@ -6,7 +6,9 @@ pull requests. Workflow: [`.github/workflows/live-provider-smoke.yml`](../../.gi
 
 The job uses GitHub Environment `provider-smoke`. It does not read staging
 or production deploy secrets. A provider whose secrets are absent is skipped,
-so the job is green before Microsoft and Apple exist.
+not failed, so a green run does not by itself mean every provider passed.
+Check the summary line the job prints (`live-provider-smoke passed=... skipped=... failed=...`)
+before trusting a green run.
 
 Events are created only on a calendar named `compass-smoke`. Every created
 event's description carries the GitHub run id. A teardown step deletes
@@ -18,8 +20,8 @@ with the provider name.
 GitHub → Settings → Environments → New environment → `provider-smoke`.
 Do not grant it access to staging or production secrets.
 
-Copy the staging Google (and later Microsoft) OAuth client into this
-Environment as well: the smoke process calls the provider APIs directly.
+Copy the staging Google and Microsoft OAuth clients into this Environment
+as well: the smoke process calls the provider APIs directly.
 
 ## Secrets and variables to paste
 
@@ -47,6 +49,34 @@ Environment variables:
 On each connected account, create a calendar named exactly `compass-smoke`
 and leave it writable. The suite refuses to run if that calendar is missing
 and never writes to any other calendar.
+
+## Minting SMOKE_MICROSOFT_REFRESH_TOKEN
+
+There is no Microsoft-provided way to generate a long-lived refresh token
+from the admin center, so use the repo's own script. It runs the same
+authorization-code exchange the app uses, against a local redirect URI that
+is already registered on the Entra app:
+
+```bash
+bun run microsoft:mint-token
+```
+
+It reads `MICROSOFT_CLIENT_ID` / `MICROSOFT_CLIENT_SECRET` from the
+environment or `compass.yaml`, prints a Microsoft sign-in URL, and waits on
+`http://localhost:3010/sync/microsoft` for the OAuth redirect. Open the URL,
+sign in with the dedicated smoke-test Microsoft account (not a real user's),
+and the script prints the refresh token and granted scopes. The script never
+sees the account password, only the OAuth redirect.
+
+Paste the printed value into the Environment:
+
+```bash
+gh secret set SMOKE_MICROSOFT_REFRESH_TOKEN --env provider-smoke --body "<token>"
+```
+
+Refresh tokens for this app are long-lived but not permanent; re-run the
+script if the smoke job starts reporting `authorizationRevoked` for
+Microsoft.
 
 ## Dispatch
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "build:sync": "bun packages/scripts/src/commands/build.sync.ts",
     "build:web": "cd packages/web && bun run build.ts",
     "sync:backup": "bun packages/scripts/src/commands/sync-backup.ts",
-    "sync:restore": "bun packages/scripts/src/commands/sync-restore.ts"
+    "sync:restore": "bun packages/scripts/src/commands/sync-restore.ts",
+    "microsoft:mint-token": "bun packages/scripts/src/commands/microsoft-mint-refresh-token.ts"
   },
   "dependencies": {
     "@compass/backend": "*",

--- a/packages/scripts/src/commands/microsoft-mint-refresh-token.ts
+++ b/packages/scripts/src/commands/microsoft-mint-refresh-token.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env bun
+/**
+ * Mint a Microsoft OAuth refresh token for the live-provider-smoke suite.
+ *
+ * Usage:
+ *   bun packages/scripts/src/commands/microsoft-mint-refresh-token.ts [--redirect-uri URL]
+ *
+ * Reads MICROSOFT_CLIENT_ID / MICROSOFT_CLIENT_SECRET from the environment,
+ * falling back to compass.yaml's `microsoft` section. Prints a Microsoft
+ * sign-in URL, opens a local server to catch the OAuth callback, exchanges
+ * the code for tokens, and prints the refresh token to set as
+ * SMOKE_MICROSOFT_REFRESH_TOKEN on the provider-smoke GitHub Environment.
+ *
+ * The default redirect URI (http://localhost:3010/sync/microsoft) must
+ * already be registered on the Entra app; it is one of the 8 the app has.
+ * Sign in with the dedicated smoke-test Microsoft account, not a real user's.
+ *
+ * This script never sees your Microsoft password: it only opens a browser
+ * to Microsoft's own sign-in page and reads back the redirect.
+ */
+import { loadCompassConfig } from "@core/config/compass.config";
+import { MicrosoftAuthAdapter } from "@sync/providers/microsoft/microsoft-auth.adapter";
+import { randomBytes } from "node:crypto";
+
+const DEFAULT_REDIRECT_URI = "http://localhost:3010/sync/microsoft";
+
+function credentials(): { clientId: string; clientSecret: string } {
+  const envId = process.env["MICROSOFT_CLIENT_ID"]?.trim();
+  const envSecret = process.env["MICROSOFT_CLIENT_SECRET"]?.trim();
+  if (envId && envSecret) return { clientId: envId, clientSecret: envSecret };
+
+  const config = loadCompassConfig().microsoft;
+  const clientId = envId || config?.clientId?.trim();
+  const clientSecret = envSecret || config?.clientSecret?.trim();
+  if (!clientId || !clientSecret) {
+    throw new Error(
+      "Set MICROSOFT_CLIENT_ID and MICROSOFT_CLIENT_SECRET (env or compass.yaml microsoft.*) before running this script",
+    );
+  }
+  return { clientId, clientSecret };
+}
+
+function redirectUri(argv: string[]): string {
+  const flag = argv.indexOf("--redirect-uri");
+  return flag >= 0 && argv[flag + 1] ? argv[flag + 1]! : DEFAULT_REDIRECT_URI;
+}
+
+async function waitForCallback(
+  redirect: string,
+  state: string,
+): Promise<string> {
+  const url = new URL(redirect);
+  return new Promise((resolve, reject) => {
+    const server = Bun.serve({
+      port: Number(url.port || 80),
+      hostname: url.hostname,
+      fetch(request) {
+        const reqUrl = new URL(request.url);
+        if (reqUrl.pathname !== url.pathname) {
+          return new Response("Not found", { status: 404 });
+        }
+        const error = reqUrl.searchParams.get("error");
+        const returnedState = reqUrl.searchParams.get("state");
+        const code = reqUrl.searchParams.get("code");
+        queueMicrotask(() => server.stop());
+        if (error) {
+          reject(
+            new Error(
+              `Microsoft returned an error: ${error} - ${reqUrl.searchParams.get("error_description")}`,
+            ),
+          );
+        } else if (returnedState !== state) {
+          reject(new Error("OAuth state mismatch, aborting"));
+        } else if (!code) {
+          reject(new Error("Microsoft redirect carried no authorization code"));
+        } else {
+          resolve(code);
+        }
+        return new Response(
+          error
+            ? "Sign-in failed. You can close this tab and check the terminal."
+            : "Signed in. You can close this tab and return to the terminal.",
+          { headers: { "Content-Type": "text/plain" } },
+        );
+      },
+    });
+  });
+}
+
+async function main(): Promise<void> {
+  const { clientId, clientSecret } = credentials();
+  const redirect = redirectUri(process.argv.slice(2));
+  const adapter = new MicrosoftAuthAdapter(clientId, clientSecret);
+  const state = randomBytes(16).toString("hex");
+
+  const authorizeUrl = adapter.buildAuthorizationUrl({
+    state,
+    redirectUri: redirect,
+    selectAccount: true,
+  });
+
+  console.log("Open this URL and sign in with the smoke-test account:\n");
+  console.log(authorizeUrl);
+  console.log(`\nWaiting for the redirect to ${redirect} ...`);
+
+  const code = await waitForCallback(redirect, state);
+  const authorization = await adapter.exchangeAuthorizationCode({
+    code,
+    redirectUri: redirect,
+  });
+
+  console.log(
+    "\nSigned in as:",
+    authorization.account.email ?? "(no email claim)",
+  );
+  console.log("Granted scopes:", authorization.grantedScopes.join(" "));
+  console.log(`\nSMOKE_MICROSOFT_REFRESH_TOKEN=${authorization.refreshToken}`);
+  console.log(
+    '\nSet it with: gh secret set SMOKE_MICROSOFT_REFRESH_TOKEN --env provider-smoke --body "<token above>"',
+  );
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add `bun run microsoft:mint-token`, a script that mints a Microsoft OAuth refresh token via the authorization-code exchange the app already uses, for `SMOKE_MICROSOFT_REFRESH_TOKEN` on the `provider-smoke` GitHub Environment.
- Document the procedure in `docs/CI-CD/live-provider-smoke.md`, including that a green live-provider-smoke run does not mean every provider passed (missing secrets are skipped silently).

## Context
Part of milestone 17 (Providers M). The `provider-smoke` Environment currently has zero secrets, so `live-provider-smoke.yml` skips Google, Microsoft, and Apple every night. There was no existing way to obtain a Microsoft refresh token outside the app's own OAuth flow, so this script reuses `MicrosoftAuthAdapter` directly rather than duplicating the token exchange.

Related: #3208 (tracking), #3273 (WP-12, closed without the smoke actually turning on for Microsoft).

## Test plan
- [x] `bun run verify --strict` (scripts tier): PASS
- [x] `bun run type-check`
- [x] `bun run lint`

VERDICT: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
