### PR TITLE
fix(sync): retry the smoke patch after an exchange change-key bump

### DIFF
--- a/packages/sync/src/providers/__contract__/live-provider-smoke.ts
+++ b/packages/sync/src/providers/__contract__/live-provider-smoke.ts
@@ -3,6 +3,7 @@ import { SyncEventContentSchema } from "@core/types/sync/event.contracts";
 import { appleLiveFactory } from "@sync/providers/__contract__/apple-contract.factory";
 import { googleLiveFactory } from "@sync/providers/__contract__/google-contract.factory";
 import { microsoftLiveFactory } from "@sync/providers/__contract__/microsoft-contract.factory";
+import { patchWithFreshVersion } from "@sync/providers/__contract__/patch-with-fresh-version";
 import { type ProviderAdapters } from "@sync/providers/provider-adapters";
 import { type CalendarDiscovery } from "@sync/providers/provider-calendar.port";
 import {
@@ -118,17 +119,28 @@ export async function runMicrosoftLiveSmoke(input: {
     // Exchange bumps an item's change key in the seconds after creation, so
     // an If-Match on the create-time etag races it (HTTP 412
     // ErrorIrresolvableConflict, seen live). Patch against the version just
-    // read, as the domain does.
-    const patched = await adapters.writer.patchEvent({
-      accessToken,
-      calendarId,
-      providerEventId: created.providerEventId,
-      expectedVersion: readBack.providerVersion,
-      content: { ...content, title: `compass-smoke ${input.runId} updated` },
-      schedule,
-      recurrence: { kind: "single" },
-      invitation: "none",
-    });
+    // read, and re-read it if that one was also pre-bump.
+    const patched = await patchWithFreshVersion(
+      adapters.writer,
+      {
+        accessToken,
+        calendarId,
+        providerEventId: created.providerEventId,
+        expectedVersion: readBack.providerVersion,
+        content: { ...content, title: `compass-smoke ${input.runId} updated` },
+        schedule,
+        recurrence: { kind: "single" },
+        invitation: "none",
+      },
+      async () => {
+        const current = await adapters.writer.fetchEvent({
+          accessToken,
+          calendarId,
+          providerEventId: created.providerEventId,
+        });
+        return current?.kind === "event" ? current.providerVersion : null;
+      },
+    );
     if (
       !patched.providerVersion ||
       patched.providerVersion === readBack.providerVersion
@@ -589,16 +601,31 @@ async function runExceptionCase(
         "fetchInstanceAt returned no occurrence",
       );
     }
-    await writer.patchEvent({
-      accessToken,
-      calendarId,
-      providerEventId: instance.providerEventId,
-      expectedVersion: instance.providerVersion,
-      content: { ...content, title: `compass-smoke exception ${runId}` },
-      schedule: instance.schedule,
-      recurrence: { kind: "instance" },
-      invitation: "none",
-    });
+    // The occurrence is read moments after the series create, so its change
+    // key can be pre-bump too (see patchWithFreshVersion).
+    await patchWithFreshVersion(
+      writer,
+      {
+        accessToken,
+        calendarId,
+        providerEventId: instance.providerEventId,
+        expectedVersion: instance.providerVersion,
+        content: { ...content, title: `compass-smoke exception ${runId}` },
+        schedule: instance.schedule,
+        recurrence: { kind: "instance" },
+        invitation: "none",
+      },
+      async () => {
+        const current = await writer.fetchInstanceAt({
+          accessToken,
+          calendarId,
+          seriesProviderEventId: created.providerEventId,
+          originalStartAt: start.toISOString(),
+          scheduleKind: "timed",
+        });
+        return current?.kind === "event" ? current.providerVersion : null;
+      },
+    );
   } finally {
     await writer
       .deleteEvent({

--- a/packages/sync/src/providers/__contract__/patch-with-fresh-version.test.ts
+++ b/packages/sync/src/providers/__contract__/patch-with-fresh-version.test.ts
@@ -1,0 +1,110 @@
+import { EventScheduleSchema } from "@core/types/event.contracts";
+import { SyncEventContentSchema } from "@core/types/sync/event.contracts";
+import { patchWithFreshVersion } from "@sync/providers/__contract__/patch-with-fresh-version";
+import {
+  type ProviderPatchInput,
+  ProviderWriteError,
+  type ProviderWriteResult,
+} from "@sync/providers/provider-event-writer.port";
+import { describe, expect, it } from "bun:test";
+
+const PATCH: ProviderPatchInput = {
+  accessToken: "token",
+  calendarId: "cal",
+  providerEventId: "evt",
+  expectedVersion: "v1",
+  content: SyncEventContentSchema.parse({
+    title: "t",
+    description: "",
+    location: null,
+    organizer: null,
+    attendees: [],
+    conference: null,
+  }),
+  schedule: EventScheduleSchema.parse({
+    kind: "timed",
+    start: "2026-09-12T10:00:00.000Z",
+    end: "2026-09-12T10:30:00.000Z",
+    timeZone: "UTC",
+  }),
+  recurrence: { kind: "single" },
+  invitation: "none",
+};
+
+const conflict = () =>
+  new ProviderWriteError("versionConflict", "stale", { cause: undefined });
+
+function fakeWriter(currentVersion: () => string) {
+  const seen: (string | null)[] = [];
+  return {
+    seen,
+    patchEvent: async (
+      input: ProviderPatchInput,
+    ): Promise<ProviderWriteResult> => {
+      seen.push(input.expectedVersion);
+      if (input.expectedVersion !== currentVersion()) throw conflict();
+      return {
+        providerEventId: input.providerEventId,
+        providerVersion: `${input.expectedVersion}-patched`,
+      };
+    },
+  };
+}
+
+describe("patchWithFreshVersion", () => {
+  it("re-reads the version after a conflict and patches against it", async () => {
+    const writer = fakeWriter(() => "v2");
+    let reads = 0;
+    const result = await patchWithFreshVersion(
+      writer,
+      PATCH,
+      async () => {
+        reads += 1;
+        return "v2";
+      },
+      0,
+    );
+    expect(result.providerVersion).toBe("v2-patched");
+    expect(writer.seen).toEqual(["v1", "v2"]);
+    expect(reads).toBe(1);
+  });
+
+  it("rethrows a non-conflict failure without re-reading", async () => {
+    let reads = 0;
+    const writer = {
+      patchEvent: async (): Promise<ProviderWriteResult> => {
+        throw new ProviderWriteError("readOnlyCalendar", "nope");
+      },
+    };
+    await expect(
+      patchWithFreshVersion(
+        writer,
+        PATCH,
+        async () => {
+          reads += 1;
+          return "v2";
+        },
+        0,
+      ),
+    ).rejects.toMatchObject({ reason: "readOnlyCalendar" });
+    expect(reads).toBe(0);
+  });
+
+  it("gives up with the conflict once the attempts are spent", async () => {
+    const writer = fakeWriter(() => "never");
+    let reads = 0;
+    await expect(
+      patchWithFreshVersion(
+        writer,
+        PATCH,
+        async () => {
+          reads += 1;
+          return `v${reads + 1}`;
+        },
+        0,
+      ),
+    ).rejects.toMatchObject({ reason: "versionConflict" });
+    expect(writer.seen).toEqual(["v1", "v2", "v3", "v4", "v5"]);
+    expect(reads).toBe(4);
+  });
+});

--- a/packages/sync/src/providers/__contract__/patch-with-fresh-version.ts
+++ b/packages/sync/src/providers/__contract__/patch-with-fresh-version.ts
@@ -1,0 +1,41 @@
+import {
+  type ProviderEventWriter,
+  type ProviderPatchInput,
+  ProviderWriteError,
+  type ProviderWriteResult,
+} from "@sync/providers/provider-event-writer.port";
+
+// Exchange rewrites an item's change key on its own in the seconds after a
+// create, so an If-Match against any version read in that window fails with
+// HTTP 412 ErrorIrresolvableConflict. Patching against a version read back
+// after the create (#3665) did not close the window: the 2026-09-12 nightly
+// read the pre-bump key and still lost the patch. Mirrors what a sync pull
+// does for a real user, refresh the stored version and write again, but
+// bounded, so a conflict that persists is still the smoke's verdict. Any
+// other failure is rethrown untouched.
+const PATCH_ATTEMPTS = 5;
+const RETRY_DELAY_MS = 1500;
+
+export async function patchWithFreshVersion(
+  writer: Pick<ProviderEventWriter, "patchEvent">,
+  input: ProviderPatchInput,
+  readVersion: () => Promise<string | null>,
+  delayMs = RETRY_DELAY_MS,
+): Promise<ProviderWriteResult> {
+  let attempt = input;
+  for (let n = 1; ; n += 1) {
+    try {
+      return await writer.patchEvent(attempt);
+    } catch (error) {
+      if (!isVersionConflict(error) || n >= PATCH_ATTEMPTS) throw error;
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      attempt = { ...attempt, expectedVersion: await readVersion() };
+    }
+  }
+}
+
+function isVersionConflict(error: unknown): boolean {
+  return (
+    error instanceof ProviderWriteError && error.reason === "versionConflict"
+  );
+}


### PR DESCRIPTION
Refs #3208

## What and why

The 2026-09-12 nightly `live-provider-smoke` posted `failed: microsoft (skipped google apple)` to Discord. The Microsoft leg died on the first patch with HTTP 412 `ErrorIrresolvableConflict` even though #3665 already patched against the version read back after create. Exchange rewrites an item's change key on its own a few seconds after a create, and the read-back can land before that bump: the failing run's smoke finished in 2.4s, the last passing one in 4.7s.

This adds `patchWithFreshVersion`, a bounded retry (five attempts, 1.5s apart) that re-reads the version on a `versionConflict` and patches again, and uses it on the Microsoft single-event patch and the shared exception-case instance patch. Any other failure, or a conflict that persists, still fails the smoke. Unit test covers retry-then-success, non-conflict passthrough, and giving up.

Live proof: `live-provider-smoke` dispatched on this branch (linked in the comments below).

## Verify

`VERDICT: PASS` from `bun run verify --strict` (test:sync:fast, type-check, lint, knip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
