### PR TITLE
feat(web): add rsvp jump target to form shortcuts

### DIFF
--- a/docs/acceptance/shortcuts.md
+++ b/docs/acceptance/shortcuts.md
@@ -248,7 +248,7 @@ Pressing Delete while an event is focused in the Day or Week grid deletes it —
 
 ### UX
 
-With a grid event focused and no form field being typed in, pressing `E` then `T` within a short window opens that event's form (if needed) and places the caret in the title. The same `E`-prefix pattern targets description (`D`), start (`S`), end (`E`), recurrence (`R`), guests (`A`), and color (`C`). Account (calendar picker) is Mod+5 only.
+With a grid event focused and no form field being typed in, pressing `E` then `T` within a short window opens that event's form (if needed) and places the caret in the title. The same `E`-prefix pattern targets description (`D`), start (`S`), end (`E`), recurrence (`R`), guests (`A`), color (`C`), and RSVP / Going (`G`). Account (calendar picker) is Mod+5 only. RSVP is Mod+- while the form is open.
 
 ### Steps
 

--- a/docs/features/attendees.md
+++ b/docs/features/attendees.md
@@ -85,8 +85,11 @@ Source: `packages/core/src/types/event-command.contracts.ts`
   labels (`1 guest (0 yes, 1 awaiting)`), distinct from the user's own
   Going / Maybe / Decline control. Jump to the guest field with `e` then
   `a`, or Mod+8 while the form is open (Mod+9 is notes; Account keeps
-  Mod+5 with no letter). When the combobox is hidden (invitee / read-only
-  / occurrence), the same shortcuts focus the read-only guest list.
+  Mod+5 with no letter). Jump to your own RSVP control with `e` then `g`,
+  or Mod+- while the form is open. When the combobox is hidden (invitee /
+  read-only / occurrence), the guest shortcuts focus the read-only guest
+  list. The RSVP chip and shortcut are omitted when the control is not
+  rendered.
 - Typing an invalid string never creates a chip — `AttendeeField`'s
   `isValidAttendeeEmail` gate rejects it inline ("Enter a valid email
   address") and nothing reaches `onChange`
@@ -228,7 +231,8 @@ Source: `packages/core/src/types/event-command.contracts.ts`
   (case-insensitive, organizer included) — on any calendar the account can
   read, including a viewer-access (reader) calendar, since answering an
   invitation is not a calendar write
-  (`EventForm.rsvp.test.tsx`).
+  (`EventForm.rsvp.test.tsx`). Jump to it with `e` then `g`, or Mod+- while
+  the form is open; hold-Mod chips `-` only when the control is rendered.
 - **Self-entry rewrite, never a full replace.** The provider write rewrites
   only the caller's own attendee entry — `executeProviderRsvp` fetches the
   target's current provider state fresh, finds the self entry by the

--- a/docs/frontend/shortcut-commandments.md
+++ b/docs/frontend/shortcut-commandments.md
@@ -20,8 +20,9 @@ in a field or focus on the grid. You do not have to change views, close
 the form, or enter a special mode first.
 
 "Any element" means first-class targets (form fields, page areas, events),
-not every DOM node. Save, All-day, and RSVP are actions or modifiers on
-those targets, not their own jump digits.
+not every DOM node. Save and All-day are actions or modifiers on those
+targets, not their own jump digits. RSVP (Going?) is a first-class field:
+`e` then `g`, or Mod+- while the form is open.
 
 ## 2. You can always discover the sequence by holding Mod
 
@@ -63,7 +64,8 @@ palette).
 ## 6. One hold-Mod gesture; context chooses the map
 
 The hold is the same everywhere. Digits are a single namespace, so the
-open event form takes them over for its fields (1–9 in DOM order). With
+open event form takes them over for its fields (1–9 in DOM order, 0 for
+actions, `-` for RSVP). With
 the form closed, the same hold numbers page areas left to right (view
 dropdown, then Day calendar columns, then month picker / Up next /
 each connected calendar account — or Life's grid/variation/details).
@@ -121,7 +123,7 @@ higher owner holds the key.
 
 Form field digits live in
 `packages/web/src/shortcuts/edit-sequence/edit-sequence.fields.ts` (DOM
-order, 1–9). Page-area digits live in
+order, 1–9, then 0 for actions and `-` for RSVP). Page-area digits live in
 `packages/web/src/shortcuts/page-jump/page-jump.targets.ts`. Day-view
 calendar columns are built by `buildDayPageJumpTargets` in left-to-right
 order (view, columns, sidebar). Meeting save-error field anchors live in

