### PR TITLE
fix(sync): match microsoft occurrences at minute precision, patch smoke against read version

### DIFF
--- a/packages/sync/src/providers/__contract__/live-provider-smoke.ts
+++ b/packages/sync/src/providers/__contract__/live-provider-smoke.ts
@@ -115,11 +115,15 @@ export async function runMicrosoftLiveSmoke(input: {
       );
     }
 
+    // Exchange bumps an item's change key in the seconds after creation, so
+    // an If-Match on the create-time etag races it (HTTP 412
+    // ErrorIrresolvableConflict, seen live). Patch against the version just
+    // read, as the domain does.
     const patched = await adapters.writer.patchEvent({
       accessToken,
       calendarId,
       providerEventId: created.providerEventId,
-      expectedVersion: created.providerVersion,
+      expectedVersion: readBack.providerVersion,
       content: { ...content, title: `compass-smoke ${input.runId} updated` },
       schedule,
       recurrence: { kind: "single" },
@@ -127,7 +131,7 @@ export async function runMicrosoftLiveSmoke(input: {
     });
     if (
       !patched.providerVersion ||
-      patched.providerVersion === created.providerVersion
+      patched.providerVersion === readBack.providerVersion
     ) {
       throw new LiveSmokeError(
         "microsoft",

--- a/packages/sync/src/providers/microsoft/microsoft-event-writer.adapter.test.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-event-writer.adapter.test.ts
@@ -598,6 +598,35 @@ describe("MicrosoftEventWriter", () => {
     }
   });
 
+  it("matches an occurrence Exchange aligned to the minute", async () => {
+    // Live Graph, 2026-09-11: a series created at 02:36:12.865Z came back
+    // with originalStart 02:36:00Z. Seconds and milliseconds are not part of
+    // the occurrence key on Microsoft.
+    const occurrence = (id: string, originalStart: string) => ({
+      ...scriptedEvent(id),
+      type: "occurrence" as const,
+      seriesMasterId: "series-1",
+      originalStart,
+    });
+    const api = new FakeWriteApi({
+      listInstances: [
+        occurrence("instance-earlier", "2026-09-12T02:35:00Z"),
+        occurrence("instance-1", "2026-09-12T02:36:00Z"),
+      ],
+    });
+    const { writer } = writerWith(api);
+
+    const read = await writer.fetchInstanceAt({
+      accessToken: "at",
+      calendarId: "cal",
+      seriesProviderEventId: "series-1",
+      originalStartAt: "2026-09-12T02:36:12.865Z",
+      scheduleKind: "timed",
+    });
+
+    expect(read?.providerEventId).toBe("instance-1");
+  });
+
   it("returns null when no instance matches the original start", async () => {
     const api = new FakeWriteApi({ listInstances: [] });
     const { writer } = writerWith(api);

--- a/packages/sync/src/providers/microsoft/microsoft-event-writer.adapter.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-event-writer.adapter.ts
@@ -401,14 +401,15 @@ function originalStartMatches(
   originalStartAt: string,
 ): boolean {
   if (!item.originalStart) return false;
-  return (
-    toCanonicalRecurrenceId(item.originalStart) ===
-    toCanonicalRecurrenceId(originalStartAt)
-  );
+  return toMinuteKey(item.originalStart) === toMinuteKey(originalStartAt);
 }
 
-function toCanonicalRecurrenceId(originalStart: string): string {
-  return new Date(originalStart).toISOString();
+// Exchange keys recurring occurrences at whole minutes: a series created at
+// 02:36:12.865Z materializes originalStart 02:36:00Z (observed live, 2026-09-11).
+// Graph recurrence frequencies are daily or coarser, so minute precision
+// cannot confuse two occurrences of one series.
+function toMinuteKey(at: string): string {
+  return dayjs.utc(at).startOf("minute").toISOString();
 }
 
 const MICROSOFT_WRITE_ERROR_POLICY: ProviderWriteErrorPolicy = {


### PR DESCRIPTION
## Summary
Two defects found by the first live Microsoft smoke runs (run 34658440198 and 34658813816), both fixed and re-proven live: run [34658985092](https://github.com/KeepSoftwareSimple/compass-calendar/actions/runs/34658985092) reports `live-provider-smoke passed=microsoft skipped=google apple failed=none`.

- **`fetchInstanceAt` never matched a series occurrence.** Exchange keys recurring occurrences at whole minutes: a series created at `02:36:12.865Z` came back with `originalStart: 02:36:00Z`. The exact-instant comparison could not match, so exception writes failed with "no occurrence". Match at minute precision (Graph recurrence frequencies are daily or coarser, so no two occurrences of one series can share a minute). Regression test uses the live-observed values.
- **Smoke patched with the create-time etag.** Exchange bumps the change key in the seconds after creation, so `If-Match` on the create-time version raced it (HTTP 412 `ErrorIrresolvableConflict`). The smoke already reads the event back after create; patch with that version, as the domain does.

## Note for the domain
The second finding is not smoke-only: a Compass user who creates a Microsoft event and edits it within a few seconds may hit the same 412 if the stored `providerVersion` is still the create-time one. The domain's `versionConflict` handling covers it if it re-reads and retries; worth a look but out of scope here.

Related: #3208 (tracking), #3663, #3664.

## Test plan
- [x] `bun run verify --strict` (sync tier, 797 tests): PASS
- [x] Live smoke dispatched from this branch: `passed=microsoft`

VERDICT: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
