### PR TITLE
fix: clear the active posthog error-tracking issues

### DIFF
--- a/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.test.ts
@@ -1258,6 +1258,74 @@ describe("SyncServiceClient", () => {
       ]);
     });
 
+    // Prod saw bursts of concurrent GETs answered with a 200, an
+    // application/json content-type and an empty body while Sync itself was
+    // healthy. A read is the same read twice, so retry it; a command is not.
+    it("retries a GET whose 200 body could not be read as JSON", async () => {
+      let call = 0;
+      const fn: SyncServiceClientOptions["fetch"] = async () => {
+        call += 1;
+        if (call === 1) {
+          return {
+            status: 200,
+            headers: contentType("application/json"),
+            json: async () => {
+              throw new SyntaxError("Unexpected end of JSON input");
+            },
+          };
+        }
+        return { status: 200, json: async () => ({ connections: [] }) };
+      };
+
+      const result = await client(fn).listConnections(principal());
+
+      expect(result.ok).toBe(true);
+      expect(call).toBe(2);
+    });
+
+    it("does not retry a POST whose 200 body could not be read as JSON", async () => {
+      let call = 0;
+      const fn: SyncServiceClientOptions["fetch"] = async () => {
+        call += 1;
+        return {
+          status: 200,
+          headers: contentType("application/json"),
+          json: async () => {
+            throw new SyntaxError("Unexpected end of JSON input");
+          },
+        };
+      };
+
+      const result = await client(fn).queryBusyAvailability(
+        principal(),
+        request([objectId()]),
+      );
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.kind).toBe("invalidResponse");
+      expect(call).toBe(1);
+    });
+
+    it("does not retry a 200 body that parsed but broke the contract", async () => {
+      // A contract mismatch is a bug, not a transport fault: the same body
+      // would come back again.
+      let call = 0;
+      const fn: SyncServiceClientOptions["fetch"] = async () => {
+        call += 1;
+        return {
+          status: 200,
+          headers: contentType("application/json"),
+          json: async () => ({ nope: true }),
+        };
+      };
+
+      const result = await client(fn).listConnections(principal());
+
+      expect(result.ok).toBe(false);
+      expect(call).toBe(1);
+    });
+
     it("stops retrying once the caller's deadline has passed", async () => {
       // Retries must fit inside the timeout the caller was promised, so a
       // nominally 50ms read cannot quietly become a multi-second one.

--- a/packages/backend/src/common/services/sync-service/sync-service.client.ts
+++ b/packages/backend/src/common/services/sync-service/sync-service.client.ts
@@ -135,6 +135,11 @@ export interface SyncClientError {
   // contract drift (which field broke) from HTML the reverse proxy returned
   // with a 200.
   detail?: string;
+  // Present only for `invalidResponse`: the 200 body could not be read as
+  // JSON at all (empty, truncated, or not JSON), as opposed to JSON that
+  // failed the contract. The distinction decides whether a retry is sane:
+  // an unreadable body is a transport fault, a contract mismatch is a bug.
+  bodyUnreadable?: true;
 }
 
 export type SyncClientResult<T> =
@@ -159,8 +164,23 @@ export interface SyncClientRetryInfo {
 // retrying tightly only deepens the backlog it is reporting; and `timeout`,
 // where the caller has already waited out the whole deadline and a retry
 // would just double the wait before the same failure.
-function isRetryableSyncError(error: SyncClientError): boolean {
-  return error.kind === "unavailable" && error.status !== 429;
+//
+// A 200 whose body cannot be read as JSON is retried too, but only for a
+// GET. Prod saw this in bursts of up to seven concurrent event-list reads
+// answered at the same millisecond with status 200, content-type
+// application/json and an empty body, while Sync itself logged nothing and
+// was not restarting (PostHog issue 01a042b6, 27 occurrences 2026-08-27..
+// 09-12). Whatever drops the body on the way over, the request never
+// reached Sync's handler in any way that matters, so a second attempt is
+// the same read again. A POST is not: the command may have been applied
+// before its acknowledgement was lost, and the command path has its own
+// idempotency story.
+function isRetryableSyncError(
+  error: SyncClientError,
+  method: "GET" | "POST" | "DELETE",
+): boolean {
+  if (error.kind === "unavailable") return error.status !== 429;
+  return error.bodyUnreadable === true && method === "GET";
 }
 
 // `backOff` retries on a *thrown* error, but #send returns a typed result and
@@ -690,7 +710,9 @@ export class SyncServiceClient {
         headers: buildHeaders(),
         correlationId,
       });
-      if (result.ok || !isRetryableSyncError(result.error)) return result;
+      if (result.ok || !isRetryableSyncError(result.error, input.method)) {
+        return result;
+      }
       if (this.#now() >= retryDeadline) return result;
       throw new RetryableSyncFailure(result.error);
     };
@@ -811,12 +833,16 @@ export class SyncServiceClient {
           parts.push(`content-length=${contentLength}`);
         }
         if (contentType) parts.push(`content-type=${contentType}`);
-        return errorResult(
-          "invalidResponse",
-          correlationId,
-          200,
-          parts.join("; "),
-        );
+        return {
+          ok: false,
+          error: {
+            kind: "invalidResponse",
+            status: 200,
+            correlationId,
+            detail: parts.join("; "),
+            bodyUnreadable: true,
+          },
+        };
       }
       const parsed = input.schema.safeParse(body);
       if (!parsed.success) {

--- a/packages/sync/src/app.ts
+++ b/packages/sync/src/app.ts
@@ -396,6 +396,14 @@ function buildHealthSnapshotSweep(
         // sit idle. Firing on the first sample would have cried wolf on the
         // very deploy that FIXED this. Requiring an hour of consecutive
         // samples costs nothing against a nine-day outage.
+        //
+        // "Never notified" also counts the provider's own proof of reaching
+        // the endpoint: Google's initial `sync` callback, and for a provider
+        // that validates the callback URL before opening a channel, the
+        // watch itself (NotificationChannel.callbackVerified). Without the
+        // latter, staging fired this for Microsoft after every restart on
+        // four idle subscriptions whose creation had already proven the
+        // route.
         for (const snapshot of snapshots) {
           if (
             !registry

--- a/packages/sync/src/domain/subscription-maintenance.service.db.test.ts
+++ b/packages/sync/src/domain/subscription-maintenance.service.db.test.ts
@@ -197,9 +197,43 @@ describe("maintainSubscription", () => {
     expect(saved?.subscriptionToken).toBe(notifications.watched[0]?.token);
     expect(saved?.subscriptionResourceId).toBe("res-1");
     expect(saved?.subscriptionExpiresAt).toEqual(expiresAt);
+    // A blind watch (Google) proves nothing about the callback route yet;
+    // the first `sync` callback records that.
+    expect(saved?.pushLastReceivedAt).toBeNull();
     expect(notifications.watched[0]?.calendarId).toBe("primary@google.com");
   });
 
+  // Microsoft Graph refuses a subscription whose notification URL fails its
+  // validation handshake, so a subscription that exists proves the provider
+  // reached this service. Recording that as a received push keeps the
+  // push-delivery alarm from reading an idle Microsoft fleet as a broken
+  // route: staging fired it after every restart on four quiet subscriptions.
+  it("records a callback-verified watch as a received push", async () => {
+    const cal = calendar(objectId());
+    const resource = await seedResource(cal);
+    const notifications = new FakeNotifications({
+      channel: {
+        channelId: "",
+        resourceId: "res-verified",
+        expiresAt: new Date("2026-07-17T00:00:00.000Z"),
+        callbackVerified: true,
+      },
+    });
+
+    const outcome = await maintainSubscription(
+      maintenanceDeps(notifications),
+      cal,
+      resource,
+      now,
+    );
+
+    expect(outcome).toEqual({ status: "watched" });
+    const saved = await reload(resource);
+    expect(saved?.subscriptionResourceId).toBe("res-verified");
+    expect(saved?.pushLastReceivedAt).toEqual(now());
+    // Only push receipt, not a pending change: nothing is owed to a pull.
+    expect(saved?.changeNotifiedAt).toBeNull();
+  });
   it("renews and stops the old channel when it is near expiry", async () => {
     const cal = calendar(objectId());
     // Expires in 1 hour: inside the default 24h renew window.

--- a/packages/sync/src/domain/subscription-maintenance.service.ts
+++ b/packages/sync/src/domain/subscription-maintenance.service.ts
@@ -187,6 +187,13 @@ export async function maintainSubscription(
       subscriptionResourceId: channel.resourceId,
       subscriptionToken: channelToken,
       subscriptionExpiresAt: channel.expiresAt,
+      // A provider that validated the callback before opening the channel
+      // has just reached this service's push endpoint, which is exactly what
+      // pushLastReceivedAt records. Without it a quiet calendar on such a
+      // provider looks identical to a broken route to the push-delivery
+      // alarm, which fired on staging after every restart for Microsoft
+      // subscriptions that had nothing to report.
+      ...(channel.callbackVerified ? { pushLastReceivedAt: now() } : {}),
     },
   );
 

--- a/packages/sync/src/providers/microsoft/microsoft-auth.adapter.test.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-auth.adapter.test.ts
@@ -388,6 +388,62 @@ describe("MicrosoftAuthAdapter", () => {
         .catch((e) => e);
 
       expect((error as ProviderAuthError).reason).toBe("exchangeFailed");
+      // The thrown cause is what tells a network fault from a rejection.
+      expect((error as ProviderAuthError).message).toBe(
+        "Microsoft rejected the authorization code exchange (network down)",
+      );
+    });
+
+    // Staging logged "rejected the authorization code exchange" three times
+    // in thirty seconds with nothing to say why. The OAuth error code and
+    // the AADSTS sentence are the diagnosis; the rest of Entra's description
+    // is a per-request trace id and timestamp that would split PostHog's
+    // grouping into one issue per attempt, so only the first sentence goes.
+    it("names the OAuth error and its first sentence on a rejected exchange", async () => {
+      const adapter = adapterWith(
+        new FakeTokenEndpoint({
+          exchangeResponse: {
+            error: "invalid_client",
+            error_description:
+              "AADSTS7000215: Invalid client secret provided. Trace ID: 1234 Correlation ID: 5678 Timestamp: 2026-09-11 01:14:28Z",
+          },
+        }),
+        new FakeIdTokenVerifier(),
+      );
+
+      const error = await adapter
+        .exchangeAuthorizationCode({
+          code: "auth-code",
+          redirectUri: "https://staging.example.com/sync/microsoft",
+        })
+        .catch((e) => e);
+
+      expect((error as ProviderAuthError).reason).toBe("exchangeFailed");
+      expect((error as ProviderAuthError).message).toBe(
+        "Microsoft rejected the authorization code exchange (invalid_client: AADSTS7000215: Invalid client secret provided)",
+      );
+    });
+
+    it("reports the HTTP status when the token endpoint answered without an OAuth error", async () => {
+      const adapter = adapterWith(
+        new FakeTokenEndpoint({
+          exchangeError: Object.assign(new Error("token_endpoint_error"), {
+            response: { status: 502, data: {} },
+          }),
+        }),
+        new FakeIdTokenVerifier(),
+      );
+
+      const error = await adapter
+        .exchangeAuthorizationCode({
+          code: "auth-code",
+          redirectUri: "https://staging.example.com/sync/microsoft",
+        })
+        .catch((e) => e);
+
+      expect((error as ProviderAuthError).message).toBe(
+        "Microsoft rejected the authorization code exchange (status 502)",
+      );
     });
 
     it("requires a refresh token", async () => {

--- a/packages/sync/src/providers/microsoft/microsoft-auth.adapter.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-auth.adapter.ts
@@ -135,7 +135,7 @@ export class MicrosoftAuthAdapter implements ProviderAuthAdapter {
     } catch (error) {
       throw new ProviderAuthError(
         "exchangeFailed",
-        "Microsoft rejected the authorization code exchange",
+        `Microsoft rejected the authorization code exchange (${tokenEndpointFailureSummary(error)})`,
         { cause: redactedCause(error) },
       );
     }
@@ -328,7 +328,31 @@ function consentOrExchangeError(
       "Microsoft requires admin consent before Compass can connect",
     );
   }
-  throw new ProviderAuthError(fallbackReason, message);
+  // The OAuth error code and the AADSTS sentence say WHY (a stale client
+  // secret, a redirect mismatch, an expired code); without them staging's
+  // "rejected the authorization code exchange" went undiagnosed. Only the
+  // first sentence: the rest of an Entra description is a per-request trace
+  // id, correlation id, and timestamp, which would split PostHog's grouping
+  // into one issue per attempt.
+  const lead = description?.split(/\.\s|\r|\n/, 1)[0]?.trim();
+  throw new ProviderAuthError(
+    fallbackReason,
+    `${message} (${lead ? `${error}: ${lead}` : error})`,
+  );
+}
+
+// Log-safe summary of a token endpoint failure that carried no OAuth error
+// body: the HTTP status and the thrown message, never the request (it holds
+// the client secret and the authorization code).
+function tokenEndpointFailureSummary(error: unknown): string {
+  const status = tokenEndpointStatus(error);
+  const parts = [
+    ...(status !== undefined ? [`status ${status}`] : []),
+    ...(error instanceof Error && error.message !== "token_endpoint_error"
+      ? [error.message]
+      : []),
+  ];
+  return parts.length > 0 ? parts.join(", ") : "no response";
 }
 
 const PERMANENT_REFRESH_ERRORS = new Set(["invalid_grant"]);

--- a/packages/sync/src/providers/microsoft/microsoft-notifications.adapter.test.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-notifications.adapter.test.ts
@@ -99,6 +99,9 @@ describe("MicrosoftNotificationAdapter watch/stop", () => {
       channelId: "sub-1",
       resourceId: "/me/calendars/AAMkAGI2TG93AAA=/events",
       expiresAt: new Date("2026-01-02T00:00:00.000Z"),
+      // Graph validated the notification URL before returning the
+      // subscription, so the watch itself proves the callback route.
+      callbackVerified: true,
     });
   });
 

--- a/packages/sync/src/providers/microsoft/microsoft-notifications.adapter.ts
+++ b/packages/sync/src/providers/microsoft/microsoft-notifications.adapter.ts
@@ -110,6 +110,9 @@ export class MicrosoftNotificationAdapter
         subscription.expirationDateTime,
         expirationDateTime,
       ),
+      // Graph only returns a subscription after our endpoint echoed its
+      // validationToken, so a created subscription proves the callback route.
+      callbackVerified: true,
     };
   }
 

--- a/packages/sync/src/providers/provider-notifications.port.ts
+++ b/packages/sync/src/providers/provider-notifications.port.ts
@@ -9,6 +9,13 @@ export interface NotificationChannel {
   readonly resourceId: string;
   // When the channel stops delivering and must be renewed.
   readonly expiresAt: Date;
+  // True when the provider confirmed it could reach `callbackUrl` before it
+  // opened the channel (Microsoft Graph refuses a subscription whose
+  // notification URL fails its validation handshake). Google opens a channel
+  // blind and reports reachability with its first `sync` callback instead,
+  // so it leaves this unset. The caller records a verified watch as a
+  // received push: the handshake IS the provider reaching the endpoint.
+  readonly callbackVerified?: boolean;
 }
 
 // What one inbound callback tells us, normalized from provider headers. It is

--- a/packages/sync/src/storage/repositories/sync-resource.repository.ts
+++ b/packages/sync/src/storage/repositories/sync-resource.repository.ts
@@ -71,6 +71,9 @@ interface SubscriptionInput {
   subscriptionResourceId: string;
   subscriptionToken: string;
   subscriptionExpiresAt: Date;
+  // Set when opening the channel itself counted as the provider reaching the
+  // push endpoint (see NotificationChannel.callbackVerified).
+  pushLastReceivedAt?: Date;
 }
 
 // Repository for `sync_resources`. Each resource is created once per

--- a/packages/web/src/common/utils/browser/missing-chunk-reload.util.test.ts
+++ b/packages/web/src/common/utils/browser/missing-chunk-reload.util.test.ts
@@ -1,0 +1,100 @@
+import {
+  isMissingChunkError,
+  reloadOnceForMissingChunk,
+} from "./missing-chunk-reload.util";
+
+const missingChunk = () =>
+  new TypeError(
+    "Failed to fetch dynamically imported module: https://compasscalendar.com/chunk-5380z7k8.js",
+  );
+
+const memoryStorage = () => {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+  };
+};
+
+describe("isMissingChunkError", () => {
+  it("recognizes each browser's wording for a chunk that no longer exists", () => {
+    expect(isMissingChunkError(missingChunk())).toBe(true);
+    expect(
+      isMissingChunkError(
+        new TypeError("error loading dynamically imported module: x"),
+      ),
+    ).toBe(true);
+    expect(
+      isMissingChunkError(new TypeError("Importing a module script failed.")),
+    ).toBe(true);
+  });
+
+  it("leaves other boot failures alone", () => {
+    expect(isMissingChunkError(new Error("boom"))).toBe(false);
+    expect(isMissingChunkError("Failed to fetch")).toBe(false);
+  });
+});
+
+describe("reloadOnceForMissingChunk", () => {
+  it("reloads the first time a chunk is missing and reports it", () => {
+    const storage = memoryStorage();
+    let reloads = 0;
+
+    const reloaded = reloadOnceForMissingChunk(missingChunk(), storage, () => {
+      reloads += 1;
+    });
+
+    expect(reloaded).toBe(true);
+    expect(reloads).toBe(1);
+  });
+
+  it("does not reload a second time for the same chunk", () => {
+    const storage = memoryStorage();
+    let reloads = 0;
+    const reload = () => {
+      reloads += 1;
+    };
+
+    reloadOnceForMissingChunk(missingChunk(), storage, reload);
+    const reloaded = reloadOnceForMissingChunk(missingChunk(), storage, reload);
+
+    expect(reloaded).toBe(false);
+    expect(reloads).toBe(1);
+  });
+
+  it("does not reload for an unrelated error", () => {
+    let reloads = 0;
+
+    const reloaded = reloadOnceForMissingChunk(
+      new Error("boom"),
+      memoryStorage(),
+      () => {
+        reloads += 1;
+      },
+    );
+
+    expect(reloaded).toBe(false);
+    expect(reloads).toBe(0);
+  });
+
+  it("does not reload when storage is unavailable, so a failure cannot loop", () => {
+    let reloads = 0;
+    const throwing = {
+      getItem: () => {
+        throw new Error("SecurityError");
+      },
+      setItem: () => {
+        throw new Error("SecurityError");
+      },
+    };
+
+    const reloaded = reloadOnceForMissingChunk(missingChunk(), throwing, () => {
+      reloads += 1;
+    });
+
+    expect(reloaded).toBe(false);
+    expect(reloads).toBe(0);
+  });
+});

--- a/packages/web/src/common/utils/browser/missing-chunk-reload.util.ts
+++ b/packages/web/src/common/utils/browser/missing-chunk-reload.util.ts
@@ -1,0 +1,45 @@
+// A deploy replaces every hashed chunk, so a tab that loaded index.html
+// before the deploy and imports a chunk after it gets a 404 dressed up by
+// the browser as one of these messages. index.html itself is served
+// `no-cache`, so one reload fetches the new chunk names and recovers.
+// TanStack Router already does exactly this for lazy route components; this
+// covers the app's own boot import, which runs before the router exists and
+// otherwise strands the user on the "ran aground" page (PostHog issue
+// 019a097a, production 2026-09-11).
+const MISSING_CHUNK_MESSAGES = [
+  "Failed to fetch dynamically imported module",
+  "error loading dynamically imported module",
+  "Importing a module script failed",
+];
+
+const RELOAD_KEY_PREFIX = "compass_missing_chunk_reload:";
+
+export function isMissingChunkError(error: unknown): error is Error {
+  return (
+    error instanceof Error &&
+    MISSING_CHUNK_MESSAGES.some((message) => error.message.includes(message))
+  );
+}
+
+// Reloads the page at most once per missing chunk, keyed on the error message
+// (which names the chunk URL) so a reload that STILL fails falls through to
+// the caller's error UI instead of looping. Returns true when a reload was
+// triggered, so the caller can stop rendering.
+export function reloadOnceForMissingChunk(
+  error: unknown,
+  storage: Pick<Storage, "getItem" | "setItem"> = sessionStorage,
+  reload: () => void = () => window.location.reload(),
+): boolean {
+  if (!isMissingChunkError(error)) return false;
+  const key = `${RELOAD_KEY_PREFIX}${error.message}`;
+  try {
+    if (storage.getItem(key)) return false;
+    storage.setItem(key, "1");
+  } catch {
+    // Storage disabled (private mode, blocked site data): a reload with no
+    // guard could loop, so show the error page instead.
+    return false;
+  }
+  reload();
+  return true;
+}

--- a/packages/web/src/index.tsx
+++ b/packages/web/src/index.tsx
@@ -2,12 +2,17 @@ import {
   getPosthogClient,
   initPosthog,
 } from "@web/auth/posthog/posthog.bootstrap";
+import { reloadOnceForMissingChunk } from "@web/common/utils/browser/missing-chunk-reload.util";
 
 initPosthog();
 
 void import("./app.bootstrap")
   .then(({ bootstrapApp }) => bootstrapApp())
   .catch((error) => {
+    // A deploy between this index.html and the import: one reload picks up
+    // the new chunk names. Only a reload that still fails is worth a report.
+    if (reloadOnceForMissingChunk(error)) return;
+
     getPosthogClient()?.captureException(error, {
       $exception_handled: false,
       $exception_source: "app-boot",


### PR DESCRIPTION
Fixes #3677
Fixes #3649

## What and why

Clears the active PostHog error-tracking issues that trace to code in this repo. Four independent fixes, one per issue:

- **Backend, empty 200 bodies from Sync (#3677, PostHog 01a042b6 and 01a04156).** Production sees bursts of 2..7 concurrent `GET /internal/events/full` (and `/internal/connections`) reads answered at the same millisecond with status 200, `content-type: application/json` and an empty body. Only 2 of ~12 bursts line up with a production deploy; for the rest Sync logged nothing and was not restarting, so the earlier "Sync exiting mid-write" theory does not hold. The client now marks a 200 whose body cannot be read as JSON as `bodyUnreadable` and retries it through the existing transient-retry path, for GET only. A POST is not retried: the command may have been applied before its acknowledgement was lost. Contract mismatches (JSON that parsed but broke the schema) are still not retried.
- **Sync, push-silence phantom for Microsoft (PostHog 01a0886b, staging, 9 firings 09-11..09-12).** Google sends a `sync` callback at channel creation, which stamps `pushLastReceivedAt`; Microsoft Graph validates the notification URL before it creates the subscription and then stays silent until a real change. Idle Microsoft subscriptions on staging therefore stayed "never notified" forever and the alarm fired after every restart. The Microsoft adapter now reports `callbackVerified: true` on the channel and `maintainSubscription` records a verified watch as a received push, since the validation handshake is the provider reaching the endpoint. No provider branching in domain code: the flag rides on the port's `NotificationChannel`.
- **Web, missing chunk on app boot (#3649, PostHog 019a097a).** TanStack Router already reloads once when a lazy route chunk is gone after a deploy; the app's own boot import of `app.bootstrap` had no such guard and stranded the user on the "ran aground" page. `reloadOnceForMissingChunk` mirrors the router's behaviour (sessionStorage key per chunk URL, so a reload that still fails falls through to the error page instead of looping). Only a failure that survives the reload is reported to PostHog.
- **Sync, Microsoft OAuth exchange diagnosability (PostHog 01a0443c, staging 09-11).** "Microsoft rejected the authorization code exchange" fired three times in thirty seconds with nothing to say why. The error now carries the OAuth error code and the first sentence of the AADSTS description (e.g. `invalid_client: AADSTS7000215: Invalid client secret provided`), or the HTTP status when there was no OAuth body. Only the first sentence: the rest of an Entra description is a per-request trace id and timestamp that would split PostHog's grouping into one issue per attempt.

Not changed: #3674 (`unexpectedStatus` 2s after a Sync SIGTERM) is a different fingerprint and stays open; the SSE "Stream is already ended" and account-deletion retry issues were already fixed by #3450 and #3444 and are resolved in PostHog.

## Verify

`VERDICT: FAIL` locally on macOS. Checks run: test:sync, test:web, test:backend:fast, type-check, lint, knip (all pass: 1554 web, 904 backend-fast, 461 sync tests). Failed: test:a11y (21) and test:e2e (41). All 62 failures are the two documented local macOS false failures (`e2e-local-macos-gotchas`): 61 are `expect(settingsDialog).toBeVisible` in the booking harness (Control+Comma does not open Settings on macOS; `booking-a11y.spec.ts`, `host-settings.spec.ts`, `connect-onboarding-a11y.spec.ts`, `plan-section-layout.spec.ts`, `microsoft-surfaces.spec.ts`, `public-booking-v15.spec.ts`) and 1 is `account-page-jump.spec.ts` hold-Mod hints. None of those specs exercise the app boot import, the only web change here. CI on Linux is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
