### PR TITLE
feat(web): simplify the welcome start screen

### DIFF
--- a/docs/frontend/frontend-runtime-flow.md
+++ b/docs/frontend/frontend-runtime-flow.md
@@ -77,15 +77,18 @@ Welcome → signup → first-event contract:
   started for free** (headline, tagline, one-sentence pitch) → **Next** over
   the five FAQ rows (digits `1`–`5` toggle them, only on this screen) →
   the auth choices. `Log in` (`i`) and a three-dot step indicator sit on
-  every screen. Escape, the backdrop and **Back** step back one screen and
+  every screen. **Back** (`Esc`) sits left of Log in from the second screen
+  on. Escape, the backdrop and **Back** step back one screen and
   are a no-op on the first, so a stray Escape never drops a first-timer into
   the practice game
 - the welcome overlay is the one calendar surface where the mouse works
   (`data-pointer-pass`): a landing page should behave like a normal site, and
   keyboard-only starts once the visitor enters the calendar
-- the last screen's CTA order is **Continue with Google** (`G`, when Google is
-  available), **Sign up with email** (`U`), then **Explore without an account**
-  (`S`), with the social and legal links (`6`–`0`) below. Google leads
+- the last screen is titled **Let's get started** with the subtitle
+  **Connect a calendar or start fresh**. Its CTA order is **Continue with Google**
+  (`G`, when Google is available), **Sign up with email** (`U`), then
+  **Explore without an account** (`S`), all the same full-width elevated
+  height, with the social and legal links (`6`–`0`) below. Google leads
   because the scopes Compass requests include the calendar, so that one round
   trip signs the user up *and* connects it, the moment the product starts
   being worth keeping

--- a/docs/frontend/frontend-runtime-flow.md
+++ b/docs/frontend/frontend-runtime-flow.md
@@ -87,8 +87,9 @@ Welcome → signup → first-event contract:
 - the last screen is titled **Let's get started** with the subtitle
   **Connect a calendar or start fresh**. Its CTA order is **Continue with Google**
   (`G`, when Google is available), **Sign up with email** (`U`), then
-  **Explore without an account** (`S`), all the same full-width elevated
-  height, with the social and legal links (`6`–`0`) below. Google leads
+  **Explore without an account** (`S`), all the same full-width height.
+  Explore is a quieter secondary pill so signup stays the stronger choice.
+  Social and legal links (`6`–`0`) sit below. Google leads
   because the scopes Compass requests include the calendar, so that one round
   trip signs the user up *and* connects it, the moment the product starts
   being worth keeping

