### PR TITLE
fix(sync): patch against the fresh provider version on a bare key rotation

### DIFF
--- a/packages/sync/src/domain/provider-command.service.db.test.ts
+++ b/packages/sync/src/domain/provider-command.service.db.test.ts
@@ -650,6 +650,39 @@ describe("executeProviderUpdate", () => {
     expect(writer.patchCalls).toHaveLength(0);
   });
 
+  it("patches against the fresh version when only the provider's version key drifted", async () => {
+    const { tenantId, principalId, calendar, event, command } = await seed();
+    const writer = new FakeProviderEventWriter();
+    // The provider rotated the version on its own (Exchange rewrites a change
+    // key seconds after a create) but still holds exactly what Compass stored,
+    // so nobody edited it elsewhere and the stale etag-1 must not block the
+    // edit.
+    writer.fetched = providerEvent("Old", "etag-1-rotated");
+
+    const result = await executeProviderUpdate(
+      {
+        commands,
+        events,
+        occurrences,
+        resources,
+        connections: stubConnectionLookup(),
+        writer,
+        custody: tokenSource(),
+      },
+      command,
+      event,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("confirmed");
+    expect(writer.patchCalls).toHaveLength(1);
+    expect(writer.patchCalls[0]!.expectedVersion).toBe("etag-1-rotated");
+    const stored = await events.findById(tenantId, principalId, event._id);
+    expect(stored?.content.title).toBe("New");
+    expect(stored?.providerVersion).toBe("etag-2" as ProviderEventVersion);
+  });
+
   it("fails with a conflict on a genuine concurrent external edit", async () => {
     const { calendar, event, command } = await seed();
     const writer = new FakeProviderEventWriter();
@@ -678,6 +711,10 @@ describe("executeProviderUpdate", () => {
     expect(
       result.outcome.state === "failed" && result.outcome.failureReason,
     ).toBe("versionConflict");
+    // The drifted version is NOT adopted when the content changed too: the
+    // patch stays conditioned on the stale version so it cannot overwrite
+    // the external edit.
+    expect(writer.patchCalls[0]!.expectedVersion).toBe("etag-1");
   });
 
   it("fails when the provider event no longer exists", async () => {
@@ -1736,6 +1773,29 @@ describe("executeProviderSeriesUpdate", () => {
     expect(writer.patchCalls).toHaveLength(0);
   });
 
+  it("patches against the fresh version when only the master's version key drifted", async () => {
+    const { calendar, master } = await seedMaster();
+    const command = await editAllCommand(master, {
+      title: "New",
+      recurrence: { kind: "preserve" },
+    });
+    const writer = new FakeProviderEventWriter();
+    // Same content, schedule, and rules as stored; only the version rotated.
+    writer.fetched = providerSeries("Old", "etag-1-rotated", weekly4);
+
+    const result = await executeProviderSeriesUpdate(
+      deps(writer),
+      command,
+      master,
+      calendar,
+      now,
+    );
+
+    expect(result.outcome.state).toBe("confirmed");
+    expect(writer.patchCalls).toHaveLength(1);
+    expect(writer.patchCalls[0]!.expectedVersion).toBe("etag-1-rotated");
+  });
+
   it("fails with a conflict on a genuine concurrent external edit", async () => {
     const { calendar, master } = await seedMaster();
     const command = await editAllCommand(master, {
@@ -1758,6 +1818,8 @@ describe("executeProviderSeriesUpdate", () => {
     expect(
       result.outcome.state === "failed" && result.outcome.failureReason,
     ).toBe("versionConflict");
+    // Content changed too, so the stale version stays on the patch.
+    expect(writer.patchCalls[0]!.expectedVersion).toBe("etag-1");
   });
 
   it("discards override exceptions but keeps cancelled tombstones", async () => {

--- a/packages/sync/src/domain/provider-command.service.ts
+++ b/packages/sync/src/domain/provider-command.service.ts
@@ -500,7 +500,12 @@ export async function executeProviderUpdate(
   const patchResult = await runProviderWrite(() =>
     deps.writer.patchEvent({
       ...location,
-      expectedVersion: command.expectedVersion,
+      expectedVersion: patchExpectedVersion(
+        command,
+        current,
+        event,
+        intendedAttendees !== undefined,
+      ),
       content,
       schedule: input.schedule,
       recurrence: intendedRecurrence,
@@ -653,7 +658,12 @@ async function executeProviderManagedUpdate(
   const patchResult = await runProviderWrite(() =>
     deps.writer.patchEvent({
       ...location,
-      expectedVersion: command.expectedVersion,
+      expectedVersion: patchExpectedVersion(
+        command,
+        current,
+        event,
+        intendedAttendees !== undefined,
+      ),
       providerManaged: true,
       content: mergedContent,
       schedule: current.schedule,
@@ -868,7 +878,12 @@ export async function executeProviderSeriesUpdate(
   const patchResult = await runProviderWrite(() =>
     deps.writer.patchEvent({
       ...location,
-      expectedVersion: command.expectedVersion,
+      expectedVersion: patchExpectedVersion(
+        command,
+        current,
+        master,
+        intendedAttendees !== undefined,
+      ),
       content,
       schedule: input.schedule,
       recurrence: intendedRecurrence,
@@ -1465,7 +1480,7 @@ export async function executeProviderSeriesFollowingDelete(
   const patchResult = await runProviderWrite(() =>
     deps.writer.patchEvent({
       ...location,
-      expectedVersion: command.expectedVersion,
+      expectedVersion: patchExpectedVersion(command, current, master),
       content: master.content,
       schedule: master.schedule,
       recurrence: truncateRecurrence,
@@ -1615,7 +1630,7 @@ export async function executeProviderSeriesFollowingUpdate(
     const truncateResult = await runProviderWrite(() =>
       deps.writer.patchEvent({
         ...originalLocation,
-        expectedVersion: command.expectedVersion,
+        expectedVersion: patchExpectedVersion(command, current, master),
         content: master.content,
         schedule: master.schedule,
         recurrence: truncateRecurrence,
@@ -2049,9 +2064,9 @@ function storedSeriesRecurrence(
 // attendeesMatchIntent). Recurrence IS written (a series edit-all changes the
 // rules), so it must be compared: a rules-only edit leaves content and
 // schedule identical, and without this a false replay would confirm the
-// command without ever writing the new rules. Used only to detect a replay,
-// so a false negative on the compared fields is still safe (it falls through
-// to the conditional patch).
+// command without ever writing the new rules. A false negative on the
+// compared fields is still safe: the replay check falls through to the
+// conditional patch, and patchExpectedVersion keeps the submitter's version.
 function matchesIntendedEdit(
   current: ProviderEvent,
   content: SyncEventContent,
@@ -2071,6 +2086,51 @@ function matchesIntendedEdit(
     recurrenceMatches(current.recurrence, recurrence) &&
     attendeesMatchIntent(current.content.attendees, intendedAttendees)
   );
+}
+
+// The If-Match version for a conditional patch on a fetched provider event.
+// The command's expectedVersion is the version its submitter last saw, so a
+// patch conditioned on it refuses to overwrite an edit made elsewhere since.
+// But a provider can rotate an event's version on its own (Exchange rewrites
+// an item's change key seconds after a create; see #3208 and the
+// live-provider-smoke), and until the next pull refreshes the stored version
+// every conditional edit would fail as a spurious versionConflict. When the
+// fetched event still carries exactly what Compass has stored for it (the
+// written fields, per matchesIntendedEdit; guest membership only when this
+// command replaces it), nobody edited it elsewhere, so the drift is the
+// provider's own rotation and the patch conditions on the fresh version. Any
+// difference keeps the submitter's version, so a genuine external edit still
+// fails as versionConflict. An unconditional command (null) stays
+// unconditional. Occurrence patches have no stored instance to compare
+// against, so they keep the submitter's version as before.
+function patchExpectedVersion(
+  command: CommandRecord,
+  current: ProviderEvent,
+  stored: EventRecord,
+  compareAttendees = false,
+): string | null {
+  if (command.expectedVersion === null) return null;
+  const unchanged = matchesIntendedEdit(
+    current,
+    stored.content,
+    stored.schedule,
+    storedWriteRecurrence(stored.recurrence),
+    compareAttendees ? stored.content.attendees : undefined,
+  );
+  return unchanged ? current.providerVersion : command.expectedVersion;
+}
+
+// The recurrence a patch would write for a stored record as it stands: a
+// series master carries its rules, an exception addresses one instance, and
+// anything else is a single event.
+function storedWriteRecurrence(
+  recurrence: EventRecord["recurrence"],
+): ProviderWriteRecurrence {
+  if (recurrence.kind === "seriesMaster") {
+    return { kind: "series", rules: recurrence.rules };
+  }
+  if (recurrence.kind === "exception") return { kind: "instance" };
+  return { kind: "single" };
 }
 
 // Membership comparison for the replay check, entered ONLY when the command


### PR DESCRIPTION
Refs #3208 (Microsoft tracking issue). Follows #3673, which worked around the same race in the live-provider-smoke.

## What and why

Exchange rewrites an item's change key on its own a few seconds after a create. Until the next sync pull refreshed the stored version, every conditional patch in `provider-command.service.ts` sent the stale version as If-Match, Graph answered 412, and the command failed as `versionConflict`, which the API surfaces as "Event was modified elsewhere". PR #3673 fixed only the smoke test; this fixes the executor.

Provider-neutral fix: a new `patchExpectedVersion` helper picks the If-Match version for a conditional patch. It compares the freshly fetched provider event against what Compass has stored for the record (title, description, location, color, schedule, recurrence, and guest membership only when the command replaces it, reusing `matchesIntendedEdit`). When they still match, nobody edited the event elsewhere, so the drift is the provider's own key rotation and the patch conditions on the fetched version. Any difference keeps the submitter's version, so a genuine external edit still fails as `versionConflict`. A null expected version stays unconditional. Applied at the single-event, provider-managed, series edit-all, and both series-following patch sites; the occurrence patch has no stored instance to compare against and is unchanged.

Note: the backend's command translation currently submits `expectedVersion: null` for every update, so today's user-facing path already patches unconditionally on Microsoft. This change hardens the executor for any submitter that does supply an expected version (the sync command API accepts one) without changing behavior for null.

Tests: key drift with unchanged content patches against the fresh version, and key drift with changed content still yields `versionConflict` with the stale version on the patch, for both `executeProviderUpdate` and `executeProviderSeriesUpdate`.

## Verify

`bun run verify --strict` selected `sync` and ran type-check, lint, and knip, all green. Its `test:sync` step could not start in this sandbox: the in-memory Mongo port picker binds `::` and the sandbox has no IPv6 (`EAFNOSUPPORT`), so the local line is `VERDICT: FAIL` on that environmental step only. Run directly with an IPv4 listen shim, the full sync suite passes: 1541 pass, 7 skip, 0 fail across 118 files, including the new tests. CI decides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WBq32X1iVzLk96xWJBRtUm

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBq32X1iVzLk96xWJBRtUm)_