### PR TITLE
docs: microsoft closeout, verified publisher, redirect shapes, staging proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ Cool things you can do with in Compass
 - Move your focus to perfect spot (no more TABing endlessly)
 - Find the perfect slot for an event with your keyboard
 - Do everything from the keyboard
-- Google Calendar sync
+- Google Calendar and Microsoft (Outlook) calendar sync
 - Create a public booking page at `/book/:username`
 
 Things you can't do in Compass Calendar:
 
 - Click
-- Connect Outlook & iCloud Calendars (WIP).
+- Connect iCloud Calendars (WIP).
 
 ## Tech stack
 

--- a/docs/features/calendar-providers.md
+++ b/docs/features/calendar-providers.md
@@ -107,9 +107,9 @@ kind to a `ProviderRegistration`: `adapters`, `scopes`, `capabilities`,
 credential custody, and the public routes resolve adapters per connection
 through `registry.get(kind)`.
 
-Google registers when `google.clientId` / `google.clientSecret` are set.
-Microsoft and Apple config is read into `SyncConfig` but those kinds are not
-registered until M-09 / A-08.
+Google registers when `google.clientId` / `google.clientSecret` are set,
+Microsoft when `microsoft.clientId` / `microsoft.clientSecret` are set, and
+Apple when its config is present.
 
 `ProviderAdapters` on a registration:
 
@@ -290,6 +290,46 @@ Each alias names the release that removes it.
   leave `providerManaged` unset; their writers ignore the hint. On patch, the
   writer receives `providerManaged: true` on the input and sends only the body
   fields that provider accepts (Google: `colorId` and attendees).
+
+## Microsoft registration and staging proof
+
+The hosted Compass app is registered in the SIMPLE SOFTWARE LLC tenant
+(`keepsoftwaresimple.onmicrosoft.com`) as a **verified publisher** (Microsoft
+AI Cloud Partner Program ID 7157084, publisher domain
+`keepsoftwaresimple.com`, verified 2026-09-11). Consent screens show the
+verified badge; no "unverified app" warning. Audience is any Entra tenant plus
+personal Microsoft accounts, matching the `/common` endpoints the adapter
+uses. Delegated Graph permissions: `User.Read`, `offline_access`,
+`Calendars.ReadWrite`, and `People.Read` (the last only for the contacts
+feature).
+
+Two redirect URI shapes are registered per deployment, both on the frontend
+origin (the frontend proxies `/sync` to the sync service):
+
+| Flow | URI shape |
+|---|---|
+| Connect a calendar (sync service, `callbackBaseUrl`) | `<origin>/sync/microsoft` |
+| Sign in with Microsoft (web, `window.location.origin`) | `<origin>/auth/microsoft/callback` |
+
+Origins: `https://compasscalendar.com`, `https://staging.compasscalendar.com`,
+`https://selfhosted.compasscalendar.com`, plus `http://localhost:3010`
+(sync) and `http://localhost:9080` (web) for development. The client id is
+public and baked into the web bundle at build time; the client secret lives
+only in `compass.yaml` and the GitHub Environments.
+
+Founder proof on staging, 2026-09-11 (#3208): sign in with Microsoft with the
+verified badge, calendars connected, an event created in Compass appeared in
+Outlook, an edit made in Outlook synced back to Compass after a reload, and a
+booking completed through `/meet`. The live smoke (`live-provider-smoke.yml`)
+now exercises the Microsoft adapters nightly; see
+[`docs/CI-CD/live-provider-smoke.md`](../CI-CD/live-provider-smoke.md).
+
+Findings from the first live runs, tracked separately: #3659 (booking
+availability did not block a slot occupied on a Microsoft calendar), #3662
+(`prompt=select_account consent` is rejected by Microsoft, so connecting a
+second Microsoft account fails), and #3664 (the smoke job is green when every
+provider is skipped). Exchange aligns recurring occurrences to whole minutes;
+`fetchInstanceAt` matches at minute precision for that reason.
 
 ## Microsoft Graph event reads
 

--- a/docs/self-hosting/microsoft-calendar.md
+++ b/docs/self-hosting/microsoft-calendar.md
@@ -7,16 +7,21 @@ registration**. Choose accounts in any organizational directory and personal
 Microsoft accounts. Compass uses delegated access; do not add application
 permissions.
 
-Register the calendar callback as a Web redirect URI for each deployment:
+Register two Web redirect URIs per deployment, both exact matches (scheme,
+host, port, path):
 
-- `http://localhost:3010/sync/microsoft`
-- `https://staging.compasscalendar.com/sync/microsoft`
-- `https://compasscalendar.com/sync/microsoft`
+| Flow | URI shape | Origin it uses |
+|---|---|---|
+| Connect a calendar | `<origin>/sync/microsoft` | the sync service's public origin (`sync.callbackBaseUrl`); on the hosted deployments this is the frontend origin, which proxies `/sync` |
+| Sign in with Microsoft | `<origin>/auth/microsoft/callback` | the web app origin |
 