--- a/e2e/accessibility/connect-onboarding-a11y.spec.ts
+++ b/e2e/accessibility/connect-onboarding-a11y.spec.ts
@@ -111,7 +111,7 @@ test("the connect-calendar onboarding step has no automatically detectable acces
   await welcomeDialog.getByRole("button", { name: "Next" }).click();
   await expect(
     welcomeDialog.getByRole("heading", {
-      name: "Connect the calendar you use",
+      name: "Let's get started",
     }),
   ).toBeVisible();
 

--- a/e2e/onboarding/welcome-cta-width.spec.ts
+++ b/e2e/onboarding/welcome-cta-width.spec.ts
@@ -4,7 +4,7 @@ import { E2E_APP_CONFIG_VERSION } from "../utils/test-constants";
 test.use({ storageState: { cookies: [], origins: [] } });
 test.use({ viewport: { width: 1600, height: 900 } });
 
-test("keeps Google and email signup buttons the same width", async ({
+test("keeps Google, email signup, and explore buttons the same width", async ({
   page,
 }) => {
   await page.route("**/api/config", async (route) => {
@@ -35,12 +35,19 @@ test("keeps Google and email signup buttons the same width", async ({
   const email = welcomeDialog.getByRole("button", {
     name: "Sign up with email",
   });
+  const explore = welcomeDialog.getByRole("button", {
+    name: "Explore without an account",
+  });
   await expect(google).toBeVisible();
   await expect(email).toBeVisible();
+  await expect(explore).toBeVisible();
 
   const googleBox = await google.boundingBox();
   const emailBox = await email.boundingBox();
+  const exploreBox = await explore.boundingBox();
   expect(googleBox).not.toBeNull();
   expect(emailBox).not.toBeNull();
+  expect(exploreBox).not.toBeNull();
   expect(googleBox?.width).toBe(emailBox?.width);
+  expect(exploreBox?.width).toBe(emailBox?.width);
 });

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -621,7 +621,13 @@ describe("WelcomeModal", () => {
       ).toHaveClass("w-full", "h-10", "c-button-elevated");
       expect(
         screen.getByRole("button", { name: "Explore without an account" }),
-      ).toHaveClass("w-full", "h-10", "c-button-elevated");
+      ).toHaveClass("w-full", "h-10", "c-button-secondary");
+      expect(
+        screen.getByRole("button", { name: "Explore without an account" }),
+      ).not.toHaveClass("c-button-primary");
+      expect(
+        screen.getByRole("button", { name: "Explore without an account" }),
+      ).not.toHaveClass("c-button-elevated");
       expect(
         screen.getByRole("button", { name: "Continue with Google" }),
       ).toHaveClass("w-full", "h-10");

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.test.tsx
@@ -244,6 +244,7 @@ describe("WelcomeModal", () => {
       "Continue with Google",
       "Explore without an account",
       "Who is Compass for?",
+      "Back",
     ]) {
       expect(screen.queryByRole("button", { name })).toBeNull();
     }
@@ -264,9 +265,12 @@ describe("WelcomeModal", () => {
     await user.click(screen.getByRole("button", { name: "Next" }));
     expect(screen.getByText("Step 3 of 3")).toBeTruthy();
     expect(
-      screen.getByRole("heading", { name: "Connect the calendar you use" }),
+      screen.getByRole("heading", { name: "Let's get started" }),
     ).toBeTruthy();
-    expect(screen.getByText("Pick how you want to start.")).toBeTruthy();
+    expect(screen.getByText("Connect a calendar or start fresh")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Back" }).parentElement).toBe(
+      screen.getByRole("button", { name: "Log in" }).parentElement,
+    );
     expect(
       screen.queryByText(
         "If you view your calendar in Apple Calendar, it may still be hosted by Google or Microsoft.",
@@ -380,6 +384,7 @@ describe("WelcomeModal", () => {
     for (const [name, key] of [
       ["Sign up", "U"],
       ["Log in", "i"],
+      ["Back", "Esc"],
       ["Explore without an account", "S"],
     ] as const) {
       const hint = within(screen.getByRole("button", { name })).getByText(key);
@@ -548,8 +553,8 @@ describe("WelcomeModal", () => {
 
     await goToChooseScreen(user);
 
-    // Not the panel's first focusable (Log in): the primary action is signing
-    // up, so that is where focus lands.
+    // Not the panel's first focusable (Back, then Log in): the primary
+    // action is signing up, so that is where focus lands.
     const signUp = screen.getByRole("button", { name: "Sign up" });
     expect(signUp).toHaveFocus();
 
@@ -558,7 +563,7 @@ describe("WelcomeModal", () => {
     expect(terms).toHaveFocus();
 
     await user.tab();
-    expect(screen.getByRole("button", { name: "Log in" })).toHaveFocus();
+    expect(screen.getByRole("button", { name: "Back" })).toHaveFocus();
     expect(
       screen.getByRole("button", { name: "Outside calendar" }),
     ).not.toHaveFocus();
@@ -613,6 +618,9 @@ describe("WelcomeModal", () => {
       // Email signup steps aside to a clearly secondary label.
       expect(
         screen.getByRole("button", { name: "Sign up with email" }),
+      ).toHaveClass("w-full", "h-10", "c-button-elevated");
+      expect(
+        screen.getByRole("button", { name: "Explore without an account" }),
       ).toHaveClass("w-full", "h-10", "c-button-elevated");
       expect(
         screen.getByRole("button", { name: "Continue with Google" }),
@@ -738,7 +746,7 @@ describe("WelcomeModal", () => {
       await goToChooseScreen(user);
 
       expect(
-        screen.getByRole("heading", { name: "Connect the calendar you use" }),
+        screen.getByRole("heading", { name: "Let's get started" }),
       ).toBeTruthy();
       expect(
         screen.getByRole("button", { name: "Connect Microsoft Calendar" }),

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -7,10 +7,7 @@ import {
   trackSignupStep,
 } from "@web/auth/posthog/signup-funnel";
 import { track } from "@web/auth/posthog/track";
-import {
-  CONNECT_CALENDAR_LABEL,
-  CONNECT_THE_CALENDAR_YOU_USE,
-} from "@web/auth/providers/provider-copy.util";
+import { CONNECT_CALENDAR_LABEL } from "@web/auth/providers/provider-copy.util";
 import { signInProviderForShortcutLetter } from "@web/auth/providers/sign-in-provider.util";
 import { useIsProviderAvailable } from "@web/auth/providers/useIsProviderAvailable";
 import { useSignInProviders } from "@web/auth/providers/useSignInProviders";
@@ -38,8 +35,8 @@ const WELCOME_STEPS: readonly WelcomeStep[] = [1, 2, 3];
 
 const PRIMARY_CTA_CLASS =
   "c-button c-button-primary c-button-elevated inline-flex h-10 w-full items-center justify-center rounded-full data-busy:pointer-events-none data-busy:opacity-60";
-const TEXT_CTA_CLASS =
-  "c-focus-ring inline-flex items-center rounded-md px-2 py-1 text-text-muted text-xs hover:bg-surface-overlay hover:text-text data-busy:pointer-events-none data-busy:opacity-60";
+const COMPACT_PILL_CLASS =
+  "c-button-compact c-button-secondary rounded-3xl px-4 py-1.5 text-xs data-busy:pointer-events-none data-busy:opacity-60";
 
 function WelcomeSteps({ step }: { step: WelcomeStep }) {
   return (
@@ -273,13 +270,6 @@ export function WelcomeModal() {
     }
   };
 
-  const backButton = (
-    <button type="button" onClick={goBack} className={TEXT_CTA_CLASS}>
-      Back
-      <ShortcutHint className="ml-2">Esc</ShortcutHint>
-    </button>
-  );
-
   return (
     <OverlayPanel
       align="start"
@@ -301,7 +291,8 @@ export function WelcomeModal() {
         {...pointerPassAttributes}
       >
         {/* Top row: pirate top-left, Log in top-right, on every screen so a
-            returning user is never walked through the pitch. */}
+            returning user is never walked through the pitch. Back sits
+            beside Log in once there is a previous screen. */}
         <div className="flex items-center justify-between">
           <div className="group relative flex items-center">
             <PixelPirate className="h-14 w-14 shrink-0" />
@@ -316,10 +307,21 @@ export function WelcomeModal() {
             </div>
           </div>
           <div className="flex shrink-0 items-center gap-2">
+            {step > 1 ? (
+              <button
+                type="button"
+                onClick={goBack}
+                className={COMPACT_PILL_CLASS}
+                {...busyProps}
+              >
+                Back
+                <ShortcutHint className="ml-2">Esc</ShortcutHint>
+              </button>
+            ) : null}
             <button
               type="button"
               onClick={() => handOffToAuth("log_in")}
-              className="c-button-compact c-button-secondary rounded-3xl px-4 py-1.5 text-xs data-busy:pointer-events-none data-busy:opacity-60"
+              className={COMPACT_PILL_CLASS}
               {...busyProps}
             >
               Log in
@@ -388,7 +390,6 @@ export function WelcomeModal() {
                 Next
                 <ShortcutHint className="ml-2">Enter</ShortcutHint>
               </button>
-              {backButton}
             </div>
           </>
         )}
@@ -397,9 +398,11 @@ export function WelcomeModal() {
           <>
             <div className="flex w-full flex-col gap-2">
               <h2 className="font-bold text-2xl text-text leading-snug">
-                {CONNECT_THE_CALENDAR_YOU_USE}
+                Let's get started
               </h2>
-              <p className="text-text-muted">Pick how you want to start.</p>
+              <p className="text-text-muted">
+                Connect a calendar or start fresh
+              </p>
             </div>
             {/* Connecting a calendar is the moment Compass starts being
                 useful, so the Google round trip, which signs up and grants
@@ -441,13 +444,12 @@ export function WelcomeModal() {
               <button
                 type="button"
                 onClick={explore}
-                className={TEXT_CTA_CLASS}
+                className={PRIMARY_CTA_CLASS}
                 {...busyProps}
               >
                 Explore without an account
                 <ShortcutHint className="ml-2">S</ShortcutHint>
               </button>
-              {backButton}
             </div>
           </>
         )}

--- a/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/packages/web/src/components/WelcomeModal/WelcomeModal.tsx
@@ -35,6 +35,8 @@ const WELCOME_STEPS: readonly WelcomeStep[] = [1, 2, 3];
 
 const PRIMARY_CTA_CLASS =
   "c-button c-button-primary c-button-elevated inline-flex h-10 w-full items-center justify-center rounded-full data-busy:pointer-events-none data-busy:opacity-60";
+const SECONDARY_CTA_CLASS =
+  "c-button c-button-secondary inline-flex h-10 w-full items-center justify-center rounded-full data-busy:pointer-events-none data-busy:opacity-60";
 const COMPACT_PILL_CLASS =
   "c-button-compact c-button-secondary rounded-3xl px-4 py-1.5 text-xs data-busy:pointer-events-none data-busy:opacity-60";
 
@@ -444,7 +446,7 @@ export function WelcomeModal() {
               <button
                 type="button"
                 onClick={explore}
-                className={PRIMARY_CTA_CLASS}
+                className={SECONDARY_CTA_CLASS}
                 {...busyProps}
               >
                 Explore without an account


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

The last welcome screen packed a long heading, a text-style explore action, and a Back control under the CTAs, which made the start choices feel busy. This shortens the heading to "Let's get started" with the subtitle "Connect a calendar or start fresh", moves Back to the top row beside Log in, and styles Explore as a full-width secondary pill so signup stays the stronger choice.

![Welcome start screen with quieter Explore button](https://cursor.com/artifacts/c/art-a34dfa39-fbe4-473b-b0e5-71161288a894)

<a href="https://cursor.com/agents/bc-6c8f6131-b6f8-4d82-b2fd-1cf73ec4e808/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwelcome_explore_secondary_cta.mp4"><img src="https://cursor.com/artifacts/c/art-b99ac4e1-222e-40c5-8ad7-1998bd3a95f1" alt="welcome_explore_secondary_cta.mp4" /></a>

## Verify

Selected checks from `bun run verify --strict`: `test:web`, `type-check`, `lint`, `knip`, then Playwright `test:a11y` and `test:e2e`.

- `test:web`, `type-check`, `lint`, `knip`: passed
- `test:a11y`: 58 passed
- Welcome-related e2e: 16 passed (`welcome-cta-width`, `connect-onboarding-a11y`, `first-run`, `shortcut-showcase`)
- WelcomeModal unit tests: 31 passed after the secondary Explore restyle
- Browser: Sign up stays the dark primary pill; Explore is a full-width bordered surface pill

The first full `test:e2e` failed on `e2e/calendars/calendar-experience.spec.ts` ("stays hidden after reload") with a hidden-event width assertion. That spec is outside this diff and passed on retry in 5.6s.

`VERDICT: PASS` for the selected checks this change can affect. CI is the gate for the unrelated calendar flake.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c8f6131-b6f8-4d82-b2fd-1cf73ec4e808?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c8f6131-b6f8-4d82-b2fd-1cf73ec4e808&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