--- a/packages/web/src/common/utils/form/form.util.test.ts
+++ b/packages/web/src/common/utils/form/form.util.test.ts
@@ -183,6 +183,16 @@ describe("form.util", () => {
       const attendeesInput = document.createElement("input");
       attendeesInput.setAttribute("role", "combobox");
       attendees.append(attendeesInput);
+      const rsvp = document.createElement("div");
+      rsvp.id = "event-form-rsvp";
+      const rsvpSelected = document.createElement("input");
+      rsvpSelected.type = "radio";
+      rsvpSelected.name = "event-rsvp";
+      rsvpSelected.checked = true;
+      const rsvpOther = document.createElement("input");
+      rsvpOther.type = "radio";
+      rsvpOther.name = "event-rsvp";
+      rsvp.append(rsvpSelected, rsvpOther);
       form.append(
         title,
         location,
@@ -193,6 +203,7 @@ describe("form.util", () => {
         calendar,
         color,
         attendees,
+        rsvp,
       );
       document.body.appendChild(form);
       return {
@@ -206,6 +217,8 @@ describe("form.util", () => {
         colorSelected,
         attendees,
         attendeesInput,
+        rsvp,
+        rsvpSelected,
       };
     };
 
@@ -238,9 +251,12 @@ describe("form.util", () => {
 
       expect(focusEventFormField("attendees")).toBe(true);
       expect(document.activeElement).toBe(fields.attendeesInput);
+
+      expect(focusEventFormField("rsvp")).toBe(true);
+      expect(document.activeElement).toBe(fields.rsvpSelected);
     });
 
-    it("anchors guests and color chips on the visible wrapper, not the inner control", () => {
+    it("anchors guests, color, and RSVP chips on the visible wrapper, not the inner control", () => {
       const fields = mountForm();
 
       expect(getEventFormFieldAnchor("attendees")).toBe(fields.attendees);
@@ -248,6 +264,9 @@ describe("form.util", () => {
 
       expect(getEventFormFieldAnchor("color")?.id).toBe("event-form-color");
       expect(getEventFormFieldElement("color")).toBe(fields.colorSelected);
+
+      expect(getEventFormFieldAnchor("rsvp")).toBe(fields.rsvp);
+      expect(getEventFormFieldElement("rsvp")).toBe(fields.rsvpSelected);
     });
 
     it("focuses the selected color swatch even when it is not first in the group", () => {
@@ -267,6 +286,26 @@ describe("form.util", () => {
       document.body.appendChild(form);
 
       expect(focusEventFormField("color")).toBe(true);
+      expect(document.activeElement).toBe(selected);
+    });
+
+    it("focuses the selected RSVP answer even when it is not first in the group", () => {
+      const form = document.createElement("form");
+      form.setAttribute("name", ID_EVENT_FORM);
+      const rsvp = document.createElement("div");
+      rsvp.id = "event-form-rsvp";
+      const first = document.createElement("input");
+      first.type = "radio";
+      first.name = "event-rsvp";
+      const selected = document.createElement("input");
+      selected.type = "radio";
+      selected.name = "event-rsvp";
+      selected.checked = true;
+      rsvp.append(first, selected);
+      form.append(rsvp);
+      document.body.appendChild(form);
+
+      expect(focusEventFormField("rsvp")).toBe(true);
       expect(document.activeElement).toBe(selected);
     });
 

--- a/packages/web/src/common/utils/form/form.util.ts
+++ b/packages/web/src/common/utils/form/form.util.ts
@@ -12,7 +12,8 @@ export type EventFormFocusField =
   | "recurrence"
   | "calendar"
   | "color"
-  | "attendees";
+  | "attendees"
+  | "rsvp";
 
 const queryEventFormElement = <T extends Element>(selector: string): T | null =>
   document.querySelector<T>(selector);
@@ -61,6 +62,7 @@ const FIELD_SELECTORS: Record<EventFormFocusField, string[]> = {
   calendar: [`#event-form-calendar`],
   color: [`#event-form-color`],
   attendees: [`#event-form-attendees`, `#event-form-guest-list`],
+  rsvp: [`#event-form-rsvp`],
 };
 
 const FOCUSABLE_SELECTOR = [
@@ -88,8 +90,9 @@ const resolveFocusElement = (
   field: EventFormFocusField,
   anchor: HTMLElement,
 ): HTMLElement => {
-  // Prefer the selected swatch so arrow keys move from the current color.
-  if (field === "color") {
+  // Prefer the selected radio so arrow keys move from the current color or
+  // RSVP answer. Unanswered RSVP has no checked input; land on the first.
+  if (field === "color" || field === "rsvp") {
     return (
       anchor.querySelector<HTMLElement>('input[type="radio"]:checked') ??
       anchor.querySelector<HTMLElement>('input[type="radio"]') ??

--- a/packages/web/src/grid/shortcuts/useGridEventFormFieldSequences.ts
+++ b/packages/web/src/grid/shortcuts/useGridEventFormFieldSequences.ts
@@ -34,9 +34,9 @@ const focusFieldAfterPaint = (field: EventFormFocusField) => {
 };
 
 /**
- * `e` (or `Mod+E` while typing) then `t`/`l`/`d`/`s`/`e`/`r`/`a`/`c`: open the
- * focused event's form (if needed) and move caret/focus to the matching field.
- * Shared by Day and Week.
+ * `e` (or `Mod+E` while typing) then `t`/`l`/`d`/`s`/`e`/`r`/`a`/`c`/`g`: open
+ * the focused event's form (if needed) and move caret/focus to the matching
+ * field. Shared by Day and Week.
  *
  * Returns the anchor resolver for the which-key menu: the focused card while
  * the sequence starts from the grid, else the docked form, which is where the

--- a/packages/web/src/shortcuts/edit-sequence/EditSequenceMenu.test.tsx
+++ b/packages/web/src/shortcuts/edit-sequence/EditSequenceMenu.test.tsx
@@ -43,10 +43,10 @@ describe("EditSequenceMenu", () => {
     ).toStrictEqual(
       "Edit which field? T for title, L for location, D for description, " +
         "S for start time, E for end time, R for recurrence, C for color, " +
-        "A for guests. " +
+        "A for guests, G for going. " +
         "Escape to cancel." +
         "Edit which field?TTitleLLocationDDescriptionSStart timeEEnd time" +
-        "RRecurrenceCColorAGuestsEsc to cancel",
+        "RRecurrenceCColorAGuestsGGoingEsc to cancel",
     );
   });
 
@@ -64,6 +64,7 @@ describe("EditSequenceMenu", () => {
       "Recurrence",
       "Color",
       "Guests",
+      "Going",
     ]) {
       expect(menu?.textContent).toContain(label);
     }

--- a/packages/web/src/shortcuts/edit-sequence/edit-sequence.fields.test.ts
+++ b/packages/web/src/shortcuts/edit-sequence/edit-sequence.fields.test.ts
@@ -9,6 +9,7 @@ describe("edit-sequence.fields", () => {
   it("assigns a unique digit to every jump target", () => {
     const digits = EDIT_SEQUENCE_FIELDS.map((entry) => entry.digit);
     expect([...digits].sort()).toEqual([
+      "-",
       "0",
       "1",
       "2",
@@ -23,10 +24,11 @@ describe("edit-sequence.fields", () => {
     expect(new Set(digits).size).toBe(digits.length);
   });
 
-  it("orders FORM_FIELD_DIGITS by physical top-row key, fields then actions", () => {
+  it("orders FORM_FIELD_DIGITS by physical top-row key, fields then actions then RSVP", () => {
     // The jump engine resolves a keypress to a physical key index, so `0`
-    // must land last (where the key sits) even though the actions toolbar it
-    // points at renders first, above the title.
+    // must land after `9` (where the key sits) even though the actions
+    // toolbar it points at renders first, above the title. RSVP uses `-`,
+    // the next key after `0`.
     expect(FORM_FIELD_DIGITS.map((entry) => entry.field)).toEqual([
       "title",
       "start",
@@ -38,6 +40,7 @@ describe("edit-sequence.fields", () => {
       "attendees",
       "description",
       "actions",
+      "rsvp",
     ]);
   });
 

--- a/packages/web/src/shortcuts/edit-sequence/edit-sequence.fields.ts
+++ b/packages/web/src/shortcuts/edit-sequence/edit-sequence.fields.ts
@@ -11,10 +11,12 @@ import { PICK_KEY_LABELS } from "@web/shortcuts/digit-pick.util";
  */
 // `digit` is the field's Mod+digit jump shortcut, assigned in the form's DOM
 // order (title → schedule → recurrence → calendar → color → location →
-// attendees → description) so the mapping is guessable without the hold-Mod
-// hint chips. The array itself keeps its original key-taught order (unrelated
-// to digit order) since EditSequenceMenu renders straight off this order.
-// Account keeps digit 5 but has no letter key: `a` is guests, and Actions is
+// attendees → description → RSVP) so the mapping is guessable without the
+// hold-Mod hint chips. 1–9 are those fields, 0 is the action toolbar, and
+// `-` (the next physical top-row key) is RSVP so existing digits stay put.
+// The array itself keeps its original key-taught order (unrelated to digit
+// order) since EditSequenceMenu renders straight off this order. Account
+// keeps digit 5 but has no letter key: `a` is guests, and Actions is
 // digit-only too — it's a toolbar, not a field, so `e`-leader has nothing to
 // focus there.
 export const EDIT_SEQUENCE_FIELDS = [
@@ -28,6 +30,7 @@ export const EDIT_SEQUENCE_FIELDS = [
   { key: "c", field: "color", label: "Color", digit: "6" },
   { key: "a", field: "attendees", label: "Guests", digit: "8" },
   { field: "actions", label: "Actions", digit: "0" },
+  { key: "g", field: "rsvp", label: "Going", digit: "-" },
 ] as const satisfies readonly {
   key?: string;
   field: EventFormFocusField;
@@ -61,10 +64,10 @@ export const EDIT_SEQUENCE_FIELD_BY_DIGIT = Object.fromEntries(
 
 /**
  * The same table in physical top-row order: the fields in DOM order under
- * 1…9, then the actions toolbar under 0. Sorted by position in
- * PICK_KEY_LABELS rather than by numeric value on purpose — the jump engine
- * resolves a keypress to a *physical key index*, so `0` has to land last,
- * where the key actually sits, not first as `Number("0")` would put it.
+ * 1…9, the actions toolbar under 0, then RSVP under `-`. Sorted by position
+ * in PICK_KEY_LABELS rather than by numeric value on purpose — the jump
+ * engine resolves a keypress to a *physical key index*, so `0` has to land
+ * after `9` (where the key sits), not first as `Number("0")` would put it.
  */
 export const FORM_FIELD_DIGITS = [...EDIT_SEQUENCE_FIELDS].sort(
   (a, b) => PICK_KEY_LABELS.indexOf(a.digit) - PICK_KEY_LABELS.indexOf(b.digit),

--- a/packages/web/src/shortcuts/form-digit-jump/FormDigitHintOverlay.test.tsx
+++ b/packages/web/src/shortcuts/form-digit-jump/FormDigitHintOverlay.test.tsx
@@ -145,9 +145,9 @@ describe("FormDigitHintOverlay", () => {
     render(<FormDigitHintOverlay visible={true} />);
 
     // Digit 5 (calendar) has no chip: no #event-form-calendar element was added,
-    // matching an edit draft where the calendar picker isn't rendered. Digit 0
-    // is the action toolbar, chipped last because that's where the key sits on
-    // the physical top row.
+    // matching an edit draft where the calendar picker isn't rendered. RSVP
+    // (`-`) is also absent here. Digit 0 is the action toolbar, chipped after
+    // 9 because that's where the key sits on the physical top row.
     expect(chipDigits()).toEqual(["1", "2", "3", "4", "6", "7", "8", "9", "0"]);
   });
 
@@ -174,6 +174,30 @@ describe("FormDigitHintOverlay", () => {
     ]);
   });
 
+  it("renders the RSVP chip once the Going control is present", () => {
+    buildForm();
+    const rsvp = document.createElement("div");
+    rsvp.id = "event-form-rsvp";
+    stubRect(rsvp, box(200, 80, 240, 240));
+    document.body.append(rsvp);
+
+    render(<FormDigitHintOverlay visible={true} />);
+
+    expect(chipDigits()).toEqual([
+      "1",
+      "2",
+      "3",
+      "4",
+      "6",
+      "7",
+      "8",
+      "9",
+      "0",
+      "-",
+    ]);
+    expect(screen.getByRole("status").textContent).toContain("- for going");
+  });
+
   it("exposes a screen-reader summary while the visible chips stay aria-hidden", () => {
     buildForm();
     render(<FormDigitHintOverlay visible={true} />);
@@ -191,9 +215,10 @@ describe("FormDigitHintOverlay", () => {
     buildForm();
     render(<FormDigitHintOverlay visible={true} />);
 
-    // No #event-form-calendar element was added (edit-draft state), so digit
-    // 5 has neither a chip nor an announcement.
+    // No #event-form-calendar or #event-form-rsvp (edit-draft / not invited),
+    // so those digits have neither a chip nor an announcement.
     expect(screen.getByRole("status").textContent).not.toContain("calendar");
+    expect(screen.getByRole("status").textContent).not.toContain("going");
   });
 
   it("chips the guests wrapper even when react-select's inner input is too small to chip", () => {

--- a/packages/web/src/shortcuts/form-digit-jump/useFormDigitJumpShortcut.test.tsx
+++ b/packages/web/src/shortcuts/form-digit-jump/useFormDigitJumpShortcut.test.tsx
@@ -109,6 +109,15 @@ const buildForm = () => {
   description.tabIndex = 0;
   document.body.append(description);
 
+  const rsvp = document.createElement("div");
+  rsvp.id = "event-form-rsvp";
+  const going = document.createElement("input");
+  going.type = "radio";
+  going.name = "event-rsvp";
+  going.checked = true;
+  rsvp.append(going);
+  form.append(rsvp);
+
   return {
     title,
     start,
@@ -120,6 +129,7 @@ const buildForm = () => {
     attendees: attendeesInput,
     description,
     actions: duplicate,
+    rsvp: going,
   };
 };
 
@@ -171,14 +181,27 @@ describe("useFormDigitJumpShortcut", () => {
         ["8", fields.attendees],
         ["9", fields.description],
         // 0 sits after 9 on the physical top row, so it lands on the actions
-        // toolbar rather than shifting every field's digit by one.
+        // toolbar rather than shifting every field's digit by one. `-` is
+        // RSVP, the next physical key after 0.
         ["0", fields.actions],
+        ["-", fields.rsvp],
       ] as const;
 
       for (const [digit, element] of cases) {
-        pressModDigit(digit, `Digit${digit}`);
+        pressModDigit(digit, digit === "-" ? "Minus" : `Digit${digit}`);
         expect(element).toHaveFocus();
       }
+    });
+
+    it("jumps to RSVP on Mod+-", () => {
+      const fields = buildForm();
+      fields.title.focus();
+      renderHook(() => useFormDigitJumpShortcut());
+
+      const event = pressModDigit("-", "Minus");
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(fields.rsvp).toHaveFocus();
     });
 
     it("ignores a bare digit with no modifier held", () => {

--- a/packages/web/src/shortcuts/form-digit-jump/useFormDigitJumpShortcut.ts
+++ b/packages/web/src/shortcuts/form-digit-jump/useFormDigitJumpShortcut.ts
@@ -13,11 +13,12 @@ export { MOD_HOLD_HINT_MS } from "@web/shortcuts/mod-hold/useModHoldHintShortcut
 const DIGIT_ORDER = FORM_FIELD_DIGITS.map((entry) => entry.digit);
 
 /**
- * Mod+digit jumps focus straight to a form field (1=title ... 9=description;
- * see edit-sequence.fields.ts for the assignment). Holding Mod alone reveals
- * the mapping as hint chips (FormDigitHintOverlay) via the shared hold-Mod
- * engine — the same discoverability contract as the `e`-leader's which-key
- * menu, but driven by a hold instead of a second keypress.
+ * Mod+digit jumps focus straight to a form field (1=title ... 9=description,
+ * 0=actions, -=RSVP; see edit-sequence.fields.ts for the assignment). Holding
+ * Mod alone reveals the mapping as hint chips (FormDigitHintOverlay) via the
+ * shared hold-Mod engine — the same discoverability contract as the
+ * `e`-leader's which-key menu, but driven by a hold instead of a second
+ * keypress.
  *
  * Mounted from EventForm, so this hook is live exactly while the form is
  * open; no separate "is the form open" gate is needed.

--- a/packages/web/src/shortcuts/keymap.ts
+++ b/packages/web/src/shortcuts/keymap.ts
@@ -17,11 +17,11 @@ export const KEYMAP = {
   createEvent: { hotkey: "C", keycaps: ["C"] },
   saveDraft: { hotkey: "Enter", keycaps: ["Enter"] },
   // 1-9 are the form's fields in DOM order; 0 is the action toolbar above the
-  // title (duplicate / delete / close).
+  // title (duplicate / delete / close); `-` is RSVP (Going?).
   jumpFormField: {
     holdModifier: "Mod",
-    digits: ["0", "9"],
-    keycaps: ["Mod", "0-9"],
+    digits: ["0", "9", "-"],
+    keycaps: ["Mod", "0-9", "-"],
   },
   // Same hold-Mod gesture outside the form: digits follow the active view's
   // target list order (page-jump.targets.ts). Day view numbers left to right

--- a/packages/web/src/shortcuts/shortcuts.menu.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.menu.test.ts
@@ -349,6 +349,10 @@ describe("shortcut menu sections", () => {
           keys: ["e", "c"],
           label: "Edit color",
         });
+        expect(shortcuts).toContainEqual({
+          keys: ["e", "g"],
+          label: "Edit going",
+        });
       }
     });
 

--- a/packages/web/src/shortcuts/shortcuts.registry.test.ts
+++ b/packages/web/src/shortcuts/shortcuts.registry.test.ts
@@ -228,6 +228,7 @@ describe("shortcuts.registry", () => {
       expect(ids).toContain("edit-focus-attendees");
       expect(ids).not.toContain("edit-focus-calendar");
       expect(ids).toContain("edit-focus-color");
+      expect(ids).toContain("edit-focus-rsvp");
       expect(ids).not.toContain("other-booking-jump");
     });
 

--- a/packages/web/src/shortcuts/useEditSequenceShortcut.test.tsx
+++ b/packages/web/src/shortcuts/useEditSequenceShortcut.test.tsx
@@ -82,6 +82,7 @@ describe("useEditSequenceShortcut", () => {
         ["r", "recurrence"],
         ["a", "attendees"],
         ["c", "color"],
+        ["g", "rsvp"],
       ] as const;
 
       for (const [second, field] of cases) {

--- a/packages/web/src/views/Forms/EventForm/EventForm.rsvp.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.rsvp.test.tsx
@@ -1,5 +1,6 @@
-import { HotkeyManager } from "@tanstack/react-hotkeys";
-import { render, screen } from "@testing-library/react";
+import { HotkeyManager, resolveModifier } from "@tanstack/react-hotkeys";
+import { act, render, screen } from "@testing-library/react";
+import { type ReactNode } from "react";
 import {
   type Calendar,
   getCalendarCapabilities,
@@ -10,9 +11,11 @@ import { type Attendee } from "@core/types/event-attendance.contracts";
 import { createStoreWrapper } from "@web/__tests__/render-with-store";
 import { createMockEvent } from "@web/__tests__/utils/factories/event.factory";
 import { calendarQueryKeys } from "@web/calendars/calendar.query";
+import { focusEventFormField } from "@web/common/utils/form/form.util";
 import { createObjectIdString } from "@web/common/utils/id/object-id.util";
 import { type GridEventDraft } from "@web/events/event-draft.types";
 import { editGridEventDraft } from "@web/events/grid-event-draft.adapter";
+import { useEditSequenceShortcut } from "@web/shortcuts/useEditSequenceShortcut";
 import { EventForm } from "@web/views/Forms/EventForm/EventForm";
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
@@ -69,11 +72,15 @@ const makeInvitedEvent = (
     ...overrides,
   });
 
-const renderEventForm = (draft: GridEventDraft, calendars: Calendar[]) => {
+const renderEventForm = (
+  draft: GridEventDraft,
+  calendars: Calendar[],
+  wrap?: (form: ReactNode) => ReactNode,
+) => {
   const { queryClient, wrapper } = createStoreWrapper();
   queryClient.setQueryData(calendarQueryKeys.all, calendars);
 
-  return render(
+  const form = (
     <EventForm
       draft={draft}
       isDraft={false}
@@ -83,10 +90,16 @@ const renderEventForm = (draft: GridEventDraft, calendars: Calendar[]) => {
       onDuplicate={mock()}
       onSubmit={mock()}
       setDraft={mock()}
-    />,
-    { wrapper },
+    />
   );
+
+  return render(wrap ? wrap(form) : form, { wrapper });
 };
+
+function WithEditLeader({ children }: { children: ReactNode }) {
+  useEditSequenceShortcut({ onSequence: focusEventFormField });
+  return <>{children}</>;
+}
 
 const editDraftOrThrow = (event: Event): GridEventDraft => {
   const draft = editGridEventDraft(event);
@@ -96,6 +109,61 @@ const editDraftOrThrow = (event: Event): GridEventDraft => {
 
 const queryRsvpGroup = () =>
   screen.queryByRole("radiogroup", { name: "Going?" });
+
+function dispatchModDigitKey(target: HTMLElement, code: string, key: string) {
+  const isControl = resolveModifier("Mod") === "Control";
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    code,
+    ctrlKey: isControl,
+    key,
+    metaKey: !isControl,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
+function dispatchModKey(target: HTMLElement, key: string) {
+  const isControl = resolveModifier("Mod") === "Control";
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    ctrlKey: isControl,
+    key,
+    metaKey: !isControl,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
+function dispatchKey(target: HTMLElement, key: string) {
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    key,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
+const stubVisibleRect = (element: HTMLElement) => {
+  element.getBoundingClientRect = () =>
+    ({
+      top: 200,
+      left: 80,
+      bottom: 240,
+      right: 320,
+      width: 240,
+      height: 40,
+      x: 80,
+      y: 200,
+      toJSON: () => ({}),
+    }) as DOMRect;
+};
 
 describe("EventForm RSVP control gating", () => {
   beforeEach(() => {
@@ -199,5 +267,136 @@ describe("EventForm RSVP control gating", () => {
     renderEventForm(editDraftOrThrow(event), [calendar]);
 
     expect(queryRsvpGroup()).not.toBeInTheDocument();
+  });
+});
+
+describe("EventForm RSVP shortcut targeting", () => {
+  beforeEach(() => {
+    HotkeyManager.resetInstance();
+    document.body.removeAttribute("data-app-locked");
+  });
+
+  it("jumps focus to the Going radio with Mod+- when unanswered", () => {
+    const calendar = makeCalendar();
+    renderEventForm(editDraftOrThrow(makeInvitedEvent(calendar.id)), [
+      calendar,
+    ]);
+
+    const titleField = screen.getByPlaceholderText("Title");
+    act(() => titleField.focus());
+    dispatchModDigitKey(titleField, "Minus", "-");
+
+    expect(screen.getByRole("radio", { name: "Going" })).toHaveFocus();
+  });
+
+  it("jumps focus to the checked RSVP answer with Mod+-", () => {
+    const calendar = makeCalendar();
+    const event = makeInvitedEvent(calendar.id, {
+      content: {
+        kind: "details",
+        title: "Team offsite",
+        description: "",
+        organizer: { email: "organizer@example.com", displayName: null },
+        attendees: [
+          { ...selfAttendee, responseStatus: "tentative" },
+          otherAttendee,
+        ],
+      },
+    });
+    renderEventForm(editDraftOrThrow(event), [calendar]);
+
+    const titleField = screen.getByPlaceholderText("Title");
+    act(() => titleField.focus());
+    dispatchModDigitKey(titleField, "Minus", "-");
+
+    expect(screen.getByRole("radio", { name: "Maybe" })).toHaveFocus();
+  });
+
+  it("jumps focus to RSVP with Mod+E then G from the title field", () => {
+    const calendar = makeCalendar();
+    renderEventForm(
+      editDraftOrThrow(makeInvitedEvent(calendar.id)),
+      [calendar],
+      (form) => <WithEditLeader>{form}</WithEditLeader>,
+    );
+
+    const titleField = screen.getByPlaceholderText("Title");
+    act(() => titleField.focus());
+    dispatchModKey(titleField, "e");
+    dispatchKey(titleField, "g");
+
+    expect(screen.getByRole("radio", { name: "Going" })).toHaveFocus();
+  });
+
+  it("reveals a hold-Mod chip on the RSVP control", async () => {
+    const calendar = makeCalendar();
+    renderEventForm(editDraftOrThrow(makeInvitedEvent(calendar.id)), [
+      calendar,
+    ]);
+
+    const wrapper = document.getElementById("event-form-rsvp");
+    expect(wrapper).not.toBeNull();
+    stubVisibleRect(wrapper!);
+
+    const isControl = resolveModifier("Mod") === "Control";
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          key: isControl ? "Control" : "Meta",
+          ctrlKey: isControl,
+          metaKey: !isControl,
+        }),
+      );
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 750));
+    });
+
+    expect(screen.getByRole("status").textContent).toContain("- for going");
+  });
+
+  it("does not advertise the RSVP jump when the control is hidden", async () => {
+    const calendar = makeCalendar();
+    const event = makeInvitedEvent(calendar.id, {
+      content: {
+        kind: "details",
+        title: "Their meeting",
+        description: "",
+        organizer: { email: "organizer@example.com", displayName: null },
+        attendees: [otherAttendee],
+      },
+    });
+    renderEventForm(editDraftOrThrow(event), [calendar]);
+
+    expect(queryRsvpGroup()).not.toBeInTheDocument();
+
+    const titleField = screen.getByPlaceholderText("Title");
+    act(() => titleField.focus());
+    expect(() => dispatchModDigitKey(titleField, "Minus", "-")).not.toThrow();
+    expect(titleField).toHaveFocus();
+
+    const isControl = resolveModifier("Mod") === "Control";
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          key: isControl ? "Control" : "Meta",
+          ctrlKey: isControl,
+          metaKey: !isControl,
+        }),
+      );
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 750));
+    });
+
+    expect(screen.getByRole("status").textContent).not.toContain("going");
   });
 });

--- a/packages/web/src/views/Forms/EventForm/EventForm.tsx
+++ b/packages/web/src/views/Forms/EventForm/EventForm.tsx
@@ -94,6 +94,7 @@ const EVENT_FORM_CALENDAR_ID = "event-form-calendar";
 const EVENT_FORM_COLOR_ID = "event-form-color";
 const EVENT_FORM_SCHEDULE_ID = "event-form-schedule";
 const EVENT_FORM_RECURRENCE_ID = "event-form-recurrence";
+const EVENT_FORM_RSVP_ID = "event-form-rsvp";
 
 const eventFormErrorId = (field: string) =>
   `event-form-error-${field.replaceAll(".", "-")}`;
@@ -893,7 +894,11 @@ export const EventForm: React.FC<GridEventFormProps> = memo(
             {/* Outside the fieldset (like the details section below): RSVP
               must stay interactive on a read-only calendar. */}
             {showRsvpControl && rsvpSource && rsvpAccountEmail && (
-              <RsvpControl event={rsvpSource} accountEmail={rsvpAccountEmail} />
+              <RsvpControl
+                id={EVENT_FORM_RSVP_ID}
+                event={rsvpSource}
+                accountEmail={rsvpAccountEmail}
+              />
             )}
 
             {/* Outside the fieldset: read-only display, not an editable

--- a/packages/web/src/views/Forms/EventForm/RsvpControl.test.tsx
+++ b/packages/web/src/views/Forms/EventForm/RsvpControl.test.tsx
@@ -47,9 +47,16 @@ const invitedEvent = (
 
 const renderControl = (event: Event) => {
   const { wrapper } = createStoreWrapper();
-  return render(<RsvpControl event={event} accountEmail={ACCOUNT_EMAIL} />, {
-    wrapper,
-  });
+  return render(
+    <RsvpControl
+      id="event-form-rsvp"
+      event={event}
+      accountEmail={ACCOUNT_EMAIL}
+    />,
+    {
+      wrapper,
+    },
+  );
 };
 
 const captureRsvpRequests = () => {
@@ -73,6 +80,7 @@ describe("RsvpControl", () => {
     expect(
       screen.getByRole("radiogroup", { name: "Going?" }),
     ).toBeInTheDocument();
+    expect(document.getElementById("event-form-rsvp")).not.toBeNull();
     expect(screen.getByRole("radio", { name: "Going" })).not.toBeChecked();
     expect(screen.getByRole("radio", { name: "Maybe" })).toBeChecked();
     expect(screen.getByRole("radio", { name: "Decline" })).not.toBeChecked();

--- a/packages/web/src/views/Forms/EventForm/RsvpControl.tsx
+++ b/packages/web/src/views/Forms/EventForm/RsvpControl.tsx
@@ -26,9 +26,11 @@ interface RsvpControlProps {
   event: Event;
   /** The connected account email the self attendee entry is matched by. */
   accountEmail: string;
+  /** Jump-target anchor for hold-Mod chips and Mod+- / e then g. */
+  id: string;
 }
 
-export const RsvpControl = ({ event, accountEmail }: RsvpControlProps) => {
+export const RsvpControl = ({ event, accountEmail, id }: RsvpControlProps) => {
   const groupName = useId();
   const labelId = useId();
   const [pendingStatus, setPendingStatus] = useState<RsvpResponseStatus | null>(
@@ -66,7 +68,10 @@ export const RsvpControl = ({ event, accountEmail }: RsvpControlProps) => {
 
   return (
     <>
-      <div className="flex items-center justify-between gap-2 rounded-md bg-surface-overlay p-3 text-text text-xs">
+      <div
+        id={id}
+        className="flex items-center justify-between gap-2 rounded-md bg-surface-overlay p-3 text-text text-xs"
+      >
         <span id={labelId} className="text-text-muted">
           Going?
         </span>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What and why

The event form's Going? RSVP control was on screen and interactive but had no hold-Mod chip or `e`-leader jump, so users could not target it the way they target every other field. RSVP is now a first-class jump target: `e` then `g`, or `Mod+-` while the form is open. `-` is the next physical top-row key after `0`, so existing 1-9 / 0 mappings stay put. Hold-Mod chips `-` only when the control is rendered.

## Verify

```
Checks run: test:web, type-check, lint, knip, test:a11y, test:e2e
Checks skipped: (none)
VERDICT: PASS
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c13afe6e-2bcc-4bb0-a1ee-e8697e7c4030?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c13afe6e-2bcc-4bb0-a1ee-e8697e7c4030&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