-For a self-hosted instance, replace the origin with your sync service's public
-origin. Also register the web sign-in callback, `/auth/microsoft/callback`,
-on each frontend origin used for Microsoft sign-in. Local ports must match
-the URLs printed by your development environment.
+The hosted Compass app registers eight: both shapes on
+`https://compasscalendar.com`, `https://staging.compasscalendar.com`, and
+`https://selfhosted.compasscalendar.com`, plus
+`http://localhost:3010/sync/microsoft` and
+`http://localhost:9080/auth/microsoft/callback` for development. For a
+self-hosted instance, register both shapes on your own origins. Local ports
+must match the URLs printed by your development environment.
 
 Under Microsoft Graph delegated permissions, add `offline_access`,
 `User.Read`, `Calendars.ReadWrite`, and `People.Read`. Under **Certificates &
@@ -25,8 +30,13 @@ operations records. Store the secret value, not its identifier.
 
 For work-tenant consent, complete publisher verification through your
 Microsoft AI Cloud Partner Program account and associate the verified
-publisher with the app. Tenant policies can still require administrator
-consent. See Microsoft's [registration guide](https://learn.microsoft.com/en-us/graph/auth-register-app-v2)
+publisher with the app (Branding & properties > Add MPN ID). The hosted
+Compass app is a verified publisher (SIMPLE SOFTWARE LLC, verified
+2026-09-11), so its consent screen shows the verified badge with no
+"unverified app" warning. A brand-new registration can be refused
+verification for about 24 hours (`UnableToAddPublisher`); retry the next
+day. Tenant policies can still require administrator consent. See
+Microsoft's [registration guide](https://learn.microsoft.com/en-us/graph/auth-register-app-v2)
 and [publisher verification requirements](https://learn.microsoft.com/en-us/entra/identity-platform/publisher-verification-overview).
 
 ## Configure Compass
@@ -56,10 +66,21 @@ Rebuild the web image after changing it.
 ## Verify and troubleshoot
 
 After deploying configuration, check `/api/config`: Microsoft `signIn` and
-`connect` should be enabled. Test both a personal Outlook account and a work
-account, each with a disposable `compass-smoke` calendar. Connect on staging,
-verify healthy state, edit in both directions, reload, and make a booking.
-Record the date and observed results before calling the staging soak complete.
+`connect` should be enabled. Then prove the chain with a real account:
+sign in with Microsoft, connect the calendar, create an event in Compass and
+find it in Outlook, edit it in Outlook and see the edit in Compass after a
+reload, and make a booking through `/meet`. The hosted staging deployment
+passed this on 2026-09-11 with a personal Microsoft account; the results are
+recorded on the tracking issue (#3208). Repeat it after any change to the
+registration, the client secret, or the redirect URIs.
+
+Use an account that has a mailbox. An Entra admin user without a Microsoft
+365 license can sign in and mint tokens, but Graph has no calendars for it and
+every calendar read fails (HTTP 404, `MailboxNotEnabledForRESTAPI`).
+
+The nightly live smoke covers the adapters after that. To set it up, run
+`bun run microsoft:mint-token` as described in
+[`docs/CI-CD/live-provider-smoke.md`](../CI-CD/live-provider-smoke.md).
 
 For `consentRequired`, reconnect and review the requested permissions. If
 the tenant requires administrator consent, its administrator must approve


### PR DESCRIPTION
## Summary
WP-14 closeout for milestone 17 (Providers M).

- `README.md`: Microsoft (Outlook) calendar sync is a feature, not a WIP; iCloud stays WIP.
- `docs/features/calendar-providers.md`: fix the stale "not registered until M-09" note; add a "Microsoft registration and staging proof" section covering the verified-publisher registration (MPN 7157084, tenant, audience, delegated permissions), the two redirect URI shapes and the eight registered URIs, the 2026-09-11 founder proof on staging (#3208), the nightly live smoke, and the findings filed from the first live runs (#3659, #3662, #3664) plus the minute-precision occurrence behavior.
- `docs/self-hosting/microsoft-calendar.md`: exact redirect URI shapes per flow, the verified-publisher state and the 24-hour `UnableToAddPublisher` retry, the recorded staging proof, the "use an account with a mailbox" caveat (Entra admin users without a license fail every calendar read with HTTP 404 `MailboxNotEnabledForRESTAPI`), and the pointer to `bun run microsoft:mint-token`.

Fixes #3274

## Test plan
- [x] `bun run verify --strict`: docs-only change; see verdict line
- [x] Content cross-checked against the Entra registration, `/api/config` on staging, the #3208 proof comment, and live smoke run 34658985092

VERDICT: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
