### PR TITLE
feat(scripts): make microsoft smoke setup a single verified command

### DIFF
--- a/docs/CI-CD/live-provider-smoke.md
+++ b/docs/CI-CD/live-provider-smoke.md
@@ -50,29 +50,40 @@ On each connected account, create a calendar named exactly `compass-smoke`
 and leave it writable. The suite refuses to run if that calendar is missing
 and never writes to any other calendar.
 
-## Minting SMOKE_MICROSOFT_REFRESH_TOKEN
+## Setting up Microsoft in one run
 
 There is no Microsoft-provided way to generate a long-lived refresh token
-from the admin center, so use the repo's own script. It runs the same
-authorization-code exchange the app uses, against a local redirect URI that
-is already registered on the Entra app:
+from the admin center, and hand-copying one between shells is how the
+Microsoft leg ended up storing a token that never refreshed. Use the repo's
+script instead; it does the whole setup and only writes secrets it has just
+proven to work:
 
 ```bash
 bun run microsoft:mint-token
 ```
 
-It reads `MICROSOFT_CLIENT_ID` / `MICROSOFT_CLIENT_SECRET` from the
-environment or `compass.yaml`, prints a Microsoft sign-in URL, and waits on
-`http://localhost:3010/sync/microsoft` for the OAuth redirect. Open the URL,
-sign in with the dedicated smoke-test Microsoft account (not a real user's),
-and the script prints the refresh token and granted scopes. The script never
-sees the account password, only the OAuth redirect.
+What it does, in order:
 
-Paste the printed value into the Environment:
+1. Resolves the target repo (`gh repo view`, or `--repo owner/name`) and
+   Environment (`provider-smoke`, or `--env`), and prints both.
+2. Takes the client id from `MICROSOFT_CLIENT_ID` or the Environment's
+   `MICROSOFT_CLIENT_ID` variable, and the client secret from
+   `MICROSOFT_CLIENT_SECRET` or a hidden terminal prompt.
+3. Opens Microsoft sign-in on the registered local redirect
+   `http://localhost:3010/sync/microsoft`. Sign in with the dedicated
+   smoke-test Microsoft account, not a real user's. The script never sees the
+   password, only the OAuth redirect.
+4. Exchanges the code, then refreshes the new token once, which is the first
+   call the nightly job makes. A token that fails here never gets stored.
+5. Finds a writable `compass-smoke` calendar on the account, creating it if
+   it is missing.
+6. Writes `MICROSOFT_CLIENT_ID` (variable), `MICROSOFT_CLIENT_SECRET` and
+   `SMOKE_MICROSOFT_REFRESH_TOKEN` (secrets) to the Environment with `gh`.
+   The token is never printed.
 
-```bash
-gh secret set SMOKE_MICROSOFT_REFRESH_TOKEN --env provider-smoke --body "<token>"
-```
+Pass `--print-only` to stop after step 5 and print the token instead of
+writing anything, for example when the smoke job runs somewhere other than
+GitHub Actions.
 
 Refresh tokens for this app are long-lived but not permanent; re-run the
 script if the smoke job starts reporting `authorizationRevoked` for

--- a/packages/scripts/src/commands/microsoft-mint-refresh-token.test.ts
+++ b/packages/scripts/src/commands/microsoft-mint-refresh-token.test.ts
@@ -1,0 +1,96 @@
+import {
+  hasScope,
+  parseArgs,
+  pickSmokeCalendar,
+} from "@scripts/commands/microsoft-mint-refresh-token";
+import { type DiscoveredCalendar } from "@sync/providers/provider-calendar.port";
+import { describe, expect, it } from "bun:test";
+
+function capabilities(canWriteEvents: boolean) {
+  return {
+    canReadEvents: true,
+    canWriteEvents,
+    canReadBusy: true,
+    canInviteAttendees: canWriteEvents,
+  };
+}
+
+function calendar(
+  overrides: Partial<DiscoveredCalendar> & { displayName: string },
+): DiscoveredCalendar {
+  return {
+    providerCalendarId: `id-${overrides.displayName}`,
+    color: null,
+    eventLabels: [],
+    primary: false,
+    active: true,
+    accessRole: "owner",
+    capabilities: capabilities(true),
+    createsGoogleMeet: false,
+    ...overrides,
+  };
+}
+
+describe("microsoft-mint-refresh-token args", () => {
+  it("defaults repo to null and environment to provider-smoke", () => {
+    expect(parseArgs([])).toEqual({
+      repo: null,
+      environment: "provider-smoke",
+      redirectUri: "http://localhost:3010/sync/microsoft",
+      printOnly: false,
+    });
+  });
+
+  it("reads every flag", () => {
+    expect(
+      parseArgs([
+        "--repo",
+        "acme/app",
+        "--env",
+        "smoke",
+        "--redirect-uri",
+        "http://localhost:9080/auth/microsoft/callback",
+        "--print-only",
+      ]),
+    ).toEqual({
+      repo: "acme/app",
+      environment: "smoke",
+      redirectUri: "http://localhost:9080/auth/microsoft/callback",
+      printOnly: true,
+    });
+  });
+});
+
+describe("pickSmokeCalendar", () => {
+  it("picks only a writable, active calendar named compass-smoke", () => {
+    const calendars = [
+      calendar({ displayName: "Calendar" }),
+      calendar({
+        displayName: "compass-smoke",
+        capabilities: capabilities(false),
+      }),
+      calendar({ displayName: "compass-smoke", active: false }),
+      calendar({ displayName: "compass-smoke", providerCalendarId: "good" }),
+    ];
+    expect(pickSmokeCalendar(calendars)?.providerCalendarId).toBe("good");
+    expect(pickSmokeCalendar([calendar({ displayName: "Work" })])).toBe(
+      undefined,
+    );
+  });
+});
+
+describe("hasScope", () => {
+  it("accepts bare and resource-prefixed scopes without matching suffixes", () => {
+    expect(hasScope(["Calendars.ReadWrite"], "Calendars.ReadWrite")).toBe(true);
+    expect(
+      hasScope(
+        ["https://graph.microsoft.com/Calendars.ReadWrite"],
+        "Calendars.ReadWrite",
+      ),
+    ).toBe(true);
+    expect(hasScope(["Calendars.Read"], "Calendars.ReadWrite")).toBe(false);
+    expect(
+      hasScope(["Calendars.ReadWrite.Shared"], "Calendars.ReadWrite"),
+    ).toBe(false);
+  });
+});

--- a/packages/scripts/src/commands/microsoft-mint-refresh-token.ts
+++ b/packages/scripts/src/commands/microsoft-mint-refresh-token.ts
@@ -1,48 +1,178 @@
 #!/usr/bin/env bun
 /**
- * Mint a Microsoft OAuth refresh token for the live-provider-smoke suite.
+ * Set up the Microsoft leg of live-provider-smoke in one run.
  *
  * Usage:
- *   bun packages/scripts/src/commands/microsoft-mint-refresh-token.ts [--redirect-uri URL]
+ *   bun run microsoft:mint-token [--repo owner/name] [--env provider-smoke]
+ *                                [--redirect-uri URL] [--print-only]
  *
- * Reads MICROSOFT_CLIENT_ID / MICROSOFT_CLIENT_SECRET from the environment,
- * falling back to compass.yaml's `microsoft` section. Prints a Microsoft
- * sign-in URL, opens a local server to catch the OAuth callback, exchanges
- * the code for tokens, and prints the refresh token to set as
- * SMOKE_MICROSOFT_REFRESH_TOKEN on the provider-smoke GitHub Environment.
+ * Reads the client id from MICROSOFT_CLIENT_ID or from the target GitHub
+ * Environment's MICROSOFT_CLIENT_ID variable, takes the client secret from
+ * MICROSOFT_CLIENT_SECRET or a hidden prompt, opens Microsoft sign-in, exchanges
+ * the code, proves the refresh token refreshes, makes sure the account has a
+ * writable `compass-smoke` calendar, and writes MICROSOFT_CLIENT_ID,
+ * MICROSOFT_CLIENT_SECRET and SMOKE_MICROSOFT_REFRESH_TOKEN to that Environment
+ * with `gh`. `--print-only` stops before writing and prints the token instead.
  *
- * The default redirect URI (http://localhost:3010/sync/microsoft) must
- * already be registered on the Entra app; it is one of the 8 the app has.
- * Sign in with the dedicated smoke-test Microsoft account, not a real user's.
- *
- * This script never sees your Microsoft password: it only opens a browser
- * to Microsoft's own sign-in page and reads back the redirect.
+ * The default redirect URI (http://localhost:3010/sync/microsoft) is one of the
+ * URIs registered on the Entra app. Sign in with the dedicated smoke-test
+ * account, not a real user's. The script never sees the account password: it
+ * only opens Microsoft's own sign-in page and reads back the redirect.
  */
-import { loadCompassConfig } from "@core/config/compass.config";
+import { SMOKE_CALENDAR_NAME } from "@sync/providers/__contract__/live-provider-smoke";
 import { MicrosoftAuthAdapter } from "@sync/providers/microsoft/microsoft-auth.adapter";
+import { MicrosoftCalendarAdapter } from "@sync/providers/microsoft/microsoft-calendar.adapter";
+import { microsoftGraphRequest } from "@sync/providers/microsoft/microsoft-graph-request";
+import { MICROSOFT_GRAPH_BASE_URL } from "@sync/providers/microsoft/microsoft-http.constants";
+import { type DiscoveredCalendar } from "@sync/providers/provider-calendar.port";
 import { randomBytes } from "node:crypto";
 
 const DEFAULT_REDIRECT_URI = "http://localhost:3010/sync/microsoft";
+const DEFAULT_ENVIRONMENT = "provider-smoke";
+const REQUIRED_SCOPE = "Calendars.ReadWrite";
 
-function credentials(): { clientId: string; clientSecret: string } {
-  const envId = process.env["MICROSOFT_CLIENT_ID"]?.trim();
-  const envSecret = process.env["MICROSOFT_CLIENT_SECRET"]?.trim();
-  if (envId && envSecret) return { clientId: envId, clientSecret: envSecret };
-
-  const config = loadCompassConfig().microsoft;
-  const clientId = envId || config?.clientId?.trim();
-  const clientSecret = envSecret || config?.clientSecret?.trim();
-  if (!clientId || !clientSecret) {
-    throw new Error(
-      "Set MICROSOFT_CLIENT_ID and MICROSOFT_CLIENT_SECRET (env or compass.yaml microsoft.*) before running this script",
-    );
-  }
-  return { clientId, clientSecret };
+export interface MintArgs {
+  readonly repo: string | null;
+  readonly environment: string;
+  readonly redirectUri: string;
+  readonly printOnly: boolean;
 }
 
-function redirectUri(argv: string[]): string {
-  const flag = argv.indexOf("--redirect-uri");
-  return flag >= 0 && argv[flag + 1] ? argv[flag + 1]! : DEFAULT_REDIRECT_URI;
+export function parseArgs(argv: readonly string[]): MintArgs {
+  const value = (flag: string): string | null => {
+    const at = argv.indexOf(flag);
+    return at >= 0 && argv[at + 1] ? argv[at + 1]! : null;
+  };
+  return {
+    repo: value("--repo"),
+    environment: value("--env") ?? DEFAULT_ENVIRONMENT,
+    redirectUri: value("--redirect-uri") ?? DEFAULT_REDIRECT_URI,
+    printOnly: argv.includes("--print-only"),
+  };
+}
+
+// Same predicate the smoke suite uses, so what this script accepts is what
+// the nightly job will find.
+export function pickSmokeCalendar(
+  calendars: readonly DiscoveredCalendar[],
+): DiscoveredCalendar | undefined {
+  return calendars.find(
+    (calendar) =>
+      calendar.displayName === SMOKE_CALENDAR_NAME &&
+      calendar.active &&
+      calendar.capabilities.canWriteEvents,
+  );
+}
+
+// Microsoft returns scopes either bare ("Calendars.ReadWrite") or as full
+// resource URIs ("https://graph.microsoft.com/Calendars.ReadWrite").
+export function hasScope(scopes: readonly string[], scope: string): boolean {
+  return scopes.some(
+    (granted) => granted === scope || granted.endsWith(`/${scope}`),
+  );
+}
+
+function gh(args: string[], stdin?: string): string {
+  const result = Bun.spawnSync({
+    cmd: ["gh", ...args],
+    stdin: stdin === undefined ? "ignore" : new TextEncoder().encode(stdin),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `gh ${args.join(" ")} failed: ${result.stderr.toString().trim()}`,
+    );
+  }
+  return result.stdout.toString().trim();
+}
+
+function resolveRepo(args: MintArgs): string {
+  if (args.repo) return args.repo;
+  return gh([
+    "repo",
+    "view",
+    "--json",
+    "nameWithOwner",
+    "--jq",
+    ".nameWithOwner",
+  ]);
+}
+
+function resolveClientId(repo: string, environment: string): string {
+  const fromEnv = process.env["MICROSOFT_CLIENT_ID"]?.trim();
+  if (fromEnv) return fromEnv;
+  try {
+    return gh([
+      "api",
+      `repos/${repo}/environments/${environment}/variables/MICROSOFT_CLIENT_ID`,
+      "--jq",
+      ".value",
+    ]);
+  } catch (error) {
+    throw new Error(
+      `Set MICROSOFT_CLIENT_ID, or create that variable on the ${environment} Environment first (${error instanceof Error ? error.message : error})`,
+    );
+  }
+}
+
+async function readHidden(label: string): Promise<string> {
+  const stdin = process.stdin;
+  if (!stdin.isTTY) {
+    throw new Error("Set MICROSOFT_CLIENT_SECRET when stdin is not a terminal");
+  }
+  process.stdout.write(label);
+  stdin.setRawMode(true);
+  stdin.resume();
+  stdin.setEncoding("utf8");
+  return new Promise((resolve, reject) => {
+    let value = "";
+    const cleanup = () => {
+      stdin.off("data", onData);
+      stdin.setRawMode(false);
+      stdin.pause();
+      process.stdout.write("\n");
+    };
+    const onData = (chunk: string) => {
+      for (const char of chunk) {
+        if (char === "") {
+          cleanup();
+          reject(new Error("Aborted"));
+          return;
+        }
+        if (char === "\r" || char === "\n") {
+          cleanup();
+          resolve(value.trim());
+          return;
+        }
+        if (char === "" || char === "\b") {
+          value = value.slice(0, -1);
+          continue;
+        }
+        value += char;
+      }
+    };
+    stdin.on("data", onData);
+  });
+}
+
+async function resolveClientSecret(): Promise<string> {
+  const fromEnv = process.env["MICROSOFT_CLIENT_SECRET"]?.trim();
+  if (fromEnv) return fromEnv;
+  const secret = await readHidden(
+    "Paste the Microsoft client secret (input is hidden), then press Enter: ",
+  );
+  if (!secret) throw new Error("No client secret entered");
+  return secret;
+}
+
+function openBrowser(url: string): void {
+  if (process.platform !== "darwin") return;
+  try {
+    Bun.spawn({ cmd: ["open", url], stdout: "ignore", stderr: "ignore" });
+  } catch {
+    // The URL is printed either way.
+  }
 }
 
 async function waitForCallback(
@@ -87,39 +217,131 @@ async function waitForCallback(
   });
 }
 
+async function ensureSmokeCalendar(accessToken: string): Promise<string> {
+  const discovery = await new MicrosoftCalendarAdapter().discoverCalendars({
+    accessToken,
+  });
+  const existing = pickSmokeCalendar(discovery.calendars);
+  if (existing) {
+    console.log(
+      `Found writable "${SMOKE_CALENDAR_NAME}" calendar: ${existing.providerCalendarId}`,
+    );
+    return existing.providerCalendarId;
+  }
+  const created = await microsoftGraphRequest<{ id: string }>({
+    accessToken,
+    method: "POST",
+    url: `${MICROSOFT_GRAPH_BASE_URL}/me/calendars`,
+    body: { name: SMOKE_CALENDAR_NAME },
+    fallbackError: "microsoft_calendar_create_failed",
+  });
+  console.log(
+    `Created "${SMOKE_CALENDAR_NAME}" calendar on this account: ${created.id}`,
+  );
+  return created.id;
+}
+
 async function main(): Promise<void> {
-  const { clientId, clientSecret } = credentials();
-  const redirect = redirectUri(process.argv.slice(2));
+  const args = parseArgs(process.argv.slice(2));
+  const repo = resolveRepo(args);
+  console.log(`Target: ${repo}, Environment ${args.environment}`);
+
+  const clientId = resolveClientId(repo, args.environment);
+  const clientSecret = await resolveClientSecret();
   const adapter = new MicrosoftAuthAdapter(clientId, clientSecret);
   const state = randomBytes(16).toString("hex");
 
   const authorizeUrl = adapter.buildAuthorizationUrl({
     state,
-    redirectUri: redirect,
+    redirectUri: args.redirectUri,
   });
-
-  console.log("Open this URL and sign in with the smoke-test account:\n");
+  console.log(
+    "\nSign in with the smoke-test account in the browser tab that opens.",
+  );
+  console.log("If nothing opens, use this URL:\n");
   console.log(authorizeUrl);
-  console.log(`\nWaiting for the redirect to ${redirect} ...`);
+  console.log(`\nWaiting for the redirect to ${args.redirectUri} ...`);
+  openBrowser(authorizeUrl);
 
-  const code = await waitForCallback(redirect, state);
+  const code = await waitForCallback(args.redirectUri, state);
   const authorization = await adapter.exchangeAuthorizationCode({
     code,
-    redirectUri: redirect,
+    redirectUri: args.redirectUri,
   });
-
   console.log(
     "\nSigned in as:",
     authorization.account.email ?? "(no email claim)",
   );
-  console.log("Granted scopes:", authorization.grantedScopes.join(" "));
-  console.log(`\nSMOKE_MICROSOFT_REFRESH_TOKEN=${authorization.refreshToken}`);
+
+  // The nightly job's first call. Failing here is the whole point of the check.
+  const refreshed = await adapter.refreshAccessToken({
+    refreshToken: authorization.refreshToken,
+  });
+  const scopes = refreshed.grantedScopes;
   console.log(
-    '\nSet it with: gh secret set SMOKE_MICROSOFT_REFRESH_TOKEN --env provider-smoke --body "<token above>"',
+    "Refresh verified. Granted scopes:",
+    scopes.join(" ") || "(none reported)",
   );
+  if (scopes.length > 0 && !hasScope(scopes, REQUIRED_SCOPE)) {
+    throw new Error(
+      `Microsoft granted no ${REQUIRED_SCOPE} scope; the smoke suite cannot write events with this token`,
+    );
+  }
+
+  await ensureSmokeCalendar(refreshed.accessToken);
+
+  if (args.printOnly) {
+    console.log(
+      `\nSMOKE_MICROSOFT_REFRESH_TOKEN=${authorization.refreshToken}`,
+    );
+    return;
+  }
+
+  gh(
+    [
+      "variable",
+      "set",
+      "MICROSOFT_CLIENT_ID",
+      "--env",
+      args.environment,
+      "--repo",
+      repo,
+    ],
+    clientId,
+  );
+  gh(
+    [
+      "secret",
+      "set",
+      "MICROSOFT_CLIENT_SECRET",
+      "--env",
+      args.environment,
+      "--repo",
+      repo,
+    ],
+    clientSecret,
+  );
+  gh(
+    [
+      "secret",
+      "set",
+      "SMOKE_MICROSOFT_REFRESH_TOKEN",
+      "--env",
+      args.environment,
+      "--repo",
+      repo,
+    ],
+    authorization.refreshToken,
+  );
+  console.log(
+    `\nWrote MICROSOFT_CLIENT_ID, MICROSOFT_CLIENT_SECRET and SMOKE_MICROSOFT_REFRESH_TOKEN to ${repo} / ${args.environment}.`,
+  );
+  console.log("Next: gh workflow run live-provider-smoke.yml");
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : error);
-  process.exit(1);
-});
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- `bun run microsoft:mint-token` is now a single verified setup step for the `provider-smoke` Environment. It resolves the repo and Environment (and prints both), takes the client id from `MICROSOFT_CLIENT_ID` or the Environment variable, the client secret from `MICROSOFT_CLIENT_SECRET` or a hidden prompt, opens Microsoft sign-in, exchanges the code, then **refreshes the new token once** (the nightly job's first call) before anything is stored.
- Ensures a writable `compass-smoke` calendar exists on the account, creating it if missing, using the same predicate as `findSmokeCalendar`.
- Writes `MICROSOFT_CLIENT_ID` (variable), `MICROSOFT_CLIENT_SECRET` and `SMOKE_MICROSOFT_REFRESH_TOKEN` (secrets) via `gh`, values passed on stdin, token never printed. `--print-only` keeps the old print-the-token behaviour.
- Docs updated in `docs/CI-CD/live-provider-smoke.md`.

## Why
The Microsoft leg of `live-provider-smoke.yml` was failing with `invalid_grant`: the token stored in the Environment came from a manual copy/export/paste chain across shells and was never a freshly minted refresh token. Verifying the refresh in the script closes that gap; writing the secrets from the script removes the chain.

Related: #3208 (tracking), #3660, #3661.

## Test plan
- [x] `bun run verify --strict`: PASS (scripts tier, 140 tests incl. 4 new for `parseArgs`, `pickSmokeCalendar`, `hasScope`)
- [x] `bun run microsoft:mint-token --print-only < /dev/null` resolves `KeepSoftwareSimple/compass-calendar` / `provider-smoke` and the client id from the Environment, then stops at the hidden prompt with a clear message
- [ ] Founder runs `bun run microsoft:mint-token`, then `gh workflow run live-provider-smoke.yml` reports `passed=microsoft`

VERDICT: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
