### PR TITLE
fix(scripts): drop select_account prompt from microsoft token minting

### DIFF
--- a/packages/scripts/src/commands/microsoft-mint-refresh-token.ts
+++ b/packages/scripts/src/commands/microsoft-mint-refresh-token.ts
@@ -96,7 +96,6 @@ async function main(): Promise<void> {
   const authorizeUrl = adapter.buildAuthorizationUrl({
     state,
     redirectUri: redirect,
-    selectAccount: true,
   });
 
   console.log("Open this URL and sign in with the smoke-test account:\n");


### PR DESCRIPTION
## Summary
- `bun run microsoft:mint-token` was calling `buildAuthorizationUrl` with `selectAccount: true`, which sends `prompt=select_account consent` to Microsoft's `/common/oauth2/v2.0/authorize` endpoint. That combined value is rejected with `AADSTS90023: Unsupported 'prompt' value` (confirmed live). Drop it: a single dedicated smoke-test account never needs the account chooser, and `prompt=consent` alone still guarantees a refresh token.

## Related finding, not fixed here
The same `selectAccount: true` path is used in production at `packages/sync/src/server/connection.routes.ts:613-639` whenever a user connects a Microsoft account while already having one connected. That means the "add another Microsoft account" flow is likely broken in production today with the same `AADSTS90023` error. Filing a separate issue for that, since fixing it needs a product decision (Microsoft only accepts one `prompt` value, so forcing the account chooser and guaranteeing a refresh token can't both happen the way Google's adapter does it).

## Test plan
- [x] `bun run verify --strict`: PASS

VERDICT: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)