### PR TITLE
fix(booking): add newly discovered calendars to meeting blockers

### DIFF
--- a/packages/backend/src/booking/booking-page.record.ts
+++ b/packages/backend/src/booking/booking-page.record.ts
@@ -26,6 +26,9 @@ export const BookingPageRecordSchema = z.object({
   durationMinutes: BookingDurationMinutesSchema,
   destinationCalendarId: CalendarIdSchema,
   blockingCalendarIds: z.array(CalendarIdSchema).min(1).readonly(),
+  // Calendars the host explicitly removed from blockers. Discovery will not
+  // put these back; a later PUT that includes them again clears the opt-out.
+  optedOutBlockingCalendarIds: z.array(CalendarIdSchema).readonly().optional(),
   timeZone: TimeZoneSchema,
   weeklyAvailability: WeeklyAvailabilitySchema,
   minNoticeHours: z

--- a/packages/backend/src/booking/booking-page.repository.ts
+++ b/packages/backend/src/booking/booking-page.repository.ts
@@ -79,6 +79,25 @@ class BookingPageRepository {
     return BookingPageRecordSchema.parse(result);
   }
 
+  async addBlockingCalendarIds(
+    userId: ObjectId,
+    calendarIds: readonly BookingPageRecord["blockingCalendarIds"][number][],
+  ): Promise<BookingPageRecord | null> {
+    if (calendarIds.length === 0) {
+      return this.findByUserId(userId);
+    }
+    const result = await mongoService.bookingPage.findOneAndUpdate(
+      { userId },
+      {
+        $addToSet: { blockingCalendarIds: { $each: [...calendarIds] } },
+        $set: { updatedAt: new Date() },
+      },
+      { returnDocument: "after" },
+    );
+    if (!result) return null;
+    return BookingPageRecordSchema.parse(result);
+  }
+
   /**
    * Stamp `hostNoticedAt` only when the document still matches the snapshot
    * the caller read, so concurrent claims cannot both report the same rows.

--- a/packages/backend/src/booking/services/booking-blocking-calendars.ts
+++ b/packages/backend/src/booking/services/booking-blocking-calendars.ts
@@ -1,0 +1,93 @@
+import { type ObjectId } from "mongodb";
+import {
+  mergeDiscoveredBlockingCalendarIds,
+  nextOptedOutBlockingCalendarIds,
+} from "@core/booking/merge-blocking-calendars";
+import {
+  type CalendarId,
+  CalendarIdSchema,
+} from "@core/types/domain-primitives";
+import { type ProviderCalendar } from "@core/types/sync/connection.contracts";
+import { type BookingPageRecord } from "@backend/booking/booking-page.record";
+import { bookingPageRepository } from "@backend/booking/booking-page.repository";
+import calendarService from "@backend/calendar/services/calendar.service";
+import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
+import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";
+
+const asCalendarId = (value: string): CalendarId | null => {
+  const parsed = CalendarIdSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+};
+
+const eligibleIdFromProviderCalendar = (
+  calendar: ProviderCalendar,
+): CalendarId | null => {
+  // Sync names the availability-read capability `canReadBusy`; the browser
+  // Calendar contract calls the same idea `canReadAvailability`.
+  if (!calendar.active || !calendar.capabilities.canReadBusy) return null;
+  return asCalendarId(calendar.id as string);
+};
+
+export const listEligibleBlockingCalendarIds = async (
+  userId: ObjectId,
+): Promise<CalendarId[]> => {
+  const ids: CalendarId[] = [];
+  const seen = new Set<CalendarId>();
+  const add = (calendarId: CalendarId | null) => {
+    if (!calendarId || seen.has(calendarId)) return;
+    seen.add(calendarId);
+    ids.push(calendarId);
+  };
+
+  const client = getSyncServiceClient();
+  try {
+    const calendarsResult = await client.listCalendars(
+      toSyncPrincipal(userId.toString()),
+    );
+    if (calendarsResult.ok) {
+      for (const calendar of calendarsResult.value.calendars) {
+        add(eligibleIdFromProviderCalendar(calendar));
+      }
+    }
+  } catch {
+    // Discovery is unavailable; keep existing blockers and still include local.
+  }
+
+  const localCalendar = await calendarService.getLocalCalendar(userId);
+  if (localCalendar) {
+    add(asCalendarId(localCalendar._id.toHexString()));
+  }
+  return ids;
+};
+
+export const optedOutBlockingCalendarIdsForPut = async (
+  userId: ObjectId,
+  submitted: readonly CalendarId[],
+  previousOptedOut: readonly CalendarId[] | undefined,
+): Promise<CalendarId[]> =>
+  nextOptedOutBlockingCalendarIds({
+    previousOptedOut: previousOptedOut ?? [],
+    eligible: await listEligibleBlockingCalendarIds(userId),
+    submitted,
+  });
+
+export const reconcileBookingPageBlockingCalendars = async (
+  page: BookingPageRecord,
+): Promise<BookingPageRecord> => {
+  const merged = mergeDiscoveredBlockingCalendarIds({
+    current: page.blockingCalendarIds,
+    optedOut: page.optedOutBlockingCalendarIds ?? [],
+    discovered: await listEligibleBlockingCalendarIds(page.userId),
+  });
+  const current = new Set(page.blockingCalendarIds);
+  const unchanged =
+    merged.length === current.size && merged.every((id) => current.has(id));
+  if (unchanged) return page;
+
+  const added = merged.filter((id) => !current.has(id));
+  const updated = await bookingPageRepository.addBlockingCalendarIds(
+    page.userId,
+    added,
+  );
+  return updated ?? { ...page, blockingCalendarIds: merged };
+};

--- a/packages/backend/src/booking/services/booking-page.service.db.test.ts
+++ b/packages/backend/src/booking/services/booking-page.service.db.test.ts
@@ -203,6 +203,8 @@ describe("BookingPageService", () => {
 
   it("returns a stored UTC timezone unchanged", async () => {
     const userId = await createNamedUser("Utc Host");
+    const calendar = writableCalendar();
+    mockHealthySync([calendar]);
 
     await bookingPageService.putAdminPage(
       userId,
@@ -221,6 +223,8 @@ describe("BookingPageService", () => {
 
   it("reports a saved-but-never-enabled page as configured", async () => {
     const userId = await createNamedUser("Draft User");
+    const calendar = writableCalendar();
+    mockHealthySync([calendar]);
 
     // Saved while disabled, so no slug is allocated and the response is the
     // bare input shape - indistinguishable from "never saved" without the
@@ -767,6 +771,53 @@ describe("BookingPageService", () => {
     expect(after?.hostNoticedAt?.getTime()).toBe(
       stamped?.hostNoticedAt?.getTime(),
     );
+  });
+
+  it("adds a calendar discovered after the booking page exists", async () => {
+    const userId = await createNamedUser("Late Discovery");
+    const google = writableCalendar();
+    mockHealthySync([google]);
+    await bookingPageService.putAdminPage(
+      userId,
+      samplePutInput({
+        enabled: false,
+        destinationCalendarId: google.id,
+        blockingCalendarIds: [google.id],
+      }),
+    );
+
+    const microsoft = writableCalendar();
+    mockHealthySync([google, microsoft]);
+    const page = await bookingPageService.getAdminPage(userId);
+
+    expect(page.blockingCalendarIds).toEqual(
+      expect.arrayContaining([google.id, microsoft.id]),
+    );
+  });
+
+  it("does not re-add a calendar the host removed from blockers", async () => {
+    const userId = await createNamedUser("Blocker Opt Out");
+    const google = writableCalendar();
+    const microsoft = writableCalendar();
+    mockHealthySync([google, microsoft]);
+    const base = samplePutInput({
+      enabled: false,
+      destinationCalendarId: google.id,
+      blockingCalendarIds: [google.id, microsoft.id],
+    });
+    await bookingPageService.putAdminPage(userId, base);
+    await bookingPageService.putAdminPage(userId, {
+      ...base,
+      blockingCalendarIds: [google.id],
+    });
+
+    mockHealthySync([google, microsoft]);
+    const page = await bookingPageService.getAdminPage(userId);
+
+    expect(page.blockingCalendarIds).toEqual(
+      expect.arrayContaining([google.id]),
+    );
+    expect(page.blockingCalendarIds).not.toContain(microsoft.id);
   });
 });
 

--- a/packages/backend/src/booking/services/booking-page.service.ts
+++ b/packages/backend/src/booking/services/booking-page.service.ts
@@ -19,6 +19,10 @@ import {
 } from "@backend/booking/booking-page.mapper";
 import { bookingPageRepository } from "@backend/booking/booking-page.repository";
 import { bookingReservationRepository } from "@backend/booking/booking-reservation.repository";
+import {
+  optedOutBlockingCalendarIdsForPut,
+  reconcileBookingPageBlockingCalendars,
+} from "@backend/booking/services/booking-blocking-calendars";
 import calendarService from "@backend/calendar/services/calendar.service";
 import mongoService from "@backend/common/services/mongo.service";
 import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
@@ -184,8 +188,8 @@ const toAdminResult = async (
 
 class BookingPageService {
   async getAdminPage(userId: ObjectId): Promise<AdminGetBookingPageResult> {
-    const record = await bookingPageRepository.findByUserId(userId);
-    if (!record) {
+    const existing = await bookingPageRepository.findByUserId(userId);
+    if (!existing) {
       const timeZone = await resolveHostTimeZone(userId);
       return {
         ...buildDefaultAdminPutInput(timeZone),
@@ -194,6 +198,7 @@ class BookingPageService {
       };
     }
 
+    const record = await reconcileBookingPageBlockingCalendars(existing);
     return toAdminResult(userId, record);
   }
 
@@ -216,6 +221,13 @@ class BookingPageService {
     }
 
     const existing = await bookingPageRepository.findByUserId(userId);
+    const optedOutBlockingCalendarIds = existing
+      ? await optedOutBlockingCalendarIdsForPut(
+          userId,
+          input.blockingCalendarIds,
+          existing.optedOutBlockingCalendarIds,
+        )
+      : [];
     const fields = mapPutInputToRecordFields(input);
     let bookingSlug = existing?.bookingSlug;
     let slugSource: SlugSource = "allocated";
@@ -245,10 +257,14 @@ class BookingPageService {
       try {
         const saved = await bookingPageRepository.upsertByUserId(userId, {
           ...fields,
+          optedOutBlockingCalendarIds,
           ...(bookingSlug ? { bookingSlug } : {}),
         });
 
-        return toAdminResult(userId, saved);
+        return toAdminResult(
+          userId,
+          await reconcileBookingPageBlockingCalendars(saved),
+        );
       } catch (error) {
         if (!isDuplicateSlugError(error)) {
           throw error;

--- a/packages/backend/src/booking/services/public-booking.service.db.test.ts
+++ b/packages/backend/src/booking/services/public-booking.service.db.test.ts
@@ -2015,6 +2015,64 @@ describe("PublicBookingService", () => {
     expect(starts).not.toContain(occupied);
     expect(starts).not.toContain(halfHour);
   });
+
+  it("blocks a slot busy on a calendar connected after the page was saved", async () => {
+    const userId = await createNamedUser("Late Busy Calendar");
+    const google = writableCalendar();
+    mockHealthySync([google]);
+    spyOn(billingGuard, "assertBillingAllowsWrites").mockResolvedValue(
+      undefined,
+    );
+    const page = await bookingPageService.putAdminPage(
+      userId,
+      samplePutInput({
+        destinationCalendarId: google.id,
+        blockingCalendarIds: [google.id],
+      }),
+    );
+    const slug = "slug" in page ? page.slug : "";
+    const microsoft = writableCalendar();
+    mockHealthySync([google, microsoft]);
+
+    getAvailability.mockImplementation(async (_userId, query) => {
+      const ids = query.calendarIds as string[];
+      if (!ids.includes(microsoft.id)) {
+        return busyResponse(true);
+      }
+      return {
+        ...busyResponse(true),
+        intervals: [
+          {
+            start: `${BOOKING_MONDAY}T10:00:00.000Z`,
+            end: `${BOOKING_MONDAY}T11:00:00.000Z`,
+            hostIsOrganizer: true,
+            hostResponseStatus: null,
+          },
+        ],
+      };
+    });
+
+    const response = await service.getSlots(slug, {
+      start: `${BOOKING_MONDAY}T00:00:00.000Z`,
+      end: `${BOOKING_TUESDAY}T00:00:00.000Z`,
+      timeZone: "UTC",
+    });
+
+    expect(
+      response.slots.some(
+        (slot) =>
+          Date.parse(slot.slotStart) ===
+          Date.parse(`${BOOKING_MONDAY}T10:00:00.000Z`),
+      ),
+    ).toBe(false);
+    expect(getAvailability).toHaveBeenCalled();
+    const queried = getAvailability.mock.calls.at(-1)?.[1] as {
+      calendarIds: string[];
+    };
+    expect(queried.calendarIds).toEqual(
+      expect.arrayContaining([google.id, microsoft.id]),
+    );
+  });
 });
 
 describe("Public booking routes", () => {

--- a/packages/backend/src/booking/services/public-booking.service.ts
+++ b/packages/backend/src/booking/services/public-booking.service.ts
@@ -52,6 +52,7 @@ import {
   bookingReservationRepository,
   confirmedReservationScanRange,
 } from "@backend/booking/booking-reservation.repository";
+import { reconcileBookingPageBlockingCalendars } from "@backend/booking/services/booking-blocking-calendars";
 import {
   emptyBookableStatus,
   hostAllowsGuestWrites,
@@ -458,8 +459,9 @@ export class PublicBookingService {
     const windowEnd =
       requestedEnd.getTime() > horizonEnd.getTime() ? horizonEnd : requestedEnd;
 
+    const reconciled = await reconcileBookingPageBlockingCalendars(page);
     const probe = await probeBookability(
-      page,
+      reconciled,
       { start: windowStart, end: windowEnd },
       this.calendarBooking,
       { excludeEventIds: options.excludeEventIds },
@@ -530,8 +532,9 @@ export class PublicBookingService {
       omitReservationStart?: Date;
     } = {},
   ): Promise<void> {
+    const reconciled = await reconcileBookingPageBlockingCalendars(page);
     const now = new Date();
-    const minNoticeMs = page.minNoticeHours * 60 * 60 * 1000;
+    const minNoticeMs = reconciled.minNoticeHours * 60 * 60 * 1000;
     if (slotStart.getTime() < now.getTime() + minNoticeMs) {
       throw bookingError(
         "SLOT_UNAVAILABLE",
@@ -540,9 +543,9 @@ export class PublicBookingService {
     }
 
     const availability = await this.calendarBooking.getAvailability(
-      page.userId.toString(),
+      reconciled.userId.toString(),
       {
-        calendarIds: page.blockingCalendarIds,
+        calendarIds: reconciled.blockingCalendarIds,
         start: DateTimeSchema.parse(slotStart.toISOString()),
         end: DateTimeSchema.parse(slotEnd.toISOString()),
         ...(options.excludeEventIds

--- a/packages/core/src/booking/merge-blocking-calendars.test.ts
+++ b/packages/core/src/booking/merge-blocking-calendars.test.ts
@@ -1,0 +1,80 @@
+import {
+  mergeDiscoveredBlockingCalendarIds,
+  nextOptedOutBlockingCalendarIds,
+} from "@core/booking/merge-blocking-calendars";
+import { CalendarIdSchema } from "@core/types/domain-primitives";
+import { describe, expect, it } from "bun:test";
+
+const id = (suffix: string) =>
+  CalendarIdSchema.parse(`00000000000000000000000${suffix}`);
+
+describe("mergeDiscoveredBlockingCalendarIds", () => {
+  const google = id("1");
+  const microsoft = id("2");
+  const local = id("3");
+
+  it("adds a calendar discovered after the page was saved", () => {
+    expect(
+      mergeDiscoveredBlockingCalendarIds({
+        current: [google],
+        optedOut: [],
+        discovered: [google, microsoft],
+      }),
+    ).toEqual([google, microsoft]);
+  });
+
+  it("does not re-add a calendar the host opted out of", () => {
+    expect(
+      mergeDiscoveredBlockingCalendarIds({
+        current: [google],
+        optedOut: [microsoft],
+        discovered: [google, microsoft, local],
+      }),
+    ).toEqual([google, local]);
+  });
+
+  it("does not duplicate calendars already blocking", () => {
+    expect(
+      mergeDiscoveredBlockingCalendarIds({
+        current: [google, microsoft],
+        optedOut: [],
+        discovered: [microsoft, google],
+      }),
+    ).toEqual([google, microsoft]);
+  });
+});
+
+describe("nextOptedOutBlockingCalendarIds", () => {
+  const google = id("1");
+  const microsoft = id("2");
+
+  it("records eligible calendars the host left unchecked", () => {
+    expect(
+      nextOptedOutBlockingCalendarIds({
+        previousOptedOut: [],
+        eligible: [google, microsoft],
+        submitted: [google],
+      }),
+    ).toEqual([microsoft]);
+  });
+
+  it("keeps an opt-out after the calendar reconnects", () => {
+    expect(
+      nextOptedOutBlockingCalendarIds({
+        previousOptedOut: [microsoft],
+        eligible: [google, microsoft],
+        submitted: [google],
+      }),
+    ).toEqual([microsoft]);
+  });
+
+  it("clears an opt-out when the host adds the calendar back", () => {
+    expect(
+      nextOptedOutBlockingCalendarIds({
+        previousOptedOut: [microsoft],
+        eligible: [google, microsoft],
+        submitted: [google, microsoft],
+      }),
+    ).toEqual([]);
+  });
+});

--- a/packages/core/src/booking/merge-blocking-calendars.ts
+++ b/packages/core/src/booking/merge-blocking-calendars.ts
@@ -1,0 +1,42 @@
+import { type CalendarId } from "@core/types/domain-primitives";
+
+/**
+ * Add discovered calendars to a booking page's blockers unless the host
+ * already opted them out. Discovery only adds; it never removes a blocker
+ * the host still has selected.
+ */
+export function mergeDiscoveredBlockingCalendarIds(input: {
+  readonly current: readonly CalendarId[];
+  readonly optedOut: readonly CalendarId[];
+  readonly discovered: readonly CalendarId[];
+}): CalendarId[] {
+  const optedOut = new Set(input.optedOut);
+  const next = [...input.current];
+  const seen = new Set(input.current);
+  for (const calendarId of input.discovered) {
+    if (optedOut.has(calendarId) || seen.has(calendarId)) continue;
+    seen.add(calendarId);
+    next.push(calendarId);
+  }
+  return next;
+}
+
+/**
+ * Persist a host's blocker opt-outs: every eligible calendar they did not
+ * submit, plus any earlier opt-out they have not added back.
+ */
+export function nextOptedOutBlockingCalendarIds(input: {
+  readonly previousOptedOut: readonly CalendarId[];
+  readonly eligible: readonly CalendarId[];
+  readonly submitted: readonly CalendarId[];
+}): CalendarId[] {
+  const submitted = new Set(input.submitted);
+  const next: CalendarId[] = [];
+  const seen = new Set<CalendarId>();
+  for (const calendarId of [...input.previousOptedOut, ...input.eligible]) {
+    if (submitted.has(calendarId) || seen.has(calendarId)) continue;
+    seen.add(calendarId);
+    next.push(calendarId);
+  }
+  return next;
+}

--- a/packages/web/src/booking/BookingSettingsSection.test.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.test.tsx
@@ -3069,6 +3069,55 @@ describe("BookingSettingsSection", () => {
     ).toBeInTheDocument();
   });
 
+  it("checks a newly connected availability calendar as a blocker", async () => {
+    const user = userEvent.setup({ delay: null });
+    const microsoftCalendar = createMockCalendar({
+      name: "Outlook",
+      accountEmail: "host@outlook.com",
+      provider: "microsoft",
+      conference: "teams",
+      createsGoogleMeet: false,
+    });
+    userMetadataActions.set({
+      google: {
+        connectionState: "HEALTHY" as const,
+        connections: [
+          createMockConnection("host@example.com"),
+          createMockConnection("host@outlook.com", { provider: "microsoft" }),
+        ],
+      },
+    });
+    server.use(
+      rest.get(bookingPageUrl, (_req, res, ctx) =>
+        res(ctx.json(savedOffPage())),
+      ),
+    );
+
+    const { wrapper, queryClient } = createStoreWrapper();
+    queryClient.setQueryData(calendarQueryKeys.all, [writableCalendar]);
+    render(
+      <HotkeysProvider>
+        <BookingSettingsSection />
+      </HotkeysProvider>,
+      { wrapper },
+    );
+
+    await user.click(await screen.findByText(BOOKING_MORE_OPTIONS_LABEL));
+    const blocking = screen.getByRole("group", { name: "Blocking calendars" });
+    expect(
+      within(blocking).getByRole("checkbox", { name: "Work" }),
+    ).toBeChecked();
+
+    queryClient.setQueryData(calendarQueryKeys.all, [
+      writableCalendar,
+      microsoftCalendar,
+    ]);
+
+    expect(
+      await within(blocking).findByRole("checkbox", { name: "Outlook" }),
+    ).toBeChecked();
+  });
+
   it("keeps More options closed by default", async () => {
     userMetadataActions.set(healthyGoogleMetadata);
     server.use(

--- a/packages/web/src/booking/BookingSettingsSection.tsx
+++ b/packages/web/src/booking/BookingSettingsSection.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { mergeDiscoveredBlockingCalendarIds } from "@core/booking/merge-blocking-calendars";
 import {
   type AdminGetBookingPageResult,
   type AdminPutBookingPageInput,
@@ -300,6 +301,7 @@ export function BookingSettingsSection({
     }
   });
   const baselineFormRef = useRef<AdminPutBookingPageInput | null>(null);
+  const optedOutBlockingRef = useRef<Set<CalendarId>>(new Set());
 
   const minNoticeInvalid =
     parseBookingCount(minNoticeText, MIN_NOTICE_BOUNDS) === null;
@@ -327,6 +329,13 @@ export function BookingSettingsSection({
       writableCalendars,
       availabilityCalendars,
     );
+    optedOutBlockingRef.current = new Set(
+      availabilityCalendars
+        .map((calendar) => calendar.id)
+        .filter(
+          (calendarId) => !seeded.blockingCalendarIds.includes(calendarId),
+        ),
+    );
     setForm(seeded);
     setMinNoticeText(String(seeded.minNoticeHours));
     setHorizonText(String(seeded.maxHorizonDays));
@@ -350,6 +359,47 @@ export function BookingSettingsSection({
       calendarsPending ||
       waitingForHostCalendars ||
       (serverPage != null && seededPageRef.current !== serverPage));
+
+  useEffect(() => {
+    if (isSeedingForm) return;
+    const discovered = availabilityCalendars.map((calendar) => calendar.id);
+    const optedOut = [...optedOutBlockingRef.current];
+    setForm((current) => {
+      const merged = mergeDiscoveredBlockingCalendarIds({
+        current: current.blockingCalendarIds,
+        optedOut,
+        discovered,
+      });
+      if (
+        merged.length === current.blockingCalendarIds.length &&
+        merged.every((calendarId) =>
+          current.blockingCalendarIds.includes(calendarId),
+        )
+      ) {
+        return current;
+      }
+      return { ...current, blockingCalendarIds: merged };
+    });
+    const baseline = baselineFormRef.current;
+    if (baseline) {
+      const mergedBaseline = mergeDiscoveredBlockingCalendarIds({
+        current: baseline.blockingCalendarIds,
+        optedOut,
+        discovered,
+      });
+      if (
+        mergedBaseline.length !== baseline.blockingCalendarIds.length ||
+        mergedBaseline.some(
+          (calendarId) => !baseline.blockingCalendarIds.includes(calendarId),
+        )
+      ) {
+        baselineFormRef.current = {
+          ...baseline,
+          blockingCalendarIds: mergedBaseline,
+        };
+      }
+    }
+  }, [availabilityCalendars, isSeedingForm]);
 
   useEffect(() => {
     if (isSeedingForm) return;
@@ -458,6 +508,11 @@ export function BookingSettingsSection({
   };
 
   const toggleBlockingCalendar = (calendarId: CalendarId, checked: boolean) => {
+    if (checked) {
+      optedOutBlockingRef.current.delete(calendarId);
+    } else {
+      optedOutBlockingRef.current.add(calendarId);
+    }
     setForm((current) => {
       const next = new Set(current.blockingCalendarIds);
       if (checked) next.add(calendarId);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3659

## What and why

A booking page's `blockingCalendarIds` is persisted at create/PUT and was never extended when a calendar connected later, so busy time on a newly connected Microsoft calendar (or any later connection) did not occupy `/meet` slots.

On calendar discovery, GET, and slot computation, every active calendar whose availability-read capability is on is added to the owner's blockers unless the host explicitly removed it. Settings > Meeting checks the new calendar in Blocking calendars. Provider-neutral: no provider-name branch.

## Verify

VERDICT: PASS

Checks run: test:core, test:web, test:backend, type-check, lint, knip, test:a11y, test:e2e
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28f094c7-fc54-4bfd-a30e-184b469e000b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28f094c7-fc54-4bfd-a30e-184b469e000b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

