### PR TITLE
fix(web): move refresh control to the sidebar footer

### DIFF
--- a/docs/development/feature-file-map.md
+++ b/docs/development/feature-file-map.md
@@ -159,7 +159,7 @@ The flow, its entry points, and the storage contract are documented in
   (week/day cursor math in `monthPickerCursor.ts` beside it)
 - Shared account sync-status + CTA labels: `packages/web/src/components/Sidebar/CalendarList/useAccountHeaderStatus.ts`
 - Account identity/sync indicator: `packages/web/src/components/Sidebar/CalendarList/CalendarListHeader.tsx`, `AccountSectionHeader.tsx`
-- Sidebar actions and shortcuts overlay: `packages/web/src/components/Sidebar/SidebarActions/SidebarActions.tsx`, `packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.tsx`
+- Sidebar actions and shortcuts overlay: `packages/web/src/components/Sidebar/SidebarActions/SidebarActions.tsx`, `packages/web/src/components/Sidebar/SidebarRefreshButton.tsx`, `packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.tsx`
 - Week mount point: `packages/web/src/views/Week/WeekView.tsx`
 - Day mount point: `packages/web/src/views/Day/view/DayViewContent.tsx`
 

--- a/docs/development/launch-ops-checklist.md
+++ b/docs/development/launch-ops-checklist.md
@@ -45,8 +45,8 @@ another one.
 The SSE alert samples a trailing 60-minute window once an hour, so a burst
 that straddles two checks can be under-counted. Widen the insight's window to
 90 minutes if that bites; 15-minute evaluation needs a PostHog add-on. The
-web app offers a header Refresh control for the same condition
-(`HeaderRefreshButton`) after the stream has been down for 30 seconds.
+web app offers a sidebar-footer Refresh control for the same condition
+(`SidebarRefreshButton`) after the stream has been down for 30 seconds.
 
 ## During launch
 

--- a/docs/frontend/frontend-runtime-flow.md
+++ b/docs/frontend/frontend-runtime-flow.md
@@ -209,6 +209,7 @@ users actually take.
 Files:
 
 - `packages/web/src/components/Sidebar/SidebarActions/useVersionCheck.ts`
+- `packages/web/src/components/Sidebar/SidebarRefreshButton.tsx`
 - `packages/web/src/components/Sidebar/SidebarActions/SidebarActions.tsx`
 
 Runtime behavior:
@@ -228,6 +229,7 @@ Files:
 - `packages/web/src/components/Sidebar/Sidebar.tsx`
 - `packages/web/src/components/Sidebar/MonthPicker/MonthPicker.tsx`
 - `packages/web/src/components/Sidebar/SidebarActions/SidebarActions.tsx`
+- `packages/web/src/components/Sidebar/SidebarRefreshButton.tsx`
 - `packages/web/src/components/Sidebar/ShortcutsOverlay/ShortcutsOverlay.tsx`
 
 Layout contract:
@@ -241,7 +243,8 @@ Control mapping:
 
 - Open shortcuts opens an in-sidebar keyboard shortcuts overlay.
 - Command palette toggle (`modifier + K`) calls open/close palette actions from the settings Zustand store (`packages/web/src/settings/settings.store.ts`).
-- Refresh appears only when `useVersionCheck()` reports an available update.
+- Refresh appears in the footer when `useVersionCheck()` reports an available
+  update, or when the live-update stream has been down for 30 seconds.
 - The account row shows temporary-account or signed-in account context.
 - Background Google import state is not shown in the sidebar footer.
 

--- a/packages/web/src/components/CalendarHeader/CalendarHeader.tsx
+++ b/packages/web/src/components/CalendarHeader/CalendarHeader.tsx
@@ -1,6 +1,5 @@
 import { type FC } from "react";
 import { ArrowButton } from "@web/components/Button/ArrowButton";
-import { HeaderRefreshButton } from "@web/components/CalendarHeader/HeaderRefreshButton";
 import { SelectView } from "@web/components/SelectView/SelectView";
 import { SidebarToggleButton } from "@web/components/Sidebar/SidebarToggleButton";
 import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
@@ -60,7 +59,6 @@ export const CalendarHeader: FC<Props> = ({
           </div>
         )}
         <SelectView label={label} onToday={onToday} />
-        <HeaderRefreshButton />
       </div>
 
       <div className="z-2 flex shrink-0 items-center pr-5">

