### PR TITLE
fix(web): explain blocked overlay shortcuts

### DIFF
--- a/packages/web/src/billing/BillingGateModal.test.tsx
+++ b/packages/web/src/billing/BillingGateModal.test.tsx
@@ -119,13 +119,19 @@ describe("BillingGateModal", () => {
     const { unmount } = renderGate();
 
     expect(
-      screen.getByText("Try Compass for free for 7 days"),
+      screen.getByText(
+        "Start a free 7-day trial to create and edit events, including keyboard shortcuts.",
+      ),
     ).toBeInTheDocument();
     expect(screen.queryByText(/\$|\/month/i)).not.toBeInTheDocument();
     unmount();
 
     renderGate("canceled");
-    expect(screen.getByText("Your trial has ended.")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Your trial has ended. Subscribe to keep creating and editing events, including keyboard shortcuts.",
+      ),
+    ).toBeInTheDocument();
     expect(screen.queryByText(/\$|\/month/i)).not.toBeInTheDocument();
   });
 

--- a/packages/web/src/billing/BillingGateModal.tsx
+++ b/packages/web/src/billing/BillingGateModal.tsx
@@ -62,8 +62,8 @@ export const BillingGateModal: FC<BillingGateModalProps> = ({ status }) => {
     ? "Start your 7-day trial"
     : "Subscribe to keep using Compass";
   const body = isAwaitingCheckout
-    ? "Try Compass for free for 7 days"
-    : "Your trial has ended.";
+    ? "Start a free 7-day trial to create and edit events, including keyboard shortcuts."
+    : "Your trial has ended. Subscribe to keep creating and editing events, including keyboard shortcuts.";
   const primaryLabel = isAwaitingCheckout ? "Start trial" : "Subscribe";
 
   useEffect(() => {

--- a/packages/web/src/shortcuts/prompt-shortcut-unavailable.test.ts
+++ b/packages/web/src/shortcuts/prompt-shortcut-unavailable.test.ts
@@ -2,6 +2,7 @@ import { createTestToastPort } from "@web/__tests__/helpers/web-test-seams";
 import { registerToastPort } from "@web/common/utils/toast/toast.port";
 import {
   EVENT_EDITING_SHORTCUT_UNAVAILABLE_MESSAGE,
+  getOverlayUnavailableMessage,
   promptShortcutUnavailable,
   promptShortcutUnavailableWhileEditingEvent,
   SHORTCUT_UNAVAILABLE_TOAST_ID,
@@ -23,6 +24,18 @@ describe("promptShortcutUnavailable", () => {
     expect(mocks.toast).toHaveBeenCalledWith(
       "Shortcut unavailable (press Esc to close)",
       expect.objectContaining({ toastId: SHORTCUT_UNAVAILABLE_TOAST_ID }),
+    );
+  });
+
+  it("names the blocked action for every instrumented overlay shortcut", () => {
+    expect(getOverlayUnavailableMessage("create-event")).toBe(
+      "Close this panel to create an event (C)",
+    );
+    expect(getOverlayUnavailableMessage("edge-focus")).toBe(
+      "Close this panel to use edge focus (Tab)",
+    );
+    expect(getOverlayUnavailableMessage("nudge")).toBe(
+      "Close this panel to move an event (Shift and arrow keys)",
     );
   });
 

--- a/packages/web/src/shortcuts/prompt-shortcut-unavailable.ts
+++ b/packages/web/src/shortcuts/prompt-shortcut-unavailable.ts
@@ -1,10 +1,25 @@
 import { type Id } from "react-toastify";
 import { showStatusToast } from "@web/common/utils/toast/status-toast.util";
+import { type ShortcutHintId } from "@web/shortcuts/tips/shortcut-tips.data";
 
 export const SHORTCUT_UNAVAILABLE_TOAST_ID: Id = "shortcut-unavailable-overlay";
 
 export const EVENT_EDITING_SHORTCUT_UNAVAILABLE_MESSAGE =
   "Shortcut unavailable while editing an event (press Esc to close)";
+
+const OVERLAY_UNAVAILABLE_MESSAGES: Partial<Record<ShortcutHintId, string>> = {
+  "create-event": "Close this panel to create an event (C)",
+  "edge-focus": "Close this panel to use edge focus (Tab)",
+  nudge: "Close this panel to move an event (Shift and arrow keys)",
+};
+
+/** Explains every tracked shortcut that is blocked by a non-billing overlay. */
+export function getOverlayUnavailableMessage(hintId: ShortcutHintId): string {
+  return (
+    OVERLAY_UNAVAILABLE_MESSAGES[hintId] ??
+    "Close this panel to use this shortcut"
+  );
+}
 
 /** One status toast for a blocked shortcut so repeated presses do not stack. */
 export function promptShortcutUnavailable(message: string): void {

--- a/packages/web/src/shortcuts/useAppShortcut.test.ts
+++ b/packages/web/src/shortcuts/useAppShortcut.test.ts
@@ -265,14 +265,22 @@ describe("useAppShortcut", () => {
     setBillingWriteLock({ locked: true, status: "awaiting_checkout" });
     setAppLockReason("settingsModal", true);
 
-    renderHook(() => useAppShortcut("C", mockHandler, WRITE_CREATE_SHORTCUT));
+    renderHook(() =>
+      useAppShortcut("C", mockHandler, {
+        ...WRITE_CREATE_SHORTCUT,
+        telemetryHintId: "create-event",
+      }),
+    );
 
     dispatchKeyEvent("c", "keydown");
 
     await waitFor(() => {
       expect(mockHandler).not.toHaveBeenCalled();
     });
-    expect(mocks.toast).not.toHaveBeenCalled();
+    expect(mocks.toast).toHaveBeenCalledWith(
+      "Close this panel to create an event (C)",
+      expect.objectContaining({ toastId: SHORTCUT_UNAVAILABLE_TOAST_ID }),
+    );
     setAppLockReason("settingsModal", false);
   });
 

--- a/packages/web/src/shortcuts/useAppShortcut.ts
+++ b/packages/web/src/shortcuts/useAppShortcut.ts
@@ -6,7 +6,10 @@ import {
 import { isBillingWriteLocked } from "@web/billing/billing-write-lock";
 import { promptShortcutUpgrade } from "@web/billing/prompt-shortcut-upgrade";
 import { hasAppLockReason, isAppLocked } from "@web/shortcuts/app-lock";
-import { promptShortcutUnavailable } from "@web/shortcuts/prompt-shortcut-unavailable";
+import {
+  getOverlayUnavailableMessage,
+  promptShortcutUnavailable,
+} from "@web/shortcuts/prompt-shortcut-unavailable";
 import { recordShortcutUnavailableAttempt } from "@web/shortcuts/tips/shortcut-telemetry";
 import {
   getShortcutHint,
@@ -111,11 +114,16 @@ export function useAppShortcut(
           hasAppLockReason("billingGate")
         ) {
           promptLockedWriteShortcut(telemetryHintId, upgradeFeatureArea);
-        } else if (
-          overlayUnavailableMessage &&
-          !hasAppLockReason("shortcutShowcase")
-        ) {
-          promptShortcutUnavailable(overlayUnavailableMessage);
+        } else if (!hasAppLockReason("shortcutShowcase")) {
+          // A recorded unavailable attempt should never feel like a silent
+          // failure. Callers can provide context-specific copy, while every
+          // instrumented shortcut gets a concise default.
+          const unavailableMessage =
+            overlayUnavailableMessage ??
+            (telemetryHintId
+              ? getOverlayUnavailableMessage(telemetryHintId)
+              : undefined);
+          if (unavailableMessage) promptShortcutUnavailable(unavailableMessage);
         }
         return;
       }


### PR DESCRIPTION
## What and why

Adds a deduplicated, action-specific toast for every instrumented shortcut blocked by a non-billing overlay. Keeps edge focus blocked while event form fields own Tab navigation, and clarifies that trials and subscriptions unlock event editing and keyboard shortcuts.

## Verify

VERDICT: FAIL (unrelated Playwright suite state leakage). Focused web tests pass, as do type-check, lint, and knip. Two strict runs failed in accessibility and booking specs after the global Keyboard Shortcuts dialog remained open, then Settings assertions timed out. The diff does not affect those flows; CI is the gate.