### PR TITLE
fix(scripts): surface the graph cause when microsoft smoke setup fails

### DIFF
--- a/packages/scripts/src/commands/microsoft-mint-refresh-token.ts
+++ b/packages/scripts/src/commands/microsoft-mint-refresh-token.ts
@@ -342,6 +342,9 @@ async function main(): Promise<void> {
 if (import.meta.main) {
   main().catch((error) => {
     console.error(error instanceof Error ? error.message : error);
+    if (error instanceof Error && error.cause instanceof Error) {
+      console.error(`Cause: ${error.cause.message}`);
+    }
     process.exit(1);
   });
 }


### PR DESCRIPTION
## Summary
When `bun run microsoft:mint-token` fails on a Graph call, print the wrapped cause (`HTTP <status>, <code>`) under the error. The first live run failed with only "Microsoft rejected the calendar list read"; the cause was an Entra admin account with no mailbox (HTTP 404 `MailboxNotEnabledForRESTAPI`), which this line would have shown. Split out of #3663 because that branch was already locked in the merge queue.

## Test plan
- [x] `bun run lint`, `bun run type-check`

VERDICT: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
