### PR TITLE
fix(sync): send a single microsoft oauth prompt value

### DIFF
--- a/packages/sync/src/providers/microsoft/microsoft-auth.adapter.test.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-auth.adapter.test.ts
@@ -179,10 +179,45 @@ describe("MicrosoftAuthAdapter", () => {
         }),
       );
 
-      // Without select_account, a browser signed into one Microsoft account
-      // re-authorizes that same account and the user never gets to pick.
-      // consent must stay so the exchange still returns a refresh token.
-      expect(url.searchParams.get("prompt")).toBe("select_account consent");
+      // Microsoft rejects combined prompt values (AADSTS90023). A second
+      // account needs the chooser only; first-connection consent already granted
+      // offline_access, and a missing refresh token re-runs with consent.
+      expect(url.searchParams.get("prompt")).toBe("select_account");
+    });
+
+    it("never sends a space-separated prompt value", () => {
+      const adapter = adapterWith(
+        new FakeTokenEndpoint(),
+        new FakeIdTokenVerifier(),
+      );
+
+      const absent = new URL(
+        adapter.buildAuthorizationUrl({
+          state: "opaque-state",
+          redirectUri: "https://staging.example.com/sync/microsoft",
+        }),
+      );
+      const explicitFalse = new URL(
+        adapter.buildAuthorizationUrl({
+          state: "opaque-state",
+          redirectUri: "https://staging.example.com/sync/microsoft",
+          selectAccount: false,
+        }),
+      );
+      const selectAccount = new URL(
+        adapter.buildAuthorizationUrl({
+          state: "opaque-state",
+          redirectUri: "https://staging.example.com/sync/microsoft",
+          selectAccount: true,
+        }),
+      );
+
+      expect(absent.searchParams.get("prompt")).toBe("consent");
+      expect(explicitFalse.searchParams.get("prompt")).toBe("consent");
+      expect(selectAccount.searchParams.get("prompt")).toBe("select_account");
+      for (const url of [absent, explicitFalse, selectAccount]) {
+        expect(url.searchParams.get("prompt")).not.toMatch(/\s/);
+      }
     });
 
     it("passes login_hint on reconnect so the same account is pre-selected", () => {

--- a/packages/sync/src/providers/microsoft/microsoft-auth.adapter.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-auth.adapter.ts
@@ -105,14 +105,13 @@ export class MicrosoftAuthAdapter implements ProviderAuthAdapter {
     );
     url.searchParams.set("state", input.state);
     url.searchParams.set("redirect_uri", input.redirectUri);
-    // offline_access + consent guarantees a refresh token even on
-    // re-authorization, which Microsoft otherwise omits after the first
-    // consent. select_account additionally forces the chooser, so adding an
-    // account cannot silently re-authorize the one already connected.
-    // Microsoft takes prompt as a space-delimited list, same as Google.
+    // Microsoft accepts exactly one prompt value. First connection uses
+    // consent so offline_access returns a refresh token. Adding an account
+    // uses select_account so the chooser appears; a later missing refresh
+    // token is already handled as missingRefreshToken and re-consent.
     url.searchParams.set(
       "prompt",
-      input.selectAccount ? "select_account consent" : "consent",
+      input.selectAccount ? "select_account" : "consent",
     );
     if (input.loginHint) {
       url.searchParams.set("login_hint", input.loginHint);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3662

## What and why

Microsoft's authorize endpoint rejects `prompt=select_account consent` with `AADSTS90023`, so a user who already has one Microsoft account connected cannot add a second. Microsoft accepts exactly one `prompt` value. This sends `prompt=select_account` when adding an account and `prompt=consent` otherwise, and corrects the adapter comment that claimed Microsoft takes a space-delimited list. Google is unchanged; it does accept a list.

## Verify

VERDICT: PASS

Checks run: test:sync:fast, type-check, lint, knip
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28f094c7-fc54-4bfd-a30e-184b469e000b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28f094c7-fc54-4bfd-a30e-184b469e000b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

