### PR TITLE
refactor: clear technical debt from the last week of merges

### DIFF
--- a/.github/scripts/autofix-pr-watchdog.sh
+++ b/.github/scripts/autofix-pr-watchdog.sh
@@ -21,9 +21,13 @@ GRACE_MINUTES=${AUTOFIX_WATCHDOG_GRACE_MINUTES:-60}
 DRY_RUN=${AUTOFIX_WATCHDOG_DRY_RUN:-}
 AUTOFIX_MODE=${AUTOFIX_MODE:-}
 
-list_stale_prs() {
+# Open autofix PRs that carry neither terminal label, so escalation is the
+# only thing left for them. `labels` has to be in `--json`: gh returns only
+# the fields asked for, so leaving it out made the filter read an absent
+# `.labels`, pass every PR, and re-notify already-escalated ones hourly.
+list_unterminated_prs() {
   gh pr list --repo "$REPO" --label autofix --state open \
-    --json number,createdAt,url \
+    --json number,createdAt,url,labels \
     --jq '[.[] | select(
       ([.labels[]?.name] | index("automerge-candidate") | not) and
       ([.labels[]?.name] | index("autofix:needs-human") | not)
@@ -77,7 +81,7 @@ escalate() {
 main() {
   local prs pr_json number created url failures=0 escalated=0
 
-  if ! prs=$(list_stale_prs); then
+  if ! prs=$(list_unterminated_prs); then
     notify "Error autofix PR watchdog could not list open autofix PRs (gh pr list failed)"
     return 1
   fi

--- a/.github/scripts/autofix-pr-watchdog.test.sh
+++ b/.github/scripts/autofix-pr-watchdog.test.sh
@@ -20,14 +20,35 @@ set -euo pipefail
 printf '%s\n' "$*" >> "${AUTOFIX_TEST_GH_LOG}"
 args="$*"
 if [[ "$args" == *"pr list"* ]]; then
+  if [ -n "${AUTOFIX_TEST_LIST_FAIL:-}" ]; then
+    echo "simulated gh pr list failure" >&2
+    exit 1
+  fi
+  # Faithful `gh pr list` fake: answer with only the fields the caller named
+  # in --json, then apply the caller's own --jq. Re-implementing the filter
+  # here instead let a script that forgot to request `labels` still look like
+  # it filtered on them, which is how the bug this guards reached CI.
   # `gh ... --jq` prints raw (unquoted) output for string results, same as
   # `jq -r`, which is what production relies on for `tojson`-per-line output.
-  jq -r '
-    [.[] | select(
-      ([.labels[]?.name] | index("automerge-candidate") | not) and
-      ([.labels[]?.name] | index("autofix:needs-human") | not)
-    )] | .[] | tojson
-  ' <<<"${AUTOFIX_TEST_PRS:-[]}"
+  fields=""
+  jq_expr="."
+  while [ $# -gt 0 ]; do
+    case $1 in
+      --json)
+        fields=$2
+        shift 2
+        ;;
+      --jq)
+        jq_expr=$2
+        shift 2
+        ;;
+      *) shift ;;
+    esac
+  done
+  jq -c --arg fields "$fields" \
+    '($fields | split(",")) as $requested
+     | [.[] | with_entries(select(.key | IN($requested[])))]' \
+    <<<"${AUTOFIX_TEST_PRS:-[]}" | jq -r "$jq_expr"
   exit 0
 fi
 if [[ "$args" == *"pr edit"* ]]; then
@@ -38,10 +59,6 @@ if [[ "$args" == *"pr edit"* ]]; then
     fi
   done
   exit 0
-fi
-if [[ "$args" == *"pr list --fail"* ]]; then
-  echo "simulated gh pr list failure" >&2
-  exit 1
 fi
 if [[ "$args" == *"label create"* ]]; then
   exit 0
@@ -63,12 +80,16 @@ iso_ago_minutes() {
 }
 
 run_watchdog() {
+  # Per-run log, so a `pr edit` from an earlier case can't satisfy (or spoil)
+  # this case's assertions.
+  : >"$GH_LOG"
   set +e
   PATH="${STUB_DIR}:${PATH}" \
     GH_REPO="example/compass" \
     AUTOFIX_TEST_GH_LOG="$GH_LOG" \
     AUTOFIX_TEST_PRS="${AUTOFIX_TEST_PRS:-[]}" \
     AUTOFIX_TEST_EDIT_FAIL_FOR="${AUTOFIX_TEST_EDIT_FAIL_FOR:-}" \
+    AUTOFIX_TEST_LIST_FAIL="${AUTOFIX_TEST_LIST_FAIL:-}" \
     AUTOFIX_WATCHDOG_GRACE_MINUTES="${AUTOFIX_WATCHDOG_GRACE_MINUTES:-60}" \
     AUTOFIX_MODE="${AUTOFIX_MODE:-}" \
     bash "${ROOT}/.github/scripts/autofix-pr-watchdog.sh" >"$OUT" 2>&1
@@ -172,6 +193,14 @@ assert_out_contains "failed to apply autofix:needs-human label" "failed label ed
 assert_out_contains "Autofix PR #3703 has been open" "second PR is still escalated after the first fails"
 assert_eq "$WATCHDOG_EXIT" "1" "a label-edit failure makes the run exit non-zero"
 AUTOFIX_TEST_EDIT_FAIL_FOR=""
+
+# 7. `gh pr list` itself fails: nothing is escalated and the run reports it.
+AUTOFIX_TEST_PRS='[]'
+AUTOFIX_TEST_LIST_FAIL="1"
+run_watchdog
+assert_eq "$WATCHDOG_EXIT" "1" "a failed pr list makes the run exit non-zero"
+assert_log_not_contains "pr edit" "no label edit is attempted when listing fails"
+AUTOFIX_TEST_LIST_FAIL=""
 
 if [ "$FAIL" -ne 0 ]; then
   echo "FAILED ${FAIL}  passed ${PASS}" >&2

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -119,17 +119,20 @@ jobs:
           # this actionlint release does not know yet; drop the ignore on upgrade.
 
       # The loop scripts' own tests (gh stub, dry-run guard). They need bash 4+.
+      # Every *.test.sh runs, rather than a hand-maintained list: the list is
+      # what left autofix-pr-watchdog.test.sh unrun from the day it landed,
+      # hiding a filter bug the test would have caught. All of them run even
+      # if one fails, so a red leg reports every broken script at once.
       - name: Test agent-loop scripts
         run: |
           bash -n .github/scripts/*.sh
-          bash .github/scripts/agent-loop-next.test.sh
-          bash .github/scripts/agent-loop-merge-guard.test.sh
-          bash .github/scripts/live-provider-smoke.test.sh
-          bash .github/scripts/detect-code-changes.test.sh
-          bash .github/scripts/autofix-preflight.test.sh
-          bash .github/scripts/autofix-unstick.test.sh
-          bash .github/scripts/autofix-sweep.test.sh
-          bash .github/scripts/autofix-lib.test.sh
+          status=0
+          for script_test in .github/scripts/*.test.sh; do
+            echo "::group::${script_test}"
+            bash "${script_test}" || status=1
+            echo "::endgroup::"
+          done
+          exit "${status}"
 
   # A skipped MATRIX job collapses to one check run, so the `unit` rollup
   # below would see `skipped` for a docs-only PR only if every leg started.

--- a/e2e/timed/mouse-inert.spec.ts
+++ b/e2e/timed/mouse-inert.spec.ts
@@ -87,12 +87,18 @@ test("an empty grid click teaches the digits that create there", async ({
   expect(timeLabel).toBeTruthy();
   // "7:15 AM" -> "7:15"; the draft's name reads "Untitled event, 7:15 - 8:15 AM".
   const startClock = (timeLabel ?? "").replace(/\s*[AP]M$/i, "");
+  // The hint always spells the minutes (Intl `minute: "2-digit"`), while the
+  // card's label drops them on a whole hour (web.date.util's getTimeLabel
+  // strips ":00"), so "2:00 PM" in the hint is "2 - 3 PM" on the card. Accept
+  // either spelling: without this the test passes all day and fails only in
+  // the windows where the clicked slot lands exactly on the hour.
+  const startPattern = startClock.replace(/:00$/, "(?::00)?");
 
   // Typed time places a draft at the clicked slot; the form opens on Enter.
   await page.keyboard.type(digits);
   await expect(
     grid.getByRole("button", {
-      name: new RegExp(`Untitled event, ${startClock} `),
+      name: new RegExp(`Untitled event, ${startPattern} `),
     }),
   ).toBeVisible();
 });

--- a/packages/backend/src/auth/services/account-linking.util.ts
+++ b/packages/backend/src/auth/services/account-linking.util.ts
@@ -1,5 +1,5 @@
 import { type Schema_UserIdentity } from "@core/types/user.types";
-import { normalizeEmail } from "@backend/common/helpers/email.util";
+import { normalizeEmail } from "@core/util/email.util";
 
 export const APPLE_PRIVATE_RELAY_DOMAIN = "privaterelay.appleid.com";
 

--- a/packages/backend/src/auth/services/apple/apple.auth.service.ts
+++ b/packages/backend/src/auth/services/apple/apple.auth.service.ts
@@ -5,6 +5,7 @@ import {
 } from "@core/types/sync/connection.contracts";
 import { StringV4Schema, zObjectId } from "@core/types/type.utils";
 import { type Schema_UserIdentity } from "@core/types/user.types";
+import { normalizeEmail } from "@core/util/email.util";
 import { emailForVerifiedAccountLinkLookup } from "@backend/auth/services/account-linking.util";
 import {
   grantedScopesIncludeCalendarAccess,
@@ -17,7 +18,6 @@ import {
   authErrorCopy,
 } from "@backend/common/errors/auth/auth.errors";
 import { error } from "@backend/common/errors/handlers/error.handler";
-import { normalizeEmail } from "@backend/common/helpers/email.util";
 import { adoptProviderAuthorization } from "@backend/common/services/sync-service/sync-connection-adoption";
 import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
 import * as syncServiceFactory from "@backend/common/services/sync-service/sync-service.factory";

--- a/packages/backend/src/auth/services/google/google.auth.service.ts
+++ b/packages/backend/src/auth/services/google/google.auth.service.ts
@@ -5,6 +5,7 @@ import {
   ProviderAccountFactsSchema,
 } from "@core/types/sync/connection.contracts";
 import { StringV4Schema, zObjectId } from "@core/types/type.utils";
+import { normalizeEmail } from "@core/util/email.util";
 import {
   determineGoogleAuthMode,
   parseReconnectGoogleParams,
@@ -12,7 +13,6 @@ import {
 import { CONFIG } from "@backend/common/constants/config.constants";
 import { AuthError } from "@backend/common/errors/auth/auth.errors";
 import { error } from "@backend/common/errors/handlers/error.handler";
-import { normalizeEmail } from "@backend/common/helpers/email.util";
 import mongoService from "@backend/common/services/mongo.service";
 import { adoptGoogleAuthorization } from "@backend/common/services/sync-service/sync-connection-adoption";
 import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";

--- a/packages/backend/src/auth/services/microsoft/microsoft.auth.service.ts
+++ b/packages/backend/src/auth/services/microsoft/microsoft.auth.service.ts
@@ -6,6 +6,7 @@ import {
 } from "@core/types/sync/connection.contracts";
 import { StringV4Schema, zObjectId } from "@core/types/type.utils";
 import { type Schema_UserIdentity } from "@core/types/user.types";
+import { normalizeEmail } from "@core/util/email.util";
 import { emailForVerifiedAccountLinkLookup } from "@backend/auth/services/account-linking.util";
 import { determineThirdPartyAuthMode } from "@backend/auth/services/google/util/google.auth.util";
 import { CONFIG } from "@backend/common/constants/config.constants";
@@ -14,7 +15,6 @@ import {
   authErrorCopy,
 } from "@backend/common/errors/auth/auth.errors";
 import { error } from "@backend/common/errors/handlers/error.handler";
-import { normalizeEmail } from "@backend/common/helpers/email.util";
 import { adoptProviderAuthorization } from "@backend/common/services/sync-service/sync-connection-adoption";
 import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
 import * as syncServiceFactory from "@backend/common/services/sync-service/sync-service.factory";

--- a/packages/backend/src/auth/services/supertokens/supertokens.user-cleanup.service.ts
+++ b/packages/backend/src/auth/services/supertokens/supertokens.user-cleanup.service.ts
@@ -7,7 +7,7 @@ import {
 } from "supertokens-node";
 import SupertokensUserMetadata from "supertokens-node/recipe/usermetadata";
 import { Logger } from "@core/logger/winston.logger";
-import { normalizeEmail } from "@backend/common/helpers/email.util";
+import { normalizeEmail } from "@core/util/email.util";
 import { initSupertokens } from "@backend/common/middleware/supertokens.middleware";
 import { type Summary_Delete } from "@backend/user/types/user.types";
 

--- a/packages/backend/src/common/helpers/email.util.ts
+++ b/packages/backend/src/common/helpers/email.util.ts
@@ -1,3 +1,0 @@
-export const normalizeEmail = (email: string): string => {
-  return email.trim().toLowerCase();
-};

--- a/packages/backend/src/user/queries/user.queries.ts
+++ b/packages/backend/src/user/queries/user.queries.ts
@@ -1,7 +1,7 @@
 import { type ProviderKind } from "@core/types/sync/identity.contracts";
 import { type Schema_User } from "@core/types/user.types";
+import { normalizeEmail } from "@core/util/email.util";
 import { hasVerifiedLoginMethod } from "@backend/auth/services/account-linking.util";
-import { normalizeEmail } from "@backend/common/helpers/email.util";
 import { getIdFilter } from "@backend/common/helpers/mongo.utils";
 import mongoService from "@backend/common/services/mongo.service";
 

--- a/packages/backend/src/user/services/user.service.ts
+++ b/packages/backend/src/user/services/user.service.ts
@@ -13,6 +13,7 @@ import {
   type Schema_UserIdentity,
   type UserProfile,
 } from "@core/types/user.types";
+import { normalizeEmail } from "@core/util/email.util";
 import { canReuseCompassUserByEmail } from "@backend/auth/services/account-linking.util";
 import compassAuthService from "@backend/auth/services/compass/compass.auth.service";
 import supertokensUserCleanupService from "@backend/auth/services/supertokens/supertokens.user-cleanup.service";
@@ -21,7 +22,6 @@ import calendarService from "@backend/calendar/services/calendar.service";
 import { Collections } from "@backend/common/constants/collections";
 import { error } from "@backend/common/errors/handlers/error.handler";
 import { UserError } from "@backend/common/errors/user/user.errors";
-import { normalizeEmail } from "@backend/common/helpers/email.util";
 import mongoService from "@backend/common/services/mongo.service";
 import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
 import { getSyncServiceClient } from "@backend/common/services/sync-service/sync-service.factory";

--- a/packages/core/src/util/email.util.test.ts
+++ b/packages/core/src/util/email.util.test.ts
@@ -1,0 +1,25 @@
+import { normalizeEmail, normalizeEmailOrNull } from "@core/util/email.util";
+import { describe, expect, it } from "bun:test";
+
+describe("normalizeEmail", () => {
+  it("folds case and strips surrounding whitespace", () => {
+    expect(normalizeEmail("  Ahab@Pequod.com \n")).toBe("ahab@pequod.com");
+  });
+
+  it("leaves an already-normalized address alone", () => {
+    expect(normalizeEmail("ahab@pequod.com")).toBe("ahab@pequod.com");
+  });
+});
+
+describe("normalizeEmailOrNull", () => {
+  it("normalizes a present address", () => {
+    expect(normalizeEmailOrNull(" Ahab@Pequod.com ")).toBe("ahab@pequod.com");
+  });
+
+  it("returns null for absent or whitespace-only values", () => {
+    expect(normalizeEmailOrNull(undefined)).toBeNull();
+    expect(normalizeEmailOrNull(null)).toBeNull();
+    expect(normalizeEmailOrNull("")).toBeNull();
+    expect(normalizeEmailOrNull("   ")).toBeNull();
+  });
+});

--- a/packages/core/src/util/email.util.ts
+++ b/packages/core/src/util/email.util.ts
@@ -1,0 +1,25 @@
+/**
+ * The one way an email address is folded before it is compared or stored.
+ * Addresses arrive with provider-chosen casing and stray whitespace (OAuth
+ * profiles, pasted invites, a typed login), so every comparison has to agree
+ * on the same fold or the same person looks like two.
+ *
+ * Lives in core because both sides need it: the API keys users by it, and the
+ * browser matches calendars, connections and reconnect targets against it.
+ */
+export const normalizeEmail = (email: string): string =>
+  email.trim().toLowerCase();
+
+/**
+ * Normalized form, or null when there is nothing left to compare (absent, or
+ * whitespace only). Callers holding an optional address use this instead of
+ * repeating the emptiness check: a `""` key would otherwise match every
+ * account that reported no email.
+ */
+export const normalizeEmailOrNull = (
+  email: string | null | undefined,
+): string | null => {
+  if (!email) return null;
+  const normalized = normalizeEmail(email);
+  return normalized.length > 0 ? normalized : null;
+};

--- a/packages/scripts/src/commands/purge-user/purge.ts
+++ b/packages/scripts/src/commands/purge-user/purge.ts
@@ -17,9 +17,9 @@ import {
   PrincipalIdSchema,
   TenantIdSchema,
 } from "@core/types/sync/identity.contracts";
+import { normalizeEmail } from "@core/util/email.util";
 import { Collections } from "@backend/common/constants/collections";
 import { IS_DEV } from "@backend/common/constants/config.constants";
-import { normalizeEmail } from "@backend/common/helpers/email.util";
 import { toSyncPrincipal } from "@backend/common/services/sync-service/sync-principal";
 import { purgePrincipal } from "@sync/domain/principal-purge.service";
 import { SYNC_COLLECTIONS } from "@sync/storage/collections";

--- a/packages/scripts/src/testing/agent-loop-routine.test.ts
+++ b/packages/scripts/src/testing/agent-loop-routine.test.ts
@@ -38,7 +38,12 @@ describe("agent-loop Routine contract", () => {
     expect(guard).not.toContain("evaluate_paths");
     const unit = readFileSync(".github/workflows/test-unit.yml", "utf8");
     expect(unit).toContain("rhysd/actionlint");
-    expect(unit).toContain("agent-loop-merge-guard.test.sh");
+    // The step loops over every `*.test.sh` rather than naming them, so the
+    // contract is the loop plus the file being there to be picked up.
+    expect(unit).toContain("for script_test in .github/scripts/*.test.sh");
+    expect(existsSync(".github/scripts/agent-loop-merge-guard.test.sh")).toBe(
+      true,
+    );
   });
 
   it("launches the next WP on merge with per-job concurrency", () => {

--- a/packages/scripts/src/testing/detect-code-changes.test.ts
+++ b/packages/scripts/src/testing/detect-code-changes.test.ts
@@ -131,7 +131,12 @@ describe("detect-code-changes", () => {
     expect(unit).toContain("code: ${{ steps.filter.outputs.code }}");
     expect(unit).toContain("web: ${{ steps.filter.outputs.web }}");
     expect(unit).toContain("needs.changes.outputs[matrix.project]");
-    expect(unit).toContain("bash .github/scripts/detect-code-changes.test.sh");
+    // The step loops over every `*.test.sh` rather than naming them, so the
+    // contract is the loop plus the file being there to be picked up.
+    expect(unit).toContain("for script_test in .github/scripts/*.test.sh");
+    expect(existsSync(".github/scripts/detect-code-changes.test.sh")).toBe(
+      true,
+    );
     expect(unit).not.toContain("outputs.e2e");
   });
 

--- a/packages/scripts/src/testing/error-autofix-routine.test.ts
+++ b/packages/scripts/src/testing/error-autofix-routine.test.ts
@@ -81,11 +81,19 @@ describe("error-autofix Routine contract", () => {
     expect(existsSync(".github/scripts/autofix-sweep.sh")).toBe(true);
     expect(existsSync(".github/scripts/autofix-unstick.sh")).toBe(true);
 
+    // The step loops over every `*.test.sh` rather than naming them, so the
+    // contract is the loop plus each test file being there to be picked up.
     const unit = readFileSync(".github/workflows/test-unit.yml", "utf8");
-    expect(unit).toContain("bash .github/scripts/autofix-preflight.test.sh");
-    expect(unit).toContain("bash .github/scripts/autofix-unstick.test.sh");
-    expect(unit).toContain("bash .github/scripts/autofix-sweep.test.sh");
-    expect(unit).toContain("bash .github/scripts/autofix-lib.test.sh");
+    expect(unit).toContain("for script_test in .github/scripts/*.test.sh");
+    for (const scriptTest of [
+      "autofix-preflight.test.sh",
+      "autofix-unstick.test.sh",
+      "autofix-sweep.test.sh",
+      "autofix-lib.test.sh",
+      "autofix-pr-watchdog.test.sh",
+    ]) {
+      expect(existsSync(`.github/scripts/${scriptTest}`)).toBe(true);
+    }
 
     const preflightTest = readFileSync(
       ".github/scripts/autofix-preflight.test.sh",

--- a/packages/web/src/__tests__/boot-shell.test.ts
+++ b/packages/web/src/__tests__/boot-shell.test.ts
@@ -9,7 +9,7 @@
  * computes against the constants it copied, so a change to either side fails
  * here instead of shifting the layout at the React swap.
  */
-import { JSDOM } from "jsdom";
+
 import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
 import { SIDEBAR_AUTO_COLLAPSE_BREAKPOINT } from "@web/components/AuthenticatedLayout/responsive.constants";
 import {
@@ -52,39 +52,41 @@ const expectedTrackWidth = (
   MAIN_COLUMN_LEFT_PADDING -
   (sidebar.isOpen ? SIDEBAR_DIVIDER_WIDTH + sidebar.width : 0);
 
+/**
+ * A fresh document plus a getItem-only storage stub, handed to the script as
+ * arguments so its free `document` / `localStorage` / `innerWidth` resolve
+ * without touching this process's own globals. Each call gets its own
+ * document, so cases cannot leak attributes into each other.
+ */
 const runHeadScript = ({
   innerWidth,
   stored = {},
 }: {
   innerWidth: number;
-  stored?: Partial<Record<string, string>>;
+  stored?: Record<string, string>;
 }) => {
-  const dom = new JSDOM(
-    `<!doctype html>
-     <html data-theme="${DEFAULT_THEME}">
-       <head>
-         <meta name="theme-color" content="${THEMES[DEFAULT_THEME].metaColor}" />
-       </head>
-       <body></body>
-     </html>`,
-    { runScripts: "outside-only", url: "http://localhost/" },
+  const doc = document.implementation.createHTMLDocument("boot shell");
+  doc.documentElement.setAttribute("data-theme", DEFAULT_THEME);
+  const meta = doc.createElement("meta");
+  meta.setAttribute("name", "theme-color");
+  meta.setAttribute("content", THEMES[DEFAULT_THEME].metaColor);
+  doc.head.appendChild(meta);
+
+  const storage = {
+    getItem: (key: string): string | null => stored[key] ?? null,
+  };
+
+  new Function("innerWidth", "document", "localStorage", headScript)(
+    innerWidth,
+    doc,
+    storage,
   );
-  Object.defineProperty(dom.window, "innerWidth", {
-    configurable: true,
-    value: innerWidth,
-  });
-  for (const [key, value] of Object.entries(stored)) {
-    if (value !== undefined) dom.window.localStorage.setItem(key, value);
-  }
 
-  dom.window.eval(headScript);
-
-  const html = dom.window.document.documentElement;
-  const themeColorMeta =
-    dom.window.document.getElementsByName("theme-color")[0];
+  const html = doc.documentElement;
+  const themeColor = doc.getElementsByName("theme-color")[0];
   return {
     theme: html.getAttribute("data-theme"),
-    themeColor: themeColorMeta?.getAttribute("content") ?? null,
+    themeColor: themeColor?.getAttribute("content") ?? null,
     sidebarState: html.dataset.bootSidebar,
     sidebarWidth: html.style.getPropertyValue("--boot-sidebar-width"),
     columns: Number(html.dataset.bootCols),

--- a/packages/web/src/__tests__/boot-shell.test.ts
+++ b/packages/web/src/__tests__/boot-shell.test.ts
@@ -1,0 +1,222 @@
+/**
+ * The pre-JavaScript boot shell in `src/index.html` runs before any module
+ * loads, so it cannot import the app's constants: it re-spells the storage
+ * keys, the sidebar geometry, the breakpoint, the theme colors and the
+ * visible-column formula as literals, under a comment asking whoever changes
+ * them to keep eight files in sync by hand.
+ *
+ * This runs the real head script from the real file and compares what it
+ * computes against the constants it copied, so a change to either side fails
+ * here instead of shifting the layout at the React swap.
+ */
+import { JSDOM } from "jsdom";
+import { STORAGE_KEYS } from "@web/common/constants/storage.constants";
+import { SIDEBAR_AUTO_COLLAPSE_BREAKPOINT } from "@web/components/AuthenticatedLayout/responsive.constants";
+import {
+  clampSidebarWidth,
+  SIDEBAR_DEFAULT_WIDTH,
+  SIDEBAR_DIVIDER_WIDTH,
+  SIDEBAR_MAX_WIDTH,
+  SIDEBAR_MIN_WIDTH,
+} from "@web/components/Sidebar/storage/sidebar-width.constants";
+import { DEFAULT_THEME, THEMES } from "@web/settings/theme/theme.constants";
+import { computeVisibleDayCount } from "@web/views/Week/util/week-window.util";
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const INDEX_HTML_PATH = path.join(import.meta.dir, "..", "index.html");
+const indexHtml = readFileSync(INDEX_HTML_PATH, "utf8");
+
+/**
+ * The two attribute-less inline scripts, in document order: the head script
+ * that themes and sizes the shell, then the body script that fills in dates.
+ * The structured-data and module scripts both carry attributes.
+ */
+const inlineScripts = [
+  ...indexHtml.matchAll(/<script>([\s\S]*?)<\/script>/g),
+].map((match) => match[1]);
+const headScript = inlineScripts[0] ?? "";
+
+/**
+ * WeekView's own left padding (`pl-8`). A Tailwind class has no importable
+ * value, so this is the one number the guard can only restate.
+ */
+const MAIN_COLUMN_LEFT_PADDING = 32;
+
+const expectedTrackWidth = (
+  innerWidth: number,
+  sidebar: { isOpen: boolean; width: number },
+): number =>
+  innerWidth -
+  MAIN_COLUMN_LEFT_PADDING -
+  (sidebar.isOpen ? SIDEBAR_DIVIDER_WIDTH + sidebar.width : 0);
+
+const runHeadScript = ({
+  innerWidth,
+  stored = {},
+}: {
+  innerWidth: number;
+  stored?: Partial<Record<string, string>>;
+}) => {
+  const dom = new JSDOM(
+    `<!doctype html>
+     <html data-theme="${DEFAULT_THEME}">
+       <head>
+         <meta name="theme-color" content="${THEMES[DEFAULT_THEME].metaColor}" />
+       </head>
+       <body></body>
+     </html>`,
+    { runScripts: "outside-only", url: "http://localhost/" },
+  );
+  Object.defineProperty(dom.window, "innerWidth", {
+    configurable: true,
+    value: innerWidth,
+  });
+  for (const [key, value] of Object.entries(stored)) {
+    if (value !== undefined) dom.window.localStorage.setItem(key, value);
+  }
+
+  dom.window.eval(headScript);
+
+  const html = dom.window.document.documentElement;
+  const themeColorMeta =
+    dom.window.document.getElementsByName("theme-color")[0];
+  return {
+    theme: html.getAttribute("data-theme"),
+    themeColor: themeColorMeta?.getAttribute("content") ?? null,
+    sidebarState: html.dataset.bootSidebar,
+    sidebarWidth: html.style.getPropertyValue("--boot-sidebar-width"),
+    columns: Number(html.dataset.bootCols),
+    columnsVariable: html.style.getPropertyValue("--boot-cols"),
+  };
+};
+
+describe("boot shell head script: sidebar state", () => {
+  it("opens the sidebar at its default width when nothing is stored", () => {
+    const shell = runHeadScript({ innerWidth: 1600 });
+
+    expect(shell.sidebarState).toBe("open");
+    expect(shell.sidebarWidth).toBe(`${SIDEBAR_DEFAULT_WIDTH}px`);
+  });
+
+  it("honors a stored collapsed sidebar", () => {
+    const shell = runHeadScript({
+      innerWidth: 1600,
+      stored: { [STORAGE_KEYS.SIDEBAR_OPEN]: "false" },
+    });
+
+    expect(shell.sidebarState).toBe("closed");
+  });
+
+  it("collapses below the auto-collapse breakpoint and opens at it", () => {
+    expect(
+      runHeadScript({ innerWidth: SIDEBAR_AUTO_COLLAPSE_BREAKPOINT - 1 })
+        .sidebarState,
+    ).toBe("closed");
+    expect(
+      runHeadScript({ innerWidth: SIDEBAR_AUTO_COLLAPSE_BREAKPOINT })
+        .sidebarState,
+    ).toBe("open");
+  });
+
+  it("clamps a stored width the way clampSidebarWidth does", () => {
+    const tooWide = runHeadScript({
+      innerWidth: 1600,
+      stored: { [STORAGE_KEYS.SIDEBAR_WIDTH]: "9999" },
+    });
+    const tooNarrow = runHeadScript({
+      innerWidth: 1600,
+      stored: { [STORAGE_KEYS.SIDEBAR_WIDTH]: "100" },
+    });
+
+    expect(tooWide.sidebarWidth).toBe(`${clampSidebarWidth(9999)}px`);
+    expect(tooWide.sidebarWidth).toBe(`${SIDEBAR_MAX_WIDTH}px`);
+    expect(tooNarrow.sidebarWidth).toBe(`${clampSidebarWidth(100)}px`);
+    expect(tooNarrow.sidebarWidth).toBe(`${SIDEBAR_MIN_WIDTH}px`);
+  });
+
+  it('reads a stored "0" as the default width, as the file documents', () => {
+    // The app clamps 0 up to SIDEBAR_MIN_WIDTH; the shell's `|| 345` fallback
+    // treats it as unset instead. Pinned so the divergence stays deliberate.
+    const shell = runHeadScript({
+      innerWidth: 1600,
+      stored: { [STORAGE_KEYS.SIDEBAR_WIDTH]: "0" },
+    });
+
+    expect(shell.sidebarWidth).toBe(`${SIDEBAR_DEFAULT_WIDTH}px`);
+  });
+});
+
+describe("boot shell head script: visible columns", () => {
+  const cases: { innerWidth: number; storedWidth?: string }[] = [
+    { innerWidth: 1600 },
+    { innerWidth: SIDEBAR_AUTO_COLLAPSE_BREAKPOINT },
+    { innerWidth: SIDEBAR_AUTO_COLLAPSE_BREAKPOINT - 1 },
+    { innerWidth: 1600, storedWidth: String(SIDEBAR_MAX_WIDTH) },
+    { innerWidth: 900 },
+    { innerWidth: 400 },
+    { innerWidth: 100 },
+  ];
+
+  for (const { innerWidth, storedWidth } of cases) {
+    it(`matches computeVisibleDayCount at ${innerWidth}px${
+      storedWidth ? ` with a ${storedWidth}px sidebar` : ""
+    }`, () => {
+      const shell = runHeadScript({
+        innerWidth,
+        stored: storedWidth
+          ? { [STORAGE_KEYS.SIDEBAR_WIDTH]: storedWidth }
+          : {},
+      });
+      const track = expectedTrackWidth(innerWidth, {
+        isOpen: shell.sidebarState === "open",
+        width: Number.parseInt(shell.sidebarWidth, 10),
+      });
+
+      expect(shell.columns).toBe(computeVisibleDayCount(track));
+      expect(shell.columnsVariable).toBe(String(shell.columns));
+    });
+  }
+});
+
+describe("boot shell head script: theme", () => {
+  it("applies the stored dark theme and its meta color before first paint", () => {
+    const shell = runHeadScript({
+      innerWidth: 1600,
+      stored: { [STORAGE_KEYS.THEME]: "dark-abyss" },
+    });
+
+    expect(shell.theme).toBe("dark-abyss");
+    expect(shell.themeColor).toBe(THEMES["dark-abyss"].metaColor);
+  });
+
+  it("keeps the default theme when nothing or an unknown value is stored", () => {
+    const unset = runHeadScript({ innerWidth: 1600 });
+    const unknown = runHeadScript({
+      innerWidth: 1600,
+      stored: { [STORAGE_KEYS.THEME]: "light-lagoon" },
+    });
+
+    for (const shell of [unset, unknown]) {
+      expect(shell.theme).toBe(DEFAULT_THEME);
+      expect(shell.themeColor).toBe(THEMES[DEFAULT_THEME].metaColor);
+    }
+  });
+});
+
+describe("boot shell markup", () => {
+  it("ships the default theme and its meta color as the static attributes", () => {
+    expect(indexHtml).toContain(
+      `<html lang="en" data-theme="${DEFAULT_THEME}">`,
+    );
+    expect(indexHtml).toContain(
+      `<meta name="theme-color" content="${THEMES[DEFAULT_THEME].metaColor}" />`,
+    );
+  });
+
+  it("carries both inline scripts the shell needs", () => {
+    expect(inlineScripts).toHaveLength(2);
+    expect(headScript).toContain("--boot-sidebar-width");
+  });
+});

--- a/packages/web/src/__tests__/boot-shell.test.ts
+++ b/packages/web/src/__tests__/boot-shell.test.ts
@@ -32,10 +32,18 @@ const indexHtml = readFileSync(INDEX_HTML_PATH, "utf8");
  * The two attribute-less inline scripts, in document order: the head script
  * that themes and sizes the shell, then the body script that fills in dates.
  * The structured-data and module scripts both carry attributes.
+ *
+ * Parsed rather than matched: `parseFromString` never executes a script, and
+ * a tag regexp here is both fragile about casing and whitespace and a
+ * standing CodeQL `js/bad-tag-filter` finding.
  */
 const inlineScripts = [
-  ...indexHtml.matchAll(/<script>([\s\S]*?)<\/script>/g),
-].map((match) => match[1]);
+  ...new window.DOMParser()
+    .parseFromString(indexHtml, "text/html")
+    .getElementsByTagName("script"),
+]
+  .filter((script) => !script.hasAttributes())
+  .map((script) => script.textContent ?? "");
 const headScript = inlineScripts[0] ?? "";
 
 /**
@@ -178,6 +186,41 @@ describe("boot shell head script: visible columns", () => {
 
       expect(shell.columns).toBe(computeVisibleDayCount(track));
       expect(shell.columnsVariable).toBe(String(shell.columns));
+    });
+  }
+
+  /**
+   * The narrowest open-sidebar viewport the imported constants say yields
+   * `columns`, found by scanning rather than restated as a literal.
+   */
+  const firstWidthWithColumns = (columns: number): number => {
+    for (
+      let innerWidth = SIDEBAR_AUTO_COLLAPSE_BREAKPOINT;
+      innerWidth <= 4000;
+      innerWidth += 1
+    ) {
+      const track = expectedTrackWidth(innerWidth, {
+        isOpen: true,
+        width: SIDEBAR_DEFAULT_WIDTH,
+      });
+      if (computeVisibleDayCount(track) === columns) return innerWidth;
+    }
+    throw new Error(`no viewport width yields ${columns} columns`);
+  };
+
+  // The cases above land in saturated stretches of the column formula's
+  // floor(), where a small change to the divider or the gutter cannot flip a
+  // count. These pin the step itself: a viewport one pixel narrower has to
+  // show one column fewer, so any drift in the geometry moves the step and
+  // fails here.
+  for (const columns of [6, 7]) {
+    it(`steps up to ${columns} columns at the width the constants imply`, () => {
+      const boundary = firstWidthWithColumns(columns);
+
+      expect(runHeadScript({ innerWidth: boundary }).columns).toBe(columns);
+      expect(runHeadScript({ innerWidth: boundary - 1 }).columns).toBe(
+        columns - 1,
+      );
     });
   }
 });

--- a/packages/web/src/auth/providers/reconnect.state.ts
+++ b/packages/web/src/auth/providers/reconnect.state.ts
@@ -15,6 +15,7 @@ import {
   type ProviderKind,
   ProviderKindSchema,
 } from "@core/types/sync/identity.contracts";
+import { normalizeEmail, normalizeEmailOrNull } from "@core/util/email.util";
 
 export type GoogleReconnectTarget = {
   connectionId?: string | null;
@@ -35,12 +36,6 @@ const notify = (): void => {
   }
 };
 
-const normalizeEmail = (email: string | null | undefined): string | null => {
-  if (!email) return null;
-  const trimmed = email.trim().toLowerCase();
-  return trimmed.length > 0 ? trimmed : null;
-};
-
 const parseProvider = (
   provider: string | null | undefined,
 ): ProviderKind | null => {
@@ -56,7 +51,7 @@ export function reconnectAccountKey(
   provider: ProviderKind,
   email: string,
 ): string {
-  return `${provider}:${email.trim().toLowerCase()}`;
+  return `${provider}:${normalizeEmail(email)}`;
 }
 
 const normalizeTarget = (
@@ -67,7 +62,7 @@ const normalizeTarget = (
   provider: ProviderKind | null;
 } => ({
   connectionId: target.connectionId?.trim() || null,
-  accountEmail: normalizeEmail(target.accountEmail),
+  accountEmail: normalizeEmailOrNull(target.accountEmail),
   provider: parseProvider(target.provider),
 });
 
@@ -180,7 +175,7 @@ export function syncReconnectRequiredFromConnections(
   const presentIds = new Set(connections.map((connection) => connection.id));
   const presentKeys = new Set<string>();
   for (const connection of connections) {
-    const email = normalizeEmail(connection.accountEmail);
+    const email = normalizeEmailOrNull(connection.accountEmail);
     if (!email) continue;
     presentKeys.add(
       reconnectAccountKey(connectionProvider(connection.provider), email),
@@ -200,7 +195,7 @@ export function syncReconnectRequiredFromConnections(
       connectionProviders.set(connection.id, provider);
       changed = true;
     }
-    const email = normalizeEmail(connection.accountEmail);
+    const email = normalizeEmailOrNull(connection.accountEmail);
     if (email) {
       const key = reconnectAccountKey(provider, email);
       if (!reconnectRequiredAccounts.has(key)) {
@@ -239,7 +234,7 @@ export function isAccountReconnectRequired(
   accountEmail: string | null | undefined,
   provider?: ProviderKind | null,
 ): boolean {
-  const email = normalizeEmail(accountEmail);
+  const email = normalizeEmailOrNull(accountEmail);
   const kind = parseProvider(provider);
   if (!email || !kind) return false;
   return reconnectRequiredAccounts.has(reconnectAccountKey(kind, email));

--- a/packages/web/src/calendars/calendar.util.ts
+++ b/packages/web/src/calendars/calendar.util.ts
@@ -4,6 +4,7 @@ import {
   providerDisplayName,
 } from "@core/types/sync/identity.contracts";
 import { type SyncConnectionSummary } from "@core/types/user.types";
+import { normalizeEmail, normalizeEmailOrNull } from "@core/util/email.util";
 import {
   calendarProviderKind,
   connectionProviderKind,
@@ -39,9 +40,7 @@ const toEmailSet = (
   emails: ReadonlySet<string> | readonly string[] | undefined,
 ): ReadonlySet<string> | null => {
   if (!emails) return null;
-  return new Set(
-    [...emails].map((email) => email.trim().toLowerCase()).filter(Boolean),
-  );
+  return new Set([...emails].map(normalizeEmail).filter(Boolean));
 };
 
 const calendarNeedsReconnect = (
@@ -49,7 +48,9 @@ const calendarNeedsReconnect = (
   reconnectRequiredEmails: ReadonlySet<string> | null,
 ): boolean => {
   if (!calendar.accountEmail) return false;
-  const email = calendar.accountEmail.toLowerCase();
+  // The same fold `toEmailSet` applied to the set being probed; lower-casing
+  // alone would miss a stored address that carries stray whitespace.
+  const email = normalizeEmail(calendar.accountEmail);
   const provider = calendarProviderKind(calendar);
   if (reconnectRequiredEmails) {
     const keyed = provider
@@ -154,7 +155,7 @@ export function emailsSharedAcrossProviders(
 ): ReadonlySet<string> {
   const counts = new Map<string, number>();
   for (const { accountEmail } of accounts) {
-    const email = accountEmail.trim().toLowerCase();
+    const email = normalizeEmail(accountEmail);
     if (!email) continue;
     counts.set(email, (counts.get(email) ?? 0) + 1);
   }
@@ -252,14 +253,13 @@ const nestLocalCalendarInMatchingGroup = (
   ungrouped: Calendar[],
   compassEmail: string | null | undefined,
 ): { groups: AccountGroup[]; ungrouped: Calendar[] } => {
-  const normalizedCompassEmail = compassEmail?.trim().toLowerCase();
+  const normalizedCompassEmail = normalizeEmailOrNull(compassEmail);
   if (!normalizedCompassEmail) return { groups, ungrouped };
 
   // Connection order is already the group order; when accounts on two
   // providers share the login email, the oldest-connected one wins.
   const matchingGroup = groups.find(
-    (group) =>
-      group.accountEmail.trim().toLowerCase() === normalizedCompassEmail,
+    (group) => normalizeEmail(group.accountEmail) === normalizedCompassEmail,
   );
   if (!matchingGroup) return { groups, ungrouped };
 

--- a/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
+++ b/packages/web/src/components/Sidebar/CalendarList/CalendarList.tsx
@@ -1,5 +1,6 @@
 import { type FC, useMemo } from "react";
 import { type Calendar } from "@core/types/calendar.contracts";
+import { normalizeEmail } from "@core/util/email.util";
 import { shouldShowContextualLoadError } from "@web/api/util/api.util";
 import { useSession } from "@web/auth/compass/session/useSession";
 import { useUser } from "@web/auth/compass/user/hooks/useUser";
@@ -128,7 +129,7 @@ export const CalendarList: FC = () => {
                   account={group}
                   connection={group.connection}
                   showProviderOnHover={sharedEmails.has(
-                    group.accountEmail.trim().toLowerCase(),
+                    normalizeEmail(group.accountEmail),
                   )}
                 />
                 {renderCollapsible(key, group.calendars)}


### PR DESCRIPTION
## What and why

Three debt items from merges in the last seven days, each its own commit.

**1. The autofix PR watchdog never filtered on the labels it reads (#3657).**
`gh pr list` was asked for `--json number,createdAt,url` and then filtered on
`.labels`. gh returns only the fields requested, so `.labels` was absent,
`[.labels[]?.name]` was `[]`, both `index(...) | not` guards were true, and
every open `autofix` PR passed. The watchdog therefore escalated PRs already
carrying `automerge-candidate` (still legitimately in flight) and re-applied
`autofix:needs-human` plus a fresh Discord ping to the same PRs every hour,
which is the opposite of what its header comment describes.

Its test passed because the `gh` stub re-implemented the production jq filter
against fixtures that *did* include `labels`: it tested the stub, not the
script. The stub is now a faithful fake, answering with only the fields the
caller named in `--json` and applying the caller's own `--jq`. Cases 2 and 3
fail against the old `--json` list and pass with `labels` added, which is the
production fix here. The stub's unreachable `pr list --fail` branch becomes an
env flag with a case covering the listing-failure path.

The test was also never wired into CI: the workflow step named its eight
script tests one at a time, so the one added alongside the watchdog went unrun
from the day it landed, hiding this bug. The step now loops over every
`*.test.sh` and reports all failing scripts in one run, so a new test cannot
be forgotten again.

**2. Four spellings of one email fold.** `normalizeEmail` lived in
`@backend/common/helpers`, a private copy in web's `reconnect.state.ts`, and
inline `.trim().toLowerCase()` in `calendar.util.ts` and `CalendarList.tsx`,
two of which last week's shared-email work added; `packages/scripts` reached
into `@backend` for the backend copy. It now lives in `@core/util/email.util`
with a `normalizeEmailOrNull` for the optional-address callers that were
repeating the emptiness check. One latent mismatch goes with it:
`calendarNeedsReconnect` lower-cased without trimming, then probed a set whose
members had been both trimmed and lower-cased, so a stored address carrying
stray whitespace missed its own reconnect entry. Behavior is otherwise
unchanged.

**3. The boot shell's copied constants had no guard.** `index.html`'s
pre-JavaScript shell (#3654) cannot import anything, so it re-spells the
storage keys, sidebar geometry, breakpoint, theme colors and the
visible-column formula as literals under a comment asking whoever changes them
to keep eight files in sync by hand, and nothing in the suite touched the
file. Drift there is invisible until the layout jumps at the React swap. The
new test runs the real head script from the real file and compares what it
computes against `computeVisibleDayCount`, `clampSidebarWidth`, `SIDEBAR_*`,
`SIDEBAR_AUTO_COLLAPSE_BREAKPOINT`, `STORAGE_KEYS` and `THEMES`. Storage keys
and theme names are pinned by behavior rather than by grepping text. WeekView's
Tailwind `pl-8` is the one value with no importable source, so it stays a named
constant in the test. Nudging any of the others fails it, which I confirmed
both ways.

The fourth commit fixes two fallouts of the first three that `verify` caught:
`jsdom` ships no type declarations and web test files are type-checked, so the
guard now runs the head script via `new Function(...)` with a fresh
`createHTMLDocument` document, a getItem-only storage stub and the viewport
width passed as arguments (no new dependency, no touched globals); and three
Routine-contract tests that asserted the literal `bash .github/scripts/<name>.test.sh`
lines now assert the glob loop plus each file's existence, which is the intent
they encode.

## Verify

```
VERDICT: FAIL
Checks run: test:core, test:web, test:scripts:fast, type-check, lint, knip
Checks skipped: test:a11y, test:e2e (Playwright Chromium missing in this sandbox)
Failed: test:backend:fast
```

`test:backend:fast` is the only failure and it is not this diff's. All 28
failures sit in three files the diff cannot reach: `sse.server.test.ts` (SSE
event timeouts), `supertokens.middleware.util.test.ts` and
`config.route.test.ts`. Checked out unmodified `origin/main` in the same
sandbox and ran the same files: identical results, 14 pass / 7 fail for the
latter two on both, and the same SSE timeouts. Nothing in this diff touches
SSE, SuperTokens middleware or the config route; the backend changes here are
seven import-path lines. CI decides.

Everything the diff does reach is green: `type-check`, `lint`, `knip`,
`test:core`, `test:scripts:fast`, `test:web` (including the 16 new boot-shell
cases), and all twelve `.github/scripts/*.test.sh` under the new loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EU974WGZuxNJTrCKgTyMbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01EU974WGZuxNJTrCKgTyMbT)_