--- a/packages/web/src/components/Sidebar/SidebarActions/SidebarActions.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarActions/SidebarActions.test.tsx
@@ -71,6 +71,9 @@ describe("SidebarActions", () => {
     expect(
       screen.getByRole("button", { name: "Open settings" }),
     ).toHaveAttribute("data-pointer-shortcut", '["Mod",","]');
+    expect(
+      screen.queryByRole("button", { name: "Refresh" }),
+    ).not.toBeInTheDocument();
   });
 
   it("labels the shortcuts button as a close action when shortcuts are open", () => {

--- a/packages/web/src/components/Sidebar/SidebarActions/SidebarActions.tsx
+++ b/packages/web/src/components/Sidebar/SidebarActions/SidebarActions.tsx
@@ -1,5 +1,6 @@
 import { CommandIcon, GearIcon, KeyboardIcon } from "@phosphor-icons/react";
 import { useGoogleUiState } from "@web/auth/providers/useProviderUiState";
+import { SidebarRefreshButton } from "@web/components/Sidebar/SidebarRefreshButton";
 import { TooltipWrapper } from "@web/components/Tooltip/TooltipWrapper";
 import {
   selectIsShortcutsOpen,
@@ -52,6 +53,7 @@ export const SidebarActions = () => {
             />
           </button>
         </TooltipWrapper>
+        <SidebarRefreshButton />
       </div>
 
       <div className="flex items-center gap-2">

--- a/packages/web/src/components/Sidebar/SidebarRefreshButton.test.tsx
+++ b/packages/web/src/components/Sidebar/SidebarRefreshButton.test.tsx
@@ -43,14 +43,14 @@ afterAll(() => {
 // Cache-bust so this file's mocks apply even when another suite already
 // loaded the component with the real hooks.
 const moduleUrl = new URL(
-  `./HeaderRefreshButton.tsx?test=${Math.random().toString(36).slice(2)}`,
+  `./SidebarRefreshButton.tsx?test=${Math.random().toString(36).slice(2)}`,
   import.meta.url,
 );
-const { HeaderRefreshButton, REFRESH_AFTER_DEGRADED_MS } = (await import(
+const { SidebarRefreshButton, REFRESH_AFTER_DEGRADED_MS } = (await import(
   moduleUrl.href
-)) as typeof import("./HeaderRefreshButton");
+)) as typeof import("./SidebarRefreshButton");
 
-describe("HeaderRefreshButton", () => {
+describe("SidebarRefreshButton", () => {
   afterEach(() => {
     degradedSinceMs = null;
     isUpdateAvailable = false;
@@ -58,7 +58,7 @@ describe("HeaderRefreshButton", () => {
   });
 
   it("renders nothing while the stream is healthy and no update is waiting", () => {
-    render(<HeaderRefreshButton />);
+    render(<SidebarRefreshButton />);
 
     expect(
       screen.queryByRole("button", { name: "Refresh" }),
@@ -68,7 +68,7 @@ describe("HeaderRefreshButton", () => {
 
   it("stays hidden during a short outage instead of showing reconnecting copy", () => {
     degradedSinceMs = Date.now();
-    render(<HeaderRefreshButton />);
+    render(<SidebarRefreshButton />);
 
     expect(
       screen.queryByRole("button", { name: "Refresh" }),
@@ -80,7 +80,7 @@ describe("HeaderRefreshButton", () => {
   it("offers a reload once the outage has outlived the refresh window", async () => {
     const user = userEvent.setup();
     degradedSinceMs = Date.now() - REFRESH_AFTER_DEGRADED_MS - 1_000;
-    render(<HeaderRefreshButton />);
+    render(<SidebarRefreshButton />);
 
     const refresh = screen.getByRole("button", { name: "Refresh" });
     await user.hover(refresh);
@@ -98,7 +98,7 @@ describe("HeaderRefreshButton", () => {
 
   it("adds the refresh control when the remaining window elapses", async () => {
     degradedSinceMs = Date.now() - REFRESH_AFTER_DEGRADED_MS + 50;
-    render(<HeaderRefreshButton />);
+    render(<SidebarRefreshButton />);
 
     expect(
       screen.queryByRole("button", { name: "Refresh" }),
@@ -110,11 +110,11 @@ describe("HeaderRefreshButton", () => {
 
   it("clears the control when the stream reopens", () => {
     degradedSinceMs = Date.now() - REFRESH_AFTER_DEGRADED_MS - 1_000;
-    const { rerender } = render(<HeaderRefreshButton />);
+    const { rerender } = render(<SidebarRefreshButton />);
     expect(screen.getByRole("button", { name: "Refresh" })).toBeInTheDocument();
 
     degradedSinceMs = null;
-    rerender(<HeaderRefreshButton />);
+    rerender(<SidebarRefreshButton />);
 
     expect(
       screen.queryByRole("button", { name: "Refresh" }),
@@ -124,7 +124,7 @@ describe("HeaderRefreshButton", () => {
   it("shows one refresh control when a newer app version is available", async () => {
     const user = userEvent.setup();
     isUpdateAvailable = true;
-    render(<HeaderRefreshButton />);
+    render(<SidebarRefreshButton />);
 
     expect(screen.getAllByRole("button", { name: "Refresh" })).toHaveLength(1);
 
@@ -137,7 +137,7 @@ describe("HeaderRefreshButton", () => {
   it("keeps a single refresh control when both an outage and an update apply", () => {
     isUpdateAvailable = true;
     degradedSinceMs = Date.now() - REFRESH_AFTER_DEGRADED_MS - 1_000;
-    render(<HeaderRefreshButton />);
+    render(<SidebarRefreshButton />);
 
     expect(screen.getAllByRole("button", { name: "Refresh" })).toHaveLength(1);
     expect(screen.queryByText("Reconnecting…")).not.toBeInTheDocument();

--- a/packages/web/src/components/Sidebar/SidebarRefreshButton.tsx
+++ b/packages/web/src/components/Sidebar/SidebarRefreshButton.tsx
@@ -57,7 +57,7 @@ export const SidebarRefreshButton: FC = () => {
         shortcut={["Mod", "R"]}
       >
         <button
-          className="c-focus-ring inline-flex h-9 items-center gap-1 rounded-default px-2 text-xs text-text-muted transition hover:bg-surface-panel hover:text-text"
+          className="c-focus-ring inline-flex h-9 items-center gap-1 rounded-default px-2 text-text-muted text-xs transition hover:bg-surface-panel hover:text-text"
           type="button"
         >
           <ArrowClockwiseIcon aria-hidden="true" size={14} />

--- a/packages/web/src/components/Sidebar/SidebarRefreshButton.tsx
+++ b/packages/web/src/components/Sidebar/SidebarRefreshButton.tsx
@@ -33,12 +33,12 @@ const useRefreshDue = (degradedSinceMs: number | null): boolean => {
 };
 
 /**
- * Single header Refresh control for a stale live-update stream or a newer
+ * Sidebar-footer Refresh control for a stale live-update stream or a newer
  * app version. Both cases reload the page. Tooltip and blocked-click hint
  * name Mod+R because pointer clicks are suppressed in the keyboard-only
  * calendar.
  */
-export const HeaderRefreshButton: FC = () => {
+export const SidebarRefreshButton: FC = () => {
   const degradedSinceMs = useSseDegradedSince();
   const refreshDue = useRefreshDue(degradedSinceMs);
   const { isUpdateAvailable } = useVersionCheck();
@@ -57,7 +57,7 @@ export const HeaderRefreshButton: FC = () => {
         shortcut={["Mod", "R"]}
       >
         <button
-          className="c-focus-ring inline-flex items-center gap-1 rounded-xs px-1.5 py-0.5 font-medium text-text hover:bg-surface-overlay"
+          className="c-focus-ring inline-flex h-9 items-center gap-1 rounded-default px-2 text-xs text-text-muted transition hover:bg-surface-panel hover:text-text"
           type="button"
         >
           <ArrowClockwiseIcon aria-hidden="true" size={14} />

--- a/packages/web/src/sse/hooks/useSseDegraded.ts
+++ b/packages/web/src/sse/hooks/useSseDegraded.ts
@@ -17,7 +17,7 @@ export function useSseDegraded(): boolean {
 
 /**
  * Epoch ms at which the stream became degraded, or null while healthy. The
- * header uses it to offer a reload once an outage has run long enough that
+ * sidebar uses it to offer a reload once an outage has run long enough that
  * native EventSource reconnect is unlikely to recover on its own.
  */
 export function useSseDegradedSince(): number | null {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

The calendar header Refresh chip sat next to the month title in medium-weight text, which made an occasional reload prompt feel like a primary control. It now lives in the sidebar footer next to the shortcuts button, styled as muted `text-xs` to match the other footer actions. Behavior is unchanged: the control still appears only after a 30s SSE outage or when a newer app version is available, and it still reloads the page.

![Header without Refresh, muted Refresh in the sidebar footer](https://cursor.com/artifacts/c/art-df1fe302-c3f7-4044-9f18-d8399db018e4)

## Verify

```
VERDICT: PASS
Selected packages: web
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e88e8299-d730-412a-a5a9-a8264a5229df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e88e8299-d730-412a-a5a9-a8264a5229df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

